### PR TITLE
fix(admin-cli): stabilize generated CLI docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7536,6 +7536,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",

--- a/crates/admin-cli/Cargo.toml
+++ b/crates/admin-cli/Cargo.toml
@@ -65,6 +65,7 @@ reqwest = { workspace = true, features = ["json"] }
 serde = { features = ["derive"], workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }

--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -150,7 +150,7 @@ pub struct Args {
     #[clap(
         long = "default_pause_ingestion_and_poweron",
         value_name = "DEFAULT_PAUSE_INGESTION_AND_POWERON",
-        help = "Optional flag to pause machine's ingestion and power on. False - don't pause, true - will pause it. The actual mutable state is stored in explored_endpoints."
+        help = "Optional flag to pause machine ingestion and power-on. False - don't pause; true - pause it. The actual mutable state is stored in explored_endpoints."
     )]
     pub default_pause_ingestion_and_poweron: Option<bool>,
 

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -167,7 +167,7 @@ pub struct Args {
     #[clap(
         long = "default_pause_ingestion_and_poweron",
         value_name = "DEFAULT_PAUSE_INGESTION_AND_POWERON",
-        help = "Optional flag to pause machine's ingestion and power on. False - don't pause, true - will pause it. The actual mutable state is stored in explored_endpoints."
+        help = "Optional flag to pause machine ingestion and power-on. False - don't pause; true - pause it. The actual mutable state is stored in explored_endpoints."
     )]
     pub default_pause_ingestion_and_poweron: Option<bool>,
 

--- a/crates/admin-cli/src/generate_docs/cmd.rs
+++ b/crates/admin-cli/src/generate_docs/cmd.rs
@@ -54,10 +54,10 @@ pub fn generate(out_dir: &Path) -> CarbideCliResult<()> {
     // Render every command's roff man page into a scratch directory. clap_mangen
     // names each file by the full command path joined with '-' (e.g.
     // `nico-admin-cli-vpc-show.1`), which we reconstruct per node below.
-    let man_dir = std::env::temp_dir().join("nico-admin-cli-cli-docs-man");
-    let _ = std::fs::remove_dir_all(&man_dir);
-    std::fs::create_dir_all(&man_dir)?;
-    clap_mangen::generate_to(root.clone(), &man_dir)?;
+    let man_dir = tempfile::Builder::new()
+        .prefix("nico-admin-cli-cli-docs-man-")
+        .tempdir()?;
+    clap_mangen::generate_to(root.clone(), man_dir.path())?;
 
     // One directory per top-level command, holding that command's page plus a
     // page for each (flattened) descendant. Rebuilt from scratch so a renamed or
@@ -89,7 +89,7 @@ pub fn generate(out_dir: &Path) -> CarbideCliResult<()> {
             sub,
             vec![BIN.to_string(), name.clone()],
             domain,
-            &man_dir,
+            man_dir.path(),
             &dir,
         )?;
 
@@ -107,7 +107,6 @@ pub fn generate(out_dir: &Path) -> CarbideCliResult<()> {
         )?;
     }
 
-    let _ = std::fs::remove_dir_all(&man_dir);
     Ok(())
 }
 
@@ -276,15 +275,20 @@ fn strip_sections(md: &str, names: &[&str]) -> String {
 /// man page's `# NAME`/`# OPTIONS`/… sections to `## ` so each generated page
 /// can own the `# ` title (the full command invocation).
 fn man_to_markdown(man_file: &Path) -> CarbideCliResult<String> {
+    let roff = std::fs::read_to_string(man_file)?;
+    let normalized_roff = normalize_roff_for_pandoc(&roff);
+    let pandoc_input = tempfile::NamedTempFile::new()?;
+    std::fs::write(pandoc_input.path(), normalized_roff)?;
+
     let mut pandoc = pandoc::new();
-    pandoc.add_input(man_file);
+    pandoc.add_input(pandoc_input.path());
     pandoc.set_input_format(pandoc::InputFormat::Other("man".to_string()), Vec::new());
     pandoc.set_output_format(pandoc::OutputFormat::Other("gfm".to_string()), Vec::new());
     pandoc.add_option(pandoc::PandocOption::ShiftHeadingLevelBy(1));
     pandoc.set_output(pandoc::OutputKind::Pipe);
 
     match pandoc.execute() {
-        Ok(pandoc::PandocOutput::ToBuffer(markdown)) => Ok(markdown),
+        Ok(pandoc::PandocOutput::ToBuffer(markdown)) => Ok(normalize_pandoc_markdown(&markdown)),
         Ok(_) => Err(CarbideCliError::GenericError(format!(
             "pandoc returned non-text output converting man page {}",
             man_file.display()
@@ -293,6 +297,299 @@ fn man_to_markdown(man_file: &Path) -> CarbideCliResult<String> {
             "while converting man page {} to markdown with pandoc: {err}",
             man_file.display()
         ))),
+    }
+}
+
+/// Expands the small subset of roff emitted by clap_mangen that pandoc's man
+/// reader does not preserve when converting to GFM.
+fn normalize_roff_for_pandoc(roff: &str) -> String {
+    let roff = normalize_roff_apostrophes(roff);
+    let mut normalized = String::with_capacity(roff.len());
+
+    for line in roff.split_inclusive('\n') {
+        let backticks = line.matches('`').count();
+        if backticks >= 2 && backticks.is_multiple_of(2) {
+            let mut in_code = false;
+            for character in line.chars() {
+                if character == '`' {
+                    normalized.push_str(if in_code { r"\f[]" } else { r"\f[C]" });
+                    in_code = !in_code;
+                } else {
+                    normalized.push(character);
+                }
+            }
+        } else {
+            normalized.push_str(line);
+        }
+    }
+
+    normalized
+}
+
+fn normalize_roff_apostrophes(roff: &str) -> String {
+    const APOSTROPHE: &str = r"\*(Aq";
+    const SUFFIXES: [&str; 7] = ["s", "t", "d", "m", "re", "ve", "ll"];
+
+    let mut normalized = String::with_capacity(roff.len());
+    let mut remaining = roff;
+    while let Some(position) = remaining.find(APOSTROPHE) {
+        normalized.push_str(&remaining[..position]);
+        let after = &remaining[position + APOSTROPHE.len()..];
+        let follows_word = normalized
+            .chars()
+            .next_back()
+            .is_some_and(char::is_alphanumeric);
+        if follows_word && SUFFIXES.iter().any(|suffix| after.starts_with(suffix)) {
+            normalized.push('\'');
+        }
+        remaining = after;
+    }
+    normalized.push_str(remaining);
+    normalized
+}
+
+/// Keeps generated GFM stable across the roff emitted by clap_mangen and the
+/// GFM writers in supported pandoc versions.
+///
+/// Newer combinations render the roff used for a value enumeration as a
+/// blockquote and use Markdown hard-break spaces. The original checked-in CLI
+/// reference used ordinary lists and backslash hard breaks. Normalize this
+/// narrow construct instead of reformatting prose, so paragraph wrapping and
+/// all user-facing text remain untouched.
+fn normalize_pandoc_markdown(markdown: &str) -> String {
+    let mut lines: Vec<String> = markdown.lines().map(str::to_string).collect();
+
+    for possible_values in 0..lines.len() {
+        if lines[possible_values].trim() != "*Possible values:*" {
+            continue;
+        }
+
+        if possible_values >= 3
+            && lines[possible_values - 1].trim().is_empty()
+            && lines[possible_values - 2].is_empty()
+            && lines[possible_values - 3].ends_with("  ")
+        {
+            let description = &mut lines[possible_values - 3];
+            description.truncate(description.len() - 2);
+            description.push('\\');
+            lines[possible_values - 1] = "\\".to_string();
+        } else if possible_values >= 2
+            && lines[possible_values - 1].trim().is_empty()
+            && lines[possible_values - 2].ends_with("  ")
+        {
+            lines[possible_values - 1] = "\\".to_string();
+        }
+    }
+
+    normalize_possible_value_lists(&mut lines);
+
+    let mut normalized = restore_escaped_markdown_links(&lines.join("\n"));
+    if markdown.ends_with('\n') {
+        normalized.push('\n');
+    }
+    normalized
+}
+
+fn restore_escaped_markdown_links(markdown: &str) -> String {
+    let mut normalized = String::with_capacity(markdown.len());
+    let mut remaining = markdown;
+
+    while let Some(open) = remaining.find(r"\[") {
+        normalized.push_str(&remaining[..open]);
+        let candidate = &remaining[open + 2..];
+        let Some(label_end) = candidate.find(r"\](") else {
+            normalized.push_str(&remaining[open..]);
+            return normalized;
+        };
+        if candidate[..label_end].contains('\n') {
+            normalized.push_str(&remaining[open..open + 2]);
+            remaining = candidate;
+            continue;
+        }
+        let destination = &candidate[label_end + 3..];
+        let Some(destination_end) = destination.find(')') else {
+            normalized.push_str(&remaining[open..]);
+            return normalized;
+        };
+        if destination[..destination_end]
+            .chars()
+            .any(|character| character == '\n' || character == ' ')
+        {
+            normalized.push_str(&remaining[open..open + 2]);
+            remaining = candidate;
+            continue;
+        }
+
+        normalized.push('[');
+        normalized.push_str(&candidate[..label_end]);
+        normalized.push_str("](");
+        normalized.push_str(&destination[..=destination_end]);
+        remaining = &destination[destination_end + 1..];
+    }
+
+    normalized.push_str(remaining);
+    normalized
+}
+
+fn normalize_possible_value_lists(lines: &mut Vec<String>) {
+    let mut heading = 0;
+    while heading < lines.len() {
+        if lines[heading].trim() != "*Possible values:*" {
+            heading += 1;
+            continue;
+        }
+
+        let start = heading + 1;
+        let mut end = start;
+        let mut items = Vec::new();
+        let mut current = String::new();
+
+        while end < lines.len() {
+            let line = &lines[end];
+            if let Some(item) = value_list_item(line) {
+                if !current.is_empty() {
+                    items.push(current);
+                }
+                current = item.to_string();
+            } else if let Some(continuation) = value_list_continuation(line) {
+                if !current.is_empty() {
+                    current.push(' ');
+                    current.push_str(continuation);
+                }
+            } else if !line.is_empty() && line != ">" {
+                break;
+            }
+            end += 1;
+        }
+        if !current.is_empty() {
+            items.push(current);
+        }
+
+        if items.is_empty() {
+            heading += 1;
+            continue;
+        }
+
+        let had_trailing_separator =
+            end > start && (lines[end - 1].is_empty() || lines[end - 1] == ">");
+        let item_count = items.len();
+        let mut rendered = vec![String::new()];
+        for (index, item) in items.into_iter().enumerate() {
+            rendered.extend(wrap_value_list_item(&item));
+            if index + 1 < item_count || had_trailing_separator {
+                rendered.push(String::new());
+            }
+        }
+        let rendered_len = rendered.len();
+        lines.splice(start..end, rendered);
+        heading = start + rendered_len;
+    }
+}
+
+fn value_list_item(line: &str) -> Option<&str> {
+    line.strip_prefix("> -")
+        .or_else(|| line.strip_prefix("- "))
+        .map(str::trim_start)
+}
+
+fn value_list_continuation(line: &str) -> Option<&str> {
+    line.strip_prefix('>')
+        .filter(|continuation| continuation.starts_with("   "))
+        .or_else(|| line.starts_with("  ").then_some(line))
+        .map(str::trim)
+}
+
+fn wrap_value_list_item(item: &str) -> Vec<String> {
+    // pandoc 2's GFM writer wrapped these roff definition-list values at 72
+    // columns. Keep that established layout when normalizing pandoc 3 output.
+    const WIDTH: usize = 72;
+
+    let mut wrapped = Vec::new();
+    let mut line = String::from("- ");
+    for word in item.split_whitespace() {
+        let separator = usize::from(line.len() > 2);
+        if line.len() + separator + word.len() > WIDTH && line.len() > 2 {
+            wrapped.push(line);
+            line = format!("  {word}");
+        } else {
+            if separator == 1 {
+                line.push(' ');
+            }
+            line.push_str(word);
+        }
+    }
+    wrapped.push(line);
+    wrapped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        normalize_pandoc_markdown, normalize_roff_for_pandoc, restore_escaped_markdown_links,
+    };
+
+    #[test]
+    fn expands_clap_mangen_apostrophes_and_inline_code_for_pandoc() {
+        let input = "Set a BMC\\*(Aqs password (use `credential rotate`)\n";
+        let expected = "Set a BMC's password (use \\f[C]credential rotate\\f[])\n";
+
+        assert_eq!(normalize_roff_for_pandoc(input), expected);
+    }
+
+    #[test]
+    fn drops_roff_quote_marks_around_help_flags() {
+        let input = "Print help (see a summary with \\*(Aq-h\\*(Aq)\n";
+        let expected = "Print help (see a summary with -h)\n";
+
+        assert_eq!(normalize_roff_for_pandoc(input), expected);
+    }
+
+    #[test]
+    fn leaves_unpaired_roff_backticks_unchanged() {
+        let input = "A lone ` is ordinary text.\n";
+
+        assert_eq!(normalize_roff_for_pandoc(input), input);
+    }
+
+    #[test]
+    fn restores_links_escaped_by_pandoc_without_touching_synopsis_brackets() {
+        let input = r"Refer to \[Phone-home\](../../configuration.md#phone-home). \[**--flag**\]";
+        let expected = r"Refer to [Phone-home](../../configuration.md#phone-home). \[**--flag**\]";
+
+        assert_eq!(restore_escaped_markdown_links(input), expected);
+    }
+
+    #[test]
+    fn normalizes_possible_value_lists_without_reflowing_prose() {
+        let input = "Description that stays on its original line.  \n\n  \n*Possible values:*\n\n> - first\n>\n> -   second: description\n\nNext paragraph.\n";
+        let expected = "Description that stays on its original line.\\\n\n\\\n*Possible values:*\n\n- first\n\n- second: description\n\nNext paragraph.\n";
+
+        assert_eq!(normalize_pandoc_markdown(input), expected);
+    }
+
+    #[test]
+    fn leaves_unrelated_markdown_unchanged() {
+        let input = "A paragraph.\n\n> A real blockquote.\n";
+
+        assert_eq!(normalize_pandoc_markdown(input), input);
+    }
+
+    #[test]
+    fn normalizes_empty_descriptions_and_wrapped_value_details() {
+        let input = "**--vendor**  \n  \n*Possible values:*\n\n> - first: a long description\n>   continued here\n";
+        let expected = "**--vendor**  \n\\\n*Possible values:*\n\n- first: a long description continued here\n";
+
+        assert_eq!(normalize_pandoc_markdown(input), expected);
+    }
+
+    #[test]
+    fn wraps_value_details_independently_of_pandoc_list_indentation() {
+        let pandoc_2 = "*Possible values:*\n\n-   flat: instances live directly on the underlay and use an operator-managed data plane instead of an overlay\n";
+        let pandoc_3 = "*Possible values:*\n\n> - flat: instances live directly on the underlay and use an\n>   operator-managed data plane instead of an overlay\n";
+        let expected = "*Possible values:*\n\n- flat: instances live directly on the underlay and use an\n  operator-managed data plane instead of an overlay\n";
+
+        assert_eq!(normalize_pandoc_markdown(pandoc_2), expected);
+        assert_eq!(normalize_pandoc_markdown(pandoc_3), expected);
     }
 }
 

--- a/crates/admin-cli/src/operating_system/create/args.rs
+++ b/crates/admin-cli/src/operating_system/create/args.rs
@@ -65,7 +65,8 @@ pub struct Args {
     #[clap(
         long,
         default_value = "false",
-        help = "Enable phone-home on first boot."
+        help = "Enable phone-home on first boot.",
+        long_help = "Hold the instance in a provisioning state until the booted OS calls back (\"phones home\") to NICo's metadata service, instead of reporting it ready as soon as provisioning finishes. NICo injects the cloud-init `phone_home` block into your user-data for you, so your `userData` must be valid cloud-init YAML when this is enabled. Refer to [Phone-home](../../../../configuration/tenant_management.md#phone-home) for what it injects, the endpoint, and usage guidance."
     )]
     pub phone_home_enabled: bool,
 

