### PR TITLE
docs(admin-cli): document selected boot interface commands

### DIFF
--- a/crates/admin-cli/src/boot_interface/candidates/args.rs
+++ b/crates/admin-cli/src/boot_interface/candidates/args.rs
@@ -31,6 +31,6 @@ As JSON (the global --format flag):
 Tip: hand a candidate to 'boot-interface set' by its MAC or Interface UUID column.
 ")]
 pub(crate) struct Args {
-    #[clap(help = "The machine ID whose boot-interface candidates to list")]
+    #[clap(help = "The machine ID for which to list boot-interface candidates")]
     pub(super) machine: MachineId,
 }

--- a/crates/admin-cli/src/boot_interface/candidates/cmd.rs
+++ b/crates/admin-cli/src/boot_interface/candidates/cmd.rs
@@ -17,11 +17,12 @@
 
 //! Render one machine's boot-interface candidates: every NIC the machine
 //! offers (managed `machine_interfaces` rows and pre-first-lease predictions),
-//! annotated with the picks the system computes among them. The picks --
-//! current, default (primary flag masked), predicted, and the explored
-//! endpoint default -- all arrive server-computed on the
-//! `GetMachineBootInterfaces` response; this module only matches rows against
-//! them, it never re-derives selection logic.
+//! annotated with the selection/default picks the system computes among them.
+//! Current, default (primary flag masked), predicted, and explored-endpoint
+//! picks all arrive server-computed on `GetMachineBootInterfaces`; this module
+//! only matches rows against them, it never re-derives selection logic. The
+//! persisted desired target and controller progress live in `boot-interface
+//! show`, not in this narrower candidate view.
 
 use std::fmt::Write as _;
 
@@ -45,11 +46,9 @@ enum CandidateSource {
     Predicted,
 }
 
