### PR TITLE
Support for creating DPF flavor, deployment and services for BF4 Astra

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -588,7 +588,7 @@ events, so consumers handle them identically.
 | `services` | `Box<DpfMandatoryServicesConfig>` | built-in mandatory-service defaults | Helm chart, image, and pull-secret settings for the six mandatory DPF services. |
 | `docker_image_pull_secret` | `Option<String>` | — | Override for the Kubernetes `imagePullSecrets` entry used to pull mandatory-service images (applied to every mandatory service except `dts` and `doca_hbn`, which take a pull secret only from their per-service config). |
 | `proxy` | `Option<DpfProxyDetails>` | — | Proxy configuration for the DPU. When set, containerd on the DPU routes outbound HTTPS traffic through it. |
-| `deployments` | `DpfDeploymentsConfig` | *(default)* | Per-generation DPUDeployment configurations. BF3 is always present with defaults; BF4Generic is opt-in via `[dpf.deployments.bf4_generic]`. |
+| `deployments` | `DpfDeploymentsConfig` | *(default)* | Per-generation DPUDeployment configurations. BF3 is always present with defaults; BF4 variants are opt-in. BF4 Astra gets default Weave DHCP agent, Weave flow controller, and Xplane services; `extra_services` can replace any of those definitions. |
 
 Omitting `[dpf.dpu_agent_bootstrap_ca]` preserves the historical download URL.
 Use the following configuration to retain download mode while overriding the

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1365,7 +1365,7 @@ pub struct DpfConfig {
     #[serde(default)]
     pub proxy: Option<DpfProxyDetails>,
     /// Per-generation DPUDeployment configurations. BF3 is always present with sensible
-    /// defaults; BF4Generic is opt-in via `[dpf.deployments.bf4_generic]`.
+    /// defaults; BF4 variants are opt-in.
     #[serde(default)]
     pub deployments: DpfDeploymentsConfig,
 }
@@ -1381,14 +1381,14 @@ impl DpfConfig {
         services
     }
 
-    /// Returns the mandatory services for `deployment`: the deployment's own
+    /// Returns the services for `deployment`: the deployment's own
     /// [`DpfDeploymentConfig::services`] override when set, otherwise the top-level
-    /// [`Self::services`]. In both cases the optional [`Self::docker_image_pull_secret`]
-    /// override is applied (see [`Self::resolved_mandatory_services`]).
+    /// [`Self::services`], plus its deployment-specific extra services. The optional
+    /// [`Self::docker_image_pull_secret`] override is applied to the mandatory services
+    /// (see [`Self::resolved_mandatory_services`]).
     pub fn resolved_services_for(
         &self,
         deployment: &DpfDeploymentConfig,
-        deployment_type: DpuDeploymentType,
     ) -> DpfResolvedMandatoryServicesConfig {
         let mut base = deployment
             .services
@@ -1396,20 +1396,11 @@ impl DpfConfig {
             .cloned()
             .unwrap_or_else(|| (*self.services).clone());
         self.apply_pull_secret_override(&mut base);
-        let extra = match deployment_type {
-            DpuDeploymentType::Bf4Astra => BTreeMap::from([
-                (
-                    DpfExtraService::DocaWeave,
-                    crate::dpf_services::default_doca_weave_service(),
-                ),
-                (
-                    DpfExtraService::DocaXplane,
-                    crate::dpf_services::default_doca_xplane_service(),
-                ),
-            ]),
-            _ => BTreeMap::new(),
-        };
-        DpfResolvedMandatoryServicesConfig { base, extra }
+
+        DpfResolvedMandatoryServicesConfig {
+            base,
+            extra: deployment.extra_services.clone(),
+        }
     }
 
     /// Applies the optional [`Self::docker_image_pull_secret`] override to every
@@ -1481,13 +1472,43 @@ impl Default for DpfMandatoryServicesConfig {
 /// Modelled as an enum (rather than a string key) so the resolver that populates
 /// the extras and the consumer that projects them into service definitions stay in
 /// sync at compile time.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)] // DOCA is part of the service identity, not a redundant prefix.
 pub enum DpfExtraService {
-    /// DOCA Weave service.
-    DocaWeave,
+    /// DOCA Weave DHCP agent service.
+    DocaWeaveDhcpAgent,
+    /// DOCA Weave Flow Controller service.
+    DocaWeaveFlowController,
     /// DOCA Xplane service.
     DocaXplane,
+}
+
+const BF4_ASTRA_EXTRA_SERVICES: &[DpfExtraService] = &[
+    DpfExtraService::DocaWeaveDhcpAgent,
+    DpfExtraService::DocaWeaveFlowController,
+    DpfExtraService::DocaXplane,
+];
+
+fn extra_service_types(deployment_type: DpuDeploymentType) -> &'static [DpfExtraService] {
+    match deployment_type {
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => &[],
+        DpuDeploymentType::Bf4Astra => BF4_ASTRA_EXTRA_SERVICES,
+    }
+}
+
+impl DpfExtraService {
+    fn default_config(self) -> DpfServiceConfig {
+        match self {
+            Self::DocaWeaveDhcpAgent => {
+                crate::dpf_services::default_doca_weave_dhcp_agent_service()
+            }
+            Self::DocaWeaveFlowController => {
+                crate::dpf_services::default_doca_weave_flow_controller_service()
+            }
+            Self::DocaXplane => crate::dpf_services::default_doca_xplane_service(),
+        }
+    }
 }
 
 /// `DpfResolvedMandatoryServicesConfig` - the compounded list of mandatory services
@@ -1527,7 +1548,8 @@ pub struct DpfServiceConfig {
 /// `flavor_name`, `deployment_name`, and `node_label_key` are required when a
 /// `[dpf.deployments.<name>]` block is written; `bfb_url` and `services` are
 /// optional. When `services` is omitted, the deployment inherits the top-level
-/// `[dpf.services]` (see [`DpfConfig::resolved_services_for`]).
+/// `[dpf.services]` (see [`DpfConfig::resolved_services_for`]). Extra services
+/// are configured per deployment in `extra_services`.
 ///
 /// The `Default` impl (BF3 values) is used when the entire
 /// `[dpf.deployments.bf3]` block is absent, via `#[serde(default)]` on the
@@ -1556,6 +1578,12 @@ pub struct DpfDeploymentConfig {
     /// [`DpfConfig::services`]. When absent, the top-level services are inherited.
     #[serde(default)]
     pub services: Option<Box<DpfMandatoryServicesConfig>>,
+
+    /// Deployment-specific Helm services. BF4 Astra receives built-in DOCA Weave
+    /// DHCP agent, Weave flow controller, and DOCA Xplane definitions; configured
+    /// entries replace matching defaults.
+    #[serde(default)]
+    pub extra_services: BTreeMap<DpfExtraService, DpfServiceConfig>,
 }
 
 impl Default for DpfDeploymentConfig {
@@ -1567,6 +1595,7 @@ impl Default for DpfDeploymentConfig {
             deployment_name: default_dpf_deployment_name(),
             node_label_key: default_dpf_node_label_key(),
             services: None,
+            extra_services: BTreeMap::new(),
         }
     }
 }
@@ -1592,7 +1621,7 @@ pub struct DpfBlueFieldSoftwareConfig {
 
 /// Named DPUDeployment configurations under `[dpf.deployments]`.
 /// Each entry creates its own BFB, DPUFlavor, and DPUDeployment CR at startup.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct DpfDeploymentsConfig {
     /// BF3 deployment. Present by default with sensible values; override individual
     /// fields in `[dpf.deployments.bf3]` when the site uses non-default names or BFBs.
@@ -1606,7 +1635,57 @@ pub struct DpfDeploymentsConfig {
     pub bf4_astra: Option<DpfDeploymentConfig>,
 }
 
+#[derive(Deserialize)]
+struct DpfDeploymentsConfigDef {
+    #[serde(default)]
+    bf3: DpfDeploymentConfig,
+    #[serde(default)]
+    bf4_generic: Option<DpfDeploymentConfig>,
+    #[serde(default)]
+    bf4_astra: Option<DpfDeploymentConfig>,
+}
+
+impl<'de> Deserialize<'de> for DpfDeploymentsConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let config = DpfDeploymentsConfigDef::deserialize(deserializer)?;
+        let mut deployments = Self {
+            bf3: config.bf3,
+            bf4_generic: config.bf4_generic,
+            bf4_astra: config.bf4_astra,
+        };
+        deployments.apply_extra_service_defaults();
+        Ok(deployments)
+    }
+}
+
 impl DpfDeploymentsConfig {
+    fn apply_extra_service_defaults(&mut self) {
+        Self::apply_extra_service_defaults_for(&mut self.bf3, DpuDeploymentType::Bf3);
+        if let Some(deployment) = &mut self.bf4_generic {
+            Self::apply_extra_service_defaults_for(deployment, DpuDeploymentType::Bf4Generic);
+        }
+        if let Some(deployment) = &mut self.bf4_astra {
+            Self::apply_extra_service_defaults_for(deployment, DpuDeploymentType::Bf4Astra);
+        }
+    }
+
+    fn apply_extra_service_defaults_for(
+        deployment: &mut DpfDeploymentConfig,
+        deployment_type: DpuDeploymentType,
+    ) {
+        let configured = std::mem::take(&mut deployment.extra_services);
+        deployment.extra_services = extra_service_types(deployment_type)
+            .iter()
+            .copied()
+            .map(|service| (service, service.default_config()))
+            .collect();
+        // A configured entry replaces only that service's built-in definition.
+        deployment.extra_services.extend(configured);
+    }
+
     /// Returns all active deployment configs as `(name, config)` pairs.
     /// Add new deployments here when they are introduced.
     fn all(&self) -> Vec<(&'static str, &DpfDeploymentConfig)> {
@@ -5448,6 +5527,114 @@ object_kind = "secret"
     }
 
     #[test]
+    fn dpf_deployment_extra_services_are_configurable() {
+        let config = toml::from_str::<DpfConfig>(
+            r#"
+[deployments.bf4_astra]
+flavor_name = "astra-flavor"
+deployment_name = "astra-deployment"
+node_label_key = "carbide.nvidia.com/astra"
+
+[deployments.bf4_astra.extra_services.doca_weave_dhcp_agent]
+name = "doca-weave-dhcp-agent"
+helm_repo_url = "https://helm.example.test/doca"
+helm_chart = "doca-weave-dhcp-agent"
+helm_version = "development-version"
+docker_repo_url = "registry.example.test/doca-weave-dhcp-agent"
+docker_image_tag = "development-tag"
+
+[deployments.bf4_astra.extra_services.doca_weave_flow_controller]
+name = "doca-weave-flow-controller"
+helm_repo_url = "https://helm.example.test/doca"
+helm_chart = "doca-weave-flow-controller"
+helm_version = "flow-controller-dev"
+docker_repo_url = "registry.example.test/doca-weave-flow-controller"
+docker_image_tag = "flow-controller-tag"
+"#,
+        )
+        .unwrap();
+
+        let deployment = config.deployments.bf4_astra.as_ref().unwrap();
+        let configured = deployment
+            .extra_services
+            .get(&DpfExtraService::DocaWeaveDhcpAgent)
+            .unwrap();
+        assert_eq!(configured.helm_version, "development-version");
+
+        let resolved = config.resolved_services_for(deployment);
+        assert_eq!(
+            resolved
+                .extra
+                .get(&DpfExtraService::DocaWeaveDhcpAgent)
+                .unwrap()
+                .docker_image_tag,
+            "development-tag"
+        );
+        assert_eq!(
+            resolved
+                .extra
+                .get(&DpfExtraService::DocaWeaveFlowController)
+                .unwrap()
+                .helm_version,
+            "flow-controller-dev"
+        );
+        assert_eq!(
+            resolved
+                .extra
+                .get(&DpfExtraService::DocaXplane)
+                .unwrap()
+                .helm_version,
+            crate::dpf_services::DOCA_XPLANE_SERVICE_HELM_VERSION
+        );
+    }
+
+    #[test]
+    fn bf4_astra_extra_services_default_without_toml() {
+        let config = toml::from_str::<DpfConfig>(
+            r#"
+[deployments.bf4_astra]
+flavor_name = "astra-flavor"
+deployment_name = "astra-deployment"
+node_label_key = "carbide.nvidia.com/astra"
+"#,
+        )
+        .unwrap();
+        let deployment = config.deployments.bf4_astra.as_ref().unwrap();
+        let resolved = config.resolved_services_for(deployment);
+
+        let dhcp_agent = resolved
+            .extra
+            .get(&DpfExtraService::DocaWeaveDhcpAgent)
+            .unwrap();
+        assert_eq!(
+            dhcp_agent.name,
+            carbide_dpf::types::DOCA_WEAVE_DHCP_AGENT_SERVICE_NAME
+        );
+        assert_eq!(
+            dhcp_agent.helm_version,
+            crate::dpf_services::DOCA_WEAVE_DHCP_AGENT_SERVICE_HELM_VERSION
+        );
+        let flow_controller = resolved
+            .extra
+            .get(&DpfExtraService::DocaWeaveFlowController)
+            .unwrap();
+        assert_eq!(
+            flow_controller.name,
+            carbide_dpf::types::DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_NAME
+        );
+        assert_eq!(
+            flow_controller.helm_version,
+            crate::dpf_services::DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_HELM_VERSION
+        );
+        let xplane = resolved.extra.get(&DpfExtraService::DocaXplane).unwrap();
+        assert_eq!(xplane.name, carbide_dpf::types::DOCA_XPLANE_SERVICE_NAME);
+        assert_eq!(
+            xplane.helm_version,
+            crate::dpf_services::DOCA_XPLANE_SERVICE_HELM_VERSION
+        );
+    }
+
+    #[test]
     fn dpf_dpu_agent_bootstrap_ca_validation_rejects_unsafe_values() {
         struct ValidationInput {
             policy: DpfDpuAgentBootstrapCa,
@@ -5953,6 +6140,7 @@ object_kind = "secret"
             deployment_name: "bf4-dep".to_string(),
             node_label_key: "carbide.nvidia.com/bf4".to_string(),
             services: None,
+            extra_services: BTreeMap::new(),
         }
     }
 
@@ -6042,14 +6230,29 @@ object_kind = "secret"
 
     #[test]
     fn validate_provisioning_sources_rejects_bf4_bfb_url() {
-        // bf4_generic is BlueFieldSoftware-only: bfb_url without bluefield_software
-        // passes the exactly-one check but fails at SDK startup, so reject it here.
-        let deployments = DpfDeploymentsConfig {
-            bf3: DpfDeploymentConfig::default(),
-            bf4_generic: Some(bf4_config(Some("http://example.com/test.bfb"), None)),
-            bf4_astra: None,
-        };
-        assert!(deployments.validate_provisioning_sources().is_err());
+        check_values(
+            [
+                Check {
+                    scenario: "generic BF4 cannot use a BFB",
+                    input: DpfDeploymentsConfig {
+                        bf3: DpfDeploymentConfig::default(),
+                        bf4_generic: Some(bf4_config(Some("http://example.com/test.bfb"), None)),
+                        bf4_astra: None,
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "Astra BF4 cannot use a BFB",
+                    input: DpfDeploymentsConfig {
+                        bf3: DpfDeploymentConfig::default(),
+                        bf4_generic: None,
+                        bf4_astra: Some(bf4_config(Some("http://example.com/test.bfb"), None)),
+                    },
+                    expect: true,
+                },
+            ],
+            |deployments| deployments.validate_provisioning_sources().is_err(),
+        );
     }
 
     #[test]

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -22,7 +22,9 @@ use std::path::PathBuf;
 
 use bmc_vendor::BMCVendor;
 use carbide_authn::config::{AllowedCertCriteria, TrustConfig};
-use carbide_dpf::types::DpfProxyDetails;
+use carbide_dpf::types::{
+    DOCA_WEAVE_SERVICE_NAME, DOCA_XPLANE_SERVICE_NAME, DpfProxyDetails, DpuDeploymentType,
+};
 use carbide_firmware::FirmwareConfig;
 use carbide_firmware::defaults::{
     BF2_BMC_VERSION, BF2_CEC_VERSION, BF2_NIC_VERSION, BF2_UEFI_VERSION, BF3_BMC_VERSION,
@@ -1388,14 +1390,28 @@ impl DpfConfig {
     pub fn resolved_services_for(
         &self,
         deployment: &DpfDeploymentConfig,
-    ) -> DpfMandatoryServicesConfig {
-        let mut services = deployment
+        deployment_type: DpuDeploymentType,
+    ) -> DpfResolvedMandatoryServicesConfig {
+        let mut base = deployment
             .services
             .as_deref()
             .cloned()
             .unwrap_or_else(|| (*self.services).clone());
-        self.apply_pull_secret_override(&mut services);
-        services
+        self.apply_pull_secret_override(&mut base);
+        let extra = match deployment_type {
+            DpuDeploymentType::Bf4Astra => HashMap::from([
+                (
+                    DOCA_WEAVE_SERVICE_NAME.to_string(),
+                    crate::dpf_services::default_doca_weave_service(),
+                ),
+                (
+                    DOCA_XPLANE_SERVICE_NAME.to_string(),
+                    crate::dpf_services::default_doca_xplane_service(),
+                ),
+            ]),
+            _ => HashMap::new(),
+        };
+        DpfResolvedMandatoryServicesConfig { base, extra }
     }
 
     /// Applies the optional [`Self::docker_image_pull_secret`] override to every
@@ -1462,6 +1478,13 @@ impl Default for DpfMandatoryServicesConfig {
     }
 }
 
+// DpfResolvedMandatoryServicesConfig - the compounded list of mandatory services
+// depending on deployment type
+pub struct DpfResolvedMandatoryServicesConfig {
+    pub base: DpfMandatoryServicesConfig,
+    pub extra: HashMap<String, DpfServiceConfig>,
+}
+
 /// Configuration for a single Helm-based DPF service.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DpfServiceConfig {
@@ -1518,7 +1541,6 @@ pub struct DpfDeploymentConfig {
     /// [`DpfConfig::services`]. When absent, the top-level services are inherited.
     #[serde(default)]
     pub services: Option<Box<DpfMandatoryServicesConfig>>,
-    // A new field can be added here similar to mandatory services but specific to deployment.
 }
 
 impl Default for DpfDeploymentConfig {
@@ -1564,6 +1586,9 @@ pub struct DpfDeploymentsConfig {
     /// BF4 generic deployment (NICo + BF4 via DPF).
     #[serde(default)]
     pub bf4_generic: Option<DpfDeploymentConfig>,
+    /// BF4 astra deployment (NICo + BF4 with Astra via DPF)
+    #[serde(default)]
+    pub bf4_astra: Option<DpfDeploymentConfig>,
 }
 
 impl DpfDeploymentsConfig {
@@ -1573,6 +1598,9 @@ impl DpfDeploymentsConfig {
         let mut v = vec![("bf3", &self.bf3)];
         if let Some(bf4) = &self.bf4_generic {
             v.push(("bf4_generic", bf4));
+        }
+        if let Some(bf4_astra) = &self.bf4_astra {
+            v.push(("bf4_astra", bf4_astra));
         }
         v
     }
@@ -1642,19 +1670,18 @@ impl DpfDeploymentsConfig {
             );
         }
 
-        // BF4 is BlueFieldSoftware-only. `bfb_url` is BF3-specific; a bf4_generic
-        // deployment must use `bluefield_software`. Reject the BFB-only case here
-        // so it fails at config validation rather than later at SDK startup,
-        // which unconditionally requires `bluefield_software` for bf4_generic.
-        if self
-            .bf4_generic
-            .as_ref()
-            .is_some_and(|cfg| cfg.bfb_url.is_some() && cfg.bluefield_software.is_none())
-        {
-            errors.push(
-                "deployment \"bf4_generic\" must set bluefield_software; BF4 does not support bfb_url"
-                    .to_string(),
-            );
+        // BF4 is BlueFieldSoftware-only. `bfb_url` is BF3-specific; bf4_generic and
+        // bf4_astra deployments must use `bluefield_software`. Reject the BFB-only case
+        // here so it fails at config validation rather than later at SDK startup.
+        for (name, cfg) in [
+            ("bf4_generic", self.bf4_generic.as_ref()),
+            ("bf4_astra", self.bf4_astra.as_ref()),
+        ] {
+            if cfg.is_some_and(|c| c.bfb_url.is_some() && c.bluefield_software.is_none()) {
+                errors.push(format!(
+                    "deployment \"{name}\" must set bluefield_software; BF4 does not support bfb_url"
+                ));
+            }
         }
 
         for (name, cfg) in self.all() {
@@ -5929,6 +5956,7 @@ object_kind = "secret"
                     )]),
                 }),
             )),
