### PR TITLE
docs: warning when resetting BMC via ipmitool

### DIFF
--- a/crates/admin-cli/src/bmc_machine/bmc_reset/args.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/args.rs
@@ -22,7 +22,11 @@ use rpc::forge as forgerpc;
 pub struct Args {
     #[clap(long, help = "ID of the machine to reboot")]
     pub machine: String,
-    #[clap(short, long, help = "Use ipmitool")]
+    #[clap(
+        short,
+        long,
+        help = "Use ipmitool instead of Redfish to reset the BMC. ipmitool bmc reset requests may be silently ignored if the BMC is in lockdown mode."
+    )]
     pub use_ipmitool: bool,
 }
 

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/cmd.rs
@@ -21,6 +21,11 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn bmc_reset(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    if args.use_ipmitool {
+        eprintln!(
+            "Warning: ipmitool bmc reset requests may be silently ignored if the BMC is in lockdown mode."
+        );
+    }
     api_client.0.admin_bmc_reset(args).await?;
     Ok(())
 }

--- a/crates/api/templates/bmc_reset.html
+++ b/crates/api/templates/bmc_reset.html
@@ -1,6 +1,6 @@
 <form id="bmcreset_action" method="POST" action="/admin/explored-endpoint/{{ bmc_ip }}/bmc-reset">
 	<span class="action-spinner"></span><div>
-		<input title="Use IPMI instead of Redfish to reset the target BMC" type="checkbox" id="use_ipmi" name="use_ipmi"
+		<input title="Use IPMI instead of Redfish to reset the target BMC. ipmitool bmc reset requests may be silently ignored if the BMC is in lockdown mode." type="checkbox" id="use_ipmi" name="use_ipmi"
 			value="true">
 		<label for="use_ipmi">Use IPMI</label>
 	</div>

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4238,6 +4238,8 @@ message AdminRebootResponse {
 message AdminBmcResetRequest {
   optional BmcEndpointRequest bmc_endpoint_request = 1;
   optional string machine_id = 2;
+  // When true, reset the BMC via ipmitool instead of Redfish.
+  // ipmitool bmc reset requests may be silently ignored if the BMC is in lockdown mode.
   bool use_ipmitool = 3;
 }
 


### PR DESCRIPTION
Requesting BMC reset via Redfish while the BMC is in lockdown mode will correctly return an error that tells you to disable lockdown mode first. However, when you run `ipmitool bmc reset cold` it tells you it successfully sent the request... but nothing actually happens if lockdown mode is enabled. ipmitool is usually used when Redfish is malfunctioning so we can't rely on Redfish for any info about lockdown status or similar. This was observed with v0.3.0-rc17-0-g29fae19 and machine Dell PowerEdge R750, iDRAC 7.20.10.50; the behavior may or may not be the same in different configurations, but I think it's worth it to warn the user that this may happen because it's not very intuitive and it's easy to forget.

Add warnings in various places the user can request BMC reset:

- carbide-admin-cli bmc-machine bmc-reset: stderr warning when --use-ipmitool is passed, plus an updated --help string
- web UI 'Use IPMI' checkbox: extended title attribute. It looks like this, following a similar pattern to when you hover over the options for power actions:
<img width="680" height="89" alt="image" src="https://github.com/user-attachments/assets/fffdca7f-8f68-4e07-a698-7e9bbf36415d" />

- forge.proto AdminBmcResetRequest.use_ipmitool: added doc comment

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

