### PR TITLE
fix(admin-cli): fix json output of single endpoint exploration report

### DIFF
--- a/crates/admin-cli/src/site_explorer/cmds.rs
+++ b/crates/admin-cli/src/site_explorer/cmds.rs
@@ -269,26 +269,24 @@ pub async fn show_discovered_managed_host(
                 )
                 .await?;
 
+                let endpoint = exploration_report
+                    .endpoints
+                    .into_iter()
+                    .find(|x| x.address == address)
+                    .ok_or_else(|| {
+                        CarbideCliError::GenericError("Endpoint not found.".to_string())
+                    })?;
+
                 if output_format == OutputFormat::Json {
                     async_writeln!(
                         output_file,
                         "{}",
-                        serde_json::to_string_pretty(&exploration_report)?
+                        serde_json::to_string_pretty(&endpoint)?
                     )?;
                     return Ok(());
                 }
 
-                display_endpoint(
-                    output_file,
-                    exploration_report
-                        .endpoints
-                        .into_iter()
-                        .find(|x| x.address == address)
-                        .ok_or_else(|| {
-                            CarbideCliError::GenericError("Endpoint not found.".to_string())
-                        })?,
-                )
-                .await?;
+                display_endpoint(output_file, endpoint).await?;
             } else {
                 let exploration_report = api_client
                     .get_site_exploration_report(internal_page_size)

--- a/crates/admin-cli/src/site_explorer/cmds.rs
+++ b/crates/admin-cli/src/site_explorer/cmds.rs
@@ -278,11 +278,7 @@ pub async fn show_discovered_managed_host(
                     })?;
 
                 if output_format == OutputFormat::Json {
-                    async_writeln!(
-                        output_file,
-                        "{}",
-                        serde_json::to_string_pretty(&endpoint)?
-                    )?;
+                    async_writeln!(output_file, "{}", serde_json::to_string_pretty(&endpoint)?)?;
                     return Ok(());
                 }
 


### PR DESCRIPTION
## Description
The `site-explorer get-report endpoint <ip>` command with `--format json` was returning all endpoints in the site, not just the one matching the requested IP. The ASCII output already filtered correctly. This fix extracts the matching endpoint before branching on output format, so both JSON and ASCII output return only the requested endpoint.

Note: This changes the JSON output from a `SiteExplorationReport` object (with an endpoints array) to a single `ExploredEndpoint` object.

Signed-off-by: Laura Gray <lgray@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

