### PR TITLE
docs(observability): refresh the instrumentation guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ cargo make clippy              # Clippy linter (warnings = errors)
 cargo make carbide-lints       # Custom lints (requires nightly setup)
 cargo make check-format-nightly # Check rustfmt formatting
 cargo make check-event-names    # Validate production Event identity uniqueness
+cargo make check-metric-docs    # Check production Event metric catalogue coverage
 cargo make check-workspace-deps # Validate dependency declarations in Cargo.toml
 cargo make check-licenses      # Validate no restricted licenses introduced
 cargo make check-bans          # Check for banned dependencies
@@ -190,11 +191,17 @@ The decision rule:
   #[derive(carbide_instrument::Event)]
   #[event(event_name = "power_control_failed",
           metric_name = "carbide_power_control_total", component = "component_manager",
-          log = warn, metric = counter, message = "power control failed")]
+          log = warn, metric = counter, message = "power control failed",
+          describe = "Number of power control operations that failed")]
   struct PowerControlFailed {
       #[label]   backend: Backend,  // bounded via LabelValue — enums, usually
       #[context] error: String,     // high-cardinality — log line only
   }
+
+  carbide_instrument::emit(PowerControlFailed {
+      backend: Backend::Rms,
+      error: "deadline exceeded".to_string(),
+  });
   ```
 
   `log = off, metric = counter` counts a hot-path event with no log line at
@@ -214,9 +221,9 @@ logs. A metric-backed Event also declares `metric_name`; when that Event logs,
 both names are present so operators can pivot directly between the metric and its
 diagnostic records. Plain `tracing::` calls do not invent an `event_name`.
 
-New metric names are validated at compile time (`carbide_` prefix, `_total`
-counters, unit-suffixed histograms) and `metric_name` is the exposed name,
-verbatim. Existing metric names never change. The full standard lives in
+New metric names are checked at compile time (`carbide_` prefix, `_total`
+counters, unit-suffixed histograms), and a checked `metric_name` is exposed
+verbatim. Existing metric contracts never change. The full standard lives in
 [`docs/observability/instrumentation.md`](docs/observability/instrumentation.md).
 
 ## Further Reading

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -166,20 +166,20 @@ the type system. See [Instrumentation](docs/observability/instrumentation.md) fo
 
 The canonical pattern, checked at compile time by the derive:
 
-- **`carbide_` prefix** on every metric name. The name in the attribute is the exposed name, verbatim, so a dashboard
+- **`carbide_` prefix** on every new metric name. A checked name in the attribute is exposed verbatim, so a dashboard
   greps straight back to the source line.
 - **`_total` suffix for counters** (never a doubled `_total_total` -- the Prometheus exporter appends the suffix), and a
   **unit suffix for histograms** (`_seconds`, `_milliseconds`, `_microseconds`, `_bytes`).
 - **A counter's `describe` opens with "Number of ..."**. That HELP text is the row the
-  [core metrics catalogue](docs/observability/core_metrics.md) records, and every framework counter and histogram --
-  apart from a `name_unchecked` one, whose exposed name is an OTel-sanitized transform -- must appear there, enforced by
-  `cargo xtask check-metric-docs`. When it flags a missing row, run `cargo xtask check-metric-docs --fix` to add it
-  automatically, in sorted position -- no hand-editing the catalogue.
+  [core metrics catalogue](docs/observability/core_metrics.md) records, and every production checked-name framework
+  counter and histogram must appear there, enforced by `cargo xtask check-metric-docs`. When the check flags a missing
+  row, run `cargo xtask check-metric-docs --fix` to add it automatically, in sorted position -- no hand-editing the
+  catalogue.
 - **Bounded `#[label]` fields; high-cardinality detail in `#[context]`**. Labels come from `LabelValue` enums; machine
   IDs, IPs, and error text stay on the log line only.
 
-`name_unchecked` and `describe_unchecked` are the greppable escape hatches for grandfathered metrics; new metrics use
-the standard form.
+`metric_name_unchecked` and `describe_unchecked` are the greppable escape hatches for grandfathered metrics. Unchecked
+names are exempt from the source catalogue check; new metrics use the standard form.
 
 ## Logging
 
