### PR TITLE
fix(admin-web): clear action spinner on browser back navigation

### DIFF
--- a/crates/api/templates/base.html
+++ b/crates/api/templates/base.html
@@ -184,8 +184,18 @@
 				document.querySelector('nav').classList.remove('nav-disabled');
 			}
 
-			window.addEventListener('pageshow', function(e) {
-				if (e.persisted) hideActionSpinner();
+			window.addEventListener('pageshow', function() {
+				document.querySelectorAll('.submitting').forEach(function(el) {
+					el.classList.remove('submitting');
+				});
+				document.querySelectorAll('.actions-busy').forEach(function(el) {
+					el.classList.remove('actions-busy');
+					el.querySelectorAll('input[type="submit"], button[type="submit"]')
+						.forEach(function(b) { b.disabled = false; });
+				});
+				var nav = document.querySelector('nav');
+				if (nav) nav.classList.remove('nav-disabled');
+				pendingScope = null;
 			});
 
 			function showToast(message) {


### PR DESCRIPTION
## Description
Bug: browser 'back' navigation is required twice to navigate back from a page where the new spinner was triggered.

- Fix action spinner persisting after browser back navigation on explored-endpoint and machine-detail pages
- Replace `pageshow` handler that depended on `e.persisted` and `pendingScope` with a DOM-scanning approach that unconditionally clears `.submitting` / `.actions-busy` state
- Affects all action forms (power control, BMC reset, boot order, etc.)

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

