### PR TITLE
docs: document expected machine interfaces

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -117,6 +117,8 @@ navigation:
           path: provisioning/ingesting-hosts.md
         - page: Ingesting Hosts (REST API)
           path: provisioning/ingesting-hosts-rest-api.md
+        - page: Configure Expected Machine Interfaces
+          path: provisioning/expected-machine-interfaces.md
         - page: Site Setup API Parity
           path: provisioning/site-setup-api-parity.md
         - page: Boot Interfaces and DPU Policies

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-add.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-add.md
@@ -13,11 +13,12 @@ nico-admin-cli-expected-machine-add - Add expected machine
 \[**-p**\|**--bmc-password**\] \<**-s**\|**--chassis-serial-number**\>
 \[**-d**\|**--fallback-dpu-serial-number**\] \[**--meta-name**\]
 \[**--meta-description**\] \[**--label**\] \[**--sku-id**\] \[**--id**\]
-\[**--host_nics**\] \[**--rack_id**\]
+\[**--interfaces**\] \[**--rack_id**\]
 \[**--default_pause_ingestion_and_poweron**\] \[**--dpf-enabled**\]
 \[**--extended**\] \[**--bmc-ip-address**\]
 \[**--bmc-retain-credentials**\] \[**--dpu-policy**\]
-\[**--disable-lockdown**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+\[**--bmc-ip-allocation**\] \[**--disable-lockdown**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
 
 ## DESCRIPTION
 
@@ -25,52 +26,63 @@ Add expected machine
 
 ## OPTIONS
 
-**-a**, **--bmc-mac-address** *\<BMC_MAC_ADDRESS\>*  
+**-a**, **--bmc-mac-address** *\<BMC_MAC_ADDRESS\>*\
 BMC MAC Address of the expected machine
 
-**-u**, **--bmc-username** *\<BMC_USERNAME\>*  
+**-u**, **--bmc-username** *\<BMC_USERNAME\>*\
 BMC username of the expected machine
 
-**-p**, **--bmc-password** *\<BMC_PASSWORD\>*  
+**-p**, **--bmc-password** *\<BMC_PASSWORD\>*\
 BMC password of the expected machine (optional; defaults to empty string
 if not provided)
 
-**-s**, **--chassis-serial-number** *\<CHASSIS_SERIAL_NUMBER\>*  
+**-s**, **--chassis-serial-number** *\<CHASSIS_SERIAL_NUMBER\>*\
 Chassis serial number of the expected machine
 
-**-d**, **--fallback-dpu-serial-number** *\<DPU_SERIAL_NUMBER\>*  
+**-d**, **--fallback-dpu-serial-number** *\<DPU_SERIAL_NUMBER\>*\
 Serial number of the DPU attached to the expected machine. This option
 should be used only as a last resort for ingesting those servers whose
 BMC/Redfish do not report serial number of network devices. This option
 can be repeated.
 
-**--meta-name** *\<META_NAME\>*  
+**--meta-name** *\<META_NAME\>*\
 The name that should be used as part of the Metadata for newly created
 Machines. If empty, the MachineId will be used
 
-**--meta-description** *\<META_DESCRIPTION\>*  
+**--meta-description** *\<META_DESCRIPTION\>*\
 The description that should be used as part of the Metadata for newly
 created Machines
 
-**--label** *\<LABEL\>*  
+**--label** *\<LABEL\>*\
 A label that will be added as metadata for the newly created Machine.
 The labels key and value must be separated by a : character. E.g.
 DATACENTER:XYZ
 
-**--sku-id** *\<SKU_ID\>*  
+**--sku-id** *\<SKU_ID\>*\
 A SKU ID that will be added for the newly created Machine.
 
-**--id** *\<UUID\>*  
+**--id** *\<UUID\>*\
 Optional unique ID to assign to the ExpectedMachine on create
 
-**--host_nics** *\<HOST_NICS\>*  
-Host NICs as a JSON array of ExpectedHostNic objects (fields:
-mac_address, nic_type, fixed_ip, fixed_mask, fixed_gateway, primary)
+**--interfaces** *\<INTERFACES\>*\
+Interfaces as a JSON array of ExpectedInterface objects (fields:
+mac_address, role, ip_allocation, network_segment_type, fixed_ip,
+fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values:
+role=host\|dpu_os\|dpu_bmc\|host_bmc and
+ip_allocation=dynamic\|fixed\|retained. network_segment_type uses
+protobuf enum numbers: tenant=0, admin=1, underlay=2, host_inband=3. An
+omitted role defaults to host. When ip_allocation is omitted, fixed_ip
+implies fixed; without fixed_ip, host_bmc defaults to retained and every
+other role defaults to dynamic. Explicit fixed policies, DPU fixed
+addresses, and inferred host_bmc fixed addresses with a segment guard
+must fall within a configured managed prefix. Legacy host entries with
+an omitted policy and unguarded inferred host_bmc fixed addresses keep
+the static-assignments fallback.
 
-**--rack_id** *\<RACK_ID\>*  
+**--rack_id** *\<RACK_ID\>*\
 Rack ID for this machine
 
-**--default_pause_ingestion_and_poweron** *\<DEFAULT_PAUSE_INGESTION_AND_POWERON\>*  
+**--default_pause_ingestion_and_poweron** *\<DEFAULT_PAUSE_INGESTION_AND_POWERON\>*\
 Optional flag to pause machines ingestion and power on. False - dont
 pause, true - will pause it. The actual mutable state is stored in
 explored_endpoints.\
@@ -82,7 +94,7 @@ explored_endpoints.\
 
 - false
 
-**--dpf-enabled** *\<DPF_ENABLED\>*  
+**--dpf-enabled** *\<DPF_ENABLED\>*\
 DPF enable/disable for this machine. Default is updated as true.\
 
 \
@@ -92,18 +104,18 @@ DPF enable/disable for this machine. Default is updated as true.\
 
 - false
 
-**--extended**  
+**--extended**\
 Extended result output.
 
 This used by measured boot, where basic output contains just what you
 probably care about, and "extended" output also dumps out all the
 internal UUIDs that are used to associate instances.
 
-**--bmc-ip-address** *\<BMC_IP_ADDRESS\>*  
+**--bmc-ip-address** *\<BMC_IP_ADDRESS\>*\
 Static BMC IP (pre-allocates machine_interface for site explorer, same
 as expected switches)
 
-**--bmc-retain-credentials** *\<BMC_RETAIN_CREDENTIALS\>*  
+**--bmc-retain-credentials** *\<BMC_RETAIN_CREDENTIALS\>*\
 When true, site-explorer skips BMC password rotation and stores
 factory-default credentials in Vault as-is\
 
@@ -116,12 +128,12 @@ factory-default credentials in Vault as-is\
 
 **--dpu-policy** *\<DPU_POLICY\>*\
 Per-host DPU policy. \`manage\` (default): inherit the site policy,
-which defaults to managing DPUs; \`nic\`: configure DPU hardware
-as plain NICs; \`ignore\`: do not configure or attach DPU hardware.
-Unset defers to the site-wide \`\[site_explorer\] dpu_policy\` setting.
-The previous \`use-as-nic\` value remains accepted as an alias. The legacy
-\`--dpu-mode\` flag also remains accepted: \`dpu-mode\` maps to \`manage\`,
-\`nic-mode\` to \`nic\`, and \`no-dpu\` to \`ignore\`.\
+which defaults to managing DPUs; \`nic\`: configure DPU hardware as
+plain NICs; \`ignore\`: do not configure or attach DPU hardware. Unset
+defers to the site-wide \`\[site_explorer\] dpu_policy\` setting. The
+previous \`use-as-nic\` value remains accepted as an alias. The legacy
+\`--dpu-mode\` flag also remains accepted: \`dpu-mode\` maps to
+\`manage\`, \`nic-mode\` to \`nic\`, and \`no-dpu\` to \`ignore\`.\
 
 \
 *Possible values:*
@@ -132,7 +144,29 @@ The previous \`use-as-nic\` value remains accepted as an alias. The legacy
 
 - ignore
 
-**--disable-lockdown** *\<DISABLE_LOCKDOWN\>*  
+**--bmc-ip-allocation** *\<BMC_IP_ALLOCATION\>*\
+Per-host control over how this BMCs IP is assigned and retained.
+\`auto\` (default): infer from \`--bmc-ip-address\` -- a configured
+address is \`fixed\`, no address is \`retained\`; \`dynamic\`: a normal
+DHCP lease that may expire and change; \`fixed\`: the operator-specified
+\`--bmc-ip-address\` (static); \`retained\`: an auto-allocated DHCP
+address that stays static for the lifetime of its machine-interface
+record. Unset defers to the server default (\`auto\`).\
+
+\
+*Possible values:*
+
+- unspecified
+
+- auto
+
+- dynamic
+
+- fixed
+
+- retained
+
+**--disable-lockdown** *\<DISABLE_LOCKDOWN\>*\
 If true, do not lock down the server as part of lifecycle management
 within the state machine. If unset or false, preserve the default
 behavior of locking down the server after configuring the BIOS.\
@@ -144,7 +178,7 @@ behavior of locking down the server after configuring the BIOS.\
 
 - false
 
-**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
 Sort output by specified field\
 
 \
@@ -154,7 +188,7 @@ Sort output by specified field\
 
 - state: Sort by state
 
-**-h**, **--help**  
+**-h**, **--help**\
 Print help (see a summary with -h)
 
 ## Examples
@@ -164,6 +198,9 @@ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-us
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --meta-name MyMachine --label DATACENTER:XYZ --sku-id DGX-H100-640GB
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --bmc-ip-address 192.0.2.20
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --dpu-policy nic
+nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --interfaces '[{"mac_address":"00:11:22:33:44:55","role":"host_bmc","ip_allocation":"retained"}]'
+nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --interfaces '[{"mac_address":"02:00:00:00:20:01","role":"dpu_os","ip_allocation":"fixed","fixed_ip":"192.0.2.10"}]'
+nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --bmc-ip-allocation retained
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-patch.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-patch.md
@@ -18,6 +18,7 @@ update, preserves unprovided fields).
 \[**--rack-id**\] \[**--default_pause_ingestion_and_poweron**\]
 \[**--dpf-enabled**\] \[**--bmc-ip-address**\] \[**--extended**\]
 \[**--bmc-retain-credentials**\] \[**--dpu-policy**\]
+\[**--bmc-ip-allocation**\] \[**--interfaces**\]
 \[**--disable-lockdown**\] \[**--sort-by**\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION
@@ -37,46 +38,46 @@ sku123 --label env:prod --label team:platform
 
 ## OPTIONS
 
-**-a**, **--bmc-mac-address** *\<BMC_MAC_ADDRESS\>*  
+**-a**, **--bmc-mac-address** *\<BMC_MAC_ADDRESS\>*\
 BMC MAC Address of the expected machine
 
-**--id** *\<ID\>*  
+**--id** *\<ID\>*\
 ID (UUID) of the expected machine to patch.
 
-**-u**, **--bmc-username** *\<BMC_USERNAME\>*  
+**-u**, **--bmc-username** *\<BMC_USERNAME\>*\
 BMC username of the expected machine
 
-**-p**, **--bmc-password** *\<BMC_PASSWORD\>*  
+**-p**, **--bmc-password** *\<BMC_PASSWORD\>*\
 BMC password of the expected machine
 
-**-s**, **--chassis-serial-number** *\<CHASSIS_SERIAL_NUMBER\>*  
+**-s**, **--chassis-serial-number** *\<CHASSIS_SERIAL_NUMBER\>*\
 Chassis serial number of the expected machine
 
-**-d**, **--fallback-dpu-serial-number** *\<DPU_SERIAL_NUMBER\>*  
+**-d**, **--fallback-dpu-serial-number** *\<DPU_SERIAL_NUMBER\>*\
 Serial number of the DPU attached to the expected machine. This option
 should be used only as a last resort for ingesting those servers whose
 BMC/Redfish do not report serial number of network devices. This option
 can be repeated.
 
-**--meta-name** *\<META_NAME\>*  
+**--meta-name** *\<META_NAME\>*\
 The name that should be used as part of the Metadata for newly created
 Machines. If empty, the MachineId will be used
 
-**--meta-description** *\<META_DESCRIPTION\>*  
+**--meta-description** *\<META_DESCRIPTION\>*\
 The description that should be used as part of the Metadata for newly
 created Machines
 
-**--label** *\<LABEL\>*  
+**--label** *\<LABEL\>*\
 A label that will be added as metadata for the newly created Machine.
 The labels key and value must be separated by a : character
 
-**--sku-id** *\<SKU_ID\>*  
+**--sku-id** *\<SKU_ID\>*\
 A SKU ID that will be added for the newly created Machine.
 
-**--rack-id** *\<RACK_ID\>*  
+**--rack-id** *\<RACK_ID\>*\
 A RACK ID that will be added for the newly created Machine.
 
-**--default_pause_ingestion_and_poweron** *\<DEFAULT_PAUSE_INGESTION_AND_POWERON\>*  
+**--default_pause_ingestion_and_poweron** *\<DEFAULT_PAUSE_INGESTION_AND_POWERON\>*\
 Optional flag to pause machines ingestion and power on. False - dont
 pause, true - will pause it. The actual mutable state is stored in
 explored_endpoints.\
@@ -88,7 +89,7 @@ explored_endpoints.\
 
 - false
 
-**--dpf-enabled** *\<DPF_ENABLED\>*  
+**--dpf-enabled** *\<DPF_ENABLED\>*\
 DPF enable/disable for this machine. Default is updated as true.\
 
 \
@@ -98,18 +99,18 @@ DPF enable/disable for this machine. Default is updated as true.\
 
 - false
 
-**--bmc-ip-address** *\<BMC_IP_ADDRESS\>*  
+**--bmc-ip-address** *\<BMC_IP_ADDRESS\>*\
 Static BMC IP (updates pre-allocated machine_interface when safe, same
 as expected switches)
 
-**--extended**  
+**--extended**\
 Extended result output.
 
 This used by measured boot, where basic output contains just what you
 probably care about, and "extended" output also dumps out all the
 internal UUIDs that are used to associate instances.
 
-**--bmc-retain-credentials** *\<BMC_RETAIN_CREDENTIALS\>*  
+**--bmc-retain-credentials** *\<BMC_RETAIN_CREDENTIALS\>*\
 When true, site-explorer skips BMC password rotation and stores
 factory-default credentials in Vault as-is\
 
@@ -124,10 +125,10 @@ factory-default credentials in Vault as-is\
 Per-host DPU policy. \`manage\`: inherit the site policy, which defaults
 to managing DPUs; \`nic\`: configure DPU hardware as plain NICs;
 \`ignore\`: do not configure or attach DPU hardware. Unset preserves the
-existing per-host value. The previous \`use-as-nic\` value remains accepted
-as an alias. The legacy \`--dpu-mode\` flag also remains accepted:
-\`dpu-mode\` maps to \`manage\`, \`nic-mode\` to \`nic\`, and \`no-dpu\`
-to \`ignore\`.\
+existing per-host value. The previous \`use-as-nic\` value remains
+accepted as an alias. The legacy \`--dpu-mode\` flag also remains
+accepted: \`dpu-mode\` maps to \`manage\`, \`nic-mode\` to \`nic\`, and
+\`no-dpu\` to \`ignore\`.\
 
 \
 *Possible values:*
@@ -138,7 +139,44 @@ to \`ignore\`.\
 
 - ignore
 
-**--disable-lockdown** *\<DISABLE_LOCKDOWN\>*  
+**--bmc-ip-allocation** *\<BMC_IP_ALLOCATION\>*\
+Per-host control over how this BMCs IP is assigned and retained.
+\`auto\` (default): infer from \`--bmc-ip-address\` -- a configured
+address is \`fixed\`, no address is \`retained\`; \`dynamic\`: a normal
+DHCP lease that may expire and change; \`fixed\`: the operator-specified
+\`--bmc-ip-address\` (static); \`retained\`: an auto-allocated DHCP
+address that stays static for the lifetime of its machine-interface
+record. Unset preserves the existing per-host value.\
+
+\
+*Possible values:*
+
+- unspecified
+
+- auto
+
+- dynamic
+
+- fixed
+
+- retained
+
+**--interfaces** *\<INTERFACES\>*\
+Interfaces as a JSON array of ExpectedInterface objects (fields:
+mac_address, role, ip_allocation, network_segment_type, fixed_ip,
+fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values:
+role=host\|dpu_os\|dpu_bmc\|host_bmc\|unspecified and
+ip_allocation=dynamic\|fixed\|retained\|unspecified.
+network_segment_type uses protobuf enum numbers: tenant=0, admin=1,
+underlay=2, host_inband=3. Replaces the machines full interface list.
+For a matching stored MAC, omitting role preserves the stored role;
+role=unspecified resets it to host. Omitting ip_allocation preserves the
+stored policy when the presence of fixed_ip is unchanged;
+ip_allocation=unspecified resets it to fixed_ip inference. Omitting any
+other optional interface field, including network_segment_type, clears
+its stored value.
+
+**--disable-lockdown** *\<DISABLE_LOCKDOWN\>*\
 If true, do not lock down the server as part of lifecycle management
 within the state machine. If unset or false, preserve the default
 behavior of locking down the server after configuring the BIOS.\
@@ -150,7 +188,7 @@ behavior of locking down the server after configuring the BIOS.\
 
 - false
 
-**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]\
 Sort output by specified field\
 
 \
@@ -160,7 +198,7 @@ Sort output by specified field\
 
 - state: Sort by state
 
-**-h**, **--help**  
+**-h**, **--help**\
 Print help (see a summary with -h)
 
 ## Examples
@@ -170,6 +208,9 @@ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --sku-
 nico-admin-cli expected-machine patch --id 12345678-1234-5678-90ab-cdef01234567 --sku-id DGX-H100-640GB
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mynewpassword
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --dpu-policy ignore
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --bmc-ip-allocation retained
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --interfaces '[{"mac_address":"02:00:00:00:20:01","fixed_ip":"192.0.2.10"}]'
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --interfaces '[{"mac_address":"02:00:00:00:20:01","role":"unspecified","ip_allocation":"unspecified","fixed_ip":"192.0.2.10"}]'
 ```
 
 ---

--- a/docs/provisioning/boot-interfaces-and-dpu-modes.md
+++ b/docs/provisioning/boot-interfaces-and-dpu-modes.md
@@ -1,8 +1,10 @@
 # Boot Interfaces and DPU Policies <Badge intent="info">v2.0</Badge> <Badge intent="launch" minimal>New</Badge>
 
-This guide explains how NICo decides **which interface a host boots from**, how a host's **DPUs are managed**, and how operators configure both through the Expected Machines table. It is the deep companion to [Ingesting Hosts](ingesting-hosts.md): that page covers the end-to-end ingest flow and the basic `expected_machines.json`; this page covers the per-host and per-NIC knobs (`dpu_policy`, `host_nics`), **what the defaults do when you set nothing**, and how a boot device is chosen and applied behind the scenes.
+This guide explains how NICo decides **which interface a host boots from**, how a host's **DPUs are managed**, and how operators configure both through the Expected Machines table. It is the deep companion to [Ingesting Hosts](ingesting-hosts.md): that page covers the end-to-end ingest flow and the basic `expected_machines.json`; this page covers the per-host and per-interface knobs (`dpu_policy`, `interfaces`), **what the defaults do when you set nothing**, and how a boot device is chosen and applied behind the scenes.
 
 For the DHCP and network-segment substrate these knobs sit on (how a relay's `giaddr` maps to a segment), see [IP and Network Configuration](ip-and-network-configuration.md).
+For interface roles and IP allocation policies, see
+[Configure Expected Machine Interfaces](expected-machine-interfaces.md).
 
 > **Who should read this.** Operators configuring hosts for ingestion, and anyone debugging "why did this host boot from *that* interface?" **Most hosts need no configuration here** — the defaults handle the common managed-DPU case. Reach for the knobs in [Section 2](#2-configuring-via-expected-machines-and-the-defaults) and [Section 3](#3-scenarios) only for `nic`, `ignore`, or integrated-NIC hosts. [Sections 6](#6-behind-the-scenes-how-a-boot-device-is-chosen-and-set)–[7](#7-the-boot-interface-data-model) explain the machinery when you need to trace a problem.
 
@@ -53,7 +55,7 @@ Boot and DPU configuration is **declarative**: you describe the host in the Expe
 
 ### If you set nothing (the default)
 
-**Most hosts with DPU hardware need zero boot/DPU configuration.** Outside rack-manager deployments, when neither the host nor the site sets `dpu_policy`, and the host has no `host_nics` declaration:
+**Most hosts with DPU hardware need zero boot/DPU configuration.** Outside rack-manager deployments, when neither the host nor the site sets `dpu_policy`, and the host has no `interfaces` declaration:
 
 - The effective `dpu_policy` resolves to **`manage`** — NICo ingests and manages the host's DPUs, and the host boots through its primary DPU on the **Admin** network.
 - Site-explorer **auto-selects the boot interface**: it uses the lowest UEFI PCI path when every matching DPU host interface in the Redfish report has one. Otherwise, it orders the DPUs by their Redfish serial numbers without regard to case and uses the first interface in that order.
@@ -89,25 +91,20 @@ JSON vocabulary rather than Forge protobuf symbols. Responses translate
 non-default policies back through `dpu_mode`; the default `manage` policy might
 leave that field unset.
 
-### `host_nics` (per-NIC declaration)
+### Expected Machine Interface Declarations
 
-The optional `host_nics` array declares specifics for individual host NICs. Each entry (`ExpectedHostNic`):
+The optional `interfaces` array declares host and DPU interfaces. Each
+`ExpectedInterface` entry identifies an interface by MAC address and can set its
+role, IP allocation policy, segment guard, and primary status.
 
-| Field | Type | Purpose | Default if unset |
-|---|---|---|---|
-| `mac_address` | string (required) | The NIC's MAC address. | — |
-| `primary` | bool | Declare **this NIC** as the host's boot/primary interface. **At most one per host.** | For hosts whose effective DPU policy is `manage`, Site Explorer chooses among discovered DPU host PFs: it selects the lowest UEFI PCI path when every matching Redfish interface has one; otherwise it orders the DPUs by Redfish serial number and uses the first DPU's host PF. Hosts using `nic` or `ignore` do not get this fallback and must declare a primary HostInband NIC. |
-| `network_segment_type` | enum: `admin` / `underlay` / `host_inband` / `tenant` | The expected segment type for this NIC's DHCP selection. It narrows candidates when a request carries multiple relay addresses and prevents a declaration from silently using the wrong segment type. | The relay's matching segment(s) stand. |
-| `fixed_ip` / `fixed_mask` / `fixed_gateway` | string | Static IP assignment for the NIC, materialized during expected-interface reconciliation. | Dynamic allocation. |
-| `nic_type` | string (legacy) | A free-form segment hint, **superseded by `network_segment_type`**. Kept for backward compatibility only. | — |
+For boot selection, declare an entry with `role: "host"` and
+`primary: true`. Only a `host` entry can set `primary`, and at most one entry
+per Expected Machine can set it to `true`. If `role` is omitted, it defaults to
+`host`.
 
-> **What `network_segment_type` actually does.** A NIC's segment is normally
-> determined by relay metadata: NICo finds the segment whose prefix contains
-> an IPv4 relay address; an exact configured DHCPv6 link-address takes
-> precedence. `network_segment_type` narrows multiple relay candidates to the
-> named type and acts as an expected-type check for explicit interface
-> policies. Network-segment prefixes cannot nest or overlap, so do not create
-> an Underlay and HostInband alias for one physical prefix.
+See [Configure Expected Machine Interfaces](expected-machine-interfaces.md)
+for the full field reference, all four roles, allocation policies, segment
+selection behavior, and backward-compatible input aliases.
 
 **Admin JSON** (an Expected Machine entry):
 
@@ -115,14 +112,15 @@ The optional `host_nics` array declares specifics for individual host NICs. Each
 {
   "bmc_mac_address": "C4:5A:B1:C8:38:0D",
   "bmc_username": "root",
-  "bmc_password": "default-password1",
+  "bmc_password": "<bmc-password>",
   "chassis_serial_number": "SERIAL-1",
   "dpu_policy": "manage",
-  "host_nics": [
+  "interfaces": [
     {
       "mac_address": "C4:5A:B1:C8:38:10",
+      "role": "host",
       "primary": true,
-      "network_segment_type": "host_inband"
+      "network_segment_type": 3
     }
   ]
 }
@@ -130,16 +128,23 @@ The optional `host_nics` array declares specifics for individual host NICs. Each
 
 **CLI** (single host):
 
+> **Security:** Values passed to `--bmc-password` can appear in shell history
+> and process listings. Substitute credentials only in a protected
+> administrative environment and follow your site's secret-handling policy.
+
 ```bash
 nico-admin-cli -a <api-url> em add \
   --bmc-mac-address C4:5A:B1:C8:38:0D \
-  --bmc-username root --bmc-password default-password1 \
+  --bmc-username root --bmc-password '<bmc-password>' \
   --chassis-serial-number SERIAL-1 \
   --dpu-policy manage \
-  --host_nics '[{"mac_address":"C4:5A:B1:C8:38:10","primary":true,"network_segment_type":"host_inband"}]'
+  --interfaces '[{"mac_address":"C4:5A:B1:C8:38:10","role":"host","primary":true,"network_segment_type":3}]'
 ```
 
 (`em` is the alias for `expected-machine`.)
+
+Admin CLI manifests and inline CLI JSON use protobuf enum values for
+`network_segment_type`. HostInband is `3`.
 
 ---
 
@@ -158,8 +163,8 @@ A plain server with one or more host NICs and no DPU. Declare `ignore` and mark 
 ```json
 {
   "dpu_policy": "ignore",
-  "host_nics": [
-    { "mac_address": "AA:BB:CC:00:00:10", "primary": true, "network_segment_type": "host_inband" }
+  "interfaces": [
+    { "mac_address": "AA:BB:CC:00:00:10", "role": "host", "primary": true, "network_segment_type": 3 }
   ]
 }
 ```
@@ -175,8 +180,8 @@ The host has DPU hardware, but you want it treated as a plain NIC (not managed).
 ```json
 {
   "dpu_policy": "nic",
-  "host_nics": [
-    { "mac_address": "AA:BB:CC:00:00:20", "primary": true, "network_segment_type": "host_inband" }
+  "interfaces": [
+    { "mac_address": "AA:BB:CC:00:00:20", "role": "host", "primary": true, "network_segment_type": 3 }
   ]
 }
 ```
@@ -188,8 +193,8 @@ This is the case where the two axes genuinely diverge: the host has cabled, expl
 ```json
 {
   "dpu_policy": "manage",
-  "host_nics": [
-    { "mac_address": "AA:BB:CC:00:00:30", "primary": true, "network_segment_type": "host_inband" }
+  "interfaces": [
+    { "mac_address": "AA:BB:CC:00:00:30", "role": "host", "primary": true, "network_segment_type": 3 }
   ]
 }
 ```
@@ -221,7 +226,7 @@ All of these are **admin-only**; the Forge gRPC service enforces admin authoriza
 
 | admin-cli | Forge RPC | Purpose |
 |---|---|---|
-| `em add …` | `AddExpectedMachine` | Add one host (BMC creds, `--dpu-policy`, `--host_nics`, metadata). |
+| `em add …` | `AddExpectedMachine` | Add one host (BMC creds, `--dpu-policy`, `--interfaces`, metadata). |
 | `em show [--bmc-mac-address <mac>]` | `GetAllExpectedMachines` / `GetExpectedMachine` | List all, or show one. Add `-f json` to export. |
 | `em update --filename <json>` | `UpdateExpectedMachine` | Full replacement of one entry from JSON. |
 | `em patch --bmc-mac-address <mac> …` | `UpdateExpectedMachine` | Partial update (e.g. `--dpu-policy`), preserving other fields. |
@@ -447,7 +452,7 @@ To request another controller pass without changing the selected target, use **R
 |---|---|
 | `boot_interface_mac_mismatch` (pairing blocker) | The host's boot MAC doesn't match any discovered DPU's pf0 MAC. Expected for an integrated-NIC host — declare the integrated NIC `primary` (see [3.4](#34-boot-an-integrated-nic-while-keeping-the-dpus-managed)); otherwise check the exploration reports. See [Ingesting Hosts → pairing blockers](ingesting-hosts.md#common-blockers-during-host--dpu-pairing). |
 | Host stuck waiting for a boot NIC | A host with no managed DPUs (zero-DPU, `ignore`, or `nic`) whose boot NIC hasn't leased yet (`AwaitingNic`). Confirm the NIC is cabled and DHCP-reachable on its HostInband segment. |
-| `Missing boot interface` for a managed-DPU host | The host has neither an owned primary interface nor a usable prediction. For an integrated-NIC boot, confirm `host_nics` declares exactly one `primary` NIC and that site-explorer created its HostInband prediction; otherwise investigate DPU pairing and promotion. |
+| `Missing boot interface` for a managed-DPU host | The host has neither an owned primary interface nor a usable prediction. For an integrated-NIC boot, confirm `interfaces` declares exactly one `host` interface with `primary: true` and that site-explorer created its HostInband prediction; otherwise investigate DPU pairing and promotion. |
 | Reconciliation is `Pending` while the host is `Assigned` | This is non-disruptive by design. The controller may observe drift but does not change Redfish or reboot a tenant host; repair begins after release returns it to unassigned `Ready`. |
 | Reconciliation is `Failed` | Read the failure and active generation in `boot-interface show` or the web UI. Correct the reported underlying cause, then request reconciliation again for the same interface or select a new target. |
 | `observed_at` is old | First compare `desired_version` and `verified_version`: a pending target retains the earlier generation's timestamp and is not eligible for periodic observation. For a verified target, a failed BMC read leaves the timestamp unchanged and retries on the next controller sweep. If Redfish is healthy, confirm the `boot_interface_observation_interval` has elapsed (default `10m`) and every managed DPU has a current network observation. Supermicro hosts with managed lockdown skip the non-disruptive periodic read because their locked boot-order view is stale. |

--- a/docs/provisioning/expected-machine-interfaces.md
+++ b/docs/provisioning/expected-machine-interfaces.md
@@ -1,0 +1,305 @@
+# Configure Expected Machine Interfaces
+
+Expected Machine interface declarations tell NICo how to allocate addresses for
+host, DPU OS, DPU BMC, and host BMC interfaces during ingestion. Use the
+`interfaces` array in an Expected Machine manifest to identify each interface
+by MAC address, assign its role, and select an IP allocation policy.
+
+Configure the network segments that contain these addresses before you upload
+the Expected Machine manifest. See [IP and Network Configuration](ip-and-network-configuration.md)
+for site network configuration and DHCP relay requirements.
+
+## Interface Fields
+
+Each `interfaces` entry supports these fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `mac_address` | Yes | MAC address that identifies the interface. |
+| `role` | No | Interface role: `host`, `dpu_os`, `dpu_bmc`, or `host_bmc`. The default is `host`. |
+| `ip_allocation` | No | Address policy: `dynamic`, `fixed`, or `retained`. NICo can also infer the policy as described in [IP Allocation Policies](#ip-allocation-policies). |
+| `fixed_ip` | For `fixed` | Address that NICo reserves for this interface. |
+| `network_segment_type` | No | Optional segment-type guard. Admin CLI manifest and RPC JSON values are Tenant `0`, Admin `1`, Underlay `2`, and HostInband `3`. The corresponding model names are `tenant`, `admin`, `underlay`, and `host_inband`. |
+| `primary` | No | Marks a `host` interface as the host boot interface. At most one `host` interface can set this to `true`. |
+| `nic_type` | No | Legacy segment hint. Use `network_segment_type` for new configurations. |
+| `fixed_mask`, `fixed_gateway` | No | Compatibility metadata. These fields do not select the managed segment or allocate the address. |
+
+## Interface Roles
+
+All roles support all three IP allocation policies.
+
+| Role | Interface | Primary behavior | Default policy |
+|---|---|---|---|
+| `host` | Host OS interface | Can be the one explicitly configured primary host interface. | `dynamic` |
+| `dpu_os` | DPU ARM OS interface | Primary for its DPU. | `dynamic` |
+| `dpu_bmc` | DPU BMC interface | Never primary. | `dynamic` |
+| `host_bmc` | Host BMC interface | Never primary. Its MAC must match the top-level `bmc_mac_address`. | `retained` |
+
+An Expected Machine can contain multiple `host`, `dpu_os`, and `dpu_bmc`
+entries, but it can contain only one `host_bmc` entry. If you repeat a MAC
+address to reserve separate IPv4 and IPv6 addresses, every entry for that MAC
+must use the same role. The one-entry limit means `host_bmc` cannot use this
+duplicate-entry form.
+
+The interface entry whose `mac_address` matches the top-level
+`bmc_mac_address` must use the `host_bmc` role.
+
+For host boot selection and DPU management policy, see
+[Boot Interfaces and DPU Policies](boot-interfaces-and-dpu-modes.md).
+
+## IP Allocation Policies
+
+Choose one policy for each declared interface:
+
+| Policy | Behavior |
+|---|---|
+| `dynamic` | NICo allocates an address from the segment selected by the DHCP relay or DHCPv6 link address. |
+| `fixed` | NICo reserves `fixed_ip` before it processes DHCP for the interface. An explicit Fixed policy requires the address to belong to a configured managed prefix. |
+| `retained` | NICo allocates an address through DHCP, then keeps that address static for the lifetime of the machine-interface record. |
+
+`dynamic` and `retained` entries cannot include `fixed_ip`. A `fixed` entry
+must include it.
+
+NICo uses these defaults when `ip_allocation` is omitted:
+
+| Configuration | Inferred policy |
+|---|---|
+| `fixed_ip` is present | `fixed` |
+| `role` is `host_bmc` and `fixed_ip` is absent | `retained` |
+| Any other role without `fixed_ip` | `dynamic` |
+
+The `fixed_ip` inference preserves manifests created before explicit allocation
+policies were available.
+
+### Retained Address Lifetime
+
+A retained address remains static only while its machine-interface record
+exists. Deleting the interface record removes the retained address. A later
+ingestion can receive a different address.
+
+Expected Machine configuration is an ingestion baseline. NICo can replace an
+existing DHCP or SLAAC address with a Fixed reservation, and it can retain an
+existing DHCP address. It does not automatically reverse an existing Static
+address to Dynamic or replace one Fixed Static address with another.
+
+For a policy change that NICo cannot reconcile automatically, update the
+Expected Machine configuration first, then use the targeted interface command:
+
+```bash
+# Find the interface ID and its current addresses.
+nico-admin-cli -a <api-url> machine-interfaces show
+nico-admin-cli -a <api-url> machine-interfaces show-addresses <interface-id>
+
+# Replace one Fixed address with another.
+nico-admin-cli -a <api-url> machine-interfaces assign-address \
+  <interface-id> <new-fixed-ip>
+
+# Remove a Static address before returning the interface to Dynamic allocation.
+nico-admin-cli -a <api-url> machine-interfaces remove-address \
+  <interface-id> <current-static-ip>
+```
+
+Delete an unassociated preallocated interface with
+`machine-interfaces delete <interface-id>` when the complete row must be
+recreated during ingestion. See the
+[machine interface command reference](../manuals/nico-admin-cli/commands/machine-interfaces/machine-interfaces.md)
+for details.
+
+Use whole-machine force deletion only when the machine requires complete
+reingestion and the targeted commands cannot restore the configured state.
+Force deletion removes the managed host and can remove all data and BMC
+interface records:
+
+```bash
+nico-admin-cli -a <api-url> machine force-delete \
+  --machine <machine-id> \
+  --delete-interfaces \
+  --delete-bmc-interfaces
+```
+
+Confirm that the machine has no tenant instance and follow the
+[Force Delete Playbook](../playbooks/force_delete.md).
+
+## Network Segment Selection
+
+NICo selects a segment before it applies the optional
+`network_segment_type` guard:
+
+- For `dynamic` and `retained`, the DHCPv4 relay address or DHCPv6 link address
+  selects the configured segment.
+- For `fixed`, the managed prefix that contains `fixed_ip` selects the segment.
+
+Except for the legacy `host` case described below, NICo rejects a request when
+the selected segment has a different `network_segment_type`. The role does not
+imply a segment type. For example, a `dpu_bmc` interface can request an
+`underlay` guard, but the guard is still checked against the segment selected
+from the DHCP request or fixed address.
+
+A legacy `host` declaration that omits `ip_allocation` uses
+`network_segment_type` only to narrow DHCP segment selection. It does not use
+the field as a Fixed-address guard.
+
+For new `fixed` declarations, put `fixed_ip` inside a configured managed
+prefix. Older `host` declarations that omit `ip_allocation` retain the
+`static-assignments` fallback. An inferred Fixed `host_bmc` declaration without
+a segment guard can also use that fallback. Set `ip_allocation` explicitly for
+new configurations.
+
+### Allow Only Reserved Addresses
+
+Set a network segment's `allocation_strategy` to `reserved` when that segment
+must serve only addresses reserved in advance:
+
+```toml
+[networks.oob]
+type = "underlay"
+prefix = "198.51.100.0/24"
+gateway = "198.51.100.1"
+mtu = 1500
+reserve_first = 5
+allocation_strategy = "reserved"
+```
+
+On a reserved segment, configure a `fixed` Expected Machine reservation before
+the interface sends DHCP. `dynamic` and `retained` declarations cannot acquire
+their first address on a reserved segment because NICo does not create an
+address when no reservation exists. The default segment allocation strategy is
+`dynamic`.
+
+## Configure All Interface Roles
+
+The following `expected_machines.json` file uses the admin CLI manifest format.
+The fixed DPU OS address assumes `192.0.2.0/24` is a configured Admin prefix.
+This format uses protobuf enum numbers for `network_segment_type`: Tenant `0`,
+Admin `1`, Underlay `2`, and HostInband `3`.
+
+```json
+{
+  "expected_machines": [
+    {
+      "bmc_mac_address": "02:00:00:00:00:01",
+      "bmc_username": "root",
+      "bmc_password": "<bmc-password>",
+      "chassis_serial_number": "SERIAL-1",
+      "interfaces": [
+        {
+          "mac_address": "02:00:00:00:00:10",
+          "role": "host",
+          "ip_allocation": "dynamic",
+          "network_segment_type": 3,
+          "primary": true
+        },
+        {
+          "mac_address": "02:00:00:00:00:20",
+          "role": "dpu_os",
+          "ip_allocation": "fixed",
+          "fixed_ip": "192.0.2.20",
+          "network_segment_type": 1
+        },
+        {
+          "mac_address": "02:00:00:00:00:21",
+          "role": "dpu_bmc",
+          "ip_allocation": "retained",
+          "network_segment_type": 2
+        },
+        {
+          "mac_address": "02:00:00:00:00:01",
+          "role": "host_bmc",
+          "ip_allocation": "retained",
+          "network_segment_type": 2
+        }
+      ]
+    }
+  ]
+}
+```
+
+Apply the complete table:
+
+```bash
+nico-admin-cli -a <api-url> em replace-all --filename expected_machines.json
+```
+
+The inline `--interfaces` option uses the same generated RPC JSON
+representation. The `role` and `ip_allocation` fields accept the names shown
+above, and `network_segment_type` uses the same enum numbers.
+
+> **Security:** Values passed to `--bmc-password` can appear in shell history
+> and process listings. Substitute credentials only in a protected
+> administrative environment and follow your site's secret-handling policy.
+
+```bash
+nico-admin-cli -a <api-url> em add \
+  --bmc-mac-address 02:00:00:00:00:01 \
+  --bmc-username root \
+  --bmc-password '<bmc-password>' \
+  --chassis-serial-number SERIAL-1 \
+  --interfaces '[{"mac_address":"02:00:00:00:00:20","role":"dpu_os","ip_allocation":"fixed","fixed_ip":"192.0.2.20","network_segment_type":1}]'
+```
+
+## Configure Host BMC Allocation
+
+Keep the host BMC identity and credentials at the top level:
+
+- `bmc_mac_address`
+- `bmc_username`
+- `bmc_password`
+- `bmc_retain_credentials`
+
+Use the matching `host_bmc` interface entry for its network allocation policy
+and optional segment guard. Existing top-level `bmc_ip_address` and
+`bmc_ip_allocation` fields remain supported. When both forms are present,
+explicit top-level BMC address and allocation values override the nested
+`host_bmc` values.
+
+The top-level Auto compatibility policy selects Fixed when `bmc_ip_address` is
+present and Retained otherwise.
+
+In an admin CLI JSON file, `bmc_ip_allocation` uses `Auto`, `Dynamic`, `Fixed`,
+or `Retained`. The `--bmc-ip-allocation` command-line option uses lowercase
+values.
+
+## Update and Clear Interfaces
+
+`em patch --interfaces` replaces the complete interface list for that Expected
+Machine. An empty array clears the list. Omitting the option preserves the
+stored list.
+
+```bash
+# Replace the complete list.
+nico-admin-cli -a <api-url> em patch \
+  --bmc-mac-address 02:00:00:00:00:01 \
+  --interfaces '[{"mac_address":"02:00:00:00:00:10","role":"host","ip_allocation":"dynamic","primary":true}]'
+
+# Clear the list.
+nico-admin-cli -a <api-url> em patch \
+  --bmc-mac-address 02:00:00:00:00:01 \
+  --interfaces '[]'
+```
+
+`em update --filename` preserves the stored list when `interfaces` is omitted
+or `null`, and clears it when `interfaces` is `[]`. `em replace-all` has no
+stored list to preserve, so omitted or `null` results in an empty list.
+
+Within a replacement list, omitting `role` for a matching stored MAC preserves
+its role. Set `role` to `unspecified` to reset it to `host`. Omitting
+`ip_allocation` preserves the stored policy when the presence of `fixed_ip`
+does not change. Set `ip_allocation` to `unspecified` to infer the policy
+again. Omitting `network_segment_type` clears the stored segment guard.
+
+Clearing the nested interface list does not clear top-level Host BMC address or
+allocation fields.
+
+## Backward Compatibility
+
+Existing configurations do not need conversion:
+
+- `host_nics` remains an input alias for `interfaces`.
+- `--host_nics` remains a CLI alias for `--interfaces`.
+- An entry without `role` remains a `host` interface.
+- An entry with `fixed_ip` and no `ip_allocation` remains a fixed reservation.
+- Top-level Host BMC allocation fields remain supported.
+
+Use either `interfaces` or `host_nics` within one Expected Machine object, not
+both. A manifest can use the old spelling for some machines and the new
+spelling for others.

--- a/docs/provisioning/ingesting-hosts.md
+++ b/docs/provisioning/ingesting-hosts.md
@@ -214,24 +214,36 @@ For optional REST fields and batch JSON examples, use [Ingesting Hosts (REST API
 
 ### Per-Host Fields With the Admin CLI
 
-Some per-host settings are not exposed through the REST API or `nicocli`. To set them, use the admin CLI's `expected-machine` command (`em`), which reads a snake_case `expected_machines.json` file and applies the whole table at once:
+The admin CLI's `expected-machine` command (`em`) provides the complete set of
+per-host fields and compatibility controls. It reads a snake_case
+`expected_machines.json` file and applies the whole table at once:
 
 - **`dpu_policy`** (`"manage"` | `"nic"` | `"ignore"`): Per-host policy for managing DPU hardware. `nic` and `ignore` override the site policy; `manage` or an omitted field inherits the site-wide policy, which defaults to `manage`. The previous `"use_as_nic"` value is still accepted, as are manifests using the `dpu_mode` key with `"dpu_mode"`, `"nic_mode"`, or `"no_dpu"` values.
 - **`dpf_enabled`** (bool, default `true`): Enable or disable DPF provisioning for this host. When omitted or `true`, DPF is the provisioning path (requires `[dpf].enabled = true` in the site config — see [DPF setup](../manuals/dpf.md)). Set to `false` to keep a host on the deprecated iPXE path.
 - **`bmc_retain_credentials`** (bool): Skip BMC password rotation.
 - **`default_pause_ingestion_and_poweron`** (bool): Pause ingestion and power-on for this host.
-- **`bmc_ip_address`** (string, optional): Fixed host-BMC address. When omitted,
-  the default allocation obtains an address through DHCP and retains it for the
-  machine-interface row's lifetime.
+- **`interfaces`** (array): Configure Host, DPU OS, DPU BMC, and Host BMC
+  interface roles and their Dynamic, Fixed, or Retained IP allocation policies.
+  See [Configure Expected Machine Interfaces](expected-machine-interfaces.md).
+- **`bmc_ip_address`** (string, optional): Compatibility top-level Host BMC
+  address. With the top-level `Auto` policy, its presence infers Fixed
+  allocation.
 - **`bmc_ip_allocation`** (`"Unspecified"` | `"Auto"` | `"Dynamic"` |
-  `"Fixed"` | `"Retained"`, default `"Auto"`): Allocation policy for the host
-  BMC in the whole-table JSON consumed by `em replace-all`. `Auto` resolves to
-  `Fixed` when `bmc_ip_address` is present and `Retained` otherwise;
-  `Unspecified` resets to `Auto`. The corresponding `em add` and `em patch`
-  flag values are lowercase. See
-  [OOB/BMC IP Addresses](ip-and-network-configuration.md#13-oobbmc-ip-addresses-static-vs-dynamic)
+  `"Fixed"` | `"Retained"`, default `"Auto"`): Compatibility Host BMC policy
+  in the whole-table JSON consumed by `em replace-all`. For the top-level
+  compatibility form, `Auto` resolves to `Fixed` when `bmc_ip_address` is
+  present and `Retained` otherwise; `Unspecified` resets to `Auto`. Explicit
+  top-level address and policy values override the nested `host_bmc` values.
+  `Dynamic` and `Retained` cannot be combined with
+  `bmc_ip_address`; use `Fixed` or `Auto` with an address. The
+  corresponding `em add` and `em patch` flag values are lowercase. See
+  [Host BMC compatibility fields](ip-and-network-configuration.md#host-bmc-compatibility-fields)
   for field interactions and the supported shared HostInband topology.
 - **`host_lifecycle_profile.disable_lockdown`** (bool, default `false`): When `true`, the state machine does not lock down the host during lifecycle management, which suits automation workflows that keep lockdown disabled.
+
+The previous `host_nics` manifest key and `--host_nics` CLI option remain
+aliases for `interfaces` and `--interfaces`. Existing manifests do not need
+conversion. Do not set both names within the same Expected Machine entry.
 
 Each manifest entry combines the required BMC credentials with any of these fields:
 
@@ -241,7 +253,7 @@ Each manifest entry combines the required BMC credentials with any of these fiel
     {
       "bmc_mac_address": "C4:5A:B1:C8:38:0D",
       "bmc_username": "root",
-      "bmc_password": "default-password1",
+      "bmc_password": "<bmc-password>",
       "chassis_serial_number": "SERIAL-1",
       "dpu_policy": "nic"
     }

--- a/docs/provisioning/ip-and-network-configuration.md
+++ b/docs/provisioning/ip-and-network-configuration.md
@@ -82,15 +82,41 @@ mtu = 1500
 
 > **Warning:** `[networks.admin]` `prefix` and `gateway` must be non-empty. `nico-api` panics at startup if either field is the empty string.
 
-### 1.3 OOB/BMC IP Addresses (Static vs. Dynamic)
+### 1.3 Expected Interface IP Allocation
 
-Every host BMC, DPU BMC, and DPU OOB interface needs an address on a
-NICo-managed physical network. The usual deployment places these interfaces on
-an OOB network represented by an `Underlay` segment. A zero-DPU host's BMC can
-instead share one `HostInband` subnet/VLAN with the host OS; see
+Expected Machine declarations can allocate addresses for host OS, DPU OS, DPU
+BMC, and host BMC interfaces. Every role supports three allocation policies:
+
+| Policy | Behavior |
+|---|---|
+| **Dynamic** | At DHCP discovery, NICo allocates an address from the segment selected by the DHCP relay or DHCPv6 link address. |
+| **Fixed** | NICo reserves the configured `fixed_ip` before DHCP. The address normally selects the managed segment whose prefix contains it; [legacy inferred reservations](expected-machine-interfaces.md#network-segment-selection) can fall back to `static-assignments`. |
+| **Retained** | NICo allocates an address through DHCP, then keeps it static for the lifetime of the machine-interface record. |
+
+All four interface roles (`host`, `dpu_os`, `dpu_bmc`, and `host_bmc`) support
+all three policies. The default is Dynamic for every role except `host_bmc`,
+which defaults to Retained. A declaration with `fixed_ip` and no explicit
+policy remains Fixed for backward compatibility.
+
+Mixing policies within the same site and Expected Machine is supported.
+See [Configure Expected Machine Interfaces](expected-machine-interfaces.md)
+for the complete field reference and examples.
+
+#### Physical Management Networks
+
+Every host BMC, DPU BMC, and DPU OOB interface needs an address on a physical
+management network. Dynamic and Retained allocations, and new explicit Fixed
+declarations, require a NICo-managed segment. Legacy inferred Fixed `host`
+declarations, and inferred Fixed `host_bmc` declarations without a segment
+guard, can instead use `static-assignments` for an address outside managed
+prefixes. The usual deployment places these interfaces on an OOB network
+represented by an `Underlay` segment. A host with no managed DPUs can instead
+place its BMC and host OS on one shared `HostInband` subnet/VLAN; see
 [Shared HostInband for a Host BMC and Host OS](#15-shared-hostinband-for-a-host-bmc-and-host-os).
 That exception applies only to the host BMC. DPU BMC and DPU OOB interfaces
 remain on `Underlay` segments.
+
+#### Host BMC Compatibility Fields
 
 The top-level Expected Machine fields `bmc_ip_address` and
 `bmc_ip_allocation` control host-BMC allocation.
@@ -119,14 +145,17 @@ deleting the machine-interface row and re-ingesting the host can select a new
 address. Use a fixed address when it must survive interface recreation. Mixing
 policies within one site is supported.
 
+#### Capacity and Network Setup
+
 **Per node**, expect to allocate:
 
 - 1 IP for the host BMC.
 - For hosts with DPUs: 1 IP for the DPU ARM OS + 1 IP for the DPU BMC, per DPU.
 
 In the conventional topology, a host with one DPU therefore consumes three OOB
-addresses. When a zero-DPU host BMC shares HostInband, its one BMC address is
-capacity on that HostInband segment rather than on a dedicated OOB segment.
+addresses. When a host with no managed DPUs shares HostInband, its one BMC
+address is capacity on that HostInband segment rather than on a dedicated OOB
+segment.
 
 The conventional OOB management network is declared as one or more
 NICo-managed `Underlay` network segments in `siteConfig`
@@ -136,9 +165,11 @@ LoadBalancer VIP; they must not assign addresses themselves. See
 [BMC and Out-of-Band Setup](../getting-started/prerequisites/bmc-oob-setup.md)
 for switch-side relay configuration.
 
-### 1.4 Predefined BMC IP Allocation for Expected Machines
+### 1.4 Configure Host BMC IP Allocation
 
-For sites that require a stable, pre-known BMC IP per host (for example, to wire DNS records or firewall rules before ingestion), set `bmc_ip_address` in the `expected_machines.json` manifest:
+For sites that require a preassigned host BMC IP, add a `host_bmc` entry whose
+MAC matches the top-level `bmc_mac_address`. Admin CLI manifests use protobuf
+enum number `2` for the Underlay segment type:
 
 ```json
 {
@@ -146,15 +177,23 @@ For sites that require a stable, pre-known BMC IP per host (for example, to wire
     {
       "bmc_mac_address": "C4:5A:B1:C8:38:0D",
       "bmc_username": "root",
-      "bmc_password": "default-password1",
+      "bmc_password": "<bmc-password>",
       "chassis_serial_number": "SERIAL-1",
-      "bmc_ip_address": "10.180.70.11"
+      "interfaces": [
+        {
+          "mac_address": "C4:5A:B1:C8:38:0D",
+          "role": "host_bmc",
+          "ip_allocation": "fixed",
+          "fixed_ip": "10.180.70.11",
+          "network_segment_type": 2
+        }
+      ]
     }
   ]
 }
 ```
 
-When `bmc_ip_address` is present:
+For this fixed declaration:
 
 - NICo records the fixed intent with the Expected Machine. The API update path
   and Site Explorer reconciliation materialize the machine-interface
@@ -165,19 +204,30 @@ When `bmc_ip_address` is present:
   prefix. It can be inside the segment's otherwise-dynamic pool: once the
   reservation exists, NICo's address-uniqueness constraint prevents the
   dynamic allocator from assigning it to another interface.
+- The optional `underlay` segment guard rejects the configuration if the
+  containing segment has another type.
 
-Changing `bmc_ip_address` does not replace an address already present on a live
-machine-interface row. Plan fixed addresses before ingestion, or use the
-machine-interface address workflow to replace existing state deliberately.
+Reconciliation can replace an existing DHCP or SLAAC address with the Fixed
+reservation. It does not automatically replace one Fixed Static address with
+another or return a Static address to Dynamic allocation. For those changes,
+follow the targeted procedure in
+[Retained Address Lifetime](expected-machine-interfaces.md#retained-address-lifetime).
 
-For the full `expected_machines.json` schema and upload command, see [Ingesting Hosts](ingesting-hosts.md).
+The legacy top-level `bmc_ip_address` and `bmc_ip_allocation` fields remain
+supported. They act as explicit overrides when a matching `host_bmc` entry is
+also present. Existing manifests that only set `bmc_ip_address` continue to
+work without conversion.
+
+For the full `expected_machines.json` schema and upload command, see
+[Ingesting Hosts](ingesting-hosts.md).
 
 ### 1.5 Shared HostInband for a Host BMC and Host OS
 
-NICo supports connecting a zero-DPU host's BMC and host OS NIC to the same
-physical subnet/VLAN. This applies when the effective DPU policy is `ignore`
-(no managed DPU) or `nic` (an installed DPU operates as a plain NIC). Each
-interface receives its own address from one `HostInband` segment.
+NICo supports connecting a host's BMC and host OS NIC to the same physical
+subnet/VLAN when the host has no managed DPUs. This applies when the effective
+DPU policy is `ignore` (no managed DPU) or `nic` (an installed DPU operates as
+a plain NIC). Each interface receives its own address from one `HostInband`
+segment.
 
 Model the prefix **once**, as `HostInband`. Do not also declare an `Underlay`
 segment for the same prefix. NICo enforces globally non-overlapping network
@@ -197,17 +247,19 @@ The shared topology has these requirements:
   `nico-admin-cli network-segment create` requires `--subdomain-id`.
 - Size the prefix for distinct host-BMC and host-OS addresses and set
   `reserve_first` high enough to protect gateway or infrastructure addresses.
-- Declare every zero-DPU host data-NIC MAC on its Expected Machine in
-  `host_nics` (`interfaces` on newer admin-CLI surfaces). Mark one data NIC
-  `primary: true`; that NIC is the host's boot interface, and declarations with
-  more than one primary are rejected. Setting
+- Declare every data-NIC MAC for a host with no managed DPUs in that host's
+  Expected Machine `interfaces` array. Mark one data NIC `primary: true`; that
+  NIC is the host's boot interface, and declarations with more than one primary
+  are rejected. Setting
   `network_segment_type: "host_inband"` is recommended so DHCP fails on a
   segment-type mismatch instead of using a relay candidate of another type.
   See the [zero-DPU site setup](../manuals/vpc/flat_vpcs_zero_dpu.md#site-operations-operator).
-- Register the BMC MAC and credentials on the Expected Machine. Omit
-  `bmc_ip_address` to use the default Auto → Retained behavior, or set it
-  to an address in the HostInband prefix when the address must remain stable
-  after interface deletion and re-ingestion.
+- Register the BMC MAC and credentials at the top level of the Expected
+  Machine, and use a matching `host_bmc` interface entry for allocation. Omit
+  both `ip_allocation` and `fixed_ip` to use the default Retained behavior, or
+  select Fixed and set `fixed_ip` to an address in the HostInband prefix when
+  the address must survive interface deletion and re-ingestion. The compatible
+  top-level `bmc_ip_address` and `bmc_ip_allocation` fields remain supported.
 - Configure the BMC-facing and host-NIC-facing switch ports so DHCP reaches
   `nico-dhcp` with relay/link metadata that identifies the HostInband prefix.
 
@@ -237,20 +289,25 @@ an explicit site security decision.
 
 `nico-dhcp` is **not** a standalone DHCP daemon. It is a [Kea DHCP](https://www.isc.org/kea/) hooks library (`cdylib`) loaded into the upstream Kea v4 server inside the `nico-dhcp` container. Every DHCPDISCOVER/REQUEST is intercepted by the hooks library and forwarded to `nico-api` over mTLS gRPC (the `discover_dhcp` RPC). `nico-api` decides what address to lease based on:
 
-- Whether the source MAC has a fixed reservation, including an Expected Machine
-  `bmc_ip_address`.
-- Otherwise, whether the source MAC is a known host/DPU BMC, DPU OOB interface,
-  or declared host NIC. `nico-api` uses relay metadata to select a network
-  segment and applies that interface's allocation policy.
+- Whether the source MAC matches a Fixed Expected Machine interface
+  reservation, including one declared through the compatible top-level
+  `bmc_ip_address` field.
+- Otherwise, whether the source MAC has a Dynamic or Retained Expected Machine
+  policy or is a known host, host BMC, DPU BMC, or DPU OS interface.
+  `nico-api` uses relay metadata to select the applicable network segment.
+  Dynamic interfaces receive the next free address. Retained interfaces reuse
+  their existing static address, or receive a new address when none exists.
 - Vendor class (option 60) determines whether the client is a PXE/iPXE/BlueField boot client, which influences the boot options returned.
 
 The hook callouts (`lease4_select` and `lease4_renew`) overwrite the lease that Kea would have selected — `yiaddr`, valid lifetime, and DHCP options are replaced with the values `nico-api` produced, and the hook can return `SKIP` to cancel Kea's own lease assignment and database write. The result is written to Kea's memfile (`kea-leases4.csv`), but the authoritative record lives in `nico-api`. From an operator perspective this means:
 
 - The state-of-truth for every lease lives in `nico-api`'s database, not in Kea's lease file.
-- There is no standalone DHCP configuration file to populate with reservations — reservations come from `expected_machines.json` and `siteConfig` network segments.
+- There is no standalone DHCP configuration file to populate with
+  reservations. Reservations come from `expected_machines.json`, and network
+  segments come from `siteConfig`.
 - If `nico-api` is unreachable, the hooks library serves cached negative responses (negative cache TTL: 5 minutes); this is a degraded-mode safety net, not a fallback pool.
 
-### 2.2 DHCP Configuration for Host BMCs, DPU BMCs, and DPU OOB Addresses
+### 2.2 DHCP Configuration for Physical Machine Interfaces
 
 All physical interface types are served by the same `nico-dhcp` instance. For
 IPv4, `nico-api` selects candidate segments by finding the configured prefix
@@ -260,26 +317,27 @@ otherwise falls back to prefix containment.
 
 | Interface | DHCP request originates on | Served from |
 |---|---|---|
-| Host BMC | Usually the OOB management network; optionally the shared zero-DPU host network | The relay-selected `Underlay`, or the supported shared `HostInband` segment |
+| Host BMC | Usually the OOB management network; optionally a shared host network when the host has no managed DPUs | The relay-selected `Underlay`, or the supported shared `HostInband` segment |
 | DPU BMC | OOB management network | The relay-selected `Underlay` segment |
 | DPU OOB (ARM OS) | OOB management network | The relay-selected `Underlay` segment; it can share the DPU BMC segment or use another Underlay prefix |
-| Zero-DPU host OS NIC | Host-facing physical network | The relay-selected `HostInband` segment |
+| Host OS NIC without managed DPUs | Host-facing physical network | The relay-selected `HostInband` segment |
 
 Each `[networks.<name>]` block declares:
 
 | Field | Purpose |
 |---|---|
-| `type` | Segment classification: `admin`, `underlay`, or `hostinband`. Tenant segments are not config-declarable. |
+| `type` | Config-seeded segment classification: `admin`, `underlay`, or `hostinband`. Tenant segments are created through the API and are not config-declarable. Expected Interfaces can use the corresponding guard described in [Network Segment Selection](expected-machine-interfaces.md#network-segment-selection). |
 | `prefix` | The IPv4 CIDR for the segment. |
 | `gateway` | The IPv4 gateway associated with the prefix and returned in network configuration. It does not have to equal `giaddr`. |
 | `mtu` | MTU advertised to clients on this segment. |
-| `reserve_first` | Number of leading addresses in the prefix to hold back from the dynamic pool (typically 5 — covers the network address, gateway, broadcast, plus headroom). |
-| `allocation_strategy` | `dynamic` (default) permits pool allocation and fixed reservations; `reserved` serves only pre-existing reservations. |
+| `reserve_first` | Number of leading addresses in the prefix to hold back from the dynamic pool. A typical value is 5. |
+| `allocation_strategy` | `dynamic` (default) permits pool allocation and Fixed reservations; `reserved` serves only reservations created before DHCP. Dynamic and Retained interfaces cannot acquire their first address on a reserved segment. |
 
 A conventional DPU site declares an `admin` segment and one or more `underlay`
-segments covering its OOB relay scopes. A zero-DPU or DPU-NIC-mode site also
-declares the required `hostinband` segments. The host BMC can use one of those
-HostInband segments as described in [section 1.5](#15-shared-hostinband-for-a-host-bmc-and-host-os).
+segments covering its OOB relay scopes. A site with hosts that have no managed
+DPUs also declares the required `hostinband` segments. The host BMC can use one
+of those HostInband segments as described in
+[section 1.5](#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 To configure these flows:
 
@@ -294,11 +352,24 @@ To configure these flows:
    The relay-facing interface must cover the L2 broadcast domain whose clients
    it serves. In the shared HostInband topology, both the host BMC and host OS
    paths must produce relay metadata for that HostInband prefix.
-3. **For predefined IPs**, upload `expected_machines.json` with
-   `bmc_ip_address` populated before ingestion. Adding it after the BMC has an
-   address does not overwrite the live machine-interface row.
-4. **Set `dhcp_servers`** in `siteConfig` to the list of DHCP server IPs reachable from bare-metal hosts. This list is informational and is passed through to agents; it does not change how `nico-dhcp` itself serves leases. May be left as `[]`.
-5. **Set `ntp_servers`** in `siteConfig` to your NTP server IPs. NICo uses this list to configure BMC NTP through Redfish during pre-ingestion, includes it in `DiscoverDhcp` responses, and passes it to DPU agents so their DHCP server advertises the same NTP servers to managed hosts.
+3. **For Fixed policies**, upload `expected_machines.json` with the applicable
+   interface reservations before the device first powers on. NICo can replace
+   an existing DHCP or SLAAC address with a Fixed reservation. If the interface
+   already has a Static address that blocks the change, follow the targeted
+   address update procedure in
+   [Retained Address Lifetime](expected-machine-interfaces.md#retained-address-lifetime).
+4. **For reservation-only segments**, set
+   `allocation_strategy = "reserved"` and configure every Fixed reservation
+   before DHCP. Dynamic and Retained declarations cannot acquire their first
+   address when no reservation exists.
+5. **Set `dhcp_servers`** in `siteConfig` to the list of DHCP server IPs
+   reachable from bare-metal hosts. This list is informational and is passed
+   through to agents; it does not change how `nico-dhcp` itself serves leases.
+   May be left as `[]`.
+6. **Set `ntp_servers`** in `siteConfig` to your NTP server IPs. NICo uses this
+   list to configure BMC NTP through Redfish during pre-ingestion, includes it
+   in `DiscoverDhcp` responses, and passes it to DPU agents so their DHCP server
+   advertises the same NTP servers to managed hosts.
 
 The values that `nico-dhcp` returns in DHCP options (nameservers, NTP servers, next-server, boot file, etc.) are sourced from:
 
@@ -545,13 +616,17 @@ expanding the rollout to the rest of the fleet:
 - [ ] `siteConfig` `[networks.admin]` has non-empty `prefix` and `gateway`.
 - [ ] Each required physical segment declared in `[networks.<name>]`:
       `underlay` capacity for every DPU BMC/OOB pair and isolated host BMC, and
-      `hostinband` capacity for every shared zero-DPU host BMC and host OS NIC.
+      `hostinband` capacity for every shared host BMC and host OS NIC on a host
+      without managed DPUs.
 - [ ] `initial_domain_name` set in `siteConfig`.
 - [ ] `dhcp_servers` set in `siteConfig` (or left as `[]`).
 - [ ] `ntp_servers` set in `siteConfig`, or the legacy `nico-ntp` DNS / `nico-dhcp` `nico-ntpserver` fallback is intentionally configured.
-- [ ] `expected_machines.json` uploaded for every host; `bmc_ip_address` populated for any host that needs a predefined BMC IP.
-- [ ] Every BMC- or zero-DPU-host-facing network configured with a DHCP relay
-      pointing to the `nico-dhcp` LoadBalancer VIP.
+- [ ] `expected_machines.json` uploaded for every host; a Fixed `host_bmc`
+      interface or compatible top-level `bmc_ip_address` configured for any
+      host that needs a predefined BMC IP.
+- [ ] Every BMC-facing network, and every host-facing network for a host without
+      managed DPUs, configured with a DHCP relay pointing to the `nico-dhcp`
+      LoadBalancer VIP.
 - [ ] LoadBalancer VIPs assigned for `nico-api`, `nico-dhcp`, `nico-pxe`, `nico-dns` (one per replica), `nico-ssh-console-rs`, and `unbound`.
 - [ ] `unbound`'s `local_data.conf` ConfigMap contains A records for `nico-api`, `nico-pxe`, `nico-static-pxe`, `unbound`, and `otel-receiver` in the `.nico` zone; include `nico-ntp` pointing at your operator-supplied NTP server if you use the legacy fallback.
 - [ ] `nico-dns` zone for `initial_domain_name` is delegated from upstream DNS, or `unbound` forwards the zone to the `nico-dns` VIPs.


### PR DESCRIPTION
Explain the interface roles and IP allocation policies available during Expected Machine ingestion.

Cover segment selection, Host BMC compatibility, legacy aliases, update behavior, and reservation-only network segments.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/4151
- Implementation: https://github.com/NVIDIA/infra-controller/issues/3990
- Host BMC support: https://github.com/NVIDIA/infra-controller/issues/4103
- Interface rename: https://github.com/NVIDIA/infra-controller/issues/4104
- CLI field clarification: https://github.com/NVIDIA/infra-controller/issues/4847
- CLI wording clarification: https://github.com/NVIDIA/infra-controller/issues/4894
- Parent effort: https://github.com/NVIDIA/infra-controller/issues/3491

## Type of Change

- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Manual testing performed

## Additional Notes

PR #4848 is the merged source companion for the Expected Interface JSON help shown in the generated command reference.

PR #4898 is the source companion for the final grammar and option-lifecycle wording. The two affected pages will be regenerated after it merges.