### PR TITLE
feat(expected-machine): per host BMC vendor override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
  "librms",
  "mac_address",
  "mockito",
+ "moka",
  "mqttea",
  "nras",
  "num_cpus",

--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -200,6 +200,13 @@ pub(crate) struct Args {
         help = "If true, do not lock down the server as part of lifecycle management within the state machine. If unset or false, preserve the default behavior of locking down the server after configuring the BIOS."
     )]
     disable_lockdown: Option<bool>,
+
+    #[clap(
+        long = "bmc-vendor-override",
+        value_name = "BMC_VENDOR_OVERRIDE",
+        help = "Pin the Redfish BMC vendor for this host. Once set it governs how NICo talks to this BMC. It picks which libredfish driver each Redfish client dispatches on, the vendor nv-redfish classifies the host by, the vendor recorded by Site Explorer, and therefore the firmware config lookup, the IPMI-vs-Redfish restart choice and the BMC console transport. The host's own DMI data is untouched, though where NICo would pick a Redfish client from that DMI vendor the pin outranks it. A RedfishVendor variant name, case-sensitive (e.g. Dell, Supermicro, NvidiaDpu, Hpe, Lenovo). Unset means automatic detection. Only the vendor is asserted, and everything else the BMC reports is left alone, so each library classifies the host the way it normally would for that vendor. Because the pin replaces detection rather than supplementing it, a wrong value can fail exploration outright instead of being ignored, and the failure is reported as the host's last exploration error. It also selects which Redfish account change NICo issues when it changes this BMC's password on the initial factory bootstrap, on the site-wide rotation schedule, when restoring credentials after a factory reset, and for bmc-machine set-root-password. A wrong pin can therefore send the wrong account change to a factory BMC. Only that choice is pinned. The clients that probe a BMC, that bootstrap it from the factory, and that carry the password change itself are still built with no vendor at all, since they must reach a BMC before any vendor is usable. bmc-machine probe-vendor is unaffected and keeps reporting what the BMC says about itself. A pin asserts a vendor rather than a platform, so it also brings that vendor's behavior, including how BMC user accounts are created and deleted and which vendor workarounds apply. Because only the vendor field is asserted, a pin naming a sub-variant such as NvidiaGH200, VeraRubin, NvidiaDpu or a power shelf still needs the product and Redfish version the BMC reports to agree, and where they do not the host can end up classified as nothing rather than as the pinned platform."
+    )]
+    bmc_vendor_override: Option<String>,
 }
 
 impl Args {
@@ -258,6 +265,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
                     disable_lockdown: Some(dl),
                 }
             }),
+            bmc_vendor_override: value.bmc_vendor_override,
         })
     }
 }

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -168,6 +168,10 @@ pub(crate) struct ExpectedMachineJson {
     /// Per-host lifecycle profile for settings that affect state-machine progression.
     #[serde(default)]
     pub(crate) host_lifecycle_profile: Option<HostLifecycleProfile>,
+    /// Operator pinned Redfish BMC vendor, a `RedfishVendor` name such as `Dell`.
+    /// Absent keeps whatever is stored, and an empty string clears it.
+    #[serde(default)]
+    pub(crate) bmc_vendor_override: Option<String>,
 }
 
 impl ExpectedMachineJson {

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -52,6 +52,7 @@ use crate::expected_machines::common::HostDpuPolicy;
 "bmc_ip_allocation",
 "dpf_enabled",
 "interfaces",
+"bmc_vendor_override",
 ])))]
 #[command(after_long_help = "\
 EXAMPLES:
@@ -85,6 +86,14 @@ fixed IP. The omitted role and allocation policy keep their stored values:
 Reset that role to Host and infer Fixed allocation from fixed_ip:
     $ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
     --interfaces '[{\"mac_address\":\"02:00:00:00:20:01\",\"role\":\"unspecified\",\"ip_allocation\":\"unspecified\",\"fixed_ip\":\"192.0.2.10\"}]'
+
+Pin the Redfish BMC vendor for a host:
+    $ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-vendor-override Dell
+
+Clear the Redfish BMC vendor override (return to automatic detection):
+    $ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-vendor-override \"\"
 
 ")]
 pub(crate) struct Args {
@@ -229,6 +238,14 @@ pub(crate) struct Args {
         help = "If true, do not lock down the server as part of lifecycle management within the state machine. If unset or false, preserve the default behavior of locking down the server after configuring the BIOS."
     )]
     pub(super) disable_lockdown: Option<bool>,
+
+    #[clap(
+        long = "bmc-vendor-override",
+        value_name = "BMC_VENDOR_OVERRIDE",
+        group = "group",
+        help = "Pin the Redfish BMC vendor for this host. Once set it governs how NICo talks to this BMC. It picks which libredfish driver each Redfish client dispatches on, the vendor nv-redfish classifies the host by, the vendor recorded by Site Explorer, and therefore the firmware config lookup, the IPMI-vs-Redfish restart choice and the BMC console transport. The host's own DMI data is untouched, though where NICo would pick a Redfish client from that DMI vendor the pin outranks it. A RedfishVendor variant name, case-sensitive (e.g. Dell, Supermicro, NvidiaDpu, Hpe, Lenovo). Redfish clients pick it up within a minute, and the recorded vendor changes at the next successful exploration. Pass an empty string to clear the override (return to automatic detection). Only the vendor is asserted, and everything else the BMC reports is left alone, so each library classifies the host the way it normally would for that vendor. Because the pin replaces detection rather than supplementing it, a wrong value can fail exploration outright instead of being ignored, and the failure is reported as the host's last exploration error. It also selects which Redfish account change NICo issues when it changes this BMC's password on the initial factory bootstrap, on the site-wide rotation schedule, when restoring credentials after a factory reset, and for bmc-machine set-root-password. A wrong pin can therefore send the wrong account change to a factory BMC. Only that choice is pinned. The clients that probe a BMC, that bootstrap it from the factory, and that carry the password change itself are still built with no vendor at all, since they must reach a BMC before any vendor is usable. bmc-machine probe-vendor is unaffected and keeps reporting what the BMC says about itself. A pin asserts a vendor rather than a platform, so it also brings that vendor's behavior, including how BMC user accounts are created and deleted and which vendor workarounds apply. Because only the vendor field is asserted, a pin naming a sub-variant such as NvidiaGH200, VeraRubin, NvidiaDpu or a power shelf still needs the product and Redfish version the BMC reports to agree, and where they do not the host can end up classified as nothing rather than as the pinned platform."
+    )]
+    pub(super) bmc_vendor_override: Option<String>,
 }
 
 impl Args {
@@ -257,8 +274,9 @@ impl Args {
             && self.dpu_policy.is_none()
             && self.bmc_ip_allocation.is_none()
             && self.interfaces.is_none()
+            && self.bmc_vendor_override.is_none()
         {
-            return Err(CarbideCliError::GenericError("one of the following options must be specified: bmc-username and bmc-password or chassis-serial-number or fallback-dpu-serial-number or sku-id or rack-id or bmc-ip-address or dpu-policy or bmc-ip-allocation or dpf-enabled or interfaces".to_string()));
+            return Err(CarbideCliError::GenericError("one of the following options must be specified: bmc-username and bmc-password or chassis-serial-number or fallback-dpu-serial-number or sku-id or rack-id or bmc-ip-address or dpu-policy or bmc-ip-allocation or dpf-enabled or interfaces or bmc-vendor-override".to_string()));
         }
         if self
             .fallback_dpu_serial_numbers

--- a/crates/admin-cli/src/expected_machines/patch/mod.rs
+++ b/crates/admin-cli/src/expected_machines/patch/mod.rs
@@ -57,6 +57,7 @@ impl Run for Args {
                         disable_lockdown: Some(dl),
                     }),
                 self.interfaces,
+                self.bmc_vendor_override,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/expected_machines/update/mod.rs
+++ b/crates/admin-cli/src/expected_machines/update/mod.rs
@@ -82,6 +82,7 @@ impl Run for Args {
                     }
                 }),
                 interfaces,
+                expected_machine.bmc_vendor_override,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -962,6 +962,7 @@ impl ApiClient {
         bmc_ip_allocation: Option<::rpc::forge::BmcIpAllocationType>,
         host_lifecycle_profile: Option<::rpc::forge::HostLifecycleProfile>,
         interfaces: Option<String>,
+        bmc_vendor_override: Option<String>,
     ) -> Result<(), CarbideCliError> {
         let get_req = match (bmc_mac_address, id) {
             (Some(_), Some(_)) => {
@@ -1060,6 +1061,9 @@ impl ApiClient {
             replace_host_nics: replace_interfaces,
             host_lifecycle_profile: host_lifecycle_profile
                 .or(expected_machine.host_lifecycle_profile),
+            // Sent as given. The server resolves the tri state against the
+            // stored row, so an omitted flag keeps the pin without a fetch.
+            bmc_vendor_override,
         };
 
         Ok(self.0.update_expected_machine(request).await?)
@@ -1105,6 +1109,7 @@ impl ApiClient {
                             disable_lockdown: hlp.disable_lockdown,
                         }
                     }),
+                    bmc_vendor_override: machine.bmc_vendor_override,
                 })
                 .collect(),
         };

--- a/crates/api-core/Cargo.toml
+++ b/crates/api-core/Cargo.toml
@@ -114,6 +114,7 @@ lazy_static = { workspace = true }
 libredfish = { workspace = true }
 librms = { workspace = true }
 mac_address = { workspace = true }
+moka = { workspace = true }
 num_cpus = { workspace = true }
 nv-redfish = { workspace = true }
 nv-redfish-dispatcher = { workspace = true }

