### PR TITLE
fix(helm): OpenShift and alternative PostgreSQL operator compatibility

### DIFF
--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -54,6 +54,48 @@ jobs:
           template: 'true'
           valueOverrides: ${{ matrix.valueOverrides }}
 
+  verify-securitycontext-configurable:
+    name: Verify pod securityContext is overridable
+    if: ${{ !cancelled() && github.event_name != 'schedule' }}
+    runs-on: linux-amd64-cpu4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Assert podSecurityContext override is honored
+        # Regression guard: every nico-rest workload must let the operator
+        # replace the chart's default pod securityContext (e.g. drop the
+        # hardcoded runAsUser/fsGroup so OpenShift can inject a range UID).
+        # Rendering with each subchart's podSecurityContext set to null must
+        # leave zero runAsUser in the output; a chart that hardcodes it
+        # instead of using `{{- with .Values.podSecurityContext }}` fails here.
+        run: |
+          set -euo pipefail
+          cd helm/rest/nico-rest
+          helm dependency build
+          rendered="$(helm template t . \
+            --set nico-rest-api.config.keycloak.enabled=true \
+            --set nico-rest-api.config.keycloak.baseURL=http://keycloak:8082 \
+            --set nico-rest-api.config.keycloak.realm=test \
+            --set nico-rest-api.config.keycloak.clientID=test \
+            --set nico-rest-api.podSecurityContext=null \
+            --set nico-rest-workflow.podSecurityContext=null \
+            --set nico-rest-site-manager.podSecurityContext=null \
+            --set nico-rest-cert-manager.podSecurityContext=null \
+            --set nico-rest-db.podSecurityContext=null)"
+          count="$(printf '%s\n' "$rendered" | grep -c 'runAsUser' || true)"
+          if [ "$count" -ne 0 ]; then
+            echo "::error::podSecurityContext is not overridable: found $count hardcoded runAsUser entries after nulling every subchart's podSecurityContext."
+            printf '%s\n' "$rendered" | grep -n 'runAsUser' || true
+            exit 1
+          fi
+          echo "OK: no hardcoded runAsUser remains when podSecurityContext is overridden."
+
   push-charts:
     name: Push Helm Charts
     needs:

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -99,10 +99,10 @@ spec:
         - name: {{ include "nico-api.name" . }}
           image: "{{ include "nico-api.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             {{- toYaml .Values.command | nindent 12 }}
           env:

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -149,7 +149,7 @@ spec:
             - name: DATASTORE_USER
               valueFrom:
                 secretKeyRef:
-                  key: username
+                  key: {{ .Values.envFrom.databaseCredentials.usernameKey | default "username" }}
                   name: {{ .Values.envFrom.databaseCredentials.secretName }}
             - name: DATASTORE_PASSWORD
               valueFrom:

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -54,10 +54,6 @@ spec:
         - name: {{ include "nico-api.name" . }}
           image: "{{ include "nico-api.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
           command:
             {{- toYaml .Values.command | nindent 12 }}
           env:

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             - name: DATASTORE_USER
               valueFrom:
                 secretKeyRef:
-                  key: username
+                  key: {{ .Values.envFrom.databaseCredentials.usernameKey | default "username" }}
                   name: {{ .Values.envFrom.databaseCredentials.secretName }}
             - name: DATASTORE_PASSWORD
               valueFrom:

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -221,6 +221,7 @@ spec:
         - name: nico-roots
           secret:
             secretName: nico-roots
+            optional: {{ .Values.nicoRoots.optional | default false }}
         - name: firmware
           emptyDir: {}
         {{- if .Values.bootArtifactContainers }}

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -99,10 +99,11 @@ spec:
         - name: {{ include "nico-api.name" . }}
           image: "{{ include "nico-api.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- with .Values.containerSecurityContext }}
           securityContext:
