### PR TITLE
Align Helm appVersions with NICo image tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1412,9 +1412,10 @@ jobs:
           persist-credentials: false
 
       - name: Validate Helm chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@197ece553bb6353e3e9cad153e41b5e311ebcf13
         with:
           chart-path: helm
+          helm-version: 'v3.18.3'
           lint: 'true'
           template: 'true'
           valueOverrides: '["global.image.repository=registry.example.invalid/nico-core"]'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1412,7 +1412,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate Helm chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@197ece553bb6353e3e9cad153e41b5e311ebcf13
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@0969f64c3efa9e757135cbf457ea13cde4c3fa38
         with:
           chart-path: helm
           helm-version: 'v3.18.3'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1417,6 +1417,7 @@ jobs:
           chart-path: helm
           lint: 'true'
           template: 'true'
+          valueOverrides: '["global.image.repository=registry.example.invalid/nico-core"]'
 
       # Publishing is intentionally disabled for PR refs, so exercise the exact
       # package metadata and render-time fallback without pushing or uploading it.
@@ -1489,6 +1490,45 @@ jobs:
             [[ "$actual" == "${excluded_app_versions[$child]}" ]] || \
               fail "$child appVersion changed unexpectedly: expected ${excluded_app_versions[$child]}, got $actual"
           done
+
+          schema_log="$tmp_dir/missing-repository-schema.log"
+          if helm template package-validation "$package" \
+            --set-string 'global.image.tag=' \
+            --set 'nico-bmc-proxy.enabled=true' \
+            >/dev/null 2>"$schema_log"; then
+            fail 'Expected schema validation without global.image.repository to fail'
+          fi
+          grep -Fq 'global.image.repository' "$schema_log" || {
+            cat "$schema_log"
+            fail 'Packaged schema error did not identify global.image.repository'
+          }
+
+          missing_repository_log="$tmp_dir/missing-repository.log"
+          if helm template package-validation "$package" \
+            --skip-schema-validation \
+            --set-string 'global.image.tag=' \
+            --set 'nico-bmc-proxy.enabled=true' \
+            >/dev/null 2>"$missing_repository_log"; then
+            fail 'Expected render without global.image.repository to fail'
+          fi
+          grep -Fq 'nico: global.image.repository is required' "$missing_repository_log" || {
+            cat "$missing_repository_log"
+            fail 'Missing-repository error did not identify global.image.repository'
+          }
+
+          whitespace_repository_log="$tmp_dir/whitespace-repository.log"
+          if helm template package-validation "$package" \
+            --skip-schema-validation \
+            --set-string 'global.image.repository=   ' \
+            --set-string 'global.image.tag=' \
+            --set 'nico-bmc-proxy.enabled=true' \
+            >/dev/null 2>"$whitespace_repository_log"; then
+            fail 'Expected render with a whitespace-only global.image.repository to fail'
+          fi
+          grep -Fq 'nico: global.image.repository is required' "$whitespace_repository_log" || {
+            cat "$whitespace_repository_log"
+            fail 'Whitespace-repository error did not identify global.image.repository'
+          }
 
           image_repository='registry.example.invalid/nico-core'
           explicit_tag='operator-override'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1418,6 +1418,136 @@ jobs:
           lint: 'true'
           template: 'true'
 