--- a/crates/api-core/src/credentials/bmc_session_manager.rs
+++ b/crates/api-core/src/credentials/bmc_session_manager.rs
@@ -1071,7 +1071,10 @@ mod tests {
         allow_basic_auth_fallback: bool,
     ) -> (Arc<BmcSessionManager>, Arc<InMemoryBmcSessionStore>) {
         let bmc_proxy = Arc::new(ArcSwap::new(Arc::new(None)));
-        let redfish_pool = carbide_redfish::nv_redfish::new_pool(bmc_proxy);
+        let redfish_pool = carbide_redfish::nv_redfish::new_pool(
+            bmc_proxy,
+            Arc::new(carbide_redfish::vendor_override::NoBmcVendorOverrides),
+        );
         let credential_manager =
             Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
                 username: "root".to_string(),
@@ -1209,7 +1212,10 @@ mod tests {
             .build()
             .expect("test runtime");
         let bmc_proxy = Arc::new(ArcSwap::new(Arc::new(None)));
-        let redfish_pool = carbide_redfish::nv_redfish::new_pool(bmc_proxy);
+        let redfish_pool = carbide_redfish::nv_redfish::new_pool(
+            bmc_proxy,
+            Arc::new(carbide_redfish::vendor_override::NoBmcVendorOverrides),
+        );
         let credential_manager =
             Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
                 username: "root".to_string(),
@@ -1343,7 +1349,10 @@ mod tests {
     #[tokio::test]
     async fn rotate_returns_missing_credentials_when_unset() {
         let bmc_proxy = Arc::new(ArcSwap::new(Arc::new(None)));
-        let redfish_pool = carbide_redfish::nv_redfish::new_pool(bmc_proxy);
+        let redfish_pool = carbide_redfish::nv_redfish::new_pool(
+            bmc_proxy,
+            Arc::new(carbide_redfish::vendor_override::NoBmcVendorOverrides),
+        );
         let credential_manager = Arc::new(TestCredentialManager::default());
         let store = InMemoryBmcSessionStore::new();
         let manager = BmcSessionManager::new(
@@ -1543,7 +1552,10 @@ mod tests {
     #[tokio::test]
     async fn rotate_serializes_per_mac_even_across_distinct_spiffe_callers() {
         let bmc_proxy = Arc::new(ArcSwap::new(Arc::new(None)));
-        let redfish_pool = carbide_redfish::nv_redfish::new_pool(bmc_proxy);
+        let redfish_pool = carbide_redfish::nv_redfish::new_pool(
+            bmc_proxy,
+            Arc::new(carbide_redfish::vendor_override::NoBmcVendorOverrides),
+        );
         let credential_manager = CountingCredentialManager::new(
             Credentials::UsernamePassword {
                 username: "root".to_string(),
@@ -2122,7 +2134,10 @@ mod tests {
     #[tokio::test]
     async fn issue_credentials_with_flag_off_surfaces_no_session_service_error() {
         let bmc_proxy = Arc::new(ArcSwap::new(Arc::new(None)));
-        let redfish_pool = carbide_redfish::nv_redfish::new_pool(bmc_proxy);
+        let redfish_pool = carbide_redfish::nv_redfish::new_pool(
+            bmc_proxy,
+            Arc::new(carbide_redfish::vendor_override::NoBmcVendorOverrides),
+        );
         let credential_manager = Arc::new(TestCredentialManager::default());
         let store = InMemoryBmcSessionStore::new();
         let manager = BmcSessionManager::new(

--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -157,8 +157,20 @@ fn parse_expected_machine_for_insert(
     };
 
     normalize_host_bmc_configuration(&mut machine, previous, overrides)?;
+    resolve_bmc_vendor_override(&mut machine, previous);
     validate_expected_machine_for_insert(&machine)?;
     Ok(machine)
+}
+
+/// Resolve `bmc_vendor_override` against the stored row, where an absent field
+/// keeps the stored pin, an empty string clears it, and a value replaces it.
+fn resolve_bmc_vendor_override(machine: &mut ExpectedMachine, previous: Option<&ExpectedMachine>) {
+    let requested = machine.data.bmc_vendor_override.take();
+    machine.data.bmc_vendor_override = match requested {
+        None => previous.and_then(|previous| previous.data.bmc_vendor_override.clone()),
+        Some(requested) if requested.is_empty() => None,
+        Some(requested) => Some(requested),
+    };
 }
 
 /// `validate_expected_machine_for_insert` applies the validation shared by the
@@ -171,8 +183,43 @@ fn validate_expected_machine_for_insert(machine: &ExpectedMachine) -> Result<(),
         .bmc_ip_allocation
         .validate(machine.data.bmc_ip_address.is_some())
         .map_err(|msg| CarbideError::InvalidArgument(msg.to_string()))?;
+    validate_bmc_vendor_override(machine)?;
 
     Ok(())
+}
+
+/// Reject a `bmc_vendor_override` libredfish could not use, so a typo fails the
+/// write. `Unknown` names a client mode rather than a vendor, so it goes too.
+///
+/// `Sushy` parses but names a development emulator that nothing can pin to.
+/// It records as an unknown vendor, so accepting it would degrade the host.
+///
+/// An empty value reaches here only from the JSON import, since every RPC path
+/// resolves it to no pin before validating.
+fn validate_bmc_vendor_override(machine: &ExpectedMachine) -> Result<(), CarbideError> {
+    use libredfish::model::service_root::RedfishVendor;
+
+    let Some(name) = machine.data.bmc_vendor_override.as_deref() else {
+        return Ok(());
+    };
+
+    if name.is_empty() {
+        return Err(CarbideError::InvalidArgument(
+            "bmc_vendor_override must not be empty, omit the field to leave this \
+             host to automatic detection"
+                .to_string(),
+        ));
+    }
+
+    match carbide_redfish::libredfish::conv::redfish_vendor_from_str(name) {
+        Some(vendor) if !matches!(vendor, RedfishVendor::Unknown | RedfishVendor::Sushy) => Ok(()),
+        _ => Err(CarbideError::InvalidArgument(format!(
+            // xtask:allow-error-case vendor spellings keep their exact casing
+            "bmc_vendor_override {name:?} is not a usable Redfish vendor name, \
+             which is the exact case-sensitive variant spelling \
+             such as \"Dell\", \"Supermicro\" or \"NvidiaDpu\""
+        ))),
+    }
 }
 
 /// Create missing expected_machines that aren't already in the database,
@@ -295,6 +342,7 @@ pub(crate) async fn update(
         data,
     };
     normalize_host_bmc_configuration(&mut machine, existing.as_ref(), overrides)?;
+    resolve_bmc_vendor_override(&mut machine, existing.as_ref());
     validate_expected_machine_for_insert(&machine)?;
 
     let preallocations = update_preallocated_interfaces(
@@ -847,6 +895,7 @@ async fn create_expected_machine(
     };
 
     normalize_host_bmc_configuration(&mut expected_machine, None, overrides)?;
+    resolve_bmc_vendor_override(&mut expected_machine, None);
     validate_expected_machine_for_insert(&expected_machine)?;
     db::expected_machine::create(txn, expected_machine).await?;
 
@@ -884,6 +933,7 @@ async fn update_expected_machine(
         data,
     };
     normalize_host_bmc_configuration(&mut expected_machine, existing.as_ref(), overrides)?;
+    resolve_bmc_vendor_override(&mut expected_machine, existing.as_ref());
     validate_expected_machine_for_insert(&expected_machine)?;
     let preallocations =
         update_preallocated_interfaces(txn, &expected_machine, retained_window).await?;
@@ -1400,5 +1450,105 @@ mod tests {
         assert_eq!(replacement.host_nics[0].primary, Some(true));
         let parsed: ExpectedMachineData = replacement.try_into().unwrap();
         assert!(validate_expected_interface_role_and_allocation(&parsed.interfaces).is_err());
+    }
+
+    /// A pin libredfish cannot use has to fail the write. Storing it would leave
+    /// an operator believing the vendor is pinned while every client detects.
+    #[test]
+    fn bmc_vendor_override_rejects_names_libredfish_cannot_use() {
+        fn validate(stored: Option<&str>) -> Result<(), CarbideError> {
+            validate_bmc_vendor_override(&ExpectedMachine {
+                id: None,
+                bmc_mac_address: "02:00:00:00:00:01".parse().expect("valid test MAC"),
+                data: ExpectedMachineData {
+                    bmc_vendor_override: stored.map(str::to_string),
+                    ..Default::default()
+                },
+            })
+        }
+
+        assert!(validate(None).is_ok(), "no pin is always valid");
+        assert!(
+            validate(Some("")).is_err(),
+            "an empty string is not a pin; `resolve_bmc_vendor_override` maps a \
+             clear request to no pin before validation, so a literal empty value \
+             reaching here (the JSON import path) is malformed"
+        );
+        assert!(validate(Some("Dell")).is_ok(), "an exact variant name");
+        assert!(
+            validate(Some("NvidiaDpu")).is_ok(),
+            "a multi-word variant name"
+        );
+
+        // Case matters, so the near miss an operator is most likely to type has
+        // to be rejected rather than silently stored.
+        assert!(validate(Some("dell")).is_err(), "wrong case");
+        assert!(validate(Some("Del")).is_err(), "typo");
+        assert!(
+            validate(Some("Unknown")).is_err(),
+            "the uninitialized-client sentinel is not a pinnable vendor"
+        );
+        assert!(
+            validate(Some("Sushy")).is_err(),
+            "the emulator parses but records as an unknown vendor, so pinning it \
+             would degrade the host rather than pin anything"
+        );
+    }
+
+    /// The column is written unconditionally, so an omitted field has to keep
+    /// what is stored, or any client predating the field would clear the pin.
+    #[test]
+    fn bmc_vendor_override_absent_keeps_the_stored_pin_and_empty_clears_it() {
+        fn machine(value: Option<&str>) -> ExpectedMachine {
+            ExpectedMachine {
+                id: None,
+                bmc_mac_address: "02:00:00:00:00:01".parse().expect("valid test MAC"),
+                data: ExpectedMachineData {
+                    bmc_vendor_override: value.map(str::to_string),
+                    ..Default::default()
+                },
+            }
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "an omitted field keeps the stored pin",
+                    input: (None, Some("Dell")),
+                    expect: Some("Dell".to_string()),
+                },
+                Check {
+                    scenario: "an omitted field on a row without a pin stays unpinned",
+                    input: (None, None),
+                    expect: None,
+                },
+                Check {
+                    scenario: "an empty string clears the stored pin",
+                    input: (Some(""), Some("Dell")),
+                    expect: None,
+                },
+                Check {
+                    scenario: "an empty string on a row without a pin is a no-op",
+                    input: (Some(""), None),
+                    expect: None,
+                },
+                Check {
+                    scenario: "a value replaces the stored pin",
+                    input: (Some("Hpe"), Some("Dell")),
+                    expect: Some("Hpe".to_string()),
+                },
+                Check {
+                    scenario: "a value sets a pin on a row without one",
+                    input: (Some("Hpe"), None),
+                    expect: Some("Hpe".to_string()),
+                },
+            ],
+            |(requested, stored): (Option<&str>, Option<&str>)| {
+                let previous = stored.map(|stored| machine(Some(stored)));
+                let mut incoming = machine(requested);
+                resolve_bmc_vendor_override(&mut incoming, previous.as_ref());
+                incoming.data.bmc_vendor_override
+            },
+        );
     }
 }

--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge::{self as rpc, AdminForceDeleteMachineResponse};
 use ::rpc::model::RpcTryFrom;
-use carbide_redfish::libredfish::RedfishAuth;
+use carbide_redfish::libredfish::{RedfishAuth, VendorSelection};
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey};
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::instance::InstanceId;
@@ -1118,7 +1118,7 @@ pub(crate) async fn invoke_power(
             RedfishAuth::Key(CredentialKey::BmcCredentials {
                 credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
             }),
-            None,
+            VendorSelection::Detect,
         )
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
 use ::rpc::model::machine::ManagedHostStateSnapshotRpc;
-use carbide_redfish::libredfish::RedfishAuth;
+use carbide_redfish::libredfish::{RedfishAuth, VendorSelection};
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
 use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
@@ -733,7 +733,7 @@ pub(crate) async fn admin_force_delete_machine(
                         RedfishAuth::Key(CredentialKey::BmcCredentials {
                             credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
                         }),
-                        None,
+                        VendorSelection::Detect,
                     )
                     .await
                 {

--- a/crates/api-core/src/lib.rs
+++ b/crates/api-core/src/lib.rs
@@ -71,6 +71,7 @@ mod measured_boot;
 mod mqtt_state_change_hook;
 mod network_segment;
 mod node_auth;
+mod redfish_vendor_override;
 mod scout_stream;
 pub mod secrets;
 mod setup;

--- a/crates/api-core/src/redfish_vendor_override.rs
+++ b/crates/api-core/src/redfish_vendor_override.rs
@@ -1,0 +1,214 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Database backed lookup for the operator BMC vendor pin.
+//! Lives here as it bridges the crate holding the trait and the one querying.
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use carbide_redfish::libredfish::conv;
+use carbide_redfish::vendor_override::{BmcVendorOverrideResolver, VendorOverrideError};
+use carbide_utils::redfish::parse_uri_host_ip;
+use libredfish::model::service_root::RedfishVendor;
+use sqlx::PgPool;
+
+/// How long a resolved pin, or the absence of one, is reused before a fresh read.
+/// Bounded staleness beats invalidation, as writes key on MAC and this on IP.
+const DEFAULT_PIN_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Upper bound on cached BMC addresses, so probing unknown ones cannot grow the
+/// cache without limit.
+const PIN_CACHE_CAPACITY: u64 = 4096;
+
+/// Resolves `bmc_vendor_override` for a BMC address, with a short lived cache.
+pub(crate) struct DbBmcVendorOverrideResolver {
+    db_pool: PgPool,
+    /// Caches the absence of a pin as well as its presence, which is the point.
+    /// Almost no BMC has one, so the common path would otherwise query Postgres.
+    cache: moka::future::Cache<IpAddr, Option<RedfishVendor>>,
+}
+
+impl DbBmcVendorOverrideResolver {
+    pub(crate) fn new(db_pool: PgPool) -> Self {
+        Self::with_cache_ttl(db_pool, DEFAULT_PIN_CACHE_TTL)
+    }
+
+    /// Same, with an explicit TTL so tests can observe expiry without sleeping.
+    pub(crate) fn with_cache_ttl(db_pool: PgPool, ttl: Duration) -> Self {
+        Self {
+            db_pool,
+            cache: moka::future::Cache::builder()
+                .max_capacity(PIN_CACHE_CAPACITY)
+                .time_to_live(ttl)
+                .build(),
+        }
+    }
+}
+
+#[async_trait]
+impl BmcVendorOverrideResolver for DbBmcVendorOverrideResolver {
+    async fn vendor_override(
+        &self,
+        host: &str,
+    ) -> Result<Option<RedfishVendor>, VendorOverrideError> {
+        // Pins resolve against `machine_interface_addresses.address`, so a BMC
+        // reached by hostname has nothing to match on and reports no pin.
+        let Some(ip) = parse_uri_host_ip(host) else {
+            return Ok(None);
+        };
+
+        // `get_with` collapses concurrent lookups into one query. A read failure
+        // resolves to no pin and caches, so an outage costs one query per TTL.
+        Ok(self
+            .cache
+            .get_with(ip, async {
+                let raw = match db::machine_interface::find_bmc_vendor_override_by_ip(
+                    &self.db_pool,
+                    ip,
+                )
+                .await
+                {
+                    Ok(raw) => raw,
+                    Err(error) => {
+                        tracing::warn!(
+                            bmc = %ip,
+                            %error,
+                            "Failed to read bmc_vendor_override, BMC clients will use automatic detection"
+                        );
+                        return None;
+                    }
+                };
+
+                // Parsing, the warning for an unusable name, and the refusal of
+                // `Unknown` all live in the single place a name is interpreted.
+                conv::redfish_vendor_override(host, raw.as_deref())
+            })
+            .await)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Seed one BMC interface at `ip` whose expected machine pins `pin`.
+    async fn seed_pinned_bmc(pool: &PgPool, ip: IpAddr, mac: &str, pin: &str) {
+        use model::network_segment::{
+            AllocationStrategy, NetworkSegmentControllerState, NetworkSegmentType,
+            NewNetworkSegment,
+        };
+
+        // Built through the real persist path rather than a hand written INSERT
+        // so this fixture cannot drift from the segment schema.
+        let segment_id = carbide_uuid::network::NetworkSegmentId::new();
+        let mut txn = db::Transaction::begin(pool).await.expect("txn");
+        db::network_segment::persist(
+            NewNetworkSegment {
+                id: segment_id,
+                name: "pin-cache-segment".to_string(),
+                subdomain_id: None,
+                vpc_id: None,
+                mtu: 1500,
+                prefixes: Vec::new(),
+                vlan_id: None,
+                vni: None,
+                segment_type: NetworkSegmentType::HostInband,
+                can_stretch: Some(false),
+                allocation_strategy: AllocationStrategy::Reserved,
+                infer_slaac_eui64_addresses: false,
+            },
+            txn.as_pgconn(),
+            NetworkSegmentControllerState::Ready,
+        )
+        .await
+        .expect("segment");
+        txn.commit().await.expect("commit segment");
+
+        let interface: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces \
+                 (segment_id, mac_address, primary_interface, hostname, interface_type) \
+             VALUES ($1, $2::macaddr, false, 'pin-cache-bmc', 'Bmc') RETURNING id",
+        )
+        .bind(segment_id)
+        .bind(mac)
+        .fetch_one(pool)
+        .await
+        .expect("interface");
+
+        sqlx::query(
+            "INSERT INTO machine_interface_addresses (interface_id, address) VALUES ($1, $2::inet)",
+        )
+        .bind(interface)
+        .bind(ip)
+        .execute(pool)
+        .await
+        .expect("address");
+
+        sqlx::query(
+            "INSERT INTO expected_machines (serial_number, bmc_mac_address, bmc_username, \
+             bmc_password, bmc_vendor_override) VALUES ('PINCACHE1', $1::macaddr, 'root', 'p', $2)",
+        )
+        .bind(mac)
+        .bind(pin)
+        .execute(pool)
+        .await
+        .expect("expected machine");
+    }
+
+    /// A BMC reached by hostname has no address row to match, so it reports no
+    /// pin rather than failing the client construction that asked.
+    #[crate::sqlx_test]
+    async fn a_hostname_addressed_bmc_has_no_pin(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let resolver = DbBmcVendorOverrideResolver::new(pool);
+        assert_eq!(resolver.vendor_override("bmc-01.example.test").await?, None);
+        Ok(())
+    }
+
+    /// The cache is what makes a lookup per `create_client` affordable, so assert
+    /// it caches, including the far more common answer of no pin at all.
+    #[crate::sqlx_test]
+    async fn resolved_pins_and_their_absence_are_both_cached(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let ip: IpAddr = "192.0.2.77".parse()?;
+
+        let cached = DbBmcVendorOverrideResolver::new(pool.clone());
+        let uncached = DbBmcVendorOverrideResolver::with_cache_ttl(pool.clone(), Duration::ZERO);
+        assert_eq!(cached.vendor_override(&ip.to_string()).await?, None);
+        assert_eq!(uncached.vendor_override(&ip.to_string()).await?, None);
+
+        seed_pinned_bmc(&pool, ip, "7A:7B:7C:7D:7E:77", "Dell").await;
+
+        assert_eq!(
+            cached.vendor_override(&ip.to_string()).await?,
+            None,
+            "the negative answer must still come from cache, the property that \
+             keeps this off the hot path"
+        );
+        assert_eq!(
+            uncached.vendor_override(&ip.to_string()).await?,
+            Some(RedfishVendor::Dell),
+            "a resolver whose entries have expired must see the new pin"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -53,6 +53,7 @@ use carbide_rack_controller::context::RackStateHandlerServices;
 use carbide_rack_controller::handler::RackStateHandler;
 use carbide_rack_controller::io::RackStateControllerIO;
 use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::vendor_override::BmcVendorOverrideResolver;
 use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::{CredentialManager, CredentialReader};
 use carbide_site_explorer::{EndpointExplorationService, SiteExplorer};
@@ -110,6 +111,7 @@ use crate::mqtt_state_change_hook::hook::MqttStateChangeHook;
 use crate::mqtt_state_change_hook::republisher::{
     ManagedHostStateRepublisher, ManagedHostStateRepublisherParams,
 };
+use crate::redfish_vendor_override::DbBmcVendorOverrideResolver;
 use crate::scout_stream::ConnectionRegistry;
 use crate::{CarbideError, attestation, db_init, ethernet_virtualization, listener};
 
@@ -137,6 +139,7 @@ fn create_ipmi_tool(
 fn create_redfish_pool(
     carbide_config: &CarbideConfig,
     credential_manager: Arc<dyn CredentialManager>,
+    vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver>,
 ) -> eyre::Result<Arc<dyn RedfishClientPool>> {
     let pool = libredfish::RedfishClientPool::builder()
         .danger_accept_invalid_certs()
@@ -185,6 +188,7 @@ fn create_redfish_pool(
         credential_manager,
         pool,
         carbide_config.site_explorer.bmc_proxy.clone(),
+        vendor_override_resolver,
     ))
 }
 
@@ -205,9 +209,19 @@ pub(crate) async fn start_runtime(
     admin_ui_routes_builder: Option<AdminUiRoutesBuilder>,
     cancel_token: CancellationToken,
 ) -> eyre::Result<SocketAddr> {
-    let shared_redfish_pool = create_redfish_pool(&carbide_config, credential_manager.clone())?;
-    let shared_nv_redfish_pool =
-        carbide_redfish::nv_redfish::new_pool(carbide_config.site_explorer.bmc_proxy.clone());
+    // One resolver for both backends, so its cache cannot hand them different
+    // answers for the same BMC while a pin is being changed.
+    let vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver> =
+        Arc::new(DbBmcVendorOverrideResolver::new(db_pool.clone()));
+    let shared_redfish_pool = create_redfish_pool(
+        &carbide_config,
+        credential_manager.clone(),
+        vendor_override_resolver.clone(),
+    )?;
+    let shared_nv_redfish_pool = carbide_redfish::nv_redfish::new_pool(
+        carbide_config.site_explorer.bmc_proxy.clone(),
+        vendor_override_resolver,
+    );
 
     let ipmi_tool = create_ipmi_tool(
         credential_manager.clone(),

--- a/crates/api-core/src/test_support/builder.rs
+++ b/crates/api-core/src/test_support/builder.rs
@@ -209,7 +209,10 @@ impl TestApiBuilder {
             .unwrap_or_else(|| ib_fabric_test_manager(&runtime_config, credential_manager.clone()));
 
         let bmc_proxy = Arc::new(ArcSwap::new(None.into()));
-        let nv_redfish_pool = carbide_redfish::nv_redfish::new_pool(bmc_proxy);
+        let nv_redfish_pool = carbide_redfish::nv_redfish::new_pool(
+            bmc_proxy,
+            Arc::new(carbide_redfish::vendor_override::NoBmcVendorOverrides),
+        );
         let bmc_session_store: Arc<dyn crate::credentials::BmcSessionStore> = Arc::new(
             crate::credentials::PgBmcSessionStore::new(self.db_pool.clone()),
         );

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -736,6 +736,7 @@ async fn test_add_expected_machine_dpu_serials(pool: sqlx::PgPool) {
         bmc_ip_allocation: None,
         replace_host_nics: false,
         host_lifecycle_profile: None,
+        bmc_vendor_override: None,
         #[allow(deprecated)]
         dpf_enabled: true,
     };

--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -909,6 +909,7 @@ pub(in crate::tests) mod tests {
                     dpu_policy: Default::default(),
                     bmc_ip_allocation: Default::default(),
                     host_lifecycle_profile: Default::default(),
+                    bmc_vendor_override: None,
                 },
             },
         )
@@ -1005,6 +1006,7 @@ pub(in crate::tests) mod tests {
                     dpu_policy: Default::default(),
                     bmc_ip_allocation: Default::default(),
                     host_lifecycle_profile: Default::default(),
+                    bmc_vendor_override: None,
                 },
             },
         )
@@ -1076,6 +1078,7 @@ pub(in crate::tests) mod tests {
                     dpu_policy: Default::default(),
                     bmc_ip_allocation: Default::default(),
                     host_lifecycle_profile: Default::default(),
+                    bmc_vendor_override: None,
                 },
             },
         )
@@ -1164,6 +1167,7 @@ pub(in crate::tests) mod tests {
                     dpu_policy: Default::default(),
                     bmc_ip_allocation: Default::default(),
                     host_lifecycle_profile: Default::default(),
+                    bmc_vendor_override: None,
                 },
             },
         )
@@ -1647,6 +1651,7 @@ pub(in crate::tests) mod tests {
                     dpu_policy: Default::default(),
                     bmc_ip_allocation: Default::default(),
                     host_lifecycle_profile: Default::default(),
+                    bmc_vendor_override: None,
                 },
             },
         )

--- a/crates/api-db/migrations/20260827104512_expected_machine_bmc_vendor_override.sql
+++ b/crates/api-db/migrations/20260827104512_expected_machine_bmc_vendor_override.sql
@@ -1,0 +1,3 @@
+-- Let an operator pin the Redfish BMC vendor for a host, holding a RedfishVendor
+-- variant name that is forced into libredfish. NULL means automatic detection.
+ALTER TABLE expected_machines ADD COLUMN bmc_vendor_override text;

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -286,9 +286,9 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedMachine> {
     let id = machine.id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_machines
-            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address, bmc_retain_credentials, dpu_mode, bmc_ip_allocation, host_lifecycle_profile)
+            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address, bmc_retain_credentials, dpu_mode, bmc_ip_allocation, host_lifecycle_profile, bmc_vendor_override)
             VALUES
-            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet, $16, $17, $18, $19::jsonb) RETURNING *";
+            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet, $16, $17, $18, $19::jsonb, $20::text) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -315,6 +315,7 @@ pub async fn create(
         .bind(machine.data.dpu_policy)
         .bind(machine.data.bmc_ip_allocation)
         .bind(sqlx::types::Json(&machine.data.host_lifecycle_profile))
+        .bind(&machine.data.bmc_vendor_override)
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -474,7 +475,8 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
                      bmc_retain_credentials=COALESCE($14, bmc_retain_credentials), \
                      dpu_mode=$15, \
                      bmc_ip_allocation=$16, \
-                     host_lifecycle_profile=COALESCE($17, host_lifecycle_profile) \
+                     host_lifecycle_profile=COALESCE($17, host_lifecycle_profile), \
+                     bmc_vendor_override=$18 \
                  WHERE ",
                 $where_clause,
             )
@@ -483,11 +485,11 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
 
     let (query, target_id) = match machine.id {
         Some(id) => (
-            update_expected_machine_query!("id=$18::uuid"),
+            update_expected_machine_query!("id=$19::uuid"),
             id.to_string(),
         ),
         None => (
-            update_expected_machine_query!("bmc_mac_address=$18::macaddr"),
+            update_expected_machine_query!("bmc_mac_address=$19::macaddr"),
             machine.bmc_mac_address.to_string(),
         ),
     };
@@ -513,6 +515,7 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
             (!machine.data.host_lifecycle_profile.is_empty())
                 .then_some(sqlx::types::Json(&machine.data.host_lifecycle_profile)),
         )