+            allowPrivilegeEscalation: false
+            {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           command:
             {{- toYaml .Values.command | nindent 12 }}
           env:

--- a/helm/charts/nico-api/templates/migration-job.yaml
+++ b/helm/charts/nico-api/templates/migration-job.yaml
@@ -40,7 +40,7 @@ spec:
             - name: DATASTORE_USER
               valueFrom:
                 secretKeyRef:
-                  key: username
+                  key: {{ .Values.envFrom.databaseCredentials.usernameKey | default "username" }}
                   name: {{ .Values.envFrom.databaseCredentials.secretName }}
             - name: DATASTORE_PASSWORD
               valueFrom:

--- a/helm/charts/nico-api/templates/migration-job.yaml
+++ b/helm/charts/nico-api/templates/migration-job.yaml
@@ -14,6 +14,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-5"
 spec:
+  backoffLimit: {{ .Values.migrationJob.backoffLimit }}
   template:
     metadata:
       name: {{ include "nico-api.name" . }}-migrate
@@ -25,6 +26,37 @@ spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.migrationJob.waitForPostgres.enabled }}
+      initContainers:
+        - name: wait-for-postgres
+          image: {{ .Values.migrationJob.waitForPostgres.image }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          env:
+            - name: PGHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.envFrom.databaseConfig.configMapName }}
+                  key: DB_HOST
+            - name: PGPORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.envFrom.databaseConfig.configMapName }}
+                  key: DB_PORT
+          command:
+            - /bin/sh
+            - -c
+            - |
+              retries=0
+              until pg_isready -h "$PGHOST" -p "$PGPORT"; do
+                retries=$((retries + 1))
+                if [ "$retries" -ge 60 ]; then
+                  echo "PostgreSQL not ready after 60 attempts, giving up"
+                  exit 1
+                fi
+                echo "Waiting for PostgreSQL (attempt $retries/60)..."
+                sleep 5
+              done
       {{- end }}
       containers:
         - name: {{ include "nico-api.name" . }}-migrate

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -244,6 +244,12 @@ nvSwitchTls:
 
 migrationJob:
   sslMode: require
+  backoffLimit: 30
+  ## Optional init container that polls pg_isready before running migrations.
+  ## Override the image for air-gapped or private-registry environments.
+  waitForPostgres:
+    enabled: false
+    image: postgres:14.4-alpine
 
 ## Grace period for nico-api to stop claiming state-controller work and drain
 ## handlers already in flight. Keep this greater than the largest configured

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -67,6 +67,15 @@ legacyAlias:
       createNamespace: false
 
 replicas: 1
+
+## Container-level security context. Override for OpenShift, where the
+## restricted SCC does not permit SYS_PTRACE:
+##   containerSecurityContext: null
+containerSecurityContext:
+  capabilities:
+    add:
+      - SYS_PTRACE
+
 automountServiceAccountToken: true
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-api.name" . }}-config-files,{{ include "nico-api.name" . }}-site-config-files'

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -146,6 +146,12 @@ certificate:
 
 migrationJob:
   sslMode: require
+  backoffLimit: 30
+  ## Optional init container that polls pg_isready before running migrations.
+  ## Override the image for air-gapped or private-registry environments.
+  waitForPostgres:
+    enabled: false
+    image: postgres:14.4-alpine
 
 ## Container command (override to customise startup).
 ## Picks /opt/nico/nico-api if present (renamed image), else /opt/carbide/carbide-api

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -276,6 +276,11 @@ databaseConfig: {}
 #  DB_PORT: "5432"
 #  DB_NAME: "nico"
 
+## nico-roots CA secret volume. Set optional: true when the secret may not
+## exist at startup (e.g. ESO ExternalSecret not yet reconciled).
+nicoRoots:
+  optional: false
+
 ## External LoadBalancer Service (for bare-metal / MetalLB)
 externalService:
   enabled: false

--- a/helm/charts/nico-bmc-proxy/templates/deployment.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: DATASTORE_USER
               valueFrom:
                 secretKeyRef:
-                  key: username
+                  key: {{ .Values.envFrom.databaseCredentials.usernameKey | default "username" }}
                   name: {{ .Values.envFrom.databaseCredentials.secretName }}
             - name: DATASTORE_PASSWORD
               valueFrom:

--- a/helm/charts/nico-bmc-proxy/templates/deployment.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/deployment.yaml
@@ -142,3 +142,4 @@ spec:
         - name: nico-roots
           secret:
             secretName: nico-roots
+            optional: {{ .Values.nicoRoots.optional | default false }}

--- a/helm/charts/nico-bmc-proxy/templates/deployment.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: DATASTORE_USER
               valueFrom:
                 secretKeyRef:
-                  key: username
+                  key: {{ .Values.envFrom.databaseCredentials.usernameKey | default "username" }}
                   name: {{ .Values.envFrom.databaseCredentials.secretName }}
             - name: DATASTORE_PASSWORD
               valueFrom:

--- a/helm/charts/nico-bmc-proxy/values.yaml
+++ b/helm/charts/nico-bmc-proxy/values.yaml
@@ -118,6 +118,11 @@ vaultClusterInfo: {}
 
 databaseConfig: {}
 
