### PR TITLE
docs(design): DPU Extension Service DPF Helm Chart type

### DIFF
--- a/docs/design/dpf-helm-chart-extension-services.md
+++ b/docs/design/dpf-helm-chart-extension-services.md
@@ -1,0 +1,652 @@
+- Feature Name: dpf-helm-chart-extension-services
+- Design Start: 1-July-2026
+- Github Issue: [#3103](https://github.com/NVIDIA/infra-controller/issues/3103)
+
+# Summary
+
+[summary]: #summary
+
+Today, extension services are deployed as local static pods by the DPU agent. That works for `KUBERNETES_POD`, but it does not use DPF's service lifecycle. For DPF-based sites, we want tenant-created extension services to be installed through DPF and then only run on the DPUs when tenant attaches them to instances.
+
+This design adds a new DPU Extension Service type called `DPF_HELM_CHART`. The main idea is:
+
+- A user creates a versioned extension service with a Helm chart reference and values.
+- NICo installs that version once into each compatible shared `DPUDeployment`.
+- The service does not run anywhere yet.
+- When an instance attaches that service version, NICo adds a generated Node label to the selected `DPUDevice`s.
+- DPF propagates that label into the DPU cluster.
+- The chart's DaemonSet uses that label to run only on the selected DPU Nodes.
+
+This keeps the existing extension-service API and lifecycle model, but moves the actual DPF Helm service reconciliation into the Site Controller.
+
+Existing `KUBERNETES_POD` behavior should not change.
+
+# Goals
+
+- preserve the existing tenant-facing extension-service workflow;
+- install a versioned Helm service once in each compatible shared DPUDeployment;
+- activate that version only on DPUs selected for instances that request it;
+- support private chart and image registries without exposing credentials;
+- report per-DPU status through the existing instance status and lifecycle gates; and
+- make create, attach, detach, and delete idempotent and recoverable.
+
+The initial release does not support:
+
+- arbitrary or unreviewed Helm charts;
+- `DPUServiceInterface`, `DPUServiceNAD`, service-chain, PF, VF, or SF creation;
+- BFB or DPUFlavor changes;
+- disruptive Node Effects;
+
+# Design Details
+
+[implementation]: #implementation
+
+This feature depends on the "Add Labels & Annotations from DPUDevic to V1.Node object for DPU" feature from DPF. See this [feature](https://redmine.mellanox.com/issues/4885907).
+
+## RPC Change
+
+### Service type
+
+Add the enum value in forge.proto gRPC message:
+
+```proto
+enum DpuExtensionServiceType {
+  KUBERNETES_POD = 0;
+  DPF_HELM_CHART = 1;
+}
+```
+
+The service type is immutable after creation.
+
+### Create and update requests
+
+```proto
+message CreateDpuExtensionServiceRequest {
+  // ===================== EXISTING FIELDS =========================
+  // Metadata
+  optional string service_id = 1; // If not provided, a new UUID will be generated
+  string service_name = 2;
+  optional string description = 3;
+  DpuExtensionServiceType service_type = 4; // Immutable
+
+  string tenant_organization_id = 5; // Immutable
+
+  // Versioned extension service spec
+  string data = 6;
+  optional DpuExtensionServiceCredential credential = 7;
+
+  // Metrics configuration to be added to the existing
+  // metrics collection service that runs on the DPU.
+  optional DpuExtensionServiceObservability observability = 8;
+
+  // ===================== NEW FIELD ===============================
+  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 9;
+}
+```
+
+#### Data
+
+The existing `data` field remains the immutable, type-specific payload. This preserves the current gRPC, REST, Temporal, and database model.
+
+For a `DPF_HELM_CHART` extension service, the tenant supplies `data` field as a JSON object containing the required chart definition. For example:
+```json
+{
+  "repoURL": "oci://registry.example.com/charts",
+  "chart": "tenant-chart",
+  "chartVersion": "1.2.3",
+  "imageRegistries": ["registry.example.com"],
+  "values": {
+    "image": {
+      "repository": "registry.example.com/tenant/repo",
+      "tag": "1.2.3"
+    },
+    "service": {
+      "logLevel": "info"
+    }
+  }
+}
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `repoURL` | Yes | Helm repo URL used by DPF / Argo CD. |
+| `chart` | Yes | Chart name in the repo. |
+| `chartVersion` | Yes | Pinned chart version.  |
+| `imageRegistries` | No | List of registries that need image pull credentials. |
+| `values` | No | Chart-specific Helm values for this immutable version. |
+
+The tenant-supplied chart source and `values` belong in `DPUServiceTemplate` because they define the reusable service version. In the initial implementation, no tenant field maps into `DPUServiceConfiguration`. NICo creates the configuration because DPUDeployment requires both a template and a configuration, and sets only the generated `deploymentServiceName` and `upgradePolicy.applyNodeEffect: false` there. This keeps deployment policy under NICo control and prevents configuration values from overriding the protected template values.
+
+NICo also generates the release name, DPF object names, placement selector, and image-pull Secret names. The selector and Secret name are merged into the template Helm values after validating that the tenant did not provide those reserved paths. They are intentionally absent from the tenant schema.
+
+NOTE: A Helm chart acceptable for this feature must first satisfy the DPF requirements described in [DPUService Helm Chart](https://gitlab-master.nvidia.com/doca-platform-foundation/doca-platform-foundation/-/blob/main/docs/public/developer-guides/services/dpuservice-development.md?ref_type=heads#dpuservice-helm-chart). Those requirements define the baseline chart contract needed for DPF to render and manage the service correctly.
+
+In addition to the DPF contract, NICo requires the chart to expose an `additionalNodeSelector`. The chart must support this value, but the tenant must not provide it in `data.values`. `additionalNodeSelector` is a NICo-reserved value: during reconciliation, NICo generates and injects the selector that limits the workload to DPU Nodes associated with instances to which the extension service is attached. Validation rejects a request whose tenant-supplied `values` contains `additionalNodeSelector`, preventing a tenant from weakening or replacing NICo's placement constraint.
+
+#### Credentials
+
+`DPF_HELM_CHART` type requires this new field because one helm chart may require a chart-repository credential and multiple credentials for image registries.
+
+The old single `credential` field is enough for `KUBERNETES_POD`, but Helm services may need more than one credential:
+- one chart repository credential
+- zero or more image registry credentials
+
+Therefore, a new field `dpf_helm_chart_credentials` is added to `CreateDpuExtensionServiceRequest` and a purpose field is added to `DpuExtensionServiceCredential`.
+
+```proto
+enum DpuExtensionServiceCredentialPurpose {
+  DPU_EXTENSION_SERVICE_CREDENTIAL_PURPOSE_UNSPECIFIED = 0;
+  DPU_EXTENSION_SERVICE_CREDENTIAL_PURPOSE_IMAGE_REGISTRY = 1;
+  DPU_EXTENSION_SERVICE_CREDENTIAL_PURPOSE_CHART_REPOSITORY = 2;
+}
+
+message DpuExtensionServiceCredential {
+  // ===================== EXISTING FIELDS =========================
+  string registry_url = 1;
+
+  oneof type {
+    UsernamePassword username_password = 2;
+  }
+
+  // ===================== NEW FIELD ===============================
+  DpuExtensionServiceCredentialPurpose purpose = 3;
+}
+
+message CreateDpuExtensionServiceRequest {
+  // Fields 1-8 unchanged, including legacy optional credential = 7
+  // ===================== NEW FIELD ===============================
+  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 9;
+}
+
+message UpdateDpuExtensionServiceRequest {
+  // fields 1-7 unchanged, including legacy optional credential = 5
+  // ===================== NEW FIELD ===============================
+  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 8;
+}
+```
+
+- `credential` is still only for `KUBERNETES_POD`.
+- `dpf_helm_chart_credentials` is only for `DPF_HELM_CHART`.
+- Supplying both is invalid.
+- A chart repo credential must match `data.repoURL`.
+- Image registry credentials must match `data.imageRegistries`.
+- Credentials are write-only. Read APIs only expose `has_credential`.
+
+#### Request Validation
+
+The API should reject the create request if:
+- the tenant, service name, service type, or version checks fail;
+- `data` is not valid JSON or has unknown top-level fields;
+- `repoURL` is not `https://` or `oci://`, has embedded credentials, or is not allowed by site config;
+- `chartVersion` is not pinned;
+- `values` is too large or tries to set NICo-owned paths;
+- credential purpose, endpoint, or duplicate checks fail.
+
+The API does not download or render the chart in the request path. Chart review is an admin process. That process should run DPF schema validation, `helm lint`, rendered-resource review, privilege review, and a test for the NICo placement contract before the chart is added to the allow-list.
+
+### Version deployment status
+
+Creating a DPF Helm service version is asynchronous. A successful create API call means only that NICo validated and persisted the version; it does not mean the service has been added to the selected `DPUDeployment` objects or accepted by DPF.
+
+Because of this, we need a version-level deployment status separate from the `InstanceDpuExtensionServiceStatus`. The `InstanceDpuExtensionServiceStatus` is aboue what happens after a version is attached to an instance. It tracks things like placement label propagation and whether the workload is ready on selected DPU. The version deployment status, on the other hand, tracks whether NICo has successfully registered the reusable service with DPF. This means NICo has reconciled the `DPUServiceTemplate`, `DPUServiceConfiguration`, and related Secrets, added them to every compatible `DPUDeployment.spec.services`, and DPF has accepted the current generated DPUService.
+
+To support this, extend the existing protobuf message `DpuExtensionServiceVersionInfo` with an optional deployment status that includes a state and a redacted message.
+
+For this status, `READY` means the service version is available to attach through its selected DPUDeployments. It does not mean that a workload Pod is already running on any DPU. The field is populated only for `DPF_HELM_CHART`, and older clients ignore it.
+
+```proto
+enum DpuExtensionServiceVersionDeploymentState {
+  DPU_EXTENSION_SERVICE_VERSION_DEPLOYMENT_UNSPECIFIED = 0;
+  DPU_EXTENSION_SERVICE_VERSION_ACCEPTED = 1;
+  DPU_EXTENSION_SERVICE_VERSION_DEPLOYING = 2;
+  DPU_EXTENSION_SERVICE_VERSION_READY = 3;
+  DPU_EXTENSION_SERVICE_VERSION_ERROR = 4;
+  DPU_EXTENSION_SERVICE_VERSION_DELETING = 5;
+}
+
+message DpuExtensionServiceVersionDeploymentStatus {
+  DpuExtensionServiceVersionDeploymentState state = 1;
+  string message = 2;
+}
+
+message DpuExtensionServiceVersionInfo {
+  // Fields 1-5 unchanged
+
+  // ===================== NEW FIELD ===============================
+  optional DpuExtensionServiceVersionDeploymentStatus deployment_status = 6;
+}
+```
+
+## Database Changes
+
+The existing tables `extension_services` and `extension_service_versions` still store the service and immutable version data.
+
+Two new DPF-specific tables are introduced: `dpf_extension_service_reconciliations` and `dpf_extension_service_attachments`.
+
+### `dpf_extension_service_reconciliations`
+
+One row per `DPF_HELM_CHART` service version. This table is the durable work item for the controller. 
+The API inserts it in the same transaction as the version and uses `id` as the State Controller object ID. The initial values are `desired_state = 'ACTIVE'`, `deployment_state = 'ACCEPTED'`, and `next_reconcile_at = CURRENT_TIMESTAMP`.
+
+```sql
+CREATE TABLE dpf_extension_service_reconciliations (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    service_id           UUID NOT NULL,
+    service_version      VARCHAR(64) NOT NULL,
+
+    dpf_service_name     VARCHAR(63) NOT NULL,
+
+    desired_state        VARCHAR(16) NOT NULL DEFAULT 'ACTIVE',
+
+    deployment_state     VARCHAR(16) NOT NULL DEFAULT 'ACCEPTED',
+    status_message       VARCHAR(2048),
+
+    reconcile_attempts   INTEGER NOT NULL DEFAULT 0,
+    last_attempted_at    TIMESTAMPTZ,
+    last_observed_at     TIMESTAMPTZ,
+    next_reconcile_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    cleanup_completed_at TIMESTAMPTZ,
+
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT dpf_extension_service_reconciliations_version_fk
+        FOREIGN KEY (service_id, service_version)
+        REFERENCES extension_service_versions (service_id, version),
+    CONSTRAINT dpf_extension_service_reconciliations_version_unique
+        UNIQUE (service_id, service_version),
+    CONSTRAINT dpf_extension_service_reconciliations_name_unique
+        UNIQUE (dpf_service_name),
+    CONSTRAINT dpf_extension_service_reconciliations_desired_state_check
+        CHECK (desired_state IN ('ACTIVE', 'DELETING')),
+    CONSTRAINT dpf_extension_service_reconciliations_deployment_state_check
+        CHECK (deployment_state IN (
+            'ACCEPTED', 'DEPLOYING', 'READY', 'ERROR', 'DELETING'
+        )),
+    CONSTRAINT dpf_extension_service_reconciliations_attempts_check
+        CHECK (reconcile_attempts >= 0),
+    CONSTRAINT dpf_extension_service_reconciliations_cleanup_check
+        CHECK (
+            cleanup_completed_at IS NULL
+            OR desired_state = 'DELETING'
+        )
+);
+
+CREATE INDEX dpf_extension_service_reconciliations_due_idx
+    ON dpf_extension_service_reconciliations
+       (next_reconcile_at, id)
+    WHERE cleanup_completed_at IS NULL;
+```
+
+`desired_state` is written by API create/delete operations. All other mutable fields are written by the controller. The controller increments `reconcile_attempts` and updates `last_attempted_at` when an attempt begins. After observing DPF it updates `deployment_state`, the bounded and redacted `status_message`, `last_observed_at`, `next_reconcile_at`, and `updated_at`. `READY` rows remain periodically scheduled to detect drift; transient failures use backoff. The due-row index supports periodic discovery and restart recovery, while the existing `WorkLockManager` prevents concurrent reconciliation of the same `id`.
+
+### `dpf_extension_service_attachments`
+
+One row per targeted DPU machine for an instance/service version.
+
+```sql
+CREATE TABLE dpf_extension_service_attachments (
+    instance_id                      UUID NOT NULL,
+    dpu_machine_id                   UUID NOT NULL,
+    service_id                       UUID NOT NULL,
+    service_version                  VARCHAR(64) NOT NULL,
+
+    extension_services_config_version VARCHAR(64) NOT NULL,
+    instance_config_version           VARCHAR(64),
+
+    placement_state                  VARCHAR(16) NOT NULL DEFAULT 'ACTIVE',
+    deployment_state                 VARCHAR(16) NOT NULL DEFAULT 'PENDING',
+    components                       JSONB NOT NULL DEFAULT '[]'::jsonb,
+    status_message                   VARCHAR(2048),
+    observed_at                      TIMESTAMPTZ,
+
+    created_at                       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT dpf_extension_service_attachments_pk
+        PRIMARY KEY (
+            instance_id,
+            dpu_machine_id,
+            service_id,
+            service_version
+        ),
+    CONSTRAINT dpf_extension_service_attachments_instance_fk
+        FOREIGN KEY (instance_id) REFERENCES instances (id),
+    CONSTRAINT dpf_extension_service_attachments_machine_fk
+        FOREIGN KEY (dpu_machine_id) REFERENCES machines (id),
+    CONSTRAINT dpf_extension_service_attachments_version_fk
+        FOREIGN KEY (service_id, service_version)
+        REFERENCES extension_service_versions (service_id, version),
+
+    CONSTRAINT dpf_extension_service_attachments_placement_check
+        CHECK (placement_state IN ('ACTIVE', 'REMOVING')),
+    CONSTRAINT dpf_extension_service_attachments_deployment_check
+        CHECK (deployment_state IN (
+            'PENDING', 'RUNNING', 'TERMINATING',
+            'TERMINATED', 'ERROR', 'UNKNOWN'
+        )),
+    CONSTRAINT dpf_extension_service_attachments_components_check
+        CHECK (jsonb_typeof(components) = 'array')
+);
+
+CREATE INDEX dpf_extension_service_attachments_version_idx
+    ON dpf_extension_service_attachments
+       (service_id, service_version, placement_state);
+
+CREATE INDEX dpf_extension_service_attachments_machine_idx
+    ON dpf_extension_service_attachments
+       (dpu_machine_id);
+```
+
+The controller inserts the row with `PENDING` before adding a label. It changes `deployment_state` only after observing the DPU, Node, and workload state. Detach or a selected-DPU-set change moves the row to `placement_state = 'REMOVING'`; the row remains until it reports `TERMINATED` and the corresponding instance-config tombstone is removed. The row can then be deleted. The foreign keys prevent the instance, DPU machine, or service version from being physically deleted while placement cleanup is still recorded.
+
+This table ensures detach and instance deletion remove labels from every DPU ever targeted, not only the current network configuration.
+
+We should not write DPF Helm observations into `machines.network_status_observation` as that is for `KUBERNETES_POD` type of extension service.
+
+## Create service workflow
+
+For `DPF_HELM_CHART` type services, `CreateDpuExtensionService` has a synchronous API phase and an asynchronous controller phase. The API validates and persists an immutable version and its reconciliation row; the Site Controller then materializes that desired state in DPF. External Kubernetes and credential operations therefore remain retryable without holding the API request open.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as NICo API
+    participant Vault as CredentialManager
+    participant DB as PostgreSQL
+    participant C as DPF Extension Service Controller
+    participant DPF as DPF Management Cluster
+    participant K8s as DPU Kubernetes Cluster
+
+    User->>API: CreateDpuExtensionService(DPF_HELM_CHART)
+    API->>API: Parse, normalize, and validate
+    API->>Vault: Store chart/image credentials
+    API->>DB: Store service, version, and reconciliation row
+    API-->>User: Return version with ACCEPTED status
+
+    C->>DB: Claim reconciliation row and load version
+    C->>Vault: Read credentials
+    C->>DPF: Reconcile Secrets
+    C->>DPF: Apply Template and Configuration
+    C->>DPF: Add service to compatible DPUDeployments
+    DPF->>K8s: Create DaemonSet with unmatched placement selector
+    C->>DPF: Observe current-generation conditions
+    C->>DB: Persist DEPLOYING, READY, or ERROR
+```
+
+### API phase
+
+For a valid request, the API handler:
+
+1. Validates or creates the `ExtensionServiceId` and uses the initial `ConfigVersion` for the new service. When an update call is received, the API handler will use the next version.
+2. Parses `data` into the new `carbide_dpf::types::DpfHelmChartServiceData` model proposed above and serializes the normalized JSON.
+3. Validates and stores credentials using deterministic `CredentialManager` paths:
+   ```text
+   machines/extension-services/<service-id>/versions/<version>/chart-repository
+   machines/extension-services/<service-id>/versions/<version>/image-registries/<sha256-registry-url>
+   ```
+4. In one PostgreSQL transaction:
+   - inserts the `extension_services` record;
+   - inserts `extension_service_versions` with normalized JSON and `has_credential`;
+   - inserts a `dpf_extension_service_reconciliations` row with `desired_state = 'ACTIVE'` and `deployment_state = 'ACCEPTED'`; and
+   - reserves the deterministic DPF service name through that row's unique `dpf_service_name` constraint.
+5. Commits and enqueues the reconciliation `id`. Periodic due-row listing is the fallback if enqueueing is lost after commit.
+6. Returns the normal `DpuExtensionService` response.
+
+If the DB transaction fails after credentials were written, the handler should best-effort delete the credentials, following the existing compensation pattern.
+
+### Controller phase
+
+Following the existing controller pattern, add a `DpfExtensionServiceController` and start it from from `api-core::setup`. 
+
+The controller is responsible for reconciling DPF Helm service versions with the DPF management cluster. The API only validates and stores the desired state. The controller does the external work, so Kubernetes, DPF, Argo CD, and credential operations can be retried safely if something fails. Therefore, the controller operations should be idempotent. Re-running the same reconciliation should be safe, whether the previous attempt finished, partially finished, or failed in the middle.
+
+For each due row in `dpf_extension_service_reconciliations` with `desired_state = 'ACTIVE'`, the controller
+1. Acquires a lock keyed by the reconciliation `id`, then re-reads the row so a concurrent delete cannot be missed.
+2. Loads the service version, site DPF configuration, and purpose-qualified credentials.
+3. Sets `deployment_state = 'DEPLOYING'`, increments `reconcile_attempts`, and records `last_attempted_at`.
+4. Revalidates deployment availability, generated-object ownership, and DPUDeployment capacity.
+5. Reconciles chart-repository and image-pull Secrets.
+6. Applies the owned `DPUServiceTemplate` and `DPUServiceConfiguration`.
+7. Adds the service entry to every compatible shared DPUDeployment using conflict retries.
+8. Observes DPF and Argo CD conditions.
+9. Atomically persists `READY`, `DEPLOYING` with a retry time, or `ERROR` with a redacted message.
+
+The DPF service name and Node label are deterministic hashes of the full service UUID and version because the `DPUDeployment.spec.services` key and both `deploymentServiceName` fields are limited to 28 characters.
+- DPF service name: `ext-<20-character-base32-hash>`
+- Node label key: `carbide.nvidia.com/extsvc-<hash>`
+- Node label value: `enabled`
+
+#### Build DPF service resources
+
+NICo does not build a `DPUService` directly. The controller parses `extension_service_versions.data`, builds the owned `DPUServiceTemplate` and `DPUServiceConfiguration`, and adds references to them under `DPUDeployment.spec.services`. DPF then generates and reconciles the resulting `DPUService`.
+
+| Source | DPF destination |
+| --- | --- |
+| Generated service name | Template/configuration names, release name, both `deploymentServiceName` fields, and DPUDeployment service key |
+| `repoURL` | `DPUServiceTemplate.spec.helmChart.source.repoURL` |
+| `chart` | `DPUServiceTemplate.spec.helmChart.source.chart` |
+| `chartVersion` | `DPUServiceTemplate.spec.helmChart.source.version` |
+| Tenant `values` | Base of `DPUServiceTemplate.spec.helmChart.values` |
+| Generated label | `helmChart.values.additionalNodeSelector` |
+| Generated image Secret | Qualified chart's reserved `imagePullSecrets` value |
+| Constant `false` | `DPUServiceConfiguration.spec.upgradePolicy.applyNodeEffect` |
+
+For the example request, the generated resources are equivalent to:
+
+```yaml
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceTemplate
+metadata:
+  name: ext-abc123
+  namespace: dpf-operator-system
+  labels:
+    carbide.nvidia.com/extension-service-id: <service-uuid>
+    carbide.nvidia.com/extension-service-version: <config-version>
+spec:
+  deploymentServiceName: ext-abc123
+  helmChart:
+    source:
+      repoURL: oci://registry.example.com/charts
+      chart: tenant-chart
+      version: 1.2.3
+      releaseName: ext-abc123
+    values:
+      image:
+        repository: registry.example.com/tenant/repo
+        tag: 1.2.3
+      service:
+        logLevel: info
+      additionalNodeSelector:
+        carbide.nvidia.com/extsvc-abc123: enabled
+      imagePullSecrets:
+        - name: ext-abc123-pull
+---
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceConfiguration
+metadata:
+  name: ext-abc123
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: ext-abc123
+  upgradePolicy:
+    applyNodeEffect: false
+```
+
+For every supported deployment type, the controller resolves the configured DPUDeployment and merges only this entry:
+
+```yaml
+spec:
+  services:
+    ext-abc123:
+      serviceTemplate: ext-abc123
+      serviceConfiguration: ext-abc123
+```
+
+The update uses a resource-version precondition and conflict retry. It does not force-apply or replace the shared DPUDeployment. The controller re-reads the live object and enforces the CRD limit of 50 service entries before adding the key.
+
+#### Why create produces no workload Pod
+
+Creating the DPF resources makes the version available but does not attach it to an instance. A qualified chart combines:
+
+- DPF's `serviceDaemonSet.nodeSelector`, selecting Nodes belonging to the DPUDeployment; and
+- NICo's `additionalNodeSelector`, selecting Nodes belonging to instances requesting this version.
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      {{- toYaml .Values.serviceDaemonSet.nodeSelector | nindent 6 }}
+nodeSelector:
+  {{- toYaml .Values.additionalNodeSelector | nindent 2 }}
+```
+
+Before attachment, no DPU-cluster Node has the generated `carbide.nvidia.com/extsvc-*` label. A DaemonSet with no matching Nodes is therefore the expected post-create state, not a failure.
+
+## Attach service version workflow
+
+The existing RPC API continues to accept `(service_id, version)` entries through `InstanceDpuExtensionServicesConfig`. The API converts that protobuf message to the existing Rust model `InstanceExtensionServicesConfig`, stores it in `instances.extension_services_config`, and increments `instances.extension_services_config_version`.
+
+For each active `DPF_HELM_CHART` service version attachment, the controller:
+
+1. Uses the same `get_used_dpus` rule as the machine controller to find the instance's selected DPUs.
+2. Writes durable target rows before changing external state.
+3. Resolves each DPU machine ID to its DPUDevice and `DpuDeploymentType`.
+4. Verifies that the version supports that deployment type and that shared DPF resources have no blocking error.
+5. Checks the generated key against the selected DPUSet template's Node labels.
+6. Adds only the generated key/value to `DPUDevice.spec.k8scluster.nodeLabels`, preserving all other keys.
+7. Waits for DPF to copy the key to `DPU.spec.cluster.nodeLabels` and the corresponding DPU-cluster Node.
+8. Observes the current DaemonSet Pod on that Node and writes config-versioned status.
+
+`DPUDevice.spec.k8scluster.nodeLabels` is the name from the pending DPF API described in this design's dependency. It is not present in the currently vendored DPF CRD; the implementation must update the CRD and generated Rust type after DPF finalizes that field name and schema.
+
+## Status and instance lifecycle
+
+A shared DPUService/Argo CD Ready condition does not prove that a Pod is running on a particular DPU. Per-DPU state combines management-cluster readiness, label propagation, and DPU-cluster Pod readiness:
+
+- `PENDING`: shared resources are not current-generation Ready, propagation is incomplete, or no current-revision Pod is Ready on the target Node.
+- `RUNNING`: the DPU and Node have the desired label and a current-revision DaemonSet Pod is Ready on that Node.
+- `TERMINATING`: placement is being removed but a DPU/Node label or matching Pod remains.
+- `TERMINATED`: the labels are absent and no matching non-terminal Pod remains.
+- `ERROR`: validation, ownership, collision, capacity, credential, DPF, Argo CD, or workload state has a non-transient failure.
+- `UNKNOWN`: required state cannot be observed or the DPUDevice cannot be mapped to a Node.
+
+Instance status should keep the two observation sources separate:
+
+- DPU-agent observations for `KUBERNETES_POD`
+- DB-backed DPF observations for `DPF_HELM_CHART`
+
+## Update, detach, and delete workflows
+
+Updating service data or credentials creates a new immutable version and reconciliation row. Existing instances stay on the previous version until explicitly updated. During an instance version change, the old attachment is marked removed and the new attachment is active until the old one reaches `TERMINATED`.
+
+Detaching marks the attachment `removed`. The controller removes only that version's label from every DPUDevice it previously targeted, waits for labels and Pods to disappear, and reports `TERMINATED`. The machine controller then removes the tombstone without another config-version increment.
+
+Deleting a service version is allowed only when no active or terminating instance references it. In one transaction, the API sets `desired_state = 'DELETING'`, `deployment_state = 'DELETING'`, and `next_reconcile_at = CURRENT_TIMESTAMP` on its reconciliation row. Instance validation immediately rejects new attachments to that version. The version remains readable with deployment status `DELETING` while the controller:
+
+1. removes the service key from every compatible DPUDeployment;
+2. waits for generated DPUService and Argo CD workloads to disappear;
+3. deletes the owned configuration, template, and generated Secrets;
+4. deletes source credentials from `CredentialManager`; and
+5. sets `cleanup_completed_at`, soft-deletes the version, and soft-deletes the parent service if no active versions remain.
+
+Source credentials remain available until generated resources are removed. Every step is idempotent and retryable after restart or dependency failure.
+
+## Credential handling
+
+Credentials are stored through `CredentialManager`, not in PostgreSQL:
+
+```text
+machines/extension-services/<service-id>/versions/<version>/chart-repository
+machines/extension-services/<service-id>/versions/<version>/image-registries/<sha256-registry-url>
+```
+
+The secrets must not appear in any version data, helm values, logs etc.
+
+The controller builds:
+
+- an Argo CD repository Secret for the chart repo;
+- a `kubernetes.io/dockerconfigjson` Secret for image pulls.
+
+
+# Testing & QA
+
+[qa]: #qa
+
+Required tests include:
+
+- Migration tests for both new tables, including foreign keys, state checks, uniqueness, JSON-array validation, and due/version indexes.
+- Attachment-row grouping into `extension_services.dpf`, DPU-agent loading into `extension_services.dpu_agent`, service-type-based source selection, and matching/stale config-version handling.
+- API JSON normalization, required/unknown fields, limits, reserved paths, allow-list, deployment types, credential purposes, duplicate endpoints, and legacy/new field exclusivity.
+- Vault compensation when a database transaction fails.
+- Version deployment status transitions and cloud REST status mapping.
+- Exact input-to-DPUServiceTemplate/DPUServiceConfiguration mapping.
+- Safe concurrent mutation of shared DPUDeployments and DPUDevices.
+- BF3-only, BF4 Generic-only, and dual-compatible versions.
+- DPUDeployment capacity and generated-name/ownership collisions.
+- DPUDevice/DPUSet Node-label collision handling.
+- Private HTTPS/OCI chart and image pulls.
+- Create followed by immediate attach while shared resources are pending.
+- Multiple instances sharing one version and one instance changing versions.
+- Selected DPU-set changes without leaked labels or Pods.
+- Detach, instance deletion, and asynchronous version deletion.
+- Mixed `KUBERNETES_POD` and `DPF_HELM_CHART` config-version/status aggregation.
+- Restart and DPF, Argo CD, DPU-cluster, Vault, and database outage recovery.
+- No Node Effect, reboot, BFB/flavor change, reprovision, or readiness regression.
+- Existing `KUBERNETES_POD` regression tests.
+
+Definition of Done:
+
+- [ ] A qualified DPF Helm version can be created, attached, updated, detached, and deleted through existing workflows.
+- [ ] Workloads run only on selected DPUs for instances requesting that exact version.
+- [ ] Operations are idempotent and recover after restart or dependency failure.
+- [ ] Status correctly gates provisioning and deletion.
+- [ ] Credentials are encrypted, redacted, and finalized in dependency order.
+- [ ] Supported operations are non-disruptive.
+- [ ] Existing extension-service behavior remains backward compatible.
+
+# Operational Changes / Concerns
+
+[operations]: #operations
+
+The Site Controller needs management-cluster RBAC for DPUServiceTemplate, DPUServiceConfiguration, DPUService, DPUDeployment, DPUSet, DPU, DPUDevice, DPUCluster, and generated Secrets. DPU-cluster status access needs read-only permission for Nodes, Pods, DaemonSets, and ControllerRevisions.
+
+A DPUDeployment permits at most 50 service entries, including mandatory services and every retained extension-service version. Metrics and alerts cover remaining capacity, reconcile failures/latency, label propagation, Pod readiness, stuck attachments, and credential cleanup.
+
+Rollout order is DPF/CRD upgrade, NICo migrations with the controller disabled, chart qualification and RBAC, then site enablement and canary testing. Before rollback or disabling the controller, all DPF Helm attachments and versions must be removed so labels, resources, and Secrets are finalized.
+
+# Drawbacks and alternatives
+
+[drawbacks]: #drawbacks
+
+- The workflow depends on PostgreSQL, Vault, DPF, Argo CD, and the DPU cluster.
+- Every retained version consumes limited shared DPUDeployment capacity even while unattached.
+- Modifying a shared DPUDeployment has a wider control-plane blast radius than a local static Pod.
+- Charts implement both the DPF contract and NICo placement/image-pull values.
+- Accurate per-DPU status requires DPU-cluster access and stable identity labels.
+- Interfaces and disruptive service changes are not supported initially.
+
+Alternatives considered:
+
+- Keep only `KUBERNETES_POD`: simpler, but it bypasses DPF's service lifecycle.
+- Create a DPUDeployment per instance: gives natural placement but duplicates shared deployment, firmware, and flavor configuration.
+- Add/remove a shared service for every attachment: cannot target one instance's DPUs and creates unnecessary shared reconciliation and Node Effect risk.
+- Hard-code the placement key in a chart: prevents safe reuse across service IDs and versions.
+
+# Unresolved Questions
+
+[unresolved-questions]: #unresolved-questions
+
+- Which `repoURL` and chart pairs should be included in the initial administrative allow-list?
+- Which DPF release contains the final DPUDevice Node-label API, and what is its exact field/schema?
+- Does that release resolve the additional-selector readiness problem?
+- What stable label or API maps a DPU-cluster Node to its DPUDevice and a rendered DaemonSet to its DPUService?
+- Can DPF provide a least-privilege DPU-cluster observation kubeconfig instead of an admin kubeconfig?
+- Is one site-managed credential per normalized Helm repository URL acceptable for the first release?
+- Which charts, privileges, and image-signing policies are approved for the initial use case?
+
+# Future Possibilities
+
+[future-possibilities]: #future-possibilities
+
+Future work can add administrator-defined interface profiles, service chains, richer observability, additional credential types, signed-chart enforcement, and planned disruptive upgrades. Native DPF support for targeting a DPUService to a subset of a DPUDeployment could eventually replace the chart-specific additional selector.

--- a/docs/design/dpf-helm-chart-extension-services.md
+++ b/docs/design/dpf-helm-chart-extension-services.md
@@ -1,53 +1,105 @@
-- Feature Name: dpf-helm-chart-extension-services
-- Design Start: 1-July-2026
-- Github Issue: [#3103](https://github.com/NVIDIA/infra-controller/issues/3103)
+# DPU Extension Service Integration with DPF
 
-# Summary
+GitHub Issue: [#3103](https://github.com/NVIDIA/infra-controller/issues/3103)
 
-[summary]: #summary
+## 1. Revision History
 
-Today, extension services are deployed as local static pods by the DPU agent. That works for `KUBERNETES_POD`, but it does not use DPF's service lifecycle. For DPF-based sites, we want tenant-created extension services to be installed through DPF and then only run on the DPUs when tenant attaches them to instances.
+| Version |    Date    | Modified By | Description     |
+| :-----: | :--------: | :---------- | :-------------- |
+|   0.1   | 07/01/2026 | Felicity Xu | Initial version |
 
-This design adds a new DPU Extension Service type called `DPF_HELM_CHART`. The main idea is:
+## 2. Summary
 
-- A user creates a versioned extension service with a Helm chart reference and values.
-- NICo installs that version once into each compatible shared `DPUDeployment`.
-- The service does not run anywhere yet.
-- When an instance attaches that service version, NICo adds a generated Node label to the selected `DPUDevice`s.
-- DPF propagates that label into the DPU cluster.
-- The chart's DaemonSet uses that label to run only on the selected DPU Nodes.
+NICo currently supports DPU Extension Services of type `KUBERNETES_POD`. A `KUBERNETES_POD` service is attached to an instance, delivered to the instance's DPUs through `GetManagedHostNetworkConfig`, and deployed locally by the DPU agent as a static Kubernetes Pod.
 
-This keeps the existing extension-service API and lifecycle model, but moves the actual DPF Helm service reconciliation into the Site Controller.
+As NICo moves to DPF, extension services should use DPF instead of being deployed directly by the DPU agent. This design introduces `DPF_HELM_CHART` for versioned Helm services managed through DPF.
 
-Existing `KUBERNETES_POD` behavior should not change.
+A user creates a `DPF_HELM_CHART` service version with a Helm chart reference, values, and required credentials. The NICo Site Controller converts it into DPF resources, registers the service with `DPUDeployment` objects, and monitors deployment status.
 
-# Goals
+The feature is delivered in two stages:
+- **Stage 1 — `ALL_DPUS`:** the service is deployed to every DPU in each compatible `DPUDeployment`.
+- **Stage 2 — `INSTANCE_DPUS`:** the service is attached to an instance and deployed only to the DPUs used by that instance.
 
-- preserve the existing tenant-facing extension-service workflow;
-- install a versioned Helm service once in each compatible shared DPUDeployment;
-- activate that version only on DPUs selected for instances that request it;
-- support private chart and image registries without exposing credentials;
-- report per-DPU status through the existing instance status and lifecycle gates; and
-- make create, attach, detach, and delete idempotent and recoverable.
+Stage 1 is implemented first. Stage 2 depends on the "Propagating labels from `DPUDevice` to the corresponding `v1.node` object" feature from DPF team. Until that dependency is available, `INSTANCE_DPUS` service creation should be rejected.
 
-The initial release does not support:
+Existing `KUBERNETES_POD` behavior remains unchanged.
 
-- arbitrary or unreviewed Helm charts;
-- `DPUServiceInterface`, `DPUServiceNAD`, service-chain, PF, VF, or SF creation;
-- BFB or DPUFlavor changes;
-- disruptive Node Effects;
+## 3. API Model
 
-# Design Details
+### 3.1 Overall Changes
 
-[implementation]: #implementation
+The existing DPU Extension Service APIs are reused for `DPF_HELM_CHART`.
 
-This feature depends on the "Add Labels & Annotations from DPUDevic to V1.Node object for DPU" feature from DPF. See this [feature](https://redmine.mellanox.com/issues/4885907).
+The main API changes are:
+- add the `DPF_HELM_CHART` service type;
+- add an immutable deployment scope field for `DPF_HELM_CHART`;
+- retain the existing `data` field, but tenants need to provide a different, Helm-specific data format when creating a `DPF_HELM_CHART` version;
+- support multiple purpose-qualified credentials for each Helm service version; and
+- add asynchronous deployment status to service-version responses.
 
-## RPC Change
+```proto
+message CreateDpuExtensionServiceRequest {
+  optional string service_id = 1;
+  string service_name = 2;
+  optional string description = 3;
+  DpuExtensionServiceType service_type = 4;
+  string tenant_organization_id = 5;
 
-### Service type
+  // Immutable, service-type-specific specification for the initial version.
+  string data = 6;
 
-Add the enum value in forge.proto gRPC message:
+  // KUBERNETES_POD only.
+  optional DpuExtensionServiceCredential credential = 7;
+
+  optional DpuExtensionServiceObservability observability = 8;
+
+  // DPF_HELM_CHART only.
+  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 9;
+
+  // DPF_HELM_CHART only.
+  DpuExtensionServiceDeploymentScope deployment_scope = 10; // Defaults to ALL_DPUS.
+}
+
+message UpdateDpuExtensionServiceRequest {
+  string service_id = 1;
+
+  optional string service_name = 2;
+  optional string description = 3;
+
+  // Creates a new immutable service version.
+  string data = 4;
+
+  // KUBERNETES_POD only.
+  optional DpuExtensionServiceCredential credential = 5;
+
+  optional int32 if_version_ctr_match = 6;
+
+  optional DpuExtensionServiceObservability observability = 7;
+
+  // DPF_HELM_CHART only.
+  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 8;
+}
+
+message DpuExtensionService {
+  // Existing fields unchanged.
+
+  // Present only for DPF_HELM_CHART.
+  optional DpuExtensionServiceDeploymentScope deployment_scope = 11;
+}
+
+message DpuExtensionServiceVersionInfo {
+  // Existing fields unchanged.
+
+  // Present only for DPF_HELM_CHART.
+  optional DpuExtensionServiceVersionDeploymentStatus deployment_status = 6;
+}
+```
+
+`deployment_scope` is not included in `UpdateDpuExtensionServiceRequest` because it is immutable at the service level. Updating `data` or credentials creates a new immutable version with the same service type and deployment scope.
+
+### 3.2 Service Type
+
+Add a new extension service type:
 
 ```proto
 enum DpuExtensionServiceType {
@@ -56,48 +108,73 @@ enum DpuExtensionServiceType {
 }
 ```
 
-The service type is immutable after creation.
+The service type is immutable and determines how the workload is deployed and reconciled:
+- `KUBERNETES_POD` is delivered to the DPU and managed locally by the DPU agent through kubelet. This behavior is unchanged.
+- `DPF_HELM_CHART` is reconciled through DPF by the `ExtensionServiceReconciliationController`.
 
-### Create and update requests
+### 3.3 Deployment Scope
+
+Add `deployment_scope` to `CreateDpuExtensionServiceRequest` to describe where a `DPF_HELM_CHART` service runs.
 
 ```proto
-message CreateDpuExtensionServiceRequest {
-  // ===================== EXISTING FIELDS =========================
-  // Metadata
-  optional string service_id = 1; // If not provided, a new UUID will be generated
-  string service_name = 2;
-  optional string description = 3;
-  DpuExtensionServiceType service_type = 4; // Immutable
-
-  string tenant_organization_id = 5; // Immutable
-
-  // Versioned extension service spec
-  string data = 6;
-  optional DpuExtensionServiceCredential credential = 7;
-
-  // Metrics configuration to be added to the existing
-  // metrics collection service that runs on the DPU.
-  optional DpuExtensionServiceObservability observability = 8;
-
-  // ===================== NEW FIELD ===============================
-  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 9;
+enum DpuExtensionServiceDeploymentScope {
+  ALL_DPUS = 0;
+  INSTANCE_DPUS = 1;
 }
 ```
 
-#### Data
+Deployment scope applies only to `DPF_HELM_CHART`. For `KUBERNETES_POD`, the default zero value is ignored; existing instance configuration still determines deployment.
 
-The existing `data` field remains the immutable, type-specific payload. This preserves the current gRPC, REST, Temporal, and database model.
+For `DPF_HELM_CHART`, omission defaults to `ALL_DPUS`. The value is stored on the parent service and shared by all versions. There is no `UNSPECIFIED` value.
 
-For a `DPF_HELM_CHART` extension service, the tenant supplies `data` field as a JSON object containing the required chart definition. For example:
+Deployment scope cannot be changed by an update. A tenant that requires a different scope must create a new extension service.
+
+#### 3.3.1 `ALL_DPUS`
+
+`ALL_DPUS` is supported in Stage 1. When a service version is created, NICo adds it to every compatible shared `DPUDeployment`. DPF then deploys the workload to all DPUs selected by those deployments.
+
+An `ALL_DPUS` service:
+- is deployed automatically to all DPUs in every compatible `DPUDeployment` after creation;
+- is not attached to an instance;
+- must not be included in an instance's extension service configuration;
+- is rejected if referenced through `updateInstance`; and
+- reports deployment state at the service-version level.
+
+#### 3.3.2 `INSTANCE_DPUS`
+
+`INSTANCE_DPUS` is supported in Stage 2 as it requires the "Propagating labels from `DPUDevice` to the corresponding `v1.node` object" feature from DPF team. When a service version is created, NICo registers it with every compatible shared `DPUDeployment`, but injects a generated Node selector that initially matches no DPU. The version can therefore become ready for attachment without running a workload.
+
+When an instance references the version through `updateInstance`, NICo:
+
+1. determines which DPUs are selected by the instance;
+2. adds a generated label to the corresponding `DPUDevice` resources;
+3. waits for DPF to propagate the label to the corresponding Kubernetes Nodes; and
+4. observes the workload running on those Nodes.
+
+The workload runs only on DPUs selected by instances that reference that exact service version.
+
+`INSTANCE_DPUS` is accepted only after the site's Stage 2 capability is enabled. Until the required DPF Node-label propagation feature is available and configured, creation requests using this scope are rejected.
+
+### 3.4 Data: Helm Chart and Values
+
+The existing `data` field remains the immutable, service-type-specific payload for each extension service version.
+
+For `DPF_HELM_CHART`, tenants must provide `data` as a JSON object describing the Helm chart and values.
+
 ```json
 {
   "repoURL": "oci://registry.example.com/charts",
-  "chart": "tenant-chart",
+  "chart": "tenant-service",
   "chartVersion": "1.2.3",
-  "imageRegistries": ["registry.example.com"],
+  "deploymentTypes": [
+    "BF3"
+  ],
+  "imageRegistries": [
+    "registry.example.com"
+  ],
   "values": {
     "image": {
-      "repository": "registry.example.com/tenant/repo",
+      "repository": "registry.example.com/tenant/service",
       "tag": "1.2.3"
     },
     "service": {
@@ -107,31 +184,44 @@ For a `DPF_HELM_CHART` extension service, the tenant supplies `data` field as a 
 }
 ```
 
-| Field | Required | Meaning |
-| --- | --- | --- |
-| `repoURL` | Yes | Helm repo URL used by DPF / Argo CD. |
-| `chart` | Yes | Chart name in the repo. |
-| `chartVersion` | Yes | Pinned chart version.  |
-| `imageRegistries` | No | List of registries that need image pull credentials. |
-| `values` | No | Chart-specific Helm values for this immutable version. |
+| Field             | Required | Description                                             |
+| ----------------- | -------- | ------------------------------------------------------- |
+| `repoURL`         | Yes      | Approved HTTPS or OCI Helm repository URL.              |
+| `chart`           | Yes      | Qualified chart name.                                   |
+| `chartVersion`    | Yes      | Exact pinned chart version.                             |
+| `deploymentTypes` | Yes      | DPU deployment types supported by this version.         |
+| `imageRegistries` | No       | Image registries for which credentials may be supplied. |
+| `values`          | No       | Immutable chart-specific Helm values.                   |
 
-The tenant-supplied chart source and `values` belong in `DPUServiceTemplate` because they define the reusable service version. In the initial implementation, no tenant field maps into `DPUServiceConfiguration`. NICo creates the configuration because DPUDeployment requires both a template and a configuration, and sets only the generated `deploymentServiceName` and `upgradePolicy.applyNodeEffect: false` there. This keeps deployment policy under NICo control and prevents configuration values from overriding the protected template values.
+The API parses, validates, normalizes, and stores this JSON. Unknown top-level fields are rejected.
 
-NICo also generates the release name, DPF object names, placement selector, and image-pull Secret names. The selector and Secret name are merged into the template Helm values after validating that the tenant did not provide those reserved paths. They are intentionally absent from the tenant schema.
+`repoURL`, `chart`, and `chartVersion` are mapped into `DPUServiceTemplate.spec.helmChart.source`. Tenant-provided `values` form the base of `DPUServiceTemplate.spec.helmChart.values`.
 
-NOTE: A Helm chart acceptable for this feature must first satisfy the DPF requirements described in [DPUService Helm Chart](https://gitlab-master.nvidia.com/doca-platform-foundation/doca-platform-foundation/-/blob/main/docs/public/developer-guides/services/dpuservice-development.md?ref_type=heads#dpuservice-helm-chart). Those requirements define the baseline chart contract needed for DPF to render and manage the service correctly.
+NICo generates and owns values required for deployment and resource management, including:
 
-In addition to the DPF contract, NICo requires the chart to expose an `additionalNodeSelector`. The chart must support this value, but the tenant must not provide it in `data.values`. `additionalNodeSelector` is a NICo-reserved value: during reconciliation, NICo generates and injects the selector that limits the workload to DPU Nodes associated with instances to which the extension service is attached. Validation rejects a request whose tenant-supplied `values` contains `additionalNodeSelector`, preventing a tenant from weakening or replacing NICo's placement constraint.
+* DPF resource names;
+* Helm release name;
+* `deploymentServiceName`;
+* ownership labels;
+* image pull Secret names;
+* the Stage 2 `INSTANCE_DPUS` Node selector; and
+* `upgradePolicy.applyNodeEffect`.
 
-#### Credentials
+Tenant-provided values must not override NICo-owned fields. Reserved paths include:
+```text
+additionalNodeSelector
+imagePullSecrets
+```
 
-`DPF_HELM_CHART` type requires this new field because one helm chart may require a chart-repository credential and multiple credentials for image registries.
+The complete reserved path list is defined by the [qualified chart contract in Appendix A](#appendix-a).
 
-The old single `credential` field is enough for `KUBERNETES_POD`, but Helm services may need more than one credential:
-- one chart repository credential
-- zero or more image registry credentials
+### 3.5 Credentials
 
-Therefore, a new field `dpf_helm_chart_credentials` is added to `CreateDpuExtensionServiceRequest` and a purpose field is added to `DpuExtensionServiceCredential`.
+The existing singular `credential` field remains specific to `KUBERNETES_POD`.
+
+A `DPF_HELM_CHART` version may require more than one credential:
+- one credential for accessing the Helm chart repository; and
+- zero or more credentials for pulling container images.
 
 ```proto
 enum DpuExtensionServiceCredentialPurpose {
@@ -141,58 +231,25 @@ enum DpuExtensionServiceCredentialPurpose {
 }
 
 message DpuExtensionServiceCredential {
-  // ===================== EXISTING FIELDS =========================
   string registry_url = 1;
 
   oneof type {
     UsernamePassword username_password = 2;
   }
 
-  // ===================== NEW FIELD ===============================
   DpuExtensionServiceCredentialPurpose purpose = 3;
-}
-
-message CreateDpuExtensionServiceRequest {
-  // Fields 1-8 unchanged, including legacy optional credential = 7
-  // ===================== NEW FIELD ===============================
-  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 9;
-}
-
-message UpdateDpuExtensionServiceRequest {
-  // fields 1-7 unchanged, including legacy optional credential = 5
-  // ===================== NEW FIELD ===============================
-  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 8;
 }
 ```
 
-- `credential` is still only for `KUBERNETES_POD`.
-- `dpf_helm_chart_credentials` is only for `DPF_HELM_CHART`.
-- Supplying both is invalid.
-- A chart repo credential must match `data.repoURL`.
-- Image registry credentials must match `data.imageRegistries`.
-- Credentials are write-only. Read APIs only expose `has_credential`.
+Credentials are stored through `CredentialManager` and are write-only. Read APIs only report whether credentials exist for a version.
+```text
+machines/extension-services/<service-id>/versions/<version>/chart-repository
+machines/extension-services/<service-id>/versions/<version>/image-registries/<sha256-registry-url>
+```
 
-#### Request Validation
+### 3.6 Version Deployment Status
 
-The API should reject the create request if:
-- the tenant, service name, service type, or version checks fail;
-- `data` is not valid JSON or has unknown top-level fields;
-- `repoURL` is not `https://` or `oci://`, has embedded credentials, or is not allowed by site config;
-- `chartVersion` is not pinned;
-- `values` is too large or tries to set NICo-owned paths;
-- credential purpose, endpoint, or duplicate checks fail.
-
-The API does not download or render the chart in the request path. Chart review is an admin process. That process should run DPF schema validation, `helm lint`, rendered-resource review, privilege review, and a test for the NICo placement contract before the chart is added to the allow-list.
-
-### Version deployment status
-
-Creating a DPF Helm service version is asynchronous. A successful create API call means only that NICo validated and persisted the version; it does not mean the service has been added to the selected `DPUDeployment` objects or accepted by DPF.
-
-Because of this, we need a version-level deployment status separate from the `InstanceDpuExtensionServiceStatus`. The `InstanceDpuExtensionServiceStatus` is aboue what happens after a version is attached to an instance. It tracks things like placement label propagation and whether the workload is ready on selected DPU. The version deployment status, on the other hand, tracks whether NICo has successfully registered the reusable service with DPF. This means NICo has reconciled the `DPUServiceTemplate`, `DPUServiceConfiguration`, and related Secrets, added them to every compatible `DPUDeployment.spec.services`, and DPF has accepted the current generated DPUService.
-
-To support this, extend the existing protobuf message `DpuExtensionServiceVersionInfo` with an optional deployment status that includes a state and a redacted message.
-
-For this status, `READY` means the service version is available to attach through its selected DPUDeployments. It does not mean that a workload Pod is already running on any DPU. The field is populated only for `DPF_HELM_CHART`, and older clients ignore it.
+A successful create or update response means that NICo validated and stored the version. It does not mean that DPF resources or workloads are ready.
 
 ```proto
 enum DpuExtensionServiceVersionDeploymentState {
@@ -208,28 +265,61 @@ message DpuExtensionServiceVersionDeploymentStatus {
   DpuExtensionServiceVersionDeploymentState state = 1;
   string message = 2;
 }
-
-message DpuExtensionServiceVersionInfo {
-  // Fields 1-5 unchanged
-
-  // ===================== NEW FIELD ===============================
-  optional DpuExtensionServiceVersionDeploymentStatus deployment_status = 6;
-}
 ```
 
-## Database Changes
+The status is populated only for `DPF_HELM_CHART`.
 
-The existing tables `extension_services` and `extension_service_versions` still store the service and immutable version data.
+- For `ALL_DPUS`, `READY` means the service has been deployed through every compatible `DPUDeployment` and the required workload readiness conditions are satisfied.
+- For `INSTANCE_DPUS`, `READY` means the reusable service has been registered and is available for attachment. It does not mean that a workload is already running on a DPU.
 
-Two new DPF-specific tables are introduced: `dpf_extension_service_reconciliations` and `dpf_extension_service_attachments`.
+### 3.7 Request Validation
 
-### `dpf_extension_service_reconciliations`
+For `DPF_HELM_CHART`, the API rejects a create or update request when:
 
-One row per `DPF_HELM_CHART` service version. This table is the durable work item for the controller. 
-The API inserts it in the same transaction as the version and uses `id` as the State Controller object ID. The initial values are `desired_state = 'ACTIVE'`, `deployment_state = 'ACCEPTED'`, and `next_reconcile_at = CURRENT_TIMESTAMP`.
+* the deployment scope is invalid or is not enabled for the site;
+* `data` is not valid Helm service JSON;
+* required chart fields are missing;
+* the repository URL is unsupported or contains embedded credentials;
+* the chart version is not pinned;
+* tenant values override NICo-owned fields;
+* the wrong credential field is used;
+* credential purposes or endpoints do not match the chart data; or
+* duplicate credentials are provided.
+
+Implementation-specific limits, such as maximum value size and exact repository URL validation, are enforced by the API but are not specified in this design.
+
+The API validates the request against stored chart qualification and site configuration. It does not download, render, or install the Helm chart in the request path.
+
+## 4. Database Changes
+
+The existing `extension_services` and `extension_service_versions` tables continue to store extension service metadata and immutable version data.
+
+`DPF_HELM_CHART` adds two kinds of persistent state:
+- service-version reconciliation state for both scopes; and
+- per-instance, per-DPU attachment state for `INSTANCE_DPUS`.
+
+### 4.1 Extension Service Deployment Scope
+
+Deployment scope is stored on `extension_services` because it is immutable and shared by all versions of the service. The column remains `NULL` for `KUBERNETES_POD`.
 
 ```sql
-CREATE TABLE dpf_extension_service_reconciliations (
+ALTER TABLE extension_services
+    ADD COLUMN deployment_scope VARCHAR(32),
+    ADD CONSTRAINT extension_services_deployment_scope_check
+        CHECK (deployment_scope IS NULL OR
+               deployment_scope IN ('ALL_DPUS', 'INSTANCE_DPUS'));
+```
+
+Note:
+- When a `DPF_HELM_CHART` create request omits `deployment_scope`, the API stores `ALL_DPUS`.
+- During Stage 1, only `ALL_DPUS` services can be created. During Stage 2, the API may also create services with `INSTANCE_DPUS` after the site capability is enabled.
+
+### 4.2 Extension Service Version Reconciliation
+
+Create `extension_service_reconciliations` with one row for each `DPF_HELM_CHART` service version.
+
+```sql
+CREATE TABLE extension_service_reconciliations (
     id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     service_id           UUID NOT NULL,
     service_version      VARCHAR(64) NOT NULL,
@@ -237,7 +327,6 @@ CREATE TABLE dpf_extension_service_reconciliations (
     dpf_service_name     VARCHAR(63) NOT NULL,
 
     desired_state        VARCHAR(16) NOT NULL DEFAULT 'ACTIVE',
-
     deployment_state     VARCHAR(16) NOT NULL DEFAULT 'ACCEPTED',
     status_message       VARCHAR(2048),
 
@@ -250,135 +339,108 @@ CREATE TABLE dpf_extension_service_reconciliations (
     created_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    CONSTRAINT dpf_extension_service_reconciliations_version_fk
-        FOREIGN KEY (service_id, service_version)
+    FOREIGN KEY (service_id, service_version)
         REFERENCES extension_service_versions (service_id, version),
-    CONSTRAINT dpf_extension_service_reconciliations_version_unique
-        UNIQUE (service_id, service_version),
-    CONSTRAINT dpf_extension_service_reconciliations_name_unique
-        UNIQUE (dpf_service_name),
-    CONSTRAINT dpf_extension_service_reconciliations_desired_state_check
-        CHECK (desired_state IN ('ACTIVE', 'DELETING')),
-    CONSTRAINT dpf_extension_service_reconciliations_deployment_state_check
-        CHECK (deployment_state IN (
-            'ACCEPTED', 'DEPLOYING', 'READY', 'ERROR', 'DELETING'
-        )),
-    CONSTRAINT dpf_extension_service_reconciliations_attempts_check
-        CHECK (reconcile_attempts >= 0),
-    CONSTRAINT dpf_extension_service_reconciliations_cleanup_check
-        CHECK (
-            cleanup_completed_at IS NULL
-            OR desired_state = 'DELETING'
-        )
+    UNIQUE (service_id, service_version),
+    UNIQUE (dpf_service_name),
+    CHECK (desired_state IN ('ACTIVE', 'DELETING')),
+    CHECK (deployment_state IN
+        ('ACCEPTED', 'DEPLOYING', 'READY', 'ERROR', 'DELETING'))
 );
-
-CREATE INDEX dpf_extension_service_reconciliations_due_idx
-    ON dpf_extension_service_reconciliations
-       (next_reconcile_at, id)
-    WHERE cleanup_completed_at IS NULL;
 ```
 
-`desired_state` is written by API create/delete operations. All other mutable fields are written by the controller. The controller increments `reconcile_attempts` and updates `last_attempted_at` when an attempt begins. After observing DPF it updates `deployment_state`, the bounded and redacted `status_message`, `last_observed_at`, `next_reconcile_at`, and `updated_at`. `READY` rows remain periodically scheduled to detect drift; transient failures use backoff. The due-row index supports periodic discovery and restart recovery, while the existing `WorkLockManager` prevents concurrent reconciliation of the same `id`.
+The row is the durable work item for `ExtensionServiceReconciliationController` and stores the desired lifecycle state, current deployment state, generated DPF service name, and retry metadata. The API creates it in the same transaction as the immutable service version.
 
-### `dpf_extension_service_attachments`
+The table is used by both scopes:
 
-One row per targeted DPU machine for an instance/service version.
+- For `ALL_DPUS`, it tracks deployment of the version to every compatible DPUDeployment.
+- For `INSTANCE_DPUS`, it tracks registration of the reusable DPF service. Instance-specific state is stored in `extension_service_attachments`.
+
+### 4.3 Extension Service Instance Attachment
+
+Create `extension_service_attachments` with per-DPU state for `INSTANCE_DPUS`.
 
 ```sql
-CREATE TABLE dpf_extension_service_attachments (
-    instance_id                      UUID NOT NULL,
-    dpu_machine_id                   UUID NOT NULL,
-    service_id                       UUID NOT NULL,
-    service_version                  VARCHAR(64) NOT NULL,
+CREATE TABLE extension_service_attachments (
+    instance_id                       UUID NOT NULL,
+    dpu_machine_id                    UUID NOT NULL,
+    service_id                        UUID NOT NULL,
+    service_version                   VARCHAR(64) NOT NULL,
 
     extension_services_config_version VARCHAR(64) NOT NULL,
     instance_config_version           VARCHAR(64),
 
-    placement_state                  VARCHAR(16) NOT NULL DEFAULT 'ACTIVE',
-    deployment_state                 VARCHAR(16) NOT NULL DEFAULT 'PENDING',
-    components                       JSONB NOT NULL DEFAULT '[]'::jsonb,
-    status_message                   VARCHAR(2048),
-    observed_at                      TIMESTAMPTZ,
+    attachment_state                  VARCHAR(16) NOT NULL DEFAULT 'ACTIVE',
+    deployment_state                  VARCHAR(16) NOT NULL DEFAULT 'PENDING',
 
-    created_at                       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at                       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    components                        JSONB NOT NULL DEFAULT '[]'::jsonb,
+    status_message                    VARCHAR(2048),
+    observed_at                       TIMESTAMPTZ,
+    created_at                        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    CONSTRAINT dpf_extension_service_attachments_pk
-        PRIMARY KEY (
-            instance_id,
-            dpu_machine_id,
-            service_id,
-            service_version
-        ),
-    CONSTRAINT dpf_extension_service_attachments_instance_fk
-        FOREIGN KEY (instance_id) REFERENCES instances (id),
-    CONSTRAINT dpf_extension_service_attachments_machine_fk
-        FOREIGN KEY (dpu_machine_id) REFERENCES machines (id),
-    CONSTRAINT dpf_extension_service_attachments_version_fk
-        FOREIGN KEY (service_id, service_version)
-        REFERENCES extension_service_versions (service_id, version),
-
-    CONSTRAINT dpf_extension_service_attachments_placement_check
-        CHECK (placement_state IN ('ACTIVE', 'REMOVING')),
-    CONSTRAINT dpf_extension_service_attachments_deployment_check
-        CHECK (deployment_state IN (
-            'PENDING', 'RUNNING', 'TERMINATING',
-            'TERMINATED', 'ERROR', 'UNKNOWN'
-        )),
-    CONSTRAINT dpf_extension_service_attachments_components_check
-        CHECK (jsonb_typeof(components) = 'array')
+    CHECK (attachment_state IN ('ACTIVE', 'REMOVING')),
+    CHECK (deployment_state IN (
+        'PENDING',
+        'RUNNING',
+        'TERMINATING',
+        'TERMINATED',
+        'ERROR',
+        'UNKNOWN'
+    ))
 );
-
-CREATE INDEX dpf_extension_service_attachments_version_idx
-    ON dpf_extension_service_attachments
-       (service_id, service_version, placement_state);
-
-CREATE INDEX dpf_extension_service_attachments_machine_idx
-    ON dpf_extension_service_attachments
-       (dpu_machine_id);
 ```
 
-The controller inserts the row with `PENDING` before adding a label. It changes `deployment_state` only after observing the DPU, Node, and workload state. Detach or a selected-DPU-set change moves the row to `placement_state = 'REMOVING'`; the row remains until it reports `TERMINATED` and the corresponding instance-config tombstone is removed. The row can then be deleted. The foreign keys prevent the instance, DPU machine, or service version from being physically deleted while placement cleanup is still recorded.
+Each row begins in `PENDING` and is updated as NICo observes label propagation and workload state. On detach or a selected-DPU-set change, affected rows move to `REMOVING` until deployment labels and workloads are gone and the attachment reaches `TERMINATED`.
 
-This table ensures detach and instance deletion remove labels from every DPU ever targeted, not only the current network configuration.
+## 5. Architecture and Lifecycle
 
-We should not write DPF Helm observations into `machines.network_status_observation` as that is for `KUBERNETES_POD` type of extension service.
+### 5.1 Architecture Overview
 
-## Create service workflow
+The NICo API validates and stores each immutable `DPF_HELM_CHART` version. `ExtensionServiceReconciliationController`, running in the Site Controller, creates reusable DPF resources and registers them with compatible shared `DPUDeployment` objects.Deployment scope determines the resulting workload placement:
+- In Stage 1, an `ALL_DPUS` service is deployed immediately to all DPUs selected by compatible deployments.
+- In Stage 2, an `INSTANCE_DPUS` service initially matches no DPU. Deployment begins only when an instance references the version and NICo labels the instance's selected DPUs.
+DPF owns the Helm release and workload lifecycle. The controller observes DPF and workload state and stores the result in PostgreSQL.
 
-For `DPF_HELM_CHART` type services, `CreateDpuExtensionService` has a synchronous API phase and an asynchronous controller phase. The API validates and persists an immutable version and its reconciliation row; the Site Controller then materializes that desired state in DPF. External Kubernetes and credential operations therefore remain retryable without holding the API request open.
+`DPF_HELM_CHART` does not flow through the DPU agent. The DPU agent remains responsible only for `KUBERNETES_POD`.
+
+### 5.2 Service Version Creation
 
 ```mermaid
 sequenceDiagram
     participant User
     participant API as NICo API
-    participant Vault as CredentialManager
+    participant Credentials as CredentialManager
     participant DB as PostgreSQL
-    participant C as DPF Extension Service Controller
+    participant Controller as ExtensionServiceReconciliationController
     participant DPF as DPF Management Cluster
     participant K8s as DPU Kubernetes Cluster
 
-    User->>API: CreateDpuExtensionService(DPF_HELM_CHART)
-    API->>API: Parse, normalize, and validate
-    API->>Vault: Store chart/image credentials
+    User->>API: CreateDpuExtensionService
+    API->>API: Validate and normalize
+    API->>Credentials: Store version credentials
     API->>DB: Store service, version, and reconciliation row
-    API-->>User: Return version with ACCEPTED status
+    API-->>User: Return ACCEPTED
 
-    C->>DB: Claim reconciliation row and load version
-    C->>Vault: Read credentials
-    C->>DPF: Reconcile Secrets
-    C->>DPF: Apply Template and Configuration
-    C->>DPF: Add service to compatible DPUDeployments
-    DPF->>K8s: Create DaemonSet with unmatched placement selector
-    C->>DPF: Observe current-generation conditions
-    C->>DB: Persist DEPLOYING, READY, or ERROR
+    Controller->>DB: Load due reconciliation
+    Controller->>Credentials: Read credentials
+    Controller->>DPF: Reconcile Secrets and service resources
+    Controller->>DPF: Register service with compatible DPUDeployments
+
+    alt scope = ALL_DPUS
+        DPF->>K8s: Deploy workload to compatible DPUs
+    else scope = INSTANCE_DPUS
+        DPF->>K8s: Create workload with unmatched selector
+    end
+
+    Controller->>DPF: Observe generated resources
+    Controller->>K8s: Observe workload when required
+    Controller->>DB: Store DEPLOYING, READY, or ERROR
 ```
-
-### API phase
 
 For a valid request, the API handler:
 
-1. Validates or creates the `ExtensionServiceId` and uses the initial `ConfigVersion` for the new service. When an update call is received, the API handler will use the next version.
+1. Validates or creates the `ExtensionServiceId`, validates the immutable deployment scope, and uses the initial `ConfigVersion` for the new service. When an update call is received, the API handler will use the next version without changing the scope.
 2. Parses `data` into the new `carbide_dpf::types::DpfHelmChartServiceData` model proposed above and serializes the normalized JSON.
 3. Validates and stores credentials using deterministic `CredentialManager` paths:
    ```text
@@ -386,53 +448,52 @@ For a valid request, the API handler:
    machines/extension-services/<service-id>/versions/<version>/image-registries/<sha256-registry-url>
    ```
 4. In one PostgreSQL transaction:
-   - inserts the `extension_services` record;
+   - inserts the `extension_services` record with its immutable `deployment_scope`;
    - inserts `extension_service_versions` with normalized JSON and `has_credential`;
-   - inserts a `dpf_extension_service_reconciliations` row with `desired_state = 'ACTIVE'` and `deployment_state = 'ACCEPTED'`; and
+   - inserts a `extension_service_reconciliations` row with `desired_state = 'ACTIVE'` and `deployment_state = 'ACCEPTED'`; and
    - reserves the deterministic DPF service name through that row's unique `dpf_service_name` constraint.
 5. Commits and enqueues the reconciliation `id`. Periodic due-row listing is the fallback if enqueueing is lost after commit.
 6. Returns the normal `DpuExtensionService` response.
 
 If the DB transaction fails after credentials were written, the handler should best-effort delete the credentials, following the existing compensation pattern.
 
-### Controller phase
+### 5.3 Extension Service Reconciliation Controller
 
-Following the existing controller pattern, add a `DpfExtensionServiceController` and start it from from `api-core::setup`. 
+Following the existing pattern, add an `ExtensionServiceReconciliationController` and start it from `api-core::setup`. It reconciles stored DPF Helm versions with the DPF management cluster. External operations are idempotent and retryable after partial failure or restart.
 
-The controller is responsible for reconciling DPF Helm service versions with the DPF management cluster. The API only validates and stores the desired state. The controller does the external work, so Kubernetes, DPF, Argo CD, and credential operations can be retried safely if something fails. Therefore, the controller operations should be idempotent. Re-running the same reconciliation should be safe, whether the previous attempt finished, partially finished, or failed in the middle.
-
-For each due row in `dpf_extension_service_reconciliations` with `desired_state = 'ACTIVE'`, the controller
+For each row in `extension_service_reconciliations` with `desired_state = 'ACTIVE'`, the controller
 1. Acquires a lock keyed by the reconciliation `id`, then re-reads the row so a concurrent delete cannot be missed.
-2. Loads the service version, site DPF configuration, and purpose-qualified credentials.
+2. Loads the service, immutable deployment scope, version, site DPF configuration, and purpose-qualified credentials.
 3. Sets `deployment_state = 'DEPLOYING'`, increments `reconcile_attempts`, and records `last_attempted_at`.
 4. Revalidates deployment availability, generated-object ownership, and DPUDeployment capacity.
 5. Reconciles chart-repository and image-pull Secrets.
 6. Applies the owned `DPUServiceTemplate` and `DPUServiceConfiguration`.
-7. Adds the service entry to every compatible shared DPUDeployment using conflict retries.
-8. Observes DPF and Argo CD conditions.
-9. Atomically persists `READY`, `DEPLOYING` with a retry time, or `ERROR` with a redacted message.
+7. Registers the service under `DPUDeployment.spec.services`.
+8. Observes the generated DPF resources and workload state. 
+9. Records the resulting deployment status.
 
-The DPF service name and Node label are deterministic hashes of the full service UUID and version because the `DPUDeployment.spec.services` key and both `deploymentServiceName` fields are limited to 28 characters.
+The DPF service name and `INSTANCE_DPUS` Node label are deterministic hashes of the full service UUID and version because the `DPUDeployment.spec.services` key and both `deploymentServiceName` fields are limited to 28 characters.
 - DPF service name: `ext-<20-character-base32-hash>`
 - Node label key: `carbide.nvidia.com/extsvc-<hash>`
 - Node label value: `enabled`
 
-#### Build DPF service resources
+#### 5.3.1 Generate DPF Resources
 
 NICo does not build a `DPUService` directly. The controller parses `extension_service_versions.data`, builds the owned `DPUServiceTemplate` and `DPUServiceConfiguration`, and adds references to them under `DPUDeployment.spec.services`. DPF then generates and reconciles the resulting `DPUService`.
 
-| Source | DPF destination |
-| --- | --- |
-| Generated service name | Template/configuration names, release name, both `deploymentServiceName` fields, and DPUDeployment service key |
-| `repoURL` | `DPUServiceTemplate.spec.helmChart.source.repoURL` |
-| `chart` | `DPUServiceTemplate.spec.helmChart.source.chart` |
-| `chartVersion` | `DPUServiceTemplate.spec.helmChart.source.version` |
-| Tenant `values` | Base of `DPUServiceTemplate.spec.helmChart.values` |
-| Generated label | `helmChart.values.additionalNodeSelector` |
-| Generated image Secret | Qualified chart's reserved `imagePullSecrets` value |
-| Constant `false` | `DPUServiceConfiguration.spec.upgradePolicy.applyNodeEffect` |
+| Source                                 | DPF destination                                                                                                |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Generated service name                 | Template/configuration names, release name, both `deploymentServiceName` fields, and DPUDeployment service key |
+| `repoURL`                              | `DPUServiceTemplate.spec.helmChart.source.repoURL`                                                             |
+| `chart`                                | `DPUServiceTemplate.spec.helmChart.source.chart`                                                               |
+| `chartVersion`                         | `DPUServiceTemplate.spec.helmChart.source.version`                                                             |
+| `deploymentTypes`                      | Compatible `DPUDeployment` selection                                                                           |
+| Tenant `values`                        | Base of `DPUServiceTemplate.spec.helmChart.values`                                                             |
+| Generated label (`INSTANCE_DPUS` only) | `helmChart.values.additionalNodeSelector`                                                                      |
+| Generated image Secret                 | Qualified chart's reserved `imagePullSecrets` value                                                            |
+| Constant `false`                       | `DPUServiceConfiguration.spec.upgradePolicy.applyNodeEffect`                                                   |
 
-For the example request, the generated resources are equivalent to:
+For the `INSTANCE_DPUS` data example in Section 3.4, the generated resources are equivalent to:
 
 ```yaml
 apiVersion: svc.dpu.nvidia.com/v1alpha1
@@ -448,12 +509,12 @@ spec:
   helmChart:
     source:
       repoURL: oci://registry.example.com/charts
-      chart: tenant-chart
+      chart: tenant-service
       version: 1.2.3
       releaseName: ext-abc123
     values:
       image:
-        repository: registry.example.com/tenant/repo
+        repository: registry.example.com/tenant/service
         tag: 1.2.3
       service:
         logLevel: info
@@ -473,7 +534,7 @@ spec:
     applyNodeEffect: false
 ```
 
-For every supported deployment type, the controller resolves the configured DPUDeployment and merges only this entry:
+For each declared deployment type (`BF3` in this example), the controller resolves the configured DPUDeployment and merges only this entry:
 
 ```yaml
 spec:
@@ -485,168 +546,163 @@ spec:
 
 The update uses a resource-version precondition and conflict retry. It does not force-apply or replace the shared DPUDeployment. The controller re-reads the live object and enforces the CRD limit of 50 service entries before adding the key.
 
-#### Why create produces no workload Pod
+#### 5.3.2 Service Deployment to DPU
 
-Creating the DPF resources makes the version available but does not attach it to an instance. A qualified chart combines:
+**Stage 1 — `ALL_DPUS`:** The controller omits `additionalNodeSelector`; charts used only with this scope need not support it. After registration, DPF deploys the workload to every DPU selected by each compatible deployment. The version becomes `READY` after all compatible deployments reference it and required resources and workloads are ready. `ALL_DPUS` creates no attachment rows, has no instance status, and cannot be detached from an instance. A new version does not remove the previous one.
 
-- DPF's `serviceDaemonSet.nodeSelector`, selecting Nodes belonging to the DPUDeployment; and
-- NICo's `additionalNodeSelector`, selecting Nodes belonging to instances requesting this version.
+**Stage 2 — `INSTANCE_DPUS`:** The controller injects a generated `additionalNodeSelector`. No Node initially has this label, so a DaemonSet with no Pods is ready for attachment. When `updateInstance` references the version, NICo stores the instance configuration and creates one `extension_service_attachments` row per selected DPU before adding the generated label to its `DPUDevice`. DPF propagates the label to the Node. The chart combines the DPF and NICo selectors:
 
 ```yaml
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       {{- toYaml .Values.serviceDaemonSet.nodeSelector | nindent 6 }}
+
 nodeSelector:
   {{- toYaml .Values.additionalNodeSelector | nindent 2 }}
 ```
 
-Before attachment, no DPU-cluster Node has the generated `carbide.nvidia.com/extsvc-*` label. A DaemonSet with no matching Nodes is therefore the expected post-create state, not a failure.
+The controller then observes label propagation and the current workload Pod on each target Node.
 
-## Attach service version workflow
+### 5.4 Status and Instance Lifecycle
 
-The existing RPC API continues to accept `(service_id, version)` entries through `InstanceDpuExtensionServicesConfig`. The API converts that protobuf message to the existing Rust model `InstanceExtensionServicesConfig`, stores it in `instances.extension_services_config`, and increments `instances.extension_services_config_version`.
+Every `DPF_HELM_CHART` version exposes version-level deployment status.
 
-For each active `DPF_HELM_CHART` service version attachment, the controller:
+For Stage 2 `ALL_DPUS`, `READY` means the service is deployed and ready across every compatible deployment.
 
-1. Uses the same `get_used_dpus` rule as the machine controller to find the instance's selected DPUs.
-2. Writes durable target rows before changing external state.
-3. Resolves each DPU machine ID to its DPUDevice and `DpuDeploymentType`.
-4. Verifies that the version supports that deployment type and that shared DPF resources have no blocking error.
-5. Checks the generated key against the selected DPUSet template's Node labels.
-6. Adds only the generated key/value to `DPUDevice.spec.k8scluster.nodeLabels`, preserving all other keys.
-7. Waits for DPF to copy the key to `DPU.spec.cluster.nodeLabels` and the corresponding DPU-cluster Node.
-8. Observes the current DaemonSet Pod on that Node and writes config-versioned status.
+For Stage 2 `INSTANCE_DPUS`, `READY` means the reusable service is registered and available for attachment.
 
-`DPUDevice.spec.k8scluster.nodeLabels` is the name from the pending DPF API described in this design's dependency. It is not present in the currently vendored DPF CRD; the implementation must update the CRD and generated Rust type after DPF finalizes that field name and schema.
+The status of the `INSTNACE_DPUS` will be reported in the instance status like existing KUBERNETES_POD type. But the observations will be produced by the ExtensionServicReconlicationController. 
 
-## Status and instance lifecycle
+`INSTANCE_DPUS` also records per-DPU attachment state:
 
-A shared DPUService/Argo CD Ready condition does not prove that a Pod is running on a particular DPU. Per-DPU state combines management-cluster readiness, label propagation, and DPU-cluster Pod readiness:
+| State         | Meaning                                                                          |
+| ------------- | -------------------------------------------------------------------------------- |
+| `PENDING`     | Placement, label propagation, Node mapping, or workload readiness is incomplete. |
+| `RUNNING`     | The deployment label is present and the current service Pod is ready.            |
+| `TERMINATING` | Placement is being removed but a label or workload remains.                      |
+| `TERMINATED`  | Placement labels and matching workloads are gone.                                |
+| `ERROR`       | A non-transient attachment failure occurred.                                     |
+| `UNKNOWN`     | NICo cannot observe enough state to determine status.                            |
 
-- `PENDING`: shared resources are not current-generation Ready, propagation is incomplete, or no current-revision Pod is Ready on the target Node.
-- `RUNNING`: the DPU and Node have the desired label and a current-revision DaemonSet Pod is Ready on that Node.
-- `TERMINATING`: placement is being removed but a DPU/Node label or matching Pod remains.
-- `TERMINATED`: the labels are absent and no matching non-terminal Pod remains.
-- `ERROR`: validation, ownership, collision, capacity, credential, DPF, Argo CD, or workload state has a non-transient failure.
-- `UNKNOWN`: required state cannot be observed or the DPUDevice cannot be mapped to a Node.
+A shared `DPUService` or Argo CD ready condition does not prove that a workload is running on a particular DPU. Per-DPU status therefore combines management-cluster readiness, label propagation, Node mapping, and Pod readiness.
 
-Instance status should keep the two observation sources separate:
+`KUBERNETES_POD` observations continue to come from the DPU agent through `RecordDpuNetworkStatus`.
 
-- DPU-agent observations for `KUBERNETES_POD`
-- DB-backed DPF observations for `DPF_HELM_CHART`
+`DPF_HELM_CHART` observations are produced by the `ExtensionServiceReconciliationController` and stored in PostgreSQL.
 
-## Update, detach, and delete workflows
+The two observation sources remain separate internally and are combined only when NICo constructs user-facing instance status.
 
-Updating service data or credentials creates a new immutable version and reconciliation row. Existing instances stay on the previous version until explicitly updated. During an instance version change, the old attachment is marked removed and the new attachment is active until the old one reaches `TERMINATED`.
+`INSTANCE_DPUS` uses the existing instance lifecycle gates. Provisioning waits for active attachments to become `RUNNING`, and instance deletion waits for removed attachments to become `TERMINATED`.
 
-Detaching marks the attachment `removed`. The controller removes only that version's label from every DPUDevice it previously targeted, waits for labels and Pods to disappear, and reports `TERMINATED`. The machine controller then removes the tombstone without another config-version increment.
+### 5.5 Detach and Instance Deletion
 
-Deleting a service version is allowed only when no active or terminating instance references it. In one transaction, the API sets `desired_state = 'DELETING'`, `deployment_state = 'DELETING'`, and `next_reconcile_at = CURRENT_TIMESTAMP` on its reconciliation row. Instance validation immediately rejects new attachments to that version. The version remains readable with deployment status `DELETING` while the controller:
+Detach applies only to `INSTANCE_DPUS`.
 
-1. removes the service key from every compatible DPUDeployment;
-2. waits for generated DPUService and Argo CD workloads to disappear;
-3. deletes the owned configuration, template, and generated Secrets;
-4. deletes source credentials from `CredentialManager`; and
-5. sets `cleanup_completed_at`, soft-deletes the version, and soft-deletes the parent service if no active versions remain.
+When a service version is removed from an instance configuration, the corresponding attachment rows move to `REMOVING`.
 
-Source credentials remain available until generated resources are removed. Every step is idempotent and retryable after restart or dependency failure.
+The controller removes the generated label only when no other active attachment for the same service version targets that DPU, then waits for the propagated Node label and workload to disappear.
 
-## Credential handling
+The attachment remains `TERMINATING` while any deployment label or matching workload remains. It becomes `TERMINATED` after both are removed.
 
-Credentials are stored through `CredentialManager`, not in PostgreSQL:
+The durable attachment rows preserve every DPU previously targeted by the service. This ensures cleanup remains correct even if the instance's current DPU selection has changed.
+
+Instance deletion uses the same removal path and waits for all `INSTANCE_DPUS` attachments to reach `TERMINATED`.
+
+### 5.7 Service Version Deletion
+
+A service version cannot be deleted while an active or terminating `INSTANCE_DPUS` attachment references it.
+
+When deletion is accepted, the API updates the reconciliation row to:
 
 ```text
-machines/extension-services/<service-id>/versions/<version>/chart-repository
-machines/extension-services/<service-id>/versions/<version>/image-registries/<sha256-registry-url>
+desired_state = DELETING
+deployment_state = DELETING
+next_reconcile_at = CURRENT_TIMESTAMP
 ```
 
-The secrets must not appear in any version data, helm values, logs etc.
+New attachments to the version are rejected immediately.
 
-The controller builds:
+The controller removes the service entry from each compatible `DPUDeployment` and waits for the generated `DPUService` and workload to disappear. It then deletes the owned `DPUServiceConfiguration`, `DPUServiceTemplate`, and generated Secrets.
 
-- an Argo CD repository Secret for the chart repo;
-- a `kubernetes.io/dockerconfigjson` Secret for image pulls.
+Source credentials remain available until the generated resources no longer require them. The controller then deletes the credentials, records cleanup completion, and soft-deletes the version.
 
+If no active versions remain, the parent extension service may also be soft-deleted.
 
-# Testing & QA
+All deletion operations are idempotent and can resume after a controller restart or dependency failure.
 
-[qa]: #qa
+## 6. Testing
 
-Required tests include:
+Testing should cover:
 
-- Migration tests for both new tables, including foreign keys, state checks, uniqueness, JSON-array validation, and due/version indexes.
-- Attachment-row grouping into `extension_services.dpf`, DPU-agent loading into `extension_services.dpu_agent`, service-type-based source selection, and matching/stale config-version handling.
-- API JSON normalization, required/unknown fields, limits, reserved paths, allow-list, deployment types, credential purposes, duplicate endpoints, and legacy/new field exclusivity.
-- Vault compensation when a database transaction fails.
-- Version deployment status transitions and cloud REST status mapping.
-- Exact input-to-DPUServiceTemplate/DPUServiceConfiguration mapping.
-- Safe concurrent mutation of shared DPUDeployments and DPUDevices.
-- BF3-only, BF4 Generic-only, and dual-compatible versions.
-- DPUDeployment capacity and generated-name/ownership collisions.
-- DPUDevice/DPUSet Node-label collision handling.
-- Private HTTPS/OCI chart and image pulls.
-- Create followed by immediate attach while shared resources are pending.
-- Multiple instances sharing one version and one instance changing versions.
-- Selected DPU-set changes without leaked labels or Pods.
-- Detach, instance deletion, and asynchronous version deletion.
-- Mixed `KUBERNETES_POD` and `DPF_HELM_CHART` config-version/status aggregation.
-- Restart and DPF, Argo CD, DPU-cluster, Vault, and database outage recovery.
-- No Node Effect, reboot, BFB/flavor change, reprovision, or readiness regression.
-- Existing `KUBERNETES_POD` regression tests.
+- creation of `DPF_HELM_CHART`;
+- omitted DPF scope defaulting to `ALL_DPUS`;
+- rejection of non-default deployment scope for `KUBERNETES_POD`;
+- rejection of `INSTANCE_DPUS` before Stage 2 enablement;
+- Helm data and reserved-value validation;
+- credential purpose and endpoint matching;
+- asynchronous version deployment status;
+- deterministic resource generation and ownership validation;
+- shared `DPUDeployment` conflict handling;
+- controller restart and dependency recovery;
+- global Stage 1 deployment and deletion;
+- Stage 2 unmatched initial selector;
+- attachment only to selected DPUs;
+- label propagation and Pod observation;
+- detach and selected-DPU-set changes;
+- instance version transitions;
+- per-DPU status aggregation;
+- version deletion blocking while attachments remain; and
+- compatibility with existing `KUBERNETES_POD` behavior.
 
-Definition of Done:
+<a id="appendix-a"></a>
+## Appendix A: External Service Contract
 
-- [ ] A qualified DPF Helm version can be created, attached, updated, detached, and deleted through existing workflows.
-- [ ] Workloads run only on selected DPUs for instances requesting that exact version.
-- [ ] Operations are idempotent and recover after restart or dependency failure.
-- [ ] Status correctly gates provisioning and deletion.
-- [ ] Credentials are encrypted, redacted, and finalized in dependency order.
-- [ ] Supported operations are non-disruptive.
-- [ ] Existing extension-service behavior remains backward compatible.
+A team providing a `DPF_HELM_CHART` service must supply a chart that satisfies both the DPF chart contract and the NICo-specific requirements below.
 
-# Operational Changes / Concerns
+### A.1 Chart Requirements
 
-[operations]: #operations
+The chart must:
 
-The Site Controller needs management-cluster RBAC for DPUServiceTemplate, DPUServiceConfiguration, DPUService, DPUDeployment, DPUSet, DPU, DPUDevice, DPUCluster, and generated Secrets. DPU-cluster status access needs read-only permission for Nodes, Pods, DaemonSets, and ControllerRevisions.
+- be hosted in an approved HTTPS or OCI repository;
+- use a pinned chart version;
+- satisfy the DPF `DPUService` Helm chart contract;
+- consume DPF-provided `serviceDaemonSet.nodeSelector`;
+- for `INSTANCE_DPUS`, support NICo-provided `additionalNodeSelector`;
+- use the approved image pull Secret value path;
+- avoid disruptive Node Effects; and
+- support all declared DPU deployment types.
 
-A DPUDeployment permits at most 50 service entries, including mandatory services and every retained extension-service version. Metrics and alerts cover remaining capacity, reconcile failures/latency, label propagation, Pod readiness, stuck attachments, and credential cleanup.
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      {{- toYaml .Values.serviceDaemonSet.nodeSelector | nindent 6 }}
 
-Rollout order is DPF/CRD upgrade, NICo migrations with the controller disabled, chart qualification and RBAC, then site enablement and canary testing. Before rollback or disabling the controller, all DPF Helm attachments and versions must be removed so labels, resources, and Secrets are finalized.
+nodeSelector:
+  {{- toYaml .Values.additionalNodeSelector | nindent 2 }}
+```
 
-# Drawbacks and alternatives
+For `ALL_DPUS`, NICo omits `additionalNodeSelector`.
 
-[drawbacks]: #drawbacks
+For `INSTANCE_DPUS`, NICo supplies the selector. The service owner must not provide or override it.
 
-- The workflow depends on PostgreSQL, Vault, DPF, Argo CD, and the DPU cluster.
-- Every retained version consumes limited shared DPUDeployment capacity even while unattached.
-- Modifying a shared DPUDeployment has a wider control-plane blast radius than a local static Pod.
-- Charts implement both the DPF contract and NICo placement/image-pull values.
-- Accurate per-DPU status requires DPU-cluster access and stable identity labels.
-- Interfaces and disruptive service changes are not supported initially.
+### A.2 Chart Qualification
 
-Alternatives considered:
+Chart qualification happens outside the create request.
 
-- Keep only `KUBERNETES_POD`: simpler, but it bypasses DPF's service lifecycle.
-- Create a DPUDeployment per instance: gives natural placement but duplicates shared deployment, firmware, and flavor configuration.
-- Add/remove a shared service for every attachment: cannot target one instance's DPUs and creates unnecessary shared reconciliation and Node Effect risk.
-- Hard-code the placement key in a chart: prevents safe reuse across service IDs and versions.
+Qualification should include:
 
-# Unresolved Questions
+* repository and chart allow-list review;
+* DPF schema validation;
+* `helm lint`;
+* representative rendering;
+* privilege and host-access review;
+* image registry review;
+* image signing or provenance checks;
+* DPF Node Effect review;
+* image pull Secret integration testing;
+* `serviceDaemonSet.nodeSelector` testing; and
+* `additionalNodeSelector` testing.
 
-[unresolved-questions]: #unresolved-questions
-
-- Which `repoURL` and chart pairs should be included in the initial administrative allow-list?
-- Which DPF release contains the final DPUDevice Node-label API, and what is its exact field/schema?
-- Does that release resolve the additional-selector readiness problem?
-- What stable label or API maps a DPU-cluster Node to its DPUDevice and a rendered DaemonSet to its DPUService?
-- Can DPF provide a least-privilege DPU-cluster observation kubeconfig instead of an admin kubeconfig?
-- Is one site-managed credential per normalized Helm repository URL acceptable for the first release?
-- Which charts, privileges, and image-signing policies are approved for the initial use case?
-
-# Future Possibilities
-
-[future-possibilities]: #future-possibilities
-
-Future work can add administrator-defined interface profiles, service chains, richer observability, additional credential types, signed-chart enforcement, and planned disruptive upgrades. Native DPF support for targeting a DPUService to a subset of a DPUDeployment could eventually replace the chart-specific additional selector.
+The API validates the requested chart against stored qualification metadata but does not download or render the chart in the request path.

--- a/docs/design/dpf-helm-chart-extension-services.md
+++ b/docs/design/dpf-helm-chart-extension-services.md
@@ -58,17 +58,16 @@ Stage 1 must:
 - update the stable DPF `DPUService` in place when an extension service’s Helm
   configuration changes, rolling the new chart revision to all DPUs of all
   currently attached instances without requiring reattachment;
-- expose per-instance, per-DPU extension-service status and complete detach or
-  instance deletion only after the service workload has terminated on each
-  relevant DPU;
-- support credentials required to retrieve Helm charts and container images;
+- expose per-instance, per-DPU extension-service based on label placement result
+  (The placement convergence status is only temporary, it will be replaced in
+  Stage 2 with status from DPF per DPU per DPUService status when it's available);
 - recover safely from transient DPF failures and NICo restarts, retrying
   unfinished DPUService lifecycle operations without losing the intended
   service state; and
 - preserve existing `KUBERNETES_POD` extension-service API behavior, DPU-agent
   delivery, and status semantics.
 
-**Stage 2 — Network-aware service configuration**
+**Stage 2 — Network-related service configuration**
 
 Stage 2 extends the Stage 1 lifecycle and placement model with network
 configuration.
@@ -77,26 +76,19 @@ Stage 2 must:
 
 - allow a `DPF_HELM_CHART` extension service to be attached to a service VPC;
 - support the DPF network resources and configuration required for that
-  attachment, including DPU service interfaces and service chains.
+  attachment, including DPU service interfaces and service chains;
+- add observability configuration for `DPF_HELM_CHART` extension services; and
+- derive instance DPF Helm extension-service status from DPF's per-DPU,
+  per-`DPUService` workload-status API once it is available.
 
 ### 2.3 Open Questions
 
-1. **Credentials.** Define how callers provide Helm-chart and image-registry
-   credentials: directly through API fields, or indirectly through launch-layer
-   creation of the required in-cluster credentials before NICo creates the
-   extension service.
-
-2. **Observability.** Define the observability configuration model and API
-   contract for `DPF_HELM_CHART` extension services.
-
-3. **`applyNodeEffect`.** Confirm whether detached DPUService creation
-   requires `applyNodeEffect: false`, and document the resulting behavior and
-   rationale.
-
-4. **DPUService contract fields.** Determine whether the API should expose
-   configuration for DPF Helm-chart contract fields -- labels, annotations,
-   updateStrategy, etc -- reserved by DPF. See 
-   [DPF contract](https://gitlab-master.nvidia.com/doca-platform-foundation/doca-platform-foundation/-/blob/main/docs/public/developer-guides/services/dpuservice-development.md?ref_type=heads). 
+1. **Credentials (required before Stage 1 completion).** The current
+   implementation rejects credentials for `DPF_HELM_CHART` services. Define
+   and implement how callers provide Helm-chart and image-registry credentials:
+   directly through API fields, or indirectly through launch-layer creation of
+   the required in-cluster credentials before NICo creates the extension
+   service.
 
 ### 2.4 Future Improvements
 
@@ -105,11 +97,14 @@ Stage 2 must:
    extension-service DPUService resources in `dpf-operator-system`. Revisit
    this when DPF provides per-DPUService namespace support.
 
-2. **Per-DPU, per-`DPUService` status.** DPF’s dedicated per-DPU,
-   per-`DPUService` status API is not expected to be available until the end of
-   August ([nvbug 6593984](https://nvbugspro.nvidia.com/bug/6593984)). Until
-   then, Stage 1 will expose a degraded status derived from DPF’s aggregate
-   DPU status.
+2. **Additional DPUService contract overrides.** Stage 1 exposes only the
+   DPUService fields NICo owns for the extension-service contract, including
+   the generated placement selector. Other DPF contract fields, such as
+   labels, annotations, and `updateStrategy`, remain unset so a
+   contract-compliant Helm chart uses its own defaults. A future NICo API may
+   expose narrowly scoped overrides for those fields when a use case
+   establishes their ownership and update.
+
 
 ## 3. Design
 
@@ -117,10 +112,19 @@ Stage 2 must:
 
 A Helm chart supplied for `DPF_HELM_CHART` must satisfy the
 [DPF DPUService contract](https://gitlab-master.nvidia.com/doca-platform-foundation/doca-platform-foundation/-/blob/main/docs/public/developer-guides/services/dpuservice-development.md?ref_type=heads#helm-chart-parameters).
+It must expose every applicable DPF contract parameter as a Helm value and
+render each value as required by that contract.
 
-In particular, the chart must expose `serviceDaemonSet.nodeSelector` and render
-that value into the Pod template. That is, the helm chart should
-expose the value `serviceDaemonSet.nodeSelector` by
+NICo will use only one of those DPF contract parameters:
+`serviceDaemonSet.nodeSelector`. NICo deterministically sets this field on the
+detached `DPUService` to select the DPUs to which an extension service is
+attached. Tenant-provided chart-specific `data.values` must not set
+`serviceDaemonSet.nodeSelector`; NICo rejects that input because allowing it
+would let a tenant bypass the placement contract.
+
+The chart must render `serviceDaemonSet.nodeSelector` into its Pod template.
+For example:
+
 ```yaml
 spec:
   template:
@@ -133,8 +137,14 @@ spec:
       {{- end }}
 ```
 
-NICo relies on this parameter to control which DPUs are eligible to run the
-extension-service workload.
+NICo does **NOT** set any other DPF contract parameters, such as `labels`, `annotations`,
+or `updateStrategy` etc, when it creates the Stage 1 `DPUService`. The Helm chart
+must therefore provide appropriate defaults for every such parameter it relies
+on.
+
+The optional `data.values` object remains available for tenant chart-specific
+configuration. It does not make generic DPUService contract fields tenant
+configurable, and it cannot override NICo's node-selector value.
 
 When NICo creates a `DPF_HELM_CHART` extension service, it creates a detached
 `DPUService` and deterministically generates
@@ -160,18 +170,16 @@ service workload eligible to run on those DPUs. The detailed attachment and
 framework to reconcile the lifecycle of the detached DPF `DPUService` for a
 `DPF_HELM_CHART` extension service. The controller is responsible only for
 `DPUService` create, update and delete. Instance attachement and detachment
-`DPUDevice` label synchronization, and per-DPU workload status are handled by
-the existing instance lifecycle and status paths.
+`DPUDevice` label synchronization and Stage 1 placement-status reporting are
+handled by the existing instance lifecycle and status paths.
 
 For `DPF_HELM_CHART` create, update, and delete operations, the API handlers
 validate the request and persist the desired lifecycle state in the database.
-The handlers do not call DPF directly. After the transaction commits, they
-enqueue the service ID for `ExtensionServiceStateController`.
-The controller processes this durable work asynchronously. It reads the
+The handlers do not call DPF directly. The controller's periodic scan discovers
+the durable lifecycle rows and processes them asynchronously. It reads the
 persisted service state, performs the required DPF operation outside a database
-transaction, and records the resulting state transition. The controller
-framework's durable queue and periodic scan recover from a missed enqueue,
-transient DPF failure, or NICo restart.
+transaction, and records the resulting state transition. Periodic scans and
+controller retries recover from transient DPF failure or a NICo restart.
 
 The migration adds the standard state-controller fields to
 `extension_services`:
@@ -188,7 +196,7 @@ and queued-object tables which are required for the controller framework. Existi
 
 For `DPF_HELM_CHART` extension services,
 
-- The controller states are `Creating`, `Ready`,
+- The controller states are `Creating`, `Active`,
   `Updating`, `Deleting`, `Deleted`, and `Failed`;
 - `controller_state_version` is independent of API-visible `version_ctr` and provides protection against
   stale controller iterations;
@@ -222,8 +230,7 @@ message DpuExtensionService {
 `CreateDpuExtensionService` is responsible for accepting the request and
 durably recording NICo's desired state. The handler validates the request,
 persists the extension-service record and its initial `Creating` state in one
-database transaction, commits that transaction, and enqueues the service ID.
-The handler does not create DPF resources.
+database transaction and commits it. The handler does not create DPF resources.
 
 `ExtensionServiceStateController` is responsible for reconciling the persisted
 intent with DPF. After it observes the committed `Creating` state, it reads the
@@ -233,9 +240,7 @@ from `Creating` to `Active`.
 
 The create response therefore means that NICo accepted the requested service;
 it does not mean that DPF accepted the CR or that the Helm workload is healthy.
-`Active` means only that the desired DPUService CR has been reconciled. Argo
-CD, Helm, and per-DPU workload health are reported through their respective
-status paths.
+`Active` means only that the desired DPUService CR has been reconciled.
 
 The DPUService remains detached after creation. It is deployed only after a
 later instance attachment causes NICo to apply the matching placement label to
@@ -255,7 +260,6 @@ sequenceDiagram
     API->>API: Validate and normalize desired service
     API->>DB: Persist service, V1, and Creating state
     API->>DB: Commit transaction
-    API->>DB: Enqueue service ID
     API-->>User: Return service in Creating state
     Controller->>DB: Read persisted Creating state and desired service
     Controller->>DPF: Create or verify detached DPUService
@@ -320,15 +324,17 @@ Example input `data`:
 
 | Field                 | Type      | Required | NICo validation and DPUService mapping                               |
 | --------------------- | --------- | -------- | -------------------------------------------------------------------- |
-| `repoURL`             | `string`  | Yes      | Helm repository URL; maps to `spec.helmChart.source.repoURL`.        |
+| `repoURL`             | `string`  | Yes      | Helm repository URL beginning with `oci://` or `https://`; maps to `spec.helmChart.source.repoURL`. |
 | `chartName`           | `string`  | Yes      | Qualified chart name; maps to `spec.helmChart.source.chart`.         |
 | `chartVersion`        | `string`  | Yes      | Exact pinned chart version; maps to `spec.helmChart.source.version`. |
 | `security.privileged` | `boolean` | Yes      | Service privilege policy; maps to `spec.security.privileged`.        |
-| `values`              | `object`  | No       | Chart-specific Helm values; maps to `spec.helmChart.values`.         |
+| `values`              | `object`  | No       | Chart-specific Helm values; maps to `spec.helmChart.values` when present and is omitted from the projected CR when absent. |
 
 The create API rejects a request when required DPF prerequisites are
 unavailable for the site, `data` is invalid, or required chart fields are
-missing.
+missing. The JSON contract rejects unknown fields. Tenant-provided `values`
+must not set `serviceDaemonSet.nodeSelector`; that selector is reserved for
+NICo's placement contract.
 
 After validation, the API handler creates or validates the
 `ExtensionServiceId` and opens a database transaction. In that transaction, it
@@ -338,18 +344,17 @@ persists the `extension_services` record, the normalized `data` in the initial
 The persisted state is the durable desired create operation; the handler does
 not call DPF while the transaction is open or after it commits.
 
-After the transaction commits, the handler enqueues the service ID for
-`ExtensionServiceStateController` and returns the service in `Creating` state.
-The response confirms that NICo accepted the create request, not that DPF has
-accepted the DPUService or that its workload is healthy. The enqueue is a
-prompt for reconciliation rather than the source of truth: the controller
-framework's periodic scan recovers a missed enqueue or NICo restart.
+After the transaction commits, the handler returns the service in `Creating`
+state. The response confirms that NICo accepted the create request, not that
+DPF has accepted the DPUService or that its workload is healthy. The
+controller's periodic scan subsequently reconciles the durable intent and also
+recovers after a NICo restart.
 
 #### 3.2.2 State Controller Create Reconciliation
 
-The `ExtensionServiceStateController` processes the queued `Creating` service by reading the
-persisted desired state and constructing the detached DPUService described in
-[Section 3.2.3](#323-dpuservice-specification).
+`ExtensionServiceStateController` periodically discovers a `Creating` service,
+reads its persisted desired state, and constructs the detached DPUService
+described in [Section 3.2.3](#323-dpuservice-specification).
 
 The controller calls `DpfOperations::create_dpu_service` outside a database
 transaction. A successful create, or an `AlreadyExists` DPUService with the
@@ -386,7 +391,7 @@ The controller maps persisted and generated values as follows:
 | `data.repoURL`                                | `spec.helmChart.source.repoURL`                                                          |
 | `data.chartName`                              | `spec.helmChart.source.chart`                                                            |
 | `data.chartVersion`                           | `spec.helmChart.source.version`                                                          |
-| `data.values`                                 | `spec.helmChart.values`                                                                  |
+| `data.values`                                 | `spec.helmChart.values` when present; otherwise omitted                                 |
 | `data.security.privileged`                    | `spec.security.privileged`                                                               |
 | Generated node selector based on ext-svc UUID | `spec.serviceDaemonSet.nodeSelector`                                                     |
 | Stage 1 deployment model                      | `spec.deployInCluster = false` and no `serviceID`, interfaces, or config ports           |
@@ -473,7 +478,7 @@ or `Failed`.
 A non-empty `data` value is a **complete** replacement Helm-service
 definition, not a DPUService or Kubernetes merge-patch document. It must
 include every field required at creation, including the chart repository URL,
-chart name, chart version, Helm values, and security policy.
+chart name, chart version, and security policy. `values` remains optional.
 
 An empty `data` value means it's a metadata-only update, which does not require
 DPF reconciliation and completed immediately after validation.
@@ -484,13 +489,13 @@ The API handler validates and normalizes the complete desired service spec and:
    requested version-owned metadata;
 2. applies requested service metadata;
 3. increments `version_ctr`; and
-4. transitions the controller state to `Updating` with the target
-   `version_ctr` and the deterministic material DPUService-specification hash.
+4. transitions the controller state from `Active` to `Updating` with a new
+   `controller_state_version`.
 
-After committing, the handler enqueues the service ID for `ExtensionServiceStateController` and returns the
-service in `Updating` state. The response means NICo durably accepted the
-desired revision; it does not mean DPF accepted the patch or that a workload
-rollout completed.
+After committing, the handler returns the service in `Updating` state. The
+controller's periodic scan reconciles the durable desired revision. The
+response means NICo accepted that revision; it does not mean DPF accepted the
+patch or that a workload rollout completed.
 
 #### 3.3.2 State Controller Update Reconciliation
 
@@ -502,9 +507,18 @@ The merge patch is an implementation detail, not a public API format.
 Before patching, the controller gets the deterministically named DPUService
 and verifies NICo ownership and immutable identity. The patch includes only
 NICo-owned mutable fields: Helm source, Helm values,
-`security.privileged`, and the revision ownership label. It does not change
-the DPUService name, Helm release name, placement selector, or fields omitted
-from the update.
+and `security.privileged`. It does not change the DPUService name, Helm release
+name, placement selector, or ownership label. NICo creates and verifies the
+ownership label, but never patches it during an update.
+
+When the persisted replacement definition changes `values` from present to
+absent, the controller emits
+`{"spec":{"helmChart":{"values":null}}}` in its internal JSON merge patch.
+Per JSON merge-patch semantics, `null` removes the existing DPUService
+`spec.helmChart.values` field; it does not retain the old values. DPF therefore
+receives no values override and Helm uses the chart's `values.yaml` defaults.
+This is distinct from supplying `values: {}`, which preserves an explicitly
+empty values object.
 
 After DPF accepts the patch, the controller transitions `Updating` to `Active`
 with a `controller_state_version` compare-and-swap transaction. A stale update
@@ -537,9 +551,9 @@ accepted.
 
 In one transaction, the handler soft-deletes the service and `V1`, and changes
 the controller state to `Deleting` with a new `controller_state_version`. It
-does not call DPF. After the transaction commits, it enqueues the service ID
-for `ExtensionServiceStateController` and returns the normal delete response.
-The response means NICo durably accepted cleanup; it does not mean DPF has
+does not call DPF. After the transaction commits, it returns the normal delete
+response; the controller's periodic scan reconciles the durable deletion
+intent. The response means NICo accepted cleanup; it does not mean DPF has
 deleted the DPUService.
 
 The soft-deleted display name is reusable only after the state gets transitioned to `DELETED`.
@@ -594,70 +608,112 @@ message InstanceDpuExtensionServiceConfig {
 }
 ```
 
-For `DPF_HELM_CHART` service, version should be an empty string as an update is always an in-place update.
+`DPF_HELM_CHART` services have one attachable initial `ConfigVersion`, whose
+logical version number is `V1`. An instance-configuration request must specify
+the exact full version string returned by NICo, for example
+`V1-T<created-at>`; the timestamp is part of `ConfigVersion` and
+must match the stored `V1` row. The literal string `V1` alone is not a valid
+attachment version. Helm-data updates are in place and do not create another
+attachable version.
 
-When extension services are present in `InstanceConfig`, API handler will validate each requested service. It permits a new `DPF_HELM_CHART`
-attachment only when the site capability gate is enabled and the service is
-`Active`. Meanwhile, an instance cannot have `DPF_HELM_CHART` and `KUBERNETES_POD` extension services at the same time.
+When extension services are present in `InstanceConfig`, the API handler
+validates each requested service. A new `DPF_HELM_CHART` attachment requires
+`dpf.enabled` for the site and an `Active` service. DPF Helm services may
+attach only to DPF-managed hosts; `KUBERNETES_POD` services are not supported
+on DPF-managed hosts. An instance cannot have `DPF_HELM_CHART` and
+`KUBERNETES_POD` extension services at the same time.
 
 The handler persists the instance extension service config. The actual labeling of `DPUDevice` is performed in instance state lifecycle.
 
 #### 3.5.2 Label Placement Reconciliation
 
-Label synchronization is added to the existing `InstanceState::Ready` handler.
-Current Ready processing already examines extension-service status and cleans
-up completed removal entries; it does not currently reconcile DPUDevice labels.
+Label synchronization runs while the instance is in
+`InstanceState::WaitingForExtensionServicesConfig`, where successful placement
+gates initial instance readiness, and again during `InstanceState::Ready` to
+repair placement drift and complete removals. A placement failure while the
+instance is already `Ready` is logged and retried by a later controller scan;
+it does not move the instance out of `Ready` or block unrelated Ready-state
+work.
 
 For each `DPF_HELM_CHART` service attached in persisted instance configuration,
-the Ready-path helper selects every physical DPU currently attached to the
-instance host. Attachment neither creates another DPUService nor changes the
-stable selector derived from the extension-service UUID in Section 3.2.3.
+the helper examines every physical DPU currently attached to the instance host
+and determines the current target DPU set. Attachment neither creates another
+DPUService nor changes the stable selector derived from the extension-service
+UUID in Section 3.2.3.
 
 Before attachment, no DPUDevice has the matching NICo-owned label. DPF can
 therefore reconcile the detached DPUService and its per-DPUCluster
-Applications while the chart workload remains absent from all DPUs. The helper
-reads each target DPUDevice and applies the matching UUID-derived
-node-selector label (ex. `nico/extsvc-<hash>: enabled`) defined in Section 3.2.3. It merge-patches only that
-attached service's NICo-owned key and value in `spec.cluster.nodeLabels`,
-preserves labels owned by DPF and other controllers, and performs DPF calls
-outside database transactions.
+Applications while the chart workload remains absent from all DPUs. For every
+physical DPUDevice, the helper merge-patches only the attached service's
+NICo-owned key in `spec.cluster.nodeLabels`: it adds the matching UUID-derived
+node-selector label (for example, `nico/extsvc-<hash>: enabled`) on current
+target DPUs, and removes that label from non-target DPUs and services marked
+`removed`. It preserves labels owned by DPF and other controllers and performs
+DPF calls outside database transactions.
 
 DPF propagates the matching DPUDevice label to the DPU-cluster Node. The Node
 then satisfies the DPUService selector and the qualified chart can schedule the
 service workload on that DPU. NICo neither creates nor deletes workload Pods during attachment.
 
-Label synchronization is idempotent: repeating it converges each target
+Label synchronization is idempotent: repeating it converges every physical
 DPUDevice on the labels derived from current instance configuration. A DPF
-error or temporarily unavailable DPUDevice is retried by later `Ready` state
-execution. It does not move the instance out of `Ready`, fail the
-instance, or block unrelated Ready-state work.
+error or temporarily unavailable DPUDevice blocks initial readiness and is
+retried. Once the instance is already `Ready`, it is retried without changing
+the instance state.
 
 ### 3.6 Instance Extension Service Status
 
-#### 3.6.1 DPF Status Dependency
+#### 3.6.1 Stage 1: Placement Status
 
-DPF is the source of workload status for `DPF_HELM_CHART`. NICo derives the
-DPUService namespace (which is currently all inside `dpf-operator-system`)
-and deterministic name from the extension-service ID and
-uses the service ownership label to identify the service. DPF must report a
-structured service-specific state, diagnostic message, and the DPUService
-generation or equivalent chart revision observed on that DPU.
+DPF does not currently provide a per-DPU, per-`DPUService` workload-status
+API. Stage 1 therefore reports **placement convergence**, not Helm workload
+health. The machine controller records a DPF Helm service as ready to run only
+after it has successfully applied the generated placement label to every
+required target `DPUDevice`; it records removal only after it has successfully
+removed that label from every required physical `DPUDevice`.
 
-#### 3.6.2 Instance Extension Service Status Mapping
+| Stage 1 condition | Reported extension-service status | Meaning |
+| --- | --- | --- |
+| All required active `DPUDevice` label patches succeed | `Running` | The service is placement-ready: its selected Nodes can satisfy the generated selector. |
+| Label reconciliation is incomplete or a DPF patch fails | `Pending` | NICo has not yet established the requested placement or removal. |
+| All required removal patches succeed | `Terminated` | The service is placement-detached. |
 
-| DPF state     | NICo state    | Meaning                                           |
-| ------------- | ------------- | ------------------------------------------------- |
-| `Pending`     | `Pending`     | Node selected; service workload is not ready.     |
-| `Running`     | `Running`     | Desired service revision is ready on the DPU.     |
-| `Terminating` | `Terminating` | Node deselected; service workload Pods remain.    |
-| `Terminated`  | `Terminated`  | Node deselected; no service workload Pods remain. |
-| `Error`       | `Error`       | DPF reports a service-specific failure.           |
-| `Unknown`     | `Unknown`     | DPF cannot determine service state.               |
+For this Stage 1 contract, `Running` does **not** mean that the Helm workload
+or its Pods are running, and `Terminated` does **not** prove that Pods have
+been deleted. They mean only that NICo successfully attached or detached the
+generated DPUDevice placement labels. The `Running` result is sufficient for
+the existing extension-service readiness gate to declare initial placement
+ready.
 
-A missing or stale DPF observation, DPF read failure, identity mismatch, or
-status result that does not identify the desired revision is `Unknown`. NICo
-must not infer `Terminated` from an absent entry unless DPF explicitly
-guarantees that the DPUService was evaluated and is absent from that DPU.
+#### 3.6.2 Observation Storage
+
+NICo stores extension-service observations in
+`machines.extension_service_status_observations`, a type-keyed JSONB object.
+Each value is an `InstanceExtensionServiceStatusObservation`; no
+DPF-specific observation type or column is introduced.
+
+- The `kubernetes_pod` entry is written from the DPU-agent report.
+- The `dpf_helm_chart` entry is written by the machine controller from the
+  Stage 1 label-placement result.
+
+The object is separate from the agent-owned `network_status_observation`,
+which the agent replaces as a whole. Each writer updates only its own service
+type key, so KubernetesPod and DPF Helm observations cannot overwrite one
+another. Instance-status derivation combines the type-keyed observations with
+the persisted extension-service configuration.
+
+#### 3.6.3 Stage 2: DPF Workload Status
+
+When DPF provides a per-DPU, per-`DPUService` status API, NICo will use that
+status for `DPF_HELM_CHART` services. The DPF observation will replace the
+Stage 1 placement writer for the existing `dpf_helm_chart` key and continue to
+use `InstanceExtensionServiceStatusObservation`; it will not introduce another
+database column or a new observation model.
+
+At that point, `Pending`, `Running`, `Terminating`, `Terminated`, `Error`, and
+`Unknown` will represent DPF's actual service workload state on each DPU. A
+missing, stale, or indeterminate DPF observation will be `Unknown` and will
+not be sufficient to infer workload termination.
 
 ### 3.7 Detach Service
 
@@ -673,48 +729,44 @@ and persists the configuration change but does not call DPF.
 
 #### 3.7.2 DPUDevice Label Removal and Recovery
 
-The `InstanceState::Ready` label-reconciliation helper derives the current
-target DPUs and removes the service's generated label from each corresponding
-`DPUDevice.spec.cluster.nodeLabels`. It uses the stable selector described in
-Section 3.5.2 and preserves labels owned by DPF and other controllers. DPF
-calls occur outside database transactions.
+The label-reconciliation helper removes the service's generated label from
+every physical `DPUDevice.spec.cluster.nodeLabels`, including target and
+non-target DPUs. It uses the stable selector described in Section 3.5.2 and
+preserves labels owned by DPF and other controllers. DPF calls occur outside
+database transactions.
 
 DPF propagates the removed label to the DPU-cluster Node. The Node no longer
-matches the stable DPUService selector, so DPF reconciles removal of the service workload.
-NICo does not delete
-Argo CD Applications or workload Pods during instance detachment.
+matches the stable DPUService selector, so DPF reconciles removal of the
+service workload. NICo does not delete Argo CD Applications or workload Pods
+during instance detachment.
 
 The removal operation is idempotent. A DPF error or temporarily unavailable
 DPUDevice leaves the `removed: true` entry in place and is retried by later
 Ready execution. It does not move the instance out of `Ready` or block
 unrelated Ready-state work.
 
-#### 3.7.3 Termination Confirmation and Completion
+#### 3.7.3 Stage 1 Termination Confirmation and Completion
 
-NICo waits for DPF to report `Terminated` for the DPUService on every current
-target DPU. A missing, stale, or indeterminate observation is `Unknown` and is
-not sufficient to complete detachment. Label absence alone does not prove that
-the workload has terminated.
+For Stage 1, successful removal of the generated label from every required
+physical DPUDevice records `Terminated` and completes detachment. NICo then
+removes the `removed: true` entry from persisted instance configuration.
+Until label removal converges, the entry remains visible as pending removal and
+prevents deletion of the referenced extension service.
 
-After all required DPUService/DPU pairs are `Terminated`, the existing Ready
-path cleans up the `removed: true` entry from persisted instance configuration.
-Until then, the entry remains visible as pending removal and prevents deletion
-of the referenced extension service.
-
-**Aug 14 Note**: DPF does not currently report a complete list of DPUServices currently
-running on a DPU. There is no way of knowing whether a DPUService is removed
-from a DPU at this point. For initial MVP, we are just going to infer the 
-DPUService is removed if the label is removed.
+This is deliberately a placement-detached completion contract, not proof that
+the workload has stopped. In Stage 2, NICo will retain the removal entry and
+wait for DPF to report `Terminated` for the service on every required DPU.
 
 ### 3.8 Instance Deletion
 
-During instance deletion, NICo applies the same label-removal synchronization
-to every physical DPU still attached to the host, then waits for DPF-reported
-termination of every required DPUService/DPU pair. DPF patch failures are
-retried and keep deletion in progress. Instance deletion completes only after
-all required services are terminated; label absence alone is insufficient.
+For Stage 1 instance deletion, NICo force-removes every DPF Helm placement
+label from every physical DPU still attached to the host. DPF patch failures
+are retried and keep deletion in progress. Successful removal from every
+required DPUDevice is the Stage 1 `Terminated` result and allows instance
+deletion to continue; it does not prove that the workload Pods are gone.
 
-**Aug 14 Note**: Again, with no DPF support, for MVP now, we treat label absence as termination.
+In Stage 2, instance deletion will instead wait for DPF to report `Terminated`
+for every required DPUService/DPU pair after label removal has converged.
 
 ### 3.9 Design Invariants / Ownership Constraints
 
@@ -739,9 +791,9 @@ The following rules apply across the lifecycle described above:
    workload absence are distinct states. A successful extension-service delete
    response means cleanup was accepted; it does not mean DPF has removed the
    DPUService or its workload.
-6. Per-DPU lifecycle decisions use per-DPU, per-`DPUService` status. Aggregate
-   DPUService conditions and DPU-wide operational conditions are not evidence
-   for one service on one DPU.
+6. In Stage 1, DPF Helm lifecycle decisions use the generated placement-label
+   convergence contract, not aggregate DPUService or DPU-wide conditions. In
+   Stage 2, they use DPF's per-DPU, per-`DPUService` workload status.
 7. A physical DPU must not be an active Stage-1 target of two instances at the
    same time. If the platform cannot enforce this, durable per-DPU attachment
    state and label reference counting are required before launch.
@@ -786,16 +838,17 @@ Testing must cover:
   idempotent update retry, and ownership/specification conflict handling;
 - delete superseding an in-flight create or update, with stale controller
   transition rejection and eventual DPUService deletion;
-- revision-aware per-DPU status;
+- Stage 1 type-keyed extension-service observation persistence and
+  placement-convergence status mapping;
 - detached DPUService creation and deletion;
 - delete acceptance persisting `Deleting` state before any DPF call;
 - controller retry, restart recovery, and DPUService finalizer polling;
 - refusal to mutate or delete a same-name DPUService with a mismatched
   extension-service ownership label;
 - unmatched initial selector before attachment;
-- attachment only to selected DPUs, label propagation, and Pod observation;
-- detach, selected-DPU-set changes, and removal cleanup only after every
-  required DPF status is `Terminated`;
+- attachment only to selected DPUs and label propagation;
+- detach, selected-DPU-set changes, and removal cleanup only after generated
+  label removal converges on every required DPU;
 - instance deletion behavior;
 - type-aware DPU-agent configuration exclusion;
 - per-service target selection when `KUBERNETES_POD` and

--- a/docs/design/dpf-helm-chart-extension-services.md
+++ b/docs/design/dpf-helm-chart-extension-services.md
@@ -81,16 +81,7 @@ Stage 2 must:
 - derive instance DPF Helm extension-service status from DPF's per-DPU,
   per-`DPUService` workload-status API once it is available.
 
-### 2.3 Open Questions
-
-1. **Credentials (required before Stage 1 completion).** The current
-   implementation rejects credentials for `DPF_HELM_CHART` services. Define
-   and implement how callers provide Helm-chart and image-registry credentials:
-   directly through API fields, or indirectly through launch-layer creation of
-   the required in-cluster credentials before NICo creates the extension
-   service.
-
-### 2.4 Future Improvements
+### 2.2 Future Improvements
 
 1. **Per-DPUService namespace.** DPF does not currently support assigning a
    dedicated namespace to each `DPUService`. Stage 1 therefore creates all
@@ -144,7 +135,12 @@ on.
 
 The optional `data.values` object remains available for tenant chart-specific
 configuration. It does not make generic DPUService contract fields tenant
-configurable, and it cannot override NICo's node-selector value.
+configurable, and it cannot override NICo's node-selector value. For the
+Stage 1 credential-provisioning contract, it also cannot override the
+top-level `imagePullSecrets` value. A chart that requires a private registry
+must set `imagePullSecrets` in its own `values.yaml` defaults and render it in
+the Pod template; Helm uses that default when NICo leaves the corresponding
+DPUService value unset.
 
 When NICo creates a `DPF_HELM_CHART` extension service, it creates a detached
 `DPUService` and deterministically generates
@@ -162,9 +158,33 @@ DPF propagates those labels to the corresponding Nodes in the DPU cluster.
 
 The Nodes then satisfy the selector rendered by the Helm chart, making the
 service workload eligible to run on those DPUs. The detailed attachment and
-`DPUDevice` label-reconciliation flow is described in Section 3.5.
+`DPUDevice` label-reconciliation flow is described in Section 3.6.
 
-### 3.1 Extension-Service State Controller
+### 3.1 Credential Pre-provisioning
+
+Stage 1 uses externally pre-provisioned credentials. Before a tenant creates a
+`DPF_HELM_CHART` extension service, an admin or launch workflow must create
+and validate the required Kubernetes Secrets. NICo does not accept, store,
+rotate, update, or delete DPF Helm-chart credentials.
+
+- A private Helm-chart repository requires an Argo CD repository Secret in the
+  namespace in which Argo CD runs, i.e. `argocd`. 
+- A private image registry requires a Secret
+  in `dpf-operator-system`, labeled `dpu.nvidia.com/image-pull-secret` so DPF
+  mirrors it to the target DPU clusters.
+- A chart that needs a private image registry must declare the approved pull
+  Secret name in the chart's `values.yaml` default and render that value as the
+  Pod template's `imagePullSecrets`. NICo leaves that value unset in the
+  DPUService and tenants cannot override it in `data.values`.
+
+Credential availability is a launch/admin prerequisite, rather than an
+eventually consistent setup step. DPF can create a DPUService and its Argo CD
+Application while the corresponding repository Secret is absent, but Argo CD
+then cannot fetch a private chart. Because Stage 1 reports placement-label
+convergence rather than DPF workload health, that failure is not sufficient to
+prevent a placement-ready service from being reported as `Running`.
+
+### 3.2 Extension-Service State Controller
 
 `ExtensionServiceStateController` uses NICo's existing state-controller
 framework to reconcile the lifecycle of the detached DPF `DPUService` for a
@@ -225,7 +245,7 @@ message DpuExtensionService {
 - `KUBERNETES_POD` services leaves this lifecycle_state as None.
 - `DPF_HELM_CHART` services report their controller state.
 
-### 3.2 Create `DPF_HELM_CHART` Extension Service
+### 3.3 Create `DPF_HELM_CHART` Extension Service
 
 `CreateDpuExtensionService` is responsible for accepting the request and
 durably recording NICo's desired state. The handler validates the request,
@@ -267,7 +287,7 @@ sequenceDiagram
     Controller->>DB: Compare-and-swap Creating state to Active state
 ```
 
-#### 3.2.1 API and Validation
+#### 3.3.1 API and Validation
 
 The existing DPU Extension Service creation API is reused for `DPF_HELM_CHART`. The only type-level API change is the addition of `DPF_HELM_CHART = 1`:
 
@@ -293,9 +313,15 @@ message CreateDpuExtensionServiceRequest {
 }
 ```
 
+For `DPF_HELM_CHART`, the legacy `credential` field is not used and must be
+unset. Helm-chart repository and image-registry credentials are externally
+pre-provisioned as described in [Section 3.1](#31-credential-pre-provisioning);
+NICo does not receive secret material in this API or persist it in Vault or
+PostgreSQL.
+
 The `service_name` is a NICo-facing display and lookup name. It will not be used as the `DPUService` name, Helm release name, or placement-label key. The current NICo database enforces name uniqueness per tenant organization, case-insensitively. Both `service_name` and `description` may be changed through
 `UpdateExtensionServiceConfig`, as described in
-[Section 3.3](#33-update-extension-service).
+[Section 3.4](#34-update-extension-service).
 
 For `DPF_HELM_CHART`, `data` contains the mutable JSON service definition used
 to construct and update the DPF `DPUService`. It includes the Helm chart source
@@ -333,8 +359,11 @@ Example input `data`:
 The create API rejects a request when required DPF prerequisites are
 unavailable for the site, `data` is invalid, or required chart fields are
 missing. The JSON contract rejects unknown fields. Tenant-provided `values`
-must not set `serviceDaemonSet.nodeSelector`; that selector is reserved for
-NICo's placement contract.
+must not set `serviceDaemonSet.nodeSelector` or top-level
+`imagePullSecrets`. The former is reserved for NICo's placement contract; the
+latter is a chart-owned default under the Stage 1 credential-provisioning
+contract. The launch/admin workflow, not this API, verifies that the required
+pre-provisioned Secrets exist before the service is created.
 
 After validation, the API handler creates or validates the
 `ExtensionServiceId` and opens a database transaction. In that transaction, it
@@ -350,11 +379,15 @@ DPF has accepted the DPUService or that its workload is healthy. The
 controller's periodic scan subsequently reconciles the durable intent and also
 recovers after a NICo restart.
 
-#### 3.2.2 State Controller Create Reconciliation
+#### 3.3.2 State Controller Create Reconciliation
 
 `ExtensionServiceStateController` periodically discovers a `Creating` service,
 reads its persisted desired state, and constructs the detached DPUService
-described in [Section 3.2.3](#323-dpuservice-specification).
+described in [Section 3.3.3](#333-dpuservice-specification).
+
+The controller does not create, read, update, rotate, or delete Helm
+repository or image-pull Secrets in Stage 1. Their availability is an external
+prerequisite described in [Section 3.1](#31-credential-pre-provisioning).
 
 The controller calls `DpfOperations::create_dpu_service` outside a database
 transaction. A successful create, or an `AlreadyExists` DPUService with the
@@ -375,7 +408,7 @@ authorization, ownership, or immutable-specification conflict transitions it
 to `Failed` with a diagnostic outcome. Services in `Creating` or `Failed`
 cannot be attached to an instance.
 
-#### 3.2.3 DPUService Specification
+#### 3.3.3 DPUService Specification
 
 For each `Creating` iteration, `ExtensionServiceStateController` reads desired
 extension service information from the service's database row and projects it
@@ -405,7 +438,7 @@ therefore stable for the service lifetime.
 - DPUService name: `extsvc-<hash>`
 - Node-label key/value: `nico/extsvc-<hash>: enabled`
 
-For the `data` example in Section 3.2.1, NICo creates the following DPUService:
+For the `data` example in Section 3.3.1, NICo creates the following DPUService:
 
 ```yaml
 apiVersion: svc.dpu.nvidia.com/v1alpha1
@@ -440,7 +473,7 @@ spec:
               values: [enabled]
 ```
 
-### 3.3 Update Extension Service
+### 3.4 Update Extension Service
 
 For `DPF_HELM_CHART`, an update is an asynchronous, in-place change to the
 stable DPF `DPUService`. It does not create another attachable
@@ -453,7 +486,7 @@ version so an instance configuration can select its old or new Pod
 specification for a tenant-directed rollout. The existing `KUBERNETES_POD`
 update behavior is unchanged.
 
-#### 3.3.1 API Handler
+#### 3.4.1 API Handler
 
 `UpdateDpuExtensionService` retains its existing API shape:
 
@@ -497,7 +530,7 @@ controller's periodic scan reconciles the durable desired revision. The
 response means NICo accepted that revision; it does not mean DPF accepted the
 patch or that a workload rollout completed.
 
-#### 3.3.2 State Controller Update Reconciliation
+#### 3.4.2 State Controller Update Reconciliation
 
 `ExtensionServiceStateController` processes an `Updating` service from its
 persisted desired `V1.data`. It constructs an internal Kubernetes merge patch
@@ -518,7 +551,8 @@ Per JSON merge-patch semantics, `null` removes the existing DPUService
 `spec.helmChart.values` field; it does not retain the old values. DPF therefore
 receives no values override and Helm uses the chart's `values.yaml` defaults.
 This is distinct from supplying `values: {}`, which preserves an explicitly
-empty values object.
+empty values object. In particular, an omitted `values` object restores the
+chart-owned `imagePullSecrets` default when the chart defines one.
 
 After DPF accepts the patch, the controller transitions `Updating` to `Active`
 with a `controller_state_version` compare-and-swap transaction. A stale update
@@ -534,9 +568,9 @@ the old revision, the new revision, or a failed workload concurrently. DPF
 does not automatically roll back an unhealthy Application; rollback means another
 in-place update.
 
-### 3.4 Delete Extension Service
+### 3.5 Delete Extension Service
 
-#### 3.4.1 API Handler
+#### 3.5.1 API Handler
 
 DPF deletes a DPUService asynchronously: after accepting deletion, it can retain
 the CR while finalizers remove the associated Argo CD Applications and related
@@ -559,7 +593,7 @@ deleted the DPUService.
 The soft-deleted display name is reusable only after the state gets transitioned to `DELETED`.
  A newly created service with that display name receives a new UUID, DPUService name, and placement-label key; it cannot refer to the deleted service.
 
-#### 3.4.2 State Controller Delete Reconciliation
+#### 3.5.2 State Controller Delete Reconciliation
 
 The controller processes a `Deleting` service by deriving its DPUService name
 from the retained service ID and getting the DPUService. `NotFound` is success.
@@ -582,9 +616,13 @@ Transient get or delete failures leave the service in `Deleting` for retry.
 This remains recoverable after a NICo restart because the soft-deleted service
 record and controller state remain in PostgreSQL.
 
-### 3.5 Attach Service to Instance
+Stage 1 deletion does not delete the externally managed Argo CD repository
+Secret, the image-pull Secret, or any source credential. Those Secrets may be
+shared by other services and remain owned by the admin/launch workflow.
 
-#### 3.5.1 Attachment to Instance API and Validation
+### 3.6 Attach Service to Instance
+
+#### 3.6.1 Attachment to Instance API and Validation
 
 An instance attaches extension services by including an
 `InstanceDpuExtensionServicesConfig` in its `InstanceConfig`. The configuration
@@ -625,7 +663,7 @@ on DPF-managed hosts. An instance cannot have `DPF_HELM_CHART` and
 
 The handler persists the instance extension service config. The actual labeling of `DPUDevice` is performed in instance state lifecycle.
 
-#### 3.5.2 Label Placement Reconciliation
+#### 3.6.2 Label Placement Reconciliation
 
 Label synchronization runs while the instance is in
 `InstanceState::WaitingForExtensionServicesConfig`, where successful placement
@@ -639,7 +677,7 @@ For each `DPF_HELM_CHART` service attached in persisted instance configuration,
 the helper examines every physical DPU currently attached to the instance host
 and determines the current target DPU set. Attachment neither creates another
 DPUService nor changes the stable selector derived from the extension-service
-UUID in Section 3.2.3.
+UUID in Section 3.3.3.
 
 Before attachment, no DPUDevice has the matching NICo-owned label. DPF can
 therefore reconcile the detached DPUService and its per-DPUCluster
@@ -661,9 +699,9 @@ error or temporarily unavailable DPUDevice blocks initial readiness and is
 retried. Once the instance is already `Ready`, it is retried without changing
 the instance state.
 
-### 3.6 Instance Extension Service Status
+### 3.7 Instance Extension Service Status
 
-#### 3.6.1 Stage 1: Placement Status
+#### 3.7.1 Stage 1: Placement Status
 
 DPF does not currently provide a per-DPU, per-`DPUService` workload-status
 API. Stage 1 therefore reports **placement convergence**, not Helm workload
@@ -685,7 +723,7 @@ generated DPUDevice placement labels. The `Running` result is sufficient for
 the existing extension-service readiness gate to declare initial placement
 ready.
 
-#### 3.6.2 Observation Storage
+#### 3.7.2 Observation Storage
 
 NICo stores extension-service observations in
 `machines.extension_service_status_observations`, a type-keyed JSONB object.
@@ -702,7 +740,7 @@ type key, so KubernetesPod and DPF Helm observations cannot overwrite one
 another. Instance-status derivation combines the type-keyed observations with
 the persisted extension-service configuration.
 
-#### 3.6.3 Stage 2: DPF Workload Status
+#### 3.7.3 Stage 2: DPF Workload Status
 
 When DPF provides a per-DPU, per-`DPUService` status API, NICo will use that
 status for `DPF_HELM_CHART` services. The DPF observation will replace the
@@ -715,9 +753,9 @@ At that point, `Pending`, `Running`, `Terminating`, `Terminated`, `Error`, and
 missing, stale, or indeterminate DPF observation will be `Unknown` and will
 not be sufficient to infer workload termination.
 
-### 3.7 Detach Service
+### 3.8 Detach Service
 
-#### 3.7.1 Detachment API and Persisted Intent
+#### 3.8.1 Detachment API and Persisted Intent
 
 An `UpdateInstanceConfig` request detaches a `DPF_HELM_CHART` service by
 removing it from the requested active-service list. NICo retains the existing
@@ -727,11 +765,11 @@ service configuration in the persisted instance configuration with
 The removed entry is the durable detachment intent. The API handler validates
 and persists the configuration change but does not call DPF. 
 
-#### 3.7.2 DPUDevice Label Removal and Recovery
+#### 3.8.2 DPUDevice Label Removal and Recovery
 
 The label-reconciliation helper removes the service's generated label from
 every physical `DPUDevice.spec.cluster.nodeLabels`, including target and
-non-target DPUs. It uses the stable selector described in Section 3.5.2 and
+non-target DPUs. It uses the stable selector described in Section 3.6.2 and
 preserves labels owned by DPF and other controllers. DPF calls occur outside
 database transactions.
 
@@ -745,7 +783,7 @@ DPUDevice leaves the `removed: true` entry in place and is retried by later
 Ready execution. It does not move the instance out of `Ready` or block
 unrelated Ready-state work.
 
-#### 3.7.3 Stage 1 Termination Confirmation and Completion
+#### 3.8.3 Stage 1 Termination Confirmation and Completion
 
 For Stage 1, successful removal of the generated label from every required
 physical DPUDevice records `Terminated` and completes detachment. NICo then
@@ -757,7 +795,7 @@ This is deliberately a placement-detached completion contract, not proof that
 the workload has stopped. In Stage 2, NICo will retain the removal entry and
 wait for DPF to report `Terminated` for the service on every required DPU.
 
-### 3.8 Instance Deletion
+### 3.9 Instance Deletion
 
 For Stage 1 instance deletion, NICo force-removes every DPF Helm placement
 label from every physical DPU still attached to the host. DPF patch failures
@@ -768,7 +806,7 @@ deletion to continue; it does not prove that the workload Pods are gone.
 In Stage 2, instance deletion will instead wait for DPF to report `Terminated`
 for every required DPUService/DPU pair after label removal has converged.
 
-### 3.9 Design Invariants / Ownership Constraints
+### 3.10 Design Invariants / Ownership Constraints
 
 The following rules apply across the lifecycle described above:
 
@@ -799,6 +837,12 @@ The following rules apply across the lifecycle described above:
    state and label reference counting are required before launch.
 8. `DPF_HELM_CHART` never flows through the DPU agent. NICo does not query
    tenant-cluster Pods directly for this service type.
+9. Stage 1 DPF Helm credentials are external prerequisites. NICo never accepts
+   their secret material through the extension-service API, writes it to Vault
+   or PostgreSQL, or manages the corresponding Kubernetes Secrets. A private
+   chart repository has one site-provisioned credential per canonical
+   repository URL, and private-image charts use the chart-owned
+   `values.yaml` `imagePullSecrets` default.
 
 ## 4. Compatibility and Rollout
 
@@ -831,6 +875,10 @@ Testing must cover:
   verified owned `AlreadyExists` results;
 - migration/backfill of controller-state fields and lifecycle state exposure;
 - Helm data, reserved-value, and qualification validation;
+- rejection of the legacy `credential` field and of tenant
+  `data.values.imagePullSecrets` for `DPF_HELM_CHART`;
+- chart-default `imagePullSecrets` behavior, and verification that create,
+  update, and delete do not manage externally pre-provisioned Secrets;
 - deterministic resource generation and ownership verification;
 - in-place `UpdateDpuExtensionService` patching of the stable DPUService with
   no `UpdateInstanceConfig` or DPUDevice label change;

--- a/docs/design/dpf-helm-chart-extension-services.md
+++ b/docs/design/dpf-helm-chart-extension-services.md
@@ -17,7 +17,7 @@ NICo currently supports DPU Extension Services of type `KUBERNETES_POD`. When a
 sent to instance's DPUs through `GetManagedHostNetworkConfig`, and deployed
 locally by the DPU agent as a static Kubernetes Pod.
 
-As NICo transitions to DPF, extension services should use DPF to manage
+However, as NICo transitions to DPF, extension services should use DPF to manage
 workloads on DPUs rather than relying on direct deployment by the DPU agent.
 This design introduces a new extension-service type, `DPF_HELM_CHART`, which
 represents a Helm chart-based extension service managed through DPF.
@@ -31,7 +31,7 @@ Argo CD Applications and the Kubernetes resources deployed by the `DPUService`.
 For each `DPF_HELM_CHART` service, NICo generates and owns a stable,
 service-specific `DPUService` Node selector and its corresponding placement
 label. When the service is attached to an instance, NICo adds the matching label
-to the `DPUDevice` resources for that instance's DPUs. DPF propagates the label
+to the `DPUDevice` for that instance's DPUs. DPF propagates the label
 to the corresponding Nodes in the DPU cluster, where it satisfies the
 `DPUService` DaemonSet selector and allows the workload to run only on the
 selected DPUs.
@@ -94,7 +94,9 @@ Stage 2 must:
    rationale.
 
 4. **DPUService contract fields.** Determine whether the API should expose
-   configuration for DPF Helm-chart contract fields -- labels, annotations, updateStrategy, etc -- reserved by DPF. See [DPF contract](https://gitlab-master.nvidia.com/doca-platform-foundation/doca-platform-foundation/-/blob/main/docs/public/developer-guides/services/dpuservice-development.md?ref_type=heads). 
+   configuration for DPF Helm-chart contract fields -- labels, annotations,
+   updateStrategy, etc -- reserved by DPF. See 
+   [DPF contract](https://gitlab-master.nvidia.com/doca-platform-foundation/doca-platform-foundation/-/blob/main/docs/public/developer-guides/services/dpuservice-development.md?ref_type=heads). 
 
 ### 2.4 Future Improvements
 

--- a/docs/design/dpf-helm-chart-extension-services.md
+++ b/docs/design/dpf-helm-chart-extension-services.md
@@ -145,8 +145,8 @@ DPUService value unset.
 When NICo creates a `DPF_HELM_CHART` extension service, it creates a detached
 `DPUService` and deterministically generates
 `DPUService.spec.serviceDaemonSet.nodeSelector` from the extension-service
-UUID. DPF exposes this selector to the Helm chart as
-`.Values.serviceDaemonSet.nodeSelector`.
+UUID ([Section 3.3.3](#333-dpuservice-specification)). DPF exposes this
+selector to the Helm chart as `.Values.serviceDaemonSet.nodeSelector`.
 
 At this point, the selector does not match any target DPU, so the `DPUService`
 can exist while its workload remains detached.
@@ -158,7 +158,8 @@ DPF propagates those labels to the corresponding Nodes in the DPU cluster.
 
 The Nodes then satisfy the selector rendered by the Helm chart, making the
 service workload eligible to run on those DPUs. The detailed attachment and
-`DPUDevice` label-reconciliation flow is described in Section 3.6.
+`DPUDevice` label-reconciliation flow is described in
+[Section 3.6.2](#362-label-placement-reconciliation).
 
 ### 3.1 Credential Pre-provisioning
 

--- a/docs/design/dpf-helm-chart-extension-services.md
+++ b/docs/design/dpf-helm-chart-extension-services.md
@@ -5,101 +5,265 @@ GitHub Issue: [#3103](https://github.com/NVIDIA/infra-controller/issues/3103)
 ## 1. Revision History
 
 | Version |    Date    | Modified By | Description     |
-| :-----: | :--------: | :---------- | :-------------- |
+| :-----: | :--------: | ----------- | --------------- |
 |   0.1   | 07/01/2026 | Felicity Xu | Initial version |
+|   0.2   | 08/13/2026 | Felicity Xu | Revised version |
+
 
 ## 2. Summary
 
-NICo currently supports DPU Extension Services of type `KUBERNETES_POD`. A `KUBERNETES_POD` service is attached to an instance, delivered to the instance's DPUs through `GetManagedHostNetworkConfig`, and deployed locally by the DPU agent as a static Kubernetes Pod.
+NICo currently supports DPU Extension Services of type `KUBERNETES_POD`. When a
+`KUBERNETES_POD` extension service is attached to an instance, it's pod spec is
+sent to instance's DPUs through `GetManagedHostNetworkConfig`, and deployed
+locally by the DPU agent as a static Kubernetes Pod.
 
-As NICo moves to DPF, extension services should use DPF instead of being deployed directly by the DPU agent. This design introduces `DPF_HELM_CHART` for versioned Helm services managed through DPF.
+As NICo transitions to DPF, extension services should use DPF to manage
+workloads on DPUs rather than relying on direct deployment by the DPU agent.
+This design introduces a new extension-service type, `DPF_HELM_CHART`, which
+represents a Helm chart-based extension service managed through DPF.
 
-A user creates a `DPF_HELM_CHART` service version with a Helm chart reference, values, and required credentials. The NICo Site Controller converts it into DPF resources, registers the service with `DPUDeployment` objects, and monitors deployment status.
+A user creates a `DPF_HELM_CHART` service by providing a Helm chart reference
+and values. The NICo API persists the desired service and its lifecycle state,
+and the extension-service state controller asynchronously creates and manages
+the corresponding detached `DPUService` CR. DPF then reconciles the associated
+Argo CD Applications and the Kubernetes resources deployed by the `DPUService`.
 
-The feature is delivered in two stages:
-- **Stage 1 — `ALL_DPUS`:** the service is deployed to every DPU in each compatible `DPUDeployment`.
-- **Stage 2 — `INSTANCE_DPUS`:** the service is attached to an instance and deployed only to the DPUs used by that instance.
+For each `DPF_HELM_CHART` service, NICo generates and owns a stable,
+service-specific `DPUService` Node selector and its corresponding placement
+label. When the service is attached to an instance, NICo adds the matching label
+to the `DPUDevice` resources for that instance's DPUs. DPF propagates the label
+to the corresponding Nodes in the DPU cluster, where it satisfies the
+`DPUService` DaemonSet selector and allows the workload to run only on the
+selected DPUs.
 
-Stage 1 is implemented first. Stage 2 depends on the "Propagating labels from `DPUDevice` to the corresponding `v1.node` object" feature from DPF team. Until that dependency is available, `INSTANCE_DPUS` service creation should be rejected.
+### 2.1 Goals
 
-Existing `KUBERNETES_POD` behavior remains unchanged.
+The feature will be delivered in two stages.
 
-## 3. API Model
+**Stage 1 — DPF-managed service lifecycle and placement**
 
-### 3.1 Overall Changes
+Stage 1 establishes the complete lifecycle for `DPF_HELM_CHART` extension
+services with no network-interface configuration.
 
-The existing DPU Extension Service APIs are reused for `DPF_HELM_CHART`.
+Stage 1 must:
 
-The main API changes are:
-- add the `DPF_HELM_CHART` service type;
-- add an immutable deployment scope field for `DPF_HELM_CHART`;
-- retain the existing `data` field, but tenants need to provide a different, Helm-specific data format when creating a `DPF_HELM_CHART` version;
-- support multiple purpose-qualified credentials for each Helm service version; and
-- add asynchronous deployment status to service-version responses.
+- support the DPF-managed lifecycle of `DPF_HELM_CHART` extension services,
+  with one detached DPF `DPUService` per extension service and durable,
+  asynchronous reconciliation of create, update, and delete operations;
+- support attaching and detaching an extension service through instance
+  configuration, placing its workload only on the DPUs associated with attached
+  instances through NICo-managed `DPUService` nodeSelector and placement
+  labels, without interface-, service-chain-, VPC-, or other network-based
+  configuration;
+- update the stable DPF `DPUService` in place when an extension service’s Helm
+  configuration changes, rolling the new chart revision to all DPUs of all
+  currently attached instances without requiring reattachment;
+- expose per-instance, per-DPU extension-service status and complete detach or
+  instance deletion only after the service workload has terminated on each
+  relevant DPU;
+- support credentials required to retrieve Helm charts and container images;
+- recover safely from transient DPF failures and NICo restarts, retrying
+  unfinished DPUService lifecycle operations without losing the intended
+  service state; and
+- preserve existing `KUBERNETES_POD` extension-service API behavior, DPU-agent
+  delivery, and status semantics.
+
+**Stage 2 — Network-aware service configuration**
+
+Stage 2 extends the Stage 1 lifecycle and placement model with network
+configuration.
+
+Stage 2 must:
+
+- allow a `DPF_HELM_CHART` extension service to be attached to a service VPC;
+- support the DPF network resources and configuration required for that
+  attachment, including DPU service interfaces and service chains.
+
+### 2.3 Open Questions
+
+1. **Credentials.** Define how callers provide Helm-chart and image-registry
+   credentials: directly through API fields, or indirectly through launch-layer
+   creation of the required in-cluster credentials before NICo creates the
+   extension service.
+
+2. **Observability.** Define the observability configuration model and API
+   contract for `DPF_HELM_CHART` extension services.
+
+3. **`applyNodeEffect`.** Confirm whether detached DPUService creation
+   requires `applyNodeEffect: false`, and document the resulting behavior and
+   rationale.
+
+4. **DPUService contract fields.** Determine whether the API should expose
+   configuration for DPF Helm-chart contract fields -- labels, annotations, updateStrategy, etc -- reserved by DPF. See [DPF contract](https://gitlab-master.nvidia.com/doca-platform-foundation/doca-platform-foundation/-/blob/main/docs/public/developer-guides/services/dpuservice-development.md?ref_type=heads). 
+
+### 2.4 Future Improvements
+
+1. **Per-DPUService namespace.** DPF does not currently support assigning a
+   dedicated namespace to each `DPUService`. Stage 1 therefore creates all
+   extension-service DPUService resources in `dpf-operator-system`. Revisit
+   this when DPF provides per-DPUService namespace support.
+
+2. **Per-DPU, per-`DPUService` status.** DPF’s dedicated per-DPU,
+   per-`DPUService` status API is not expected to be available until the end of
+   August ([nvbug 6593984](https://nvbugspro.nvidia.com/bug/6593984)). Until
+   then, Stage 1 will expose a degraded status derived from DPF’s aggregate
+   DPU status.
+
+## 3. Design
+
+### 3.0 Helm Chart Requirements
+
+A Helm chart supplied for `DPF_HELM_CHART` must satisfy the
+[DPF DPUService contract](https://gitlab-master.nvidia.com/doca-platform-foundation/doca-platform-foundation/-/blob/main/docs/public/developer-guides/services/dpuservice-development.md?ref_type=heads#helm-chart-parameters).
+
+In particular, the chart must expose `serviceDaemonSet.nodeSelector` and render
+that value into the Pod template. That is, the helm chart should
+expose the value `serviceDaemonSet.nodeSelector` by
+```yaml
+spec:
+  template:
+    spec:
+      {{- with .Values.serviceDaemonSet.nodeSelector }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            {{- toYaml . | nindent 12 }}
+      {{- end }}
+```
+
+NICo relies on this parameter to control which DPUs are eligible to run the
+extension-service workload.
+
+When NICo creates a `DPF_HELM_CHART` extension service, it creates a detached
+`DPUService` and deterministically generates
+`DPUService.spec.serviceDaemonSet.nodeSelector` from the extension-service
+UUID. DPF exposes this selector to the Helm chart as
+`.Values.serviceDaemonSet.nodeSelector`.
+
+At this point, the selector does not match any target DPU, so the `DPUService`
+can exist while its workload remains detached.
+
+When the extension service is later attached to an instance, either during
+instance creation or through `UpdateInstanceConfig`, NICo applies the matching
+placement label to the `DPUDevice` resources for the instance's target DPUs.
+DPF propagates those labels to the corresponding Nodes in the DPU cluster.
+
+The Nodes then satisfy the selector rendered by the Helm chart, making the
+service workload eligible to run on those DPUs. The detailed attachment and
+`DPUDevice` label-reconciliation flow is described in Section 3.5.
+
+### 3.1 Extension-Service State Controller
+
+`ExtensionServiceStateController` uses NICo's existing state-controller
+framework to reconcile the lifecycle of the detached DPF `DPUService` for a
+`DPF_HELM_CHART` extension service. The controller is responsible only for
+`DPUService` create, update and delete. Instance attachement and detachment
+`DPUDevice` label synchronization, and per-DPU workload status are handled by
+the existing instance lifecycle and status paths.
+
+For `DPF_HELM_CHART` create, update, and delete operations, the API handlers
+validate the request and persist the desired lifecycle state in the database.
+The handlers do not call DPF directly. After the transaction commits, they
+enqueue the service ID for `ExtensionServiceStateController`.
+The controller processes this durable work asynchronously. It reads the
+persisted service state, performs the required DPF operation outside a database
+transaction, and records the resulting state transition. The controller
+framework's durable queue and periodic scan recover from a missed enqueue,
+transient DPF failure, or NICo restart.
+
+The migration adds the standard state-controller fields to
+`extension_services`:
+
+```sql
+ALTER TABLE extension_services
+    ADD COLUMN controller_state JSONB,
+    ADD COLUMN controller_state_version VARCHAR(64),
+    ADD COLUMN controller_state_outcome JSONB DEFAULT NULL;
+```
+
+The migration should also creates the extension-service state-history, controller-iteration-ID,
+and queued-object tables which are required for the controller framework. Existing `KUBERNETES_POD` services are backfilled to `Active`.
+
+For `DPF_HELM_CHART` extension services,
+
+- The controller states are `Creating`, `Ready`,
+  `Updating`, `Deleting`, `Deleted`, and `Failed`;
+- `controller_state_version` is independent of API-visible `version_ctr` and provides protection against
+  stale controller iterations;
+- `controller_state_outcome` stores the latest safe
+  diagnostic; it is not desired service state.
+
+The API exposes lifecycle state through additive `DpuExtensionService.lifecycle_state`.
 
 ```proto
-message CreateDpuExtensionServiceRequest {
-  optional string service_id = 1;
-  string service_name = 2;
-  optional string description = 3;
-  DpuExtensionServiceType service_type = 4;
-  string tenant_organization_id = 5;
-
-  // Immutable, service-type-specific specification for the initial version.
-  string data = 6;
-
-  // KUBERNETES_POD only.
-  optional DpuExtensionServiceCredential credential = 7;
-
-  optional DpuExtensionServiceObservability observability = 8;
-
-  // DPF_HELM_CHART only.
-  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 9;
-
-  // DPF_HELM_CHART only.
-  DpuExtensionServiceDeploymentScope deployment_scope = 10; // Defaults to ALL_DPUS.
-}
-
-message UpdateDpuExtensionServiceRequest {
-  string service_id = 1;
-
-  optional string service_name = 2;
-  optional string description = 3;
-
-  // Creates a new immutable service version.
-  string data = 4;
-
-  // KUBERNETES_POD only.
-  optional DpuExtensionServiceCredential credential = 5;
-
-  optional int32 if_version_ctr_match = 6;
-
-  optional DpuExtensionServiceObservability observability = 7;
-
-  // DPF_HELM_CHART only.
-  repeated DpuExtensionServiceCredential dpf_helm_chart_credentials = 8;
+enum DpuExtensionServiceLifecycleState {
+  DPU_EXTENSION_SERVICE_LIFECYCLE_UNKNOWN = 0;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_CREATING = 1;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_ACTIVE = 2;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_UPDATING = 3;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_DELETING = 4;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_FAILED = 5;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_DELETED = 6;
 }
 
 message DpuExtensionService {
-  // Existing fields unchanged.
-
-  // Present only for DPF_HELM_CHART.
-  optional DpuExtensionServiceDeploymentScope deployment_scope = 11;
-}
-
-message DpuExtensionServiceVersionInfo {
-  // Existing fields unchanged.
-
-  // Present only for DPF_HELM_CHART.
-  optional DpuExtensionServiceVersionDeploymentStatus deployment_status = 6;
+  // Existing fields 1 through 10.
+  optional DpuExtensionServiceLifecycleState lifecycle_state = 11;
 }
 ```
 
-`deployment_scope` is not included in `UpdateDpuExtensionServiceRequest` because it is immutable at the service level. Updating `data` or credentials creates a new immutable version with the same service type and deployment scope.
+- `KUBERNETES_POD` services leaves this lifecycle_state as None.
+- `DPF_HELM_CHART` services report their controller state.
 
-### 3.2 Service Type
+### 3.2 Create `DPF_HELM_CHART` Extension Service
 
-Add a new extension service type:
+`CreateDpuExtensionService` is responsible for accepting the request and
+durably recording NICo's desired state. The handler validates the request,
+persists the extension-service record and its initial `Creating` state in one
+database transaction, commits that transaction, and enqueues the service ID.
+The handler does not create DPF resources.
+
+`ExtensionServiceStateController` is responsible for reconciling the persisted
+intent with DPF. After it observes the committed `Creating` state, it reads the
+desired service, creates or verifies the detached DPF `DPUService`, and records
+the reconciliation outcome. Successful reconciliation transitions the service
+from `Creating` to `Active`.
+
+The create response therefore means that NICo accepted the requested service;
+it does not mean that DPF accepted the CR or that the Helm workload is healthy.
+`Active` means only that the desired DPUService CR has been reconciled. Argo
+CD, Helm, and per-DPU workload health are reported through their respective
+status paths.
+
+The DPUService remains detached after creation. It is deployed only after a
+later instance attachment causes NICo to apply the matching placement label to
+the target `DPUDevice` resources.
+
+The create workflow is:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as NICo API
+    participant DB as PostgreSQL
+    participant Controller as ExtensionServiceStateController
+    participant DPF as DPF Management Cluster
+
+    User->>API: CreateDpuExtensionService
+    API->>API: Validate and normalize desired service
+    API->>DB: Persist service, V1, and Creating state
+    API->>DB: Commit transaction
+    API->>DB: Enqueue service ID
+    API-->>User: Return service in Creating state
+    Controller->>DB: Read persisted Creating state and desired service
+    Controller->>DPF: Create or verify detached DPUService
+    DPF-->>Controller: Created or verified owned DPUService
+    Controller->>DB: Compare-and-swap Creating state to Active state
+```
+
+#### 3.2.1 API and Validation
+
+The existing DPU Extension Service creation API is reused for `DPF_HELM_CHART`. The only type-level API change is the addition of `DPF_HELM_CHART = 1`:
 
 ```proto
 enum DpuExtensionServiceType {
@@ -108,70 +272,38 @@ enum DpuExtensionServiceType {
 }
 ```
 
-The service type is immutable and determines how the workload is deployed and reconciled:
-- `KUBERNETES_POD` is delivered to the DPU and managed locally by the DPU agent through kubelet. This behavior is unchanged.
-- `DPF_HELM_CHART` is reconciled through DPF by the `ExtensionServiceReconciliationController`.
-
-### 3.3 Deployment Scope
-
-Add `deployment_scope` to `CreateDpuExtensionServiceRequest` to describe where a `DPF_HELM_CHART` service runs.
+The existing create request fields are reused and unchanged:
 
 ```proto
-enum DpuExtensionServiceDeploymentScope {
-  ALL_DPUS = 0;
-  INSTANCE_DPUS = 1;
+message CreateDpuExtensionServiceRequest {
+  optional string service_id = 1;
+  string service_name = 2;
+  optional string description = 3;
+  DpuExtensionServiceType service_type = 4;
+  string tenant_organization_id = 5;
+  string data = 6;
+  optional DpuExtensionServiceCredential credential = 7;
+  optional DpuExtensionServiceObservability observability = 8;
 }
 ```
 
-Deployment scope applies only to `DPF_HELM_CHART`. For `KUBERNETES_POD`, the default zero value is ignored; existing instance configuration still determines deployment.
+The `service_name` is a NICo-facing display and lookup name. It will not be used as the `DPUService` name, Helm release name, or placement-label key. The current NICo database enforces name uniqueness per tenant organization, case-insensitively. Both `service_name` and `description` may be changed through
+`UpdateExtensionServiceConfig`, as described in
+[Section 3.3](#33-update-extension-service).
 
-For `DPF_HELM_CHART`, omission defaults to `ALL_DPUS`. The value is stored on the parent service and shared by all versions. There is no `UNSPECIFIED` value.
+For `DPF_HELM_CHART`, `data` contains the mutable JSON service definition used
+to construct and update the DPF `DPUService`. It includes the Helm chart source
+and version, chart-specific Helm values, and other supported service
+configuration.
 
-Deployment scope cannot be changed by an update. A tenant that requires a different scope must create a new extension service.
-
-#### 3.3.1 `ALL_DPUS`
-
-`ALL_DPUS` is supported in Stage 1. When a service version is created, NICo adds it to every compatible shared `DPUDeployment`. DPF then deploys the workload to all DPUs selected by those deployments.
-
-An `ALL_DPUS` service:
-- is deployed automatically to all DPUs in every compatible `DPUDeployment` after creation;
-- is not attached to an instance;
-- must not be included in an instance's extension service configuration;
-- is rejected if referenced through `updateInstance`; and
-- reports deployment state at the service-version level.
-
-#### 3.3.2 `INSTANCE_DPUS`
-
-`INSTANCE_DPUS` is supported in Stage 2 as it requires the "Propagating labels from `DPUDevice` to the corresponding `v1.node` object" feature from DPF team. When a service version is created, NICo registers it with every compatible shared `DPUDeployment`, but injects a generated Node selector that initially matches no DPU. The version can therefore become ready for attachment without running a workload.
-
-When an instance references the version through `updateInstance`, NICo:
-
-1. determines which DPUs are selected by the instance;
-2. adds a generated label to the corresponding `DPUDevice` resources;
-3. waits for DPF to propagate the label to the corresponding Kubernetes Nodes; and
-4. observes the workload running on those Nodes.
-
-The workload runs only on DPUs selected by instances that reference that exact service version.
-
-`INSTANCE_DPUS` is accepted only after the site's Stage 2 capability is enabled. Until the required DPF Node-label propagation feature is available and configured, creation requests using this scope are rejected.
-
-### 3.4 Data: Helm Chart and Values
-
-The existing `data` field remains the immutable, service-type-specific payload for each extension service version.
-
-For `DPF_HELM_CHART`, tenants must provide `data` as a JSON object describing the Helm chart and values.
+Example input `data`:
 
 ```json
 {
   "repoURL": "oci://registry.example.com/charts",
-  "chart": "tenant-service",
+  "chartName": "tenant-service",
   "chartVersion": "1.2.3",
-  "deploymentTypes": [
-    "BF3"
-  ],
-  "imageRegistries": [
-    "registry.example.com"
-  ],
+  "security.privileged": true,
   "values": {
     "image": {
       "repository": "registry.example.com/tenant/service",
@@ -184,525 +316,489 @@ For `DPF_HELM_CHART`, tenants must provide `data` as a JSON object describing th
 }
 ```
 
-| Field             | Required | Description                                             |
-| ----------------- | -------- | ------------------------------------------------------- |
-| `repoURL`         | Yes      | Approved HTTPS or OCI Helm repository URL.              |
-| `chart`           | Yes      | Qualified chart name.                                   |
-| `chartVersion`    | Yes      | Exact pinned chart version.                             |
-| `deploymentTypes` | Yes      | DPU deployment types supported by this version.         |
-| `imageRegistries` | No       | Image registries for which credentials may be supplied. |
-| `values`          | No       | Immutable chart-specific Helm values.                   |
-
-The API parses, validates, normalizes, and stores this JSON. Unknown top-level fields are rejected.
-
-`repoURL`, `chart`, and `chartVersion` are mapped into `DPUServiceTemplate.spec.helmChart.source`. Tenant-provided `values` form the base of `DPUServiceTemplate.spec.helmChart.values`.
-
-NICo generates and owns values required for deployment and resource management, including:
-
-* DPF resource names;
-* Helm release name;
-* `deploymentServiceName`;
-* ownership labels;
-* image pull Secret names;
-* the Stage 2 `INSTANCE_DPUS` Node selector; and
-* `upgradePolicy.applyNodeEffect`.
-
-Tenant-provided values must not override NICo-owned fields. Reserved paths include:
-```text
-additionalNodeSelector
-imagePullSecrets
-```
-
-The complete reserved path list is defined by the [qualified chart contract in Appendix A](#appendix-a).
-
-### 3.5 Credentials
-
-The existing singular `credential` field remains specific to `KUBERNETES_POD`.
-
-A `DPF_HELM_CHART` version may require more than one credential:
-- one credential for accessing the Helm chart repository; and
-- zero or more credentials for pulling container images.
-
-```proto
-enum DpuExtensionServiceCredentialPurpose {
-  DPU_EXTENSION_SERVICE_CREDENTIAL_PURPOSE_UNSPECIFIED = 0;
-  DPU_EXTENSION_SERVICE_CREDENTIAL_PURPOSE_IMAGE_REGISTRY = 1;
-  DPU_EXTENSION_SERVICE_CREDENTIAL_PURPOSE_CHART_REPOSITORY = 2;
-}
-
-message DpuExtensionServiceCredential {
-  string registry_url = 1;
-
-  oneof type {
-    UsernamePassword username_password = 2;
-  }
-
-  DpuExtensionServiceCredentialPurpose purpose = 3;
-}
-```
-
-Credentials are stored through `CredentialManager` and are write-only. Read APIs only report whether credentials exist for a version.
-```text
-machines/extension-services/<service-id>/versions/<version>/chart-repository
-machines/extension-services/<service-id>/versions/<version>/image-registries/<sha256-registry-url>
-```
-
-### 3.6 Version Deployment Status
-
-A successful create or update response means that NICo validated and stored the version. It does not mean that DPF resources or workloads are ready.
-
-```proto
-enum DpuExtensionServiceVersionDeploymentState {
-  DPU_EXTENSION_SERVICE_VERSION_DEPLOYMENT_UNSPECIFIED = 0;
-  DPU_EXTENSION_SERVICE_VERSION_ACCEPTED = 1;
-  DPU_EXTENSION_SERVICE_VERSION_DEPLOYING = 2;
-  DPU_EXTENSION_SERVICE_VERSION_READY = 3;
-  DPU_EXTENSION_SERVICE_VERSION_ERROR = 4;
-  DPU_EXTENSION_SERVICE_VERSION_DELETING = 5;
-}
-
-message DpuExtensionServiceVersionDeploymentStatus {
-  DpuExtensionServiceVersionDeploymentState state = 1;
-  string message = 2;
-}
-```
-
-The status is populated only for `DPF_HELM_CHART`.
-
-- For `ALL_DPUS`, `READY` means the service has been deployed through every compatible `DPUDeployment` and the required workload readiness conditions are satisfied.
-- For `INSTANCE_DPUS`, `READY` means the reusable service has been registered and is available for attachment. It does not mean that a workload is already running on a DPU.
-
-### 3.7 Request Validation
-
-For `DPF_HELM_CHART`, the API rejects a create or update request when:
-
-* the deployment scope is invalid or is not enabled for the site;
-* `data` is not valid Helm service JSON;
-* required chart fields are missing;
-* the repository URL is unsupported or contains embedded credentials;
-* the chart version is not pinned;
-* tenant values override NICo-owned fields;
-* the wrong credential field is used;
-* credential purposes or endpoints do not match the chart data; or
-* duplicate credentials are provided.
-
-Implementation-specific limits, such as maximum value size and exact repository URL validation, are enforced by the API but are not specified in this design.
-
-The API validates the request against stored chart qualification and site configuration. It does not download, render, or install the Helm chart in the request path.
-
-## 4. Database Changes
-
-The existing `extension_services` and `extension_service_versions` tables continue to store extension service metadata and immutable version data.
-
-`DPF_HELM_CHART` adds two kinds of persistent state:
-- service-version reconciliation state for both scopes; and
-- per-instance, per-DPU attachment state for `INSTANCE_DPUS`.
-
-### 4.1 Extension Service Deployment Scope
-
-Deployment scope is stored on `extension_services` because it is immutable and shared by all versions of the service. The column remains `NULL` for `KUBERNETES_POD`.
-
-```sql
-ALTER TABLE extension_services
-    ADD COLUMN deployment_scope VARCHAR(32),
-    ADD CONSTRAINT extension_services_deployment_scope_check
-        CHECK (deployment_scope IS NULL OR
-               deployment_scope IN ('ALL_DPUS', 'INSTANCE_DPUS'));
-```
-
-Note:
-- When a `DPF_HELM_CHART` create request omits `deployment_scope`, the API stores `ALL_DPUS`.
-- During Stage 1, only `ALL_DPUS` services can be created. During Stage 2, the API may also create services with `INSTANCE_DPUS` after the site capability is enabled.
-
-### 4.2 Extension Service Version Reconciliation
-
-Create `extension_service_reconciliations` with one row for each `DPF_HELM_CHART` service version.
-
-```sql
-CREATE TABLE extension_service_reconciliations (
-    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    service_id           UUID NOT NULL,
-    service_version      VARCHAR(64) NOT NULL,
-
-    dpf_service_name     VARCHAR(63) NOT NULL,
-
-    desired_state        VARCHAR(16) NOT NULL DEFAULT 'ACTIVE',
-    deployment_state     VARCHAR(16) NOT NULL DEFAULT 'ACCEPTED',
-    status_message       VARCHAR(2048),
-
-    reconcile_attempts   INTEGER NOT NULL DEFAULT 0,
-    last_attempted_at    TIMESTAMPTZ,
-    last_observed_at     TIMESTAMPTZ,
-    next_reconcile_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    cleanup_completed_at TIMESTAMPTZ,
-
-    created_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    FOREIGN KEY (service_id, service_version)
-        REFERENCES extension_service_versions (service_id, version),
-    UNIQUE (service_id, service_version),
-    UNIQUE (dpf_service_name),
-    CHECK (desired_state IN ('ACTIVE', 'DELETING')),
-    CHECK (deployment_state IN
-        ('ACCEPTED', 'DEPLOYING', 'READY', 'ERROR', 'DELETING'))
-);
-```
-
-The row is the durable work item for `ExtensionServiceReconciliationController` and stores the desired lifecycle state, current deployment state, generated DPF service name, and retry metadata. The API creates it in the same transaction as the immutable service version.
-
-The table is used by both scopes:
-
-- For `ALL_DPUS`, it tracks deployment of the version to every compatible DPUDeployment.
-- For `INSTANCE_DPUS`, it tracks registration of the reusable DPF service. Instance-specific state is stored in `extension_service_attachments`.
-
-### 4.3 Extension Service Instance Attachment
-
-Create `extension_service_attachments` with per-DPU state for `INSTANCE_DPUS`.
-
-```sql
-CREATE TABLE extension_service_attachments (
-    instance_id                       UUID NOT NULL,
-    dpu_machine_id                    UUID NOT NULL,
-    service_id                        UUID NOT NULL,
-    service_version                   VARCHAR(64) NOT NULL,
-
-    extension_services_config_version VARCHAR(64) NOT NULL,
-    instance_config_version           VARCHAR(64),
-
-    attachment_state                  VARCHAR(16) NOT NULL DEFAULT 'ACTIVE',
-    deployment_state                  VARCHAR(16) NOT NULL DEFAULT 'PENDING',
-
-    components                        JSONB NOT NULL DEFAULT '[]'::jsonb,
-    status_message                    VARCHAR(2048),
-    observed_at                       TIMESTAMPTZ,
-    created_at                        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at                        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CHECK (attachment_state IN ('ACTIVE', 'REMOVING')),
-    CHECK (deployment_state IN (
-        'PENDING',
-        'RUNNING',
-        'TERMINATING',
-        'TERMINATED',
-        'ERROR',
-        'UNKNOWN'
-    ))
-);
-```
-
-Each row begins in `PENDING` and is updated as NICo observes label propagation and workload state. On detach or a selected-DPU-set change, affected rows move to `REMOVING` until deployment labels and workloads are gone and the attachment reaches `TERMINATED`.
-
-## 5. Architecture and Lifecycle
-
-### 5.1 Architecture Overview
-
-The NICo API validates and stores each immutable `DPF_HELM_CHART` version. `ExtensionServiceReconciliationController`, running in the Site Controller, creates reusable DPF resources and registers them with compatible shared `DPUDeployment` objects.Deployment scope determines the resulting workload placement:
-- In Stage 1, an `ALL_DPUS` service is deployed immediately to all DPUs selected by compatible deployments.
-- In Stage 2, an `INSTANCE_DPUS` service initially matches no DPU. Deployment begins only when an instance references the version and NICo labels the instance's selected DPUs.
-DPF owns the Helm release and workload lifecycle. The controller observes DPF and workload state and stores the result in PostgreSQL.
-
-`DPF_HELM_CHART` does not flow through the DPU agent. The DPU agent remains responsible only for `KUBERNETES_POD`.
-
-### 5.2 Service Version Creation
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant API as NICo API
-    participant Credentials as CredentialManager
-    participant DB as PostgreSQL
-    participant Controller as ExtensionServiceReconciliationController
-    participant DPF as DPF Management Cluster
-    participant K8s as DPU Kubernetes Cluster
-
-    User->>API: CreateDpuExtensionService
-    API->>API: Validate and normalize
-    API->>Credentials: Store version credentials
-    API->>DB: Store service, version, and reconciliation row
-    API-->>User: Return ACCEPTED
-
-    Controller->>DB: Load due reconciliation
-    Controller->>Credentials: Read credentials
-    Controller->>DPF: Reconcile Secrets and service resources
-    Controller->>DPF: Register service with compatible DPUDeployments
-
-    alt scope = ALL_DPUS
-        DPF->>K8s: Deploy workload to compatible DPUs
-    else scope = INSTANCE_DPUS
-        DPF->>K8s: Create workload with unmatched selector
-    end
-
-    Controller->>DPF: Observe generated resources
-    Controller->>K8s: Observe workload when required
-    Controller->>DB: Store DEPLOYING, READY, or ERROR
-```
-
-For a valid request, the API handler:
-
-1. Validates or creates the `ExtensionServiceId`, validates the immutable deployment scope, and uses the initial `ConfigVersion` for the new service. When an update call is received, the API handler will use the next version without changing the scope.
-2. Parses `data` into the new `carbide_dpf::types::DpfHelmChartServiceData` model proposed above and serializes the normalized JSON.
-3. Validates and stores credentials using deterministic `CredentialManager` paths:
-   ```text
-   machines/extension-services/<service-id>/versions/<version>/chart-repository
-   machines/extension-services/<service-id>/versions/<version>/image-registries/<sha256-registry-url>
-   ```
-4. In one PostgreSQL transaction:
-   - inserts the `extension_services` record with its immutable `deployment_scope`;
-   - inserts `extension_service_versions` with normalized JSON and `has_credential`;
-   - inserts a `extension_service_reconciliations` row with `desired_state = 'ACTIVE'` and `deployment_state = 'ACCEPTED'`; and
-   - reserves the deterministic DPF service name through that row's unique `dpf_service_name` constraint.
-5. Commits and enqueues the reconciliation `id`. Periodic due-row listing is the fallback if enqueueing is lost after commit.
-6. Returns the normal `DpuExtensionService` response.
-
-If the DB transaction fails after credentials were written, the handler should best-effort delete the credentials, following the existing compensation pattern.
-
-### 5.3 Extension Service Reconciliation Controller
-
-Following the existing pattern, add an `ExtensionServiceReconciliationController` and start it from `api-core::setup`. It reconciles stored DPF Helm versions with the DPF management cluster. External operations are idempotent and retryable after partial failure or restart.
-
-For each row in `extension_service_reconciliations` with `desired_state = 'ACTIVE'`, the controller
-1. Acquires a lock keyed by the reconciliation `id`, then re-reads the row so a concurrent delete cannot be missed.
-2. Loads the service, immutable deployment scope, version, site DPF configuration, and purpose-qualified credentials.
-3. Sets `deployment_state = 'DEPLOYING'`, increments `reconcile_attempts`, and records `last_attempted_at`.
-4. Revalidates deployment availability, generated-object ownership, and DPUDeployment capacity.
-5. Reconciles chart-repository and image-pull Secrets.
-6. Applies the owned `DPUServiceTemplate` and `DPUServiceConfiguration`.
-7. Registers the service under `DPUDeployment.spec.services`.
-8. Observes the generated DPF resources and workload state. 
-9. Records the resulting deployment status.
-
-The DPF service name and `INSTANCE_DPUS` Node label are deterministic hashes of the full service UUID and version because the `DPUDeployment.spec.services` key and both `deploymentServiceName` fields are limited to 28 characters.
-- DPF service name: `ext-<20-character-base32-hash>`
-- Node label key: `carbide.nvidia.com/extsvc-<hash>`
-- Node label value: `enabled`
-
-#### 5.3.1 Generate DPF Resources
-
-NICo does not build a `DPUService` directly. The controller parses `extension_service_versions.data`, builds the owned `DPUServiceTemplate` and `DPUServiceConfiguration`, and adds references to them under `DPUDeployment.spec.services`. DPF then generates and reconciles the resulting `DPUService`.
-
-| Source                                 | DPF destination                                                                                                |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| Generated service name                 | Template/configuration names, release name, both `deploymentServiceName` fields, and DPUDeployment service key |
-| `repoURL`                              | `DPUServiceTemplate.spec.helmChart.source.repoURL`                                                             |
-| `chart`                                | `DPUServiceTemplate.spec.helmChart.source.chart`                                                               |
-| `chartVersion`                         | `DPUServiceTemplate.spec.helmChart.source.version`                                                             |
-| `deploymentTypes`                      | Compatible `DPUDeployment` selection                                                                           |
-| Tenant `values`                        | Base of `DPUServiceTemplate.spec.helmChart.values`                                                             |
-| Generated label (`INSTANCE_DPUS` only) | `helmChart.values.additionalNodeSelector`                                                                      |
-| Generated image Secret                 | Qualified chart's reserved `imagePullSecrets` value                                                            |
-| Constant `false`                       | `DPUServiceConfiguration.spec.upgradePolicy.applyNodeEffect`                                                   |
-
-For the `INSTANCE_DPUS` data example in Section 3.4, the generated resources are equivalent to:
+| Field                 | Type      | Required | NICo validation and DPUService mapping                               |
+| --------------------- | --------- | -------- | -------------------------------------------------------------------- |
+| `repoURL`             | `string`  | Yes      | Helm repository URL; maps to `spec.helmChart.source.repoURL`.        |
+| `chartName`           | `string`  | Yes      | Qualified chart name; maps to `spec.helmChart.source.chart`.         |
+| `chartVersion`        | `string`  | Yes      | Exact pinned chart version; maps to `spec.helmChart.source.version`. |
+| `security.privileged` | `boolean` | Yes      | Service privilege policy; maps to `spec.security.privileged`.        |
+| `values`              | `object`  | No       | Chart-specific Helm values; maps to `spec.helmChart.values`.         |
+
+The create API rejects a request when required DPF prerequisites are
+unavailable for the site, `data` is invalid, or required chart fields are
+missing.
+
+After validation, the API handler creates or validates the
+`ExtensionServiceId` and opens a database transaction. In that transaction, it
+persists the `extension_services` record, the normalized `data` in the initial
+`extension_service_versions` row `V1`, and
+`controller_state = Creating` with its initial `controller_state_version`.
+The persisted state is the durable desired create operation; the handler does
+not call DPF while the transaction is open or after it commits.
+
+After the transaction commits, the handler enqueues the service ID for
+`ExtensionServiceStateController` and returns the service in `Creating` state.
+The response confirms that NICo accepted the create request, not that DPF has
+accepted the DPUService or that its workload is healthy. The enqueue is a
+prompt for reconciliation rather than the source of truth: the controller
+framework's periodic scan recovers a missed enqueue or NICo restart.
+
+#### 3.2.2 State Controller Create Reconciliation
+
+The `ExtensionServiceStateController` processes the queued `Creating` service by reading the
+persisted desired state and constructing the detached DPUService described in
+[Section 3.2.3](#323-dpuservice-specification).
+
+The controller calls `DpfOperations::create_dpu_service` outside a database
+transaction. A successful create, or an `AlreadyExists` DPUService with the
+expected NICo ownership and immutable identity, permits a compare-and-swap
+transition from `Creating` to `Active`. The transition succeeds only when
+`controller_state_version` still matches the version read by that controller
+iteration.
+
+For example, a delete request may change the service to `Deleting` while a
+create operation is in flight. The stale create iteration cannot overwrite
+`Deleting` with `Active` because its compare-and-swap transition fails. When the
+controller transition loses the compare-and-swap check ,it automatically
+re-enqueues the service ID. The next iteration observes `Deleting` and performs
+cleanup instead.
+
+Transient DPF failures leave the service in `Creating` for retry. A validation,
+authorization, ownership, or immutable-specification conflict transitions it
+to `Failed` with a diagnostic outcome. Services in `Creating` or `Failed`
+cannot be attached to an instance.
+
+#### 3.2.3 DPUService Specification
+
+For each `Creating` iteration, `ExtensionServiceStateController` reads desired
+extension service information from the service's database row and projects it
+into one detached `DPUService` spec.
+
+The controller maps persisted and generated values as follows:
+
+| NICo source or generated value                | DPUService field or behavior                                                             |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Generated ext-svc name based on ext-svc UUID  | `metadata.name` and `spec.helmChart.source.releaseName`                                  |
+| Service UUID                                  | `metadata.labels["nico/extension-service-id"]` for NICo ownership verification           |
+| Management namespace                          | `metadata.namespace = dpf-operator-system`                                               |
+| `data.repoURL`                                | `spec.helmChart.source.repoURL`                                                          |
+| `data.chartName`                              | `spec.helmChart.source.chart`                                                            |
+| `data.chartVersion`                           | `spec.helmChart.source.version`                                                          |
+| `data.values`                                 | `spec.helmChart.values`                                                                  |
+| `data.security.privileged`                    | `spec.security.privileged`                                                               |
+| Generated node selector based on ext-svc UUID | `spec.serviceDaemonSet.nodeSelector`                                                     |
+| Stage 1 deployment model                      | `spec.deployInCluster = false` and no `serviceID`, interfaces, or config ports           |
+| Stage 1 DPUCluster model                      | `spec.dpuClusterSelector` is unset; DPF creates an Application in every known DPUCluster |
+
+NOTE: The `DPUService` name and node selector are deterministically derived from the
+extension service UUID rather than from the mutable service name.
+The Kubernetes resource name, Helm release name, and placement-label key are
+therefore stable for the service lifetime.
+
+- DPUService name: `extsvc-<hash>`
+- Node-label key/value: `nico/extsvc-<hash>: enabled`
+
+For the `data` example in Section 3.2.1, NICo creates the following DPUService:
 
 ```yaml
 apiVersion: svc.dpu.nvidia.com/v1alpha1
-kind: DPUServiceTemplate
+kind: DPUService
 metadata:
-  name: ext-abc123
+  name: extsvc-abc123
   namespace: dpf-operator-system
   labels:
-    carbide.nvidia.com/extension-service-id: <service-uuid>
-    carbide.nvidia.com/extension-service-version: <config-version>
+    nico/extension-service-id: <service-uuid>
 spec:
-  deploymentServiceName: ext-abc123
+  deployInCluster: false
+  security:
+    privileged: true
   helmChart:
     source:
       repoURL: oci://registry.example.com/charts
       chart: tenant-service
       version: 1.2.3
-      releaseName: ext-abc123
+      releaseName: extsvc-abc123
     values:
       image:
         repository: registry.example.com/tenant/service
         tag: 1.2.3
       service:
         logLevel: info
-      additionalNodeSelector:
-        carbide.nvidia.com/extsvc-abc123: enabled
-      imagePullSecrets:
-        - name: ext-abc123-pull
----
-apiVersion: svc.dpu.nvidia.com/v1alpha1
-kind: DPUServiceConfiguration
-metadata:
-  name: ext-abc123
-  namespace: dpf-operator-system
-spec:
-  deploymentServiceName: ext-abc123
-  upgradePolicy:
-    applyNodeEffect: false
+  serviceDaemonSet:
+    nodeSelector:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: nico/extsvc-abc123
+              operator: In
+              values: [enabled]
 ```
 
-For each declared deployment type (`BF3` in this example), the controller resolves the configured DPUDeployment and merges only this entry:
+### 3.3 Update Extension Service
 
-```yaml
-spec:
-  services:
-    ext-abc123:
-      serviceTemplate: ext-abc123
-      serviceConfiguration: ext-abc123
+For `DPF_HELM_CHART`, an update is an asynchronous, in-place change to the
+stable DPF `DPUService`. It does not create another attachable
+`ConfigVersion`. The only active version remains `V1`, and every instance that
+has the service attached receives the updated chart revision without an
+`UpdateInstanceConfig` call or reattachment.
+
+This differs from `KUBERNETES_POD`, where each data update creates a new
+version so an instance configuration can select its old or new Pod
+specification for a tenant-directed rollout. The existing `KUBERNETES_POD`
+update behavior is unchanged.
+
+#### 3.3.1 API Handler
+
+`UpdateDpuExtensionService` retains its existing API shape:
+
+```proto
+message UpdateDpuExtensionServiceRequest {
+  string service_id = 1;
+  optional string service_name = 2;
+  optional string description = 3;
+  string data = 4;
+  optional DpuExtensionServiceCredential credential = 5;
+  optional int32 if_version_ctr_match = 6;
+  optional DpuExtensionServiceObservability observability = 7;
+}
 ```
 
-The update uses a resource-version precondition and conflict retry. It does not force-apply or replace the shared DPUDeployment. The controller re-reads the live object and enforces the CRD limit of 50 service entries before adding the key.
+For `DPF_HELM_CHART`, the update API handler first locks the service row and checks
+`if_version_ctr_match`, when supplied, against the current `version_ctr`. A
+Helm-data update is accepted only while the controller state is `Active`; it is
+rejected while the service is `Creating`, `Updating`, `Deleting`, `Deleted`,
+or `Failed`.
 
-#### 5.3.2 Service Deployment to DPU
+A non-empty `data` value is a **complete** replacement Helm-service
+definition, not a DPUService or Kubernetes merge-patch document. It must
+include every field required at creation, including the chart repository URL,
+chart name, chart version, Helm values, and security policy.
 
-**Stage 1 — `ALL_DPUS`:** The controller omits `additionalNodeSelector`; charts used only with this scope need not support it. After registration, DPF deploys the workload to every DPU selected by each compatible deployment. The version becomes `READY` after all compatible deployments reference it and required resources and workloads are ready. `ALL_DPUS` creates no attachment rows, has no instance status, and cannot be detached from an instance. A new version does not remove the previous one.
+An empty `data` value means it's a metadata-only update, which does not require
+DPF reconciliation and completed immediately after validation.
 
-**Stage 2 — `INSTANCE_DPUS`:** The controller injects a generated `additionalNodeSelector`. No Node initially has this label, so a DaemonSet with no Pods is ready for attachment. When `updateInstance` references the version, NICo stores the instance configuration and creates one `extension_service_attachments` row per selected DPU before adding the generated label to its `DPUDevice`. DPF propagates the label to the Node. The chart combines the DPF and NICo selectors:
+The API handler validates and normalizes the complete desired service spec and:
 
-```yaml
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      {{- toYaml .Values.serviceDaemonSet.nodeSelector | nindent 6 }}
+1. updates the existing `V1` row with the desired normalized `data` and
+   requested version-owned metadata;
+2. applies requested service metadata;
+3. increments `version_ctr`; and
+4. transitions the controller state to `Updating` with the target
+   `version_ctr` and the deterministic material DPUService-specification hash.
 
-nodeSelector:
-  {{- toYaml .Values.additionalNodeSelector | nindent 2 }}
+After committing, the handler enqueues the service ID for `ExtensionServiceStateController` and returns the
+service in `Updating` state. The response means NICo durably accepted the
+desired revision; it does not mean DPF accepted the patch or that a workload
+rollout completed.
+
+#### 3.3.2 State Controller Update Reconciliation
+
+`ExtensionServiceStateController` processes an `Updating` service from its
+persisted desired `V1.data`. It constructs an internal Kubernetes merge patch
+and calls `DpfOperations::patch_dpu_service` outside a database transaction.
+The merge patch is an implementation detail, not a public API format.
+
+Before patching, the controller gets the deterministically named DPUService
+and verifies NICo ownership and immutable identity. The patch includes only
+NICo-owned mutable fields: Helm source, Helm values,
+`security.privileged`, and the revision ownership label. It does not change
+the DPUService name, Helm release name, placement selector, or fields omitted
+from the update.
+
+After DPF accepts the patch, the controller transitions `Updating` to `Active`
+with a `controller_state_version` compare-and-swap transaction. A stale update
+iteration cannot overwrite a later delete or update state; a failed
+compare-and-swap is re-enqueued by the state-controller framework, and the
+next iteration reads the winning state. `active_versions` continues to contain
+only `V1`.
+
+Note when DPF accepts an update, it reconciles the existing Argo CD Application in
+each selected DPUCluster rather than creating a new Application for the chart
+revision. The resulting rollout is asynchronous and non-atomic: DPUs can run
+the old revision, the new revision, or a failed workload concurrently. DPF
+does not automatically roll back an unhealthy Application; rollback means another
+in-place update.
+
+### 3.4 Delete Extension Service
+
+#### 3.4.1 API Handler
+
+DPF deletes a DPUService asynchronously: after accepting deletion, it can retain
+the CR while finalizers remove the associated Argo CD Applications and related
+resources. For `DPF_HELM_CHART`, an omitted version or `V1` identifies the
+sole deployable service; any other version is rejected.
+
+The handler locks the service and rejects deletion while it is referenced by an
+active instance, or by a deleting instance whose extension-service cleanup is
+incomplete. It accepts deletion from `Creating`, `Active`, `Updating`, or
+`Failed`. A repeat request while the service is `Deleting` is idempotently
+accepted.
+
+In one transaction, the handler soft-deletes the service and `V1`, and changes
+the controller state to `Deleting` with a new `controller_state_version`. It
+does not call DPF. After the transaction commits, it enqueues the service ID
+for `ExtensionServiceStateController` and returns the normal delete response.
+The response means NICo durably accepted cleanup; it does not mean DPF has
+deleted the DPUService.
+
+The soft-deleted display name is reusable only after the state gets transitioned to `DELETED`.
+ A newly created service with that display name receives a new UUID, DPUService name, and placement-label key; it cannot refer to the deleted service.
+
+#### 3.4.2 State Controller Delete Reconciliation
+
+The controller processes a `Deleting` service by deriving its DPUService name
+from the retained service ID and getting the DPUService. `NotFound` is success.
+When the object exists, the controller verifies the NICo ownership label before
+calling `DpfOperations::delete_dpu_service` outside a database transaction. An
+ownership mismatch transitions the service to `Failed`; NICo must not delete an
+unrecognized object.
+
+An in-flight create or update DPF call can still complete after the delete
+transaction commits. Its stale state transition cannot overwrite `Deleting`
+because the controller-state compare-and-swap fails. The state-controller
+framework re-enqueues the service, and the next iteration observes `Deleting`
+and removes the deterministically named DPUService.
+
+DPF can retain a successfully deleted DPUService with a deletion timestamp
+until its finalizers have removed dependent resources. The controller therefore
+continues to get the DPUService until it receives `NotFound`, then transitions
+`Deleting` to `Deleted` through a `controller_state_version` compare-and-swap.
+Transient get or delete failures leave the service in `Deleting` for retry.
+This remains recoverable after a NICo restart because the soft-deleted service
+record and controller state remain in PostgreSQL.
+
+### 3.5 Attach Service to Instance
+
+#### 3.5.1 Attachment to Instance API and Validation
+
+An instance attaches extension services by including an
+`InstanceDpuExtensionServicesConfig` in its `InstanceConfig`. The configuration
+may be supplied when the instance is created or later through
+`UpdateInstanceConfig`. Each entry identifies an extension service and its
+selected version.
+
+```proto
+message InstanceConfig {
+  ...
+  optional InstanceDpuExtensionServicesConfig dpu_extension_services = 23;
+}
+
+message InstanceDpuExtensionServicesConfig {
+  repeated InstanceDpuExtensionServiceConfig service_configs = 1;
+}
+
+message InstanceDpuExtensionServiceConfig {
+  string service_id = 1;
+  string version = 2;
+}
 ```
 
-The controller then observes label propagation and the current workload Pod on each target Node.
+For `DPF_HELM_CHART` service, version should be an empty string as an update is always an in-place update.
 
-### 5.4 Status and Instance Lifecycle
+When extension services are present in `InstanceConfig`, API handler will validate each requested service. It permits a new `DPF_HELM_CHART`
+attachment only when the site capability gate is enabled and the service is
+`Active`. Meanwhile, an instance cannot have `DPF_HELM_CHART` and `KUBERNETES_POD` extension services at the same time.
 
-Every `DPF_HELM_CHART` version exposes version-level deployment status.
+The handler persists the instance extension service config. The actual labeling of `DPUDevice` is performed in instance state lifecycle.
 
-For Stage 2 `ALL_DPUS`, `READY` means the service is deployed and ready across every compatible deployment.
+#### 3.5.2 Label Placement Reconciliation
 
-For Stage 2 `INSTANCE_DPUS`, `READY` means the reusable service is registered and available for attachment.
+Label synchronization is added to the existing `InstanceState::Ready` handler.
+Current Ready processing already examines extension-service status and cleans
+up completed removal entries; it does not currently reconcile DPUDevice labels.
 
-The status of the `INSTNACE_DPUS` will be reported in the instance status like existing KUBERNETES_POD type. But the observations will be produced by the ExtensionServicReconlicationController. 
+For each `DPF_HELM_CHART` service attached in persisted instance configuration,
+the Ready-path helper selects every physical DPU currently attached to the
+instance host. Attachment neither creates another DPUService nor changes the
+stable selector derived from the extension-service UUID in Section 3.2.3.
 
-`INSTANCE_DPUS` also records per-DPU attachment state:
+Before attachment, no DPUDevice has the matching NICo-owned label. DPF can
+therefore reconcile the detached DPUService and its per-DPUCluster
+Applications while the chart workload remains absent from all DPUs. The helper
+reads each target DPUDevice and applies the matching UUID-derived
+node-selector label (ex. `nico/extsvc-<hash>: enabled`) defined in Section 3.2.3. It merge-patches only that
+attached service's NICo-owned key and value in `spec.cluster.nodeLabels`,
+preserves labels owned by DPF and other controllers, and performs DPF calls
+outside database transactions.
 
-| State         | Meaning                                                                          |
-| ------------- | -------------------------------------------------------------------------------- |
-| `PENDING`     | Placement, label propagation, Node mapping, or workload readiness is incomplete. |
-| `RUNNING`     | The deployment label is present and the current service Pod is ready.            |
-| `TERMINATING` | Placement is being removed but a label or workload remains.                      |
-| `TERMINATED`  | Placement labels and matching workloads are gone.                                |
-| `ERROR`       | A non-transient attachment failure occurred.                                     |
-| `UNKNOWN`     | NICo cannot observe enough state to determine status.                            |
+DPF propagates the matching DPUDevice label to the DPU-cluster Node. The Node
+then satisfies the DPUService selector and the qualified chart can schedule the
+service workload on that DPU. NICo neither creates nor deletes workload Pods during attachment.
 
-A shared `DPUService` or Argo CD ready condition does not prove that a workload is running on a particular DPU. Per-DPU status therefore combines management-cluster readiness, label propagation, Node mapping, and Pod readiness.
+Label synchronization is idempotent: repeating it converges each target
+DPUDevice on the labels derived from current instance configuration. A DPF
+error or temporarily unavailable DPUDevice is retried by later `Ready` state
+execution. It does not move the instance out of `Ready`, fail the
+instance, or block unrelated Ready-state work.
 
-`KUBERNETES_POD` observations continue to come from the DPU agent through `RecordDpuNetworkStatus`.
+### 3.6 Instance Extension Service Status
 
-`DPF_HELM_CHART` observations are produced by the `ExtensionServiceReconciliationController` and stored in PostgreSQL.
+#### 3.6.1 DPF Status Dependency
 
-The two observation sources remain separate internally and are combined only when NICo constructs user-facing instance status.
+DPF is the source of workload status for `DPF_HELM_CHART`. NICo derives the
+DPUService namespace (which is currently all inside `dpf-operator-system`)
+and deterministic name from the extension-service ID and
+uses the service ownership label to identify the service. DPF must report a
+structured service-specific state, diagnostic message, and the DPUService
+generation or equivalent chart revision observed on that DPU.
 
-`INSTANCE_DPUS` uses the existing instance lifecycle gates. Provisioning waits for active attachments to become `RUNNING`, and instance deletion waits for removed attachments to become `TERMINATED`.
+#### 3.6.2 Instance Extension Service Status Mapping
 
-### 5.5 Detach and Instance Deletion
+| DPF state     | NICo state    | Meaning                                           |
+| ------------- | ------------- | ------------------------------------------------- |
+| `Pending`     | `Pending`     | Node selected; service workload is not ready.     |
+| `Running`     | `Running`     | Desired service revision is ready on the DPU.     |
+| `Terminating` | `Terminating` | Node deselected; service workload Pods remain.    |
+| `Terminated`  | `Terminated`  | Node deselected; no service workload Pods remain. |
+| `Error`       | `Error`       | DPF reports a service-specific failure.           |
+| `Unknown`     | `Unknown`     | DPF cannot determine service state.               |
 
-Detach applies only to `INSTANCE_DPUS`.
+A missing or stale DPF observation, DPF read failure, identity mismatch, or
+status result that does not identify the desired revision is `Unknown`. NICo
+must not infer `Terminated` from an absent entry unless DPF explicitly
+guarantees that the DPUService was evaluated and is absent from that DPU.
 
-When a service version is removed from an instance configuration, the corresponding attachment rows move to `REMOVING`.
+### 3.7 Detach Service
 
-The controller removes the generated label only when no other active attachment for the same service version targets that DPU, then waits for the propagated Node label and workload to disappear.
+#### 3.7.1 Detachment API and Persisted Intent
 
-The attachment remains `TERMINATING` while any deployment label or matching workload remains. It becomes `TERMINATED` after both are removed.
+An `UpdateInstanceConfig` request detaches a `DPF_HELM_CHART` service by
+removing it from the requested active-service list. NICo retains the existing
+service configuration in the persisted instance configuration with
+`removed: true`; it does not remove it immediately.
 
-The durable attachment rows preserve every DPU previously targeted by the service. This ensures cleanup remains correct even if the instance's current DPU selection has changed.
+The removed entry is the durable detachment intent. The API handler validates
+and persists the configuration change but does not call DPF. 
 
-Instance deletion uses the same removal path and waits for all `INSTANCE_DPUS` attachments to reach `TERMINATED`.
+#### 3.7.2 DPUDevice Label Removal and Recovery
 
-### 5.7 Service Version Deletion
+The `InstanceState::Ready` label-reconciliation helper derives the current
+target DPUs and removes the service's generated label from each corresponding
+`DPUDevice.spec.cluster.nodeLabels`. It uses the stable selector described in
+Section 3.5.2 and preserves labels owned by DPF and other controllers. DPF
+calls occur outside database transactions.
 
-A service version cannot be deleted while an active or terminating `INSTANCE_DPUS` attachment references it.
+DPF propagates the removed label to the DPU-cluster Node. The Node no longer
+matches the stable DPUService selector, so DPF reconciles removal of the service workload.
+NICo does not delete
+Argo CD Applications or workload Pods during instance detachment.
 
-When deletion is accepted, the API updates the reconciliation row to:
+The removal operation is idempotent. A DPF error or temporarily unavailable
+DPUDevice leaves the `removed: true` entry in place and is retried by later
+Ready execution. It does not move the instance out of `Ready` or block
+unrelated Ready-state work.
 
-```text
-desired_state = DELETING
-deployment_state = DELETING
-next_reconcile_at = CURRENT_TIMESTAMP
-```
+#### 3.7.3 Termination Confirmation and Completion
 
-New attachments to the version are rejected immediately.
+NICo waits for DPF to report `Terminated` for the DPUService on every current
+target DPU. A missing, stale, or indeterminate observation is `Unknown` and is
+not sufficient to complete detachment. Label absence alone does not prove that
+the workload has terminated.
 
-The controller removes the service entry from each compatible `DPUDeployment` and waits for the generated `DPUService` and workload to disappear. It then deletes the owned `DPUServiceConfiguration`, `DPUServiceTemplate`, and generated Secrets.
+After all required DPUService/DPU pairs are `Terminated`, the existing Ready
+path cleans up the `removed: true` entry from persisted instance configuration.
+Until then, the entry remains visible as pending removal and prevents deletion
+of the referenced extension service.
 
-Source credentials remain available until the generated resources no longer require them. The controller then deletes the credentials, records cleanup completion, and soft-deletes the version.
+**Aug 14 Note**: DPF does not currently report a complete list of DPUServices currently
+running on a DPU. There is no way of knowing whether a DPUService is removed
+from a DPU at this point. For initial MVP, we are just going to infer the 
+DPUService is removed if the label is removed.
 
-If no active versions remain, the parent extension service may also be soft-deleted.
+### 3.8 Instance Deletion
 
-All deletion operations are idempotent and can resume after a controller restart or dependency failure.
+During instance deletion, NICo applies the same label-removal synchronization
+to every physical DPU still attached to the host, then waits for DPF-reported
+termination of every required DPUService/DPU pair. DPF patch failures are
+retried and keep deletion in progress. Instance deletion completes only after
+all required services are terminated; label absence alone is insufficient.
 
-## 6. Testing
+**Aug 14 Note**: Again, with no DPF support, for MVP now, we treat label absence as termination.
 
-Testing should cover:
+### 3.9 Design Invariants / Ownership Constraints
 
-- creation of `DPF_HELM_CHART`;
-- omitted DPF scope defaulting to `ALL_DPUS`;
-- rejection of non-default deployment scope for `KUBERNETES_POD`;
-- rejection of `INSTANCE_DPUS` before Stage 2 enablement;
-- Helm data and reserved-value validation;
-- credential purpose and endpoint matching;
-- asynchronous version deployment status;
-- deterministic resource generation and ownership validation;
-- shared `DPUDeployment` conflict handling;
-- controller restart and dependency recovery;
-- global Stage 1 deployment and deletion;
-- Stage 2 unmatched initial selector;
-- attachment only to selected DPUs;
-- label propagation and Pod observation;
-- detach and selected-DPU-set changes;
-- instance version transitions;
-- per-DPU status aggregation;
-- version deletion blocking while attachments remain; and
-- compatibility with existing `KUBERNETES_POD` behavior.
+The following rules apply across the lifecycle described above:
 
-<a id="appendix-a"></a>
-## Appendix A: External Service Contract
+1. One stable DPF `DPUService` belongs to one `DPF_HELM_CHART` extension
+   service. Its management namespace, name, and placement-label key derive
+   from the full extension-service UUID and remain stable across Helm
+   revisions. NICo verifies the extension-service-ID ownership label and
+   immutable placement fields before acting on an existing object.
+2. NICo owns extension-service desired state, Helm-data validation and
+   authorization, and instance attachment intent. DPF owns Argo CD
+   Application and Helm workload reconciliation.
+3. Instance configuration is the durable source of attachment intent.
+   `DPUDevice.spec.cluster.nodeLabels` are derived placement state; NICo
+   converges them idempotently and modifies only its generated
+   extension-service label keys.
+4. Tenant-cluster Node-label propagation is owned by DPF. NICo relies on it to
+   make a DPUService eligible to run only on DPUs selected by an instance
+   attachment.
+5. DPUService CR acceptance, Node-label propagation, workload readiness, and
+   workload absence are distinct states. A successful extension-service delete
+   response means cleanup was accepted; it does not mean DPF has removed the
+   DPUService or its workload.
+6. Per-DPU lifecycle decisions use per-DPU, per-`DPUService` status. Aggregate
+   DPUService conditions and DPU-wide operational conditions are not evidence
+   for one service on one DPU.
+7. A physical DPU must not be an active Stage-1 target of two instances at the
+   same time. If the platform cannot enforce this, durable per-DPU attachment
+   state and label reference counting are required before launch.
+8. `DPF_HELM_CHART` never flows through the DPU agent. NICo does not query
+   tenant-cluster Pods directly for this service type.
 
-A team providing a `DPF_HELM_CHART` service must supply a chart that satisfies both the DPF chart contract and the NICo-specific requirements below.
+## 4. Compatibility and Rollout
 
-### A.1 Chart Requirements
+`KUBERNETES_POD` remains wire-compatible and retains numeric enum value `0`.
+It continues to use versioned rows, credentials, DPU-agent configuration,
+agent-side termination, and DPU-agent status.
 
-The chart must:
+`GetManagedHostNetworkConfig` sends only `KUBERNETES_POD` service
+configurations, including removed configurations required for existing
+agent-side termination. It never sends `DPF_HELM_CHART` data, credentials, or
+removal markers to the DPU agent.
 
-- be hosted in an approved HTTPS or OCI repository;
-- use a pinned chart version;
-- satisfy the DPF `DPUService` Helm chart contract;
-- consume DPF-provided `serviceDaemonSet.nodeSelector`;
-- for `INSTANCE_DPUS`, support NICo-provided `additionalNodeSelector`;
-- use the approved image pull Secret value path;
-- avoid disruptive Node Effects; and
-- support all declared DPU deployment types.
+The database migration is additive. It backfills existing `KUBERNETES_POD`
+rows with the terminal `Active` lifecycle state; existing instance
+configurations require no change. The `type` column is already a string column
+and requires no database type migration.
 
-```yaml
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      {{- toYaml .Values.serviceDaemonSet.nodeSelector | nindent 6 }}
+NICo must deploy a binary capable of decoding `dpf_helm_chart` before enabling
+the capability gate. Old and new NICo binaries must not run concurrently after
+the first `DPF_HELM_CHART` row is created. If rollout is paused, disable new
+DPF Helm service creation and attachment while allowing the extension-service
+state controller to clean up existing DPF resources.
 
-nodeSelector:
-  {{- toYaml .Values.additionalNodeSelector | nindent 2 }}
-```
+## 5. Testing
 
-For `ALL_DPUS`, NICo omits `additionalNodeSelector`.
+Testing must cover:
 
-For `INSTANCE_DPUS`, NICo supplies the selector. The service owner must not provide or override it.
-
-### A.2 Chart Qualification
-
-Chart qualification happens outside the create request.
-
-Qualification should include:
-
-* repository and chart allow-list review;
-* DPF schema validation;
-* `helm lint`;
-* representative rendering;
-* privilege and host-access review;
-* image registry review;
-* image signing or provenance checks;
-* DPF Node Effect review;
-* image pull Secret integration testing;
-* `serviceDaemonSet.nodeSelector` testing; and
-* `additionalNodeSelector` testing.
-
-The API validates the requested chart against stored qualification metadata but does not download or render the chart in the request path.
+- creation of `DPF_HELM_CHART` in `Creating` state before DPF is called;
+- extension-service controller create retry after a process restart and
+  verified owned `AlreadyExists` results;
+- migration/backfill of controller-state fields and lifecycle state exposure;
+- Helm data, reserved-value, and qualification validation;
+- deterministic resource generation and ownership verification;
+- in-place `UpdateDpuExtensionService` patching of the stable DPUService with
+  no `UpdateInstanceConfig` or DPUDevice label change;
+- optimistic-concurrency rejection, controller-state compare-and-swap,
+  idempotent update retry, and ownership/specification conflict handling;
+- delete superseding an in-flight create or update, with stale controller
+  transition rejection and eventual DPUService deletion;
+- revision-aware per-DPU status;
+- detached DPUService creation and deletion;
+- delete acceptance persisting `Deleting` state before any DPF call;
+- controller retry, restart recovery, and DPUService finalizer polling;
+- refusal to mutate or delete a same-name DPUService with a mismatched
+  extension-service ownership label;
+- unmatched initial selector before attachment;
+- attachment only to selected DPUs, label propagation, and Pod observation;
+- detach, selected-DPU-set changes, and removal cleanup only after every
+  required DPF status is `Terminated`;
+- instance deletion behavior;
+- type-aware DPU-agent configuration exclusion;
+- per-service target selection when `KUBERNETES_POD` and
+  `DPF_HELM_CHART` coexist;
+- service deletion blocking while attachments remain, including deleting
+  instances whose cleanup is incomplete; and
+- compatibility with existing `KUBERNETES_POD` behavior and capability-gate
+  rollout.

--- a/docs/design/dpf-helm-chart-extension-services.md
+++ b/docs/design/dpf-helm-chart-extension-services.md
@@ -1,4 +1,4 @@
-# DPU Extension Service Integration with DPF
+# DPU Extension Service Integration with DPF - Stage 1
 
 GitHub Issue: [#3103](https://github.com/NVIDIA/infra-controller/issues/3103)
 
@@ -9,11 +9,10 @@ GitHub Issue: [#3103](https://github.com/NVIDIA/infra-controller/issues/3103)
 |   0.1   | 07/01/2026 | Felicity Xu | Initial version |
 |   0.2   | 08/13/2026 | Felicity Xu | Revised version |
 
-
 ## 2. Summary
 
 NICo currently supports DPU Extension Services of type `KUBERNETES_POD`. When a
-`KUBERNETES_POD` extension service is attached to an instance, it's pod spec is
+`KUBERNETES_POD` extension service is attached to an instance, its pod spec is
 sent to instance's DPUs through `GetManagedHostNetworkConfig`, and deployed
 locally by the DPU agent as a static Kubernetes Pod.
 
@@ -96,7 +95,6 @@ Stage 2 must:
    expose narrowly scoped overrides for those fields when a use case
    establishes their ownership and update.
 
-
 ## 3. Design
 
 ### 3.0 Helm Chart Requirements
@@ -134,13 +132,11 @@ must therefore provide appropriate defaults for every such parameter it relies
 on.
 
 The optional `data.values` object remains available for tenant chart-specific
-configuration. It does not make generic DPUService contract fields tenant
-configurable, and it cannot override NICo's node-selector value. For the
-Stage 1 credential-provisioning contract, it also cannot override the
-top-level `imagePullSecrets` value. A chart that requires a private registry
-must set `imagePullSecrets` in its own `values.yaml` defaults and render it in
-the Pod template; Helm uses that default when NICo leaves the corresponding
-DPUService value unset.
+configuration. It cannot override NICo's node-selector value. Other values,
+including a top-level `imagePullSecrets` value, are passed through to the
+`DPUService` as tenant-provided chart configuration. NICo does not validate
+referenced Secret names or create, update, rotate, or delete those Secrets. A
+chart may instead define `imagePullSecrets` in its own `values.yaml` defaults.
 
 When NICo creates a `DPF_HELM_CHART` extension service, it creates a detached
 `DPUService` and deterministically generates
@@ -169,14 +165,14 @@ and validate the required Kubernetes Secrets. NICo does not accept, store,
 rotate, update, or delete DPF Helm-chart credentials.
 
 - A private Helm-chart repository requires an Argo CD repository Secret in the
-  namespace in which Argo CD runs, i.e. `argocd`. 
+  namespace in which Argo CD runs, i.e. `argocd`.
 - A private image registry requires a Secret
   in `dpf-operator-system`, labeled `dpu.nvidia.com/image-pull-secret` so DPF
   mirrors it to the target DPU clusters.
-- A chart that needs a private image registry must declare the approved pull
-  Secret name in the chart's `values.yaml` default and render that value as the
-  Pod template's `imagePullSecrets`. NICo leaves that value unset in the
-  DPUService and tenants cannot override it in `data.values`.
+- A chart that needs a private image registry must render `imagePullSecrets`
+  in its Pod template. The Secret name can come from the chart's `values.yaml`
+  default or tenant-provided `data.values`; in either case, provisioning and
+  ownership of the Secret remain external to NICo.
 
 Credential availability is a launch/admin prerequisite, rather than an
 eventually consistent setup step. DPF can create a DPUService and its Argo CD
@@ -212,39 +208,51 @@ ALTER TABLE extension_services
     ADD COLUMN controller_state_outcome JSONB DEFAULT NULL;
 ```
 
-The migration should also creates the extension-service state-history, controller-iteration-ID,
-and queued-object tables which are required for the controller framework. Existing `KUBERNETES_POD` services are backfilled to `Active`.
+The migration also creates the extension-service state-history,
+controller-iteration-ID, and queued-object tables required by the controller
+framework. Existing live `KUBERNETES_POD` services are backfilled to `Ready`;
+existing deleted services are backfilled to `Deleted`.
 
 For `DPF_HELM_CHART` extension services,
 
-- The controller states are `Creating`, `Active`,
+- The controller states are `Creating`, `Ready`,
   `Updating`, `Deleting`, `Deleted`, and `Failed`;
 - `controller_state_version` is independent of API-visible `version_ctr` and provides protection against
   stale controller iterations;
 - `controller_state_outcome` stores the latest safe
   diagnostic; it is not desired service state.
 
-The API exposes lifecycle state through additive `DpuExtensionService.lifecycle_state`.
+The Core API exposes the lifecycle through the additive generic
+`DpuExtensionService.lifecycle_status` field. The dedicated enum defines the
+valid state names encoded in `LifecycleStatus.state`.
 
 ```proto
 enum DpuExtensionServiceLifecycleState {
-  DPU_EXTENSION_SERVICE_LIFECYCLE_UNKNOWN = 0;
-  DPU_EXTENSION_SERVICE_LIFECYCLE_CREATING = 1;
-  DPU_EXTENSION_SERVICE_LIFECYCLE_ACTIVE = 2;
-  DPU_EXTENSION_SERVICE_LIFECYCLE_UPDATING = 3;
-  DPU_EXTENSION_SERVICE_LIFECYCLE_DELETING = 4;
-  DPU_EXTENSION_SERVICE_LIFECYCLE_FAILED = 5;
-  DPU_EXTENSION_SERVICE_LIFECYCLE_DELETED = 6;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_STATE_CREATING = 0;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_STATE_READY = 1;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_STATE_UPDATING = 2;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_STATE_DELETING = 3;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_STATE_DELETED = 4;
+  DPU_EXTENSION_SERVICE_LIFECYCLE_STATE_FAILED = 5;
 }
 
 message DpuExtensionService {
   // Existing fields 1 through 10.
-  optional DpuExtensionServiceLifecycleState lifecycle_state = 11;
+  LifecycleStatus lifecycle_status = 11;
 }
 ```
 
-- `KUBERNETES_POD` services leaves this lifecycle_state as None.
-- `DPF_HELM_CHART` services report their controller state.
+`LifecycleStatus.state` contains a JSON envelope such as
+`{"state":"creating"}` or `{"state":"ready"}`. Both service types expose a
+lifecycle status: a `KUBERNETES_POD` service is synchronously `Ready`, while a
+`DPF_HELM_CHART` service reports its asynchronous controller state.
+
+The REST API projects Core lifecycle state to its existing status model:
+`Creating` becomes `Pending`, `Ready` remains `Ready`, `Updating` remains
+`Updating`, `Deleting` and `Deleted` become `Deleting`, and `Failed` becomes
+`Error`. After Core reaches `Deleted`, the service is omitted from inventory,
+so REST clients normally observe it disappear rather than observe a terminal
+`Deleted` status.
 
 ### 3.3 Create `DPF_HELM_CHART` Extension Service
 
@@ -257,11 +265,11 @@ database transaction and commits it. The handler does not create DPF resources.
 intent with DPF. After it observes the committed `Creating` state, it reads the
 desired service, creates or verifies the detached DPF `DPUService`, and records
 the reconciliation outcome. Successful reconciliation transitions the service
-from `Creating` to `Active`.
+from `Creating` to `Ready`.
 
 The create response therefore means that NICo accepted the requested service;
 it does not mean that DPF accepted the CR or that the Helm workload is healthy.
-`Active` means only that the desired DPUService CR has been reconciled.
+`Ready` means only that the desired DPUService CR has been reconciled.
 
 The DPUService remains detached after creation. It is deployed only after a
 later instance attachment causes NICo to apply the matching placement label to
@@ -285,7 +293,7 @@ sequenceDiagram
     Controller->>DB: Read persisted Creating state and desired service
     Controller->>DPF: Create or verify detached DPUService
     DPF-->>Controller: Created or verified owned DPUService
-    Controller->>DB: Compare-and-swap Creating state to Active state
+    Controller->>DB: Compare-and-swap Creating state to Ready state
 ```
 
 #### 3.3.1 API and Validation
@@ -357,14 +365,15 @@ Example input `data`:
 | `security.privileged` | `boolean` | Yes      | Service privilege policy; maps to `spec.security.privileged`.        |
 | `values`              | `object`  | No       | Chart-specific Helm values; maps to `spec.helmChart.values` when present and is omitted from the projected CR when absent. |
 
-The create API rejects a request when required DPF prerequisites are
-unavailable for the site, `data` is invalid, or required chart fields are
-missing. The JSON contract rejects unknown fields. Tenant-provided `values`
-must not set `serviceDaemonSet.nodeSelector` or top-level
-`imagePullSecrets`. The former is reserved for NICo's placement contract; the
-latter is a chart-owned default under the Stage 1 credential-provisioning
-contract. The launch/admin workflow, not this API, verifies that the required
-pre-provisioned Secrets exist before the service is created.
+The create API rejects a request when DPF is disabled for the site, `data` is
+invalid, or required chart fields are missing. The JSON contract rejects
+unknown fields. Tenant-provided `values` must not set
+`serviceDaemonSet.nodeSelector`, which is reserved for NICo's placement
+contract. Other chart values, including `imagePullSecrets`, are passed through.
+The launch/admin workflow, not this API, verifies that any referenced,
+pre-provisioned Secrets exist before the service is created. The API also
+rejects the legacy `credential` field and Stage 2 `observability` configuration
+for this service type.
 
 After validation, the API handler creates or validates the
 `ExtensionServiceId` and opens a database transaction. In that transaction, it
@@ -393,21 +402,23 @@ prerequisite described in [Section 3.1](#31-credential-pre-provisioning).
 The controller calls `DpfOperations::create_dpu_service` outside a database
 transaction. A successful create, or an `AlreadyExists` DPUService with the
 expected NICo ownership and immutable identity, permits a compare-and-swap
-transition from `Creating` to `Active`. The transition succeeds only when
+transition from `Creating` to `Ready`. The transition succeeds only when
 `controller_state_version` still matches the version read by that controller
 iteration.
 
 For example, a delete request may change the service to `Deleting` while a
 create operation is in flight. The stale create iteration cannot overwrite
-`Deleting` with `Active` because its compare-and-swap transition fails. When the
-controller transition loses the compare-and-swap check ,it automatically
+`Deleting` with `Ready` because its compare-and-swap transition fails. When the
+controller transition loses the compare-and-swap check, it automatically
 re-enqueues the service ID. The next iteration observes `Deleting` and performs
 cleanup instead.
 
-Transient DPF failures leave the service in `Creating` for retry. A validation,
-authorization, ownership, or immutable-specification conflict transitions it
-to `Failed` with a diagnostic outcome. Services in `Creating` or `Failed`
-cannot be attached to an instance.
+Transient DPF failures leave the service in `Creating` for retry. A DPF
+configuration error, Kubernetes API `400` or `422` response, ownership
+conflict, or immutable-specification conflict transitions it to `Failed`.
+Other DPF API failures are retried. Exact DPF error details are logged; the
+persisted controller outcome remains non-sensitive. Services in `Creating` or
+`Failed` cannot be attached to an instance.
 
 #### 3.3.3 DPUService Specification
 
@@ -431,24 +442,26 @@ The controller maps persisted and generated values as follows:
 | Stage 1 deployment model                      | `spec.deployInCluster = false` and no `serviceID`, interfaces, or config ports           |
 | Stage 1 DPUCluster model                      | `spec.dpuClusterSelector` is unset; DPF creates an Application in every known DPUCluster |
 
-NOTE: The `DPUService` name and node selector are deterministically derived from the
-extension service UUID rather than from the mutable service name.
+NOTE: The `DPUService` name and node selector are deterministically derived from
+the full, canonical extension-service UUID rather than from the mutable service
+name. The implementation does not hash or truncate the UUID.
 The Kubernetes resource name, Helm release name, and placement-label key are
 therefore stable for the service lifetime.
 
-- DPUService name: `extsvc-<hash>`
-- Node-label key/value: `nico/extsvc-<hash>: enabled`
+- DPUService name: `extsvc-<service-uuid>`
+- Node-label key/value: `nico/extsvc-<service-uuid>: enabled`
 
-For the `data` example in Section 3.3.1, NICo creates the following DPUService:
+For a service with UUID `00000000-0000-0000-0000-000000000001` and the `data`
+example in Section 3.3.1, NICo creates the following DPUService:
 
 ```yaml
 apiVersion: svc.dpu.nvidia.com/v1alpha1
 kind: DPUService
 metadata:
-  name: extsvc-abc123
+  name: extsvc-00000000-0000-0000-0000-000000000001
   namespace: dpf-operator-system
   labels:
-    nico/extension-service-id: <service-uuid>
+    nico/extension-service-id: 00000000-0000-0000-0000-000000000001
 spec:
   deployInCluster: false
   security:
@@ -458,7 +471,7 @@ spec:
       repoURL: oci://registry.example.com/charts
       chart: tenant-service
       version: 1.2.3
-      releaseName: extsvc-abc123
+      releaseName: extsvc-00000000-0000-0000-0000-000000000001
     values:
       image:
         repository: registry.example.com/tenant/service
@@ -469,7 +482,7 @@ spec:
     nodeSelector:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: nico/extsvc-abc123
+            - key: nico/extsvc-00000000-0000-0000-0000-000000000001
               operator: In
               values: [enabled]
 ```
@@ -505,25 +518,30 @@ message UpdateDpuExtensionServiceRequest {
 
 For `DPF_HELM_CHART`, the update API handler first locks the service row and checks
 `if_version_ctr_match`, when supplied, against the current `version_ctr`. A
-Helm-data update is accepted only while the controller state is `Active`; it is
+Helm-data update is accepted only while the controller state is `Ready`; it is
 rejected while the service is `Creating`, `Updating`, `Deleting`, `Deleted`,
-or `Failed`.
+or `Failed`. The legacy `credential` field and Stage 2 `observability`
+configuration are rejected.
 
 A non-empty `data` value is a **complete** replacement Helm-service
 definition, not a DPUService or Kubernetes merge-patch document. It must
 include every field required at creation, including the chart repository URL,
 chart name, chart version, and security policy. `values` remains optional.
 
-An empty `data` value means it's a metadata-only update, which does not require
-DPF reconciliation and completed immediately after validation.
+An empty `data` value together with a name or description change is a
+metadata-only update. It does not require `Ready`, increment `version_ctr`,
+change the lifecycle, or invoke DPF. It completes immediately after database
+validation. A non-empty definition identical to the current normalized data is
+rejected as a no-op.
 
-The API handler validates and normalizes the complete desired service spec and:
+For a Helm-data update, the API handler validates and normalizes the complete
+desired service spec and:
 
 1. updates the existing `V1` row with the desired normalized `data` and
    requested version-owned metadata;
 2. applies requested service metadata;
 3. increments `version_ctr`; and
-4. transitions the controller state from `Active` to `Updating` with a new
+4. transitions the controller state from `Ready` to `Updating` with a new
    `controller_state_version`.
 
 After committing, the handler returns the service in `Updating` state. The
@@ -555,12 +573,17 @@ This is distinct from supplying `values: {}`, which preserves an explicitly
 empty values object. In particular, an omitted `values` object restores the
 chart-owned `imagePullSecrets` default when the chart defines one.
 
-After DPF accepts the patch, the controller transitions `Updating` to `Active`
+After DPF accepts the patch, the controller transitions `Updating` to `Ready`
 with a `controller_state_version` compare-and-swap transaction. A stale update
 iteration cannot overwrite a later delete or update state; a failed
 compare-and-swap is re-enqueued by the state-controller framework, and the
 next iteration reads the winning state. `active_versions` continues to contain
 only `V1`.
+
+A transient DPF read or patch error leaves the service in `Updating` for retry.
+A missing DPUService, ownership or immutable-specification conflict, DPF
+configuration error, or Kubernetes API `400` or `422` response transitions the
+service to `Failed`. The update path does not recreate a missing DPUService.
 
 Note when DPF accepts an update, it reconciles the existing Argo CD Application in
 each selected DPUCluster rather than creating a new Application for the chart
@@ -580,7 +603,7 @@ sole deployable service; any other version is rejected.
 
 The handler locks the service and rejects deletion while it is referenced by an
 active instance, or by a deleting instance whose extension-service cleanup is
-incomplete. It accepts deletion from `Creating`, `Active`, `Updating`, or
+incomplete. It accepts deletion from `Creating`, `Ready`, `Updating`, or
 `Failed`. A repeat request while the service is `Deleting` is idempotently
 accepted.
 
@@ -592,7 +615,7 @@ intent. The response means NICo accepted cleanup; it does not mean DPF has
 deleted the DPUService.
 
 The soft-deleted display name is reusable only after the state gets transitioned to `DELETED`.
- A newly created service with that display name receives a new UUID, DPUService name, and placement-label key; it cannot refer to the deleted service.
+A newly created service with that display name receives a new UUID, DPUService name, and placement-label key; it cannot refer to the deleted service.
 
 #### 3.5.2 State Controller Delete Reconciliation
 
@@ -656,11 +679,12 @@ attachment version. Helm-data updates are in place and do not create another
 attachable version.
 
 When extension services are present in `InstanceConfig`, the API handler
-validates each requested service. A new `DPF_HELM_CHART` attachment requires
-`dpf.enabled` for the site and an `Active` service. DPF Helm services may
-attach only to DPF-managed hosts; `KUBERNETES_POD` services are not supported
-on DPF-managed hosts. An instance cannot have `DPF_HELM_CHART` and
-`KUBERNETES_POD` extension services at the same time.
+validates each requested service. A `DPF_HELM_CHART` service can be created
+only when DPF is enabled for the site, and a new attachment requires a `Ready`
+service on a DPF-managed host. `KUBERNETES_POD` services are not supported on
+DPF-managed hosts. An instance cannot have `DPF_HELM_CHART` and
+`KUBERNETES_POD` extension services at the same time, and it cannot list the
+same service more than once.
 
 The handler persists the instance extension service config. The actual labeling of `DPUDevice` is performed in instance state lifecycle.
 
@@ -685,7 +709,7 @@ therefore reconcile the detached DPUService and its per-DPUCluster
 Applications while the chart workload remains absent from all DPUs. For every
 physical DPUDevice, the helper merge-patches only the attached service's
 NICo-owned key in `spec.cluster.nodeLabels`: it adds the matching UUID-derived
-node-selector label (for example, `nico/extsvc-<hash>: enabled`) on current
+node-selector label (for example, `nico/extsvc-<service-uuid>: enabled`) on current
 target DPUs, and removes that label from non-target DPUs and services marked
 `removed`. It preserves labels owned by DPF and other controllers and performs
 DPF calls outside database transactions.
@@ -706,16 +730,28 @@ the instance state.
 
 DPF does not currently provide a per-DPU, per-`DPUService` workload-status
 API. Stage 1 therefore reports **placement convergence**, not Helm workload
-health. The machine controller records a DPF Helm service as ready to run only
-after it has successfully applied the generated placement label to every
-required target `DPUDevice`; it records removal only after it has successfully
-removed that label from every required physical `DPUDevice`.
+health. The machine controller merge-patches a DPUDevice and then reads its
+labels back. The resulting per-DPU service status describes that verified
+placement state. For ordinary attachment and detachment, the required DPU set
+is the instance's currently used DPUs. Instance deletion instead requires all
+physical DPUs attached to the host.
 
 | Stage 1 condition | Reported extension-service status | Meaning |
 | --- | --- | --- |
-| All required active `DPUDevice` label patches succeed | `Running` | The service is placement-ready: its selected Nodes can satisfy the generated selector. |
-| Label reconciliation is incomplete or a DPF patch fails | `Pending` | NICo has not yet established the requested placement or removal. |
-| All required removal patches succeed | `Terminated` | The service is placement-detached. |
+| No current observation exists for the instance extension-service config version | `Unknown` | NICo has not yet observed this desired configuration; `configs_synced` is `Pending`. |
+| An active target DPU is observed without the exact generated label and value | `Pending` | NICo has not yet established the requested placement. |
+| An active target DPU is observed with the exact generated label and value | `Running` | The service is placement-ready: its selected Node can satisfy the generated selector. |
+| A removed or untargeted service is observed with the generated label still present | `Terminating` | Label removal has not converged on that DPU. |
+| A removed or untargeted service is observed without the generated label | `Terminated` | The service is placement-detached from that DPU. |
+| A required DPUDevice patch or read fails | `Error` | NICo records the DPF failure for that DPU and retries during later reconciliation. |
+
+The aggregate service status is derived from its required per-DPU statuses.
+`Error` has precedence over `Unknown`, `Pending`, `Running`, `Terminating`, and
+`Terminated`. `configs_synced` means that every required DPU has an observation
+for the current extension-service configuration version; it can therefore be
+`Synced` while a current observation reports `Error`. Initial instance
+readiness additionally requires every active service to be `Running` and every
+removed service to be `Terminated`.
 
 For this Stage 1 contract, `Running` does **not** mean that the Helm workload
 or its Pods are running, and `Terminated` does **not** prove that Pods have
@@ -760,11 +796,11 @@ not be sufficient to infer workload termination.
 
 An `UpdateInstanceConfig` request detaches a `DPF_HELM_CHART` service by
 removing it from the requested active-service list. NICo retains the existing
-service configuration in the persisted instance configuration with
-`removed: true`; it does not remove it immediately.
+service configuration in the persisted instance configuration with its
+`removed` timestamp set; it does not remove it immediately.
 
 The removed entry is the durable detachment intent. The API handler validates
-and persists the configuration change but does not call DPF. 
+and persists the configuration change but does not call DPF.
 
 #### 3.8.2 DPUDevice Label Removal and Recovery
 
@@ -779,18 +815,23 @@ matches the stable DPUService selector, so DPF reconciles removal of the
 service workload. NICo does not delete Argo CD Applications or workload Pods
 during instance detachment.
 
-The removal operation is idempotent. A DPF error or temporarily unavailable
-DPUDevice leaves the `removed: true` entry in place and is retried by later
-Ready execution. It does not move the instance out of `Ready` or block
-unrelated Ready-state work.
+The removal operation is idempotent. For an instance's currently used DPUs, a
+DPF error leaves the timestamped `removed` entry in place, reports `Error`, and
+is retried by later Ready execution. Cleanup is also attempted on other
+physical DPUs on the host, but a failure on one of those non-target DPUs does
+not affect instance status or block detach completion; it is retried only while
+the service entry remains in persisted instance configuration. An absent
+DPUDevice is already clean for removal and is treated as success. These
+failures do not move the instance out of `Ready` or block unrelated Ready-state
+work.
 
 #### 3.8.3 Stage 1 Termination Confirmation and Completion
 
-For Stage 1, successful removal of the generated label from every required
-physical DPUDevice records `Terminated` and completes detachment. NICo then
-removes the `removed: true` entry from persisted instance configuration.
-Until label removal converges, the entry remains visible as pending removal and
-prevents deletion of the referenced extension service.
+For Stage 1, verified removal of the generated label from every currently used
+DPUDevice records `Terminated` and completes ordinary detachment. NICo then
+removes the timestamped `removed` entry from persisted instance configuration.
+Until label removal converges on those required DPUs, the entry remains visible
+as pending removal and prevents deletion of the referenced extension service.
 
 This is deliberately a placement-detached completion contract, not proof that
 the workload has stopped. In Stage 2, NICo will retain the removal entry and
@@ -842,8 +883,9 @@ The following rules apply across the lifecycle described above:
    their secret material through the extension-service API, writes it to Vault
    or PostgreSQL, or manages the corresponding Kubernetes Secrets. A private
    chart repository has one site-provisioned credential per canonical
-   repository URL, and private-image charts use the chart-owned
-   `values.yaml` `imagePullSecrets` default.
+   repository URL. Private-image charts may obtain `imagePullSecrets` from the
+   chart's default values or from tenant-provided `data.values`, but the
+   referenced Secret remains externally provisioned and managed.
 
 ## 4. Compatibility and Rollout
 
@@ -856,10 +898,11 @@ configurations, including removed configurations required for existing
 agent-side termination. It never sends `DPF_HELM_CHART` data, credentials, or
 removal markers to the DPU agent.
 
-The database migration is additive. It backfills existing `KUBERNETES_POD`
-rows with the terminal `Active` lifecycle state; existing instance
-configurations require no change. The `type` column is already a string column
-and requires no database type migration.
+The database migration is additive. It backfills existing live
+`KUBERNETES_POD` rows with the terminal `Ready` lifecycle state and deleted
+rows with `Deleted`; existing instance configurations require no change. The
+`type` column is already a string column and requires no database type
+migration.
 
 NICo must deploy a binary capable of decoding `dpf_helm_chart` before enabling
 the capability gate. Old and new NICo binaries must not run concurrently after
@@ -871,38 +914,41 @@ state controller to clean up existing DPF resources.
 
 Testing must cover:
 
-- creation of `DPF_HELM_CHART` in `Creating` state before DPF is called;
-- extension-service controller create retry after a process restart and
-  verified owned `AlreadyExists` results;
-- migration/backfill of controller-state fields and lifecycle state exposure;
-- Helm data, reserved-value, and qualification validation;
-- rejection of the legacy `credential` field and of tenant
-  `data.values.imagePullSecrets` for `DPF_HELM_CHART`;
-- chart-default `imagePullSecrets` behavior, and verification that create,
-  update, and delete do not manage externally pre-provisioned Secrets;
-- deterministic resource generation and ownership verification;
-- in-place `UpdateDpuExtensionService` patching of the stable DPUService with
-  no `UpdateInstanceConfig` or DPUDevice label change;
-- optimistic-concurrency rejection, controller-state compare-and-swap,
-  idempotent update retry, and ownership/specification conflict handling;
-- delete superseding an in-flight create or update, with stale controller
-  transition rejection and eventual DPUService deletion;
+- Creation of `DPF_HELM_CHART` in `Creating` state before DPF is called
+- Extension-service controller create retry after a process restart and
+  verified owned `AlreadyExists` results
+- Migration/backfill of controller-state fields and lifecycle state exposure
+- Helm data and reserved node-selector validation, plus use of a test chart
+  that has been qualified separately against the DPUService contract
+- Rejection of the legacy `credential` and Stage 2 `observability` fields for
+  `DPF_HELM_CHART`
+- Pass-through and chart-default `imagePullSecrets` behavior, plus verification
+  that create, update, and delete do not manage externally pre-provisioned
+  Secrets
+- Deterministic resource generation and ownership verification
+- In-place `UpdateDpuExtensionService` patching of the stable DPUService with
+  no `UpdateInstanceConfig` or DPUDevice label change
+- Optimistic-concurrency rejection, controller-state compare-and-swap,
+  idempotent update retry, and ownership/specification conflict handling
+- Delete superseding an in-flight create or update, with stale controller
+  transition rejection and eventual DPUService deletion
 - Stage 1 type-keyed extension-service observation persistence and
-  placement-convergence status mapping;
-- detached DPUService creation and deletion;
-- delete acceptance persisting `Deleting` state before any DPF call;
-- controller retry, restart recovery, and DPUService finalizer polling;
-- refusal to mutate or delete a same-name DPUService with a mismatched
-  extension-service ownership label;
-- unmatched initial selector before attachment;
-- attachment only to selected DPUs and label propagation;
-- detach, selected-DPU-set changes, and removal cleanup only after generated
-  label removal converges on every required DPU;
-- instance deletion behavior;
-- type-aware DPU-agent configuration exclusion;
-- per-service target selection when `KUBERNETES_POD` and
-  `DPF_HELM_CHART` coexist;
-- service deletion blocking while attachments remain, including deleting
-  instances whose cleanup is incomplete; and
-- compatibility with existing `KUBERNETES_POD` behavior and capability-gate
-  rollout.
+  placement-convergence status mapping
+- Detached DPUService creation and deletion
+- Delete acceptance persisting `Deleting` state before any DPF call
+- Controller retry, restart recovery, and DPUService finalizer polling
+- Refusal to mutate or delete a same-name DPUService with a mismatched
+  extension-service ownership label
+- Unmatched initial selector before attachment
+- Attachment only to selected DPUs and label propagation
+- Detach, selected-DPU-set changes, and removal cleanup only after generated
+  label removal converges on every required DPU
+- Instance deletion behavior
+- Type-aware DPU-agent configuration exclusion
+- Rejection when `KUBERNETES_POD` and `DPF_HELM_CHART` are attached to the
+  same instance, plus preservation of each type's independent observation and
+  delivery path
+- Service deletion blocking while attachments remain, including deleting
+  instances whose cleanup is incomplete
+- Compatibility with existing `KUBERNETES_POD` behavior and capability-gate
+  rollout


### PR DESCRIPTION
Add a design doc for DPU extension service integration with DPF. The design describes how tenant-created extension services can be installed through the DPF Helm service lifecycle while only running on DPUs selected by instance attachments. 

## Related issues
Related to [#3103](https://github.com/NVIDIA/infra-controller/issues/3103)