-/// One candidate NIC with the marks the picks put on it. Markers are matched
-/// by MAC: the boot target the BMC ultimately receives is a MAC (plus its
-/// Redfish id), so a MAC-level mark is the semantically honest granularity --
-/// duplicate MACs across segments both light up, mirroring what the BMC
-/// operation would actually aim at.
+/// One candidate NIC with the marks the picks put on it. The pick messages
+/// identify targets by MAC (plus a Redfish id), not by managed row id, so
+/// duplicate MACs across segments both receive the same MAC-level mark.
 #[derive(Debug, Serialize)]
 struct CandidateRow {
     mac_address: String,
@@ -62,12 +61,13 @@ struct CandidateRow {
     network_segment_type: Option<String>,
     source: CandidateSource,
     primary_interface: bool,
-    /// Whether the selection considers this row at all. Mirrors the pick
-    /// functions' one exclusion -- underlay rows are never boot candidates --
-    /// for display only; the actual picks are server-computed.
+    /// Whether selection considers this row: a declared primary is eligible
+    /// regardless of segment, while non-primary underlay rows are excluded
+    /// from the automatic fallback. Display only; the actual picks are
+    /// server-computed.
     eligible: bool,
-    /// This NIC is what resolution targets right now: the effective managed
-    /// pick, or the predicted pick while no managed row offers a candidate.
+    /// This NIC is the effective managed/predicted selection. Persisted
+    /// desired state may differ and is intentionally outside this view.
     current: bool,
     /// This NIC is the automatic pick with the primary flag masked -- what
     /// the system would choose if nothing were declared.
@@ -82,8 +82,8 @@ struct CandidateRow {
 struct CandidatesReport {
     machine_id: Option<MachineId>,
     candidates: Vec<CandidateRow>,
-    /// What resolution targets right now -- the effective managed pick, else
-    /// the predicted pick for a machine with no managed candidate yet.
+    /// The effective managed pick, else the predicted pick when managed rows
+    /// offer no candidate. Persisted desired state may differ.
     current_boot_interface_mac: Option<String>,
     current_boot_interface_id: Option<String>,
     current_source: Option<CandidateSource>,
@@ -178,12 +178,12 @@ impl From<forgerpc::GetMachineBootInterfacesResponse> for CandidatesReport {
             .collect();
 
         let mark = |mac: &str, pick: &Option<String>| pick.as_deref() == Some(mac);
-        // The one exclusion the pick functions apply, matched against the
-        // segment type's wire form (`NetworkSegmentType` serializes `Underlay`
-        // as "tor"). Display only -- the picks themselves arrive
-        // server-computed.
+        // Primary wins regardless of segment; non-primary underlay rows are
+        // excluded from the automatic fallback. Match against the segment
+        // type's display form (`NetworkSegmentType::Underlay` renders as
+        // "tor"). Display only -- the picks themselves arrive server-computed.
         let underlay = model::network_segment::NetworkSegmentType::Underlay.to_string();
-        let eligible = |segment: Option<&str>| segment != Some(underlay.as_str());
+        let is_eligible = |primary, segment| primary || segment != Some(underlay.as_str());
 
         let mut candidates: Vec<CandidateRow> = r
             .machine_interfaces
@@ -195,7 +195,7 @@ impl From<forgerpc::GetMachineBootInterfacesResponse> for CandidatesReport {
                 network_segment_type: i.network_segment_type.clone(),
                 source: CandidateSource::Managed,
                 primary_interface: i.primary_interface,
-                eligible: eligible(i.network_segment_type.as_deref()),
+                eligible: is_eligible(i.primary_interface, i.network_segment_type.as_deref()),
                 current: mark(&i.mac_address, &current_mac),
                 default: mark(&i.mac_address, &default_mac),
                 explored_default: explored_macs.contains(&i.mac_address),
@@ -208,7 +208,7 @@ impl From<forgerpc::GetMachineBootInterfacesResponse> for CandidatesReport {
             network_segment_type: p.network_segment_type.clone(),
             source: CandidateSource::Predicted,
             primary_interface: p.primary_interface,
-            eligible: eligible(p.network_segment_type.as_deref()),
+            eligible: is_eligible(p.primary_interface, p.network_segment_type.as_deref()),
             current: mark(&p.mac_address, &current_mac),
             default: mark(&p.mac_address, &default_mac),
             explored_default: explored_macs.contains(&p.mac_address),
@@ -308,7 +308,11 @@ fn render_candidates(report: &CandidatesReport) -> String {
                 CandidateSource::Managed => "managed",
                 CandidateSource::Predicted => "predicted",
             };
-            let eligible = if c.eligible { "yes" } else { "no (underlay)" };
+            let eligible = if c.eligible {
+                "yes"
+            } else {
+                "no (non-primary underlay)"
+            };
             table.add_row(Row::new(vec![
                 Cell::new(&c.mac_address),
                 Cell::new(&dash(&c.interface_id)),
@@ -519,7 +523,10 @@ mod tests {
         assert!(lower.default, "the lower non-underlay MAC is the default");
 
         let underlay = &report.candidates[2];
-        assert!(!underlay.eligible, "underlay rows are never candidates");
+        assert!(
+            !underlay.eligible,
+            "non-primary underlay rows are excluded from the fallback"
+        );
         assert!(!underlay.current && !underlay.default);
 
         let prediction = &report.candidates[3];
@@ -571,11 +578,26 @@ mod tests {
     }
 
     #[test]
+    fn a_declared_primary_underlay_row_is_eligible() {
+        let mut response = sample_response();
+        response.machine_interfaces[0].primary_interface = false;
+        response.machine_interfaces[2].primary_interface = true;
+        response.effective_boot_interface_mac = Some("aa:bb:cc:00:00:00".to_string());
+        response.effective_boot_interface_id = None;
+
+        let report = CandidatesReport::from(response);
+        let underlay = &report.candidates[2];
+
+        assert!(underlay.eligible);
+        assert!(underlay.current);
+    }
+
+    #[test]
     fn ascii_render_shows_markers_and_summary() {
         let rendered = render_candidates(&CandidatesReport::from(sample_response()));
 
         assert!(rendered.contains("current,explored"));
-        assert!(rendered.contains("no (underlay)"));
+        assert!(rendered.contains("no (non-primary underlay)"));
         assert!(
             rendered.contains("Current boot interface:       aa:bb:cc:00:00:02 (NIC.Slot.2-1-1)\n")
         );

--- a/crates/admin-cli/src/boot_interface/mod.rs
+++ b/crates/admin-cli/src/boot_interface/mod.rs
@@ -43,34 +43,40 @@ pub(crate) enum Cmd {
         visible_alias = "details",
         about = "Show boot interfaces for a machine from every store (troubleshooting)",
         long_about = "Gather the boot-interface view for one machine from all four stores and \
-            print them together: the managed `machine_interfaces` rows (authoritative for a \
-            managed machine), `predicted_machine_interfaces` (pre-first-lease candidates), \
-            the `explored_endpoints` default (for endpoints without a machine), and the \
-            retained post-deletion pairs (including stale records). Also reports the \
-            effective boot interface, flags when the stores disagree, and shows desired-state \
-            reconciliation progress when one exists. Read-only."
+            print them together: the managed `machine_interfaces` rows (owned candidates and \
+            primary selection), `predicted_machine_interfaces` (pre-first-lease candidates), \
+            the `explored_endpoints` default, and retained post-deletion pairs (including stale \
+            records). Also reports the effective owned pick and flags when current selection \
+            signals disagree (the effective owned pick, explored defaults, and declared-primary \
+            predictions; retained history and the desired target are excluded). The persisted \
+            desired target and reconciliation progress appear separately. Read-only."
     )]
     Show(show::Args),
     #[clap(
         about = "List boot-interface candidates for a machine and the picks among them",
         long_about = "List every NIC that could be the boot interface for a machine -- the \
             managed `machine_interfaces` rows and the pre-first-lease predictions -- and \
-            mark the picks among them: `current` (what resolution targets now: the primary \
-            interface if one is set, else the lowest-MAC non-underlay interface), `default` \
-            (what the automatic selection would choose if no primary interface were set), \
-            and `explored` (the default site-explorer recorded for the BMC endpoint of the \
-            machine). Underlay rows are listed but marked ineligible. Every pick is computed \
-            server-side by the same selection code the machine-controller acts on. Read-only."
+            mark the picks among them: `current` (the effective managed pick, or the predicted \
+            pick before the first lease), `default` (the lowest-MAC non-underlay managed \
+            interface if no primary interface were set), and `explored` (the default \
+            site-explorer recorded for the BMC endpoint of the machine). The predicted pick is \
+            a declared primary, or the sole non-underlay prediction; with several eligible \
+            undeclared predictions the system refuses to guess. For selection, an already-declared \
+            primary is eligible regardless of segment; otherwise underlay rows are excluded from \
+            the automatic fallback. The selection/default picks are computed server-side; use \
+            `boot-interface show` to compare them with the persisted desired target and controller \
+            progress. Read-only."
     )]
     Candidates(candidates::Args),
     #[clap(
-        about = "Set the boot interface for a machine (promotes it to the primary interface)",
-        long_about = "Make an interface the boot interface for a machine by promoting it to \
-            the primary interface -- the designation every boot flow keys on. This is the \
-            same operation as `managed-host set-primary-interface`: the primary row and desired \
-            target commit together, then machine-controller reconciles the BMC when the host is \
-            eligible. The interface can be named by machine-interface UUID or by MAC address; a \
-            MAC must match exactly one managed interface row on the machine."
+        about = "Set the boot interface for a managed host (promotes it to the primary interface)",
+        long_about = "Make an interface both the primary interface and persisted desired boot \
+            target for a managed host. This is the same operation as `managed-host \
+            set-primary-interface`: the primary row and desired target commit together, then \
+            machine-controller reconciles the BMC when the host is eligible. The interface can \
+            be named by machine-interface UUID or by MAC address; a MAC must match exactly one \
+            managed interface row on the machine. If the host has a DPU-backed Admin interface, \
+            the selected interface must also be on the Admin segment."
     )]
     Set(set::Args),
 }

--- a/crates/admin-cli/src/boot_interface/set/args.rs
+++ b/crates/admin-cli/src/boot_interface/set/args.rs
@@ -39,18 +39,18 @@ Request another reconciliation for the selected interface:
 Tip: 'boot-interface candidates <MACHINE_ID>' lists the candidate NICs with their MACs and UUIDs.
 ")]
 pub(crate) struct Args {
-    #[clap(help = "The machine whose boot interface to set")]
+    #[clap(help = "The managed host for which to set the boot interface")]
     pub(super) machine: MachineId,
     #[clap(help = "The interface to boot from -- a machine-interface UUID or a MAC address")]
     pub(super) interface: InterfaceSelector,
     #[clap(
         long,
-        help = "Request a fresh machine-controller reconciliation even when this interface is already selected"
+        help = "Request a fresh machine-controller reconciliation even when this interface is already selected. Sends only force_reconcile=true; servers without force_reconcile support ignore it, while supporting servers leave any required restart to machine-controller"
     )]
     pub(super) force_reconcile: bool,
     #[clap(
         long,
-        help = "Deprecated compatibility alias; use --force-reconcile with current servers"
+        help = "Deprecated compatibility option for servers without force_reconcile support. Sends reboot=true and force_reconcile=true; supporting servers treat it as reconciliation, while older servers force-restart the host after changing the target"
     )]
     pub(super) reboot: bool,
 }

--- a/crates/admin-cli/src/boot_interface/set/cmd.rs
+++ b/crates/admin-cli/src/boot_interface/set/cmd.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-//! Set a machine's boot interface by promoting the chosen interface to the
-//! machine's primary -- the designation `pick_boot_interface` keys on. A thin
-//! front for the same `SetPrimaryInterface` RPC behind
+//! Set a managed host's boot interface by promoting the chosen interface to
+//! the host's primary -- the designation `pick_boot_interface` keys on. A
+//! thin front for the same `SetPrimaryInterface` RPC behind
 //! `managed-host set-primary-interface`: the server commits the selected row
 //! and desired target together, then machine-controller converges Redfish.
 //! The only client-side work is resolving an operator-entered MAC to its

--- a/crates/admin-cli/src/boot_interface/show/args.rs
+++ b/crates/admin-cli/src/boot_interface/show/args.rs
@@ -31,6 +31,6 @@ As JSON or YAML (the global --format flag):
 
 ")]
 pub(crate) struct Args {
-    #[clap(help = "The machine ID whose boot interfaces to gather")]
+    #[clap(help = "The machine ID for which to gather boot interfaces")]
     pub(super) machine: MachineId,
 }

--- a/crates/admin-cli/src/boot_interface/show/cmd.rs
+++ b/crates/admin-cli/src/boot_interface/show/cmd.rs
@@ -16,10 +16,10 @@
  */
 
 //! Render one machine's boot-interface view (the `GetMachineBootInterfaces`
-//! RPC) as an ASCII table, JSON, or YAML. The view gathers the four stores a
-//! host's boot interface can live in -- managed interface rows, predictions, the
-//! explored endpoint default, and the retained post-deletion pairs -- plus the
-//! effective boot interface, store divergence, and desired-state reconciliation.
+//! RPC) as an ASCII table, JSON, or YAML. The view gathers managed interface
+//! rows, predictions, explored-endpoint defaults, and retained post-deletion
+//! pairs around the separate desired-state record. It also reports the
+//! effective owned pick, current-selection disagreement, and reconciliation.
 
 use std::fmt::Write as _;
 
@@ -47,12 +47,13 @@ struct BootInterfacesReport {
     predicted_interfaces: Vec<PredictedRow>,
     explored_endpoints: Vec<ExploredRow>,
     retained_interfaces: Vec<RetainedRow>,
-    /// MAC the system would boot from now (`pick_boot_interface` over the managed
-    /// rows). `None` when there is no managed candidate yet.
+    /// Effective owned MAC (`pick_boot_interface` over the managed rows).
+    /// `None` when there is no managed candidate yet.
     effective_boot_interface_mac: Option<String>,
-    /// The fully-populated effective boot interface id, when captured.
+    /// Fully populated Redfish interface id for the effective owned pick.
     effective_boot_interface_id: Option<String>,
-    /// True when the stores disagree about which MAC boots this machine.
+    /// Whether the effective owned pick, explored defaults, and declared-primary
+    /// predictions contain more than one MAC.
     divergent: bool,
     /// Desired generation and the machine controller's progress toward it.
     reconciliation: Option<ReconciliationReport>,
@@ -205,8 +206,8 @@ pub(super) async fn handle_boot_interfaces(
     Ok(())
 }
 
-/// One labeled table per store, then a summary block with the effective boot
-/// interface and the divergence flag.
+/// One labeled table per store, then the effective owned pick, selection
+/// disagreement, and desired-state reconciliation.
 fn render_tables(report: &BootInterfacesReport) -> String {
     let mut out = String::new();
     let dash = |s: &Option<String>| s.as_deref().unwrap_or("-").to_string();
@@ -218,7 +219,7 @@ fn render_tables(report: &BootInterfacesReport) -> String {
         .unwrap_or_default();
     let _ = writeln!(out, "Boot interfaces for machine {machine_id}");
 
-    // Store 1: managed interface rows (authoritative for a managed machine).
+    // Store 1: managed interface candidates and primary selection.
     let _ = writeln!(out, "\nmachine_interfaces (managed rows):");
     let mut managed = Table::new();
     managed.set_titles(Row::new(

--- a/crates/admin-cli/src/managed_host/mod.rs
+++ b/crates/admin-cli/src/managed_host/mod.rs
@@ -59,9 +59,26 @@ pub(crate) enum Cmd {
     PowerOptions(power_options::Args),
     #[clap(about = "Start updates for machines with delayed updates, such as GB200")]
     StartUpdates(start_updates::Args),
-    #[clap(about = "Set the primary interface (boot device) for the managed host")]
+    #[clap(
+        about = "Set the primary interface (boot device) for the managed host",
+        long_about = "Set the primary interface for a managed host. The selected machine-interface \
+            row, Admin network identity, and persisted desired boot target update atomically. If \
+            the host has a DPU-backed Admin interface, the selected interface must be on the Admin \
+            segment. The machine-controller converges the BMC to the desired target when the host is \
+            eligible."
+    )]
     SetPrimaryInterface(set_primary_interface::Args),
-    #[clap(about = "Deprecated: use set-primary-interface. Sets the primary DPU.")]
+    #[clap(
+        about = "Deprecated: use set-primary-interface with a machine-interface ID, not a DPU machine ID",
+        long_about = "Deprecated compatibility form for managed hosts. This command accepts a \
+            DPU_MACHINE_ID, chooses the host-facing interface row owned by that DPU, and atomically \
+            updates the primary interface, Admin network identity, and persisted desired boot \
+            target. The selected interface must be on the Admin segment when the host has a \
+            DPU-backed Admin interface. The machine-controller converges the BMC to the desired target \
+            when the host is eligible. Use set-primary-interface with an INTERFACE_ID \
+            (machine-interface ID): \
+            https://github.com/NVIDIA/infra-controller/blob/main/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-interface.md"
+    )]
     SetPrimaryDpu(set_primary_dpu::Args),
     #[clap(about = "Download debug bundle with logs for a specific host")]
     DebugBundle(debug_bundle::Args),

--- a/crates/admin-cli/src/managed_host/set_primary_dpu/args.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_dpu/args.rs
@@ -39,12 +39,12 @@ pub(crate) struct Args {
     dpu_machine_id: MachineId,
     #[clap(
         long,
-        help = "Request a fresh machine-controller reconciliation even when this DPU is already selected"
+        help = "Request a fresh machine-controller reconciliation even when this DPU is already selected. Sends only force_reconcile=true; servers without force_reconcile support ignore it, while supporting servers leave any required restart to machine-controller"
     )]
     force_reconcile: bool,
     #[clap(
         long,
-        help = "Deprecated compatibility alias; use --force-reconcile with current servers"
+        help = "Deprecated compatibility option for servers without force_reconcile support. Sends reboot=true and force_reconcile=true; supporting servers treat it as reconciliation, while older servers force-restart the host after changing the target"
     )]
     reboot: bool,
 }

