### PR TITLE
docs: add scout_last_observed_version to ingestion troubleshooting section

### DIFF
--- a/docs/playbooks/stuck_objects/host_ingestion_failures.md
+++ b/docs/playbooks/stuck_objects/host_ingestion_failures.md
@@ -91,6 +91,23 @@ Look for:
 - NIC or DPU pairing problems
 - SKU or validation input mismatch
 
+### Check the Scout version
+
+NICo records the build version of Scout most recently observed during machine
+discovery. Use this value to determine whether ingestion or validation failures
+may correlate with a specific Scout release:
+
+```bash
+nico-admin-cli -a <api-url> -f json machine show <host-machine-id> \
+  | jq -r '.last_scout_observed_version // "unknown"'
+```
+
+The `last_scout_observed_version` value is updated whenever Scout registers the
+host during discovery and remains associated with the machine after assignment.
+It identifies the last discovery image, not necessarily a currently running agent.
+The value is `null` for machines that have not completed discovery with a Scout 
+version that reports it, and a later Scout discovery replaces the stored value.
+
 ## Validation and SKU
 
 After discovery, ingestion may block on validation.

--- a/docs/playbooks/stuck_objects/host_ingestion_failures.md
+++ b/docs/playbooks/stuck_objects/host_ingestion_failures.md
@@ -105,7 +105,7 @@ nico-admin-cli -a <api-url> -f json machine show <host-machine-id> \
 The `last_scout_observed_version` value is updated whenever Scout registers the
 host during discovery and remains associated with the machine after assignment.
 It identifies the last discovery image, not necessarily a currently running agent.
-The value is `null` for machines that have not completed discovery with a Scout 
+The value is `null` for machines that have not completed discovery with a Scout
 version that reports it, and a later Scout discovery replaces the stored value.
 
 ## Validation and SKU


### PR DESCRIPTION
<!-- Describe what this PR does -->
Documenting #2037 - makes site operators aware of the `last_scout_observed_version` value exposed in Core and how it can be used to help troubleshoot.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