@@ -203,11 +203,11 @@ domain-specific key such as `configured_log_level` or `error_location` instead. 
 metric-only labels with these names remain allowed because renaming them would change the metric contract.
 
 Typed Events declare a globally unique, flat `lower_snake_case` `event_name` that identifies the reusable event
-category, not an individual occurrence. A metric-backed Event separately declares the exact Prometheus
-`metric_name`. Event-generated log lines include `event_name` and, when applicable, `metric_name`; ordinary
-`tracing::` calls do not add either field. Keep `message` as a stable human-readable description on Events that log,
-even when it resembles the machine-facing `event_name`. See
-[`docs/observability/instrumentation.md`](docs/observability/instrumentation.md) for the declaration and naming rules.
+category, not an individual occurrence. A metric-backed Event separately declares `metric_name`. Event-generated log
+lines include `event_name` and, when applicable, `metric_name`; ordinary `tracing::` calls do not add either field.
+Keep `message` as a stable human-readable description on Events that log, even when it resembles the machine-facing
+`event_name`. See [`docs/observability/instrumentation.md`](docs/observability/instrumentation.md) for the declaration
+and naming rules.
 
 Field names are part of the operational interface: dashboards, alerts, and ad hoc searches depend on them. The table
 below defines the common vocabulary. It is not an exhaustive schema -- event-specific fields should still describe

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -299,6 +299,8 @@ navigation:
               path: bootable_artifacts.md
             - page: Local Development
               path: development.md
+            - page: Instrumentation
+              path: observability/instrumentation.md
             - page: Running a PXE Client in a VM
               path: development/vm_pxe_client.md
             - page: TLS and SPIFFE Certificates

--- a/docs/observability/instrumentation.md
+++ b/docs/observability/instrumentation.md
@@ -4,6 +4,9 @@ How to instrument significant events with `carbide-instrument`: this framework p
 produces a structured log line, a Prometheus metric, or both -- correlated, consistently
 named, and with metric cardinality bounded by the type system.
 
+This guide is for contributors adding or migrating Rust instrumentation. For the
+operator-facing references, refer to [Core Metrics](core_metrics.md) and [Logging](logging.md).
+
 ---
 
 ## TL;DR
@@ -14,15 +17,15 @@ named, and with metric cardinality bounded by the type system.
   options -- `log = error|warn|info|debug|trace|off` and `metric = counter|histogram|none` --
   cover metric-only, log-only, or both from the same call.
 - **Every Event has a stable identity.** `event_name` is a unique, flat `lower_snake_case`
-  category for searches and schemas. Metric-backed Events separately declare the exact
-  Prometheus `metric_name`; Event-generated logs carry both names when both sides emit.
+  category for searches and schemas. Metric-backed Events separately declare `metric_name`;
+  Event-generated logs include both names when both sides emit.
 - **Cardinality is enforced by the types.** `#[label]` fields must be bounded via
   `LabelValue` -- usually a fieldless enum, with a manual impl on a bounded newtype as the
   reviewed escape hatch; high-cardinality detail (`machine_id`, IPs, error text) goes in
   `#[context]` fields, which appear only when the Event emits a log line and *cannot* become
   metric labels.
-- **The `metric_name` in the attribute is the exposed name, verbatim** -- what you grep on a
-  dashboard is the string in the source. The derive validates it at compile time
+- **A checked `metric_name` in the attribute is the exposed name, verbatim** -- what you grep
+  on a dashboard is the string in the source. The derive validates it at compile time
   (`carbide_` prefix, `_total` for counters, a unit suffix for histograms).
 - **Point-in-time state (gauges) is unchanged.** The framework models *occurrences*; observable
   gauges and `SharedMetricsHolder` snapshots stay exactly as they are.
@@ -44,9 +47,16 @@ Part of the instrumentation-coherency initiative
 
 **Adoption is opt-in** and call-site-by-call-site. Existing `tracing::` sites and existing
 metric emitter structs keep working unchanged; when a site *does* migrate, its log line
-keeps the same level, message, and domain fields (labels and context render as ordinary
-logfmt fields), so existing greps keep working. Event-generated logs also gain the stable
-identity fields, and a metric-backed migration gains the declared metric.
+must preserve the existing level, message, and domain field keys except where a key conflicts
+with the [reserved Event-log fields](#potential-hazards) described below. An existing metric
+keeps its family name, kind, unit, HELP text, label keys, and label values. Labels and context
+render as ordinary logfmt fields, so preserving those contracts keeps existing greps and
+dashboards working. Event-generated logs also gain the stable identity fields, and a
+metric-backed migration gains the declared metric.
+
+A pre-migration `?field` uses Debug rendering, for which Events have no `#[context(debug)]`
+equivalent. Keep that site on `tracing::`, or define a deliberate stable Display/value
+representation before migrating it.
 
 ## Quick start
 
@@ -70,7 +80,7 @@ enum Backend {
     log         = warn,                          // error|warn|info|debug|trace|off
     metric      = counter,                       // counter | histogram | none
     message     = "power control failed",
-    describe    = "Power control has failed.",
+    describe    = "Number of power control operations that failed",
 )]
 struct PowerControlFailed {
     #[label]
@@ -93,10 +103,10 @@ if let Err(e) = backend.power_control(&target, action).await {
 }
 ```
 
-One `emit()` writes both the log line and the metric. The log line carries the surrounding
-span's `span_id`; the metric is an aggregate with no per-request identity, so correlation
-runs the other way: pivot from the moving metric to the matching log lines by metric name
-and label values, and `span_id` then ties each line to its request:
+For this Event, one `emit()` writes both the log line and the metric. The log line includes
+the surrounding span's `span_id`; the metric is an aggregate with no per-request identity,
+so correlation runs the other way: pivot from the moving metric to the matching log lines by
+metric name and label values, and `span_id` then ties each line to its request:
 
 ```logfmt
 level=WARN component=nico-api span_id=0x4f... event_name=power_control_failed metric_name=carbide_power_control_total msg="power control failed" backend=rms outcome=error bmc_ip_address=10.0.0.5 error="deadline exceeded" location="..."
@@ -106,9 +116,17 @@ level=WARN component=nico-api span_id=0x4f... event_name=power_control_failed me
 carbide_power_control_total{backend="rms",outcome="error"} 1
 ```
 
-Install the meter provider at startup **before the first emit** (every NICo binary
-already does, for its existing metrics); instruments resolve from the global meter once
-per event type.
+The declaration's `component` names the owning subsystem for source tooling and tests. The
+declaration value is not written as a log field; runtime logfmt `component` still comes from
+subscriber configuration and surrounding spans, which is why the example log line above uses
+`component=nico-api`.
+
+Install the meter provider once at startup **before the first metric-backed `emit()` or
+`initialize_counter_series()` call** (every NICo binary already does this for its existing
+metrics). The generated instrument resolves from the global meter once per Event type and is
+then cached, so a first use against the default no-op provider leaves that Event type on the
+no-op instrument for the rest of the process. Production NICo binaries follow an install-once
+provider contract; cached Event instruments do not rebind after a later provider replacement.
 
 ## Log and metric options
 
@@ -225,30 +243,52 @@ Refer to [Per-object state progress metrics](../operations/monitoring-health.md#
 
 ## Histograms and observations
 
-A histogram event carries exactly one `#[observation]` field: a `Duration` (converted to
+A histogram event has exactly one `#[observation]` field: a `Duration` (converted to
 the unit the metric name declares) or a plain number (recorded as-is).
 
 ```rust
 #[derive(Event)]
 #[event(
-    event_name = "bfb_copy_finished",
-    metric_name = "carbide_preingestion_bfb_copy_duration_seconds",
-    component = "preingestion-manager",
+    event_name = "artifact_transfer_finished",
+    metric_name = "carbide_artifact_transfer_duration_seconds",
+    component = "artifact-transfer",
     log = info,
     metric = histogram,
-    message = "BFB copy finished",
+    message = "Artifact transfer finished",
+    describe = "Artifact transfer duration",
 )]
-struct BfbCopyFinished {
+struct ArtifactTransferFinished {
     #[label]
     outcome: Outcome,
+    #[context(value)]
+    duration_seconds: f64, // searchable on the log line
     #[observation]
-    took: std::time::Duration, // recorded in seconds -- checked against metric_name
+    duration: std::time::Duration, // metric only; converted to seconds
     #[context]
     host_ip_address: std::net::IpAddr,
 }
+
+impl ArtifactTransferFinished {
+    fn new(
+        outcome: Outcome,
+        duration: std::time::Duration,
+        host_ip_address: std::net::IpAddr,
+    ) -> Self {
+        Self {
+            outcome,
+            duration_seconds: duration.as_secs_f64(),
+            duration,
+            host_ip_address,
+        }
+    }
+}
 ```
 
-A histogram already exports a `_count` series, so it never needs a twin counter.
+`#[observation]` feeds the histogram and is not rendered on the log line. When the measured
+value must also be searchable in logs, record it separately as a native structured
+`#[context(value)]` field, as the example does. A histogram already exports a `_count` series,
+so it never needs a twin counter. Construct the context and observation from the same source
+value when building the Event, so the logged duration cannot drift from the recorded one.
 
 ## Naming conventions
 
@@ -258,8 +298,9 @@ A histogram already exports a `_count` series, so it never needs a twin counter.
   `lower_snake_case` literal, starts with a letter, and has no dot namespace, component
   prefix, severity, or unit. Add a semantic qualifier only when distinct Events would
   otherwise collide. Changing it breaks saved log searches and future schemas.
-- `metric_name` is required exactly when `metric != none`. It is the exposed Prometheus
-  name, verbatim, and keeps the existing metric compatibility contract.
+- `metric_name` is required exactly when `metric != none`. A checked name is the exposed
+  Prometheus name, verbatim; legacy compatibility uses `metric_name_unchecked` as described
+  below.
 
 `cargo xtask check-event-names` verifies that production Event declarations have unique
 static event names. One Event declaration may still be emitted from any number of call
@@ -274,16 +315,23 @@ For `metric_name`, the derive enforces these conventions at compile time:
 - Gauge names (existing pattern, not the framework) are mixed legacy forms; follow established
   neighboring names rather than a single suffix rule.
 
-The `metric_name` in the attribute is the Prometheus metric-family name operators use -- a
-dashboard name greps straight back to the declaring line. The framework accounts for the
-exporter's suffix handling when it registers the instrument: a counter's declared `_total` remains
-the exposed family name, while a histogram additionally exposes the normal `_bucket`, `_sum`, and
-`_count` series derived from its family name.
+In every declaration, `metric_name` states the intended operator-facing family on `/metrics`,
+not the internal OpenTelemetry instrument name. For a checked Event, the derive guarantees
+that family round-trips verbatim. The framework strips one declared counter `_total` at
+registration and the exporter restores it; the derive rejects a missing or doubled `_total`.
+For a checked histogram, the derive infers the unit from its required suffix, then the
+framework strips that suffix at registration before the exporter restores it and adds the
+normal `_bucket`, `_sum`, and `_count` series.
 
-**Existing metric names never change.** Migrating a pre-standard site onto the framework keeps
-its frozen name via `metric_name_unchecked` (plus an explicit `unit = "..."` for histograms);
-there are no such sites today, and a future use stays easy to audit because new metrics cannot use
-the opt-out silently.
+**Existing metric contracts never change.** `metric_name_unchecked` bypasses the new-name
+validation for a frozen declaration, but it does not disable the exporter's suffix handling.
+An unchecked counter that already ends in `_total` round-trips verbatim; one without `_total`
+gains that suffix. An unchecked histogram with a recognized suffix infers its unit and also
+round-trips verbatim; one without a recognized suffix requires an explicit `unit = "..."` and
+can gain the exporter's unit suffix. An explicit histogram `unit` overrides suffix inference,
+so a conflicting unit can append another suffix. Verify the exposed `/metrics` family before
+migrating, and do not accept a renamed family as part of the conversion. Use this escape
+hatch only for a reviewed existing contract; new metrics use the checked form.
 
 An Event that can log keeps a required, stable, human-readable `message`. `event_name` is
 the machine contract while `message` is presentation for people and UIs; occasional wording
@@ -291,16 +339,38 @@ overlap is fine. Metric-only Events require no message because they construct no
 
 A counter documents itself: its `describe = "..."` is required and opens with "Number of ..." (the
 tech-writer house rule, enforced by the derive). The text becomes the Prometheus HELP and the
-Description column of the [core_metrics.md](core_metrics.md) catalogue. A grandfathered describe
-keeps its wording with `describe_unchecked` -- the counterpart to `name_unchecked` -- and a search
-for either finds every opt-out. A histogram takes any `describe` (or none); a log-only event
+Description column of the [Core Metrics](core_metrics.md) catalogue. A grandfathered describe
+keeps its wording with `describe_unchecked` -- the counterpart to `metric_name_unchecked` -- and a
+search for either finds every opt-out. A histogram takes any `describe` (or none); a log-only event
 (`metric = none`) has no metric to document, so it must omit `describe`.
 
-The catalogue is regenerated by `test_integration`, which scrapes `/metrics`, and checked in CI.
-Because a metric no test exercises is never scraped, `cargo xtask check-metric-docs` also reads the
-`#[event(...)]` declarations directly and fails if any framework counter or histogram -- other than a
-`name_unchecked` one, whose exposed name is an OTel-sanitized transform (see #3221) -- is missing a
-catalogue row, so a new metric cannot land undocumented.
+The catalogue is regenerated by `test_integration`, which scrapes the carbide-api integration
+environment's `/metrics`, and checked in CI. Because a metric no test exercises is never
+scraped, `cargo xtask check-metric-docs` also reads the `#[event(...)]` declarations directly
+and fails if any production framework counter or histogram -- other than a
+`metric_name_unchecked` compatibility metric, whose exposed family can be transformed by the
+exporter -- is missing a catalogue row. An unchecked metric can enter through the current
+generator only when it appears in that carbide-api scrape; compatibility metrics owned by
+other binaries remain outside the catalogue. New checked metrics cannot land undocumented.
+Precisely matching unchecked declarations to exported families remains tracked in
+[#3221](https://github.com/NVIDIA/infra-controller/issues/3221).
+
+## Startup zero series
+
+Most Event series appear after their first occurrence. When an existing metric contract
+requires a counter's bounded label set to be exposed at zero during startup, call
+`initialize_counter_series(&event)` after installing the meter provider:
+
+```rust
+let initialized = carbide_instrument::initialize_counter_series(&event);
+debug_assert!(initialized, "zero-series initialization requires a counter Event");
+```
+
+The function selects the series from the Event's labels, ignores its context, and does not
+write the Event's log line. It returns `false` for a non-counter Event. Keep the initialization
+call outside `debug_assert!`, or release builds will skip it. Call it once for each bounded
+label combination the startup contract requires. Do not fake an `emit()` or register a second
+counter for the same metric.
 
 ## Derivation outputs and costs
 
@@ -319,8 +389,15 @@ with the semantics in attributes. The generated code:
 
 ## Testing the coherency
 
-The `test-support` feature provides capture helpers, so "this event logged at WARN *and*
-ticked the counter" is a plain unit test:
+Enable the `test-support` feature in the consuming crate's development dependencies:
+
+```toml
+[dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
+```
+
+The feature provides capture helpers, so "this event logged at WARN *and* ticked the
+counter" is a plain unit test:
 
 ```rust
 use carbide_instrument::testing::{capture_logs, MetricsCapture};
@@ -342,15 +419,28 @@ assert_eq!(
 `capture_logs` is per-thread. `render()` prints the raw exposition text when a test needs
 inspection.
 
+## New metric-serving binaries
+
+A new metric-serving binary wires up the fleet-wide `carbide_log_events_total` baseline in
+two places: add `carbide_instrument::LogEventsMetric::new(component).layer()` to its tracing
+subscriber before logs start, then call `carbide_instrument::log_events::register(&meter)` after
+installing the meter provider. The Event derive does not install this baseline automatically.
+
 ## Potential hazards
 
 - **`LogLimiter`-gated sites**: before migration, the limiter suppresses the log call
   before any event fires, so the true rate is invisible to everything -- including the
   framework. After migration onto an `Event`, the metric ticks on every occurrence and the
   limiter gates only the log line.
-- **The logfmt `component` key** continues to come from the subscriber configuration and
-  span attributes (as everywhere else); the event's `component` names the subsystem for
-  tooling and tests and is not written as a log field.
+- **Test provider replacement**: some integration-test processes replace the global provider.
+  Because Event instruments keep the first binding described above, a later setup's registry
+  scrape can omit that Event. The current catalogue path retains existing rows and checks
+  checked-name declarations from source, so it does not assume one scrape is complete. Use
+  `MetricsCapture` for unit-level Event assertions; when regenerating a row that depends on a
+  scrape, run the provider-owning integration test by itself in a fresh test process. Late
+  provider-setup hardening is tracked in
+  [#4174](https://github.com/NVIDIA/infra-controller/issues/4174); it does not cover test-side
+  provider replacement.
 - **Events are occurrences.** Do not model state with counters; keep gauges on the
   existing observable-gauge pattern.
 - **Reserved Event-log fields**: `message` is always reserved. Events that can log must
@@ -358,13 +448,15 @@ inspection.
   `event_name`, or `metric_name`. Metric-only legacy labels remain allowed because renaming
   a Prometheus label would break its metric contract. When such a metric-only Event gains a
   log, preserve the label key with `#[label(name = "component")]` on a domain-specific Rust
-  field such as `publisher`; only the metric key is aliased.
+  field such as `publisher`; only the metric key is aliased. A reserved context key has no
+  alias, so rename it and update its log consumers, or leave the site on `tracing::`.
 
 ## References
 
 - The initiative: [#3169](https://github.com/NVIDIA/infra-controller/issues/3169)
   (unify logging and metrics behind a single instrumentation standard).
 - The crate: `crates/instrument` (rustdoc on `Event`, `emit`, `LabelValue`, `testing`).
-- The catalogue: [core_metrics.md](core_metrics.md) -- every new metric lands there.
+- The catalogue: [Core Metrics](core_metrics.md) -- the generated and source-checked
+  metric-family reference.
 - Conventions: [Prometheus metric and label naming](https://prometheus.io/docs/practices/naming/).
-- Neighbors: [logging.md](logging.md), [tracing.md](tracing.md).
+- Neighbors: [Logging](logging.md), [Traces](tracing.md).


### PR DESCRIPTION
The `carbide-instrument` crate already has a compile-checked hello world, but the contributor-facing copies around it had drifted: both visible counter examples failed the current `describe = "Number of ..."` contract, the style guidance still named the retired `name_unchecked` attribute, and the full guide was absent from the published navigation.

So, make `AGENTS.md`, `STYLE_GUIDE.md`, and the instrumentation guide agree with the API contributors actually use. The guide now distinguishes the checked `/metrics` family contract from the internal OpenTelemetry instrument name, documents provider and zero-series ordering, fills in testing and new-binary bootstrap details, and is published under Reference → Development.

This remains documentation-only. It does not change Event behavior, existing metric contracts, or the generated Core Metrics catalogue.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4194

Part of #3169.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `cargo test -p carbide-instrument --doc`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- Parsed `docs/index.yml` and verified the instrumentation target exists
- Local CodeRabbit, Claude, and independent repository-aware review

## Additional Notes

`docs/observability/core_metrics.md` is intentionally unchanged; this PR corrects the contributor model and navigation without changing the generated metric catalogue.