--- a/crates/admin-cli/src/operating_system/update/args.rs
+++ b/crates/admin-cli/src/operating_system/update/args.rs
@@ -52,7 +52,11 @@ pub struct Args {
     #[clap(long, help = "Set whether users can override OS parameters.")]
     pub allow_override: Option<bool>,
 
-    #[clap(long, help = "Set whether phone-home on first boot is enabled.")]
+    #[clap(
+        long,
+        help = "Set whether phone-home on first boot is enabled.",
+        long_help = "Set whether the instance is held in a provisioning state until the booted OS calls back (\"phones home\") to NICo's metadata service, instead of being reported ready as soon as provisioning finishes. NICo injects the cloud-init `phone_home` block into your user-data for you, so your `userData` must be valid cloud-init YAML when this is enabled. Refer to [Phone-home](../../../../configuration/tenant_management.md#phone-home) for what it injects, the endpoint, and usage guidance."
+    )]
     pub phone_home_enabled: Option<bool>,
 
     #[clap(long, help = "Update the cloud-init / user-data script.")]

--- a/crates/admin-cli/src/rack/mod.rs
+++ b/crates/admin-cli/src/rack/mod.rs
@@ -47,6 +47,9 @@ pub enum Cmd {
     Profile(profile::Args),
     #[clap(subcommand, about = "On-demand rack maintenance")]
     Maintenance(maintenance::Args),
-    #[clap(about = "Show rack state history")]
+    #[clap(
+        about = "Show rack state history",
+        long_about = "Show rack state history.\n\nRecords are always returned in chronological order (oldest first). The global --sort-by option is inherited by this command but has no effect on the output."
+    )]
     StateHistory(state_history::Args),
 }

--- a/crates/admin-cli/src/redfish/args.rs
+++ b/crates/admin-cli/src/redfish/args.rs
@@ -179,7 +179,7 @@ Gracefully shut a machine down (also accepted as the alias `shutdown`):
     GetChassisAll,
     /// List Chassis Subsystem
     GetChassis(Chassis),
-    /// Show BMC's Ethernet interface information
+    /// Show BMC Ethernet interface information
     GetBmcEthernetInterfaces,
     /// Show System Ethernet interface information
     GetSystemEthernetInterfaces,
@@ -231,10 +231,11 @@ Clear the UEFI password (supply the current one):
     ClearNvram,
     /// Set BIOS options
     SetBios(SetBios),
-    /// Reset BIOS settings to factory defaults. Returns once the BMC accepts
-    /// the reset request. A system restart is required for the settings to
-    /// take effect.
-    #[command(after_long_help = "\
+    /// Reset BIOS settings to factory defaults.
+    #[command(
+        about = "Reset BIOS settings to factory defaults",
+        long_about = "Reset BIOS settings to factory defaults. Returns once the BMC accepts the reset request. A system restart is required for the settings to take effect.",
+        after_long_help = "\
 EXAMPLES:
 
 Reset BIOS settings to factory defaults:
@@ -244,7 +245,8 @@ Reset BIOS settings and restart the system to apply the change:
     $ nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
     reset-bios --reboot
 
-")]
+"
+    )]
     ResetBios(ResetBiosArgs),
     /// Get DPU mode
     GetNicMode,
@@ -329,8 +331,8 @@ Show DPU port information:
 
 ")]
 pub enum DpuOperations {
-    /// BMC's FW Commands
-    #[clap(visible_alias = "fw", about = "BMC's FW Commands", subcommand)]
+    /// BMC firmware commands
+    #[clap(visible_alias = "fw", about = "BMC firmware commands", subcommand)]
     Firmware(FwCommand),
     /// Show ports information
     Ports(ShowPort),
@@ -356,7 +358,7 @@ Show all discovered firmware versions:
 pub enum FwCommand {
     /// Print FW update status
     Status,
-    /// Update BMC's FW to the given FW package
+    /// Update BMC firmware to the given firmware package
     Update(FwPackage),
     /// Show FW versions of different components
     Show(ShowFw),

--- a/crates/admin-cli/src/set/bmc_proxy/args.rs
+++ b/crates/admin-cli/src/set/bmc_proxy/args.rs
@@ -31,6 +31,10 @@ Disable the BMC proxy:
 pub struct Args {
     #[clap(long, action = clap::ArgAction::Set, help = "Enable site-explorer bmc_proxy")]
     pub enabled: bool,
-    #[clap(long, action = clap::ArgAction::Set, help = "host:port string use as a proxy for talking to BMC's")]
+    #[clap(
+        long,
+        action = clap::ArgAction::Set,
+        help = "host:port string to use as a proxy for talking to BMCs"
+    )]
     pub proxy: Option<String>,
 }