+            bf4_astra: None,
         };
         assert!(deployments.validate_provisioning_sources().is_ok());
     }
@@ -5948,6 +5976,7 @@ object_kind = "secret"
                     )]),
                 }),
             )),
+            bf4_astra: None,
         };
         assert!(both.validate_provisioning_sources().is_err());
 
@@ -5955,6 +5984,7 @@ object_kind = "secret"
         let neither = DpfDeploymentsConfig {
             bf3: DpfDeploymentConfig::default(),
             bf4_generic: Some(bf4_config(None, None)),
+            bf4_astra: None,
         };
         assert!(neither.validate_provisioning_sources().is_err());
 
@@ -5968,6 +5998,7 @@ object_kind = "secret"
                     pldm_fw_bundle: BTreeMap::new(),
                 }),
             )),
+            bf4_astra: None,
         };
         assert!(empty_map.validate_provisioning_sources().is_err());
     }
@@ -5979,6 +6010,7 @@ object_kind = "secret"
         let deployments = DpfDeploymentsConfig {
             bf3: bf4_config(None, Some(bf4_with_psids(&["MT_0000000884"]))),
             bf4_generic: None,
+            bf4_astra: None,
         };
         assert!(deployments.validate_provisioning_sources().is_err());
     }
@@ -6000,6 +6032,7 @@ object_kind = "secret"
         let deployments = DpfDeploymentsConfig {
             bf3: DpfDeploymentConfig::default(),
             bf4_generic: Some(bf4_config(Some("http://example.com/test.bfb"), None)),
+            bf4_astra: None,
         };
         assert!(deployments.validate_provisioning_sources().is_err());
     }
@@ -6010,6 +6043,7 @@ object_kind = "secret"
         let one = DpfDeploymentsConfig {
             bf3: DpfDeploymentConfig::default(),
             bf4_generic: Some(bf4_config(None, Some(bf4_with_psids(&["MT_0000000884"])))),
+            bf4_astra: None,
         };
         assert!(one.validate_provisioning_sources().is_ok());
 
@@ -6020,6 +6054,7 @@ object_kind = "secret"
                 None,
                 Some(bf4_with_psids(&["MT_0000000884", "MT_0000000992"])),
             )),
+            bf4_astra: None,
         };
         assert!(many.validate_provisioning_sources().is_err());
     }

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -22,9 +22,7 @@ use std::path::PathBuf;
 
 use bmc_vendor::BMCVendor;
 use carbide_authn::config::{AllowedCertCriteria, TrustConfig};
-use carbide_dpf::types::{
-    DOCA_WEAVE_SERVICE_NAME, DOCA_XPLANE_SERVICE_NAME, DpfProxyDetails, DpuDeploymentType,
-};
+use carbide_dpf::types::{DpfProxyDetails, DpuDeploymentType};
 use carbide_firmware::FirmwareConfig;
 use carbide_firmware::defaults::{
     BF2_BMC_VERSION, BF2_CEC_VERSION, BF2_NIC_VERSION, BF2_UEFI_VERSION, BF3_BMC_VERSION,
@@ -1399,17 +1397,17 @@ impl DpfConfig {
             .unwrap_or_else(|| (*self.services).clone());
         self.apply_pull_secret_override(&mut base);
         let extra = match deployment_type {
-            DpuDeploymentType::Bf4Astra => HashMap::from([
+            DpuDeploymentType::Bf4Astra => BTreeMap::from([
                 (
-                    DOCA_WEAVE_SERVICE_NAME.to_string(),
+                    DpfExtraService::DocaWeave,
                     crate::dpf_services::default_doca_weave_service(),
                 ),
                 (
-                    DOCA_XPLANE_SERVICE_NAME.to_string(),
+                    DpfExtraService::DocaXplane,
                     crate::dpf_services::default_doca_xplane_service(),
                 ),
             ]),
-            _ => HashMap::new(),
+            _ => BTreeMap::new(),
         };
         DpfResolvedMandatoryServicesConfig { base, extra }
     }
@@ -1478,11 +1476,28 @@ impl Default for DpfMandatoryServicesConfig {
     }
 }
 
-// DpfResolvedMandatoryServicesConfig - the compounded list of mandatory services
-// depending on deployment type
+/// Deployment-type-specific service that supplements the mandatory base set.
+///
+/// Modelled as an enum (rather than a string key) so the resolver that populates
+/// the extras and the consumer that projects them into service definitions stay in
+/// sync at compile time.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::enum_variant_names)] // DOCA is part of the service identity, not a redundant prefix.
+pub enum DpfExtraService {
+    /// DOCA Weave service.
+    DocaWeave,
+    /// DOCA Xplane service.
+    DocaXplane,
+}
+
+/// `DpfResolvedMandatoryServicesConfig` - the compounded list of mandatory services
+/// depending on deployment type.
 pub struct DpfResolvedMandatoryServicesConfig {
+    /// Base mandatory services present for every deployment type.
     pub base: DpfMandatoryServicesConfig,
-    pub extra: HashMap<String, DpfServiceConfig>,
+    /// Deployment-type-specific extra services. Keyed by [`DpfExtraService`] in a
+    /// [`BTreeMap`] so iteration order is deterministic.
+    pub extra: BTreeMap<DpfExtraService, DpfServiceConfig>,
 }
 
 /// Configuration for a single Helm-based DPF service.

--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -32,12 +32,8 @@ use carbide_dpf::{
 };
 
 use crate::cfg::file::{
-<<<<<<< HEAD
     DpfBootstrapCaObjectKind, DpfDpuAgentBootstrapCa, DpfMandatoryServicesConfig, DpfServiceConfig,
-=======
-    DEFAULT_DPF_IMAGE_PULL_SECRET, DpfBootstrapCaObjectKind, DpfDpuAgentBootstrapCa,
-    DpfResolvedMandatoryServicesConfig, DpfServiceConfig,
->>>>>>> 0ca6c913a (Support for creating DPF flavor, deployment and services for BF4 Astra)
+    DpfExtraService, DpfResolvedMandatoryServicesConfig, DpfServiceConfig,
 };
 
 /// Default DOCA helm registry (DPUServiceTemplate source.repoURL).
@@ -558,11 +554,10 @@ pub fn mandatory_services(
         otelcol_service(&resolved.base.otel),
     ];
 
-    for (name, cfg) in &resolved.extra {
-        match name.as_str() {
-            DOCA_WEAVE_SERVICE_NAME => service_vec.push(doca_weave_service(cfg)),
-            DOCA_XPLANE_SERVICE_NAME => service_vec.push(doca_xplane_service(cfg)),
-            _ => {}
+    for (service, cfg) in &resolved.extra {
+        match service {
+            DpfExtraService::DocaWeave => service_vec.push(doca_weave_service(cfg)),
+            DpfExtraService::DocaXplane => service_vec.push(doca_xplane_service(cfg)),
         }
     }
 

--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -22,8 +22,9 @@ use std::fmt::Write;
 
 use carbide_dpf::sdk::build_dpu_interfaces_vec;
 use carbide_dpf::types::{
-    DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME,
-    FMDS_SERVICE_NAME, OTEL_COLLECTOR_SERVICE_NAME,
+    DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DOCA_WEAVE_SERVICE_NAME,
+    DOCA_XPLANE_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, FMDS_SERVICE_NAME,
+    OTEL_COLLECTOR_SERVICE_NAME,
 };
 use carbide_dpf::{
     ConfigPortsServiceType, ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition,
@@ -31,7 +32,12 @@ use carbide_dpf::{
 };
 
 use crate::cfg::file::{
+<<<<<<< HEAD
     DpfBootstrapCaObjectKind, DpfDpuAgentBootstrapCa, DpfMandatoryServicesConfig, DpfServiceConfig,
+=======
+    DEFAULT_DPF_IMAGE_PULL_SECRET, DpfBootstrapCaObjectKind, DpfDpuAgentBootstrapCa,
+    DpfResolvedMandatoryServicesConfig, DpfServiceConfig,
+>>>>>>> 0ca6c913a (Support for creating DPF flavor, deployment and services for BF4 Astra)
 };
 
 /// Default DOCA helm registry (DPUServiceTemplate source.repoURL).
@@ -77,6 +83,18 @@ pub const FMDS_SERVICE_MTU: i64 = 1500;
 /// OTel Collector Service Definitions
 pub const OTEL_COLLECTOR_SERVICE_HELM_NAME: &str = "nico-otelcol";
 pub const OTEL_COLLECTOR_SERVICE_IMAGE_NAME: &str = "otelcol-contrib";
+
+/// Weave service Definitions
+pub const DOCA_WEAVE_SERVICE_HELM_NAME: &str = "doca-weave";
+pub const DOCA_WEAVE_SERVICE_HELM_VERSION: &str = "1.0";
+pub const DOCA_WEAVE_SERVICE_IMAGE_NAME: &str = "doca_weave";
+pub const DOCA_WEAVE_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
+
+/// Xplane service Definitions
+pub const DOCA_XPLANE_SERVICE_HELM_NAME: &str = "doca-xplane";
+pub const DOCA_XPLANE_SERVICE_HELM_VERSION: &str = "1.0";
+pub const DOCA_XPLANE_SERVICE_IMAGE_NAME: &str = "doca_xplane";
+pub const DOCA_XPLANE_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
 
 /// Compile-time helm version (set by CI via VERSION env var). Empty on PR/fork builds.
 pub(crate) const COMPILE_TIME_HELM_VERSION: &str = match option_env!("CARBIDE_BUILD_HELM_VERSION") {
@@ -233,6 +251,30 @@ fn apply_image_pull_secrets(helm_values: &mut serde_json::Value, cfg: &DpfServic
             "imagePullSecrets".to_string(),
             serde_json::json!([{ "name": secret }]),
         );
+
+pub(crate) fn default_doca_weave_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DOCA_WEAVE_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
+        helm_chart: DOCA_WEAVE_SERVICE_HELM_NAME.to_string(),
+        helm_version: DOCA_WEAVE_SERVICE_HELM_VERSION.to_string(),
+        docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_WEAVE_SERVICE_IMAGE_NAME}"),
+        docker_image_tag: DOCA_WEAVE_SERVICE_IMAGE_TAG.to_string(),
+        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
+    }
+}
+
+pub(crate) fn default_doca_xplane_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DOCA_XPLANE_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
+        helm_chart: DOCA_XPLANE_SERVICE_HELM_NAME.to_string(),
+        helm_version: DOCA_XPLANE_SERVICE_HELM_VERSION.to_string(),
+        docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_XPLANE_SERVICE_IMAGE_NAME}"),
+        docker_image_tag: DOCA_XPLANE_SERVICE_IMAGE_TAG.to_string(),
+        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
+    }
+>>>>>>> 0ca6c913a (Support for creating DPF flavor, deployment and services for BF4 Astra)
 }
 
 /// DOCA HBN service definition.