+      # Publishing is intentionally disabled for PR refs, so exercise the exact
+      # package metadata and render-time fallback without pushing or uploading it.
+      - name: Validate packaged Helm appVersion fallback
+        if: ${{ success() && startsWith(github.ref, 'refs/heads/pull-request/') }}
+        shell: bash
+        env:
+          APP_VERSION: ${{ needs.prepare.outputs.version }}
+          CHART_VERSION: ${{ needs.prepare.outputs.helm_version }}
+        run: |
+          set -euo pipefail
+          : "${APP_VERSION:?APP_VERSION must not be empty}"
+          : "${CHART_VERSION:?CHART_VERSION must not be empty}"
+
+          fail() { echo "::error::$*"; exit 1; }
+          tmp_dir="$(mktemp -d "${RUNNER_TEMP}/nico-core-package.XXXXXX")"
+          trap 'rm -rf "$tmp_dir"' EXIT
+          chart_dir="$tmp_dir/helm"
+          package_dir="$tmp_dir/packages"
+          cp -R helm "$chart_dir"
+          mkdir -p "$package_dir"
+
+          children=(
+            nico-api
+            nico-bmc-proxy
+            nico-dhcp
+            nico-dns
+            nico-dsx-exchange-consumer
+            nico-hardware-health
+            nico-pxe
+            nico-ssh-console-rs
+          )
+          excluded_children=(nico-flow nico-ntp unbound)
+          declare -A excluded_app_versions=()
+          for child in "${excluded_children[@]}"; do
+            metadata="$chart_dir/charts/$child/Chart.yaml"
+            [[ -f "$metadata" ]] || fail "Missing excluded child metadata: $metadata"
+            excluded_app_versions["$child"]="$(yq -r '.appVersion // ""' "$metadata")"
+          done
+          for child in "${children[@]}"; do
+            metadata="$chart_dir/charts/$child/Chart.yaml"
+            [[ -f "$metadata" ]] || fail "Missing child metadata: $metadata"
+            yq -i '.appVersion = strenv(APP_VERSION)' "$metadata"
+          done
+
+          chart_name="$(yq -r '.name' "$chart_dir/Chart.yaml")"
+          helm package "$chart_dir" \
+            --dependency-update \
+            --version "$CHART_VERSION" \
+            --app-version "$APP_VERSION" \
+            --destination "$package_dir"
+          shopt -s nullglob
+          packages=("$package_dir"/*.tgz)
+          [[ ${#packages[@]} -eq 1 ]] || fail "Expected one package, found ${#packages[@]}"
+          package="${packages[0]}"
+          [[ "$package" == "$package_dir/${chart_name}-${CHART_VERSION}.tgz" ]] || \
+            fail "Unexpected package name: $package"
+          tar -tzf "$package" >/dev/null
+
+          actual="$(helm show chart "$package" | yq -r '.version')"
+          [[ "$actual" == "$CHART_VERSION" ]] || fail "Root version: expected $CHART_VERSION, got $actual"
+          actual="$(helm show chart "$package" | yq -r '.appVersion')"
+          [[ "$actual" == "$APP_VERSION" ]] || fail "Root appVersion: expected $APP_VERSION, got $actual"
+          for child in "${children[@]}"; do
+            actual="$(tar -xOf "$package" "$chart_name/charts/$child/Chart.yaml" | yq -r '.appVersion')"
+            [[ "$actual" == "$APP_VERSION" ]] || fail "$child appVersion: expected $APP_VERSION, got $actual"
+          done
+          for child in "${excluded_children[@]}"; do
+            actual="$(tar -xOf "$package" "$chart_name/charts/$child/Chart.yaml" | yq -r '.appVersion // ""')"
+            [[ "$actual" == "${excluded_app_versions[$child]}" ]] || \
+              fail "$child appVersion changed unexpectedly: expected ${excluded_app_versions[$child]}, got $actual"
+          done
+
+          image_repository='registry.example.invalid/nico-core'
+          explicit_tag='operator-override'
+          fallback_manifest="$tmp_dir/fallback.yaml"
+          explicit_manifest="$tmp_dir/explicit.yaml"
+          helm template package-validation "$package" \
+            --set-string "global.image.repository=${image_repository}" \
+            --set-string 'global.image.tag=' \
+            --set 'nico-bmc-proxy.enabled=true' > "$fallback_manifest"
+          helm template package-validation "$package" \
+            --set-string "global.image.repository=${image_repository}" \
+            --set-string "global.image.tag=${explicit_tag}" \
+            --set 'nico-bmc-proxy.enabled=true' > "$explicit_manifest"
+
+          image_for() {
+            local manifest="$1" workload="$2" container="$3"
+            WORKLOAD="$workload" CONTAINER="$container" yq ea -r '
+              select(.metadata.name == strenv(WORKLOAD) and
+                (.kind == "Deployment" or .kind == "StatefulSet" or .kind == "DaemonSet")) |
+              .spec.template.spec.containers[] |
+              select(.name == strenv(CONTAINER)) |
+              .image
+            ' "$manifest"
+          }
+          assert_image() {
+            local manifest="$1" workload="$2" container="$3" expected="$4" actual
+            actual="$(image_for "$manifest" "$workload" "$container")"
+            [[ "$actual" == "$expected" ]] || \
+              fail "$workload/$container image: expected $expected, got ${actual:-<missing>}"
+          }
+
+          workloads=(
+            'nico-api:nico-api'
+            'nico-bmc-proxy:nico-bmc-proxy'
+            'nico-dhcp:nico-dhcp'
+            'nico-dns:nico-dns'
+            'nico-dsx-exchange-consumer:nico-dsx-exchange-consumer'
+            'nico-hardware-health:nico-hardware-health'
+            'nico-pxe:nico-pxe'
+            'nico-ssh-console-rs:ssh-console-rs'
+          )
+          for entry in "${workloads[@]}"; do
+            workload="${entry%%:*}"
+            container="${entry#*:}"
+            assert_image "$fallback_manifest" "$workload" "$container" "$image_repository:$APP_VERSION"
+            assert_image "$explicit_manifest" "$workload" "$container" "$image_repository:$explicit_tag"
+          done
+
+          sha256="$(sha256sum "$package" | awk '{print $1}')"
+          [[ "$sha256" =~ ^[0-9a-f]{64}$ ]] || fail "Invalid package SHA-256: $sha256"
+          {
+            echo '### Helm package-only validation'
+            echo '| Chart | Version | appVersion | SHA-256 |'
+            echo '|---|---|---|---|'
+            echo "| $chart_name | \`$CHART_VERSION\` | \`$APP_VERSION\` | \`$sha256\` |"
+            echo
+            echo '> CI evidence only: the publish job rebuilds the package. No package artifact was uploaded.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   build-push-helm-chart:
     needs:
       - prepare
@@ -1429,6 +1559,31 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Install yq
+        uses: dcarbone/install-yq-action@64b1b9eb28920bb1a4c13c05321df284f9a8f940 # v1.1.1
+        with:
+          version: v4.46.1
+
+      - name: Stamp child chart appVersions
+        env:
+          APP_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          : "${APP_VERSION:?APP_VERSION must not be empty}"
+          charts=(
+            helm/charts/nico-api/Chart.yaml
+            helm/charts/nico-bmc-proxy/Chart.yaml
+            helm/charts/nico-dhcp/Chart.yaml
+            helm/charts/nico-dns/Chart.yaml
+            helm/charts/nico-dsx-exchange-consumer/Chart.yaml
+            helm/charts/nico-hardware-health/Chart.yaml
+            helm/charts/nico-pxe/Chart.yaml
+            helm/charts/nico-ssh-console-rs/Chart.yaml
+          )
+          for chart in "${charts[@]}"; do
+            yq -i '.appVersion = strenv(APP_VERSION)' "$chart"
+          done
 
       - name: Package and push Helm chart to NGC
         if: ${{ needs.prepare.outputs.target_ngc_path != '' }}

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -149,7 +149,7 @@ jobs:
     uses: ./.github/workflows/rest-helm-workflows.yml
     with:
       ngc_path: ${{ needs.prepare.outputs.target_ngc_path }}
-      app_version: ${{ needs.prepare.outputs.semantic_version }}
+      app_version: ${{ needs.prepare.outputs.is_main_branch == 'true' && needs.prepare.outputs.semantic_version || needs.prepare.outputs.release_tag || needs.prepare.outputs.branch_sha_tag }}
       chart_version: ${{ needs.prepare.outputs.helm_version }}
     secrets:
       NVCR_STG_TOKEN: ${{ secrets.NVCR_TOKEN }}

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate Helm chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@197ece553bb6353e3e9cad153e41b5e311ebcf13
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@0969f64c3efa9e757135cbf457ea13cde4c3fa38
         with:
           chart-path: ${{ matrix.chart }}
           helm-version: 'v3.18.3'

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -44,9 +44,10 @@ jobs:
           persist-credentials: false
 
       - name: Validate Helm chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@197ece553bb6353e3e9cad153e41b5e311ebcf13
         with:
           chart-path: ${{ matrix.chart }}
+          helm-version: 'v3.18.3'
           lint: 'true'
           template: 'true'
           valueOverrides: ${{ matrix.valueOverrides }}

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -33,9 +33,10 @@ jobs:
       matrix:
         include:
           - chart: helm/rest/nico-rest
-            valueOverrides: '["nico-rest-api.config.keycloak.enabled=true","nico-rest-api.config.keycloak.baseURL=http://keycloak:8082","nico-rest-api.config.keycloak.realm=test","nico-rest-api.config.keycloak.clientID=test"]'
+            valueOverrides: >-
+              ["global.image.repository=registry.example.invalid/nico-rest","nico-rest-api.config.keycloak.enabled=true","nico-rest-api.config.keycloak.baseURL=http://keycloak:8082","nico-rest-api.config.keycloak.realm=test","nico-rest-api.config.keycloak.clientID=test"]
           - chart: helm/rest/nico-rest-site-agent
-            valueOverrides: '[]'
+            valueOverrides: '["global.image.repository=registry.example.invalid/nico-rest"]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -128,6 +129,53 @@ jobs:
             [[ "$actual" == "${excluded_app_versions[$child]}" ]] || \
               fail "$child appVersion changed unexpectedly: expected ${excluded_app_versions[$child]}, got $actual"
           done
+
+          negative_render_args=()
+          expected_guard="$chart_name: global.image.repository is required"
+          if [[ "$chart_name" == 'nico-rest' ]]; then
+            negative_render_args+=(
+              --set 'nico-rest-api.config.keycloak.enabled=true'
+              --set-string 'nico-rest-api.config.keycloak.baseURL=http://keycloak:8082'
+              --set-string 'nico-rest-api.config.keycloak.realm=test'
+              --set-string 'nico-rest-api.config.keycloak.clientID=test'
+            )
+          fi
+
+          schema_log="$tmp_dir/missing-repository-schema.log"
+          if helm template package-validation "$package" "${negative_render_args[@]}" \
+            --set-string 'global.image.tag=' \
+            >/dev/null 2>"$schema_log"; then
+            fail 'Expected schema validation without global.image.repository to fail'
+          fi
+          grep -Fq 'global.image.repository' "$schema_log" || {
+            cat "$schema_log"
+            fail 'Packaged schema error did not identify global.image.repository'
+          }
+
+          missing_repository_log="$tmp_dir/missing-repository.log"
+          if helm template package-validation "$package" "${negative_render_args[@]}" \
+            --skip-schema-validation \
+            --set-string 'global.image.tag=' \
+            >/dev/null 2>"$missing_repository_log"; then
+            fail 'Expected render without global.image.repository to fail'
+          fi
+          grep -Fq "$expected_guard" "$missing_repository_log" || {
+            cat "$missing_repository_log"
+            fail 'Missing-repository error did not identify global.image.repository'
+          }
+
+          whitespace_repository_log="$tmp_dir/whitespace-repository.log"
+          if helm template package-validation "$package" "${negative_render_args[@]}" \
+            --skip-schema-validation \
+            --set-string 'global.image.repository=   ' \
+            --set-string 'global.image.tag=' \
+            >/dev/null 2>"$whitespace_repository_log"; then
+            fail 'Expected render with a whitespace-only global.image.repository to fail'
+          fi
+          grep -Fq "$expected_guard" "$whitespace_repository_log" || {
+            cat "$whitespace_repository_log"
+            fail 'Whitespace-repository error did not identify global.image.repository'
+          }
 
           image_repository='registry.example.invalid/nico-rest'
           explicit_tag='operator-override'

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -50,6 +50,171 @@ jobs:
           template: 'true'
           valueOverrides: ${{ matrix.valueOverrides }}
 
+      # Publishing is intentionally disabled for PR refs, so exercise the exact
+      # package metadata and render-time fallback without pushing or uploading it.
+      - name: Validate packaged Helm appVersion fallback
+        if: ${{ success() && startsWith(github.ref, 'refs/heads/pull-request/') }}
+        shell: bash
+        env:
+          APP_VERSION: ${{ inputs.app_version }}
+          CHART_VERSION: ${{ inputs.chart_version }}
+          CHART_PATH: ${{ matrix.chart }}
+        run: |
+          set -euo pipefail
+          : "${APP_VERSION:?APP_VERSION must not be empty}"
+          : "${CHART_VERSION:?CHART_VERSION must not be empty}"
+          : "${CHART_PATH:?CHART_PATH must not be empty}"
+
+          fail() { echo "::error::$*"; exit 1; }
+          tmp_dir="$(mktemp -d "${RUNNER_TEMP}/nico-rest-package.XXXXXX")"
+          trap 'rm -rf "$tmp_dir"' EXIT
+          chart_dir="$tmp_dir/chart"
+          package_dir="$tmp_dir/packages"
+          cp -R "$CHART_PATH" "$chart_dir"
+          mkdir -p "$package_dir"
+
+          chart_name="$(yq -r '.name' "$chart_dir/Chart.yaml")"
+          children=()
+          excluded_children=()
+          case "$chart_name" in
+            nico-rest)
+              children=(
+                nico-rest-api
+                nico-rest-cert-manager
+                nico-rest-db
+                nico-rest-site-manager
+                nico-rest-workflow
+              )
+              excluded_children=(nico-rest-common)
+              ;;
+            nico-rest-site-agent) ;;
+            *) fail "Unexpected REST chart: $chart_name" ;;
+          esac
+          declare -A excluded_app_versions=()
+          for child in "${excluded_children[@]}"; do
+            metadata="$chart_dir/charts/$child/Chart.yaml"
+            [[ -f "$metadata" ]] || fail "Missing excluded child metadata: $metadata"
+            excluded_app_versions["$child"]="$(yq -r '.appVersion // ""' "$metadata")"
+          done
+          for child in "${children[@]}"; do
+            metadata="$chart_dir/charts/$child/Chart.yaml"
+            [[ -f "$metadata" ]] || fail "Missing child metadata: $metadata"
+            yq -i '.appVersion = strenv(APP_VERSION)' "$metadata"
+          done
+
+          helm package "$chart_dir" \
+            --dependency-update \
+            --version "$CHART_VERSION" \
+            --app-version "$APP_VERSION" \
+            --destination "$package_dir"
+          shopt -s nullglob
+          packages=("$package_dir"/*.tgz)
+          [[ ${#packages[@]} -eq 1 ]] || fail "Expected one package, found ${#packages[@]}"
+          package="${packages[0]}"
+          [[ "$package" == "$package_dir/${chart_name}-${CHART_VERSION}.tgz" ]] || \
+            fail "Unexpected package name: $package"
+          tar -tzf "$package" >/dev/null
+
+          actual="$(helm show chart "$package" | yq -r '.version')"
+          [[ "$actual" == "$CHART_VERSION" ]] || fail "Root version: expected $CHART_VERSION, got $actual"
+          actual="$(helm show chart "$package" | yq -r '.appVersion')"
+          [[ "$actual" == "$APP_VERSION" ]] || fail "Root appVersion: expected $APP_VERSION, got $actual"
+          for child in "${children[@]}"; do
+            actual="$(tar -xOf "$package" "$chart_name/charts/$child/Chart.yaml" | yq -r '.appVersion')"
+            [[ "$actual" == "$APP_VERSION" ]] || fail "$child appVersion: expected $APP_VERSION, got $actual"
+          done
+          for child in "${excluded_children[@]}"; do
+            actual="$(tar -xOf "$package" "$chart_name/charts/$child/Chart.yaml" | yq -r '.appVersion // ""')"
+            [[ "$actual" == "${excluded_app_versions[$child]}" ]] || \
+              fail "$child appVersion changed unexpectedly: expected ${excluded_app_versions[$child]}, got $actual"
+          done
+
+          image_repository='registry.example.invalid/nico-rest'
+          explicit_tag='operator-override'
+          fallback_manifest="$tmp_dir/fallback.yaml"
+          explicit_manifest="$tmp_dir/explicit.yaml"
+          render_args=(--set-string "global.image.repository=${image_repository}")
+          if [[ "$chart_name" == 'nico-rest' ]]; then
+            render_args+=(
+              --set 'nico-rest-api.config.keycloak.enabled=true'
+              --set-string 'nico-rest-api.config.keycloak.baseURL=http://keycloak:8082'
+              --set-string 'nico-rest-api.config.keycloak.realm=test'
+              --set-string 'nico-rest-api.config.keycloak.clientID=test'
+            )
+          fi
+          helm template package-validation "$package" "${render_args[@]}" \
+            --set-string 'global.image.tag=' > "$fallback_manifest"
+          helm template package-validation "$package" "${render_args[@]}" \
+            --set-string "global.image.tag=${explicit_tag}" > "$explicit_manifest"
+
+          image_for() {
+            local manifest="$1" kind="$2" workload="$3" container="$4"
+            KIND="$kind" WORKLOAD="$workload" CONTAINER="$container" yq ea -r '
+              select(.kind == strenv(KIND) and .metadata.name == strenv(WORKLOAD)) |
+              .spec.template.spec.containers[] |
+              select(.name == strenv(CONTAINER)) |
+              .image
+            ' "$manifest"
+          }
+          init_image_for() {
+            local manifest="$1" kind="$2" workload="$3" container="$4"
+            KIND="$kind" WORKLOAD="$workload" CONTAINER="$container" yq ea -r '
+              select(.kind == strenv(KIND) and .metadata.name == strenv(WORKLOAD)) |
+              .spec.template.spec.initContainers[] |
+              select(.name == strenv(CONTAINER)) |
+              .image
+            ' "$manifest"
+          }
+          assert_image() {
+            local manifest="$1" kind="$2" workload="$3" container="$4" expected="$5" actual
+            actual="$(image_for "$manifest" "$kind" "$workload" "$container")"
+            [[ "$actual" == "$expected" ]] || \
+              fail "$kind/$workload/$container image: expected $expected, got ${actual:-<missing>}"
+          }
+
+          if [[ "$chart_name" == 'nico-rest' ]]; then
+            workloads=(
+              'Deployment:nico-rest-api:api:nico-rest-api'
+              'Deployment:nico-rest-cert-manager:cert-manager:nico-rest-cert-manager'
+              'Deployment:nico-rest-site-manager:site-manager:nico-rest-site-manager'
+              'Deployment:nico-rest-cloud-worker:nico-rest-cloud-worker:nico-rest-workflow'
+              'Deployment:nico-rest-site-worker:nico-rest-site-worker:nico-rest-workflow'
+            )
+            migration_suffix="${APP_VERSION//./-}"
+            migration_suffix="${migration_suffix//+/-}"
+            fallback_job="nico-rest-db-migration-$migration_suffix"
+            assert_image "$fallback_manifest" Job "$fallback_job" migrations \
+              "$image_repository/nico-rest-db:$APP_VERSION"
+            assert_image "$explicit_manifest" Job 'nico-rest-db-migration-operator-override' migrations \
+              "$image_repository/nico-rest-db:$explicit_tag"
+            actual="$(init_image_for "$fallback_manifest" Job "$fallback_job" wait-for-postgres)"
+            [[ "$actual" == 'postgres:14.4-alpine' ]] || \
+              fail "wait-for-postgres image changed unexpectedly: $actual"
+          else
+            workloads=(
+              'StatefulSet:nico-rest-site-agent:site-agent:nico-rest-site-agent'
+            )
+          fi
+
+          for entry in "${workloads[@]}"; do
+            IFS=: read -r kind workload container image_name <<< "$entry"
+            assert_image "$fallback_manifest" "$kind" "$workload" "$container" \
+              "$image_repository/$image_name:$APP_VERSION"
+            assert_image "$explicit_manifest" "$kind" "$workload" "$container" \
+              "$image_repository/$image_name:$explicit_tag"
+          done
+
+          sha256="$(sha256sum "$package" | awk '{print $1}')"
+          [[ "$sha256" =~ ^[0-9a-f]{64}$ ]] || fail "Invalid package SHA-256: $sha256"
+          {
+            echo '### Helm package-only validation'
+            echo '| Chart | Version | appVersion | SHA-256 |'
+            echo '|---|---|---|---|'
+            echo "| $chart_name | \`$CHART_VERSION\` | \`$APP_VERSION\` | \`$sha256\` |"
+            echo
+            echo '> CI evidence only: the publish job rebuilds the package. No package artifact was uploaded.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   push-charts:
     name: Push Helm Charts
     needs:
@@ -66,6 +231,30 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Install yq
+        if: ${{ matrix.chart == 'helm/rest/nico-rest' }}
+        uses: dcarbone/install-yq-action@64b1b9eb28920bb1a4c13c05321df284f9a8f940 # v1.1.1
+        with:
+          version: v4.46.1
+
+      - name: Stamp child chart appVersions
+        if: ${{ matrix.chart == 'helm/rest/nico-rest' }}
+        env:
+          APP_VERSION: ${{ inputs.app_version }}
+        run: |
+          set -euo pipefail
+          : "${APP_VERSION:?APP_VERSION must not be empty}"
+          charts=(
+            helm/rest/nico-rest/charts/nico-rest-api/Chart.yaml
+            helm/rest/nico-rest/charts/nico-rest-cert-manager/Chart.yaml
+            helm/rest/nico-rest/charts/nico-rest-db/Chart.yaml
+            helm/rest/nico-rest/charts/nico-rest-site-manager/Chart.yaml
+            helm/rest/nico-rest/charts/nico-rest-workflow/Chart.yaml
+          )
+          for chart in "${charts[@]}"; do
+            yq -i '.appVersion = strenv(APP_VERSION)' "$chart"
+          done
 
       - name: Package and push Helm chart to NGC
         if: ${{ inputs.ngc_path != '' }}

--- a/helm/README.md
+++ b/helm/README.md
@@ -61,7 +61,7 @@ Top-level `global:` values are automatically passed to all subcharts.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `global.image.repository` | Container image repository (**REQUIRED**) | `""` |
-| `global.image.tag` | Container image tag (**REQUIRED**) | `""` |
+| `global.image.tag` | Optional image tag override; an empty value uses each owned runtime subchart's packaged `appVersion` | `""` |
 | `global.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `global.imagePullSecrets` | Image pull secrets | `[]` |
 | `global.certificate.duration` | Certificate validity period | `720h0m0s` |
@@ -146,7 +146,7 @@ unbound:
 
 ### Image Configuration
 
-The `global.image.repository` and `global.image.tag` values **must** be set -- they default to empty strings. Most subcharts use the global image reference. The following subcharts use their own separate image references and do **not** inherit `global.image`:
+`global.image.repository` **must** be set because the chart intentionally has no registry-specific default. `global.image.tag` is optional for published release packages: an empty value uses each NICo-owned runtime subchart's packaged `appVersion`. Set the tag explicitly when installing from a source checkout or when overriding the release version. The independently released `nico-flow` images must also be pinned explicitly when Flow is enabled. The following subcharts use separate image references and do **not** inherit the core image fallback:
 
 | Subchart | Image Parameter | Default |
 |----------|----------------|---------|

--- a/helm/charts/nico-api/templates/_helpers.tpl
+++ b/helm/charts/nico-api/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/component: api
 Global image reference
 */}}
 {{- define "nico-api.image" -}}
