### PR TITLE
fix(pxe): fully write out sparse OS images

### DIFF
--- a/pxe/common_files/disk_imaging.sh
+++ b/pxe/common_files/disk_imaging.sh
@@ -531,7 +531,7 @@ function main() {
 	fi
 
 	echo "Imaging $file to $image_disk" | tee $log_output
-	qemu-img convert -p -O raw $file $image_disk 2>&1 | tee $log_output
+	qemu-img convert -p -O raw -S 0 $file $image_disk 2>&1 | tee $log_output
 	ret=$?
 	if [ $ret -ne 0 ]; then
 		echo "Imaging failed $ret" | tee $log_output


### PR DESCRIPTION
## Description

Ensure OS image conversion writes zero-filled and unallocated source regions to the destination boot disk. Without `-S 0`, sparse conversion can leave stale filesystem or volume metadata behind when reprovisioning a previously used disk.

* Example: 
  * QEMU image A is 2GB of `1`s
  * QEMU image B is 1GB of `1`s then a 9GB sparse region of `0`s
  * Writing QEMU image B over a disk with image A without the `-S 0` flag will not overwrite the 2nd GB of `1`s with zeros as expected; the disk will still contain 2GB of `1`s.

## Related issues
<!-- Refer to existing GitHub issues here -->

- Related to #2605

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `git diff --check nvidia-upstream/main...personal-upstream/codex/pxe-overwrite-sparse-images`
- `bash -n pxe/common_files/disk_imaging.sh`

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

`qemu-img convert -S 0` disables sparse-region detection so zero-filled regions represented by the source image are explicitly written. This is not a secure wipe of any destination capacity beyond the source image's virtual size.