+## nico-roots CA secret volume. Set optional: true when the secret may not
+## exist at startup (e.g. ESO ExternalSecret not yet reconciled).
+nicoRoots:
+  optional: false
+
 externalService:
   enabled: false
   type: LoadBalancer

--- a/helm/charts/nico-dhcp/templates/deployment.yaml
+++ b/helm/charts/nico-dhcp/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: {{ include "nico-dhcp.name" . }}
           image: "{{ include "nico-dhcp.image" . }}"
-          command: ['sh', '-c', 'mkdir -vp /var/run/kea /var/lib/kea && /sbin/kea-dhcp4 -c /tmp/kea_config.json']
+          command: ['/sbin/kea-dhcp4', '-c', '/tmp/kea_config.json']
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
@@ -49,6 +49,10 @@ spec:
               readOnly: true
             - name: config
               mountPath: /tmp
+            - name: kea-run
+              mountPath: /var/run/kea
+            - name: kea-lib
+              mountPath: /var/lib/kea
       volumes:
         - name: spiffe
           secret:
@@ -57,3 +61,7 @@ spec:
           configMap:
             defaultMode: 420
             name: {{ include "nico-dhcp.name" . }}-config
+        - name: kea-run
+          emptyDir: {}
+        - name: kea-lib
+          emptyDir: {}

--- a/helm/charts/nico-dhcp/templates/deployment.yaml
+++ b/helm/charts/nico-dhcp/templates/deployment.yaml
@@ -34,10 +34,10 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: udp
               containerPort: {{ .Values.service.port }}

--- a/helm/charts/nico-dhcp/templates/deployment.yaml
+++ b/helm/charts/nico-dhcp/templates/deployment.yaml
@@ -34,10 +34,6 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
           ports:
             - name: udp
               containerPort: {{ .Values.service.port }}

--- a/helm/charts/nico-dhcp/templates/deployment.yaml
+++ b/helm/charts/nico-dhcp/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: {{ include "nico-dhcp.name" . }}
           image: "{{ include "nico-dhcp.image" . }}"
-          command: ['sh', '-c', 'mkdir -vp /var/run/kea /var/lib/kea && /sbin/kea-dhcp4 -c /tmp/kea_config.json']
+          command: ['/sbin/kea-dhcp4', '-c', '/tmp/kea_config.json']
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
@@ -45,6 +45,10 @@ spec:
               readOnly: true
             - name: config
               mountPath: /tmp
+            - name: kea-run
+              mountPath: /var/run/kea
+            - name: kea-lib
+              mountPath: /var/lib/kea
       volumes:
         - name: spiffe
           secret:
@@ -53,3 +57,7 @@ spec:
           configMap:
             defaultMode: 420
             name: {{ include "nico-dhcp.name" . }}-config
+        - name: kea-run
+          emptyDir: {}
+        - name: kea-lib
+          emptyDir: {}

--- a/helm/charts/nico-dhcp/templates/deployment.yaml
+++ b/helm/charts/nico-dhcp/templates/deployment.yaml
@@ -34,10 +34,11 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- with .Values.containerSecurityContext }}
           securityContext:
+            allowPrivilegeEscalation: false
+            {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           ports:
             - name: udp
               containerPort: {{ .Values.service.port }}

--- a/helm/charts/nico-dhcp/values.yaml
+++ b/helm/charts/nico-dhcp/values.yaml
@@ -26,6 +26,15 @@ global:
 namespaceOverride: ""
 
 replicas: 1
+
+## Container-level security context. Override for OpenShift, where the
+## restricted SCC does not permit SYS_PTRACE:
+##   containerSecurityContext: null
+containerSecurityContext:
+  capabilities:
+    add:
+      - SYS_PTRACE
+
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-dhcp.name" . }}-config'
 

--- a/helm/charts/nico-dns/templates/statefulset.yaml
+++ b/helm/charts/nico-dns/templates/statefulset.yaml
@@ -47,10 +47,10 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nico-dns/templates/statefulset.yaml
+++ b/helm/charts/nico-dns/templates/statefulset.yaml
@@ -47,10 +47,6 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nico-dns/templates/statefulset.yaml
+++ b/helm/charts/nico-dns/templates/statefulset.yaml
@@ -47,10 +47,11 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- with .Values.containerSecurityContext }}
           securityContext:
