### PR TITLE
fix(pxe): always seed NoCloud userdata during imaging

### DIFF
--- a/pxe/common_files/disk_imaging.sh
+++ b/pxe/common_files/disk_imaging.sh
@@ -147,8 +147,8 @@ function add_cloud_init() {
 	fi
 	seed_dir=/mnt/var/lib/cloud/seed/nocloud-net
 	mkdir -p "$seed_dir"
-	curl --retry 5 --retry-all-errors -k "$cloud_init_url/user-data" --output "$seed_dir/user-data" 2>&1 | tee $log_output
-	curl --retry 5 --retry-all-errors -k "$cloud_init_url/meta-data" --output "$seed_dir/meta-data" 2>&1 | tee $log_output
+	curl --fail --retry 5 --retry-all-errors -k "$cloud_init_url/user-data" --output "$seed_dir/user-data" 2>&1 | tee "$log_output"
+	curl --fail --retry 5 --retry-all-errors -k "$cloud_init_url/meta-data" --output "$seed_dir/meta-data" 2>&1 | tee "$log_output"
 }
 
 function expand_root_fs() {

--- a/pxe/common_files/disk_imaging.sh
+++ b/pxe/common_files/disk_imaging.sh
@@ -141,10 +141,14 @@ function get_distro_image() {
 
 function add_cloud_init() {
 	echo "fetching from cloud-init url: $cloud_init_url" | tee $log_output
-	if [ -d /mnt/etc/cloud/cloud.cfg.d ]; then
+	if [ -d /mnt/etc/cloud ]; then
+		mkdir -p /mnt/etc/cloud/cloud.cfg.d
 		echo "datasource_list: [ NoCloud, None ]" | tee /mnt/etc/cloud/cloud.cfg.d/98-forge-dslist.cfg
-		curl --retry 5 --retry-all-errors -k "$cloud_init_url/user-data" --output /mnt/etc/cloud/cloud.cfg.d/99-user-data.cfg 2>&1 | tee $log_output
 	fi
+	seed_dir=/mnt/var/lib/cloud/seed/nocloud-net
+	mkdir -p "$seed_dir"
+	curl --retry 5 --retry-all-errors -k "$cloud_init_url/user-data" --output "$seed_dir/user-data" 2>&1 | tee $log_output
+	curl --retry 5 --retry-all-errors -k "$cloud_init_url/meta-data" --output "$seed_dir/meta-data" 2>&1 | tee $log_output
 }
 
 function expand_root_fs() {


### PR DESCRIPTION
## Description
This PR replaces #2608 with the smaller NoCloud-seeding portion of that change.

It updates `pxe/common_files/disk_imaging.sh` so host OS imaging:
- creates `/mnt/etc/cloud/cloud.cfg.d` when cloud-init is present before writing the datasource list
- seeds allocation-time cloud-init through the canonical NoCloud `user-data` and `meta-data` files
- creates `/mnt/var/lib/cloud/seed/nocloud-net` even when the source image does not already contain cloud-init state directories

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Part of #2604. Replaces #2608.

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Manual testing:
- `bash -n pxe/common_files/disk_imaging.sh`
- `git diff --check`

## Additional Notes
N/A