--- a/crates/admin-cli/src/managed_host/set_primary_interface/args.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_interface/args.rs
@@ -40,12 +40,12 @@ pub(crate) struct Args {
     interface_id: MachineInterfaceId,
     #[clap(
         long,
-        help = "Request a fresh machine-controller reconciliation even when this interface is already selected"
+        help = "Request a fresh machine-controller reconciliation even when this interface is already selected. Sends only force_reconcile=true; servers without force_reconcile support ignore it, while supporting servers leave any required restart to machine-controller"
     )]
     force_reconcile: bool,
     #[clap(
         long,
-        help = "Deprecated compatibility alias; use --force-reconcile with current servers"
+        help = "Deprecated compatibility option for servers without force_reconcile support. Sends reboot=true and force_reconcile=true; supporting servers treat it as reconciliation, while older servers force-restart the host after changing the target"
     )]
     reboot: bool,
 }

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-candidates.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-candidates.md
@@ -1,0 +1,66 @@
+# `nico-admin-cli boot-interface candidates`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **candidates**_
+
+## NAME
+
+nico-admin-cli-boot-interface-candidates - List boot-interface
+candidates for a machine and the picks among them
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface candidates** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*MACHINE*\>
+
+## DESCRIPTION
+
+List every NIC that could be the boot interface for a machine -- the
+managed \`machine_interfaces\` rows and the pre-first-lease predictions
+-- and mark the picks among them: \`current\` (the effective managed
+pick, or the predicted pick before the first lease), \`default\` (the
+lowest-MAC non-underlay managed interface if no primary interface were
+set), and \`explored\` (the default site-explorer recorded for the BMC
+endpoint of the machine). The predicted pick is a declared primary, or
+the sole non-underlay prediction; with several eligible undeclared
+predictions the system refuses to guess. For selection, an
+already-declared primary is eligible regardless of segment; otherwise
+underlay rows are excluded from the automatic fallback. The
+selection/default picks are computed server-side; use \`boot-interface
+show\` to compare them with the persisted desired target and controller
+progress. Read-only.
+
+## OPTIONS
+
+**--extended**\
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary ID
+
+- state: Sort by state
+
+**-h**, **--help**\
+Print help (see a summary with -h)
+
+\<*MACHINE*\>\
+The machine ID for which to list boot-interface candidates
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface candidates 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format json boot-interface candidates 12345678-1234-5678-90ab-cdef01234567
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-set.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-set.md
@@ -1,0 +1,77 @@
+# `nico-admin-cli boot-interface set`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **set**_
+
+## NAME
+
+nico-admin-cli-boot-interface-set - Set the boot interface for a managed
+host (promotes it to the primary interface)
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface set** \[**--force-reconcile**\]
+\[**--reboot**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\] \<*MACHINE*\> \<*INTERFACE*\>
+
+## DESCRIPTION
+
+Make an interface both the primary interface and persisted desired boot
+target for a managed host. This is the same operation as \`managed-host
+set-primary-interface\`: the primary row and desired target commit
+together, then machine-controller reconciles the BMC when the host is
+eligible. The interface can be named by machine-interface UUID or by MAC
+address; a MAC must match exactly one managed interface row on the
+machine. If the host has a DPU-backed Admin interface, the selected
+interface must also be on the Admin segment.
+
+## OPTIONS
+
+**--force-reconcile**\
+Request a fresh machine-controller reconciliation even when this
+interface is already selected. Sends only force_reconcile=true; servers
+without force_reconcile support ignore it, while supporting servers
+leave any required restart to machine-controller
+
+**--reboot**\
+Deprecated compatibility option for servers without force_reconcile
+support. Sends reboot=true and force_reconcile=true; supporting servers
+treat it as reconciliation, while older servers force-restart the host
+after changing the target
+
+**--extended**\
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary ID
+
+- state: Sort by state
+
+**-h**, **--help**\
+Print help (see a summary with -h)
+
+\<*MACHINE*\>\
+The managed host for which to set the boot interface
+
+\<*INTERFACE*\>\
+The interface to boot from -- a machine-interface UUID or a MAC address
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 00:11:22:33:44:55
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 00:11:22:33:44:55 --force-reconcile
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-show.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-show.md
@@ -1,0 +1,63 @@
+# `nico-admin-cli boot-interface show`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **show**_
+
+## NAME
+
+nico-admin-cli-boot-interface-show - Show boot interfaces for a machine
+from every store (troubleshooting)
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface show** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*MACHINE*\>
+
+## DESCRIPTION
+
+Gather the boot-interface view for one machine from all four stores and
+print them together: the managed \`machine_interfaces\` rows (owned
+candidates and primary selection), \`predicted_machine_interfaces\`
+(pre-first-lease candidates), the \`explored_endpoints\` default, and
+retained post-deletion pairs (including stale records). Also reports the
+effective owned pick and flags when current selection signals disagree
+(the effective owned pick, explored defaults, and declared-primary
+predictions; retained history and the desired target are excluded). The
+persisted desired target and reconciliation progress appear separately.
+Read-only.
+
+## OPTIONS
+
+**--extended**\
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary ID
+
+- state: Sort by state
+
+**-h**, **--help**\
+Print help (see a summary with -h)
+
+\<*MACHINE*\>\
+The machine ID for which to gather boot interfaces
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface show 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format json boot-interface show 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format yaml boot-interface show 12345678-1234-5678-90ab-cdef01234567
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface.md
@@ -1,0 +1,50 @@
+# `nico-admin-cli boot-interface`
+
+_[Hardware commands](../../hardware.md) › **boot-interface**_
+
+## NAME
+
+nico-admin-cli-boot-interface - Machine boot-interface management
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface** \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+Machine boot-interface management
+
+## OPTIONS
+
+**--extended**\
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary ID
+
+- state: Sort by state
+
+**-h**, **--help**\
+Print help (see a summary with -h)
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`show`](./boot-interface-show.md) | Show boot interfaces for a machine from every store (troubleshooting) |
+| [`candidates`](./boot-interface-candidates.md) | List boot-interface candidates for a machine and the picks among them |
+| [`set`](./boot-interface-set.md) | Set the boot interface for a managed host (promotes it to the primary interface) |
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-dpu.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-dpu.md
@@ -4,23 +4,41 @@ _[Hardware commands](../../hardware.md) â€º [managed-host](./managed-host.md) â€
 
 ## NAME
 
-nico-admin-cli-managed-host-set-primary-dpu - Set the primary DPU for
-the managed host
+nico-admin-cli-managed-host-set-primary-dpu - Deprecated: use
+set-primary-interface with a machine-interface ID, not a DPU machine ID
 
 ## SYNOPSIS
 
-**nico-admin-cli managed-host set-primary-dpu** \[**--reboot**\]
-\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
-\<*HOST_MACHINE_ID*\> \<*DPU_MACHINE_ID*\>
+**nico-admin-cli managed-host set-primary-dpu**
+\[**--force-reconcile**\] \[**--reboot**\] \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*HOST_MACHINE_ID*\>
+\<*DPU_MACHINE_ID*\>
 
 ## DESCRIPTION
 
-Set the primary DPU for the managed host
+Deprecated compatibility form for managed hosts. This command accepts a
+DPU_MACHINE_ID, chooses the host-facing interface row owned by that DPU,
+and atomically updates the primary interface, Admin network identity,
+and persisted desired boot target. The selected interface must be on the
+Admin segment when the host has a DPU-backed Admin interface. The
+machine-controller converges the BMC to the desired target when the host
+is eligible. Use set-primary-interface with an INTERFACE_ID
+(machine-interface ID):
+[set-primary-interface reference](https://github.com/NVIDIA/infra-controller/blob/main/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-interface.md)
 
 ## OPTIONS
 
+**--force-reconcile**\
+Request a fresh machine-controller reconciliation even when this DPU is
+already selected. Sends only force_reconcile=true; servers without
+force_reconcile support ignore it, while supporting servers leave any
+required restart to machine-controller
+
 **--reboot**  
-Reboot the host after the update
+Deprecated compatibility option for servers without force_reconcile
+support. Sends reboot=true and force_reconcile=true; supporting servers
+treat it as reconciliation, while older servers force-restart the host
+after changing the target
 
 **--extended**  
 Extended result output.
@@ -52,7 +70,7 @@ ID of the DPU machine to make primary
 
 ```sh
 nico-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789