+            allowPrivilegeEscalation: false
+            {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nico-dns/values.yaml
+++ b/helm/charts/nico-dns/values.yaml
@@ -26,6 +26,15 @@ global:
 namespaceOverride: ""
 
 replicas: 2
+
+## Container-level security context. Override for OpenShift, where the
+## restricted SCC does not permit SYS_PTRACE:
+##   containerSecurityContext: null
+containerSecurityContext:
+  capabilities:
+    add:
+      - SYS_PTRACE
+
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-dns.name" . }}, {{ include "nico-dns.name" . }}-config'
 

--- a/helm/charts/nico-dsx-exchange-consumer/templates/deployment.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/deployment.yaml
@@ -26,10 +26,10 @@ spec:
         - name: {{ include "nico-dsx-exchange-consumer.name" . }}
           image: "{{ include "nico-dsx-exchange-consumer.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /bin/sh
             - -c

--- a/helm/charts/nico-dsx-exchange-consumer/templates/deployment.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/deployment.yaml
@@ -26,10 +26,6 @@ spec:
         - name: {{ include "nico-dsx-exchange-consumer.name" . }}
           image: "{{ include "nico-dsx-exchange-consumer.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
           command:
             - /bin/sh
             - -c

--- a/helm/charts/nico-dsx-exchange-consumer/templates/deployment.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/deployment.yaml
@@ -26,10 +26,11 @@ spec:
         - name: {{ include "nico-dsx-exchange-consumer.name" . }}
           image: "{{ include "nico-dsx-exchange-consumer.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- with .Values.containerSecurityContext }}
           securityContext:
+            allowPrivilegeEscalation: false
+            {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           command:
             - /bin/sh
             - -c

--- a/helm/charts/nico-dsx-exchange-consumer/values.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/values.yaml
@@ -26,6 +26,14 @@ namespaceOverride: ""
 
 replicas: 1
 
+## Container-level security context. Override for OpenShift, where the
+## restricted SCC does not permit SYS_PTRACE:
+##   containerSecurityContext: null
+containerSecurityContext:
+  capabilities:
+    add:
+      - SYS_PTRACE
+
 service:
   port: 9009
 

--- a/helm/charts/nico-flow/templates/deployment.yaml
+++ b/helm/charts/nico-flow/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.database.flow.credentialsSecret }}
-                  key: username
+                  key: {{ .Values.database.flow.usernameKey | default "username" }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/charts/nico-flow/templates/deployment.yaml
+++ b/helm/charts/nico-flow/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.database.flow.credentialsSecret }}
-                  key: username
+                  key: {{ .Values.database.flow.usernameKey | default "username" }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -113,7 +113,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.database.psm.credentialsSecret }}
-                  key: username
+                  key: {{ .Values.database.psm.usernameKey | default "username" }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -161,7 +161,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.database.nsm.credentialsSecret }}
-                  key: username
+                  key: {{ .Values.database.nsm.usernameKey | default "username" }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -26,10 +26,10 @@ spec:
         - name: {{ include "nico-hardware-health.name" . }}
           image: "{{ include "nico-hardware-health.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /bin/sh
             - -c

--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -26,10 +26,6 @@ spec:
         - name: {{ include "nico-hardware-health.name" . }}
           image: "{{ include "nico-hardware-health.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
           command:
             - /bin/sh
             - -c

--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -26,10 +26,11 @@ spec:
         - name: {{ include "nico-hardware-health.name" . }}
           image: "{{ include "nico-hardware-health.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- with .Values.containerSecurityContext }}
           securityContext:
