### PR TITLE
feat(flow): dispatch whole-rack power/firmware via RMS

### DIFF
--- a/rest-api/flow/cmd/serve.go
+++ b/rest-api/flow/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -49,6 +50,12 @@ const (
 	// TODO: remove this override and the compute/nicolegacy package once
 	// every Flow deployment runs on the Component Manager path.
 	computeImplEnvVar = "COMPONENT_MANAGER_COMPUTE"
+
+	// wholeRackUseRMSEnvVar makes whole-rack power and firmware operations hand
+	// the rack to Core's component manager (RMS) as a single unit instead of
+	// Flow expanding the rack into per-component targets. Accepts the values
+	// strconv.ParseBool understands (1, t, true, 0, f, false, ...).
+	wholeRackUseRMSEnvVar = "FLOW_WHOLE_RACK_USE_RMS"
 )
 
 var (
@@ -166,6 +173,27 @@ func applyComputeImplementationOverride(cfg *cmconfig.Config) {
 		Str("previous_implementation", previous).
 		Str("implementation", override).
 		Msg("Compute component manager implementation overridden by environment")
+}
+
+// wholeRackUseRMSEnabled reports whether the FLOW_WHOLE_RACK_USE_RMS env var
+// requests the RMS rack-dispatch path. An unset or empty value is false; an
+// unparseable value is treated as false and logged so a typo does not silently
+// flip behaviour.
+func wholeRackUseRMSEnabled() bool {
+	raw := strings.TrimSpace(os.Getenv(wholeRackUseRMSEnvVar))
+	if raw == "" {
+		return false
+	}
+
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		log.Warn().
+			Str("env_var", wholeRackUseRMSEnvVar).
+			Str("value", raw).
+			Msg("Unparseable FLOW_WHOLE_RACK_USE_RMS value, defaulting to disabled")
+		return false
+	}
+	return enabled
 }
 
 // doServe is the main entry point for the serve subcommand. It loads all
