### PR TITLE
fix(web ui): default NMX-M Browser path field to /nmx/v1/services

### DIFF
--- a/crates/api/templates/nmxm_browser.html
+++ b/crates/api/templates/nmxm_browser.html
@@ -14,7 +14,7 @@ For valid path, please refer to the <a href="https://docs.nvidia.com/networking-
 <form id="nmxm_console" method="GET" action="/admin/nmxm-browser">
 	<div>
 		<label for="path_input">Path to query:</label>
-		<input type=text size="80" id="path_input" name="path" placeholder="/nmx/v1/services" value="{{ path }}" />
+		<input type=text size="80" id="path_input" name="path" value="{% if path.is_empty() %}/nmx/v1/services{% else %}{{ path }}{% endif %}" />
 	</div>
 	<input type="submit" value="Start query">
 </form>


### PR DESCRIPTION
## Description
Previously '/nmx/v1/services' was only shown as a placeholder, requiring the user to type a path before clicking "Start query" would do anything. Promote it to the field's default value so the common case works with a single click.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