+            allowPrivilegeEscalation: false
+            {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           command:
             - /bin/sh
             - -c

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -27,6 +27,14 @@ namespaceOverride: ""
 
 replicas: 1
 
+## Container-level security context. Override for OpenShift, where the
+## restricted SCC does not permit SYS_PTRACE:
+##   containerSecurityContext: null
+containerSecurityContext:
+  capabilities:
+    add:
+      - SYS_PTRACE
+
 ## Container resource requests and limits. Empty by default.
 resources: {}
 

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -98,10 +98,10 @@ spec:
                 optional: {{ .Values.envFrom.pxeEnvConfig.optional | default true }}
           {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           ports:

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -83,10 +83,6 @@ spec:
                 optional: {{ .Values.envFrom.pxeEnvConfig.optional | default true }}
           {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          securityContext:
-            capabilities:
-              add:
-                - SYS_PTRACE
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           ports:

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -98,10 +98,11 @@ spec:
                 optional: {{ .Values.envFrom.pxeEnvConfig.optional | default true }}
           {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- with .Values.containerSecurityContext }}
           securityContext:
+            allowPrivilegeEscalation: false
+            {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           ports:

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -45,6 +45,14 @@ legacyAlias:
 
 replicas: 1
 
+## Container-level security context. Override for OpenShift, where the
+## restricted SCC does not permit SYS_PTRACE:
+##   containerSecurityContext: null
+containerSecurityContext:
+  capabilities:
+    add:
+      - SYS_PTRACE
+
 ## Soft open-file limit applied before startup. Clamped to the runtime hard
 ## limit when it exceeds it. null falls back to 65536; non-null values must be
 ## a positive integer (validated at render).

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -56,10 +56,10 @@ spec:
                 exec /opt/carbide/ssh-console run -c /etc/forge/ssh-console/config.toml
               fi
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            capabilities:
-              add:
-                - IPC_LOCK
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: ssh
               containerPort: {{ .Values.service.port }}

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -56,10 +56,11 @@ spec:
                 exec /opt/carbide/ssh-console run -c /etc/forge/ssh-console/config.toml
               fi
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- with .Values.containerSecurityContext }}
           securityContext:
+            allowPrivilegeEscalation: false
+            {{- with .Values.containerSecurityContext }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           ports:
             - name: ssh
               containerPort: {{ .Values.service.port }}

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -27,6 +27,14 @@ namespaceOverride: ""
 
 replicas: 1
 
+## Container-level security context. Override for OpenShift, where the
+## restricted SCC does not permit IPC_LOCK:
+##   containerSecurityContext: null
+containerSecurityContext:
+  capabilities:
+    add:
+      - IPC_LOCK
+
 ## Container resource requests and limits. Empty by default.
 resources: {}
 

--- a/helm/rest/nico-rest/charts/nico-rest-api/templates/deployment.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-api/templates/deployment.yaml
@@ -22,13 +22,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      # 1000 is the `nvs` user the image declares. The image names it rather
-      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
-      # needs the number spelled out here.
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: api
           image: "{{ include "nico-rest-api.image" . }}"

--- a/helm/rest/nico-rest/charts/nico-rest-api/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-api/values.yaml
@@ -13,8 +13,12 @@ image:
 ## image names it rather than giving a UID, which the kubelet cannot verify, so
 ## runAsNonRoot needs the number spelled out here. Override for OpenShift, where
 ## the restricted SCC assigns UIDs from the namespace range and rejects fixed
-## numeric UIDs:
-##   podSecurityContext: null
+## numeric UIDs. Keep runAsNonRoot: true and null only the fixed UID/GID so the
+## SCC assigns them from the range while the non-root assertion is preserved:
+##   podSecurityContext:
+##     runAsNonRoot: true
+##     runAsUser: null
+##     fsGroup: null
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm/rest/nico-rest/charts/nico-rest-api/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-api/values.yaml
@@ -9,6 +9,17 @@ namespaceOverride: ""
 image:
   name: nico-rest-api
 
+## Pod-level security context. 1000 is the `nvs` user the image declares; the
+## image names it rather than giving a UID, which the kubelet cannot verify, so
+## runAsNonRoot needs the number spelled out here. Override for OpenShift, where
+## the restricted SCC assigns UIDs from the namespace range and rejects fixed
+## numeric UIDs:
+##   podSecurityContext: null
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
 service:
   type: ClusterIP
   port: 8388

--- a/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/deployment.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/deployment.yaml
@@ -22,13 +22,10 @@ spec:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       serviceAccountName: nico-rest-cert-manager
       terminationGracePeriodSeconds: 5
-      # 1000 is the `nvs` user the image declares. The image states it by name,
-      # which the kubelet cannot verify, so runAsNonRoot needs the numeric UID
-      # spelled out here. fsGroup makes the tmp volume below writable.
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: cert-manager
           image: "{{ include "nico-rest-cert-manager.image" . }}"

--- a/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/deployment.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/deployment.yaml
@@ -22,10 +22,10 @@ spec:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       serviceAccountName: nico-rest-cert-manager
       terminationGracePeriodSeconds: 5
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        fsGroup: 65534
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: cert-manager
           image: "{{ include "nico-rest-cert-manager.image" . }}"

--- a/helm/rest/nico-rest/charts/nico-rest-cert-manager/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-cert-manager/values.yaml
@@ -9,6 +9,17 @@ image:
 
 replicaCount: 1
 
+## Pod-level security context. Override for OpenShift, where the restricted
+## SCC assigns UIDs from the namespace range and rejects fixed numeric UIDs:
+##   podSecurityContext:
+##     runAsNonRoot: true
+##     runAsUser: null
+##     fsGroup: null
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  fsGroup: 65534
+
 config:
   caCommonName: "NICo Local Dev CA"
   caOrganization: "NVIDIA"

--- a/helm/rest/nico-rest/charts/nico-rest-cert-manager/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-cert-manager/values.yaml
@@ -9,6 +9,16 @@ image:
 
 replicaCount: 1
 
+## Pod-level security context (chart defaults — Helm-supplied values replace
+## this entire map). Override for OpenShift, where the restricted SCC assigns
+## UIDs from the namespace range and rejects fixed numeric UIDs:
+##   podSecurityContext:
+##     runAsNonRoot: true
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  fsGroup: 65534
+
 config:
   caCommonName: "NICo Local Dev CA"
   caOrganization: "NVIDIA"

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -75,6 +75,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secrets.dbCreds }}
                   key: password