-nico-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789 --reboot
+nico-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789 --force-reconcile
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-interface.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-interface.md
@@ -1,0 +1,75 @@
+# `nico-admin-cli managed-host set-primary-interface`
+
+_[Hardware commands](../../hardware.md) › [managed-host](./managed-host.md) › **set-primary-interface**_
+
+## NAME
+
+nico-admin-cli-managed-host-set-primary-interface - Set the primary
+interface (boot device) for the managed host
+
+## SYNOPSIS
+
+**nico-admin-cli managed-host set-primary-interface**
+\[**--force-reconcile**\] \[**--reboot**\] \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*HOST_MACHINE_ID*\>
+\<*INTERFACE_ID*\>
+
+## DESCRIPTION
+
+Set the primary interface for a managed host. The selected
+machine-interface row, Admin network identity, and persisted desired
+boot target update atomically. If the host has a DPU-backed Admin
+interface, the selected interface must be on the Admin segment. The
+machine-controller converges the BMC to the desired target when the host
+is eligible.
+
+## OPTIONS
+
+**--force-reconcile**\
+Request a fresh machine-controller reconciliation even when this
+interface is already selected. Sends only force_reconcile=true; servers
+without force_reconcile support ignore it, while supporting servers
+leave any required restart to machine-controller
+
+**--reboot**\
+Deprecated compatibility option for servers without force_reconcile
+support. Sends reboot=true and force_reconcile=true; supporting servers
+treat it as reconciliation, while older servers force-restart the host
+after changing the target
+
+**--extended**\
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary ID
+
+- state: Sort by state
+
+**-h**, **--help**\
+Print help (see a summary with -h)
+
+\<*HOST_MACHINE_ID*\>\
+ID of the host machine
+
+\<*INTERFACE_ID*\>\
+ID of the machine interface to make primary (the boot device)
+
+## Examples
+
+```sh
+nico-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789
+nico-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789 --force-reconcile
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host.md
@@ -47,7 +47,8 @@ Print help (see a summary with -h)
 | [`reset-host-reprovisioning`](./managed-host-reset-host-reprovisioning.md) | Reset host reprovisioning back to CheckingFirmware |
 | [`power-options`](./managed-host-power-options.md) | Power Manager related settings. |
 | [`start-updates`](./managed-host-start-updates.md) | Start updates for machines with delayed updates, such as GB200 |
-| [`set-primary-dpu`](./managed-host-set-primary-dpu.md) | Set the primary DPU for the managed host |
+| [`set-primary-interface`](./managed-host-set-primary-interface.md) | Set the primary interface (boot device) for the managed host |
+| [`set-primary-dpu`](./managed-host-set-primary-dpu.md) | Deprecated: use set-primary-interface with a machine-interface ID, not a DPU machine ID |
 | [`debug-bundle`](./managed-host-debug-bundle.md) | Download debug bundle with logs for a specific host |
 | [`decommission`](./managed-host-decommission.md) | Start decommissioning a managed host |
 

--- a/docs/manuals/nico-admin-cli/hardware.md
+++ b/docs/manuals/nico-admin-cli/hardware.md
@@ -8,6 +8,7 @@ For global flags and setup, see [the overview](./README.md) and [`setup.md`](./s
 |---|---|
 | [`attestation`](./commands/attestation/attestation.md) | MeasuredBoot or SPDM attestations. |
 | [`bmc-machine`](./commands/bmc-machine/bmc-machine.md) | BMC Machine related handling. |
+| [`boot-interface`](./commands/boot-interface/boot-interface.md) | Machine boot-interface management. |
 | [`boot-override`](./commands/boot-override/boot-override.md) | Machine boot override. |
 | [`browse`](./commands/browse/browse.md) | Browse subsystem resource trees via the API server. |
 | [`component-manager`](./commands/component-manager/component-manager.md) | Component manager actions. |

--- a/docs/provisioning/boot-interfaces-and-dpu-modes.md
+++ b/docs/provisioning/boot-interfaces-and-dpu-modes.md
@@ -10,14 +10,15 @@ For the DHCP and network-segment substrate these knobs sit on (how a relay's `gi
 
 ## 1. The mental model: two independent axes
 
-Historically, two separate decisions were conflated into "what kind of host is this." Keep them apart:
+Historically, several related decisions were conflated into "what kind of host is this." Keep them apart:
 
 | Axis | Question | Controlled by |
 |---|---|---|
 | **DPU management** | Does NICo manage this host's DPUs (upgrade them, run agents, and attach them to the ManagedHost)? | `dpu_policy` |
-| **Boot interface** | Which NIC does the host OS actually boot from and run its management network on? | the host's **primary** interface |
+| **Redfish boot target** | Which NIC should the BMC boot? | the durable desired boot-interface target, initialized from discovery/Expected Machine data |
+| **Admin network identity** | Which owned NIC supplies the host's admin address and network identity? | the managed `primary_interface` selection; modern setters update it together with the desired boot target |
 