+        .bind(&machine.data.bmc_vendor_override)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -434,6 +434,8 @@ pub async fn lookup_bmc_access_info(
     ip: IpAddr,
     port: Option<u16>,
 ) -> DatabaseResult<BmcAccessInfo> {
+    // The operator vendor pin is deliberately not read here. It resolves inside
+    // `create_client`, so a copy here would be a second source of truth.
     let mac_address = find_by_ip(db, ip)
         .await?
         .ok_or_else(|| DatabaseError::NotFoundError {
@@ -446,6 +448,32 @@ pub async fn lookup_bmc_access_info(
         port,
         mac_address,
     })
+}
+
+/// Resolve the operator pinned Redfish vendor for the BMC reachable at `ip`.
+/// Bridges the MAC keyed pin to a BMC address. No pin is normal, not an error.
+pub async fn find_bmc_vendor_override_by_ip(
+    db: impl DbReader<'_>,
+    ip: IpAddr,
+) -> DatabaseResult<Option<String>> {
+    let query = r"SELECT em.bmc_vendor_override
+        FROM machine_interface_addresses mia
+        INNER JOIN machine_interfaces mi ON mi.id = mia.interface_id
+        INNER JOIN expected_machines em ON em.bmc_mac_address = mi.mac_address
+        WHERE mia.address = $1::inet
+          AND mi.interface_type = 'Bmc'
+          AND em.bmc_vendor_override IS NOT NULL
+        -- One address should reach one BMC, but a stale or duplicated interface
+        -- row can make several match. Order so the answer cannot flip between
+        -- calls and leave a BMC dispatching on a different vendor each time.
+        ORDER BY em.bmc_mac_address
+        LIMIT 1";
+    sqlx::query_scalar(query)
+        .bind(ip)
+        .fetch_optional(db)
+        .await
+        .map(Option::flatten)
+        .map_err(|e| DatabaseError::query(query, e))
 }
 
 pub async fn find_by_ip(

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -1388,3 +1388,136 @@ async fn test_expected_interface_role_controls_observed_interface_creation(
 
     Ok(())
 }
+
+/// The pin is keyed by BMC MAC while consumers hold a BMC address, so this query
+/// bridges the two. A broken join would silence every pin and fail no other test.
+#[crate::sqlx_test]
+async fn find_bmc_vendor_override_by_ip_bridges_mac_keyed_pin_to_bmc_address(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment = create_test_segment(&pool, "bmc-vendor-override-segment").await?;
+
+    // Mac, ip, hostname and the pin, where `None` means no expected machine row.
+    let fixtures: [(MacAddress, IpAddr, &str, Option<&str>); 5] = [
+        (
+            "7A:7B:7C:7D:7E:51".parse()?,
+            "192.0.2.51".parse()?,
+            "pinned",
+            Some("Dell"),
+        ),
+        (
+            "7A:7B:7C:7D:7E:52".parse()?,
+            "192.0.2.52".parse()?,
+            "no-machine",
+            None,
+        ),
+        (
+            "7A:7B:7C:7D:7E:53".parse()?,
+            "192.0.2.53".parse()?,
+            "null-pin",
+            Some(""),
+        ),
+        (
+            "7A:7B:7C:7D:7E:54".parse()?,
+            "192.0.2.54".parse()?,
+            "bogus-pin",
+            Some("NotAVendor"),
+        ),
+        (
+            "7A:7B:7C:7D:7E:55".parse()?,
+            "2001:db8::55".parse()?,
+            "v6-pinned",
+            Some("NvidiaDpu"),
+        ),
+    ];
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    for (index, (mac, ip, hostname, pin)) in fixtures.iter().enumerate() {
+        let interface_id: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (segment_id, mac_address, primary_interface, hostname, interface_type)
+             VALUES ($1, $2, false, $3, 'Bmc') RETURNING id",
+        )
+        .bind(segment)
+        .bind(mac)
+        .bind(hostname)
+        .fetch_one(txn.as_pgconn())
+        .await?;
+
+        sqlx::query(
+            "INSERT INTO machine_interface_addresses (interface_id, address) VALUES ($1, $2::inet)",
+        )
+        .bind(interface_id)
+        .bind(ip)
+        .execute(txn.as_pgconn())
+        .await?;
+
+        if let Some(pin) = pin {
+            // An empty string stores as SQL NULL, covering the unset shape too.
+            sqlx::query(
+                "INSERT INTO expected_machines
+                    (serial_number, bmc_mac_address, bmc_username, bmc_password, bmc_vendor_override)
+                 VALUES ($1, $2, 'root', 'pass', NULLIF($3, ''))",
+            )
+            .bind(format!("VVG121G{index}"))
+            .bind(mac)
+            .bind(pin)
+            .execute(txn.as_pgconn())
+            .await?;
+        }
+    }
+
+    for (_, ip, hostname, expected) in fixtures.iter() {
+        // The query hands back the raw string. Parsing and rejecting unusable
+        // names happens a layer up, so a bogus name survives this one intact.
+        let expected = expected.filter(|pin| !pin.is_empty()).map(str::to_string);
+        assert_eq!(
+            find_bmc_vendor_override_by_ip(txn.as_pgconn(), *ip).await?,
+            expected,
+            "pin lookup for {hostname} at {ip}"
+        );
+    }
+
+    // An address with no interface row at all has no pin, and is not an error.
+    assert_eq!(
+        find_bmc_vendor_override_by_ip(txn.as_pgconn(), "192.0.2.99".parse()?).await?,
+        None,
+        "an unknown BMC address simply has no pin"
+    );
+
+    // A pin belongs to a BMC, so a data interface sharing an expected machine MAC
+    // must not hand its pin to whatever else answers on that address.
+    let data_mac: MacAddress = "7A:7B:7C:7D:7E:56".parse()?;
+    let data_ip: IpAddr = "192.0.2.56".parse()?;
+    let data_interface: uuid::Uuid = sqlx::query_scalar(
+        "INSERT INTO machine_interfaces
+             (segment_id, mac_address, primary_interface, hostname, interface_type)
+         VALUES ($1, $2, false, 'data-nic', 'Data') RETURNING id",
+    )
+    .bind(segment)
+    .bind(data_mac)
+    .fetch_one(txn.as_pgconn())
+    .await?;
+    sqlx::query(
+        "INSERT INTO machine_interface_addresses (interface_id, address) VALUES ($1, $2::inet)",
+    )
+    .bind(data_interface)
+    .bind(data_ip)
+    .execute(txn.as_pgconn())
+    .await?;
+    sqlx::query(
+        "INSERT INTO expected_machines
+            (serial_number, bmc_mac_address, bmc_username, bmc_password, bmc_vendor_override)
+         VALUES ('VVG121GZ', $1, 'root', 'pass', 'Dell')",
+    )
+    .bind(data_mac)
+    .execute(txn.as_pgconn())
+    .await?;
+    assert_eq!(
+        find_bmc_vendor_override_by_ip(txn.as_pgconn(), data_ip).await?,
+        None,
+        "a non BMC interface must never resolve a pin"
+    );
+
+    Ok(())
+}

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -811,6 +811,10 @@ pub struct ExpectedMachineData {
     /// knobs should be added here rather than as new flat columns.
     #[serde(default)]
     pub host_lifecycle_profile: HostLifecycleProfile,
+    /// Operator pinned Redfish BMC vendor, a `RedfishVendor` name such as `Dell`.
+    /// Absent means no pin when stored, and keep the stored pin when written.
+    #[serde(default)]
+    pub bmc_vendor_override: Option<String>,
 }
 // Important : new fields for expected machine (and data) should be optional _and_ serde(default),
 // unless you want to go update all the files in each production deployment that autoload
@@ -887,6 +891,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedMachine {
                 host_lifecycle_profile: row
                     .try_get::<sqlx::types::Json<HostLifecycleProfile>, _>("host_lifecycle_profile")
                     .map(|j| j.0)?,
+                bmc_vendor_override: row.try_get("bmc_vendor_override")?,
             },
         })
     }

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -66,7 +66,8 @@ pub struct EndpointExplorationReport {
     /// The time it took to explore the endpoint in the last site explorer run
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_exploration_latency: Option<std::time::Duration>,
-    /// Vendor as reported by Redfish
+    /// The BMC vendor, either what Redfish reported or the operator pin.
+    /// Selects the firmware key, restart path and console transport.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vendor: Option<bmc_vendor::BMCVendor>,
     /// `Managers` reported by Redfish

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -91,6 +91,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         credential_provider.clone(),
         rf_pool,
         proxy_address.clone(),
+        // This CLI explores a BMC straight from its arguments and has no expected
+        // machine store to read a vendor pin from, so it opts out.
+        Arc::new(carbide_redfish::vendor_override::NoBmcVendorOverrides),
     );
     let mode = match args.mode.as_str() {
         "libredfish" => SiteExplorerExploreMode::LibRedfish,
@@ -107,7 +110,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let explorer = BmcEndpointExplorer::new(
         redfish_client_pool,
-        Arc::new(NvRedfishClientPool::new(proxy_address)),
+        Arc::new(NvRedfishClientPool::new(
+            proxy_address,
+            Arc::new(carbide_redfish::vendor_override::NoBmcVendorOverrides),
+        )),
         carbide_ipmi::test_support(),
         credential_provider.clone(),
         rotate_switch_nvos_credentials,

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -414,6 +414,8 @@ async fn build_delta_powershelf_report<B: Bmc>(
     })
 }
 
+/// Refine a pinned platform with facts only the explored hardware can supply.
+/// The pin selects the family and the hardware selects the variant.
 pub(crate) fn hw_type<B: Bmc>(
     root: &nv_redfish::ServiceRoot<B>,
     explored_system: &ExploredComputerSystem<B>,

--- a/crates/component-manager/src/core_compute_manager.rs
+++ b/crates/component-manager/src/core_compute_manager.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::{RedfishClientPool, VendorSelection};
 use carbide_secrets::credentials::Credentials;
 use model::component_manager::{ComputeTrayComponent, PowerAction};
 
@@ -31,14 +31,16 @@ impl CoreComputeTrayManager {
     }
 }
 