-{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/helm/charts/nico-bmc-proxy/templates/_helpers.tpl
+++ b/helm/charts/nico-bmc-proxy/templates/_helpers.tpl
@@ -25,7 +25,7 @@ deployments, the main nico image contains all binaries, so we can use that.
 {{- if not (eq (toString (.Values.image.repository | default "")) "") }}
 {{- .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}
 {{- else }}
-{{- .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+{{- .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 {{- end }}
 

--- a/helm/charts/nico-dhcp/templates/_helpers.tpl
+++ b/helm/charts/nico-dhcp/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/component: dhcp
 Global image reference
 */}}
 {{- define "nico-dhcp.image" -}}
-{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/helm/charts/nico-dns/templates/_helpers.tpl
+++ b/helm/charts/nico-dns/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/component: dns
 Global image reference
 */}}
 {{- define "nico-dns.image" -}}
-{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/helm/charts/nico-dsx-exchange-consumer/templates/_helpers.tpl
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/component: dsx-exchange-consumer
 Global image reference
 */}}
 {{- define "nico-dsx-exchange-consumer.image" -}}
-{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/helm/charts/nico-flow/values.yaml
+++ b/helm/charts/nico-flow/values.yaml
@@ -46,9 +46,10 @@ automountServiceAccountToken: true
 ## flow container to exit on startup validation. Override per environment.
 flowEnv: production
 
-## Per-component image overrides.
-## Repositories default to <global.image.repository>/nico-flow etc, but each can
-## be overridden independently if you want to pin one container to a different tag.
+## Per-component image overrides. Flow, PSM, and NSM are released by the REST
+## pipeline rather than with the core chart, so set their tags explicitly when
+## this chart is enabled. Repositories default to
+## <global.image.repository>/nico-flow etc.
 images:
   flow:
     repository: ""   # defaults to <global.image.repository>/nico-flow

--- a/helm/charts/nico-hardware-health/templates/_helpers.tpl
+++ b/helm/charts/nico-hardware-health/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/component: hardware-health
 Global image reference
 */}}
 {{- define "nico-hardware-health.image" -}}
-{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/helm/charts/nico-pxe/templates/_helpers.tpl
+++ b/helm/charts/nico-pxe/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/component: pxe
 Global image reference
 */}}
 {{- define "nico-pxe.image" -}}