@@ -480,19 +522,51 @@ pub fn otelcol_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     }
 }
 
-/// Build the full list of mandatory DPU services from config.
+pub fn doca_weave_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    ServiceDefinition {
+        ..ServiceDefinition::new(
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
+        )
+    }
+}
+
+pub fn doca_xplane_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    ServiceDefinition {
+        ..ServiceDefinition::new(
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
+        )
+    }
+}
+
+/// Build the full list of resolved mandatory DPU services.
 pub fn mandatory_services(
-    cfg: &DpfMandatoryServicesConfig,
+    resolved: &DpfResolvedMandatoryServicesConfig,
     bootstrap_ca: &DpfDpuAgentBootstrapCa,
 ) -> Vec<ServiceDefinition> {
-    vec![
-        dts_service(&cfg.dts),
-        doca_hbn_service(&cfg.doca_hbn),
-        dhcp_server_service(&cfg.dhcp_server),
-        dpu_agent_service(&cfg.dpu_agent, bootstrap_ca),
-        fmds_service(&cfg.fmds),
-        otelcol_service(&cfg.otel),
-    ]
+    let mut service_vec = vec![
+        dts_service(&resolved.base.dts),
+        doca_hbn_service(&resolved.base.doca_hbn),
+        dhcp_server_service(&resolved.base.dhcp_server),
+        dpu_agent_service(&resolved.base.dpu_agent, bootstrap_ca),
+        fmds_service(&resolved.base.fmds),
+        otelcol_service(&resolved.base.otel),
+    ];
+
+    for (name, cfg) in &resolved.extra {
+        match name.as_str() {
+            DOCA_WEAVE_SERVICE_NAME => service_vec.push(doca_weave_service(cfg)),
+            DOCA_XPLANE_SERVICE_NAME => service_vec.push(doca_xplane_service(cfg)),
+            _ => {}
+        }
+    }
+
+    service_vec
 }
 
 #[cfg(test)]

--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -22,9 +22,9 @@ use std::fmt::Write;
 
 use carbide_dpf::sdk::build_dpu_interfaces_vec;
 use carbide_dpf::types::{
-    DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DOCA_WEAVE_SERVICE_NAME,
-    DOCA_XPLANE_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, FMDS_SERVICE_NAME,
-    OTEL_COLLECTOR_SERVICE_NAME,
+    DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DOCA_WEAVE_DHCP_AGENT_SERVICE_NAME,
+    DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_NAME, DOCA_XPLANE_SERVICE_NAME, DPU_AGENT_SERVICE_NAME,
+    DTS_SERVICE_NAME, FMDS_SERVICE_NAME, OTEL_COLLECTOR_SERVICE_NAME,
 };
 use carbide_dpf::{
     ConfigPortsServiceType, ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition,
@@ -32,8 +32,8 @@ use carbide_dpf::{
 };
 
 use crate::cfg::file::{
-    DpfBootstrapCaObjectKind, DpfDpuAgentBootstrapCa, DpfMandatoryServicesConfig, DpfServiceConfig,
-    DpfExtraService, DpfResolvedMandatoryServicesConfig, DpfServiceConfig,
+    DpfBootstrapCaObjectKind, DpfDpuAgentBootstrapCa, DpfExtraService,
+    DpfResolvedMandatoryServicesConfig, DpfServiceConfig,
 };
 
 /// Default DOCA helm registry (DPUServiceTemplate source.repoURL).
@@ -80,13 +80,19 @@ pub const FMDS_SERVICE_MTU: i64 = 1500;
 pub const OTEL_COLLECTOR_SERVICE_HELM_NAME: &str = "nico-otelcol";
 pub const OTEL_COLLECTOR_SERVICE_IMAGE_NAME: &str = "otelcol-contrib";
 
-/// Weave service Definitions
-pub const DOCA_WEAVE_SERVICE_HELM_NAME: &str = "doca-weave";
-pub const DOCA_WEAVE_SERVICE_HELM_VERSION: &str = "1.0";
-pub const DOCA_WEAVE_SERVICE_IMAGE_NAME: &str = "doca_weave";
-pub const DOCA_WEAVE_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
+/// Weave DHCP agent service definitions.
+pub const DOCA_WEAVE_DHCP_AGENT_SERVICE_HELM_NAME: &str = "doca-weave-dhcp-agent";
+pub const DOCA_WEAVE_DHCP_AGENT_SERVICE_HELM_VERSION: &str = "1.0";
+pub const DOCA_WEAVE_DHCP_AGENT_SERVICE_IMAGE_NAME: &str = "doca_weave_dhcp_agent";
+pub const DOCA_WEAVE_DHCP_AGENT_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
 
-/// Xplane service Definitions
+/// Weave flow (ovs) controller service definitions.
+pub const DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_HELM_NAME: &str = "doca-weave-flow-controller";
+pub const DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_HELM_VERSION: &str = "1.0";
+pub const DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_IMAGE_NAME: &str = "doca_weave_flow_controller";
+pub const DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
+
+/// Xplane service definitions.
 pub const DOCA_XPLANE_SERVICE_HELM_NAME: &str = "doca-xplane";
 pub const DOCA_XPLANE_SERVICE_HELM_VERSION: &str = "1.0";
 pub const DOCA_XPLANE_SERVICE_IMAGE_NAME: &str = "doca_xplane";
@@ -231,6 +237,46 @@ pub(crate) fn default_otelcol_service() -> DpfServiceConfig {
     }
 }
 
+pub(crate) fn default_doca_weave_dhcp_agent_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DOCA_WEAVE_DHCP_AGENT_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
+        helm_chart: DOCA_WEAVE_DHCP_AGENT_SERVICE_HELM_NAME.to_string(),
+        helm_version: DOCA_WEAVE_DHCP_AGENT_SERVICE_HELM_VERSION.to_string(),
+        docker_repo_url: format!(
+            "{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_WEAVE_DHCP_AGENT_SERVICE_IMAGE_NAME}"
+        ),
+        docker_image_tag: DOCA_WEAVE_DHCP_AGENT_SERVICE_IMAGE_TAG.to_string(),
+        docker_image_pull_secret: None,
+    }
+}
+
+pub(crate) fn default_doca_weave_flow_controller_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
+        helm_chart: DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_HELM_NAME.to_string(),
+        helm_version: DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_HELM_VERSION.to_string(),
+        docker_repo_url: format!(
+            "{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_IMAGE_NAME}"
+        ),
+        docker_image_tag: DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_IMAGE_TAG.to_string(),
+        docker_image_pull_secret: None,
+    }
+}
+
+pub(crate) fn default_doca_xplane_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DOCA_XPLANE_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
+        helm_chart: DOCA_XPLANE_SERVICE_HELM_NAME.to_string(),
+        helm_version: DOCA_XPLANE_SERVICE_HELM_VERSION.to_string(),
+        docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_XPLANE_SERVICE_IMAGE_NAME}"),
+        docker_image_tag: DOCA_XPLANE_SERVICE_IMAGE_TAG.to_string(),
+        docker_image_pull_secret: None,
+    }
+}
+
 /// Adds an `imagePullSecrets` block to a service's Helm values when the service has
 /// a configured pull secret, omitting it entirely otherwise. Mandatory services carry
 /// no pull secret by default (public-registry pulls); one is emitted only when set via
@@ -247,30 +293,6 @@ fn apply_image_pull_secrets(helm_values: &mut serde_json::Value, cfg: &DpfServic
             "imagePullSecrets".to_string(),
             serde_json::json!([{ "name": secret }]),
         );
-
-pub(crate) fn default_doca_weave_service() -> DpfServiceConfig {
-    DpfServiceConfig {
-        name: DOCA_WEAVE_SERVICE_NAME.to_string(),
-        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
-        helm_chart: DOCA_WEAVE_SERVICE_HELM_NAME.to_string(),
-        helm_version: DOCA_WEAVE_SERVICE_HELM_VERSION.to_string(),
-        docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_WEAVE_SERVICE_IMAGE_NAME}"),
-        docker_image_tag: DOCA_WEAVE_SERVICE_IMAGE_TAG.to_string(),
-        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
-    }
-}
-
-pub(crate) fn default_doca_xplane_service() -> DpfServiceConfig {
-    DpfServiceConfig {
-        name: DOCA_XPLANE_SERVICE_NAME.to_string(),
-        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
-        helm_chart: DOCA_XPLANE_SERVICE_HELM_NAME.to_string(),
-        helm_version: DOCA_XPLANE_SERVICE_HELM_VERSION.to_string(),
-        docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_XPLANE_SERVICE_IMAGE_NAME}"),
-        docker_image_tag: DOCA_XPLANE_SERVICE_IMAGE_TAG.to_string(),
-        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
-    }
->>>>>>> 0ca6c913a (Support for creating DPF flavor, deployment and services for BF4 Astra)
 }
 
 /// DOCA HBN service definition.
@@ -518,8 +540,35 @@ pub fn otelcol_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     }
 }
 