@@ -297,6 +325,7 @@ func doServe() {
 			CMConfig:         cmConfig,
 			ProviderRegistry: providerRegistry,
 			DevMode:          devMode,
+			WholeRackUseRMS:  wholeRackUseRMSEnabled(),
 			CertConfig: pkgcerts.Config{
 				CACert:  globalCACert,
 				TLSCert: globalTLSCert,

--- a/rest-api/flow/internal/service/config.go
+++ b/rest-api/flow/internal/service/config.go
@@ -72,6 +72,11 @@ type Config struct {
 	// logging. Must not be set in staging/production environments.
 	DevMode bool
 
+	// WholeRackUseRMS makes whole-rack power and firmware operations dispatch the
+	// rack to Core's component manager (RMS) as a single unit instead of
+	// expanding it into per-component targets.
+	WholeRackUseRMS bool
+
 	// CertConfig holds certificate file paths for the gRPC server listener.
 	// When set, these take precedence over CERTDIR / the k8s default.
 	// Either all three fields must be set or none.

--- a/rest-api/flow/internal/service/service.go
+++ b/rest-api/flow/internal/service/service.go
@@ -82,6 +82,7 @@ func New(ctx context.Context, c Config) (*Service, error) {
 			InventoryStore: invStore,
 			TaskStore:      tskStore,
 			ExecutorConfig: c.ExecutorConf,
+			WholeRackUseRMS: c.WholeRackUseRMS,
 		},
 	)
 	if err != nil {

--- a/rest-api/flow/internal/task/componentmanager/builtin/manifest.go
+++ b/rest-api/flow/internal/task/componentmanager/builtin/manifest.go
@@ -14,6 +14,7 @@ import (
 	powershelfnico "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/powershelf/nico"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/providerapi"
 	nicoprovider "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/providers/nico"
+	racknico "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/rack/nico"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/readiness"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 )
@@ -30,6 +31,7 @@ func defaultServiceComponentManagers() map[devicetypes.ComponentType]string {
 		devicetypes.ComponentTypeCompute:    computenicolegacy.ImplementationName,
 		devicetypes.ComponentTypeNVSwitch:   nvswitchnico.ImplementationName,
 		devicetypes.ComponentTypePowerShelf: powershelfnico.ImplementationName,
+		devicetypes.ComponentTypeRack:       racknico.ImplementationName,
 	}
 }
 
@@ -61,6 +63,7 @@ func serviceDescriptors() []cmcatalog.Descriptor {
 		computenicolegacy.Descriptor(),
 		nvswitchnico.Descriptor(),
 		powershelfnico.Descriptor(),
+		racknico.Descriptor(),
 	}
 
 	descriptors = append(descriptors, mock.Descriptors()...)
@@ -88,6 +91,7 @@ func serviceFactorySpecs(
 		computenicolegacy.FactorySpec(computePowerDelay, gate),
 		nvswitchnico.FactorySpec(gate),
 		powershelfnico.FactorySpec(gate),
+		racknico.FactorySpec(),
 	}
 
 	factorySpecs = append(factorySpecs, mock.FactorySpecs()...)

--- a/rest-api/flow/internal/task/componentmanager/rack/nico/nico.go
+++ b/rest-api/flow/internal/task/componentmanager/rack/nico/nico.go
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nico is the rack manager implementation. It drives a whole rack as a
+// single unit through NICo Core's Component Manager dispatch, handing Core the
+// rack id instead of Flow expanding the rack into per-component (compute /
+// nvswitch / powershelf) targets. It is selected for rack-scoped power and
+// firmware operations when whole-rack RMS mode is enabled.
+//
+// The Core Component Manager RPCs (ComponentPowerControl,
+// UpdateComponentFirmware, GetComponentFirmwareStatus) do not yet carry a
+// rack-ids target variant in their oneof; that variant lands in a future Core
+// proto release. The operation mapping (power operation -> SystemPowerControl,
+// firmware sub-target handling) is wired here so that enabling the rack target
+// after the proto update is a one-line change at each dispatch point plus a
+// gRPC regeneration. Until then the rack dispatch points return
+// errRackTargetPendingCoreProto so the RMS path fails loudly rather than
+// silently sending a target-less request.
+package nico
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	pb "github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi/gen"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/capability"
+	cmcatalog "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/catalog"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/providerapi"
+	nicoprovider "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/providers/nico"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/executor/temporalworkflow/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+// ImplementationName is the name used to identify this implementation in the
+// component manager catalog and in YAML / env configuration.
+const ImplementationName = "nico"
+
+// errRackTargetPendingCoreProto is returned by the rack dispatch points until
+// Core's Component Manager RPCs gain a rack-ids target variant. See the
+// package doc for the migration step.
+var errRackTargetPendingCoreProto = errors.New(
+	"rack component manager dispatch pending Core Component Manager rack target",
+)
+
+// Manager drives a whole rack through NICo Core's Component Manager RPCs.
+// Unlike the per-component managers it does not consult a readiness gate:
+// rack readiness is owned by Core when the rack is handed over as a unit.
+type Manager struct {
+	nicoClient nicoapi.Client
+}
+
+// New creates a rack Manager backed by the supplied NICo client.
+func New(nicoClient nicoapi.Client) *Manager {
+	return &Manager{nicoClient: nicoClient}
+}
+
+// Factory returns a factory that resolves the NICo provider's client.
+func Factory() componentmanager.ManagerFactory {
+	return func(
+		providerRegistry *providerapi.ProviderRegistry,
+	) (componentmanager.ComponentManager, error) {
+		provider, err := providerapi.GetTyped[*nicoprovider.Provider](
+			providerRegistry,
+			nicoprovider.ProviderName,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("rack/nico requires nico provider: %w", err)
+		}
+		return New(provider.Client()), nil
+	}
+}
+
+// Descriptor returns the rack/nico manager descriptor.
+func Descriptor() cmcatalog.Descriptor {
+	return cmcatalog.Descriptor{
+		DescriptorIdentity: cmcatalog.DescriptorIdentity{
+			Type:           devicetypes.ComponentTypeRack,
+			Implementation: ImplementationName,
+		},
+		RequiredProviders: []string{nicoprovider.ProviderName},
+		Capabilities: capability.CapabilitySet{
+			capability.CapabilityFirmwareControl,
+			capability.CapabilityFirmwareStatus,
+			capability.CapabilityPowerControl,
+		},
+	}
+}
+
+// FactorySpec returns the rack/nico runtime factory spec.
+func FactorySpec() componentmanager.FactorySpec {
+	return componentmanager.FactorySpec{
+		Descriptor: Descriptor(),
+		Factory:    Factory(),
+	}
+}
+
+// Descriptor returns the rack/nico manager descriptor.
+func (m *Manager) Descriptor() cmcatalog.Descriptor {
+	return Descriptor()
+}
+
+// powerActionFromOperation maps a Flow power operation to the Core
+// SystemPowerControl enum. The mapping mirrors the per-component managers so
+// rack power control follows the same semantics.
+func powerActionFromOperation(op operations.PowerOperation) (pb.SystemPowerControl, error) {
+	switch op {
+	case operations.PowerOperationPowerOn, operations.PowerOperationForcePowerOn:
+		return pb.SystemPowerControl_SYSTEM_POWER_CONTROL_ON, nil
+	case operations.PowerOperationPowerOff:
+		return pb.SystemPowerControl_SYSTEM_POWER_CONTROL_GRACEFUL_SHUTDOWN, nil
+	case operations.PowerOperationForcePowerOff:
+		return pb.SystemPowerControl_SYSTEM_POWER_CONTROL_FORCE_OFF, nil
+	case operations.PowerOperationRestart, operations.PowerOperationWarmReset:
+		return pb.SystemPowerControl_SYSTEM_POWER_CONTROL_GRACEFUL_RESTART, nil
+	case operations.PowerOperationForceRestart:
+		return pb.SystemPowerControl_SYSTEM_POWER_CONTROL_FORCE_RESTART, nil
+	case operations.PowerOperationColdReset:
+		return pb.SystemPowerControl_SYSTEM_POWER_CONTROL_AC_POWERCYCLE, nil
+	default:
+		return 0, fmt.Errorf("unsupported power operation for rack: %v", op)
+	}
+}
+
+// PowerControl performs a power operation on the whole rack via Core's
+// ComponentPowerControl RPC with a rack target.
+func (m *Manager) PowerControl(
+	ctx context.Context,
+	target common.Target,
+	info operations.PowerControlTaskInfo,
+) error {
+	if err := target.Validate(); err != nil {
+		return fmt.Errorf("target is invalid: %w", err)
+	}
+
+	if _, err := powerActionFromOperation(info.Operation); err != nil {
+		return err
+	}
+
+	// TODO: once Core's ComponentPowerControlRequest target oneof gains a
+	// rack-ids variant, build the request with the rack id(s) in
+	// target.ComponentIDs, set Action to powerActionFromOperation(info.Operation),
+	// set BypassStateController from info.OverrideReadinessCheck, call
+	// m.nicoClient.ComponentPowerControl, and check the per-result status the
+	// same way compute/nvswitch/powershelf do. Remove the sentinel below.
+	return errRackTargetPendingCoreProto
+}
+
+// FirmwareControl schedules a firmware update for the whole rack via Core's
+// UpdateComponentFirmware RPC with a rack target.
+func (m *Manager) FirmwareControl(
+	ctx context.Context,
+	target common.Target,
+	info operations.FirmwareControlTaskInfo,
+) error {
+	if err := target.Validate(); err != nil {
+		return fmt.Errorf("target is invalid: %w", err)
+	}
+
+	// TODO: once Core's UpdateComponentFirmwareRequest target oneof gains a
+	// rack variant, build the request with the rack id(s) and
+	// info.TargetVersion, call m.nicoClient.UpdateComponentFirmware, and check
+	// the per-result status. Remove the sentinel below.
+	return errRackTargetPendingCoreProto
+}
+
+// GetFirmwareStatus returns the firmware update status for the rack. The
+// rule-driven firmware action polls this after FirmwareControl, so the rack
+// manager must expose it.
+func (m *Manager) GetFirmwareStatus(
+	ctx context.Context,
+	target common.Target,
+) (map[string]operations.FirmwareUpdateStatus, error) {
+	if err := target.Validate(); err != nil {
+		return nil, fmt.Errorf("target is invalid: %w", err)
+	}
+
+	// TODO: once Core's GetComponentFirmwareStatusRequest target oneof gains a
+	// rack variant, query m.nicoClient.GetComponentFirmwareStatus and aggregate
+	// the per-rack statuses. Remove the sentinel below.
+	return nil, errRackTargetPendingCoreProto
+}

--- a/rest-api/flow/internal/task/componentmanager/rack/nico/nico_test.go
+++ b/rest-api/flow/internal/task/componentmanager/rack/nico/nico_test.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nico
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi/gen"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/capability"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/executor/temporalworkflow/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+// The rack manager must satisfy the capability interfaces matching the
+// capabilities its descriptor declares.
+var (
+	_ componentmanager.PowerController      = (*Manager)(nil)
+	_ componentmanager.FirmwareController   = (*Manager)(nil)
+	_ componentmanager.FirmwareStatusReader = (*Manager)(nil)
+)
+
+func validRackTarget() common.Target {
+	return common.Target{
+		Type:         devicetypes.ComponentTypeRack,
+		ComponentIDs: []string{"11111111-1111-1111-1111-111111111111"},
+	}
+}
+
+func TestDescriptor(t *testing.T) {
+	t.Parallel()
+
+	desc := Descriptor()
+
+	assert.Equal(t, devicetypes.ComponentTypeRack, desc.Type)
+	assert.Equal(t, ImplementationName, desc.Implementation)
+	assert.Contains(t, desc.RequiredProviders, "nico")
+	assert.True(t, desc.Capabilities.Contains(capability.CapabilityPowerControl))
+	assert.True(t, desc.Capabilities.Contains(capability.CapabilityFirmwareControl))
+	assert.True(t, desc.Capabilities.Contains(capability.CapabilityFirmwareStatus))
+}
+
+func TestPowerActionFromOperation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		op   operations.PowerOperation
+		want pb.SystemPowerControl
+	}{
+		{"on", operations.PowerOperationPowerOn, pb.SystemPowerControl_SYSTEM_POWER_CONTROL_ON},
+		{"force_on", operations.PowerOperationForcePowerOn, pb.SystemPowerControl_SYSTEM_POWER_CONTROL_ON},
+		{"off", operations.PowerOperationPowerOff, pb.SystemPowerControl_SYSTEM_POWER_CONTROL_GRACEFUL_SHUTDOWN},
+		{"force_off", operations.PowerOperationForcePowerOff, pb.SystemPowerControl_SYSTEM_POWER_CONTROL_FORCE_OFF},
+		{"restart", operations.PowerOperationRestart, pb.SystemPowerControl_SYSTEM_POWER_CONTROL_GRACEFUL_RESTART},
+		{"force_restart", operations.PowerOperationForceRestart, pb.SystemPowerControl_SYSTEM_POWER_CONTROL_FORCE_RESTART},
+		{"cold_reset", operations.PowerOperationColdReset, pb.SystemPowerControl_SYSTEM_POWER_CONTROL_AC_POWERCYCLE},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := powerActionFromOperation(tc.op)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPowerActionFromOperationUnknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := powerActionFromOperation(operations.PowerOperationUnknown)
+	require.Error(t, err)
+}
+
+func TestPowerControlRejectsInvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	m := New(nil)
+	err := m.PowerControl(context.Background(), common.Target{}, operations.PowerControlTaskInfo{
+		Operation: operations.PowerOperationPowerOn,
+	})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errRackTargetPendingCoreProto)
+}
+
+func TestPowerControlRejectsUnsupportedOperation(t *testing.T) {
+	t.Parallel()
+
+	m := New(nil)
+	err := m.PowerControl(context.Background(), validRackTarget(), operations.PowerControlTaskInfo{
+		Operation: operations.PowerOperationUnknown,
+	})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errRackTargetPendingCoreProto)
+}
+
+func TestPowerControlPendingCoreProto(t *testing.T) {
+	t.Parallel()
+
+	m := New(nil)
+	err := m.PowerControl(context.Background(), validRackTarget(), operations.PowerControlTaskInfo{
+		Operation: operations.PowerOperationPowerOn,
+	})
+
+	require.ErrorIs(t, err, errRackTargetPendingCoreProto)
+}
+
+func TestFirmwareControlPendingCoreProto(t *testing.T) {
+	t.Parallel()
+
+	m := New(nil)
+	err := m.FirmwareControl(context.Background(), validRackTarget(), operations.FirmwareControlTaskInfo{
+		Operation: operations.FirmwareOperationUpgrade,
+	})
+
+	require.ErrorIs(t, err, errRackTargetPendingCoreProto)
+}
+
+func TestFirmwareControlRejectsInvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	m := New(nil)
+	err := m.FirmwareControl(context.Background(), common.Target{}, operations.FirmwareControlTaskInfo{})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errRackTargetPendingCoreProto)
+}
+
+func TestGetFirmwareStatusPendingCoreProto(t *testing.T) {
+	t.Parallel()
+
+	m := New(nil)
+	statuses, err := m.GetFirmwareStatus(context.Background(), validRackTarget())
+
+	require.ErrorIs(t, err, errRackTargetPendingCoreProto)
+	assert.Nil(t, statuses)
+}
+
+func TestGetFirmwareStatusRejectsInvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	m := New(nil)
+	_, err := m.GetFirmwareStatus(context.Background(), common.Target{})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errRackTargetPendingCoreProto)
+}
+
+func TestErrIsPlaceholderSentinel(t *testing.T) {
+	t.Parallel()
+
+	// Guards against accidentally wrapping the sentinel in a way that breaks
+	// errors.Is for callers that branch on the pending-proto condition.
+	require.True(t, errors.Is(errRackTargetPendingCoreProto, errRackTargetPendingCoreProto))
+}

