### PR TITLE
Provide more robust command to capture successful calls to confirm gRPC is up

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -354,8 +354,8 @@ kubectl get pods -n temporal            # Temporal
 ### Verify That the Site-agent Is Connected
 
 ```bash
-kubectl logs -n nico-rest -l app.kubernetes.io/name=nico-rest-site-agent --prefix \
-    | grep "NicoClient"
+kubectl logs -n nico-rest -l app.kubernetes.io/name=nico-rest-site-agent --prefix --tail=-1 \
+  | grep -E "Successfully connected to server|method=/forge.Forge/Version, code=Ok|gRPC client is not connected to the server"
 ```
 
 Look for the "successfully connected to server" message in the logs.


### PR DESCRIPTION
This PR updates the command to capture "successfully connected" logs from the nico-rest-site-agent to confirm that gRPC is working correctly.

## Related issues
None

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