-{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/helm/charts/nico-ssh-console-rs/templates/_helpers.tpl
+++ b/helm/charts/nico-ssh-console-rs/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/component: ssh-console-rs
 Global image reference
 */}}
 {{- define "nico-ssh-console-rs.image" -}}
-{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/helm/examples/values-minimal.yaml
+++ b/helm/examples/values-minimal.yaml
@@ -2,17 +2,19 @@
 ## Minimal Values — NICo Bare Metal Manager
 ## =============================================================================
 ## This is the minimum configuration required to deploy NICo.
-## You MUST set global.image.repository and global.image.tag.
+## You MUST set global.image.repository. Published release charts can use their
+## stamped appVersion when tag is empty; set tag explicitly for source checkouts
+## or to override the packaged release version.
 ## See PREREQUISITES.md for required Secrets, ConfigMaps, and operators.
 ##
 ## Install with: helm install nico ./helm -n nico-system --create-namespace -f values-minimal.yaml
 ## =============================================================================
 
 global:
-  ## REQUIRED: Set your container image repository and tag
+  ## REQUIRED: Set your container image repository
   image:
     repository: ""   # e.g. your-registry.example.com/nico-core
-    tag: ""          # e.g. v2025.12.30
+    tag: ""          # optional override, e.g. v2025.12.30
 
 ## ---------------------------------------------------------------------------
 ## All core services enabled by default — disable any you don't need

--- a/helm/rest/README.md
+++ b/helm/rest/README.md
@@ -2,6 +2,12 @@
 
 Helm charts for deploying the NICo REST API platform services.
 
+Published release charts stamp their runtime image tag into `appVersion`.
+`global.image.repository` remains required, while an empty
+`global.image.tag` falls back to that packaged version. The examples below set
+the tag explicitly so they also work when installing directly from a source
+checkout.
+
 ## Charts
 
 | Chart | Path | Description |

--- a/helm/rest/nico-rest-site-agent/templates/_helpers.tpl
+++ b/helm/rest/nico-rest-site-agent/templates/_helpers.tpl
@@ -25,5 +25,5 @@ app.kubernetes.io/component: site-agent
 {{- end }}
 
 {{- define "nico-rest-site-agent.image" -}}
-{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}

--- a/helm/rest/nico-rest-site-agent/templates/validate-values.yaml
+++ b/helm/rest/nico-rest-site-agent/templates/validate-values.yaml
@@ -1,0 +1,8 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- $repository := .Values.global.image.repository | default "" | trim -}}
+{{- if eq $repository "" -}}
+{{- fail "nico-rest-site-agent: global.image.repository is required; set it through Helm values or Argo CD Application values (for example, registry.example.com/team/nico-rest)" -}}
+{{- end -}}