-A "normal" host couples them (managed DPU + boot through that DPU). But they are independent: you can keep a host's DPUs **managed** and still boot it from a plain **integrated NIC**. This guide treats the two axes separately, because the configuration knobs are separate.
+A "normal" host aligns them (managed DPU + boot and admin identity through that DPU). But DPU management is independent: you can keep a host's DPUs **managed** and still boot it from a plain **integrated NIC**. Modern managed-host setters keep the boot target and admin network identity aligned; the legacy explored-endpoint action can change only the desired target.
 
 The policy is also separate from the card's current hardware state. NICo models
 operator intent as `HostDpuPolicy::{Manage, Nic, Ignore}` and the mode
@@ -38,9 +39,11 @@ A host's management network lives on one of a few segment types. Which one depen
 
 **Rule of thumb:** the host-OS segment follows the boot interface's mode — boot via DPU ⇒ **Admin**; boot via a plain NIC ⇒ **HostInband**. A non-DPU NIC is never on the Admin segment, because Admin *is* the DPU overlay.
 
-### The boot (primary) interface
+### The boot and primary interface
 
-In NICo the **boot interface and the primary interface are the same thing by construction**: a host's `primary` interface is the one its boot order targets. A boot interface is a `(MAC, Redfish interface id)` pair — the MAC identifies the NIC on the wire; the Redfish id lets NICo set the boot order on the BMC. NICo refers to this pair as the host's `MachineBootInterface`.
+The managed `primary_interface` row selects the host's admin network identity and supplies the ordinary boot default. The machine-scoped `machine_boot_interfaces` row separately persists the desired Redfish target that `Ready` convergence applies. Operator setters update both in one transaction, so they normally remain aligned, but they are different facts: desired intent can exist from a prediction before DHCP creates an owned row, and a pending target can temporarily differ from the current primary/default view.
+
+A complete boot interface is a `(MAC, Redfish interface id)` pair — the MAC identifies the NIC on the wire; the Redfish id lets NICo set the boot order on the BMC. NICo calls that pair a `MachineBootInterface`; a desired target may remain MAC-only until site-explorer learns one unambiguous Redfish id.
 
 ---
 
@@ -196,7 +199,7 @@ nico-admin-cli -a <api-url> em patch --bmc-mac-address <bmc-mac> --dpu-policy ni
 nico-admin-cli -a <api-url> machine force-delete --machine <machine-id> --delete-interfaces
 ```
 
-See the [Force Delete playbook](../playbooks/force_delete.md) for the full re-ingest procedure. NICo preserves the host's boot-interface **Redfish id** across the deletion gap via the retained-boot-interface mechanism ([Section 7.3](#73-retained-boot-interfaces)), so the host can be re-targeted for boot before a fresh exploration completes. After a flip, you can re-apply the resolved boot interface with one click via **Restore Boot Interface** in the web UI ([Section 5](#5-web-ui)).
+See the [Force Delete playbook](../playbooks/force_delete.md) for the full re-ingest procedure. NICo preserves the host's boot-interface **Redfish id** across the deletion gap via the retained-boot-interface mechanism ([Section 7.4](#74-retained-boot-interfaces)), so the host can be re-targeted for boot before a fresh exploration completes. After a flip, you can re-apply the resolved boot interface with one click via **Restore Boot Interface** in the web UI ([Section 5](#5-web-ui)).
 
 The mode change itself takes effect only across a power cycle: The queued `Mode.Set` stays staged on the DPU until the host power-cycles. Site-explorer issues that power cycle automatically on every vendor, trying the standard Redfish `PowerCycle` reset first and escalating to a cold `ACPowercycle` on platforms that refuse it (HPE, Lenovo, Supermicro, and GBx00 systems). Repeat cycles are rate-limited, so a host mid-flip can take a pass or two of exploration to converge. If both reset types are refused, or the DPUs still report the old mode after cycling, the host surfaces the `manual_power_cycle_required` pairing blocker and waits for an operator (refer to [Section 8](#8-verifying-and-troubleshooting)).
 
@@ -222,11 +225,11 @@ All of these are **admin-only**; the Forge gRPC service enforces admin authoriza
 
 | admin-cli | Forge RPC | Purpose |
 |---|---|---|
-| `managed-host set-primary-interface <host-id> <interface-id> [--force-reconcile] [--reboot]` | `SetPrimaryInterface` | Designate an eligible machine interface as the host's primary/boot interface. A host with a DPU-backed Admin interface restricts this command to Admin interfaces; configure an integrated HostInband primary through Expected Machines before ingestion. `--force-reconcile` opens a fresh reconciliation generation even when the interface is already selected. `--reboot` is a deprecated compatibility flag whose behavior depends on the server version. |
-| `managed-host set-primary-dpu <host-id> <dpu-id> [--force-reconcile] [--reboot]` | `SetPrimaryDpu` | Deprecated compatibility command that selects the host interface attached to `<dpu-id>`. The reconciliation flags behave as they do for `set-primary-interface`. Use `set-primary-interface` instead. |
-| `boot-interface show <machine-id>` | `GetMachineBootInterfaces` | Show a machine's boot interface across every store (managed, predicted, explored, retained), the effective interface the system would select, its selection source and decision time, and any disagreement between stores. Read-only. |
-| `boot-interface candidates <machine-id>` | `GetMachineBootInterfaces` | List a machine's candidate boot NICs and the picks among them (`current`, `default`, `explored`), plus the desired selection source and decision time; underlay rows are listed but ineligible. Read-only. |
-| `boot-interface set <machine-id> <interface> [--force-reconcile] [--reboot]` | `SetPrimaryInterface` | Set a machine's boot interface by promoting it to the primary interface. It uses the same operation and reconciliation flags as `set-primary-interface`. `<interface>` is a machine-interface UUID or a MAC (a MAC must match exactly one managed interface row). |
+| `managed-host set-primary-interface <host-id> <interface-id> [--force-reconcile] [--reboot]` | `SetPrimaryInterface` | Atomically make one owned interface primary, move the corresponding Admin address/network identity, and persist that exact desired boot target. Hosts with a DPU-backed Admin interface require the selected interface to be on the Admin segment. `--force-reconcile` opens a fresh reconciliation generation even when the interface is already selected; `--reboot` is a deprecated compatibility flag whose behavior depends on the server version. |
+| `managed-host set-primary-dpu <host-id> <dpu-id> [--force-reconcile] [--reboot]` | `SetPrimaryDpu` | Deprecated compatibility command that selects the DPU's host-facing interface through the same primary/desired-state transaction. The reconciliation flags behave as they do for `set-primary-interface`. Prefer `set-primary-interface`, which takes a machine-interface ID rather than a DPU machine ID. |
+| `boot-interface show <machine-id>` | `GetMachineBootInterfaces` | Show every store (managed, predicted, explored, retained), the effective owned pick, persisted desired target, selection source and decision time, desired/verified versions, observation kind/time, derived reconciliation state, active controller version/failure, and current-selection disagreement. Read-only. |
+| `boot-interface candidates <machine-id>` | `GetMachineBootInterfaces` | List a machine's candidate boot NICs and the picks among them (`current`, `default`, `explored`), plus the desired selection source and decision time. An already-declared primary remains eligible regardless of segment; non-primary underlay rows are ineligible for the automatic fallback. Read-only. |
+| `boot-interface set <machine-id> <interface> [--force-reconcile] [--reboot]` | `SetPrimaryInterface` | Run the same primary/Admin-identity/desired-state transaction as `set-primary-interface`, selecting by machine-interface UUID or by a MAC that matches exactly one managed row. Hosts with a DPU-backed Admin interface require the selected interface to be on the Admin segment. The reconciliation flags behave as they do for `set-primary-interface`. |
 | `boot-override set <interface-id> [--custom-pxe <f>] [--custom-user-data <f>]` | `SetMachineBootOverride` | Override the iPXE script / cloud-init user-data served at boot. |
 | `boot-override get <interface-id>` | `GetMachineBootOverride` | Show the current boot override. |
 | `boot-override clear <interface-id>` | `ClearMachineBootOverride` | Revert to the default PXE/cloud-init. |
@@ -273,7 +276,7 @@ Without `--force-reconcile` or its deprecated `--reboot` alias, selecting the cu
 `Operator` authority without opening a new Redfish reconciliation generation. Repeating that same explicit choice reports
 that the operator already selected the primary interface. Either reconciliation flag instead opens a fresh generation.
 
-> Setting the DPU first boot order directly (by MAC) is also exposed as a single action through the web UI ([Section 5](#5-web-ui)). Under normal operation the machine controller sets the boot order automatically during ingestion ([Section 6](#6-behind-the-scenes-how-a-boot-device-is-chosen-and-set)).
+> The explored-endpoint web view also exposes a legacy **Set First** action by MAC ([Section 5](#5-web-ui)). For an endpoint owned by a managed or predicted host, that request changes only the desired target; it does not promote an owned `machine_interfaces` row to primary. Prefer the managed-host action when an owned row should become both primary and desired. Unowned and DPU-owned endpoints apply Redfish directly. Under normal operation machine-controller sets a managed host's boot order automatically ([Section 6](#6-behind-the-scenes-how-a-boot-device-is-chosen-and-set)).
 
 ### Ingestion control
 
@@ -281,25 +284,25 @@ that the operator already selected the primary interface. Either reconciliation 
 |---|---|---|
 | `site-explorer remediation <bmc-ip> --pause` / `--resume` | `PauseExploredEndpointRemediation` | Pause/resume site-explorer's automatic remediation (and ingestion processing) for an endpoint. |
 | `machine force-delete --machine <id> [--delete-interfaces] [--delete-bmc-interfaces] [--delete-bmc-credentials]` | `AdminForceDeleteMachine` | Remove a machine (and optionally its interfaces/credentials) from the database, bypassing the normal lifecycle. |
-| `managed-host show [--all \| <machine-id>]` | (query) | Inspect a host's current state, interfaces, and primary/boot interface. |
+| `managed-host show [--all \| <machine-id>]` | (query) | Inspect a host's current state, interfaces, and database primary selection. This does not prove that Redfish matches; use `boot-interface show` for reconciliation. |
 
 ---
 
 ## 5. Web UI
 
-The NICo admin web UI (`/admin/…`) is primarily for **visibility**, with a focused set of boot/ingestion actions. **There is no DPU-policy control in the UI** — change `dpu_policy` via Expected Machines (CLI/JSON) as in [Section 2](#2-configuring-via-expected-machines-and-the-defaults).
+The NICo admin web UI (`/admin/…`) exposes the managed host's desired boot interface and a focused set of boot/ingestion actions. **There is no DPU-policy control in the UI** — change `dpu_policy` via Expected Machines (CLI/JSON) as in [Section 2](#2-configuring-via-expected-machines-and-the-defaults).
 
 **View:**
 
-- `/admin/machine` and `/admin/machine/{id}` — machine inventory and detail, including each interface's **primary indicator**, MAC, segment, and attached DPU ID. The detail page also shows the desired boot interface's selection source and decision time.
+- `/admin/machine` and `/admin/machine/{id}` — machine inventory and detail, including each interface's **primary indicator**, MAC, segment, and attached DPU ID. A managed host's **Desired Boot Interface** section shows its persisted target, selection source and decision time, desired and verified versions, observation time, derived reconciliation state, active controller version, failure (if any), and managed/predicted candidates.
 - `/admin/dpu` and `/admin/dpu/versions` — DPU inventory, associated host, and version info (read-only).
 - `/admin/expected-machine` — a status board of expected vs. unexpected machines, with tabs for **Completed / Unseen / Unexplored / Unlinked / Unexpected**. (Read-only; entries are defined via the CLI/JSON.)
 - `/admin/explored-endpoint` — discovered BMC endpoints with their **preingestion state**, last-exploration latency, and errors.
 
 **Act:**
 
-- **Set DPU First Boot Order** (by MAC) — on a machine or explored endpoint.
-- **Restore Boot Interface** — one-click re-apply of the host's resolved boot interface. It uses the machine's designated primary once managed, or site-explorer's automatic default before that. Handy right after a DPU↔NIC-mode flip.
+- On a managed-host detail page, **Set desired interface** selects one exact managed interface and also moves the host's primary/admin network identity. **Use system default** persists the current unambiguous default once; it does not follow future default changes. Predicted candidates remain informational until DHCP creates an owned row. **Request reconciliation** preserves an initialized target while opening a fresh controller generation, and requires complete BMC data. These actions update desired state; they do not call Redfish from the web request.
+- On an explored-endpoint page, **Set First** accepts a boot-interface MAC and **Restore Boot Interface** reuses the resolved target. If the endpoint belongs to a managed or predicted host, the request changes only the desired target for machine-controller; it does not promote an owned interface to primary. Prefer the managed-host action when both selections should change. Unowned and DPU-owned endpoints use the direct Redfish path because no managed-host state controller owns them.
 - **Machine Setup** — prepare an endpoint for ingestion (optionally with a boot-interface MAC; Dell endpoints require it).
 - Endpoint controls — **Re-Explore**, **Refresh**, **Clear Last Error**, **Pause/Resume Remediation**, plus power, Secure Boot, lockdown, and BMC-reset actions.
 
@@ -307,11 +310,13 @@ The NICo admin web UI (`/admin/…`) is primarily for **visibility**, with a foc
 
 ## 6. Behind the scenes: how a boot device is chosen and set
 
-Boot configuration spans two components: **site-explorer** discovers the host and records what it should boot from; the **machine-controller** state machine applies it.
+Boot configuration spans two components with separate ownership: **site-explorer** discovers candidate identities and initializes or enriches the durable desired target, while the observation-driven **machine-controller** applies and verifies that target for managed hosts. Site-explorer never replaces an existing operator-selected MAC. Managed-host selection and reapply APIs are declarative; raw `nico-admin-cli redfish …` commands remain direct. Explored-endpoint actions are also direct for unowned and DPU-owned endpoints. `MachineSetup` has one compatibility fallback: if a confirmed or predicted host has no resolvable target, it can still apply untargeted BIOS setup directly.
 
-### The host lifecycle
+### Simplified boot-order flow
 
 A host moves through these states (see the [Managed Host State Diagrams](../architecture/state_machines/managedhost.md) for the full picture):
+
+This diagram intentionally summarizes the success and release paths; the canonical state-machine documentation linked above and the narrative below cover retry, failure, and persisted-resume behavior.
 
 ```text
 Created → DpuDiscoveringState → HostInit → Validation → Ready
