### PR TITLE
fix: require instance type machine capabilities

### DIFF
--- a/crates/api-core/src/handlers/instance_type.rs
+++ b/crates/api-core/src/handlers/instance_type.rs
@@ -36,6 +36,24 @@ use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::cfg::file::ComputeAllocationEnforcement;
 
+fn desired_capabilities_from_attributes(
+    attributes: Option<rpc::InstanceTypeAttributes>,
+) -> Result<Vec<InstanceTypeMachineCapabilityFilter>, Status> {
+    let desired_capabilities = attributes.unwrap_or_default().desired_capabilities;
+    if desired_capabilities.is_empty() {
+        return Err(CarbideError::InvalidArgument(
+            "at least one desired capability must be provided".to_string(),
+        )
+        .into());
+    }
+
+    desired_capabilities
+        .into_iter()
+        .map(InstanceTypeMachineCapabilityFilter::try_from)
+        .collect::<Result<Vec<_>, RpcDataConversionError>>()
+        .map_err(Into::into)
+}
+
 pub(crate) async fn create(
     api: &Api,
     request: Request<rpc::CreateInstanceTypeRequest>,
@@ -64,18 +82,7 @@ pub(crate) async fn create(
 
     metadata.validate(true).map_err(CarbideError::from)?;
 
-    // Prepare the capabilities list
-    let mut desired_capabilities = Vec::<InstanceTypeMachineCapabilityFilter>::new();
-
-    for cap in req
-        .instance_type_attributes
-        .unwrap_or(rpc::InstanceTypeAttributes {
-            ..Default::default()
-        })
-        .desired_capabilities
-    {
-        desired_capabilities.push(cap.try_into()?);
-    }
+    let desired_capabilities = desired_capabilities_from_attributes(req.instance_type_attributes)?;
 
     // Start a new transaction for a db write.
     let mut txn = api.txn_begin().await?;
@@ -274,18 +281,7 @@ pub(crate) async fn update(
 
     metadata.validate(true).map_err(CarbideError::from)?;
 
-    // Prepare the desired capabilities list
-    let mut desired_capabilities = Vec::<InstanceTypeMachineCapabilityFilter>::new();
-
-    for cap in req
-        .instance_type_attributes
-        .unwrap_or(rpc::InstanceTypeAttributes {
-            ..Default::default()
-        })
-        .desired_capabilities
-    {
-        desired_capabilities.push(cap.try_into()?);
-    }
+    let desired_capabilities = desired_capabilities_from_attributes(req.instance_type_attributes)?;
 
     // Start a new transaction for a db write.
     let mut txn = api.txn_begin().await?;

--- a/crates/api-core/src/tests/instance_type.rs
+++ b/crates/api-core/src/tests/instance_type.rs
@@ -153,6 +153,84 @@ async fn test_instance_type_create(pool: sqlx::PgPool) -> Result<(), Box<dyn std
 }
 
 #[crate::sqlx_test]
+async fn test_instance_type_create_and_update_require_desired_capabilities(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let id = "requires_non_empty_capabilities";
+    let metadata = Some(rpc::forge::Metadata {
+        name: "requires non-empty capabilities".to_string(),
+        description: "".to_string(),
+        labels: vec![],
+    });
+
+    for (scenario, instance_type_attributes) in [
+        ("attributes omitted", None),
+        (
+            "desired capabilities empty",
+            Some(rpc::forge::InstanceTypeAttributes::default()),
+        ),
+    ] {
+        let status = env
+            .api
+            .create_instance_type(tonic::Request::new(rpc::forge::CreateInstanceTypeRequest {
+                id: Some(id.to_string()),
+                metadata: metadata.clone(),
+                instance_type_attributes,
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), Code::InvalidArgument, "{scenario}");
+        assert_eq!(
+            status.message(),
+            "at least one desired capability must be provided",
+            "{scenario}"
+        );
+    }
+
+    let valid_attributes = Some(rpc::forge::InstanceTypeAttributes {
+        desired_capabilities: vec![rpc::forge::InstanceTypeMachineCapabilityFilterAttributes {
+            capability_type: rpc::forge::MachineCapabilityType::CapTypeCpu.into(),
+            name: Some("pentium 4 HT".to_string()),
+            ..Default::default()
+        }],
+    });
+    env.api
+        .create_instance_type(tonic::Request::new(rpc::forge::CreateInstanceTypeRequest {
+            id: Some(id.to_string()),
+            metadata: metadata.clone(),
+            instance_type_attributes: valid_attributes,
+        }))
+        .await
+        .unwrap();
+
+    for (scenario, instance_type_attributes) in [
+        ("attributes omitted", None),
+        (
+            "desired capabilities empty",
+            Some(rpc::forge::InstanceTypeAttributes::default()),
+        ),
+    ] {
+        let status = env
+            .api
+            .update_instance_type(tonic::Request::new(rpc::forge::UpdateInstanceTypeRequest {
+                id: id.to_string(),
+                metadata: metadata.clone(),
+                instance_type_attributes,
+                if_version_match: None,
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), Code::InvalidArgument, "{scenario}");
+        assert_eq!(
+            status.message(),
+            "at least one desired capability must be provided",
+            "{scenario}"
+        );
+    }
+}
+
+#[crate::sqlx_test]
 async fn test_instance_type_update(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
 

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -123,6 +123,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_site_explorer_created_power_shelves_count</td><td>gauge</td><td>The amount of Power Shelves that had been created by Site Explorer after being identified</td></tr>
 <tr><td>carbide_site_explorer_enabled</td><td>gauge</td><td>Whether site-explorer is enabled (1) or paused (0)</td></tr>
 <tr><td>carbide_site_explorer_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration</td></tr>
+<tr><td>carbide_site_explorer_last_run_status</td><td>gauge</td><td>The status of the latest Site Explorer run</td></tr>
 <tr><td>carbide_site_explorer_phase_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration phase</td></tr>
 <tr><td>carbide_site_explorer_update_explored_endpoints_count</td><td>gauge</td><td>Counts from the last update_explored_endpoints phase by kind</td></tr>
 <tr><td>carbide_switches_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_switches in the system</td></tr>

--- a/rest-api/api/pkg/api/handler/instancetype_test.go
+++ b/rest-api/api/pkg/api/handler/instancetype_test.go
@@ -205,19 +205,38 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 		},
 	}
 
-	itcrValidWithoutMachineCapabilities := &model.APIInstanceTypeCreateRequest{
+	itcrInvalidMissingMachineCapabilities := &model.APIInstanceTypeCreateRequest{
 		Name:        "x2.large.missing.mc",
 		Description: sutil.GetPtr("Test Description"),
 		SiteID:      st.ID.String(),
 	}
 
+	itcrInvalidEmptyMachineCapabilities := &model.APIInstanceTypeCreateRequest{
+		Name:                "x2.large.empty.mc",
+		Description:         sutil.GetPtr("Test Description"),
+		SiteID:              st.ID.String(),
+		MachineCapabilities: []model.APIMachineCapability{},
+	}
+
 	itcrInvalid1 := &model.APIInstanceTypeCreateRequest{
 		Name: "x2.large",
+		MachineCapabilities: []model.APIMachineCapability{
+			{
+				Type: cdbm.MachineCapabilityTypeCPU,
+				Name: "Intel Xeon E5-2650 v2",
+			},
+		},
 	}
 
 	itcrInvalid2 := &model.APIInstanceTypeCreateRequest{
 		Name:   "x2.large",
 		SiteID: uuid.New().String(),
+		MachineCapabilities: []model.APIMachineCapability{
+			{
+				Type: cdbm.MachineCapabilityTypeCPU,
+				Name: "Intel Xeon E5-2650 v2",
+			},
+		},
 	}
 
 	common.TestBuildInstanceType(t, dbSession, "test-it-name-1", nil, st, map[string]string{
@@ -234,6 +253,12 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 		Description:           sutil.GetPtr("Test Description"),
 		SiteID:                st.ID.String(),
 		ControllerMachineType: sutil.GetPtr("intel_xeon_e5_2650v2"),
+		MachineCapabilities: []model.APIMachineCapability{
+			{
+				Type: cdbm.MachineCapabilityTypeCPU,
+				Name: "Intel Xeon E5-2650 v2",
+			},
+		},
 	}
 
 	cfg := common.GetTestConfig()
@@ -339,7 +364,12 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 						"description": "Test x9001 Instance Type ",
 					},
 					ControllerMachineType: sutil.GetPtr("intel_goku_e9001_dbzv2"),
-					MachineCapabilities:   []model.APIMachineCapability{},
+					MachineCapabilities: []model.APIMachineCapability{
+						{
+							Type: cdbm.MachineCapabilityTypeCPU,
+							Name: "Intel Goku E9001",
+						},
+					},
 				},
 			},
 			wantErr:                false,
@@ -360,12 +390,18 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 					Description:           sutil.GetPtr("Test Description"),
 					SiteID:                st.ID.String(),
 					ControllerMachineType: sutil.GetPtr("intel_goku_e9001_dbzv2"),
-					MachineCapabilities:   []model.APIMachineCapability{},
+					MachineCapabilities: []model.APIMachineCapability{
+						{
+							Type: cdbm.MachineCapabilityTypeCPU,
+							Name: "Intel Goku E9001",
+						},
+					},
 				},
 			},
-			wantErr:                false,
-			expectedResourcesCount: 1,
-			respCode:               http.StatusCreated,
+			wantErr:                     false,
+			expectedResourcesCount:      1,
+			expectedMachineCapabilities: 1,
+			respCode:                    http.StatusCreated,
 		},
 		{
 			name: "test create Instance Type API endpoint with valid data",
@@ -385,7 +421,7 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 			verifyChildSpanner:          true,
 		},
 		{
-			name: "test create Instance Type API endpoint with valid data but no machine capabilities",
+			name: "test create Instance Type API endpoint rejects missing machine capabilities",
 			fields: fields{
 				dbSession: dbSession,
 				tc:        &tmocks.Client{},
@@ -393,12 +429,24 @@ func TestCreateInstanceTypeHandler_Handle(t *testing.T) {
 				cfg:       cfg,
 			},
 			args: args{
-				reqData: itcrValidWithoutMachineCapabilities,
+				reqData: itcrInvalidMissingMachineCapabilities,
 			},
-			wantErr:                     false,
-			respCode:                    http.StatusCreated,
-			expectedResourcesCount:      1,
-			expectedMachineCapabilities: 0,
+			wantErr:  false,
+			respCode: http.StatusBadRequest,
+		},
+		{
+			name: "test create Instance Type API endpoint rejects empty machine capabilities",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: itcrInvalidEmptyMachineCapabilities,
+			},
+			wantErr:  false,
+			respCode: http.StatusBadRequest,
 		},
 		{
 			name: "error create Instance Type API endpoint with name clash",
@@ -2114,6 +2162,24 @@ func TestUpdateInstanceTypeHandler_Handle(t *testing.T) {
 				reqData:        &model.APIInstanceTypeUpdateRequest{},
 			},
 			wantRespCode: http.StatusOK,
+		},
+		{
+			name: "test Instance Type update rejects empty machine capabilities",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        &tmocks.Client{},
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				user:           ipu,
+				org:            org,
+				instanceTypeID: it2.ID,
+				reqData: &model.APIInstanceTypeUpdateRequest{
+					MachineCapabilities: []model.APIMachineCapability{},
+				},
+			},
+			wantRespCode: http.StatusBadRequest,
 		},
 		{
 			name: "test Instance Type update fail with new capability of a bad type",

--- a/rest-api/api/pkg/api/model/instancetype.go
+++ b/rest-api/api/pkg/api/model/instancetype.go
@@ -43,7 +43,8 @@ func (itcr *APIInstanceTypeCreateRequest) Validate() error {
 			validation.Required.Error(validationErrorValueRequired),
 			validationis.UUID.Error(validationErrorInvalidUUID)),
 		validation.Field(&itcr.Labels, validation.By(util.ValidateLabels)),
-		validation.Field(&itcr.MachineCapabilities),
+		validation.Field(&itcr.MachineCapabilities,
+			validation.Required.Error(validationErrorValueRequired)),
 	)
 }
 
@@ -87,7 +88,9 @@ func (itur *APIInstanceTypeUpdateRequest) Validate() error {
 			validation.When(itur.Name != nil, validation.By(util.ValidateNameCharacters)),
 			validation.When(itur.Name != nil, validation.Length(2, 256).Error(validationErrorStringLength))),
 		validation.Field(&itur.Labels, validation.By(util.ValidateLabels)),
-		validation.Field(&itur.MachineCapabilities),
+		validation.Field(&itur.MachineCapabilities,
+			validation.When(itur.MachineCapabilities != nil,
+				validation.Required.Error(validationErrorValueRequired))),
 	)
 }
 

