### PR TITLE
fix: reject host discovery identity conflicts

### DIFF
--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -140,24 +140,6 @@ pub(crate) async fn discover_machine(
                 "ignoring DiscoverMachine request for non-tpm enabled host with InterfaceId {interface_id:?}"
             ))
             .into());
-    } else if !hardware_info.is_dpu() && hardware_info.tpm_ek_certificate.is_some() {
-        // this means we do have an EK cert for a host
-
-        // get the EK cert from incoming message
-        let tpm_ek_cert =
-            hardware_info
-                .tpm_ek_certificate
-                .as_ref()
-                .ok_or(CarbideError::InvalidArgument(
-                    "tpm_ek_cert is empty".to_string(),
-                ))?;
-
-        attest::match_insert_new_ek_cert_status_against_ca(
-            &mut txn,
-            tpm_ek_cert,
-            &stable_machine_id,
-        )
-        .await?;
     }
 
     let interface =
@@ -211,7 +193,7 @@ pub(crate) async fn discover_machine(
             // Site-explorer will update if machine is created by site-explorer.
             db::machine_interface::associate_interface_with_dpu_machine(
                 &interface.id,
-                &stable_machine_id,
+                &machine.id,
                 &mut txn,
             )
             .await?;
@@ -231,23 +213,16 @@ pub(crate) async fn discover_machine(
             })?
         };
 