@@ -323,40 +328,63 @@ Created → DpuDiscoveringState → HostInit → Validation → Ready
                                    ├─ SetBootOrder                     (set boot order)
                                    ├─ … (UEFI lockdown, measuring)
                                    └─ Discovered
+
+Ready ── pending desired version ──→ BootConfiguring ── verified ──→ Ready
+Ready ── allocation ──→ Assigned ── release ──→ Ready
+                         └─ read-only drift observation; repair waits for release
 ```
 
-Site-explorer creates the host in `Created` (DPUs, if any, in `DpuDiscoveringState`) and records the boot **predictions** (below). The machine-controller picks it up and drives it through `HostInit`, where it configures BIOS and sets the boot order.
+Site-explorer creates the host in `Created` (DPUs, if any, in `DpuDiscoveringState`), records the boot **predictions**, and initializes the desired target as soon as selection is unambiguous. The machine-controller then drives `HostInit`, where it configures BIOS and sets the boot order. If final verification cannot be recorded there, the desired version remains pending and `Ready` enters the persisted `BootConfiguring` path before the host can be allocated.
 
-### Resolving the boot interface
+### Resolving and persisting the boot interface
 
-At each boot-config step the controller resolves the target via `load_boot_predictions` → `boot_interface_target`, with this precedence:
+When no desired target exists, site-explorer initializes one with this precedence:
 
-1. The host's **own owned interface row** (`machine_interfaces`), if it has a boot interface — used once the host has taken its first DHCP lease.
-2. Otherwise, the **boot prediction** (`pick_boot_prediction`) — used *before* the first lease.
-3. Otherwise, a classification:
-   - **AwaitingNic** — a zero-DPU host using `ignore` or `nic` whose boot NIC hasn't appeared yet; wait.
-   - **Missing** — a host with managed DPUs has neither an owned primary interface nor a usable prediction; a fault to investigate. This includes a managed-DPU host declared to boot from an integrated HostInband NIC if that declaration did not produce a prediction.
+1. An explicitly declared primary prediction.
+2. The host's effective owned interface (`primary_interface`, otherwise the lowest-MAC non-underlay row).
+3. The sole non-underlay prediction when owned rows yield no candidate.
 
-> **Key timing.** A host has no `machine_interfaces` row until its first DHCP lease. Predictions are what let the controller configure boot **before** that lease. Once the host leases and the prediction is promoted to an owned row, the **owned row supersedes** the prediction.
+After initialization, site-explorer may add a newly discovered Redfish interface ID for the same MAC, but it does not select a different MAC. Operator changes through `SetPrimaryInterface` update the primary row and exact desired target together in one database transaction.
+
+During `HostInit`, the shared boot driver resolves the current owned row or pre-first-lease prediction. During `BootConfiguring`, it instead captures the persisted desired target and version and keeps that exact input across restarts and in-flight vendor jobs. A missing lifecycle target is classified as:
+
+- **AwaitingNic** — a host with no managed DPUs (zero-DPU, `ignore`, or `nic`) whose boot NIC hasn't appeared yet; wait.
+- **Missing** — a host with managed DPUs has neither an owned primary interface nor a usable prediction; a fault to investigate. This includes a managed-DPU host declared to boot from an integrated HostInband NIC if that declaration did not produce a prediction.
+
+> **Key timing.** Managed-DPU hosts usually acquire an owned primary host-facing row while the DPU is attached. A zero-DPU, NIC-mode, or declared integrated NIC can remain prediction-only until its first DHCP lease. When DHCP promotes that prediction to an owned row, the machine-scoped desired target remains stable across the handoff.
 
 ### Applying the boot order
 
 - `configure_host_bios` (at `WaitingForPlatformConfiguration`) calls Redfish `machine_setup` with the resolved boot interface; on Dell this schedules a BIOS job (`WaitingForBiosJob`).
 - `PollingBiosSetup` verifies the BIOS settings took.
-- `SetBootOrder` targets the resolved primary interface via Redfish. In the default managed-DPU topology that is the primary DPU host-PF; for a declared integrated primary or a host using `ignore` or `nic`, it is the resolved HostInband interface. A "no DPU" response from the BMC is expected and treated as success only for a host with no managed DPUs.
-- On a reprovision repair, `check_host_boot_config` re-checks BIOS + boot order and only remediates if they drifted.
+- During `HostInit`, `SetBootOrder` targets the owned/predicted resolution via Redfish. In the default managed-DPU topology that is the primary DPU host-PF; for a declared integrated primary or a host using `ignore` or `nic`, it is the resolved HostInband interface. During `BootConfiguring`, the same stage uses the captured persisted desired target instead. A "no DPU" response from the BMC is expected and treated as success only for a host with no managed DPUs.
+- An unassigned `Ready` host with an unverified desired version enters `BootConfiguring`. An ordinary host starts with a read-only Redfish inspection; a Supermicro host first disables lockdown and restarts because its locked boot-order view can be stale. The controller then reuses the shared BIOS/job/boot-order driver for only the work required, restores the configured lockdown policy, and records the exact desired version verified only after a final matching read. Persisted substates make the work restart-safe; a terminal failure stays visible and keeps the host out of allocation until maintenance or a fresh desired generation takes control.
+- Every successful verification records `verified_version` and `observed_at`. A verified target becomes eligible for another read after `machine_state_controller.boot_interface_observation_interval` (default `10m`). Idle `Ready` and `Assigned` iterations inspect Redfish without mutating it once every managed DPU also has a current network observation. A successful match advances `observed_at`; a read failure leaves it unchanged so the next controller sweep retries. A mismatch opens a new pending generation: `Ready` repairs it, while `Assigned` defers disruptive work until the host is released.
+- Managed-host selection and reapply paths update database state (primary and desired as applicable) and wake machine-controller; machine-controller decides whether BIOS work, boot-order work, or a reboot is required. Raw Redfish commands, DPU-owned endpoint actions, unowned endpoints, and the untargeted `MachineSetup` fallback retain direct behavior.
+- On a reprovision repair, `check_host_boot_config` also re-checks BIOS + boot order and only remediates if they drifted.
 
 ---
 
 ## 7. The boot-interface data model
 
-The boot interface flows through three tables: **predicted → managed → retained**.
+The durable machine-scoped request and its reconciliation/verification metadata live in `machine_boot_interfaces`. Predicted, managed, explored, and retained records supply discovery identity and defaults around that request.
 
-### 7.1 Predicted (`predicted_machine_interfaces`)
+### 7.1 Desired and verified (`machine_boot_interfaces`)
+
+Each confirmed or predicted host can have one row:
+
+- `desired_mac_address` and optional `desired_interface_id` identify a complete `Pair` or a valid MAC-only target while the Redfish ID is not yet known.
+- `desired_version` starts at initialization and advances when an operator changes or force-reconciles a target, site-explorer adds the same MAC's Redfish ID, or periodic observation reopens the same target after drift. Same-MAC enrichment preserves a current verification because it strengthens the identity without selecting another NIC.
+- `verified_version` identifies the last desired generation treated as verified, and `observed_at` records when that verification was established. A newer pending desired generation leaves both fields on the prior verification until convergence.
+- `assumed` distinguishes the rollout compatibility baseline used when an already-stable `Ready` or `Assigned` host is initialized without a Redfish read; the next successful Redfish check clears it.
+
+Reconciliation state is derived rather than stored as another mutable enum: matching desired and verified versions are `Converged`; otherwise current `BootConfiguring` work is `Converging` or `Failed`, and all other cases are `Pending`. The schema migration does not backfill targets. Site-explorer incrementally initializes missing rows from current interface or prediction data, one machine transaction at a time, and preserves an existing operator choice.
+
+### 7.2 Predicted (`predicted_machine_interfaces`)
 
 Site-explorer mints a prediction per declared host NIC **before** the host's first DHCP lease. A prediction carries `machine_id`, `mac_address`, `network_segment_type`, the operator's declared `primary` intent, and the `boot_interface_id` (the Redfish `EthernetInterface.Id`, captured from the exploration report once available). Predictions are what the controller uses to configure boot pre-lease.
 
-### 7.2 Managed (`machine_interfaces`) — promotion
+### 7.3 Managed (`machine_interfaces`) — promotion
 
 When the host first DHCPs on a predicted NIC, `move_predicted_machine_interface_to_machine` **promotes** the prediction into an owned `machine_interfaces` row:
 
@@ -365,28 +393,29 @@ When the host first DHCPs on a predicted NIC, `move_predicted_machine_interface_
 - The `boot_interface_id` is resolved by precedence: **prediction > existing row value > retained** (see below).
 - The prediction is deleted — the owned row is now authoritative.
 
