### PR TITLE
fix(admin-cli): honor -f json for 'ip find' and wrap 'managed-host show' list output

### DIFF
--- a/crates/admin-cli/src/ip/find/cmd.rs
+++ b/crates/admin-cli/src/ip/find/cmd.rs
@@ -15,20 +15,68 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
+use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::forge::IpType;
+use serde::Serialize;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn find(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+#[derive(Serialize)]
+struct IpFindResult {
+    ip_type: String,
+    owner_id: Option<String>,
+    message: String,
+}
+
+#[derive(Serialize)]
+struct IpFindOutput {
+    results: Vec<IpFindResult>,
+    errors: Vec<String>,
+}
+
+pub async fn find(
+    args: Args,
+    format: OutputFormat,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
     let resp = api_client.0.find_ip_address(args).await?;
-    for r in resp.matches {
-        tracing::info!("{}", r.message);
-    }
-    if !resp.errors.is_empty() {
-        tracing::warn!("These matchers failed:");
-        for err in resp.errors {
-            tracing::warn!("\t{err}");
+
+    let output = IpFindOutput {
+        results: resp
+            .matches
+            .into_iter()
+            .map(|m| {
+                let ip_type = IpType::try_from(m.ip_type)
+                    .map(|t| t.as_str_name().to_string())
+                    .unwrap_or_else(|_| format!("Unknown({})", m.ip_type));
+                IpFindResult {
+                    ip_type,
+                    owner_id: m.owner_id,
+                    message: m.message,
+                }
+            })
+            .collect(),
+        errors: resp.errors,
+    };
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&output)?);
+        }
+        OutputFormat::Yaml => {
+            println!("{}", serde_yaml::to_string(&output)?);
+        }
+        OutputFormat::AsciiTable | OutputFormat::Csv => {
+            for r in &output.results {
+                println!("{}", r.message);
+            }
+            if !output.errors.is_empty() {
+                eprintln!("These matchers failed:");
+                for err in &output.errors {
+                    eprintln!("\t{err}");
+                }
+            }
         }
     }
     Ok(())

--- a/crates/admin-cli/src/ip/find/mod.rs
+++ b/crates/admin-cli/src/ip/find/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::find(self, &ctx.api_client).await
+        cmd::find(self, ctx.config.format, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/managed_host/show/cmd.rs
+++ b/crates/admin-cli/src/managed_host/show/cmd.rs
@@ -39,6 +39,11 @@ struct ManagedHostOutputWrapper {
     managed_host_output: utils::ManagedHostOutput,
 }
 
+#[derive(Serialize)]
+struct ManagedHostList<'a> {
+    managed_hosts: &'a [utils::ManagedHostOutput],
+}
+
 #[derive(Default, Clone, Copy, Serialize)]
 struct ManagedHostOutputOptions {
     show_ips: bool,
@@ -221,7 +226,10 @@ async fn show_managed_hosts(
                     )?
                 )
             } else {
-                println!("{}", serde_json::to_string_pretty(&managed_hosts)?)
+                let wrapped = ManagedHostList {
+                    managed_hosts: &managed_hosts,
+                };
+                println!("{}", serde_json::to_string_pretty(&wrapped)?)
             }
         }
         OutputFormat::Yaml => {
@@ -232,7 +240,10 @@ async fn show_managed_hosts(
                     serde_yaml::to_string(managed_hosts.first().ok_or(CarbideCliError::Empty)?)?
                 )
             } else {
-                println!("{}", serde_yaml::to_string(&managed_hosts)?)
+                let wrapped = ManagedHostList {
+                    managed_hosts: &managed_hosts,
+                };
+                println!("{}", serde_yaml::to_string(&wrapped)?)
             }
         }
         OutputFormat::Csv => {


### PR DESCRIPTION
## Description

fix(admin-cli): honor -f json for `ip find` and wrap `managed-host show` list output

Two CLI output-shape fixes so programmatic consumers can rely on `-f json` across commands:

- `ip find`: previously ignored the global `-f` flag. Structured data leaked onto stderr as `tracing::info!` lines (ANSI codes, timestamps) and stdout was empty. Now emits `{"results": [...], "errors": [...]}` on stdout for `-f json`/`-f yaml`, with `ip_type` stringified via `IpType::as_str_name()`. Default ASCII/CSV paths print match messages to stdout via `println!` (matcher errors still go to stderr).

- `managed-host show`: multi-host JSON/YAML output was a bare top-level array, inconsistent with `machine show` (`{"machines": [...]}`) and `instance show` (`{"instances": [...]}`). Now wrapped as `{"managed_hosts": [...]}`. Single-host detail view still emits a bare object, matching `machine show <id>`.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