--- a/crates/admin-cli/src/set/log_filter/args.rs
+++ b/crates/admin-cli/src/set/log_filter/args.rs
@@ -29,7 +29,7 @@ Set a targeted filter that reverts after 30 minutes:
 
 ")]
 pub struct Args {
-    #[clap(short, long, help = "Set server's RUST_LOG.")]
+    #[clap(short, long, help = "Set the server's RUST_LOG.")]
     pub filter: String,
     #[clap(
         long,

--- a/crates/admin-cli/src/sku/mod.rs
+++ b/crates/admin-cli/src/sku/mod.rs
@@ -58,7 +58,7 @@ pub enum Cmd {
     Verify(verify::Args),
     #[clap(about = "Update the metadata of a SKU")]
     UpdateMetadata(update_metadata::Args),
-    #[clap(about = "Update multiple SKU's metadata from a file")]
+    #[clap(about = "Update metadata for multiple SKUs from a file")]
     BulkUpdateMetadata(bulk_update_metadata::Args),
     #[clap(about = "Replace the component list of a SKU")]
     Replace(replace::Args),

--- a/crates/admin-cli/src/ssh/mod.rs
+++ b/crates/admin-cli/src/ssh/mod.rs
@@ -40,6 +40,6 @@ pub enum Cmd {
     EnableRshim(enable_rshim::Args),
     #[clap(about = "Copy BFB to the DPU BMC's RSHIM ")]
     CopyBfb(copy_bfb::Args),
-    #[clap(about = "Show the DPU's BMC's OBMC log")]
+    #[clap(about = "Show the OBMC log for the DPU's BMC")]
     ShowObmcLog(show_obmc_log::Args),
 }

--- a/docs/manuals/nico-admin-cli/admin.md
+++ b/docs/manuals/nico-admin-cli/admin.md
@@ -10,5 +10,6 @@ For global flags and setup, see [the overview](./README.md) and [`setup.md`](./s
 | [`generate-shell-complete`](./commands/generate-shell-complete/generate-shell-complete.md) | Generate shell autocomplete. Source the output of this command: `source <(nico-admin-cli generate-shell-complete bash)`. |
 | [`jump`](./commands/jump/jump.md) | Broad search across multiple object types. |
 | [`ping`](./commands/ping/ping.md) | Query the Version gRPC endpoint repeatedly printing how long it took and any failures. |
+| [`secrets`](./commands/secrets/secrets.md) | Secrets management. |
 | [`ssh`](./commands/ssh/ssh.md) | SSH Util functions. |
 | [`version`](./commands/version/version.md) | Print API server version. |

--- a/docs/manuals/nico-admin-cli/commands/attestation/attestation-measured-boot-site-trusted-machine-approve.md
+++ b/docs/manuals/nico-admin-cli/commands/attestation/attestation-measured-boot-site-trusted-machine-approve.md
@@ -50,7 +50,7 @@ Print help (see a summary with -h)
 The machine-id to approve (or \* for all).
 
 \<*APPROVAL_TYPE*\>  
-Whether to set \`oneshot\` or \`persist\`.\
+Whether to set `oneshot` or `persist`.\
 
 \
 *Possible values:*

--- a/docs/manuals/nico-admin-cli/commands/attestation/attestation-measured-boot-site-trusted-profile-approve.md
+++ b/docs/manuals/nico-admin-cli/commands/attestation/attestation-measured-boot-site-trusted-profile-approve.md
@@ -50,7 +50,7 @@ Print help (see a summary with -h)
 The profile-id to approve.
 
 \<*APPROVAL_TYPE*\>  
-Whether to set \`oneshot\` or \`persist\`.\
+Whether to set `oneshot` or `persist`.\
 
 \
 *Possible values:*

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-candidates.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-candidates.md
@@ -1,0 +1,61 @@
+# `nico-admin-cli boot-interface candidates`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **candidates**_
+
+## NAME
+
+nico-admin-cli-boot-interface-candidates - List boot-interface
+candidates for a machine and the picks among them
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface candidates** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*MACHINE*\>
+
+## DESCRIPTION
+
+List every NIC that could be the boot interface for a machine -- the
+managed `machine_interfaces` rows and the pre-first-lease predictions --
+and mark the picks among them: `current` (what resolution targets now:
+the primary interface if one is set, else the lowest-MAC non-underlay
+interface), `default` (what the automatic selection would choose if no
+primary interface were set), and `explored` (the default site-explorer
+recorded for the BMC endpoint of the machine). Underlay rows are listed
+but marked ineligible. Every pick is computed server-side by the same
+selection code the machine-controller acts on. Read-only.
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*MACHINE*\>  
+The machine ID whose boot-interface candidates to list
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface candidates 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format json boot-interface candidates 12345678-1234-5678-90ab-cdef01234567
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-set.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-set.md
@@ -1,0 +1,72 @@
+# `nico-admin-cli boot-interface set`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **set**_
+
+## NAME
+
+nico-admin-cli-boot-interface-set - Set the boot interface for a machine
+(promotes it to the primary interface)
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface set** \[**--force-reconcile**\]
+\[**--reboot**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\] \<*MACHINE*\> \<*INTERFACE*\>
+
+## DESCRIPTION
+
+Make an interface the boot interface for a machine by promoting it to
+the primary interface -- the designation every boot flow keys on. This
+is the same operation as `managed-host set-primary-interface`: the
+primary row and desired target commit together, then machine-controller
+reconciles the BMC when the host is eligible. The interface can be named
+by machine-interface UUID or by MAC address; a MAC must match exactly
+one managed interface row on the machine.
+
+## OPTIONS
+
+**--force-reconcile**  
+Request a fresh machine-controller reconciliation even when this
+interface is already selected
+
+**--reboot**  
+Deprecated compatibility alias; use --force-reconcile with current
+servers
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*MACHINE*\>  
+The machine whose boot interface to set
+
+\<*INTERFACE*\>  
+The interface to boot from -- a machine-interface UUID or a MAC address
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 00:11:22:33:44:55
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 00:11:22:33:44:55 --force-reconcile
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-show.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-show.md
@@ -1,0 +1,61 @@
+# `nico-admin-cli boot-interface show`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **show**_
+
+## NAME
+
+nico-admin-cli-boot-interface-show - Show boot interfaces for a machine
+from every store (troubleshooting)
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface show** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*MACHINE*\>
+
+## DESCRIPTION
+
+Gather the boot-interface view for one machine from all four stores and
+print them together: the managed `machine_interfaces` rows
+(authoritative for a managed machine), `predicted_machine_interfaces`
+(pre-first-lease candidates), the `explored_endpoints` default (for
+endpoints without a machine), and the retained post-deletion pairs
+(including stale records). Also reports the effective boot interface,
+flags when the stores disagree, and shows desired-state reconciliation
+progress when one exists. Read-only.
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*MACHINE*\>  
+The machine ID whose boot interfaces to gather
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface show 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format json boot-interface show 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format yaml boot-interface show 12345678-1234-5678-90ab-cdef01234567
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface.md
@@ -1,0 +1,50 @@
+# `nico-admin-cli boot-interface`
+
+_[Hardware commands](../../hardware.md) › **boot-interface**_
+
+## NAME
+
+nico-admin-cli-boot-interface - Machine boot-interface management
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface** \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+Machine boot-interface management
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`show`](./boot-interface-show.md) | Show boot interfaces for a machine from every store (troubleshooting) |
+| [`candidates`](./boot-interface-candidates.md) | List boot-interface candidates for a machine and the picks among them |
+| [`set`](./boot-interface-set.md) | Set the boot interface for a machine (promotes it to the primary interface) |
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-override/boot-override-set.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-override/boot-override-set.md
@@ -17,7 +17,9 @@ nico-admin-cli-boot-override-set
 ## OPTIONS
 
 **-p**, **--custom-pxe** *\<CUSTOM_PXE\>*  
+
 **-u**, **--custom-user-data** *\<CUSTOM_USER_DATA\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/browse/browse-nmxc.md
+++ b/docs/manuals/nico-admin-cli/commands/browse/browse-nmxc.md
@@ -30,9 +30,15 @@ NMX-C browse operation to run\
 
 - compute-node-info-list
 
+- switch-node-info-list
+
 - gpu-info
 
 - gpu-info-list
+
+- partition-info-list
+
+- get-domain-properties
 
 **--gpu-uid** *\<GPU_UID\>* \[default: 0\]  
 GPU UID (used by the gpu-info operation)
@@ -62,7 +68,10 @@ Print help (see a summary with -h)
 ```sh
 nico-admin-cli browse nmxc --chassis-serial 1234567890 --operation gpu-info-list
 nico-admin-cli browse nmxc --chassis-serial 1234567890 --operation compute-node-info-list
+nico-admin-cli browse nmxc --chassis-serial 1234567890 --operation switch-node-info-list
 nico-admin-cli browse nmxc --chassis-serial 1234567890 --operation gpu-info --gpu-uid 42
+nico-admin-cli browse nmxc --chassis-serial 1234567890 --operation partition-info-list
+nico-admin-cli browse nmxc --chassis-serial 1234567890 --operation get-domain-properties
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/component-manager/component-manager-configure-switch-certificate.md
+++ b/docs/manuals/nico-admin-cli/commands/component-manager/component-manager-configure-switch-certificate.md
@@ -1,0 +1,66 @@
+# `nico-admin-cli component-manager configure-switch-certificate`
+
+_[Hardware commands](../../hardware.md) › [component-manager](./component-manager.md) › **configure-switch-certificate**_
+
+## NAME
+
+nico-admin-cli-component-manager-configure-switch-certificate - Rotate
+or reinstall switch NVOS mTLS certificates via the switch Maintenance
+phase
+
+## SYNOPSIS
+
+**nico-admin-cli component-manager configure-switch-certificate**
+\<**--switch-id**\> \[**--domain-name**\]
+\[**--bypass-state-controller**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Rotate or reinstall switch NVOS mTLS certificates via the switch
+Maintenance phase
+
+## OPTIONS
+
+**--switch-id** *\<SWITCH_IDS\>...*  
+Switch IDs to target
+
+**--domain-name** *\<DOMAIN_NAME\>*  
+Optional certificate domain passed through to RMS; omit to use the RMS
+default
+
+**--bypass-state-controller**  
+Bypass the switch state controller and dispatch directly to the
+component backend
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli component-manager configure-switch-certificate --switch-id 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli component-manager configure-switch-certificate --switch-id 12345678-1234-5678-90ab-cdef01234567,abcdef01-2345-6789-abcd-ef0123456789
+nico-admin-cli component-manager configure-switch-certificate --switch-id 12345678-1234-5678-90ab-cdef01234567 --bypass-state-controller
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/component-manager/component-manager-update-firmware-compute-tray.md
+++ b/docs/manuals/nico-admin-cli/commands/component-manager/component-manager-update-firmware-compute-tray.md
@@ -28,7 +28,7 @@ Machine IDs to target
 Firmware target version for legacy direct-update paths
 
 **--sot-json-file** *\<PATH\>*  
-SOT JSON file for RMS ApplyFirmwareObjectFromJSON
+SOT JSON file for RMS ApplyFirmwareObject
 
 **--access-token** *\<ACCESS_TOKEN\>*  
 Artifact access token for RMS SOT JSON downloads; omit or pass empty for

--- a/docs/manuals/nico-admin-cli/commands/component-manager/component-manager-update-firmware-rack.md
+++ b/docs/manuals/nico-admin-cli/commands/component-manager/component-manager-update-firmware-rack.md
@@ -27,7 +27,7 @@ Rack IDs to target
 Firmware target version for legacy direct-update paths
 
 **--sot-json-file** *\<PATH\>*  
-SOT JSON file for RMS ApplyFirmwareObjectFromJSON
+SOT JSON file for RMS ApplyFirmwareObject
 
 **--access-token** *\<ACCESS_TOKEN\>*  
 Artifact access token for RMS SOT JSON downloads; omit or pass empty for

--- a/docs/manuals/nico-admin-cli/commands/component-manager/component-manager-update-firmware-switch.md
+++ b/docs/manuals/nico-admin-cli/commands/component-manager/component-manager-update-firmware-switch.md
@@ -28,7 +28,7 @@ Switch IDs to target
 Firmware target version for legacy direct-update paths
 
 **--sot-json-file** *\<PATH\>*  
-SOT JSON file for RMS ApplyFirmwareObjectFromJSON
+SOT JSON file for RMS ApplyFirmwareObject
 
 **--access-token** *\<ACCESS_TOKEN\>*  
 Artifact access token for RMS SOT JSON downloads; omit or pass empty for

--- a/docs/manuals/nico-admin-cli/commands/component-manager/component-manager.md
+++ b/docs/manuals/nico-admin-cli/commands/component-manager/component-manager.md
@@ -45,6 +45,7 @@ Print help (see a summary with -h)
 | [`get-firmware-update-status`](./component-manager-get-firmware-update-status.md) | Get component firmware update status |
 | [`get-firmware-versions`](./component-manager-get-firmware-versions.md) | List available component firmware versions |
 | [`component-power-control`](./component-manager-component-power-control.md) | Issue a power-control action against components (switches, power shelves, compute trays) |
+| [`configure-switch-certificate`](./component-manager-configure-switch-certificate.md) | Rotate or reinstall switch NVOS mTLS certificates via the switch Maintenance phase |
 
 ---
 

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-add-nic-lockdown-ikm.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-add-nic-lockdown-ikm.md
@@ -1,0 +1,52 @@
+# `nico-admin-cli credential add-nic-lockdown-ikm`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › **add-nic-lockdown-ikm**_
+
+## NAME
+
+nico-admin-cli-credential-add-nic-lockdown-ikm - Set the site-wide
+SuperNIC lockdown IKM (input key material)
+
+## SYNOPSIS
+
+**nico-admin-cli credential add-nic-lockdown-ikm** \<**--password**\>
+\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Set the site-wide SuperNIC lockdown IKM (input key material)
+
+## OPTIONS
+
+**--password** *\<PASSWORD\>*  
+The site-wide NIC lockdown IKM value
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+carbide-admin-cli credential add-nic-lockdown-ikm --password mypassword
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-force-bmc-clear.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-force-bmc-clear.md
@@ -1,0 +1,61 @@
+# `nico-admin-cli credential force-bmc clear`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › [force-bmc](./credential-force-bmc.md) › **clear**_
+
+## NAME
+
+nico-admin-cli-credential-force-bmc-clear - Clear a pending BMC
+force-converge request for a machine, switch, or power shelf.
+
+## SYNOPSIS
+
+**nico-admin-cli credential force-bmc clear** \[**-i**\|**--id**\]
+\[**--bmc-mac**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Clear a pending BMC force-converge request for a machine, switch, or
+power shelf.
+
+## OPTIONS
+
+**-i**, **--id** *\<ID\>*  
+Machine, DPU, switch, or power shelf ID whose pending BMC force-converge
+request should be cleared. Provide this or --bmc-mac.
+
+**--bmc-mac** *\<BMC_MAC\>*  
+MAC of the BMC whose pending request should be cleared.
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential force-bmc clear --id fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc clear --id sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc clear --id ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc clear --bmc-mac 00:11:22:33:44:55
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-force-bmc-set.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-force-bmc-set.md
@@ -1,0 +1,62 @@
+# `nico-admin-cli credential force-bmc set`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › [force-bmc](./credential-force-bmc.md) › **set**_
+
+## NAME
+
+nico-admin-cli-credential-force-bmc-set - Request an immediate BMC
+credential rotation of a machine, switch, or power shelf.
+
+## SYNOPSIS
+
+**nico-admin-cli credential force-bmc set** \[**-i**\|**--id**\]
+\[**--bmc-mac**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Request an immediate BMC credential rotation of a machine, switch, or
+power shelf.
+
+## OPTIONS
+
+**-i**, **--id** *\<ID\>*  
+ID of the machine, DPU, switch, or power shelf that owns the BMC.
+Provide this or --bmc-mac.
+
+**--bmc-mac** *\<BMC_MAC\>*  
+MAC of the BMC to target (machine, switch, or power shelf). Provide this
+or --id; if an id is also given they must identify the same device.
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential force-bmc set --id fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc set --id sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc set --id ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc set --bmc-mac 00:11:22:33:44:55
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-force-bmc.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-force-bmc.md
@@ -1,0 +1,60 @@
+# `nico-admin-cli credential force-bmc`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › **force-bmc**_
+
+## NAME
+
+nico-admin-cli-credential-force-bmc - Force-converge a single BMC's
+credentials now (operator escape hatch)
+
+## SYNOPSIS
+
+**nico-admin-cli credential force-bmc** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+Force-converge a single BMC's credentials now (operator escape hatch)
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential force-bmc set --id fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc set --id sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc set --id ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-bmc set --bmc-mac 00:11:22:33:44:55
+nico-admin-cli credential force-bmc clear --id fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`set`](./credential-force-bmc-set.md) | Request an immediate BMC credential rotation of a machine, switch, or power shelf. |
+| [`clear`](./credential-force-bmc-clear.md) | Clear a pending BMC force-converge request for a machine, switch, or power shelf. |
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-force-uefi-clear.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-force-uefi-clear.md
@@ -1,0 +1,58 @@
+# `nico-admin-cli credential force-uefi clear`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › [force-uefi](./credential-force-uefi.md) › **clear**_
+
+## NAME
+
+nico-admin-cli-credential-force-uefi-clear - Clear a pending UEFI
+force-converge request for a machine (host).
+
+## SYNOPSIS
+
+**nico-admin-cli credential force-uefi clear** \[**-i**\|**--id**\]
+\[**--bmc-mac**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Clear a pending UEFI force-converge request for a machine (host).
+
+## OPTIONS
+
+**-i**, **--id** *\<ID\>*  
+Machine ID whose pending UEFI force-converge request should be cleared.
+Provide this or --bmc-mac.
+
+**--bmc-mac** *\<BMC_MAC\>*  
+MAC of the machine's BMC whose pending request should be cleared.
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential force-uefi clear --id fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-uefi clear --bmc-mac 00:11:22:33:44:55
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-force-uefi-set.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-force-uefi-set.md
@@ -1,0 +1,59 @@
+# `nico-admin-cli credential force-uefi set`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › [force-uefi](./credential-force-uefi.md) › **set**_
+
+## NAME
+
+nico-admin-cli-credential-force-uefi-set - Request an immediate UEFI
+credential rotation of a machine (host).
+
+## SYNOPSIS
+
+**nico-admin-cli credential force-uefi set** \[**-i**\|**--id**\]
+\[**--bmc-mac**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Request an immediate UEFI credential rotation of a machine (host).
+
+## OPTIONS
+
+**-i**, **--id** *\<ID\>*  
+Machine ID that owns the UEFI credential (a host machine). Provide this
+or --bmc-mac.
+
+**--bmc-mac** *\<BMC_MAC\>*  
+MAC of the machine's BMC. Provide this or --id; if both are given they
+must identify the same machine.
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential force-uefi set --id fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-uefi set --bmc-mac 00:11:22:33:44:55
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-force-uefi.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-force-uefi.md
@@ -1,0 +1,59 @@
+# `nico-admin-cli credential force-uefi`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › **force-uefi**_
+
+## NAME
+
+nico-admin-cli-credential-force-uefi - Force-converge a single machine's
+UEFI credential now (operator escape hatch)
+
+## SYNOPSIS
+
+**nico-admin-cli credential force-uefi** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+Force-converge a single machine's UEFI credential now (operator escape
+hatch)
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential force-uefi set --id fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+nico-admin-cli credential force-uefi set --bmc-mac 00:11:22:33:44:55
+nico-admin-cli credential force-uefi clear --id fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`set`](./credential-force-uefi-set.md) | Request an immediate UEFI credential rotation of a machine (host). |
+| [`clear`](./credential-force-uefi-clear.md) | Clear a pending UEFI force-converge request for a machine (host). |
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-registry-set.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-registry-set.md
@@ -1,0 +1,59 @@
+# `nico-admin-cli credential registry set`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › [registry](./credential-registry.md) › **set**_
+
+## NAME
+
+nico-admin-cli-credential-registry-set - Set credentials for a container
+registry
+
+## SYNOPSIS
+
+**nico-admin-cli credential registry set** \<**--registry**\>
+\<**--username**\> \<**--password**\> \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Set credentials for a container registry
+
+## OPTIONS
+
+**--registry** *\<REGISTRY\>*  
+Registry hostname (e.g. nvcr.io)
+
+**--username** *\<USERNAME\>*  
+Registry username
+
+**--password** *\<PASSWORD\>*  
+Registry password or API key
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential registry set --registry nvcr.io --username '$oauthtoken' --password mypassword
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-registry.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-registry.md
@@ -1,0 +1,49 @@
+# `nico-admin-cli credential registry`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › **registry**_
+
+## NAME
+
+nico-admin-cli-credential-registry - Manage container registry
+credentials
+
+## SYNOPSIS
+
+**nico-admin-cli credential registry** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+Manage container registry credentials
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`set`](./credential-registry-set.md) | Set credentials for a container registry |
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-rotate.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-rotate.md
@@ -1,0 +1,77 @@
+# `nico-admin-cli credential rotate`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › **rotate**_
+
+## NAME
+
+nico-admin-cli-credential-rotate - Stage a site-wide credential rotation
+(auto-generate or explicit password)
+
+## SYNOPSIS
+
+**nico-admin-cli credential rotate** \<**--type**\> \[**--password**\]
+\[**--reason**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Stage a site-wide credential rotation (auto-generate or explicit
+password)
+
+## OPTIONS
+
+**--type**=*\<CREDENTIAL_TYPE\>*  
+Credential family to rotate\
+
+\
+*Possible values:*
+
+- bmc
+
+- host-uefi
+
+- dpu-uefi
+
+- nvos
+
+- lockdown-ikm
+
+**--password**=*\<PASSWORD\>*  
+Explicit rotate-to password. Omit to have the server auto-generate a
+strong one.
+
+**--reason** *\<REASON\>*  
+Free-form note recorded with the rotation (must not contain secrets)
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential rotate --type=bmc
+nico-admin-cli credential rotate --type=host-uefi --password=Str0ng-Explicit-Pw!
+nico-admin-cli credential rotate --type=nvos --password=MyNvosPassword-2026
+nico-admin-cli credential rotate --type=lockdown-ikm --reason="quarterly rotation"
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-rotation-status.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-rotation-status.md
@@ -1,0 +1,71 @@
+# `nico-admin-cli credential rotation-status`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › **rotation-status**_
+
+## NAME
+
+nico-admin-cli-credential-rotation-status - Show convergence status of a
+site-wide credential rotation
+
+## SYNOPSIS
+
+**nico-admin-cli credential rotation-status** \<**--type**\>
+\[**--mac-address**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Show convergence status of a site-wide credential rotation
+
+## OPTIONS
+
+**--type**=*\<CREDENTIAL_TYPE\>*  
+Credential family to report on\
+
+\
+*Possible values:*
+
+- bmc
+
+- host-uefi
+
+- dpu-uefi
+
+- nvos
+
+- lockdown-ikm
+
+**--mac-address** *\<MAC_ADDRESS\>*  
+Report on a single device by MAC instead of the whole site
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential rotation-status --type=bmc
+nico-admin-cli credential rotation-status --type=lockdown-ikm
+nico-admin-cli credential rotation-status --type=bmc --mac-address 00:11:22:33:44:55
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential.md
@@ -46,12 +46,18 @@ Print help (see a summary with -h)
 | [`generate-ufm-cert`](./credential-generate-ufm-cert.md) | Generate UFM credential |
 | [`add-bmc`](./credential-add-bmc.md) | Add BMC credentials |
 | [`delete-bmc`](./credential-delete-bmc.md) | Delete BMC credentials |
+| [`add-nic-lockdown-ikm`](./credential-add-nic-lockdown-ikm.md) | Set the site-wide SuperNIC lockdown IKM (input key material) |
 | [`add-uefi`](./credential-add-uefi.md) | Add site-wide DPU UEFI default credential (NOTE: this parameter can be set only once) |
 | [`add-host-factory-default`](./credential-add-host-factory-default.md) | Add manufacturer factory default BMC user/pass for a given vendor |
 | [`add-dpu-factory-default`](./credential-add-dpu-factory-default.md) | Add manufacturer factory default BMC user/pass for the DPUs |
 | [`add-nmx-m`](./credential-add-nmx-m.md) | Deprecated compatibility command; NMX-M is no longer supported |
 | [`delete-nmx-m`](./credential-delete-nmx-m.md) | Deprecated compatibility command; NMX-M is no longer supported |
 | [`bgp`](./credential-bgp.md) | Manage leaf BGP passwords |
+| [`registry`](./credential-registry.md) | Manage container registry credentials |
+| [`rotate`](./credential-rotate.md) | Stage a site-wide credential rotation (auto-generate or explicit password) |
+| [`rotation-status`](./credential-rotation-status.md) | Show convergence status of a site-wide credential rotation |
+| [`force-bmc`](./credential-force-bmc.md) | Force-converge a single BMC's credentials now (operator escape hatch) |
+| [`force-uefi`](./credential-force-uefi.md) | Force-converge a single machine's UEFI credential now (operator escape hatch) |
 
 ---
 

--- a/docs/manuals/nico-admin-cli/commands/dev-env/dev-env-config-apply.md
+++ b/docs/manuals/nico-admin-cli/commands/dev-env/dev-env-config-apply.md
@@ -18,7 +18,7 @@ Apply devenv config
 ## OPTIONS
 
 **-m**, **--mode** *\<MODE\>*  
-Vpc prefix or network segment?\
+Vpc prefix, tenant network segment, or HostInband segment?\
 
 \
 *Possible values:*
@@ -26,6 +26,9 @@ Vpc prefix or network segment?\
 - network-segment
 
 - vpc-prefix
+
+- host-inband-segment: Flat VPC plus HostInband segment for hosts with
+  no DPU
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/dpa/dpa-ensure.md
+++ b/docs/manuals/nico-admin-cli/commands/dpa/dpa-ensure.md
@@ -10,7 +10,7 @@ nico-admin-cli-dpa-ensure - Create/ensure a DPA interface
 
 **nico-admin-cli dpa ensure** \[**--extended**\] \[**--sort-by**\]
 \[**-h**\|**--help**\] \<*MACHINE_ID*\> \<*MAC_ADDR*\> \<*DEVICE_TYPE*\>
-\<*PCI_NAME*\> \[*DEVICE_DESCRIPTION*\]
+\<*PCI_NAME*\> \<*INTERFACE_TYPE*\> \[*DEVICE_DESCRIPTION*\]
 
 ## DESCRIPTION
 
@@ -49,6 +49,16 @@ Device type (e.g. BlueField3)
 
 \<*PCI_NAME*\>  
 PCI name (e.g. 5e:00.0)
+
+\<*INTERFACE_TYPE*\>  
+Interface type (e.g. SVPC or ASTRA)\
+
+\
+*Possible values:*
+
+- svpc
+
+- astra
 
 \[*DEVICE_DESCRIPTION*\]  
 Device description (e.g. NVIDIA BlueField-3 B3140L E-Series FHHL

--- a/docs/manuals/nico-admin-cli/commands/dpf/dpf.md
+++ b/docs/manuals/nico-admin-cli/commands/dpf/dpf.md
@@ -6,9 +6,10 @@ _[Hardware commands](../../hardware.md) › **dpf**_
 
 nico-admin-cli-dpf - DPF-related commands. Note: These commands update
 the DPF state of the machine, which determines DPF-based DPU
-re-provisioning. The state is saved in the machines metadata and will be
-deleted if the machine is force-deleted. To make the state persistent,
-add the DPF state for a machine (host) to the expected machines table.
+re-provisioning. The state is saved in the machine's metadata and will
+be deleted if the machine is force-deleted. To make the state
+persistent, add the DPF state for a machine (host) to the expected
+machines table.
 
 ## SYNOPSIS
 
@@ -19,7 +20,7 @@ add the DPF state for a machine (host) to the expected machines table.
 
 DPF-related commands. Note: These commands update the DPF state of the
 machine, which determines DPF-based DPU re-provisioning. The state is
-saved in the machines metadata and will be deleted if the machine is
+saved in the machine's metadata and will be deleted if the machine is
 force-deleted. To make the state persistent, add the DPF state for a
 machine (host) to the expected machines table.
 

--- a/docs/manuals/nico-admin-cli/commands/dpu-remediation/dpu-remediation-show.md
+++ b/docs/manuals/nico-admin-cli/commands/dpu-remediation/dpu-remediation-show.md
@@ -18,6 +18,7 @@ Display remediation information
 ## OPTIONS
 
 **--display-script**  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/dpu/dpu-health-report-remove.md
+++ b/docs/manuals/nico-admin-cli/commands/dpu/dpu-health-report-remove.md
@@ -40,6 +40,7 @@ Sort output by specified field\
 Print help (see a summary with -h)
 
 \<*DPU_ID*\>  
+
 \<*REPORT_SOURCE*\>
 
 ## Examples

--- a/docs/manuals/nico-admin-cli/commands/dpu/dpu-reprovision-clear.md
+++ b/docs/manuals/nico-admin-cli/commands/dpu/dpu-reprovision-clear.md
@@ -23,6 +23,7 @@ DPU Machine ID for which reprovisioning should be cleared, or host
 machine id if all DPUs should be cleared.
 
 **-u**, **--update-firmware**  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/dpu/dpu-reprovision-restart.md
+++ b/docs/manuals/nico-admin-cli/commands/dpu/dpu-reprovision-restart.md
@@ -22,6 +22,7 @@ Restart the DPU reprovision.
 Host Machine ID for which reprovisioning should be restarted.
 
 **-u**, **--update-firmware**  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/dpu/dpu-reprovision-set.md
+++ b/docs/manuals/nico-admin-cli/commands/dpu/dpu-reprovision-set.md
@@ -23,6 +23,7 @@ DPU Machine ID for which reprovisioning is needed, or host machine id if
 all DPUs should be reprovisioned.
 
 **-u**, **--update-firmware**  
+
 **--update-message** *\<UPDATE_MESSAGE\>*  
 If set, a HostUpdateInProgress health alert will be applied to the host
 

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-add.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-add.md
@@ -13,11 +13,12 @@ nico-admin-cli-expected-machine-add - Add expected machine
 \[**-p**\|**--bmc-password**\] \<**-s**\|**--chassis-serial-number**\>
 \[**-d**\|**--fallback-dpu-serial-number**\] \[**--meta-name**\]
 \[**--meta-description**\] \[**--label**\] \[**--sku-id**\] \[**--id**\]
-\[**--host_nics**\] \[**--rack_id**\]
+\[**--interfaces**\] \[**--rack_id**\]
 \[**--default_pause_ingestion_and_poweron**\] \[**--dpf-enabled**\]
 \[**--extended**\] \[**--bmc-ip-address**\]
 \[**--bmc-retain-credentials**\] \[**--dpu-policy**\]
-\[**--disable-lockdown**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+\[**--bmc-ip-allocation**\] \[**--disable-lockdown**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
 
 ## DESCRIPTION
 
@@ -63,16 +64,26 @@ A SKU ID that will be added for the newly created Machine.
 **--id** *\<UUID\>*  
 Optional unique ID to assign to the ExpectedMachine on create
 
-**--host_nics** *\<HOST_NICS\>*  
-Host NICs as a JSON array of ExpectedHostNic objects (fields:
-mac_address, nic_type, fixed_ip, fixed_mask, fixed_gateway, primary)
+**--interfaces** *\<INTERFACES\>*  
+Interfaces as a JSON array of ExpectedInterface objects (fields:
+mac_address, role, ip_allocation, network_segment_type, fixed_ip,
+fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values:
+role=host\|dpu_os\|dpu_bmc\|host_bmc and
+ip_allocation=dynamic\|fixed\|retained. An omitted role defaults to
+host. When ip_allocation is omitted, fixed_ip implies fixed; without
+fixed_ip, host_bmc defaults to retained and every other role defaults to
+dynamic. Explicit fixed policies, DPU fixed addresses, and inferred
+host_bmc fixed addresses with a segment guard must fall within a
+configured managed prefix. Legacy host entries with an omitted policy
+and unguarded inferred host_bmc fixed addresses keep the
+static-assignments fallback.
 
 **--rack_id** *\<RACK_ID\>*  
 Rack ID for this machine
 
 **--default_pause_ingestion_and_poweron** *\<DEFAULT_PAUSE_INGESTION_AND_POWERON\>*  
-Optional flag to pause machines ingestion and power on. False - dont
-pause, true - will pause it. The actual mutable state is stored in
+Optional flag to pause machine ingestion and power-on. False - don't
+pause; true - pause it. The actual mutable state is stored in
 explored_endpoints.\
 
 \
@@ -114,14 +125,14 @@ factory-default credentials in Vault as-is\
 
 - false
 
-**--dpu-policy** *\<DPU_POLICY\>*\
-Per-host DPU policy. \`manage\` (default): inherit the site policy,
-which defaults to managing DPUs; \`nic\`: configure DPU hardware
-as plain NICs; \`ignore\`: do not configure or attach DPU hardware.
-Unset defers to the site-wide \`\[site_explorer\] dpu_policy\` setting.
-The previous \`use-as-nic\` value remains accepted as an alias. The legacy
-\`--dpu-mode\` flag also remains accepted: \`dpu-mode\` maps to \`manage\`,
-\`nic-mode\` to \`nic\`, and \`no-dpu\` to \`ignore\`.\
+**--dpu-policy** *\<DPU_POLICY\>*  
+Per-host DPU policy. `manage` (default): inherit the site policy, which
+defaults to managing DPUs; `nic`: configure DPU hardware as plain NICs;
+`ignore`: do not configure or attach DPU hardware. Unset defers to the
+site-wide `[site_explorer] dpu_policy` setting. The previous
+`use-as-nic` value remains accepted as an alias. The legacy `--dpu-mode`
+flag also remains accepted: `dpu-mode` maps to `manage`, `nic-mode` to
+`nic`, and `no-dpu` to `ignore`.\
 
 \
 *Possible values:*
@@ -131,6 +142,28 @@ The previous \`use-as-nic\` value remains accepted as an alias. The legacy
 - nic
 
 - ignore
+
+**--bmc-ip-allocation** *\<BMC_IP_ALLOCATION\>*  
+Per-host control over how this BMC's IP is assigned and retained. `auto`
+(default): infer from `--bmc-ip-address` -- a configured address is
+`fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that
+may expire and change; `fixed`: the operator-specified
+`--bmc-ip-address` (static); `retained`: an auto-allocated address
+pinned as static (never expires). Unset defers to the server default
+(`auto`).\
+
+\
+*Possible values:*
+
+- unspecified
+
+- auto
+
+- dynamic
+
+- fixed
+
+- retained
 
 **--disable-lockdown** *\<DISABLE_LOCKDOWN\>*  
 If true, do not lock down the server as part of lifecycle management
@@ -164,6 +197,9 @@ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-us
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --meta-name MyMachine --label DATACENTER:XYZ --sku-id DGX-H100-640GB
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --bmc-ip-address 192.0.2.20
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --dpu-policy nic
+nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --interfaces '[{"mac_address":"00:11:22:33:44:55","role":"host_bmc","ip_allocation":"retained"}]'
+nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --interfaces '[{"mac_address":"02:00:00:00:20:01","role":"dpu_os","ip_allocation":"fixed","fixed_ip":"192.0.2.10"}]'
+nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --bmc-ip-allocation retained
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-patch.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-patch.md
@@ -18,6 +18,7 @@ update, preserves unprovided fields).
 \[**--rack-id**\] \[**--default_pause_ingestion_and_poweron**\]
 \[**--dpf-enabled**\] \[**--bmc-ip-address**\] \[**--extended**\]
 \[**--bmc-retain-credentials**\] \[**--dpu-policy**\]
+\[**--bmc-ip-allocation**\] \[**--interfaces**\]
 \[**--disable-lockdown**\] \[**--sort-by**\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION
@@ -77,8 +78,8 @@ A SKU ID that will be added for the newly created Machine.
 A RACK ID that will be added for the newly created Machine.
 
 **--default_pause_ingestion_and_poweron** *\<DEFAULT_PAUSE_INGESTION_AND_POWERON\>*  
-Optional flag to pause machines ingestion and power on. False - dont
-pause, true - will pause it. The actual mutable state is stored in
+Optional flag to pause machine ingestion and power-on. False - don't
+pause; true - pause it. The actual mutable state is stored in
 explored_endpoints.\
 
 \
@@ -120,14 +121,13 @@ factory-default credentials in Vault as-is\
 
 - false
 
-**--dpu-policy** *\<DPU_POLICY\>*\
-Per-host DPU policy. \`manage\`: inherit the site policy, which defaults
-to managing DPUs; \`nic\`: configure DPU hardware as plain NICs;
-\`ignore\`: do not configure or attach DPU hardware. Unset preserves the
-existing per-host value. The previous \`use-as-nic\` value remains accepted
-as an alias. The legacy \`--dpu-mode\` flag also remains accepted:
-\`dpu-mode\` maps to \`manage\`, \`nic-mode\` to \`nic\`, and \`no-dpu\`
-to \`ignore\`.\
+**--dpu-policy** *\<DPU_POLICY\>*  
+Per-host DPU policy. `manage`: inherit the site policy, which defaults
+to managing DPUs; `nic`: configure DPU hardware as plain NICs; `ignore`:
+do not configure or attach DPU hardware. Unset preserves the existing
+per-host value. The previous `use-as-nic` value remains accepted as an
+alias. The legacy `--dpu-mode` flag also remains accepted: `dpu-mode`
+maps to `manage`, `nic-mode` to `nic`, and `no-dpu` to `ignore`.\
 
 \
 *Possible values:*
@@ -137,6 +137,39 @@ to \`ignore\`.\
 - nic
 
 - ignore
+
+**--bmc-ip-allocation** *\<BMC_IP_ALLOCATION\>*  
+Per-host control over how this BMC's IP is assigned and retained. `auto`
+(default): infer from `--bmc-ip-address` -- a configured address is
+`fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that
+may expire and change; `fixed`: the operator-specified
+`--bmc-ip-address` (static); `retained`: an auto-allocated address
+pinned as static (never expires). Unset preserves the existing per-host
+value.\
+
+\
+*Possible values:*
+
+- unspecified
+
+- auto
+
+- dynamic
+
+- fixed
+
+- retained
+
+**--interfaces** *\<INTERFACES\>*  
+Interfaces as a JSON array of ExpectedInterface objects (fields:
+mac_address, role, ip_allocation, network_segment_type, fixed_ip,
+fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values:
+role=host\|dpu_os\|dpu_bmc\|host_bmc\|unspecified and
+ip_allocation=dynamic\|fixed\|retained\|unspecified. Replaces the
+machine's full interface list. For a matching stored MAC, omitting role
+preserves the stored role; role=unspecified resets it to host. Omitting
+ip_allocation preserves the stored policy when the presence of fixed_ip
+is unchanged; ip_allocation=unspecified resets it to fixed_ip inference.
 
 **--disable-lockdown** *\<DISABLE_LOCKDOWN\>*  
 If true, do not lock down the server as part of lifecycle management
@@ -170,6 +203,9 @@ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --sku-
 nico-admin-cli expected-machine patch --id 12345678-1234-5678-90ab-cdef01234567 --sku-id DGX-H100-640GB
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mynewpassword
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --dpu-policy ignore
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --bmc-ip-allocation retained
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --interfaces '[{"mac_address":"02:00:00:00:20:01","fixed_ip":"192.0.2.10"}]'
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --interfaces '[{"mac_address":"02:00:00:00:20:01","role":"unspecified","ip_allocation":"unspecified","fixed_ip":"192.0.2.10"}]'
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-replace-all.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-replace-all.md
@@ -30,6 +30,7 @@ Example json file: { "expected_machines": \[ { "bmc_mac_address":
 ## OPTIONS
 
 **-f**, **--filename** *\<FILENAME\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/expected-power-shelf/expected-power-shelf-replace-all.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-power-shelf/expected-power-shelf-replace-all.md
@@ -20,6 +20,7 @@ Replace all expected power shelves
 ## OPTIONS
 
 **-f**, **--filename** *\<FILENAME\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/expected-rack/expected-rack-replace-all.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-rack/expected-rack-replace-all.md
@@ -18,6 +18,7 @@ Replace all expected racks
 ## OPTIONS
 
 **-f**, **--filename** *\<FILENAME\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/expected-switch/expected-switch-replace-all.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-switch/expected-switch-replace-all.md
@@ -20,6 +20,7 @@ Replace all expected switches
 ## OPTIONS
 
 **-f**, **--filename** *\<FILENAME\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/generate-shell-complete/generate-shell-complete.md
+++ b/docs/manuals/nico-admin-cli/commands/generate-shell-complete/generate-shell-complete.md
@@ -5,8 +5,8 @@ _[Admin commands](../../admin.md) › **generate-shell-complete**_
 ## NAME
 
 nico-admin-cli-generate-shell-complete - Generate shell autocomplete.
-Source the output of this command: \`source \<(nico-admin-cli
-generate-shell-complete bash)\`
+Source the output of this command:
+`source <(nico-admin-cli generate-shell-complete bash)`
 
 ## SYNOPSIS
 
@@ -15,8 +15,8 @@ generate-shell-complete bash)\`
 
 ## DESCRIPTION
 
-Generate shell autocomplete. Source the output of this command: \`source
-\<(nico-admin-cli generate-shell-complete bash)\`
+Generate shell autocomplete. Source the output of this command:
+`source <(nico-admin-cli generate-shell-complete bash)`
 
 ## OPTIONS
 

--- a/docs/manuals/nico-admin-cli/commands/host/host-reprovision-clear.md
+++ b/docs/manuals/nico-admin-cli/commands/host/host-reprovision-clear.md
@@ -22,6 +22,7 @@ Clear the reprovisioning mode.
 Machine ID for which reprovisioning should be cleared.
 
 **-u**, **--update-firmware**  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/host/host-reprovision-set.md
+++ b/docs/manuals/nico-admin-cli/commands/host/host-reprovision-set.md
@@ -23,6 +23,7 @@ Set the host in reprovisioning mode.
 Machine ID for which reprovisioning is needed.
 
 **-u**, **--update-firmware**  
+
 **--update-message** *\<UPDATE_MESSAGE\>*  
 If set, a HostUpdateInProgress health alert will be applied to the host
 

--- a/docs/manuals/nico-admin-cli/commands/instance/instance-allocate.md
+++ b/docs/manuals/nico-admin-cli/commands/instance/instance-allocate.md
@@ -13,7 +13,7 @@ nico-admin-cli-instance-allocate - Allocate instance
 \<**-p**\|**--prefix-name**\> \[**--label-key**\] \[**--label-value**\]
 \[**--network-security-group-id**\] \[**--instance-type-id**\]
 \[**--os**\] \[**--spxconfig**\] \[**--vf-subnet**\]
-\[**-v**\|**--vpc-prefix-id**\] \[**--zero-dpu**\] \[**--extended**\]
+\[**-v**\|**--vpc-prefix-id**\] \[**--flat-vpc-id**\] \[**--extended**\]
 \[**--vf-vpc-prefix-id**\] \[**--ip-address**\] \[**--vf-ip-address**\]
 \[**--ipv6-vpc-prefix-id**\] \[**--ipv6-vf-prefix-id**\]
 \[**--ipv6-ip-address**\] \[**--ipv6-vf-ip-address**\]
@@ -27,11 +27,14 @@ Allocate instance
 ## OPTIONS
 
 **-n**, **--number** *\<NUMBER\>*  
+
 **-s**, **--subnet** *\<SUBNET\>*  
 The subnet to assign to a PF
 
 **-t**, **--tenant-org** *\<TENANT_ORG\>*  
+
 **-p**, **--prefix-name** *\<PREFIX_NAME\>*  
+
 **--label-key** *\<LABEL_KEY\>*  
 The key of label instance to query
 
@@ -58,8 +61,8 @@ The subnet to assign to a VF
 **-v**, **--vpc-prefix-id** *\<VPC_PREFIX_ID\>*  
 The VPC prefix to assign to a PF
 
-**--zero-dpu**  
-Allocate a zero-dpu host
+**--flat-vpc-id** *\<FLAT_VPC_ID\>*  
+Create an instance in the given "flat" VPC, for machines without DPUs
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/instance/instance-reboot.md
+++ b/docs/manuals/nico-admin-cli/commands/instance/instance-reboot.md
@@ -20,8 +20,11 @@ Reboot instance, potentially applying firmware updates
 ## OPTIONS
 
 **-i**, **--instance** *\<INSTANCE\>*  
+
 **-c**, **--custom-pxe**  
+
 **-a**, **--apply-updates-on-reboot**  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/instance/instance-release.md
+++ b/docs/manuals/nico-admin-cli/commands/instance/instance-release.md
@@ -19,7 +19,9 @@ De-allocate instance
 ## OPTIONS
 
 **-i**, **--instance** *\<INSTANCE\>*  
+
 **-m**, **--machine** *\<MACHINE\>*  
+
 **--label-key** *\<LABEL_KEY\>*  
 The key of label instance to query
 

--- a/docs/manuals/nico-admin-cli/commands/instance/instance-show.md
+++ b/docs/manuals/nico-admin-cli/commands/instance/instance-show.md
@@ -20,6 +20,7 @@ Display instance information
 ## OPTIONS
 
 **-e**, **--extrainfo**  
+
 **-t**, **--tenant-org-id** *\<TENANT_ORG_ID\>*  
 The Tenant Org ID to query
 

--- a/docs/manuals/nico-admin-cli/commands/instance/instance-update-ib-config.md
+++ b/docs/manuals/nico-admin-cli/commands/instance/instance-update-ib-config.md
@@ -20,6 +20,7 @@ Update instance IB configuration
 ## OPTIONS
 
 **-i**, **--instance** *\<INSTANCE\>*  
+
 **--config** *\<IB_JSON\>*  
 IB configuration in JSON format
 

--- a/docs/manuals/nico-admin-cli/commands/instance/instance-update-nv-link-config.md
+++ b/docs/manuals/nico-admin-cli/commands/instance/instance-update-nv-link-config.md
@@ -20,6 +20,7 @@ Update instance NVLink configuration
 ## OPTIONS
 
 **-i**, **--instance** *\<INSTANCE\>*  
+
 **--config** *\<NVLINK_JSON\>*  
 NVLink configuration in JSON format
 

--- a/docs/manuals/nico-admin-cli/commands/instance/instance-update-os.md
+++ b/docs/manuals/nico-admin-cli/commands/instance/instance-update-os.md
@@ -18,6 +18,7 @@ Update instance OS
 ## OPTIONS
 
 **-i**, **--instance** *\<INSTANCE\>*  
+
 **--os** *\<OS_JSON\>*  
 OS definition in JSON format
 

--- a/docs/manuals/nico-admin-cli/commands/instance/instance-update-spx-config.md
+++ b/docs/manuals/nico-admin-cli/commands/instance/instance-update-spx-config.md
@@ -20,6 +20,7 @@ Update instance SPX configuration
 ## OPTIONS
 
 **-i**, **--instance** *\<INSTANCE\>*  
+
 **--config** *\<SPX_JSON\>*  
 SPX configuration in JSON format
 

--- a/docs/manuals/nico-admin-cli/commands/machine-interfaces/machine-interfaces-delete.md
+++ b/docs/manuals/nico-admin-cli/commands/machine-interfaces/machine-interfaces-delete.md
@@ -38,8 +38,7 @@ Sort output by specified field\
 Print help (see a summary with -h)
 
 \<*INTERFACE_ID*\>  
-The interface ID to delete. Redeploy kea after deleting machine
-interfaces.
+The interface ID to delete.
 
 ## Examples
 

--- a/docs/manuals/nico-admin-cli/commands/machine-interfaces/machine-interfaces-show.md
+++ b/docs/manuals/nico-admin-cli/commands/machine-interfaces/machine-interfaces-show.md
@@ -22,6 +22,7 @@ List of all Machine interfaces
 Show all machine interfaces (DEPRECATED)
 
 **--more**  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/machine-validation/machine-validation-on-demand-start.md
+++ b/docs/manuals/nico-admin-cli/commands/machine-validation/machine-validation-on-demand-start.md
@@ -21,6 +21,7 @@ Start on demand machine validation
 ## OPTIONS
 
 **--help**  
+
 **-m**, **--machine** *\<MACHINE\>*  
 Machine id for start validation
 

--- a/docs/manuals/nico-admin-cli/commands/machine-validation/machine-validation-tests-add.md
+++ b/docs/manuals/nico-admin-cli/commands/machine-validation/machine-validation-tests-add.md
@@ -36,7 +36,7 @@ Command args
 List of contexts
 
 **--img-name** *\<IMG_NAME\>*  
-Container image name
+Container image name (must include @sha256:\<digest\>)
 
 **--execute-in-host** *\<EXECUTE_IN_HOST\>*  
 Run command using chroot in case of container\

--- a/docs/manuals/nico-admin-cli/commands/machine-validation/machine-validation-tests-update.md
+++ b/docs/manuals/nico-admin-cli/commands/machine-validation/machine-validation-tests-update.md
@@ -34,7 +34,7 @@ Version to be verify
 List of contexts
 
 **--img-name** *\<IMG_NAME\>*  
-Container image name
+Container image name (must include @sha256:\<digest\>)
 
 **--execute-in-host** *\<EXECUTE_IN_HOST\>*  
 Run command using chroot in case of container\

--- a/docs/manuals/nico-admin-cli/commands/machine/machine-force-delete.md
+++ b/docs/manuals/nico-admin-cli/commands/machine/machine-force-delete.md
@@ -26,10 +26,10 @@ Force delete a machine
 UUID, IPv4, MAC or hostnmame of the host or DPU machine to delete
 
 **-d**, **--delete-interfaces**  
-Delete interfaces. Redeploy kea after deleting machine interfaces.
+Delete interfaces.
 
 **-b**, **--delete-bmc-interfaces**  
-Delete BMC interfaces. Redeploy kea after deleting machine interfaces.
+Delete BMC interfaces.
 
 **-c**, **--delete-bmc-credentials**  
 Delete BMC credentials. Only applicable if site explorer has configured

--- a/docs/manuals/nico-admin-cli/commands/machine/machine-show.md
+++ b/docs/manuals/nico-admin-cli/commands/machine/machine-show.md
@@ -20,6 +20,7 @@ Display Machine information
 ## OPTIONS
 
 **--help**  
+
 **-a**, **--all**  
 Show all machines (DEPRECATED)
 
@@ -33,7 +34,7 @@ Show only hosts
 Show only machines for this instance type
 
 **-c**, **--history-count** *\<HISTORY_COUNT\>* \[default: 5\]  
-History count. Valid if \`machine\` argument is passed.
+History count. Valid if `machine` argument is passed.
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-debug-bundle.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-debug-bundle.md
@@ -21,11 +21,11 @@ Download debug bundle with logs for a specific host
 ## OPTIONS
 
 **--start-time** *\<START_TIME\>*  
-Start time: YYYY-MM-DD HH:MM:SS or HH:MM:SS (uses todays date). Default:
-local timezone, use --utc for UTC
+Start time: YYYY-MM-DD HH:MM:SS or HH:MM:SS (uses today's date).
+Default: local timezone, use --utc for UTC
 
 **--end-time** *\<END_TIME\>*  
-End time: YYYY-MM-DD HH:MM:SS or HH:MM:SS (uses todays date). Defaults
+End time: YYYY-MM-DD HH:MM:SS or HH:MM:SS (uses today's date). Defaults
 to current time if not provided. Default: local timezone, use --utc for
 UTC
 

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-maintenance-on.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-maintenance-on.md
@@ -24,7 +24,7 @@ assigned to it
 Managed Host ID
 
 **--reference** *\<REFERENCE\>*  
-URL of reference (ticket, issue, etc) for this machines maintenance
+URL of reference (ticket, issue, etc) for this machine's maintenance
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-dpu.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-dpu.md
@@ -4,23 +4,29 @@ _[Hardware commands](../../hardware.md) â€º [managed-host](./managed-host.md) â€
 
 ## NAME
 
-nico-admin-cli-managed-host-set-primary-dpu - Set the primary DPU for
-the managed host
+nico-admin-cli-managed-host-set-primary-dpu - Deprecated: use
+set-primary-interface. Sets the primary DPU.
 
 ## SYNOPSIS
 
-**nico-admin-cli managed-host set-primary-dpu** \[**--reboot**\]
-\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
-\<*HOST_MACHINE_ID*\> \<*DPU_MACHINE_ID*\>
+**nico-admin-cli managed-host set-primary-dpu**
+\[**--force-reconcile**\] \[**--reboot**\] \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*HOST_MACHINE_ID*\>
+\<*DPU_MACHINE_ID*\>
 
 ## DESCRIPTION
 
-Set the primary DPU for the managed host
+Deprecated: use set-primary-interface. Sets the primary DPU.
 
 ## OPTIONS
 
+**--force-reconcile**  
+Request a fresh machine-controller reconciliation even when this DPU is
+already selected
+
 **--reboot**  
-Reboot the host after the update
+Deprecated compatibility alias; use --force-reconcile with current
+servers
 
 **--extended**  
 Extended result output.
@@ -52,7 +58,7 @@ ID of the DPU machine to make primary
 
 ```sh
 nico-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789
-nico-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789 --reboot
+nico-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789 --force-reconcile
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-interface.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-set-primary-interface.md
@@ -1,0 +1,66 @@
+# `nico-admin-cli managed-host set-primary-interface`
+
+_[Hardware commands](../../hardware.md) › [managed-host](./managed-host.md) › **set-primary-interface**_
+
+## NAME
+
+nico-admin-cli-managed-host-set-primary-interface - Set the primary
+interface (boot device) for the managed host
+
+## SYNOPSIS
+
+**nico-admin-cli managed-host set-primary-interface**
+\[**--force-reconcile**\] \[**--reboot**\] \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*HOST_MACHINE_ID*\>
+\<*INTERFACE_ID*\>
+
+## DESCRIPTION
+
+Set the primary interface (boot device) for the managed host
+
+## OPTIONS
+
+**--force-reconcile**  
+Request a fresh machine-controller reconciliation even when this
+interface is already selected
+
+**--reboot**  
+Deprecated compatibility alias; use --force-reconcile with current
+servers
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*HOST_MACHINE_ID*\>  
+ID of the host machine
+
+\<*INTERFACE_ID*\>  
+ID of the machine interface to make primary (the boot device)
+
+## Examples
+
+```sh
+nico-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789
+nico-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789 --force-reconcile
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-show.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host-show.md
@@ -20,6 +20,7 @@ Display managed host information
 ## OPTIONS
 
 **--help**  
+
 **-a**, **--all**  
 Show all managed hosts (DEPRECATED)
 

--- a/docs/manuals/nico-admin-cli/commands/managed-host/managed-host.md
+++ b/docs/manuals/nico-admin-cli/commands/managed-host/managed-host.md
@@ -47,7 +47,8 @@ Print help (see a summary with -h)
 | [`reset-host-reprovisioning`](./managed-host-reset-host-reprovisioning.md) | Reset host reprovisioning back to CheckingFirmware |
 | [`power-options`](./managed-host-power-options.md) | Power Manager related settings. |
 | [`start-updates`](./managed-host-start-updates.md) | Start updates for machines with delayed updates, such as GB200 |
-| [`set-primary-dpu`](./managed-host-set-primary-dpu.md) | Set the primary DPU for the managed host |
+| [`set-primary-interface`](./managed-host-set-primary-interface.md) | Set the primary interface (boot device) for the managed host |
+| [`set-primary-dpu`](./managed-host-set-primary-dpu.md) | Deprecated: use set-primary-interface. Sets the primary DPU. |
 | [`debug-bundle`](./managed-host-debug-bundle.md) | Download debug bundle with logs for a specific host |
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/network-device/network-device-show.md
+++ b/docs/manuals/nico-admin-cli/commands/network-device/network-device-show.md
@@ -41,8 +41,8 @@ Sort output by specified field\
 Print help (see a summary with -h)
 
 \[*ID*\] \[default: \]  
-Show data for the given network device (e.g. \`mac=\<mac\>\`), leave
-empty for all (default)
+Show data for the given network device (e.g. `mac=<mac>`), leave empty
+for all (default)
 
 ## Examples
 

--- a/docs/manuals/nico-admin-cli/commands/network-segment/network-segment-attach-vpc.md
+++ b/docs/manuals/nico-admin-cli/commands/network-segment/network-segment-attach-vpc.md
@@ -1,0 +1,60 @@
+# `nico-admin-cli network-segment attach-vpc`
+
+_[Network commands](../../network.md) › [network-segment](./network-segment.md) › **attach-vpc**_
+
+## NAME
+
+nico-admin-cli-network-segment-attach-vpc - Attach Network Segment to
+VPC
+
+## SYNOPSIS
+
+**nico-admin-cli network-segment attach-vpc** \<**--id**\>
+\<**--vpc-id**\> \[**--force**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Attach Network Segment to VPC
+
+## OPTIONS
+
+**--id** *\<ID\>*  
+Id of the network segment
+
+**--vpc-id** *\<VPC_ID\>*  
+Id of the VPC
+
+**--force**  
+Allow reassigning a segment that is attached to another VPC
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+carbide-admin-cli network-segment attach-vpc --id 12345678-1234-5678-90ab-cdef01234567 --vpc-id abcdef01-2345-6789-abcd-ef0123456789
+carbide-admin-cli network-segment attach-vpc --id 12345678-1234-5678-90ab-cdef01234567 --vpc-id abcdef01-2345-6789-abcd-ef0123456789 --force
+```
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/network-segment/network-segment-create.md
+++ b/docs/manuals/nico-admin-cli/commands/network-segment/network-segment-create.md
@@ -1,0 +1,96 @@
+# `nico-admin-cli network-segment create`
+
+_[Network commands](../../network.md) › [network-segment](./network-segment.md) › **create**_
+
+## NAME
+
+nico-admin-cli-network-segment-create - Create Network Segment
+
+## SYNOPSIS
+
+**nico-admin-cli network-segment create** \<**--name**\> \[**--id**\]
+\[**--vpc-id**\] \[**--subdomain-id**\] \[**--mtu**\] \<**--prefix**\>
+\[**--gateway**\] \[**--dhcpv6-link-address**\] \[**--reserve-first**\]
+\[**--segment-type**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Create Network Segment
+
+## OPTIONS
+
+**--name** *\<NAME\>*  
+Network segment name
+
+**--id** *\<NetworkSegmentId\>*  
+Optional network segment ID to use instead of allowing the API server to
+generate one
+
+**--vpc-id** *\<VpcId\>*  
+Optional VPC ID to attach the new segment to
+
+**--subdomain-id** *\<DomainId\>*  
+DNS subdomain ID used for DHCP and DNS records on the segment. Required
+for segments of type host-inband
+
+**--mtu** *\<MTU\>*  
+Optional MTU for the segment. Defaults to 9000 for tenant segments and
+1500 for other segment types
+
+**--prefix** *\<CIDR-prefix\>*  
+Network prefix in CIDR notation. Repeat once per address family
+
+**--gateway** *\<IP-address\>*  
+IPv4 gateway for the IPv4 prefix
+
+**--dhcpv6-link-address** *\<IPv6-address\>*  
+DHCPv6 relay link-address for the IPv6 prefix
+
+**--reserve-first** *\<COUNT\>* \[default: 0\]  
+Number of addresses to reserve before dynamic allocation starts
+
+**--segment-type** *\<SEGMENT_TYPE\>* \[default: tenant\]  
+Network segment type\
+
+\
+*Possible values:*
+
+- tenant
+
+- admin
+
+- underlay
+
+- host-inband
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli --cloud-unsafe-op=my_username network-segment create --name tenant-segment-1 --vpc-id 12345678-1234-5678-90ab-cdef01234567 --prefix 10.0.0.0/24 --gateway 10.0.0.1
+nico-admin-cli --cloud-unsafe-op=my_username network-segment create --name host-inband-a --segment-type host-inband --id 12345678-1234-5678-90ab-cdef01234567 --prefix 192.0.2.0/24 --gateway 192.0.2.1 --prefix 2001:db8::/64 --dhcpv6-link-address fe80::1 --subdomain-id 3ea8d9a2-4fe3-4189-97fc-cf9134e31f8f
+```
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/network-segment/network-segment.md
+++ b/docs/manuals/nico-admin-cli/commands/network-segment/network-segment.md
@@ -42,7 +42,9 @@ Print help (see a summary with -h)
 | Subcommand | Description |
 |---|---|
 | [`show`](./network-segment-show.md) | Display Network Segment information |
+| [`attach-vpc`](./network-segment-attach-vpc.md) | Attach Network Segment to VPC |
 | [`delete`](./network-segment-delete.md) | Delete Network Segment |
+| [`create`](./network-segment-create.md) | Create Network Segment |
 
 ---
 

--- a/docs/manuals/nico-admin-cli/commands/nvlink-nmxc-endpoints/nvlink-nmxc-endpoints-create.md
+++ b/docs/manuals/nico-admin-cli/commands/nvlink-nmxc-endpoints/nvlink-nmxc-endpoints-create.md
@@ -20,6 +20,7 @@ Insert a mapping for a chassis serial
 ## OPTIONS
 
 **--chassis-serial** *\<SERIAL\>*  
+
 **--endpoint** *\<ENDPOINT\>*  
 NMX-C gRPC base URL (e.g. https://host:50051)
 

--- a/docs/manuals/nico-admin-cli/commands/nvlink-nmxc-endpoints/nvlink-nmxc-endpoints-delete.md
+++ b/docs/manuals/nico-admin-cli/commands/nvlink-nmxc-endpoints/nvlink-nmxc-endpoints-delete.md
@@ -19,6 +19,7 @@ Remove a mapping by chassis serial
 ## OPTIONS
 
 **--chassis-serial** *\<SERIAL\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/nvlink-nmxc-endpoints/nvlink-nmxc-endpoints-update.md
+++ b/docs/manuals/nico-admin-cli/commands/nvlink-nmxc-endpoints/nvlink-nmxc-endpoints-update.md
@@ -20,7 +20,9 @@ Change the endpoint URL for a chassis serial
 ## OPTIONS
 
 **--chassis-serial** *\<SERIAL\>*  
+
 **--endpoint** *\<ENDPOINT\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-create.md
+++ b/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-create.md
@@ -10,7 +10,7 @@ definition.
 ## SYNOPSIS
 
 **nico-admin-cli operating-system create** \<**-n**\|**--name**\>
-\<**-o**\|**--org**\> \[**--id**\] \[**-d**\|**--description**\]
+\[**-o**\|**--org**\] \[**--id**\] \[**-d**\|**--description**\]
 \[**--is-active**\] \[**--allow-override**\]
 \[**--phone-home-enabled**\] \[**--user-data**\] \[**--ipxe-script**\]
 \[**--ipxe-template-id**\] \[**--param**\] \[**--extended**\]
@@ -26,7 +26,8 @@ Create a new operating system definition.
 Name of the operating system definition.
 
 **-o**, **--org** *\<ORG\>*  
-Organization identifier for this OS definition.
+Optional tenant organization identifier for this OS definition. Omit for
+OS definitions owned by provider.
 
 **--id** *\<ID\>*  
 Optional UUID for the new OS definition (default: server-generated).
@@ -49,12 +50,12 @@ Allow users to override OS parameters.
 
 **--phone-home-enabled**  
 Hold the instance in a provisioning state until the booted OS calls back
-("phones home") to NICo's metadata service, instead of reporting it ready as
-soon as provisioning finishes. NICo injects the cloud-init `phone_home` block
-into your user-data for you, so your `userData` must be valid cloud-init YAML
-when this is enabled. Refer to
-[Phone-home](../../../../configuration/tenant_management.md#phone-home) for
-what it injects, the endpoint, and usage guidance.
+("phones home") to NICo's metadata service, instead of reporting it
+ready as soon as provisioning finishes. NICo injects the cloud-init
+`phone_home` block into your user-data for you, so your `userData` must
+be valid cloud-init YAML when this is enabled. Refer to
+[Phone-home](../../../../configuration/tenant_management.md#phone-home)
+for what it injects, the endpoint, and usage guidance.
 
 **--user-data** *\<USER_DATA\>*  
 Optional cloud-init / user-data script.
@@ -97,4 +98,4 @@ nico-admin-cli operating-system create --name ubuntu-22.04 --org fds34511233a --
 
 ---
 
-**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../index.md)
+**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-update.md
+++ b/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-update.md
@@ -49,13 +49,13 @@ Set whether users can override OS parameters.\
 - false
 
 **--phone-home-enabled** *\<PHONE_HOME_ENABLED\>*  
-Set whether the instance is held in a provisioning state until the booted OS
-calls back ("phones home") to NICo's metadata service, instead of being
-reported ready as soon as provisioning finishes. NICo injects the cloud-init
-`phone_home` block into your user-data for you, so your `userData` must be
-valid cloud-init YAML when this is enabled. Refer to
-[Phone-home](../../../../configuration/tenant_management.md#phone-home) for
-what it injects, the endpoint, and usage guidance.\
+Set whether the instance is held in a provisioning state until the
+booted OS calls back ("phones home") to NICo's metadata service, instead
+of being reported ready as soon as provisioning finishes. NICo injects
+the cloud-init `phone_home` block into your user-data for you, so your
+`userData` must be valid cloud-init YAML when this is enabled. Refer to
+[Phone-home](../../../../configuration/tenant_management.md#phone-home)
+for what it injects, the endpoint, and usage guidance.\
 
 \
 *Possible values:*
@@ -110,4 +110,4 @@ nico-admin-cli operating-system update 12345678-1234-5678-90ab-cdef01234567 --ip
 
 ---
 
-**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../index.md)
+**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/power-shelf/power-shelf-health-report-remove.md
+++ b/docs/manuals/nico-admin-cli/commands/power-shelf/power-shelf-health-report-remove.md
@@ -40,6 +40,7 @@ Sort output by specified field\
 Print help (see a summary with -h)
 
 \<*POWER_SHELF_ID*\>  
+
 \<*REPORT_SOURCE*\>
 
 ## Examples

--- a/docs/manuals/nico-admin-cli/commands/rack/rack-maintenance-start.md
+++ b/docs/manuals/nico-admin-cli/commands/rack/rack-maintenance-start.md
@@ -41,7 +41,7 @@ configure-nmx-cluster, power-sequence (omit for all)
 Raw SOT JSON for firmware-upgrade activity (prefer --sot-json-file)
 
 **--sot-json-file** *\<PATH\>*  
-SOT JSON file for RMS ApplyFirmwareObjectFromJSON
+SOT JSON file for RMS ApplyFirmwareObject
 
 **--access-token** *\<ACCESS_TOKEN\>*  
 Artifact access token for RMS SOT JSON downloads; omit or pass empty for

--- a/docs/manuals/nico-admin-cli/commands/rack/rack-profile-list.md
+++ b/docs/manuals/nico-admin-cli/commands/rack/rack-profile-list.md
@@ -13,14 +13,18 @@ nico-admin-cli-rack-profile-list - List configured rack profiles
 
 ## DESCRIPTION
 
-List rack profiles from the effective runtime configuration. Rack profiles are not persisted rack resources. To add or change a profile, update the runtime configuration.
+List rack profiles from the effective runtime configuration. Rack
+profiles are not persisted rack resources. To add or change a profile,
+update the runtime configuration.
 
 ## OPTIONS
 
 **--extended**  
 Extended result output.
 
-Used by measured boot. Basic output contains the details typically of interest, and "extended" output also dumps out all the internal UUIDs that are used to associate instances.
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
 
 **--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
 Sort output by specified field\

--- a/docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md
+++ b/docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md
@@ -1,0 +1,55 @@
+# `nico-admin-cli rack state-history`
+
+_[Hardware commands](../../hardware.md) › [rack](./rack.md) › **state-history**_
+
+## NAME
+
+nico-admin-cli-rack-state-history - Show rack state history
+
+## SYNOPSIS
+
+**nico-admin-cli rack state-history** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*RACK_ID*\>
+
+## DESCRIPTION
+
+Show rack state history.
+
+Records are always returned in chronological order (oldest first). The
+global --sort-by option is inherited by this command but has no effect
+on the output.
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*RACK_ID*\>  
+Rack ID to show state history for
+
+## Examples
+
+```sh
+nico-admin-cli rack state-history ipp6-b03-gb-nvl-124-mini2
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/rack/rack.md
+++ b/docs/manuals/nico-admin-cli/commands/rack/rack.md
@@ -48,6 +48,7 @@ Print help (see a summary with -h)
 | [`metadata`](./rack-metadata.md) | Edit Metadata associated with a Rack |
 | [`profile`](./rack-profile.md) | Rack profile |
 | [`maintenance`](./rack-maintenance.md) | On-demand rack maintenance |
+| [`state-history`](./rack-state-history.md) | Show rack state history |
 
 ---
 

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-dpu-firmware-show.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-dpu-firmware-show.md
@@ -26,10 +26,10 @@ Show all discovered firmware key/values
 Show BMC FW Version
 
 **--dpu-os**  
-Show DPU OS version (shortcut for \`show DPU_OS\`)
+Show DPU OS version (shortcut for `show DPU_OS`)
 
 **--uefi**  
-Show UEFI version (shortcut for \`show DPU_UEFI\`)
+Show UEFI version (shortcut for `show DPU_UEFI`)
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-dpu-firmware-update.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-dpu-firmware-update.md
@@ -4,8 +4,8 @@ _[Hardware commands](../../hardware.md) › [redfish](./redfish.md) › [dpu](./
 
 ## NAME
 
-nico-admin-cli-redfish-dpu-firmware-update - Update BMCs FW to the given
-FW package
+nico-admin-cli-redfish-dpu-firmware-update - Update BMC firmware to the
+given firmware package
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ FW package
 
 ## DESCRIPTION
 
-Update BMCs FW to the given FW package
+Update BMC firmware to the given firmware package
 
 ## OPTIONS
 

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-dpu-firmware.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-dpu-firmware.md
@@ -4,7 +4,7 @@ _[Hardware commands](../../hardware.md) › [redfish](./redfish.md) › [dpu](./
 
 ## NAME
 
-nico-admin-cli-redfish-dpu-firmware - BMCs FW Commands
+nico-admin-cli-redfish-dpu-firmware - BMC firmware commands
 
 ## SYNOPSIS
 
@@ -13,7 +13,7 @@ nico-admin-cli-redfish-dpu-firmware - BMCs FW Commands
 
 ## DESCRIPTION
 
-BMCs FW Commands
+BMC firmware commands
 
 ## OPTIONS
 
@@ -50,7 +50,7 @@ nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypasswo
 | Subcommand | Description |
 |---|---|
 | [`status`](./redfish-dpu-firmware-status.md) | Print FW update status |
-| [`update`](./redfish-dpu-firmware-update.md) | Update BMC's FW to the given FW package |
+| [`update`](./redfish-dpu-firmware-update.md) | Update BMC firmware to the given firmware package |
 | [`show`](./redfish-dpu-firmware-show.md) | Show FW versions of different components |
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-dpu.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-dpu.md
@@ -48,7 +48,7 @@ nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypasswo
 
 | Subcommand | Description |
 |---|---|
-| [`firmware`](./redfish-dpu-firmware.md) | BMC's FW Commands |
+| [`firmware`](./redfish-dpu-firmware.md) | BMC firmware commands |
 | [`ports`](./redfish-dpu-ports.md) | Show ports information |
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-get-bmc-ethernet-interfaces.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-get-bmc-ethernet-interfaces.md
@@ -4,7 +4,7 @@ _[Hardware commands](../../hardware.md) › [redfish](./redfish.md) › **get-bm
 
 ## NAME
 
-nico-admin-cli-redfish-get-bmc-ethernet-interfaces - Show BMCs Ethernet
+nico-admin-cli-redfish-get-bmc-ethernet-interfaces - Show BMC Ethernet
 interface information
 
 ## SYNOPSIS
@@ -14,7 +14,7 @@ interface information
 
 ## DESCRIPTION
 
-Show BMCs Ethernet interface information
+Show BMC Ethernet interface information
 
 ## OPTIONS
 

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-get-boot-option.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-get-boot-option.md
@@ -19,7 +19,9 @@ List one or all BIOS boot options
 ## OPTIONS
 
 **--all**  
+
 **--id** *\<ID\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-machine-setup-status.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-machine-setup-status.md
@@ -5,7 +5,7 @@ _[Hardware commands](../../hardware.md) › [redfish](./redfish.md) › **machin
 ## NAME
 
 nico-admin-cli-redfish-machine-setup-status - Is everything MachineSetup
-does already done? Whats missing?
+does already done? What's missing?
 
 ## SYNOPSIS
 
@@ -15,7 +15,7 @@ does already done? Whats missing?
 
 ## DESCRIPTION
 
-Is everything MachineSetup does already done? Whats missing?
+Is everything MachineSetup does already done? What's missing?
 
 ## OPTIONS
 

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-reset-bios.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-reset-bios.md
@@ -10,7 +10,7 @@ defaults
 ## SYNOPSIS
 
 **nico-admin-cli redfish reset-bios** \[**-r**\|**--reboot**\]
-\[**--extended**\] \[**--sort-by** *\<SORT_BY\>*\] \[**-h**\|**--help**\]
+\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION
 
@@ -26,7 +26,7 @@ Perform a forced restart after the BMC accepts the BIOS reset request
 **--extended**  
 Extended result output.
 
-This is used by measured boot, where basic output contains just what you
+This used by measured boot, where basic output contains just what you
 probably care about, and "extended" output also dumps out all the
 internal UUIDs that are used to associate instances.
 

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish.md
@@ -99,7 +99,7 @@ nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypasswo
 | [`disable-secure-boot`](./redfish-disable-secure-boot.md) | Disable Secure Boot |
 | [`get-chassis-all`](./redfish-get-chassis-all.md) | List Chassis |
 | [`get-chassis`](./redfish-get-chassis.md) | List Chassis Subsystem |
-| [`get-bmc-ethernet-interfaces`](./redfish-get-bmc-ethernet-interfaces.md) | Show BMC's Ethernet interface information |
+| [`get-bmc-ethernet-interfaces`](./redfish-get-bmc-ethernet-interfaces.md) | Show BMC Ethernet interface information |
 | [`get-system-ethernet-interfaces`](./redfish-get-system-ethernet-interfaces.md) | Show System Ethernet interface information |
 | [`get-bmc-accounts`](./redfish-get-bmc-accounts.md) | List of existing BMC accounts |
 | [`change-bmc-username`](./redfish-change-bmc-username.md) | Rename an account |

--- a/docs/manuals/nico-admin-cli/commands/resource-pool/resource-pool-grow.md
+++ b/docs/manuals/nico-admin-cli/commands/resource-pool/resource-pool-grow.md
@@ -21,6 +21,7 @@ carbide-api admin_grow_resource_pool docs for example TOML.
 ## OPTIONS
 
 **-f**, **--filename** *\<FILENAME\>*  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/route-server/route-server-add.md
+++ b/docs/manuals/nico-admin-cli/commands/route-server/route-server-add.md
@@ -18,7 +18,8 @@ Add route server addresses
 ## OPTIONS
 
 **--source-type** *\<SOURCE_TYPE\>* \[default: admin_api\]  
-The source_type to use for the target addresses. Defaults to admin_api.\
+The source_type to use for the target addresses. Defaults to
+admin_api.\
 
 \
 *Possible values:*

--- a/docs/manuals/nico-admin-cli/commands/route-server/route-server-remove.md
+++ b/docs/manuals/nico-admin-cli/commands/route-server/route-server-remove.md
@@ -18,7 +18,8 @@ Remove route server addresses
 ## OPTIONS
 
 **--source-type** *\<SOURCE_TYPE\>* \[default: admin_api\]  
-The source_type to use for the target addresses. Defaults to admin_api.\
+The source_type to use for the target addresses. Defaults to
+admin_api.\
 
 \
 *Possible values:*

--- a/docs/manuals/nico-admin-cli/commands/route-server/route-server-replace.md
+++ b/docs/manuals/nico-admin-cli/commands/route-server/route-server-replace.md
@@ -18,7 +18,8 @@ Replace all route server addresses
 ## OPTIONS
 
 **--source-type** *\<SOURCE_TYPE\>* \[default: admin_api\]  
-The source_type to use for the target addresses. Defaults to admin_api.\
+The source_type to use for the target addresses. Defaults to
+admin_api.\
 
 \
 *Possible values:*

--- a/docs/manuals/nico-admin-cli/commands/secrets/secrets-re-wrap.md
+++ b/docs/manuals/nico-admin-cli/commands/secrets/secrets-re-wrap.md
@@ -1,0 +1,54 @@
+# `nico-admin-cli secrets re-wrap`
+
+_[Admin commands](../../admin.md) › [secrets](./secrets.md) › **re-wrap**_
+
+## NAME
+
+nico-admin-cli-secrets-re-wrap - Re-wrap secret DEKs to use the
+currently active KEK per routing config
+
+## SYNOPSIS
+
+**nico-admin-cli secrets re-wrap** \[**--batch-size**\]
+\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Re-wrap secret DEKs to use the currently active KEK per routing config
+
+## OPTIONS
+
+**--batch-size** *\<BATCH_SIZE\>*  
+Rows scanned per batch during the walk. The server applies its own
+default and limits.
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli secrets re-wrap
+nico-admin-cli secrets re-wrap --batch-size 25
+```
+
+---
+
+**See also:** [Admin commands](../../admin.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/secrets/secrets.md
+++ b/docs/manuals/nico-admin-cli/commands/secrets/secrets.md
@@ -1,0 +1,48 @@
+# `nico-admin-cli secrets`
+
+_[Admin commands](../../admin.md) › **secrets**_
+
+## NAME
+
+nico-admin-cli-secrets - Secrets management
+
+## SYNOPSIS
+
+**nico-admin-cli secrets** \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+Secrets management
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`re-wrap`](./secrets-re-wrap.md) | Re-wrap secret DEKs to use the currently active KEK per routing config |
+
+---
+
+**See also:** [Admin commands](../../admin.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/set/set-bmc-proxy.md
+++ b/docs/manuals/nico-admin-cli/commands/set/set-bmc-proxy.md
@@ -28,7 +28,7 @@ Enable site-explorer bmc_proxy\
 - false
 
 **--proxy** *\<PROXY\>*  
-host:port string use as a proxy for talking to BMCs
+host:port string to use as a proxy for talking to BMCs
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/set/set-log-filter.md
+++ b/docs/manuals/nico-admin-cli/commands/set/set-log-filter.md
@@ -19,7 +19,7 @@ Set RUST_LOG
 ## OPTIONS
 
 **-f**, **--filter** *\<FILTER\>*  
-Set servers RUST_LOG.
+Set the server's RUST_LOG.
 
 **--expiry** *\<EXPIRY\>* \[default: 1h\]  
 Revert to startup RUST_LOG after this much time, friendly format e.g.

--- a/docs/manuals/nico-admin-cli/commands/site-explorer/site-explorer-mlx-devices.md
+++ b/docs/manuals/nico-admin-cli/commands/site-explorer/site-explorer-mlx-devices.md
@@ -38,14 +38,14 @@ probably care about, and "extended" output also dumps out all the
 internal UUIDs that are used to associate instances.
 
 **--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
-Sort output by specified field  
+Sort output by specified field\
 
-  
+\
 *Possible values:*
 
-> - primary-id: Sort by the primary id
->
-> - state: Sort by state
+- primary-id: Sort by the primary id
+
+- state: Sort by state
 
 **-h**, **--help**  
 Print help (see a summary with -h)

--- a/docs/manuals/nico-admin-cli/commands/site-explorer/site-explorer.md
+++ b/docs/manuals/nico-admin-cli/commands/site-explorer/site-explorer.md
@@ -25,14 +25,14 @@ probably care about, and "extended" output also dumps out all the
 internal UUIDs that are used to associate instances.
 
 **--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
-Sort output by specified field  
+Sort output by specified field\
 
-  
+\
 *Possible values:*
 
-> - primary-id: Sort by the primary id
->
-> - state: Sort by state
+- primary-id: Sort by the primary id
+
+- state: Sort by state
 
 **-h**, **--help**  
 Print help (see a summary with -h)

--- a/docs/manuals/nico-admin-cli/commands/sku/sku-assign.md
+++ b/docs/manuals/nico-admin-cli/commands/sku/sku-assign.md
@@ -18,6 +18,7 @@ Assign a SKU to a machine
 ## OPTIONS
 
 **--force**  
+
 **--extended**  
 Extended result output.
 
@@ -39,6 +40,7 @@ Sort output by specified field\
 Print help (see a summary with -h)
 
 \<*SKU_ID*\>  
+
 \<*MACHINE_ID*\>
 
 ## Examples

--- a/docs/manuals/nico-admin-cli/commands/sku/sku-bulk-update-metadata.md
+++ b/docs/manuals/nico-admin-cli/commands/sku/sku-bulk-update-metadata.md
@@ -4,8 +4,8 @@ _[Hardware commands](../../hardware.md) › [sku](./sku.md) › **bulk-update-me
 
 ## NAME
 
-nico-admin-cli-sku-bulk-update-metadata - Update multiple SKUs metadata
-from a file
+nico-admin-cli-sku-bulk-update-metadata - Update metadata for multiple
+SKUs from a file
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ from a file
 
 ## DESCRIPTION
 
-Update multiple SKUs metadata from a file
+Update metadata for multiple SKUs from a file
 
 ## OPTIONS
 

--- a/docs/manuals/nico-admin-cli/commands/sku/sku-unassign.md
+++ b/docs/manuals/nico-admin-cli/commands/sku/sku-unassign.md
@@ -18,6 +18,7 @@ Unassign a SKU from a machine
 ## OPTIONS
 
 **--force**  
+
 **--extended**  
 Extended result output.
 

--- a/docs/manuals/nico-admin-cli/commands/sku/sku-update-metadata.md
+++ b/docs/manuals/nico-admin-cli/commands/sku/sku-update-metadata.md
@@ -19,10 +19,10 @@ Update the metadata of a SKU
 ## OPTIONS
 
 **--description** *\<DESCRIPTION\>*  
-Update the SKUs description
+Update the SKU's description
 
 **--device-type** *\<DEVICE_TYPE\>*  
-Update the SKUs device type
+Update the SKU's device type
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/sku/sku.md
+++ b/docs/manuals/nico-admin-cli/commands/sku/sku.md
@@ -50,7 +50,7 @@ Print help (see a summary with -h)
 | [`unassign`](./sku-unassign.md) | Unassign a SKU from a machine |
 | [`verify`](./sku-verify.md) | Verify a machine against its SKU |
 | [`update-metadata`](./sku-update-metadata.md) | Update the metadata of a SKU |
-| [`bulk-update-metadata`](./sku-bulk-update-metadata.md) | Update multiple SKU's metadata from a file |
+| [`bulk-update-metadata`](./sku-bulk-update-metadata.md) | Update metadata for multiple SKUs from a file |
 | [`replace`](./sku-replace.md) | Replace the component list of a SKU |
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/ssh/ssh-copy-bfb.md
+++ b/docs/manuals/nico-admin-cli/commands/ssh/ssh-copy-bfb.md
@@ -4,7 +4,7 @@ _[Admin commands](../../admin.md) › [ssh](./ssh.md) › **copy-bfb**_
 
 ## NAME
 
-nico-admin-cli-ssh-copy-bfb - Copy BFB to the DPU BMCs RSHIM
+nico-admin-cli-ssh-copy-bfb - Copy BFB to the DPU BMC's RSHIM
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ nico-admin-cli-ssh-copy-bfb - Copy BFB to the DPU BMCs RSHIM
 
 ## DESCRIPTION
 
-Copy BFB to the DPU BMCs RSHIM
+Copy BFB to the DPU BMC's RSHIM
 
 ## OPTIONS
 

--- a/docs/manuals/nico-admin-cli/commands/ssh/ssh-show-obmc-log.md
+++ b/docs/manuals/nico-admin-cli/commands/ssh/ssh-show-obmc-log.md
@@ -4,7 +4,7 @@ _[Admin commands](../../admin.md) › [ssh](./ssh.md) › **show-obmc-log**_
 
 ## NAME
 
-nico-admin-cli-ssh-show-obmc-log - Show the DPUs BMCs OBMC log
+nico-admin-cli-ssh-show-obmc-log - Show the OBMC log for the DPU's BMC
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ nico-admin-cli-ssh-show-obmc-log - Show the DPUs BMCs OBMC log
 
 ## DESCRIPTION
 
-Show the DPUs BMCs OBMC log
+Show the OBMC log for the DPU's BMC
 
 ## OPTIONS
 

--- a/docs/manuals/nico-admin-cli/commands/ssh/ssh.md
+++ b/docs/manuals/nico-admin-cli/commands/ssh/ssh.md
@@ -45,7 +45,7 @@ Print help (see a summary with -h)
 | [`disable-rshim`](./ssh-disable-rshim.md) | Disable Rshim |
 | [`enable-rshim`](./ssh-enable-rshim.md) | EnableRshim |
 | [`copy-bfb`](./ssh-copy-bfb.md) | Copy BFB to the DPU BMC's RSHIM |
-| [`show-obmc-log`](./ssh-show-obmc-log.md) | Show the DPU's BMC's OBMC log |
+| [`show-obmc-log`](./ssh-show-obmc-log.md) | Show the OBMC log for the DPU's BMC |
 
 ---
 

--- a/docs/manuals/nico-admin-cli/commands/switch/switch-health-report-remove.md
+++ b/docs/manuals/nico-admin-cli/commands/switch/switch-health-report-remove.md
@@ -40,6 +40,7 @@ Sort output by specified field\
 Print help (see a summary with -h)
 
 \<*SWITCH_ID*\>  
+
 \<*REPORT_SOURCE*\>
 
 ## Examples

--- a/docs/manuals/nico-admin-cli/commands/vpc/vpc-create.md
+++ b/docs/manuals/nico-admin-cli/commands/vpc/vpc-create.md
@@ -1,0 +1,90 @@
+# `nico-admin-cli vpc create`
+
+_[Network commands](../../network.md) › [vpc](./vpc.md) › **create**_
+
+## NAME
+
+nico-admin-cli-vpc-create - Create VPC
+
+## SYNOPSIS
+
+**nico-admin-cli vpc create** \<**--name**\> \[**--description**\]
+\[**--id**\] \<**--org-id**\> \[**--virtualization-type**\]
+\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Create VPC
+
+## OPTIONS
+
+**--name** *\<NAME\>*  
+Name to give the new VPC
+
+**--description** *\<DESCRIPTION\>*  
+Discription for the new VPC
+
+**--id** *\<VpcId\>*  
+Optional VPC ID to use instead of allowing the API server to generate
+one
+
+**--org-id** *\<ORG_ID\>*  
+Tenant organization ID (Plain text string, used by cloud API)
+
+**--virtualization-type** *\<VIRTUALIZATION_TYPE\>* \[default: ethernet-virtualizer\]  
+Network virtualization type\
+
+\
+*Possible values:*
+
+- ethernet-virtualizer
+
+- ethernet-virtualizer-with-nvue: 1 was previously
+  FORGE_NATIVE_NETWORKING ETHERNET_VIRTUALIZER_WITH_NVUE is deprecated.
+  NVUE is now implied; just use ETHERNET_VIRTUALIZER
+
+- fnn-classic: Deprecated: FN_CLASSIC and FNN_L3 are deprecated now. Use
+  FNN only
+
+- fnn-l3
+
+- fnn
+
+- flat: FLAT is for VPCs whose tenant instances live directly on the
+  underlay (zero-DPU hosts, or hosts with their DPU in NIC mode). Their
+  interfaces are bound to `HostInband` network segments rather than a
+  Carbide-managed overlay. Flat VPCs are still real tenant VPCs with a
+  VNI and NSGs, but Carbide doesn't drive their data plane -- routing
+  and ACL enforcement between Flat VPCs and other VPCs is the network
+  operator's responsibility
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli --cloud-unsafe-op=my_username vpc create --name tenant-vpc-1 --org-id tenant-org-1
+nico-admin-cli --cloud-unsafe-op=my_username vpc create --name tenant-vpc-1 --org-id tenant-org-1 --id ad1f9fd5-8438-4407-b259-72fdb7896d42 --virtualization-type flat
+```
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/vpc/vpc-set-virtualizer.md
+++ b/docs/manuals/nico-admin-cli/commands/vpc/vpc-set-virtualizer.md
@@ -48,13 +48,13 @@ The virtualizer to use for this VPC\
 
 - fnn
 
-- flat: \`Flat\` is for VPCs whose tenant instances live directly on the
+- flat: `Flat` is for VPCs whose tenant instances live directly on the
   underlay (zero-DPU hosts, or hosts with their DPU in NIC mode) and
-  whose interfaces are bound to \`HostInband\` network segments rather
+  whose interfaces are bound to `HostInband` network segments rather
   than a NICo-managed overlay. Flat VPCs are still real tenant VPCs with
-  a VNI and NSGs, but NICo doesnt drive their data plane -- routing and
+  a VNI and NSGs, but NICo doesn't drive their data plane -- routing and
   ACL enforcement between Flat VPCs and other VPCs is the network
-  operators responsibility
+  operator's responsibility
 
 ## Examples
 

--- a/docs/manuals/nico-admin-cli/commands/vpc/vpc.md
+++ b/docs/manuals/nico-admin-cli/commands/vpc/vpc.md
@@ -41,6 +41,7 @@ Print help (see a summary with -h)
 
 | Subcommand | Description |
 |---|---|
+| [`create`](./vpc-create.md) | Create VPC |
 | [`show`](./vpc-show.md) | Display VPC information |
 | [`set-virtualizer`](./vpc-set-virtualizer.md) |  |
 

--- a/docs/manuals/nico-admin-cli/hardware.md
+++ b/docs/manuals/nico-admin-cli/hardware.md
@@ -8,6 +8,7 @@ For global flags and setup, see [the overview](./README.md) and [`setup.md`](./s
 |---|---|
 | [`attestation`](./commands/attestation/attestation.md) | MeasuredBoot or SPDM attestations. |
 | [`bmc-machine`](./commands/bmc-machine/bmc-machine.md) | BMC Machine related handling. |
+| [`boot-interface`](./commands/boot-interface/boot-interface.md) | Machine boot-interface management. |
 | [`boot-override`](./commands/boot-override/boot-override.md) | Machine boot override. |
 | [`browse`](./commands/browse/browse.md) | Browse subsystem resource trees via the API server. |
 | [`component-manager`](./commands/component-manager/component-manager.md) | Component manager actions. |


### PR DESCRIPTION
The checked-in `nico-admin-cli` reference contained manual edits that were not represented in the Clap command definitions. Regenerating the documentation could therefore overwrite useful operator guidance. Pandoc versions also produced different Markdown formatting, creating large unrelated diffs.

This PR moves the relevant descriptions back into the authoritative Clap sources and makes `generate-cli-docs` deterministic across supported Pandoc versions. The generator now preserves apostrophes, inline code, and Markdown links while normalizing value lists and hard breaks without reformatting unrelated prose.

The complete reference is regenerated from the current command tree, including pages for commands that were previously missing from the checked-in documentation.

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

CI enforcement is intentionally deferred to a separate change that will add a `doc-police` job running `cargo make check-cli-docs`.