--- a/rest-api/api/pkg/api/model/instancetype_test.go
+++ b/rest-api/api/pkg/api/model/instancetype_test.go
@@ -195,6 +195,23 @@ func TestAPIInstanceTypeCreateRequest_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "test invalid Instance Type create request - missing Machine Capabilities",
+			fields: fields{
+				Name:   "test-name",
+				SiteID: uuid.New().String(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "test invalid Instance Type create request - empty Machine Capabilities",
+			fields: fields{
+				Name:                "test-name",
+				SiteID:              uuid.New().String(),
+				MachineCapabilities: []APIMachineCapability{},
+			},
+			wantErr: true,
+		},
+		{
 			name: "test invalid Instance Type create request - invalid Site ID",
 			fields: fields{
 				Name:                  "test-name",
@@ -450,9 +467,10 @@ func TestAPIInstanceTypeCreateRequest_Validate(t *testing.T) {
 
 func TestAPIInstanceTypeUpdateRequest_Validate(t *testing.T) {
 	type fields struct {
-		Name        *string
-		Description *string
-		Labels      map[string]string
+		Name                *string
+		Description         *string
+		Labels              map[string]string
+		MachineCapabilities APIMachineCapabilities
 	}
 	tests := []struct {
 		name    string
@@ -471,14 +489,39 @@ func TestAPIInstanceTypeUpdateRequest_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:    "test valid Instance Type update request - Machine Capabilities omitted",
+			fields:  fields{},
+			wantErr: false,
+		},
+		{
+			name: "test invalid Instance Type update request - empty Machine Capabilities",
+			fields: fields{
+				MachineCapabilities: APIMachineCapabilities{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test valid Instance Type update request - non-empty Machine Capabilities",
+			fields: fields{
+				MachineCapabilities: APIMachineCapabilities{
+					{
+						Type: cdbm.MachineCapabilityTypeCPU,
+						Name: "AMD Opteron Series x10",
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			itur := APIInstanceTypeUpdateRequest{
-				Name:        tt.fields.Name,
-				Description: tt.fields.Description,
-				Labels:      tt.fields.Labels,
+				Name:                tt.fields.Name,
+				Description:         tt.fields.Description,
+				Labels:              tt.fields.Labels,
+				MachineCapabilities: tt.fields.MachineCapabilities,
 			}
 			err := itur.Validate()
 			if tt.wantErr {

--- a/rest-api/flow/internal/nicoapi/gen/nico.pb.go
+++ b/rest-api/flow/internal/nicoapi/gen/nico.pb.go
@@ -1569,8 +1569,9 @@ func (MessageKind) EnumDescriptor() ([]byte, []int) {
 type ExpireDhcpLeaseStatus int32
 
 const (
-	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_RELEASED  ExpireDhcpLeaseStatus = 0
-	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND ExpireDhcpLeaseStatus = 1
+	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_RELEASED         ExpireDhcpLeaseStatus = 0
+	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND        ExpireDhcpLeaseStatus = 1
+	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED ExpireDhcpLeaseStatus = 2
 )
 
 // Enum value maps for ExpireDhcpLeaseStatus.
@@ -1578,10 +1579,12 @@ var (
 	ExpireDhcpLeaseStatus_name = map[int32]string{
 		0: "EXPIRE_DHCP_LEASE_STATUS_RELEASED",
 		1: "EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND",
+		2: "EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED",
 	}
 	ExpireDhcpLeaseStatus_value = map[string]int32{
-		"EXPIRE_DHCP_LEASE_STATUS_RELEASED":  0,
-		"EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND": 1,
+		"EXPIRE_DHCP_LEASE_STATUS_RELEASED":         0,
+		"EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND":        1,
+		"EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED": 2,
 	}
 )
 
@@ -63245,10 +63248,11 @@ const file_nico_proto_rawDesc = "" +
 	"\x18MESSAGE_KIND_V4_DISCOVER\x10\x01\x12\x1b\n" +
 	"\x17MESSAGE_KIND_V6_SOLICIT\x10\x02\x12\x1b\n" +
 	"\x17MESSAGE_KIND_V6_REQUEST\x10\x03\x12 \n" +
-	"\x1cMESSAGE_KIND_V6_INFO_REQUEST\x10\x04*f\n" +
+	"\x1cMESSAGE_KIND_V6_INFO_REQUEST\x10\x04*\x95\x01\n" +
 	"\x15ExpireDhcpLeaseStatus\x12%\n" +
 	"!EXPIRE_DHCP_LEASE_STATUS_RELEASED\x10\x00\x12&\n" +
-	"\"EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND\x10\x01*D\n" +
+	"\"EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND\x10\x01\x12-\n" +
+	")EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED\x10\x02*D\n" +
 	"\tUserRoles\x12\b\n" +
 	"\x04USER\x10\x00\x12\x11\n" +
 	"\rADMINISTRATOR\x10\x01\x12\f\n" +
@@ -63484,7 +63488,7 @@ const file_nico_proto_rawDesc = "" +
 	"\x13OperatingSystemType\x12\x17\n" +
 	"\x13OS_TYPE_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fOS_TYPE_IPXE\x10\x01\x12\x1a\n" +
-	"\x16OS_TYPE_TEMPLATED_IPXE\x10\x022\xa1\xc7\x02\n" +
+	"\x16OS_TYPE_TEMPLATED_IPXE\x10\x022\xff\xc7\x02\n" +
 	"\x05Forge\x122\n" +
 	"\aVersion\x12\x15.forge.VersionRequest\x1a\x10.forge.BuildInfo\x12C\n" +
 	"\x12CreateDomainLegacy\x12\x13.forge.DomainLegacy\x1a\x13.forge.DomainLegacy\"\x03\x88\x02\x01\x12C\n" +
@@ -63619,6 +63623,7 @@ const file_nico_proto_rawDesc = "" +
 	"\x18GetSwitchNvosCredentials\x12&.forge.GetSwitchNvosCredentialsRequest\x1a .forge.GetBmcCredentialsResponse\x12q\n" +
 	"\x1eGetAllManagedHostNetworkStatus\x12&.forge.ManagedHostNetworkStatusRequest\x1a'.forge.ManagedHostNetworkStatusResponse\x12b\n" +
 	"\x18GetSiteExplorationReport\x12 .forge.GetSiteExplorationRequest\x1a$.site_explorer.SiteExplorationReport\x12\\\n" +
+	"\x16GetSiteExplorerLastRun\x12\x16.google.protobuf.Empty\x1a*.site_explorer.SiteExplorerLastRunResponse\x12\\\n" +
 	"\x19ClearSiteExplorationError\x12'.forge.ClearSiteExplorationErrorRequest\x1a\x16.google.protobuf.Empty\x12R\n" +
 	"\x12IsBmcInManagedHost\x12\x19.forge.BmcEndpointRequest\x1a!.forge.IsBmcInManagedHostResponse\x12T\n" +
 	"\x13BmcCredentialStatus\x12\x19.forge.BmcEndpointRequest\x1a\".forge.BmcCredentialStatusResponse\x12N\n" +
@@ -64985,13 +64990,13 @@ var file_nico_proto_goTypes = []any{
 	(SystemPowerControl)(0),                              // 1021: common.SystemPowerControl
 	(*SerializableMlxConfigProfile)(nil),                 // 1022: mlx_device.SerializableMlxConfigProfile
 	(*FirmwareFlasherProfile)(nil),                       // 1023: mlx_device.FirmwareFlasherProfile
-	(*ExploredEndpointSearchFilter)(nil),                 // 1024: site_explorer.ExploredEndpointSearchFilter
-	(*ExploredEndpointsByIdsRequest)(nil),                // 1025: site_explorer.ExploredEndpointsByIdsRequest
-	(*ExploredManagedHostSearchFilter)(nil),              // 1026: site_explorer.ExploredManagedHostSearchFilter
-	(*ExploredManagedHostsByIdsRequest)(nil),             // 1027: site_explorer.ExploredManagedHostsByIdsRequest
-	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1028: site_explorer.ExploredMlxDeviceHostSearchFilter
-	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1029: site_explorer.ExploredMlxDevicesByIdsRequest
-	(*emptypb.Empty)(nil),                                // 1030: google.protobuf.Empty
+	(*emptypb.Empty)(nil),                                // 1024: google.protobuf.Empty
+	(*ExploredEndpointSearchFilter)(nil),                 // 1025: site_explorer.ExploredEndpointSearchFilter
+	(*ExploredEndpointsByIdsRequest)(nil),                // 1026: site_explorer.ExploredEndpointsByIdsRequest
+	(*ExploredManagedHostSearchFilter)(nil),              // 1027: site_explorer.ExploredManagedHostSearchFilter
+	(*ExploredManagedHostsByIdsRequest)(nil),             // 1028: site_explorer.ExploredManagedHostsByIdsRequest
+	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1029: site_explorer.ExploredMlxDeviceHostSearchFilter
+	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1030: site_explorer.ExploredMlxDevicesByIdsRequest
 	(*CreateMeasurementBundleRequest)(nil),               // 1031: measured_boot.CreateMeasurementBundleRequest
 	(*DeleteMeasurementBundleRequest)(nil),               // 1032: measured_boot.DeleteMeasurementBundleRequest
 	(*RenameMeasurementBundleRequest)(nil),               // 1033: measured_boot.RenameMeasurementBundleRequest
@@ -65053,73 +65058,74 @@ var file_nico_proto_goTypes = []any{
 	(*MlxAdminConfigSyncRequest)(nil),                    // 1089: mlx_device.MlxAdminConfigSyncRequest
 	(*MlxAdminConfigCompareRequest)(nil),                 // 1090: mlx_device.MlxAdminConfigCompareRequest
 	(*SiteExplorationReport)(nil),                        // 1091: site_explorer.SiteExplorationReport
-	(*ExploredEndpoint)(nil),                             // 1092: site_explorer.ExploredEndpoint
-	(*ExploredEndpointIdList)(nil),                       // 1093: site_explorer.ExploredEndpointIdList
-	(*ExploredEndpointList)(nil),                         // 1094: site_explorer.ExploredEndpointList
-	(*ExploredManagedHostIdList)(nil),                    // 1095: site_explorer.ExploredManagedHostIdList
-	(*ExploredManagedHostList)(nil),                      // 1096: site_explorer.ExploredManagedHostList
-	(*ExploredMlxDeviceHostIdList)(nil),                  // 1097: site_explorer.ExploredMlxDeviceHostIdList
-	(*ExploredMlxDeviceList)(nil),                        // 1098: site_explorer.ExploredMlxDeviceList
-	(*CreateMeasurementBundleResponse)(nil),              // 1099: measured_boot.CreateMeasurementBundleResponse
-	(*DeleteMeasurementBundleResponse)(nil),              // 1100: measured_boot.DeleteMeasurementBundleResponse
-	(*RenameMeasurementBundleResponse)(nil),              // 1101: measured_boot.RenameMeasurementBundleResponse
-	(*UpdateMeasurementBundleResponse)(nil),              // 1102: measured_boot.UpdateMeasurementBundleResponse
-	(*ShowMeasurementBundleResponse)(nil),                // 1103: measured_boot.ShowMeasurementBundleResponse
-	(*ShowMeasurementBundlesResponse)(nil),               // 1104: measured_boot.ShowMeasurementBundlesResponse
-	(*ListMeasurementBundlesResponse)(nil),               // 1105: measured_boot.ListMeasurementBundlesResponse
-	(*ListMeasurementBundleMachinesResponse)(nil),        // 1106: measured_boot.ListMeasurementBundleMachinesResponse
-	(*DeleteMeasurementJournalResponse)(nil),             // 1107: measured_boot.DeleteMeasurementJournalResponse
-	(*ShowMeasurementJournalResponse)(nil),               // 1108: measured_boot.ShowMeasurementJournalResponse
-	(*ShowMeasurementJournalsResponse)(nil),              // 1109: measured_boot.ShowMeasurementJournalsResponse
-	(*ListMeasurementJournalResponse)(nil),               // 1110: measured_boot.ListMeasurementJournalResponse
-	(*AttestCandidateMachineResponse)(nil),               // 1111: measured_boot.AttestCandidateMachineResponse
-	(*ShowCandidateMachineResponse)(nil),                 // 1112: measured_boot.ShowCandidateMachineResponse
-	(*ShowCandidateMachinesResponse)(nil),                // 1113: measured_boot.ShowCandidateMachinesResponse
-	(*ListCandidateMachinesResponse)(nil),                // 1114: measured_boot.ListCandidateMachinesResponse
-	(*CreateMeasurementSystemProfileResponse)(nil),       // 1115: measured_boot.CreateMeasurementSystemProfileResponse
-	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1116: measured_boot.DeleteMeasurementSystemProfileResponse
-	(*RenameMeasurementSystemProfileResponse)(nil),       // 1117: measured_boot.RenameMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfileResponse)(nil),         // 1118: measured_boot.ShowMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1119: measured_boot.ShowMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfilesResponse)(nil),        // 1120: measured_boot.ListMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1121: measured_boot.ListMeasurementSystemProfileBundlesResponse
-	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1122: measured_boot.ListMeasurementSystemProfileMachinesResponse
-	(*CreateMeasurementReportResponse)(nil),              // 1123: measured_boot.CreateMeasurementReportResponse
-	(*DeleteMeasurementReportResponse)(nil),              // 1124: measured_boot.DeleteMeasurementReportResponse
-	(*PromoteMeasurementReportResponse)(nil),             // 1125: measured_boot.PromoteMeasurementReportResponse
-	(*RevokeMeasurementReportResponse)(nil),              // 1126: measured_boot.RevokeMeasurementReportResponse
-	(*ShowMeasurementReportForIdResponse)(nil),           // 1127: measured_boot.ShowMeasurementReportForIdResponse
-	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1128: measured_boot.ShowMeasurementReportsForMachineResponse
-	(*ShowMeasurementReportsResponse)(nil),               // 1129: measured_boot.ShowMeasurementReportsResponse
-	(*ListMeasurementReportResponse)(nil),                // 1130: measured_boot.ListMeasurementReportResponse
-	(*MatchMeasurementReportResponse)(nil),               // 1131: measured_boot.MatchMeasurementReportResponse
-	(*ImportSiteMeasurementsResponse)(nil),               // 1132: measured_boot.ImportSiteMeasurementsResponse
-	(*ExportSiteMeasurementsResponse)(nil),               // 1133: measured_boot.ExportSiteMeasurementsResponse
-	(*AddMeasurementTrustedMachineResponse)(nil),         // 1134: measured_boot.AddMeasurementTrustedMachineResponse
-	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1135: measured_boot.RemoveMeasurementTrustedMachineResponse
-	(*AddMeasurementTrustedProfileResponse)(nil),         // 1136: measured_boot.AddMeasurementTrustedProfileResponse
-	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1137: measured_boot.RemoveMeasurementTrustedProfileResponse
-	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1138: measured_boot.ListMeasurementTrustedMachinesResponse
-	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1139: measured_boot.ListMeasurementTrustedProfilesResponse
-	(*ListAttestationSummaryResponse)(nil),               // 1140: measured_boot.ListAttestationSummaryResponse
-	(*LockdownStatus)(nil),                               // 1141: site_explorer.LockdownStatus
-	(*PublishMlxDeviceReportResponse)(nil),               // 1142: mlx_device.PublishMlxDeviceReportResponse
-	(*PublishMlxObservationReportResponse)(nil),          // 1143: mlx_device.PublishMlxObservationReportResponse
-	(*MlxAdminProfileSyncResponse)(nil),                  // 1144: mlx_device.MlxAdminProfileSyncResponse
-	(*MlxAdminProfileShowResponse)(nil),                  // 1145: mlx_device.MlxAdminProfileShowResponse
-	(*MlxAdminProfileCompareResponse)(nil),               // 1146: mlx_device.MlxAdminProfileCompareResponse
-	(*MlxAdminProfileListResponse)(nil),                  // 1147: mlx_device.MlxAdminProfileListResponse
-	(*MlxAdminLockdownLockResponse)(nil),                 // 1148: mlx_device.MlxAdminLockdownLockResponse
-	(*MlxAdminLockdownUnlockResponse)(nil),               // 1149: mlx_device.MlxAdminLockdownUnlockResponse
-	(*MlxAdminLockdownStatusResponse)(nil),               // 1150: mlx_device.MlxAdminLockdownStatusResponse
-	(*MlxAdminDeviceInfoResponse)(nil),                   // 1151: mlx_device.MlxAdminDeviceInfoResponse
-	(*MlxAdminDeviceReportResponse)(nil),                 // 1152: mlx_device.MlxAdminDeviceReportResponse
-	(*MlxAdminRegistryListResponse)(nil),                 // 1153: mlx_device.MlxAdminRegistryListResponse
-	(*MlxAdminRegistryShowResponse)(nil),                 // 1154: mlx_device.MlxAdminRegistryShowResponse
-	(*MlxAdminConfigQueryResponse)(nil),                  // 1155: mlx_device.MlxAdminConfigQueryResponse
-	(*MlxAdminConfigSetResponse)(nil),                    // 1156: mlx_device.MlxAdminConfigSetResponse
-	(*MlxAdminConfigSyncResponse)(nil),                   // 1157: mlx_device.MlxAdminConfigSyncResponse
-	(*MlxAdminConfigCompareResponse)(nil),                // 1158: mlx_device.MlxAdminConfigCompareResponse
+	(*SiteExplorerLastRunResponse)(nil),                  // 1092: site_explorer.SiteExplorerLastRunResponse
+	(*ExploredEndpoint)(nil),                             // 1093: site_explorer.ExploredEndpoint
+	(*ExploredEndpointIdList)(nil),                       // 1094: site_explorer.ExploredEndpointIdList
+	(*ExploredEndpointList)(nil),                         // 1095: site_explorer.ExploredEndpointList
+	(*ExploredManagedHostIdList)(nil),                    // 1096: site_explorer.ExploredManagedHostIdList
+	(*ExploredManagedHostList)(nil),                      // 1097: site_explorer.ExploredManagedHostList
+	(*ExploredMlxDeviceHostIdList)(nil),                  // 1098: site_explorer.ExploredMlxDeviceHostIdList
+	(*ExploredMlxDeviceList)(nil),                        // 1099: site_explorer.ExploredMlxDeviceList
+	(*CreateMeasurementBundleResponse)(nil),              // 1100: measured_boot.CreateMeasurementBundleResponse
+	(*DeleteMeasurementBundleResponse)(nil),              // 1101: measured_boot.DeleteMeasurementBundleResponse
+	(*RenameMeasurementBundleResponse)(nil),              // 1102: measured_boot.RenameMeasurementBundleResponse
+	(*UpdateMeasurementBundleResponse)(nil),              // 1103: measured_boot.UpdateMeasurementBundleResponse
+	(*ShowMeasurementBundleResponse)(nil),                // 1104: measured_boot.ShowMeasurementBundleResponse
+	(*ShowMeasurementBundlesResponse)(nil),               // 1105: measured_boot.ShowMeasurementBundlesResponse
+	(*ListMeasurementBundlesResponse)(nil),               // 1106: measured_boot.ListMeasurementBundlesResponse
+	(*ListMeasurementBundleMachinesResponse)(nil),        // 1107: measured_boot.ListMeasurementBundleMachinesResponse
+	(*DeleteMeasurementJournalResponse)(nil),             // 1108: measured_boot.DeleteMeasurementJournalResponse
+	(*ShowMeasurementJournalResponse)(nil),               // 1109: measured_boot.ShowMeasurementJournalResponse
+	(*ShowMeasurementJournalsResponse)(nil),              // 1110: measured_boot.ShowMeasurementJournalsResponse
+	(*ListMeasurementJournalResponse)(nil),               // 1111: measured_boot.ListMeasurementJournalResponse
+	(*AttestCandidateMachineResponse)(nil),               // 1112: measured_boot.AttestCandidateMachineResponse
+	(*ShowCandidateMachineResponse)(nil),                 // 1113: measured_boot.ShowCandidateMachineResponse
+	(*ShowCandidateMachinesResponse)(nil),                // 1114: measured_boot.ShowCandidateMachinesResponse
+	(*ListCandidateMachinesResponse)(nil),                // 1115: measured_boot.ListCandidateMachinesResponse
+	(*CreateMeasurementSystemProfileResponse)(nil),       // 1116: measured_boot.CreateMeasurementSystemProfileResponse
+	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1117: measured_boot.DeleteMeasurementSystemProfileResponse
+	(*RenameMeasurementSystemProfileResponse)(nil),       // 1118: measured_boot.RenameMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfileResponse)(nil),         // 1119: measured_boot.ShowMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1120: measured_boot.ShowMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfilesResponse)(nil),        // 1121: measured_boot.ListMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1122: measured_boot.ListMeasurementSystemProfileBundlesResponse
+	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1123: measured_boot.ListMeasurementSystemProfileMachinesResponse
+	(*CreateMeasurementReportResponse)(nil),              // 1124: measured_boot.CreateMeasurementReportResponse
+	(*DeleteMeasurementReportResponse)(nil),              // 1125: measured_boot.DeleteMeasurementReportResponse
+	(*PromoteMeasurementReportResponse)(nil),             // 1126: measured_boot.PromoteMeasurementReportResponse
+	(*RevokeMeasurementReportResponse)(nil),              // 1127: measured_boot.RevokeMeasurementReportResponse
+	(*ShowMeasurementReportForIdResponse)(nil),           // 1128: measured_boot.ShowMeasurementReportForIdResponse
+	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1129: measured_boot.ShowMeasurementReportsForMachineResponse
+	(*ShowMeasurementReportsResponse)(nil),               // 1130: measured_boot.ShowMeasurementReportsResponse
+	(*ListMeasurementReportResponse)(nil),                // 1131: measured_boot.ListMeasurementReportResponse
+	(*MatchMeasurementReportResponse)(nil),               // 1132: measured_boot.MatchMeasurementReportResponse
+	(*ImportSiteMeasurementsResponse)(nil),               // 1133: measured_boot.ImportSiteMeasurementsResponse
+	(*ExportSiteMeasurementsResponse)(nil),               // 1134: measured_boot.ExportSiteMeasurementsResponse
+	(*AddMeasurementTrustedMachineResponse)(nil),         // 1135: measured_boot.AddMeasurementTrustedMachineResponse
+	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1136: measured_boot.RemoveMeasurementTrustedMachineResponse
+	(*AddMeasurementTrustedProfileResponse)(nil),         // 1137: measured_boot.AddMeasurementTrustedProfileResponse
+	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1138: measured_boot.RemoveMeasurementTrustedProfileResponse
+	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1139: measured_boot.ListMeasurementTrustedMachinesResponse
+	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1140: measured_boot.ListMeasurementTrustedProfilesResponse
+	(*ListAttestationSummaryResponse)(nil),               // 1141: measured_boot.ListAttestationSummaryResponse
+	(*LockdownStatus)(nil),                               // 1142: site_explorer.LockdownStatus
+	(*PublishMlxDeviceReportResponse)(nil),               // 1143: mlx_device.PublishMlxDeviceReportResponse
+	(*PublishMlxObservationReportResponse)(nil),          // 1144: mlx_device.PublishMlxObservationReportResponse
+	(*MlxAdminProfileSyncResponse)(nil),                  // 1145: mlx_device.MlxAdminProfileSyncResponse
+	(*MlxAdminProfileShowResponse)(nil),                  // 1146: mlx_device.MlxAdminProfileShowResponse
+	(*MlxAdminProfileCompareResponse)(nil),               // 1147: mlx_device.MlxAdminProfileCompareResponse
+	(*MlxAdminProfileListResponse)(nil),                  // 1148: mlx_device.MlxAdminProfileListResponse
+	(*MlxAdminLockdownLockResponse)(nil),                 // 1149: mlx_device.MlxAdminLockdownLockResponse
+	(*MlxAdminLockdownUnlockResponse)(nil),               // 1150: mlx_device.MlxAdminLockdownUnlockResponse
+	(*MlxAdminLockdownStatusResponse)(nil),               // 1151: mlx_device.MlxAdminLockdownStatusResponse
+	(*MlxAdminDeviceInfoResponse)(nil),                   // 1152: mlx_device.MlxAdminDeviceInfoResponse
+	(*MlxAdminDeviceReportResponse)(nil),                 // 1153: mlx_device.MlxAdminDeviceReportResponse
+	(*MlxAdminRegistryListResponse)(nil),                 // 1154: mlx_device.MlxAdminRegistryListResponse
+	(*MlxAdminRegistryShowResponse)(nil),                 // 1155: mlx_device.MlxAdminRegistryShowResponse
+	(*MlxAdminConfigQueryResponse)(nil),                  // 1156: mlx_device.MlxAdminConfigQueryResponse
+	(*MlxAdminConfigSetResponse)(nil),                    // 1157: mlx_device.MlxAdminConfigSetResponse
+	(*MlxAdminConfigSyncResponse)(nil),                   // 1158: mlx_device.MlxAdminConfigSyncResponse
+	(*MlxAdminConfigCompareResponse)(nil),                // 1159: mlx_device.MlxAdminConfigCompareResponse
 }
 var file_nico_proto_depIdxs = []int32{
 	341,  // 0: forge.LifecycleStatus.state_reason:type_name -> forge.ControllerStateReason
@@ -66379,773 +66385,775 @@ var file_nico_proto_depIdxs = []int32{
 	357,  // 1254: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
 	390,  // 1255: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
 	360,  // 1256: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
-	361,  // 1257: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
-	367,  // 1258: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
-	367,  // 1259: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
-	367,  // 1260: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
-	362,  // 1261: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
-	363,  // 1262: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
-	364,  // 1263: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
-	365,  // 1264: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
-	1024, // 1265: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
-	1025, // 1266: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
-	1026, // 1267: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
-	1027, // 1268: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
-	1028, // 1269: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
-	1029, // 1270: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
-	371,  // 1271: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
-	396,  // 1272: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
-	485,  // 1273: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
-	488,  // 1274: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
-	333,  // 1275: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
-	334,  // 1276: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
-	335,  // 1277: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
-	336,  // 1278: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
-	749,  // 1279: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
-	492,  // 1280: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
-	493,  // 1281: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
-	503,  // 1282: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
-	504,  // 1283: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
-	506,  // 1284: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
-	507,  // 1285: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
-	961,  // 1286: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
-	513,  // 1287: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
-	982,  // 1288: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
-	516,  // 1289: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
-	982,  // 1290: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
-	916,  // 1291: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
-	525,  // 1292: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
-	526,  // 1293: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
-	126,  // 1294: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
-	127,  // 1295: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
-	1030, // 1296: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
-	528,  // 1297: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
-	528,  // 1298: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
-	528,  // 1299: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
-	337,  // 1300: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
-	299,  // 1301: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
-	531,  // 1302: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
-	533,  // 1303: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
-	546,  // 1304: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
-	547,  // 1305: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	546,  // 1306: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
-	547,  // 1307: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	1030, // 1308: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
-	548,  // 1309: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
-	1030, // 1310: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
-	1030, // 1311: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
-	1030, // 1312: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
-	553,  // 1313: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	553,  // 1314: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	205,  // 1315: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	206,  // 1316: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	205,  // 1317: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	206,  // 1318: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	1030, // 1319: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	207,  // 1320: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
-	1030, // 1321: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	1030, // 1322: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
-	227,  // 1323: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
-	228,  // 1324: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	227,  // 1325: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
-	228,  // 1326: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	1030, // 1327: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
-	229,  // 1328: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
-	1030, // 1329: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
-	1030, // 1330: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
-	232,  // 1331: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
-	233,  // 1332: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
-	232,  // 1333: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
-	233,  // 1334: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
-	1030, // 1335: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
-	234,  // 1336: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
-	1030, // 1337: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
-	124,  // 1338: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
-	628,  // 1339: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
-	630,  // 1340: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
-	632,  // 1341: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
-	637,  // 1342: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
-	634,  // 1343: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
-	638,  // 1344: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
-	640,  // 1345: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
-	1031, // 1346: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
-	1032, // 1347: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
-	1033, // 1348: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
-	1034, // 1349: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
-	1035, // 1350: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
-	1036, // 1351: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
-	1037, // 1352: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
-	1038, // 1353: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
-	1039, // 1354: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
-	1040, // 1355: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
-	1041, // 1356: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
-	1042, // 1357: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
-	1043, // 1358: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
-	1044, // 1359: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
-	1045, // 1360: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
-	1046, // 1361: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
-	1047, // 1362: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
-	1048, // 1363: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
-	1049, // 1364: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
-	1050, // 1365: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
-	1051, // 1366: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
-	1052, // 1367: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
-	1053, // 1368: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
-	1054, // 1369: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
-	1055, // 1370: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
-	1056, // 1371: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
-	1057, // 1372: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
-	1058, // 1373: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
-	1059, // 1374: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
-	1060, // 1375: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
-	1061, // 1376: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
-	1062, // 1377: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
-	1063, // 1378: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
-	1064, // 1379: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
-	1065, // 1380: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
-	1066, // 1381: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
-	1067, // 1382: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
-	1068, // 1383: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
-	1069, // 1384: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
-	1070, // 1385: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
-	1071, // 1386: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
-	1072, // 1387: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
-	1073, // 1388: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
-	659,  // 1389: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
-	661,  // 1390: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
-	663,  // 1391: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
-	666,  // 1392: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
-	667,  // 1393: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
-	673,  // 1394: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
-	676,  // 1395: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
-	535,  // 1396: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
-	539,  // 1397: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
-	537,  // 1398: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
-	972,  // 1399: forge.Forge.GetOsImage:input_type -> common.UUID
-	535,  // 1400: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
-	541,  // 1401: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
-	542,  // 1402: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
-	557,  // 1403: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
-	562,  // 1404: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
-	564,  // 1405: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
-	559,  // 1406: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
-	567,  // 1407: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
-	569,  // 1408: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
-	572,  // 1409: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
-	574,  // 1410: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
-	591,  // 1411: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
-	592,  // 1412: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
-	594,  // 1413: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
-	597,  // 1414: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
-	599,  // 1415: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
-	575,  // 1416: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
-	603,  // 1417: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
-	605,  // 1418: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
-	604,  // 1419: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
-	608,  // 1420: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
-	612,  // 1421: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
-	613,  // 1422: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
-	615,  // 1423: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
-	409,  // 1424: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
-	586,  // 1425: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
-	367,  // 1426: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
-	399,  // 1427: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
-	401,  // 1428: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
-	403,  // 1429: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
-	405,  // 1430: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
-	777,  // 1431: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
-	779,  // 1432: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
-	411,  // 1433: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
-	413,  // 1434: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
-	576,  // 1435: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
-	584,  // 1436: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
-	120,  // 1437: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
-	1030, // 1438: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
-	1030, // 1439: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
-	117,  // 1440: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
-	642,  // 1441: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
-	644,  // 1442: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
-	649,  // 1443: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
-	651,  // 1444: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
-	651,  // 1445: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
-	651,  // 1446: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
-	655,  // 1447: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
-	679,  // 1448: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
-	695,  // 1449: forge.Forge.CreateSku:input_type -> forge.SkuList
-	961,  // 1450: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
-	961,  // 1451: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
-	693,  // 1452: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
-	694,  // 1453: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
-	696,  // 1454: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
-	1030, // 1455: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
-	698,  // 1456: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
-	708,  // 1457: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
-	692,  // 1458: forge.Forge.ReplaceSku:input_type -> forge.Sku
-	379,  // 1459: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
-	381,  // 1460: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
-	383,  // 1461: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
-	961,  // 1462: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
-	370,  // 1463: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
-	1030, // 1464: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
-	703,  // 1465: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
-	701,  // 1466: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	701,  // 1467: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	706,  // 1468: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
-	709,  // 1469: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
-	710,  // 1470: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
-	367,  // 1471: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
-	367,  // 1472: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
-	729,  // 1473: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
-	731,  // 1474: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
-	726,  // 1475: forge.Forge.GetRack:input_type -> forge.GetRackRequest
-	736,  // 1476: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
-	737,  // 1477: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
-	744,  // 1478: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
-	715,  // 1479: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
-	717,  // 1480: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
-	719,  // 1481: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
-	722,  // 1482: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
-	723,  // 1483: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
-	781,  // 1484: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
-	783,  // 1485: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
-	1074, // 1486: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
-	1075, // 1487: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
-	786,  // 1488: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
-	1030, // 1489: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
-	788,  // 1490: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	788,  // 1491: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	790,  // 1492: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
-	791,  // 1493: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
-	796,  // 1494: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
-	797,  // 1495: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
-	798,  // 1496: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
-	799,  // 1497: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
-	1030, // 1498: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
-	793,  // 1499: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
-	800,  // 1500: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
-	802,  // 1501: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
-	805,  // 1502: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
-	807,  // 1503: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
-	809,  // 1504: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
-	810,  // 1505: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
-	816,  // 1506: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
-	817,  // 1507: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
-	818,  // 1508: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
-	820,  // 1509: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
-	822,  // 1510: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
-	824,  // 1511: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
-	826,  // 1512: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
-	92,   // 1513: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
-	961,  // 1514: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
-	93,   // 1515: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
-	961,  // 1516: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
-	95,   // 1517: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
-	97,   // 1518: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	100,  // 1519: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
-	97,   // 1520: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	105,  // 1521: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	107,  // 1522: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
-	105,  // 1523: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	108,  // 1524: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
-	113,  // 1525: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
-	114,  // 1526: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
-	833,  // 1527: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
-	836,  // 1528: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
-	838,  // 1529: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
-	840,  // 1530: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
-	1076, // 1531: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
-	1077, // 1532: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
-	1078, // 1533: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
-	1079, // 1534: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
-	1080, // 1535: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
-	1081, // 1536: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
-	1082, // 1537: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
-	1083, // 1538: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
-	1084, // 1539: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
-	1085, // 1540: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
-	1086, // 1541: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
-	1087, // 1542: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
-	1088, // 1543: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
-	1089, // 1544: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
-	1090, // 1545: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
-	761,  // 1546: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
-	762,  // 1547: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
-	150,  // 1548: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	772,  // 1549: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
-	773,  // 1550: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
-	769,  // 1551: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
-	775,  // 1552: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
-	770,  // 1553: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
-	150,  // 1554: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	854,  // 1555: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
-	755,  // 1556: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
-	857,  // 1557: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
-	859,  // 1558: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
-	860,  // 1559: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
-	862,  // 1560: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
-	871,  // 1561: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
-	868,  // 1562: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
-	878,  // 1563: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
-	880,  // 1564: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
-	882,  // 1565: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
-	899,  // 1566: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
-	979,  // 1567: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
-	902,  // 1568: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
-	903,  // 1569: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
-	905,  // 1570: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
-	907,  // 1571: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
-	909,  // 1572: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	912,  // 1573: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	914,  // 1574: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
-	131,  // 1575: forge.Forge.Version:output_type -> forge.BuildInfo
-	848,  // 1576: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
-	848,  // 1577: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
-	851,  // 1578: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
-	849,  // 1579: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
-	153,  // 1580: forge.Forge.CreateVpc:output_type -> forge.Vpc
-	156,  // 1581: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
-	158,  // 1582: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
-	160,  // 1583: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
-	148,  // 1584: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
-	161,  // 1585: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
-	887,  // 1586: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
-	890,  // 1587: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
-	888,  // 1588: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
-	892,  // 1589: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
-	162,  // 1590: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
-	168,  // 1591: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
-	169,  // 1592: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
-	162,  // 1593: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
-	172,  // 1594: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
-	174,  // 1595: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
-	175,  // 1596: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
-	176,  // 1597: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
-	181,  // 1598: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
-	248,  // 1599: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
-	353,  // 1600: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
-	240,  // 1601: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
-	240,  // 1602: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
-	244,  // 1603: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
-	353,  // 1604: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
-	192,  // 1605: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
-	185,  // 1606: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
-	184,  // 1607: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
-	184,  // 1608: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
-	189,  // 1609: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
-	185,  // 1610: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
-	196,  // 1611: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
-	867,  // 1612: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
-	196,  // 1613: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
-	199,  // 1614: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
-	897,  // 1615: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
-	1030, // 1616: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
-	216,  // 1617: forge.Forge.FindSwitches:output_type -> forge.SwitchList
-	866,  // 1618: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
-	216,  // 1619: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
-	219,  // 1620: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
-	895,  // 1621: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
-	236,  // 1622: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
-	289,  // 1623: forge.Forge.AllocateInstance:output_type -> forge.Instance
-	262,  // 1624: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
-	303,  // 1625: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
-	289,  // 1626: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
-	289,  // 1627: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
-	258,  // 1628: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
-	254,  // 1629: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
-	254,  // 1630: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
-	374,  // 1631: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
-	1030, // 1632: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
-	454,  // 1633: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
-	1030, // 1634: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
-	1030, // 1635: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
-	454,  // 1636: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
-	1030, // 1637: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
-	1030, // 1638: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
-	454,  // 1639: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
-	1030, // 1640: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
-	1030, // 1641: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
-	454,  // 1642: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
-	1030, // 1643: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
-	1030, // 1644: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
-	454,  // 1645: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
-	1030, // 1646: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	1030, // 1647: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	454,  // 1648: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
-	1030, // 1649: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
-	1030, // 1650: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
-	393,  // 1651: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
-	395,  // 1652: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
-	253,  // 1653: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
-	420,  // 1654: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
-	427,  // 1655: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
-	426,  // 1656: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
-	428,  // 1657: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
-	429,  // 1658: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
-	431,  // 1659: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
-	352,  // 1660: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
-	351,  // 1661: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
-	322,  // 1662: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
-	324,  // 1663: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
-	327,  // 1664: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
-	317,  // 1665: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
-	1030, // 1666: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
-	495,  // 1667: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
-	1019, // 1668: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
-	318,  // 1669: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
-	307,  // 1670: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
-	310,  // 1671: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
-	223,  // 1672: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
-	223,  // 1673: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
-	223,  // 1674: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
-	223,  // 1675: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
-	223,  // 1676: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
-	316,  // 1677: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
-	315,  // 1678: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
-	518,  // 1679: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
-	522,  // 1680: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
-	521,  // 1681: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
-	519,  // 1682: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
-	497,  // 1683: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
-	500,  // 1684: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
-	502,  // 1685: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
-	416,  // 1686: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
-	418,  // 1687: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
-	433,  // 1688: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
-	437,  // 1689: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
-	134,  // 1690: forge.Forge.Echo:output_type -> forge.EchoResponse
-	464,  // 1691: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
-	468,  // 1692: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
-	466,  // 1693: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
-	474,  // 1694: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
-	481,  // 1695: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
-	475,  // 1696: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
-	477,  // 1697: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
-	479,  // 1698: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
-	484,  // 1699: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
-	358,  // 1700: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
-	358,  // 1701: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
-	391,  // 1702: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
-	1091, // 1703: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
-	1030, // 1704: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
-	601,  // 1705: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
-	602,  // 1706: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
-	1020, // 1707: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
-	1030, // 1708: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
-	1092, // 1709: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
-	366,  // 1710: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
-	1030, // 1711: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
-	1093, // 1712: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
-	1094, // 1713: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
-	1095, // 1714: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
-	1096, // 1715: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
-	1097, // 1716: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
-	1098, // 1717: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
-	1030, // 1718: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
-	397,  // 1719: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
-	486,  // 1720: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
-	489,  // 1721: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
-	1030, // 1722: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
-	1030, // 1723: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
-	1030, // 1724: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
-	1030, // 1725: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
-	1030, // 1726: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
-	1030, // 1727: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
-	1030, // 1728: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
-	1030, // 1729: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
-	505,  // 1730: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
-	1030, // 1731: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
-	508,  // 1732: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
-	1030, // 1733: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
-	514,  // 1734: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
-	516,  // 1735: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
-	1030, // 1736: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
-	1030, // 1737: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
-	921,  // 1738: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
-	527,  // 1739: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
-	527,  // 1740: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
-	128,  // 1741: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
-	129,  // 1742: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
-	529,  // 1743: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
-	1030, // 1744: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
-	1030, // 1745: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
-	1030, // 1746: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
-	1030, // 1747: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
-	300,  // 1748: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
-	532,  // 1749: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
-	534,  // 1750: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
-	1030, // 1751: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
-	1030, // 1752: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
-	1030, // 1753: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
-	546,  // 1754: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
-	548,  // 1755: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
-	1030, // 1756: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
-	1030, // 1757: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
-	549,  // 1758: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
-	551,  // 1759: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
-	555,  // 1760: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	555,  // 1761: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	1030, // 1762: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1030, // 1763: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1030, // 1764: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
-	205,  // 1765: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
-	207,  // 1766: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
-	1030, // 1767: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	1030, // 1768: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	208,  // 1769: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
-	1030, // 1770: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
-	1030, // 1771: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
-	1030, // 1772: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
-	227,  // 1773: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
-	229,  // 1774: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
-	1030, // 1775: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
-	1030, // 1776: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
-	230,  // 1777: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
-	1030, // 1778: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
-	1030, // 1779: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
-	1030, // 1780: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
-	232,  // 1781: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
-	234,  // 1782: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
-	1030, // 1783: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
-	1030, // 1784: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
-	125,  // 1785: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
-	629,  // 1786: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
-	631,  // 1787: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
-	633,  // 1788: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
-	636,  // 1789: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
-	635,  // 1790: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
-	639,  // 1791: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
-	641,  // 1792: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
-	1099, // 1793: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
-	1100, // 1794: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
-	1101, // 1795: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
-	1102, // 1796: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
-	1103, // 1797: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1104, // 1798: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
-	1105, // 1799: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
-	1106, // 1800: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
-	1103, // 1801: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1107, // 1802: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
-	1108, // 1803: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
-	1109, // 1804: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
-	1110, // 1805: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
-	1111, // 1806: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
-	1112, // 1807: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
-	1113, // 1808: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
-	1114, // 1809: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
-	1115, // 1810: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
-	1116, // 1811: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
-	1117, // 1812: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
-	1118, // 1813: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
-	1119, // 1814: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
-	1120, // 1815: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
-	1121, // 1816: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
-	1122, // 1817: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
-	1123, // 1818: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
-	1124, // 1819: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
-	1125, // 1820: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
-	1126, // 1821: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
-	1127, // 1822: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
-	1128, // 1823: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
-	1129, // 1824: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
-	1130, // 1825: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
-	1131, // 1826: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
-	1132, // 1827: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
-	1133, // 1828: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
-	1134, // 1829: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
-	1135, // 1830: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
-	1136, // 1831: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
-	1137, // 1832: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
-	1138, // 1833: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
-	1139, // 1834: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
-	1140, // 1835: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
-	660,  // 1836: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
-	662,  // 1837: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
-	664,  // 1838: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
-	665,  // 1839: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
-	668,  // 1840: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
-	671,  // 1841: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
-	678,  // 1842: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
-	536,  // 1843: forge.Forge.CreateOsImage:output_type -> forge.OsImage
-	540,  // 1844: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
-	538,  // 1845: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
-	536,  // 1846: forge.Forge.GetOsImage:output_type -> forge.OsImage
-	536,  // 1847: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
-	265,  // 1848: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
-	543,  // 1849: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
-	556,  // 1850: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
-	1030, // 1851: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
-	563,  // 1852: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
-	560,  // 1853: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
-	568,  // 1854: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
-	571,  // 1855: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
-	573,  // 1856: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
-	1030, // 1857: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	590,  // 1858: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
-	593,  // 1859: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
-	595,  // 1860: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
-	598,  // 1861: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
-	600,  // 1862: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
-	1030, // 1863: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	607,  // 1864: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
-	606,  // 1865: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	606,  // 1866: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	609,  // 1867: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
-	611,  // 1868: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
-	614,  // 1869: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
-	616,  // 1870: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
-	410,  // 1871: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
-	587,  // 1872: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
-	398,  // 1873: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
-	400,  // 1874: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
-	1141, // 1875: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
-	404,  // 1876: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
-	406,  // 1877: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
-	778,  // 1878: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
-	780,  // 1879: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
-	412,  // 1880: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
-	414,  // 1881: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
-	577,  // 1882: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
-	585,  // 1883: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
-	116,  // 1884: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
-	122,  // 1885: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
-	119,  // 1886: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
-	1030, // 1887: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
-	643,  // 1888: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
-	645,  // 1889: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
-	650,  // 1890: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
-	652,  // 1891: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
-	653,  // 1892: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
-	654,  // 1893: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
-	656,  // 1894: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
-	680,  // 1895: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
-	696,  // 1896: forge.Forge.CreateSku:output_type -> forge.SkuIdList
-	692,  // 1897: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
-	1030, // 1898: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
-	1030, // 1899: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
-	1030, // 1900: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
-	1030, // 1901: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
-	696,  // 1902: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
-	695,  // 1903: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
-	1030, // 1904: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
-	692,  // 1905: forge.Forge.ReplaceSku:output_type -> forge.Sku
-	380,  // 1906: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
-	382,  // 1907: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
-	384,  // 1908: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
-	1030, // 1909: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
-	1030, // 1910: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
-	702,  // 1911: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
-	704,  // 1912: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
-	700,  // 1913: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
-	700,  // 1914: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
-	707,  // 1915: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
-	712,  // 1916: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
-	712,  // 1917: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
-	1030, // 1918: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
-	115,  // 1919: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
-	730,  // 1920: forge.Forge.FindRackIds:output_type -> forge.RackIdList
-	728,  // 1921: forge.Forge.FindRacksByIds:output_type -> forge.RackList
-	727,  // 1922: forge.Forge.GetRack:output_type -> forge.GetRackResponse
-	1030, // 1923: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
-	738,  // 1924: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
-	745,  // 1925: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
-	716,  // 1926: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
-	718,  // 1927: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
-	720,  // 1928: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
-	721,  // 1929: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
-	724,  // 1930: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
-	782,  // 1931: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
-	784,  // 1932: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
-	1142, // 1933: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
-	1143, // 1934: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
-	787,  // 1935: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
-	789,  // 1936: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
-	788,  // 1937: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	788,  // 1938: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	1030, // 1939: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
-	792,  // 1940: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
-	1030, // 1941: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
-	1030, // 1942: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
-	1030, // 1943: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
-	1030, // 1944: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
-	793,  // 1945: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
-	794,  // 1946: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
-	801,  // 1947: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
-	804,  // 1948: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
-	806,  // 1949: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
-	1030, // 1950: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
-	1030, // 1951: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
-	1030, // 1952: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
-	815,  // 1953: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
-	815,  // 1954: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
-	819,  // 1955: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
-	821,  // 1956: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
-	823,  // 1957: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
-	825,  // 1958: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
-	827,  // 1959: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
-	89,   // 1960: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
-	1030, // 1961: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
-	94,   // 1962: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
-	91,   // 1963: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
-	96,   // 1964: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
-	101,  // 1965: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	101,  // 1966: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	1030, // 1967: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
-	104,  // 1968: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	104,  // 1969: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	1030, // 1970: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
-	110,  // 1971: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
-	111,  // 1972: forge.Forge.GetJWKS:output_type -> forge.Jwks
-	112,  // 1973: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
-	834,  // 1974: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
-	837,  // 1975: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
-	839,  // 1976: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
-	841,  // 1977: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
-	1144, // 1978: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
-	1145, // 1979: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
-	1146, // 1980: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
-	1147, // 1981: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
-	1148, // 1982: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
-	1149, // 1983: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
-	1150, // 1984: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
-	1151, // 1985: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
-	1152, // 1986: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
-	1153, // 1987: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
-	1154, // 1988: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
-	1155, // 1989: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
-	1156, // 1990: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
-	1157, // 1991: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
-	1158, // 1992: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
-	763,  // 1993: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
-	758,  // 1994: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
-	758,  // 1995: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
-	774,  // 1996: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
-	768,  // 1997: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
-	767,  // 1998: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
-	776,  // 1999: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
-	771,  // 2000: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
-	768,  // 2001: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
-	855,  // 2002: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
-	756,  // 2003: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
-	1030, // 2004: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
-	858,  // 2005: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
-	861,  // 2006: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
-	864,  // 2007: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
-	872,  // 2008: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
-	870,  // 2009: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
-	879,  // 2010: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
-	881,  // 2011: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
-	885,  // 2012: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
-	898,  // 2013: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
-	898,  // 2014: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
-	898,  // 2015: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
-	904,  // 2016: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
-	906,  // 2017: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
-	908,  // 2018: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
-	910,  // 2019: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	910,  // 2020: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	915,  // 2021: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
-	1575, // [1575:2022] is the sub-list for method output_type
-	1128, // [1128:1575] is the sub-list for method input_type
+	1024, // 1257: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
+	361,  // 1258: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
+	367,  // 1259: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
+	367,  // 1260: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
+	367,  // 1261: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
+	362,  // 1262: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
+	363,  // 1263: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
+	364,  // 1264: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
+	365,  // 1265: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
+	1025, // 1266: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
+	1026, // 1267: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
+	1027, // 1268: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
+	1028, // 1269: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
+	1029, // 1270: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
+	1030, // 1271: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
+	371,  // 1272: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
+	396,  // 1273: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
+	485,  // 1274: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
+	488,  // 1275: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
+	333,  // 1276: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
+	334,  // 1277: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
+	335,  // 1278: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
+	336,  // 1279: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
+	749,  // 1280: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
+	492,  // 1281: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
+	493,  // 1282: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
+	503,  // 1283: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
+	504,  // 1284: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
+	506,  // 1285: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
+	507,  // 1286: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
+	961,  // 1287: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
+	513,  // 1288: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
+	982,  // 1289: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
+	516,  // 1290: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
+	982,  // 1291: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
+	916,  // 1292: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
+	525,  // 1293: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
+	526,  // 1294: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
+	126,  // 1295: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
+	127,  // 1296: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
+	1024, // 1297: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
+	528,  // 1298: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
+	528,  // 1299: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
+	528,  // 1300: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
+	337,  // 1301: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
+	299,  // 1302: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
+	531,  // 1303: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
+	533,  // 1304: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
+	546,  // 1305: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
+	547,  // 1306: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	546,  // 1307: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
+	547,  // 1308: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	1024, // 1309: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
+	548,  // 1310: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
+	1024, // 1311: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
+	1024, // 1312: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
+	1024, // 1313: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
+	553,  // 1314: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	553,  // 1315: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	205,  // 1316: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	206,  // 1317: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	205,  // 1318: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	206,  // 1319: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	1024, // 1320: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	207,  // 1321: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
+	1024, // 1322: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	1024, // 1323: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
+	227,  // 1324: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
+	228,  // 1325: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	227,  // 1326: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
+	228,  // 1327: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	1024, // 1328: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
+	229,  // 1329: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
+	1024, // 1330: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
+	1024, // 1331: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
+	232,  // 1332: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
+	233,  // 1333: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
+	232,  // 1334: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
+	233,  // 1335: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
+	1024, // 1336: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
+	234,  // 1337: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
+	1024, // 1338: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
+	124,  // 1339: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
+	628,  // 1340: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
+	630,  // 1341: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
+	632,  // 1342: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
+	637,  // 1343: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
+	634,  // 1344: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
+	638,  // 1345: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
+	640,  // 1346: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
+	1031, // 1347: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
+	1032, // 1348: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
+	1033, // 1349: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
+	1034, // 1350: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
+	1035, // 1351: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
+	1036, // 1352: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
+	1037, // 1353: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
+	1038, // 1354: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
+	1039, // 1355: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
+	1040, // 1356: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
+	1041, // 1357: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
+	1042, // 1358: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
+	1043, // 1359: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
+	1044, // 1360: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
+	1045, // 1361: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
+	1046, // 1362: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
+	1047, // 1363: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
+	1048, // 1364: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
+	1049, // 1365: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
+	1050, // 1366: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
+	1051, // 1367: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
+	1052, // 1368: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
+	1053, // 1369: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
+	1054, // 1370: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
+	1055, // 1371: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
+	1056, // 1372: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
+	1057, // 1373: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
+	1058, // 1374: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
+	1059, // 1375: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
+	1060, // 1376: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
+	1061, // 1377: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
+	1062, // 1378: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
+	1063, // 1379: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
+	1064, // 1380: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
+	1065, // 1381: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
+	1066, // 1382: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
+	1067, // 1383: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
+	1068, // 1384: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
+	1069, // 1385: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
+	1070, // 1386: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
+	1071, // 1387: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
+	1072, // 1388: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
+	1073, // 1389: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
+	659,  // 1390: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
+	661,  // 1391: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
+	663,  // 1392: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
+	666,  // 1393: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
+	667,  // 1394: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
+	673,  // 1395: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
+	676,  // 1396: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
+	535,  // 1397: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
+	539,  // 1398: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
+	537,  // 1399: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
+	972,  // 1400: forge.Forge.GetOsImage:input_type -> common.UUID
+	535,  // 1401: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
+	541,  // 1402: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
+	542,  // 1403: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
+	557,  // 1404: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
+	562,  // 1405: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
+	564,  // 1406: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
+	559,  // 1407: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
+	567,  // 1408: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
+	569,  // 1409: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
+	572,  // 1410: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
+	574,  // 1411: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
+	591,  // 1412: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
+	592,  // 1413: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
+	594,  // 1414: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
+	597,  // 1415: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
+	599,  // 1416: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
+	575,  // 1417: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
+	603,  // 1418: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
+	605,  // 1419: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
+	604,  // 1420: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
+	608,  // 1421: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
+	612,  // 1422: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
+	613,  // 1423: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
+	615,  // 1424: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
+	409,  // 1425: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
+	586,  // 1426: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
+	367,  // 1427: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
+	399,  // 1428: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
+	401,  // 1429: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
+	403,  // 1430: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
+	405,  // 1431: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
+	777,  // 1432: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
+	779,  // 1433: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
+	411,  // 1434: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
+	413,  // 1435: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
+	576,  // 1436: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
+	584,  // 1437: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
+	120,  // 1438: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
+	1024, // 1439: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
+	1024, // 1440: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
+	117,  // 1441: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
+	642,  // 1442: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
+	644,  // 1443: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
+	649,  // 1444: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
+	651,  // 1445: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
+	651,  // 1446: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
+	651,  // 1447: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
+	655,  // 1448: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
+	679,  // 1449: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
+	695,  // 1450: forge.Forge.CreateSku:input_type -> forge.SkuList
+	961,  // 1451: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
+	961,  // 1452: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
+	693,  // 1453: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
+	694,  // 1454: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
+	696,  // 1455: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
+	1024, // 1456: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
+	698,  // 1457: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
+	708,  // 1458: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
+	692,  // 1459: forge.Forge.ReplaceSku:input_type -> forge.Sku
+	379,  // 1460: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
+	381,  // 1461: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
+	383,  // 1462: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
+	961,  // 1463: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
+	370,  // 1464: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
+	1024, // 1465: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
+	703,  // 1466: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
+	701,  // 1467: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	701,  // 1468: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	706,  // 1469: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
+	709,  // 1470: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
+	710,  // 1471: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
+	367,  // 1472: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
+	367,  // 1473: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
+	729,  // 1474: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
+	731,  // 1475: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
+	726,  // 1476: forge.Forge.GetRack:input_type -> forge.GetRackRequest
+	736,  // 1477: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
+	737,  // 1478: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
+	744,  // 1479: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
+	715,  // 1480: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
+	717,  // 1481: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
+	719,  // 1482: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
+	722,  // 1483: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
+	723,  // 1484: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
+	781,  // 1485: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
+	783,  // 1486: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
+	1074, // 1487: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
+	1075, // 1488: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
+	786,  // 1489: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
+	1024, // 1490: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
+	788,  // 1491: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	788,  // 1492: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	790,  // 1493: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
+	791,  // 1494: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
+	796,  // 1495: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
+	797,  // 1496: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
+	798,  // 1497: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
+	799,  // 1498: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
+	1024, // 1499: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
+	793,  // 1500: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
+	800,  // 1501: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
+	802,  // 1502: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
+	805,  // 1503: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
+	807,  // 1504: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
+	809,  // 1505: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
+	810,  // 1506: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
+	816,  // 1507: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
+	817,  // 1508: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
+	818,  // 1509: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
+	820,  // 1510: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
+	822,  // 1511: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
+	824,  // 1512: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
+	826,  // 1513: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
+	92,   // 1514: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
+	961,  // 1515: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
+	93,   // 1516: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
+	961,  // 1517: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
+	95,   // 1518: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
+	97,   // 1519: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	100,  // 1520: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
+	97,   // 1521: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	105,  // 1522: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	107,  // 1523: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
+	105,  // 1524: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	108,  // 1525: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
+	113,  // 1526: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
+	114,  // 1527: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
+	833,  // 1528: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
+	836,  // 1529: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
+	838,  // 1530: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
+	840,  // 1531: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
+	1076, // 1532: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
+	1077, // 1533: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
+	1078, // 1534: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
+	1079, // 1535: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
+	1080, // 1536: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
+	1081, // 1537: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
+	1082, // 1538: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
+	1083, // 1539: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
+	1084, // 1540: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
+	1085, // 1541: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
+	1086, // 1542: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
+	1087, // 1543: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
+	1088, // 1544: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
+	1089, // 1545: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
+	1090, // 1546: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
+	761,  // 1547: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
+	762,  // 1548: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
+	150,  // 1549: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	772,  // 1550: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
+	773,  // 1551: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
+	769,  // 1552: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
+	775,  // 1553: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
+	770,  // 1554: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
+	150,  // 1555: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	854,  // 1556: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
+	755,  // 1557: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
+	857,  // 1558: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
+	859,  // 1559: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
+	860,  // 1560: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
+	862,  // 1561: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
+	871,  // 1562: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
+	868,  // 1563: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
+	878,  // 1564: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
+	880,  // 1565: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
+	882,  // 1566: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
+	899,  // 1567: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
+	979,  // 1568: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
+	902,  // 1569: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
+	903,  // 1570: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
+	905,  // 1571: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
+	907,  // 1572: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
+	909,  // 1573: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	912,  // 1574: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	914,  // 1575: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
+	131,  // 1576: forge.Forge.Version:output_type -> forge.BuildInfo
+	848,  // 1577: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
+	848,  // 1578: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
+	851,  // 1579: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
+	849,  // 1580: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
+	153,  // 1581: forge.Forge.CreateVpc:output_type -> forge.Vpc
+	156,  // 1582: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
+	158,  // 1583: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
+	160,  // 1584: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
+	148,  // 1585: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
+	161,  // 1586: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
+	887,  // 1587: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
+	890,  // 1588: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
+	888,  // 1589: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
+	892,  // 1590: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
+	162,  // 1591: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
+	168,  // 1592: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
+	169,  // 1593: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
+	162,  // 1594: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
+	172,  // 1595: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
+	174,  // 1596: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
+	175,  // 1597: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
+	176,  // 1598: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
+	181,  // 1599: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
+	248,  // 1600: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
+	353,  // 1601: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
+	240,  // 1602: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
+	240,  // 1603: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
+	244,  // 1604: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
+	353,  // 1605: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
+	192,  // 1606: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
+	185,  // 1607: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
+	184,  // 1608: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
+	184,  // 1609: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
+	189,  // 1610: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
+	185,  // 1611: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
+	196,  // 1612: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
+	867,  // 1613: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
+	196,  // 1614: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
+	199,  // 1615: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
+	897,  // 1616: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
+	1024, // 1617: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
+	216,  // 1618: forge.Forge.FindSwitches:output_type -> forge.SwitchList
+	866,  // 1619: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
+	216,  // 1620: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
+	219,  // 1621: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
+	895,  // 1622: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
+	236,  // 1623: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
+	289,  // 1624: forge.Forge.AllocateInstance:output_type -> forge.Instance
+	262,  // 1625: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
+	303,  // 1626: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
+	289,  // 1627: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
+	289,  // 1628: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
+	258,  // 1629: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
+	254,  // 1630: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
+	254,  // 1631: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
+	374,  // 1632: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
+	1024, // 1633: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
+	454,  // 1634: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
+	1024, // 1635: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
+	1024, // 1636: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
+	454,  // 1637: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
+	1024, // 1638: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
+	1024, // 1639: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
+	454,  // 1640: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
+	1024, // 1641: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
+	1024, // 1642: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
+	454,  // 1643: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
+	1024, // 1644: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
+	1024, // 1645: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
+	454,  // 1646: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
+	1024, // 1647: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	1024, // 1648: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	454,  // 1649: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
+	1024, // 1650: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
+	1024, // 1651: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
+	393,  // 1652: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
+	395,  // 1653: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
+	253,  // 1654: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
+	420,  // 1655: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
+	427,  // 1656: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
+	426,  // 1657: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
+	428,  // 1658: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
+	429,  // 1659: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
+	431,  // 1660: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
+	352,  // 1661: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
+	351,  // 1662: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
+	322,  // 1663: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
+	324,  // 1664: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
+	327,  // 1665: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
+	317,  // 1666: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
+	1024, // 1667: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
+	495,  // 1668: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
+	1019, // 1669: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
+	318,  // 1670: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
+	307,  // 1671: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
+	310,  // 1672: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
+	223,  // 1673: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
+	223,  // 1674: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
+	223,  // 1675: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
+	223,  // 1676: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
+	223,  // 1677: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
+	316,  // 1678: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
+	315,  // 1679: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
+	518,  // 1680: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
+	522,  // 1681: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
+	521,  // 1682: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
+	519,  // 1683: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
+	497,  // 1684: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
+	500,  // 1685: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
+	502,  // 1686: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
+	416,  // 1687: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
+	418,  // 1688: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
+	433,  // 1689: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
+	437,  // 1690: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
+	134,  // 1691: forge.Forge.Echo:output_type -> forge.EchoResponse
+	464,  // 1692: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
+	468,  // 1693: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
+	466,  // 1694: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
+	474,  // 1695: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
+	481,  // 1696: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
+	475,  // 1697: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
+	477,  // 1698: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
+	479,  // 1699: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
+	484,  // 1700: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
+	358,  // 1701: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
+	358,  // 1702: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
+	391,  // 1703: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
+	1091, // 1704: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
+	1092, // 1705: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
+	1024, // 1706: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
+	601,  // 1707: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
+	602,  // 1708: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
+	1020, // 1709: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
+	1024, // 1710: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
+	1093, // 1711: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
+	366,  // 1712: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
+	1024, // 1713: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
+	1094, // 1714: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
+	1095, // 1715: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
+	1096, // 1716: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
+	1097, // 1717: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
+	1098, // 1718: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
+	1099, // 1719: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
+	1024, // 1720: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
+	397,  // 1721: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
+	486,  // 1722: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
+	489,  // 1723: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
+	1024, // 1724: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
+	1024, // 1725: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
+	1024, // 1726: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
+	1024, // 1727: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
+	1024, // 1728: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
+	1024, // 1729: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
+	1024, // 1730: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
+	1024, // 1731: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
+	505,  // 1732: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
+	1024, // 1733: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
+	508,  // 1734: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
+	1024, // 1735: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
+	514,  // 1736: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
+	516,  // 1737: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
+	1024, // 1738: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
+	1024, // 1739: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
+	921,  // 1740: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
+	527,  // 1741: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
+	527,  // 1742: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
+	128,  // 1743: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
+	129,  // 1744: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
+	529,  // 1745: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
+	1024, // 1746: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
+	1024, // 1747: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
+	1024, // 1748: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
+	1024, // 1749: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
+	300,  // 1750: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
+	532,  // 1751: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
+	534,  // 1752: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
+	1024, // 1753: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
+	1024, // 1754: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
+	1024, // 1755: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
+	546,  // 1756: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
+	548,  // 1757: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
+	1024, // 1758: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
+	1024, // 1759: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
+	549,  // 1760: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
+	551,  // 1761: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
+	555,  // 1762: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	555,  // 1763: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	1024, // 1764: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1024, // 1765: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1024, // 1766: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
+	205,  // 1767: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
+	207,  // 1768: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
+	1024, // 1769: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	1024, // 1770: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	208,  // 1771: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
+	1024, // 1772: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
+	1024, // 1773: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
+	1024, // 1774: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
+	227,  // 1775: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
+	229,  // 1776: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
+	1024, // 1777: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
+	1024, // 1778: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
+	230,  // 1779: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
+	1024, // 1780: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
+	1024, // 1781: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
+	1024, // 1782: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
+	232,  // 1783: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
+	234,  // 1784: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
+	1024, // 1785: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
+	1024, // 1786: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
+	125,  // 1787: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
+	629,  // 1788: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
+	631,  // 1789: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
+	633,  // 1790: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
+	636,  // 1791: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
+	635,  // 1792: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
+	639,  // 1793: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
+	641,  // 1794: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
+	1100, // 1795: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
+	1101, // 1796: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
+	1102, // 1797: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
+	1103, // 1798: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
+	1104, // 1799: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1105, // 1800: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
+	1106, // 1801: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
+	1107, // 1802: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
+	1104, // 1803: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1108, // 1804: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
+	1109, // 1805: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
+	1110, // 1806: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
+	1111, // 1807: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
+	1112, // 1808: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
+	1113, // 1809: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
+	1114, // 1810: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
+	1115, // 1811: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
+	1116, // 1812: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
+	1117, // 1813: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
+	1118, // 1814: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
+	1119, // 1815: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
+	1120, // 1816: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
+	1121, // 1817: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
+	1122, // 1818: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
+	1123, // 1819: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
+	1124, // 1820: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
+	1125, // 1821: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
+	1126, // 1822: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
+	1127, // 1823: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
+	1128, // 1824: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
+	1129, // 1825: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
+	1130, // 1826: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
+	1131, // 1827: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
+	1132, // 1828: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
+	1133, // 1829: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
+	1134, // 1830: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
+	1135, // 1831: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
+	1136, // 1832: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
+	1137, // 1833: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
+	1138, // 1834: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
+	1139, // 1835: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
+	1140, // 1836: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
+	1141, // 1837: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
+	660,  // 1838: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
+	662,  // 1839: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
+	664,  // 1840: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
+	665,  // 1841: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
+	668,  // 1842: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
+	671,  // 1843: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
+	678,  // 1844: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
+	536,  // 1845: forge.Forge.CreateOsImage:output_type -> forge.OsImage
+	540,  // 1846: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
+	538,  // 1847: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
+	536,  // 1848: forge.Forge.GetOsImage:output_type -> forge.OsImage
+	536,  // 1849: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
+	265,  // 1850: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
+	543,  // 1851: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
+	556,  // 1852: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
+	1024, // 1853: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
+	563,  // 1854: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
+	560,  // 1855: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
+	568,  // 1856: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
+	571,  // 1857: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
+	573,  // 1858: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
+	1024, // 1859: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	590,  // 1860: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
+	593,  // 1861: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
+	595,  // 1862: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
+	598,  // 1863: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
+	600,  // 1864: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
+	1024, // 1865: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	607,  // 1866: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
+	606,  // 1867: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	606,  // 1868: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	609,  // 1869: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
+	611,  // 1870: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
+	614,  // 1871: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
+	616,  // 1872: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
+	410,  // 1873: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
+	587,  // 1874: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
+	398,  // 1875: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
+	400,  // 1876: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
+	1142, // 1877: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
+	404,  // 1878: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
+	406,  // 1879: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
+	778,  // 1880: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
+	780,  // 1881: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
+	412,  // 1882: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
+	414,  // 1883: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
+	577,  // 1884: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
+	585,  // 1885: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
+	116,  // 1886: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
+	122,  // 1887: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
+	119,  // 1888: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
+	1024, // 1889: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
+	643,  // 1890: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
+	645,  // 1891: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
+	650,  // 1892: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
+	652,  // 1893: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
+	653,  // 1894: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
+	654,  // 1895: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
+	656,  // 1896: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
+	680,  // 1897: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
+	696,  // 1898: forge.Forge.CreateSku:output_type -> forge.SkuIdList
+	692,  // 1899: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
+	1024, // 1900: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
+	1024, // 1901: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
+	1024, // 1902: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
+	1024, // 1903: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
+	696,  // 1904: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
+	695,  // 1905: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
+	1024, // 1906: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
+	692,  // 1907: forge.Forge.ReplaceSku:output_type -> forge.Sku
+	380,  // 1908: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
+	382,  // 1909: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
+	384,  // 1910: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
+	1024, // 1911: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
+	1024, // 1912: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
+	702,  // 1913: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
+	704,  // 1914: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
+	700,  // 1915: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
+	700,  // 1916: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
+	707,  // 1917: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
+	712,  // 1918: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
+	712,  // 1919: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
+	1024, // 1920: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
+	115,  // 1921: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
+	730,  // 1922: forge.Forge.FindRackIds:output_type -> forge.RackIdList
+	728,  // 1923: forge.Forge.FindRacksByIds:output_type -> forge.RackList
+	727,  // 1924: forge.Forge.GetRack:output_type -> forge.GetRackResponse
+	1024, // 1925: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
+	738,  // 1926: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
+	745,  // 1927: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
+	716,  // 1928: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
+	718,  // 1929: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
+	720,  // 1930: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
+	721,  // 1931: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
+	724,  // 1932: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
+	782,  // 1933: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
+	784,  // 1934: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
+	1143, // 1935: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
+	1144, // 1936: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
+	787,  // 1937: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
+	789,  // 1938: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
+	788,  // 1939: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	788,  // 1940: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	1024, // 1941: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
+	792,  // 1942: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
+	1024, // 1943: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
+	1024, // 1944: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
+	1024, // 1945: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
+	1024, // 1946: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
+	793,  // 1947: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
+	794,  // 1948: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
+	801,  // 1949: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
+	804,  // 1950: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
+	806,  // 1951: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
+	1024, // 1952: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
+	1024, // 1953: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
+	1024, // 1954: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
+	815,  // 1955: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
+	815,  // 1956: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
+	819,  // 1957: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
+	821,  // 1958: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
+	823,  // 1959: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
+	825,  // 1960: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
+	827,  // 1961: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
+	89,   // 1962: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
+	1024, // 1963: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
+	94,   // 1964: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
+	91,   // 1965: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
+	96,   // 1966: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
+	101,  // 1967: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	101,  // 1968: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	1024, // 1969: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
+	104,  // 1970: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	104,  // 1971: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	1024, // 1972: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
+	110,  // 1973: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
+	111,  // 1974: forge.Forge.GetJWKS:output_type -> forge.Jwks
+	112,  // 1975: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
+	834,  // 1976: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
+	837,  // 1977: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
+	839,  // 1978: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
+	841,  // 1979: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
+	1145, // 1980: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
+	1146, // 1981: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
+	1147, // 1982: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
+	1148, // 1983: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
+	1149, // 1984: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
+	1150, // 1985: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
+	1151, // 1986: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
+	1152, // 1987: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
+	1153, // 1988: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
+	1154, // 1989: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
+	1155, // 1990: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
+	1156, // 1991: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
+	1157, // 1992: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
+	1158, // 1993: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
+	1159, // 1994: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
+	763,  // 1995: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
+	758,  // 1996: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
+	758,  // 1997: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
+	774,  // 1998: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
+	768,  // 1999: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
+	767,  // 2000: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
+	776,  // 2001: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
+	771,  // 2002: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
+	768,  // 2003: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
+	855,  // 2004: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
+	756,  // 2005: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
+	1024, // 2006: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
+	858,  // 2007: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
+	861,  // 2008: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
+	864,  // 2009: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
+	872,  // 2010: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
+	870,  // 2011: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
+	879,  // 2012: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
+	881,  // 2013: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
+	885,  // 2014: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
+	898,  // 2015: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
+	898,  // 2016: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
+	898,  // 2017: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
+	904,  // 2018: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
+	906,  // 2019: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
+	908,  // 2020: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
+	910,  // 2021: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	910,  // 2022: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	915,  // 2023: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
+	1576, // [1576:2024] is the sub-list for method output_type
+	1128, // [1128:1576] is the sub-list for method input_type
 	1128, // [1128:1128] is the sub-list for extension type_name
 	1128, // [1128:1128] is the sub-list for extension extendee
 	0,    // [0:1128] is the sub-list for field type_name

--- a/rest-api/flow/internal/nicoapi/gen/nico_grpc.pb.go
+++ b/rest-api/flow/internal/nicoapi/gen/nico_grpc.pb.go
@@ -152,6 +152,7 @@ const (
 	Forge_GetSwitchNvosCredentials_FullMethodName                           = "/forge.Forge/GetSwitchNvosCredentials"
 	Forge_GetAllManagedHostNetworkStatus_FullMethodName                     = "/forge.Forge/GetAllManagedHostNetworkStatus"
 	Forge_GetSiteExplorationReport_FullMethodName                           = "/forge.Forge/GetSiteExplorationReport"
+	Forge_GetSiteExplorerLastRun_FullMethodName                             = "/forge.Forge/GetSiteExplorerLastRun"
 	Forge_ClearSiteExplorationError_FullMethodName                          = "/forge.Forge/ClearSiteExplorationError"
 	Forge_IsBmcInManagedHost_FullMethodName                                 = "/forge.Forge/IsBmcInManagedHost"
 	Forge_BmcCredentialStatus_FullMethodName                                = "/forge.Forge/BmcCredentialStatus"
@@ -682,6 +683,8 @@ type ForgeClient interface {
 	// Gets the latest Site Exploration report
 	// DEPRECATED: use FindExploredEndpointIds, FindExploredEndpointsByIds and FindExploredManagedHostIds, FindExploredManagedHostsByIds instead
 	GetSiteExplorationReport(ctx context.Context, in *GetSiteExplorationRequest, opts ...grpc.CallOption) (*SiteExplorationReport, error)
+	// Gets metadata about the latest Site Explorer run without fetching endpoint rows.
+	GetSiteExplorerLastRun(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*SiteExplorerLastRunResponse, error)
 	// Clear the last known error for the BMC
 	ClearSiteExplorationError(ctx context.Context, in *ClearSiteExplorationErrorRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// IsBmcInManagedHost returns true if a Host+DPU pair that includes the endpoint has been identified
@@ -2548,6 +2551,16 @@ func (c *forgeClient) GetSiteExplorationReport(ctx context.Context, in *GetSiteE
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SiteExplorationReport)
 	err := c.cc.Invoke(ctx, Forge_GetSiteExplorationReport_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *forgeClient) GetSiteExplorerLastRun(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*SiteExplorerLastRunResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SiteExplorerLastRunResponse)
+	err := c.cc.Invoke(ctx, Forge_GetSiteExplorerLastRun_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -5947,6 +5960,8 @@ type ForgeServer interface {
 	// Gets the latest Site Exploration report
 	// DEPRECATED: use FindExploredEndpointIds, FindExploredEndpointsByIds and FindExploredManagedHostIds, FindExploredManagedHostsByIds instead
 	GetSiteExplorationReport(context.Context, *GetSiteExplorationRequest) (*SiteExplorationReport, error)
+	// Gets metadata about the latest Site Explorer run without fetching endpoint rows.
+	GetSiteExplorerLastRun(context.Context, *emptypb.Empty) (*SiteExplorerLastRunResponse, error)
 	// Clear the last known error for the BMC
 	ClearSiteExplorationError(context.Context, *ClearSiteExplorationErrorRequest) (*emptypb.Empty, error)
 	// IsBmcInManagedHost returns true if a Host+DPU pair that includes the endpoint has been identified
@@ -6907,6 +6922,9 @@ func (UnimplementedForgeServer) GetAllManagedHostNetworkStatus(context.Context, 
 }
 func (UnimplementedForgeServer) GetSiteExplorationReport(context.Context, *GetSiteExplorationRequest) (*SiteExplorationReport, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSiteExplorationReport not implemented")
+}
+func (UnimplementedForgeServer) GetSiteExplorerLastRun(context.Context, *emptypb.Empty) (*SiteExplorerLastRunResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSiteExplorerLastRun not implemented")
 }
 func (UnimplementedForgeServer) ClearSiteExplorationError(context.Context, *ClearSiteExplorationErrorRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method ClearSiteExplorationError not implemented")
@@ -10200,6 +10218,24 @@ func _Forge_GetSiteExplorationReport_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ForgeServer).GetSiteExplorationReport(ctx, req.(*GetSiteExplorationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Forge_GetSiteExplorerLastRun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ForgeServer).GetSiteExplorerLastRun(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Forge_GetSiteExplorerLastRun_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ForgeServer).GetSiteExplorerLastRun(ctx, req.(*emptypb.Empty))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -16439,6 +16475,10 @@ var Forge_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSiteExplorationReport",
 			Handler:    _Forge_GetSiteExplorationReport_Handler,
+		},
+		{
+			MethodName: "GetSiteExplorerLastRun",
+			Handler:    _Forge_GetSiteExplorerLastRun_Handler,
 		},
 		{
 			MethodName: "ClearSiteExplorationError",

--- a/rest-api/flow/internal/nicoapi/gen/site_explorer.pb.go
+++ b/rest-api/flow/internal/nicoapi/gen/site_explorer.pb.go
@@ -653,7 +653,9 @@ type SiteExplorationReport struct {
 	// The endpoints that had been explored
 	Endpoints []*ExploredEndpoint `protobuf:"bytes,1,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
 	// The managed-hosts which have been explored
-	ManagedHosts  []*ExploredManagedHost `protobuf:"bytes,2,rep,name=managed_hosts,json=managedHosts,proto3" json:"managed_hosts,omitempty"`
+	ManagedHosts []*ExploredManagedHost `protobuf:"bytes,2,rep,name=managed_hosts,json=managedHosts,proto3" json:"managed_hosts,omitempty"`
+	// Metadata about the latest site explorer run
+	LastRun       *SiteExplorerLastRun `protobuf:"bytes,3,opt,name=last_run,json=lastRun,proto3,oneof" json:"last_run,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -702,6 +704,184 @@ func (x *SiteExplorationReport) GetManagedHosts() []*ExploredManagedHost {
 	return nil
 }
 
+func (x *SiteExplorationReport) GetLastRun() *SiteExplorerLastRun {
+	if x != nil {
+		return x.LastRun
+	}
+	return nil
+}
+
+type SiteExplorerLastRunResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Metadata about the latest site explorer run, if site explorer has run
+	LastRun       *SiteExplorerLastRun `protobuf:"bytes,1,opt,name=last_run,json=lastRun,proto3,oneof" json:"last_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SiteExplorerLastRunResponse) Reset() {
+	*x = SiteExplorerLastRunResponse{}
+	mi := &file_site_explorer_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SiteExplorerLastRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SiteExplorerLastRunResponse) ProtoMessage() {}
+
+func (x *SiteExplorerLastRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_site_explorer_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SiteExplorerLastRunResponse.ProtoReflect.Descriptor instead.
+func (*SiteExplorerLastRunResponse) Descriptor() ([]byte, []int) {
+	return file_site_explorer_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SiteExplorerLastRunResponse) GetLastRun() *SiteExplorerLastRun {
+	if x != nil {
+		return x.LastRun
+	}
+	return nil
+}
+
+type SiteExplorerLastRun struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// When the run started
+	StartedAt string `protobuf:"bytes,1,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	// When the run finished
+	FinishedAt string `protobuf:"bytes,2,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
+	// Whether the run completed successfully
+	Success bool `protobuf:"varint,3,opt,name=success,proto3" json:"success,omitempty"`
+	// Error string for a failed run
+	Error *string `protobuf:"bytes,4,opt,name=error,proto3,oneof" json:"error,omitempty"`
+	// Number of endpoint exploration attempts made during the run
+	EndpointExplorations int64 `protobuf:"varint,5,opt,name=endpoint_explorations,json=endpointExplorations,proto3" json:"endpoint_explorations,omitempty"`
+	// Number of successful endpoint explorations during the run
+	EndpointExplorationsSuccess int64 `protobuf:"varint,6,opt,name=endpoint_explorations_success,json=endpointExplorationsSuccess,proto3" json:"endpoint_explorations_success,omitempty"`
+	// Number of endpoint exploration errors during the run
+	EndpointExplorationsFailed int64 `protobuf:"varint,7,opt,name=endpoint_explorations_failed,json=endpointExplorationsFailed,proto3" json:"endpoint_explorations_failed,omitempty"`
+	// Failure category for a failed run
+	FailureCategory *string `protobuf:"bytes,8,opt,name=failure_category,json=failureCategory,proto3,oneof" json:"failure_category,omitempty"`
+	// When the most recent successful run finished
+	LastSuccessfulFinishedAt *string `protobuf:"bytes,9,opt,name=last_successful_finished_at,json=lastSuccessfulFinishedAt,proto3,oneof" json:"last_successful_finished_at,omitempty"`
+	// When the most recent failed run finished
+	LastFailedFinishedAt *string `protobuf:"bytes,10,opt,name=last_failed_finished_at,json=lastFailedFinishedAt,proto3,oneof" json:"last_failed_finished_at,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *SiteExplorerLastRun) Reset() {
+	*x = SiteExplorerLastRun{}
+	mi := &file_site_explorer_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SiteExplorerLastRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SiteExplorerLastRun) ProtoMessage() {}
+
+func (x *SiteExplorerLastRun) ProtoReflect() protoreflect.Message {
+	mi := &file_site_explorer_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SiteExplorerLastRun.ProtoReflect.Descriptor instead.
+func (*SiteExplorerLastRun) Descriptor() ([]byte, []int) {
+	return file_site_explorer_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SiteExplorerLastRun) GetStartedAt() string {
+	if x != nil {
+		return x.StartedAt
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetFinishedAt() string {
+	if x != nil {
+		return x.FinishedAt
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *SiteExplorerLastRun) GetError() string {
+	if x != nil && x.Error != nil {
+		return *x.Error
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetEndpointExplorations() int64 {
+	if x != nil {
+		return x.EndpointExplorations
+	}
+	return 0
+}
+
+func (x *SiteExplorerLastRun) GetEndpointExplorationsSuccess() int64 {
+	if x != nil {
+		return x.EndpointExplorationsSuccess
+	}
+	return 0
+}
+
+func (x *SiteExplorerLastRun) GetEndpointExplorationsFailed() int64 {
+	if x != nil {
+		return x.EndpointExplorationsFailed
+	}
+	return 0
+}
+
+func (x *SiteExplorerLastRun) GetFailureCategory() string {
+	if x != nil && x.FailureCategory != nil {
+		return *x.FailureCategory
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetLastSuccessfulFinishedAt() string {
+	if x != nil && x.LastSuccessfulFinishedAt != nil {
+		return *x.LastSuccessfulFinishedAt
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetLastFailedFinishedAt() string {
+	if x != nil && x.LastFailedFinishedAt != nil {
+		return *x.LastFailedFinishedAt
+	}
+	return ""
+}
+
 type ExploredEndpointSearchFilter struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -710,7 +890,7 @@ type ExploredEndpointSearchFilter struct {
 
 func (x *ExploredEndpointSearchFilter) Reset() {
 	*x = ExploredEndpointSearchFilter{}
-	mi := &file_site_explorer_proto_msgTypes[5]
+	mi := &file_site_explorer_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -722,7 +902,7 @@ func (x *ExploredEndpointSearchFilter) String() string {
 func (*ExploredEndpointSearchFilter) ProtoMessage() {}
 
 func (x *ExploredEndpointSearchFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[5]
+	mi := &file_site_explorer_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -735,7 +915,7 @@ func (x *ExploredEndpointSearchFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredEndpointSearchFilter.ProtoReflect.Descriptor instead.
 func (*ExploredEndpointSearchFilter) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{5}
+	return file_site_explorer_proto_rawDescGZIP(), []int{7}
 }
 
 type ExploredEndpointIdList struct {
@@ -748,7 +928,7 @@ type ExploredEndpointIdList struct {
 
 func (x *ExploredEndpointIdList) Reset() {
 	*x = ExploredEndpointIdList{}
-	mi := &file_site_explorer_proto_msgTypes[6]
+	mi := &file_site_explorer_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -760,7 +940,7 @@ func (x *ExploredEndpointIdList) String() string {
 func (*ExploredEndpointIdList) ProtoMessage() {}
 
 func (x *ExploredEndpointIdList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[6]
+	mi := &file_site_explorer_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -773,7 +953,7 @@ func (x *ExploredEndpointIdList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredEndpointIdList.ProtoReflect.Descriptor instead.
 func (*ExploredEndpointIdList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{6}
+	return file_site_explorer_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ExploredEndpointIdList) GetEndpointIds() []string {
@@ -793,7 +973,7 @@ type ExploredEndpointsByIdsRequest struct {
 
 func (x *ExploredEndpointsByIdsRequest) Reset() {
 	*x = ExploredEndpointsByIdsRequest{}
-	mi := &file_site_explorer_proto_msgTypes[7]
+	mi := &file_site_explorer_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -805,7 +985,7 @@ func (x *ExploredEndpointsByIdsRequest) String() string {
 func (*ExploredEndpointsByIdsRequest) ProtoMessage() {}
 
 func (x *ExploredEndpointsByIdsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[7]
+	mi := &file_site_explorer_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -818,7 +998,7 @@ func (x *ExploredEndpointsByIdsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredEndpointsByIdsRequest.ProtoReflect.Descriptor instead.
 func (*ExploredEndpointsByIdsRequest) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{7}
+	return file_site_explorer_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ExploredEndpointsByIdsRequest) GetEndpointIds() []string {
@@ -837,7 +1017,7 @@ type ExploredEndpointList struct {
 
 func (x *ExploredEndpointList) Reset() {
 	*x = ExploredEndpointList{}
-	mi := &file_site_explorer_proto_msgTypes[8]
+	mi := &file_site_explorer_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -849,7 +1029,7 @@ func (x *ExploredEndpointList) String() string {
 func (*ExploredEndpointList) ProtoMessage() {}
 
 func (x *ExploredEndpointList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[8]
+	mi := &file_site_explorer_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -862,7 +1042,7 @@ func (x *ExploredEndpointList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredEndpointList.ProtoReflect.Descriptor instead.
 func (*ExploredEndpointList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{8}
+	return file_site_explorer_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ExploredEndpointList) GetEndpoints() []*ExploredEndpoint {
@@ -880,7 +1060,7 @@ type ExploredManagedHostSearchFilter struct {
 
 func (x *ExploredManagedHostSearchFilter) Reset() {
 	*x = ExploredManagedHostSearchFilter{}
-	mi := &file_site_explorer_proto_msgTypes[9]
+	mi := &file_site_explorer_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -892,7 +1072,7 @@ func (x *ExploredManagedHostSearchFilter) String() string {
 func (*ExploredManagedHostSearchFilter) ProtoMessage() {}
 
 func (x *ExploredManagedHostSearchFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[9]
+	mi := &file_site_explorer_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -905,7 +1085,7 @@ func (x *ExploredManagedHostSearchFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredManagedHostSearchFilter.ProtoReflect.Descriptor instead.
 func (*ExploredManagedHostSearchFilter) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{9}
+	return file_site_explorer_proto_rawDescGZIP(), []int{11}
 }
 
 type ExploredManagedHostIdList struct {
@@ -918,7 +1098,7 @@ type ExploredManagedHostIdList struct {
 
 func (x *ExploredManagedHostIdList) Reset() {
 	*x = ExploredManagedHostIdList{}
-	mi := &file_site_explorer_proto_msgTypes[10]
+	mi := &file_site_explorer_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -930,7 +1110,7 @@ func (x *ExploredManagedHostIdList) String() string {
 func (*ExploredManagedHostIdList) ProtoMessage() {}
 
 func (x *ExploredManagedHostIdList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[10]
+	mi := &file_site_explorer_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -943,7 +1123,7 @@ func (x *ExploredManagedHostIdList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredManagedHostIdList.ProtoReflect.Descriptor instead.
 func (*ExploredManagedHostIdList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{10}
+	return file_site_explorer_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ExploredManagedHostIdList) GetHostIds() []string {
@@ -963,7 +1143,7 @@ type ExploredManagedHostsByIdsRequest struct {
 
 func (x *ExploredManagedHostsByIdsRequest) Reset() {
 	*x = ExploredManagedHostsByIdsRequest{}
-	mi := &file_site_explorer_proto_msgTypes[11]
+	mi := &file_site_explorer_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -975,7 +1155,7 @@ func (x *ExploredManagedHostsByIdsRequest) String() string {
 func (*ExploredManagedHostsByIdsRequest) ProtoMessage() {}
 
 func (x *ExploredManagedHostsByIdsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[11]
+	mi := &file_site_explorer_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -988,7 +1168,7 @@ func (x *ExploredManagedHostsByIdsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredManagedHostsByIdsRequest.ProtoReflect.Descriptor instead.
 func (*ExploredManagedHostsByIdsRequest) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{11}
+	return file_site_explorer_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ExploredManagedHostsByIdsRequest) GetHostIds() []string {
@@ -1007,7 +1187,7 @@ type ExploredManagedHostList struct {
 
 func (x *ExploredManagedHostList) Reset() {
 	*x = ExploredManagedHostList{}
-	mi := &file_site_explorer_proto_msgTypes[12]
+	mi := &file_site_explorer_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1019,7 +1199,7 @@ func (x *ExploredManagedHostList) String() string {
 func (*ExploredManagedHostList) ProtoMessage() {}
 
 func (x *ExploredManagedHostList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[12]
+	mi := &file_site_explorer_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1032,7 +1212,7 @@ func (x *ExploredManagedHostList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredManagedHostList.ProtoReflect.Descriptor instead.
 func (*ExploredManagedHostList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{12}
+	return file_site_explorer_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ExploredManagedHostList) GetManagedHosts() []*ExploredManagedHost {
@@ -1077,7 +1257,7 @@ type ExploredMlxDevice struct {
 
 func (x *ExploredMlxDevice) Reset() {
 	*x = ExploredMlxDevice{}
-	mi := &file_site_explorer_proto_msgTypes[13]
+	mi := &file_site_explorer_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1089,7 +1269,7 @@ func (x *ExploredMlxDevice) String() string {
 func (*ExploredMlxDevice) ProtoMessage() {}
 
 func (x *ExploredMlxDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[13]
+	mi := &file_site_explorer_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1102,7 +1282,7 @@ func (x *ExploredMlxDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredMlxDevice.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDevice) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{13}
+	return file_site_explorer_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ExploredMlxDevice) GetHostBmcIp() string {
@@ -1184,7 +1364,7 @@ type ExploredMlxDeviceList struct {
 
 func (x *ExploredMlxDeviceList) Reset() {
 	*x = ExploredMlxDeviceList{}
-	mi := &file_site_explorer_proto_msgTypes[14]
+	mi := &file_site_explorer_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1196,7 +1376,7 @@ func (x *ExploredMlxDeviceList) String() string {
 func (*ExploredMlxDeviceList) ProtoMessage() {}
 
 func (x *ExploredMlxDeviceList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[14]
+	mi := &file_site_explorer_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1209,7 +1389,7 @@ func (x *ExploredMlxDeviceList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredMlxDeviceList.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDeviceList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{14}
+	return file_site_explorer_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ExploredMlxDeviceList) GetDevices() []*ExploredMlxDevice {
@@ -1229,7 +1409,7 @@ type ExploredMlxDeviceHostSearchFilter struct {
 
 func (x *ExploredMlxDeviceHostSearchFilter) Reset() {
 	*x = ExploredMlxDeviceHostSearchFilter{}
-	mi := &file_site_explorer_proto_msgTypes[15]
+	mi := &file_site_explorer_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1241,7 +1421,7 @@ func (x *ExploredMlxDeviceHostSearchFilter) String() string {
 func (*ExploredMlxDeviceHostSearchFilter) ProtoMessage() {}
 
 func (x *ExploredMlxDeviceHostSearchFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[15]
+	mi := &file_site_explorer_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1254,7 +1434,7 @@ func (x *ExploredMlxDeviceHostSearchFilter) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ExploredMlxDeviceHostSearchFilter.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDeviceHostSearchFilter) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{15}
+	return file_site_explorer_proto_rawDescGZIP(), []int{17}
 }
 
 type ExploredMlxDeviceHostIdList struct {
@@ -1267,7 +1447,7 @@ type ExploredMlxDeviceHostIdList struct {
 
 func (x *ExploredMlxDeviceHostIdList) Reset() {
 	*x = ExploredMlxDeviceHostIdList{}
-	mi := &file_site_explorer_proto_msgTypes[16]
+	mi := &file_site_explorer_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1279,7 +1459,7 @@ func (x *ExploredMlxDeviceHostIdList) String() string {
 func (*ExploredMlxDeviceHostIdList) ProtoMessage() {}
 
 func (x *ExploredMlxDeviceHostIdList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[16]
+	mi := &file_site_explorer_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1292,7 +1472,7 @@ func (x *ExploredMlxDeviceHostIdList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredMlxDeviceHostIdList.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDeviceHostIdList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{16}
+	return file_site_explorer_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ExploredMlxDeviceHostIdList) GetHostIds() []string {
@@ -1312,7 +1492,7 @@ type ExploredMlxDevicesByIdsRequest struct {
 
 func (x *ExploredMlxDevicesByIdsRequest) Reset() {
 	*x = ExploredMlxDevicesByIdsRequest{}
-	mi := &file_site_explorer_proto_msgTypes[17]
+	mi := &file_site_explorer_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1324,7 +1504,7 @@ func (x *ExploredMlxDevicesByIdsRequest) String() string {
 func (*ExploredMlxDevicesByIdsRequest) ProtoMessage() {}
 
 func (x *ExploredMlxDevicesByIdsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[17]
+	mi := &file_site_explorer_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1337,7 +1517,7 @@ func (x *ExploredMlxDevicesByIdsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredMlxDevicesByIdsRequest.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDevicesByIdsRequest) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{17}
+	return file_site_explorer_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ExploredMlxDevicesByIdsRequest) GetHostIds() []string {
@@ -1356,7 +1536,7 @@ type ComputerSystemAttributes struct {
 
 func (x *ComputerSystemAttributes) Reset() {
 	*x = ComputerSystemAttributes{}
-	mi := &file_site_explorer_proto_msgTypes[18]
+	mi := &file_site_explorer_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1368,7 +1548,7 @@ func (x *ComputerSystemAttributes) String() string {
 func (*ComputerSystemAttributes) ProtoMessage() {}
 
 func (x *ComputerSystemAttributes) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[18]
+	mi := &file_site_explorer_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1381,7 +1561,7 @@ func (x *ComputerSystemAttributes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComputerSystemAttributes.ProtoReflect.Descriptor instead.
 func (*ComputerSystemAttributes) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{18}
+	return file_site_explorer_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ComputerSystemAttributes) GetNicMode() NicMode {
@@ -1409,7 +1589,7 @@ type ComputerSystem struct {
 
 func (x *ComputerSystem) Reset() {
 	*x = ComputerSystem{}
-	mi := &file_site_explorer_proto_msgTypes[19]
+	mi := &file_site_explorer_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1421,7 +1601,7 @@ func (x *ComputerSystem) String() string {
 func (*ComputerSystem) ProtoMessage() {}
 
 func (x *ComputerSystem) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[19]
+	mi := &file_site_explorer_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1434,7 +1614,7 @@ func (x *ComputerSystem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComputerSystem.ProtoReflect.Descriptor instead.
 func (*ComputerSystem) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{19}
+	return file_site_explorer_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ComputerSystem) GetId() string {
@@ -1511,7 +1691,7 @@ type Manager struct {
 
 func (x *Manager) Reset() {
 	*x = Manager{}
-	mi := &file_site_explorer_proto_msgTypes[20]
+	mi := &file_site_explorer_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1523,7 +1703,7 @@ func (x *Manager) String() string {
 func (*Manager) ProtoMessage() {}
 
 func (x *Manager) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[20]
+	mi := &file_site_explorer_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1536,7 +1716,7 @@ func (x *Manager) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Manager.ProtoReflect.Descriptor instead.
 func (*Manager) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{20}
+	return file_site_explorer_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Manager) GetId() string {
@@ -1568,7 +1748,7 @@ type EthernetInterface struct {
 
 func (x *EthernetInterface) Reset() {
 	*x = EthernetInterface{}
-	mi := &file_site_explorer_proto_msgTypes[21]
+	mi := &file_site_explorer_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1580,7 +1760,7 @@ func (x *EthernetInterface) String() string {
 func (*EthernetInterface) ProtoMessage() {}
 
 func (x *EthernetInterface) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[21]
+	mi := &file_site_explorer_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1593,7 +1773,7 @@ func (x *EthernetInterface) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EthernetInterface.ProtoReflect.Descriptor instead.
 func (*EthernetInterface) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{21}
+	return file_site_explorer_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *EthernetInterface) GetId() string {
@@ -1646,7 +1826,7 @@ type Chassis struct {
 
 func (x *Chassis) Reset() {
 	*x = Chassis{}
-	mi := &file_site_explorer_proto_msgTypes[22]
+	mi := &file_site_explorer_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1658,7 +1838,7 @@ func (x *Chassis) String() string {
 func (*Chassis) ProtoMessage() {}
 
 func (x *Chassis) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[22]
+	mi := &file_site_explorer_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1671,7 +1851,7 @@ func (x *Chassis) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Chassis.ProtoReflect.Descriptor instead.
 func (*Chassis) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{22}
+	return file_site_explorer_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Chassis) GetId() string {
@@ -1730,7 +1910,7 @@ type NetworkAdapter struct {
 
 func (x *NetworkAdapter) Reset() {
 	*x = NetworkAdapter{}
-	mi := &file_site_explorer_proto_msgTypes[23]
+	mi := &file_site_explorer_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1742,7 +1922,7 @@ func (x *NetworkAdapter) String() string {
 func (*NetworkAdapter) ProtoMessage() {}
 
 func (x *NetworkAdapter) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[23]
+	mi := &file_site_explorer_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1755,7 +1935,7 @@ func (x *NetworkAdapter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkAdapter.ProtoReflect.Descriptor instead.
 func (*NetworkAdapter) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{23}
+	return file_site_explorer_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *NetworkAdapter) GetId() string {
@@ -1804,7 +1984,7 @@ type Service struct {
 
 func (x *Service) Reset() {
 	*x = Service{}
-	mi := &file_site_explorer_proto_msgTypes[24]
+	mi := &file_site_explorer_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1816,7 +1996,7 @@ func (x *Service) String() string {
 func (*Service) ProtoMessage() {}
 
 func (x *Service) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[24]
+	mi := &file_site_explorer_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1829,7 +2009,7 @@ func (x *Service) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Service.ProtoReflect.Descriptor instead.
 func (*Service) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{24}
+	return file_site_explorer_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *Service) GetId() string {
@@ -1859,7 +2039,7 @@ type Inventory struct {
 
 func (x *Inventory) Reset() {
 	*x = Inventory{}
-	mi := &file_site_explorer_proto_msgTypes[25]
+	mi := &file_site_explorer_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1871,7 +2051,7 @@ func (x *Inventory) String() string {
 func (*Inventory) ProtoMessage() {}
 
 func (x *Inventory) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[25]
+	mi := &file_site_explorer_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1884,7 +2064,7 @@ func (x *Inventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Inventory.ProtoReflect.Descriptor instead.
 func (*Inventory) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{25}
+	return file_site_explorer_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Inventory) GetId() string {
@@ -1926,7 +2106,7 @@ type MachineSetupStatus struct {
 
 func (x *MachineSetupStatus) Reset() {
 	*x = MachineSetupStatus{}
-	mi := &file_site_explorer_proto_msgTypes[26]
+	mi := &file_site_explorer_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1938,7 +2118,7 @@ func (x *MachineSetupStatus) String() string {
 func (*MachineSetupStatus) ProtoMessage() {}
 
 func (x *MachineSetupStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[26]
+	mi := &file_site_explorer_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1951,7 +2131,7 @@ func (x *MachineSetupStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineSetupStatus.ProtoReflect.Descriptor instead.
 func (*MachineSetupStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{26}
+	return file_site_explorer_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *MachineSetupStatus) GetIsDone() bool {
@@ -1980,7 +2160,7 @@ type MachineSetupDiff struct {
 
 func (x *MachineSetupDiff) Reset() {
 	*x = MachineSetupDiff{}
-	mi := &file_site_explorer_proto_msgTypes[27]
+	mi := &file_site_explorer_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1992,7 +2172,7 @@ func (x *MachineSetupDiff) String() string {
 func (*MachineSetupDiff) ProtoMessage() {}
 
 func (x *MachineSetupDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[27]
+	mi := &file_site_explorer_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2005,7 +2185,7 @@ func (x *MachineSetupDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineSetupDiff.ProtoReflect.Descriptor instead.
 func (*MachineSetupDiff) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{27}
+	return file_site_explorer_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *MachineSetupDiff) GetKey() string {
@@ -2046,7 +2226,7 @@ type PCIeDevice struct {
 
 func (x *PCIeDevice) Reset() {
 	*x = PCIeDevice{}
-	mi := &file_site_explorer_proto_msgTypes[28]
+	mi := &file_site_explorer_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2058,7 +2238,7 @@ func (x *PCIeDevice) String() string {
 func (*PCIeDevice) ProtoMessage() {}
 
 func (x *PCIeDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[28]
+	mi := &file_site_explorer_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2071,7 +2251,7 @@ func (x *PCIeDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PCIeDevice.ProtoReflect.Descriptor instead.
 func (*PCIeDevice) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{28}
+	return file_site_explorer_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PCIeDevice) GetDescription() string {
@@ -2148,7 +2328,7 @@ type SystemStatus struct {
 
 func (x *SystemStatus) Reset() {
 	*x = SystemStatus{}
-	mi := &file_site_explorer_proto_msgTypes[29]
+	mi := &file_site_explorer_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2160,7 +2340,7 @@ func (x *SystemStatus) String() string {
 func (*SystemStatus) ProtoMessage() {}
 
 func (x *SystemStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[29]
+	mi := &file_site_explorer_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2173,7 +2353,7 @@ func (x *SystemStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemStatus.ProtoReflect.Descriptor instead.
 func (*SystemStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{29}
+	return file_site_explorer_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *SystemStatus) GetHealth() string {
@@ -2206,7 +2386,7 @@ type BootOrder struct {
 
 func (x *BootOrder) Reset() {
 	*x = BootOrder{}
-	mi := &file_site_explorer_proto_msgTypes[30]
+	mi := &file_site_explorer_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2218,7 +2398,7 @@ func (x *BootOrder) String() string {
 func (*BootOrder) ProtoMessage() {}
 
 func (x *BootOrder) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[30]
+	mi := &file_site_explorer_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2231,7 +2411,7 @@ func (x *BootOrder) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootOrder.ProtoReflect.Descriptor instead.
 func (*BootOrder) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{30}
+	return file_site_explorer_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *BootOrder) GetBootOrder() []*BootOption {
@@ -2253,7 +2433,7 @@ type BootOption struct {
 
 func (x *BootOption) Reset() {
 	*x = BootOption{}
-	mi := &file_site_explorer_proto_msgTypes[31]
+	mi := &file_site_explorer_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2265,7 +2445,7 @@ func (x *BootOption) String() string {
 func (*BootOption) ProtoMessage() {}
 
 func (x *BootOption) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[31]
+	mi := &file_site_explorer_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2278,7 +2458,7 @@ func (x *BootOption) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootOption.ProtoReflect.Descriptor instead.
 func (*BootOption) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{31}
+	return file_site_explorer_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *BootOption) GetDisplayName() string {
@@ -2318,7 +2498,7 @@ type SecureBootStatus struct {
 
 func (x *SecureBootStatus) Reset() {
 	*x = SecureBootStatus{}
-	mi := &file_site_explorer_proto_msgTypes[32]
+	mi := &file_site_explorer_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2330,7 +2510,7 @@ func (x *SecureBootStatus) String() string {
 func (*SecureBootStatus) ProtoMessage() {}
 
 func (x *SecureBootStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[32]
+	mi := &file_site_explorer_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2343,7 +2523,7 @@ func (x *SecureBootStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecureBootStatus.ProtoReflect.Descriptor instead.
 func (*SecureBootStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{32}
+	return file_site_explorer_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *SecureBootStatus) GetIsEnabled() bool {
@@ -2364,7 +2544,7 @@ type LockdownStatus struct {
 
 func (x *LockdownStatus) Reset() {
 	*x = LockdownStatus{}
-	mi := &file_site_explorer_proto_msgTypes[33]
+	mi := &file_site_explorer_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2376,7 +2556,7 @@ func (x *LockdownStatus) String() string {
 func (*LockdownStatus) ProtoMessage() {}
 
 func (x *LockdownStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_proto_msgTypes[33]
+	mi := &file_site_explorer_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2389,7 +2569,7 @@ func (x *LockdownStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockdownStatus.ProtoReflect.Descriptor instead.
 func (*LockdownStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_proto_rawDescGZIP(), []int{33}
+	return file_site_explorer_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *LockdownStatus) GetStatus() InternalLockdownStatus {
@@ -2455,10 +2635,33 @@ const file_site_explorer_proto_rawDesc = "" +
 	"dpu_bmc_ip\x18\x02 \x01(\tR\bdpuBmcIp\x122\n" +
 	"\x13host_pf_mac_address\x18\x03 \x01(\tH\x00R\x10hostPfMacAddress\x88\x01\x01\x12.\n" +
 	"\x04dpus\x18\v \x03(\v2\x1a.site_explorer.ExploredDpuR\x04dpusB\x16\n" +
-	"\x14_host_pf_mac_address\"\x9f\x01\n" +
+	"\x14_host_pf_mac_address\"\xf0\x01\n" +
 	"\x15SiteExplorationReport\x12=\n" +
 	"\tendpoints\x18\x01 \x03(\v2\x1f.site_explorer.ExploredEndpointR\tendpoints\x12G\n" +
-	"\rmanaged_hosts\x18\x02 \x03(\v2\".site_explorer.ExploredManagedHostR\fmanagedHosts\"\x1e\n" +
+	"\rmanaged_hosts\x18\x02 \x03(\v2\".site_explorer.ExploredManagedHostR\fmanagedHosts\x12B\n" +
+	"\blast_run\x18\x03 \x01(\v2\".site_explorer.SiteExplorerLastRunH\x00R\alastRun\x88\x01\x01B\v\n" +
+	"\t_last_run\"n\n" +
+	"\x1bSiteExplorerLastRunResponse\x12B\n" +
+	"\blast_run\x18\x01 \x01(\v2\".site_explorer.SiteExplorerLastRunH\x00R\alastRun\x88\x01\x01B\v\n" +
+	"\t_last_run\"\xd0\x04\n" +
+	"\x13SiteExplorerLastRun\x12\x1d\n" +
+	"\n" +
+	"started_at\x18\x01 \x01(\tR\tstartedAt\x12\x1f\n" +
+	"\vfinished_at\x18\x02 \x01(\tR\n" +
+	"finishedAt\x12\x18\n" +
+	"\asuccess\x18\x03 \x01(\bR\asuccess\x12\x19\n" +
+	"\x05error\x18\x04 \x01(\tH\x00R\x05error\x88\x01\x01\x123\n" +
+	"\x15endpoint_explorations\x18\x05 \x01(\x03R\x14endpointExplorations\x12B\n" +
+	"\x1dendpoint_explorations_success\x18\x06 \x01(\x03R\x1bendpointExplorationsSuccess\x12@\n" +
+	"\x1cendpoint_explorations_failed\x18\a \x01(\x03R\x1aendpointExplorationsFailed\x12.\n" +
+	"\x10failure_category\x18\b \x01(\tH\x01R\x0ffailureCategory\x88\x01\x01\x12B\n" +
+	"\x1blast_successful_finished_at\x18\t \x01(\tH\x02R\x18lastSuccessfulFinishedAt\x88\x01\x01\x12:\n" +
+	"\x17last_failed_finished_at\x18\n" +
+	" \x01(\tH\x03R\x14lastFailedFinishedAt\x88\x01\x01B\b\n" +
+	"\x06_errorB\x13\n" +
+	"\x11_failure_categoryB\x1e\n" +
+	"\x1c_last_successful_finished_atB\x1a\n" +
+	"\x18_last_failed_finished_at\"\x1e\n" +
 	"\x1cExploredEndpointSearchFilter\";\n" +
 	"\x16ExploredEndpointIdList\x12!\n" +
 	"\fendpoint_ids\x18\x01 \x03(\tR\vendpointIds\"B\n" +
@@ -2666,7 +2869,7 @@ func file_site_explorer_proto_rawDescGZIP() []byte {
 }
 
 var file_site_explorer_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_site_explorer_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_site_explorer_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_site_explorer_proto_goTypes = []any{
 	(MlxDeviceKind)(0),                        // 0: site_explorer.MlxDeviceKind
 	(NicMode)(0),                              // 1: site_explorer.NicMode
@@ -2677,75 +2880,79 @@ var file_site_explorer_proto_goTypes = []any{
 	(*ExploredDpu)(nil),                       // 6: site_explorer.ExploredDpu
 	(*ExploredManagedHost)(nil),               // 7: site_explorer.ExploredManagedHost
 	(*SiteExplorationReport)(nil),             // 8: site_explorer.SiteExplorationReport
-	(*ExploredEndpointSearchFilter)(nil),      // 9: site_explorer.ExploredEndpointSearchFilter
-	(*ExploredEndpointIdList)(nil),            // 10: site_explorer.ExploredEndpointIdList
-	(*ExploredEndpointsByIdsRequest)(nil),     // 11: site_explorer.ExploredEndpointsByIdsRequest
-	(*ExploredEndpointList)(nil),              // 12: site_explorer.ExploredEndpointList
-	(*ExploredManagedHostSearchFilter)(nil),   // 13: site_explorer.ExploredManagedHostSearchFilter
-	(*ExploredManagedHostIdList)(nil),         // 14: site_explorer.ExploredManagedHostIdList
-	(*ExploredManagedHostsByIdsRequest)(nil),  // 15: site_explorer.ExploredManagedHostsByIdsRequest
-	(*ExploredManagedHostList)(nil),           // 16: site_explorer.ExploredManagedHostList
-	(*ExploredMlxDevice)(nil),                 // 17: site_explorer.ExploredMlxDevice
-	(*ExploredMlxDeviceList)(nil),             // 18: site_explorer.ExploredMlxDeviceList
-	(*ExploredMlxDeviceHostSearchFilter)(nil), // 19: site_explorer.ExploredMlxDeviceHostSearchFilter
-	(*ExploredMlxDeviceHostIdList)(nil),       // 20: site_explorer.ExploredMlxDeviceHostIdList
-	(*ExploredMlxDevicesByIdsRequest)(nil),    // 21: site_explorer.ExploredMlxDevicesByIdsRequest
-	(*ComputerSystemAttributes)(nil),          // 22: site_explorer.ComputerSystemAttributes
-	(*ComputerSystem)(nil),                    // 23: site_explorer.ComputerSystem
-	(*Manager)(nil),                           // 24: site_explorer.Manager
-	(*EthernetInterface)(nil),                 // 25: site_explorer.EthernetInterface
-	(*Chassis)(nil),                           // 26: site_explorer.Chassis
-	(*NetworkAdapter)(nil),                    // 27: site_explorer.NetworkAdapter
-	(*Service)(nil),                           // 28: site_explorer.Service
-	(*Inventory)(nil),                         // 29: site_explorer.Inventory
-	(*MachineSetupStatus)(nil),                // 30: site_explorer.MachineSetupStatus
-	(*MachineSetupDiff)(nil),                  // 31: site_explorer.MachineSetupDiff
-	(*PCIeDevice)(nil),                        // 32: site_explorer.PCIeDevice
-	(*SystemStatus)(nil),                      // 33: site_explorer.SystemStatus
-	(*BootOrder)(nil),                         // 34: site_explorer.BootOrder
-	(*BootOption)(nil),                        // 35: site_explorer.BootOption
-	(*SecureBootStatus)(nil),                  // 36: site_explorer.SecureBootStatus
-	(*LockdownStatus)(nil),                    // 37: site_explorer.LockdownStatus
-	nil,                                       // 38: site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
-	(*durationpb.Duration)(nil),               // 39: google.protobuf.Duration
+	(*SiteExplorerLastRunResponse)(nil),       // 9: site_explorer.SiteExplorerLastRunResponse
+	(*SiteExplorerLastRun)(nil),               // 10: site_explorer.SiteExplorerLastRun
+	(*ExploredEndpointSearchFilter)(nil),      // 11: site_explorer.ExploredEndpointSearchFilter
+	(*ExploredEndpointIdList)(nil),            // 12: site_explorer.ExploredEndpointIdList
+	(*ExploredEndpointsByIdsRequest)(nil),     // 13: site_explorer.ExploredEndpointsByIdsRequest
+	(*ExploredEndpointList)(nil),              // 14: site_explorer.ExploredEndpointList
+	(*ExploredManagedHostSearchFilter)(nil),   // 15: site_explorer.ExploredManagedHostSearchFilter
+	(*ExploredManagedHostIdList)(nil),         // 16: site_explorer.ExploredManagedHostIdList
+	(*ExploredManagedHostsByIdsRequest)(nil),  // 17: site_explorer.ExploredManagedHostsByIdsRequest
+	(*ExploredManagedHostList)(nil),           // 18: site_explorer.ExploredManagedHostList
+	(*ExploredMlxDevice)(nil),                 // 19: site_explorer.ExploredMlxDevice
+	(*ExploredMlxDeviceList)(nil),             // 20: site_explorer.ExploredMlxDeviceList
+	(*ExploredMlxDeviceHostSearchFilter)(nil), // 21: site_explorer.ExploredMlxDeviceHostSearchFilter
+	(*ExploredMlxDeviceHostIdList)(nil),       // 22: site_explorer.ExploredMlxDeviceHostIdList
+	(*ExploredMlxDevicesByIdsRequest)(nil),    // 23: site_explorer.ExploredMlxDevicesByIdsRequest
+	(*ComputerSystemAttributes)(nil),          // 24: site_explorer.ComputerSystemAttributes
+	(*ComputerSystem)(nil),                    // 25: site_explorer.ComputerSystem
+	(*Manager)(nil),                           // 26: site_explorer.Manager
+	(*EthernetInterface)(nil),                 // 27: site_explorer.EthernetInterface
+	(*Chassis)(nil),                           // 28: site_explorer.Chassis
+	(*NetworkAdapter)(nil),                    // 29: site_explorer.NetworkAdapter
+	(*Service)(nil),                           // 30: site_explorer.Service
+	(*Inventory)(nil),                         // 31: site_explorer.Inventory
+	(*MachineSetupStatus)(nil),                // 32: site_explorer.MachineSetupStatus
+	(*MachineSetupDiff)(nil),                  // 33: site_explorer.MachineSetupDiff
+	(*PCIeDevice)(nil),                        // 34: site_explorer.PCIeDevice
+	(*SystemStatus)(nil),                      // 35: site_explorer.SystemStatus
+	(*BootOrder)(nil),                         // 36: site_explorer.BootOrder
+	(*BootOption)(nil),                        // 37: site_explorer.BootOption
+	(*SecureBootStatus)(nil),                  // 38: site_explorer.SecureBootStatus
+	(*LockdownStatus)(nil),                    // 39: site_explorer.LockdownStatus
+	nil,                                       // 40: site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
+	(*durationpb.Duration)(nil),               // 41: google.protobuf.Duration
 }
 var file_site_explorer_proto_depIdxs = []int32{
-	39, // 0: site_explorer.EndpointExplorationReport.last_exploration_latency:type_name -> google.protobuf.Duration
-	24, // 1: site_explorer.EndpointExplorationReport.managers:type_name -> site_explorer.Manager
-	23, // 2: site_explorer.EndpointExplorationReport.systems:type_name -> site_explorer.ComputerSystem
-	26, // 3: site_explorer.EndpointExplorationReport.chassis:type_name -> site_explorer.Chassis
-	28, // 4: site_explorer.EndpointExplorationReport.service:type_name -> site_explorer.Service
-	30, // 5: site_explorer.EndpointExplorationReport.machine_setup_status:type_name -> site_explorer.MachineSetupStatus
-	36, // 6: site_explorer.EndpointExplorationReport.secure_boot_status:type_name -> site_explorer.SecureBootStatus
-	37, // 7: site_explorer.EndpointExplorationReport.lockdown_status:type_name -> site_explorer.LockdownStatus
-	38, // 8: site_explorer.EndpointExplorationReport.firmware_versions:type_name -> site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
+	41, // 0: site_explorer.EndpointExplorationReport.last_exploration_latency:type_name -> google.protobuf.Duration
+	26, // 1: site_explorer.EndpointExplorationReport.managers:type_name -> site_explorer.Manager
+	25, // 2: site_explorer.EndpointExplorationReport.systems:type_name -> site_explorer.ComputerSystem
+	28, // 3: site_explorer.EndpointExplorationReport.chassis:type_name -> site_explorer.Chassis
+	30, // 4: site_explorer.EndpointExplorationReport.service:type_name -> site_explorer.Service
+	32, // 5: site_explorer.EndpointExplorationReport.machine_setup_status:type_name -> site_explorer.MachineSetupStatus
+	38, // 6: site_explorer.EndpointExplorationReport.secure_boot_status:type_name -> site_explorer.SecureBootStatus
+	39, // 7: site_explorer.EndpointExplorationReport.lockdown_status:type_name -> site_explorer.LockdownStatus
+	40, // 8: site_explorer.EndpointExplorationReport.firmware_versions:type_name -> site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
 	4,  // 9: site_explorer.ExploredEndpoint.report:type_name -> site_explorer.EndpointExplorationReport
 	6,  // 10: site_explorer.ExploredManagedHost.dpus:type_name -> site_explorer.ExploredDpu
 	5,  // 11: site_explorer.SiteExplorationReport.endpoints:type_name -> site_explorer.ExploredEndpoint
 	7,  // 12: site_explorer.SiteExplorationReport.managed_hosts:type_name -> site_explorer.ExploredManagedHost
-	5,  // 13: site_explorer.ExploredEndpointList.endpoints:type_name -> site_explorer.ExploredEndpoint
-	7,  // 14: site_explorer.ExploredManagedHostList.managed_hosts:type_name -> site_explorer.ExploredManagedHost
-	0,  // 15: site_explorer.ExploredMlxDevice.device_kind:type_name -> site_explorer.MlxDeviceKind
-	1,  // 16: site_explorer.ExploredMlxDevice.nic_mode:type_name -> site_explorer.NicMode
-	17, // 17: site_explorer.ExploredMlxDeviceList.devices:type_name -> site_explorer.ExploredMlxDevice
-	1,  // 18: site_explorer.ComputerSystemAttributes.nic_mode:type_name -> site_explorer.NicMode
-	22, // 19: site_explorer.ComputerSystem.attributes:type_name -> site_explorer.ComputerSystemAttributes
-	25, // 20: site_explorer.ComputerSystem.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
-	32, // 21: site_explorer.ComputerSystem.pcie_devices:type_name -> site_explorer.PCIeDevice
-	2,  // 22: site_explorer.ComputerSystem.power_state:type_name -> site_explorer.ComputerSystemPowerState
-	34, // 23: site_explorer.ComputerSystem.boot_order:type_name -> site_explorer.BootOrder
-	25, // 24: site_explorer.Manager.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
-	27, // 25: site_explorer.Chassis.network_adapters:type_name -> site_explorer.NetworkAdapter
-	29, // 26: site_explorer.Service.inventories:type_name -> site_explorer.Inventory
-	31, // 27: site_explorer.MachineSetupStatus.diffs:type_name -> site_explorer.MachineSetupDiff
-	33, // 28: site_explorer.PCIeDevice.status:type_name -> site_explorer.SystemStatus
-	35, // 29: site_explorer.BootOrder.boot_order:type_name -> site_explorer.BootOption
-	3,  // 30: site_explorer.LockdownStatus.status:type_name -> site_explorer.InternalLockdownStatus
-	31, // [31:31] is the sub-list for method output_type
-	31, // [31:31] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	10, // 13: site_explorer.SiteExplorationReport.last_run:type_name -> site_explorer.SiteExplorerLastRun
+	10, // 14: site_explorer.SiteExplorerLastRunResponse.last_run:type_name -> site_explorer.SiteExplorerLastRun
+	5,  // 15: site_explorer.ExploredEndpointList.endpoints:type_name -> site_explorer.ExploredEndpoint
+	7,  // 16: site_explorer.ExploredManagedHostList.managed_hosts:type_name -> site_explorer.ExploredManagedHost
+	0,  // 17: site_explorer.ExploredMlxDevice.device_kind:type_name -> site_explorer.MlxDeviceKind
+	1,  // 18: site_explorer.ExploredMlxDevice.nic_mode:type_name -> site_explorer.NicMode
+	19, // 19: site_explorer.ExploredMlxDeviceList.devices:type_name -> site_explorer.ExploredMlxDevice
+	1,  // 20: site_explorer.ComputerSystemAttributes.nic_mode:type_name -> site_explorer.NicMode
+	24, // 21: site_explorer.ComputerSystem.attributes:type_name -> site_explorer.ComputerSystemAttributes
+	27, // 22: site_explorer.ComputerSystem.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
+	34, // 23: site_explorer.ComputerSystem.pcie_devices:type_name -> site_explorer.PCIeDevice
+	2,  // 24: site_explorer.ComputerSystem.power_state:type_name -> site_explorer.ComputerSystemPowerState
+	36, // 25: site_explorer.ComputerSystem.boot_order:type_name -> site_explorer.BootOrder
+	27, // 26: site_explorer.Manager.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
+	29, // 27: site_explorer.Chassis.network_adapters:type_name -> site_explorer.NetworkAdapter
+	31, // 28: site_explorer.Service.inventories:type_name -> site_explorer.Inventory
+	33, // 29: site_explorer.MachineSetupStatus.diffs:type_name -> site_explorer.MachineSetupDiff
+	35, // 30: site_explorer.PCIeDevice.status:type_name -> site_explorer.SystemStatus
+	37, // 31: site_explorer.BootOrder.boot_order:type_name -> site_explorer.BootOption
+	3,  // 32: site_explorer.LockdownStatus.status:type_name -> site_explorer.InternalLockdownStatus
+	33, // [33:33] is the sub-list for method output_type
+	33, // [33:33] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_site_explorer_proto_init() }
@@ -2756,23 +2963,26 @@ func file_site_explorer_proto_init() {
 	file_site_explorer_proto_msgTypes[0].OneofWrappers = []any{}
 	file_site_explorer_proto_msgTypes[2].OneofWrappers = []any{}
 	file_site_explorer_proto_msgTypes[3].OneofWrappers = []any{}
-	file_site_explorer_proto_msgTypes[13].OneofWrappers = []any{}
-	file_site_explorer_proto_msgTypes[18].OneofWrappers = []any{}
-	file_site_explorer_proto_msgTypes[19].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[4].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[5].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[6].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[15].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[20].OneofWrappers = []any{}
 	file_site_explorer_proto_msgTypes[21].OneofWrappers = []any{}
-	file_site_explorer_proto_msgTypes[22].OneofWrappers = []any{}
 	file_site_explorer_proto_msgTypes[23].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[24].OneofWrappers = []any{}
 	file_site_explorer_proto_msgTypes[25].OneofWrappers = []any{}
-	file_site_explorer_proto_msgTypes[28].OneofWrappers = []any{}
-	file_site_explorer_proto_msgTypes[29].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[27].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[30].OneofWrappers = []any{}
 	file_site_explorer_proto_msgTypes[31].OneofWrappers = []any{}
+	file_site_explorer_proto_msgTypes[33].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_site_explorer_proto_rawDesc), len(file_site_explorer_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   35,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/rest-api/flow/internal/nicoapi/nicoproto/nico.proto
+++ b/rest-api/flow/internal/nicoapi/nicoproto/nico.proto
@@ -274,6 +274,8 @@ service Forge {
   // Gets the latest Site Exploration report
   // DEPRECATED: use FindExploredEndpointIds, FindExploredEndpointsByIds and FindExploredManagedHostIds, FindExploredManagedHostsByIds instead
   rpc GetSiteExplorationReport(GetSiteExplorationRequest) returns (site_explorer.SiteExplorationReport);
+  // Gets metadata about the latest Site Explorer run without fetching endpoint rows.
+  rpc GetSiteExplorerLastRun(google.protobuf.Empty) returns (site_explorer.SiteExplorerLastRunResponse);
   // Clear the last known error for the BMC
   rpc ClearSiteExplorationError(ClearSiteExplorationErrorRequest) returns (google.protobuf.Empty);
   // IsBmcInManagedHost returns true if a Host+DPU pair that includes the endpoint has been identified

--- a/rest-api/flow/internal/nicoapi/nicoproto/site_explorer.proto
+++ b/rest-api/flow/internal/nicoapi/nicoproto/site_explorer.proto
@@ -91,6 +91,36 @@ message SiteExplorationReport {
   repeated ExploredEndpoint endpoints = 1;
   // The managed-hosts which have been explored
   repeated ExploredManagedHost managed_hosts = 2;
+  // Metadata about the latest site explorer run
+  optional SiteExplorerLastRun last_run = 3;
+}
+
+message SiteExplorerLastRunResponse {
+  // Metadata about the latest site explorer run, if site explorer has run
+  optional SiteExplorerLastRun last_run = 1;
+}
+
+message SiteExplorerLastRun {
+  // When the run started
+  string started_at = 1;
+  // When the run finished
+  string finished_at = 2;
+  // Whether the run completed successfully
+  bool success = 3;
+  // Error string for a failed run
+  optional string error = 4;
+  // Number of endpoint exploration attempts made during the run
+  int64 endpoint_explorations = 5;
+  // Number of successful endpoint explorations during the run
+  int64 endpoint_explorations_success = 6;
+  // Number of endpoint exploration errors during the run
+  int64 endpoint_explorations_failed = 7;
+  // Failure category for a failed run
+  optional string failure_category = 8;
+  // When the most recent successful run finished
+  optional string last_successful_finished_at = 9;
+  // When the most recent failed run finished
+  optional string last_failed_finished_at = 10;
 }
 
 message ExploredEndpointSearchFilter {

--- a/rest-api/openapi/oasdiff-breaking-changes-ignore.txt
+++ b/rest-api/openapi/oasdiff-breaking-changes-ignore.txt
@@ -3,3 +3,6 @@ PUT /v2/org/{org}/nico/credential/bmc removed the enum value `site-wide-root` of
 API POST /v2/org/{org}/nico/instance the `interfaces/items/virtualFunctionId` request property's max was decreased to `15.00`
 API POST /v2/org/{org}/nico/instance/batch the `interfaces/items/virtualFunctionId` request property's max was decreased to `15.00`
 API PATCH /v2/org/{org}/nico/instance/{instanceId} the `interfaces/items/virtualFunctionId` request property's max was decreased to `15.00`
+API POST /v2/org/{org}/nico/instance/type the request property `machineCapabilities` became required
+API POST /v2/org/{org}/nico/instance/type the `machineCapabilities` request property's minItems was increased to `1`
+API PATCH /v2/org/{org}/nico/instance/type/{instanceTypeId} the `machineCapabilities` request property's minItems was increased to `1`

--- a/rest-api/openapi/spec.yaml
+++ b/rest-api/openapi/spec.yaml
@@ -16104,6 +16104,8 @@ components:
           description: 'Date/time when the InstanceType was last updated'
           format: date-time
           readOnly: true
+      required:
+        - machineCapabilities
     InstanceTypeSummary:
       title: InstanceTypeSummary
       type: object
@@ -16221,12 +16223,14 @@ components:
           description: 'Site Controller assigned Machine type'
         machineCapabilities:
           type: array
+          minItems: 1
           items:
             $ref: '#/components/schemas/InstanceTypeCapabilityCreateRequest'
           description: 'List of Machine Capabilities to match'
       required:
         - name
         - siteId
+        - machineCapabilities
     InstanceTypeUpdateRequest:
       title: InstanceTypeUpdateRequest
       type: object
@@ -16251,6 +16255,7 @@ components:
           description: 'User-defined key-value labels for the Instance Type'
         machineCapabilities:
           type: array
+          minItems: 1
           items:
             $ref: '#/components/schemas/MachineCapability'
           description: 'List of Machine Capabilities to match'

--- a/rest-api/sdk/standard/model_instance_type.go
+++ b/rest-api/sdk/standard/model_instance_type.go
@@ -14,7 +14,9 @@ API version: 1.6.0
 package standard
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -38,7 +40,7 @@ type InstanceType struct {
 	// User-defined key-value labels for the Instance Type
 	Labels map[string]string `json:"labels,omitempty"`
 	// List of capabilities that are supported by the Machine's of this Instance Type
-	MachineCapabilities []MachineCapability `json:"machineCapabilities,omitempty"`
+	MachineCapabilities []MachineCapability `json:"machineCapabilities"`
 	// Available only for Providers
 	MachineInstanceTypes []MachineInstanceType `json:"machineInstanceTypes,omitempty"`
 	// summary of machine counts by allocation status
@@ -55,12 +57,15 @@ type InstanceType struct {
 	Updated *time.Time `json:"updated,omitempty"`
 }
 
+type _InstanceType InstanceType
+
 // NewInstanceType instantiates a new InstanceType object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewInstanceType() *InstanceType {
+func NewInstanceType(machineCapabilities []MachineCapability) *InstanceType {
 	this := InstanceType{}
+	this.MachineCapabilities = machineCapabilities
 	return &this
 }
 
@@ -318,34 +323,26 @@ func (o *InstanceType) SetLabels(v map[string]string) {
 	o.Labels = v
 }
 
-// GetMachineCapabilities returns the MachineCapabilities field value if set, zero value otherwise.
+// GetMachineCapabilities returns the MachineCapabilities field value
 func (o *InstanceType) GetMachineCapabilities() []MachineCapability {
-	if o == nil || IsNil(o.MachineCapabilities) {
+	if o == nil {
 		var ret []MachineCapability
 		return ret
 	}
+
 	return o.MachineCapabilities
 }
 
-// GetMachineCapabilitiesOk returns a tuple with the MachineCapabilities field value if set, nil otherwise
+// GetMachineCapabilitiesOk returns a tuple with the MachineCapabilities field value
 // and a boolean to check if the value has been set.
 func (o *InstanceType) GetMachineCapabilitiesOk() ([]MachineCapability, bool) {
-	if o == nil || IsNil(o.MachineCapabilities) {
+	if o == nil {
 		return nil, false
 	}
 	return o.MachineCapabilities, true
 }
 
-// HasMachineCapabilities returns a boolean if a field has been set.
-func (o *InstanceType) HasMachineCapabilities() bool {
-	if o != nil && !IsNil(o.MachineCapabilities) {
-		return true
-	}
-
-	return false
-}
-
-// SetMachineCapabilities gets a reference to the given []MachineCapability and assigns it to the MachineCapabilities field.
+// SetMachineCapabilities sets field value
 func (o *InstanceType) SetMachineCapabilities(v []MachineCapability) {
 	o.MachineCapabilities = v
 }
@@ -605,9 +602,7 @@ func (o InstanceType) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Labels) {
 		toSerialize["labels"] = o.Labels
 	}
-	if !IsNil(o.MachineCapabilities) {
-		toSerialize["machineCapabilities"] = o.MachineCapabilities
-	}
+	toSerialize["machineCapabilities"] = o.MachineCapabilities
 	if !IsNil(o.MachineInstanceTypes) {
 		toSerialize["machineInstanceTypes"] = o.MachineInstanceTypes
 	}
@@ -630,6 +625,43 @@ func (o InstanceType) ToMap() (map[string]interface{}, error) {
 		toSerialize["updated"] = o.Updated
 	}
 	return toSerialize, nil
+}
+
+func (o *InstanceType) UnmarshalJSON(data []byte) (err error) {
+	// This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"machineCapabilities",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(data, &allProperties)
+
+	if err != nil {
+		return err
+	}
+
+	for _, requiredProperty := range requiredProperties {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varInstanceType := _InstanceType{}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varInstanceType)
+
+	if err != nil {
+		return err
+	}
+
+	*o = InstanceType(varInstanceType)
+
+	return err
 }
 
 type NullableInstanceType struct {

--- a/rest-api/sdk/standard/model_instance_type_create_request.go
+++ b/rest-api/sdk/standard/model_instance_type_create_request.go
@@ -35,7 +35,7 @@ type InstanceTypeCreateRequest struct {
 	// Site Controller assigned Machine type
 	ControllerMachineType NullableString `json:"controllerMachineType,omitempty"`
 	// List of Machine Capabilities to match
-	MachineCapabilities []InstanceTypeCapabilityCreateRequest `json:"machineCapabilities,omitempty"`
+	MachineCapabilities []InstanceTypeCapabilityCreateRequest `json:"machineCapabilities"`
 }
 
 type _InstanceTypeCreateRequest InstanceTypeCreateRequest
@@ -44,10 +44,11 @@ type _InstanceTypeCreateRequest InstanceTypeCreateRequest
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewInstanceTypeCreateRequest(name string, siteId string) *InstanceTypeCreateRequest {
+func NewInstanceTypeCreateRequest(name string, siteId string, machineCapabilities []InstanceTypeCapabilityCreateRequest) *InstanceTypeCreateRequest {
 	this := InstanceTypeCreateRequest{}
 	this.Name = name
 	this.SiteId = siteId
+	this.MachineCapabilities = machineCapabilities
 	return &this
 }
 
@@ -225,34 +226,26 @@ func (o *InstanceTypeCreateRequest) UnsetControllerMachineType() {
 	o.ControllerMachineType.Unset()
 }
 
-// GetMachineCapabilities returns the MachineCapabilities field value if set, zero value otherwise.
+// GetMachineCapabilities returns the MachineCapabilities field value
 func (o *InstanceTypeCreateRequest) GetMachineCapabilities() []InstanceTypeCapabilityCreateRequest {
-	if o == nil || IsNil(o.MachineCapabilities) {
+	if o == nil {
 		var ret []InstanceTypeCapabilityCreateRequest
 		return ret
 	}
+
 	return o.MachineCapabilities
 }
 
-// GetMachineCapabilitiesOk returns a tuple with the MachineCapabilities field value if set, nil otherwise
+// GetMachineCapabilitiesOk returns a tuple with the MachineCapabilities field value
 // and a boolean to check if the value has been set.
 func (o *InstanceTypeCreateRequest) GetMachineCapabilitiesOk() ([]InstanceTypeCapabilityCreateRequest, bool) {
-	if o == nil || IsNil(o.MachineCapabilities) {
+	if o == nil {
 		return nil, false
 	}
 	return o.MachineCapabilities, true
 }
 
-// HasMachineCapabilities returns a boolean if a field has been set.
-func (o *InstanceTypeCreateRequest) HasMachineCapabilities() bool {
-	if o != nil && !IsNil(o.MachineCapabilities) {
-		return true
-	}
-
-	return false
-}
-
-// SetMachineCapabilities gets a reference to the given []InstanceTypeCapabilityCreateRequest and assigns it to the MachineCapabilities field.
+// SetMachineCapabilities sets field value
 func (o *InstanceTypeCreateRequest) SetMachineCapabilities(v []InstanceTypeCapabilityCreateRequest) {
 	o.MachineCapabilities = v
 }
@@ -278,9 +271,7 @@ func (o InstanceTypeCreateRequest) ToMap() (map[string]interface{}, error) {
 	if o.ControllerMachineType.IsSet() {
 		toSerialize["controllerMachineType"] = o.ControllerMachineType.Get()
 	}
-	if !IsNil(o.MachineCapabilities) {
-		toSerialize["machineCapabilities"] = o.MachineCapabilities
-	}
+	toSerialize["machineCapabilities"] = o.MachineCapabilities
 	return toSerialize, nil
 }
 
@@ -291,6 +282,7 @@ func (o *InstanceTypeCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	requiredProperties := []string{
 		"name",
 		"siteId",
+		"machineCapabilities",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/rest-api/workflow-schema/schema/site-agent/workflows/v1/nico_nico.pb.go
+++ b/rest-api/workflow-schema/schema/site-agent/workflows/v1/nico_nico.pb.go
@@ -1569,8 +1569,9 @@ func (MessageKind) EnumDescriptor() ([]byte, []int) {
 type ExpireDhcpLeaseStatus int32
 
 const (
-	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_RELEASED  ExpireDhcpLeaseStatus = 0
-	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND ExpireDhcpLeaseStatus = 1
+	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_RELEASED         ExpireDhcpLeaseStatus = 0
+	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND        ExpireDhcpLeaseStatus = 1
+	ExpireDhcpLeaseStatus_EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED ExpireDhcpLeaseStatus = 2
 )
 
 // Enum value maps for ExpireDhcpLeaseStatus.
@@ -1578,10 +1579,12 @@ var (
 	ExpireDhcpLeaseStatus_name = map[int32]string{
 		0: "EXPIRE_DHCP_LEASE_STATUS_RELEASED",
 		1: "EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND",
+		2: "EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED",
 	}
 	ExpireDhcpLeaseStatus_value = map[string]int32{
-		"EXPIRE_DHCP_LEASE_STATUS_RELEASED":  0,
-		"EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND": 1,
+		"EXPIRE_DHCP_LEASE_STATUS_RELEASED":         0,
+		"EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND":        1,
+		"EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED": 2,
 	}
 )
 
@@ -63312,10 +63315,11 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x18MESSAGE_KIND_V4_DISCOVER\x10\x01\x12\x1b\n" +
 	"\x17MESSAGE_KIND_V6_SOLICIT\x10\x02\x12\x1b\n" +
 	"\x17MESSAGE_KIND_V6_REQUEST\x10\x03\x12 \n" +
-	"\x1cMESSAGE_KIND_V6_INFO_REQUEST\x10\x04*f\n" +
+	"\x1cMESSAGE_KIND_V6_INFO_REQUEST\x10\x04*\x95\x01\n" +
 	"\x15ExpireDhcpLeaseStatus\x12%\n" +
 	"!EXPIRE_DHCP_LEASE_STATUS_RELEASED\x10\x00\x12&\n" +
-	"\"EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND\x10\x01*D\n" +
+	"\"EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND\x10\x01\x12-\n" +
+	")EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED\x10\x02*D\n" +
 	"\tUserRoles\x12\b\n" +
 	"\x04USER\x10\x00\x12\x11\n" +
 	"\rADMINISTRATOR\x10\x01\x12\f\n" +
@@ -63561,7 +63565,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x13OperatingSystemType\x12\x17\n" +
 	"\x13OS_TYPE_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fOS_TYPE_IPXE\x10\x01\x12\x1a\n" +
-	"\x16OS_TYPE_TEMPLATED_IPXE\x10\x022\xe7\xcb\x02\n" +
+	"\x16OS_TYPE_TEMPLATED_IPXE\x10\x022\xc5\xcc\x02\n" +
 	"\x05Forge\x122\n" +
 	"\aVersion\x12\x15.forge.VersionRequest\x1a\x10.forge.BuildInfo\x125\n" +
 	"\fCreateDomain\x12\x18.dns.CreateDomainRequest\x1a\v.dns.Domain\x125\n" +
@@ -63704,6 +63708,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x18GetSwitchNvosCredentials\x12&.forge.GetSwitchNvosCredentialsRequest\x1a .forge.GetBmcCredentialsResponse\x12q\n" +
 	"\x1eGetAllManagedHostNetworkStatus\x12&.forge.ManagedHostNetworkStatusRequest\x1a'.forge.ManagedHostNetworkStatusResponse\x12b\n" +
 	"\x18GetSiteExplorationReport\x12 .forge.GetSiteExplorationRequest\x1a$.site_explorer.SiteExplorationReport\x12\\\n" +
+	"\x16GetSiteExplorerLastRun\x12\x16.google.protobuf.Empty\x1a*.site_explorer.SiteExplorerLastRunResponse\x12\\\n" +
 	"\x19ClearSiteExplorationError\x12'.forge.ClearSiteExplorationErrorRequest\x1a\x16.google.protobuf.Empty\x12R\n" +
 	"\x12IsBmcInManagedHost\x12\x19.forge.BmcEndpointRequest\x1a!.forge.IsBmcInManagedHostResponse\x12T\n" +
 	"\x13BmcCredentialStatus\x12\x19.forge.BmcEndpointRequest\x1a\".forge.BmcCredentialStatusResponse\x12N\n" +
@@ -65074,13 +65079,13 @@ var file_nico_nico_proto_goTypes = []any{
 	(*DnsResourceRecordLookupRequest)(nil),               // 1025: dns.DnsResourceRecordLookupRequest
 	(*GetAllDomainsRequest)(nil),                         // 1026: dns.GetAllDomainsRequest
 	(*DomainMetadataRequest)(nil),                        // 1027: dns.DomainMetadataRequest
-	(*ExploredEndpointSearchFilter)(nil),                 // 1028: site_explorer.ExploredEndpointSearchFilter
-	(*ExploredEndpointsByIdsRequest)(nil),                // 1029: site_explorer.ExploredEndpointsByIdsRequest
-	(*ExploredManagedHostSearchFilter)(nil),              // 1030: site_explorer.ExploredManagedHostSearchFilter
-	(*ExploredManagedHostsByIdsRequest)(nil),             // 1031: site_explorer.ExploredManagedHostsByIdsRequest
-	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1032: site_explorer.ExploredMlxDeviceHostSearchFilter
-	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1033: site_explorer.ExploredMlxDevicesByIdsRequest
-	(*emptypb.Empty)(nil),                                // 1034: google.protobuf.Empty
+	(*emptypb.Empty)(nil),                                // 1028: google.protobuf.Empty
+	(*ExploredEndpointSearchFilter)(nil),                 // 1029: site_explorer.ExploredEndpointSearchFilter
+	(*ExploredEndpointsByIdsRequest)(nil),                // 1030: site_explorer.ExploredEndpointsByIdsRequest
+	(*ExploredManagedHostSearchFilter)(nil),              // 1031: site_explorer.ExploredManagedHostSearchFilter
+	(*ExploredManagedHostsByIdsRequest)(nil),             // 1032: site_explorer.ExploredManagedHostsByIdsRequest
+	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1033: site_explorer.ExploredMlxDeviceHostSearchFilter
+	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1034: site_explorer.ExploredMlxDevicesByIdsRequest
 	(*CreateMeasurementBundleRequest)(nil),               // 1035: measured_boot.CreateMeasurementBundleRequest
 	(*DeleteMeasurementBundleRequest)(nil),               // 1036: measured_boot.DeleteMeasurementBundleRequest
 	(*RenameMeasurementBundleRequest)(nil),               // 1037: measured_boot.RenameMeasurementBundleRequest
@@ -65147,73 +65152,74 @@ var file_nico_nico_proto_goTypes = []any{
 	(*GetAllDomainsResponse)(nil),                        // 1098: dns.GetAllDomainsResponse
 	(*DomainMetadataResponse)(nil),                       // 1099: dns.DomainMetadataResponse
 	(*SiteExplorationReport)(nil),                        // 1100: site_explorer.SiteExplorationReport
-	(*ExploredEndpoint)(nil),                             // 1101: site_explorer.ExploredEndpoint
-	(*ExploredEndpointIdList)(nil),                       // 1102: site_explorer.ExploredEndpointIdList
-	(*ExploredEndpointList)(nil),                         // 1103: site_explorer.ExploredEndpointList
-	(*ExploredManagedHostIdList)(nil),                    // 1104: site_explorer.ExploredManagedHostIdList
-	(*ExploredManagedHostList)(nil),                      // 1105: site_explorer.ExploredManagedHostList
-	(*ExploredMlxDeviceHostIdList)(nil),                  // 1106: site_explorer.ExploredMlxDeviceHostIdList
-	(*ExploredMlxDeviceList)(nil),                        // 1107: site_explorer.ExploredMlxDeviceList
-	(*CreateMeasurementBundleResponse)(nil),              // 1108: measured_boot.CreateMeasurementBundleResponse
-	(*DeleteMeasurementBundleResponse)(nil),              // 1109: measured_boot.DeleteMeasurementBundleResponse
-	(*RenameMeasurementBundleResponse)(nil),              // 1110: measured_boot.RenameMeasurementBundleResponse
-	(*UpdateMeasurementBundleResponse)(nil),              // 1111: measured_boot.UpdateMeasurementBundleResponse
-	(*ShowMeasurementBundleResponse)(nil),                // 1112: measured_boot.ShowMeasurementBundleResponse
-	(*ShowMeasurementBundlesResponse)(nil),               // 1113: measured_boot.ShowMeasurementBundlesResponse
-	(*ListMeasurementBundlesResponse)(nil),               // 1114: measured_boot.ListMeasurementBundlesResponse
-	(*ListMeasurementBundleMachinesResponse)(nil),        // 1115: measured_boot.ListMeasurementBundleMachinesResponse
-	(*DeleteMeasurementJournalResponse)(nil),             // 1116: measured_boot.DeleteMeasurementJournalResponse
-	(*ShowMeasurementJournalResponse)(nil),               // 1117: measured_boot.ShowMeasurementJournalResponse
-	(*ShowMeasurementJournalsResponse)(nil),              // 1118: measured_boot.ShowMeasurementJournalsResponse
-	(*ListMeasurementJournalResponse)(nil),               // 1119: measured_boot.ListMeasurementJournalResponse
-	(*AttestCandidateMachineResponse)(nil),               // 1120: measured_boot.AttestCandidateMachineResponse
-	(*ShowCandidateMachineResponse)(nil),                 // 1121: measured_boot.ShowCandidateMachineResponse
-	(*ShowCandidateMachinesResponse)(nil),                // 1122: measured_boot.ShowCandidateMachinesResponse
-	(*ListCandidateMachinesResponse)(nil),                // 1123: measured_boot.ListCandidateMachinesResponse
-	(*CreateMeasurementSystemProfileResponse)(nil),       // 1124: measured_boot.CreateMeasurementSystemProfileResponse
-	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1125: measured_boot.DeleteMeasurementSystemProfileResponse
-	(*RenameMeasurementSystemProfileResponse)(nil),       // 1126: measured_boot.RenameMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfileResponse)(nil),         // 1127: measured_boot.ShowMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1128: measured_boot.ShowMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfilesResponse)(nil),        // 1129: measured_boot.ListMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1130: measured_boot.ListMeasurementSystemProfileBundlesResponse
-	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1131: measured_boot.ListMeasurementSystemProfileMachinesResponse
-	(*CreateMeasurementReportResponse)(nil),              // 1132: measured_boot.CreateMeasurementReportResponse
-	(*DeleteMeasurementReportResponse)(nil),              // 1133: measured_boot.DeleteMeasurementReportResponse
-	(*PromoteMeasurementReportResponse)(nil),             // 1134: measured_boot.PromoteMeasurementReportResponse
-	(*RevokeMeasurementReportResponse)(nil),              // 1135: measured_boot.RevokeMeasurementReportResponse
-	(*ShowMeasurementReportForIdResponse)(nil),           // 1136: measured_boot.ShowMeasurementReportForIdResponse
-	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1137: measured_boot.ShowMeasurementReportsForMachineResponse
-	(*ShowMeasurementReportsResponse)(nil),               // 1138: measured_boot.ShowMeasurementReportsResponse
-	(*ListMeasurementReportResponse)(nil),                // 1139: measured_boot.ListMeasurementReportResponse
-	(*MatchMeasurementReportResponse)(nil),               // 1140: measured_boot.MatchMeasurementReportResponse
-	(*ImportSiteMeasurementsResponse)(nil),               // 1141: measured_boot.ImportSiteMeasurementsResponse
-	(*ExportSiteMeasurementsResponse)(nil),               // 1142: measured_boot.ExportSiteMeasurementsResponse
-	(*AddMeasurementTrustedMachineResponse)(nil),         // 1143: measured_boot.AddMeasurementTrustedMachineResponse
-	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1144: measured_boot.RemoveMeasurementTrustedMachineResponse
-	(*AddMeasurementTrustedProfileResponse)(nil),         // 1145: measured_boot.AddMeasurementTrustedProfileResponse
-	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1146: measured_boot.RemoveMeasurementTrustedProfileResponse
-	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1147: measured_boot.ListMeasurementTrustedMachinesResponse
-	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1148: measured_boot.ListMeasurementTrustedProfilesResponse
-	(*ListAttestationSummaryResponse)(nil),               // 1149: measured_boot.ListAttestationSummaryResponse
-	(*LockdownStatus)(nil),                               // 1150: site_explorer.LockdownStatus
-	(*PublishMlxDeviceReportResponse)(nil),               // 1151: mlx_device.PublishMlxDeviceReportResponse
-	(*PublishMlxObservationReportResponse)(nil),          // 1152: mlx_device.PublishMlxObservationReportResponse
-	(*MlxAdminProfileSyncResponse)(nil),                  // 1153: mlx_device.MlxAdminProfileSyncResponse
-	(*MlxAdminProfileShowResponse)(nil),                  // 1154: mlx_device.MlxAdminProfileShowResponse
-	(*MlxAdminProfileCompareResponse)(nil),               // 1155: mlx_device.MlxAdminProfileCompareResponse
-	(*MlxAdminProfileListResponse)(nil),                  // 1156: mlx_device.MlxAdminProfileListResponse
-	(*MlxAdminLockdownLockResponse)(nil),                 // 1157: mlx_device.MlxAdminLockdownLockResponse
-	(*MlxAdminLockdownUnlockResponse)(nil),               // 1158: mlx_device.MlxAdminLockdownUnlockResponse
-	(*MlxAdminLockdownStatusResponse)(nil),               // 1159: mlx_device.MlxAdminLockdownStatusResponse
-	(*MlxAdminDeviceInfoResponse)(nil),                   // 1160: mlx_device.MlxAdminDeviceInfoResponse
-	(*MlxAdminDeviceReportResponse)(nil),                 // 1161: mlx_device.MlxAdminDeviceReportResponse
-	(*MlxAdminRegistryListResponse)(nil),                 // 1162: mlx_device.MlxAdminRegistryListResponse
-	(*MlxAdminRegistryShowResponse)(nil),                 // 1163: mlx_device.MlxAdminRegistryShowResponse
-	(*MlxAdminConfigQueryResponse)(nil),                  // 1164: mlx_device.MlxAdminConfigQueryResponse
-	(*MlxAdminConfigSetResponse)(nil),                    // 1165: mlx_device.MlxAdminConfigSetResponse
-	(*MlxAdminConfigSyncResponse)(nil),                   // 1166: mlx_device.MlxAdminConfigSyncResponse
-	(*MlxAdminConfigCompareResponse)(nil),                // 1167: mlx_device.MlxAdminConfigCompareResponse
+	(*SiteExplorerLastRunResponse)(nil),                  // 1101: site_explorer.SiteExplorerLastRunResponse
+	(*ExploredEndpoint)(nil),                             // 1102: site_explorer.ExploredEndpoint
+	(*ExploredEndpointIdList)(nil),                       // 1103: site_explorer.ExploredEndpointIdList
+	(*ExploredEndpointList)(nil),                         // 1104: site_explorer.ExploredEndpointList
+	(*ExploredManagedHostIdList)(nil),                    // 1105: site_explorer.ExploredManagedHostIdList
+	(*ExploredManagedHostList)(nil),                      // 1106: site_explorer.ExploredManagedHostList
+	(*ExploredMlxDeviceHostIdList)(nil),                  // 1107: site_explorer.ExploredMlxDeviceHostIdList
+	(*ExploredMlxDeviceList)(nil),                        // 1108: site_explorer.ExploredMlxDeviceList
+	(*CreateMeasurementBundleResponse)(nil),              // 1109: measured_boot.CreateMeasurementBundleResponse
+	(*DeleteMeasurementBundleResponse)(nil),              // 1110: measured_boot.DeleteMeasurementBundleResponse
+	(*RenameMeasurementBundleResponse)(nil),              // 1111: measured_boot.RenameMeasurementBundleResponse
+	(*UpdateMeasurementBundleResponse)(nil),              // 1112: measured_boot.UpdateMeasurementBundleResponse
+	(*ShowMeasurementBundleResponse)(nil),                // 1113: measured_boot.ShowMeasurementBundleResponse
+	(*ShowMeasurementBundlesResponse)(nil),               // 1114: measured_boot.ShowMeasurementBundlesResponse
+	(*ListMeasurementBundlesResponse)(nil),               // 1115: measured_boot.ListMeasurementBundlesResponse
+	(*ListMeasurementBundleMachinesResponse)(nil),        // 1116: measured_boot.ListMeasurementBundleMachinesResponse
+	(*DeleteMeasurementJournalResponse)(nil),             // 1117: measured_boot.DeleteMeasurementJournalResponse
+	(*ShowMeasurementJournalResponse)(nil),               // 1118: measured_boot.ShowMeasurementJournalResponse
+	(*ShowMeasurementJournalsResponse)(nil),              // 1119: measured_boot.ShowMeasurementJournalsResponse
+	(*ListMeasurementJournalResponse)(nil),               // 1120: measured_boot.ListMeasurementJournalResponse
+	(*AttestCandidateMachineResponse)(nil),               // 1121: measured_boot.AttestCandidateMachineResponse
+	(*ShowCandidateMachineResponse)(nil),                 // 1122: measured_boot.ShowCandidateMachineResponse
+	(*ShowCandidateMachinesResponse)(nil),                // 1123: measured_boot.ShowCandidateMachinesResponse
+	(*ListCandidateMachinesResponse)(nil),                // 1124: measured_boot.ListCandidateMachinesResponse
+	(*CreateMeasurementSystemProfileResponse)(nil),       // 1125: measured_boot.CreateMeasurementSystemProfileResponse
+	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1126: measured_boot.DeleteMeasurementSystemProfileResponse
+	(*RenameMeasurementSystemProfileResponse)(nil),       // 1127: measured_boot.RenameMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfileResponse)(nil),         // 1128: measured_boot.ShowMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1129: measured_boot.ShowMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfilesResponse)(nil),        // 1130: measured_boot.ListMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1131: measured_boot.ListMeasurementSystemProfileBundlesResponse
+	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1132: measured_boot.ListMeasurementSystemProfileMachinesResponse
+	(*CreateMeasurementReportResponse)(nil),              // 1133: measured_boot.CreateMeasurementReportResponse
+	(*DeleteMeasurementReportResponse)(nil),              // 1134: measured_boot.DeleteMeasurementReportResponse
+	(*PromoteMeasurementReportResponse)(nil),             // 1135: measured_boot.PromoteMeasurementReportResponse
+	(*RevokeMeasurementReportResponse)(nil),              // 1136: measured_boot.RevokeMeasurementReportResponse
+	(*ShowMeasurementReportForIdResponse)(nil),           // 1137: measured_boot.ShowMeasurementReportForIdResponse
+	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1138: measured_boot.ShowMeasurementReportsForMachineResponse
+	(*ShowMeasurementReportsResponse)(nil),               // 1139: measured_boot.ShowMeasurementReportsResponse
+	(*ListMeasurementReportResponse)(nil),                // 1140: measured_boot.ListMeasurementReportResponse
+	(*MatchMeasurementReportResponse)(nil),               // 1141: measured_boot.MatchMeasurementReportResponse
+	(*ImportSiteMeasurementsResponse)(nil),               // 1142: measured_boot.ImportSiteMeasurementsResponse
+	(*ExportSiteMeasurementsResponse)(nil),               // 1143: measured_boot.ExportSiteMeasurementsResponse
+	(*AddMeasurementTrustedMachineResponse)(nil),         // 1144: measured_boot.AddMeasurementTrustedMachineResponse
+	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1145: measured_boot.RemoveMeasurementTrustedMachineResponse
+	(*AddMeasurementTrustedProfileResponse)(nil),         // 1146: measured_boot.AddMeasurementTrustedProfileResponse
+	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1147: measured_boot.RemoveMeasurementTrustedProfileResponse
+	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1148: measured_boot.ListMeasurementTrustedMachinesResponse
+	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1149: measured_boot.ListMeasurementTrustedProfilesResponse
+	(*ListAttestationSummaryResponse)(nil),               // 1150: measured_boot.ListAttestationSummaryResponse
+	(*LockdownStatus)(nil),                               // 1151: site_explorer.LockdownStatus
+	(*PublishMlxDeviceReportResponse)(nil),               // 1152: mlx_device.PublishMlxDeviceReportResponse
+	(*PublishMlxObservationReportResponse)(nil),          // 1153: mlx_device.PublishMlxObservationReportResponse
+	(*MlxAdminProfileSyncResponse)(nil),                  // 1154: mlx_device.MlxAdminProfileSyncResponse
+	(*MlxAdminProfileShowResponse)(nil),                  // 1155: mlx_device.MlxAdminProfileShowResponse
+	(*MlxAdminProfileCompareResponse)(nil),               // 1156: mlx_device.MlxAdminProfileCompareResponse
+	(*MlxAdminProfileListResponse)(nil),                  // 1157: mlx_device.MlxAdminProfileListResponse
+	(*MlxAdminLockdownLockResponse)(nil),                 // 1158: mlx_device.MlxAdminLockdownLockResponse
+	(*MlxAdminLockdownUnlockResponse)(nil),               // 1159: mlx_device.MlxAdminLockdownUnlockResponse
+	(*MlxAdminLockdownStatusResponse)(nil),               // 1160: mlx_device.MlxAdminLockdownStatusResponse
+	(*MlxAdminDeviceInfoResponse)(nil),                   // 1161: mlx_device.MlxAdminDeviceInfoResponse
+	(*MlxAdminDeviceReportResponse)(nil),                 // 1162: mlx_device.MlxAdminDeviceReportResponse
+	(*MlxAdminRegistryListResponse)(nil),                 // 1163: mlx_device.MlxAdminRegistryListResponse
+	(*MlxAdminRegistryShowResponse)(nil),                 // 1164: mlx_device.MlxAdminRegistryShowResponse
+	(*MlxAdminConfigQueryResponse)(nil),                  // 1165: mlx_device.MlxAdminConfigQueryResponse
+	(*MlxAdminConfigSetResponse)(nil),                    // 1166: mlx_device.MlxAdminConfigSetResponse
+	(*MlxAdminConfigSyncResponse)(nil),                   // 1167: mlx_device.MlxAdminConfigSyncResponse
+	(*MlxAdminConfigCompareResponse)(nil),                // 1168: mlx_device.MlxAdminConfigCompareResponse
 }
 var file_nico_nico_proto_depIdxs = []int32{
 	336,  // 0: forge.LifecycleStatus.state_reason:type_name -> forge.ControllerStateReason
@@ -66475,782 +66481,784 @@ var file_nico_nico_proto_depIdxs = []int32{
 	352,  // 1256: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
 	385,  // 1257: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
 	355,  // 1258: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
-	356,  // 1259: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
-	362,  // 1260: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
-	362,  // 1261: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
-	362,  // 1262: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
-	357,  // 1263: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
-	358,  // 1264: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
-	359,  // 1265: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
-	360,  // 1266: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
-	1028, // 1267: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
-	1029, // 1268: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
-	1030, // 1269: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
-	1031, // 1270: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
-	1032, // 1271: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
-	1033, // 1272: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
-	366,  // 1273: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
-	391,  // 1274: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
-	480,  // 1275: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
-	483,  // 1276: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
-	328,  // 1277: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
-	329,  // 1278: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
-	330,  // 1279: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
-	331,  // 1280: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
-	744,  // 1281: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
-	487,  // 1282: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
-	488,  // 1283: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
-	498,  // 1284: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
-	499,  // 1285: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
-	501,  // 1286: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
-	502,  // 1287: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
-	956,  // 1288: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
-	553,  // 1289: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
-	508,  // 1290: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
-	977,  // 1291: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
-	511,  // 1292: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
-	977,  // 1293: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
-	911,  // 1294: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
-	520,  // 1295: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
-	521,  // 1296: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
-	126,  // 1297: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
-	127,  // 1298: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
-	1034, // 1299: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
-	523,  // 1300: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
-	523,  // 1301: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
-	523,  // 1302: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
-	332,  // 1303: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
-	294,  // 1304: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
-	526,  // 1305: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
-	528,  // 1306: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
-	541,  // 1307: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
-	542,  // 1308: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	541,  // 1309: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
-	542,  // 1310: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	1034, // 1311: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
-	543,  // 1312: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
-	1034, // 1313: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
-	1034, // 1314: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
-	1034, // 1315: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
-	548,  // 1316: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	548,  // 1317: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	200,  // 1318: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	201,  // 1319: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	200,  // 1320: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	201,  // 1321: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	1034, // 1322: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	202,  // 1323: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
-	1034, // 1324: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	1034, // 1325: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
-	222,  // 1326: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
-	223,  // 1327: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	222,  // 1328: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
-	223,  // 1329: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	1034, // 1330: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
-	224,  // 1331: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
-	1034, // 1332: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
-	1034, // 1333: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
-	227,  // 1334: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
-	228,  // 1335: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
-	227,  // 1336: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
-	228,  // 1337: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
-	1034, // 1338: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
-	229,  // 1339: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
-	1034, // 1340: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
-	124,  // 1341: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
-	623,  // 1342: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
-	625,  // 1343: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
-	627,  // 1344: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
-	632,  // 1345: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
-	629,  // 1346: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
-	633,  // 1347: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
-	635,  // 1348: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
-	1035, // 1349: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
-	1036, // 1350: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
-	1037, // 1351: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
-	1038, // 1352: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
-	1039, // 1353: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
-	1040, // 1354: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
-	1041, // 1355: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
-	1042, // 1356: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
-	1043, // 1357: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
-	1044, // 1358: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
-	1045, // 1359: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
-	1046, // 1360: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
-	1047, // 1361: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
-	1048, // 1362: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
-	1049, // 1363: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
-	1050, // 1364: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
-	1051, // 1365: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
-	1052, // 1366: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
-	1053, // 1367: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
-	1054, // 1368: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
-	1055, // 1369: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
-	1056, // 1370: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
-	1057, // 1371: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
-	1058, // 1372: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
-	1059, // 1373: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
-	1060, // 1374: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
-	1061, // 1375: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
-	1062, // 1376: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
-	1063, // 1377: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
-	1064, // 1378: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
-	1065, // 1379: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
-	1066, // 1380: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
-	1067, // 1381: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
-	1068, // 1382: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
-	1069, // 1383: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
-	1070, // 1384: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
-	1071, // 1385: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
-	1072, // 1386: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
-	1073, // 1387: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
-	1074, // 1388: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
-	1075, // 1389: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
-	1076, // 1390: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
-	1077, // 1391: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
-	654,  // 1392: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
-	656,  // 1393: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
-	658,  // 1394: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
-	661,  // 1395: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
-	662,  // 1396: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
-	668,  // 1397: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
-	671,  // 1398: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
-	530,  // 1399: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
-	534,  // 1400: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
-	532,  // 1401: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
-	966,  // 1402: forge.Forge.GetOsImage:input_type -> common.UUID
-	530,  // 1403: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
-	536,  // 1404: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
-	537,  // 1405: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
-	552,  // 1406: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
-	557,  // 1407: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
-	559,  // 1408: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
-	554,  // 1409: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
-	562,  // 1410: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
-	564,  // 1411: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
-	567,  // 1412: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
-	569,  // 1413: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
-	586,  // 1414: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
-	587,  // 1415: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
-	589,  // 1416: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
-	592,  // 1417: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
-	594,  // 1418: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
-	570,  // 1419: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
-	598,  // 1420: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
-	600,  // 1421: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
-	599,  // 1422: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
-	603,  // 1423: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
-	607,  // 1424: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
-	608,  // 1425: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
-	610,  // 1426: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
-	404,  // 1427: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
-	581,  // 1428: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
-	362,  // 1429: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
-	394,  // 1430: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
-	396,  // 1431: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
-	398,  // 1432: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
-	400,  // 1433: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
-	772,  // 1434: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
-	774,  // 1435: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
-	406,  // 1436: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
-	408,  // 1437: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
-	571,  // 1438: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
-	579,  // 1439: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
-	120,  // 1440: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
-	1034, // 1441: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
-	1034, // 1442: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
-	117,  // 1443: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
-	637,  // 1444: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
-	639,  // 1445: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
-	644,  // 1446: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
-	646,  // 1447: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
-	646,  // 1448: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
-	646,  // 1449: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
-	650,  // 1450: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
-	674,  // 1451: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
-	690,  // 1452: forge.Forge.CreateSku:input_type -> forge.SkuList
-	956,  // 1453: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
-	956,  // 1454: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
-	688,  // 1455: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
-	689,  // 1456: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
-	691,  // 1457: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
-	1034, // 1458: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
-	693,  // 1459: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
-	703,  // 1460: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
-	687,  // 1461: forge.Forge.ReplaceSku:input_type -> forge.Sku
-	374,  // 1462: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
-	376,  // 1463: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
-	378,  // 1464: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
-	956,  // 1465: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
-	365,  // 1466: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
-	1034, // 1467: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
-	698,  // 1468: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
-	696,  // 1469: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	696,  // 1470: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	701,  // 1471: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
-	704,  // 1472: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
-	705,  // 1473: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
-	362,  // 1474: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
-	362,  // 1475: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
-	724,  // 1476: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
-	726,  // 1477: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
-	721,  // 1478: forge.Forge.GetRack:input_type -> forge.GetRackRequest
-	731,  // 1479: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
-	732,  // 1480: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
-	739,  // 1481: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
-	710,  // 1482: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
-	712,  // 1483: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
-	714,  // 1484: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
-	717,  // 1485: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
-	718,  // 1486: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
-	776,  // 1487: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
-	778,  // 1488: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
-	1078, // 1489: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
-	1079, // 1490: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
-	781,  // 1491: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
-	1034, // 1492: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
-	783,  // 1493: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	783,  // 1494: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	785,  // 1495: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
-	786,  // 1496: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
-	791,  // 1497: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
-	792,  // 1498: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
-	793,  // 1499: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
-	794,  // 1500: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
-	1034, // 1501: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
-	788,  // 1502: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
-	795,  // 1503: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
-	797,  // 1504: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
-	800,  // 1505: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
-	802,  // 1506: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
-	804,  // 1507: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
-	805,  // 1508: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
-	811,  // 1509: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
-	812,  // 1510: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
-	813,  // 1511: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
-	815,  // 1512: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
-	817,  // 1513: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
-	819,  // 1514: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
-	821,  // 1515: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
-	92,   // 1516: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
-	956,  // 1517: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
-	93,   // 1518: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
-	956,  // 1519: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
-	95,   // 1520: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
-	97,   // 1521: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	100,  // 1522: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
-	97,   // 1523: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	105,  // 1524: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	107,  // 1525: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
-	105,  // 1526: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	108,  // 1527: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
-	113,  // 1528: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
-	114,  // 1529: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
-	828,  // 1530: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
-	831,  // 1531: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
-	833,  // 1532: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
-	835,  // 1533: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
-	1080, // 1534: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
-	1081, // 1535: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
-	1082, // 1536: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
-	1083, // 1537: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
-	1084, // 1538: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
-	1085, // 1539: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
-	1086, // 1540: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
-	1087, // 1541: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
-	1088, // 1542: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
-	1089, // 1543: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
-	1090, // 1544: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
-	1091, // 1545: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
-	1092, // 1546: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
-	1093, // 1547: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
-	1094, // 1548: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
-	756,  // 1549: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
-	757,  // 1550: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
-	145,  // 1551: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	767,  // 1552: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
-	768,  // 1553: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
-	764,  // 1554: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
-	770,  // 1555: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
-	765,  // 1556: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
-	145,  // 1557: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	849,  // 1558: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
-	750,  // 1559: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
-	852,  // 1560: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
-	854,  // 1561: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
-	855,  // 1562: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
-	857,  // 1563: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
-	866,  // 1564: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
-	863,  // 1565: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
-	873,  // 1566: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
-	875,  // 1567: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
-	877,  // 1568: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
-	894,  // 1569: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
-	974,  // 1570: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
-	897,  // 1571: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
-	898,  // 1572: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
-	900,  // 1573: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
-	902,  // 1574: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
-	904,  // 1575: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	907,  // 1576: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	909,  // 1577: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
-	131,  // 1578: forge.Forge.Version:output_type -> forge.BuildInfo
-	1014, // 1579: forge.Forge.CreateDomain:output_type -> dns.Domain
-	1014, // 1580: forge.Forge.UpdateDomain:output_type -> dns.Domain
-	1095, // 1581: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
-	1096, // 1582: forge.Forge.FindDomain:output_type -> dns.DomainList
-	843,  // 1583: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
-	843,  // 1584: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
-	846,  // 1585: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
-	844,  // 1586: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
-	148,  // 1587: forge.Forge.CreateVpc:output_type -> forge.Vpc
-	151,  // 1588: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
-	153,  // 1589: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
-	155,  // 1590: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
-	143,  // 1591: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
-	156,  // 1592: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
-	882,  // 1593: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
-	885,  // 1594: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
-	883,  // 1595: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
-	887,  // 1596: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
-	157,  // 1597: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
-	163,  // 1598: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
-	164,  // 1599: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
-	157,  // 1600: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
-	167,  // 1601: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
-	169,  // 1602: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
-	170,  // 1603: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
-	171,  // 1604: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
-	176,  // 1605: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
-	243,  // 1606: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
-	348,  // 1607: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
-	235,  // 1608: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
-	235,  // 1609: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
-	239,  // 1610: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
-	348,  // 1611: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
-	187,  // 1612: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
-	180,  // 1613: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
-	179,  // 1614: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
-	179,  // 1615: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
-	184,  // 1616: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
-	180,  // 1617: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
-	191,  // 1618: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
-	862,  // 1619: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
-	191,  // 1620: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
-	194,  // 1621: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
-	892,  // 1622: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
-	1034, // 1623: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
-	211,  // 1624: forge.Forge.FindSwitches:output_type -> forge.SwitchList
-	861,  // 1625: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
-	211,  // 1626: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
-	214,  // 1627: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
-	890,  // 1628: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
-	231,  // 1629: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
-	284,  // 1630: forge.Forge.AllocateInstance:output_type -> forge.Instance
-	257,  // 1631: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
-	298,  // 1632: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
-	284,  // 1633: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
-	284,  // 1634: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
-	253,  // 1635: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
-	249,  // 1636: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
-	249,  // 1637: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
-	369,  // 1638: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
-	1034, // 1639: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
-	449,  // 1640: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
-	1034, // 1641: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
-	1034, // 1642: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
-	449,  // 1643: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
-	1034, // 1644: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
-	1034, // 1645: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
-	449,  // 1646: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
-	1034, // 1647: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
-	1034, // 1648: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
-	449,  // 1649: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
-	1034, // 1650: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
-	1034, // 1651: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
-	449,  // 1652: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
-	1034, // 1653: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	1034, // 1654: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	449,  // 1655: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
-	1034, // 1656: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
-	1034, // 1657: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
-	388,  // 1658: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
-	390,  // 1659: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
-	1097, // 1660: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
-	1098, // 1661: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
-	1099, // 1662: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
-	248,  // 1663: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
-	415,  // 1664: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
-	422,  // 1665: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
-	421,  // 1666: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
-	423,  // 1667: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
-	424,  // 1668: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
-	426,  // 1669: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
-	347,  // 1670: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
-	346,  // 1671: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
-	317,  // 1672: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
-	319,  // 1673: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
-	322,  // 1674: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
-	312,  // 1675: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
-	1034, // 1676: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
-	490,  // 1677: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
-	1015, // 1678: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
-	313,  // 1679: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
-	302,  // 1680: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
-	305,  // 1681: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
-	218,  // 1682: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
-	218,  // 1683: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
-	218,  // 1684: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
-	218,  // 1685: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
-	218,  // 1686: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
-	311,  // 1687: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
-	310,  // 1688: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
-	513,  // 1689: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
-	517,  // 1690: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
-	516,  // 1691: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
-	514,  // 1692: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
-	492,  // 1693: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
-	495,  // 1694: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
-	497,  // 1695: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
-	411,  // 1696: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
-	413,  // 1697: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
-	428,  // 1698: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
-	432,  // 1699: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
-	134,  // 1700: forge.Forge.Echo:output_type -> forge.EchoResponse
-	459,  // 1701: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
-	463,  // 1702: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
-	461,  // 1703: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
-	469,  // 1704: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
-	476,  // 1705: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
-	470,  // 1706: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
-	472,  // 1707: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
-	474,  // 1708: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
-	479,  // 1709: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
-	353,  // 1710: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
-	353,  // 1711: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
-	386,  // 1712: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
-	1100, // 1713: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
-	1034, // 1714: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
-	596,  // 1715: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
-	597,  // 1716: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
-	1016, // 1717: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
-	1034, // 1718: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
-	1101, // 1719: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
-	361,  // 1720: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
-	1034, // 1721: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
-	1102, // 1722: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
-	1103, // 1723: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
-	1104, // 1724: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
-	1105, // 1725: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
-	1106, // 1726: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
-	1107, // 1727: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
-	1034, // 1728: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
-	392,  // 1729: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
-	481,  // 1730: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
-	484,  // 1731: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
-	1034, // 1732: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
-	1034, // 1733: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
-	1034, // 1734: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
-	1034, // 1735: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
-	1034, // 1736: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
-	1034, // 1737: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
-	1034, // 1738: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
-	1034, // 1739: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
-	500,  // 1740: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
-	1034, // 1741: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
-	503,  // 1742: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
-	1034, // 1743: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
-	1034, // 1744: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
-	509,  // 1745: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
-	511,  // 1746: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
-	1034, // 1747: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
-	1034, // 1748: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
-	916,  // 1749: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
-	522,  // 1750: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
-	522,  // 1751: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
-	128,  // 1752: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
-	129,  // 1753: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
-	524,  // 1754: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
-	1034, // 1755: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
-	1034, // 1756: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
-	1034, // 1757: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
-	1034, // 1758: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
-	295,  // 1759: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
-	527,  // 1760: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
-	529,  // 1761: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
-	1034, // 1762: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
-	1034, // 1763: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
-	1034, // 1764: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
-	541,  // 1765: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
-	543,  // 1766: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
-	1034, // 1767: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
-	1034, // 1768: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
-	544,  // 1769: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
-	546,  // 1770: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
-	550,  // 1771: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	550,  // 1772: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	1034, // 1773: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1034, // 1774: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1034, // 1775: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
-	200,  // 1776: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
-	202,  // 1777: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
-	1034, // 1778: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	1034, // 1779: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	203,  // 1780: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
-	1034, // 1781: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
-	1034, // 1782: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
-	1034, // 1783: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
-	222,  // 1784: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
-	224,  // 1785: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
-	1034, // 1786: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
-	1034, // 1787: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
-	225,  // 1788: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
-	1034, // 1789: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
-	1034, // 1790: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
-	1034, // 1791: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
-	227,  // 1792: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
-	229,  // 1793: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
-	1034, // 1794: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
-	1034, // 1795: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
-	125,  // 1796: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
-	624,  // 1797: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
-	626,  // 1798: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
-	628,  // 1799: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
-	631,  // 1800: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
-	630,  // 1801: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
-	634,  // 1802: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
-	636,  // 1803: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
-	1108, // 1804: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
-	1109, // 1805: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
-	1110, // 1806: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
-	1111, // 1807: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
-	1112, // 1808: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1113, // 1809: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
-	1114, // 1810: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
-	1115, // 1811: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
-	1112, // 1812: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1116, // 1813: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
-	1117, // 1814: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
-	1118, // 1815: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
-	1119, // 1816: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
-	1120, // 1817: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
-	1121, // 1818: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
-	1122, // 1819: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
-	1123, // 1820: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
-	1124, // 1821: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
-	1125, // 1822: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
-	1126, // 1823: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
-	1127, // 1824: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
-	1128, // 1825: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
-	1129, // 1826: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
-	1130, // 1827: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
-	1131, // 1828: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
-	1132, // 1829: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
-	1133, // 1830: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
-	1134, // 1831: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
-	1135, // 1832: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
-	1136, // 1833: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
-	1137, // 1834: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
-	1138, // 1835: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
-	1139, // 1836: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
-	1140, // 1837: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
-	1141, // 1838: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
-	1142, // 1839: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
-	1143, // 1840: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
-	1144, // 1841: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
-	1145, // 1842: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
-	1146, // 1843: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
-	1147, // 1844: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
-	1148, // 1845: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
-	1149, // 1846: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
-	655,  // 1847: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
-	657,  // 1848: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
-	659,  // 1849: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
-	660,  // 1850: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
-	663,  // 1851: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
-	666,  // 1852: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
-	673,  // 1853: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
-	531,  // 1854: forge.Forge.CreateOsImage:output_type -> forge.OsImage
-	535,  // 1855: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
-	533,  // 1856: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
-	531,  // 1857: forge.Forge.GetOsImage:output_type -> forge.OsImage
-	531,  // 1858: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
-	260,  // 1859: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
-	538,  // 1860: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
-	551,  // 1861: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
-	1034, // 1862: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
-	558,  // 1863: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
-	555,  // 1864: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
-	563,  // 1865: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
-	566,  // 1866: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
-	568,  // 1867: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
-	1034, // 1868: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	585,  // 1869: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
-	588,  // 1870: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
-	590,  // 1871: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
-	593,  // 1872: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
-	595,  // 1873: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
-	1034, // 1874: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	602,  // 1875: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
-	601,  // 1876: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	601,  // 1877: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	604,  // 1878: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
-	606,  // 1879: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
-	609,  // 1880: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
-	611,  // 1881: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
-	405,  // 1882: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
-	582,  // 1883: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
-	393,  // 1884: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
-	395,  // 1885: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
-	1150, // 1886: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
-	399,  // 1887: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
-	401,  // 1888: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
-	773,  // 1889: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
-	775,  // 1890: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
-	407,  // 1891: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
-	409,  // 1892: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
-	572,  // 1893: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
-	580,  // 1894: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
-	116,  // 1895: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
-	122,  // 1896: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
-	119,  // 1897: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
-	1034, // 1898: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
-	638,  // 1899: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
-	640,  // 1900: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
-	645,  // 1901: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
-	647,  // 1902: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
-	648,  // 1903: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
-	649,  // 1904: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
-	651,  // 1905: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
-	675,  // 1906: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
-	691,  // 1907: forge.Forge.CreateSku:output_type -> forge.SkuIdList
-	687,  // 1908: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
-	1034, // 1909: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
-	1034, // 1910: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
-	1034, // 1911: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
-	1034, // 1912: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
-	691,  // 1913: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
-	690,  // 1914: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
-	1034, // 1915: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
-	687,  // 1916: forge.Forge.ReplaceSku:output_type -> forge.Sku
-	375,  // 1917: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
-	377,  // 1918: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
-	379,  // 1919: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
-	1034, // 1920: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
-	1034, // 1921: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
-	697,  // 1922: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
-	699,  // 1923: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
-	695,  // 1924: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
-	695,  // 1925: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
-	702,  // 1926: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
-	707,  // 1927: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
-	707,  // 1928: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
-	1034, // 1929: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
-	115,  // 1930: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
-	725,  // 1931: forge.Forge.FindRackIds:output_type -> forge.RackIdList
-	723,  // 1932: forge.Forge.FindRacksByIds:output_type -> forge.RackList
-	722,  // 1933: forge.Forge.GetRack:output_type -> forge.GetRackResponse
-	1034, // 1934: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
-	733,  // 1935: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
-	740,  // 1936: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
-	711,  // 1937: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
-	713,  // 1938: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
-	715,  // 1939: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
-	716,  // 1940: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
-	719,  // 1941: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
-	777,  // 1942: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
-	779,  // 1943: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
-	1151, // 1944: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
-	1152, // 1945: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
-	782,  // 1946: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
-	784,  // 1947: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
-	783,  // 1948: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	783,  // 1949: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	1034, // 1950: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
-	787,  // 1951: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
-	1034, // 1952: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
-	1034, // 1953: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
-	1034, // 1954: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
-	1034, // 1955: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
-	788,  // 1956: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
-	789,  // 1957: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
-	796,  // 1958: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
-	799,  // 1959: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
-	801,  // 1960: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
-	1034, // 1961: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
-	1034, // 1962: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
-	1034, // 1963: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
-	810,  // 1964: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
-	810,  // 1965: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
-	814,  // 1966: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
-	816,  // 1967: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
-	818,  // 1968: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
-	820,  // 1969: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
-	822,  // 1970: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
-	89,   // 1971: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
-	1034, // 1972: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
-	94,   // 1973: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
-	91,   // 1974: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
-	96,   // 1975: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
-	101,  // 1976: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	101,  // 1977: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	1034, // 1978: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
-	104,  // 1979: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	104,  // 1980: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	1034, // 1981: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
-	110,  // 1982: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
-	111,  // 1983: forge.Forge.GetJWKS:output_type -> forge.Jwks
-	112,  // 1984: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
-	829,  // 1985: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
-	832,  // 1986: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
-	834,  // 1987: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
-	836,  // 1988: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
-	1153, // 1989: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
-	1154, // 1990: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
-	1155, // 1991: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
-	1156, // 1992: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
-	1157, // 1993: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
-	1158, // 1994: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
-	1159, // 1995: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
-	1160, // 1996: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
-	1161, // 1997: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
-	1162, // 1998: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
-	1163, // 1999: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
-	1164, // 2000: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
-	1165, // 2001: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
-	1166, // 2002: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
-	1167, // 2003: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
-	758,  // 2004: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
-	753,  // 2005: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
-	753,  // 2006: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
-	769,  // 2007: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
-	763,  // 2008: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
-	762,  // 2009: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
-	771,  // 2010: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
-	766,  // 2011: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
-	763,  // 2012: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
-	850,  // 2013: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
-	751,  // 2014: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
-	1034, // 2015: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
-	853,  // 2016: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
-	856,  // 2017: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
-	859,  // 2018: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
-	867,  // 2019: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
-	865,  // 2020: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
-	874,  // 2021: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
-	876,  // 2022: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
-	880,  // 2023: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
-	893,  // 2024: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
-	893,  // 2025: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
-	893,  // 2026: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
-	899,  // 2027: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
-	901,  // 2028: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
-	903,  // 2029: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
-	905,  // 2030: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	905,  // 2031: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	910,  // 2032: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
-	1578, // [1578:2033] is the sub-list for method output_type
-	1123, // [1123:1578] is the sub-list for method input_type
+	1028, // 1259: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
+	356,  // 1260: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
+	362,  // 1261: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
+	362,  // 1262: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
+	362,  // 1263: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
+	357,  // 1264: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
+	358,  // 1265: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
+	359,  // 1266: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
+	360,  // 1267: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
+	1029, // 1268: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
+	1030, // 1269: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
+	1031, // 1270: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
+	1032, // 1271: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
+	1033, // 1272: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
+	1034, // 1273: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
+	366,  // 1274: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
+	391,  // 1275: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
+	480,  // 1276: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
+	483,  // 1277: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
+	328,  // 1278: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
+	329,  // 1279: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
+	330,  // 1280: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
+	331,  // 1281: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
+	744,  // 1282: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
+	487,  // 1283: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
+	488,  // 1284: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
+	498,  // 1285: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
+	499,  // 1286: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
+	501,  // 1287: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
+	502,  // 1288: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
+	956,  // 1289: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
+	553,  // 1290: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
+	508,  // 1291: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
+	977,  // 1292: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
+	511,  // 1293: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
+	977,  // 1294: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
+	911,  // 1295: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
+	520,  // 1296: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
+	521,  // 1297: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
+	126,  // 1298: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
+	127,  // 1299: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
+	1028, // 1300: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
+	523,  // 1301: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
+	523,  // 1302: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
+	523,  // 1303: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
+	332,  // 1304: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
+	294,  // 1305: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
+	526,  // 1306: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
+	528,  // 1307: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
+	541,  // 1308: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
+	542,  // 1309: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	541,  // 1310: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
+	542,  // 1311: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	1028, // 1312: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
+	543,  // 1313: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
+	1028, // 1314: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
+	1028, // 1315: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
+	1028, // 1316: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
+	548,  // 1317: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	548,  // 1318: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	200,  // 1319: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	201,  // 1320: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	200,  // 1321: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	201,  // 1322: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	1028, // 1323: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	202,  // 1324: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
+	1028, // 1325: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	1028, // 1326: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
+	222,  // 1327: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
+	223,  // 1328: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	222,  // 1329: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
+	223,  // 1330: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	1028, // 1331: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
+	224,  // 1332: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
+	1028, // 1333: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
+	1028, // 1334: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
+	227,  // 1335: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
+	228,  // 1336: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
+	227,  // 1337: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
+	228,  // 1338: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
+	1028, // 1339: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
+	229,  // 1340: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
+	1028, // 1341: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
+	124,  // 1342: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
+	623,  // 1343: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
+	625,  // 1344: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
+	627,  // 1345: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
+	632,  // 1346: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
+	629,  // 1347: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
+	633,  // 1348: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
+	635,  // 1349: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
+	1035, // 1350: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
+	1036, // 1351: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
+	1037, // 1352: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
+	1038, // 1353: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
+	1039, // 1354: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
+	1040, // 1355: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
+	1041, // 1356: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
+	1042, // 1357: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
+	1043, // 1358: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
+	1044, // 1359: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
+	1045, // 1360: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
+	1046, // 1361: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
+	1047, // 1362: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
+	1048, // 1363: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
+	1049, // 1364: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
+	1050, // 1365: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
+	1051, // 1366: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
+	1052, // 1367: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
+	1053, // 1368: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
+	1054, // 1369: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
+	1055, // 1370: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
+	1056, // 1371: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
+	1057, // 1372: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
+	1058, // 1373: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
+	1059, // 1374: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
+	1060, // 1375: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
+	1061, // 1376: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
+	1062, // 1377: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
+	1063, // 1378: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
+	1064, // 1379: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
+	1065, // 1380: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
+	1066, // 1381: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
+	1067, // 1382: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
+	1068, // 1383: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
+	1069, // 1384: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
+	1070, // 1385: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
+	1071, // 1386: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
+	1072, // 1387: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
+	1073, // 1388: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
+	1074, // 1389: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
+	1075, // 1390: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
+	1076, // 1391: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
+	1077, // 1392: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
+	654,  // 1393: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
+	656,  // 1394: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
+	658,  // 1395: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
+	661,  // 1396: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
+	662,  // 1397: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
+	668,  // 1398: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
+	671,  // 1399: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
+	530,  // 1400: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
+	534,  // 1401: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
+	532,  // 1402: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
+	966,  // 1403: forge.Forge.GetOsImage:input_type -> common.UUID
+	530,  // 1404: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
+	536,  // 1405: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
+	537,  // 1406: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
+	552,  // 1407: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
+	557,  // 1408: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
+	559,  // 1409: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
+	554,  // 1410: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
+	562,  // 1411: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
+	564,  // 1412: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
+	567,  // 1413: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
+	569,  // 1414: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
+	586,  // 1415: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
+	587,  // 1416: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
+	589,  // 1417: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
+	592,  // 1418: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
+	594,  // 1419: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
+	570,  // 1420: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
+	598,  // 1421: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
+	600,  // 1422: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
+	599,  // 1423: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
+	603,  // 1424: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
+	607,  // 1425: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
+	608,  // 1426: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
+	610,  // 1427: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
+	404,  // 1428: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
+	581,  // 1429: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
+	362,  // 1430: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
+	394,  // 1431: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
+	396,  // 1432: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
+	398,  // 1433: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
+	400,  // 1434: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
+	772,  // 1435: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
+	774,  // 1436: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
+	406,  // 1437: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
+	408,  // 1438: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
+	571,  // 1439: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
+	579,  // 1440: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
+	120,  // 1441: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
+	1028, // 1442: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
+	1028, // 1443: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
+	117,  // 1444: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
+	637,  // 1445: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
+	639,  // 1446: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
+	644,  // 1447: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
+	646,  // 1448: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
+	646,  // 1449: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
+	646,  // 1450: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
+	650,  // 1451: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
+	674,  // 1452: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
+	690,  // 1453: forge.Forge.CreateSku:input_type -> forge.SkuList
+	956,  // 1454: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
+	956,  // 1455: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
+	688,  // 1456: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
+	689,  // 1457: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
+	691,  // 1458: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
+	1028, // 1459: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
+	693,  // 1460: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
+	703,  // 1461: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
+	687,  // 1462: forge.Forge.ReplaceSku:input_type -> forge.Sku
+	374,  // 1463: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
+	376,  // 1464: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
+	378,  // 1465: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
+	956,  // 1466: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
+	365,  // 1467: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
+	1028, // 1468: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
+	698,  // 1469: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
+	696,  // 1470: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	696,  // 1471: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	701,  // 1472: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
+	704,  // 1473: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
+	705,  // 1474: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
+	362,  // 1475: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
+	362,  // 1476: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
+	724,  // 1477: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
+	726,  // 1478: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
+	721,  // 1479: forge.Forge.GetRack:input_type -> forge.GetRackRequest
+	731,  // 1480: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
+	732,  // 1481: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
+	739,  // 1482: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
+	710,  // 1483: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
+	712,  // 1484: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
+	714,  // 1485: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
+	717,  // 1486: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
+	718,  // 1487: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
+	776,  // 1488: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
+	778,  // 1489: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
+	1078, // 1490: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
+	1079, // 1491: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
+	781,  // 1492: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
+	1028, // 1493: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
+	783,  // 1494: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	783,  // 1495: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	785,  // 1496: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
+	786,  // 1497: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
+	791,  // 1498: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
+	792,  // 1499: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
+	793,  // 1500: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
+	794,  // 1501: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
+	1028, // 1502: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
+	788,  // 1503: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
+	795,  // 1504: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
+	797,  // 1505: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
+	800,  // 1506: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
+	802,  // 1507: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
+	804,  // 1508: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
+	805,  // 1509: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
+	811,  // 1510: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
+	812,  // 1511: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
+	813,  // 1512: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
+	815,  // 1513: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
+	817,  // 1514: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
+	819,  // 1515: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
+	821,  // 1516: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
+	92,   // 1517: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
+	956,  // 1518: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
+	93,   // 1519: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
+	956,  // 1520: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
+	95,   // 1521: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
+	97,   // 1522: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	100,  // 1523: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
+	97,   // 1524: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	105,  // 1525: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	107,  // 1526: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
+	105,  // 1527: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	108,  // 1528: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
+	113,  // 1529: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
+	114,  // 1530: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
+	828,  // 1531: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
+	831,  // 1532: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
+	833,  // 1533: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
+	835,  // 1534: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
+	1080, // 1535: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
+	1081, // 1536: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
+	1082, // 1537: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
+	1083, // 1538: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
+	1084, // 1539: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
+	1085, // 1540: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
+	1086, // 1541: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
+	1087, // 1542: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
+	1088, // 1543: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
+	1089, // 1544: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
+	1090, // 1545: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
+	1091, // 1546: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
+	1092, // 1547: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
+	1093, // 1548: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
+	1094, // 1549: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
+	756,  // 1550: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
+	757,  // 1551: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
+	145,  // 1552: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	767,  // 1553: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
+	768,  // 1554: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
+	764,  // 1555: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
+	770,  // 1556: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
+	765,  // 1557: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
+	145,  // 1558: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	849,  // 1559: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
+	750,  // 1560: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
+	852,  // 1561: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
+	854,  // 1562: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
+	855,  // 1563: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
+	857,  // 1564: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
+	866,  // 1565: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
+	863,  // 1566: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
+	873,  // 1567: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
+	875,  // 1568: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
+	877,  // 1569: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
+	894,  // 1570: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
+	974,  // 1571: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
+	897,  // 1572: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
+	898,  // 1573: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
+	900,  // 1574: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
+	902,  // 1575: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
+	904,  // 1576: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	907,  // 1577: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	909,  // 1578: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
+	131,  // 1579: forge.Forge.Version:output_type -> forge.BuildInfo
+	1014, // 1580: forge.Forge.CreateDomain:output_type -> dns.Domain
+	1014, // 1581: forge.Forge.UpdateDomain:output_type -> dns.Domain
+	1095, // 1582: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
+	1096, // 1583: forge.Forge.FindDomain:output_type -> dns.DomainList
+	843,  // 1584: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
+	843,  // 1585: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
+	846,  // 1586: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
+	844,  // 1587: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
+	148,  // 1588: forge.Forge.CreateVpc:output_type -> forge.Vpc
+	151,  // 1589: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
+	153,  // 1590: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
+	155,  // 1591: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
+	143,  // 1592: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
+	156,  // 1593: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
+	882,  // 1594: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
+	885,  // 1595: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
+	883,  // 1596: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
+	887,  // 1597: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
+	157,  // 1598: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
+	163,  // 1599: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
+	164,  // 1600: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
+	157,  // 1601: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
+	167,  // 1602: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
+	169,  // 1603: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
+	170,  // 1604: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
+	171,  // 1605: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
+	176,  // 1606: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
+	243,  // 1607: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
+	348,  // 1608: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
+	235,  // 1609: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
+	235,  // 1610: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
+	239,  // 1611: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
+	348,  // 1612: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
+	187,  // 1613: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
+	180,  // 1614: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
+	179,  // 1615: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
+	179,  // 1616: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
+	184,  // 1617: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
+	180,  // 1618: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
+	191,  // 1619: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
+	862,  // 1620: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
+	191,  // 1621: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
+	194,  // 1622: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
+	892,  // 1623: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
+	1028, // 1624: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
+	211,  // 1625: forge.Forge.FindSwitches:output_type -> forge.SwitchList
+	861,  // 1626: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
+	211,  // 1627: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
+	214,  // 1628: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
+	890,  // 1629: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
+	231,  // 1630: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
+	284,  // 1631: forge.Forge.AllocateInstance:output_type -> forge.Instance
+	257,  // 1632: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
+	298,  // 1633: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
+	284,  // 1634: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
+	284,  // 1635: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
+	253,  // 1636: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
+	249,  // 1637: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
+	249,  // 1638: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
+	369,  // 1639: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
+	1028, // 1640: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
+	449,  // 1641: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
+	1028, // 1642: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
+	1028, // 1643: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
+	449,  // 1644: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
+	1028, // 1645: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
+	1028, // 1646: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
+	449,  // 1647: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
+	1028, // 1648: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
+	1028, // 1649: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
+	449,  // 1650: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
+	1028, // 1651: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
+	1028, // 1652: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
+	449,  // 1653: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
+	1028, // 1654: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	1028, // 1655: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	449,  // 1656: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
+	1028, // 1657: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
+	1028, // 1658: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
+	388,  // 1659: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
+	390,  // 1660: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
+	1097, // 1661: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
+	1098, // 1662: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
+	1099, // 1663: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
+	248,  // 1664: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
+	415,  // 1665: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
+	422,  // 1666: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
+	421,  // 1667: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
+	423,  // 1668: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
+	424,  // 1669: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
+	426,  // 1670: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
+	347,  // 1671: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
+	346,  // 1672: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
+	317,  // 1673: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
+	319,  // 1674: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
+	322,  // 1675: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
+	312,  // 1676: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
+	1028, // 1677: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
+	490,  // 1678: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
+	1015, // 1679: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
+	313,  // 1680: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
+	302,  // 1681: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
+	305,  // 1682: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
+	218,  // 1683: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
+	218,  // 1684: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
+	218,  // 1685: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
+	218,  // 1686: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
+	218,  // 1687: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
+	311,  // 1688: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
+	310,  // 1689: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
+	513,  // 1690: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
+	517,  // 1691: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
+	516,  // 1692: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
+	514,  // 1693: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
+	492,  // 1694: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
+	495,  // 1695: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
+	497,  // 1696: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
+	411,  // 1697: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
+	413,  // 1698: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
+	428,  // 1699: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
+	432,  // 1700: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
+	134,  // 1701: forge.Forge.Echo:output_type -> forge.EchoResponse
+	459,  // 1702: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
+	463,  // 1703: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
+	461,  // 1704: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
+	469,  // 1705: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
+	476,  // 1706: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
+	470,  // 1707: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
+	472,  // 1708: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
+	474,  // 1709: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
+	479,  // 1710: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
+	353,  // 1711: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
+	353,  // 1712: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
+	386,  // 1713: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
+	1100, // 1714: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
+	1101, // 1715: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
+	1028, // 1716: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
+	596,  // 1717: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
+	597,  // 1718: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
+	1016, // 1719: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
+	1028, // 1720: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
+	1102, // 1721: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
+	361,  // 1722: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
+	1028, // 1723: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
+	1103, // 1724: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
+	1104, // 1725: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
+	1105, // 1726: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
+	1106, // 1727: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
+	1107, // 1728: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
+	1108, // 1729: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
+	1028, // 1730: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
+	392,  // 1731: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
+	481,  // 1732: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
+	484,  // 1733: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
+	1028, // 1734: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
+	1028, // 1735: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
+	1028, // 1736: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
+	1028, // 1737: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
+	1028, // 1738: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
+	1028, // 1739: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
+	1028, // 1740: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
+	1028, // 1741: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
+	500,  // 1742: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
+	1028, // 1743: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
+	503,  // 1744: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
+	1028, // 1745: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
+	1028, // 1746: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
+	509,  // 1747: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
+	511,  // 1748: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
+	1028, // 1749: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
+	1028, // 1750: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
+	916,  // 1751: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
+	522,  // 1752: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
+	522,  // 1753: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
+	128,  // 1754: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
+	129,  // 1755: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
+	524,  // 1756: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
+	1028, // 1757: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
+	1028, // 1758: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
+	1028, // 1759: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
+	1028, // 1760: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
+	295,  // 1761: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
+	527,  // 1762: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
+	529,  // 1763: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
+	1028, // 1764: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
+	1028, // 1765: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
+	1028, // 1766: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
+	541,  // 1767: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
+	543,  // 1768: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
+	1028, // 1769: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
+	1028, // 1770: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
+	544,  // 1771: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
+	546,  // 1772: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
+	550,  // 1773: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	550,  // 1774: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	1028, // 1775: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1028, // 1776: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1028, // 1777: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
+	200,  // 1778: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
+	202,  // 1779: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
+	1028, // 1780: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	1028, // 1781: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	203,  // 1782: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
+	1028, // 1783: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
+	1028, // 1784: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
+	1028, // 1785: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
+	222,  // 1786: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
+	224,  // 1787: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
+	1028, // 1788: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
+	1028, // 1789: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
+	225,  // 1790: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
+	1028, // 1791: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
+	1028, // 1792: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
+	1028, // 1793: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
+	227,  // 1794: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
+	229,  // 1795: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
+	1028, // 1796: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
+	1028, // 1797: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
+	125,  // 1798: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
+	624,  // 1799: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
+	626,  // 1800: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
+	628,  // 1801: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
+	631,  // 1802: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
+	630,  // 1803: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
+	634,  // 1804: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
+	636,  // 1805: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
+	1109, // 1806: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
+	1110, // 1807: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
+	1111, // 1808: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
+	1112, // 1809: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
+	1113, // 1810: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1114, // 1811: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
+	1115, // 1812: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
+	1116, // 1813: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
+	1113, // 1814: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1117, // 1815: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
+	1118, // 1816: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
+	1119, // 1817: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
+	1120, // 1818: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
+	1121, // 1819: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
+	1122, // 1820: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
+	1123, // 1821: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
+	1124, // 1822: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
+	1125, // 1823: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
+	1126, // 1824: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
+	1127, // 1825: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
+	1128, // 1826: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
+	1129, // 1827: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
+	1130, // 1828: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
+	1131, // 1829: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
+	1132, // 1830: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
+	1133, // 1831: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
+	1134, // 1832: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
+	1135, // 1833: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
+	1136, // 1834: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
+	1137, // 1835: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
+	1138, // 1836: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
+	1139, // 1837: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
+	1140, // 1838: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
+	1141, // 1839: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
+	1142, // 1840: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
+	1143, // 1841: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
+	1144, // 1842: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
+	1145, // 1843: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
+	1146, // 1844: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
+	1147, // 1845: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
+	1148, // 1846: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
+	1149, // 1847: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
+	1150, // 1848: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
+	655,  // 1849: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
+	657,  // 1850: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
+	659,  // 1851: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
+	660,  // 1852: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
+	663,  // 1853: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
+	666,  // 1854: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
+	673,  // 1855: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
+	531,  // 1856: forge.Forge.CreateOsImage:output_type -> forge.OsImage
+	535,  // 1857: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
+	533,  // 1858: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
+	531,  // 1859: forge.Forge.GetOsImage:output_type -> forge.OsImage
+	531,  // 1860: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
+	260,  // 1861: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
+	538,  // 1862: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
+	551,  // 1863: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
+	1028, // 1864: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
+	558,  // 1865: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
+	555,  // 1866: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
+	563,  // 1867: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
+	566,  // 1868: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
+	568,  // 1869: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
+	1028, // 1870: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	585,  // 1871: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
+	588,  // 1872: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
+	590,  // 1873: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
+	593,  // 1874: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
+	595,  // 1875: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
+	1028, // 1876: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	602,  // 1877: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
+	601,  // 1878: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	601,  // 1879: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	604,  // 1880: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
+	606,  // 1881: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
+	609,  // 1882: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
+	611,  // 1883: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
+	405,  // 1884: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
+	582,  // 1885: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
+	393,  // 1886: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
+	395,  // 1887: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
+	1151, // 1888: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
+	399,  // 1889: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
+	401,  // 1890: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
+	773,  // 1891: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
+	775,  // 1892: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
+	407,  // 1893: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
+	409,  // 1894: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
+	572,  // 1895: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
+	580,  // 1896: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
+	116,  // 1897: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
+	122,  // 1898: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
+	119,  // 1899: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
+	1028, // 1900: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
+	638,  // 1901: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
+	640,  // 1902: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
+	645,  // 1903: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
+	647,  // 1904: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
+	648,  // 1905: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
+	649,  // 1906: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
+	651,  // 1907: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
+	675,  // 1908: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
+	691,  // 1909: forge.Forge.CreateSku:output_type -> forge.SkuIdList
+	687,  // 1910: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
+	1028, // 1911: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
+	1028, // 1912: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
+	1028, // 1913: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
+	1028, // 1914: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
+	691,  // 1915: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
+	690,  // 1916: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
+	1028, // 1917: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
+	687,  // 1918: forge.Forge.ReplaceSku:output_type -> forge.Sku
+	375,  // 1919: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
+	377,  // 1920: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
+	379,  // 1921: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
+	1028, // 1922: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
+	1028, // 1923: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
+	697,  // 1924: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
+	699,  // 1925: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
+	695,  // 1926: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
+	695,  // 1927: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
+	702,  // 1928: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
+	707,  // 1929: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
+	707,  // 1930: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
+	1028, // 1931: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
+	115,  // 1932: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
+	725,  // 1933: forge.Forge.FindRackIds:output_type -> forge.RackIdList
+	723,  // 1934: forge.Forge.FindRacksByIds:output_type -> forge.RackList
+	722,  // 1935: forge.Forge.GetRack:output_type -> forge.GetRackResponse
+	1028, // 1936: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
+	733,  // 1937: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
+	740,  // 1938: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
+	711,  // 1939: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
+	713,  // 1940: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
+	715,  // 1941: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
+	716,  // 1942: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
+	719,  // 1943: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
+	777,  // 1944: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
+	779,  // 1945: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
+	1152, // 1946: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
+	1153, // 1947: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
+	782,  // 1948: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
+	784,  // 1949: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
+	783,  // 1950: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	783,  // 1951: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	1028, // 1952: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
+	787,  // 1953: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
+	1028, // 1954: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
+	1028, // 1955: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
+	1028, // 1956: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
+	1028, // 1957: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
+	788,  // 1958: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
+	789,  // 1959: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
+	796,  // 1960: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
+	799,  // 1961: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
+	801,  // 1962: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
+	1028, // 1963: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
+	1028, // 1964: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
+	1028, // 1965: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
+	810,  // 1966: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
+	810,  // 1967: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
+	814,  // 1968: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
+	816,  // 1969: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
+	818,  // 1970: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
+	820,  // 1971: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
+	822,  // 1972: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
+	89,   // 1973: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
+	1028, // 1974: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
+	94,   // 1975: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
+	91,   // 1976: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
+	96,   // 1977: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
+	101,  // 1978: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	101,  // 1979: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	1028, // 1980: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
+	104,  // 1981: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	104,  // 1982: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	1028, // 1983: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
+	110,  // 1984: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
+	111,  // 1985: forge.Forge.GetJWKS:output_type -> forge.Jwks
+	112,  // 1986: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
+	829,  // 1987: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
+	832,  // 1988: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
+	834,  // 1989: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
+	836,  // 1990: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
+	1154, // 1991: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
+	1155, // 1992: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
+	1156, // 1993: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
+	1157, // 1994: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
+	1158, // 1995: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
+	1159, // 1996: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
+	1160, // 1997: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
+	1161, // 1998: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
+	1162, // 1999: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
+	1163, // 2000: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
+	1164, // 2001: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
+	1165, // 2002: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
+	1166, // 2003: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
+	1167, // 2004: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
+	1168, // 2005: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
+	758,  // 2006: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
+	753,  // 2007: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
+	753,  // 2008: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
+	769,  // 2009: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
+	763,  // 2010: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
+	762,  // 2011: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
+	771,  // 2012: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
+	766,  // 2013: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
+	763,  // 2014: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
+	850,  // 2015: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
+	751,  // 2016: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
+	1028, // 2017: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
+	853,  // 2018: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
+	856,  // 2019: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
+	859,  // 2020: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
+	867,  // 2021: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
+	865,  // 2022: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
+	874,  // 2023: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
+	876,  // 2024: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
+	880,  // 2025: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
+	893,  // 2026: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
+	893,  // 2027: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
+	893,  // 2028: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
+	899,  // 2029: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
+	901,  // 2030: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
+	903,  // 2031: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
+	905,  // 2032: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	905,  // 2033: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	910,  // 2034: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
+	1579, // [1579:2035] is the sub-list for method output_type
+	1123, // [1123:1579] is the sub-list for method input_type
 	1123, // [1123:1123] is the sub-list for extension type_name
 	1123, // [1123:1123] is the sub-list for extension extendee
 	0,    // [0:1123] is the sub-list for field type_name

--- a/rest-api/workflow-schema/schema/site-agent/workflows/v1/nico_nico_grpc.pb.go
+++ b/rest-api/workflow-schema/schema/site-agent/workflows/v1/nico_nico_grpc.pb.go
@@ -159,6 +159,7 @@ const (
 	Forge_GetSwitchNvosCredentials_FullMethodName                           = "/forge.Forge/GetSwitchNvosCredentials"
 	Forge_GetAllManagedHostNetworkStatus_FullMethodName                     = "/forge.Forge/GetAllManagedHostNetworkStatus"
 	Forge_GetSiteExplorationReport_FullMethodName                           = "/forge.Forge/GetSiteExplorationReport"
+	Forge_GetSiteExplorerLastRun_FullMethodName                             = "/forge.Forge/GetSiteExplorerLastRun"
 	Forge_ClearSiteExplorationError_FullMethodName                          = "/forge.Forge/ClearSiteExplorationError"
 	Forge_IsBmcInManagedHost_FullMethodName                                 = "/forge.Forge/IsBmcInManagedHost"
 	Forge_BmcCredentialStatus_FullMethodName                                = "/forge.Forge/BmcCredentialStatus"
@@ -701,6 +702,8 @@ type ForgeClient interface {
 	// Gets the latest Site Exploration report
 	// DEPRECATED: use FindExploredEndpointIds, FindExploredEndpointsByIds and FindExploredManagedHostIds, FindExploredManagedHostsByIds instead
 	GetSiteExplorationReport(ctx context.Context, in *GetSiteExplorationRequest, opts ...grpc.CallOption) (*SiteExplorationReport, error)
+	// Gets metadata about the latest Site Explorer run without fetching endpoint rows.
+	GetSiteExplorerLastRun(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*SiteExplorerLastRunResponse, error)
 	// Clear the last known error for the BMC
 	ClearSiteExplorationError(ctx context.Context, in *ClearSiteExplorationErrorRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// IsBmcInManagedHost returns true if a Host+DPU pair that includes the endpoint has been identified
@@ -2639,6 +2642,16 @@ func (c *forgeClient) GetSiteExplorationReport(ctx context.Context, in *GetSiteE
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SiteExplorationReport)
 	err := c.cc.Invoke(ctx, Forge_GetSiteExplorationReport_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *forgeClient) GetSiteExplorerLastRun(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*SiteExplorerLastRunResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SiteExplorerLastRunResponse)
+	err := c.cc.Invoke(ctx, Forge_GetSiteExplorerLastRun_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -6059,6 +6072,8 @@ type ForgeServer interface {
 	// Gets the latest Site Exploration report
 	// DEPRECATED: use FindExploredEndpointIds, FindExploredEndpointsByIds and FindExploredManagedHostIds, FindExploredManagedHostsByIds instead
 	GetSiteExplorationReport(context.Context, *GetSiteExplorationRequest) (*SiteExplorationReport, error)
+	// Gets metadata about the latest Site Explorer run without fetching endpoint rows.
+	GetSiteExplorerLastRun(context.Context, *emptypb.Empty) (*SiteExplorerLastRunResponse, error)
 	// Clear the last known error for the BMC
 	ClearSiteExplorationError(context.Context, *ClearSiteExplorationErrorRequest) (*emptypb.Empty, error)
 	// IsBmcInManagedHost returns true if a Host+DPU pair that includes the endpoint has been identified
@@ -7042,6 +7057,9 @@ func (UnimplementedForgeServer) GetAllManagedHostNetworkStatus(context.Context, 
 }
 func (UnimplementedForgeServer) GetSiteExplorationReport(context.Context, *GetSiteExplorationRequest) (*SiteExplorationReport, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSiteExplorationReport not implemented")
+}
+func (UnimplementedForgeServer) GetSiteExplorerLastRun(context.Context, *emptypb.Empty) (*SiteExplorerLastRunResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSiteExplorerLastRun not implemented")
 }
 func (UnimplementedForgeServer) ClearSiteExplorationError(context.Context, *ClearSiteExplorationErrorRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method ClearSiteExplorationError not implemented")
@@ -10464,6 +10482,24 @@ func _Forge_GetSiteExplorationReport_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ForgeServer).GetSiteExplorationReport(ctx, req.(*GetSiteExplorationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Forge_GetSiteExplorerLastRun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ForgeServer).GetSiteExplorerLastRun(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Forge_GetSiteExplorerLastRun_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ForgeServer).GetSiteExplorerLastRun(ctx, req.(*emptypb.Empty))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -16749,6 +16785,10 @@ var Forge_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSiteExplorationReport",
 			Handler:    _Forge_GetSiteExplorationReport_Handler,
+		},
+		{
+			MethodName: "GetSiteExplorerLastRun",
+			Handler:    _Forge_GetSiteExplorerLastRun_Handler,
 		},
 		{
 			MethodName: "ClearSiteExplorationError",

--- a/rest-api/workflow-schema/schema/site-agent/workflows/v1/site_explorer_nico.pb.go
+++ b/rest-api/workflow-schema/schema/site-agent/workflows/v1/site_explorer_nico.pb.go
@@ -654,7 +654,9 @@ type SiteExplorationReport struct {
 	// The endpoints that had been explored
 	Endpoints []*ExploredEndpoint `protobuf:"bytes,1,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
 	// The managed-hosts which have been explored
-	ManagedHosts  []*ExploredManagedHost `protobuf:"bytes,2,rep,name=managed_hosts,json=managedHosts,proto3" json:"managed_hosts,omitempty"`
+	ManagedHosts []*ExploredManagedHost `protobuf:"bytes,2,rep,name=managed_hosts,json=managedHosts,proto3" json:"managed_hosts,omitempty"`
+	// Metadata about the latest site explorer run
+	LastRun       *SiteExplorerLastRun `protobuf:"bytes,3,opt,name=last_run,json=lastRun,proto3,oneof" json:"last_run,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -703,6 +705,184 @@ func (x *SiteExplorationReport) GetManagedHosts() []*ExploredManagedHost {
 	return nil
 }
 
+func (x *SiteExplorationReport) GetLastRun() *SiteExplorerLastRun {
+	if x != nil {
+		return x.LastRun
+	}
+	return nil
+}
+
+type SiteExplorerLastRunResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Metadata about the latest site explorer run, if site explorer has run
+	LastRun       *SiteExplorerLastRun `protobuf:"bytes,1,opt,name=last_run,json=lastRun,proto3,oneof" json:"last_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SiteExplorerLastRunResponse) Reset() {
+	*x = SiteExplorerLastRunResponse{}
+	mi := &file_site_explorer_nico_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SiteExplorerLastRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SiteExplorerLastRunResponse) ProtoMessage() {}
+
+func (x *SiteExplorerLastRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_site_explorer_nico_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SiteExplorerLastRunResponse.ProtoReflect.Descriptor instead.
+func (*SiteExplorerLastRunResponse) Descriptor() ([]byte, []int) {
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SiteExplorerLastRunResponse) GetLastRun() *SiteExplorerLastRun {
+	if x != nil {
+		return x.LastRun
+	}
+	return nil
+}
+
+type SiteExplorerLastRun struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// When the run started
+	StartedAt string `protobuf:"bytes,1,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	// When the run finished
+	FinishedAt string `protobuf:"bytes,2,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
+	// Whether the run completed successfully
+	Success bool `protobuf:"varint,3,opt,name=success,proto3" json:"success,omitempty"`
+	// Error string for a failed run
+	Error *string `protobuf:"bytes,4,opt,name=error,proto3,oneof" json:"error,omitempty"`
+	// Number of endpoint exploration attempts made during the run
+	EndpointExplorations int64 `protobuf:"varint,5,opt,name=endpoint_explorations,json=endpointExplorations,proto3" json:"endpoint_explorations,omitempty"`
+	// Number of successful endpoint explorations during the run
+	EndpointExplorationsSuccess int64 `protobuf:"varint,6,opt,name=endpoint_explorations_success,json=endpointExplorationsSuccess,proto3" json:"endpoint_explorations_success,omitempty"`
+	// Number of endpoint exploration errors during the run
+	EndpointExplorationsFailed int64 `protobuf:"varint,7,opt,name=endpoint_explorations_failed,json=endpointExplorationsFailed,proto3" json:"endpoint_explorations_failed,omitempty"`
+	// Failure category for a failed run
+	FailureCategory *string `protobuf:"bytes,8,opt,name=failure_category,json=failureCategory,proto3,oneof" json:"failure_category,omitempty"`
+	// When the most recent successful run finished
+	LastSuccessfulFinishedAt *string `protobuf:"bytes,9,opt,name=last_successful_finished_at,json=lastSuccessfulFinishedAt,proto3,oneof" json:"last_successful_finished_at,omitempty"`
+	// When the most recent failed run finished
+	LastFailedFinishedAt *string `protobuf:"bytes,10,opt,name=last_failed_finished_at,json=lastFailedFinishedAt,proto3,oneof" json:"last_failed_finished_at,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *SiteExplorerLastRun) Reset() {
+	*x = SiteExplorerLastRun{}
+	mi := &file_site_explorer_nico_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SiteExplorerLastRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SiteExplorerLastRun) ProtoMessage() {}
+
+func (x *SiteExplorerLastRun) ProtoReflect() protoreflect.Message {
+	mi := &file_site_explorer_nico_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SiteExplorerLastRun.ProtoReflect.Descriptor instead.
+func (*SiteExplorerLastRun) Descriptor() ([]byte, []int) {
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SiteExplorerLastRun) GetStartedAt() string {
+	if x != nil {
+		return x.StartedAt
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetFinishedAt() string {
+	if x != nil {
+		return x.FinishedAt
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *SiteExplorerLastRun) GetError() string {
+	if x != nil && x.Error != nil {
+		return *x.Error
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetEndpointExplorations() int64 {
+	if x != nil {
+		return x.EndpointExplorations
+	}
+	return 0
+}
+
+func (x *SiteExplorerLastRun) GetEndpointExplorationsSuccess() int64 {
+	if x != nil {
+		return x.EndpointExplorationsSuccess
+	}
+	return 0
+}
+
+func (x *SiteExplorerLastRun) GetEndpointExplorationsFailed() int64 {
+	if x != nil {
+		return x.EndpointExplorationsFailed
+	}
+	return 0
+}
+
+func (x *SiteExplorerLastRun) GetFailureCategory() string {
+	if x != nil && x.FailureCategory != nil {
+		return *x.FailureCategory
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetLastSuccessfulFinishedAt() string {
+	if x != nil && x.LastSuccessfulFinishedAt != nil {
+		return *x.LastSuccessfulFinishedAt
+	}
+	return ""
+}
+
+func (x *SiteExplorerLastRun) GetLastFailedFinishedAt() string {
+	if x != nil && x.LastFailedFinishedAt != nil {
+		return *x.LastFailedFinishedAt
+	}
+	return ""
+}
+
 type ExploredEndpointSearchFilter struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -711,7 +891,7 @@ type ExploredEndpointSearchFilter struct {
 
 func (x *ExploredEndpointSearchFilter) Reset() {
 	*x = ExploredEndpointSearchFilter{}
-	mi := &file_site_explorer_nico_proto_msgTypes[5]
+	mi := &file_site_explorer_nico_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -723,7 +903,7 @@ func (x *ExploredEndpointSearchFilter) String() string {
 func (*ExploredEndpointSearchFilter) ProtoMessage() {}
 
 func (x *ExploredEndpointSearchFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[5]
+	mi := &file_site_explorer_nico_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -736,7 +916,7 @@ func (x *ExploredEndpointSearchFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredEndpointSearchFilter.ProtoReflect.Descriptor instead.
 func (*ExploredEndpointSearchFilter) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{5}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{7}
 }
 
 type ExploredEndpointIdList struct {
@@ -749,7 +929,7 @@ type ExploredEndpointIdList struct {
 
 func (x *ExploredEndpointIdList) Reset() {
 	*x = ExploredEndpointIdList{}
-	mi := &file_site_explorer_nico_proto_msgTypes[6]
+	mi := &file_site_explorer_nico_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -761,7 +941,7 @@ func (x *ExploredEndpointIdList) String() string {
 func (*ExploredEndpointIdList) ProtoMessage() {}
 
 func (x *ExploredEndpointIdList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[6]
+	mi := &file_site_explorer_nico_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -774,7 +954,7 @@ func (x *ExploredEndpointIdList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredEndpointIdList.ProtoReflect.Descriptor instead.
 func (*ExploredEndpointIdList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{6}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ExploredEndpointIdList) GetEndpointIds() []string {
@@ -794,7 +974,7 @@ type ExploredEndpointsByIdsRequest struct {
 
 func (x *ExploredEndpointsByIdsRequest) Reset() {
 	*x = ExploredEndpointsByIdsRequest{}
-	mi := &file_site_explorer_nico_proto_msgTypes[7]
+	mi := &file_site_explorer_nico_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -806,7 +986,7 @@ func (x *ExploredEndpointsByIdsRequest) String() string {
 func (*ExploredEndpointsByIdsRequest) ProtoMessage() {}
 
 func (x *ExploredEndpointsByIdsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[7]
+	mi := &file_site_explorer_nico_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -819,7 +999,7 @@ func (x *ExploredEndpointsByIdsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredEndpointsByIdsRequest.ProtoReflect.Descriptor instead.
 func (*ExploredEndpointsByIdsRequest) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{7}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ExploredEndpointsByIdsRequest) GetEndpointIds() []string {
@@ -838,7 +1018,7 @@ type ExploredEndpointList struct {
 
 func (x *ExploredEndpointList) Reset() {
 	*x = ExploredEndpointList{}
-	mi := &file_site_explorer_nico_proto_msgTypes[8]
+	mi := &file_site_explorer_nico_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -850,7 +1030,7 @@ func (x *ExploredEndpointList) String() string {
 func (*ExploredEndpointList) ProtoMessage() {}
 
 func (x *ExploredEndpointList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[8]
+	mi := &file_site_explorer_nico_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -863,7 +1043,7 @@ func (x *ExploredEndpointList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredEndpointList.ProtoReflect.Descriptor instead.
 func (*ExploredEndpointList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{8}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ExploredEndpointList) GetEndpoints() []*ExploredEndpoint {
@@ -881,7 +1061,7 @@ type ExploredManagedHostSearchFilter struct {
 
 func (x *ExploredManagedHostSearchFilter) Reset() {
 	*x = ExploredManagedHostSearchFilter{}
-	mi := &file_site_explorer_nico_proto_msgTypes[9]
+	mi := &file_site_explorer_nico_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -893,7 +1073,7 @@ func (x *ExploredManagedHostSearchFilter) String() string {
 func (*ExploredManagedHostSearchFilter) ProtoMessage() {}
 
 func (x *ExploredManagedHostSearchFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[9]
+	mi := &file_site_explorer_nico_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -906,7 +1086,7 @@ func (x *ExploredManagedHostSearchFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredManagedHostSearchFilter.ProtoReflect.Descriptor instead.
 func (*ExploredManagedHostSearchFilter) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{9}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{11}
 }
 
 type ExploredManagedHostIdList struct {
@@ -919,7 +1099,7 @@ type ExploredManagedHostIdList struct {
 
 func (x *ExploredManagedHostIdList) Reset() {
 	*x = ExploredManagedHostIdList{}
-	mi := &file_site_explorer_nico_proto_msgTypes[10]
+	mi := &file_site_explorer_nico_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -931,7 +1111,7 @@ func (x *ExploredManagedHostIdList) String() string {
 func (*ExploredManagedHostIdList) ProtoMessage() {}
 
 func (x *ExploredManagedHostIdList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[10]
+	mi := &file_site_explorer_nico_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -944,7 +1124,7 @@ func (x *ExploredManagedHostIdList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredManagedHostIdList.ProtoReflect.Descriptor instead.
 func (*ExploredManagedHostIdList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{10}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ExploredManagedHostIdList) GetHostIds() []string {
@@ -964,7 +1144,7 @@ type ExploredManagedHostsByIdsRequest struct {
 
 func (x *ExploredManagedHostsByIdsRequest) Reset() {
 	*x = ExploredManagedHostsByIdsRequest{}
-	mi := &file_site_explorer_nico_proto_msgTypes[11]
+	mi := &file_site_explorer_nico_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -976,7 +1156,7 @@ func (x *ExploredManagedHostsByIdsRequest) String() string {
 func (*ExploredManagedHostsByIdsRequest) ProtoMessage() {}
 
 func (x *ExploredManagedHostsByIdsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[11]
+	mi := &file_site_explorer_nico_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -989,7 +1169,7 @@ func (x *ExploredManagedHostsByIdsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredManagedHostsByIdsRequest.ProtoReflect.Descriptor instead.
 func (*ExploredManagedHostsByIdsRequest) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{11}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ExploredManagedHostsByIdsRequest) GetHostIds() []string {
@@ -1008,7 +1188,7 @@ type ExploredManagedHostList struct {
 
 func (x *ExploredManagedHostList) Reset() {
 	*x = ExploredManagedHostList{}
-	mi := &file_site_explorer_nico_proto_msgTypes[12]
+	mi := &file_site_explorer_nico_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1020,7 +1200,7 @@ func (x *ExploredManagedHostList) String() string {
 func (*ExploredManagedHostList) ProtoMessage() {}
 
 func (x *ExploredManagedHostList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[12]
+	mi := &file_site_explorer_nico_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1033,7 +1213,7 @@ func (x *ExploredManagedHostList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredManagedHostList.ProtoReflect.Descriptor instead.
 func (*ExploredManagedHostList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{12}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ExploredManagedHostList) GetManagedHosts() []*ExploredManagedHost {
@@ -1078,7 +1258,7 @@ type ExploredMlxDevice struct {
 
 func (x *ExploredMlxDevice) Reset() {
 	*x = ExploredMlxDevice{}
-	mi := &file_site_explorer_nico_proto_msgTypes[13]
+	mi := &file_site_explorer_nico_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1090,7 +1270,7 @@ func (x *ExploredMlxDevice) String() string {
 func (*ExploredMlxDevice) ProtoMessage() {}
 
 func (x *ExploredMlxDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[13]
+	mi := &file_site_explorer_nico_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1103,7 +1283,7 @@ func (x *ExploredMlxDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredMlxDevice.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDevice) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{13}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ExploredMlxDevice) GetHostBmcIp() string {
@@ -1185,7 +1365,7 @@ type ExploredMlxDeviceList struct {
 
 func (x *ExploredMlxDeviceList) Reset() {
 	*x = ExploredMlxDeviceList{}
-	mi := &file_site_explorer_nico_proto_msgTypes[14]
+	mi := &file_site_explorer_nico_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1197,7 +1377,7 @@ func (x *ExploredMlxDeviceList) String() string {
 func (*ExploredMlxDeviceList) ProtoMessage() {}
 
 func (x *ExploredMlxDeviceList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[14]
+	mi := &file_site_explorer_nico_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1210,7 +1390,7 @@ func (x *ExploredMlxDeviceList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredMlxDeviceList.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDeviceList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{14}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ExploredMlxDeviceList) GetDevices() []*ExploredMlxDevice {
@@ -1230,7 +1410,7 @@ type ExploredMlxDeviceHostSearchFilter struct {
 
 func (x *ExploredMlxDeviceHostSearchFilter) Reset() {
 	*x = ExploredMlxDeviceHostSearchFilter{}
-	mi := &file_site_explorer_nico_proto_msgTypes[15]
+	mi := &file_site_explorer_nico_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1242,7 +1422,7 @@ func (x *ExploredMlxDeviceHostSearchFilter) String() string {
 func (*ExploredMlxDeviceHostSearchFilter) ProtoMessage() {}
 
 func (x *ExploredMlxDeviceHostSearchFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[15]
+	mi := &file_site_explorer_nico_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1255,7 +1435,7 @@ func (x *ExploredMlxDeviceHostSearchFilter) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ExploredMlxDeviceHostSearchFilter.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDeviceHostSearchFilter) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{15}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{17}
 }
 
 type ExploredMlxDeviceHostIdList struct {
@@ -1268,7 +1448,7 @@ type ExploredMlxDeviceHostIdList struct {
 
 func (x *ExploredMlxDeviceHostIdList) Reset() {
 	*x = ExploredMlxDeviceHostIdList{}
-	mi := &file_site_explorer_nico_proto_msgTypes[16]
+	mi := &file_site_explorer_nico_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1280,7 +1460,7 @@ func (x *ExploredMlxDeviceHostIdList) String() string {
 func (*ExploredMlxDeviceHostIdList) ProtoMessage() {}
 
 func (x *ExploredMlxDeviceHostIdList) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[16]
+	mi := &file_site_explorer_nico_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1293,7 +1473,7 @@ func (x *ExploredMlxDeviceHostIdList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredMlxDeviceHostIdList.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDeviceHostIdList) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{16}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ExploredMlxDeviceHostIdList) GetHostIds() []string {
@@ -1313,7 +1493,7 @@ type ExploredMlxDevicesByIdsRequest struct {
 
 func (x *ExploredMlxDevicesByIdsRequest) Reset() {
 	*x = ExploredMlxDevicesByIdsRequest{}
-	mi := &file_site_explorer_nico_proto_msgTypes[17]
+	mi := &file_site_explorer_nico_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1325,7 +1505,7 @@ func (x *ExploredMlxDevicesByIdsRequest) String() string {
 func (*ExploredMlxDevicesByIdsRequest) ProtoMessage() {}
 
 func (x *ExploredMlxDevicesByIdsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[17]
+	mi := &file_site_explorer_nico_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1338,7 +1518,7 @@ func (x *ExploredMlxDevicesByIdsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploredMlxDevicesByIdsRequest.ProtoReflect.Descriptor instead.
 func (*ExploredMlxDevicesByIdsRequest) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{17}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ExploredMlxDevicesByIdsRequest) GetHostIds() []string {
@@ -1357,7 +1537,7 @@ type ComputerSystemAttributes struct {
 
 func (x *ComputerSystemAttributes) Reset() {
 	*x = ComputerSystemAttributes{}
-	mi := &file_site_explorer_nico_proto_msgTypes[18]
+	mi := &file_site_explorer_nico_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1369,7 +1549,7 @@ func (x *ComputerSystemAttributes) String() string {
 func (*ComputerSystemAttributes) ProtoMessage() {}
 
 func (x *ComputerSystemAttributes) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[18]
+	mi := &file_site_explorer_nico_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1382,7 +1562,7 @@ func (x *ComputerSystemAttributes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComputerSystemAttributes.ProtoReflect.Descriptor instead.
 func (*ComputerSystemAttributes) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{18}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ComputerSystemAttributes) GetNicMode() NicMode {
@@ -1410,7 +1590,7 @@ type ComputerSystem struct {
 
 func (x *ComputerSystem) Reset() {
 	*x = ComputerSystem{}
-	mi := &file_site_explorer_nico_proto_msgTypes[19]
+	mi := &file_site_explorer_nico_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1422,7 +1602,7 @@ func (x *ComputerSystem) String() string {
 func (*ComputerSystem) ProtoMessage() {}
 
 func (x *ComputerSystem) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[19]
+	mi := &file_site_explorer_nico_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1435,7 +1615,7 @@ func (x *ComputerSystem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComputerSystem.ProtoReflect.Descriptor instead.
 func (*ComputerSystem) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{19}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ComputerSystem) GetId() string {
@@ -1512,7 +1692,7 @@ type Manager struct {
 
 func (x *Manager) Reset() {
 	*x = Manager{}
-	mi := &file_site_explorer_nico_proto_msgTypes[20]
+	mi := &file_site_explorer_nico_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1524,7 +1704,7 @@ func (x *Manager) String() string {
 func (*Manager) ProtoMessage() {}
 
 func (x *Manager) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[20]
+	mi := &file_site_explorer_nico_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1537,7 +1717,7 @@ func (x *Manager) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Manager.ProtoReflect.Descriptor instead.
 func (*Manager) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{20}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Manager) GetId() string {
@@ -1569,7 +1749,7 @@ type EthernetInterface struct {
 
 func (x *EthernetInterface) Reset() {
 	*x = EthernetInterface{}
-	mi := &file_site_explorer_nico_proto_msgTypes[21]
+	mi := &file_site_explorer_nico_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1581,7 +1761,7 @@ func (x *EthernetInterface) String() string {
 func (*EthernetInterface) ProtoMessage() {}
 
 func (x *EthernetInterface) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[21]
+	mi := &file_site_explorer_nico_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1594,7 +1774,7 @@ func (x *EthernetInterface) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EthernetInterface.ProtoReflect.Descriptor instead.
 func (*EthernetInterface) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{21}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *EthernetInterface) GetId() string {
@@ -1647,7 +1827,7 @@ type Chassis struct {
 
 func (x *Chassis) Reset() {
 	*x = Chassis{}
-	mi := &file_site_explorer_nico_proto_msgTypes[22]
+	mi := &file_site_explorer_nico_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1659,7 +1839,7 @@ func (x *Chassis) String() string {
 func (*Chassis) ProtoMessage() {}
 
 func (x *Chassis) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[22]
+	mi := &file_site_explorer_nico_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1672,7 +1852,7 @@ func (x *Chassis) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Chassis.ProtoReflect.Descriptor instead.
 func (*Chassis) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{22}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Chassis) GetId() string {
@@ -1731,7 +1911,7 @@ type NetworkAdapter struct {
 
 func (x *NetworkAdapter) Reset() {
 	*x = NetworkAdapter{}
-	mi := &file_site_explorer_nico_proto_msgTypes[23]
+	mi := &file_site_explorer_nico_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1743,7 +1923,7 @@ func (x *NetworkAdapter) String() string {
 func (*NetworkAdapter) ProtoMessage() {}
 
 func (x *NetworkAdapter) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[23]
+	mi := &file_site_explorer_nico_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1756,7 +1936,7 @@ func (x *NetworkAdapter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkAdapter.ProtoReflect.Descriptor instead.
 func (*NetworkAdapter) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{23}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *NetworkAdapter) GetId() string {
@@ -1805,7 +1985,7 @@ type Service struct {
 
 func (x *Service) Reset() {
 	*x = Service{}
-	mi := &file_site_explorer_nico_proto_msgTypes[24]
+	mi := &file_site_explorer_nico_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1817,7 +1997,7 @@ func (x *Service) String() string {
 func (*Service) ProtoMessage() {}
 
 func (x *Service) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[24]
+	mi := &file_site_explorer_nico_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1830,7 +2010,7 @@ func (x *Service) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Service.ProtoReflect.Descriptor instead.
 func (*Service) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{24}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *Service) GetId() string {
@@ -1860,7 +2040,7 @@ type Inventory struct {
 
 func (x *Inventory) Reset() {
 	*x = Inventory{}
-	mi := &file_site_explorer_nico_proto_msgTypes[25]
+	mi := &file_site_explorer_nico_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1872,7 +2052,7 @@ func (x *Inventory) String() string {
 func (*Inventory) ProtoMessage() {}
 
 func (x *Inventory) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[25]
+	mi := &file_site_explorer_nico_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1885,7 +2065,7 @@ func (x *Inventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Inventory.ProtoReflect.Descriptor instead.
 func (*Inventory) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{25}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Inventory) GetId() string {
@@ -1927,7 +2107,7 @@ type MachineSetupStatus struct {
 
 func (x *MachineSetupStatus) Reset() {
 	*x = MachineSetupStatus{}
-	mi := &file_site_explorer_nico_proto_msgTypes[26]
+	mi := &file_site_explorer_nico_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1939,7 +2119,7 @@ func (x *MachineSetupStatus) String() string {
 func (*MachineSetupStatus) ProtoMessage() {}
 
 func (x *MachineSetupStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[26]
+	mi := &file_site_explorer_nico_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1952,7 +2132,7 @@ func (x *MachineSetupStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineSetupStatus.ProtoReflect.Descriptor instead.
 func (*MachineSetupStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{26}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *MachineSetupStatus) GetIsDone() bool {
@@ -1981,7 +2161,7 @@ type MachineSetupDiff struct {
 
 func (x *MachineSetupDiff) Reset() {
 	*x = MachineSetupDiff{}
-	mi := &file_site_explorer_nico_proto_msgTypes[27]
+	mi := &file_site_explorer_nico_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1993,7 +2173,7 @@ func (x *MachineSetupDiff) String() string {
 func (*MachineSetupDiff) ProtoMessage() {}
 
 func (x *MachineSetupDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[27]
+	mi := &file_site_explorer_nico_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2006,7 +2186,7 @@ func (x *MachineSetupDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineSetupDiff.ProtoReflect.Descriptor instead.
 func (*MachineSetupDiff) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{27}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *MachineSetupDiff) GetKey() string {
@@ -2047,7 +2227,7 @@ type PCIeDevice struct {
 
 func (x *PCIeDevice) Reset() {
 	*x = PCIeDevice{}
-	mi := &file_site_explorer_nico_proto_msgTypes[28]
+	mi := &file_site_explorer_nico_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2059,7 +2239,7 @@ func (x *PCIeDevice) String() string {
 func (*PCIeDevice) ProtoMessage() {}
 
 func (x *PCIeDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[28]
+	mi := &file_site_explorer_nico_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2072,7 +2252,7 @@ func (x *PCIeDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PCIeDevice.ProtoReflect.Descriptor instead.
 func (*PCIeDevice) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{28}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PCIeDevice) GetDescription() string {
@@ -2149,7 +2329,7 @@ type SystemStatus struct {
 
 func (x *SystemStatus) Reset() {
 	*x = SystemStatus{}
-	mi := &file_site_explorer_nico_proto_msgTypes[29]
+	mi := &file_site_explorer_nico_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2161,7 +2341,7 @@ func (x *SystemStatus) String() string {
 func (*SystemStatus) ProtoMessage() {}
 
 func (x *SystemStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[29]
+	mi := &file_site_explorer_nico_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2174,7 +2354,7 @@ func (x *SystemStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemStatus.ProtoReflect.Descriptor instead.
 func (*SystemStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{29}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *SystemStatus) GetHealth() string {
@@ -2207,7 +2387,7 @@ type BootOrder struct {
 
 func (x *BootOrder) Reset() {
 	*x = BootOrder{}
-	mi := &file_site_explorer_nico_proto_msgTypes[30]
+	mi := &file_site_explorer_nico_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2219,7 +2399,7 @@ func (x *BootOrder) String() string {
 func (*BootOrder) ProtoMessage() {}
 
 func (x *BootOrder) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[30]
+	mi := &file_site_explorer_nico_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2232,7 +2412,7 @@ func (x *BootOrder) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootOrder.ProtoReflect.Descriptor instead.
 func (*BootOrder) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{30}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *BootOrder) GetBootOrder() []*BootOption {
@@ -2254,7 +2434,7 @@ type BootOption struct {
 
 func (x *BootOption) Reset() {
 	*x = BootOption{}
-	mi := &file_site_explorer_nico_proto_msgTypes[31]
+	mi := &file_site_explorer_nico_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2266,7 +2446,7 @@ func (x *BootOption) String() string {
 func (*BootOption) ProtoMessage() {}
 
 func (x *BootOption) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[31]
+	mi := &file_site_explorer_nico_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2279,7 +2459,7 @@ func (x *BootOption) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootOption.ProtoReflect.Descriptor instead.
 func (*BootOption) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{31}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *BootOption) GetDisplayName() string {
@@ -2319,7 +2499,7 @@ type SecureBootStatus struct {
 
 func (x *SecureBootStatus) Reset() {
 	*x = SecureBootStatus{}
-	mi := &file_site_explorer_nico_proto_msgTypes[32]
+	mi := &file_site_explorer_nico_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2331,7 +2511,7 @@ func (x *SecureBootStatus) String() string {
 func (*SecureBootStatus) ProtoMessage() {}
 
 func (x *SecureBootStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[32]
+	mi := &file_site_explorer_nico_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2344,7 +2524,7 @@ func (x *SecureBootStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecureBootStatus.ProtoReflect.Descriptor instead.
 func (*SecureBootStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{32}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *SecureBootStatus) GetIsEnabled() bool {
@@ -2365,7 +2545,7 @@ type LockdownStatus struct {
 
 func (x *LockdownStatus) Reset() {
 	*x = LockdownStatus{}
-	mi := &file_site_explorer_nico_proto_msgTypes[33]
+	mi := &file_site_explorer_nico_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2377,7 +2557,7 @@ func (x *LockdownStatus) String() string {
 func (*LockdownStatus) ProtoMessage() {}
 
 func (x *LockdownStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[33]
+	mi := &file_site_explorer_nico_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2390,7 +2570,7 @@ func (x *LockdownStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockdownStatus.ProtoReflect.Descriptor instead.
 func (*LockdownStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{33}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *LockdownStatus) GetStatus() InternalLockdownStatus {
@@ -2456,10 +2636,33 @@ const file_site_explorer_nico_proto_rawDesc = "" +
 	"dpu_bmc_ip\x18\x02 \x01(\tR\bdpuBmcIp\x122\n" +
 	"\x13host_pf_mac_address\x18\x03 \x01(\tH\x00R\x10hostPfMacAddress\x88\x01\x01\x12.\n" +
 	"\x04dpus\x18\v \x03(\v2\x1a.site_explorer.ExploredDpuR\x04dpusB\x16\n" +
-	"\x14_host_pf_mac_address\"\x9f\x01\n" +
+	"\x14_host_pf_mac_address\"\xf0\x01\n" +
 	"\x15SiteExplorationReport\x12=\n" +
 	"\tendpoints\x18\x01 \x03(\v2\x1f.site_explorer.ExploredEndpointR\tendpoints\x12G\n" +
-	"\rmanaged_hosts\x18\x02 \x03(\v2\".site_explorer.ExploredManagedHostR\fmanagedHosts\"\x1e\n" +
+	"\rmanaged_hosts\x18\x02 \x03(\v2\".site_explorer.ExploredManagedHostR\fmanagedHosts\x12B\n" +
+	"\blast_run\x18\x03 \x01(\v2\".site_explorer.SiteExplorerLastRunH\x00R\alastRun\x88\x01\x01B\v\n" +
+	"\t_last_run\"n\n" +
+	"\x1bSiteExplorerLastRunResponse\x12B\n" +
+	"\blast_run\x18\x01 \x01(\v2\".site_explorer.SiteExplorerLastRunH\x00R\alastRun\x88\x01\x01B\v\n" +
+	"\t_last_run\"\xd0\x04\n" +
+	"\x13SiteExplorerLastRun\x12\x1d\n" +
+	"\n" +
+	"started_at\x18\x01 \x01(\tR\tstartedAt\x12\x1f\n" +
+	"\vfinished_at\x18\x02 \x01(\tR\n" +
+	"finishedAt\x12\x18\n" +
+	"\asuccess\x18\x03 \x01(\bR\asuccess\x12\x19\n" +
+	"\x05error\x18\x04 \x01(\tH\x00R\x05error\x88\x01\x01\x123\n" +
+	"\x15endpoint_explorations\x18\x05 \x01(\x03R\x14endpointExplorations\x12B\n" +
+	"\x1dendpoint_explorations_success\x18\x06 \x01(\x03R\x1bendpointExplorationsSuccess\x12@\n" +
+	"\x1cendpoint_explorations_failed\x18\a \x01(\x03R\x1aendpointExplorationsFailed\x12.\n" +
+	"\x10failure_category\x18\b \x01(\tH\x01R\x0ffailureCategory\x88\x01\x01\x12B\n" +
+	"\x1blast_successful_finished_at\x18\t \x01(\tH\x02R\x18lastSuccessfulFinishedAt\x88\x01\x01\x12:\n" +
+	"\x17last_failed_finished_at\x18\n" +
+	" \x01(\tH\x03R\x14lastFailedFinishedAt\x88\x01\x01B\b\n" +
+	"\x06_errorB\x13\n" +
+	"\x11_failure_categoryB\x1e\n" +
+	"\x1c_last_successful_finished_atB\x1a\n" +
+	"\x18_last_failed_finished_at\"\x1e\n" +
 	"\x1cExploredEndpointSearchFilter\";\n" +
 	"\x16ExploredEndpointIdList\x12!\n" +
 	"\fendpoint_ids\x18\x01 \x03(\tR\vendpointIds\"B\n" +
@@ -2666,7 +2869,7 @@ func file_site_explorer_nico_proto_rawDescGZIP() []byte {
 }
 
 var file_site_explorer_nico_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_site_explorer_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_site_explorer_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_site_explorer_nico_proto_goTypes = []any{
 	(MlxDeviceKind)(0),                        // 0: site_explorer.MlxDeviceKind
 	(NicMode)(0),                              // 1: site_explorer.NicMode
@@ -2677,75 +2880,79 @@ var file_site_explorer_nico_proto_goTypes = []any{
 	(*ExploredDpu)(nil),                       // 6: site_explorer.ExploredDpu
 	(*ExploredManagedHost)(nil),               // 7: site_explorer.ExploredManagedHost
 	(*SiteExplorationReport)(nil),             // 8: site_explorer.SiteExplorationReport
-	(*ExploredEndpointSearchFilter)(nil),      // 9: site_explorer.ExploredEndpointSearchFilter
-	(*ExploredEndpointIdList)(nil),            // 10: site_explorer.ExploredEndpointIdList
-	(*ExploredEndpointsByIdsRequest)(nil),     // 11: site_explorer.ExploredEndpointsByIdsRequest
-	(*ExploredEndpointList)(nil),              // 12: site_explorer.ExploredEndpointList
-	(*ExploredManagedHostSearchFilter)(nil),   // 13: site_explorer.ExploredManagedHostSearchFilter
-	(*ExploredManagedHostIdList)(nil),         // 14: site_explorer.ExploredManagedHostIdList
-	(*ExploredManagedHostsByIdsRequest)(nil),  // 15: site_explorer.ExploredManagedHostsByIdsRequest
-	(*ExploredManagedHostList)(nil),           // 16: site_explorer.ExploredManagedHostList
-	(*ExploredMlxDevice)(nil),                 // 17: site_explorer.ExploredMlxDevice
-	(*ExploredMlxDeviceList)(nil),             // 18: site_explorer.ExploredMlxDeviceList
-	(*ExploredMlxDeviceHostSearchFilter)(nil), // 19: site_explorer.ExploredMlxDeviceHostSearchFilter
-	(*ExploredMlxDeviceHostIdList)(nil),       // 20: site_explorer.ExploredMlxDeviceHostIdList
-	(*ExploredMlxDevicesByIdsRequest)(nil),    // 21: site_explorer.ExploredMlxDevicesByIdsRequest
-	(*ComputerSystemAttributes)(nil),          // 22: site_explorer.ComputerSystemAttributes
-	(*ComputerSystem)(nil),                    // 23: site_explorer.ComputerSystem
-	(*Manager)(nil),                           // 24: site_explorer.Manager
-	(*EthernetInterface)(nil),                 // 25: site_explorer.EthernetInterface
-	(*Chassis)(nil),                           // 26: site_explorer.Chassis
-	(*NetworkAdapter)(nil),                    // 27: site_explorer.NetworkAdapter
-	(*Service)(nil),                           // 28: site_explorer.Service
-	(*Inventory)(nil),                         // 29: site_explorer.Inventory
-	(*MachineSetupStatus)(nil),                // 30: site_explorer.MachineSetupStatus
-	(*MachineSetupDiff)(nil),                  // 31: site_explorer.MachineSetupDiff
-	(*PCIeDevice)(nil),                        // 32: site_explorer.PCIeDevice
-	(*SystemStatus)(nil),                      // 33: site_explorer.SystemStatus
-	(*BootOrder)(nil),                         // 34: site_explorer.BootOrder
-	(*BootOption)(nil),                        // 35: site_explorer.BootOption
-	(*SecureBootStatus)(nil),                  // 36: site_explorer.SecureBootStatus
-	(*LockdownStatus)(nil),                    // 37: site_explorer.LockdownStatus
-	nil,                                       // 38: site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
-	(*durationpb.Duration)(nil),               // 39: google.protobuf.Duration
+	(*SiteExplorerLastRunResponse)(nil),       // 9: site_explorer.SiteExplorerLastRunResponse
+	(*SiteExplorerLastRun)(nil),               // 10: site_explorer.SiteExplorerLastRun
+	(*ExploredEndpointSearchFilter)(nil),      // 11: site_explorer.ExploredEndpointSearchFilter
+	(*ExploredEndpointIdList)(nil),            // 12: site_explorer.ExploredEndpointIdList
+	(*ExploredEndpointsByIdsRequest)(nil),     // 13: site_explorer.ExploredEndpointsByIdsRequest
+	(*ExploredEndpointList)(nil),              // 14: site_explorer.ExploredEndpointList
+	(*ExploredManagedHostSearchFilter)(nil),   // 15: site_explorer.ExploredManagedHostSearchFilter
+	(*ExploredManagedHostIdList)(nil),         // 16: site_explorer.ExploredManagedHostIdList
+	(*ExploredManagedHostsByIdsRequest)(nil),  // 17: site_explorer.ExploredManagedHostsByIdsRequest
+	(*ExploredManagedHostList)(nil),           // 18: site_explorer.ExploredManagedHostList
+	(*ExploredMlxDevice)(nil),                 // 19: site_explorer.ExploredMlxDevice
+	(*ExploredMlxDeviceList)(nil),             // 20: site_explorer.ExploredMlxDeviceList
+	(*ExploredMlxDeviceHostSearchFilter)(nil), // 21: site_explorer.ExploredMlxDeviceHostSearchFilter
+	(*ExploredMlxDeviceHostIdList)(nil),       // 22: site_explorer.ExploredMlxDeviceHostIdList
+	(*ExploredMlxDevicesByIdsRequest)(nil),    // 23: site_explorer.ExploredMlxDevicesByIdsRequest
+	(*ComputerSystemAttributes)(nil),          // 24: site_explorer.ComputerSystemAttributes
+	(*ComputerSystem)(nil),                    // 25: site_explorer.ComputerSystem
+	(*Manager)(nil),                           // 26: site_explorer.Manager
+	(*EthernetInterface)(nil),                 // 27: site_explorer.EthernetInterface
+	(*Chassis)(nil),                           // 28: site_explorer.Chassis
+	(*NetworkAdapter)(nil),                    // 29: site_explorer.NetworkAdapter
+	(*Service)(nil),                           // 30: site_explorer.Service
+	(*Inventory)(nil),                         // 31: site_explorer.Inventory
+	(*MachineSetupStatus)(nil),                // 32: site_explorer.MachineSetupStatus
+	(*MachineSetupDiff)(nil),                  // 33: site_explorer.MachineSetupDiff
+	(*PCIeDevice)(nil),                        // 34: site_explorer.PCIeDevice
+	(*SystemStatus)(nil),                      // 35: site_explorer.SystemStatus
+	(*BootOrder)(nil),                         // 36: site_explorer.BootOrder
+	(*BootOption)(nil),                        // 37: site_explorer.BootOption
+	(*SecureBootStatus)(nil),                  // 38: site_explorer.SecureBootStatus
+	(*LockdownStatus)(nil),                    // 39: site_explorer.LockdownStatus
+	nil,                                       // 40: site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
+	(*durationpb.Duration)(nil),               // 41: google.protobuf.Duration
 }
 var file_site_explorer_nico_proto_depIdxs = []int32{
-	39, // 0: site_explorer.EndpointExplorationReport.last_exploration_latency:type_name -> google.protobuf.Duration
-	24, // 1: site_explorer.EndpointExplorationReport.managers:type_name -> site_explorer.Manager
-	23, // 2: site_explorer.EndpointExplorationReport.systems:type_name -> site_explorer.ComputerSystem
-	26, // 3: site_explorer.EndpointExplorationReport.chassis:type_name -> site_explorer.Chassis
-	28, // 4: site_explorer.EndpointExplorationReport.service:type_name -> site_explorer.Service
-	30, // 5: site_explorer.EndpointExplorationReport.machine_setup_status:type_name -> site_explorer.MachineSetupStatus
-	36, // 6: site_explorer.EndpointExplorationReport.secure_boot_status:type_name -> site_explorer.SecureBootStatus
-	37, // 7: site_explorer.EndpointExplorationReport.lockdown_status:type_name -> site_explorer.LockdownStatus
-	38, // 8: site_explorer.EndpointExplorationReport.firmware_versions:type_name -> site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
+	41, // 0: site_explorer.EndpointExplorationReport.last_exploration_latency:type_name -> google.protobuf.Duration
+	26, // 1: site_explorer.EndpointExplorationReport.managers:type_name -> site_explorer.Manager
+	25, // 2: site_explorer.EndpointExplorationReport.systems:type_name -> site_explorer.ComputerSystem
+	28, // 3: site_explorer.EndpointExplorationReport.chassis:type_name -> site_explorer.Chassis
+	30, // 4: site_explorer.EndpointExplorationReport.service:type_name -> site_explorer.Service
+	32, // 5: site_explorer.EndpointExplorationReport.machine_setup_status:type_name -> site_explorer.MachineSetupStatus
+	38, // 6: site_explorer.EndpointExplorationReport.secure_boot_status:type_name -> site_explorer.SecureBootStatus
+	39, // 7: site_explorer.EndpointExplorationReport.lockdown_status:type_name -> site_explorer.LockdownStatus
+	40, // 8: site_explorer.EndpointExplorationReport.firmware_versions:type_name -> site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
 	4,  // 9: site_explorer.ExploredEndpoint.report:type_name -> site_explorer.EndpointExplorationReport
 	6,  // 10: site_explorer.ExploredManagedHost.dpus:type_name -> site_explorer.ExploredDpu
 	5,  // 11: site_explorer.SiteExplorationReport.endpoints:type_name -> site_explorer.ExploredEndpoint
 	7,  // 12: site_explorer.SiteExplorationReport.managed_hosts:type_name -> site_explorer.ExploredManagedHost
-	5,  // 13: site_explorer.ExploredEndpointList.endpoints:type_name -> site_explorer.ExploredEndpoint
-	7,  // 14: site_explorer.ExploredManagedHostList.managed_hosts:type_name -> site_explorer.ExploredManagedHost
-	0,  // 15: site_explorer.ExploredMlxDevice.device_kind:type_name -> site_explorer.MlxDeviceKind
-	1,  // 16: site_explorer.ExploredMlxDevice.nic_mode:type_name -> site_explorer.NicMode
-	17, // 17: site_explorer.ExploredMlxDeviceList.devices:type_name -> site_explorer.ExploredMlxDevice
-	1,  // 18: site_explorer.ComputerSystemAttributes.nic_mode:type_name -> site_explorer.NicMode
-	22, // 19: site_explorer.ComputerSystem.attributes:type_name -> site_explorer.ComputerSystemAttributes
-	25, // 20: site_explorer.ComputerSystem.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
-	32, // 21: site_explorer.ComputerSystem.pcie_devices:type_name -> site_explorer.PCIeDevice
-	2,  // 22: site_explorer.ComputerSystem.power_state:type_name -> site_explorer.ComputerSystemPowerState
-	34, // 23: site_explorer.ComputerSystem.boot_order:type_name -> site_explorer.BootOrder
-	25, // 24: site_explorer.Manager.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
-	27, // 25: site_explorer.Chassis.network_adapters:type_name -> site_explorer.NetworkAdapter
-	29, // 26: site_explorer.Service.inventories:type_name -> site_explorer.Inventory
-	31, // 27: site_explorer.MachineSetupStatus.diffs:type_name -> site_explorer.MachineSetupDiff
-	33, // 28: site_explorer.PCIeDevice.status:type_name -> site_explorer.SystemStatus
-	35, // 29: site_explorer.BootOrder.boot_order:type_name -> site_explorer.BootOption
-	3,  // 30: site_explorer.LockdownStatus.status:type_name -> site_explorer.InternalLockdownStatus
-	31, // [31:31] is the sub-list for method output_type
-	31, // [31:31] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	10, // 13: site_explorer.SiteExplorationReport.last_run:type_name -> site_explorer.SiteExplorerLastRun
+	10, // 14: site_explorer.SiteExplorerLastRunResponse.last_run:type_name -> site_explorer.SiteExplorerLastRun
+	5,  // 15: site_explorer.ExploredEndpointList.endpoints:type_name -> site_explorer.ExploredEndpoint
+	7,  // 16: site_explorer.ExploredManagedHostList.managed_hosts:type_name -> site_explorer.ExploredManagedHost
+	0,  // 17: site_explorer.ExploredMlxDevice.device_kind:type_name -> site_explorer.MlxDeviceKind
+	1,  // 18: site_explorer.ExploredMlxDevice.nic_mode:type_name -> site_explorer.NicMode
+	19, // 19: site_explorer.ExploredMlxDeviceList.devices:type_name -> site_explorer.ExploredMlxDevice
+	1,  // 20: site_explorer.ComputerSystemAttributes.nic_mode:type_name -> site_explorer.NicMode
+	24, // 21: site_explorer.ComputerSystem.attributes:type_name -> site_explorer.ComputerSystemAttributes
+	27, // 22: site_explorer.ComputerSystem.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
+	34, // 23: site_explorer.ComputerSystem.pcie_devices:type_name -> site_explorer.PCIeDevice
+	2,  // 24: site_explorer.ComputerSystem.power_state:type_name -> site_explorer.ComputerSystemPowerState
+	36, // 25: site_explorer.ComputerSystem.boot_order:type_name -> site_explorer.BootOrder
+	27, // 26: site_explorer.Manager.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
+	29, // 27: site_explorer.Chassis.network_adapters:type_name -> site_explorer.NetworkAdapter
+	31, // 28: site_explorer.Service.inventories:type_name -> site_explorer.Inventory
+	33, // 29: site_explorer.MachineSetupStatus.diffs:type_name -> site_explorer.MachineSetupDiff
+	35, // 30: site_explorer.PCIeDevice.status:type_name -> site_explorer.SystemStatus
+	37, // 31: site_explorer.BootOrder.boot_order:type_name -> site_explorer.BootOption
+	3,  // 32: site_explorer.LockdownStatus.status:type_name -> site_explorer.InternalLockdownStatus
+	33, // [33:33] is the sub-list for method output_type
+	33, // [33:33] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_site_explorer_nico_proto_init() }
@@ -2756,23 +2963,26 @@ func file_site_explorer_nico_proto_init() {
 	file_site_explorer_nico_proto_msgTypes[0].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[2].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[3].OneofWrappers = []any{}
-	file_site_explorer_nico_proto_msgTypes[13].OneofWrappers = []any{}
-	file_site_explorer_nico_proto_msgTypes[18].OneofWrappers = []any{}
-	file_site_explorer_nico_proto_msgTypes[19].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[4].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[5].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[6].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[15].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[20].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[21].OneofWrappers = []any{}
-	file_site_explorer_nico_proto_msgTypes[22].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[23].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[24].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[25].OneofWrappers = []any{}
-	file_site_explorer_nico_proto_msgTypes[28].OneofWrappers = []any{}
-	file_site_explorer_nico_proto_msgTypes[29].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[27].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[30].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[31].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[33].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_site_explorer_nico_proto_rawDesc), len(file_site_explorer_nico_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   35,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/rest-api/workflow-schema/site-agent/workflows/v1/nico_nico.proto
+++ b/rest-api/workflow-schema/site-agent/workflows/v1/nico_nico.proto
@@ -286,6 +286,8 @@ service Forge {
   // Gets the latest Site Exploration report
   // DEPRECATED: use FindExploredEndpointIds, FindExploredEndpointsByIds and FindExploredManagedHostIds, FindExploredManagedHostsByIds instead
   rpc GetSiteExplorationReport(GetSiteExplorationRequest) returns (site_explorer.SiteExplorationReport);
+  // Gets metadata about the latest Site Explorer run without fetching endpoint rows.
+  rpc GetSiteExplorerLastRun(google.protobuf.Empty) returns (site_explorer.SiteExplorerLastRunResponse);
   // Clear the last known error for the BMC
   rpc ClearSiteExplorationError(ClearSiteExplorationErrorRequest) returns (google.protobuf.Empty);
   // IsBmcInManagedHost returns true if a Host+DPU pair that includes the endpoint has been identified
@@ -3937,6 +3939,7 @@ message ExpireDhcpLeaseRequest {
 enum ExpireDhcpLeaseStatus {
   EXPIRE_DHCP_LEASE_STATUS_RELEASED = 0;
   EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND = 1;
+  EXPIRE_DHCP_LEASE_STATUS_FEATURE_DISABLED = 2;
 }
 
 message ExpireDhcpLeaseResponse {

--- a/rest-api/workflow-schema/site-agent/workflows/v1/site_explorer_nico.proto
+++ b/rest-api/workflow-schema/site-agent/workflows/v1/site_explorer_nico.proto
@@ -93,6 +93,36 @@ message SiteExplorationReport {
   repeated ExploredEndpoint endpoints = 1;
   // The managed-hosts which have been explored
   repeated ExploredManagedHost managed_hosts = 2;
+  // Metadata about the latest site explorer run
+  optional SiteExplorerLastRun last_run = 3;
+}
+
+message SiteExplorerLastRunResponse {
+  // Metadata about the latest site explorer run, if site explorer has run
+  optional SiteExplorerLastRun last_run = 1;
+}
+
+message SiteExplorerLastRun {
+  // When the run started
+  string started_at = 1;
+  // When the run finished
+  string finished_at = 2;
+  // Whether the run completed successfully
+  bool success = 3;
+  // Error string for a failed run
+  optional string error = 4;
+  // Number of endpoint exploration attempts made during the run
+  int64 endpoint_explorations = 5;
+  // Number of successful endpoint explorations during the run
+  int64 endpoint_explorations_success = 6;
+  // Number of endpoint exploration errors during the run
+  int64 endpoint_explorations_failed = 7;
+  // Failure category for a failed run
+  optional string failure_category = 8;
+  // When the most recent successful run finished
+  optional string last_successful_finished_at = 9;
+  // When the most recent failed run finished
+  optional string last_failed_finished_at = 10;
 }
 
 message ExploredEndpointSearchFilter {


### PR DESCRIPTION
## Description

Require each instance type to declare at least one `machineCapabilities` entry. This prevents instance types with no provider-supplied capability constraints from being created or updated.

This change:

- rejects omitted or empty desired capabilities in API Core `CreateInstanceType` and `UpdateInstanceType` requests;
- requires a non-empty `machineCapabilities` list when creating an instance type through REST;
- preserves partial REST updates that omit the field, while rejecting an explicitly empty list;
- marks the REST/OpenAPI contract and generated standard SDK models as requiring machine capabilities where applicable;
- adds Core and REST model/handler coverage for missing and empty capability lists; and
- regenerates the checked-in REST protobuf bindings and synchronizes the generated Core metrics reference.

## Related issues

Closes #2350

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [x] **This PR contains breaking changes**

`CreateInstanceType` callers and REST `POST /v2/org/{org}/nico/instance/type` clients must now provide a non-empty `machineCapabilities` list. Direct API Core updates must also include desired capabilities; REST partial updates may omit the field but cannot provide an empty list. Generated REST SDK constructors now require capabilities where the OpenAPI contract does.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Passed in GitHub CI:

- Core `test-release-container-services`, including the database-backed instance-type coverage
- REST `Lint and Test / Test (api)`, including model and handler coverage for missing and empty capabilities
- REST OpenAPI lint and breaking-change checks
- REST generated-file and protobuf-generated-code checks
- `core-ci-pass` and `rest-ci-pass`

## Additional Notes

The OpenAPI breaking-change allowlist records the intentional contract changes: `machineCapabilities` is required and has a minimum of one item for instance-type creation, and an explicitly supplied list on update must also contain at least one item.

The REST generated protobuf snapshots on `main` were already stale for the Site Explorer change from #2591 and the DHCP lease status enum change from #2877. The regeneration commit includes that deterministic baseline; all protobuf-generated files were produced by `cargo make --no-workspace generate-rest-core-proto`, not edited by hand.

The `carbide_site_explorer_last_run_status` row in `docs/observability/core_metrics.md` is emitted by the existing Core metrics-doc generator and predates this behavior change.