-The owned table is **Store B**: the authoritative source of truth once a host is owned, kept current by per-exploration updates.
+The owned table is **Store B**: the authoritative source for candidate and primary-interface selection once a host is owned, kept current by per-exploration updates. The separate `machine_boot_interfaces` row remains the authoritative desired Redfish target.
 
-### 7.3 Retained boot interfaces
+### 7.4 Retained boot interfaces
 
 The Redfish boot-interface id is the one fact a MAC cannot always rediscover after deletion (a DPU/NIC-mode flip can drop the MAC from BMC reports while the id stays stable; a re-ingested host needs to be targeted for boot before a fresh exploration). So:
 
 - On **deletion** of a `machine_interfaces` row, its `boot_interface_id` is **upserted** into `retained_boot_interfaces` (keyed by MAC; newest wins).
 - On **creation** of a new row, any retained id for that MAC is **consumed** and applied — provided it's within the configured `retained_boot_interface_window` (default: no expiry, i.e. retained forever; set a window to bound recycled-MAC reuse).
 
-This is what carries a host's boot target across a force-delete / re-ingest gap.
+This preserves the Redfish interface ID for the same MAC across a force-delete / re-ingest gap. Expected Machine, prediction, and owned-interface selection still choose the MAC; the machine-scoped desired row and version are deleted with the machine.
 
-### 7.4 Selection precedence
+### 7.5 Selection precedence
 
-The same precedence applies wherever NICo picks a boot interface, over owned rows, predictions, or the explored report respectively:
+The persisted desired target is authoritative for desired-state and `Ready` convergence. `HostInit` and reprovision lifecycle paths still resolve owned/predicted selection. The following functions compute initial/default candidates without replacing an existing desired MAC:
 
 | Function | Operates on | Precedence |
 |---|---|---|