--- a/helm/rest/nico-rest-site-agent/values.schema.json
+++ b/helm/rest/nico-rest-site-agent/values.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["global"],
+  "properties": {
+    "global": {
+      "type": "object",
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "type": "object",
+          "required": ["repository"],
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/helm/rest/nico-rest-site-agent/values.yaml
+++ b/helm/rest/nico-rest-site-agent/values.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 global:
+  # The repository is intentionally user-supplied. An empty tag falls back to
+  # this chart's release-stamped appVersion.
   image:
     repository: ""
     tag: ""

--- a/helm/rest/nico-rest/charts/nico-rest-api/templates/_helpers.tpl
+++ b/helm/rest/nico-rest/charts/nico-rest-api/templates/_helpers.tpl
@@ -25,7 +25,7 @@ app.kubernetes.io/component: api
 {{- end }}
 
 {{- define "nico-rest-api.image" -}}
-{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{- define "nico-rest-api.validateAuth" -}}

--- a/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/_helpers.tpl
+++ b/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/_helpers.tpl
@@ -26,5 +26,5 @@ app.kubernetes.io/component: cert-manager
 {{- end }}
 
 {{- define "nico-rest-cert-manager.image" -}}
-{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/_helpers.tpl
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/_helpers.tpl
@@ -19,5 +19,5 @@ app.kubernetes.io/component: migrations
 {{- end }}
 
 {{- define "nico-rest-db.image" -}}
-{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- $tag := .Values.global.image.tag | default "latest" | replace "." "-" | replace "+" "-" }}
+{{- $tag := .Values.global.image.tag | default .Chart.AppVersion | replace "." "-" | replace "+" "-" }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/rest/nico-rest/charts/nico-rest-site-manager/templates/_helpers.tpl
+++ b/helm/rest/nico-rest/charts/nico-rest-site-manager/templates/_helpers.tpl
@@ -25,5 +25,5 @@ app.kubernetes.io/component: site-manager
 {{- end }}
 
 {{- define "nico-rest-site-manager.image" -}}
-{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}

--- a/helm/rest/nico-rest/charts/nico-rest-workflow/templates/_helpers.tpl
+++ b/helm/rest/nico-rest/charts/nico-rest-workflow/templates/_helpers.tpl
@@ -18,7 +18,7 @@ app.kubernetes.io/name: nico-rest-workflow
 {{- end }}
 
 {{- define "nico-rest-workflow.image" -}}
-{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag }}
+{{ .Values.global.image.repository }}/{{ .Values.image.name }}:{{ .Values.global.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{- define "nico-rest-workflow.dbCredsVolumeMount" -}}

--- a/helm/rest/nico-rest/templates/validate-values.yaml
+++ b/helm/rest/nico-rest/templates/validate-values.yaml
@@ -1,0 +1,8 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- $repository := .Values.global.image.repository | default "" | trim -}}
+{{- if eq $repository "" -}}
+{{- fail "nico-rest: global.image.repository is required; set it through Helm values or Argo CD Application values (for example, registry.example.com/team/nico-rest)" -}}
+{{- end -}}

--- a/helm/rest/nico-rest/values.schema.json
+++ b/helm/rest/nico-rest/values.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["global"],
+  "properties": {
+    "global": {
+      "type": "object",
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "type": "object",
+          "required": ["repository"],
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/helm/rest/nico-rest/values.yaml
+++ b/helm/rest/nico-rest/values.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 global:
+  # The repository is intentionally user-supplied. An empty tag falls back to
+  # the release-stamped appVersion of each NICo-owned runtime subchart.
   image:
     repository: ""
     tag: ""

--- a/helm/templates/validate-values.yaml
+++ b/helm/templates/validate-values.yaml
@@ -1,0 +1,8 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- $repository := .Values.global.image.repository | default "" | trim -}}
+{{- if eq $repository "" -}}
+{{- fail "nico: global.image.repository is required; set it through Helm values or Argo CD Application values (for example, registry.example.com/team/nico-core)" -}}
+{{- end -}}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["global"],
+  "properties": {
+    "global": {
+      "type": "object",
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "type": "object",
+          "required": ["repository"],
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,9 +5,10 @@
 ## platform. See README.md for full documentation and PREREQUISITES.md for
 ## required infrastructure setup.
 ##
-## IMPORTANT: You MUST set global.image.repository and global.image.tag before
-## installing. They default to empty strings and the chart will not render
-## valid manifests without them.
+## IMPORTANT: You MUST set global.image.repository before installing. Published
+## release packages stamp each owned runtime subchart's appVersion, which is
+## used when global.image.tag is empty. When installing from a source checkout,
+## set the tag explicitly unless those source appVersions match your images.
 ##
 ## Top-level `global:` values are automatically passed to ALL sub-charts.
 ## Per-subchart overrides go under <chart-name>: key.
@@ -18,7 +19,9 @@
 ## Global settings (shared by all sub-charts)
 ## ---------------------------------------------------------------------------
 global:
-  ## Container image for NICo core services (REQUIRED -- must be set by user)
+  ## Container image for NICo core services. The repository is REQUIRED and
+  ## intentionally has no registry-specific default. When tag is empty, the
+  ## packaged subchart appVersion is used.
   ## Services that share this image: nico-api, nico-dhcp, nico-dns,
   ## nico-dsx-exchange-consumer, nico-hardware-health, nico-pxe,
   ## nico-ssh-console-rs.
@@ -117,6 +120,9 @@ nico-dsx-exchange-consumer:
 ## keeps the umbrella from auto-rendering it. Deploy with:
 ##   helm install flow ./helm/charts/nico-flow -n flow ...
 ## (helm-prereqs/setup.sh phase 7i does this for you.)
+## Flow, PSM, and NSM images are released by the REST pipeline. Set
+## nico-flow.images.*.tag explicitly to the matching REST release; these
+## independently released images do not inherit the core chart appVersion.
 ## ---------------------------------------------------------------------------
 nico-flow:
   enabled: false


### PR DESCRIPTION
NICo release charts currently require repeated image-tag overrides even though
the runtime version is already known by the release pipeline. Stamping only the
umbrella chart is insufficient because dependency templates resolve
`.Chart.AppVersion` from each child chart's own `Chart.yaml`.

This change:

- makes NICo-owned runtime image helpers prefer an explicit image tag and
  otherwise fall back to the child chart's packaged `appVersion`;
- stamps only the allowlisted owned child charts immediately before packaging;
- passes the tag selected from the existing REST prepare outputs to Helm
  `appVersion`, without changing REST image build/push inputs or behavior;
- adds PR-only package validation for core, REST, and site-agent without
  publishing or uploading the disposable packages; and
- documents that the registry remains user-supplied while the tag is an
  optional release-version override.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validation performed:

- PR CI copies each chart into `$RUNNER_TEMP`, stamps the same owned-child
  allowlists used by publishing, and runs a real `helm package
  --dependency-update`;
- packaged root/child metadata, excluded-child preservation, AppVersion
  fallback, explicit-tag precedence, and the REST migration Job name/image are
  asserted for core, REST, and site-agent;
- each disposable package's SHA-256 is written to the job summary as CI
  evidence, then the package is deleted; no artifact is uploaded or pushed;
- confirmed the REST image build/push workflows are byte-identical to
  `upstream/main`;
- verified existing main/release/branch image-tag selection is mirrored by the
  Helm `appVersion` input;
- ran the exact new workflow shell locally for core, REST, and site-agent;
- ran `helm lint` for all three packaged charts; and
- ran `git diff --check`, YAML parsing, and filtered `actionlint` with no new
  findings.

## Additional Notes

`nico-flow`, `nico-psm`, and `nico-nsm` remain intentionally excluded from
the core chart `appVersion` fallback. Their images are produced by the REST
pipeline while their chart is currently packaged with core, so treating the
core version as their fallback could reference a tag that was never published.
When Flow is enabled, its component tags must continue to be pinned to the
matching REST release until version ownership is unified.

Third-party or independently versioned images (`nico-ntp`, `unbound`, helper
containers, and REST bootstrap/wait images) are also deliberately unchanged.
The custom-repository path for `nico-bmc-proxy` keeps its existing `latest`
fallback; only its global NICo image path uses the packaged `appVersion`.