### PR TITLE
fix(scout): tolerate a dead NVMe during cleanup (do not fail the whole machine)

### DIFF
--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -498,8 +498,16 @@ async fn all_nvme_cleanup() -> Result<(), CarbideClientError> {
         "NVMe cleanup completed"
     );
 
+    if !errors.is_empty() && success_count == 0 {
+        return Err(CarbideClientError::GenericError(format!(
+            "all NVMe device(s) failed cleanup:\n{}",
+            errors.join("\n")
+        )));
+    }
     if !errors.is_empty() {
-        return Err(CarbideClientError::GenericError(errors.join("\n")));
+        // a dead/failed drive must not fail the whole machine; the OS install targets a
+        // healthy drive. Extends the per-format tolerance from #2820 to the cleanup result.
+        tracing::warn!(success_count, failed = errors.len(), "some NVMe devices failed cleanup but at least one succeeded; continuing");
     }
 
     Ok(())


### PR DESCRIPTION
## Problem

In `crates/scout/src/deprovision/scrabbing.rs`, `all_nvme_cleanup` returns an error if **any** NVMe device fails cleanup. Because a single dead or failing drive aborts the entire cleanup, the machine transitions to `FAILED/NVMECleanFailed` and can never be provisioned again — even though the OS install only requires **one** healthy drive. A single bad disk should not condemn an otherwise-usable machine.

## Real incident

A drive returning `nvme delete-ns ... Internal Error 0x6006` failed its per-device cleanup. The error propagated out of `all_nvme_cleanup`, putting the whole machine into `NVMECleanFailed` and making it unprovisionable, despite the remaining drives being healthy and cleaned successfully.

## Fix

Fail the cleanup only when **every** drive failed (`success_count == 0`). If at least one drive succeeded, log a `tracing::warn!` with the success/failure counts and continue — the OS install targets a healthy drive. This extends the per-format error tolerance introduced in #2820 to the overall cleanup result. The analogous HDD/SAS cleanup block is intentionally left unchanged.