-fn map_vendor(vendor: ComputeTrayVendor) -> Option<libredfish::model::service_root::RedfishVendor> {
+/// Translate the tray recorded vendor into a client construction request.
+/// It comes from DMI, so it is a hint an operator pin outranks.
+fn map_vendor(vendor: ComputeTrayVendor) -> VendorSelection {
     use libredfish::model::service_root::RedfishVendor;
     match vendor {
-        ComputeTrayVendor::Dell => Some(RedfishVendor::Dell),
-        ComputeTrayVendor::Hpe => Some(RedfishVendor::Hpe),
-        ComputeTrayVendor::Lenovo => Some(RedfishVendor::Lenovo),
-        ComputeTrayVendor::Supermicro => Some(RedfishVendor::Supermicro),
-        ComputeTrayVendor::Nvidia | ComputeTrayVendor::Unknown => None,
+        ComputeTrayVendor::Dell => VendorSelection::Hint(RedfishVendor::Dell),
+        ComputeTrayVendor::Hpe => VendorSelection::Hint(RedfishVendor::Hpe),
+        ComputeTrayVendor::Lenovo => VendorSelection::Hint(RedfishVendor::Lenovo),
+        ComputeTrayVendor::Supermicro => VendorSelection::Hint(RedfishVendor::Supermicro),
+        ComputeTrayVendor::Nvidia | ComputeTrayVendor::Unknown => VendorSelection::Detect,
     }
 }
 
@@ -145,16 +147,16 @@ mod tests {
     #[test]
     fn compute_tray_vendor_maps_to_redfish_vendor() {
         value_scenarios!(map_vendor:
-            "supported Redfish vendors" {
-                ComputeTrayVendor::Dell => Some(RedfishVendor::Dell),
-                ComputeTrayVendor::Hpe => Some(RedfishVendor::Hpe),
-                ComputeTrayVendor::Lenovo => Some(RedfishVendor::Lenovo),
-                ComputeTrayVendor::Supermicro => Some(RedfishVendor::Supermicro),
+            "supported Redfish vendors become a hint an operator pin can outrank" {
+                ComputeTrayVendor::Dell => VendorSelection::Hint(RedfishVendor::Dell),
+                ComputeTrayVendor::Hpe => VendorSelection::Hint(RedfishVendor::Hpe),
+                ComputeTrayVendor::Lenovo => VendorSelection::Hint(RedfishVendor::Lenovo),
+                ComputeTrayVendor::Supermicro => VendorSelection::Hint(RedfishVendor::Supermicro),
             }
 
-            "vendors without a Redfish adapter" {
-                ComputeTrayVendor::Nvidia => None,
-                ComputeTrayVendor::Unknown => None,
+            "vendors without a Redfish adapter fall back to detection" {
+                ComputeTrayVendor::Nvidia => VendorSelection::Detect,
+                ComputeTrayVendor::Unknown => VendorSelection::Detect,
             }
         );
     }

--- a/crates/credential-rotation/src/lib.rs
+++ b/crates/credential-rotation/src/lib.rs
@@ -261,8 +261,9 @@ pub enum DispatchVendor {
     /// probes it in its own controller layer before calling). Nothing persists
     /// it -- `Fixed` only means "resolved by the caller, not the engine".
     Fixed(RedfishVendor),
-    /// Resolve the vendor at rotation time by probing the BMC's Chassis
-    /// manufacturer ([`RedfishClientPool::probe_bmc_vendor`]) -- power-shelf
+    /// Resolve the vendor at rotation time from an operator pin, or failing
+    /// that by probing the BMC's Chassis
+    /// manufacturer ([`RedfishClientPool::dispatch_bmc_vendor`]) -- power-shelf
     /// PMCs (Lite-On/Delta), which do *not* expose a recognized vendor in their
     /// Redfish service root. The probe runs *inside* the engine's
     /// quarantine-on-failure envelope and reuses the same credential candidates
@@ -1095,6 +1096,9 @@ async fn change_or_recover(
 /// probe that never authenticates returns `Err`, which the caller records as a
 /// quarantine with backoff. Returns an already-`to_string`-ed error (still to be
 /// redacted by the caller); never returns a secret-bearing string itself.
+///
+/// An operator vendor pin answers a `Probe` target before any login.
+/// Without that, a BMC pinned for not identifying itself could never rotate.
 async fn resolve_dispatch_vendor(
     redfish_pool: &dyn RedfishClientPool,
     bmc: &BmcRotationTarget,
@@ -1107,7 +1111,7 @@ async fn resolve_dispatch_vendor(
             let mut last_err = None;
             for candidate in [rotate_from, rotate_to] {
                 match redfish_pool
-                    .probe_bmc_vendor(&bmc.host, bmc.port, candidate.clone())
+                    .dispatch_bmc_vendor(&bmc.host, bmc.port, candidate.clone())
                     .await
                 {
                     Ok(vendor) => return Ok(vendor),
@@ -1588,6 +1592,39 @@ mod tests {
             .expect("a Lite-On/Delta chassis must resolve a power-shelf vendor");
             assert_eq!(vendor, expected, "manufacturer {manufacturer:?}");
         }
+    }
+
+    /// A host is pinned because it cannot identify itself, so the pin has to
+    /// carry rotation too. Without it this device quarantines on every sweep.
+    #[tokio::test]
+    async fn resolve_dispatch_vendor_prefers_the_operator_pin_over_probing() {
+        let unidentifiable = || {
+            let sim = RedfishSim::default();
+            sim.set_service_root_vendor(Some("Unrecognized Vendor".to_string()));
+            sim.set_chassis_manufacturer(Some("Acme".to_string()));
+            sim
+        };
+        let resolve = async |sim| {
+            resolve_dispatch_vendor(
+                &sim,
+                &probe_target(),
+                &creds("root", "old"),
+                &creds("root", "new"),
+            )
+            .await
+        };
+
+        assert!(
+            resolve(unidentifiable()).await.is_err(),
+            "precondition, an unpinned BMC that identifies as nothing cannot rotate"
+        );
+
+        let pinned = unidentifiable();
+        pinned.set_vendor_override("127.0.0.1", RedfishVendor::Dell);
+        assert_eq!(
+            resolve(pinned).await.expect("a pinned BMC resolves"),
+            RedfishVendor::Dell
+        );
     }
 
     #[test]

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -397,6 +397,7 @@ impl ApiClient {
                 dpu_mode: dpu_policy.map(|policy| rpc::forge::DpuMode::from(policy) as i32),
                 bmc_ip_allocation: None,
                 host_lifecycle_profile: None,
+                bmc_vendor_override: None,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/machine-controller/src/handler/factory_reset.rs
+++ b/crates/machine-controller/src/handler/factory_reset.rs
@@ -75,12 +75,11 @@
 //!   rather than silently attempting a speculative unlock.
 
 use carbide_credential_rotation::site_explorer_pause::{self, GateDecision};
-use carbide_redfish::libredfish::RedfishAuth;
 use carbide_redfish::libredfish::error::state_handler_redfish_error as redfish_error;
+use carbide_redfish::libredfish::{RedfishAuth, VendorSelection};
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
 use eyre::eyre;
 use libredfish::RedfishError;
-use libredfish::model::service_root::RedfishVendor;
 use mac_address::MacAddress;
 use model::machine::{
     FactoryResetBmcState, HostPlatformConfigurationState, InstanceState, ManagedHostState,
@@ -493,16 +492,15 @@ async fn wait_for_bmc(
 
     let (host, port) = bmc_host_port(mh_snapshot)?;
 
-    // Readiness = a successful anonymous service-root read. The `Unknown` path
-    // does no I/O at client creation and works against a just-reset BMC on its
-    // factory password without consuming an authenticated login attempt.
+    // Readiness is a successful anonymous service root read. The uninitialized
+    // path does no I/O and works on a reset BMC still at its factory password.
     let redfish = ctx.services.redfish_client_pool.clone();
     let ready = match redfish
         .create_client(
             &host,
             port,
             RedfishAuth::Anonymous,
-            Some(RedfishVendor::Unknown),
+            VendorSelection::Uninitialized,
         )
         .await
     {
@@ -634,7 +632,7 @@ async fn restore_credentials(
     // Resolve the exact dispatch vendor, then change the device from factory
     // default back to its previous per-device password.
     let vendor = redfish
-        .probe_bmc_vendor(&host, port, factory_creds.clone())
+        .dispatch_bmc_vendor(&host, port, factory_creds.clone())
         .await?;
 
     match redfish

--- a/crates/machine-controller/src/handler/host_boot_config.rs
+++ b/crates/machine-controller/src/handler/host_boot_config.rs
@@ -478,7 +478,7 @@ mod tests {
 
     use carbide_health_metrics::PerObjectMetricsRegistry;
     use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
-    use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool};
+    use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool, VendorSelection};
     use carbide_secrets::test_support::credentials::TestCredentialManager;
     use carbide_test_support::value_scenarios;
     use model::machine_boot_interface::MachineBootInterface;
@@ -531,7 +531,12 @@ mod tests {
 
         let redfish_sim = Arc::new(RedfishSim::default());
         let redfish_client = redfish_sim
-            .create_client(REDFISH_HOST, None, RedfishAuth::Anonymous, None)
+            .create_client(
+                REDFISH_HOST,
+                None,
+                RedfishAuth::Anonymous,
+                VendorSelection::Detect,
+            )
             .await
             .unwrap();
         redfish_sim.set_machine_setup_bios_job_id(Some("bios-job".to_string()));

--- a/crates/machine-controller/src/handler/test_machine_setup.rs
+++ b/crates/machine-controller/src/handler/test_machine_setup.rs
@@ -18,7 +18,7 @@
 use std::collections::HashMap;
 
 use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimAction};
-use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool};
+use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool, VendorSelection};
 use carbide_secrets::credentials::{CredentialKey, CredentialType};
 use libredfish::BiosProfileType;
 use libredfish::model::service_root::RedfishVendor;
@@ -57,7 +57,7 @@ async fn test_oem_manager_profiles_passed_to_machine_setup() {
             RedfishAuth::Key(CredentialKey::HostRedfish {
                 credential_type: CredentialType::SiteDefault,
             }),
-            None,
+            VendorSelection::Detect,
         )
         .await
         .unwrap();

--- a/crates/redfish/src/lib.rs
+++ b/crates/redfish/src/lib.rs
@@ -18,3 +18,4 @@
 pub mod boot_interface;
 pub mod libredfish;
 pub mod nv_redfish;
+pub mod vendor_override;

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -196,12 +196,85 @@ impl IntoModel<Evidence> for libredfish::model::component_integrity::Evidence {
     }
 }
 
+/// Parse a vendor name via libredfish's own `Deserialize` impl, so NICo keeps
+/// no vendor list. Returns `None` when the name matches no variant.
+pub fn redfish_vendor_from_str(
+    name: &str,
+) -> Option<libredfish::model::service_root::RedfishVendor> {
+    use serde::Deserialize;
+    let de = serde::de::value::StrDeserializer::<serde::de::value::Error>::new(name);
+    libredfish::model::service_root::RedfishVendor::deserialize(de).ok()
+}
+
+/// Resolve an operator stored override string into a forced `RedfishVendor`.
+/// Absent, empty, unmatched, or `Unknown` all mean no override.
+pub fn redfish_vendor_override(
+    host: &str,
+    raw: Option<&str>,
+) -> Option<libredfish::model::service_root::RedfishVendor> {
+    use libredfish::model::service_root::RedfishVendor;
+
+    let name = raw.filter(|s| !s.is_empty())?;
+    let vendor = redfish_vendor_from_str(name).filter(|vendor| *vendor != RedfishVendor::Unknown);
+    if vendor.is_none() {
+        tracing::warn!(
+            bmc = %host,
+            bmc_vendor_override = %name,
+            "bmc_vendor_override matches no usable Redfish vendor, using automatic detection"
+        );
+    }
+    vendor
+}
+
 #[cfg(test)]
 mod tests {
     use carbide_test_support::value_scenarios;
     use libredfish::model::service_root::RedfishVendor;
 
     use super::*;
+
+    #[test]
+    fn parses_known_variant_names() {
+        assert_eq!(redfish_vendor_from_str("Dell"), Some(RedfishVendor::Dell));
+        assert_eq!(
+            redfish_vendor_from_str("NvidiaDpu"),
+            Some(RedfishVendor::NvidiaDpu)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_or_miscased_names() {
+        assert_eq!(redfish_vendor_from_str("dell"), None);
+        assert_eq!(redfish_vendor_from_str("NotARealVendor"), None);
+        assert_eq!(redfish_vendor_from_str(""), None);
+    }
+
+    #[test]
+    fn override_helper_handles_empty_and_unmatched() {
+        assert_eq!(redfish_vendor_override("bmc", None), None);
+        assert_eq!(redfish_vendor_override("bmc", Some("")), None);
+        assert_eq!(
+            redfish_vendor_override("bmc", Some("Dell")),
+            Some(RedfishVendor::Dell)
+        );
+        assert_eq!(redfish_vendor_override("bmc", Some("bogus")), None);
+    }
+
+    /// `Unknown` parses, but it is the pool sentinel for an uninitialized client
+    /// rather than a pinnable vendor, so the resolver drops it for detection.
+    #[test]
+    fn override_helper_rejects_unknown_sentinel() {
+        assert_eq!(
+            redfish_vendor_from_str("Unknown"),
+            Some(RedfishVendor::Unknown),
+            "the parser reports whichever variant the name matched"
+        );
+        assert_eq!(
+            redfish_vendor_override("bmc", Some("Unknown")),
+            None,
+            "the override resolver falls back to automatic detection"
+        );
+    }
 
     #[test]
     fn redfish_vendors_map_to_bmc_vendors() {

--- a/crates/redfish/src/libredfish/implementation.rs
+++ b/crates/redfish/src/libredfish/implementation.rs
@@ -30,7 +30,11 @@ use libredfish::model::service_root::RedfishVendor;
 use libredfish::{Endpoint, Redfish};
 
 use crate::libredfish::instrumented::{InstrumentedRedfish, REDFISH_BACKEND};
-use crate::libredfish::{RedfishAuth, RedfishClientCreationError, RedfishClientPool};
+use crate::libredfish::vendor_selection::ClientMode;
+use crate::libredfish::{
+    BmcVendorOverrideResolver, RedfishAuth, RedfishClientCreationError, RedfishClientPool,
+    VendorSelection,
+};
 
 /// Formats a host for the URL authority that `libredfish` constructs internally.
 ///
@@ -49,6 +53,7 @@ pub(super) struct RedfishClientPoolImpl {
     pool: libredfish::RedfishClientPool,
     credential_reader: Arc<dyn CredentialReader>,
     proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
+    vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver>,
 }
 
 impl RedfishClientPoolImpl {
@@ -56,11 +61,31 @@ impl RedfishClientPoolImpl {
         credential_reader: Arc<dyn CredentialReader>,
         pool: libredfish::RedfishClientPool,
         proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
+        vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver>,
     ) -> Self {
         RedfishClientPoolImpl {
             credential_reader,
             pool,
             proxy_address,
+            vendor_override_resolver,
+        }
+    }
+
+    /// The operator pinned vendor for `host`, or `None` for detection.
+    /// The single place a resolver failure is handled, and it cannot fail hard.
+    async fn pinned_vendor(&self, host: &str) -> Option<RedfishVendor> {
+        match self.vendor_override_resolver.vendor_override(host).await {
+            Ok(vendor) => vendor,
+            Err(error) => {
+                // Warn, matching the `nv_redfish` pool. Every BMC client is built
+                // through here, so a quieter line would hide a resolver outage.
+                tracing::warn!(
+                    bmc = %host,
+                    %error,
+                    "Failed to resolve bmc_vendor_override, using automatic detection"
+                );
+                None
+            }
         }
     }
 }
@@ -72,7 +97,7 @@ impl RedfishClientPool for RedfishClientPoolImpl {
         host: &str,
         port: Option<u16>,
         auth: RedfishAuth,
-        vendor: Option<RedfishVendor>,
+        vendor: VendorSelection,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
         let original_host = host;
 
@@ -134,11 +159,18 @@ impl RedfishClientPool for RedfishClientPoolImpl {
             Vec::default()
         };
 
+        // Resolve the operator pin only for the modes it can apply to. The
+        // uninitialized mode returns first, as a vendor breaks factory bootstrap.
+        let mode = match vendor {
+            VendorSelection::Uninitialized => ClientMode::Uninitialized,
+            selection => selection.resolve(self.pinned_vendor(original_host).await),
+        };
+
         // The initializing paths below make HTTP calls of their own, so they
         // are metered like any other Redfish operation.
-        let client = match vendor {
+        let client = match mode {
             // Auto-detect vendor from the service root.
-            None => red::instrumented(
+            ClientMode::Detect => red::instrumented(
                 REDFISH_BACKEND,
                 "create_client",
                 self.pool
@@ -146,20 +178,14 @@ impl RedfishClientPool for RedfishClientPoolImpl {
             )
             .await
             .map_err(RedfishClientCreationError::RedfishError)?,
-            // Unknown means "no vendor" — return a standard client without
-            // making any HTTP calls (used by the anonymous probe client).
-            // This restores the behavior of the old `initialize: false` path
-            // which called create_standard_client. The full initialization
-            // path (create_client_with_vendor) makes HTTP calls to /Systems,
-            // /Managers, etc. that fail with 401 on BMCs requiring auth.
-            // With no I/O here, there is no external call to meter either.
-            Some(RedfishVendor::Unknown) => self
+            // No vendor, so return a standard client making no HTTP calls, as the
+            // anonymous probe needs. /Systems answers 401 where auth is required.
+            ClientMode::Uninitialized => self
                 .pool
                 .create_standard_client_with_custom_headers(endpoint, custom_headers)
                 .map_err(RedfishClientCreationError::RedfishError)
                 .map(|c| c as Box<dyn Redfish>)?,
-            // Use the provided vendor directly.
-            Some(vendor) => red::instrumented(
+            ClientMode::Vendor(vendor) => red::instrumented(
                 REDFISH_BACKEND,
                 "create_client",
                 self.pool
@@ -176,6 +202,10 @@ impl RedfishClientPool for RedfishClientPoolImpl {
 
     fn credential_reader(&self) -> &dyn CredentialReader {
         &*self.credential_reader
+    }
+
+    async fn pinned_bmc_vendor(&self, host: &str) -> Option<RedfishVendor> {
+        self.pinned_vendor(host).await
     }
 }
 

--- a/crates/redfish/src/libredfish/instrumented.rs
+++ b/crates/redfish/src/libredfish/instrumented.rs
@@ -430,7 +430,7 @@ mod tests {
 
     use super::*;
     use crate::libredfish::test_support::RedfishSim;
-    use crate::libredfish::{RedfishAuth, RedfishClientPool};
+    use crate::libredfish::{RedfishAuth, RedfishClientPool, VendorSelection};
 
     async fn sim_client(sim: &RedfishSim) -> InstrumentedRedfish {
         let client = sim
@@ -440,7 +440,7 @@ mod tests {
                 RedfishAuth::Key(CredentialKey::HostRedfish {
                     credential_type: CredentialType::SiteDefault,
                 }),
-                None,
+                VendorSelection::Detect,
             )
             .await
             .expect("sim client");

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -24,6 +24,7 @@ pub mod dpu_bios;
 pub mod error;
 #[cfg(feature = "test-support")]
 pub mod test_support;
+pub mod vendor_selection;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -38,6 +39,9 @@ use carbide_utils::redfish::BmcAccessInfo;
 pub use error::RedfishClientCreationError;
 use libredfish::Redfish;
 use libredfish::model::service_root::RedfishVendor;
+pub use vendor_selection::VendorSelection;
+
+use crate::vendor_override::BmcVendorOverrideResolver;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
 enum DpuUefiPasswordSetupSkipReason {
@@ -97,15 +101,19 @@ fn emit_dpu_uefi_password_setup_skipped_if_needed(
     true
 }
 
+/// Builds the production client pool.
+/// Pass [`NoBmcVendorOverrides`] to opt out of the operator vendor pin.
 pub fn new_pool(
     credential_reader: Arc<dyn CredentialReader>,
     pool: libredfish::RedfishClientPool,
     proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
+    vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver>,
 ) -> Arc<dyn RedfishClientPool> {
     Arc::new(implementation::RedfishClientPoolImpl::new(
         credential_reader,
         pool,
         proxy_address,
+        vendor_override_resolver,
     ))
 }
 
@@ -115,20 +123,21 @@ pub trait RedfishClientPool: Send + Sync + 'static {
     // MARK: - Required methods
 
     /// Creates a new Redfish client for a Machines BMC.
-    /// `host` is the IP address or hostname of the BMC.
-    /// `vendor` allows you to pre-assign the underlying
-    /// RedfishVendor to use for the client, saving the
-    /// service root call to auto-detect the vendor.
+    /// Every BMC client is built here, so this is where an operator pin applies.
     async fn create_client(
         &self,
         host: &str,
         port: Option<u16>,
         auth: RedfishAuth,
-        vendor: Option<RedfishVendor>,
+        vendor: VendorSelection,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError>;
 
     /// Returns a CredentialReader for use in setting credentials in the UEFI/BMC.
     fn credential_reader(&self) -> &dyn CredentialReader;
+
+    /// The operator pinned vendor for this BMC, or `None` for detection.
+    /// For callers needing the pin as a value rather than as a client.
+    async fn pinned_bmc_vendor(&self, host: &str) -> Option<RedfishVendor>;
 
     // MARK: - Default (helper) methods
 
@@ -141,7 +150,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 &bmc_ip_address.ip().to_string(),
                 Some(bmc_ip_address.port()),
                 RedfishAuth::Anonymous,
-                Some(RedfishVendor::Unknown),
+                VendorSelection::Uninitialized,
             )
             .await?;
 
@@ -153,6 +162,8 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Builds a client for a BMC described by a [`BmcAccessInfo`].
+    /// Asks for detection, since `create_client` applies any pin itself.
     async fn client_by_info(
         &self,
         access: &BmcAccessInfo,
@@ -161,7 +172,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
             &access.host,
             access.port,
             RedfishAuth::for_bmc_mac(access.mac_address),
-            None,
+            VendorSelection::Detect,
         )
         .await
     }
@@ -375,7 +386,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 host,
                 port,
                 RedfishAuth::Direct(curr_user.clone(), curr_password.clone()),
-                Some(RedfishVendor::Unknown),
+                VendorSelection::Uninitialized,
             )
             .await?;
 
@@ -470,7 +481,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 host,
                 port,
                 RedfishAuth::Direct(curr_user.to_string(), new_password),
-                Some(vendor),
+                VendorSelection::Hint(vendor),
             )
             .await?;
 
@@ -499,7 +510,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 host,
                 port,
                 RedfishAuth::Direct(root_user.clone(), root_password.clone()),
-                Some(RedfishVendor::Unknown),
+                VendorSelection::Uninitialized,
             )
             .await?;
 
@@ -549,7 +560,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 host,
                 port,
                 RedfishAuth::Direct(username, password),
-                Some(RedfishVendor::Unknown),
+                VendorSelection::Uninitialized,
             )
             .await?;
 
@@ -577,15 +588,15 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         port: Option<u16>,
         credentials: Credentials,
     ) -> Result<RedfishVendor, RedfishClientCreationError> {
-        // Anonymous service-root probe. An uninitialized `Unknown` client is
-        // enough to read `/redfish/v1`, and works on factory BMCs that would
+        // Anonymous service-root probe. An uninitialized client is enough to
+        // read `/redfish/v1`, and works on factory BMCs that would
         // otherwise block reads until the password is rotated.
         let anon_client = self
             .create_client(
                 host,
                 port,
                 RedfishAuth::Anonymous,
-                Some(RedfishVendor::Unknown),
+                VendorSelection::Uninitialized,
             )
             .await?;
 
@@ -598,9 +609,16 @@ pub trait RedfishClientPool: Send + Sync + 'static {
 
         // Chassis `Manufacturer` fallback for BMCs (Lite-On / Delta power
         // shelves) that don't expose a recognized vendor in the service root.
+        // Uninitialized, so this stays the BMC's own answer and no pin reaches it.
+        // Detection just failed here anyway, so there is no vendor to initialize.
         let Credentials::UsernamePassword { username, password } = credentials;
         let client = self
-            .create_client(host, port, RedfishAuth::Direct(username, password), None)
+            .create_client(
+                host,
+                port,
+                RedfishAuth::Direct(username, password),
+                VendorSelection::Uninitialized,
+            )
             .await?;
 
         let chassis_ids = client
@@ -625,6 +643,22 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         Err(RedfishClientCreationError::RedfishError(
             libredfish::RedfishError::MissingVendor,
         ))
+    }
+
+    /// The vendor `set_bmc_root_password` branches on for this BMC.
+    /// A pin answers it outright, and pins the branch only, never a client.
+    async fn dispatch_bmc_vendor(
+        &self,
+        host: &str,
+        port: Option<u16>,
+        credentials: Credentials,
+    ) -> Result<RedfishVendor, RedfishClientCreationError> {
+        // A pin exists because what the BMC reports about itself is absent or
+        // wrong, which is all the probe has to go on, so it cannot answer this.
+        match self.pinned_bmc_vendor(host).await {
+            Some(pinned) => Ok(pinned),
+            None => self.probe_bmc_vendor(host, port, credentials).await,
+        }
     }
 }
 
@@ -935,7 +969,7 @@ mod tests {
                 RedfishAuth::Key(CredentialKey::HostRedfish {
                     credential_type: CredentialType::SiteDefault,
                 }),
-                None,
+                VendorSelection::Detect,
             )
             .await
             .unwrap();
@@ -954,7 +988,7 @@ mod tests {
                 RedfishAuth::Key(CredentialKey::HostRedfish {
                     credential_type: CredentialType::SiteDefault,
                 }),
-                None,
+                VendorSelection::Detect,
             )
             .await
             .unwrap();
@@ -1001,6 +1035,66 @@ mod tests {
             .into_iter()
             .map(|call| call.vendor)
             .collect()
+    }
+
+    /// `client_by_info` is the shared entry point, so a pin must reach the client.
+    /// It asks for detection and the pool applies the pin, as every caller does.
+    #[tokio::test]
+    async fn client_by_info_applies_the_operator_pin() {
+        const HOST: &str = "127.0.0.1";
+
+        async fn vendor_passed_for(pin: Option<RedfishVendor>) -> Option<RedfishVendor> {
+            let sim = RedfishSim::default();
+            if let Some(pin) = pin {
+                sim.set_vendor_override(HOST, pin);
+            }
+            let access = BmcAccessInfo {
+                host: HOST.to_string(),
+                port: Some(443),
+                mac_address: mac_address::MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]),
+            };
+
+            sim.client_by_info(&access).await.expect("sim client");
+
+            let calls = sim.create_client_calls();
+            assert_eq!(calls.len(), 1, "one client per client_by_info call");
+            assert_eq!(
+                calls[0].selection,
+                VendorSelection::Detect,
+                "client_by_info must delegate the pin to the pool, not resolve it itself"
+            );
+            calls[0].vendor
+        }
+
+        assert_eq!(
+            vendor_passed_for(Some(RedfishVendor::Dell)).await,
+            Some(RedfishVendor::Dell),
+            "a pinned vendor must reach create_client"
+        );
+        assert_eq!(
+            vendor_passed_for(None).await,
+            None,
+            "no pin leaves automatic detection in place"
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_pin_is_scoped_to_its_own_host() {
+        let sim = RedfishSim::default();
+        sim.set_vendor_override("127.0.0.1", RedfishVendor::Dell);
+
+        let access = BmcAccessInfo {
+            host: "127.0.0.2".to_string(),
+            port: Some(443),
+            mac_address: mac_address::MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x02]),
+        };
+        sim.client_by_info(&access).await.expect("sim client");
+
+        assert_eq!(
+            sim.create_client_calls()[0].vendor,
+            None,
+            "an unpinned BMC must still auto-detect"
+        );
     }
 
     #[tokio::test]
@@ -1166,6 +1260,66 @@ mod tests {
         let sim = RedfishSim::default();
         let vendor = sim
             .probe_bmc_vendor("127.0.0.1", Some(443), Credentials::new("root", "pw"))
+            .await
+            .unwrap();
+        // The sim's service root reports Nvidia / "GB200 NVL".
+        assert_eq!(vendor, RedfishVendor::NvidiaGBx00);
+    }
+
+    /// The pin has to answer the dispatch vendor without asking, since the BMC
+    /// it is set on is the one whose own answer cannot be trusted.
+    #[tokio::test]
+    async fn dispatch_bmc_vendor_answers_from_the_pin_without_probing() {
+        let sim = RedfishSim::default();
+        sim.set_service_root_vendor(Some("Unrecognized Vendor".to_string()));
+        sim.set_vendor_override("127.0.0.1", RedfishVendor::Dell);
+
+        let vendor = sim
+            .dispatch_bmc_vendor("127.0.0.1", Some(443), Credentials::new("root", "pw"))
+            .await
+            .expect("a pinned BMC resolves without a usable service root");
+
+        assert_eq!(vendor, RedfishVendor::Dell);
+        assert!(
+            sim.create_client_calls().is_empty(),
+            "a pinned dispatch vendor must cost no client and no BMC call"
+        );
+    }
+
+    /// The operator vendor probe reports what the BMC says about itself, so a
+    /// pin must not reach it, including on the chassis fallback.
+    #[tokio::test]
+    async fn probe_bmc_vendor_stays_uninitialized_on_a_pinned_host() {
+        let sim = RedfishSim::default();
+        sim.set_service_root_vendor(Some("Unrecognized Vendor".to_string()));
+        sim.set_chassis_manufacturer(Some("Lite-On Technology Corp.".to_string()));
+        sim.set_vendor_override("127.0.0.1", RedfishVendor::Dell);
+
+        let vendor = sim
+            .probe_bmc_vendor("127.0.0.1", Some(443), Credentials::new("root", "pw"))
+            .await
+            .expect("the chassis fallback still resolves a vendor");
+
+        assert_eq!(
+            vendor,
+            RedfishVendor::LiteOnPowerShelf,
+            "the probe reports the chassis answer, not the pin"
+        );
+        let calls = sim.create_client_calls();
+        assert!(
+            calls
+                .iter()
+                .all(|call| call.selection == VendorSelection::Uninitialized),
+            "every probe client must stay uninitialized, got {calls:?}"
+        );
+    }
+
+    /// Unpinned hosts keep resolving the way they did before pins existed.
+    #[tokio::test]
+    async fn dispatch_bmc_vendor_falls_back_to_the_probe_when_unpinned() {
+        let sim = RedfishSim::default();
+        let vendor = sim
+            .dispatch_bmc_vendor("127.0.0.1", Some(443), Credentials::new("root", "pw"))
             .await
             .unwrap();
         // The sim's service root reports Nvidia / "GB200 NVL".

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -43,7 +43,10 @@ use libredfish::{
 };
 use mac_address::MacAddress;
 
-use crate::libredfish::{RedfishAuth, RedfishClientCreationError, RedfishClientPool};
+use crate::libredfish::vendor_selection::ClientMode;
+use crate::libredfish::{
+    RedfishAuth, RedfishClientCreationError, RedfishClientPool, VendorSelection,
+};
 
 const TRIGGER_EVIDENCE_TASK_ID: &str = "SpdmTriggerEvidenceTaskId";
 
@@ -73,6 +76,9 @@ struct RedfishSimState {
     /// Records every call to `RedfishClientPool::create_client` so tests can
     /// assert what vendor was passed at each call site.
     create_client_calls: Vec<CreateClientCall>,
+    /// Operator pinned vendors by BMC host, standing in for the stored value.
+    /// Empty by default, so seed it to assert a pin reaches a given call site.
+    vendor_overrides: HashMap<String, RedfishVendor>,
     /// When set, `change_password` fails with
     /// [`RedfishError::PasswordChangeRequired`] to model a factory BMC (e.g.
     /// Viking) that refuses the by-username change until the initial
@@ -146,6 +152,11 @@ fn sim_http_error(status: http::StatusCode, url: &str, body: &str) -> RedfishErr
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreateClientCall {
     pub host: String,
+    /// What the call site asked for, before any pin was applied. Assert on this
+    /// to prove a probe path stayed uninitialized.
+    pub selection: VendorSelection,
+    /// The vendor the client was built with, after the pin was applied. `None`
+    /// means detection. Assert on this to prove a pin took effect.
     pub vendor: Option<RedfishVendor>,
 }
 
@@ -443,6 +454,16 @@ impl RedfishSim {
     /// drive model-specific behavior such as DPU factory credential selection.
     pub fn set_service_root_product(&self, product: Option<String>) {
         self.state.lock().unwrap().service_root_product = product;
+    }
+
+    /// Pin an operator vendor for `host`, standing in for the stored value.
+    /// `host` must match what the call site passes, the BMC IP without its port.
+    pub fn set_vendor_override(&self, host: &str, vendor: RedfishVendor) {
+        self.state
+            .lock()
+            .unwrap()
+            .vendor_overrides
+            .insert(host.to_string(), vendor);
     }
 
     /// Override the `Manufacturer` reported by `get_chassis`, so tests can
@@ -2431,13 +2452,24 @@ impl RedfishClientPool for RedfishSim {
         host: &str,
         port: Option<u16>,
         auth: RedfishAuth,
-        vendor: Option<RedfishVendor>,
+        vendor: VendorSelection,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
         {
             let mut state = self.state.lock().unwrap();
+            // Apply the seeded pin as the production pool does, so a test
+            // asserting on `vendor` sees what a real client would dispatch on.
+            let pin = state.vendor_overrides.get(host).copied();
+            let applied = match vendor.resolve(pin) {
+                ClientMode::Detect => None,
+                ClientMode::Vendor(vendor) => Some(vendor),
+                // Recorded as `Unknown` to match how this mode was spelled
+                // before `VendorSelection`, which the rotation assertions read.
+                ClientMode::Uninitialized => Some(RedfishVendor::Unknown),
+            };
             state.create_client_calls.push(CreateClientCall {
                 host: host.to_string(),
-                vendor,
+                selection: vendor,
+                vendor: applied,
             });
             let default_lockdown = state.default_lockdown.unwrap_or(EnabledDisabled::Disabled);
             state
@@ -2461,6 +2493,15 @@ impl RedfishClientPool for RedfishSim {
 
     fn credential_reader(&self) -> &dyn CredentialReader {
         &self.credential_manager
+    }
+
+    async fn pinned_bmc_vendor(&self, host: &str) -> Option<RedfishVendor> {
+        self.state
+            .lock()
+            .unwrap()
+            .vendor_overrides
+            .get(host)
+            .copied()
     }
 
     async fn uefi_setup(

--- a/crates/redfish/src/libredfish/vendor_selection.rs
+++ b/crates/redfish/src/libredfish/vendor_selection.rs
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use libredfish::model::service_root::RedfishVendor;
+
+/// How `create_client` picks the vendor implementation a client dispatches on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VendorSelection {
+    /// Detect the vendor from the BMC service root.
+    /// An operator pin wins instead, since a pin exists for wrong detection.
+    Detect,
+    /// A vendor the caller resolved itself, from DMI or a probe.
+    /// An operator pin outranks it, being the operator correction to detection.
+    Hint(RedfishVendor),
+    /// Probe and bootstrap mode, an uninitialized client that fetches nothing.
+    /// Never pinned, as factory GBx00 BMCs refuse `/Systems` until rotation.
+    Uninitialized,
+}
+
+/// The client construction mode after any operator pin has been applied.
+/// Separate from [`VendorSelection`] so precedence stays one pure function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClientMode {
+    Detect,
+    Vendor(RedfishVendor),
+    Uninitialized,
+}
+
+impl VendorSelection {
+    /// Apply the operator pin to this selection.
+    /// A pin wins over `Detect` and `Hint`, and `Uninitialized` ignores it.
+    pub(crate) fn resolve(self, pin: Option<RedfishVendor>) -> ClientMode {
+        match (self, pin) {
+            // Never pinnable. The caller asked for a client that can reach a BMC
+            // no vendor client can initialize against yet.
+            (Self::Uninitialized, _) => ClientMode::Uninitialized,
+            (Self::Detect | Self::Hint(_), Some(pinned)) => ClientMode::Vendor(pinned),
+            (Self::Detect, None) => ClientMode::Detect,
+            (Self::Hint(vendor), None) => ClientMode::Vendor(vendor),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[test]
+    fn pin_outranks_detection_but_never_the_uninitialized_mode() {
+        value_scenarios!(
+            run = |(selection, pin): (VendorSelection, Option<RedfishVendor>)| selection
+                .resolve(pin);
+
+            "no pin leaves the caller's intent intact" {
+                (VendorSelection::Detect, None) => ClientMode::Detect,
+                (VendorSelection::Hint(RedfishVendor::Dell), None)
+                    => ClientMode::Vendor(RedfishVendor::Dell),
+                (VendorSelection::Uninitialized, None) => ClientMode::Uninitialized,
+            }
+
+            "a pin wins over detection and over a caller-resolved vendor" {
+                (VendorSelection::Detect, Some(RedfishVendor::Dell))
+                    => ClientMode::Vendor(RedfishVendor::Dell),
+                (VendorSelection::Hint(RedfishVendor::NvidiaGBx00), Some(RedfishVendor::Dell))
+                    => ClientMode::Vendor(RedfishVendor::Dell),
+            }
+
+            // The rule factory BMC bootstrap and credential rotation depend on.
+            // If this row ever flips, rotation deadlocks on factory GBx00 BMCs.
+            "a pin never reaches the uninitialized mode" {
+                (VendorSelection::Uninitialized, Some(RedfishVendor::Dell))
+                    => ClientMode::Uninitialized,
+            }
+        );
+    }
+}

--- a/crates/redfish/src/nv_redfish/mod.rs
+++ b/crates/redfish/src/nv_redfish/mod.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+pub mod vendor_pin;
+
 use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
@@ -26,6 +28,7 @@ use arc_swap::ArcSwap;
 use carbide_secrets::credentials::Credentials;
 use carbide_utils::HostPortPair;
 use carbide_utils::redfish::format_forwarded_host_parameter;
+use libredfish::model::service_root::RedfishVendor;
 pub use nv_redfish::bmc_http::reqwest::BmcError;
 use nv_redfish::bmc_http::reqwest::{
     Client as RedfishReqwestClient, ClientParams as RedfishReqwestClientParams,
@@ -35,8 +38,11 @@ use nv_redfish::oem::hpe::ilo_service_ext::ManagerType as HpeManagerType;
 use nv_redfish::{Error as NvError, ServiceRoot as NvServiceRoot};
 use reqwest::header::HeaderMap;
 use url::Url;
+use vendor_pin::VendorPinnedHttpClient;
 
-pub type RedfishBmc = HttpBmc<RedfishReqwestClient>;
+use crate::vendor_override::BmcVendorOverrideResolver;
+
+pub type RedfishBmc = HttpBmc<VendorPinnedHttpClient<RedfishReqwestClient>>;
 pub type ServiceRoot = NvServiceRoot<RedfishBmc>;
 pub type Error = NvError<RedfishBmc>;
 
@@ -44,14 +50,20 @@ pub type Error = NvError<RedfishBmc>;
 /// observe BMC replacements, upgrades, and configuration changes.
 const DEFAULT_SERVICE_ROOT_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 
-pub fn new_pool(proxy_address: Arc<ArcSwap<Option<HostPortPair>>>) -> Arc<NvRedfishClientPool> {
-    NvRedfishClientPool::new(proxy_address).into()
+/// Builds the production pool.
+/// Pass [`NoBmcVendorOverrides`] to opt out of the operator vendor pin.
+pub fn new_pool(
+    proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
+    vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver>,
+) -> Arc<NvRedfishClientPool> {
+    NvRedfishClientPool::new(proxy_address, vendor_override_resolver).into()
 }
 
 pub struct NvRedfishClientPool {
     proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
     cache: Arc<Mutex<ServiceRootCache>>,
     cache_ttl: Duration,
+    vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver>,
 }
 
 #[derive(Default)]
@@ -113,11 +125,21 @@ struct PoolKey {
     proxy_address: Arc<Option<HostPortPair>>,
     bmc_address: SocketAddr,
     credentials: BmcCredentials,
+    /// The pin the cached root was built under. Keyed so that setting or clearing
+    /// a pin takes effect on the next call instead of after the cache lifetime.
+    pinned_vendor: Option<RedfishVendor>,
 }
 
 impl NvRedfishClientPool {
-    pub fn new(proxy_address: Arc<ArcSwap<Option<HostPortPair>>>) -> Self {
-        Self::with_cache_ttl(proxy_address, DEFAULT_SERVICE_ROOT_CACHE_TTL)
+    pub fn new(
+        proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
+        vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver>,
+    ) -> Self {
+        Self::with_cache_ttl(
+            proxy_address,
+            DEFAULT_SERVICE_ROOT_CACHE_TTL,
+            vendor_override_resolver,
+        )
     }
 
     /// Creates a client pool with an explicit service-root cache lifetime.
@@ -127,11 +149,29 @@ impl NvRedfishClientPool {
     pub fn with_cache_ttl(
         proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
         cache_ttl: Duration,
+        vendor_override_resolver: Arc<dyn BmcVendorOverrideResolver>,
     ) -> Self {
         Self {
             proxy_address,
             cache: Default::default(),
             cache_ttl,
+            vendor_override_resolver,
+        }
+    }
+
+    /// The operator pinned vendor for `host`, or `None` for detection.
+    /// A resolver failure is advisory here, so it warns and falls back.
+    async fn pinned_bmc_vendor(&self, host: &str) -> Option<RedfishVendor> {
+        match self.vendor_override_resolver.vendor_override(host).await {
+            Ok(vendor) => vendor,
+            Err(error) => {
+                tracing::warn!(
+                    bmc = %host,
+                    %error,
+                    "Failed to resolve bmc_vendor_override, using automatic detection"
+                );
+                None
+            }
         }
     }
 
@@ -156,12 +196,18 @@ impl NvRedfishClientPool {
 
         let Credentials::UsernamePassword { username, password } = credentials;
         let bmc_credentials = BmcCredentials::new(username, password);
+        let pinned_vendor = self.pinned_bmc_vendor(&bmc_address.ip().to_string()).await;
 
-        if let Some(sevice_root) = self.cached_root(bmc_address, bmc_credentials.clone()) {
+        if let Some(sevice_root) =
+            self.cached_root(bmc_address, bmc_credentials.clone(), pinned_vendor)
+        {
             Ok(sevice_root)
         } else {
-            let bmc = self.create_bmc(bmc_address, bmc_credentials.clone(), false)?;
+            let bmc =
+                self.create_bmc(bmc_address, bmc_credentials.clone(), false, pinned_vendor)?;
             let service_root = ServiceRoot::new(bmc).await?;
+            // A pin to `Hpe` already reads back as `HPE`, since the decorator
+            // rewrote the service root before this parsed it.
             let service_root = if service_root.vendor()
                 == Some(nv_redfish::service_root::Vendor::new("HPE"))
                 && let Some(HpeManagerType::Ilo(version)) = service_root
@@ -179,14 +225,20 @@ impl NvRedfishClientPool {
                 // when reqwest thinks that connection is alive but it
                 // is about to close by server. Reusing such
                 // connections causes errors.
-                let bmc = self.create_bmc(bmc_address, bmc_credentials.clone(), true)?;
+                let bmc =
+                    self.create_bmc(bmc_address, bmc_credentials.clone(), true, pinned_vendor)?;
                 service_root.replace_bmc(bmc.clone())
             } else {
                 service_root
             };
             let service_root = Arc::new(service_root);
             if should_cache(&service_root) {
-                self.update_cache(bmc_address, bmc_credentials, service_root.clone());
+                self.update_cache(
+                    bmc_address,
+                    bmc_credentials,
+                    pinned_vendor,
+                    service_root.clone(),
+                );
             }
             Ok(service_root)
         }
@@ -196,12 +248,14 @@ impl NvRedfishClientPool {
         &self,
         bmc_address: SocketAddr,
         credentials: BmcCredentials,
+        pinned_vendor: Option<RedfishVendor>,
     ) -> Option<Arc<ServiceRoot>> {
         let proxy_address = self.proxy_address.load();
         let key = PoolKey {
             proxy_address: proxy_address.clone(),
             bmc_address,
             credentials,
+            pinned_vendor,
         };
         self.cache
             .lock()
@@ -215,6 +269,7 @@ impl NvRedfishClientPool {
         &self,
         bmc_address: SocketAddr,
         credentials: BmcCredentials,
+        pinned_vendor: Option<RedfishVendor>,
         root: Arc<ServiceRoot>,
     ) {
         let proxy_address = self.proxy_address.load();
@@ -222,6 +277,7 @@ impl NvRedfishClientPool {
             proxy_address: proxy_address.clone(),
             bmc_address,
             credentials,
+            pinned_vendor,
         };
         let mut cache = self
             .cache
@@ -263,11 +319,12 @@ impl NvRedfishClientPool {
         }
     }
 
-    pub fn create_bmc(
+    fn create_bmc(
         &self,
         bmc_address: SocketAddr,
         credentials: BmcCredentials,
         connection_close: bool,
+        pinned_vendor: Option<RedfishVendor>,
     ) -> Result<Arc<RedfishBmc>, Error> {
         let proxy_address = self.proxy_address.load();
         let bmc_url = build_bmc_url(proxy_address.as_ref(), bmc_address)
@@ -293,6 +350,8 @@ impl NvRedfishClientPool {
             RedfishReqwestClientParams::new().accept_invalid_certs(true),
         )
         .map_err(|err| Error::Bmc(err.into()))?;
+        // Wrapped so the pin reaches the platform `nv_redfish` classifies.
+        let client = VendorPinnedHttpClient::new(client, pinned_vendor);
         Ok(Arc::new(RedfishBmc::with_custom_headers(
             client,
             bmc_url,
@@ -342,6 +401,7 @@ mod tests {
             proxy_address: Arc::new(None),
             bmc_address: "127.0.0.1:443".parse().unwrap(),
             credentials: BmcCredentials::new("root".to_string(), "password".to_string()),
+            pinned_vendor: None,
         };
         let mut cache = ServiceRootCache {
             expirations: BinaryHeap::from([Reverse(CacheExpiration {

--- a/crates/redfish/src/nv_redfish/vendor_pin.rs
+++ b/crates/redfish/src/nv_redfish/vendor_pin.rs
@@ -1,0 +1,406 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Applies the operator vendor pin to what `nv_redfish` reads.
+//! It takes no forced vendor, so its service root is rewritten instead.
+
+use std::future::Future;
+
+use libredfish::model::service_root::RedfishVendor;
+use nv_redfish::bmc_http::credentials::BmcCredentials;
+use nv_redfish::bmc_http::reqwest::BmcError;
+use nv_redfish::bmc_http::{HttpClient, MultipartUpdateRequest};
+use nv_redfish::core::odata::ODataETag;
+use nv_redfish::core::upload::UploadReader;
+use nv_redfish::core::{BoxTryStream, ModificationResponse, SessionCreateResponse};
+use reqwest::header::HeaderMap;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use url::Url;
+
+/// What a pin writes into the service root vendor field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VendorWrite {
+    Set(&'static str),
+    /// Some platforms are recognized by the absence of a vendor.
+    Remove,
+}
+
+/// The service root vendor a pin asserts, as `nv_redfish` spells it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PinnedIdentity {
+    vendor: VendorWrite,
+}
+
+/// The vendor a pin asserts, or `None` to leave the service root untouched.
+/// Only the vendor is written, so classification proceeds as it always would.
+fn pinned_identity(pin: RedfishVendor) -> Option<PinnedIdentity> {
+    let vendor = match pin {
+        RedfishVendor::Dell => VendorWrite::Set("Dell"),
+        RedfishVendor::Hpe => VendorWrite::Set("HPE"),
+        RedfishVendor::AMI => VendorWrite::Set("AMI"),
+        RedfishVendor::Lenovo | RedfishVendor::LenovoAMI | RedfishVendor::LenovoGB300 => {
+            VendorWrite::Set("Lenovo")
+        }
+        RedfishVendor::Supermicro => VendorWrite::Set("Supermicro"),
+        // BlueField reports the mixed case spelling, the rest report upper case.
+        RedfishVendor::NvidiaDpu => VendorWrite::Set("Nvidia"),
+        RedfishVendor::NvidiaGBx00
+        | RedfishVendor::NvidiaGH200
+        | RedfishVendor::VeraRubin
+        | RedfishVendor::NvidiaGBSwitch
+        | RedfishVendor::P3809 => VendorWrite::Set("NVIDIA"),
+        // Both shelves present with no vendor, which is how they are recognized.
+        RedfishVendor::LiteOnPowerShelf | RedfishVendor::DeltaPowerShelf => VendorWrite::Remove,
+        // Sushy is a development emulator `nv_redfish` does not classify, so a
+        // pin has no vendor to assert and the service root is left untouched.
+        RedfishVendor::Sushy | RedfishVendor::Unknown => return None,
+    };
+
+    Some(PinnedIdentity { vendor })
+}
+
+impl PinnedIdentity {
+    /// Rewrite the vendor on a fetched service root, in place.
+    fn apply(self, body: &mut serde_json::Value) {
+        let Some(root) = body.as_object_mut() else {
+            return;
+        };
+        match self.vendor {
+            VendorWrite::Set(vendor) => {
+                root.insert("Vendor".to_string(), serde_json::Value::from(vendor));
+            }
+            VendorWrite::Remove => {
+                root.remove("Vendor");
+            }
+        }
+    }
+}
+
+/// True for the service root, the one response a pin rewrites.
+fn is_service_root(url: &Url) -> bool {
+    matches!(url.path(), "/redfish/v1" | "/redfish/v1/")
+}
+
+/// Wraps an HTTP client so the operator vendor pin reaches `nv_redfish`.
+pub struct VendorPinnedHttpClient<C> {
+    inner: C,
+    identity: Option<PinnedIdentity>,
+}
+
+impl<C> VendorPinnedHttpClient<C> {
+    pub fn new(inner: C, pin: Option<RedfishVendor>) -> Self {
+        Self {
+            inner,
+            identity: pin.and_then(pinned_identity),
+        }
+    }
+}
+
+impl<C> HttpClient for VendorPinnedHttpClient<C>
+where
+    C: HttpClient<Error = BmcError>,
+{
+    type Error = BmcError;
+
+    async fn get<T>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        etag: Option<ODataETag>,
+        custom_headers: &HeaderMap,
+    ) -> Result<T, Self::Error>
+    where
+        T: DeserializeOwned + Send + Sync,
+    {
+        let Some(identity) = self.identity.filter(|_| is_service_root(&url)) else {
+            return self.inner.get(url, credentials, etag, custom_headers).await;
+        };
+
+        // Parsed twice, since `HttpClient` hands back a deserialized value rather
+        // than bytes. Bounded to one document per pinned BMC per cache miss.
+        let mut body: serde_json::Value = self
+            .inner
+            .get(url, credentials, etag, custom_headers)
+            .await?;
+        identity.apply(&mut body);
+        serde_json::from_value(body).map_err(BmcError::DecodeError)
+    }
+
+    fn post<B, T>(
+        &self,
+        url: Url,
+        body: &B,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner.post(url, body, credentials, custom_headers)
+    }
+
+    fn post_session<B, T>(
+        &self,
+        url: Url,
+        body: &B,
+        custom_headers: &HeaderMap,
+    ) -> impl Future<Output = Result<SessionCreateResponse<T>, Self::Error>> + Send
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner.post_session(url, body, custom_headers)
+    }
+
+    fn post_multipart_update<U, V, T>(
+        &self,
+        url: Url,
+        request: MultipartUpdateRequest<'_, U, V>,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+    where
+        U: UploadReader,
+        T: DeserializeOwned + Send + Sync,
+        V: Serialize + Send + Sync,
+    {
+        self.inner
+            .post_multipart_update(url, request, credentials, custom_headers)
+    }
+
+    fn patch<B, T>(
+        &self,
+        url: Url,
+        etag: ODataETag,
+        body: &B,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner
+            .patch(url, etag, body, credentials, custom_headers)
+    }
+
+    fn delete<T>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+    where
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner.delete(url, credentials, custom_headers)
+    }
+
+    fn sse<T: Sized + for<'de> serde::Deserialize<'de> + Send>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> impl Future<Output = Result<BoxTryStream<T, Self::Error>, Self::Error>> + Send {
+        self.inner.sse(url, credentials, custom_headers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    fn root() -> serde_json::Value {
+        serde_json::json!({
+            "@odata.id": "/redfish/v1/",
+            "Vendor": "AMI",
+            "Product": "Some Product",
+            "RedfishVersion": "1.15.1",
+        })
+    }
+
+    fn applied(pin: RedfishVendor) -> serde_json::Value {
+        let mut body = root();
+        if let Some(identity) = pinned_identity(pin) {
+            identity.apply(&mut body);
+        }
+        body
+    }
+
+    /// A pin names a vendor and nothing else, so every other field the BMC
+    /// reported survives and `nv_redfish` classifies as it always would.
+    #[test]
+    fn a_rewritten_root_carries_the_pinned_vendor_and_nothing_else() {
+        value_scenarios!(
+            run = |pin: RedfishVendor| {
+                let body = applied(pin);
+                (
+                    body.get("Vendor").and_then(|v| v.as_str()).map(str::to_string),
+                    body.get("Product").and_then(|v| v.as_str()).map(str::to_string),
+                    body.get("RedfishVersion").and_then(|v| v.as_str()).map(str::to_string),
+                )
+            };
+
+            "a pinned vendor replaces the reported one" {
+                RedfishVendor::Dell => (
+                    Some("Dell".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::Hpe => (
+                    Some("HPE".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::Supermicro => (
+                    Some("Supermicro".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::AMI => (
+                    Some("AMI".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+            }
+
+            "the three Lenovo pins share one wire spelling" {
+                RedfishVendor::Lenovo => (
+                    Some("Lenovo".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::LenovoAMI => (
+                    Some("Lenovo".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::LenovoGB300 => (
+                    Some("Lenovo".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+            }
+
+            "BlueField uses the mixed case spelling, the rest upper case" {
+                RedfishVendor::NvidiaDpu => (
+                    Some("Nvidia".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::NvidiaGBx00 => (
+                    Some("NVIDIA".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::VeraRubin => (
+                    Some("NVIDIA".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::NvidiaGH200 => (
+                    Some("NVIDIA".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::NvidiaGBSwitch => (
+                    Some("NVIDIA".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::P3809 => (
+                    Some("NVIDIA".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+            }
+
+            "both shelves present with no vendor at all" {
+                RedfishVendor::LiteOnPowerShelf => (
+                    None,
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::DeltaPowerShelf => (
+                    None,
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+            }
+
+            "an unusable pin leaves the root untouched" {
+                RedfishVendor::Unknown => (
+                    Some("AMI".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+                RedfishVendor::Sushy => (
+                    Some("AMI".to_string()),
+                    Some("Some Product".to_string()),
+                    Some("1.15.1".to_string()),
+                ),
+            }
+        );
+    }
+
+    /// A malformed root must pass through rather than panic, since this runs in
+    /// the HTTP path for pinned hosts.
+    #[test]
+    fn applying_a_pin_to_a_body_that_is_not_an_object_changes_nothing() {
+        let identity = pinned_identity(RedfishVendor::Dell).expect("Dell rewrites");
+        for mut body in [
+            serde_json::json!([]),
+            serde_json::json!("not a root"),
+            serde_json::json!(null),
+        ] {
+            let before = body.clone();
+            identity.apply(&mut body);
+            assert_eq!(body, before, "a non object body must pass through");
+        }
+    }
+
+    /// Removing a vendor that was never there has to be a no op, not a panic.
+    #[test]
+    fn removing_an_absent_vendor_is_tolerated() {
+        let identity = pinned_identity(RedfishVendor::LiteOnPowerShelf).expect("LiteOn rewrites");
+        let mut body = serde_json::json!({ "@odata.id": "/redfish/v1/" });
+        identity.apply(&mut body);
+
+        assert_eq!(body, serde_json::json!({ "@odata.id": "/redfish/v1/" }));
+    }
+
+    /// Only the service root is rewritten, so no other resource is touched.
+    #[test]
+    fn only_the_service_root_is_rewritten() {
+        assert!(is_service_root(
+            &Url::parse("https://bmc/redfish/v1").unwrap()
+        ));
+        assert!(is_service_root(
+            &Url::parse("https://bmc/redfish/v1/").unwrap()
+        ));
+        assert!(!is_service_root(
+            &Url::parse("https://bmc/redfish/v1/Systems").unwrap()
+        ));
+        assert!(!is_service_root(
+            &Url::parse("https://bmc/redfish/v1/Chassis/1").unwrap()
+        ));
+    }
+}

--- a/crates/redfish/src/vendor_override.rs
+++ b/crates/redfish/src/vendor_override.rs
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use async_trait::async_trait;
+use libredfish::model::service_root::RedfishVendor;
+
+/// Resolves the operator pinned Redfish vendor for a BMC.
+/// Injected so this crate need not reach the database, and keyed by host.
+#[async_trait]
+pub trait BmcVendorOverrideResolver: Send + Sync + 'static {
+    /// The pinned vendor for the BMC at `host`, or `None` when it has no pin.
+    /// `host` is the real BMC host, never the site wide BMC proxy in its place.
+    async fn vendor_override(
+        &self,
+        host: &str,
+    ) -> Result<Option<RedfishVendor>, VendorOverrideError>;
+}
+
+/// A pin lookup that failed.
+/// Advisory, so the pool warns and falls back to detection.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to resolve bmc_vendor_override for {host}: {source}")]
+pub struct VendorOverrideError {
+    pub host: String,
+    #[source]
+    pub source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl VendorOverrideError {
+    pub fn new(
+        host: impl Into<String>,
+        source: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            source: source.into(),
+        }
+    }
+}
+
+/// A resolver that never pins anything.
+/// Named rather than absent so having no pins is visible at the call site.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoBmcVendorOverrides;
+
+#[async_trait]
+impl BmcVendorOverrideResolver for NoBmcVendorOverrides {
+    async fn vendor_override(
+        &self,
+        _host: &str,
+    ) -> Result<Option<RedfishVendor>, VendorOverrideError> {
+        Ok(None)
+    }
+}

--- a/crates/redfish/tests/nv_vendor_pin.rs
+++ b/crates/redfish/tests/nv_vendor_pin.rs
@@ -1,0 +1,276 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! The `nv_redfish` pool reads the operator vendor pin, so its service root
+//! cache has to distinguish one pin from another.
+
+use std::net::{SocketAddr, TcpListener};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use arc_swap::ArcSwap;
+use axum::Router;
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum_server::tls_rustls::RustlsConfig;
+use carbide_redfish::nv_redfish::NvRedfishClientPool;
+use carbide_redfish::vendor_override::{BmcVendorOverrideResolver, VendorOverrideError};
+use carbide_secrets::credentials::Credentials;
+use libredfish::model::service_root::RedfishVendor;
+
+/// A resolver whose answer can be changed, standing in for an operator editing
+/// `bmc_vendor_override` while the process is running.
+struct SettablePin(Mutex<Option<RedfishVendor>>);
+
+impl SettablePin {
+    fn new(pin: Option<RedfishVendor>) -> Arc<Self> {
+        Arc::new(Self(Mutex::new(pin)))
+    }
+
+    fn set(&self, pin: Option<RedfishVendor>) {
+        *self.0.lock().expect("pin mutex poisoned") = pin;
+    }
+}
+
+#[async_trait::async_trait]
+impl BmcVendorOverrideResolver for SettablePin {
+    async fn vendor_override(
+        &self,
+        _host: &str,
+    ) -> Result<Option<RedfishVendor>, VendorOverrideError> {
+        Ok(*self.0.lock().expect("pin mutex poisoned"))
+    }
+}
+
+#[derive(Clone)]
+struct AppState {
+    root_hits: Arc<AtomicUsize>,
+}
+
+const SERVICE_ROOT: &str = r##"{
+  "@odata.id": "/redfish/v1/",
+  "@odata.type": "#ServiceRoot.v1_13_0.ServiceRoot",
+  "Id": "RootService",
+  "Name": "Root Service",
+  "RedfishVersion": "1.15.1",
+  "Vendor": "Supermicro",
+  "Product": "Supermicro Redfish Server",
+  "UUID": "6acb216c-bfde-11d3-02c0-146dd4e0ff10",
+  "Chassis": { "@odata.id": "/redfish/v1/Chassis" },
+  "Systems": { "@odata.id": "/redfish/v1/Systems" },
+  "Managers": { "@odata.id": "/redfish/v1/Managers" },
+  "UpdateService": { "@odata.id": "/redfish/v1/UpdateService" },
+  "SessionService": { "@odata.id": "/redfish/v1/SessionService" },
+  "Links": { "Sessions": { "@odata.id": "/redfish/v1/SessionService/Sessions" } },
+  "ProtocolFeaturesSupported": {
+    "ExpandQuery": { "ExpandAll": true, "Levels": true, "Links": true, "MaxLevels": 5, "NoLinks": true },
+    "FilterQuery": true,
+    "SelectQuery": true
+  }
+}"##;
+
+async fn service_root(State(state): State<AppState>) -> impl IntoResponse {
+    state.root_hits.fetch_add(1, Ordering::SeqCst);
+    (
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        SERVICE_ROOT,
+    )
+}
+
+fn spawn_mock_bmc(root_hits: Arc<AtomicUsize>) -> SocketAddr {
+    let app = Router::new()
+        .route("/redfish/v1", get(service_root))
+        .route("/redfish/v1/", get(service_root))
+        .with_state(AppState { root_hits });
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let tls = bmc_mock::tls::server_config(None::<&str>).unwrap();
+    let config = RustlsConfig::from_config(Arc::new(tls));
+    tokio::spawn(async move {
+        axum_server::from_tcp_rustls(listener, config)
+            .unwrap()
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    addr
+}
+
+/// Without the pin in the cache key, an operator setting or clearing a pin would
+/// keep getting a root built under the old one until the cache lifetime elapsed.
+#[tokio::test]
+async fn changing_the_pin_rebuilds_the_cached_service_root() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    let root_hits = Arc::new(AtomicUsize::new(0));
+    let addr = spawn_mock_bmc(root_hits.clone());
+    let resolver = SettablePin::new(None);
+    let pool = NvRedfishClientPool::new(Arc::new(ArcSwap::new(Arc::new(None))), resolver.clone());
+    let creds = || Credentials::UsernamePassword {
+        username: "root".to_string(),
+        password: "placeholder".to_string(),
+    };
+
+    pool.service_root(addr, creds()).await.expect("first fetch");
+    assert_eq!(root_hits.load(Ordering::SeqCst), 1, "first call fetches");
+
+    pool.service_root(addr, creds()).await.expect("cache hit");
+    assert_eq!(
+        root_hits.load(Ordering::SeqCst),
+        1,
+        "an unchanged pin must be served from cache"
+    );
+
+    resolver.set(Some(RedfishVendor::Dell));
+    pool.service_root(addr, creds()).await.expect("after pin");
+    assert_eq!(
+        root_hits.load(Ordering::SeqCst),
+        2,
+        "setting a pin must not serve the root cached without one"
+    );
+
+    pool.service_root(addr, creds()).await.expect("cache hit");
+    assert_eq!(
+        root_hits.load(Ordering::SeqCst),
+        2,
+        "the new pin caches in its own right"
+    );
+
+    // Each pin caches in its own right, so going back to a pin already seen
+    // reuses that entry rather than refetching.
+    resolver.set(None);
+    pool.service_root(addr, creds()).await.expect("after clear");
+    assert_eq!(
+        root_hits.load(Ordering::SeqCst),
+        2,
+        "clearing a pin returns to the entry built without one"
+    );
+
+    resolver.set(Some(RedfishVendor::Hpe));
+    pool.service_root(addr, creds()).await.expect("third pin");
+    assert_eq!(
+        root_hits.load(Ordering::SeqCst),
+        3,
+        "a pin never seen before must fetch its own root"
+    );
+}
+
+/// The pin has to reach what `nv_redfish` parses, not just NICo's own reads, so
+/// the root the pool hands back carries the pinned vendor and nothing else.
+#[tokio::test]
+async fn a_pinned_root_reports_the_pinned_vendor_to_nv_redfish() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    let root_hits = Arc::new(AtomicUsize::new(0));
+    let addr = spawn_mock_bmc(root_hits.clone());
+    let creds = || Credentials::UsernamePassword {
+        username: "root".to_string(),
+        password: "placeholder".to_string(),
+    };
+
+    // The mock reports Supermicro with a product, while the operator says Dell.
+    let unpinned = NvRedfishClientPool::new(
+        Arc::new(ArcSwap::new(Arc::new(None))),
+        SettablePin::new(None),
+    );
+    let detected = unpinned
+        .service_root(addr, creds())
+        .await
+        .expect("detected");
+    assert_eq!(
+        detected.vendor(),
+        Some(nv_redfish::service_root::Vendor::new("Supermicro")),
+        "precondition, the BMC reports its own vendor"
+    );
+    assert!(
+        detected.product().is_some(),
+        "precondition, it has a product"
+    );
+    let detected_product = detected.product().map(|p| p.into_inner().to_string());
+
+    let pinned_pool = NvRedfishClientPool::new(
+        Arc::new(ArcSwap::new(Arc::new(None))),
+        SettablePin::new(Some(RedfishVendor::Dell)),
+    );
+    let pinned = pinned_pool
+        .service_root(addr, creds())
+        .await
+        .expect("pinned");
+
+    assert_eq!(
+        pinned.vendor(),
+        Some(nv_redfish::service_root::Vendor::new("Dell")),
+        "the pin must reach the vendor nv_redfish classifies on"
+    );
+    assert_eq!(
+        pinned.product().map(|p| p.into_inner().to_string()),
+        detected_product,
+        "only the vendor is written, so the product is left as reported"
+    );
+}
+
+/// A resolver failure is advisory, so the pool must still build a client.
+#[tokio::test]
+async fn a_resolver_failure_falls_back_to_detection() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    struct AlwaysFails;
+
+    #[async_trait::async_trait]
+    impl BmcVendorOverrideResolver for AlwaysFails {
+        async fn vendor_override(
+            &self,
+            host: &str,
+        ) -> Result<Option<RedfishVendor>, VendorOverrideError> {
+            Err(VendorOverrideError::new(
+                host,
+                Box::new(std::io::Error::other("database down")),
+            ))
+        }
+    }
+
+    let root_hits = Arc::new(AtomicUsize::new(0));
+    let addr = spawn_mock_bmc(root_hits.clone());
+    let pool = NvRedfishClientPool::new(
+        Arc::new(ArcSwap::new(Arc::new(None))),
+        Arc::new(AlwaysFails),
+    );
+
+    let root = pool
+        .service_root(
+            addr,
+            Credentials::UsernamePassword {
+                username: "root".to_string(),
+                password: "placeholder".to_string(),
+            },
+        )
+        .await;
+
+    assert!(root.is_ok(), "a resolver failure must not fail the client");
+    assert_eq!(root_hits.load(Ordering::SeqCst), 1);
+}

--- a/crates/redfish/tests/service_root_cache_poisoning.rs
+++ b/crates/redfish/tests/service_root_cache_poisoning.rs
@@ -21,6 +21,7 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum_server::tls_rustls::RustlsConfig;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
+use carbide_redfish::vendor_override::NoBmcVendorOverrides;
 use carbide_secrets::credentials::Credentials;
 
 // A full, healthy AMI service root including the `Chassis` navigation property.
@@ -129,7 +130,10 @@ async fn poisoned_service_root_cache_recovers_after_bmc_heals() {
     let root_hits = Arc::new(AtomicUsize::new(0));
     let addr = spawn_mock_bmc(root_hits.clone());
 
-    let pool = NvRedfishClientPool::new(Arc::new(ArcSwap::new(Arc::new(None))));
+    let pool = NvRedfishClientPool::new(
+        Arc::new(ArcSwap::new(Arc::new(None))),
+        Arc::new(NoBmcVendorOverrides),
+    );
     let creds = || Credentials::UsernamePassword {
         username: "root".to_string(),
         password: "placeholder".to_string(),
@@ -192,8 +196,11 @@ async fn expired_service_root_is_refetched_without_invalidating_existing_holders
     // Start at one so the mock serves a complete root on every request.
     let root_hits = Arc::new(AtomicUsize::new(1));
     let addr = spawn_mock_bmc(root_hits.clone());
-    let pool =
-        NvRedfishClientPool::with_cache_ttl(Arc::new(ArcSwap::new(Arc::new(None))), Duration::ZERO);
+    let pool = NvRedfishClientPool::with_cache_ttl(
+        Arc::new(ArcSwap::new(Arc::new(None))),
+        Duration::ZERO,
+        Arc::new(NoBmcVendorOverrides),
+    );
     let creds = || Credentials::UsernamePassword {
         username: "root".to_string(),
         password: "placeholder".to_string(),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6821,6 +6821,11 @@ message ExpectedMachine {
   // host_nics, including `[]`; older clients leave it false so an unknown
   // nested HostBmc is not removed by a read-modify-write.
   bool replace_host_nics = 19;
+  // Operator pinned Redfish BMC vendor, a `RedfishVendor` name such as "Dell",
+  // forced into libredfish. Unset keeps whatever the stored row holds, so a
+  // client predating this field cannot clear a pin. Empty clears it, which
+  // returns the host to automatic detection.
+  optional string bmc_vendor_override = 20;
 }
 
 message ExpectedMachineRequest {

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -364,6 +364,7 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
                         .host_lifecycle_profile
                         .disable_lockdown,
                 }),
+            bmc_vendor_override: expected_machine.data.bmc_vendor_override,
         }
     }
 }
@@ -498,6 +499,9 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
                     disable_lockdown: hlp.disable_lockdown,
                 })
                 .unwrap_or_default(),
+            // Carried through verbatim. Only the handler reads the stored row,
+            // so it is the one that tells absent apart from empty.
+            bmc_vendor_override: em.bmc_vendor_override,
         })
     }
 }

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -43,6 +43,7 @@ use super::config::SiteExplorerExploreMode;
 use super::credentials::{CredentialClient, get_bmc_root_credential_key};
 use super::metrics::SiteExplorationMetrics;
 use super::redfish::RedfishClient;
+use crate::redfish::ResolvedVendor;
 
 const BMC_AUTH_RETRY_DURATION: Duration = Duration::from_secs(3);
 
@@ -285,13 +286,55 @@ impl BmcEndpointExplorer {
             .await
     }
 
+    /// Produce the exploration report, then let an operator pin override the
+    /// reported vendor. Applied after the mode dispatch, which knows both.
     pub async fn generate_exploration_report(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
         boot_interface: Option<&BootInterfaceTarget>,
-        vendor: Option<RedfishVendor>,
+        vendor: Option<ResolvedVendor>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
+        let report = self
+            .generate_reported_exploration_report(
+                bmc_ip_address,
+                credentials,
+                boot_interface,
+                vendor,
+            )
+            .await;
+
+        let Some(pin) = vendor.and_then(ResolvedVendor::pinned) else {
+            return report;
+        };
+        report.map(|mut report| {
+            let pinned = carbide_redfish::libredfish::conv::bmc_vendor(pin);
+            if report.vendor != Some(pinned) {
+                // Debug, as disagreeing with the BMC is the steady state for a
+                // pinned host, so this would log on every exploration.
+                tracing::debug!(
+                    %bmc_ip_address,
+                    reported = ?report.vendor,
+                    %pinned,
+                    redfish_vendor = %pin,
+                    explore_mode = ?self.mode,
+                    "Recording the operator-pinned BMC vendor instead of the reported one"
+                );
+            }
+            report.vendor = Some(pinned);
+            report
+        })
+    }
+
+    async fn generate_reported_exploration_report(
+        &self,
+        bmc_ip_address: SocketAddr,
+        credentials: Credentials,
+        boot_interface: Option<&BootInterfaceTarget>,
+        resolved_vendor: Option<ResolvedVendor>,
+    ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
+        let vendor = resolved_vendor.map(ResolvedVendor::vendor);
+
         match self.mode {
             SiteExplorerExploreMode::LibRedfish => {
                 self.redfish_client
@@ -677,62 +720,80 @@ impl EndpointExplorer for BmcEndpointExplorer {
         }
 
         let bmc_mac_address = interface.mac_address;
-        let vendor = match self.redfish_client.get_redfish_vendor(bmc_ip_address).await {
-            Ok(vendor) => vendor,
-            Err(e) => {
-                tracing::error!(
+
+        // An operator pinned vendor replaces detection outright. Read from the
+        // client pool, not `expected`, so it cannot disagree with the clients.
+        let resolved_vendor = match self.redfish_client.pinned_bmc_vendor(bmc_ip_address).await {
+            Some(vendor) => {
+                // Debug rather than info, as this runs for a pinned BMC on every
+                // iteration and the log below was demoted for that reason in #4149.
+                tracing::debug!(
                     %bmc_ip_address,
-                    error = %e,
-                    "Failed to probe Redfish service root endpoint"
+                    %bmc_mac_address,
+                    %vendor,
+                    "Using operator-pinned BMC vendor, skipping service root detection"
                 );
+                ResolvedVendor::Pinned(vendor)
+            }
+            None => match self.redfish_client.get_redfish_vendor(bmc_ip_address).await {
+                Ok(vendor) => ResolvedVendor::Detected(vendor),
+                Err(e) => {
+                    tracing::error!(
+                        %bmc_ip_address,
+                        error = %e,
+                        "Failed to probe Redfish service root endpoint"
+                    );
 
-                // Lite-On power shelf BMCs don't expose Vendor details in the
-                // service root, so we fall back to probing the Chassis endpoint.
-                // Only attempt this for power shelf endpoints — machines and
-                // switches should never need this workaround.
-                //
-                // In the future, if we want to expand this to other kinds of trays we can
-                // expand the pattern matching logic below.
-                let Some(ExpectedEntity::PowerShelf(eps)) = expected else {
-                    return Err(e);
-                };
-
-                let (username, password) =
-                    match self.get_bmc_root_credentials(bmc_mac_address).await {
-                        Ok(Credentials::UsernamePassword { username, password }) => {
-                            (username, password)
-                        }
-                        Err(_) => (eps.bmc_username.clone(), eps.bmc_password.clone()),
+                    // Lite-On power shelf BMCs don't expose Vendor details in the
+                    // service root, so we fall back to probing the Chassis endpoint.
+                    // Only attempt this for power shelf endpoints — machines and
+                    // switches should never need this workaround.
+                    //
+                    // In the future, if we want to expand this to other kinds of trays we can
+                    // expand the pattern matching logic below.
+                    let Some(ExpectedEntity::PowerShelf(eps)) = expected else {
+                        return Err(e);
                     };
 
-                // Lite-On and Delta power shelf BMCs don't expose vendor
-                // details in the service root, so we fall back to checking the
-                // Manufacturer field across all Chassis entries.
-                let vendor = match self
-                    .redfish_client
-                    .probe_vendor_name_from_chassis(bmc_ip_address, username, password)
-                    .await
-                {
-                    Ok(v) => v,
-                    Err(chassis_err) => {
-                        tracing::error!(
-                            %bmc_ip_address,
-                            error = %chassis_err,
-                            "Failed to probe vendor from chassis"
-                        );
+                    let (username, password) =
+                        match self.get_bmc_root_credentials(bmc_mac_address).await {
+                            Ok(Credentials::UsernamePassword { username, password }) => {
+                                (username, password)
+                            }
+                            Err(_) => (eps.bmc_username.clone(), eps.bmc_password.clone()),
+                        };
+
+                    // Lite-On and Delta power shelf BMCs don't expose vendor
+                    // details in the service root, so we fall back to checking the
+                    // Manufacturer field across all Chassis entries.
+                    let vendor = match self
+                        .redfish_client
+                        .probe_vendor_name_from_chassis(bmc_ip_address, username, password)
+                        .await
+                    {
+                        Ok(v) => v,
+                        Err(chassis_err) => {
+                            tracing::error!(
+                                %bmc_ip_address,
+                                error = %chassis_err,
+                                "Failed to probe vendor from chassis"
+                            );
+                            return Err(e);
+                        }
+                    };
+                    let vendor_lc = vendor.to_lowercase();
+                    if vendor_lc.contains("lite-on") {
+                        ResolvedVendor::Detected(RedfishVendor::LiteOnPowerShelf)
+                    } else if vendor_lc.contains("delta") {
+                        ResolvedVendor::Detected(RedfishVendor::DeltaPowerShelf)
+                    } else {
                         return Err(e);
                     }
-                };
-                let vendor_lc = vendor.to_lowercase();
-                if vendor_lc.contains("lite-on") {
-                    RedfishVendor::LiteOnPowerShelf
-                } else if vendor_lc.contains("delta") {
-                    RedfishVendor::DeltaPowerShelf
-                } else {
-                    return Err(e);
                 }
-            }
+            },
         };
+
+        let vendor = resolved_vendor.vendor();
 
         tracing::debug!(
             target: "carbide_diagnostics::bmc_redfish_supported",
@@ -753,7 +814,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
                         bmc_ip_address,
                         credentials,
                         boot_interface,
-                        Some(vendor),
+                        Some(resolved_vendor),
                     )
                     .await
                 {
@@ -929,7 +990,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     bmc_ip_address,
                     bmc_credentials,
                     boot_interface,
-                    Some(vendor),
+                    Some(resolved_vendor),
                 )
                 .await?
             }
@@ -1364,10 +1425,10 @@ impl EndpointExplorer for BmcEndpointExplorer {
             })?;
 
         // Resolve the dispatch vendor `set_bmc_root_password` branches on using
-        // the current credentials, then set the new password on the device.
+        // the operator pin or, failing that, the current credentials.
         let vendor = self
             .redfish_client
-            .probe_bmc_vendor(bmc_ip_address, current_credentials.clone())
+            .dispatch_bmc_vendor(bmc_ip_address, current_credentials.clone())
             .await?;
         let new_credentials = self
             .set_bmc_root_password(
@@ -1781,6 +1842,7 @@ mod tests {
         RedfishSim, RedfishSimAuthAttempt, RedfishSimBootInterfaceRef,
     };
     use carbide_redfish::nv_redfish::NvRedfishClientPool;
+    use carbide_redfish::vendor_override::NoBmcVendorOverrides;
     use carbide_secrets::credentials::{
         BmcCredentialType, CredentialKey, CredentialReader, CredentialWriter,
     };
@@ -1821,7 +1883,10 @@ mod tests {
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
         let explorer = BmcEndpointExplorer::new(
             Arc::new(RedfishSim::default()),
-            Arc::new(NvRedfishClientPool::new(proxy_address)),
+            Arc::new(NvRedfishClientPool::new(
+                proxy_address,
+                Arc::new(NoBmcVendorOverrides),
+            )),
             carbide_ipmi::test_support(),
             Arc::new(TestCredentialManager::default()),
             Arc::new(AtomicBool::new(false)),
@@ -1955,7 +2020,10 @@ mod tests {
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
         let explorer = BmcEndpointExplorer::new(
             sim.clone(),
-            Arc::new(NvRedfishClientPool::new(proxy_address)),
+            Arc::new(NvRedfishClientPool::new(
+                proxy_address,
+                Arc::new(NoBmcVendorOverrides),
+            )),
             carbide_ipmi::test_support(),
             Arc::new(TestCredentialManager::default()),
             Arc::new(AtomicBool::new(false)),
@@ -1989,6 +2057,136 @@ mod tests {
             .map_err(|error| error.to_string())?;
 
         Ok(sim.machine_setup_status_targets(&bmc_ip_address.ip().to_string()))
+    }
+
+    /// Explore a host reporting `service_root_vendor`, with `pin` as the override.
+    /// Returns the vendor every client used and the vendor the report recorded.
+    async fn explore_with_vendor_pin(
+        service_root_vendor: Option<&str>,
+        pin: Option<RedfishVendor>,
+    ) -> Result<(Vec<Option<RedfishVendor>>, EndpointExplorationReport), String> {
+        let sim = Arc::new(RedfishSim::default());
+        sim.set_service_root_vendor(service_root_vendor.map(str::to_string));
+        sim.seed_user("root", "factory-password");
+        let bmc_ip_address: SocketAddr = "127.0.0.1:443".parse().expect("valid test BMC address");
+        if let Some(pin) = pin {
+            // Seeded on the pool, where production reads it from, so this
+            // exercises the same path rather than a test only shortcut.
+            sim.set_vendor_override(&bmc_ip_address.ip().to_string(), pin);
+        }
+        let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
+        let explorer = BmcEndpointExplorer::new(
+            sim.clone(),
+            Arc::new(NvRedfishClientPool::new(
+                proxy_address,
+                Arc::new(NoBmcVendorOverrides),
+            )),
+            carbide_ipmi::test_support(),
+            Arc::new(TestCredentialManager::default()),
+            Arc::new(AtomicBool::new(false)),
+            SiteExplorerExploreMode::LibRedfish,
+            None,
+        );
+        let bmc_mac_address: MacAddress = "02:00:00:00:00:02".parse().expect("valid test BMC MAC");
+        let interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
+        let expected = ExpectedEntity::Machine(ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                bmc_username: "root".to_string(),
+                bmc_password: "factory-password".to_string(),
+                serial_number: "vendor-pin-host".to_string(),
+                bmc_retain_credentials: Some(true),
+                ..Default::default()
+            },
+        });
+
+        let report = explorer
+            .explore_endpoint(bmc_ip_address, &interface, Some(&expected), None, None)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        Ok((
+            sim.create_client_calls()
+                .into_iter()
+                .map(|call| call.vendor)
+                .collect(),
+            report,
+        ))
+    }
+
+    /// The motivating case, a BMC whose service root does not identify it at all.
+    /// Detection fails outright, so the pin must reach the client and the report.
+    #[tokio::test]
+    async fn explore_endpoint_honors_a_pinned_vendor_when_detection_fails() {
+        const UNIDENTIFIABLE: Option<&str> = Some("TotallyNotAKnownVendor");
+
+        let detected_only = explore_with_vendor_pin(UNIDENTIFIABLE, None).await;
+        assert!(
+            detected_only.is_err(),
+            "an unidentifiable BMC must fail exploration without a pin, got {detected_only:?}"
+        );
+
+        let (client_vendors, report) =
+            explore_with_vendor_pin(UNIDENTIFIABLE, Some(RedfishVendor::Dell))
+                .await
+                .expect("a pinned vendor should carry the exploration past detection");
+        assert!(
+            client_vendors.contains(&Some(RedfishVendor::Dell)),
+            "the pinned vendor must reach create_client, got {client_vendors:?}"
+        );
+        assert_eq!(
+            report.vendor,
+            Some(bmc_vendor::BMCVendor::Dell),
+            "the pin must be what gets persisted; the BMC reported nothing usable"
+        );
+    }
+
+    /// A pin outranks what the BMC reports, so an operator can also correct a
+    /// host that misidentifies itself and not only one that stays silent.
+    #[tokio::test]
+    async fn explore_endpoint_prefers_a_pinned_vendor_over_detection() {
+        let (client_vendors, report) =
+            explore_with_vendor_pin(Some("Nvidia"), Some(RedfishVendor::Dell))
+                .await
+                .expect("exploration should succeed");
+        assert!(
+            client_vendors.contains(&Some(RedfishVendor::Dell)),
+            "the pin must win over the detected vendor, got {client_vendors:?}"
+        );
+        assert_eq!(
+            report.vendor,
+            Some(bmc_vendor::BMCVendor::Dell),
+            "the pin must overwrite the vendor the BMC reported, not just the client"
+        );
+
+        let (client_vendors, report) = explore_with_vendor_pin(Some("Nvidia"), None)
+            .await
+            .expect("exploration should succeed");
+        assert!(
+            !client_vendors.contains(&Some(RedfishVendor::Dell)),
+            "without a pin nothing should force Dell, got {client_vendors:?}"
+        );
+        assert_eq!(
+            report.vendor,
+            Some(bmc_vendor::BMCVendor::Nvidia),
+            "an unpinned host must keep recording what it reported"
+        );
+    }
+
+    /// The pin is stored as a `RedfishVendor` name but persisted as the coarser
+    /// `BMCVendor`, so pinning a Lenovo GB300 records `LenovoAMI` by contract.
+    #[tokio::test]
+    async fn a_pinned_vendor_is_persisted_through_the_bmc_vendor_mapping() {
+        let (_, report) = explore_with_vendor_pin(Some("Nvidia"), Some(RedfishVendor::LenovoGB300))
+            .await
+            .expect("exploration should succeed");
+        assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::LenovoAMI));
+
+        // The persisted spelling and not just the enum, because the report JSON
+        // and the `desired_firmware` join both compare this string.
+        let wire = serde_json::to_value(&report).expect("report serializes");
+        assert_eq!(wire["Vendor"], serde_json::json!("LenovoAMI"));
     }
 
     #[tokio::test]
@@ -2074,7 +2272,10 @@ mod tests {
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
         let explorer = BmcEndpointExplorer::new(
             sim.clone(),
-            Arc::new(NvRedfishClientPool::new(proxy_address)),
+            Arc::new(NvRedfishClientPool::new(
+                proxy_address,
+                Arc::new(NoBmcVendorOverrides),
+            )),
             carbide_ipmi::test_support(),
             credential_manager.clone(),
             Arc::new(AtomicBool::new(false)),

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -25,7 +25,9 @@ use carbide_network::deserialize_input_mac_to_address;
 use carbide_redfish::boot_interface::BootInterfaceTarget;
 use carbide_redfish::libredfish::conv::{IntoModel, bmc_vendor};
 use carbide_redfish::libredfish::dpu_bios::is_dpu_bios_attributes_not_ready;
-use carbide_redfish::libredfish::{RedfishAuth, RedfishClientCreationError, RedfishClientPool};
+use carbide_redfish::libredfish::{
+    RedfishAuth, RedfishClientCreationError, RedfishClientPool, VendorSelection,
+};
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use carbide_secrets::credentials::Credentials;
 use libredfish::model::ODataId;
@@ -45,6 +47,34 @@ use regex::Regex;
 
 const NOT_FOUND: u16 = 404;
 const BF4_NDF0_TO_BASE_MAC_OFFSET: u64 = 0x10;
+
+/// The vendor NICo resolved for a BMC, and how it got there.
+/// Both carry the same vendor, as the report records what the client used.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResolvedVendor {
+    /// Set by an operator via `bmc_vendor_override`. Authoritative for client
+    /// construction and for the persisted vendor, so detection cannot undo it.
+    Pinned(RedfishVendor),
+    /// Probed from the service root or the power shelf Chassis fallback.
+    Detected(RedfishVendor),
+}
+
+impl ResolvedVendor {
+    pub fn vendor(self) -> RedfishVendor {
+        match self {
+            Self::Pinned(vendor) | Self::Detected(vendor) => vendor,
+        }
+    }
+
+    /// `Some` only when an operator set this vendor, meaning it may overwrite
+    /// what the BMC reported.
+    pub fn pinned(self) -> Option<RedfishVendor> {
+        match self {
+            Self::Pinned(vendor) => Some(vendor),
+            Self::Detected(_) => None,
+        }
+    }
+}
 
 // RedfishClient is a wrapper around a redfish client pool and implements redfish utility functions that the site explorer utilizes.
 // TODO: In the future, we should refactor a lot of this client's work to api/src/redfish.rs because other components in carbide can utilize this functionality.
@@ -69,7 +99,7 @@ impl RedfishClient {
         &self,
         bmc_ip_address: SocketAddr,
         auth: RedfishAuth,
-        vendor: Option<RedfishVendor>,
+        vendor: VendorSelection,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
         self.redfish_client_pool
             .create_client(
@@ -85,15 +115,12 @@ impl RedfishClient {
         &self,
         bmc_ip_address: SocketAddr,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
-        // This currently uses a "standard" client without any vendor
-        // specific implementations. If we end up ever needing vendor
-        // specific support for a caller using this, we could simply
-        // just drop in vendor: Option<RedfishVendor> to support an
-        // override of using RedfishVendor::Unknown.
+        // A standard client with no vendor implementation, which is all the probes
+        // need and the only kind a factory BMC accepts before rotation. Not pinnable.
         self.create_redfish_client(
             bmc_ip_address,
             RedfishAuth::Anonymous,
-            Some(RedfishVendor::Unknown),
+            VendorSelection::Uninitialized,
         )
         .await
     }
@@ -102,7 +129,7 @@ impl RedfishClient {
         &self,
         bmc_ip_address: SocketAddr,
         Credentials::UsernamePassword { username, password }: Credentials,
-        vendor: Option<RedfishVendor>,
+        vendor: VendorSelection,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
         self.create_redfish_client(
             bmc_ip_address,
@@ -112,12 +139,25 @@ impl RedfishClient {
         .await
     }
 
+    /// The operator pinned vendor for this BMC, if it has one.
+    /// Read from the pool so it matches what `create_client` applies.
+    pub(crate) async fn pinned_bmc_vendor(
+        &self,
+        bmc_ip_address: SocketAddr,
+    ) -> Option<RedfishVendor> {
+        self.redfish_client_pool
+            .pinned_bmc_vendor(&bmc_ip_address.ip().to_string())
+            .await
+    }
+
+    /// The sole constructor for authenticated Site Explorer clients, and the one
+    /// place the vendor pin enters, so a new operation inherits it by calling this.
     async fn create_authenticated_redfish_client(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
-        self.create_direct_redfish_client(bmc_ip_address, credentials, None)
+        self.create_direct_redfish_client(bmc_ip_address, credentials, VendorSelection::Detect)
             .await
     }
 
@@ -202,7 +242,11 @@ impl RedfishClient {
         credentials: Credentials,
     ) -> Result<(), EndpointExplorationError> {
         let client = self
-            .create_direct_redfish_client(bmc_ip_address, credentials, Some(RedfishVendor::Unknown))
+            .create_direct_redfish_client(
+                bmc_ip_address,
+                credentials,
+                VendorSelection::Uninitialized,
+            )
             .await
             .map_err(map_redfish_client_creation_error)?;
 
@@ -222,6 +266,23 @@ impl RedfishClient {
     ) -> Result<RedfishVendor, EndpointExplorationError> {
         self.redfish_client_pool
             .probe_bmc_vendor(
+                &bmc_ip_address.ip().to_string(),
+                Some(bmc_ip_address.port()),
+                credentials,
+            )
+            .await
+            .map_err(map_redfish_client_creation_error)
+    }
+
+    /// The vendor the BMC password change branches on, pin first.
+    /// Read through the pool, so it agrees with what `create_client` applies.
+    pub(super) async fn dispatch_bmc_vendor(
+        &self,
+        bmc_ip_address: SocketAddr,
+        credentials: Credentials,
+    ) -> Result<RedfishVendor, EndpointExplorationError> {
+        self.redfish_client_pool
+            .dispatch_bmc_vendor(
                 &bmc_ip_address.ip().to_string(),
                 Some(bmc_ip_address.port()),
                 credentials,
@@ -280,7 +341,11 @@ impl RedfishClient {
         vendor: Option<RedfishVendor>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         let client = self
-            .create_direct_redfish_client(bmc_ip_address, credentials, vendor)
+            .create_direct_redfish_client(
+                bmc_ip_address,
+                credentials,
+                vendor.map_or(VendorSelection::Detect, VendorSelection::Hint),
+            )
             .await
             .map_err(map_redfish_client_creation_error)?;
 
@@ -288,9 +353,13 @@ impl RedfishClient {
         let redfish_vendor = service_root.vendor();
         // Lenovo XCC is the platform where we have verified that adapter Ports
         // belong to the linked host chassis. Keep that policy here so the
-        // inventory path stays generic.
-        let supports_adapter_port_mac_inventory = redfish_vendor == Some(RedfishVendor::Lenovo);
-        let vendor = redfish_vendor.map(bmc_vendor);
+        // inventory path stays generic. Keyed on the vendor the client was built
+        // with rather than the reported one, so a pinned host stays consistent.
+        let supports_adapter_port_mac_inventory =
+            vendor.or(redfish_vendor) == Some(RedfishVendor::Lenovo);
+        // What the BMC reports about itself, which a pin overrides one layer up.
+        // The `vendor` parameter may be a probe result that disagrees with this.
+        let reported_vendor = redfish_vendor.map(bmc_vendor);
 
         let manager = fetch_manager(client.as_ref())
             .await
@@ -387,7 +456,7 @@ impl RedfishClient {
             systems: vec![system],
             chassis,
             service,
-            vendor,
+            vendor: reported_vendor,
             versions: HashMap::default(),
             model: None,
             power_shelf_id: None,
@@ -1701,6 +1770,7 @@ mod tests {
     use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
     use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool};
     use carbide_redfish::nv_redfish::NvRedfishClientPool;
+    use carbide_redfish::vendor_override::NoBmcVendorOverrides;
     use carbide_secrets::credentials::Credentials;
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, Check, check_cases_async, check_values, value_scenarios};
@@ -1710,8 +1780,8 @@ mod tests {
 
     use super::{
         BootInterfaceTarget, EndpointExplorationError, MachineSetupStatus, RedfishClient,
-        fetch_machine_setup_status, nv_bmc_explore_config, record_evaluated_boot_interface,
-        should_fetch_network_adapter_ports,
+        VendorSelection, fetch_machine_setup_status, nv_bmc_explore_config,
+        record_evaluated_boot_interface, should_fetch_network_adapter_ports,
     };
 
     fn test_addr() -> SocketAddr {
@@ -1720,7 +1790,10 @@ mod tests {
 
     fn build_redfish_client(sim: Arc<RedfishSim>) -> RedfishClient {
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
-        let nv_pool = Arc::new(NvRedfishClientPool::new(proxy_address));
+        let nv_pool = Arc::new(NvRedfishClientPool::new(
+            proxy_address,
+            Arc::new(NoBmcVendorOverrides),
+        ));
         RedfishClient::new(sim, nv_pool)
     }
 
@@ -1773,7 +1846,12 @@ mod tests {
             0x94, 0x6d, 0xae, 0x53, 0xcb, 0x9b,
         ])]);
         let client = sim
-            .create_client("test-host", None, RedfishAuth::Anonymous, None)
+            .create_client(
+                "test-host",
+                None,
+                RedfishAuth::Anonymous,
+                VendorSelection::Detect,
+            )
             .await
             .unwrap();
 
@@ -1861,7 +1939,12 @@ mod tests {
     > {
         let sim = RedfishSim::default();
         let client = sim
-            .create_client("test-host", None, RedfishAuth::Anonymous, None)
+            .create_client(
+                "test-host",
+                None,
+                RedfishAuth::Anonymous,
+                VendorSelection::Detect,
+            )
             .await
             .map_err(|error| error.to_string())?;
         let status = fetch_machine_setup_status(client.as_ref(), target.as_ref())
@@ -2025,5 +2108,254 @@ mod tests {
             password_change_client_vendors,
         )
         .await;
+    }
+
+    /// Every authenticated operation must honor the pin and stay unaffected
+    /// without one. Driven twice, so the second half guards against regression.
+    #[tokio::test]
+    async fn every_authenticated_operation_honors_the_pin_and_is_unchanged_without_one() {
+        const PIN: RedfishVendor = RedfishVendor::Dell;
+
+        let boot_interface =
+            BootInterfaceTarget::MacOnly(MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]));
+
+        // Each entry drives one operation and discards its result. Only the
+        // vendor the client was constructed with matters here.
+        #[allow(clippy::type_complexity)]
+        let operations: Vec<(
+            &str,
+            Box<
+                dyn for<'a> Fn(
+                    &'a RedfishClient,
+                    SocketAddr,
+                    Credentials,
+                )
+                    -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>>,
+            >,
+        )> = vec![
+            (
+                "reset_bmc",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.reset_bmc(a, k, None).await;
+                    })
+                }),
+            ),
+            (
+                "get_power_state",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.get_power_state(a, k).await;
+                    })
+                }),
+            ),
+            (
+                "power",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.power(a, k, libredfish::SystemPowerControl::On).await;
+                    })
+                }),
+            ),
+            (
+                "disable_secure_boot",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.disable_secure_boot(a, k).await;
+                    })
+                }),
+            ),
+            (
+                "lockdown",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c
+                            .lockdown(a, k, libredfish::EnabledDisabled::Disabled)
+                            .await;
+                    })
+                }),
+            ),
+            (
+                "lockdown_status",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.lockdown_status(a, k).await;
+                    })
+                }),
+            ),
+            (
+                "enable_infinite_boot",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.enable_infinite_boot(a, k).await;
+                    })
+                }),
+            ),
+            (
+                "is_infinite_boot_enabled",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.is_infinite_boot_enabled(a, k).await;
+                    })
+                }),
+            ),
+            (
+                "machine_setup",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.machine_setup(a, k, None).await;
+                    })
+                }),
+            ),
+            (
+                "is_viking",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.is_viking(a, k).await;
+                    })
+                }),
+            ),
+            (
+                "clear_nvram",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.clear_nvram(a, k).await;
+                    })
+                }),
+            ),
+            (
+                "set_nic_mode",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.set_nic_mode(a, k, super::NicMode::Dpu).await;
+                    })
+                }),
+            ),
+            (
+                "create_bmc_user",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c
+                            .create_bmc_user(a, k, "u", "p", libredfish::RoleId::Administrator)
+                            .await;
+                    })
+                }),
+            ),
+            (
+                "delete_bmc_user",
+                Box::new(|c: &RedfishClient, a, k| {
+                    Box::pin(async move {
+                        let _ = c.delete_bmc_user(a, k, "u").await;
+                    })
+                }),
+            ),
+            (
+                "probe_vendor_name_from_chassis",
+                Box::new(|c: &RedfishClient, a, _k| {
+                    Box::pin(async move {
+                        let _ = c
+                            .probe_vendor_name_from_chassis(
+                                a,
+                                "root".to_string(),
+                                "pass".to_string(),
+                            )
+                            .await;
+                    })
+                }),
+            ),
+        ];
+
+        // Pin to seed, then the vendor every client must be built with. `None`
+        // is the behavior before pins existed, leaving the vendor to detection.
+        let expectations = [(Some(PIN), Some(PIN)), (None, None)];
+
+        for (name, drive) in operations {
+            for (pin, expected) in expectations {
+                let sim = Arc::new(RedfishSim::default());
+                if let Some(pin) = pin {
+                    sim.set_vendor_override(&test_addr().ip().to_string(), pin);
+                }
+                let client = build_redfish_client(sim.clone());
+
+                drive(&client, test_addr(), Credentials::new("root", "pass")).await;
+
+                let vendors: Vec<Option<RedfishVendor>> = sim
+                    .create_client_calls()
+                    .into_iter()
+                    .map(|call| call.vendor)
+                    .collect();
+                assert!(
+                    !vendors.is_empty(),
+                    "{name} built no Redfish client, so this row proves nothing"
+                );
+                assert!(
+                    vendors.iter().all(|vendor| *vendor == expected),
+                    "{name} with pin {pin:?} must build every client with {expected:?}, got {vendors:?}"
+                );
+            }
+        }
+
+        // `set_boot_order_dpu_first` takes its boot interface by reference and so
+        // does not fit the closure shape used above.
+        for (pin, expected) in expectations {
+            let sim = Arc::new(RedfishSim::default());
+            if let Some(pin) = pin {
+                sim.set_vendor_override(&test_addr().ip().to_string(), pin);
+            }
+            let client = build_redfish_client(sim.clone());
+            let _ = client
+                .set_boot_order_dpu_first(
+                    test_addr(),
+                    Credentials::new("root", "pass"),
+                    &boot_interface,
+                )
+                .await;
+            assert!(
+                sim.create_client_calls()
+                    .iter()
+                    .all(|call| call.vendor == expected),
+                "set_boot_order_dpu_first with pin {pin:?} must use {expected:?}"
+            );
+        }
+    }
+
+    /// The probe and credential bootstrap paths must stay unpinnable. They need an
+    /// uninitialized client, so a pin reaching them would deadlock rotation.
+    #[tokio::test]
+    async fn probe_paths_ignore_the_operator_pin() {
+        // Both directions matter. With a pin because it must not reach these,
+        // and without one because nothing about them changed.
+        for pin in [Some(RedfishVendor::Dell), None] {
+            probe_paths_stay_uninitialized(pin).await;
+        }
+    }
+
+    async fn probe_paths_stay_uninitialized(pin: Option<RedfishVendor>) {
+        let sim = Arc::new(RedfishSim::default());
+        if let Some(pin) = pin {
+            sim.set_vendor_override(&test_addr().ip().to_string(), pin);
+        }
+        let client = build_redfish_client(sim.clone());
+
+        let _ = client.get_redfish_product(test_addr()).await;
+        let _ = client.get_redfish_vendor(test_addr()).await;
+        let _ = client
+            .validate_bmc_credentials(test_addr(), Credentials::new("root", "pass"))
+            .await;
+
+        let calls = sim.create_client_calls();
+        assert!(!calls.is_empty(), "expected probe clients to be built");
+        for call in calls {
+            assert_eq!(
+                call.selection,
+                VendorSelection::Uninitialized,
+                "a probe path must ask for an uninitialized client"
+            );
+            assert_eq!(
+                call.vendor,
+                Some(RedfishVendor::Unknown),
+                "a probe client must stay uninitialized (pin {pin:?})"
+            );
+        }
     }
 }

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -1086,6 +1086,7 @@ async fn test_expected_machine_device_type_metrics(
                 dpu_policy: Default::default(),
                 bmc_ip_allocation: Default::default(),
                 host_lifecycle_profile: Default::default(),
+                bmc_vendor_override: None,
             },
         },
     )
@@ -1112,6 +1113,7 @@ async fn test_expected_machine_device_type_metrics(
                 dpu_policy: Default::default(),
                 bmc_ip_allocation: Default::default(),
                 host_lifecycle_profile: Default::default(),
+                bmc_vendor_override: None,
             },
         },
     )
@@ -1138,6 +1140,7 @@ async fn test_expected_machine_device_type_metrics(
                 dpu_policy: Default::default(),
                 bmc_ip_allocation: Default::default(),
                 host_lifecycle_profile: Default::default(),
+                bmc_vendor_override: None,
             },
         },
     )
@@ -2640,6 +2643,7 @@ async fn test_fallback_dpu_serial(pool: PgPool) -> Result<(), Box<dyn std::error
                 dpu_policy: Default::default(),
                 bmc_ip_allocation: Default::default(),
                 host_lifecycle_profile: Default::default(),
+                bmc_vendor_override: None,
             },
         },
     )
@@ -2692,6 +2696,7 @@ async fn test_fallback_dpu_serial(pool: PgPool) -> Result<(), Box<dyn std::error
         dpu_policy: Default::default(),
         bmc_ip_allocation: Default::default(),
         host_lifecycle_profile: Default::default(),
+        bmc_vendor_override: None,
     };
     db::expected_machine::update(&mut txn, &host1_expected_machine).await?;
     txn.commit().await?;

--- a/crates/switch-controller/src/decommissioning.rs
+++ b/crates/switch-controller/src/decommissioning.rs
@@ -17,7 +17,7 @@
 
 //! Managed-switch decommissioning.
 
-use carbide_redfish::libredfish::RedfishAuth;
+use carbide_redfish::libredfish::{RedfishAuth, VendorSelection};
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialWriter};
 use carbide_uuid::switch::SwitchId;
 use libredfish::model::service_root::RedfishVendor;
@@ -269,7 +269,7 @@ async fn handle_factory_reset_bmc(
             &bmc_ip_address.to_string(),
             bmc_info.port,
             RedfishAuth::for_bmc_mac(bmc_mac_address),
-            Some(RedfishVendor::NvidiaGBSwitch),
+            VendorSelection::Hint(RedfishVendor::NvidiaGBSwitch),
         )
         .await
         .map_err(|error| external_error("failed to create switch BMC Redfish client", error))?;

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-add.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-add.md
@@ -17,8 +17,8 @@ nico-admin-cli-expected-machine-add - Add expected machine
 \[**--default_pause_ingestion_and_poweron**\] \[**--dpf-enabled**\]
 \[**--extended**\] \[**--bmc-ip-address**\]
 \[**--bmc-retain-credentials**\] \[**--dpu-policy**\]
-\[**--bmc-ip-allocation**\] \[**--disable-lockdown**\] \[**--sort-by**\]
-\[**-h**\|**--help**\]
+\[**--bmc-ip-allocation**\] \[**--disable-lockdown**\]
+\[**--bmc-vendor-override**\] \[**--sort-by**\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION
 
@@ -177,6 +177,38 @@ behavior of locking down the server after configuring the BIOS.\
 - true
 
 - false
+
+**--bmc-vendor-override** *\<BMC_VENDOR_OVERRIDE\>*\
+Pin the Redfish BMC vendor for this host. Once set it governs how NICo
+talks to this BMC. It picks which libredfish driver each Redfish client
+dispatches on, the vendor nv-redfish classifies the host by, the vendor
+recorded by Site Explorer, and therefore the firmware config lookup, the
+IPMI-vs-Redfish restart choice and the BMC console transport. The hosts
+own DMI data is untouched, though where NICo would pick a Redfish client
+from that DMI vendor the pin outranks it. A RedfishVendor variant name,
+case-sensitive (e.g. Dell, Supermicro, NvidiaDpu, Hpe, Lenovo). Unset
+means automatic detection. Only the vendor is asserted, and everything
+else the BMC reports is left alone, so each library classifies the host
+the way it normally would for that vendor. Because the pin replaces
+detection rather than supplementing it, a wrong value can fail
+exploration outright instead of being ignored, and the failure is
+reported as the hosts last exploration error. It also selects which
+Redfish account change NICo issues when it changes this BMCs password on
+the initial factory bootstrap, on the site-wide rotation schedule, when
+restoring credentials after a factory reset, and for bmc-machine
+set-root-password. A wrong pin can therefore send the wrong account
+change to a factory BMC. Only that choice is pinned. The clients that
+probe a BMC, that bootstrap it from the factory, and that carry the
+password change itself are still built with no vendor at all, since they
+must reach a BMC before any vendor is usable. bmc-machine probe-vendor
+is unaffected and keeps reporting what the BMC says about itself. A pin
+asserts a vendor rather than a platform, so it also brings that vendors
+behavior, including how BMC user accounts are created and deleted and
+which vendor workarounds apply. Because only the vendor field is
+asserted, a pin naming a sub-variant such as NvidiaGH200, VeraRubin,
+NvidiaDpu or a power shelf still needs the product and Redfish version
+the BMC reports to agree, and where they do not the host can end up
+classified as nothing rather than as the pinned platform.
 
 **--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
 Sort output by specified field\

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-patch.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-patch.md
@@ -19,7 +19,8 @@ update, preserves unprovided fields).
 \[**--dpf-enabled**\] \[**--bmc-ip-address**\] \[**--extended**\]
 \[**--bmc-retain-credentials**\] \[**--dpu-policy**\]
 \[**--bmc-ip-allocation**\] \[**--interfaces**\]
-\[**--disable-lockdown**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+\[**--disable-lockdown**\] \[**--bmc-vendor-override**\]
+\[**--sort-by**\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION
 
@@ -188,6 +189,40 @@ behavior of locking down the server after configuring the BIOS.\
 
 - false
 
+**--bmc-vendor-override** *\<BMC_VENDOR_OVERRIDE\>*\
+Pin the Redfish BMC vendor for this host. Once set it governs how NICo
+talks to this BMC. It picks which libredfish driver each Redfish client
+dispatches on, the vendor nv-redfish classifies the host by, the vendor
+recorded by Site Explorer, and therefore the firmware config lookup, the
+IPMI-vs-Redfish restart choice and the BMC console transport. The hosts
+own DMI data is untouched, though where NICo would pick a Redfish client
+from that DMI vendor the pin outranks it. A RedfishVendor variant name,
+case-sensitive (e.g. Dell, Supermicro, NvidiaDpu, Hpe, Lenovo). Redfish
+clients pick it up within a minute, and the recorded vendor changes at
+the next successful exploration. Pass an empty string to clear the
+override (return to automatic detection). Only the vendor is asserted,
+and everything else the BMC reports is left alone, so each library
+classifies the host the way it normally would for that vendor. Because
+the pin replaces detection rather than supplementing it, a wrong value
+can fail exploration outright instead of being ignored, and the failure
+is reported as the hosts last exploration error. It also selects which
+Redfish account change NICo issues when it changes this BMCs password on
+the initial factory bootstrap, on the site-wide rotation schedule, when
+restoring credentials after a factory reset, and for bmc-machine
+set-root-password. A wrong pin can therefore send the wrong account
+change to a factory BMC. Only that choice is pinned. The clients that
+probe a BMC, that bootstrap it from the factory, and that carry the
+password change itself are still built with no vendor at all, since they
+must reach a BMC before any vendor is usable. bmc-machine probe-vendor
+is unaffected and keeps reporting what the BMC says about itself. A pin
+asserts a vendor rather than a platform, so it also brings that vendors
+behavior, including how BMC user accounts are created and deleted and
+which vendor workarounds apply. Because only the vendor field is
+asserted, a pin naming a sub-variant such as NvidiaGH200, VeraRubin,
+NvidiaDpu or a power shelf still needs the product and Redfish version
+the BMC reports to agree, and where they do not the host can end up
+classified as nothing rather than as the pinned platform.
+
 **--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
 Sort output by specified field\
 
@@ -211,6 +246,8 @@ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --dpu-
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --bmc-ip-allocation retained
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --interfaces '[{"mac_address":"02:00:00:00:20:01","fixed_ip":"192.0.2.10"}]'
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --interfaces '[{"mac_address":"02:00:00:00:20:01","role":"unspecified","ip_allocation":"unspecified","fixed_ip":"192.0.2.10"}]'
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --bmc-vendor-override Dell
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --bmc-vendor-override ""
 ```
 
 ---

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -36900,6 +36900,11 @@ type ExpectedMachine struct {
 	// host_nics, including `[]`; older clients leave it false so an unknown
 	// nested HostBmc is not removed by a read-modify-write.
 	ReplaceHostNics bool `protobuf:"varint,19,opt,name=replace_host_nics,json=replaceHostNics,proto3" json:"replace_host_nics,omitempty"`
+	// Operator pinned Redfish BMC vendor, a `RedfishVendor` name such as "Dell",
+	// forced into libredfish. Unset keeps whatever the stored row holds, so a
+	// client predating this field cannot clear a pin. Empty clears it, which
+	// returns the host to automatic detection.
+	BmcVendorOverride *string `protobuf:"bytes,20,opt,name=bmc_vendor_override,json=bmcVendorOverride,proto3,oneof" json:"bmc_vendor_override,omitempty"`
 	// WARNING: Following fields are not present in Core, but added directly in REST snapshot
 	Name            *string `protobuf:"bytes,21,opt,name=name,proto3,oneof" json:"name,omitempty"`
 	Manufacturer    *string `protobuf:"bytes,22,opt,name=manufacturer,proto3,oneof" json:"manufacturer,omitempty"`
@@ -37075,6 +37080,13 @@ func (x *ExpectedMachine) GetReplaceHostNics() bool {
 		return x.ReplaceHostNics
 	}
 	return false
+}
+
+func (x *ExpectedMachine) GetBmcVendorOverride() string {
+	if x != nil && x.BmcVendorOverride != nil {
+		return *x.BmcVendorOverride
+	}
+	return ""
 }
 
 func (x *ExpectedMachine) GetName() string {
@@ -67667,7 +67679,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x0e_ip_allocation\"[\n" +
 	"\x14HostLifecycleProfile\x12.\n" +
 	"\x10disable_lockdown\x18\x01 \x01(\bH\x00R\x0fdisableLockdown\x88\x01\x01B\x13\n" +
-	"\x11_disable_lockdown\"\x8e\f\n" +
+	"\x11_disable_lockdown\"\xdb\f\n" +
 	"\x0fExpectedMachine\x12&\n" +
 	"\x0fbmc_mac_address\x18\x01 \x01(\tR\rbmcMacAddress\x12!\n" +
 	"\fbmc_username\x18\x02 \x01(\tR\vbmcUsername\x12!\n" +
@@ -67689,16 +67701,17 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\bdpu_mode\x18\x10 \x01(\x0e2\x0e.forge.DpuModeH\aR\adpuMode\x88\x01\x01\x12V\n" +
 	"\x16host_lifecycle_profile\x18\x11 \x01(\v2\x1b.forge.HostLifecycleProfileH\bR\x14hostLifecycleProfile\x88\x01\x01\x12K\n" +
 	"\x11bmc_ip_allocation\x18\x12 \x01(\x0e2\x1a.forge.BmcIpAllocationTypeH\tR\x0fbmcIpAllocation\x88\x01\x01\x12*\n" +
-	"\x11replace_host_nics\x18\x13 \x01(\bR\x0freplaceHostNics\x12\x17\n" +
-	"\x04name\x18\x15 \x01(\tH\n" +
-	"R\x04name\x88\x01\x01\x12'\n" +
-	"\fmanufacturer\x18\x16 \x01(\tH\vR\fmanufacturer\x88\x01\x01\x12\x19\n" +
-	"\x05model\x18\x17 \x01(\tH\fR\x05model\x88\x01\x01\x12%\n" +
-	"\vdescription\x18\x18 \x01(\tH\rR\vdescription\x88\x01\x01\x12.\n" +
-	"\x10firmware_version\x18\x19 \x01(\tH\x0eR\x0ffirmwareVersion\x88\x01\x01\x12\x1c\n" +
-	"\aslot_id\x18\x1a \x01(\x05H\x0fR\x06slotId\x88\x01\x01\x12\x1e\n" +
-	"\btray_idx\x18\x1b \x01(\x05H\x10R\atrayIdx\x88\x01\x01\x12\x1c\n" +
-	"\ahost_id\x18\x1c \x01(\x05H\x11R\x06hostId\x88\x01\x01B\t\n" +
+	"\x11replace_host_nics\x18\x13 \x01(\bR\x0freplaceHostNics\x123\n" +
+	"\x13bmc_vendor_override\x18\x14 \x01(\tH\n" +
+	"R\x11bmcVendorOverride\x88\x01\x01\x12\x17\n" +
+	"\x04name\x18\x15 \x01(\tH\vR\x04name\x88\x01\x01\x12'\n" +
+	"\fmanufacturer\x18\x16 \x01(\tH\fR\fmanufacturer\x88\x01\x01\x12\x19\n" +
+	"\x05model\x18\x17 \x01(\tH\rR\x05model\x88\x01\x01\x12%\n" +
+	"\vdescription\x18\x18 \x01(\tH\x0eR\vdescription\x88\x01\x01\x12.\n" +
+	"\x10firmware_version\x18\x19 \x01(\tH\x0fR\x0ffirmwareVersion\x88\x01\x01\x12\x1c\n" +
+	"\aslot_id\x18\x1a \x01(\x05H\x10R\x06slotId\x88\x01\x01\x12\x1e\n" +
+	"\btray_idx\x18\x1b \x01(\x05H\x11R\atrayIdx\x88\x01\x01\x12\x1c\n" +
+	"\ahost_id\x18\x1c \x01(\x05H\x12R\x06hostId\x88\x01\x01B\t\n" +
 	"\a_sku_idB\x05\n" +
 	"\x03_idB\n" +
 	"\n" +
@@ -67709,7 +67722,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x17_bmc_retain_credentialsB\v\n" +
 	"\t_dpu_modeB\x19\n" +
 	"\x17_host_lifecycle_profileB\x14\n" +
-	"\x12_bmc_ip_allocationB\a\n" +
+	"\x12_bmc_ip_allocationB\x16\n" +
+	"\x14_bmc_vendor_overrideB\a\n" +
 	"\x05_nameB\x0f\n" +
 	"\r_manufacturerB\b\n" +
 	"\x06_modelB\x0e\n" +

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -6586,6 +6586,11 @@ message ExpectedMachine {
   // host_nics, including `[]`; older clients leave it false so an unknown
   // nested HostBmc is not removed by a read-modify-write.
   bool replace_host_nics = 19;
+  // Operator pinned Redfish BMC vendor, a `RedfishVendor` name such as "Dell",
+  // forced into libredfish. Unset keeps whatever the stored row holds, so a
+  // client predating this field cannot clear a pin. Empty clears it, which
+  // returns the host to automatic detection.
+  optional string bmc_vendor_override = 20;
 
   // WARNING: Following fields are not present in Core, but added directly in REST snapshot
   optional string name = 21;


### PR DESCRIPTION
Pin a Redfish BMC vendor on the expected machine record. Resolved inside
`create_client` so every BMC client honors it, and recorded by Site Explorer so
it also drives the firmware config key, the restart path and the console
transport. Probe and factory-bootstrap clients stay unpinnable, since forcing a
vendor there deadlocks credential rotation. Unpinned hosts are unchanged.

## Related issues
...

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
...

