### PR TITLE
chore: remove unused pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    integration: marks integration tests which are slow and require root


### PR DESCRIPTION
`pytest.ini` only declared an `integration` marker that is not referenced anywhere in the repo. There is no other pytest configuration that points at it. Removing the dead config.