+| `desired_boot_interface_update` | durable-target initialization/enrichment | complete desired pair stays; a MAC-only target may gain the same MAC's ID; otherwise declared-primary prediction → owned pick → unambiguous prediction → none |
 | `pick_boot_interface` | owned `machine_interfaces` | declared primary → lowest-MAC non-underlay → none |
 | `pick_boot_prediction` | predictions | declared primary → the sole non-underlay prediction → none |
 | `select_host_primary_interface` and Site Explorer fallback | the explored report (**Store A**, the default before ownership) | declared primary → lowest UEFI PCI path when every matching DPU host interface in the Redfish report has one → stable Redfish serial ordering → none |
 
-**Store A vs. Store B:** before a host is owned, Site Explorer records a boot default on the explored endpoint (`explored_endpoints.boot_interface_mac`/`_id`, using `select_host_primary_interface`). Once owned, `machine_interfaces` (Store B) is authoritative. A declared `primary` wins in **both** stores, so the boot interface is consistent across the ownership handoff.
+**Store A vs. Store B:** before a host is owned, Site Explorer records a boot default on the explored endpoint (`explored_endpoints.boot_interface_mac`/`_id`, using `select_host_primary_interface`). Once owned, `machine_interfaces` (Store B) supplies current candidates. A declared `primary` wins in **both** stores, while `machine_boot_interfaces` preserves the selected desired target across the ownership handoff.
 
 ---
 
@@ -398,18 +427,23 @@ The same precedence applies wherever NICo picks a boot interface, over owned row
 nico-admin-cli -a <api-url> managed-host show <machine-id>
 ```
 
-The interfaces section shows each NIC's MAC, segment, and which one is `primary` (the boot interface). The web UI machine-detail page shows the same with a primary indicator.
+The interfaces section shows each NIC's MAC, segment, and which one is `primary`. The web UI machine-detail page also has a **Desired Boot Interface** section with the persisted target, reconciliation state, versions, last observation, active controller generation, and selectable candidates.
 
-To inspect the boot interface itself, use `boot-interface show <machine-id>`. It displays every store (managed, predicted, explored, retained), the effective interface, and any disagreement between stores. `boot-interface candidates <machine-id>` narrows the output to candidate NICs and their picks. Both commands also show the selection source and decision time. When NICo cannot recover the historical selection, including a migrated row or a compatibility baseline for an existing Ready or Assigned host, the commands report `LegacyUnknown` without a decision time. Both commands are read-only ([Section 4](#4-admin-cli-and-grpc-reference)).
+To inspect the boot interface itself — every store (managed, predicted, explored, retained) side by side, the effective owned pick, desired-state reconciliation (`Pending`, `Converging`, `Converged`, or `Failed`), and a flag when current selection signals disagree — use `boot-interface show <machine-id>`. The disagreement check compares the effective owned pick, explored defaults, and declared-primary predictions; it excludes retained history and the desired target. `boot-interface candidates <machine-id>` narrows the view to candidate NICs and includes the combined current pick, falling back to an unambiguous prediction before the first lease. Both commands also show the desired selection source and decision time. When NICo cannot recover the historical selection, including a migrated row or a compatibility baseline for an existing Ready or Assigned host, the commands report `LegacyUnknown` without a decision time. Both are read-only ([Section 4](#4-admin-cli-and-grpc-reference)).
+
+To request another controller pass without changing the selected target, use **Request reconciliation** in the web UI. The CLI equivalent is `boot-interface set <machine-id> <interface> --force-reconcile` only when that interface is already the intended managed primary; the command is still a `SetPrimaryInterface` operation and can otherwise move the primary/admin network identity.
 
 **Common situations:**
 
 | Symptom | Likely cause / action |
 |---|---|
 | `boot_interface_mac_mismatch` (pairing blocker) | The host's boot MAC doesn't match any discovered DPU's pf0 MAC. Expected for an integrated-NIC host — declare the integrated NIC `primary` (see [3.4](#34-boot-an-integrated-nic-while-keeping-the-dpus-managed)); otherwise check the exploration reports. See [Ingesting Hosts → pairing blockers](ingesting-hosts.md#common-blockers-during-host--dpu-pairing). |
-| Host stuck waiting for a boot NIC | A host using `ignore` or `nic` whose boot NIC hasn't leased yet (`AwaitingNic`). Confirm the NIC is cabled and DHCP-reachable on its HostInband segment. |
+| Host stuck waiting for a boot NIC | A host with no managed DPUs (zero-DPU, `ignore`, or `nic`) whose boot NIC hasn't leased yet (`AwaitingNic`). Confirm the NIC is cabled and DHCP-reachable on its HostInband segment. |
 | `Missing boot interface` for a managed-DPU host | The host has neither an owned primary interface nor a usable prediction. For an integrated-NIC boot, confirm `host_nics` declares exactly one `primary` NIC and that site-explorer created its HostInband prediction; otherwise investigate DPU pairing and promotion. |
-| Boot interface wrong after a DPU↔NIC-mode flip | Use **Restore Boot Interface** in the web UI, or re-ingest ([3.5](#35-flipping-a-dpu-to-nic-mode)). |
+| Reconciliation is `Pending` while the host is `Assigned` | This is non-disruptive by design. The controller may observe drift but does not change Redfish or reboot a tenant host; repair begins after release returns it to unassigned `Ready`. |
+| Reconciliation is `Failed` | Read the failure and active generation in `boot-interface show` or the web UI. Correct the reported underlying cause, then request reconciliation again for the same interface or select a new target. |
+| `observed_at` is old | First compare `desired_version` and `verified_version`: a pending target retains the earlier generation's timestamp and is not eligible for periodic observation. For a verified target, a failed BMC read leaves the timestamp unchanged and retries on the next controller sweep. If Redfish is healthy, confirm the `boot_interface_observation_interval` has elapsed (default `10m`) and every managed DPU has a current network observation. Supermicro hosts with managed lockdown skip the non-disruptive periodic read because their locked boot-order view is stale. |
+| Boot interface wrong after a DPU↔NIC-mode flip | For a managed host, use **Request reconciliation** (or a qualified `--force-reconcile` call as described above) to reapply its persisted target. **Restore Boot Interface** is also declarative when the explored endpoint belongs to a managed or predicted host; it applies Redfish directly only for an unowned or DPU-owned endpoint. Re-ingest if needed ([3.5](#35-flipping-a-dpu-to-nic-mode)). |
 | `manual_power_cycle_required` (pairing blocker) after a queued NIC-mode flip | Site-explorer could not apply the queued mode change: The BMC refused both Redfish reset types (`PowerCycle` and `ACPowercycle`), or the DPUs still report the old mode after cycling. Power-cycle the host manually (BMC UI, or the admin CLI's `redfish ac-power-cycle`); the next exploration pass verifies the mode and clears the blocker. A host can also sit here briefly mid-flip; repeat cycles are rate-limited. |
 | Boot interface disabled or no longer the boot device after a DPU replacement (notably on Dell) | The replacement DPU came up in InfiniBand (VPI) link type. NICo self-heals this: DPU cloud-init normalizes the ports to Ethernet and reboots before management-network setup runs, and DPU reprovision then repairs the host BIOS/boot-order configuration automatically — no manual action is needed. If it persists, confirm the DPU ran the normalization (`/var/log/forge/link-type.log` on the DPU) and re-ingest. |
 | DPU mode "unknown" (`dpu_nic_mode_unknown`) | DPU BMC firmware too old to report mode. Install a fresh DPU OS — see [Ingesting Hosts](ingesting-hosts.md#dpu-related-issues-installing-a-fresh-dpu-os). |


### PR DESCRIPTION
The existing boot-interface documentation predates the desired-state convergence series and conflates owned primary/default selection with the persisted Redfish target. It also leaves the operator-facing compatibility behavior incomplete.

This updates the generated references for `boot-interface show`, `candidates`, and `set` plus the managed-host compatibility commands. The operator guide now distinguishes the desired boot target from admin network identity, explains `Ready` and `Assigned` reconciliation and drift observation, documents the web UI paths, and describes the desired/verified data model. The command help spells out `--force-reconcile` versus the older-server `--reboot` path and the deprecated DPU machine ID to machine-interface ID migration.

The candidate projection also treats a declared-primary underlay row as eligible, matching the server-side selection rule.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4227.
This documents https://github.com/NVIDIA/infra-controller/issues/4193.

## Type of Change

- [x] **Fix** - Bug fixes
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed