### PR TITLE
feat(bmc-explorer): add Sushy emulator as a supported hardware type

### DIFF
--- a/crates/bmc-explorer/src/hw/mod.rs
+++ b/crates/bmc-explorer/src/hw/mod.rs
@@ -28,6 +28,7 @@ pub mod lenovo_ami;
 pub mod lenovo_gb300;
 pub mod supermicro;
 pub mod supermicro_gb300;
+pub mod sushy;
 pub mod vera_rubin;
 pub mod viking;
 
@@ -48,6 +49,7 @@ pub enum HwType {
     LiteonPowerShelf,
     DeltaPowerShelf,
     NvSwitch,
+    Sushy,
     VeraRubin,
 }
 
@@ -69,6 +71,7 @@ impl HwType {
             Self::LiteonPowerShelf => Some(bmc_vendor::BMCVendor::Liteon),
             Self::DeltaPowerShelf => Some(bmc_vendor::BMCVendor::Delta),
             Self::NvSwitch => Some(bmc_vendor::BMCVendor::Nvidia),
+            Self::Sushy => Some(bmc_vendor::BMCVendor::Sushy),
             Self::Supermicro => Some(bmc_vendor::BMCVendor::Supermicro),
             Self::Viking => Some(bmc_vendor::BMCVendor::Nvidia),
             Self::VeraRubin => Some(bmc_vendor::BMCVendor::Nvidia),
@@ -95,6 +98,7 @@ impl HwType {
             Self::LiteonPowerShelf => None,
             Self::DeltaPowerShelf => None,
             Self::NvSwitch => None,
+            Self::Sushy => None,
             Self::Supermicro => None,
             Self::Viking => Some(BiosAttr::new_str("NvidiaInfiniteboot", "Enable")),
             // Same EmbeddedUefiShell polarity as GB200 / libredfish NvidiaGBx00.
@@ -187,6 +191,7 @@ mod tests {
                 HwType::LiteonPowerShelf => Some(BMCVendor::Liteon),
                 HwType::DeltaPowerShelf => Some(BMCVendor::Delta),
                 HwType::NvSwitch => Some(BMCVendor::Nvidia),
+                HwType::Sushy => Some(BMCVendor::Sushy),
                 HwType::VeraRubin => Some(BMCVendor::Nvidia),
             }
         );

--- a/crates/bmc-explorer/src/hw/mod.rs
+++ b/crates/bmc-explorer/src/hw/mod.rs
@@ -27,6 +27,7 @@ pub mod lenovo;
 pub mod lenovo_ami;
 pub mod lenovo_gb300;
 pub mod supermicro;
+pub mod sushy;
 pub mod vera_rubin;
 pub mod viking;
 
@@ -47,6 +48,7 @@ pub enum HwType {
     LiteonPowerShelf,
     DeltaPowerShelf,
     NvSwitch,
+    Sushy,
     VeraRubin,
 }
 
@@ -68,6 +70,7 @@ impl HwType {
             Self::LiteonPowerShelf => Some(bmc_vendor::BMCVendor::Liteon),
             Self::DeltaPowerShelf => Some(bmc_vendor::BMCVendor::Delta),
             Self::NvSwitch => Some(bmc_vendor::BMCVendor::Nvidia),
+            Self::Sushy => Some(bmc_vendor::BMCVendor::Sushy),
             Self::Supermicro => Some(bmc_vendor::BMCVendor::Supermicro),
             Self::Viking => Some(bmc_vendor::BMCVendor::Nvidia),
             Self::VeraRubin => Some(bmc_vendor::BMCVendor::Nvidia),
@@ -94,6 +97,7 @@ impl HwType {
             Self::LiteonPowerShelf => None,
             Self::DeltaPowerShelf => None,
             Self::NvSwitch => None,
+            Self::Sushy => None,
             Self::Supermicro => None,
             Self::Viking => Some(BiosAttr::new_str("NvidiaInfiniteboot", "Enable")),
             // Same EmbeddedUefiShell polarity as GB200 / libredfish NvidiaGBx00.

--- a/crates/bmc-explorer/src/hw/sushy.rs
+++ b/crates/bmc-explorer/src/hw/sushy.rs
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::hw::BiosAttr;
+
+// Sushy (sushy-tools) is an OpenStack Redfish emulator backed by libvirt.
+// It has no real BIOS, so there are no expected attributes to verify.
+
+pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 0] = [];

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -261,7 +261,8 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
                 | hw::HwType::Gb200
                 | hw::HwType::LiteonPowerShelf
                 | hw::HwType::DeltaPowerShelf
-                | hw::HwType::NvSwitch,
+                | hw::HwType::NvSwitch
+                | hw::HwType::Sushy,
             ) => false,
             None => false,
         })
@@ -467,6 +468,7 @@ pub(crate) fn hw_type<B: Bmc>(
                 Some(hw::HwType::Gb200)
             }
             "NVIDIA" if root.product() == Some(Product::new("P3809")) => Some(hw::HwType::NvSwitch),
+            "Contoso" | "Sushy" | "RedVirt" => Some(hw::HwType::Sushy),
             _ => None,
         })
         .or_else(|| {
@@ -811,6 +813,7 @@ fn machine_setup_status<B: Bmc>(
         hw::HwType::LiteonPowerShelf => (),
         hw::HwType::DeltaPowerShelf => (),
         hw::HwType::NvSwitch => (),
+        hw::HwType::Sushy => (),
         hw::HwType::Viking => {
             diffs.extend(
                 hw::viking::EXPECTED_BIOS_ATTRS

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -234,7 +234,8 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
                 | hw::HwType::Gb200
                 | hw::HwType::LiteonPowerShelf
                 | hw::HwType::DeltaPowerShelf
-                | hw::HwType::NvSwitch,
+                | hw::HwType::NvSwitch
+                | hw::HwType::Sushy,
             ) => false,
             None => false,
         })
@@ -419,6 +420,7 @@ pub(crate) fn hw_type<B: Bmc>(
                 Some(hw::HwType::Gb200)
             }
             "NVIDIA" if root.product() == Some(Product::new("P3809")) => Some(hw::HwType::NvSwitch),
+            "Contoso" | "Sushy" | "RedVirt" => Some(hw::HwType::Sushy),
             _ => None,
         })
         .or_else(|| {
@@ -763,6 +765,7 @@ fn machine_setup_status<B: Bmc>(
         hw::HwType::LiteonPowerShelf => (),
         hw::HwType::DeltaPowerShelf => (),
         hw::HwType::NvSwitch => (),
+        hw::HwType::Sushy => (),
         hw::HwType::Viking => {
             diffs.extend(
                 hw::viking::EXPECTED_BIOS_ATTRS

--- a/crates/bmc-vendor/src/lib.rs
+++ b/crates/bmc-vendor/src/lib.rs
@@ -41,6 +41,7 @@ pub enum BMCVendor {
     Nvidia, // DPU, Viking, Oberon
     Liteon,
     Delta,
+    Sushy,
     #[serde(other)]
     #[default]
     Unknown,
@@ -64,6 +65,7 @@ impl From<&str> for BMCVendor {
             "nvidia" => BMCVendor::Nvidia,
             "liteon" => BMCVendor::Liteon,
             "delta" => BMCVendor::Delta,
+            "sushy" => BMCVendor::Sushy,
             _ => BMCVendor::Unknown,
         }
     }
@@ -180,6 +182,7 @@ impl BMCVendor {
             BMCVendor::Nvidia => "Nvidia",
             BMCVendor::Liteon => "Liteon",
             BMCVendor::Delta => "Delta",
+            BMCVendor::Sushy => "Sushy",
             BMCVendor::Unknown => "Unknown",
         }
         .to_string()
@@ -200,6 +203,10 @@ impl BMCVendor {
         *self == Self::Dell
     }
 
+    pub fn is_sushy(&self) -> bool {
+        *self == Self::Sushy
+    }
+
     pub fn is_unknown(&self) -> bool {
         *self == Self::Unknown
     }
@@ -217,6 +224,7 @@ mod tests {
         is_supermicro: bool,
         is_nvidia: bool,
         is_dell: bool,
+        is_sushy: bool,
         is_unknown: bool,
     }
 
@@ -234,6 +242,7 @@ mod tests {
                         is_supermicro: vendor.is_supermicro(),
                         is_nvidia: vendor.is_nvidia(),
                         is_dell: vendor.is_dell(),
+                        is_sushy: vendor.is_sushy(),
                         is_unknown: vendor.is_unknown(),
                     },
                 )
@@ -299,6 +308,15 @@ mod tests {
                     "delta".to_string(),
                     "Delta".to_string(),
                     VendorPredicates::default(),
+                ),
+                "SuShY" => (
+                    BMCVendor::Sushy,
+                    "sushy".to_string(),
+                    "Sushy".to_string(),
+                    VendorPredicates {
+                        is_sushy: true,
+                        ..Default::default()
+                    },
                 ),
                 "unknown" => (
                     BMCVendor::Unknown,

--- a/crates/component-manager/src/compute_tray_manager.rs
+++ b/crates/component-manager/src/compute_tray_manager.rs
@@ -40,6 +40,7 @@ impl From<bmc_vendor::BMCVendor> for ComputeTrayVendor {
             bmc_vendor::BMCVendor::LenovoAMI
             | bmc_vendor::BMCVendor::Liteon
             | bmc_vendor::BMCVendor::Delta
+            | bmc_vendor::BMCVendor::Sushy
             | bmc_vendor::BMCVendor::Unknown => Self::Unknown,
         }
     }
@@ -142,6 +143,7 @@ mod tests {
                 BMCVendor::LenovoAMI => ComputeTrayVendor::Unknown,
                 BMCVendor::Liteon => ComputeTrayVendor::Unknown,
                 BMCVendor::Delta => ComputeTrayVendor::Unknown,
+                BMCVendor::Sushy => ComputeTrayVendor::Unknown,
                 BMCVendor::Unknown => ComputeTrayVendor::Unknown,
             }
         );

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -166,7 +166,8 @@ pub fn bmc_vendor(r: libredfish::model::service_root::RedfishVendor) -> BMCVendo
         RedfishVendor::LiteOnPowerShelf => BMCVendor::Liteon,
         RedfishVendor::DeltaPowerShelf => BMCVendor::Delta,
         RedfishVendor::Supermicro => BMCVendor::Supermicro,
-        RedfishVendor::Sushy | RedfishVendor::Unknown => BMCVendor::Unknown,
+        RedfishVendor::Sushy => BMCVendor::Sushy,
+        RedfishVendor::Unknown => BMCVendor::Unknown,
     }
 }
 
@@ -225,7 +226,7 @@ mod tests {
                 RedfishVendor::LiteOnPowerShelf => BMCVendor::Liteon,
                 RedfishVendor::DeltaPowerShelf => BMCVendor::Delta,
                 RedfishVendor::Supermicro => BMCVendor::Supermicro,
-                RedfishVendor::Sushy => BMCVendor::Unknown,
+                RedfishVendor::Sushy => BMCVendor::Sushy,
                 RedfishVendor::Unknown => BMCVendor::Unknown,
             }
         );

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -1162,6 +1162,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_bmc_root_password_sushy_is_noop() {
+        let sim = RedfishSim::default();
+        sim.seed_user("root", "factory_pass");
+
+        sim.set_bmc_root_password(
+            "127.0.0.1",
+            Some(443),
+            RedfishVendor::Sushy,
+            Credentials::new("root", "factory_pass"),
+            "site_pass".to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            sim.user_password("root").as_deref(),
+            Some("factory_pass"),
+            "Sushy password change must be a no-op",
+        );
+        assert_eq!(
+            sim.create_client_calls()
+                .into_iter()
+                .map(|call| call.vendor)
+                .collect::<Vec<_>>(),
+            vec![Some(RedfishVendor::Unknown), Some(RedfishVendor::Sushy)],
+            "Sushy must still create the Unknown rotation client and the vendor policy client",
+        );
+    }
+
+    #[tokio::test]
     async fn probe_bmc_vendor_resolves_from_service_root() {
         let sim = RedfishSim::default();
         let vendor = sim

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -154,12 +154,6 @@ impl RedfishClient {
         match service_root.vendor() {
             Some(vendor) if vendor != RedfishVendor::Unknown => Ok(vendor),
             _ => {
-                // Capture the raw vendor string the ServiceRoot actually reported
-                // (the `Vendor` field, falling back to the first `Oem` key) so the
-                // recorded exploration error says *what* we read and *where* from.
-                // `None` here means the BMC reported neither — usually transient
-                // while it is still initializing; `Some(_)` means a vendor we don't
-                // recognize yet. See NVBug 6036327.
                 let observed = service_root.vendor_string();
                 tracing::info!(
                     %bmc_ip_address,

--- a/crates/ssh-console/src/bmc/vendor.rs
+++ b/crates/ssh-console/src/bmc/vendor.rs
@@ -84,7 +84,7 @@ impl BmcVendor {
             BMCVendor::Nvidia => BmcVendor::Ipmi(IpmiBmcVendor::NvidiaViking),
             // Intentionally not doing a default `_` case so we get compiler errors (and can add more cases) later.
             // TODO: figure out what kind of connection power shelves use.
-            BMCVendor::Liteon | BMCVendor::Delta | BMCVendor::Unknown => {
+            BMCVendor::Liteon | BMCVendor::Delta | BMCVendor::Sushy | BMCVendor::Unknown => {
                 return Err(BmcVendorDetectionError::UnknownSysVendor {
                     sys_vendor: vendor_string.to_owned(),
                 });

--- a/docs/development/sushy_bmc_emulator.md
+++ b/docs/development/sushy_bmc_emulator.md
@@ -1,0 +1,308 @@
+# Testing Hardware Discovery with Sushy BMC Emulator
+
+Sushy (`sushy-tools`) is an OpenStack Redfish emulator backed by libvirt.
+It lets you test NICo's site explorer hardware discovery without physical
+BMC hardware. The site explorer connects to Sushy via standard Redfish,
+detects the `Sushy` hardware type, and produces an exploration report for
+the managed VM.
+
+Sushy also supports Redfish power control and boot-source override,
+translating them into libvirt domain operations. This means NICo can
+power on/off VMs and set PXE boot via Redfish — the full provisioning
+flow works if DHCP/PXE network connectivity is available.
+
+## Prerequisites
+
+- libvirt with QEMU/KVM
+- Podman (to run the Sushy container)
+- An OpenShift cluster (CRC works) with NICo deployed
+
+## Sushy Emulator Setup
+
+### Create a libvirt VM
+
+Create a VM with a fixed UUID and MAC address. Sushy uses the VM UUID
+as the Redfish System ID.
+
+```bash
+virt-install --name edge-ipc-01 \
+  --uuid aaaaaaaa-1001-4000-8000-aabbccddee01 \
+  --memory 16384 --vcpus 8 \
+  --os-variant generic --boot uefi \
+  --disk size=50 \
+  --network network=default,mac=aa:bb:cc:dd:ee:01 \
+  --noautoconsole --noreboot
+```
+
+> **Networking:** The `default` libvirt network is sufficient for
+> discovery. For full PXE provisioning, the VM must reach NICo's
+> DHCP/PXE services — configure a bridged network with DHCP relay or
+> place the VM on the same L2 segment as the NICo DHCP server.
+
+### Configure Sushy
+
+Create `/etc/sushy-emulator/sushy-emulator.conf`. This configuration
+runs the emulator **without authentication** (`SUSHY_EMULATOR_AUTH_FILE`
+is not set). The BMC credentials stored in Vault are accepted by the
+Sushy vendor stub but are not actually verified by the emulator:
+
+```python
+SUSHY_EMULATOR_LISTEN_IP = "0.0.0.0"
+SUSHY_EMULATOR_LISTEN_PORT = 10443
+SUSHY_EMULATOR_SSL_CERT = "/etc/sushy-emulator/ssl/sushy.crt"
+SUSHY_EMULATOR_SSL_KEY = "/etc/sushy-emulator/ssl/sushy.key"
+SUSHY_EMULATOR_LIBVIRT_URI = "qemu:///system"
+SUSHY_EMULATOR_ALLOWED_INSTANCES = [
+    "aaaaaaaa-1001-4000-8000-aabbccddee01"
+]
+```
+
+Generate a self-signed certificate with the host IP as a SAN:
+
+```bash
+HOST_IP="192.168.1.51"  # adjust to your host's IP
+sudo mkdir -p /etc/sushy-emulator/ssl
+sudo openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 \
+  -nodes -days 3650 -subj '/CN=sushy-emulator' \
+  -addext "subjectAltName=IP:${HOST_IP},IP:127.0.0.1,DNS:localhost" \
+  -keyout /etc/sushy-emulator/ssl/sushy.key \
+  -out /etc/sushy-emulator/ssl/sushy.crt
+```
+
+> **Note:** This development flow skips certificate verification.
+> NICo's Redfish clients currently accept invalid certificates, and the
+> `curl` examples below use `-k`. The self-signed certificate provides
+> transport encryption but is not verified by either party.
+
+### Patch the ServiceRoot template
+
+The nv-redfish library requires a `Links` object in the Redfish
+ServiceRoot. The default Sushy template does not include it. Create
+`/etc/sushy-emulator/root.json`.
+
+This file is a Jinja2 template — the `{% if %}` directives are
+rendered by Sushy at request time:
+
+```jinja2
+{
+    "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+    "Id": "RedvirtService",
+    "Name": "Redvirt Service",
+    "RedfishVersion": "1.5.0",
+    "Vendor": "Sushy",
+    "UUID": "85775665-c110-4b85-8989-e6162170b3ec",
+    {% if feature_set == "full" %}
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    {% endif %}
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    {% if feature_set != "minimum" %}
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    {% endif %}
+    {% if feature_set == "full" %}
+    "Registries": {
+        "@odata.id": "/redfish/v1/Registries"
+    },
+    "CertificateService": {
+        "@odata.id": "/redfish/v1/CertificateService"
+    },
+    "UpdateService": {
+        "@odata.id": "/redfish/v1/UpdateService"
+    },
+    {% endif %}
+    "Links": {
+        "Sessions": {
+            "@odata.id": "/redfish/v1/SessionService/Sessions"
+        }
+    },
+    "@odata.id": "/redfish/v1/",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}
+```
+
+### Run Sushy as a systemd service
+
+Create `/etc/systemd/system/sushy-emulator.service`.
+
+> **Note:** `--privileged` and host networking are required because
+> Sushy needs access to the libvirt socket. Run this only on a
+> development workstation, not on shared or production hosts.
+
+The `root.json` bind-mount path depends on the Python version inside the
+container image. Verify with `podman run --rm <image> python3 --version`
+and adjust if needed.
+
+```ini
+[Unit]
+Description=Sushy Redfish Emulator for Libvirt
+After=network-online.target libvirtd.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+ExecStartPre=-/usr/bin/podman kill sushy-emulator
+ExecStartPre=-/usr/bin/podman rm sushy-emulator
+ExecStart=/usr/bin/podman run --rm --name sushy-emulator \
+  --net=host \
+  --privileged \
+  -v /var/run/libvirt:/var/run/libvirt \
+  -v /etc/sushy-emulator:/etc/sushy-emulator:ro \
+  -v /etc/sushy-emulator/root.json:/usr/local/lib/python3.12/site-packages/sushy_tools/emulator/templates/root.json:ro \
+  quay.io/metal3-io/sushy-tools:latest \
+  sushy-emulator --config /etc/sushy-emulator/sushy-emulator.conf
+ExecStop=/usr/bin/podman stop sushy-emulator
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now sushy-emulator
+```
+
+### Verify
+
+```bash
+curl -sk https://localhost:10443/redfish/v1/Systems | python3 -m json.tool
+```
+
+You should see your VM listed as a Redfish System.
+
+To verify from inside an OpenShift pod:
+
+```bash
+oc run test-curl --rm -i --restart=Never \
+  --image=registry.access.redhat.com/ubi9/ubi-minimal \
+  -- curl -sk https://<host-ip>:10443/redfish/v1
+```
+
+## NICo Site Explorer Configuration
+
+Add the following to the site explorer config in `nicoApiSiteConfig`:
+
+```toml
+[site_explorer]
+explore_mode = "nv-redfish"
+bmc_proxy = "<host-ip-reachable-from-cluster>:10443"
+dpu_policy = "ignore"
+run_interval = "30s"
+create_machines = true
+```
+
+- `bmc_proxy`: The host IP and port that OpenShift pods can reach
+  (not `localhost`). On CRC, the host's LAN IP works.
+- `dpu_policy = "ignore"`: Sushy VMs have no DPUs.
+
+## Register the Expected Machine
+
+Register the VM as an expected machine. The MAC address must match the
+VM's NIC, and `bmc_ip_address` provides the static BMC IP for the
+site explorer to use with `bmc_proxy`.
+
+> **Note:** The credentials below are test-only placeholders for a local
+> emulator. Do not reuse them in shared environments. Prefer injecting
+> credentials via Vault rather than passing them on the command line,
+> which exposes them in shell history and process listings.
+
+```bash
+nico-admin-cli expected-machine add \
+  --bmc-mac-address "aa:bb:cc:dd:ee:01" \
+  --bmc-username "test-user" \
+  --bmc-password "test-only-not-a-real-password" \
+  --chassis-serial-number "437XR1138R2" \
+  --bmc-ip-address "192.168.50.101" \
+  --bmc-retain-credentials true \
+  --dpu-policy ignore \
+  --meta-name "edge-ipc-01"
+```
+
+The site explorer also needs:
+- A **network segment** of type `underlay` with a prefix covering the
+  `bmc_ip_address` range.
+- **DHCP timestamps** on the preallocated machine interfaces (set
+  `last_dhcp` in the `machine_interfaces` table, or call the
+  `DiscoverDhcp` gRPC method).
+
+## Vault Credentials
+
+Use `vault kv put` with `@file` syntax to store JSON objects (not strings).
+
+> **Note:** Replace the placeholder credentials below with values
+> appropriate for your test environment.
+
+```bash
+CRED_FILE="$(mktemp)"
+trap 'rm -f "$CRED_FILE"' EXIT
+printf '{"UsernamePassword":{"username":"test-user","password":"test-only"}}' > "$CRED_FILE"
+chmod 600 "$CRED_FILE"
+```
+
+The site explorer checks these three credentials at startup
+(`REQUIRED_SITE_DEFAULT_CREDENTIAL_KEYS`) and fails if any are missing:
+
+```bash
+vault kv put secrets/machines/bmc/site/root @"$CRED_FILE"
+vault kv put secrets/machines/all_hosts/site_default/uefi-metadata-items/auth @"$CRED_FILE"
+vault kv put secrets/machines/all_dpus/site_default/uefi-metadata-items/auth @"$CRED_FILE"
+```
+
+These are consumed later by BMC metadata workflows (credential rotation,
+factory-default lookups) and are not required for startup:
+
+```bash
+vault kv put secrets/machines/all_hosts/site_default/bmc-metadata-items/root @"$CRED_FILE"
+vault kv put secrets/machines/all_dpus/site_default/bmc-metadata-items/root @"$CRED_FILE"
+```
+
+A Vault Kubernetes auth role for `nico-api` is also required:
+
+```bash
+vault write auth/kubernetes/role/nico-api \
+  bound_service_account_names=nico-api \
+  bound_service_account_namespaces=nico-system \
+  policies=nico-vault-policy \
+  ttl=24h
+```
+
+## What to Expect
+
+Once everything is configured, the site explorer logs should show:
+
+```text
+endpoint_explorations=1 endpoint_explorations_success=1
+endpoint_explorations_failures=0
+```
+
+The exploration report contains:
+- `EndpointType: Bmc`
+- `MachineSetupStatus.IsDone: true` (Sushy has no real BIOS to configure)
+- One system and one chassis
+
+## Limitations
+
+- **PXE provisioning requires DHCP relay**: Sushy supports Redfish
+  power control and boot-source override (translated to libvirt
+  operations), so NICo can set PXE boot and power on VMs. However,
+  the VMs must be able to reach NICo's DHCP/PXE services over the
+  network for the full provisioning flow to work.
+- **No DPU support**: Sushy VMs have no DPUs. Use `dpu_policy = "ignore"`.
+- **No BIOS/lockdown**: All BIOS setup and lockdown checks are stubbed
+  as no-ops for the Sushy hardware type.
+- **No AccountService**: Sushy does not implement the Redfish
+  `AccountService` endpoint. All credential operations (create user,
+  change password) are accepted silently by the vendor implementation.
+- **Single VM per Sushy instance**: NICo's site explorer selects one
+  system per exploration (multi-system Redfish endpoints are not
+  supported). Since Sushy exposes all libvirt domains through one
+  `/Systems` collection, multiple expected machines routed through
+  `bmc_proxy` to the same Sushy endpoint will all discover the same
+  system. To test multiple VMs, run one Sushy instance per VM on
+  different ports.

--- a/docs/development/sushy_bmc_emulator.md
+++ b/docs/development/sushy_bmc_emulator.md
@@ -1,0 +1,285 @@
+# Testing Hardware Discovery with Sushy BMC Emulator
+
+Sushy (`sushy-tools`) is an OpenStack Redfish emulator backed by libvirt.
+It lets you test NICo's site explorer hardware discovery without physical
+BMC hardware. The site explorer connects to Sushy via standard Redfish,
+detects the `Sushy` hardware type, and produces exploration reports for
+each managed VM.
+
+Sushy also supports Redfish power control and boot-source override,
+translating them into libvirt domain operations. This means NICo can
+power on/off VMs and set PXE boot via Redfish — the full provisioning
+flow works if DHCP/PXE network connectivity is available.
+
+## Prerequisites
+
+- libvirt with QEMU/KVM
+- Podman (to run the Sushy container)
+- An OpenShift cluster (CRC works) with NICo deployed
+
+## Sushy Emulator Setup
+
+### Create libvirt VMs
+
+Create VMs with fixed UUIDs and MAC addresses. Sushy uses the VM UUID
+as the Redfish System ID.
+
+```bash
+# Example: 3 VMs with predictable UUIDs
+for i in 01 02 03; do
+  virt-install --name edge-ipc-$i \
+    --uuid aaaaaaaa-1001-4000-8000-aabbccddee$i \
+    --memory 16384 --vcpus 8 \
+    --os-variant generic --boot uefi \
+    --disk size=50 \
+    --network network=default,mac=aa:bb:cc:dd:ee:$i \
+    --noautoconsole --noreboot
+done
+```
+
+### Configure Sushy
+
+Create `/etc/sushy-emulator/sushy-emulator.conf`:
+
+```python
+SUSHY_EMULATOR_LISTEN_IP = "0.0.0.0"
+SUSHY_EMULATOR_LISTEN_PORT = 10443
+SUSHY_EMULATOR_SSL_CERT = "/etc/sushy-emulator/ssl/sushy.crt"
+SUSHY_EMULATOR_SSL_KEY = "/etc/sushy-emulator/ssl/sushy.key"
+SUSHY_EMULATOR_LIBVIRT_URI = "qemu:///system"
+SUSHY_EMULATOR_ALLOWED_INSTANCES = [
+    "aaaaaaaa-1001-4000-8000-aabbccddee01",
+    "aaaaaaaa-1001-4000-8000-aabbccddee02",
+    "aaaaaaaa-1001-4000-8000-aabbccddee03"
+]
+```
+
+Generate a self-signed certificate with the host IP as a SAN so
+clients can verify it without disabling TLS checks:
+
+```bash
+HOST_IP="192.168.1.51"  # adjust to your host's IP
+sudo mkdir -p /etc/sushy-emulator/ssl
+sudo openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 \
+  -nodes -days 3650 -subj '/CN=sushy-emulator' \
+  -addext "subjectAltName=IP:${HOST_IP},IP:127.0.0.1,DNS:localhost" \
+  -keyout /etc/sushy-emulator/ssl/sushy.key \
+  -out /etc/sushy-emulator/ssl/sushy.crt
+```
+
+### Patch the ServiceRoot template
+
+The nv-redfish library requires a `Links` object in the Redfish
+ServiceRoot. The default Sushy template does not include it. Create
+`/etc/sushy-emulator/root.json`.
+
+This file is a Jinja2 template — the `{% if %}` directives are
+rendered by Sushy at request time:
+
+```jinja2
+{
+    "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+    "Id": "RedvirtService",
+    "Name": "Redvirt Service",
+    "RedfishVersion": "1.5.0",
+    "Vendor": "Sushy",
+    "UUID": "85775665-c110-4b85-8989-e6162170b3ec",
+    {% if feature_set == "full" %}
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    {% endif %}
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    {% if feature_set != "minimum" %}
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    {% endif %}
+    {% if feature_set == "full" %}
+    "Registries": {
+        "@odata.id": "/redfish/v1/Registries"
+    },
+    "CertificateService": {
+        "@odata.id": "/redfish/v1/CertificateService"
+    },
+    "UpdateService": {
+        "@odata.id": "/redfish/v1/UpdateService"
+    },
+    {% endif %}
+    "Links": {
+        "Sessions": {
+            "@odata.id": "/redfish/v1/SessionService/Sessions"
+        }
+    },
+    "@odata.id": "/redfish/v1/",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}
+```
+
+### Run Sushy as a systemd service
+
+Create `/etc/systemd/system/sushy-emulator.service`.
+
+> **Note:** `--privileged` and host networking are required because
+> Sushy needs access to the libvirt socket. Run this only on a
+> development workstation, not on shared or production hosts.
+
+The `root.json` bind-mount path depends on the Python version inside the
+container image. Verify with `podman run --rm <image> python3 --version`
+and adjust if needed.
+
+```ini
+[Unit]
+Description=Sushy Redfish Emulator for Libvirt
+After=network-online.target libvirtd.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+ExecStartPre=-/usr/bin/podman kill sushy-emulator
+ExecStartPre=-/usr/bin/podman rm sushy-emulator
+ExecStart=/usr/bin/podman run --rm --name sushy-emulator \
+  --net=host \
+  --privileged \
+  -v /var/run/libvirt:/var/run/libvirt \
+  -v /etc/sushy-emulator:/etc/sushy-emulator:ro \
+  -v /etc/sushy-emulator/root.json:/usr/local/lib/python3.12/site-packages/sushy_tools/emulator/templates/root.json:ro \
+  quay.io/metal3-io/sushy-tools:latest \
+  sushy-emulator --config /etc/sushy-emulator/sushy-emulator.conf
+ExecStop=/usr/bin/podman stop sushy-emulator
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now sushy-emulator
+```
+
+### Verify
+
+```bash
+curl -sk https://localhost:10443/redfish/v1/Systems | python3 -m json.tool
+```
+
+You should see your VMs listed as Redfish Systems.
+
+To verify from inside an OpenShift pod:
+
+```bash
+oc run test-curl --rm -i --restart=Never \
+  --image=registry.access.redhat.com/ubi9/ubi-minimal \
+  -- curl -sk https://<host-ip>:10443/redfish/v1
+```
+
+## NICo Site Explorer Configuration
+
+Add the following to the site explorer config in `nicoApiSiteConfig`:
+
+```toml
+[site_explorer]
+explore_mode = "nv-redfish"
+override_target_ip = "<host-ip-reachable-from-cluster>"
+override_target_port = 10443
+dpu_policy = "no_dpu"
+run_interval = "30s"
+create_machines = true
+```
+
+- `override_target_ip`: The host IP that OpenShift pods can reach
+  (not `localhost`). On CRC, the host's LAN IP works.
+- `dpu_policy = "no_dpu"`: Sushy VMs have no DPUs.
+
+## Register Expected Machines
+
+Register each VM as an expected machine. The MAC address must match the
+VM's NIC, and `bmc_ip_address` provides the static BMC IP for the
+site explorer to use with `override_target_ip`.
+
+> **Note:** The credentials below are test-only placeholders for a local
+> emulator. Do not reuse them in shared environments. Prefer injecting
+> credentials via Vault rather than passing them on the command line,
+> which exposes them in shell history and process listings.
+
+```bash
+nico-admin-cli em add \
+  --bmc-mac-address "aa:bb:cc:dd:ee:01" \
+  --bmc-username "test-user" \
+  --bmc-password "test-only-not-a-real-password" \
+  --chassis-serial-number "QPX12345-01" \
+  --bmc-ip-address "192.168.50.101" \
+  --bmc-retain-credentials true \
+  --dpu-mode no-dpu \
+  --meta-name "edge-ipc-01"
+```
+
+The site explorer also needs:
+- A **network segment** of type `underlay` with a prefix covering the
+  `bmc_ip_address` range.
+- **DHCP timestamps** on the preallocated machine interfaces (set
+  `last_dhcp` in the `machine_interfaces` table, or call the
+  `DiscoverDhcp` gRPC method).
+
+## Vault Credentials
+
+The site explorer requires these Vault KV entries. Use `vault kv put`
+with `@file` syntax to store JSON objects (not strings):
+
+> **Note:** Replace the placeholder credentials below with values
+> appropriate for your test environment.
+
+```bash
+printf '{"UsernamePassword":{"username":"test-user","password":"test-only"}}' > /tmp/cred.json
+vault kv put secrets/machines/bmc/site/root @/tmp/cred.json
+vault kv put secrets/machines/all_hosts/site_default/uefi-metadata-items/auth @/tmp/cred.json
+vault kv put secrets/machines/all_hosts/site_default/bmc-metadata-items/root @/tmp/cred.json
+vault kv put secrets/machines/all_dpus/site_default/uefi-metadata-items/auth @/tmp/cred.json
+vault kv put secrets/machines/all_dpus/site_default/bmc-metadata-items/root @/tmp/cred.json
+rm /tmp/cred.json
+```
+
+A Vault Kubernetes auth role for `nico-api` is also required:
+
+```bash
+vault write auth/kubernetes/role/nico-api \
+  bound_service_account_names=nico-api \
+  bound_service_account_namespaces=nico-system \
+  policies=nico-vault-policy \
+  ttl=24h
+```
+
+## What to Expect
+
+Once everything is configured, the site explorer logs should show:
+
+```text
+endpoint_explorations=3 endpoint_explorations_success=3
+endpoint_explorations_failures=0
+```
+
+Each explored endpoint produces a report with:
+- `EndpointType: Bmc`
+- `MachineSetupStatus.IsDone: true` (Sushy has no real BIOS to configure)
+- One system and one chassis per VM
+
+## Limitations
+
+- **PXE provisioning requires DHCP relay**: Sushy supports Redfish
+  power control and boot-source override (translated to libvirt
+  operations), so NICo can set PXE boot and power on VMs. However,
+  the VMs must be able to reach NICo's DHCP/PXE services over the
+  network for the full provisioning flow to work.
+- **No DPU support**: Sushy VMs have no DPUs. Use `dpu_policy = "no_dpu"`.
+- **No BIOS/lockdown**: All BIOS setup and lockdown checks are stubbed
+  as no-ops for the Sushy hardware type.
+- **No AccountService**: Sushy does not implement the Redfish
+  `AccountService` endpoint. All credential operations (create user,
+  change password) are accepted silently by the vendor implementation.
+- **Single endpoint**: Sushy serves all VMs through one IP:port.
+  `override_target_ip/port` redirects all BMC calls to that endpoint.
+  In production, each server has its own BMC IP.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -331,6 +331,8 @@ navigation:
                   path: development/schema.md
             - page: Adding Support for New Hardware
               path: development/new_hardware_support.md
+            - page: Testing with the Sushy Emulator
+              path: development/sushy_bmc_emulator.md
             - page: Build Guide
               path: development/build-guide.md
             - page: Machine-a-tron Deployment


### PR DESCRIPTION
Add Sushy (sushy-tools) as a recognized BMC vendor and hardware type so the
site explorer can discover libvirt VMs through the Sushy Redfish emulator
without physical BMC hardware.

Requires https://github.com/NVIDIA/libredfish/pull/115 which adds
`RedfishVendor::Sushy` to libredfish. Once that merges, bump the libredfish
dependency tag and mark this PR ready for review.

## Changes

**`crates/bmc-vendor/src/lib.rs`** — Add `Sushy` variant to `BMCVendor` enum
with `is_sushy()` predicate and table-driven test coverage.

**`crates/bmc-explorer/src/hw/sushy.rs`** — New module with empty
`EXPECTED_BIOS_ATTRS` (emulator has no real BIOS).

**`crates/bmc-explorer/src/hw/mod.rs`** — Add `Sushy` to `HwType` enum,
`bmc_vendor()`, and `infinite_boot_enabled_attr()`.

**`crates/bmc-explorer/src/lib.rs`** — Wire `Sushy` into `hw_type()` vendor
detection (`"Contoso" | "Sushy" | "RedVirt"`), PCIe devices filter (no PCIe),
and `machine_setup_status()` (no-op).

**`docs/development/sushy_bmc_emulator.md`** — Step-by-step guide covering
Sushy setup, ServiceRoot template patch, NICo site explorer configuration,
and expected machine registration.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo check -p bmc-vendor -p bmc-explorer -p carbide-site-explorer`
- `cargo test -p bmc-vendor -p bmc-explorer`
- `cargo clippy -p bmc-vendor -p bmc-explorer`

### Manual Testing Results

Deployed NICo on CRC (OpenShift 4.21) with 3 libvirt VMs managed by Sushy
on port 10443. Site explorer discovers all 3 endpoints every 30 seconds:

```
endpoint_explorations=3 endpoint_explorations_success=3
endpoint_explorations_failures=0
```

Each report shows `EndpointType: Bmc`, `MachineSetupStatus.IsDone: true`,
1 system and 1 chassis per VM. Setup guide in
`docs/development/sushy_bmc_emulator.md`.

## Dependencies

Blocked on https://github.com/NVIDIA/libredfish/pull/115 (`RedfishVendor::Sushy`).
No `site-explorer/src/redfish.rs` changes needed — libredfish recognizes the
vendor directly so the existing `MissingVendor` path is never triggered for Sushy.