--- a/rest-api/flow/internal/task/manager/manager.go
+++ b/rest-api/flow/internal/task/manager/manager.go
@@ -48,6 +48,12 @@ type Config struct {
 	// PromoterConfig tunes the Promoter's sweep interval and channel size.
 	// Zero values use the Promoter's own defaults.
 	PromoterConfig conflict.PromoterConfig
+
+	// WholeRackUseRMS makes whole-rack power and firmware operations dispatch the
+	// rack to Core's component manager (RMS) as a single unit, instead of Flow
+	// expanding the rack into per-component targets. Other operation types are
+	// unaffected.
+	WholeRackUseRMS bool
 }
 
 func (c *Config) applyDefaults() {
@@ -101,6 +107,7 @@ type ManagerImpl struct {
 
 	maxWaitingPerRack   int
 	defaultQueueTimeout time.Duration
+	wholeRackUseRMS     bool
 
 	ctx       context.Context
 	cancel    context.CancelFunc
@@ -120,6 +127,7 @@ func New(ctx context.Context, conf *Config) (*ManagerImpl, error) {
 		inventoryStore:      conf.InventoryStore,
 		maxWaitingPerRack:   conf.MaxWaitingTasksPerRack,
 		defaultQueueTimeout: conf.DefaultQueueTimeout,
+		wholeRackUseRMS:     conf.WholeRackUseRMS,
 	}
 
 	// Promoter needs m.promoteTask.
@@ -379,25 +387,57 @@ func (m *ManagerImpl) promoteTask(ctx context.Context, taskID uuid.UUID) error {
 	return m.resolveAndExecuteTask(ctx, task, targetRack)
 }
 
-// resolveAndExecuteTask resolves the operation rule for a task, executes it,
-// and updates the task record with the execution result. It is shared by the
-// immediate-execution path in createAndExecuteTask and the promotion path in
-// promoteTask.
-func (m *ManagerImpl) resolveAndExecuteTask(
+// isRMSOperation reports whether an operation type is dispatched to the rack
+// component manager as a single unit when whole-rack RMS is enabled. Only
+// power and firmware operations take the rack path; bring-up, ingest, and the
+// like keep Flow's per-component expansion.
+func isRMSOperation(t taskcommon.TaskType) bool {
+	return t == taskcommon.TaskTypePowerControl ||
+		t == taskcommon.TaskTypeFirmwareControl
+}
+
+// planExecution selects the rule definition and the set of workflow components
+// to execute for a task. In whole-rack RMS mode a rack-scoped power or firmware
+// operation resolves to the single-step rack rule and a single rack
+// pseudo-component, bypassing Flow's rack-to-component expansion and rule
+// resolution; Core then owns the per-component sequencing. Every other case
+// keeps the existing behaviour: resolve the stored / default rule and expand
+// the rack into its tracked components.
+func (m *ManagerImpl) planExecution(
 	ctx context.Context,
 	task *taskdef.Task,
 	targetRack *rack.Rack,
-) error {
+) (*operationrules.RuleDefinition, []taskdef.WorkflowComponent, error) {
+	if m.wholeRackUseRMS && isRMSOperation(task.Operation.Type) {
+		ruleDef := operationrules.BuildRackRule(task.Operation.Type)
+		if ruleDef == nil {
+			return nil, nil, fmt.Errorf(
+				"RMS rack rule unavailable for operation type %s",
+				task.Operation.Type,
+			)
+		}
+		log.Info().
+			Str("operation_type", string(task.Operation.Type)).
+			Str("operation", task.Operation.Code).
+			Str("rack_id", task.RackID.String()).
+			Msg("Whole-rack RMS: dispatching rack as a single unit")
+		components := []taskdef.WorkflowComponent{{
+			Type:        devicetypes.ComponentTypeRack,
+			ComponentID: task.RackID.String(),
+		}}
+		return ruleDef, components, nil
+	}
+
 	ruleID := operations.ExtractRuleID(task.Operation.Info)
 
 	rule, err := m.ruleResolver.ResolveRule(
 		ctx, task.Operation.Type, task.Operation.Code, task.RackID, ruleID,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to resolve operation rule: %w", err)
+		return nil, nil, fmt.Errorf("failed to resolve operation rule: %w", err)
 	}
 	if rule == nil {
-		return fmt.Errorf("resolver returned nil rule (should never happen)")
+		return nil, nil, fmt.Errorf("resolver returned nil rule (should never happen)")
 	}
 
 	if rule.ID != uuid.Nil {
@@ -418,7 +458,24 @@ func (m *ManagerImpl) resolveAndExecuteTask(
 			Msg("Using hardcoded default rule for task")
 	}
 
-	resp, err := m.executeTask(ctx, task, targetRack, &rule.RuleDefinition)
+	return &rule.RuleDefinition, workflowComponentsFrom(targetRack), nil
+}
+
+// resolveAndExecuteTask resolves the operation rule for a task, executes it,
+// and updates the task record with the execution result. It is shared by the
+// immediate-execution path in createAndExecuteTask and the promotion path in
+// promoteTask.
+func (m *ManagerImpl) resolveAndExecuteTask(
+	ctx context.Context,
+	task *taskdef.Task,
+	targetRack *rack.Rack,
+) error {
+	ruleDef, components, err := m.planExecution(ctx, task, targetRack)
+	if err != nil {
+		return err
+	}
+
+	resp, err := m.executeTask(ctx, task, components, ruleDef)
 	if err != nil {
 		if uerr := m.taskStore.UpdateTaskStatus(ctx, &taskdef.TaskStatusUpdate{
 			ID:      task.ID,
@@ -535,7 +592,7 @@ func workflowComponentsFrom(
 func (m *ManagerImpl) executeTask(
 	ctx context.Context,
 	task *taskdef.Task,
-	targetRack *rack.Rack,
+	components []taskdef.WorkflowComponent,
 	ruleDef *operationrules.RuleDefinition,
 ) (*taskdef.ExecutionResponse, error) {
 	if task == nil {
@@ -545,7 +602,7 @@ func (m *ManagerImpl) executeTask(
 	req := taskdef.ExecutionRequest{
 		Info: taskdef.ExecutionInfo{
 			TaskID:         task.ID,
-			Components:     workflowComponentsFrom(targetRack),
+			Components:     components,
 			RuleDefinition: ruleDef,
 			OperationType:  task.Operation.Type,
 			OperationInfo:  task.Operation.Info, // already json.RawMessage from the DB

--- a/rest-api/flow/internal/task/manager/rms_test.go
+++ b/rest-api/flow/internal/task/manager/rms_test.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
+	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	taskdef "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/task"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+func TestIsRMSOperation(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isRMSOperation(taskcommon.TaskTypePowerControl))
+	assert.True(t, isRMSOperation(taskcommon.TaskTypeFirmwareControl))
+	assert.False(t, isRMSOperation(taskcommon.TaskTypeBringUp))
+}
+
+func rmsTask(opType taskcommon.TaskType, code string) *taskdef.Task {
+	return &taskdef.Task{
+		ID:     uuid.New(),
+		RackID: uuid.New(),
+		Operation: operation.Wrapper{
+			Type: opType,
+			Code: code,
+		},
+	}
+}
+
+func TestPlanExecutionRMSPower(t *testing.T) {
+	t.Parallel()
+
+	m := &ManagerImpl{wholeRackUseRMS: true}
+	task := rmsTask(taskcommon.TaskTypePowerControl, "power_on")
+
+	ruleDef, components, err := m.planExecution(context.Background(), task, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ruleDef)
+	require.Len(t, ruleDef.Steps, 1)
+	assert.Equal(t, devicetypes.ComponentTypeRack, ruleDef.Steps[0].ComponentType)
+
+	require.Len(t, components, 1)
+	assert.Equal(t, devicetypes.ComponentTypeRack, components[0].Type)
+	assert.Equal(t, task.RackID.String(), components[0].ComponentID)
+}
+
+func TestPlanExecutionRMSFirmware(t *testing.T) {
+	t.Parallel()
+
+	m := &ManagerImpl{wholeRackUseRMS: true}
+	task := rmsTask(taskcommon.TaskTypeFirmwareControl, "upgrade")
+
+	ruleDef, components, err := m.planExecution(context.Background(), task, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ruleDef)
+	require.Len(t, components, 1)
+	assert.Equal(t, devicetypes.ComponentTypeRack, components[0].Type)
+}

--- a/rest-api/flow/internal/task/operationrules/rack_rules.go
+++ b/rest-api/flow/internal/task/operationrules/rack_rules.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package operationrules
+
+import (
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+// Rack-scoped operations run as a single step against the rack component
+// manager. The staged, per-component-type sequencing the default rules apply
+// is Core's responsibility in RMS mode, so the rack rule deliberately carries
+// one stage with one step and no reachability / power-status verification.
+const (
+	rackPowerStepTimeout    = 30 * time.Minute
+	rackFirmwareStepTimeout = 90 * time.Minute
+	rackFirmwarePollInterval = "2m"
+	rackFirmwarePollTimeout  = "60m"
+)
+
+// BuildRackRule returns the rule definition used when an operation targets a
+// rack as a single unit (whole-rack RMS mode). It returns nil for operation
+// types that have no rack-level mapping, so callers can fall back to the
+// per-component path.
+func BuildRackRule(operationType common.TaskType) *RuleDefinition {
+	var step SequenceStep
+	switch operationType {
+	case common.TaskTypePowerControl:
+		step = SequenceStep{
+			ComponentType: devicetypes.ComponentTypeRack,
+			Stage:         1,
+			Timeout:       rackPowerStepTimeout,
+			MainOperation: ActionConfig{Name: ActionPowerControl},
+		}
+	case common.TaskTypeFirmwareControl:
+		step = SequenceStep{
+			ComponentType: devicetypes.ComponentTypeRack,
+			Stage:         1,
+			Timeout:       rackFirmwareStepTimeout,
+			MainOperation: ActionConfig{
+				Name: ActionFirmwareControl,
+				Parameters: map[string]any{
+					ParamPollInterval: rackFirmwarePollInterval,
+					ParamPollTimeout:  rackFirmwarePollTimeout,
+				},
+			},
+		}
+	default:
+		return nil
+	}
+
+	return &RuleDefinition{
+		Version: CurrentRuleDefinitionVersion,
+		Steps:   []SequenceStep{step},
+	}
+}

--- a/rest-api/flow/internal/task/operationrules/rack_rules_test.go
+++ b/rest-api/flow/internal/task/operationrules/rack_rules_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package operationrules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+func TestBuildRackRulePower(t *testing.T) {
+	t.Parallel()
+
+	rd := BuildRackRule(common.TaskTypePowerControl)
+	require.NotNil(t, rd)
+	require.NoError(t, rd.Validate())
+	require.Len(t, rd.Steps, 1)
+
+	step := rd.Steps[0]
+	assert.Equal(t, devicetypes.ComponentTypeRack, step.ComponentType)
+	assert.Equal(t, 1, step.Stage)
+	assert.Equal(t, ActionPowerControl, step.MainOperation.Name)
+	assert.Empty(t, step.PostOperation)
+}
+
+func TestBuildRackRuleFirmware(t *testing.T) {
+	t.Parallel()
+
+	rd := BuildRackRule(common.TaskTypeFirmwareControl)
+	require.NotNil(t, rd)
+	require.NoError(t, rd.Validate())
+	require.Len(t, rd.Steps, 1)
+
+	step := rd.Steps[0]
+	assert.Equal(t, devicetypes.ComponentTypeRack, step.ComponentType)
+	assert.Equal(t, 1, step.Stage)
+	assert.Equal(t, ActionFirmwareControl, step.MainOperation.Name)
+	assert.Contains(t, step.MainOperation.Parameters, ParamPollInterval)
+	assert.Contains(t, step.MainOperation.Parameters, ParamPollTimeout)
+}
+
+func TestBuildRackRuleUnsupported(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, BuildRackRule(common.TaskTypeBringUp))
+	assert.Nil(t, BuildRackRule(common.TaskType("nonsense")))
+}

--- a/rest-api/flow/pkg/common/devicetypes/component.go
+++ b/rest-api/flow/pkg/common/devicetypes/component.go
@@ -20,6 +20,11 @@ const (
 	ComponentTypeToRSwitch
 	ComponentTypeUMS
 	ComponentTypeCDU
+	// ComponentTypeRack targets a whole rack as a single unit. It is not a
+	// physical component: it routes rack-scoped operations to the rack
+	// component manager, which hands the rack id to Core instead of Flow
+	// expanding the rack into per-component targets.
+	ComponentTypeRack
 )
 
 var (
@@ -31,6 +36,7 @@ var (
 		ComponentTypeToRSwitch:  "ToRSwitch",
 		ComponentTypeUMS:        "UMS",
 		ComponentTypeCDU:        "CDU",
+		ComponentTypeRack:       "Rack",
 	}
 
 	componentTypeStringMaxLen int
@@ -54,6 +60,7 @@ func ComponentTypes() []ComponentType {
 		ComponentTypeToRSwitch,
 		ComponentTypeUMS,
 		ComponentTypeCDU,
+		ComponentTypeRack,
 	}
 }
 


### PR DESCRIPTION


## Description
When FLOW_WHOLE_RACK_USE_RMS is set, rack-scoped power and firmware operations hand the rack to Core's component manager as a single unit instead of expanding the rack into per-component targets. Adds a Rack pseudo component type and a rack component manager that rides the existing rule/stage/activity pipeline via a synthesized single-step rule. The Core rack-target RPC variant is not yet available, so the dispatch points return a pending-proto sentinel until the proto lands.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#2425 

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