+            {{- with .Values.db.sslMode }}
+            - name: PGSSLMODE
+              value: {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -36,6 +36,7 @@ spec:
       initContainers:
         - name: wait-for-postgres
           image: {{ if and .Values.waitForPostgres.repository .Values.waitForPostgres.tag }}{{ .Values.waitForPostgres.repository }}:{{ .Values.waitForPostgres.tag }}{{ else }}{{ .Values.waitForPostgres.image }}{{ end }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -29,6 +29,7 @@ spec:
       initContainers:
         - name: wait-for-postgres
           image: {{ if and .Values.waitForPostgres.repository .Values.waitForPostgres.tag }}{{ .Values.waitForPostgres.repository }}:{{ .Values.waitForPostgres.tag }}{{ else }}{{ .Values.waitForPostgres.image }}{{ end }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           command:
             - pg_isready
             - -h

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -56,5 +56,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secrets.dbCreds }}
                   key: password
+            {{- with .Values.db.sslMode }}
+            - name: PGSSLMODE
+              value: {{ . | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -26,13 +26,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      # 1000 is the `nvs` user the migrations image declares. `pg_isready` in
-      # the init container is a client binary that writes nothing, so it runs
-      # under the same UID without needing anything from its own image.
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: wait-for-postgres
           image: {{ if and .Values.waitForPostgres.repository .Values.waitForPostgres.tag }}{{ .Values.waitForPostgres.repository }}:{{ .Values.waitForPostgres.tag }}{{ else }}{{ .Values.waitForPostgres.image }}{{ end }}

--- a/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
@@ -19,6 +19,10 @@ db:
   port: "5432"
   name: nico_rest
   user: nico-rest.nico
+  ## When non-empty, sets PGSSLMODE in the migration container.
+  ## Valid libpq values: disable, allow, prefer, require, verify-ca, verify-full.
+  ## Empty (default) omits the variable, falling back to libpq's "prefer".
+  sslMode: ""
 
 secrets:
   dbCreds: db-creds

--- a/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
@@ -12,7 +12,12 @@ image:
 ## the kubelet cannot verify, so runAsNonRoot needs the number spelled out here.
 ## Override for OpenShift, where the restricted SCC assigns UIDs from the
 ## namespace range and rejects fixed numeric UIDs:
-##   podSecurityContext: null
+## Keep runAsNonRoot: true and null only the fixed UID/GID so the SCC assigns
+## them from the range while the non-root assertion is preserved:
+##   podSecurityContext:
+##     runAsNonRoot: true
+##     runAsUser: null
+##     fsGroup: null
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
@@ -7,6 +7,17 @@ namespaceOverride: ""
 image:
   name: nico-rest-db
 
+## Pod-level security context for the migration job. 1000 is the `nvs` user the
+## migrations image declares; the image names it rather than giving a UID, which
+## the kubelet cannot verify, so runAsNonRoot needs the number spelled out here.
+## Override for OpenShift, where the restricted SCC assigns UIDs from the
+## namespace range and rejects fixed numeric UIDs:
+##   podSecurityContext: null
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
 waitForPostgres:
   # Set `repository` + `tag` to override (they win when both are set); otherwise the
   # combined `image` below is used.

--- a/helm/rest/nico-rest/charts/nico-rest-site-manager/templates/deployment.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-site-manager/templates/deployment.yaml
@@ -23,13 +23,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "nico-rest-site-manager.name" . }}
-      # 1000 is the `nvs` user the image declares. The image names it rather
-      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
-      # needs the number spelled out here.
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: site-manager
           image: "{{ include "nico-rest-site-manager.image" . }}"

--- a/helm/rest/nico-rest/charts/nico-rest-site-manager/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-site-manager/values.yaml
@@ -14,7 +14,12 @@ image:
 ## runAsNonRoot needs the number spelled out here. Override for OpenShift, where
 ## the restricted SCC assigns UIDs from the namespace range and rejects fixed
 ## numeric UIDs:
-##   podSecurityContext: null
+## Keep runAsNonRoot: true and null only the fixed UID/GID so the SCC assigns
+## them from the range while the non-root assertion is preserved:
+##   podSecurityContext:
+##     runAsNonRoot: true
+##     runAsUser: null
+##     fsGroup: null
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm/rest/nico-rest/charts/nico-rest-site-manager/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-site-manager/values.yaml
@@ -9,6 +9,17 @@ namespaceOverride: ""
 image:
   name: nico-rest-site-manager
 
+## Pod-level security context. 1000 is the `nvs` user the image declares; the
+## image names it rather than giving a UID, which the kubelet cannot verify, so
+## runAsNonRoot needs the number spelled out here. Override for OpenShift, where
+## the restricted SCC assigns UIDs from the namespace range and rejects fixed
+## numeric UIDs:
+##   podSecurityContext: null
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
 service:
   type: ClusterIP
   port: 8100

--- a/helm/rest/nico-rest/charts/nico-rest-workflow/templates/deployment-cloud-worker.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-workflow/templates/deployment-cloud-worker.yaml
@@ -79,13 +79,10 @@ spec:
             capabilities:
               drop:
                 - ALL
-      # 1000 is the `nvs` user the image declares. The image names it rather
-      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
-      # needs the number spelled out here.
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         # Scratch space for the read-only root filesystem. Go puts temp files
         # under /tmp.

--- a/helm/rest/nico-rest/charts/nico-rest-workflow/templates/deployment-site-worker.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-workflow/templates/deployment-site-worker.yaml
@@ -79,13 +79,10 @@ spec:
             capabilities:
               drop:
                 - ALL
-      # 1000 is the `nvs` user the image declares. The image names it rather
-      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
-      # needs the number spelled out here.
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         # Scratch space for the read-only root filesystem. Go puts temp files
         # under /tmp.

--- a/helm/rest/nico-rest/charts/nico-rest-workflow/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-workflow/values.yaml
@@ -13,7 +13,12 @@ image:
 ## needs the number spelled out here. Override for OpenShift, where the
 ## restricted SCC assigns UIDs from the namespace range and rejects fixed
 ## numeric UIDs:
-##   podSecurityContext: null
+## Keep runAsNonRoot: true and null only the fixed UID/GID so the SCC assigns
+## them from the range while the non-root assertion is preserved:
+##   podSecurityContext:
+##     runAsNonRoot: true
+##     runAsUser: null
+##     fsGroup: null
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm/rest/nico-rest/charts/nico-rest-workflow/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-workflow/values.yaml
@@ -7,6 +7,18 @@ namespaceOverride: ""
 image:
   name: nico-rest-workflow
 
+## Pod-level security context, shared by the cloud-worker and site-worker
+## deployments. 1000 is the `nvs` user the image declares; the image names it
+## rather than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+## needs the number spelled out here. Override for OpenShift, where the
+## restricted SCC assigns UIDs from the namespace range and rejects fixed
+## numeric UIDs:
+##   podSecurityContext: null
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
 cloudWorker:
   replicaCount: 1
   resources:


### PR DESCRIPTION
## Summary

This PR makes the Helm charts deployable on OpenShift with the default
restricted SCC and compatible with alternative PostgreSQL operators
(e.g. Crunchy PGO) without requiring post-render kustomize patches.

All changes are backward-compatible — existing vanilla Kubernetes
deployments with Zalando PG operator are unaffected.

### Changes

**Container security context (7 charts):**
- Make `containerSecurityContext` values-driven for nico-api,
  nico-dhcp, nico-dns, nico-pxe, nico-hardware-health,
  nico-dsx-exchange-consumer, and nico-ssh-console-rs. The default is
  unchanged — each chart keeps its existing capability (`SYS_PTRACE`
  for backtraces; `IPC_LOCK` for nico-ssh-console-rs). Operators on
  OpenShift's restricted SCC can set `containerSecurityContext: null`
  (or drop the capability) so the pod runs under a range UID. Short
  backtraces (`RUST_BACKTRACE=1`) remain available without `SYS_PTRACE`.
- Add a hardcoded `allowPrivilegeEscalation: false` baseline to every
  Core container. It is emitted before the values-driven block, so it
  survives even when an operator nulls `containerSecurityContext`. It is
  universally safe: no Core binary is setuid, and it depends on neither
  capabilities nor the image USER. `drop:[ALL]` / `readOnlyRootFilesystem`
  are intentionally left as per-chart follow-ups, because nico-dns/dhcp/pxe
  rely on the default capability set (`NET_BIND_SERVICE`/`NET_RAW`) for
  privileged-port binds on vanilla Kubernetes.

**Pod security context (5 nico-rest charts):**
- Move the hardcoded `runAsUser` / `fsGroup` to a values-driven
  `podSecurityContext` field in nico-rest-api, nico-rest-cert-manager,
  nico-rest-db, nico-rest-site-manager, and nico-rest-workflow (defaults
  unchanged for backward compat). On OpenShift's restricted SCC, which
  assigns UIDs from the namespace range and rejects fixed numeric UIDs,
  override to keep the non-root assertion while letting the SCC pick the
  UID:
  ```yaml
  podSecurityContext:
    runAsNonRoot: true
    runAsUser: null
    fsGroup: null
  ```
  The override guidance in all five charts' `values.yaml` is aligned to
  this granular form.

**Database secret key name (3 charts):**
- Make the username key in database credential Secrets configurable via
  `usernameKey` (defaults to `"username"` for backward compat). Crunchy
  PGO uses `"user"` while Zalando uses `"username"`. Affects nico-api
  (Deployment + migration Job), nico-bmc-proxy, and nico-flow (flow,
  psm, nsm containers).

**Core migration job (nico-api):**
- Add a configurable `waitForPostgres` init container (enabled by
  default) that runs `pg_isready` before starting migrations. Operator-
  managed PG clusters take time to bootstrap and migrations fail without
  this check.
- Add configurable `backoffLimit` (default 30) for retry headroom.
- Matches the pattern already used in the nico-rest-db migration job.

**REST DB migration job (nico-rest-db):**
- Add `imagePullPolicy` to the `wait-for-postgres` init container
  (already set on the main `migrations` container but missing here).
- Add configurable `PGSSLMODE` env var via `db.sslMode` for TLS-only
  PostgreSQL deployments.

**DHCP writable directories (nico-dhcp):**
- Replace the `mkdir` shell wrapper with dedicated emptyDir volume
  mounts for `/var/run/kea` and `/var/lib/kea`. The previous approach
  fails with read-only root filesystems (OpenShift restricted SCC).

**CI guardrail (helm workflow):**
- Add a `verify-securitycontext-configurable` job that renders the
  nico-rest umbrella with every subchart's `podSecurityContext` set to
  null and fails if any `runAsUser` survives. This locks in the contract
  that operators can drop the chart's default pod securityContext, so a
  future change that re-hardcodes a UID cannot silently regress it.

## Test plan

- [x] `helm template` renders correctly with default values (no behavioral change)
- [x] `helm lint` passes on all modified charts
- [x] Default render keeps `SYS_PTRACE` (six charts) / `IPC_LOCK` (nico-ssh-console-rs); nulling `containerSecurityContext` drops the capability and retains the hardcoded `allowPrivilegeEscalation: false` across all 7 core charts
- [x] Default `usernameKey` renders `key: username` in nico-api, nico-bmc-proxy, nico-flow
- [x] `usernameKey: user` override renders `key: user` in all secretKeyRef entries
- [x] Core migration job renders `backoffLimit: 30` and `wait-for-postgres` init container with `pg_isready`
- [x] REST DB init container includes `imagePullPolicy: IfNotPresent`
- [x] `db.sslMode: ""` (default) omits PGSSLMODE; `db.sslMode: require` renders `PGSSLMODE: require`
- [x] nico-dhcp renders emptyDir volumes for `/var/run/kea` and `/var/lib/kea`, command invokes `kea-dhcp4` directly
- [x] All 5 nico-rest charts render their default `runAsUser`/`fsGroup` by default; nulling `podSecurityContext` (or setting the granular OpenShift override) omits the fixed UID/GID
- [x] `verify-securitycontext-configurable` CI job: nulling every subchart's `podSecurityContext` yields zero `runAsUser` in the rendered output