-pub fn doca_weave_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+pub fn doca_weave_dhcp_agent_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    let mut helm_values = serde_json::json!({
+        "image": {
+            "repository": cfg.docker_repo_url,
+            "tag": cfg.docker_image_tag,
+        }
+    });
+    apply_image_pull_secrets(&mut helm_values, cfg);
     ServiceDefinition {
+        helm_values: Some(helm_values),
+        ..ServiceDefinition::new(
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
+        )
+    }
+}
+
+pub fn doca_weave_flow_controller_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    let mut helm_values = serde_json::json!({
+        "image": {
+            "repository": cfg.docker_repo_url,
+            "tag": cfg.docker_image_tag,
+        }
+    });
+    apply_image_pull_secrets(&mut helm_values, cfg);
+    ServiceDefinition {
+        helm_values: Some(helm_values),
         ..ServiceDefinition::new(
             &cfg.name,
             &cfg.helm_repo_url,
@@ -530,7 +579,15 @@ pub fn doca_weave_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
 }
 
 pub fn doca_xplane_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    let mut helm_values = serde_json::json!({
+        "image": {
+            "repository": cfg.docker_repo_url,
+            "tag": cfg.docker_image_tag,
+        }
+    });
+    apply_image_pull_secrets(&mut helm_values, cfg);
     ServiceDefinition {
+        helm_values: Some(helm_values),
         ..ServiceDefinition::new(
             &cfg.name,
             &cfg.helm_repo_url,
@@ -556,7 +613,12 @@ pub fn mandatory_services(
 
     for (service, cfg) in &resolved.extra {
         match service {
-            DpfExtraService::DocaWeave => service_vec.push(doca_weave_service(cfg)),
+            DpfExtraService::DocaWeaveDhcpAgent => {
+                service_vec.push(doca_weave_dhcp_agent_service(cfg))
+            }
+            DpfExtraService::DocaWeaveFlowController => {
+                service_vec.push(doca_weave_flow_controller_service(cfg))
+            }
             DpfExtraService::DocaXplane => service_vec.push(doca_xplane_service(cfg)),
         }
     }
@@ -657,6 +719,58 @@ mod tests {
         assert_eq!(
             dts_service(&dts_cfg).helm_values.unwrap()["imagePullSecrets"],
             expected
+        );
+    }
+
+    #[test]
+    fn deployment_specific_services_emit_image_pull_secrets_when_configured() {
+        value_scenarios!(
+            run = |service| {
+                let (mut config, build): (
+                    DpfServiceConfig,
+                    fn(&DpfServiceConfig) -> ServiceDefinition,
+                ) = match service {
+                    DpfExtraService::DocaWeaveDhcpAgent => (
+                        default_doca_weave_dhcp_agent_service(),
+                        doca_weave_dhcp_agent_service,
+                    ),
+                    DpfExtraService::DocaWeaveFlowController => (
+                        default_doca_weave_flow_controller_service(),
+                        doca_weave_flow_controller_service,
+                    ),
+                    DpfExtraService::DocaXplane => (
+                        default_doca_xplane_service(),
+                        doca_xplane_service,
+                    ),
+                };
+                let rendered_secret = |definition: ServiceDefinition| {
+                    definition
+                        .helm_values
+                        .and_then(|values| {
+                            values["imagePullSecrets"][0]["name"]
+                                .as_str()
+                                .map(str::to_string)
+                        })
+                };
+                let default_secret = rendered_secret(build(&config));
+                config.docker_image_pull_secret = Some("private-doca-secret".to_string());
+                let configured_secret = rendered_secret(build(&config));
+                (default_secret, configured_secret)
+            };
+            "Weave DHCP agent" {
+                DpfExtraService::DocaWeaveDhcpAgent
+                    => (None, Some("private-doca-secret".to_string())),
+            }
+
+            "Weave flow controller" {
+                DpfExtraService::DocaWeaveFlowController
+                    => (None, Some("private-doca-secret".to_string())),
+            }
+
+            "Xplane" {
+                DpfExtraService::DocaXplane
+                    => (None, Some("private-doca-secret".to_string())),
+            }
         );
     }
 

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -550,7 +550,7 @@ async fn initialize_dpf_sdk(
         return Ok(None);
     }
 
-    tracing::info!("Initializing DPF SDK");
+    tracing::info!("Initializing DPF SDK BF4 Astra");
 
     carbide_config
         .dpf
@@ -598,7 +598,9 @@ async fn initialize_dpf_sdk(
         |deployment: &crate::cfg::file::DpfDeploymentConfig,
          deployment_type: DpuDeploymentType,
          bluefield_software: Option<carbide_dpf::BlueFieldSoftwareParams>| {
-            let services = carbide_config.dpf.resolved_services_for(deployment);
+            let services = carbide_config
+                .dpf
+                .resolved_services_for(deployment, deployment_type);
             carbide_dpf::InitDpfResourcesConfig {
                 bfb_url: deployment.bfb_url.clone().unwrap_or_default(),
                 bluefield_software,
@@ -641,6 +643,28 @@ async fn initialize_dpf_sdk(
         .map_err(|err| eyre::eyre!("failed to initialize bf4_generic DPF deployment: {err}"))?;
     }
 
+    if let Some(bf4_astra) = &carbide_config.dpf.deployments.bf4_astra {
+        let bfs = bf4_astra
+            .bluefield_software
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("bf4_astra DPF deployment is missing bluefield_software"))?;
+        let pldm_url =
+            bfs.pldm_fw_bundle.values().next().ok_or_else(|| {
+                eyre::eyre!("bf4_astra DPF deployment has an empty pldm_fw_bundle")
+            })?;
+        let params = carbide_dpf::BlueFieldSoftwareParams {
+            os_iso: bfs.os_iso.clone(),
+            pldm_fw_bundle: Some(pldm_url.clone()),
+        };
+        sdk.create_initialization_objects(&make_init_config(
+            bf4_astra,
+            DpuDeploymentType::Bf4Astra,
+            Some(params),
+        ))
+        .await
+        .map_err(|err| eyre::eyre!("Failed to initialize bf4_astra DPF deployment: {err}"))?;
+    }
+
     Ok(Some(Arc::new(DpfSdkOps::new(
         Arc::new(sdk),
         db_pool,
@@ -675,6 +699,13 @@ fn build_deployment_type_labels(
         map.insert(
             DpuDeploymentType::Bf4Generic,
             make_labels(&bf4.node_label_key),
+        );
+    }
+
+    if let Some(bf4_astra) = &carbide_config.dpf.deployments.bf4_astra {
+        map.insert(
+            DpuDeploymentType::Bf4Astra,
+            make_labels(&bf4_astra.node_label_key),
         );
     }
 

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -550,7 +550,14 @@ async fn initialize_dpf_sdk(
         return Ok(None);
     }
 
-    tracing::info!("Initializing DPF SDK BF4 Astra");
+    let mut deployments = vec!["bf3"];
+    if carbide_config.dpf.deployments.bf4_generic.is_some() {
+        deployments.push("bf4_generic");
+    }
+    if carbide_config.dpf.deployments.bf4_astra.is_some() {
+        deployments.push("bf4_astra");
+    }
+    tracing::info!(?deployments, "Initializing DPF SDK");
 
     carbide_config
         .dpf
@@ -662,7 +669,7 @@ async fn initialize_dpf_sdk(
             Some(params),
         ))
         .await
-        .map_err(|err| eyre::eyre!("Failed to initialize bf4_astra DPF deployment: {err}"))?;
+        .map_err(|err| eyre::eyre!("failed to initialize bf4_astra DPF deployment: {err}"))?;
     }
 
     Ok(Some(Arc::new(DpfSdkOps::new(

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -605,9 +605,7 @@ async fn initialize_dpf_sdk(
         |deployment: &crate::cfg::file::DpfDeploymentConfig,
          deployment_type: DpuDeploymentType,
          bluefield_software: Option<carbide_dpf::BlueFieldSoftwareParams>| {
-            let services = carbide_config
-                .dpf
-                .resolved_services_for(deployment, deployment_type);
+            let services = carbide_config.dpf.resolved_services_for(deployment);
             carbide_dpf::InitDpfResourcesConfig {
                 bfb_url: deployment.bfb_url.clone().unwrap_or_default(),
                 bluefield_software,

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -1090,6 +1090,7 @@ fn get_bf4_astra_config_files(
                     "LOCAL_SERIAL=$(echo \"$LOCAL_SERIAL\" | tr -d '[:space:]')\n",
                     "\n",
                     "if [ -z \"$LOCAL_SERIAL\" ]; then\n",
+                    "    echo \"failed to detect local DPU serial from PCI device 0002:01:00.0; cannot select rail addresses\" >&2\n",
                     "    exit 1\n",
                     "fi\n",
                     "\n",
@@ -1107,6 +1108,7 @@ fn get_bf4_astra_config_files(
                     "done\n",
                     "\n",
                     "if [ -z \"$NODE_ADDR\" ] || [ -z \"$GW_ADDR\" ]; then\n",
+                    "    echo \"no rail address mapping for DPU serial ${LOCAL_SERIAL}; NODE_ADDR=${NODE_ADDR:-unset} GW_ADDR=${GW_ADDR:-unset}\" >&2\n",
                     "    exit 1\n",
                     "fi\n",
                     "\n",
@@ -1587,18 +1589,14 @@ mod tests {
                 ) => true,
             }
 
-            "OVS bootstrap invokes both Astra scripts with blank line and 2-space helper indent" {
+            "OVS bootstrap invokes both Astra scripts" {
                 (
-                    ovs_script.contains(
-                        "# Shared helper used by the called scripts; exported so they inherit it\n\n# create an entry"
-                    )
-                        && ovs_script.contains("  ovs-vsctl --timeout 30 \"$@\"")
-                        && ovs_script.contains("/etc/mellanox/ovs-script.sh")
+                    ovs_script.contains("/etc/mellanox/ovs-script.sh")
                         && ovs_script.contains("/etc/mellanox/xplane-bridge.sh")
                 ) => true,
             }
 
-            "Spectrum-X config file has no stray block marker and correct Adaptive Routing Force indent" {
+            "Spectrum-X config has the Adaptive Routing Force setting" {
                 {
                     let spectrum = flavor
                         .spec
@@ -1609,11 +1607,44 @@ mod tests {
                         .find(|file| file.path == "/bindata/spectrum-x/RA2.2-runtime.yaml")
                         .and_then(|file| file.raw.as_ref())
                         .unwrap();
-                    !spectrum.starts_with('|')
-                        && spectrum.contains(
-                            "    - name: Adaptive Routing Force\n      value: true\n      dmsPath:"
-                        )
-                        && spectrum.contains("      valueType: bool\n  congestionControl:\n")
+                    serde_yaml::from_str::<serde_yaml::Value>(spectrum)
+                        .ok()
+                        .is_some_and(|document| {
+                            let runtime = &document["runtimeConfig"];
+                            runtime["adaptiveRouting"]
+                                .as_sequence()
+                                .is_some_and(|settings| {
+                                    settings.iter().any(|setting| {
+                                        setting["name"].as_str() == Some("Adaptive Routing Force")
+                                            && setting["value"].as_bool() == Some(true)
+                                            && setting["valueType"].as_str() == Some("bool")
+                                            && setting["dmsPath"].as_str()
+                                                == Some(
+                                                    "/interfaces/interface/nvidia/roce/config/adaptive-routing-force",
+                                                )
+                                    })
+                                })
+                                && runtime["congestionControl"].is_sequence()
+                        })
+                } => true,
+            }
+
+            "xplane bridge setup diagnoses missing serial and address mappings" {
+                {
+                    let xplane_script = flavor
+                        .spec
+                        .config_files
+                        .as_ref()
+                        .unwrap()
+                        .iter()
+                        .find(|file| file.path == "/etc/mellanox/xplane-bridge.sh")
+                        .and_then(|file| file.raw.as_ref())
+                        .unwrap();
+                    xplane_script.contains(
+                        "failed to detect local DPU serial from PCI device 0002:01:00.0; cannot select rail addresses"
+                    ) && xplane_script.contains(
+                        "no rail address mapping for DPU serial ${LOCAL_SERIAL}; NODE_ADDR=${NODE_ADDR:-unset} GW_ADDR=${GW_ADDR:-unset}"
+                    )
                 } => true,
             }
 
@@ -1643,19 +1674,16 @@ mod tests {
             "ewNic rawNvConfig has correct programmable CC and locality mode" {
                 {
                     let raw = ew_nic.raw_nv_config.as_ref().unwrap();
-                    let names: Vec<_> = raw.iter().map(|entry| entry.name.as_str()).collect();
                     let programmable_cc = raw.iter().find(|entry| {
                         entry.name == "USER_PROGRAMMABLE_CC"
                     });
                     let locality = raw.iter().find(|entry| {
                         entry.name == "TX_SCHEDULER_LOCALITY_MODE"
                     });
-                    names
-                        .iter()
-                        .filter(|name| **name == "ROCE_ADAPTIVE_ROUTING_EN")
+                    raw.iter()
+                        .filter(|entry| entry.name == "ROCE_ADAPTIVE_ROUTING_EN")
                         .count()
                         == 1
-                        && !names.contains(&"USER_PROGAMMABLE_CC")
                         && programmable_cc.is_some_and(|entry| entry.value == "1")
                         && locality.is_some_and(|entry| entry.value == "2")
                 } => true,

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -21,8 +21,12 @@ use kube::core::ObjectMeta;
 use sha2::{Digest, Sha256};
 
 use crate::crds::dpuflavors_generated::{
-    DPUFlavor, DpuFlavorConfigFiles, DpuFlavorConfigFilesOperation, DpuFlavorDpuMode,
-    DpuFlavorGrub, DpuFlavorNvconfig, DpuFlavorNvconfigDevice, DpuFlavorSpec,
+    DPUFlavor, DpuFlavorConfigFiles, DpuFlavorConfigFilesOperation, DpuFlavorContainerdConfig,
+    DpuFlavorDpuMode, DpuFlavorEwNicConfigurations, DpuFlavorEwNicConfigurationsNetworkBay,
+    DpuFlavorEwNicConfigurationsRawNvConfig, DpuFlavorEwNicConfigurationsSpectrumXOptimized,
+    DpuFlavorEwNicConfigurationsSpectrumXOptimizedMultiplaneMode,
+    DpuFlavorEwNicConfigurationsSpectrumXOptimizedOverlay, DpuFlavorGrub, DpuFlavorNvconfig,
+    DpuFlavorNvconfigDevice, DpuFlavorOvs, DpuFlavorSpec, DpuFlavorSysctl,
 };
 use crate::types::{DpfProxyDetails, DpuDeploymentType};
 
@@ -124,6 +128,29 @@ fn get_bf4_ovs_defaults() -> String {
     .to_string()
 }
 
+/// OVS raw config script for the BF4 flavor.
+fn get_bf4_astra_ovs_defaults() -> String {
+    concat!(
+        "#!/bin/bash\n",
+        "# Shared helper used by the called scripts; exported so they inherit it\n",
+        "\n",
+        "# create an entry in /etc/hosts to allow self hostname resolution: (bug fix)\n",
+        "grep -qw \"$HOSTNAME\" /etc/hosts || echo \"127.0.0.1 $HOSTNAME\" | sudo tee -a /etc/hosts > /dev/null\n",
+        "\n",
+        "_ovs-vsctl() {\n",
+        "  ovs-vsctl --timeout 30 \"$@\"\n",
+        "}\n",
+        "export -f _ovs-vsctl\n",
+        "\n",
+        "# 1. Configure OVS bridges and xplane ports\n",
+        "/etc/mellanox/ovs-script.sh\n",
+        "\n",
+        "# 2. Configure rail bridge addressing (netplan)\n",
+        "/etc/mellanox/xplane-bridge.sh\n",
+    )
+    .to_string()
+}
+
 /// Rejects proxy strings containing characters that would break a systemd `Environment="..."` line:
 /// double-quotes (break the quoting), newlines / carriage returns (break the unit-file line), and
 /// any other ASCII control character (< 0x20 or DEL 0x7f).
@@ -153,6 +180,7 @@ pub fn default_flavor_for(
 ) -> Result<DPUFlavor, crate::error::DpfError> {
     match deployment_type {
         DpuDeploymentType::Bf4Generic => flavor_bf4(namespace, proxy),
+        DpuDeploymentType::Bf4Astra => flavor_bf4_astra(namespace, proxy),
         DpuDeploymentType::Bf3 => default_flavor(namespace, proxy),
     }
 }
@@ -202,6 +230,52 @@ pub fn flavor_bf4(
     })
 }
 
+/// Build the BF4 Astra DPUFlavor spec, with BF4-astra grub and OVS
+/// configuration.
+/// If `proxy` is set, a containerd proxy drop-in config file is appended so the DPU can pull
+/// images through the proxy.
+///
+/// Returns `ConfigError` if any proxy string contains characters that would
+/// break the generated systemd `Environment="..."` lines (quotes, newlines,
+/// or other control characters).
+///
+/// `metadata.name` is left unset; callers must set it (typically via [`DPUFlavor::unique_name`])
+/// before creating the resource in the cluster.
+pub fn flavor_bf4_astra(
+    namespace: &str,
+    proxy: &Option<DpfProxyDetails>,
+) -> Result<DPUFlavor, crate::error::DpfError> {
+    Ok(DPUFlavor {
+        metadata: ObjectMeta {
+            name: None,
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        spec: DpuFlavorSpec {
+            bfcfg_parameters: None,
+            config_files: Some(get_bf4_astra_config_files(proxy)?),
+            containerd_config: Some(DpuFlavorContainerdConfig {
+                registry_endpoint: None,
+            }),
+            dpu_mode: None,
+            dpu_resources: None,
+            ew_nic_configurations: Some(bf4_astra_ew_nic_configurations()),
+            grub: Some(bf4_astra_grub_params()),
+            host_network_interface_configs: None,
+            nvconfig: Some(vec![get_bf4_astra_nvconfig()]),
+            ovs: Some(DpuFlavorOvs {
+                raw_config_script: Some(get_bf4_astra_ovs_defaults()),
+            }),
+            packages: Some(vec![]),
+            sysctl: Some(DpuFlavorSysctl {
+                parameters: Some(vec![]),
+            }),
+            system_reserved_resources: None,
+            systemd_services: Some(vec![]),
+        },
+    })
+}
+
 /// Default grub kernel parameters for the BF4 flavor.
 pub fn bf4_grub_params() -> DpuFlavorGrub {
     DpuFlavorGrub {
@@ -221,6 +295,126 @@ pub fn bf4_grub_params() -> DpuFlavorGrub {
             .collect(),
         ),
     }
+}
+
+/// Default grub kernel parameters for the BF4 astra flavor.
+pub fn bf4_astra_grub_params() -> DpuFlavorGrub {
+    DpuFlavorGrub {
+        kernel_parameters: Some(
+            vec![
+                "console=hvc0",
+                "console=ttyAMA0",
+                "fixrttc",
+                "net.ifnames=0",
+                "biosdevname=0",
+                "iommu.passthrough=1",
+                "cgroup_no_v1=net_prio,net_cls",
+                "hugepagesz=2048kB",
+                "hugepages=8072",
+            ]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect(),
+        ),
+    }
+}
+
+fn bf4_astra_ew_nic_configurations() -> Vec<DpuFlavorEwNicConfigurations> {
+    vec![DpuFlavorEwNicConfigurations {
+        force: None,
+        link_type: None,
+        network_bay: Some(DpuFlavorEwNicConfigurationsNetworkBay {
+            conf: "conf1".to_string(),
+        }),
+        num_vfs: 1,
+        raw_nv_config: Some(vec![
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "BOARD_CONFIGURATION_MODE".to_string(),
+                value: "0".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "LOAD_BALANCE_MODE_P1".to_string(),
+                value: "2".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "LAG_RESOURCE_ALLOCATION".to_string(),
+                value: "1".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "FLEX_PARSER_PROFILE_ENABLE".to_string(),
+                value: "10".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "RDE_DISABLE".to_string(),
+                value: "1".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "VF_LOG_BAR_SIZE".to_string(),
+                value: "5".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "SRIOV_EN".to_string(),
+                value: "1".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "NUM_OF_VFS".to_string(),
+                value: "1".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "KEEP_ETH_LINK_UP_P1".to_string(),
+                value: "0".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "ROCE_ADAPTIVE_ROUTING_EN".to_string(),
+                value: "1".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "USER_PROGRAMMABLE_CC".to_string(),
+                value: "1".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "TX_SCHEDULER_LOCALITY_MODE".to_string(),
+                value: "2".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "ROCE_RTT_RESP_DSCP_P1".to_string(),
+                value: "48".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "ROCE_RTT_RESP_DSCP_MODE_P1".to_string(),
+                value: "1".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "ROCE_CC_STEERING_EXT".to_string(),
+                value: "2".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "NUM_OF_PLANES_P1".to_string(),
+                value: "4".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "NUM_OF_PF".to_string(),
+                value: "4".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "LINK_TYPE_P1".to_string(),
+                value: "2".to_string(),
+            },
+            DpuFlavorEwNicConfigurationsRawNvConfig {
+                name: "HIDE_PORT2_PF".to_string(),
+                value: "1".to_string(),
+            },
+        ]),
+        spectrum_x_optimized: Some(DpuFlavorEwNicConfigurationsSpectrumXOptimized {
+            enabled: true,
+            multiplane_mode: Some(
+                DpuFlavorEwNicConfigurationsSpectrumXOptimizedMultiplaneMode::Hwplb,
+            ),
+            number_of_planes: Some(4),
+            overlay: Some(DpuFlavorEwNicConfigurationsSpectrumXOptimizedOverlay::None),
+            version: "RA2.2-runtime".to_string(),
+        }),
+    }]
 }
 
 /// Build the default DPUFlavor spec. If `proxy` is set, a containerd proxy drop-in config file
@@ -431,6 +625,561 @@ fn get_bf4_default_nvconfig() -> DpuFlavorNvconfig {
     }
 }
 
+/// Returns the bf4 astra config files, plus an optional containerd proxy drop-in if `proxy` is set.
+fn get_bf4_astra_config_files(
+    proxy: &Option<DpfProxyDetails>,
+) -> Result<Vec<DpuFlavorConfigFiles>, crate::error::DpfError> {
+    let mut config_files = vec![
+        DpuFlavorConfigFiles {
+            content_from: None,
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/etc/mellanox/mlnx-bf.conf".to_string(),
+            permissions: Some("0644".to_string()),
+            raw: Some(
+                concat!(
+                    "ALLOW_SHARED_RQ=\"no\"\n",
+                    "IPSEC_FULL_OFFLOAD=\"no\"\n",
+                    "ENABLE_ESWITCH_MULTIPORT=\"yes\"\n",
+                )
+                .to_string(),
+            ),
+            r#type: None,
+        },
+        DpuFlavorConfigFiles {
+            content_from: None,
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/etc/mellanox/mlnx-ovs.conf".to_string(),
+            permissions: Some("0644".to_string()),
+            raw: Some(
+                concat!(
+                    "CREATE_OVS_BRIDGES=\"no\"\n",
+                    "OVS_DOCA=\"yes\"\n",
+                )
+                .to_string(),
+            ),
+            r#type: None,
+        },
+        DpuFlavorConfigFiles {
+            content_from: None,
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/etc/mellanox/mlnx-sf.conf".to_string(),
+            permissions: Some("0644".to_string()),
+            raw: Some(String::new()),
+            r#type: None,
+        },
+        DpuFlavorConfigFiles {
+            content_from: None,
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/bindata/spectrum-x/RA2.2-runtime.yaml".to_string(),
+            permissions: Some("0644".to_string()),
+            raw: Some(
+                concat!(
+                    "# Copyright 2025 NVIDIA CORPORATION & AFFILIATES\n",
+                    "#\n",
+                    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+                    "# you may not use this file except in compliance with the License.\n",
+                    "# You may obtain a copy of the License at\n",
+                    "#\n",
+                    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+                    "#\n",
+                    "# Unless required by applicable law or agreed to in writing, software\n",
+                    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+                    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+                    "# See the License for the specific language governing permissions and\n",
+                    "# limitations under the License.\n",
+                    "#\n",
+                    "# SPDX-License-Identifier: Apache-2.0\n",
+                    "runtimeConfig:\n",
+                    "  roce:\n",
+                    "    - name: Trust\n",
+                    "      value: dscp\n",
+                    "      dmsPath: /interfaces/interface/nvidia/qos/config/trust-mode\n",
+                    "      valueType: string\n",
+                    "      alternativeValue: QOS_TRUST_MODE_DSCP\n",
+                    "    - name: PFC\n",
+                    "      value: \"00010000\"\n",
+                    "      dmsPath: /interfaces/interface/nvidia/qos/config/pfc\n",
+                    "      valueType: string\n",
+                    "  adaptiveRouting:\n",
+                    "    - name: Enable CC per plane\n",
+                    "      value: \"0x00000001\"\n",
+                    "      multiplane: hwplb\n",
+                    "      mlxreg:\n",
+                    "        register: ROCE_ACCL\n",
+                    "        field: cc_per_plane_en\n",
+                    "        setFields:\n",
+                    "          - name: cc_per_plane_en\n",
+                    "            value: \"0x1\"\n",
+                    "          - name: cc_per_plane_en_field_select\n",
+                    "            value: \"0x1\"\n",
+                    "    - name: Adaptive Retransmission\n",
+                    "      value: true\n",
+                    "      dmsPath: /interfaces/interface/nvidia/roce/config/adaptive-retransmission\n",
+                    "      valueType: bool\n",
+                    "    - name: Tx Window\n",
+                    "      value: true\n",
+                    "      dmsPath: /interfaces/interface/nvidia/roce/config/tx-window\n",
+                    "      valueType: bool\n",
+                    "    - name: Slow Restart\n",
+                    "      value: false\n",
+                    "      dmsPath: /interfaces/interface/nvidia/roce/config/slow-restart\n",
+                    "      valueType: bool\n",
+                    "    - name: Slow Restart Idle\n",
+                    "      value: false\n",
+                    "      dmsPath: /interfaces/interface/nvidia/roce/config/slow-restart-idle\n",
+                    "      valueType: bool\n",
+                    "    - name: CC Probe MP mode\n",
+                    "      value: \"0x00000001\"\n",
+                    "      multiplane: hwplb\n",
+                    "      mlxreg:\n",
+                    "        register: ROCE_ACCL\n",
+                    "        field: cc_probe_mp_mode\n",
+                    "        setFields:\n",
+                    "          - name: cc_probe_mp_mode\n",
+                    "            value: \"0x1\"\n",
+                    "          - name: cc_probe_mp_mode_field_select\n",
+                    "            value: \"0x1\"\n",
+                    "    - name: Adaptive Routing Force\n",
+                    "      value: true\n",
+                    "      dmsPath: /interfaces/interface/nvidia/roce/config/adaptive-routing-force\n",
+                    "      valueType: bool\n",
+                    "  congestionControl:\n",
+                    "    - name: Congestion Control on RP points\n",
+                    "      value: true\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/config/priority/rp_enabled\n",
+                    "      valueType: bool\n",
+                    "      alternativeValue: \"1\"\n",
+                    "      hwplbFirstPortOnly: true\n",
+                    "    - name: Congestion Control on NP points\n",
+                    "      value: true\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/config/priority/np_enabled\n",
+                    "      valueType: bool\n",
+                    "      alternativeValue: \"1\"\n",
+                    "      hwplbFirstPortOnly: true\n",
+                    "    - name: Congestion Control\n",
+                    "      value: true\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/config/enabled\n",
+                    "      valueType: bool\n",
+                    "    - name: Congestion Control with Counters\n",
+                    "      value: true\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/config/counter_enable\n",
+                    "      valueType: bool\n",
+                    "    - name: DCQCN\n",
+                    "      value: false\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=15]/config/enabled\n",
+                    "      valueType: bool\n",
+                    "    - name: Bandwidth\n",
+                    "      value: 400\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value\n",
+                    "      valueType: int\n",
+                    "      deviceId: \"1023\"\n",
+                    "      breakout: 2\n",
+                    "    - name: Bandwidth\n",
+                    "      value: 200\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value\n",
+                    "      valueType: int\n",
+                    "      deviceId: \"1023\"\n",
+                    "      breakout: 4\n",
+                    "    - name: Bandwidth\n",
+                    "      value: 400\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value\n",
+                    "      valueType: int\n",
+                    "      deviceId: \"1025\"\n",
+                    "      breakout: 2\n",
+                    "    - name: Bandwidth\n",
+                    "      value: 200\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value\n",
+                    "      valueType: int\n",
+                    "      deviceId: \"1025\"\n",
+                    "      breakout: 4\n",
+                    "    - name: Bandwidth\n",
+                    "      value: 200\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value\n",
+                    "      valueType: int\n",
+                    "      deviceId: \"a2dc\"\n",
+                    "      breakout: 2\n",
+                    "    - name: Bandwidth\n",
+                    "      value: 100\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value\n",
+                    "      valueType: int\n",
+                    "      deviceId: \"a2dc\"\n",
+                    "      breakout: 4\n",
+                    "    - name: Responsiveness Alpha Factor\n",
+                    "      value: 6553\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=1]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Maximum Decrease Factor\n",
+                    "      value: 63570\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=2]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Maximum Increase Factor\n",
+                    "      value: 69468\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=3]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Additive Increase Step Size\n",
+                    "      value: 96\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=4]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: High Additive Increase Step Size\n",
+                    "      value: 1700\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=5]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: High Additive Increase Interval Period\n",
+                    "      value: 200000\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=6]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: ZTR_CC_CONGESTION_DELAY_THRESHOLD\n",
+                    "      value: 13000\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=7]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Maximum Queuing Delay\n",
+                    "      value: 250000\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=8]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Rate on First Congestion\n",
+                    "      value: 524288\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=9]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Delay Only\n",
+                    "      value: 0\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=10]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: CNP Validity\n",
+                    "      value: 1\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=11]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Transmit Rate Decrement Step\n",
+                    "      value: 1\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=12]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Fixed Transmission Rate\n",
+                    "      value: 0\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=13]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Fast Scheduling Factor\n",
+                    "      value: 2097152\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=14]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Topology Awareness\n",
+                    "      value: 1\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=15]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Advanced Features\n",
+                    "      value: 1\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=16]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Troubleshooting Capabilities\n",
+                    "      value: 0\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=17]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: CC_FIXED_CWND\n",
+                    "      value: 0\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=18]/config/value\n",
+                    "      valueType: int\n",
+                    "    - name: Enable CC Plane Failure Detection\n",
+                    "      value: 1\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=22]/config/value\n",
+                    "      valueType: int\n",
+                    "      multiplane: hwplb\n",
+                    "    - name: CC Plane Failure Threshold\n",
+                    "      value: 3\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=23]/config/value\n",
+                    "      valueType: int\n",
+                    "      multiplane: hwplb\n",
+                    "    - name: CC Plane Recovery Threshold\n",
+                    "      value: 1\n",
+                    "      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=24]/config/value\n",
+                    "      valueType: int\n",
+                    "      multiplane: hwplb\n",
+                    "  interPacketGap:\n",
+                    "    pureL3:\n",
+                    "      - name: Inter Packet Gap for no overlay\n",
+                    "        value: 25\n",
+                    "        dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap\n",
+                    "        valueType: int\n",
+                    "    l3EVPN:\n",
+                    "      - name: Inter Packet Gap for L3 EVPN overlay\n",
+                    "        value: 33\n",
+                    "        dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap\n",
+                    "        valueType: int\n",
+                    "docaCCVersion: 3.4.0\n",
+                    "useSoftwareCCAlgorithm: true\n",
+                )
+                .to_string(),
+            ),
+            r#type: None,
+        },
+        DpuFlavorConfigFiles {
+            content_from: None,
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/etc/mellanox/ovs-script.sh".to_string(),
+            permissions: Some("0755".to_string()),
+            raw: Some(
+                concat!(
+                    "#!/bin/bash\n",
+                    "\n",
+                    "# Remove default OVS configuration on the DPU and ensure no leftovers on the OVS kernel side\n",
+                    "seq -f 'ovsbr%g' 1 99 | xargs -r -n1 ovs-vsctl --if-exists del-br\n",
+                    "\n",
+                    "ovs-appctl --timeout 15 dpctl/del-dp system@ovs-system || true\n",
+                    "\n",
+                    "# Run devlink commands to set eswitch multiport:\n",
+                    "CX9_DEVS=(pci/0004:03:00 pci/0005:03:00 pci/0004:06:00 pci/0005:06:00 pci/0000:03:00 pci/0001:03:00 pci/0000:06:00 pci/0001:06:00)\n",
+                    "for dev in \"${CX9_DEVS[@]}\"; do\n",
+                    "  for i in 0 1 2 3; do devlink dev eswitch set ${dev}.$i mode switchdev; done\n",
+                    "done\n",
+                    "for dev in \"${CX9_DEVS[@]}\"; do\n",
+                    "  for i in 0 1 2 3; do devlink dev param set ${dev}.$i name esw_multiport value true cmode runtime; done\n",
+                    "done\n",
+                    "\n",
+                    "# 2. Configure OVS\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:doca-init=true\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:dpdk-max-memzones=50000\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:hw-offload=true\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:pmd-quiet-idle=true\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:max-idle=20000\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:max-revalidator=5000\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:doca-congestion-threshold=60\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:flow-limit=500000\n",
+                    "_ovs-vsctl set Open_vSwitch . other_config:hw-offload-ct-unidir-udp-enabled=true\n",
+                    "_ovs-vsctl remove Open_vSwitch . other_config default-datapath-type || true\n",
+                    "\n",
+                    "if systemctl list-unit-files openvswitch-switch.service &>/dev/null; then\n",
+                    "  systemctl restart openvswitch-switch\n",
+                    "elif systemctl list-unit-files openvswitch.service &>/dev/null; then\n",
+                    "  systemctl restart openvswitch\n",
+                    "fi\n",
+                    "\n",
+                    "\n",
+                    "_ovs-vsctl --may-exist add-br br-sfc\n",
+                    "_ovs-vsctl set bridge br-sfc datapath_type=netdev\n",
+                    "_ovs-vsctl set bridge br-sfc fail_mode=secure\n",
+                    "_ovs-vsctl --may-exist add-br br-hbn\n",
+                    "_ovs-vsctl set bridge br-hbn datapath_type=netdev\n",
+                    "_ovs-vsctl set bridge br-hbn fail_mode=secure\n",
+                    "\n",
+                    "# Pre plug p0 to br-sfc\n",
+                    "_ovs-vsctl --may-exist add-port br-sfc p0\n",
+                    "_ovs-vsctl set Interface p0 type=dpdk\n",
+                    "_ovs-vsctl set Interface p0 mtu_request=9216\n",
+                    "_ovs-vsctl set Port p0 external_ids:dpf-type=physical\n",
+                    "\n",
+                    "# Pre plug p1 to br-sfc\n",
+                    "_ovs-vsctl --may-exist add-port br-sfc p1\n",
+                    "_ovs-vsctl set Interface p1 type=dpdk\n",
+                    "_ovs-vsctl set Interface p1 mtu_request=9216\n",
+                    "_ovs-vsctl set Port p1 external_ids:dpf-type=physical\n",
+                    "\n",
+                    "# Configure ovs bridges for xplane:\n",
+                    "RAILS=(0 1 2 3)\n",
+                    "SW_PLANES=(0 1)\n",
+                    "HW_PLANES=(0 1 2 3)\n",
+                    "\n",
+                    "for rail in \"${RAILS[@]}\"; do\n",
+                    "    for sw_plane in \"${SW_PLANES[@]}\"; do\n",
+                    "        bridge=\"brcx-r${rail}swpln${sw_plane}\"\n",
+                    "        _ovs-vsctl --may-exist add-br \"$bridge\"\n",
+                    "        _ovs-vsctl set bridge \"$bridge\" datapath_type=netdev\n",
+                    "        _ovs-vsctl set bridge \"$bridge\" fail_mode=standalone\n",
+                    "    done\n",
+                    "done\n",
+                    "\n",
+                    "_ovs-vsctl --may-exist add-br br-xplane\n",
+                    "_ovs-vsctl set bridge br-xplane datapath_type=netdev\n",
+                    "_ovs-vsctl set bridge br-xplane fail_mode=secure\n",
+                    "\n",
+                    "# Map (rail, sw_plane) -> CX9 ID\n",
+                    "# Rail 0: SW 0 -> CX1, SW 1 -> CX2\n",
+                    "# Rail 1: SW 0 -> CX0, SW 1 -> CX3\n",
+                    "# Rail 2: SW 0 -> CX5, SW 1 -> CX6\n",
+                    "# Rail 3: SW 0 -> CX4, SW 1 -> CX7\n",
+                    "declare -A CX9_MAP\n",
+                    "CX9_MAP[\"0,0\"]=1\n",
+                    "CX9_MAP[\"0,1\"]=2\n",
+                    "CX9_MAP[\"1,0\"]=0\n",
+                    "CX9_MAP[\"1,1\"]=3\n",
+                    "CX9_MAP[\"2,0\"]=5\n",
+                    "CX9_MAP[\"2,1\"]=6\n",
+                    "CX9_MAP[\"3,0\"]=4\n",
+                    "CX9_MAP[\"3,1\"]=7\n",
+                    "\n",
+                    "# Map CX9 ID -> interface name (Ax)\n",
+                    "# A2 -> CX0, A3 -> CX1, A0 -> CX2, A1 -> CX3\n",
+                    "# A4 -> CX4, A5 -> CX5, A6 -> CX6, A7 -> CX7\n",
+                    "declare -A IFACE_MAP\n",
+                    "IFACE_MAP[0]=\"A2\"\n",
+                    "IFACE_MAP[1]=\"A3\"\n",
+                    "IFACE_MAP[2]=\"A0\"\n",
+                    "IFACE_MAP[3]=\"A1\"\n",
+                    "IFACE_MAP[4]=\"A4\"\n",
+                    "IFACE_MAP[5]=\"A5\"\n",
+                    "IFACE_MAP[6]=\"A6\"\n",
+                    "IFACE_MAP[7]=\"A7\"\n",
+                    "\n",
+                    "for rail in \"${RAILS[@]}\"; do\n",
+                    "    for sw_plane in \"${SW_PLANES[@]}\"; do\n",
+                    "        group_id=\"r${rail}swpln${sw_plane}\"\n",
+                    "        cx9_id=\"${CX9_MAP[\"${rail},${sw_plane}\"]}\"\n",
+                    "        iface_prefix=\"${IFACE_MAP[$cx9_id]}\"\n",
+                    "\n",
+                    "        for hw_plane in \"${HW_PLANES[@]}\"; do\n",
+                    "            interface_val=\"${iface_prefix}p${hw_plane}\"\n",
+                    "\n",
+                    "            _ovs-vsctl --may-exist add-port br-xplane \"$interface_val\"\n",
+                    "            _ovs-vsctl set Interface \"$interface_val\" type=dpdk\n",
+                    "            _ovs-vsctl set Interface \"$interface_val\" mtu_request=9216\n",
+                    "            _ovs-vsctl set Interface \"$interface_val\" external_ids:xplane=true\n",
+                    "            _ovs-vsctl set Interface \"$interface_val\" external_ids:xplane-group-id=\"$group_id\"\n",
+                    "            _ovs-vsctl set Interface \"$interface_val\" external_ids:xplane-uplink=true\n",
+                    "            _ovs-vsctl set Interface \"$interface_val\" external_ids:xplane-plane-id=\"$hw_plane\"\n",
+                    "        done\n",
+                    "    done\n",
+                    "done\n",
+                )
+                .to_string(),
+            ),
+            r#type: None,
+        },
+        DpuFlavorConfigFiles {
+            content_from: None,
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/etc/mellanox/xplane-bridge.sh".to_string(),
+            permissions: Some("0755".to_string()),
+            raw: Some(
+                concat!(
+                    "#!/bin/bash\n",
+                    "\n",
+                    "# Node list: \"Serial|NodeAddress|GWAddress\"\n",
+                    "NODES=(\n",
+                    "    \"MT26206064EV|212|213\"\n",
+                    "    \"MT2619602QZU|214|215\"\n",
+                    "    \"MT26206064DV|216|217\"\n",
+                    "    \"MT26206064LM|218|219\"\n",
+                    "    \"MT2620606MXD|220|221\"\n",
+                    "    \"MT26206064EC|222|223\"\n",
+                    "    \"MT26206064CC|224|225\"\n",
+                    "    \"MT26206064NF|226|227\"\n",
+                    "    \"MT26206064C6|228|229\"\n",
+                    "    \"MT26206064LQ|230|231\"\n",
+                    "    \"MT26206064HB|232|233\"\n",
+                    "    \"MT26206064C5|234|235\"\n",
+                    "    \"MT26206064HY|236|237\"\n",
+                    "    \"MT26206064NE|238|239\"\n",
+                    "    \"MT26206064GW|240|241\"\n",
+                    "    \"MT26206064FY|242|243\"\n",
+                    "    \"MT26206064MA|244|245\"\n",
+                    "    \"MT26206064KK|246|247\"\n",
+                    ")\n",
+                    "\n",
+                    "# Define Subnet Prefixes as an associative array indexed by \"rail,sw_plane\"\n",
+                    "# sw_plane 0 = ports p01-p04, sw_plane 1 = ports p05-p08\n",
+                    "declare -A SUB_PREFIXES\n",
+                    "SUB_PREFIXES[\"0,0\"]=\"100.96.0\"\n",
+                    "SUB_PREFIXES[\"1,0\"]=\"100.97.0\"\n",
+                    "SUB_PREFIXES[\"2,0\"]=\"100.98.0\"\n",
+                    "SUB_PREFIXES[\"3,0\"]=\"100.99.0\"\n",
+                    "SUB_PREFIXES[\"0,1\"]=\"100.104.0\"\n",
+                    "SUB_PREFIXES[\"1,1\"]=\"100.105.0\"\n",
+                    "SUB_PREFIXES[\"2,1\"]=\"100.106.0\"\n",
+                    "SUB_PREFIXES[\"3,1\"]=\"100.107.0\"\n",
+                    "\n",
+                    "# 1. Detect local node serial number\n",
+                    "LOCAL_SERIAL=$(lspci -s 0002:01:00.0 -vvv 2>/dev/null | sed -n 's/.*Serial number: //p')\n",
+                    "\n",
+                    "# Fallback: Strip whitespaces if any exist\n",
+                    "LOCAL_SERIAL=$(echo \"$LOCAL_SERIAL\" | tr -d '[:space:]')\n",
+                    "\n",
+                    "if [ -z \"$LOCAL_SERIAL\" ]; then\n",
+                    "    exit 1\n",
+                    "fi\n",
+                    "\n",
+                    "# 2. Find matching node variables from the list\n",
+                    "NODE_ADDR=\"\"\n",
+                    "GW_ADDR=\"\"\n",
+                    "\n",
+                    "for node in \"${NODES[@]}\"; do\n",
+                    "    IFS=\"|\" read -r s_num n_addr g_addr <<< \"$node\"\n",
+                    "    if [ \"$s_num\" == \"$LOCAL_SERIAL\" ]; then\n",
+                    "        NODE_ADDR=\"$n_addr\"\n",
+                    "        GW_ADDR=\"$g_addr\"\n",
+                    "        break\n",
+                    "    fi\n",
+                    "done\n",
+                    "\n",
+                    "if [ -z \"$NODE_ADDR\" ] || [ -z \"$GW_ADDR\" ]; then\n",
+                    "    exit 1\n",
+                    "fi\n",
+                    "\n",
+                    "# 3. Generate the Netplan Configuration File\n",
+                    "NETPLAN_FILE=\"/etc/netplan/99-cx9-rails.yaml\"\n",
+                    "\n",
+                    "{\n",
+                    "    echo \"network:\"\n",
+                    "    echo \"  version: 2\"\n",
+                    "    echo \"  ethernets:\"\n",
+                    "\n",
+                    "    for rail in 0 1 2 3; do\n",
+                    "        for sw_plane in 0 1; do\n",
+                    "            prefix=\"${SUB_PREFIXES[\"$rail,$sw_plane\"]}\"\n",
+                    "\n",
+                    "            echo \"    brcx-r${rail}swpln${sw_plane}:\"\n",
+                    "            echo \"      addresses:\"\n",
+                    "            echo \"        - ${prefix}.${NODE_ADDR}/31\"\n",
+                    "            echo \"      routes:\"\n",
+                    "            echo \"        - to: ${prefix}.0/16\"\n",
+                    "            echo \"          via: ${prefix}.${GW_ADDR}\"\n",
+                    "            echo \"        - to: ${SUB_PREFIXES[0,$sw_plane]}.0/13\"\n",
+                    "            echo \"          via: ${prefix}.${GW_ADDR}\"\n",
+                    "        done\n",
+                    "    done\n",
+                    "} > \"$NETPLAN_FILE\"\n",
+                    "\n",
+                    "netplan apply\n",
+                )
+                .to_string(),
+            ),
+            r#type: None,
+        },
+    ];
+
+    if let Some(proxy) = proxy {
+        validate_proxy_string(&proxy.https_proxy, "https_proxy")?;
+
+        let mut raw = format!(
+            "[Service]\nEnvironment=\"HTTPS_PROXY={0}\"\nEnvironment=\"https_proxy={0}\"\n",
+            proxy.https_proxy
+        );
+        let mut entries: Vec<&str> = proxy
+            .no_proxy
+            .iter()
+            .map(|e| e.trim())
+            .filter(|e| !e.is_empty())
+            .collect();
+        if !entries.is_empty() {
+            for entry in &entries {
+                validate_proxy_string(entry, "no_proxy entry")?;
+            }
+            entries.sort_unstable();
+            entries.dedup();
+            let no_proxy = entries.join(",");
+            raw.push_str(&format!(
+                "Environment=\"NO_PROXY={0}\"\nEnvironment=\"no_proxy={0}\"\n",
+                no_proxy
+            ));
+        }
+        config_files.push(DpuFlavorConfigFiles {
+            path: "/etc/systemd/system/containerd.service.d/socks-proxy.conf".to_string(),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some(raw),
+            content_from: None,
+            r#type: None,
+        });
+    }
+
+    Ok(config_files)
+}
+
 fn get_default_nvconfig() -> DpuFlavorNvconfig {
     let parameters = vec![
         "PF_BAR2_ENABLE=0".to_string(),
@@ -447,6 +1196,31 @@ fn get_default_nvconfig() -> DpuFlavorNvconfig {
         "NUM_OF_VFS=16".to_string(),
         "HIDE_PORT2_PF=True".to_string(),
         "NUM_OF_PF=1".to_string(),
+        "LINK_TYPE_P1=ETH".to_string(),
+        "LINK_TYPE_P2=ETH".to_string(),
+    ];
+
+    DpuFlavorNvconfig {
+        // DPF does not allow anyother wild card. It takes only '*'
+        device: Some(DpuFlavorNvconfigDevice::KopiumVariant0), //"*"
+        parameters: Some(parameters),
+    }
+}
+
+fn get_bf4_astra_nvconfig() -> DpuFlavorNvconfig {
+    let parameters = vec![
+        "PF_BAR2_ENABLE=0".to_string(),
+        "PER_PF_NUM_SF=1".to_string(),
+        "PF_TOTAL_SF=20".to_string(),
+        "PF_SF_BAR_SIZE=14".to_string(),
+        "NUM_PF_MSIX_VALID=0".to_string(),
+        "PF_NUM_PF_MSIX_VALID=1".to_string(),
+        "PF_NUM_PF_MSIX=228".to_string(),
+        "INTERNAL_CPU_MODEL=1".to_string(),
+        "INTERNAL_CPU_OFFLOAD_ENGINE=0".to_string(),
+        "SRIOV_EN=1".to_string(),
+        "NUM_OF_VFS=46".to_string(),
+        "LAG_RESOURCE_ALLOCATION=1".to_string(),
         "LINK_TYPE_P1=ETH".to_string(),
         "LINK_TYPE_P2=ETH".to_string(),
     ];
@@ -714,6 +1488,205 @@ mod tests {
 
             "containerd_config unset" {
                 flavor.spec.containerd_config.is_none() => true,
+            }
+        );
+    }
+
+    #[test]
+    fn bf4_astra_flavor_spec_invariants() {
+        let flavor = flavor_bf4_astra("astra-ns", &None).unwrap();
+        let ew_nic = flavor
+            .spec
+            .ew_nic_configurations
+            .as_ref()
+            .and_then(|configs| configs.first())
+            .unwrap();
+        let spectrum_x = ew_nic.spectrum_x_optimized.as_ref().unwrap();
+        let grub_parameters = flavor
+            .spec
+            .grub
+            .as_ref()
+            .and_then(|grub| grub.kernel_parameters.as_ref())
+            .unwrap();
+        let nvconfig_parameters = flavor
+            .spec
+            .nvconfig
+            .as_ref()
+            .and_then(|configs| configs.first())
+            .and_then(|config| config.parameters.as_ref())
+            .unwrap();
+        let ovs_script = flavor
+            .spec
+            .ovs
+            .as_ref()
+            .and_then(|ovs| ovs.raw_config_script.as_ref())
+            .unwrap();
+
+        value_scenarios!(
+            run = |valid| valid;
+            "namespace is passed through and name is left unset" {
+                (
+                    flavor.metadata.namespace.as_deref() == Some("astra-ns")
+                        && flavor.metadata.name.is_none()
+                ) => true,
+            }
+
+            "deprecated generic fields are unset" {
+                (
+                    flavor.spec.bfcfg_parameters.is_none()
+                        && flavor.spec.dpu_mode.is_none()
+                ) => true,
+            }
+
+            "network bay configuration selects conf1 with one VF" {
+                (
+                    ew_nic.num_vfs == 1
+                        && ew_nic.link_type.is_none()
+                        && ew_nic
+                            .network_bay
+                            .as_ref()
+                            .is_some_and(|network_bay| network_bay.conf == "conf1")
+                ) => true,
+            }
+
+            "Spectrum-X configuration selects the Astra profile" {
+                (
+                    spectrum_x.enabled
+                        && matches!(
+                            spectrum_x.multiplane_mode.as_ref(),
+                            Some(
+                                DpuFlavorEwNicConfigurationsSpectrumXOptimizedMultiplaneMode::Hwplb
+                            )
+                        )
+                        && spectrum_x.number_of_planes == Some(4)
+                        && matches!(
+                            spectrum_x.overlay.as_ref(),
+                            Some(DpuFlavorEwNicConfigurationsSpectrumXOptimizedOverlay::None)
+                        )
+                        && spectrum_x.version == "RA2.2-runtime"
+                ) => true,
+            }
+
+            "Astra grub parameters include fixrttc and 8072 huge pages" {
+                (
+                    grub_parameters.iter().any(|parameter| parameter == "fixrttc")
+                        && grub_parameters
+                            .iter()
+                            .any(|parameter| parameter == "hugepages=8072")
+                ) => true,
+            }
+
+            "Astra nvconfig requests 20 total SFs and 46 VFs" {
+                (
+                    nvconfig_parameters
+                        .iter()
+                        .any(|parameter| parameter == "PF_TOTAL_SF=20")
+                        && nvconfig_parameters
+                            .iter()
+                            .any(|parameter| parameter == "NUM_OF_VFS=46")
+                ) => true,
+            }
+
+            "OVS bootstrap invokes both Astra scripts with blank line and 2-space helper indent" {
+                (
+                    ovs_script.contains(
+                        "# Shared helper used by the called scripts; exported so they inherit it\n\n# create an entry"
+                    )
+                        && ovs_script.contains("  ovs-vsctl --timeout 30 \"$@\"")
+                        && ovs_script.contains("/etc/mellanox/ovs-script.sh")
+                        && ovs_script.contains("/etc/mellanox/xplane-bridge.sh")
+                ) => true,
+            }
+
+            "Spectrum-X config file has no stray block marker and correct Adaptive Routing Force indent" {
+                {
+                    let spectrum = flavor
+                        .spec
+                        .config_files
+                        .as_ref()
+                        .unwrap()
+                        .iter()
+                        .find(|file| file.path == "/bindata/spectrum-x/RA2.2-runtime.yaml")
+                        .and_then(|file| file.raw.as_ref())
+                        .unwrap();
+                    !spectrum.starts_with('|')
+                        && spectrum.contains(
+                            "    - name: Adaptive Routing Force\n      value: true\n      dmsPath:"
+                        )
+                        && spectrum.contains("      valueType: bool\n  congestionControl:\n")
+                } => true,
+            }
+
+            "empty containerd/sysctl/packages/systemdServices placeholders are set" {
+                (
+                    flavor.spec.containerd_config.is_some()
+                        && flavor
+                            .spec
+                            .sysctl
+                            .as_ref()
+                            .is_some_and(|sysctl| {
+                                sysctl.parameters.as_ref().is_some_and(Vec::is_empty)
+                            })
+                        && flavor
+                            .spec
+                            .packages
+                            .as_ref()
+                            .is_some_and(Vec::is_empty)
+                        && flavor
+                            .spec
+                            .systemd_services
+                            .as_ref()
+                            .is_some_and(Vec::is_empty)
+                ) => true,
+            }
+
+            "ewNic rawNvConfig has correct programmable CC and locality mode" {
+                {
+                    let raw = ew_nic.raw_nv_config.as_ref().unwrap();
+                    let names: Vec<_> = raw.iter().map(|entry| entry.name.as_str()).collect();
+                    let programmable_cc = raw.iter().find(|entry| {
+                        entry.name == "USER_PROGRAMMABLE_CC"
+                    });
+                    let locality = raw.iter().find(|entry| {
+                        entry.name == "TX_SCHEDULER_LOCALITY_MODE"
+                    });
+                    names
+                        .iter()
+                        .filter(|name| **name == "ROCE_ADAPTIVE_ROUTING_EN")
+                        .count()
+                        == 1
+                        && !names.contains(&"USER_PROGAMMABLE_CC")
+                        && programmable_cc.is_some_and(|entry| entry.value == "1")
+                        && locality.is_some_and(|entry| entry.value == "2")
+                } => true,
+            }
+        );
+    }
+
+    #[test]
+    fn bf4_astra_proxy_config_file_count() {
+        value_scenarios!(
+            run = |p| {
+                let files = flavor_bf4_astra("astra-ns", &p)
+                    .unwrap()
+                    .spec
+                    .config_files
+                    .unwrap();
+                let proxy_file_count = files
+                    .iter()
+                    .filter(|file| {
+                        file.path
+                            == "/etc/systemd/system/containerd.service.d/socks-proxy.conf"
+                    })
+                    .count();
+                (files.len(), proxy_file_count)
+            };
+            "no proxy keeps only the six Astra base files" {
+                None => (6, 0),
+            }
+
+            "configured proxy appends exactly one proxy file" {
+                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => (7, 1),
             }
         );
     }

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -813,9 +813,9 @@ pub fn build_deployment(
     namespace: &str,
     interfaces: &[DpuServiceInterfaceTemplateDefinition],
     deployment_node_labels: BTreeMap<String, String>,
-    suffix: &str,
     deployment_type: DpuDeploymentType,
 ) -> DPUDeployment {
+    let suffix = deployment_cr_suffix(deployment_type);
     let services_map: BTreeMap<String, DpuDeploymentServices> = services
         .iter()
         .map(|svc| {
@@ -1287,7 +1287,6 @@ async fn create_flavor_services_and_deployment<
         namespace,
         &interfaces,
         deployment_node_labels,
-        suffix,
         deployment_type,
     );
     DpuDeploymentRepository::apply(repo, &deployment).await?;
@@ -2193,6 +2192,7 @@ mod tests {
     use std::sync::{Arc, RwLock};
 
     use async_trait::async_trait;
+    use carbide_test_support::value_scenarios;
     use kube::Resource;
 
     use super::*;
@@ -2235,7 +2235,6 @@ mod tests {
             TEST_NAMESPACE,
             &[],
             BTreeMap::new(),
-            "bf3",
             DpuDeploymentType::Bf3,
         );
 
@@ -2297,7 +2296,6 @@ mod tests {
             TEST_NAMESPACE,
             &[],
             BTreeMap::new(),
-            bf4_suffix,
             DpuDeploymentType::Bf4Generic,
         );
         let entry = bf4_deployment
@@ -2312,6 +2310,39 @@ mod tests {
         assert_eq!(
             entry.service_configuration.as_deref(),
             Some("doca-hbn-bf4generic")
+        );
+    }
+
+    #[test]
+    fn deployment_type_controls_cr_suffix_and_astra_enablement() {
+        value_scenarios!(
+            run = |deployment_type| {
+                let deployment = build_deployment(
+                    &[],
+                    "deployment",
+                    &DpuProvisioningSource::Bfb("bfb".to_string()),
+                    "flavor",
+                    TEST_NAMESPACE,
+                    &[],
+                    BTreeMap::new(),
+                    deployment_type,
+                );
+                (
+                    deployment_cr_suffix(deployment_type),
+                    deployment.spec.dpus.astra_enabled,
+                )
+            };
+            "BF3 preserves unsuffixed resource names" {
+                DpuDeploymentType::Bf3 => ("", None),
+            }
+
+            "generic BF4 uses its deployment suffix" {
+                DpuDeploymentType::Bf4Generic => ("bf4generic", None),
+            }
+
+            "Astra BF4 uses its deployment suffix and enables Astra" {
+                DpuDeploymentType::Bf4Astra => ("bf4astra", Some(true)),
+            }
         );
     }
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -617,6 +617,7 @@ pub fn deployment_cr_suffix(deployment_type: DpuDeploymentType) -> &'static str 
     match deployment_type {
         DpuDeploymentType::Bf3 => "",
         DpuDeploymentType::Bf4Generic => "bf4generic",
+        DpuDeploymentType::Bf4Astra => "bf4astra",
     }
 }
 
@@ -813,6 +814,7 @@ pub fn build_deployment(
     interfaces: &[DpuServiceInterfaceTemplateDefinition],
     deployment_node_labels: BTreeMap<String, String>,
     suffix: &str,
+    deployment_type: DpuDeploymentType,
 ) -> DPUDeployment {
     let services_map: BTreeMap<String, DpuDeploymentServices> = services
         .iter()
@@ -950,7 +952,8 @@ pub fn build_deployment(
                     r#type: DpuDeploymentDpusDpuSetStrategyType::OnDelete,
                 },
                 secure_boot: None,
-                astra_enabled: None,
+                astra_enabled: matches!(deployment_type, DpuDeploymentType::Bf4Astra)
+                    .then_some(true),
                 blue_field_software: match source {
                     DpuProvisioningSource::Bfb(_) => None,
                     DpuProvisioningSource::BlueFieldSoftware(name) => Some(name.clone()),
@@ -1285,6 +1288,7 @@ async fn create_flavor_services_and_deployment<
         &interfaces,
         deployment_node_labels,
         suffix,
+        deployment_type,
     );
     DpuDeploymentRepository::apply(repo, &deployment).await?;
     Ok(())
@@ -2232,6 +2236,7 @@ mod tests {
             &[],
             BTreeMap::new(),
             "bf3",
+            DpuDeploymentType::Bf3,
         );
 
         let otel = deployment
@@ -2293,6 +2298,7 @@ mod tests {
             &[],
             BTreeMap::new(),
             bf4_suffix,
+            DpuDeploymentType::Bf4Generic,
         );
         let entry = bf4_deployment
             .spec

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -479,7 +479,6 @@ async fn service_versions_fail_when_referenced_template_is_missing() {
         TEST_NS,
         &[],
         BTreeMap::new(),
-        "",
         crate::types::DpuDeploymentType::Bf3,
     );
     DpuDeploymentRepository::apply(&mock, &deployment)

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -480,6 +480,7 @@ async fn service_versions_fail_when_referenced_template_is_missing() {
         &[],
         BTreeMap::new(),
         "",
+        crate::types::DpuDeploymentType::Bf3,
     );
     DpuDeploymentRepository::apply(&mock, &deployment)
         .await

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -43,10 +43,11 @@ impl BmcPasswordProvider for String {
 pub const DOCA_HBN_SERVICE_NAME: &str = "doca-hbn";
 pub const DHCP_SERVER_SERVICE_NAME: &str = "carbide-dhcp-server";
 pub const FMDS_SERVICE_NAME: &str = "carbide-fmds";
-
 pub const DPU_AGENT_SERVICE_NAME: &str = "carbide-dpu-agent";
 pub const OTEL_COLLECTOR_SERVICE_NAME: &str = "carbide-otelcol";
 pub const DTS_SERVICE_NAME: &str = "dts";
+pub const DOCA_WEAVE_SERVICE_NAME: &str = "doca-weave";
+pub const DOCA_XPLANE_SERVICE_NAME: &str = "doca-xplane";
 
 /// Configuration for creating DPF operator resources (BFB, DPUFlavor,
 /// DPUDeployment, service templates, etc.) during initialization.
@@ -270,6 +271,7 @@ pub struct DpuFlavorBridgeDefinition {
 pub enum DpuDeploymentType {
     Bf3,
     Bf4Generic,
+    Bf4Astra,
 }
 
 /// Information about a DPU device (DPUDevice CR).

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -46,7 +46,8 @@ pub const FMDS_SERVICE_NAME: &str = "carbide-fmds";
 pub const DPU_AGENT_SERVICE_NAME: &str = "carbide-dpu-agent";
 pub const OTEL_COLLECTOR_SERVICE_NAME: &str = "carbide-otelcol";
 pub const DTS_SERVICE_NAME: &str = "dts";
-pub const DOCA_WEAVE_SERVICE_NAME: &str = "doca-weave";
+pub const DOCA_WEAVE_DHCP_AGENT_SERVICE_NAME: &str = "doca-weave-dhcp-agent";
+pub const DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_NAME: &str = "doca-weave-flow-controller";
 pub const DOCA_XPLANE_SERVICE_NAME: &str = "doca-xplane";
 
 /// Configuration for creating DPF operator resources (BFB, DPUFlavor,

--- a/doca-weave-flow-controller-dpuserviceconfig.yaml
+++ b/doca-weave-flow-controller-dpuserviceconfig.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceConfiguration
+metadata:
+  name: doca-weave-flow-controller
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: doca-weave-flow-controller
+  upgradePolicy:
+    applyNodeEffect: false
+  serviceConfiguration:
+    helmChart:
+      values:
+        weaveFlowController:
+          enabled: true
+          underlayConfigMapData:
+            nicIDType: mac
+            interfaces:
+              - pciAddress: "0004:03:00.0"
+                underlayInterface: brcx-r0swpln0
+                overlayDHCPInterface: r0swpln0
+                dhcpBridgeName: br-dhcp-r0swpln0
+                dropBridgeName: br-drop-r0swpln0
+              - pciAddress: "0004:06:00.0"
+                underlayInterface: brcx-r1swpln0
+                overlayDHCPInterface: r1swpln0
+                dhcpBridgeName: br-dhcp-r1swpln0
+                dropBridgeName: br-drop-r1swpln0
+              - pciAddress: "0005:03:00.0"
+                underlayInterface: brcx-r0swpln1
+                overlayDHCPInterface: r0swpln1
+                dhcpBridgeName: br-dhcp-r0swpln1
+                dropBridgeName: br-drop-r0swpln1
+              - pciAddress: "0005:06:00.0"
+                underlayInterface: brcx-r1swpln1
+                overlayDHCPInterface: r1swpln1
+                dhcpBridgeName: br-dhcp-r1swpln1
+                dropBridgeName: br-drop-r1swpln1
+              - pciAddress: "0000:03:00.0"
+                underlayInterface: brcx-r2swpln0
+                overlayDHCPInterface: r2swpln0
+                dhcpBridgeName: br-dhcp-r2swpln0
+                dropBridgeName: br-drop-r2swpln0
+              - pciAddress: "0000:06:00.0"
+                underlayInterface: brcx-r3swpln0
+                overlayDHCPInterface: r3swpln0
+                dhcpBridgeName: br-dhcp-r3swpln0
+                dropBridgeName: br-drop-r3swpln0
+              - pciAddress: "0001:03:00.0"
+                underlayInterface: brcx-r2swpln1
+                overlayDHCPInterface: r2swpln1
+                dhcpBridgeName: br-dhcp-r2swpln1
+                dropBridgeName: br-drop-r2swpln1
+              - pciAddress: "0001:06:00.0"
+                underlayInterface: brcx-r3swpln1
+                overlayDHCPInterface: r3swpln1
+                dhcpBridgeName: br-dhcp-r3swpln1
+                dropBridgeName: br-drop-r3swpln1

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -566,10 +566,11 @@ a Kubernetes image-pull Secret name when the service is served from a private re
 
 Each DPU generation is provisioned by its own `DPUDeployment`, configured under
 `[dpf.deployments.<name>]`. **BF3** is always present with built-in defaults;
-**BF4 (generic)** is opt-in and is activated only when a
-`[dpf.deployments.bf4_generic]` table is present. Both deployments run
-side-by-side, each with its own `DPUFlavor` and `DPUDeployment`. BF3 uses a
-BFB URL (`bfb_url`) and BF4 uses a `[bluefield_software]` block instead of a BFB.
+**BF4 (generic)** and **BF4 Astra** are opt-in and are activated by
+`[dpf.deployments.bf4_generic]` and `[dpf.deployments.bf4_astra]`,
+respectively. Active deployments run side-by-side, each with its own
+`DPUFlavor` and `DPUDeployment`. BF3 uses a BFB URL (`bfb_url`), while BF4
+uses a `[bluefield_software]` block instead of a BFB.
 
 Every active deployment must have a **unique** `deployment_name`, `flavor_name`,
 and `node_label_key`; carbide-api validates this at startup and refuses to start
@@ -612,6 +613,7 @@ Per-deployment field reference:
 | `deployment_name` | yes | `nico-deployment-v2` | `DPUDeployment` CR name. |
 | `node_label_key` | yes | `carbide.nvidia.com/controlled.node.v2` | Node-selector label key applied to this deployment's DPUNodes. |
 | `services` | no | inherit `[dpf.services]` | Optional per-deployment mandatory-services override (see below). |
+| `extra_services` | no | Weave DHCP agent, Weave flow controller, and Xplane for BF4 Astra; otherwise empty | Optional replacement definitions for deployment-specific services. |
 
 **Per-deployment services override.** By default every deployment inherits the
 top-level `[dpf.services]` mandatory services. A deployment can pin its own
@@ -633,6 +635,36 @@ helm_version             = "3.4.0"
 docker_repo_url          = "nvcr.io/nvidia/doca/doca_hbn"
 docker_image_tag         = "3.4.0-doca3.4.0"
 # ...plus dts, dpu_agent, dhcp_server, fmds, and otel sub-tables.
+```
+
+BF4 Astra includes three built-in deployment-specific services with no
+`extra_services` TOML required:
+
+- `doca_weave_dhcp_agent`
+- `doca_weave_flow_controller`
+- `doca_xplane`
+
+To pin a different chart/image for development without rebuilding NICo, provide
+a complete `DpfServiceConfig` for only the service being replaced:
+
+```toml
+[dpf.deployments.bf4_astra.extra_services.doca_weave_dhcp_agent]
+name             = "doca-weave-dhcp-agent"
+helm_repo_url    = "https://helm.ngc.nvidia.com/nvidia/doca"
+helm_chart       = "doca-weave-dhcp-agent"
+helm_version     = "1.0"
+docker_repo_url  = "nvcr.io/nvidia/doca/doca_weave_dhcp_agent"
+docker_image_tag = "3.2.1-doca3.2.1"
+# Optional; omit when the registry needs no Kubernetes pull secret.
+docker_image_pull_secret = "private-doca-pull-secret"
+
+[dpf.deployments.bf4_astra.extra_services.doca_weave_flow_controller]
+name             = "doca-weave-flow-controller"
+helm_repo_url    = "https://helm.ngc.nvidia.com/nvidia/doca"
+helm_chart       = "doca-weave-flow-controller"
+helm_version     = "1.0"
+docker_repo_url  = "nvcr.io/nvidia/doca/doca_weave_flow_controller"
+docker_image_tag = "3.2.1-doca3.2.1"
 ```
 
 If your environment routes DPU image pulls through an HTTPS forward proxy (Option B
@@ -661,7 +693,9 @@ Field reference (all under `[dpf]`):
 | `services.<svc>` | table | per-service defaults | Helm/image overrides for each mandatory DPUService. |
 | `deployments.bf3` | table | BF3 defaults | BF3 DPUDeployment config; always active. |
 | `deployments.bf4_generic` | table | — | BF4 (generic) DPUDeployment config; opt-in, active only when present. |
+| `deployments.bf4_astra` | table | — | BF4 Astra DPUDeployment config; opt-in, active only when present. |
 | `deployments.<name>.services.<svc>` | table | inherit `[dpf.services]` | Optional per-deployment mandatory-service override. |
+| `deployments.<name>.extra_services.<svc>` | table | Weave DHCP agent, Weave flow controller, and Xplane for BF4 Astra; otherwise empty | Complete replacement for one deployment-specific service. Supported keys are `doca_weave_dhcp_agent`, `doca_weave_flow_controller`, and `doca_xplane`. |
 | `proxy.https_proxy` | string | — | HTTPS proxy URL for DPU image pulls (see section 3.5). |
 | `proxy.no_proxy` | list of strings | `[]` | Hosts/CIDRs that must bypass the proxy. |
 


### PR DESCRIPTION
This PR adds support to create DPUFlavor and other yamls for BF4 Astra

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3205

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


Closes https://github.com/NVIDIA/infra-controller/issues/5487