-        if db_machine.network_config.loopback_ip.is_none() {
-            let loopback_ip = db::machine::allocate_loopback_ip(
-                &api.common_pools,
-                &mut txn,
-                &stable_machine_id.to_string(),
-            )
-            .await?;
-
-            let mut network_config = db_machine.network_config.value.clone();
-            network_config.loopback_ip = Some(loopback_ip);
-            db::machine::try_update_network_config(
-                &mut txn,
-                &stable_machine_id,
-                db_machine.network_config.version,
-                &network_config,
-            )
-            .await?;
+        let mut network_config = db_machine.network_config.value.clone();
+        if network_config.loopback_ip.is_none() {
+            network_config.loopback_ip = Some(
+                db::machine::allocate_loopback_ip(
+                    &api.common_pools,
+                    &mut txn,
+                    &db_machine.id.to_string(),
+                )
+                .await?,
+            );
         }
 
         if api
@@ -256,27 +231,33 @@ pub(crate) async fn discover_machine(
             .as_ref()
             .map(|vc| vc.secondary_overlay_support)
             .unwrap_or_default()
-            && db_machine
-                .network_config
-                .secondary_overlay_vtep_ip
-                .is_none()
+            && network_config.secondary_overlay_vtep_ip.is_none()
         {
-            let secondary_vtep_ip = db::machine::allocate_secondary_vtep_ip(
-                &api.common_pools,
-                &mut txn,
-                &stable_machine_id.to_string(),
-            )
-            .await?;
+            network_config.secondary_overlay_vtep_ip = Some(
+                db::machine::allocate_secondary_vtep_ip(
+                    &api.common_pools,
+                    &mut txn,
+                    &db_machine.id.to_string(),
+                )
+                .await?,
+            );
+        }
 
-            let mut network_config = db_machine.network_config.value.clone();
-            network_config.secondary_overlay_vtep_ip = Some(secondary_vtep_ip);
-            db::machine::try_update_network_config(
+        if network_config != db_machine.network_config.value {
+            let updated = db::machine::try_update_network_config(
                 &mut txn,
-                &stable_machine_id,
+                &db_machine.id,
                 db_machine.network_config.version,
                 &network_config,
             )
             .await?;
+            if !updated {
+                return Err(db::DatabaseError::ConcurrentModificationError(
+                    "machine",
+                    db_machine.network_config.version.to_string(),
+                )
+                .into());
+            }
         }
 
         db_machine.id
@@ -290,9 +271,25 @@ pub(crate) async fn discover_machine(
         .await?
     };
 
+    if !hardware_info.is_dpu() && hardware_info.tpm_ek_certificate.is_some() {
+        // this means we do have an EK cert for a host
+
+        // get the EK cert from incoming message
+        let tpm_ek_cert =
+            hardware_info
+                .tpm_ek_certificate
+                .as_ref()
+                .ok_or(CarbideError::InvalidArgument(
+                    "tpm_ek_cert is empty".to_string(),
+                ))?;
+
+        attest::match_insert_new_ek_cert_status_against_ca(&mut txn, tpm_ek_cert, &machine_id)
+            .await?;
+    }
+
     db::machine_topology::create_or_update_with_bom_validation(
         &mut txn,
-        &stable_machine_id,
+        &machine_id,
         &hardware_info,
         api.runtime_config.bom_validation.enabled,
     )
@@ -411,7 +408,7 @@ pub(crate) async fn discover_machine(
             crate::handlers::measured_boot::create_attest_key_bind_challenge(
                 &mut txn,
                 &attest_key_info,
-                &stable_machine_id,
+                &machine_id,
             )
             .await?,
         )
@@ -419,7 +416,7 @@ pub(crate) async fn discover_machine(
         tracing::info!(
             attestation_enabled = api.runtime_config.attestation_enabled,
             is_dpu = hardware_info.is_dpu(),
-            %stable_machine_id,
+            %machine_id,
             "Vending attestation certificates",
         );
 
@@ -436,12 +433,8 @@ pub(crate) async fn discover_machine(
             .as_deref()
             .none_if_empty()
     {
-        db::machine::update_last_scout_observed_version(
-            &stable_machine_id,
-            scout_version,
-            &mut txn,
-        )
-        .await?;
+        db::machine::update_last_scout_observed_version(&machine_id, scout_version, &mut txn)
+            .await?;
     }
 
     txn.commit().await?;
@@ -452,7 +445,7 @@ pub(crate) async fn discover_machine(
         } else {
             Some(
                 api.certificate_provider
-                    .get_certificate(&stable_machine_id.to_string(), None, None)
+                    .get_certificate(&machine_id.to_string(), None, None)
                     .await
                     .map_err(|err| CarbideError::ClientCertificateError(err.to_string()))?
                     .into(),
@@ -463,7 +456,7 @@ pub(crate) async fn discover_machine(
     };
 
     let response = Ok(Response::new(rpc::MachineDiscoveryResult {
-        machine_id: Some(stable_machine_id),
+        machine_id: Some(machine_id),
         machine_certificate,
         attest_key_challenge,
         machine_interface_id: Some(interface.id),
@@ -483,7 +476,7 @@ pub(crate) async fn discover_machine(
             db::network_devices::dpu_to_network_device_map::create_dpu_network_device_association(
                 txn,
                 &dpu_info.switches,
-                &stable_machine_id,
+                &machine_id,
             )
             .boxed()
         })

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use ::rpc::measured_boot::FromGrpc;
-use base64::prelude::*;
 use carbide_machine_controller::context::MachineStateHandlerContextObjects;
 use carbide_machine_controller::handler::{MachineStateHandlerBuilder, handler_host_power_control};
 use carbide_machine_controller::metrics::MachineMetrics;
@@ -39,7 +38,9 @@ use common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
     create_host_inband_network_segment,
 };
-use common::api_fixtures::tpm_attestation::{CA_CERT_SERIALIZED, EK_CERT_SERIALIZED};
+use common::api_fixtures::tpm_attestation::{
+    CA_CERT_SERIALIZED, EK_CERT_SERIALIZED, EK2_CERT_SERIALIZED,
+};
 use common::api_fixtures::{
     TestEnv, TestManagedHost, create_managed_host, create_managed_host_with_config,
     create_test_env, create_test_env_with_overrides, get_config,
@@ -55,6 +56,7 @@ use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
 use model::hardware_info::TpmEkCertificate;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
+use model::machine::machine_id::from_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     BiosConfigInfo, BiosConfigState, CleanupContext, CleanupState, DpuDiscoveringState,
@@ -4137,19 +4139,25 @@ async fn test_scout_heartbeat_timeout_alert_not_cleared_when_unhealthy_allocatio
 }
 
 #[crate::sqlx_test]
-async fn test_tpm_logging(pool: sqlx::PgPool) {
+async fn test_discover_machine_rejects_mismatched_tpm_identity_before_topology_insert(
+    pool: sqlx::PgPool,
+) {
     let env = create_test_env(pool).await;
-    let host_config = env.managed_host_config();
+    let mut host_config = env.managed_host_config();
+    host_config.tpm_ek_cert = TpmEkCertificate::from(EK_CERT_SERIALIZED.to_vec());
     let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
 
     let machine_interface_id = host_discover_dhcp(&env, &host_config, &dpu_machine_id).await;
 
-    host_discover_machine(&env, &host_config, machine_interface_id).await;
+    let original_machine_id = host_discover_machine(&env, &host_config, machine_interface_id).await;
 
-    let mut discovery_info =
-        DiscoveryInfo::try_from(model::hardware_info::HardwareInfo::from(&host_config)).unwrap();
-    discovery_info.tpm_ek_certificate =
-        Some(BASE64_STANDARD.encode(common::api_fixtures::tpm_attestation::EK_CERT_SERIALIZED));
+    let mut candidate_hardware_info = model::hardware_info::HardwareInfo::from(&host_config);
+    candidate_hardware_info.tpm_ek_certificate =
+        Some(TpmEkCertificate::from(EK2_CERT_SERIALIZED.to_vec()));
+    let candidate_machine_id = from_hardware_info(&candidate_hardware_info).unwrap();
+    assert_ne!(original_machine_id, candidate_machine_id);
+
+    let mut discovery_info = DiscoveryInfo::try_from(candidate_hardware_info).unwrap();
     discovery_info.attest_key_info = Some(AttestKeyInfo {
         ek_pub: common::api_fixtures::tpm_attestation::EK_PUB_SERIALIZED.to_vec(),
         ak_pub: common::api_fixtures::tpm_attestation::AK_PUB_SERIALIZED.to_vec(),
@@ -4165,13 +4173,54 @@ async fn test_tpm_logging(pool: sqlx::PgPool) {
         }))
         .await;
 
-    let err = result.expect_err("Expected FK violation from mismatched TPM");
+    let err = result.expect_err("Expected identity conflict from mismatched TPM");
     assert_eq!(err.code(), Code::FailedPrecondition);
     assert!(
-        err.message().contains("machine_id foreign key violation"),
+        err.message().contains("host identity mismatch"),
         "Expected TPM mismatch error, got: {}",
         err.message()
     );
+    assert!(
+        !err.message().contains("foreign key"),
+        "Expected discovery to fail before topology insert, got: {}",
+        err.message()
+    );
+
+    let mut txn = env.db_txn().await;
+    let candidate_topology =
+        db::machine_topology::find_latest_by_machine_ids(&mut txn, &[candidate_machine_id])
+            .await
+            .unwrap();
+    assert!(
+        !candidate_topology.contains_key(&candidate_machine_id),
+        "expected no topology row for rejected candidate machine id {candidate_machine_id}"
+    );
+    let candidate_ek_status = db::attestation::ek_cert_verification_status::get_by_machine_id(
+        &mut txn,
+        candidate_machine_id,
+    )
+    .await
+    .unwrap();
+    assert!(
+        candidate_ek_status.is_none(),
+        "expected no EK cert status row for rejected candidate machine id {candidate_machine_id}"
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_discover_machine_allows_repeated_tpm_identity(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mut host_config = env.managed_host_config();
+    host_config.tpm_ek_cert = TpmEkCertificate::from(EK_CERT_SERIALIZED.to_vec());
+    let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
+
+    let machine_interface_id = host_discover_dhcp(&env, &host_config, &dpu_machine_id).await;
+
+    let original_machine_id = host_discover_machine(&env, &host_config, machine_interface_id).await;
+    let rediscovered_machine_id =
+        host_discover_machine(&env, &host_config, machine_interface_id).await;
+
+    assert_eq!(rediscovered_machine_id, original_machine_id);
 }
 
 #[crate::sqlx_test]

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -1440,10 +1440,20 @@ pub async fn try_sync_stable_id_with_current_machine_id_for_host(
         });
     };
 
-    // This is repeated call. Machine is already updated with stable ID.
+    // This is a repeated call. Machine is already updated with stable ID.
     if !current_machine_id.machine_type().is_predicted_host() {
-        return match find_one(txn, current_machine_id, MachineSearchConfig::default()).await? {
-            Some(machine) => Ok(machine.id),
+        return match find_one(
+            &mut *txn,
+            current_machine_id,
+            MachineSearchConfig::default(),
+        )
+        .await?
+        {
+            Some(machine) if machine.id == *stable_machine_id => Ok(machine.id),
+            Some(machine) => Err(DatabaseError::FailedPrecondition(format!(
+                "host identity mismatch: interface is already associated with machine id {}, but discovery derived {}; refusing to alias different host identities",
+                machine.id, stable_machine_id
+            ))),
             None => Err(DatabaseError::NotFoundError {
                 kind: "machine",
                 id: current_machine_id.to_string(),


### PR DESCRIPTION
## Problem

Host `DiscoverMachine` can derive a candidate host ID that differs from the existing non-predicted host already attached to the interface. The handler then used the candidate ID for topology, attestation, and certificate writes, which can produce FK failures instead of a clear identity conflict.

## Fix

- Treat a non-predicted existing host ID mismatch as `FailedPrecondition` during host ID reconciliation.
- Use the reconciled authoritative machine ID for topology, EK status, attestation challenge, scout version, certificate vending, DPU follow-up writes, and response.
- Cover TPM-to-TPM mismatch, repeated same-TPM discovery, and absence of candidate topology/EK status writes in tests.

## Caveat

This fails closed rather than aliasing two different real host IDs. Existing machines already enrolled under a divergent TPM-derived ID still need an audit or explicit migration decision.

Refs #3128.