### PR TITLE
feat(dhcp-server): add per-interface DHCPv6 serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ version = "0.0.0"
 dependencies = [
  "carbide-dhcp",
  "carbide-dhcp-common",
+ "carbide-dhcpv6",
  "carbide-instrument",
  "carbide-rpc",
  "carbide-test-support",
@@ -1688,6 +1689,7 @@ name = "carbide-dhcp-server"
 version = "0.1.0"
 dependencies = [
  "carbide-dhcp-common",
+ "carbide-dhcpv6",
  "carbide-instrument",
  "carbide-rpc",
  "carbide-rpc-utils",
@@ -1698,7 +1700,11 @@ dependencies = [
  "clap",
  "dhcproto",
  "futures",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "ipnetwork",
+ "libc",
  "logfmt",
  "lru",
  "metrics-endpoint",
@@ -1715,6 +1721,16 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "carbide-dhcpv6"
+version = "0.1.0"
+dependencies = [
+ "carbide-test-support",
+ "dhcproto",
+ "mac_address",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,6 +1663,7 @@ version = "0.0.0"
 dependencies = [
  "carbide-dhcp",
  "carbide-dhcp-common",
+ "carbide-dhcpv6",
  "carbide-instrument",
  "carbide-rpc",
  "carbide-test-support",
@@ -1707,6 +1708,7 @@ name = "carbide-dhcp-server"
 version = "0.1.0"
 dependencies = [
  "carbide-dhcp-common",
+ "carbide-dhcpv6",
  "carbide-instrument",
  "carbide-rpc",
  "carbide-rpc-utils",
@@ -1717,7 +1719,11 @@ dependencies = [
  "clap",
  "dhcproto",
  "futures",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "ipnetwork",
+ "libc",
  "logfmt",
  "lru 0.18.0",
  "metrics-endpoint",
@@ -1734,6 +1740,16 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "carbide-dhcpv6"
+version = "0.1.0"
+dependencies = [
+ "carbide-test-support",
+ "dhcproto",
+ "mac_address",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/agent/src/dhcp.rs
+++ b/crates/agent/src/dhcp.rs
@@ -44,6 +44,11 @@ pub(super) const RELOAD_DHCP_SERVER: &str =
 pub(super) const STOP_DHCP_SERVER: &str =
     "supervisorctl update;supervisorctl stop forge-dhcp-server-default";
 
+/// Preferred lifetime advertised for DPU-side DHCPv6 address bindings.
+pub(super) const DHCPV6_PREFERRED_LIFETIME_SECS: u32 = 3600;
+/// Valid lifetime advertised for DPU-side DHCPv6 address bindings.
+pub(super) const DHCPV6_VALID_LIFETIME_SECS: u32 = 7200;
+
 /// Generate default-forge-dhcp-server.conf
 pub(super) fn build_server_supervisord_config(
     conf: DhcpServerSupervisordConfig,
@@ -63,17 +68,24 @@ pub(super) fn blank() -> String {
 pub(super) fn build_server_config(
     pxe_ip: Ipv4Addr,
     ntpservers: Vec<Ipv4Addr>,
+    ntpservers_v6: Vec<Ipv6Addr>,
     nameservers: Vec<Ipv4Addr>,
     nameservers_v6: Vec<Ipv6Addr>,
     loopback_ip: Ipv4Addr,
 ) -> Result<String, eyre::Report> {
-    let dhcp_config = carbide_rpc_utils::dhcp::DhcpConfig::from_forge_dhcp_config(
+    let mut dhcp_config = carbide_rpc_utils::dhcp::DhcpConfig::from_forge_dhcp_config(
         pxe_ip,
         ntpservers,
         nameservers,
         nameservers_v6,
         loopback_ip,
     )?;
+
+    // The legacy constructor owns common/v4 fields; apply the new v6-only
+    // option source and explicit nonzero address lifetimes here.
+    dhcp_config.carbide_ntpservers_v6 = ntpservers_v6;
+    dhcp_config.dhcpv6_preferred_lifetime_secs = DHCPV6_PREFERRED_LIFETIME_SECS;
+    dhcp_config.dhcpv6_valid_lifetime_secs = DHCPV6_VALID_LIFETIME_SECS;
 
     Ok(serde_yaml::to_string(&dhcp_config)?)
 }

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -126,21 +126,21 @@ struct DhcpServerPaths {
     host_config: FPath,
 }
 
-/// Stores addresses of dependent services that the DHCP module announces.
-/// Note that these can apply to both IPv4 and IPv6; pxe_ips is actually
-/// UEFI HTTP boot in this case, and NTP is still NTP. We should be able
-/// to leverage this struct even in DHCPv6 land (whereas other things don't
-/// really carry through to DHCPv6).
+/// Stores dual-stack PXE/UEFI HTTP, NTP, and DNS service addresses.
+///
+/// These are remote dependent services advertised as DHCP options; none is a
+/// local listener address.
+// TODO(dhcpv6-server-address): Populate `carbide_dhcp_server_v6` only after a
+// non-gating consumer and authoritative server-address source are defined.
 pub(super) struct ServiceAddresses {
     pub(super) pxe_ips: Vec<IpAddr>,
     pub(super) ntpservers: Vec<IpAddr>,
     pub(super) nameservers: Vec<IpAddr>,
 }
 
-/// Split a dual-stack nameserver list into its IPv4 and IPv6 members, so the
-/// gRPC and file-write DHCP-config paths derive both families the same way.
-fn split_nameservers_by_family(nameservers: &[IpAddr]) -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
-    nameservers
+/// Split a dual-stack address list into its IPv4 and IPv6 members.
+fn split_addresses_by_family(addresses: &[IpAddr]) -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
+    addresses
         .iter()
         .copied()
         .fold((Vec::new(), Vec::new()), |(mut v4, mut v6), addr| {
@@ -152,50 +152,43 @@ fn split_nameservers_by_family(nameservers: &[IpAddr]) -> (Vec<Ipv4Addr>, Vec<Ip
         })
 }
 
+/// Resolve DHCP NTP options for both families with per-family site precedence.
 fn build_dhcp_ntp_servers(
     nc: &rpc::ManagedHostNetworkConfigResponse,
     service_addrs: &ServiceAddresses,
-) -> Vec<Ipv4Addr> {
+) -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
     // Start with the NTP servers from the service addresses, which is read from carbide-ntp.forge.
-    let mut ntp_servers = service_addrs
-        .ntpservers
-        .iter()
-        .filter_map(|x| match x {
-            IpAddr::V4(x) => Some(*x),
-            _ => None,
-        })
-        .collect::<Vec<Ipv4Addr>>();
+    let (mut ntpservers_v4, mut ntpservers_v6) =
+        split_addresses_by_family(&service_addrs.ntpservers);
 
-    // If the site has configured NTP servers, use them instead.
+    // A site override replaces only the families it actually configures, so a
+    // single-family override does not discard the other service fallback.
     if !nc.ntp_servers.is_empty() {
-        let site_ntp_servers: Vec<Ipv4Addr> = nc.ntp_servers
-        .iter()
-        .filter_map(|s| match IpAddr::from_str(s) {
-            Ok(IpAddr::V4(ip)) => Some(ip),
-            Ok(IpAddr::V6(_)) => {
-                tracing::debug!(
-                    ntp_server = %s,
-                    "IPv6 NTP server from ManagedHostNetworkConfigResponse is ignored for DHCPv4 config"
-                );
-                None
-            }
-            Err(e) => {
-                tracing::debug!(
-                    ntp_server = %s,
-                    error = %e,
-                    "Invalid NTP server IP from ManagedHostNetworkConfigResponse, ignoring"
-                );
-                None
-            }
-        })
-        .collect();
-
-        if !site_ntp_servers.is_empty() {
-            ntp_servers = site_ntp_servers;
+        let site_ntp_servers = nc
+            .ntp_servers
+            .iter()
+            .filter_map(|server| match IpAddr::from_str(server) {
+                Ok(address) => Some(address),
+                Err(error) => {
+                    tracing::debug!(
+                        ntp_server = %server,
+                        error = %error,
+                        "Invalid NTP server IP from ManagedHostNetworkConfigResponse, ignoring"
+                    );
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        let (site_v4, site_v6) = split_addresses_by_family(&site_ntp_servers);
+        if !site_v4.is_empty() {
+            ntpservers_v4 = site_v4;
+        }
+        if !site_v6.is_empty() {
+            ntpservers_v6 = site_v6;
         }
     }
 
-    ntp_servers
+    (ntpservers_v4, ntpservers_v6)
 }
 
 /// How we tell HBN to notice the new file we wrote
@@ -955,9 +948,9 @@ async fn update_dhcp_via_grpc(
     };
     let loopback_ip: Ipv4Addr = mh_nc.loopback_ip.parse()?;
 
-    let (nameservers_v4, nameservers_v6) = split_nameservers_by_family(&service_addrs.nameservers);
+    let (nameservers_v4, nameservers_v6) = split_addresses_by_family(&service_addrs.nameservers);
 
-    let ntpservers_v4 = build_dhcp_ntp_servers(network_config, service_addrs);
+    let (ntpservers_v4, ntpservers_v6) = build_dhcp_ntp_servers(network_config, service_addrs);
 
     let pxe_ip_v4 = service_addrs
         .pxe_ips
@@ -973,13 +966,18 @@ async fn update_dhcp_via_grpc(
             )
         })?;
 
-    let dhcp_config = carbide_rpc_utils::dhcp::DhcpConfig::from_forge_dhcp_config(
+    let mut dhcp_config = carbide_rpc_utils::dhcp::DhcpConfig::from_forge_dhcp_config(
         pxe_ip_v4,
         ntpservers_v4,
         nameservers_v4,
         nameservers_v6,
         loopback_ip,
     )?;
+
+    // Keep the gRPC model byte-equivalent to the file-backed YAML builder.
+    dhcp_config.carbide_ntpservers_v6 = ntpservers_v6;
+    dhcp_config.dhcpv6_preferred_lifetime_secs = dhcp::DHCPV6_PREFERRED_LIFETIME_SECS;
+    dhcp_config.dhcpv6_valid_lifetime_secs = dhcp::DHCPV6_VALID_LIFETIME_SECS;
     let mut host_config = carbide_rpc_utils::dhcp::HostConfig::try_from(
         network_config.clone(),
         hbn_device_names.reps[0],
@@ -1291,9 +1289,8 @@ pub(super) async fn reset(hbn_root: &Path, skip_post: bool) {
 // 3. Copy host_config file
 // 4. Reload supervisord
 //
-// This is currently scoped to IPv4 only, and there are
-// a few IPv4-specific checks for things like NTP servers,
-// UEFI HTTP/PXE IP, and nameservers below.
+// TODO(ipv6-only): InterfaceInfo still requires IPv4 fields, so a host with
+// only IPv6 needs a synthetic v4 entry until rpc-utils relaxes that schema.
 fn write_dhcp_v4_server_config(
     dhcp_relay_path: &FPath,
     dhcp_server_path: &DhcpServerPaths,
@@ -1362,12 +1359,11 @@ fn write_dhcp_v4_server_config(
 
     let loopback_ip = mh_nc.loopback_ip.parse()?;
 
-    // Split the dual-stack nameservers by family: the IPv4 set drives the
-    // DHCPv4 options written here, while the IPv6 set is held in the config for
-    // the eventual DHCPv6 / RA consumer (inert in this path for now).
-    let (nameservers_v4, nameservers_v6) = split_nameservers_by_family(&service_addrs.nameservers);
+    // Split the dual-stack nameservers by family for the sibling v4 and v6
+    // listeners that consume this shared server configuration.
+    let (nameservers_v4, nameservers_v6) = split_addresses_by_family(&service_addrs.nameservers);
 
-    let ntpservers_v4 = build_dhcp_ntp_servers(nc, service_addrs);
+    let (ntpservers_v4, ntpservers_v6) = build_dhcp_ntp_servers(nc, service_addrs);
 
     let pxe_ip_v4 = service_addrs
         .pxe_ips
@@ -1407,6 +1403,7 @@ fn write_dhcp_v4_server_config(
     let next_contents = dhcp::build_server_config(
         pxe_ip_v4,
         ntpservers_v4,
+        ntpservers_v6,
         nameservers_v4,
         nameservers_v6,
         loopback_ip,
@@ -1846,6 +1843,9 @@ mod tests {
         carbide_host_support::init_logging("nico-dpu-agent").unwrap();
     }
 
+    /// Verifies managed-host loopbacks preserve optional IPv6 and reject invalid families.
+    ///
+    /// This keeps family validation at the NVUE rendering boundary.
     #[test]
     fn test_parse_managed_host_loopback_ips() {
         use carbide_test_support::Outcome::*;
@@ -1898,51 +1898,49 @@ mod tests {
         );
     }
 
+    /// Verifies configured NTP values replace service fallbacks independently
+    /// for IPv4 and IPv6.
     #[test]
     fn test_build_dhcp_ntp_servers() {
+        use carbide_test_support::value_scenarios;
+
         let service_addrs = ServiceAddresses {
             pxe_ips: vec![],
-            ntpservers: vec![IpAddr::from([192, 0, 2, 20])],
-            nameservers: vec![],
-        };
-        let nc = rpc::ManagedHostNetworkConfigResponse {
-            ntp_servers: vec!["198.51.100.1".to_string(), "198.51.100.2".to_string()],
-            ..Default::default()
-        };
-
-        let out = build_dhcp_ntp_servers(&nc, &service_addrs);
-        assert_eq!(
-            out,
-            vec![
-                Ipv4Addr::from([198, 51, 100, 1]),
-                Ipv4Addr::from([198, 51, 100, 2])
-            ]
-        );
-    }
-
-    #[test]
-    fn test_build_dhcp_ntp_servers_fallback() {
-        let service_addrs = ServiceAddresses {
-            pxe_ips: vec![],
-            ntpservers: vec![IpAddr::from([192, 0, 2, 20])],
+            ntpservers: vec![
+                IpAddr::from([192, 0, 2, 20]),
+                "2001:db8::20".parse().unwrap(),
+            ],
             nameservers: vec![],
         };
 
-        let empty_nc = rpc::ManagedHostNetworkConfigResponse::default();
-
-        assert_eq!(
-            build_dhcp_ntp_servers(&empty_nc, &service_addrs),
-            vec![Ipv4Addr::from([192, 0, 2, 20])]
-        );
-
-        let invalid_nc = rpc::ManagedHostNetworkConfigResponse {
-            ntp_servers: vec!["not-an-ip".to_string(), "2001:db8::1".to_string()],
-            ..Default::default()
-        };
-
-        assert_eq!(
-            build_dhcp_ntp_servers(&invalid_nc, &service_addrs),
-            vec![Ipv4Addr::from([192, 0, 2, 20])]
+        value_scenarios!(run = |ntp_servers: Vec<String>| {
+                let nc = rpc::ManagedHostNetworkConfigResponse {
+                    ntp_servers,
+                    ..Default::default()
+                };
+                build_dhcp_ntp_servers(&nc, &service_addrs)
+            };
+            "configured overrides" {
+                // Both configured families replace their service fallbacks.
+                vec!["198.51.100.1".to_string(), "2001:db8::123".to_string()] => (
+                    vec![Ipv4Addr::from([198, 51, 100, 1])],
+                    vec!["2001:db8::123".parse::<Ipv6Addr>().unwrap()],
+                ),
+            }
+            "empty configuration fallback" {
+                // With no site values, both service-provided families survive.
+                vec![] => (
+                    vec![Ipv4Addr::from([192, 0, 2, 20])],
+                    vec!["2001:db8::20".parse::<Ipv6Addr>().unwrap()],
+                ),
+            }
+            "invalid-address fallback" {
+                // Valid site IPv6 replaces only v6; invalid v4 retains its fallback.
+                vec!["not-an-ip".to_string(), "2001:db8::1".to_string()] => (
+                    vec![Ipv4Addr::from([192, 0, 2, 20])],
+                    vec!["2001:db8::1".parse::<Ipv6Addr>().unwrap()],
+                ),
+            }
         );
     }
 
@@ -3160,15 +3158,17 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies generic service-address partitioning preserves order within each family.
     #[test]
-    fn split_nameservers_by_family_partitions_by_family() {
+    fn split_addresses_by_family_partitions_by_family() {
         use carbide_test_support::value_scenarios;
 
         value_scenarios!(
             run = |input: Vec<IpAddr>| -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
-                split_nameservers_by_family(&input)
+                split_addresses_by_family(&input)
             };
             "splits nameservers by family" {
+                // Mixed input preserves the original order within each family.
                 vec![
                     IpAddr::from([10, 0, 0, 1]),
                     "2001:db8::1".parse::<IpAddr>().unwrap(),
@@ -3177,9 +3177,12 @@ mod tests {
                     vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
                     vec!["2001:db8::1".parse::<Ipv6Addr>().unwrap()],
                 ),
+                // IPv4-only input leaves the IPv6 result empty.
                 vec![IpAddr::from([10, 0, 0, 1])] => (vec![Ipv4Addr::new(10, 0, 0, 1)], vec![]),
+                // IPv6-only input leaves the IPv4 result empty.
                 vec!["2001:db8::1".parse::<IpAddr>().unwrap()]
                     => (vec![], vec!["2001:db8::1".parse::<Ipv6Addr>().unwrap()]),
+                // Empty input produces two empty family lists.
                 vec![] => (vec![], vec![]),
             }
         );
@@ -3197,6 +3200,26 @@ mod tests {
             expected.carbide_provisioning_server_ipv4
         );
         assert_eq!(received.carbide_dhcp_server, expected.carbide_dhcp_server);
+        assert_eq!(
+            received.carbide_nameservers_v6,
+            expected.carbide_nameservers_v6
+        );
+        assert_eq!(
+            received.carbide_ntpservers_v6,
+            expected.carbide_ntpservers_v6
+        );
+        assert_eq!(
+            received.carbide_dhcp_server_v6,
+            expected.carbide_dhcp_server_v6
+        );
+        assert_eq!(
+            received.dhcpv6_preferred_lifetime_secs,
+            expected.dhcpv6_preferred_lifetime_secs
+        );
+        assert_eq!(
+            received.dhcpv6_valid_lifetime_secs,
+            expected.dhcpv6_valid_lifetime_secs
+        );
     }
 
     fn validate_host_config(received: HostConfig, expected: HostConfig) {
@@ -3219,13 +3242,14 @@ mod tests {
             assert_eq!(ip_config_received.gateway, ip_config_expected.gateway);
             assert_eq!(ip_config_received.address, ip_config_expected.address);
             assert_eq!(ip_config_received.prefix, ip_config_expected.prefix);
+            assert_eq!(ip_config_received.ipv6, ip_config_expected.ipv6);
         }
     }
 
+    /// Verifies the file-backed DHCP server config renders dual-stack options and host state.
     #[test]
     fn test_with_tenant_dhcp_server() -> Result<(), Box<dyn std::error::Error>> {
-        // The config we received from API server
-        // Admin won't be used
+        // Model the API-provided admin interface with both address families.
         let admin_interface_prefix: IpNetwork = "10.217.5.123/32".parse().unwrap();
         let admin_interface = rpc::FlatInterfaceConfig {
             function_type: rpc::InterfaceFunctionType::Physical.into(),
@@ -3248,7 +3272,11 @@ mod tests {
             network_security_group: None,
             internal_uuid: None,
             mtu: None,
-            ipv6_interface_config: None,
+            ipv6_interface_config: Some(rpc::FlatInterfaceIpv6Config {
+                ip: "2001:db8::123".to_string(),
+                interface_prefix: "2001:db8::/64".to_string(),
+                svi_ip: None,
+            }),
             vpc_routing_profile: None,
             interface_routing_profile: None,
         };
@@ -3338,12 +3366,16 @@ mod tests {
                 Ipv4Addr::from([127, 0, 0, 2]),
                 Ipv4Addr::from([127, 0, 0, 3]),
             ],
+            carbide_nameservers_v6: vec!["2001:db8::53".parse().unwrap()],
+            carbide_ntpservers_v6: vec!["2001:db8::123".parse().unwrap()],
             carbide_provisioning_server_ipv4: Ipv4Addr::from([10, 0, 0, 1]),
             lease_time_secs: 604800,
             renewal_time_secs: 3600,
             rebinding_time_secs: 432000,
             carbide_api_url: None,
             carbide_dhcp_server: Ipv4Addr::from([10, 217, 5, 39]),
+            dhcpv6_preferred_lifetime_secs: dhcp::DHCPV6_PREFERRED_LIFETIME_SECS,
+            dhcpv6_valid_lifetime_secs: dhcp::DHCPV6_VALID_LIFETIME_SECS,
             ..Default::default()
         };
 
@@ -3442,13 +3474,16 @@ mod tests {
                 IpAddr::from([127, 0, 0, 1]),
                 IpAddr::from([127, 0, 0, 2]),
                 IpAddr::from([127, 0, 0, 3]),
+                "2001:db8::123".parse().unwrap(),
             ],
-            nameservers: vec![IpAddr::from([10, 1, 1, 1])],
+            nameservers: vec![IpAddr::from([10, 1, 1, 1]), "2001:db8::53".parse().unwrap()],
         };
 
         let mut host_config_str =
             dhcp::build_server_host_config(network_config.clone(), &HBNDeviceNames::pre_23())?;
         assert!(!host_config_str.contains("mtu"));
+        assert!(host_config_str.contains("ipv6:"));
+        assert!(host_config_str.contains("2001:db8::123"));
 
         let mut network_config2 = network_config.clone();
         network_config2.admin_interface = Some(admin_interface_with_mtu);
@@ -3539,6 +3574,8 @@ mod tests {
             rebinding_time_secs: 432000,
             carbide_api_url: None,
             carbide_dhcp_server: Ipv4Addr::from([10, 217, 5, 39]),
+            dhcpv6_preferred_lifetime_secs: dhcp::DHCPV6_PREFERRED_LIFETIME_SECS,
+            dhcpv6_valid_lifetime_secs: dhcp::DHCPV6_VALID_LIFETIME_SECS,
             ..Default::default()
         };
         let dhcp_contents = super::read_limited(g.path())?;

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -126,21 +126,21 @@ struct DhcpServerPaths {
     host_config: FPath,
 }
 
-/// Stores addresses of dependent services that the DHCP module announces.
-/// Note that these can apply to both IPv4 and IPv6; pxe_ips is actually
-/// UEFI HTTP boot in this case, and NTP is still NTP. We should be able
-/// to leverage this struct even in DHCPv6 land (whereas other things don't
-/// really carry through to DHCPv6).
+/// Stores dual-stack PXE/UEFI HTTP, NTP, and DNS service addresses.
+///
+/// These are remote dependent services advertised as DHCP options; none is a
+/// local listener address.
+// TODO(dhcpv6-server-address): Populate `carbide_dhcp_server_v6` only after a
+// non-gating consumer and authoritative server-address source are defined.
 pub(super) struct ServiceAddresses {
     pub(super) pxe_ips: Vec<IpAddr>,
     pub(super) ntpservers: Vec<IpAddr>,
     pub(super) nameservers: Vec<IpAddr>,
 }
 
-/// Split a dual-stack nameserver list into its IPv4 and IPv6 members, so the
-/// gRPC and file-write DHCP-config paths derive both families the same way.
-fn split_nameservers_by_family(nameservers: &[IpAddr]) -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
-    nameservers
+/// Split a dual-stack address list into its IPv4 and IPv6 members.
+fn split_addresses_by_family(addresses: &[IpAddr]) -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
+    addresses
         .iter()
         .copied()
         .fold((Vec::new(), Vec::new()), |(mut v4, mut v6), addr| {
@@ -152,50 +152,38 @@ fn split_nameservers_by_family(nameservers: &[IpAddr]) -> (Vec<Ipv4Addr>, Vec<Ip
         })
 }
 
+/// Resolve site-configured DHCPv4 NTP and DNS-discovered DHCPv6 NTP options.
 fn build_dhcp_ntp_servers(
     nc: &rpc::ManagedHostNetworkConfigResponse,
     service_addrs: &ServiceAddresses,
-) -> Vec<Ipv4Addr> {
+) -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
     // Start with the NTP servers from the service addresses, which is read from carbide-ntp.forge.
-    let mut ntp_servers = service_addrs
-        .ntpservers
-        .iter()
-        .filter_map(|x| match x {
-            IpAddr::V4(x) => Some(*x),
-            _ => None,
-        })
-        .collect::<Vec<Ipv4Addr>>();
+    let (mut ntpservers_v4, ntpservers_v6) = split_addresses_by_family(&service_addrs.ntpservers);
 
-    // If the site has configured NTP servers, use them instead.
+    // The site configuration contract is IPv4-only, so it replaces option 42
+    // without suppressing the DNS-derived DHCPv6 option 56 fallback.
     if !nc.ntp_servers.is_empty() {
-        let site_ntp_servers: Vec<Ipv4Addr> = nc.ntp_servers
-        .iter()
-        .filter_map(|s| match IpAddr::from_str(s) {
-            Ok(IpAddr::V4(ip)) => Some(ip),
-            Ok(IpAddr::V6(_)) => {
-                tracing::debug!(
-                    ntp_server = %s,
-                    "IPv6 NTP server from ManagedHostNetworkConfigResponse is ignored for DHCPv4 config"
-                );
-                None
-            }
-            Err(e) => {
-                tracing::debug!(
-                    ntp_server = %s,
-                    error = %e,
-                    "Invalid NTP server IP from ManagedHostNetworkConfigResponse, ignoring"
-                );
-                None
-            }
-        })
-        .collect();
-
-        if !site_ntp_servers.is_empty() {
-            ntp_servers = site_ntp_servers;
+        let site_v4 = nc
+            .ntp_servers
+            .iter()
+            .filter_map(|server| match Ipv4Addr::from_str(server) {
+                Ok(address) => Some(address),
+                Err(error) => {
+                    tracing::debug!(
+                        ntp_server = %server,
+                        error = %error,
+                        "Invalid IPv4 NTP server from ManagedHostNetworkConfigResponse, ignoring"
+                    );
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        if !site_v4.is_empty() {
+            ntpservers_v4 = site_v4;
         }
     }
 
-    ntp_servers
+    (ntpservers_v4, ntpservers_v6)
 }
 
 /// How we tell HBN to notice the new file we wrote
@@ -969,9 +957,9 @@ async fn update_dhcp_via_grpc(
     };
     let loopback_ip: Ipv4Addr = mh_nc.loopback_ip.parse()?;
 
-    let (nameservers_v4, nameservers_v6) = split_nameservers_by_family(&service_addrs.nameservers);
+    let (nameservers_v4, nameservers_v6) = split_addresses_by_family(&service_addrs.nameservers);
 
-    let ntpservers_v4 = build_dhcp_ntp_servers(network_config, service_addrs);
+    let (ntpservers_v4, ntpservers_v6) = build_dhcp_ntp_servers(network_config, service_addrs);
 
     let pxe_ip_v4 = service_addrs
         .pxe_ips
@@ -987,13 +975,18 @@ async fn update_dhcp_via_grpc(
             )
         })?;
 
-    let dhcp_config = carbide_rpc_utils::dhcp::DhcpConfig::from_forge_dhcp_config(
+    let mut dhcp_config = carbide_rpc_utils::dhcp::DhcpConfig::from_forge_dhcp_config(
         pxe_ip_v4,
         ntpservers_v4,
         nameservers_v4,
         nameservers_v6,
         loopback_ip,
     )?;
+
+    // Keep the gRPC model byte-equivalent to the file-backed YAML builder.
+    dhcp_config.carbide_ntpservers_v6 = ntpservers_v6;
+    dhcp_config.dhcpv6_preferred_lifetime_secs = dhcp::DHCPV6_PREFERRED_LIFETIME_SECS;
+    dhcp_config.dhcpv6_valid_lifetime_secs = dhcp::DHCPV6_VALID_LIFETIME_SECS;
     let mut host_config = carbide_rpc_utils::dhcp::HostConfig::try_from(
         network_config.clone(),
         hbn_device_names.reps[0],
@@ -1380,12 +1373,11 @@ fn write_dhcp_v4_server_config(
 
     let loopback_ip = mh_nc.loopback_ip.parse()?;
 
-    // Split the dual-stack nameservers by family: the IPv4 set drives the
-    // DHCPv4 options written here, while the IPv6 set is held in the config for
-    // the eventual DHCPv6 / RA consumer (inert in this path for now).
-    let (nameservers_v4, nameservers_v6) = split_nameservers_by_family(&service_addrs.nameservers);
+    // Split the dual-stack nameservers by family for the sibling v4 and v6
+    // listeners that consume this shared server configuration.
+    let (nameservers_v4, nameservers_v6) = split_addresses_by_family(&service_addrs.nameservers);
 
-    let ntpservers_v4 = build_dhcp_ntp_servers(nc, service_addrs);
+    let (ntpservers_v4, ntpservers_v6) = build_dhcp_ntp_servers(nc, service_addrs);
 
     let pxe_ip_v4 = service_addrs
         .pxe_ips
@@ -1425,6 +1417,7 @@ fn write_dhcp_v4_server_config(
     let next_contents = dhcp::build_server_config(
         pxe_ip_v4,
         ntpservers_v4,
+        ntpservers_v6,
         nameservers_v4,
         nameservers_v6,
         loopback_ip,
@@ -1860,6 +1853,9 @@ mod tests {
         InterfaceState, ServiceAddresses, needed_interface_state,
     };
     use crate::{HBNDeviceNames, dhcp, nvue};
+    /// Verifies managed-host loopbacks preserve optional IPv6 and reject invalid families.
+    ///
+    /// This keeps family validation at the NVUE rendering boundary.
     #[test]
     fn test_parse_managed_host_loopback_ips() {
         use carbide_test_support::Outcome::*;
@@ -1912,51 +1908,48 @@ mod tests {
         );
     }
 
+    /// Verifies IPv4 site NTP overrides do not suppress DNS-derived DHCPv6 NTP.
     #[test]
     fn test_build_dhcp_ntp_servers() {
+        use carbide_test_support::value_scenarios;
+
         let service_addrs = ServiceAddresses {
             pxe_ips: vec![],
-            ntpservers: vec![IpAddr::from([192, 0, 2, 20])],
-            nameservers: vec![],
-        };
-        let nc = rpc::ManagedHostNetworkConfigResponse {
-            ntp_servers: vec!["198.51.100.1".to_string(), "198.51.100.2".to_string()],
-            ..Default::default()
-        };
-
-        let out = build_dhcp_ntp_servers(&nc, &service_addrs);
-        assert_eq!(
-            out,
-            vec![
-                Ipv4Addr::from([198, 51, 100, 1]),
-                Ipv4Addr::from([198, 51, 100, 2])
-            ]
-        );
-    }
-
-    #[test]
-    fn test_build_dhcp_ntp_servers_fallback() {
-        let service_addrs = ServiceAddresses {
-            pxe_ips: vec![],
-            ntpservers: vec![IpAddr::from([192, 0, 2, 20])],
+            ntpservers: vec![
+                IpAddr::from([192, 0, 2, 20]),
+                "2001:db8::20".parse().unwrap(),
+            ],
             nameservers: vec![],
         };
 
-        let empty_nc = rpc::ManagedHostNetworkConfigResponse::default();
-
-        assert_eq!(
-            build_dhcp_ntp_servers(&empty_nc, &service_addrs),
-            vec![Ipv4Addr::from([192, 0, 2, 20])]
-        );
-
-        let invalid_nc = rpc::ManagedHostNetworkConfigResponse {
-            ntp_servers: vec!["not-an-ip".to_string(), "2001:db8::1".to_string()],
-            ..Default::default()
-        };
-
-        assert_eq!(
-            build_dhcp_ntp_servers(&invalid_nc, &service_addrs),
-            vec![Ipv4Addr::from([192, 0, 2, 20])]
+        value_scenarios!(run = |ntp_servers: Vec<String>| {
+                let nc = rpc::ManagedHostNetworkConfigResponse {
+                    ntp_servers,
+                    ..Default::default()
+                };
+                build_dhcp_ntp_servers(&nc, &service_addrs)
+            };
+            "configured overrides" {
+                // The supported site IPv4 value replaces only its service fallback.
+                vec!["198.51.100.1".to_string()] => (
+                    vec![Ipv4Addr::from([198, 51, 100, 1])],
+                    vec!["2001:db8::20".parse::<Ipv6Addr>().unwrap()],
+                ),
+            }
+            "empty configuration fallback" {
+                // With no site values, both service-provided families survive.
+                vec![] => (
+                    vec![Ipv4Addr::from([192, 0, 2, 20])],
+                    vec!["2001:db8::20".parse::<Ipv6Addr>().unwrap()],
+                ),
+            }
+            "invalid-address fallback" {
+                // An invalid site IPv4 value retains both service-provided families.
+                vec!["not-an-ip".to_string()] => (
+                    vec![Ipv4Addr::from([192, 0, 2, 20])],
+                    vec!["2001:db8::20".parse::<Ipv6Addr>().unwrap()],
+                ),
+            }
         );
     }
 
@@ -3189,15 +3182,17 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies generic service-address partitioning preserves order within each family.
     #[test]
-    fn split_nameservers_by_family_partitions_by_family() {
+    fn split_addresses_by_family_partitions_by_family() {
         use carbide_test_support::value_scenarios;
 
         value_scenarios!(
             run = |input: Vec<IpAddr>| -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
-                split_nameservers_by_family(&input)
+                split_addresses_by_family(&input)
             };
             "splits nameservers by family" {
+                // Mixed input preserves the original order within each family.
                 vec![
                     IpAddr::from([10, 0, 0, 1]),
                     "2001:db8::1".parse::<IpAddr>().unwrap(),
@@ -3206,9 +3201,12 @@ mod tests {
                     vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
                     vec!["2001:db8::1".parse::<Ipv6Addr>().unwrap()],
                 ),
+                // IPv4-only input leaves the IPv6 result empty.
                 vec![IpAddr::from([10, 0, 0, 1])] => (vec![Ipv4Addr::new(10, 0, 0, 1)], vec![]),
+                // IPv6-only input leaves the IPv4 result empty.
                 vec!["2001:db8::1".parse::<IpAddr>().unwrap()]
                     => (vec![], vec!["2001:db8::1".parse::<Ipv6Addr>().unwrap()]),
+                // Empty input produces two empty family lists.
                 vec![] => (vec![], vec![]),
             }
         );
@@ -3226,6 +3224,26 @@ mod tests {
             expected.carbide_provisioning_server_ipv4
         );
         assert_eq!(received.carbide_dhcp_server, expected.carbide_dhcp_server);
+        assert_eq!(
+            received.carbide_nameservers_v6,
+            expected.carbide_nameservers_v6
+        );
+        assert_eq!(
+            received.carbide_ntpservers_v6,
+            expected.carbide_ntpservers_v6
+        );
+        assert_eq!(
+            received.carbide_dhcp_server_v6,
+            expected.carbide_dhcp_server_v6
+        );
+        assert_eq!(
+            received.dhcpv6_preferred_lifetime_secs,
+            expected.dhcpv6_preferred_lifetime_secs
+        );
+        assert_eq!(
+            received.dhcpv6_valid_lifetime_secs,
+            expected.dhcpv6_valid_lifetime_secs
+        );
     }
 
     fn validate_host_config(received: HostConfig, expected: HostConfig) {
@@ -3248,15 +3266,16 @@ mod tests {
             assert_eq!(ip_config_received.gateway, ip_config_expected.gateway);
             assert_eq!(ip_config_received.address, ip_config_expected.address);
             assert_eq!(ip_config_received.prefix, ip_config_expected.prefix);
+            assert_eq!(ip_config_received.ipv6, ip_config_expected.ipv6);
         }
     }
 
-    // Exercises the DHCP renderer's deprecated compatibility input.
+    /// Verifies the deprecated file-backed DHCP compatibility input renders
+    /// dual-stack options and host state.
     #[test]
     #[allow(deprecated)]
     fn test_with_tenant_dhcp_server() -> Result<(), Box<dyn std::error::Error>> {
-        // The config we received from API server
-        // Admin won't be used
+        // Model the API-provided admin interface with both address families.
         let admin_interface_prefix: IpNetwork = "10.217.5.123/32".parse().unwrap();
         let admin_interface = rpc::FlatInterfaceConfig {
             function_type: rpc::InterfaceFunctionType::Physical.into(),
@@ -3282,7 +3301,23 @@ mod tests {
             ipv6_interface_config: None,
             vpc_routing_profile: None,
             interface_routing_profile: None,
-            addresses: vec![],
+            addresses: vec![
+                rpc::InterfaceAddressConfig {
+                    address_family: rpc::AddressFamily::V4.into(),
+                    gateway: Some("10.217.5.123".to_string()),
+                    ip: "10.217.5.123".to_string(),
+                    interface_prefix: admin_interface_prefix.to_string(),
+                    prefix: "10.217.5.123".to_string(),
+                    tenant_vrf_loopback_ip: Some("10.213.2.1".to_string()),
+                    ..Default::default()
+                },
+                rpc::InterfaceAddressConfig {
+                    address_family: rpc::AddressFamily::V6.into(),
+                    ip: "2001:db8::123".to_string(),
+                    interface_prefix: "2001:db8::/64".to_string(),
+                    ..Default::default()
+                },
+            ],
         };
 
         let mut admin_interface_with_mtu = admin_interface.clone();
@@ -3372,12 +3407,16 @@ mod tests {
                 Ipv4Addr::from([127, 0, 0, 2]),
                 Ipv4Addr::from([127, 0, 0, 3]),
             ],
+            carbide_nameservers_v6: vec!["2001:db8::53".parse().unwrap()],
+            carbide_ntpservers_v6: vec!["2001:db8::123".parse().unwrap()],
             carbide_provisioning_server_ipv4: Ipv4Addr::from([10, 0, 0, 1]),
             lease_time_secs: 604800,
             renewal_time_secs: 3600,
             rebinding_time_secs: 432000,
             carbide_api_url: None,
             carbide_dhcp_server: Ipv4Addr::from([10, 217, 5, 39]),
+            dhcpv6_preferred_lifetime_secs: dhcp::DHCPV6_PREFERRED_LIFETIME_SECS,
+            dhcpv6_valid_lifetime_secs: dhcp::DHCPV6_VALID_LIFETIME_SECS,
             ..Default::default()
         };
 
@@ -3476,13 +3515,16 @@ mod tests {
                 IpAddr::from([127, 0, 0, 1]),
                 IpAddr::from([127, 0, 0, 2]),
                 IpAddr::from([127, 0, 0, 3]),
+                "2001:db8::123".parse().unwrap(),
             ],
-            nameservers: vec![IpAddr::from([10, 1, 1, 1])],
+            nameservers: vec![IpAddr::from([10, 1, 1, 1]), "2001:db8::53".parse().unwrap()],
         };
 
         let mut host_config_str =
             dhcp::build_server_host_config(network_config.clone(), &HBNDeviceNames::pre_23())?;
         assert!(!host_config_str.contains("mtu"));
+        assert!(host_config_str.contains("ipv6:"));
+        assert!(host_config_str.contains("2001:db8::123"));
 
         let mut network_config2 = network_config.clone();
         network_config2.admin_interface = Some(admin_interface_with_mtu);
@@ -3573,6 +3615,8 @@ mod tests {
             rebinding_time_secs: 432000,
             carbide_api_url: None,
             carbide_dhcp_server: Ipv4Addr::from([10, 217, 5, 39]),
+            dhcpv6_preferred_lifetime_secs: dhcp::DHCPV6_PREFERRED_LIFETIME_SECS,
+            dhcpv6_valid_lifetime_secs: dhcp::DHCPV6_VALID_LIFETIME_SECS,
             ..Default::default()
         };
         let dhcp_contents = super::read_limited(g.path())?;

--- a/crates/dhcp-server/Cargo.toml
+++ b/crates/dhcp-server/Cargo.toml
@@ -34,6 +34,7 @@ path = "src/main.rs"
 # [local-dependencies]
 carbide-dhcp-common = { path = "../dhcp-common" }
 carbide-instrument = { path = "../instrument" }
+carbide-dhcpv6 = { path = "../dhcpv6" }
 carbide-tls = { path = "../tls" }
 logfmt = { path = "../logfmt" }
 carbide-rpc = { path = "../rpc" }
@@ -60,12 +61,17 @@ thiserror = { workspace = true }
 lru = { workspace = true }
 socket2 = { workspace = true }
 chrono = { workspace = true }
-futures = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
+tokio = { workspace = true, features = ["test-util"] }
+futures = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["http2"] }
+hyper-util = { workspace = true, features = ["tokio"] }
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/crates/dhcp-server/Cargo.toml
+++ b/crates/dhcp-server/Cargo.toml
@@ -34,6 +34,7 @@ path = "src/main.rs"
 # [local-dependencies]
 carbide-dhcp-common = { path = "../dhcp-common" }
 carbide-instrument = { path = "../instrument" }
+carbide-dhcpv6 = { path = "../dhcpv6" }
 carbide-tls = { path = "../tls" }
 logfmt = { path = "../logfmt" }
 carbide-rpc = { path = "../rpc" }
@@ -60,12 +61,16 @@ thiserror = { workspace = true }
 lru = { workspace = true }
 socket2 = { workspace = true }
 chrono = { workspace = true }
-futures = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
+futures = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["http2"] }
+hyper-util = { workspace = true, features = ["tokio"] }
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/crates/dhcp-server/src/cache.rs
+++ b/crates/dhcp-server/src/cache.rs
@@ -31,12 +31,12 @@ use rpc::forge::DhcpRecord;
 /// Data in cache is only valid this long
 const MACHINE_CACHE_TIMEOUT: Duration = Duration::from_secs(60);
 /// How many entries to keep. After that we evict the entry used the longest ago.
-pub(super) const MACHINE_CACHE_SIZE: usize = 1000;
+pub const MACHINE_CACHE_SIZE: usize = 1000;
 /// If the cache key comes out shorter than this something went wrong, don't use it.
 const MIN_KEY_LEN: usize = 10;
 
 #[derive(Debug, Clone)]
-pub(super) struct CacheEntry {
+pub struct CacheEntry {
     pub(super) dhcp_record: DhcpRecord,
     timestamp: Instant,
 }

--- a/crates/dhcp-server/src/errors.rs
+++ b/crates/dhcp-server/src/errors.rs
@@ -20,6 +20,7 @@ use std::str::Utf8Error;
 
 use dhcproto::v4::relay::RelayCode;
 use dhcproto::v4::{MessageType, OptionCode};
+use dhcproto::v6::{MessageType as MessageTypeV6, OptionCode as OptionCodeV6};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -80,4 +81,25 @@ pub enum DhcpError {
 
     #[error("multiple interfaces are provided, but only 1 is supported: {0}")]
     MultipleInterfacesProvidedOneSupported(usize),
+
+    #[error("missing DHCPv6 option: {0:?}")]
+    MissingOptionV6(OptionCodeV6),
+
+    #[error("unhandled DHCPv6 message type: {0:?}")]
+    UnhandledMessageTypeV6(MessageTypeV6),
+
+    #[error("malformed DHCPv6 client DUID")]
+    MalformedDuid,
+
+    #[error("unsupported DHCPv6 DUID type: {0}")]
+    UnsupportedDuidType(u16),
+
+    #[error("DHCPv6 client identity has no MAC and relay option 79 is absent")]
+    NoMacNoOption79,
+
+    #[error("nested DHCPv6 relay messages are unsupported")]
+    NestedRelayV6,
+
+    #[error("DHCPv6 relay hop count {0} is invalid for the supported single-envelope path")]
+    RelayHopCountExceededV6(u8),
 }

--- a/crates/dhcp-server/src/errors.rs
+++ b/crates/dhcp-server/src/errors.rs
@@ -17,9 +17,11 @@
 use std::io;
 use std::net::{AddrParseError, Ipv4Addr};
 use std::str::Utf8Error;
+use std::time::Duration;
 
 use dhcproto::v4::relay::RelayCode;
 use dhcproto::v4::{MessageType, OptionCode};
+use dhcproto::v6::{MessageType as MessageTypeV6, OptionCode as OptionCodeV6};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -57,13 +59,13 @@ pub enum DhcpError {
     #[error("utf8 decoding failure: {0}")]
     Utf8Error(#[from] Utf8Error),
 
-    #[error("utf8 decoding failure: {0}")]
+    #[error("packet decoding failure: {0}")]
     PacketDecodeFailure(#[from] dhcproto::error::DecodeError),
 
-    #[error("utf8 decoding failure: {0}")]
+    #[error("packet encoding failure: {0}")]
     PacketEncodeFailure(#[from] dhcproto::error::EncodeError),
 
-    #[error("utf8 decoding failure: {0}")]
+    #[error("address parse failure: {0}")]
     AddressParseError(#[from] AddrParseError),
 
     #[error("non relayed packet received: {0}. dropping!")]
@@ -80,4 +82,51 @@ pub enum DhcpError {
 
     #[error("multiple interfaces are provided, but only 1 is supported: {0}")]
     MultipleInterfacesProvidedOneSupported(usize),
+
+    #[error("missing DHCPv6 option: {0:?}")]
+    MissingOptionV6(OptionCodeV6),
+
+    #[error("unhandled DHCPv6 message type: {0:?}")]
+    UnhandledMessageTypeV6(MessageTypeV6),
+
+    #[error("malformed DHCPv6 client DUID")]
+    MalformedDuid,
+
+    /// The selected interface has no DHCPv6 host or prefix configuration.
+    #[error("no DHCPv6 configuration for interface {0}")]
+    NoIpv6Configuration(String),
+
+    /// Stateful response lifetimes violate the DHCPv6 configuration contract.
+    #[error(
+        "invalid DHCPv6 lifetimes: preferred {preferred_lifetime_secs}s, valid {valid_lifetime_secs}s; both must be nonzero and preferred must not exceed valid"
+    )]
+    InvalidDhcpV6Lifetimes {
+        preferred_lifetime_secs: u32,
+        valid_lifetime_secs: u32,
+    },
+
+    /// A DHCPv6 client or relay used a UDP source port assigned to the other role.
+    #[error("DHCPv6 {sender} packet originated from UDP port {actual}, expected {expected}")]
+    UnexpectedDhcpV6SourcePort {
+        sender: &'static str,
+        actual: u16,
+        expected: u16,
+    },
+
+    /// The request contains an address-association type this server cannot represent.
+    #[error("unsupported DHCPv6 address association: {0:?}")]
+    UnsupportedAddressAssociationV6(OptionCodeV6),
+
+    #[error("DHCPv6 client identity has no MAC and relay option 79 is absent")]
+    NoMacNoOption79,
+
+    #[error("nested DHCPv6 relay messages are unsupported")]
+    NestedRelayV6,
+
+    #[error("DHCPv6 relay hop count {0} is invalid for the supported single-envelope path")]
+    RelayHopCountExceededV6(u8),
+
+    /// The Controller API did not complete within the DHCPv6 transaction budget.
+    #[error("DHCPv6 API discovery timed out after {0:?}")]
+    DhcpV6ApiTimeout(Duration),
 }

--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -36,14 +36,13 @@ mod proto {
     tonic::include_proto!("dhcp_server_control");
 }
 
+use carbide_dhcp_server::errors::DhcpError;
+use carbide_dhcp_server::metrics::DhcpTimestampFileFailed;
 use proto::dhcp_server_control_server::{DhcpServerControl, DhcpServerControlServer};
 use proto::{
     GetDhcpTimestampsRequest, GetDhcpTimestampsResponse, StopServerRequest, StopServerResponse,
     UpdateAndReloadConfigRequest, UpdateAndReloadConfigResponse,
 };
-
-use crate::errors::DhcpError;
-use crate::metrics::DhcpTimestampFileFailed;
 
 // ── Control channel types ────────────────────────────────────────────────────
 

--- a/crates/dhcp-server/src/lib.rs
+++ b/crates/dhcp-server/src/lib.rs
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod cache;
+pub mod errors;
+pub mod metrics;
+pub mod modes;
+pub mod packet_handler;
+pub mod packet_handler_v6;
+mod rpc;
+pub mod util;
+
+use ::rpc::forge_tls_client::ForgeClientConfig;
+use carbide_rpc_utils::dhcp::{DhcpConfig, HostConfig};
+
+/// Runtime configuration shared by the DHCPv4 and DHCPv6 packet paths.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub(crate) dhcp_config: DhcpConfig,
+    pub(crate) host_config: Option<HostConfig>,
+    pub(crate) relay_response_port: u16,
+    pub(crate) forge_client_config: ForgeClientConfig,
+}
+
+impl Config {
+    /// Build one immutable server configuration for a listener generation.
+    pub fn new(
+        dhcp_config: DhcpConfig,
+        host_config: Option<HostConfig>,
+        relay_response_port: u16,
+        forge_client_config: ForgeClientConfig,
+    ) -> Self {
+        Self {
+            dhcp_config,
+            host_config,
+            relay_response_port,
+            forge_client_config,
+        }
+    }
+
+    /// Return the DPU-provided host configuration when the server runs in DPU mode.
+    pub fn host_config(&self) -> Option<&HostConfig> {
+        self.host_config.as_ref()
+    }
+}

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -16,50 +16,77 @@
  */
 #![cfg_attr(not(test), deny(dead_code_pub_in_binary))]
 
-mod cache;
 mod command_line;
-mod errors;
 mod grpc_server;
-mod metrics;
-mod modes;
-mod packet_handler;
-mod rpc;
-mod util;
-
 use std::error::Error;
-use std::net::SocketAddr;
+use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::sync::Arc;
 
 use ::rpc::forge_tls_client::ForgeClientConfig;
-use cache::CacheEntry;
+use carbide_dhcp_server::cache::{self, CacheEntry};
+use carbide_dhcp_server::errors::DhcpError;
+use carbide_dhcp_server::metrics::{
+    DhcpPacketDropped, DhcpTimestampFileFailed, DhcpV6ListenerUnavailable, DhcpV6ReplySent,
+    DhcpV6RequestDropped, DropReason, V6DropReason, record_v6_request_received,
+};
+use carbide_dhcp_server::modes::DhcpMode;
+use carbide_dhcp_server::modes::controller::Controller;
+use carbide_dhcp_server::modes::dpu::{Dpu, get_host_config};
+use carbide_dhcp_server::{Config, packet_handler, packet_handler_v6, util};
 use carbide_instrument::emit;
-use carbide_rpc_utils::dhcp::{DhcpConfig, DhcpTimestamps, DhcpTimestampsFilePath, HostConfig};
+use carbide_rpc_utils::dhcp::{DhcpConfig, DhcpTimestamps, DhcpTimestampsFilePath};
 use chrono::Utc;
 use command_line::{Args, ServerMode};
-use errors::DhcpError;
 use forge_tls::client_config::ClientCert;
 use forge_tls::default::{default_client_cert, default_client_key, default_root_ca};
 use grpc_server::{ControlRequest, run_grpc_server};
 use lru::LruCache;
-use metrics::{DhcpPacketDropped, DhcpTimestampFileFailed, DropReason};
 use metrics_endpoint::{MetricsEndpointConfig, new_metrics_setup, run_metrics_endpoint};
-use modes::DhcpMode;
-use modes::controller::Controller;
-use modes::dpu::{Dpu, get_host_config};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::prelude::*;
-
-use crate::util::get_socket;
+use util::{get_socket, get_socket_v6};
 
 struct Server {
     socket: Arc<UdpSocket>,
 }
 
+/// Values shared by packets received on one DHCPv6 listener.
+#[derive(Clone)]
+struct V6ListenerContext {
+    socket: Arc<UdpSocket>,
+    config: Arc<Config>,
+    handler: Arc<Box<dyn DhcpMode>>,
+    interface: String,
+    machine_cache: Arc<Mutex<LruCache<String, CacheEntry>>>,
+    dhcp_timestamps: Arc<Mutex<DhcpTimestamps>>,
+}
+
 const MAX_PARALLEL_PACKET_HANDLING_ALLOWED: usize = 128;
+
+/// Records why a DHCPv4 listener violated the generation-lifetime invariant.
+#[derive(Debug)]
+enum V4ListenerFailure {
+    /// The listener returned before its generation was cancelled.
+    Returned,
+    /// The listener task panicked or was otherwise cancelled unexpectedly.
+    Join(tokio::task::JoinError),
+}
+
+impl std::fmt::Display for V4ListenerFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Returned => {
+                formatter.write_str("listener returned before generation cancellation")
+            }
+            Self::Join(error) => write!(formatter, "listener task failed: {error}"),
+        }
+    }
+}
 
 /// Run one generation of the DHCP server (all interfaces) until `cancel_token` is cancelled.
 ///
@@ -100,16 +127,26 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
         d
     }));
 
-    // Rate limiter limits the packet processing from all interfaces.
+    // Each family has an independent packet-processing limit across all interfaces.
     let rate_limiter_ = Arc::new(tokio::sync::Semaphore::new(
         MAX_PARALLEL_PACKET_HANDLING_ALLOWED,
     ));
+    let v6_rate_limiter_ = Arc::new(tokio::sync::Semaphore::new(
+        MAX_PARALLEL_PACKET_HANDLING_ALLOWED,
+    ));
 
-    let mut join_handles = vec![];
+    let mut v4_tasks = JoinSet::new();
+    let mut v6_tasks = JoinSet::new();
 
     // Create a new socket for each interface.
     // In case of Controller, there will be only 1 interface.
     for interface in args.interfaces {
+        let v6_interface = interface.clone();
+        let v6_config = config__.clone();
+        let v6_mode = args.mode.clone();
+        let v6_timestamps = dhcp_timestamps.clone();
+        let v6_rate_limiter = v6_rate_limiter_.clone();
+        let v6_cancel = cancel_token.clone();
         let config_ = config__.clone();
         let args_mode = args.mode.clone();
         let listen_address = args.listen_addr;
@@ -117,7 +154,7 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
         let rate_limiter = rate_limiter_.clone();
         let cancel = cancel_token.clone();
 
-        let handle = tokio::spawn(async move {
+        v4_tasks.spawn(async move {
             let handler: Arc<Box<dyn DhcpMode>> = Arc::new(get_mode(&args_mode));
 
             let socket = get_socket(listen_address, interface.clone()).await;
@@ -225,11 +262,241 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
             }
         });
 
-        join_handles.push(handle);
+        // Milestone 04 admits DHCPv6 in both modes; socket setup failure remains
+        // nonfatal so an unavailable v6 stack cannot take down DHCPv4.
+        v6_tasks.spawn(run_dhcp_v6_listener(
+            v6_interface,
+            v6_config,
+            v6_mode,
+            v6_cancel,
+            v6_rate_limiter,
+            v6_timestamps,
+        ));
     }
 
-    // Wait for all interface tasks to finish (they all exit on cancellation).
-    futures::future::join_all(join_handles).await;
+    // Preserve optional IPv6 availability without hiding a failed IPv4 listener.
+    if let Err(error) = supervise_listener_tasks(v4_tasks, v6_tasks, cancel_token).await {
+        tracing::error!(
+            error = %error,
+            "DHCPv4 listener exited unexpectedly"
+        );
+    }
+}
+
+/// Supervises a generation while preserving the listeners' family-specific semantics.
+///
+/// A v4 listener must run until generation cancellation, so every earlier completion
+/// is reported and losing the last v4 listener fails the generation. A normally
+/// returning v6 task represents expected optional listener unavailability and does
+/// not stop healthy v4 service.
+async fn supervise_listener_tasks(
+    mut v4_tasks: JoinSet<()>,
+    mut v6_tasks: JoinSet<()>,
+    cancel_token: CancellationToken,
+) -> Result<(), V4ListenerFailure> {
+    if v4_tasks.is_empty() {
+        return Ok(());
+    }
+
+    let failure = loop {
+        tokio::select! {
+            biased;
+
+            _ = cancel_token.cancelled() => break None,
+            Some(result) = v4_tasks.join_next(), if !v4_tasks.is_empty() => {
+                // Cancellation is intentionally clean even when a listener exits concurrently.
+                if cancel_token.is_cancelled() {
+                    break None;
+                }
+
+                let failure = match result {
+                    Ok(()) => V4ListenerFailure::Returned,
+                    Err(error) => V4ListenerFailure::Join(error),
+                };
+                if !v4_tasks.is_empty() {
+                    tracing::error!(
+                        error = %failure,
+                        remaining_v4_listener_count = v4_tasks.len(),
+                        "DHCPv4 listener exited unexpectedly"
+                    );
+                    continue;
+                }
+
+                cancel_token.cancel();
+                v4_tasks.abort_all();
+                v6_tasks.abort_all();
+                break Some(failure);
+            }
+            Some(result) = v6_tasks.join_next(), if !v6_tasks.is_empty() => {
+                if let Err(error) = result {
+                    tracing::warn!(
+                        error = %error,
+                        "DHCPv6 listener exited unexpectedly"
+                    );
+                }
+            }
+        }
+    };
+
+    // Join every listener task. TODO(dhcp-reload): DHCPv4 and DHCPv6 packet tasks
+    // remain detached, so they can retain old sockets and config and send stale
+    // replies after reload.
+    while v4_tasks.join_next().await.is_some() {}
+    while v6_tasks.join_next().await.is_some() {}
+
+    match failure {
+        Some(failure) => Err(failure),
+        None => Ok(()),
+    }
+}
+
+/// Count one DHCPv6 datagram at ingress and apply the handler admission limit.
+fn admit_v6_packet(
+    packet: &[u8],
+    source_address: SocketAddr,
+    rate_limiter: &Arc<tokio::sync::Semaphore>,
+) -> Option<tokio::sync::OwnedSemaphorePermit> {
+    record_v6_request_received(packet, source_address);
+    match rate_limiter.clone().try_acquire_owned() {
+        Ok(permit) => Some(permit),
+        Err(_) => {
+            emit(DhcpV6RequestDropped {
+                reason: V6DropReason::RateLimited,
+                error: "parallel packet handling limit reached".to_string(),
+            });
+            None
+        }
+    }
+}
+
+/// Enforce the UDP source ports assigned to DHCPv6 clients and relay agents.
+fn validate_v6_source_port(packet: &[u8], source: &SocketAddrV6) -> Result<(), DhcpError> {
+    let (sender, expected_port) = if packet.first().copied() == Some(carbide_dhcpv6::RELAY_FORWARD)
+    {
+        ("relay", dhcproto::v6::SERVER_PORT)
+    } else {
+        ("client", dhcproto::v6::CLIENT_PORT)
+    };
+    if source.port() != expected_port {
+        return Err(DhcpError::UnexpectedDhcpV6SourcePort {
+            sender,
+            actual: source.port(),
+            expected: expected_port,
+        });
+    }
+    Ok(())
+}
+
+/// Run the independent DHCPv6 receive loop for one configured interface.
+async fn run_dhcp_v6_listener(
+    interface: String,
+    config: Config,
+    mode: ServerMode,
+    cancel: CancellationToken,
+    rate_limiter: Arc<tokio::sync::Semaphore>,
+    dhcp_timestamps: Arc<Mutex<DhcpTimestamps>>,
+) {
+    let handler: Arc<Box<dyn DhcpMode>> = Arc::new(get_mode(&mode));
+    // Controller mode accepts relay traffic; DPU mode retains its direct-only
+    // trust boundary and therefore does not subscribe to relay discovery.
+    let join_site_scoped_group = matches!(mode, ServerMode::Controller);
+    let listen_address = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, dhcproto::v6::SERVER_PORT, 0, 0);
+
+    // Socket retries remain interruptible when a server generation is cancelled.
+    let socket_result = tokio::select! {
+        _ = cancel.cancelled() => return,
+        result = get_socket_v6(listen_address, &interface, join_site_scoped_group) => result,
+    };
+    let socket = match socket_result {
+        Ok(socket) => Arc::new(socket),
+        Err(error) => {
+            // IPv4-only hosts are valid, so failure to establish the sibling
+            // IPv6 listener must not take down the existing DHCPv4 service.
+            emit(DhcpV6ListenerUnavailable::InitialSocketSetup {
+                interface_name: interface,
+                error: error.to_string(),
+            });
+            return;
+        }
+    };
+    tracing::info!(
+        %listen_address,
+        interface_name = interface,
+        mode = ?handler,
+        "DHCPv6 server listening"
+    );
+
+    let Some(cache_size) = std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE) else {
+        tracing::error!("DHCP machine cache size must be nonzero");
+        return;
+    };
+    let machine_cache = Arc::new(Mutex::new(LruCache::new(cache_size)));
+    let mut context = V6ListenerContext {
+        socket,
+        config: Arc::new(config),
+        handler,
+        interface,
+        machine_cache,
+        dhcp_timestamps,
+    };
+
+    // DHCPv6 has a four-byte base header, so it intentionally does not use
+    // the DHCPv4 path's 236-byte BOOTP minimum. Keep one full-size UDP buffer
+    // per listener so relay options cannot be silently truncated at Ethernet MTU.
+    let mut buffer = vec![0; usize::from(u16::MAX)];
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                tracing::info!(
+                    interface_name = context.interface,
+                    "DHCPv6 server received cancellation, shutting down"
+                );
+                break;
+            }
+            result = context.socket.recv_from(&mut buffer) => {
+                let (length, source) = match result {
+                    Ok(received) => received,
+                    Err(error) => {
+                        tracing::error!(
+                            interface_name = context.interface,
+                            error = %error,
+                            "DHCPv6 socket receive failed"
+                        );
+                        let recreated = tokio::select! {
+                            _ = cancel.cancelled() => return,
+                            result = get_socket_v6(
+                                listen_address,
+                                &context.interface,
+                                join_site_scoped_group,
+                            ) => result,
+                        };
+                        match recreated {
+                            Ok(recreated) => context.socket = Arc::new(recreated),
+                            Err(error) => {
+                                emit(DhcpV6ListenerUnavailable::SocketRecreation {
+                                    interface_name: context.interface.clone(),
+                                    error: error.to_string(),
+                                });
+                                return;
+                            }
+                        }
+                        continue;
+                    }
+                };
+
+                let Some(permit) = admit_v6_packet(&buffer[..length], source, &rate_limiter) else {
+                    continue;
+                };
+
+                let packet = buffer[..length].to_vec();
+                let packet_context = context.clone();
+                tokio::spawn(async move {
+                    process_v6(source, &packet, packet_context).await;
+                    drop(permit);
+                });
+            }
+        }
+    }
 }
 
 /// Initialises the tracing subscriber with per-crate log-level overrides.
@@ -559,14 +826,6 @@ fn get_mode(args_mode: &ServerMode) -> Box<dyn DhcpMode> {
     }
 }
 
-#[derive(Debug, Clone)]
-struct Config {
-    dhcp_config: DhcpConfig,
-    host_config: Option<HostConfig>, // Valid only for Dpu mode.
-    relay_response_port: u16,
-    forge_client_config: ForgeClientConfig,
-}
-
 async fn init(args: Args) -> Result<Config, DhcpError> {
     let forge_client_config = forge_client_config(&args)?;
     let f = tokio::fs::read_to_string(args.dhcp_config).await?;
@@ -579,12 +838,12 @@ async fn init(args: Args) -> Result<Config, DhcpError> {
         host_config = None;
     };
 
-    Ok(Config {
+    Ok(Config::new(
         dhcp_config,
         host_config,
-        relay_response_port: args.relay_response_port,
+        args.relay_response_port,
         forge_client_config,
-    })
+    ))
 }
 
 fn forge_client_config(args: &Args) -> Result<ForgeClientConfig, DhcpError> {
@@ -673,50 +932,129 @@ async fn process(
         });
     }
 
-    // Tell forge-dpu-agent that an IP has been requested for this interface.
-    if let Some(host_config) = config.host_config {
-        let mut dhcp_timestamps = dhcp_timestamps.lock().await;
-        dhcp_timestamps.add_timestamp(host_config.host_interface_id, Utc::now().to_rfc3339());
-        if let Err(e) = dhcp_timestamps.write() {
-            emit(DhcpTimestampFileFailed::Write {
-                dhcp_timestamps_path: DhcpTimestampsFilePath::HbnTmp.path_str().to_string(),
-                host_interface_id: host_config.host_interface_id.to_string(),
-                error: e.to_string(),
+    record_dhcp_timestamp(&config, dhcp_timestamps).await;
+}
+
+/// Process one DHCPv6 datagram and send its response to the exact UDP source.
+#[tracing::instrument(skip_all)]
+async fn process_v6(source: SocketAddr, packet: &[u8], mut context: V6ListenerContext) {
+    let SocketAddr::V6(source) = source else {
+        let error = format!("source address {source} is not IPv6");
+        emit(DhcpV6RequestDropped {
+            reason: V6DropReason::InvalidPacket,
+            error,
+        });
+        return;
+    };
+    if let Err(error) = validate_v6_source_port(packet, &source) {
+        emit(DhcpV6RequestDropped {
+            reason: V6DropReason::from(&error),
+            error: error.to_string(),
+        });
+        return;
+    }
+
+    tracing::debug!(source_address = %source, "Received DHCPv6 packet");
+    let response = match packet_handler_v6::process_packet(
+        packet,
+        *source.ip(),
+        &context.config,
+        &context.interface,
+        &**context.handler,
+        &mut context.machine_cache,
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            emit(DhcpV6RequestDropped {
+                reason: V6DropReason::from(&error),
+                error: error.to_string(),
             });
+            return;
         }
+    };
+
+    // An indeterminate CONFIRM is intentionally discarded without counting
+    // it as an invalid or dropped request.
+    let Some(response) = response else {
+        return;
+    };
+
+    tracing::debug!(destination_address = %source, "Sending DHCPv6 packet");
+    match context
+        .socket
+        .send_to(response.encoded_packet(), source)
+        .await
+    {
+        Ok(_) => emit(DhcpV6ReplySent {
+            message_type: response.message_type,
+            destination_address: source,
+        }),
+        Err(error) => emit(DhcpV6RequestDropped {
+            reason: V6DropReason::SendFailed,
+            error: error.to_string(),
+        }),
+    }
+    record_dhcp_timestamp(&context.config, context.dhcp_timestamps.clone()).await;
+}
+
+/// Record that the DPU-side interface has served a DHCP request.
+async fn record_dhcp_timestamp(config: &Config, dhcp_timestamps: Arc<Mutex<DhcpTimestamps>>) {
+    let Some(host_config) = config.host_config() else {
+        return;
+    };
+
+    let mut dhcp_timestamps = dhcp_timestamps.lock().await;
+    dhcp_timestamps.add_timestamp(host_config.host_interface_id, Utc::now().to_rfc3339());
+    if let Err(error) = dhcp_timestamps.write() {
+        emit(DhcpTimestampFileFailed::Write {
+            dhcp_timestamps_path: DhcpTimestampsFilePath::HbnTmp.path_str().to_string(),
+            host_interface_id: host_config.host_interface_id.to_string(),
+            error: error.to_string(),
+        });
     }
 }
 
 #[cfg(test)]
 mod test {
     use std::env;
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
     use std::path::PathBuf;
     use std::str::FromStr;
     use std::sync::Arc;
 
-    use carbide_instrument::testing::capture_logs_async;
+    use carbide_dhcp_server::errors::DhcpError;
+    use carbide_dhcp_server::modes::V6Outcome;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs_async};
     use carbide_rpc_utils::dhcp::{DhcpTimestamps, DhcpTimestampsFilePath};
+    use carbide_test_support::value_scenarios;
     use chrono::{DateTime, Utc};
     use dhcproto::v4::{DhcpOption, Message, MessageType, OptionCode};
+    use dhcproto::v6::MessageType as MessageTypeV6;
     use dhcproto::{Decodable, Decoder, Encodable};
     use lru::LruCache;
     use rpc::forge::{DhcpDiscovery, DhcpRecord};
     use tempfile::TempDir;
     use tokio::net::UdpSocket;
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, oneshot};
+    use tokio::task::JoinSet;
+    use tokio::time::{Duration, timeout};
     use tokio_util::sync::CancellationToken;
     use tonic::async_trait;
 
     use crate::cache::CacheEntry;
     use crate::command_line::{Args, ServerMode};
-    use crate::errors::DhcpError;
     use crate::{
-        Config, DhcpMode, cache, forge_client_config, handle_reload, init, packet_handler, process,
+        Config, DhcpMode, V4ListenerFailure, admit_v6_packet, cache, forge_client_config,
+        handle_reload, init, packet_handler, process, supervise_listener_tasks,
+        validate_v6_source_port,
     };
 
     const TEST_SOURCE_ADDRESS: SocketAddr =
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 10), 68));
+    const TEST_CLIENT_MAC: &[u8] = &[0x00, 0x1b, 0x63, 0x84, 0x45, 0xe6];
+    const TEST_CLIENT_MAC_TEXT: &str = "00:1b:63:84:45:e6";
 
     #[derive(Debug)]
     struct TestArm {}
@@ -732,6 +1070,16 @@ mod test {
             Test::dhcp_record()
         }
 
+        /// Return a deterministic relayed DHCPv6 record for binary-level tests.
+        async fn discover_dhcp_v6(
+            &self,
+            _discovery_request: DhcpDiscovery,
+            _config: &Config,
+            _machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
+        ) -> Result<V6Outcome, DhcpError> {
+            Ok(V6Outcome::Stateful(Test::dhcp_record_v6()?))
+        }
+
         // Packets received from DPU to API must be relayed.
         fn should_be_relayed(&self) -> bool {
             true
@@ -742,6 +1090,7 @@ mod test {
     struct Test {}
 
     impl Test {
+        /// Return the deterministic DHCPv4 record used by packet-processing tests.
         fn dhcp_record() -> Result<DhcpRecord, DhcpError> {
             Ok(DhcpRecord {
                 machine_id: Some(
@@ -763,6 +1112,17 @@ mod test {
                 ntp_servers: vec!["1.2.3.4".to_string(), "5.6.7.8".to_string()],
             })
         }
+
+        /// Return the deterministic DHCPv6 record used by packet-processing tests.
+        fn dhcp_record_v6() -> Result<DhcpRecord, DhcpError> {
+            Ok(DhcpRecord {
+                address: "2001:db8::204".to_string(),
+                prefix: "2001:db8::/64".to_string(),
+                gateway: None,
+                ntp_servers: vec!["2001:db8::123".to_string()],
+                ..Self::dhcp_record()?
+            })
+        }
     }
 
     #[async_trait]
@@ -774,6 +1134,16 @@ mod test {
             _machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
         ) -> Result<DhcpRecord, DhcpError> {
             Test::dhcp_record()
+        }
+
+        /// Return a deterministic direct DHCPv6 record for binary-level tests.
+        async fn discover_dhcp_v6(
+            &self,
+            _discovery_request: DhcpDiscovery,
+            _config: &Config,
+            _machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
+        ) -> Result<V6Outcome, DhcpError> {
+            Ok(V6Outcome::Stateful(Test::dhcp_record_v6()?))
         }
 
         fn should_be_relayed(&self) -> bool {
@@ -795,6 +1165,278 @@ mod test {
             grpc_listen_addr: None,
             metrics_listen_addr: None,
         }
+    }
+
+    /// Verifies direct clients and relay agents use their assigned DHCPv6 source ports.
+    #[test]
+    fn validates_dhcpv6_source_ports() {
+        value_scenarios!(run = |(packet_type, source_port): (u8, u16)| {
+                let source = SocketAddrV6::new(Ipv6Addr::LOCALHOST, source_port, 0, 0);
+                validate_v6_source_port(&[packet_type], &source).is_ok()
+            };
+            "assigned source ports" {
+                // A direct client sends from the DHCPv6 client port.
+                (u8::from(MessageTypeV6::Solicit), dhcproto::v6::CLIENT_PORT) => true,
+                // A relay agent sends Relay-Forward from the DHCPv6 server port.
+                (carbide_dhcpv6::RELAY_FORWARD, dhcproto::v6::SERVER_PORT) => true,
+            }
+            "crossed source ports" {
+                // Direct client traffic on the relay/server port is rejected.
+                (u8::from(MessageTypeV6::Solicit), dhcproto::v6::SERVER_PORT) => false,
+                // Relay traffic on the client port is rejected.
+                (carbide_dhcpv6::RELAY_FORWARD, dhcproto::v6::CLIENT_PORT) => false,
+            }
+        );
+    }
+
+    /// Verifies both forms of last-listener v4 completion fail the generation.
+    #[tokio::test]
+    async fn listener_supervision_fails_when_the_last_v4_listener_exits() {
+        // Exercise normal return and panic because Tokio reports them through different paths.
+        for should_panic in [false, true] {
+            let cancel_token = CancellationToken::new();
+            let mut v4_tasks = JoinSet::new();
+            let (completion_tx, completion_rx) = oneshot::channel();
+            v4_tasks.spawn(async move {
+                completion_tx
+                    .send(())
+                    .expect("supervision test waits for v4 completion");
+                if should_panic {
+                    panic!("synthetic v4 listener panic");
+                }
+            });
+            completion_rx
+                .await
+                .expect("synthetic v4 listener reached its exit");
+
+            // Keep a sibling pending so the test catches the former join_all masking behavior.
+            let mut v6_tasks = JoinSet::new();
+            v6_tasks.spawn(std::future::pending::<()>());
+
+            // Verify supervision reports the exact failure form and tears down the generation.
+            let result = timeout(
+                Duration::from_secs(1),
+                supervise_listener_tasks(v4_tasks, v6_tasks, cancel_token.clone()),
+            )
+            .await
+            .expect("unexpected v4 completion must surface promptly");
+
+            assert!(
+                cancel_token.is_cancelled(),
+                "unexpected v4 completion must cancel its generation"
+            );
+            match (should_panic, result) {
+                (false, Err(V4ListenerFailure::Returned)) => {}
+                (true, Err(V4ListenerFailure::Join(_))) => {}
+                (_, other) => panic!("unexpected v4 supervision result: {other:?}"),
+            }
+        }
+    }
+
+    /// Verifies one failed v4 interface preserves healthy siblings until the last one exits.
+    #[tokio::test]
+    async fn listener_supervision_preserves_siblings_until_the_last_v4_listener_exits() {
+        for (scenario, should_panic) in [
+            // A listener can return after exhausting its bounded socket retries.
+            ("normal return", false),
+            // A listener panic arrives as a Tokio JoinError but has the same cardinality policy.
+            ("panic", true),
+        ] {
+            let cancel_token = CancellationToken::new();
+            let mut v4_tasks = JoinSet::new();
+            let (first_exit_tx, first_exit_rx) = oneshot::channel();
+            v4_tasks.spawn(async move {
+                first_exit_tx
+                    .send(())
+                    .expect("supervision test waits for the first v4 listener");
+                if should_panic {
+                    panic!("synthetic v4 listener panic");
+                }
+            });
+            first_exit_rx
+                .await
+                .expect("first synthetic v4 listener reached its exit");
+
+            // Hold the healthy sibling until the partial failure has been observed.
+            let (last_exit_tx, last_exit_rx) = oneshot::channel();
+            v4_tasks.spawn(async move {
+                last_exit_rx
+                    .await
+                    .expect("supervision test releases the last v4 listener");
+            });
+
+            let mut v6_tasks = JoinSet::new();
+            v6_tasks.spawn(std::future::pending::<()>());
+
+            let ((result, was_cancelled), logs) = capture_logs_async(async {
+                let supervision =
+                    supervise_listener_tasks(v4_tasks, v6_tasks, cancel_token.clone());
+                tokio::pin!(supervision);
+
+                assert!(
+                    timeout(Duration::from_millis(100), &mut supervision)
+                        .await
+                        .is_err(),
+                    "{scenario} from one v4 listener must preserve its healthy sibling"
+                );
+                assert!(
+                    !cancel_token.is_cancelled(),
+                    "{scenario} from one v4 listener must not cancel the generation"
+                );
+
+                last_exit_tx
+                    .send(())
+                    .expect("last synthetic v4 listener is waiting for release");
+                let result = timeout(Duration::from_secs(1), supervision)
+                    .await
+                    .expect("last v4 completion must surface promptly");
+                (result, cancel_token.is_cancelled())
+            })
+            .await;
+
+            assert!(
+                matches!(result, Err(V4ListenerFailure::Returned)),
+                "last v4 listener should fail after first-listener {scenario}: {result:?}"
+            );
+            assert!(was_cancelled, "last v4 exit must cancel the generation");
+            assert!(
+                logs.iter().any(|entry| {
+                    entry.message == "DHCPv4 listener exited unexpectedly"
+                        && entry.field("remaining_v4_listener_count") == Some("1")
+                }),
+                "first-listener {scenario} must be logged as a partial failure"
+            );
+        }
+    }
+
+    /// Verifies explicit cancellation remains clean after partial v4 degradation.
+    #[tokio::test]
+    async fn listener_supervision_cancels_cleanly_after_partial_v4_failure() {
+        let cancel_token = CancellationToken::new();
+        let mut v4_tasks = JoinSet::new();
+        v4_tasks.spawn(async {});
+
+        // Keep both remaining families alive until the generation is intentionally cancelled.
+        let v4_cancel = cancel_token.clone();
+        v4_tasks.spawn(async move {
+            v4_cancel.cancelled().await;
+        });
+        let mut v6_tasks = JoinSet::new();
+        let v6_cancel = cancel_token.clone();
+        v6_tasks.spawn(async move {
+            v6_cancel.cancelled().await;
+        });
+
+        let mut supervision = tokio::spawn(supervise_listener_tasks(
+            v4_tasks,
+            v6_tasks,
+            cancel_token.clone(),
+        ));
+        assert!(
+            timeout(Duration::from_millis(100), &mut supervision)
+                .await
+                .is_err(),
+            "partial v4 failure must keep the generation alive"
+        );
+        assert!(!cancel_token.is_cancelled());
+
+        cancel_token.cancel();
+        let result = timeout(Duration::from_secs(1), supervision)
+            .await
+            .expect("explicit cancellation must drain listener supervision")
+            .expect("listener supervisor task must join");
+        assert!(result.is_ok());
+    }
+
+    /// Verifies v6 exit is non-fatal and intentional generation cancellation remains clean.
+    #[tokio::test]
+    async fn listener_supervision_keeps_v4_running_after_v6_exit() {
+        // Normal return models expected unavailability; panic models an unexpected v6 JoinError.
+        for should_panic in [false, true] {
+            let cancel_token = CancellationToken::new();
+
+            // Keep v4 healthy until the generation is intentionally cancelled.
+            let mut v4_tasks = JoinSet::new();
+            let listener_cancel = cancel_token.clone();
+            v4_tasks.spawn(async move {
+                listener_cancel.cancelled().await;
+            });
+
+            // Hold v6 at a deterministic boundary until supervision is actively running.
+            let mut v6_tasks = JoinSet::new();
+            let (ready_tx, ready_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            v6_tasks.spawn(async move {
+                ready_tx
+                    .send(())
+                    .expect("supervision test waits for the v6 listener");
+                release_rx
+                    .await
+                    .expect("supervision test releases the v6 listener");
+                if should_panic {
+                    panic!("synthetic v6 listener panic");
+                }
+            });
+
+            let mut supervision = tokio::spawn(supervise_listener_tasks(
+                v4_tasks,
+                v6_tasks,
+                cancel_token.clone(),
+            ));
+            ready_rx
+                .await
+                .expect("synthetic v6 listener reached the release boundary");
+
+            // Release v6 while the supervisor is being polled; neither exit form may finish it.
+            release_tx
+                .send(())
+                .expect("synthetic v6 listener is waiting for release");
+            assert!(
+                timeout(Duration::from_millis(100), &mut supervision)
+                    .await
+                    .is_err(),
+                "v6 completion must not end the generation"
+            );
+            assert!(
+                !cancel_token.is_cancelled(),
+                "v6 completion must not cancel healthy v4 service"
+            );
+
+            // Explicit cancellation must drain the v4 task and return cleanly.
+            cancel_token.cancel();
+            let result = timeout(Duration::from_secs(1), supervision)
+                .await
+                .expect("intentional cancellation must finish promptly")
+                .expect("listener supervision task must join");
+            assert!(result.is_ok(), "intentional cancellation must be clean");
+        }
+    }
+
+    /// A packet rejected by the DHCPv6 handler admission limit is counted as
+    /// both received and dropped, preserving the metric subset relationship.
+    #[test]
+    fn rate_limited_v6_packet_is_counted_at_ingress() {
+        let metrics = MetricsCapture::start();
+        let packet = [u8::from(MessageTypeV6::Renew), 0, 0, 1];
+        let rate_limiter = Arc::new(tokio::sync::Semaphore::new(0));
+
+        assert!(
+            admit_v6_packet(&packet, "[fe80::1]:546".parse().unwrap(), &rate_limiter,).is_none()
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "renew")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
+                &[("reason", "rate_limited")]
+            ),
+            1.0
+        );
     }
 
     /// Reload with no staged `_new` files must not start the server.
@@ -1079,7 +1721,7 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            packet.dst_address(),
+            handler.get_destination_address(&packet),
             SocketAddrV4::new(Ipv4Addr::from([0x0a, 0xd9, 0x05, 0x29]), 6768)
         );
         let packet = Message::decode(&mut dhcproto::Decoder::new(packet.encoded_packet())).unwrap();
@@ -1163,10 +1805,7 @@ mod test {
             request_log.field("giaddr"),
             Some(expected_received_packet.giaddr().to_string().as_str())
         );
-        assert_eq!(
-            request_log.field("chaddr"),
-            Some(crate::util::u8_to_mac(expected_received_packet.chaddr()).as_str())
-        );
+        assert_eq!(request_log.field("chaddr"), Some(TEST_CLIENT_MAC_TEXT));
         assert_eq!(request_log.field("received_packet"), None);
 
         let debug_log = logs
@@ -1308,10 +1947,7 @@ mod test {
             reply_log.field("giaddr"),
             Some(expected_reply.giaddr().to_string().as_str())
         );
-        assert_eq!(
-            reply_log.field("chaddr"),
-            Some(crate::util::u8_to_mac(expected_reply.chaddr()).as_str())
-        );
+        assert_eq!(reply_log.field("chaddr"), Some(TEST_CLIENT_MAC_TEXT));
         assert_eq!(reply_log.field("sent_packet"), None);
 
         let debug_log = logs
@@ -1350,7 +1986,7 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            packet.dst_address(),
+            handler.get_destination_address(&packet),
             SocketAddrV4::new(Ipv4Addr::from([10, 217, 5, 41]), 67)
         );
 
@@ -1410,7 +2046,7 @@ mod test {
         let dhcp_timestamps = dhcp_timestamps.lock().await;
 
         let timestamp = dhcp_timestamps
-            .get_timestamp(&config.host_config.as_ref().unwrap().host_interface_id)
+            .get_timestamp(&config.host_config().unwrap().host_interface_id)
             .unwrap();
 
         let dhcp_time: DateTime<Utc> = timestamp.parse().unwrap();
@@ -1419,7 +2055,7 @@ mod test {
         let mut dhcp_timestamps_new = DhcpTimestamps::new(DhcpTimestampsFilePath::Test);
         dhcp_timestamps_new.read().unwrap();
         let file_timestamp: DateTime<Utc> = dhcp_timestamps_new
-            .get_timestamp(&config.host_config.unwrap().host_interface_id)
+            .get_timestamp(&config.host_config().unwrap().host_interface_id)
             .unwrap()
             .parse()
             .unwrap();
@@ -1431,7 +2067,7 @@ mod test {
     async fn validate_test_host_config() {
         let config = init(get_test_args()).await.unwrap();
 
-        let host_config = config.host_config.unwrap();
+        let host_config = config.host_config().unwrap();
         assert_eq!(host_config.host_ip_addresses.len(), 2);
         assert!(host_config.host_ip_addresses["vlan200"].booturl.is_none());
     }
@@ -1447,7 +2083,7 @@ mod test {
             Ipv4Addr::new(0, 0, 0, 0),
             Ipv4Addr::new(0, 0, 0, 0),
             Ipv4Addr::new(0, 0, 0, 0),
-            &[00, 0x1b, 0x63, 0x84, 0x45, 0xe6],
+            TEST_CLIENT_MAC,
         );
 
         if let Some(giaddr) = giaddr {
@@ -1488,15 +2124,8 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            encoded_packet.dst_address(),
+            handler.get_destination_address(&encoded_packet),
             SocketAddrV4::new(Ipv4Addr::BROADCAST, 68)
-        );
-
-        // The reply type the send path counts lease grants under matches the
-        // encoded reply.
-        assert_eq!(
-            encoded_packet.message_type(),
-            crate::metrics::MessageTypeLabel::Ack
         );
 
         let packet = Message::decode(&mut Decoder::new(encoded_packet.encoded_packet())).unwrap();
@@ -1526,12 +2155,6 @@ mod test {
         )
         .await
         .unwrap();
-
-        // The nak_packet branch reports the refusal, not the request's type.
-        assert_eq!(
-            encoded_packet.message_type(),
-            crate::metrics::MessageTypeLabel::Nak
-        );
 
         let packet = Message::decode(&mut Decoder::new(encoded_packet.encoded_packet())).unwrap();
         assert_eq!(

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -15,54 +15,81 @@
  * limitations under the License.
  */
 
-mod cache;
 mod command_line;
-mod errors;
 mod grpc_server;
-mod metrics;
-mod modes;
-mod packet_handler;
-mod rpc;
-mod util;
-
 use std::error::Error;
-use std::net::SocketAddr;
+use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::sync::Arc;
 
 #[cfg(test)]
 use ::rpc::forge::{DhcpDiscovery, DhcpRecord};
 use ::rpc::forge_tls_client::ForgeClientConfig;
-use cache::CacheEntry;
+use carbide_dhcp_server::cache::{self, CacheEntry};
+use carbide_dhcp_server::errors::DhcpError;
+use carbide_dhcp_server::metrics::{
+    DhcpPacketDropped, DhcpTimestampFileFailed, DhcpV6ListenerUnavailable, DhcpV6ReplySent,
+    DhcpV6RequestDropped, DropReason, V6DropReason,
+};
+use carbide_dhcp_server::modes::controller::Controller;
+use carbide_dhcp_server::modes::dpu::{Dpu, get_host_config};
+use carbide_dhcp_server::modes::{DhcpMode, V6Outcome};
+use carbide_dhcp_server::{Config, packet_handler, packet_handler_v6, util};
 use carbide_instrument::emit;
-use carbide_rpc_utils::dhcp::{DhcpConfig, DhcpTimestamps, DhcpTimestampsFilePath, HostConfig};
+use carbide_rpc_utils::dhcp::{DhcpConfig, DhcpTimestamps, DhcpTimestampsFilePath};
 use chrono::Utc;
 use command_line::{Args, ServerMode};
-use errors::DhcpError;
 use forge_tls::client_config::ClientCert;
 use forge_tls::default::{default_client_cert, default_client_key, default_root_ca};
 use grpc_server::{ControlRequest, run_grpc_server};
 use lru::LruCache;
-use metrics::{DhcpPacketDropped, DhcpTimestampFileFailed, DropReason};
 use metrics_endpoint::{MetricsEndpointConfig, new_metrics_setup, run_metrics_endpoint};
-use modes::DhcpMode;
-use modes::controller::Controller;
-use modes::dpu::{Dpu, get_host_config};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 #[cfg(test)]
 use tonic::async_trait;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::prelude::*;
-
-use crate::util::get_socket;
+use util::{get_socket, get_socket_v6};
 
 struct Server {
     socket: Arc<UdpSocket>,
 }
 
+/// Values shared by packets received on one DHCPv6 listener.
+#[derive(Clone)]
+struct V6ListenerContext {
+    socket: Arc<UdpSocket>,
+    config: Arc<Config>,
+    handler: Arc<Box<dyn DhcpMode>>,
+    interface: String,
+    machine_cache: Arc<Mutex<LruCache<String, CacheEntry>>>,
+    dhcp_timestamps: Arc<Mutex<DhcpTimestamps>>,
+}
+
 const MAX_PARALLEL_PACKET_HANDLING_ALLOWED: usize = 128;
+
+/// Records why a DHCPv4 listener violated the generation-lifetime invariant.
+#[derive(Debug)]
+enum V4ListenerFailure {
+    /// The listener returned before its generation was cancelled.
+    Returned,
+    /// The listener task panicked or was otherwise cancelled unexpectedly.
+    Join(tokio::task::JoinError),
+}
+
+impl std::fmt::Display for V4ListenerFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Returned => {
+                formatter.write_str("listener returned before generation cancellation")
+            }
+            Self::Join(error) => write!(formatter, "listener task failed: {error}"),
+        }
+    }
+}
 
 /// Run one generation of the DHCP server (all interfaces) until `cancel_token` is cancelled.
 ///
@@ -103,16 +130,26 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
         d
     }));
 
-    // Rate limiter limits the packet processing from all interfaces.
+    // Each family has an independent packet-processing limit across all interfaces.
     let rate_limiter_ = Arc::new(tokio::sync::Semaphore::new(
         MAX_PARALLEL_PACKET_HANDLING_ALLOWED,
     ));
+    let v6_rate_limiter_ = Arc::new(tokio::sync::Semaphore::new(
+        MAX_PARALLEL_PACKET_HANDLING_ALLOWED,
+    ));
 
-    let mut join_handles = vec![];
+    let mut v4_tasks = JoinSet::new();
+    let mut v6_tasks = JoinSet::new();
 
     // Create a new socket for each interface.
     // In case of Controller, there will be only 1 interface.
     for interface in args.interfaces {
+        let v6_interface = interface.clone();
+        let v6_config = config__.clone();
+        let v6_mode = args.mode.clone();
+        let v6_timestamps = dhcp_timestamps.clone();
+        let v6_rate_limiter = v6_rate_limiter_.clone();
+        let v6_cancel = cancel_token.clone();
         let config_ = config__.clone();
         let args_mode = args.mode.clone();
         let listen_address = args.listen_addr;
@@ -120,7 +157,7 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
         let rate_limiter = rate_limiter_.clone();
         let cancel = cancel_token.clone();
 
-        let handle = tokio::spawn(async move {
+        v4_tasks.spawn(async move {
             let handler: Arc<Box<dyn DhcpMode>> = Arc::new(get_mode(&args_mode));
 
             let socket = get_socket(listen_address, interface.clone()).await;
@@ -228,11 +265,201 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
             }
         });
 
-        join_handles.push(handle);
+        // Milestone 04 admits DHCPv6 in both modes; socket setup failure remains
+        // nonfatal so an unavailable v6 stack cannot take down DHCPv4.
+        v6_tasks.spawn(run_dhcp_v6_listener(
+            v6_interface,
+            v6_config,
+            v6_mode,
+            v6_cancel,
+            v6_rate_limiter,
+            v6_timestamps,
+        ));
     }
 
-    // Wait for all interface tasks to finish (they all exit on cancellation).
-    futures::future::join_all(join_handles).await;
+    // Preserve optional IPv6 availability without hiding a failed IPv4 listener.
+    if let Err(error) = supervise_listener_tasks(v4_tasks, v6_tasks, cancel_token).await {
+        tracing::error!(
+            error = %error,
+            "DHCPv4 listener exited unexpectedly"
+        );
+    }
+}
+
+/// Supervises a generation while preserving the listeners' family-specific semantics.
+///
+/// A v4 listener must run until generation cancellation, so every earlier completion
+/// is reported and losing the last v4 listener fails the generation. A normally
+/// returning v6 task represents expected optional listener unavailability and does
+/// not stop healthy v4 service.
+async fn supervise_listener_tasks(
+    mut v4_tasks: JoinSet<()>,
+    mut v6_tasks: JoinSet<()>,
+    cancel_token: CancellationToken,
+) -> Result<(), V4ListenerFailure> {
+    if v4_tasks.is_empty() {
+        return Ok(());
+    }
+
+    let failure = loop {
+        tokio::select! {
+            biased;
+
+            _ = cancel_token.cancelled() => break None,
+            Some(result) = v4_tasks.join_next(), if !v4_tasks.is_empty() => {
+                // Cancellation is intentionally clean even when a listener exits concurrently.
+                if cancel_token.is_cancelled() {
+                    break None;
+                }
+
+                let failure = match result {
+                    Ok(()) => V4ListenerFailure::Returned,
+                    Err(error) => V4ListenerFailure::Join(error),
+                };
+                if !v4_tasks.is_empty() {
+                    tracing::error!(
+                        error = %failure,
+                        remaining_v4_listener_count = v4_tasks.len(),
+                        "DHCPv4 listener exited unexpectedly"
+                    );
+                    continue;
+                }
+
+                cancel_token.cancel();
+                v4_tasks.abort_all();
+                v6_tasks.abort_all();
+                break Some(failure);
+            }
+            Some(result) = v6_tasks.join_next(), if !v6_tasks.is_empty() => {
+                if let Err(error) = result {
+                    tracing::warn!(
+                        error = %error,
+                        "DHCPv6 listener exited unexpectedly"
+                    );
+                }
+            }
+        }
+    };
+
+    // Join every listener task. TODO(dhcp-reload): DHCPv4 and DHCPv6 packet tasks
+    // remain detached, so they can retain old sockets and config and send stale
+    // replies after reload.
+    while v4_tasks.join_next().await.is_some() {}
+    while v6_tasks.join_next().await.is_some() {}
+
+    match failure {
+        Some(failure) => Err(failure),
+        None => Ok(()),
+    }
+}
+
+/// Run the independent DHCPv6 receive loop for one configured interface.
+async fn run_dhcp_v6_listener(
+    interface: String,
+    config: Config,
+    mode: ServerMode,
+    cancel: CancellationToken,
+    rate_limiter: Arc<tokio::sync::Semaphore>,
+    dhcp_timestamps: Arc<Mutex<DhcpTimestamps>>,
+) {
+    let handler: Arc<Box<dyn DhcpMode>> = Arc::new(get_mode(&mode));
+    let listen_address = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, dhcproto::v6::SERVER_PORT, 0, 0);
+
+    // Socket retries remain interruptible when a server generation is cancelled.
+    let socket_result = tokio::select! {
+        _ = cancel.cancelled() => return,
+        result = get_socket_v6(listen_address, &interface) => result,
+    };
+    let socket = match socket_result {
+        Ok(socket) => Arc::new(socket),
+        Err(error) => {
+            // IPv4-only hosts are valid, so failure to establish the sibling
+            // IPv6 listener must not take down the existing DHCPv4 service.
+            emit(DhcpV6ListenerUnavailable::InitialSocketSetup {
+                interface_name: interface,
+                error: error.to_string(),
+            });
+            return;
+        }
+    };
+    tracing::info!(
+        %listen_address,
+        interface_name = interface,
+        mode = ?handler,
+        "DHCPv6 server listening"
+    );
+
+    let Some(cache_size) = std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE) else {
+        tracing::error!("DHCP machine cache size must be nonzero");
+        return;
+    };
+    let machine_cache = Arc::new(Mutex::new(LruCache::new(cache_size)));
+    let mut context = V6ListenerContext {
+        socket,
+        config: Arc::new(config),
+        handler,
+        interface,
+        machine_cache,
+        dhcp_timestamps,
+    };
+
+    // DHCPv6 has a four-byte base header, so it intentionally does not use
+    // the DHCPv4 path's 236-byte BOOTP minimum. Keep one full-size UDP buffer
+    // per listener so relay options cannot be silently truncated at Ethernet MTU.
+    let mut buffer = vec![0; usize::from(u16::MAX)];
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                tracing::info!(
+                    interface_name = context.interface,
+                    "DHCPv6 server received cancellation, shutting down"
+                );
+                break;
+            }
+            result = context.socket.recv_from(&mut buffer) => {
+                let (length, source) = match result {
+                    Ok(received) => received,
+                    Err(error) => {
+                        tracing::error!(
+                            interface_name = context.interface,
+                            error = %error,
+                            "DHCPv6 socket receive failed"
+                        );
+                        let recreated = tokio::select! {
+                            _ = cancel.cancelled() => return,
+                            result = get_socket_v6(listen_address, &context.interface) => result,
+                        };
+                        match recreated {
+                            Ok(recreated) => context.socket = Arc::new(recreated),
+                            Err(error) => {
+                                emit(DhcpV6ListenerUnavailable::SocketRecreation {
+                                    interface_name: context.interface.clone(),
+                                    error: error.to_string(),
+                                });
+                                return;
+                            }
+                        }
+                        continue;
+                    }
+                };
+
+                let Ok(permit) = rate_limiter.clone().try_acquire_owned() else {
+                    emit(DhcpV6RequestDropped {
+                        reason: V6DropReason::RateLimited,
+                        error: "parallel packet handling limit reached".to_string(),
+                    });
+                    continue;
+                };
+
+                let packet = buffer[..length].to_vec();
+                let packet_context = context.clone();
+                tokio::spawn(async move {
+                    process_v6(source, &packet, packet_context).await;
+                    drop(permit);
+                });
+            }
+        }
+    }
 }
 
 /// Initialises the tracing subscriber with per-crate log-level overrides.
@@ -562,14 +789,6 @@ fn get_mode(args_mode: &ServerMode) -> Box<dyn DhcpMode> {
     }
 }
 
-#[derive(Debug, Clone)]
-struct Config {
-    dhcp_config: DhcpConfig,
-    host_config: Option<HostConfig>, // Valid only for Dpu mode.
-    relay_response_port: u16,
-    forge_client_config: ForgeClientConfig,
-}
-
 async fn init(args: Args) -> Result<Config, DhcpError> {
     let forge_client_config = forge_client_config(&args)?;
     let f = tokio::fs::read_to_string(args.dhcp_config).await?;
@@ -582,12 +801,12 @@ async fn init(args: Args) -> Result<Config, DhcpError> {
         host_config = None;
     };
 
-    Ok(Config {
+    Ok(Config::new(
         dhcp_config,
         host_config,
-        relay_response_port: args.relay_response_port,
+        args.relay_response_port,
         forge_client_config,
-    })
+    ))
 }
 
 fn forge_client_config(args: &Args) -> Result<ForgeClientConfig, DhcpError> {
@@ -630,6 +849,16 @@ impl DhcpMode for TestArm {
         Test::dhcp_record()
     }
 
+    /// Return a deterministic relayed DHCPv6 record for binary-level tests.
+    async fn discover_dhcp_v6(
+        &self,
+        _discovery_request: DhcpDiscovery,
+        _config: &Config,
+        _machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
+    ) -> Result<V6Outcome, DhcpError> {
+        Ok(V6Outcome::Stateful(Test::dhcp_record_v6()?))
+    }
+
     // Packets received from DPU to API must be relayed.
     fn should_be_relayed(&self) -> bool {
         true
@@ -642,6 +871,7 @@ struct Test {}
 
 #[cfg(test)]
 impl Test {
+    /// Return the deterministic DHCPv4 record used by packet-processing tests.
     fn dhcp_record() -> Result<DhcpRecord, DhcpError> {
         Ok(DhcpRecord {
             machine_id: Some(
@@ -663,6 +893,17 @@ impl Test {
             ntp_servers: vec!["1.2.3.4".to_string(), "5.6.7.8".to_string()],
         })
     }
+
+    /// Return the deterministic DHCPv6 record used by packet-processing tests.
+    fn dhcp_record_v6() -> Result<DhcpRecord, DhcpError> {
+        Ok(DhcpRecord {
+            address: "2001:db8::204".to_string(),
+            prefix: "2001:db8::/64".to_string(),
+            gateway: None,
+            ntp_servers: vec!["2001:db8::123".to_string()],
+            ..Self::dhcp_record()?
+        })
+    }
 }
 
 #[cfg(test)]
@@ -675,6 +916,16 @@ impl DhcpMode for Test {
         _machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
     ) -> Result<DhcpRecord, DhcpError> {
         Test::dhcp_record()
+    }
+
+    /// Return a deterministic direct DHCPv6 record for binary-level tests.
+    async fn discover_dhcp_v6(
+        &self,
+        _discovery_request: DhcpDiscovery,
+        _config: &Config,
+        _machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
+    ) -> Result<V6Outcome, DhcpError> {
+        Ok(V6Outcome::Stateful(Test::dhcp_record_v6()?))
     }
 
     fn should_be_relayed(&self) -> bool {
@@ -744,17 +995,79 @@ async fn process(
         });
     }
 
-    // Tell forge-dpu-agent that an IP has been requested for this interface.
-    if let Some(host_config) = config.host_config {
-        let mut dhcp_timestamps = dhcp_timestamps.lock().await;
-        dhcp_timestamps.add_timestamp(host_config.host_interface_id, Utc::now().to_rfc3339());
-        if let Err(e) = dhcp_timestamps.write() {
-            emit(DhcpTimestampFileFailed::Write {
-                dhcp_timestamps_path: DhcpTimestampsFilePath::HbnTmp.path_str().to_string(),
-                host_interface_id: host_config.host_interface_id.to_string(),
-                error: e.to_string(),
+    record_dhcp_timestamp(&config, dhcp_timestamps).await;
+}
+
+/// Process one DHCPv6 datagram and send its response to the exact UDP source.
+#[tracing::instrument(skip_all)]
+async fn process_v6(source: SocketAddr, packet: &[u8], mut context: V6ListenerContext) {
+    let SocketAddr::V6(source) = source else {
+        let error = format!("source address {source} is not IPv6");
+        emit(DhcpV6RequestDropped {
+            reason: V6DropReason::InvalidPacket,
+            error,
+        });
+        return;
+    };
+
+    tracing::debug!(source_address = %source, "Received DHCPv6 packet");
+    let response = match packet_handler_v6::process_packet(
+        packet,
+        *source.ip(),
+        &context.config,
+        &context.interface,
+        &**context.handler,
+        &mut context.machine_cache,
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            emit(DhcpV6RequestDropped {
+                reason: V6DropReason::from(&error),
+                error: error.to_string(),
             });
+            return;
         }
+    };
+
+    // An indeterminate CONFIRM is intentionally discarded without counting
+    // it as an invalid or dropped request.
+    let Some(response) = response else {
+        return;
+    };
+
+    tracing::debug!(destination_address = %source, "Sending DHCPv6 packet");
+    match context
+        .socket
+        .send_to(response.encoded_packet(), source)
+        .await
+    {
+        Ok(_) => emit(DhcpV6ReplySent {
+            message_type: response.message_type,
+        }),
+        Err(error) => emit(DhcpV6RequestDropped {
+            reason: V6DropReason::SendFailed,
+            error: error.to_string(),
+        }),
+    }
+    record_dhcp_timestamp(&context.config, context.dhcp_timestamps.clone()).await;
+}
+
+/// Record that the DPU-side interface has served a DHCP request.
+async fn record_dhcp_timestamp(config: &Config, dhcp_timestamps: Arc<Mutex<DhcpTimestamps>>) {
+    let Some(host_config) = config.host_config() else {
+        return;
+    };
+
+    let mut dhcp_timestamps = dhcp_timestamps.lock().await;
+    dhcp_timestamps.add_timestamp(host_config.host_interface_id, Utc::now().to_rfc3339());
+    if let Err(error) = dhcp_timestamps.write() {
+        emit(DhcpTimestampFileFailed::Write {
+            dhcp_timestamps_path: DhcpTimestampsFilePath::HbnTmp.path_str().to_string(),
+            host_interface_id: host_config.host_interface_id.to_string(),
+            error: error.to_string(),
+        });
     }
 }
 
@@ -766,6 +1079,7 @@ mod test {
     use std::str::FromStr;
     use std::sync::Arc;
 
+    use carbide_dhcp_server::errors::DhcpError;
     use carbide_instrument::testing::capture_logs_async;
     use carbide_rpc_utils::dhcp::{DhcpTimestamps, DhcpTimestampsFilePath};
     use chrono::{DateTime, Utc};
@@ -774,18 +1088,21 @@ mod test {
     use lru::LruCache;
     use tempfile::TempDir;
     use tokio::net::UdpSocket;
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, oneshot};
+    use tokio::task::JoinSet;
+    use tokio::time::{Duration, timeout};
     use tokio_util::sync::CancellationToken;
 
     use crate::command_line::{Args, ServerMode};
-    use crate::errors::DhcpError;
     use crate::{
-        DhcpMode, Test, TestArm, cache, forge_client_config, handle_reload, init, packet_handler,
-        process,
+        DhcpMode, Test, TestArm, V4ListenerFailure, cache, forge_client_config, handle_reload,
+        init, packet_handler, process, supervise_listener_tasks,
     };
 
     const TEST_SOURCE_ADDRESS: SocketAddr =
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 10), 68));
+    const TEST_CLIENT_MAC: &[u8] = &[0x00, 0x1b, 0x63, 0x84, 0x45, 0xe6];
+    const TEST_CLIENT_MAC_TEXT: &str = "00:1b:63:84:45:e6";
 
     fn make_reload_args(td: &TempDir, interfaces: Vec<String>) -> Args {
         Args {
@@ -800,6 +1117,232 @@ mod test {
             mode: ServerMode::Dpu,
             grpc_listen_addr: None,
             metrics_listen_addr: None,
+        }
+    }
+
+    /// Verifies both forms of last-listener v4 completion fail the generation.
+    #[tokio::test]
+    async fn listener_supervision_fails_when_the_last_v4_listener_exits() {
+        // Exercise normal return and panic because Tokio reports them through different paths.
+        for should_panic in [false, true] {
+            let cancel_token = CancellationToken::new();
+            let mut v4_tasks = JoinSet::new();
+            let (completion_tx, completion_rx) = oneshot::channel();
+            v4_tasks.spawn(async move {
+                completion_tx
+                    .send(())
+                    .expect("supervision test waits for v4 completion");
+                if should_panic {
+                    panic!("synthetic v4 listener panic");
+                }
+            });
+            completion_rx
+                .await
+                .expect("synthetic v4 listener reached its exit");
+
+            // Keep a sibling pending so the test catches the former join_all masking behavior.
+            let mut v6_tasks = JoinSet::new();
+            v6_tasks.spawn(std::future::pending::<()>());
+
+            // Verify supervision reports the exact failure form and tears down the generation.
+            let result = timeout(
+                Duration::from_secs(1),
+                supervise_listener_tasks(v4_tasks, v6_tasks, cancel_token.clone()),
+            )
+            .await
+            .expect("unexpected v4 completion must surface promptly");
+
+            assert!(
+                cancel_token.is_cancelled(),
+                "unexpected v4 completion must cancel its generation"
+            );
+            match (should_panic, result) {
+                (false, Err(V4ListenerFailure::Returned)) => {}
+                (true, Err(V4ListenerFailure::Join(_))) => {}
+                (_, other) => panic!("unexpected v4 supervision result: {other:?}"),
+            }
+        }
+    }
+
+    /// Verifies one failed v4 interface preserves healthy siblings until the last one exits.
+    #[tokio::test]
+    async fn listener_supervision_preserves_siblings_until_the_last_v4_listener_exits() {
+        for (scenario, should_panic) in [
+            // A listener can return after exhausting its bounded socket retries.
+            ("normal return", false),
+            // A listener panic arrives as a Tokio JoinError but has the same cardinality policy.
+            ("panic", true),
+        ] {
+            let cancel_token = CancellationToken::new();
+            let mut v4_tasks = JoinSet::new();
+            let (first_exit_tx, first_exit_rx) = oneshot::channel();
+            v4_tasks.spawn(async move {
+                first_exit_tx
+                    .send(())
+                    .expect("supervision test waits for the first v4 listener");
+                if should_panic {
+                    panic!("synthetic v4 listener panic");
+                }
+            });
+            first_exit_rx
+                .await
+                .expect("first synthetic v4 listener reached its exit");
+
+            // Hold the healthy sibling until the partial failure has been observed.
+            let (last_exit_tx, last_exit_rx) = oneshot::channel();
+            v4_tasks.spawn(async move {
+                last_exit_rx
+                    .await
+                    .expect("supervision test releases the last v4 listener");
+            });
+
+            let mut v6_tasks = JoinSet::new();
+            v6_tasks.spawn(std::future::pending::<()>());
+
+            let ((result, was_cancelled), logs) = capture_logs_async(async {
+                let mut supervision = tokio::spawn(supervise_listener_tasks(
+                    v4_tasks,
+                    v6_tasks,
+                    cancel_token.clone(),
+                ));
+
+                assert!(
+                    timeout(Duration::from_millis(100), &mut supervision)
+                        .await
+                        .is_err(),
+                    "{scenario} from one v4 listener must preserve its healthy sibling"
+                );
+                assert!(
+                    !cancel_token.is_cancelled(),
+                    "{scenario} from one v4 listener must not cancel the generation"
+                );
+
+                last_exit_tx
+                    .send(())
+                    .expect("last synthetic v4 listener is waiting for release");
+                let result = timeout(Duration::from_secs(1), supervision)
+                    .await
+                    .expect("last v4 completion must surface promptly")
+                    .expect("listener supervisor task must join");
+                (result, cancel_token.is_cancelled())
+            })
+            .await;
+
+            assert!(
+                matches!(result, Err(V4ListenerFailure::Returned)),
+                "last v4 listener should fail after first-listener {scenario}: {result:?}"
+            );
+            assert!(was_cancelled, "last v4 exit must cancel the generation");
+            assert!(
+                logs.iter().any(|entry| {
+                    entry.message == "DHCPv4 listener exited unexpectedly"
+                        && entry.field("remaining_v4_listener_count") == Some("1")
+                }),
+                "first-listener {scenario} must be logged as a partial failure"
+            );
+        }
+    }
+
+    /// Verifies explicit cancellation remains clean after partial v4 degradation.
+    #[tokio::test]
+    async fn listener_supervision_cancels_cleanly_after_partial_v4_failure() {
+        let cancel_token = CancellationToken::new();
+        let mut v4_tasks = JoinSet::new();
+        v4_tasks.spawn(async {});
+
+        // Keep both remaining families alive until the generation is intentionally cancelled.
+        let v4_cancel = cancel_token.clone();
+        v4_tasks.spawn(async move {
+            v4_cancel.cancelled().await;
+        });
+        let mut v6_tasks = JoinSet::new();
+        let v6_cancel = cancel_token.clone();
+        v6_tasks.spawn(async move {
+            v6_cancel.cancelled().await;
+        });
+
+        let mut supervision = tokio::spawn(supervise_listener_tasks(
+            v4_tasks,
+            v6_tasks,
+            cancel_token.clone(),
+        ));
+        assert!(
+            timeout(Duration::from_millis(100), &mut supervision)
+                .await
+                .is_err(),
+            "partial v4 failure must keep the generation alive"
+        );
+        assert!(!cancel_token.is_cancelled());
+
+        cancel_token.cancel();
+        let result = timeout(Duration::from_secs(1), supervision)
+            .await
+            .expect("explicit cancellation must drain listener supervision")
+            .expect("listener supervisor task must join");
+        assert!(result.is_ok());
+    }
+
+    /// Verifies v6 exit is non-fatal and intentional generation cancellation remains clean.
+    #[tokio::test]
+    async fn listener_supervision_keeps_v4_running_after_v6_exit() {
+        // Normal return models expected unavailability; panic models an unexpected v6 JoinError.
+        for should_panic in [false, true] {
+            let cancel_token = CancellationToken::new();
+
+            // Keep v4 healthy until the generation is intentionally cancelled.
+            let mut v4_tasks = JoinSet::new();
+            let listener_cancel = cancel_token.clone();
+            v4_tasks.spawn(async move {
+                listener_cancel.cancelled().await;
+            });
+
+            // Hold v6 at a deterministic boundary until supervision is actively running.
+            let mut v6_tasks = JoinSet::new();
+            let (ready_tx, ready_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            v6_tasks.spawn(async move {
+                ready_tx
+                    .send(())
+                    .expect("supervision test waits for the v6 listener");
+                release_rx
+                    .await
+                    .expect("supervision test releases the v6 listener");
+                if should_panic {
+                    panic!("synthetic v6 listener panic");
+                }
+            });
+
+            let mut supervision = tokio::spawn(supervise_listener_tasks(
+                v4_tasks,
+                v6_tasks,
+                cancel_token.clone(),
+            ));
+            ready_rx
+                .await
+                .expect("synthetic v6 listener reached the release boundary");
+
+            // Release v6 while the supervisor is being polled; neither exit form may finish it.
+            release_tx
+                .send(())
+                .expect("synthetic v6 listener is waiting for release");
+            assert!(
+                timeout(Duration::from_millis(100), &mut supervision)
+                    .await
+                    .is_err(),
+                "v6 completion must not end the generation"
+            );
+            assert!(
+                !cancel_token.is_cancelled(),
+                "v6 completion must not cancel healthy v4 service"
+            );
+
+            // Explicit cancellation must drain the v4 task and return cleanly.
+            cancel_token.cancel();
+            let result = timeout(Duration::from_secs(1), supervision)
+                .await
+                .expect("intentional cancellation must finish promptly")
+                .expect("listener supervision task must join");
+            assert!(result.is_ok(), "intentional cancellation must be clean");
         }
     }
 
@@ -1085,7 +1628,7 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            packet.dst_address(),
+            handler.get_destination_address(&packet),
             SocketAddrV4::new(Ipv4Addr::from([0x0a, 0xd9, 0x05, 0x29]), 6768)
         );
         let packet = Message::decode(&mut dhcproto::Decoder::new(packet.encoded_packet())).unwrap();
@@ -1169,10 +1712,7 @@ mod test {
             request_log.field("giaddr"),
             Some(expected_received_packet.giaddr().to_string().as_str())
         );
-        assert_eq!(
-            request_log.field("chaddr"),
-            Some(crate::util::u8_to_mac(expected_received_packet.chaddr()).as_str())
-        );
+        assert_eq!(request_log.field("chaddr"), Some(TEST_CLIENT_MAC_TEXT));
         assert_eq!(request_log.field("received_packet"), None);
 
         let debug_log = logs
@@ -1314,10 +1854,7 @@ mod test {
             reply_log.field("giaddr"),
             Some(expected_reply.giaddr().to_string().as_str())
         );
-        assert_eq!(
-            reply_log.field("chaddr"),
-            Some(crate::util::u8_to_mac(expected_reply.chaddr()).as_str())
-        );
+        assert_eq!(reply_log.field("chaddr"), Some(TEST_CLIENT_MAC_TEXT));
         assert_eq!(reply_log.field("sent_packet"), None);
 
         let debug_log = logs
@@ -1356,7 +1893,7 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            packet.dst_address(),
+            handler.get_destination_address(&packet),
             SocketAddrV4::new(Ipv4Addr::from([10, 217, 5, 41]), 67)
         );
 
@@ -1416,7 +1953,7 @@ mod test {
         let dhcp_timestamps = dhcp_timestamps.lock().await;
 
         let timestamp = dhcp_timestamps
-            .get_timestamp(&config.host_config.as_ref().unwrap().host_interface_id)
+            .get_timestamp(&config.host_config().unwrap().host_interface_id)
             .unwrap();
 
         let dhcp_time: DateTime<Utc> = timestamp.parse().unwrap();
@@ -1425,7 +1962,7 @@ mod test {
         let mut dhcp_timestamps_new = DhcpTimestamps::new(DhcpTimestampsFilePath::Test);
         dhcp_timestamps_new.read().unwrap();
         let file_timestamp: DateTime<Utc> = dhcp_timestamps_new
-            .get_timestamp(&config.host_config.unwrap().host_interface_id)
+            .get_timestamp(&config.host_config().unwrap().host_interface_id)
             .unwrap()
             .parse()
             .unwrap();
@@ -1437,7 +1974,7 @@ mod test {
     async fn validate_test_host_config() {
         let config = init(get_test_args()).await.unwrap();
 
-        let host_config = config.host_config.unwrap();
+        let host_config = config.host_config().unwrap();
         assert_eq!(host_config.host_ip_addresses.len(), 2);
         assert!(host_config.host_ip_addresses["vlan200"].booturl.is_none());
     }
@@ -1453,7 +1990,7 @@ mod test {
             Ipv4Addr::new(0, 0, 0, 0),
             Ipv4Addr::new(0, 0, 0, 0),
             Ipv4Addr::new(0, 0, 0, 0),
-            &[00, 0x1b, 0x63, 0x84, 0x45, 0xe6],
+            TEST_CLIENT_MAC,
         );
 
         if let Some(giaddr) = giaddr {
@@ -1494,15 +2031,8 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            encoded_packet.dst_address(),
+            handler.get_destination_address(&encoded_packet),
             SocketAddrV4::new(Ipv4Addr::BROADCAST, 68)
-        );
-
-        // The reply type the send path counts lease grants under matches the
-        // encoded reply.
-        assert_eq!(
-            encoded_packet.message_type(),
-            crate::metrics::MessageTypeLabel::Ack
         );
 
         let packet = Message::decode(&mut Decoder::new(encoded_packet.encoded_packet())).unwrap();
@@ -1532,12 +2062,6 @@ mod test {
         )
         .await
         .unwrap();
-
-        // The nak_packet branch reports the refusal, not the request's type.
-        assert_eq!(
-            encoded_packet.message_type(),
-            crate::metrics::MessageTypeLabel::Nak
-        );
 
         let packet = Message::decode(&mut Decoder::new(encoded_packet.encoded_packet())).unwrap();
         assert_eq!(

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -15,36 +15,61 @@
  * limitations under the License.
  */
 
-//! Packet-level counters and logs for the DHCP server. Request and reply
-//! Events write INFO records with selected BOOTP header and socket details,
-//! while full packets (including their options) stay at DEBUG for forensics. A
-//! drop is the operational error, so its Event also writes the ERROR line --
-//! one declaration moves the counter and logs the reason together.
+//! Packet-level counters and logs for the DHCP server. Request and reply Events
+//! write INFO records with bounded protocol and socket details. DHCPv4 keeps
+//! option-rich packets at DEBUG, while DHCPv6 keeps transport direction there.
+//! Drop Events count every rejected packet; routine DHCPv6 policy outcomes
+//! remain at DEBUG while processing failures write ERROR records.
 //! Timestamp-file failures share a counter by operation while their paths,
 //! host interface, and errors remain log-only diagnostics.
 
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
-use carbide_instrument::{Event, LabelValue, MetricFamily};
+use carbide_instrument::{DynamicLog, Event, LabelValue, LogAt, MetricFamily, emit};
 use dhcproto::v4::MessageType;
+use dhcproto::v6::MessageType as MessageTypeV6;
 
 use crate::errors::DhcpError;
 
-/// The DHCP message type of a packet, as a bounded metric label. The named
-/// variants are the RFC 2131 message set this server handles; anything else
-/// (lease-query extensions, unknown codes, a missing message-type option)
-/// counts as `other`.
+/// The DHCP message type of a packet, as a bounded metric label. Named variants
+/// cover the v4 and v6 exchanges this server handles; extensions and unknown
+/// codes count as `other`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
 pub(super) enum MessageTypeLabel {
     Discover,
+    Solicit,
     Request,
+    Renew,
+    Rebind,
+    Confirm,
+    InformationRequest,
     Offer,
+    Advertise,
     Ack,
     Nak,
+    Reply,
     Release,
     Decline,
     Inform,
     Other,
+}
+
+impl From<MessageTypeV6> for MessageTypeLabel {
+    fn from(message_type: MessageTypeV6) -> Self {
+        match message_type {
+            MessageTypeV6::Solicit => Self::Solicit,
+            MessageTypeV6::Request => Self::Request,
+            MessageTypeV6::Renew => Self::Renew,
+            MessageTypeV6::Rebind => Self::Rebind,
+            MessageTypeV6::Confirm => Self::Confirm,
+            MessageTypeV6::InformationRequest => Self::InformationRequest,
+            MessageTypeV6::Advertise => Self::Advertise,
+            MessageTypeV6::Reply => Self::Reply,
+            MessageTypeV6::Release => Self::Release,
+            MessageTypeV6::Decline => Self::Decline,
+            _ => Self::Other,
+        }
+    }
 }
 
 impl From<MessageType> for MessageTypeLabel {
@@ -63,12 +88,11 @@ impl From<MessageType> for MessageTypeLabel {
     }
 }
 
-/// Why a packet was dropped, as a bounded metric label: one variant per
-/// [`DhcpError`] variant, plus the drop sites that never construct a
-/// `DhcpError` -- rate limiting, undersized packets, non-IPv4 sources, and
-/// send failures.
+/// Why a DHCPv4 packet was dropped, including receive-loop failures that do not
+/// construct a [`DhcpError`]. DHCPv6-only errors map to the closest legacy
+/// category only to keep the conversion total; the v6 path uses [`V6DropReason`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
-pub(super) enum DropReason {
+pub enum DropReason {
     RateLimited,
     TooShort,
     NotIpv4,
@@ -92,6 +116,12 @@ pub(super) enum DropReason {
     NotMyPacket,
     VendorClassParseError,
     MultipleInterfaces,
+    MissingOptionV6,
+    UnhandledMessageTypeV6,
+    MalformedDuid,
+    NoMacNoOption79,
+    NestedRelayV6,
+    RelayHopCountExceededV6,
 }
 
 impl From<&DhcpError> for DropReason {
@@ -116,8 +146,105 @@ impl From<&DhcpError> for DropReason {
             DhcpError::NotMyPacket(_) => Self::NotMyPacket,
             DhcpError::VendorClassParseError(_) => Self::VendorClassParseError,
             DhcpError::MultipleInterfacesProvidedOneSupported(_) => Self::MultipleInterfaces,
+            DhcpError::MissingOptionV6(_) => Self::MissingOptionV6,
+            DhcpError::UnhandledMessageTypeV6(_) => Self::UnhandledMessageTypeV6,
+            DhcpError::MalformedDuid => Self::MalformedDuid,
+            DhcpError::NoIpv6Configuration(_) => Self::MissingArgument,
+            DhcpError::InvalidDhcpV6Lifetimes { .. }
+            | DhcpError::UnexpectedDhcpV6SourcePort { .. } => Self::InvalidInput,
+            DhcpError::UnsupportedAddressAssociationV6(_) => Self::UnhandledMessageTypeV6,
+            DhcpError::NoMacNoOption79 => Self::NoMacNoOption79,
+            DhcpError::NestedRelayV6 => Self::NestedRelayV6,
+            DhcpError::RelayHopCountExceededV6(_) => Self::RelayHopCountExceededV6,
+            DhcpError::DhcpV6ApiTimeout(_) => Self::UpstreamApiError,
         }
     }
+}
+
+/// Why a DHCPv6 request was dropped or refused before a safe response was possible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub enum V6DropReason {
+    InvalidPacket,
+    /// The request violates a DHCPv6 input or admission constraint.
+    InvalidInput,
+    /// Local or upstream configuration cannot produce a valid response.
+    InvalidConfiguration,
+    /// The selected interface intentionally has no IPv6 configuration.
+    NoIpv6Configuration,
+    /// The request explicitly selected a different DHCPv6 server.
+    NotMyPacket,
+    /// The client or relay used the other DHCPv6 role's source port.
+    UnexpectedSourcePort,
+    /// A required DHCPv6 option is absent.
+    MissingOption,
+    /// The DHCPv6 packet could not be decoded.
+    PacketDecodeFailure,
+    /// The DHCPv6 response could not be encoded.
+    PacketEncodeFailure,
+    /// A configured or discovered IPv6 address is malformed.
+    AddressParseError,
+    /// The request contains an address-association type the server cannot represent.
+    UnsupportedAssociation,
+    NestedRelay,
+    RelayHopCountExceeded,
+    NoMacNoOption79,
+    MalformedDuid,
+    UnsupportedMessage,
+    FetchMachineError,
+    RateLimited,
+    SendFailed,
+}
+
+/// Why a DHCPv6 listener became unavailable after bounded socket retries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum V6ListenerUnavailableReason {
+    InitialSocketSetup,
+    SocketRecreation,
+}
+
+impl From<&DhcpError> for V6DropReason {
+    fn from(error: &DhcpError) -> Self {
+        match error {
+            DhcpError::InvalidInput(_) => Self::InvalidInput,
+            DhcpError::SerdeYaml(_) | DhcpError::MultipleInterfacesProvidedOneSupported(_) => {
+                Self::InvalidConfiguration
+            }
+            DhcpError::InvalidDhcpV6Lifetimes { .. } => Self::InvalidConfiguration,
+            DhcpError::NoIpv6Configuration(_) => Self::NoIpv6Configuration,
+            DhcpError::NotMyPacket(_) => Self::NotMyPacket,
+            DhcpError::UnexpectedDhcpV6SourcePort { .. } => Self::UnexpectedSourcePort,
+            DhcpError::MissingOptionV6(_) => Self::MissingOption,
+            DhcpError::PacketDecodeFailure(_) => Self::PacketDecodeFailure,
+            DhcpError::PacketEncodeFailure(_) => Self::PacketEncodeFailure,
+            DhcpError::AddressParseError(_) => Self::AddressParseError,
+            DhcpError::UnsupportedAddressAssociationV6(_) => Self::UnsupportedAssociation,
+            DhcpError::NestedRelayV6 => Self::NestedRelay,
+            DhcpError::RelayHopCountExceededV6(_) => Self::RelayHopCountExceeded,
+            DhcpError::NoMacNoOption79 => Self::NoMacNoOption79,
+            DhcpError::MalformedDuid => Self::MalformedDuid,
+            DhcpError::UnhandledMessageTypeV6(_) => Self::UnsupportedMessage,
+            DhcpError::TonicStatusError(_)
+            | DhcpError::GenericError(_)
+            | DhcpError::DhcpV6ApiTimeout(_) => Self::FetchMachineError,
+            DhcpError::IoError(_)
+            | DhcpError::MissingArgument(_)
+            | DhcpError::MissingOption(_)
+            | DhcpError::UnhandledMessageType(_)
+            | DhcpError::DhcpDeclineMessage(_, _)
+            | DhcpError::MissingRelayCode(_)
+            | DhcpError::Utf8Error(_)
+            | DhcpError::NonRelayedPacket(_)
+            | DhcpError::UnknownPacket(_)
+            | DhcpError::VendorClassParseError(_) => Self::InvalidPacket,
+        }
+    }
+}
+
+/// The inner DHCPv6 response type sent directly or inside a relay envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub enum V6ReplyMessageType {
+    Advertise,
+    Reply,
 }
 
 /// The timestamp-file operation that failed. These are the only three file
@@ -333,7 +460,7 @@ impl DhcpInterfaceBindFailed {
     }
 }
 
-/// A DHCP packet with a usable BOOTP header was decoded from the wire. Its
+/// A DHCPv4 packet with a usable BOOTP header was decoded from the wire. Its
 /// selected header fields and source socket stay on the log line and never
 /// become metric labels; the option-rich full packet stays at DEBUG.
 #[derive(Event)]
@@ -344,7 +471,7 @@ impl DhcpInterfaceBindFailed {
     log = info,
     metric = counter,
     message = "Decoded DHCP packet",
-    describe = "Number of DHCP packets received and decoded, by DHCP message type."
+    describe = "Number of DHCPv4 packets received and decoded, by DHCP message type."
 )]
 pub(super) struct DhcpRequestReceived {
     #[label]
@@ -369,7 +496,7 @@ pub(super) struct DhcpRequestReceived {
     pub(super) chaddr: String,
 }
 
-/// A packet was dropped without a reply reaching the client -- anywhere from
+/// A DHCPv4 packet was dropped without a reply reaching the client -- anywhere from
 /// the receive loop (rate limiting, undersized or non-IPv4 packets) through
 /// packet processing to the final send.
 #[derive(Event)]
@@ -380,20 +507,20 @@ pub(super) struct DhcpRequestReceived {
     message = "Dropped a DHCP packet",
     log = error,
     metric = counter,
-    describe = "Number of DHCP packets dropped without a reply, by drop reason."
+    describe = "Number of DHCPv4 packets dropped without a reply, by drop reason."
 )]
-pub(super) struct DhcpPacketDropped {
+pub struct DhcpPacketDropped {
     #[label]
-    pub(super) reason: DropReason,
+    pub reason: DropReason,
     /// The detail behind the drop (an error's Display text where one exists).
     /// Log-line-only by construction; never a metric label.
     #[context]
-    pub(super) error: String,
+    pub error: String,
 }
 
-/// A DHCP reply was sent, labelled by the reply's message type: an `offer` is
-/// a proposed lease, an `ack` a committed one, a `nak` a refusal. Its selected
-/// BOOTP header fields and destination stay on the log line only; the
+/// A DHCPv4 reply was sent, labelled by the reply's message type: an `offer` is
+/// a proposed lease, an `ack` a committed one, and a `nak` a refusal. Its
+/// selected BOOTP header fields and destination stay on the log line only; the
 /// option-rich full packet stays at DEBUG.
 #[derive(Event)]
 #[event(
@@ -403,7 +530,7 @@ pub(super) struct DhcpPacketDropped {
     log = info,
     metric = counter,
     message = "Sent DHCP reply",
-    describe = "Number of DHCP replies sent, by reply message type."
+    describe = "Number of DHCPv4 replies sent, by reply message type."
 )]
 pub(super) struct DhcpReplySent {
     #[label]
@@ -426,6 +553,123 @@ pub(super) struct DhcpReplySent {
     pub(super) chaddr: String,
 }
 
+/// A DHCPv6 datagram reached the standalone listener.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_v6_request_received",
+    metric_name = "carbide_dhcp_v6_requests_total",
+    component = "nico-dhcp",
+    log = info,
+    metric = counter,
+    message = "Received DHCPv6 request",
+    describe = "Number of DHCPv6 requests received, by DHCP message type."
+)]
+pub(super) struct DhcpV6RequestReceived {
+    #[label]
+    pub(super) message_type: MessageTypeLabel,
+    #[context]
+    pub(super) source_address: SocketAddr,
+}
+
+/// Count one received DHCPv6 datagram using bounded ingress classification.
+pub fn record_v6_request_received(packet: &[u8], source_address: SocketAddr) {
+    emit(DhcpV6RequestReceived {
+        message_type: MessageTypeLabel::from(carbide_dhcpv6::request_message_type(packet)),
+        source_address,
+    });
+}
+
+/// A DHCPv6 request was rejected by the DPU-side transport.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_v6_request_dropped",
+    metric_name = "carbide_dhcp_v6_requests_dropped_total",
+    component = "nico-dhcp",
+    message = "Dropped a DHCPv6 packet",
+    log = dynamic,
+    metric = counter,
+    describe = "Number of DHCPv6 requests dropped or refused, by reason."
+)]
+pub struct DhcpV6RequestDropped {
+    #[label]
+    pub reason: V6DropReason,
+    /// The detail behind the drop. This remains log-only and never becomes a
+    /// metric label.
+    #[context]
+    pub error: String,
+}
+
+impl DynamicLog for DhcpV6RequestDropped {
+    fn log_at(&self) -> LogAt {
+        match self.reason {
+            // These are expected selection or enablement outcomes, so retain
+            // diagnostics without reporting a packet-processing failure.
+            V6DropReason::NoIpv6Configuration | V6DropReason::NotMyPacket => {
+                LogAt::Level(tracing::Level::DEBUG)
+            }
+            _ => LogAt::Level(tracing::Level::ERROR),
+        }
+    }
+}
+
+/// A DHCPv6 listener exhausted its bounded socket setup retries.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_v6_listener_unavailable",
+    metric_name = "carbide_dhcp_v6_listener_unavailable_total",
+    component = "nico-dhcp",
+    metric = counter,
+    describe = "Number of DHCPv6 listeners made unavailable by socket setup failure, by reason.",
+    labels(reason: V6ListenerUnavailableReason),
+)]
+pub enum DhcpV6ListenerUnavailable {
+    /// Initial socket setup failed, so this interface starts without DHCPv6.
+    #[event(
+        labels(reason = InitialSocketSetup),
+        log = warn,
+        message = "DHCPv6 listener unavailable"
+    )]
+    InitialSocketSetup {
+        #[context(value)]
+        interface_name: String,
+        #[context]
+        error: String,
+    },
+
+    /// A receive failure was followed by unsuccessful socket recreation.
+    #[event(
+        labels(reason = SocketRecreation),
+        log = warn,
+        message = "DHCPv6 listener could not be recreated"
+    )]
+    SocketRecreation {
+        #[context(value)]
+        interface_name: String,
+        #[context]
+        error: String,
+    },
+}
+
+/// A DHCPv6 response was sent, labelled by its inner message type.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_v6_reply_sent",
+    metric_name = "carbide_dhcp_v6_replies_sent_total",
+    component = "nico-dhcp",
+    log = info,
+    metric = counter,
+    message = "Sent DHCPv6 reply",
+    describe = "Number of DHCPv6 replies sent, by response message type."
+)]
+pub struct DhcpV6ReplySent {
+    /// The bounded inner response kind.
+    #[label]
+    pub message_type: V6ReplyMessageType,
+    /// The client or relay socket that received the response.
+    #[context]
+    pub destination_address: SocketAddrV6,
+}
+
 /// A DHCP timestamp-file operation failed. Each variant is one operation, and
 /// holds only what that path has -- only a write is per-interface, so only it
 /// has a `host_interface_id`.
@@ -438,7 +682,7 @@ pub(super) struct DhcpReplySent {
     describe = "Number of DHCP timestamp file failures, by operation",
     labels(operation: TimestampFileOperation),
 )]
-pub(crate) enum DhcpTimestampFileFailed {
+pub enum DhcpTimestampFileFailed {
     /// The startup write could not initialize the file, so this server
     /// generation does not start.
     #[event(
@@ -487,6 +731,7 @@ pub(crate) enum DhcpTimestampFileFailed {
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
+    use std::time::Duration;
 
     use carbide_instrument::emit;
     use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
@@ -498,6 +743,7 @@ mod tests {
 
     const SOCKET_SETUP_FAILURE_METRIC: &str = "carbide_dhcp_socket_setup_failures_total";
     const TIMESTAMP_FILE_FAILURE_METRIC: &str = "carbide_dhcp_timestamp_file_failures_total";
+    const V6_LISTENER_UNAVAILABLE_METRIC: &str = "carbide_dhcp_v6_listener_unavailable_total";
 
     struct SocketSetupFailureCase {
         emit: fn(),
@@ -1013,6 +1259,82 @@ mod tests {
         );
     }
 
+    /// Verifies DHCPv6 wire types use bounded labels shared with transport metrics.
+    #[test]
+    fn message_type_label_maps_the_supported_dhcpv6_set() {
+        check_values(
+            [
+                // SOLICIT retains its allocation-start label.
+                Check {
+                    scenario: "solicit",
+                    input: MessageTypeV6::Solicit,
+                    expect: MessageTypeLabel::Solicit,
+                },
+                // REQUEST retains its allocation-commit label.
+                Check {
+                    scenario: "request",
+                    input: MessageTypeV6::Request,
+                    expect: MessageTypeLabel::Request,
+                },
+                // RENEW remains distinguishable from initial allocation traffic.
+                Check {
+                    scenario: "renew",
+                    input: MessageTypeV6::Renew,
+                    expect: MessageTypeLabel::Renew,
+                },
+                // REBIND remains distinguishable from server-targeted renewal.
+                Check {
+                    scenario: "rebind",
+                    input: MessageTypeV6::Rebind,
+                    expect: MessageTypeLabel::Rebind,
+                },
+                // CONFIRM retains its link-validation label.
+                Check {
+                    scenario: "confirm",
+                    input: MessageTypeV6::Confirm,
+                    expect: MessageTypeLabel::Confirm,
+                },
+                // Information-only traffic keeps its dedicated bounded label.
+                Check {
+                    scenario: "information request",
+                    input: MessageTypeV6::InformationRequest,
+                    expect: MessageTypeLabel::InformationRequest,
+                },
+                // ADVERTISE remains distinguishable from final replies.
+                Check {
+                    scenario: "advertise",
+                    input: MessageTypeV6::Advertise,
+                    expect: MessageTypeLabel::Advertise,
+                },
+                // REPLY retains the common final-response label.
+                Check {
+                    scenario: "reply",
+                    input: MessageTypeV6::Reply,
+                    expect: MessageTypeLabel::Reply,
+                },
+                // RELEASE retains its lease-end label.
+                Check {
+                    scenario: "release",
+                    input: MessageTypeV6::Release,
+                    expect: MessageTypeLabel::Release,
+                },
+                // DECLINE retains its unusable-address label.
+                Check {
+                    scenario: "decline",
+                    input: MessageTypeV6::Decline,
+                    expect: MessageTypeLabel::Decline,
+                },
+                // Relay envelopes are transport wrappers, not client request kinds.
+                Check {
+                    scenario: "relay forward buckets as other",
+                    input: MessageTypeV6::RelayForw,
+                    expect: MessageTypeLabel::Other,
+                },
+            ],
+            MessageTypeLabel::from,
+        );
+    }
+
     #[test]
     fn drop_reason_covers_every_dhcp_error_variant() {
         // 0x80 is a lone UTF-8 continuation byte -- the decode failure is the
@@ -1126,8 +1448,528 @@ mod tests {
                     input: DhcpError::MultipleInterfacesProvidedOneSupported(2),
                     expect: DropReason::MultipleInterfaces,
                 },
+                Check {
+                    scenario: "missing DHCPv6 option",
+                    input: DhcpError::MissingOptionV6(dhcproto::v6::OptionCode::ClientId),
+                    expect: DropReason::MissingOptionV6,
+                },
+                Check {
+                    scenario: "unhandled DHCPv6 message",
+                    input: DhcpError::UnhandledMessageTypeV6(MessageTypeV6::Advertise),
+                    expect: DropReason::UnhandledMessageTypeV6,
+                },
+                // A structurally invalid DUID remains distinct from an unsupported type.
+                Check {
+                    scenario: "malformed DUID",
+                    input: DhcpError::MalformedDuid,
+                    expect: DropReason::MalformedDuid,
+                },
+                // A v6-disabled interface remains a missing-configuration input to v4 metrics.
+                Check {
+                    scenario: "missing DHCPv6 configuration",
+                    input: DhcpError::NoIpv6Configuration("eth0".to_string()),
+                    expect: DropReason::MissingArgument,
+                },
+                // Invalid v6 lifetimes remain an invalid-input category outside v6 metrics.
+                Check {
+                    scenario: "invalid DHCPv6 lifetimes",
+                    input: DhcpError::InvalidDhcpV6Lifetimes {
+                        preferred_lifetime_secs: 0,
+                        valid_lifetime_secs: 7200,
+                    },
+                    expect: DropReason::InvalidInput,
+                },
+                // The shared v4 taxonomy has no source-port-specific category.
+                Check {
+                    scenario: "unexpected DHCPv6 source port",
+                    input: DhcpError::UnexpectedDhcpV6SourcePort {
+                        sender: "client",
+                        actual: 547,
+                        expected: 546,
+                    },
+                    expect: DropReason::InvalidInput,
+                },
+                // Unsupported v6 associations remain within the existing v6 message category.
+                Check {
+                    scenario: "unsupported DHCPv6 address association",
+                    input: DhcpError::UnsupportedAddressAssociationV6(
+                        dhcproto::v6::OptionCode::IAPD,
+                    ),
+                    expect: DropReason::UnhandledMessageTypeV6,
+                },
+                Check {
+                    scenario: "non-MAC DUID without relay identity",
+                    input: DhcpError::NoMacNoOption79,
+                    expect: DropReason::NoMacNoOption79,
+                },
+                Check {
+                    scenario: "nested DHCPv6 relay",
+                    input: DhcpError::NestedRelayV6,
+                    expect: DropReason::NestedRelayV6,
+                },
+                Check {
+                    scenario: "DHCPv6 relay hop count exceeded",
+                    input: DhcpError::RelayHopCountExceededV6(2),
+                    expect: DropReason::RelayHopCountExceededV6,
+                },
             ],
             |error| DropReason::from(&error),
+        );
+    }
+
+    /// Verifies materially different DHCPv6 failures retain bounded operational labels.
+    #[test]
+    fn v6_drop_reason_preserves_distinct_failure_categories() {
+        check_values(
+            [
+                // Nested relay envelopes remain distinct from malformed client traffic.
+                Check {
+                    scenario: "nested relay",
+                    input: DhcpError::NestedRelayV6,
+                    expect: V6DropReason::NestedRelay,
+                },
+                // Unsupported relay topology retains its dedicated bounded label.
+                Check {
+                    scenario: "relay hop count exceeded",
+                    input: DhcpError::RelayHopCountExceededV6(2),
+                    expect: V6DropReason::RelayHopCountExceeded,
+                },
+                // Missing authoritative identity remains actionable in controller mode.
+                Check {
+                    scenario: "missing relay identity",
+                    input: DhcpError::NoMacNoOption79,
+                    expect: V6DropReason::NoMacNoOption79,
+                },
+                // A malformed DUID is rejected before mode-specific identity selection.
+                Check {
+                    scenario: "malformed DUID",
+                    input: DhcpError::MalformedDuid,
+                    expect: V6DropReason::MalformedDuid,
+                },
+                // A selected interface without IPv6 is an expected enablement outcome.
+                Check {
+                    scenario: "missing IPv6 configuration",
+                    input: DhcpError::NoIpv6Configuration("eth0".to_string()),
+                    expect: V6DropReason::NoIpv6Configuration,
+                },
+                // Invalid stateful lifetimes identify local configuration rather than a bad client.
+                Check {
+                    scenario: "invalid DHCPv6 lifetimes",
+                    input: DhcpError::InvalidDhcpV6Lifetimes {
+                        preferred_lifetime_secs: 0,
+                        valid_lifetime_secs: 7200,
+                    },
+                    expect: V6DropReason::InvalidConfiguration,
+                },
+                // A crossed DHCPv6 role port retains its transport-specific label.
+                Check {
+                    scenario: "unexpected source port",
+                    input: DhcpError::UnexpectedDhcpV6SourcePort {
+                        sender: "client",
+                        actual: 547,
+                        expected: 546,
+                    },
+                    expect: V6DropReason::UnexpectedSourcePort,
+                },
+                // Unsupported address-association types are distinct from message policy.
+                Check {
+                    scenario: "unsupported address association",
+                    input: DhcpError::UnsupportedAddressAssociationV6(
+                        dhcproto::v6::OptionCode::IAPD,
+                    ),
+                    expect: V6DropReason::UnsupportedAssociation,
+                },
+                // Server selection is a normal protocol-policy discard.
+                Check {
+                    scenario: "packet for another server",
+                    input: DhcpError::NotMyPacket("0002".to_string()),
+                    expect: V6DropReason::NotMyPacket,
+                },
+                // Required DHCPv6 options retain a specific bounded reason.
+                Check {
+                    scenario: "missing option",
+                    input: DhcpError::MissingOptionV6(dhcproto::v6::OptionCode::ClientId),
+                    expect: V6DropReason::MissingOption,
+                },
+                // Wire decoding failures remain distinct from policy rejection.
+                Check {
+                    scenario: "packet decode failure",
+                    input: DhcpError::PacketDecodeFailure(
+                        dhcproto::error::DecodeError::NotEnoughBytes,
+                    ),
+                    expect: V6DropReason::PacketDecodeFailure,
+                },
+                // Response encoding failures identify a server-side packet failure.
+                Check {
+                    scenario: "packet encode failure",
+                    input: DhcpError::PacketEncodeFailure(
+                        dhcproto::error::EncodeError::AddOverflow,
+                    ),
+                    expect: V6DropReason::PacketEncodeFailure,
+                },
+                // API or configuration address text failures retain their own category.
+                Check {
+                    scenario: "address parse failure",
+                    input: DhcpError::AddressParseError(
+                        "not-an-ip".parse::<Ipv4Addr>().unwrap_err(),
+                    ),
+                    expect: V6DropReason::AddressParseError,
+                },
+                // Unsupported DHCPv6 exchanges remain distinct from malformed packets.
+                Check {
+                    scenario: "unsupported message",
+                    input: DhcpError::UnhandledMessageTypeV6(MessageTypeV6::RelayForw),
+                    expect: V6DropReason::UnsupportedMessage,
+                },
+                // A typed gRPC status identifies controller lookup failure.
+                Check {
+                    scenario: "API status failure",
+                    input: DhcpError::TonicStatusError(tonic::Status::unavailable("api down")),
+                    expect: V6DropReason::FetchMachineError,
+                },
+                // A non-status API error belongs to the same bounded lookup-failure family.
+                Check {
+                    scenario: "generic API failure",
+                    input: DhcpError::GenericError("api transport failed".to_string()),
+                    expect: V6DropReason::FetchMachineError,
+                },
+                // A bounded Controller deadline remains an upstream lookup failure.
+                Check {
+                    scenario: "API deadline exceeded",
+                    input: DhcpError::DhcpV6ApiTimeout(Duration::from_secs(5)),
+                    expect: V6DropReason::FetchMachineError,
+                },
+                // Unclassified input errors retain the generic malformed-packet label.
+                Check {
+                    scenario: "ordinary malformed packet",
+                    input: DhcpError::InvalidInput("bad packet".to_string()),
+                    expect: V6DropReason::InvalidInput,
+                },
+            ],
+            |error| V6DropReason::from(&error),
+        );
+    }
+
+    /// Verifies final DHCPv6 socket failures retain their distinct bounded
+    /// reasons and diagnostic warning context.
+    #[test]
+    fn v6_listener_unavailability_counts_each_reason_and_logs_diagnostics() {
+        let metrics = MetricsCapture::start();
+
+        // Emit one final failure from each listener lifecycle boundary.
+        let logs = capture_logs(|| {
+            emit(DhcpV6ListenerUnavailable::InitialSocketSetup {
+                interface_name: "eth0".to_string(),
+                error: "address unavailable".to_string(),
+            });
+            emit(DhcpV6ListenerUnavailable::SocketRecreation {
+                interface_name: "eth1".to_string(),
+                error: "device disappeared".to_string(),
+            });
+        });
+
+        // Both reasons have independent counters and preserve their warnings.
+        assert_eq!(
+            metrics.counter_delta(
+                V6_LISTENER_UNAVAILABLE_METRIC,
+                &[("reason", "initial_socket_setup")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                V6_LISTENER_UNAVAILABLE_METRIC,
+                &[("reason", "socket_recreation")]
+            ),
+            1.0
+        );
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].level, tracing::Level::WARN);
+        assert_eq!(logs[0].message, "DHCPv6 listener unavailable");
+        assert_eq!(logs[0].field("interface_name"), Some("eth0"));
+        assert_eq!(logs[0].field("error"), Some("address unavailable"));
+        assert_eq!(logs[1].level, tracing::Level::WARN);
+        assert_eq!(logs[1].message, "DHCPv6 listener could not be recreated");
+        assert_eq!(logs[1].field("interface_name"), Some("eth1"));
+        assert_eq!(logs[1].field("error"), Some("device disappeared"));
+    }
+
+    /// Expected DHCPv6 selection and enablement drops remain diagnosable
+    /// without appearing as packet-processing errors at the default log level.
+    #[test]
+    fn expected_v6_drops_log_at_debug() {
+        // Exercise the two routine outcomes that are counted but not operational failures.
+        let logs = capture_logs(|| {
+            emit(DhcpV6RequestDropped {
+                reason: V6DropReason::NoIpv6Configuration,
+                error: "no DHCPv6 configuration for interface eth0".to_string(),
+            });
+            emit(DhcpV6RequestDropped {
+                reason: V6DropReason::NotMyPacket,
+                error: "packet received for other server: 0002".to_string(),
+            });
+        });
+
+        // Both outcomes retain bounded context at DEBUG rather than ERROR.
+        assert_eq!(logs.len(), 2);
+        assert!(
+            logs.iter()
+                .all(|entry| entry.level == tracing::Level::DEBUG)
+        );
+        assert_eq!(logs[0].field("reason"), Some("no_ipv6_configuration"));
+        assert_eq!(logs[1].field("reason"), Some("not_my_packet"));
+    }
+
+    /// Every packet Event moves exactly its counter. Both families log bounded
+    /// request and reply activity at INFO, while processing drops log at ERROR.
+    #[test]
+    fn packet_events_count_per_label_and_log_at_their_operational_level() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            // Labels deliberately unused by any other test in this binary:
+            // the capture mutex serializes only capture-holding tests, so
+            // shared labels (a Discover request, an Offer grant) would race
+            // with the end-to-end packet tests.
+            emit(DhcpRequestReceived {
+                message_type: MessageTypeLabel::Release,
+                bootp_op: 1,
+                source_address: "192.0.2.10:68".parse().unwrap(),
+                xid: 0x0102_0304,
+                broadcast_flag: true,
+                ciaddr: Ipv4Addr::new(192, 0, 2, 20),
+                yiaddr: Ipv4Addr::new(192, 0, 2, 21),
+                siaddr: Ipv4Addr::new(192, 0, 2, 1),
+                giaddr: Ipv4Addr::new(192, 0, 2, 254),
+                chaddr: "00:11:22:33:44:55".to_string(),
+            });
+            emit(DhcpRequestReceived {
+                message_type: MessageTypeLabel::Release,
+                bootp_op: 1,
+                source_address: "192.0.2.10:68".parse().unwrap(),
+                xid: 0x0102_0304,
+                broadcast_flag: true,
+                ciaddr: Ipv4Addr::new(192, 0, 2, 20),
+                yiaddr: Ipv4Addr::new(192, 0, 2, 21),
+                siaddr: Ipv4Addr::new(192, 0, 2, 1),
+                giaddr: Ipv4Addr::new(192, 0, 2, 254),
+                chaddr: "00:11:22:33:44:55".to_string(),
+            });
+            emit(DhcpReplySent {
+                message_type: MessageTypeLabel::Nak,
+                destination_address: "192.0.2.10:68".parse().unwrap(),
+                xid: 0x0102_0304,
+                broadcast_flag: true,
+                ciaddr: Ipv4Addr::new(192, 0, 2, 20),
+                yiaddr: Ipv4Addr::new(192, 0, 2, 21),
+                siaddr: Ipv4Addr::new(192, 0, 2, 1),
+                giaddr: Ipv4Addr::new(192, 0, 2, 254),
+                chaddr: "00:11:22:33:44:55".to_string(),
+            });
+            emit(DhcpV6RequestReceived {
+                message_type: MessageTypeLabel::Confirm,
+                source_address: "[fe80::10]:546".parse().unwrap(),
+            });
+            emit(DhcpV6ReplySent {
+                message_type: V6ReplyMessageType::Reply,
+                destination_address: "[fe80::10]:546".parse().unwrap(),
+            });
+            emit(DhcpPacketDropped {
+                reason: DropReason::RateLimited,
+                error: "parallel packet handling limit reached".to_string(),
+            });
+            let error = DhcpError::TonicStatusError(tonic::Status::unavailable("api down"));
+            emit(DhcpPacketDropped {
+                reason: DropReason::from(&error),
+                error: error.to_string(),
+            });
+            emit(DhcpV6RequestDropped {
+                reason: V6DropReason::RateLimited,
+                error: "v6 parallel packet handling limit reached".to_string(),
+            });
+        });
+
+        assert_eq!(logs.len(), 8, "each logging packet Event writes one record");
+        let request_logs: Vec<_> = logs
+            .iter()
+            .filter(|entry| entry.metadata_name == "dhcp_server_request_received")
+            .collect();
+        let reply_logs: Vec<_> = logs
+            .iter()
+            .filter(|entry| entry.metadata_name == "dhcp_server_reply_sent")
+            .collect();
+        let v6_request_logs: Vec<_> = logs
+            .iter()
+            .filter(|entry| entry.metadata_name == "dhcp_server_v6_request_received")
+            .collect();
+        let v6_reply_logs: Vec<_> = logs
+            .iter()
+            .filter(|entry| entry.metadata_name == "dhcp_server_v6_reply_sent")
+            .collect();
+        let drop_logs: Vec<_> = logs
+            .iter()
+            .filter(|entry| {
+                entry.metadata_name == "dhcp_server_packet_dropped"
+                    || entry.metadata_name == "dhcp_server_v6_request_dropped"
+            })
+            .collect();
+
+        assert_eq!(request_logs.len(), 2, "each request writes one INFO line");
+        for entry in request_logs {
+            assert_eq!(entry.level, tracing::Level::INFO);
+            assert_eq!(entry.message, "Decoded DHCP packet");
+            assert_eq!(
+                entry.field("event_name"),
+                Some("dhcp_server_request_received")
+            );
+            assert_eq!(
+                entry.field("metric_name"),
+                Some("carbide_dhcp_requests_total")
+            );
+            assert_eq!(entry.field("message_type"), Some("release"));
+            assert_eq!(entry.field("bootp_op"), Some("1"));
+            assert_eq!(entry.field_kind("bootp_op"), Some(CapturedFieldKind::I64));
+            assert_eq!(entry.field("source_address"), Some("192.0.2.10:68"));
+            assert_eq!(entry.field("xid"), Some("16909060"));
+            assert_eq!(entry.field_kind("xid"), Some(CapturedFieldKind::I64));
+            assert_eq!(entry.field("broadcast_flag"), Some("true"));
+            assert_eq!(
+                entry.field_kind("broadcast_flag"),
+                Some(CapturedFieldKind::Bool)
+            );
+            assert_eq!(entry.field("ciaddr"), Some("192.0.2.20"));
+            assert_eq!(entry.field("yiaddr"), Some("192.0.2.21"));
+            assert_eq!(entry.field("siaddr"), Some("192.0.2.1"));
+            assert_eq!(entry.field("giaddr"), Some("192.0.2.254"));
+            assert_eq!(entry.field("chaddr"), Some("00:11:22:33:44:55"));
+            assert_eq!(entry.field_kind("chaddr"), Some(CapturedFieldKind::String));
+            assert_eq!(entry.field("received_packet"), None);
+        }
+
+        let [reply_log] = reply_logs.as_slice() else {
+            panic!("the reply Event should write one INFO line, got {reply_logs:?}");
+        };
+        assert_eq!(reply_log.level, tracing::Level::INFO);
+        assert_eq!(reply_log.message, "Sent DHCP reply");
+        assert_eq!(
+            reply_log.field("event_name"),
+            Some("dhcp_server_reply_sent")
+        );
+        assert_eq!(
+            reply_log.field("metric_name"),
+            Some("carbide_dhcp_replies_sent_total")
+        );
+        assert_eq!(reply_log.field("message_type"), Some("nak"));
+        assert_eq!(
+            reply_log.field("destination_address"),
+            Some("192.0.2.10:68")
+        );
+        assert_eq!(reply_log.field("xid"), Some("16909060"));
+        assert_eq!(reply_log.field_kind("xid"), Some(CapturedFieldKind::I64));
+        assert_eq!(reply_log.field("broadcast_flag"), Some("true"));
+        assert_eq!(
+            reply_log.field_kind("broadcast_flag"),
+            Some(CapturedFieldKind::Bool)
+        );
+        assert_eq!(reply_log.field("ciaddr"), Some("192.0.2.20"));
+        assert_eq!(reply_log.field("yiaddr"), Some("192.0.2.21"));
+        assert_eq!(reply_log.field("siaddr"), Some("192.0.2.1"));
+        assert_eq!(reply_log.field("giaddr"), Some("192.0.2.254"));
+        assert_eq!(reply_log.field("chaddr"), Some("00:11:22:33:44:55"));
+        assert_eq!(
+            reply_log.field_kind("chaddr"),
+            Some(CapturedFieldKind::String)
+        );
+        assert_eq!(reply_log.field("sent_packet"), None);
+
+        let [v6_request_log] = v6_request_logs.as_slice() else {
+            panic!("the DHCPv6 request Event should write one INFO line, got {v6_request_logs:?}");
+        };
+        assert_eq!(v6_request_log.level, tracing::Level::INFO);
+        assert_eq!(v6_request_log.message, "Received DHCPv6 request");
+        assert_eq!(v6_request_log.field("message_type"), Some("confirm"));
+        assert_eq!(
+            v6_request_log.field("source_address"),
+            Some("[fe80::10]:546")
+        );
+
+        let [v6_reply_log] = v6_reply_logs.as_slice() else {
+            panic!("the DHCPv6 reply Event should write one INFO line, got {v6_reply_logs:?}");
+        };
+        assert_eq!(v6_reply_log.level, tracing::Level::INFO);
+        assert_eq!(v6_reply_log.message, "Sent DHCPv6 reply");
+        assert_eq!(v6_reply_log.field("message_type"), Some("reply"));
+        assert_eq!(
+            v6_reply_log.field("destination_address"),
+            Some("[fe80::10]:546")
+        );
+
+        assert_eq!(drop_logs.len(), 3, "each drop writes one error line");
+        assert!(
+            drop_logs
+                .iter()
+                .all(|entry| entry.level == tracing::Level::ERROR)
+        );
+        assert_eq!(drop_logs[0].field("reason"), Some("rate_limited"));
+        assert!(
+            drop_logs[1]
+                .field("error")
+                .is_some_and(|error| error.contains("api down")),
+            "the drop line carries the upstream error detail"
+        );
+        assert!(
+            drop_logs[2]
+                .field("error")
+                .is_some_and(|error| error.contains("v6 parallel")),
+            "the v6 drop line carries its diagnostic detail"
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_requests_total",
+                &[("message_type", "release")]
+            ),
+            2.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_replies_sent_total",
+                &[("message_type", "nak")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "confirm")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_replies_sent_total",
+                &[("message_type", "reply")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_dropped_requests_total",
+                &[("reason", "rate_limited")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
+                &[("reason", "rate_limited")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_dropped_requests_total",
+                &[("reason", "upstream_api_error")]
+            ),
+            1.0
         );
     }
 }

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//! Packet-level counters and logs for the DHCP server. Request and reply
+//! Packet-level counters and logs for the DHCP server. DHCPv4 request and reply
 //! Events write INFO records with selected BOOTP header and socket details,
 //! while full packets (including their options) stay at DEBUG for forensics. A
 //! drop is the operational error, so its Event also writes the ERROR line --
@@ -27,24 +27,49 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use carbide_instrument::{Event, LabelValue, MetricFamily};
 use dhcproto::v4::MessageType;
+use dhcproto::v6::MessageType as MessageTypeV6;
 
 use crate::errors::DhcpError;
 
-/// The DHCP message type of a packet, as a bounded metric label. The named
-/// variants are the RFC 2131 message set this server handles; anything else
-/// (lease-query extensions, unknown codes, a missing message-type option)
-/// counts as `other`.
+/// The DHCP message type of a packet, as a bounded metric label. Named variants
+/// cover the v4 and v6 exchanges this server handles; extensions and unknown
+/// codes count as `other`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
 pub(super) enum MessageTypeLabel {
     Discover,
+    Solicit,
     Request,
+    Renew,
+    Rebind,
+    Confirm,
+    InformationRequest,
     Offer,
+    Advertise,
     Ack,
     Nak,
+    Reply,
     Release,
     Decline,
     Inform,
     Other,
+}
+
+impl From<MessageTypeV6> for MessageTypeLabel {
+    fn from(message_type: MessageTypeV6) -> Self {
+        match message_type {
+            MessageTypeV6::Solicit => Self::Solicit,
+            MessageTypeV6::Request => Self::Request,
+            MessageTypeV6::Renew => Self::Renew,
+            MessageTypeV6::Rebind => Self::Rebind,
+            MessageTypeV6::Confirm => Self::Confirm,
+            MessageTypeV6::InformationRequest => Self::InformationRequest,
+            MessageTypeV6::Advertise => Self::Advertise,
+            MessageTypeV6::Reply => Self::Reply,
+            MessageTypeV6::Release => Self::Release,
+            MessageTypeV6::Decline => Self::Decline,
+            _ => Self::Other,
+        }
+    }
 }
 
 impl From<MessageType> for MessageTypeLabel {
@@ -64,11 +89,10 @@ impl From<MessageType> for MessageTypeLabel {
 }
 
 /// Why a packet was dropped, as a bounded metric label: one variant per
-/// [`DhcpError`] variant, plus the drop sites that never construct a
-/// `DhcpError` -- rate limiting, undersized packets, non-IPv4 sources, and
-/// send failures.
+/// [`DhcpError`] variant, plus drop sites that never construct an error (rate
+/// limiting, undersized packets, wrong-family sources, and send failures).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
-pub(super) enum DropReason {
+pub enum DropReason {
     RateLimited,
     TooShort,
     NotIpv4,
@@ -92,6 +116,13 @@ pub(super) enum DropReason {
     NotMyPacket,
     VendorClassParseError,
     MultipleInterfaces,
+    MissingOptionV6,
+    UnhandledMessageTypeV6,
+    MalformedDuid,
+    UnsupportedDuid,
+    NoMacNoOption79,
+    NestedRelayV6,
+    RelayHopCountExceededV6,
 }
 
 impl From<&DhcpError> for DropReason {
@@ -116,8 +147,59 @@ impl From<&DhcpError> for DropReason {
             DhcpError::NotMyPacket(_) => Self::NotMyPacket,
             DhcpError::VendorClassParseError(_) => Self::VendorClassParseError,
             DhcpError::MultipleInterfacesProvidedOneSupported(_) => Self::MultipleInterfaces,
+            DhcpError::MissingOptionV6(_) => Self::MissingOptionV6,
+            DhcpError::UnhandledMessageTypeV6(_) => Self::UnhandledMessageTypeV6,
+            DhcpError::MalformedDuid => Self::MalformedDuid,
+            DhcpError::UnsupportedDuidType(_) => Self::UnsupportedDuid,
+            DhcpError::NoMacNoOption79 => Self::NoMacNoOption79,
+            DhcpError::NestedRelayV6 => Self::NestedRelayV6,
+            DhcpError::RelayHopCountExceededV6(_) => Self::RelayHopCountExceededV6,
         }
     }
+}
+
+/// Why the DHCPv6 transport rejected a packet before a safe response was possible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub enum V6DropReason {
+    InvalidPacket,
+    NestedRelay,
+    RelayHopCountExceeded,
+    NoMacNoOption79,
+    MalformedDuid,
+    UnsupportedDuid,
+    UnsupportedMessage,
+    FetchMachineError,
+    RateLimited,
+    SendFailed,
+}
+
+/// Why a DHCPv6 listener became unavailable after bounded socket retries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum V6ListenerUnavailableReason {
+    InitialSocketSetup,
+    SocketRecreation,
+}
+
+impl From<&DhcpError> for V6DropReason {
+    fn from(error: &DhcpError) -> Self {
+        match error {
+            DhcpError::NestedRelayV6 => Self::NestedRelay,
+            DhcpError::RelayHopCountExceededV6(_) => Self::RelayHopCountExceeded,
+            DhcpError::NoMacNoOption79 => Self::NoMacNoOption79,
+            DhcpError::MalformedDuid => Self::MalformedDuid,
+            DhcpError::UnsupportedDuidType(_) => Self::UnsupportedDuid,
+            DhcpError::UnhandledMessageTypeV6(_) => Self::UnsupportedMessage,
+            DhcpError::TonicStatusError(_) | DhcpError::GenericError(_) => Self::FetchMachineError,
+            _ => Self::InvalidPacket,
+        }
+    }
+}
+
+/// The inner DHCPv6 response type sent directly or inside a relay envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub enum V6ReplyMessageType {
+    Advertise,
+    Reply,
 }
 
 /// The timestamp-file operation that failed. These are the only three file
@@ -333,7 +415,7 @@ impl DhcpInterfaceBindFailed {
     }
 }
 
-/// A DHCP packet with a usable BOOTP header was decoded from the wire. Its
+/// A DHCPv4 packet with a usable BOOTP header was decoded from the wire. Its
 /// selected header fields and source socket stay on the log line and never
 /// become metric labels; the option-rich full packet stays at DEBUG.
 #[derive(Event)]
@@ -344,7 +426,7 @@ impl DhcpInterfaceBindFailed {
     log = info,
     metric = counter,
     message = "Decoded DHCP packet",
-    describe = "Number of DHCP packets received and decoded, by DHCP message type."
+    describe = "Number of DHCPv4 packets received and decoded, by DHCP message type."
 )]
 pub(super) struct DhcpRequestReceived {
     #[label]
@@ -369,7 +451,7 @@ pub(super) struct DhcpRequestReceived {
     pub(super) chaddr: String,
 }
 
-/// A packet was dropped without a reply reaching the client -- anywhere from
+/// A DHCPv4 packet was dropped without a reply reaching the client -- anywhere from
 /// the receive loop (rate limiting, undersized or non-IPv4 packets) through
 /// packet processing to the final send.
 #[derive(Event)]
@@ -380,20 +462,20 @@ pub(super) struct DhcpRequestReceived {
     message = "Dropped a DHCP packet",
     log = error,
     metric = counter,
-    describe = "Number of DHCP packets dropped without a reply, by drop reason."
+    describe = "Number of DHCPv4 packets dropped without a reply, by drop reason."
 )]
-pub(super) struct DhcpPacketDropped {
+pub struct DhcpPacketDropped {
     #[label]
-    pub(super) reason: DropReason,
+    pub reason: DropReason,
     /// The detail behind the drop (an error's Display text where one exists).
     /// Log-line-only by construction; never a metric label.
     #[context]
-    pub(super) error: String,
+    pub error: String,
 }
 
-/// A DHCP reply was sent, labelled by the reply's message type: an `offer` is
-/// a proposed lease, an `ack` a committed one, a `nak` a refusal. Its selected
-/// BOOTP header fields and destination stay on the log line only; the
+/// A DHCPv4 reply was sent, labelled by the reply's message type: an `offer` is
+/// a proposed lease, an `ack` a committed one, and a `nak` a refusal. Its
+/// selected BOOTP header fields and destination stay on the log line only; the
 /// option-rich full packet stays at DEBUG.
 #[derive(Event)]
 #[event(
@@ -403,7 +485,7 @@ pub(super) struct DhcpPacketDropped {
     log = info,
     metric = counter,
     message = "Sent DHCP reply",
-    describe = "Number of DHCP replies sent, by reply message type."
+    describe = "Number of DHCPv4 replies sent, by reply message type."
 )]
 pub(super) struct DhcpReplySent {
     #[label]
@@ -426,6 +508,94 @@ pub(super) struct DhcpReplySent {
     pub(super) chaddr: String,
 }
 
+/// A decoded DHCPv6 client request reached standalone packet processing.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_v6_request_received",
+    metric_name = "carbide_dhcp_v6_requests_total",
+    component = "nico-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of DHCPv6 requests received, by DHCP message type."
+)]
+pub(super) struct DhcpV6RequestReceived {
+    #[label]
+    pub(super) message_type: MessageTypeLabel,
+}
+
+/// A DHCPv6 request was rejected by the DPU-side transport.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_v6_request_dropped",
+    metric_name = "carbide_dhcp_v6_requests_dropped_total",
+    component = "nico-dhcp",
+    message = "Dropped a DHCPv6 packet",
+    log = error,
+    metric = counter,
+    describe = "Number of DHCPv6 requests dropped or refused, by reason."
+)]
+pub struct DhcpV6RequestDropped {
+    #[label]
+    pub reason: V6DropReason,
+    /// The detail behind the drop. This remains log-only and never becomes a
+    /// metric label.
+    #[context]
+    pub error: String,
+}
+
+/// A DHCPv6 listener exhausted its bounded socket setup retries.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_v6_listener_unavailable",
+    metric_name = "carbide_dhcp_v6_listener_unavailable_total",
+    component = "nico-dhcp",
+    metric = counter,
+    describe = "Number of DHCPv6 listeners made unavailable by socket setup failure, by reason.",
+    labels(reason: V6ListenerUnavailableReason),
+)]
+pub enum DhcpV6ListenerUnavailable {
+    /// Initial socket setup failed, so this interface starts without DHCPv6.
+    #[event(
+        labels(reason = InitialSocketSetup),
+        log = warn,
+        message = "DHCPv6 listener unavailable"
+    )]
+    InitialSocketSetup {
+        #[context(value)]
+        interface_name: String,
+        #[context]
+        error: String,
+    },
+
+    /// A receive failure was followed by unsuccessful socket recreation.
+    #[event(
+        labels(reason = SocketRecreation),
+        log = warn,
+        message = "DHCPv6 listener could not be recreated"
+    )]
+    SocketRecreation {
+        #[context(value)]
+        interface_name: String,
+        #[context]
+        error: String,
+    },
+}
+
+/// A DHCPv6 response was sent, labelled by its inner message type.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_v6_reply_sent",
+    metric_name = "carbide_dhcp_v6_replies_sent_total",
+    component = "nico-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of DHCPv6 replies sent, by response message type."
+)]
+pub struct DhcpV6ReplySent {
+    #[label]
+    pub message_type: V6ReplyMessageType,
+}
+
 /// A DHCP timestamp-file operation failed. Each variant is one operation, and
 /// holds only what that path has -- only a write is per-interface, so only it
 /// has a `host_interface_id`.
@@ -438,7 +608,7 @@ pub(super) struct DhcpReplySent {
     describe = "Number of DHCP timestamp file failures, by operation",
     labels(operation: TimestampFileOperation),
 )]
-pub(crate) enum DhcpTimestampFileFailed {
+pub enum DhcpTimestampFileFailed {
     /// The startup write could not initialize the file, so this server
     /// generation does not start.
     #[event(
@@ -498,6 +668,7 @@ mod tests {
 
     const SOCKET_SETUP_FAILURE_METRIC: &str = "carbide_dhcp_socket_setup_failures_total";
     const TIMESTAMP_FILE_FAILURE_METRIC: &str = "carbide_dhcp_timestamp_file_failures_total";
+    const V6_LISTENER_UNAVAILABLE_METRIC: &str = "carbide_dhcp_v6_listener_unavailable_total";
 
     struct SocketSetupFailureCase {
         emit: fn(),
@@ -1013,6 +1184,82 @@ mod tests {
         );
     }
 
+    /// Verifies DHCPv6 wire types use bounded labels shared with transport metrics.
+    #[test]
+    fn message_type_label_maps_the_supported_dhcpv6_set() {
+        check_values(
+            [
+                // SOLICIT retains its allocation-start label.
+                Check {
+                    scenario: "solicit",
+                    input: MessageTypeV6::Solicit,
+                    expect: MessageTypeLabel::Solicit,
+                },
+                // REQUEST retains its allocation-commit label.
+                Check {
+                    scenario: "request",
+                    input: MessageTypeV6::Request,
+                    expect: MessageTypeLabel::Request,
+                },
+                // RENEW remains distinguishable from initial allocation traffic.
+                Check {
+                    scenario: "renew",
+                    input: MessageTypeV6::Renew,
+                    expect: MessageTypeLabel::Renew,
+                },
+                // REBIND remains distinguishable from server-targeted renewal.
+                Check {
+                    scenario: "rebind",
+                    input: MessageTypeV6::Rebind,
+                    expect: MessageTypeLabel::Rebind,
+                },
+                // CONFIRM retains its link-validation label.
+                Check {
+                    scenario: "confirm",
+                    input: MessageTypeV6::Confirm,
+                    expect: MessageTypeLabel::Confirm,
+                },
+                // Information-only traffic keeps its dedicated bounded label.
+                Check {
+                    scenario: "information request",
+                    input: MessageTypeV6::InformationRequest,
+                    expect: MessageTypeLabel::InformationRequest,
+                },
+                // ADVERTISE remains distinguishable from final replies.
+                Check {
+                    scenario: "advertise",
+                    input: MessageTypeV6::Advertise,
+                    expect: MessageTypeLabel::Advertise,
+                },
+                // REPLY retains the common final-response label.
+                Check {
+                    scenario: "reply",
+                    input: MessageTypeV6::Reply,
+                    expect: MessageTypeLabel::Reply,
+                },
+                // RELEASE retains its lease-end label.
+                Check {
+                    scenario: "release",
+                    input: MessageTypeV6::Release,
+                    expect: MessageTypeLabel::Release,
+                },
+                // DECLINE retains its unusable-address label.
+                Check {
+                    scenario: "decline",
+                    input: MessageTypeV6::Decline,
+                    expect: MessageTypeLabel::Decline,
+                },
+                // Relay envelopes are transport wrappers, not client request kinds.
+                Check {
+                    scenario: "relay forward buckets as other",
+                    input: MessageTypeV6::RelayForw,
+                    expect: MessageTypeLabel::Other,
+                },
+            ],
+            MessageTypeLabel::from,
+        );
+    }
+
     #[test]
     fn drop_reason_covers_every_dhcp_error_variant() {
         // 0x80 is a lone UTF-8 continuation byte -- the decode failure is the
@@ -1126,14 +1373,159 @@ mod tests {
                     input: DhcpError::MultipleInterfacesProvidedOneSupported(2),
                     expect: DropReason::MultipleInterfaces,
                 },
+                Check {
+                    scenario: "missing DHCPv6 option",
+                    input: DhcpError::MissingOptionV6(dhcproto::v6::OptionCode::ClientId),
+                    expect: DropReason::MissingOptionV6,
+                },
+                Check {
+                    scenario: "unhandled DHCPv6 message",
+                    input: DhcpError::UnhandledMessageTypeV6(MessageTypeV6::Advertise),
+                    expect: DropReason::UnhandledMessageTypeV6,
+                },
+                // A structurally invalid DUID remains distinct from an unsupported type.
+                Check {
+                    scenario: "malformed DUID",
+                    input: DhcpError::MalformedDuid,
+                    expect: DropReason::MalformedDuid,
+                },
+                // A valid link-layer DUID with unsupported hardware retains its identity label.
+                Check {
+                    scenario: "unsupported DUID",
+                    input: DhcpError::UnsupportedDuidType(99),
+                    expect: DropReason::UnsupportedDuid,
+                },
+                Check {
+                    scenario: "non-MAC DUID without relay identity",
+                    input: DhcpError::NoMacNoOption79,
+                    expect: DropReason::NoMacNoOption79,
+                },
+                Check {
+                    scenario: "nested DHCPv6 relay",
+                    input: DhcpError::NestedRelayV6,
+                    expect: DropReason::NestedRelayV6,
+                },
+                Check {
+                    scenario: "DHCPv6 relay hop count exceeded",
+                    input: DhcpError::RelayHopCountExceededV6(2),
+                    expect: DropReason::RelayHopCountExceededV6,
+                },
             ],
             |error| DropReason::from(&error),
         );
     }
 
-    /// Every packet Event moves exactly its counter and writes the matching
-    /// operational record: request and reply activity at INFO, and drops at
-    /// ERROR.
+    /// Verifies security-sensitive DHCPv6 failures retain distinct bounded metric labels.
+    #[test]
+    fn v6_drop_reason_preserves_identity_relay_and_api_failures() {
+        check_values(
+            [
+                // Nested relay envelopes remain distinct from malformed client traffic.
+                Check {
+                    scenario: "nested relay",
+                    input: DhcpError::NestedRelayV6,
+                    expect: V6DropReason::NestedRelay,
+                },
+                // Unsupported relay topology retains its dedicated bounded label.
+                Check {
+                    scenario: "relay hop count exceeded",
+                    input: DhcpError::RelayHopCountExceededV6(2),
+                    expect: V6DropReason::RelayHopCountExceeded,
+                },
+                // Missing authoritative identity remains actionable in controller mode.
+                Check {
+                    scenario: "missing relay identity",
+                    input: DhcpError::NoMacNoOption79,
+                    expect: V6DropReason::NoMacNoOption79,
+                },
+                // A malformed DUID is rejected before mode-specific identity selection.
+                Check {
+                    scenario: "malformed DUID",
+                    input: DhcpError::MalformedDuid,
+                    expect: V6DropReason::MalformedDuid,
+                },
+                // Unsupported link-layer identity remains distinct from malformed input.
+                Check {
+                    scenario: "unsupported DUID",
+                    input: DhcpError::UnsupportedDuidType(99),
+                    expect: V6DropReason::UnsupportedDuid,
+                },
+                // Unsupported DHCPv6 exchanges remain distinct from malformed packets.
+                Check {
+                    scenario: "unsupported message",
+                    input: DhcpError::UnhandledMessageTypeV6(MessageTypeV6::RelayForw),
+                    expect: V6DropReason::UnsupportedMessage,
+                },
+                // A typed gRPC status identifies controller lookup failure.
+                Check {
+                    scenario: "API status failure",
+                    input: DhcpError::TonicStatusError(tonic::Status::unavailable("api down")),
+                    expect: V6DropReason::FetchMachineError,
+                },
+                // A non-status API error belongs to the same bounded lookup-failure family.
+                Check {
+                    scenario: "generic API failure",
+                    input: DhcpError::GenericError("api transport failed".to_string()),
+                    expect: V6DropReason::FetchMachineError,
+                },
+                // Unclassified input errors retain the generic malformed-packet label.
+                Check {
+                    scenario: "ordinary malformed packet",
+                    input: DhcpError::InvalidInput("bad packet".to_string()),
+                    expect: V6DropReason::InvalidPacket,
+                },
+            ],
+            |error| V6DropReason::from(&error),
+        );
+    }
+
+    /// Verifies final DHCPv6 socket failures retain their distinct bounded
+    /// reasons and diagnostic warning context.
+    #[test]
+    fn v6_listener_unavailability_counts_each_reason_and_logs_diagnostics() {
+        let metrics = MetricsCapture::start();
+
+        // Emit one final failure from each listener lifecycle boundary.
+        let logs = capture_logs(|| {
+            emit(DhcpV6ListenerUnavailable::InitialSocketSetup {
+                interface_name: "eth0".to_string(),
+                error: "address unavailable".to_string(),
+            });
+            emit(DhcpV6ListenerUnavailable::SocketRecreation {
+                interface_name: "eth1".to_string(),
+                error: "device disappeared".to_string(),
+            });
+        });
+
+        // Both reasons have independent counters and preserve their warnings.
+        assert_eq!(
+            metrics.counter_delta(
+                V6_LISTENER_UNAVAILABLE_METRIC,
+                &[("reason", "initial_socket_setup")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                V6_LISTENER_UNAVAILABLE_METRIC,
+                &[("reason", "socket_recreation")]
+            ),
+            1.0
+        );
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].level, tracing::Level::WARN);
+        assert_eq!(logs[0].message, "DHCPv6 listener unavailable");
+        assert_eq!(logs[0].field("interface_name"), Some("eth0"));
+        assert_eq!(logs[0].field("error"), Some("address unavailable"));
+        assert_eq!(logs[1].level, tracing::Level::WARN);
+        assert_eq!(logs[1].message, "DHCPv6 listener could not be recreated");
+        assert_eq!(logs[1].field("interface_name"), Some("eth1"));
+        assert_eq!(logs[1].field("error"), Some("device disappeared"));
+    }
+
+    /// Every packet Event moves exactly its counter. DHCPv4 request and reply
+    /// activity logs at INFO, DHCPv6 request and reply activity remains
+    /// metric-only, and family-specific drops log at ERROR.
     #[test]
     fn packet_events_count_per_label_and_log_at_their_operational_level() {
         let metrics = MetricsCapture::start();
@@ -1177,6 +1569,12 @@ mod tests {
                 giaddr: Ipv4Addr::new(192, 0, 2, 254),
                 chaddr: "00:11:22:33:44:55".to_string(),
             });
+            emit(DhcpV6RequestReceived {
+                message_type: MessageTypeLabel::Confirm,
+            });
+            emit(DhcpV6ReplySent {
+                message_type: V6ReplyMessageType::Reply,
+            });
             emit(DhcpPacketDropped {
                 reason: DropReason::RateLimited,
                 error: "parallel packet handling limit reached".to_string(),
@@ -1186,9 +1584,13 @@ mod tests {
                 reason: DropReason::from(&error),
                 error: error.to_string(),
             });
+            emit(DhcpV6RequestDropped {
+                reason: V6DropReason::RateLimited,
+                error: "v6 parallel packet handling limit reached".to_string(),
+            });
         });
 
-        assert_eq!(logs.len(), 5, "each packet Event writes one log record");
+        assert_eq!(logs.len(), 6, "each logging packet Event writes one record");
         let request_logs: Vec<_> = logs
             .iter()
             .filter(|entry| entry.metadata_name == "dhcp_server_request_received")
@@ -1199,7 +1601,10 @@ mod tests {
             .collect();
         let drop_logs: Vec<_> = logs
             .iter()
-            .filter(|entry| entry.metadata_name == "dhcp_server_packet_dropped")
+            .filter(|entry| {
+                entry.metadata_name == "dhcp_server_packet_dropped"
+                    || entry.metadata_name == "dhcp_server_v6_request_dropped"
+            })
             .collect();
 
         assert_eq!(request_logs.len(), 2, "each request writes one INFO line");
@@ -1270,7 +1675,7 @@ mod tests {
         );
         assert_eq!(reply_log.field("sent_packet"), None);
 
-        assert_eq!(drop_logs.len(), 2, "each drop writes one error line");
+        assert_eq!(drop_logs.len(), 3, "each drop writes one error line");
         assert!(
             drop_logs
                 .iter()
@@ -1282,6 +1687,12 @@ mod tests {
                 .field("error")
                 .is_some_and(|error| error.contains("api down")),
             "the drop line carries the upstream error detail"
+        );
+        assert!(
+            drop_logs[2]
+                .field("error")
+                .is_some_and(|error| error.contains("v6 parallel")),
+            "the v6 drop line carries its diagnostic detail"
         );
         assert_eq!(
             metrics.counter_delta(
@@ -1299,7 +1710,28 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "confirm")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_replies_sent_total",
+                &[("message_type", "reply")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
                 "carbide_dhcp_dropped_requests_total",
+                &[("reason", "rate_limited")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "rate_limited")]
             ),
             1.0

--- a/crates/dhcp-server/src/modes/controller.rs
+++ b/crates/dhcp-server/src/modes/controller.rs
@@ -14,24 +14,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::IpAddr;
+use std::future::Future;
+use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
+use std::time::Duration;
 
-use ::rpc::forge::DhcpDiscovery;
+use ::rpc::forge::{DhcpDiscovery, MessageKind};
 use carbide_dhcp_common::VendorClass;
 use lru::LruCache;
 use rpc::forge::DhcpRecord;
 use tokio::sync::Mutex;
+use tokio::time::timeout;
 use tonic::async_trait;
 
-use super::DhcpMode;
+use super::{DhcpMode, V6Outcome, v6_message_kind};
 use crate::Config;
 use crate::cache::{self, CacheEntry};
 use crate::errors::DhcpError;
 use crate::rpc::client::discover_dhcp;
 
 #[derive(Debug)]
-pub(crate) struct Controller {}
+pub struct Controller {}
+
+const DHCPV6_API_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Bound Controller work by the time in which a DHCPv6 response is still useful.
+async fn with_dhcpv6_api_deadline(
+    future: impl Future<Output = Result<DhcpRecord, DhcpError>>,
+) -> Result<DhcpRecord, DhcpError> {
+    timeout(DHCPV6_API_REQUEST_TIMEOUT, future)
+        .await
+        .map_err(|_| DhcpError::DhcpV6ApiTimeout(DHCPV6_API_REQUEST_TIMEOUT))?
+}
 
 #[async_trait]
 impl DhcpMode for Controller {
@@ -98,5 +112,54 @@ impl DhcpMode for Controller {
         );
 
         Ok(record)
+    }
+
+    /// Resolve DHCPv6 through the authoritative Forge API and v6-local cache.
+    async fn discover_dhcp_v6(
+        &self,
+        discovery_request: DhcpDiscovery,
+        config: &Config,
+        machine_cache: &mut std::sync::Arc<Mutex<LruCache<String, CacheEntry>>>,
+    ) -> Result<V6Outcome, DhcpError> {
+        let message_kind = v6_message_kind(&discovery_request)?;
+
+        // Information-only and stateful API responses have different address
+        // shapes, so do not let an options-only response poison the stateful cache.
+        if message_kind == MessageKind::V6InfoRequest {
+            let record = with_dhcpv6_api_deadline(discover_dhcp(discovery_request, config)).await?;
+            // Information-only exchanges never gain IA_NA merely because the
+            // API also knows a stateful address for this interface.
+            return Ok(V6Outcome::OptionsOnly(record));
+        }
+
+        let record =
+            with_dhcpv6_api_deadline(self.discover_dhcp(discovery_request, config, machine_cache))
+                .await?;
+        if record.address.is_empty() {
+            return Ok(V6Outcome::NoAddress);
+        }
+
+        record.address.parse::<Ipv6Addr>()?;
+        Ok(V6Outcome::Stateful(record))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+
+    use super::*;
+
+    /// Verifies a stalled Controller dependency cannot retain a DHCPv6 permit indefinitely.
+    #[tokio::test(start_paused = true)]
+    async fn dhcpv6_api_work_has_a_transaction_deadline() {
+        let error = with_dhcpv6_api_deadline(pending())
+            .await
+            .expect_err("a pending API operation must reach the DHCPv6 deadline");
+
+        assert!(matches!(
+            error,
+            DhcpError::DhcpV6ApiTimeout(timeout) if timeout == DHCPV6_API_REQUEST_TIMEOUT
+        ));
     }
 }

--- a/crates/dhcp-server/src/modes/controller.rs
+++ b/crates/dhcp-server/src/modes/controller.rs
@@ -14,24 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
 
-use ::rpc::forge::DhcpDiscovery;
+use ::rpc::forge::{DhcpDiscovery, MessageKind};
 use carbide_dhcp_common::VendorClass;
 use lru::LruCache;
 use rpc::forge::DhcpRecord;
 use tokio::sync::Mutex;
 use tonic::async_trait;
 
-use super::DhcpMode;
+use super::{DhcpMode, V6Outcome, v6_message_kind};
 use crate::Config;
 use crate::cache::{self, CacheEntry};
 use crate::errors::DhcpError;
 use crate::rpc::client::discover_dhcp;
 
 #[derive(Debug)]
-pub(crate) struct Controller {}
+pub struct Controller {}
 
 #[async_trait]
 impl DhcpMode for Controller {
@@ -98,5 +98,34 @@ impl DhcpMode for Controller {
         );
 
         Ok(record)
+    }
+
+    /// Resolve DHCPv6 through the authoritative Forge API and v6-local cache.
+    async fn discover_dhcp_v6(
+        &self,
+        discovery_request: DhcpDiscovery,
+        config: &Config,
+        machine_cache: &mut std::sync::Arc<Mutex<LruCache<String, CacheEntry>>>,
+    ) -> Result<V6Outcome, DhcpError> {
+        let message_kind = v6_message_kind(&discovery_request)?;
+
+        // Information-only and stateful API responses have different address
+        // shapes, so do not let an options-only response poison the stateful cache.
+        if message_kind == MessageKind::V6InfoRequest {
+            let record = discover_dhcp(discovery_request, config).await?;
+            // Information-only exchanges never gain IA_NA merely because the
+            // API also knows a stateful address for this interface.
+            return Ok(V6Outcome::OptionsOnly(record));
+        }
+
+        let record = self
+            .discover_dhcp(discovery_request, config, machine_cache)
+            .await?;
+        if record.address.is_empty() {
+            return Ok(V6Outcome::NoAddress);
+        }
+
+        record.address.parse::<Ipv6Addr>()?;
+        Ok(V6Outcome::Stateful(record))
     }
 }

--- a/crates/dhcp-server/src/modes/dpu.rs
+++ b/crates/dhcp-server/src/modes/dpu.rs
@@ -14,20 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use carbide_rpc_utils::dhcp::InterfaceInfo;
+use carbide_rpc_utils::dhcp::{HostConfig, InterfaceInfo, InterfaceInfoV6};
 use carbide_uuid::machine::MachineInterfaceId;
 use lru::LruCache;
-use rpc::forge::{DhcpDiscovery, DhcpRecord};
+use rpc::forge::{DhcpDiscovery, DhcpRecord, MessageKind};
 use tonic::async_trait;
 
-use super::DhcpMode;
+use super::{DhcpMode, V6Outcome, v6_message_kind};
+use crate::Config;
 use crate::cache::CacheEntry;
 use crate::errors::DhcpError;
 use crate::packet_handler::DecodedPacket;
-use crate::{Config, HostConfig};
 
 #[derive(Debug)]
-pub(crate) struct Dpu {}
+pub struct Dpu {}
 
 fn from_host_conf(value: &InterfaceInfo, interface_id: MachineInterfaceId) -> DhcpRecord {
     // Fill only needed fields. Rest are left empty or none.
@@ -46,6 +46,38 @@ fn from_host_conf(value: &InterfaceInfo, interface_id: MachineInterfaceId) -> Dh
         last_invalidation_time: None,
         ntp_servers: vec![],
     }
+}
+
+/// Build the family-neutral API record consumed by the DHCPv6 encoder.
+fn from_host_conf_v6(
+    value: &InterfaceInfo,
+    ipv6: &InterfaceInfoV6,
+    interface_id: MachineInterfaceId,
+) -> Result<DhcpRecord, DhcpError> {
+    let mtu = value
+        .mtu
+        .map(i32::try_from)
+        .transpose()
+        .map_err(|_| DhcpError::InvalidInput("DHCPv6 MTU exceeds the API range".to_string()))?
+        .unwrap_or_default();
+
+    Ok(DhcpRecord {
+        machine_id: None,
+        machine_interface_id: Some(interface_id),
+        segment_id: None,
+        subdomain_id: None,
+        fqdn: value.fqdn.clone(),
+        mac_address: String::new(),
+        address: ipv6
+            .address
+            .map_or_else(String::new, |address| address.to_string()),
+        mtu,
+        prefix: ipv6.prefix.clone(),
+        gateway: None,
+        booturl: None,
+        last_invalidation_time: None,
+        ntp_servers: vec![],
+    })
 }
 
 #[async_trait]
@@ -81,6 +113,58 @@ impl DhcpMode for Dpu {
         Ok(from_host_conf(ip_details, host_config.host_interface_id))
     }
 
+    /// Resolve DHCPv6 directly from the interface block delivered in host.yaml.
+    async fn discover_dhcp_v6(
+        &self,
+        discovery_request: DhcpDiscovery,
+        config: &Config,
+        _machine_cache: &mut std::sync::Arc<tokio::sync::Mutex<LruCache<String, CacheEntry>>>,
+    ) -> Result<V6Outcome, DhcpError> {
+        let message_kind = v6_message_kind(&discovery_request)?;
+        let Some(circuit_id) = discovery_request.circuit_id else {
+            return Err(DhcpError::MissingArgument("DHCPv6 circuit id".to_string()));
+        };
+
+        // DPU mode selects the precomputed host entry by the receiving interface,
+        // matching its DHCPv4 path.
+        let host_config = config
+            .host_config
+            .as_ref()
+            .ok_or_else(|| DhcpError::InvalidInput("host input is invalid".to_string()))?;
+        let interface = host_config
+            .host_ip_addresses
+            .get(&circuit_id)
+            .ok_or_else(|| {
+                DhcpError::MissingArgument(format!("could not find IP details for {circuit_id}"))
+            })?;
+        let Some(ipv6) = interface.ipv6.as_ref() else {
+            // No IPv6 block means this interface is v6-disabled. This is
+            // distinct from a SLAAC-only block whose address is absent.
+            // TODO(ipv6-only): InterfaceInfo still requires IPv4 fields, so an
+            // IPv6-only host needs a synthetic v4 entry until rpc-utils relaxes.
+            return Err(DhcpError::MissingArgument(
+                "IPv6 interface config".to_string(),
+            ));
+        };
+
+        let record = || from_host_conf_v6(interface, ipv6, host_config.host_interface_id);
+
+        match message_kind {
+            // Stateless requests receive configuration regardless of whether
+            // the interface also owns a stateful address.
+            MessageKind::V6InfoRequest => Ok(V6Outcome::OptionsOnly(record()?)),
+            MessageKind::V6Solicit | MessageKind::V6Request if ipv6.address.is_some() => {
+                Ok(V6Outcome::Stateful(record()?))
+            }
+            // A present prefix with no address is the explicit SLAAC-only
+            // contract. The encoder retains the wire type to choose the RFC status.
+            MessageKind::V6Solicit | MessageKind::V6Request => Ok(V6Outcome::NoAddress),
+            _ => Err(DhcpError::InvalidInput(
+                "non-DHCPv6 message kind passed to DHCPv6 mode".to_string(),
+            )),
+        }
+    }
+
     /// Here circuit is interface name. This is what dhcp-relay used to fill.
     fn get_circuit_id(&self, _packet: &DecodedPacket, circuit_id: &str) -> Option<String> {
         Some(circuit_id.to_string())
@@ -93,7 +177,7 @@ impl DhcpMode for Dpu {
 
 /// This config is fetched by dpu-agent from controller periodically. In case of any change in
 /// this configuration, dpu-agent MUST restart dhcp-server.
-pub(crate) async fn get_host_config(
+pub async fn get_host_config(
     host_config_path: Option<String>,
 ) -> Result<Option<HostConfig>, DhcpError> {
     let Some(host_config) = host_config_path else {

--- a/crates/dhcp-server/src/modes/dpu.rs
+++ b/crates/dhcp-server/src/modes/dpu.rs
@@ -14,20 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use carbide_rpc_utils::dhcp::InterfaceInfo;
+use carbide_rpc_utils::dhcp::{HostConfig, InterfaceInfo, InterfaceInfoV6};
 use carbide_uuid::machine::MachineInterfaceId;
 use lru::LruCache;
-use rpc::forge::{DhcpDiscovery, DhcpRecord};
+use rpc::forge::{DhcpDiscovery, DhcpRecord, MessageKind};
 use tonic::async_trait;
 
-use super::DhcpMode;
+use super::{DhcpMode, V6Outcome, v6_message_kind};
+use crate::Config;
 use crate::cache::CacheEntry;
 use crate::errors::DhcpError;
 use crate::packet_handler::DecodedPacket;
-use crate::{Config, HostConfig};
 
 #[derive(Debug)]
-pub(crate) struct Dpu {}
+pub struct Dpu {}
 
 fn from_host_conf(
     value: &InterfaceInfo,
@@ -57,6 +57,38 @@ fn from_host_conf(
         prefix,
         gateway: Some(gateway.to_string()),
         booturl: value.booturl.clone(),
+        last_invalidation_time: None,
+        ntp_servers: vec![],
+    })
+}
+
+/// Build the family-neutral API record consumed by the DHCPv6 encoder.
+fn from_host_conf_v6(
+    value: &InterfaceInfo,
+    ipv6: &InterfaceInfoV6,
+    interface_id: MachineInterfaceId,
+) -> Result<DhcpRecord, DhcpError> {
+    let mtu = value
+        .mtu
+        .map(i32::try_from)
+        .transpose()
+        .map_err(|_| DhcpError::InvalidInput("DHCPv6 MTU exceeds the API range".to_string()))?
+        .unwrap_or_default();
+
+    Ok(DhcpRecord {
+        machine_id: None,
+        machine_interface_id: Some(interface_id),
+        segment_id: None,
+        subdomain_id: None,
+        fqdn: value.fqdn.clone(),
+        mac_address: String::new(),
+        address: ipv6
+            .address
+            .map_or_else(String::new, |address| address.to_string()),
+        mtu,
+        prefix: ipv6.prefix.clone(),
+        gateway: None,
+        booturl: None,
         last_invalidation_time: None,
         ntp_servers: vec![],
     })
@@ -95,6 +127,54 @@ impl DhcpMode for Dpu {
         from_host_conf(ip_details, host_config.host_interface_id)
     }
 
+    /// Resolve DHCPv6 directly from the interface block delivered in host.yaml.
+    async fn discover_dhcp_v6(
+        &self,
+        discovery_request: DhcpDiscovery,
+        config: &Config,
+        _machine_cache: &mut std::sync::Arc<tokio::sync::Mutex<LruCache<String, CacheEntry>>>,
+    ) -> Result<V6Outcome, DhcpError> {
+        let message_kind = v6_message_kind(&discovery_request)?;
+        let Some(circuit_id) = discovery_request.circuit_id else {
+            return Err(DhcpError::MissingArgument("DHCPv6 circuit id".to_string()));
+        };
+
+        // DPU mode selects the precomputed host entry by the receiving interface,
+        // matching its DHCPv4 path.
+        let host_config = config
+            .host_config
+            .as_ref()
+            .ok_or_else(|| DhcpError::InvalidInput("host input is invalid".to_string()))?;
+        let interface = host_config
+            .host_ip_addresses
+            .get(&circuit_id)
+            .ok_or_else(|| {
+                DhcpError::MissingArgument(format!("could not find IP details for {circuit_id}"))
+            })?;
+        let Some(ipv6) = interface.ipv6.as_ref() else {
+            // No IPv6 block means this interface is v6-disabled. This is
+            // distinct from a SLAAC-only block whose address is absent.
+            return Err(DhcpError::NoIpv6Configuration(circuit_id));
+        };
+
+        let record = || from_host_conf_v6(interface, ipv6, host_config.host_interface_id);
+
+        match message_kind {
+            // Stateless requests receive configuration regardless of whether
+            // the interface also owns a stateful address.
+            MessageKind::V6InfoRequest => Ok(V6Outcome::OptionsOnly(record()?)),
+            MessageKind::V6Solicit | MessageKind::V6Request if ipv6.address.is_some() => {
+                Ok(V6Outcome::Stateful(record()?))
+            }
+            // A present prefix with no address is the explicit SLAAC-only
+            // contract. The encoder retains the wire type to choose the RFC status.
+            MessageKind::V6Solicit | MessageKind::V6Request => Ok(V6Outcome::NoAddress),
+            _ => Err(DhcpError::InvalidInput(
+                "non-DHCPv6 message kind passed to DHCPv6 mode".to_string(),
+            )),
+        }
+    }
+
     /// Here circuit is interface name. This is what dhcp-relay used to fill.
     fn get_circuit_id(&self, _packet: &DecodedPacket, circuit_id: &str) -> Option<String> {
         Some(circuit_id.to_string())
@@ -123,7 +203,7 @@ fn validate_host_config(host_config: &HostConfig) -> Result<(), DhcpError> {
 
 /// This config is fetched by dpu-agent from controller periodically. In case of any change in
 /// this configuration, dpu-agent MUST restart dhcp-server.
-pub(crate) async fn get_host_config(
+pub async fn get_host_config(
     host_config_path: Option<String>,
 ) -> Result<Option<HostConfig>, DhcpError> {
     let Some(host_config) = host_config_path else {

--- a/crates/dhcp-server/src/modes/mod.rs
+++ b/crates/dhcp-server/src/modes/mod.rs
@@ -18,7 +18,7 @@ use std::net::SocketAddrV4;
 use std::sync::Arc;
 
 use lru::LruCache;
-use rpc::forge::{DhcpDiscovery, DhcpRecord};
+use rpc::forge::{DhcpDiscovery, DhcpRecord, MessageKind};
 use tokio::sync::Mutex;
 use tonic::async_trait;
 
@@ -27,11 +27,22 @@ use crate::cache::CacheEntry;
 use crate::errors::DhcpError;
 use crate::packet_handler::{DecodedPacket, Packet};
 
-pub(super) mod controller;
-pub(super) mod dpu;
+pub mod controller;
+pub mod dpu;
+
+/// Result of resolving one DHCPv6 request against the selected serving mode.
+#[derive(Debug, Clone)]
+pub enum V6Outcome {
+    /// A stateful address and configuration options are available.
+    Stateful(DhcpRecord),
+    /// Configuration options are available without an address assignment.
+    OptionsOnly(DhcpRecord),
+    /// The interface is IPv6-enabled but has no stateful address binding.
+    NoAddress,
+}
 
 #[async_trait]
-pub(super) trait DhcpMode: Send + Sync + std::fmt::Debug {
+pub trait DhcpMode: Send + Sync + std::fmt::Debug {
     /// Method to determine IP address to be returned to client.
     async fn discover_dhcp(
         &self,
@@ -39,6 +50,13 @@ pub(super) trait DhcpMode: Send + Sync + std::fmt::Debug {
         config: &Config,
         machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
     ) -> Result<DhcpRecord, DhcpError>;
+    /// Resolve a DHCPv6 request without collapsing address-less outcomes into a record.
+    async fn discover_dhcp_v6(
+        &self,
+        discovery_request: DhcpDiscovery,
+        config: &Config,
+        machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
+    ) -> Result<V6Outcome, DhcpError>;
     /// And at what address?
     fn get_destination_address(&self, packet: &Packet) -> SocketAddrV4 {
         packet.dst_address()
@@ -52,4 +70,17 @@ pub(super) trait DhcpMode: Send + Sync + std::fmt::Debug {
     fn should_be_relayed(&self) -> bool {
         true
     }
+}
+
+/// Return the message kind carried by the discovery request built from the
+/// DHCPv6 wire message.
+fn v6_message_kind(discovery_request: &DhcpDiscovery) -> Result<MessageKind, DhcpError> {
+    let message_kind = discovery_request.message_kind.ok_or_else(|| {
+        DhcpError::InvalidInput("DHCPv6 discovery request is missing message kind".to_string())
+    })?;
+    MessageKind::try_from(message_kind).map_err(|_| {
+        DhcpError::InvalidInput(format!(
+            "DHCPv6 discovery request has unknown message kind {message_kind}"
+        ))
+    })
 }

--- a/crates/dhcp-server/src/packet_handler.rs
+++ b/crates/dhcp-server/src/packet_handler.rs
@@ -33,12 +33,13 @@ use tokio::sync::Mutex;
 use crate::cache::CacheEntry;
 use crate::errors::DhcpError;
 use crate::metrics::{DhcpReplySent, DhcpRequestReceived, MessageTypeLabel};
-use crate::{Config, DhcpMode, util};
+use crate::modes::DhcpMode;
+use crate::{Config, util};
 
 const PKT_TYPE_OP_REQUEST: u8 = 1;
 const BOOTP_CHADDR_LEN: u8 = 16;
 
-pub(super) struct DecodedPacket {
+pub struct DecodedPacket {
     packet: Message,
 }
 
@@ -209,7 +210,7 @@ impl DecodedPacket {
     }
 }
 
-pub(super) struct Packet {
+pub struct Packet {
     encoded_packet: Vec<u8>,
     sent_packet: Message,
     dst_address: Ipv4Addr,
@@ -220,14 +221,9 @@ pub(super) struct Packet {
 }
 
 impl Packet {
-    #[cfg(test)]
-    pub(super) fn encoded_packet(&self) -> &Vec<u8> {
+    /// Return the encoded DHCPv4 response bytes.
+    pub fn encoded_packet(&self) -> &[u8] {
         &self.encoded_packet
-    }
-
-    #[cfg(test)]
-    pub(super) fn message_type(&self) -> MessageTypeLabel {
-        self.message_type
     }
 
     pub(super) fn dst_address(&self) -> SocketAddrV4 {
@@ -236,7 +232,7 @@ impl Packet {
 }
 
 impl Packet {
-    pub(super) async fn send(
+    pub async fn send(
         &self,
         dst_address: SocketAddrV4,
         socket: Arc<UdpSocket>,
@@ -268,7 +264,7 @@ impl Packet {
     }
 }
 
-pub(super) async fn process_packet(
+pub async fn process_packet(
     buf: &[u8],
     source_address: SocketAddr,
     config: &Config,
@@ -418,6 +414,7 @@ fn create_dhcp_reply_packet(
     let (prefix, broadcast) = match parse {
         Ok(prefix) => match prefix {
             IpNetwork::V4(prefix) => (prefix.mask(), prefix.broadcast()),
+            // Kept for safety until v6 path is at parity.
             IpNetwork::V6(prefix) => {
                 return Err(DhcpError::GenericError(format!(
                     "Prefix ({prefix}) is an IPv6 network, which is not supported."

--- a/crates/dhcp-server/src/packet_handler_v6.rs
+++ b/crates/dhcp-server/src/packet_handler_v6.rs
@@ -1,0 +1,971 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! DHCPv6 packet decoding and response encoding for the DPU-side server.
+//!
+//! `dhcproto 0.15` models option 9 exclusively as another `RelayMessage`, but
+//! the innermost option 9 contains a normal client `Message`. The shared
+//! `carbide-dhcpv6` decoder therefore uses a deliberately small raw-TLV parser,
+//! while this server uses dhcproto's typed API for response options.
+
+use std::net::Ipv6Addr;
+use std::sync::Arc;
+
+use carbide_dhcpv6::{
+    DecodeError as WireDecodeError, DecodedPacket as WirePacket, DuidMac, RELAY_REPLY,
+    RelayEnvelope, decode as decode_wire_packet, extract_mac_from_duid, extract_mac_from_option79,
+};
+use dhcproto::v6::{
+    DhcpOption, DhcpOptions, IAAddr, IANA, Message, MessageType, NtpSuboption, OptionCode, Status,
+    StatusCode, UnknownOption,
+};
+use dhcproto::{Encodable, Encoder};
+use ipnetwork::Ipv6Network;
+use lru::LruCache;
+use rpc::forge::{AddressFamily, DhcpDiscovery, MessageKind};
+use tokio::sync::Mutex;
+
+use crate::cache::CacheEntry;
+use crate::errors::DhcpError;
+use crate::metrics::V6ReplyMessageType;
+use crate::modes::{DhcpMode, V6Outcome};
+use crate::{Config, util};
+
+const DUID_EN: u16 = 2;
+const NVIDIA_ENTERPRISE_NUMBER: u32 = 5703;
+
+#[derive(Debug)]
+struct DecodedPacketV6 {
+    message: Message,
+    relay: Option<RelayEnvelope>,
+    duid: Vec<u8>,
+    duid_mac: DuidMac,
+}
+
+/// An encoded DHCPv6 response and the bounded response type used for metrics.
+#[derive(Debug)]
+pub struct PacketV6 {
+    encoded_packet: Vec<u8>,
+    pub message_type: V6ReplyMessageType,
+}
+
+impl PacketV6 {
+    /// Return the wire bytes for the transport responsible for sending this response.
+    pub fn encoded_packet(&self) -> &[u8] {
+        &self.encoded_packet
+    }
+}
+
+impl DecodedPacketV6 {
+    /// Decode a direct client message or one supported Relay-Forward envelope.
+    fn decode(packet: &[u8]) -> Result<Self, DhcpError> {
+        let WirePacket { message, relay } = decode_wire_packet(packet).map_err(map_wire_error)?;
+
+        let (duid, duid_mac) = client_identifier(&message)?;
+
+        Ok(Self {
+            message,
+            relay,
+            duid,
+            duid_mac,
+        })
+    }
+
+    /// Resolve the authoritative lookup MAC with trusted relay identity taking precedence.
+    fn selected_mac_address(&self) -> Result<String, DhcpError> {
+        let duid_mac = match self.duid_mac {
+            DuidMac::Mac(mac) => Some(mac),
+            DuidMac::NoLinkLayerMac => None,
+        };
+        let relay_mac = self
+            .relay
+            .as_ref()
+            .and_then(|relay| relay.client_link_layer.as_deref())
+            .and_then(extract_mac_from_option79);
+
+        // RFC 6939 identifies the sending link and therefore takes precedence
+        // over a DUID that may have been formed from another permanent NIC.
+        let selected_mac = match (relay_mac, duid_mac) {
+            (Some(relay_mac), Some(duid_mac)) => {
+                if relay_mac != duid_mac {
+                    tracing::warn!(
+                        client_mac_address = %util::u8_to_mac(&relay_mac.bytes()),
+                        duid_mac_address = %util::u8_to_mac(&duid_mac.bytes()),
+                        "DHCPv6 option 79 MAC disagrees with DUID MAC"
+                    );
+                }
+                relay_mac
+            }
+            (Some(relay_mac), None) => relay_mac,
+            (None, Some(duid_mac)) => duid_mac,
+            (None, None) => {
+                tracing::warn!(
+                    relay_link_ip_address = ?self.relay.as_ref().map(|relay| relay.link_address),
+                    "DHCPv6 request has a non-MAC DUID and no RFC 6939 option 79"
+                );
+                return Err(DhcpError::NoMacNoOption79);
+            }
+        };
+
+        Ok(util::u8_to_mac(&selected_mac.bytes()))
+    }
+
+    /// Return the single IA_NA supported by Carbide's one-address API contract.
+    fn ia_na(&self) -> Result<Option<&IANA>, DhcpError> {
+        let mut associations = self
+            .message
+            .opts()
+            .get_all(OptionCode::IANA)
+            .into_iter()
+            .flatten()
+            .filter_map(|option| match option {
+                DhcpOption::IANA(association) => Some(association),
+                _ => None,
+            });
+        let association = associations.next();
+        if associations.next().is_some() {
+            Err(DhcpError::InvalidInput(
+                "multiple DHCPv6 IA_NA options are unsupported".to_string(),
+            ))
+        } else {
+            Ok(association)
+        }
+    }
+
+    /// Return the optional single IAADDR hint carried inside the client's IA_NA.
+    fn desired_address(&self) -> Result<Option<Ipv6Addr>, DhcpError> {
+        let Some(association) = self.ia_na()? else {
+            return Ok(None);
+        };
+        let mut addresses = association
+            .opts
+            .get_all(OptionCode::IAAddr)
+            .into_iter()
+            .flatten()
+            .filter_map(|option| match option {
+                DhcpOption::IAAddr(address) => Some(address.addr),
+                _ => None,
+            });
+        let address = addresses.next();
+        if addresses.next().is_some() {
+            Err(DhcpError::InvalidInput(
+                "multiple DHCPv6 IAADDR options are unsupported".to_string(),
+            ))
+        } else {
+            Ok(address)
+        }
+    }
+
+    /// Select the circuit identifier used by DPU lookup and API cache routing.
+    fn circuit_id(&self, local_interface: Option<&str>) -> Result<Option<String>, DhcpError> {
+        // A DPU listener is bound to one host interface, so that ingress name is
+        // authoritative even when a client supplies a Relay-Forward envelope.
+        if let Some(local_interface) = local_interface {
+            return Ok(Some(local_interface.to_string()));
+        }
+
+        // Controller mode has no local host.yaml authority and preserves the
+        // relay's opaque identifier for API routing.
+        Ok(self
+            .relay
+            .as_ref()
+            .and_then(|relay| relay.interface_id.as_deref())
+            .map(bytes_to_hex))
+    }
+
+    /// Build the family-aware API discovery request for this wire message.
+    fn discovery_request(
+        &self,
+        source_address: Ipv6Addr,
+        local_interface: &str,
+        message_kind: MessageKind,
+        use_local_circuit_id: bool,
+    ) -> Result<DhcpDiscovery, DhcpError> {
+        // Local DPU lookup is keyed by ingress interface. Only the authoritative
+        // controller path needs a MAC for API and cache identity.
+        let mac_address = if use_local_circuit_id {
+            String::new()
+        } else {
+            self.selected_mac_address()?
+        };
+        let relay_address = self
+            .relay
+            .as_ref()
+            .map_or(source_address, |relay| relay.link_address);
+        let vendor_string = match self.message.opts().get(OptionCode::VendorClass) {
+            Some(DhcpOption::VendorClass(vendor)) => vendor
+                .data
+                .iter()
+                .find_map(|value| std::str::from_utf8(value).ok().map(str::to_owned)),
+            _ => None,
+        };
+
+        Ok(DhcpDiscovery {
+            mac_address,
+            relay_address: relay_address.to_string(),
+            vendor_string,
+            link_address: self
+                .relay
+                .as_ref()
+                .map(|relay| relay.link_address.to_string()),
+            circuit_id: self.circuit_id(use_local_circuit_id.then_some(local_interface))?,
+            remote_id: self
+                .relay
+                .as_ref()
+                .and_then(|relay| relay.remote_id.as_deref())
+                .map(bytes_to_hex),
+            desired_address: self.desired_address()?.map(|address| address.to_string()),
+            address_family: Some(AddressFamily::V6 as i32),
+            message_kind: Some(message_kind as i32),
+            duid: Some(self.duid.clone()),
+        })
+    }
+}
+
+/// Process one DHCPv6 request and return no packet when the protocol requires silence.
+pub async fn process_packet(
+    packet: &[u8],
+    source_address: Ipv6Addr,
+    config: &Config,
+    local_interface: &str,
+    handler: &dyn DhcpMode,
+    machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
+) -> Result<Option<PacketV6>, DhcpError> {
+    let decoded = DecodedPacketV6::decode(packet)?;
+
+    let requires_relay = handler.should_be_relayed();
+    // Controller mode trusts its validated relay topology; DPU mode trusts
+    // only the receiving interface and rejects relay-controlled metadata.
+    match (requires_relay, decoded.relay.is_some()) {
+        (true, false) => {
+            return Err(DhcpError::InvalidInput(
+                "controller mode requires a relayed DHCPv6 packet".to_string(),
+            ));
+        }
+        (false, true) => {
+            return Err(DhcpError::InvalidInput(
+                "DPU mode requires a direct DHCPv6 packet".to_string(),
+            ));
+        }
+        _ => {}
+    }
+    ensure_server_identifier(&decoded.message, config)?;
+
+    // TODO(dhcpv6-rapid-commit): Milestone 05 may turn SOLICIT directly into
+    // REPLY when option 14 is present. This milestone always uses ADVERTISE.
+    let wire_type = decoded.message.msg_type();
+    let ia_na = decoded.ia_na()?;
+
+    // IA_TA and IA_PD cannot be represented by the single-address API model.
+    // Reject them before protocol-local replies can acknowledge unsupported state.
+    if let Some(option_code) = [OptionCode::IATA, OptionCode::IAPD]
+        .into_iter()
+        .find(|option_code| decoded.message.opts().get(*option_code).is_some())
+    {
+        return Err(DhcpError::UnsupportedAddressAssociationV6(option_code));
+    }
+
+    let message_kind = match wire_type {
+        MessageType::Solicit if ia_na.is_some() => MessageKind::V6Solicit,
+        MessageType::Solicit | MessageType::InformationRequest if ia_na.is_none() => {
+            MessageKind::V6InfoRequest
+        }
+        MessageType::Request | MessageType::Renew | MessageType::Rebind if ia_na.is_some() => {
+            MessageKind::V6Request
+        }
+        MessageType::Confirm => {
+            return encode_local_reply(&decoded, config, local_interface);
+        }
+        MessageType::Release | MessageType::Decline => {
+            if ia_na.is_none() {
+                return Err(DhcpError::MissingOptionV6(OptionCode::IANA));
+            }
+            if decoded.desired_address()?.is_none() {
+                return Err(DhcpError::MissingOptionV6(OptionCode::IAAddr));
+            }
+            // Controller mode uses a relay-selected MAC as its authoritative
+            // client identity even when the protocol response remains local.
+            if requires_relay {
+                decoded.selected_mac_address()?;
+            }
+            // DHCPv6 acknowledges RELEASE/DECLINE with a Reply, unlike the
+            // standalone DHCPv4 path. This server has no Kea-style binding
+            // database, so Success acknowledges a validly addressed lease-end
+            // notification; it does not prove an active (DUID, IAID, address)
+            // binding, release the API-owned allocation, or quarantine a
+            // declined address.
+            return encode_local_reply(&decoded, config, local_interface);
+        }
+        MessageType::Solicit | MessageType::Request | MessageType::Renew | MessageType::Rebind => {
+            return Err(DhcpError::MissingOptionV6(OptionCode::IANA));
+        }
+        other => return Err(DhcpError::UnhandledMessageTypeV6(other)),
+    };
+
+    // Stateful controller discovery can allocate, so reject unusable local
+    // lifetime configuration before crossing the API boundary. DPU discovery
+    // is read-only and keeps serving address-less bindings without lifetimes.
+    if requires_relay && message_kind != MessageKind::V6InfoRequest {
+        stateful_lifetimes(config)?;
+    }
+
+    // DPU mode keys direct requests by the receiving interface; controller mode
+    // forwards only relay-provided circuit identity and never invents one.
+    let discovery = decoded.discovery_request(
+        source_address,
+        local_interface,
+        message_kind,
+        !requires_relay,
+    )?;
+    let outcome = handler
+        .discover_dhcp_v6(discovery, config, machine_cache)
+        .await?;
+    let outcome = match (wire_type, outcome) {
+        // A refresh is valid only when the client names the authoritative binding;
+        // no address or a different address has no binding to renew.
+        (MessageType::Renew | MessageType::Rebind, V6Outcome::Stateful(record)) => {
+            match decoded.desired_address()? {
+                Some(desired) if record.address.parse::<Ipv6Addr>()? == desired => {
+                    V6Outcome::Stateful(record)
+                }
+                _ => V6Outcome::NoAddress,
+            }
+        }
+        (_, outcome) => outcome,
+    };
+    encode_mode_reply(&decoded, outcome, config).map(Some)
+}
+
+/// Return and classify the request's single structurally valid ClientId.
+fn client_identifier(message: &Message) -> Result<(Vec<u8>, DuidMac), DhcpError> {
+    let mut identifiers = message
+        .opts()
+        .get_all(OptionCode::ClientId)
+        .into_iter()
+        .flatten();
+    let identifier = identifiers.next();
+    if identifiers.next().is_some() {
+        return Err(DhcpError::InvalidInput(
+            "multiple DHCPv6 ClientId options are unsupported".to_string(),
+        ));
+    }
+
+    let Some(DhcpOption::ClientId(duid)) = identifier else {
+        return Err(DhcpError::MissingOptionV6(OptionCode::ClientId));
+    };
+    let duid_mac = extract_mac_from_duid(duid).map_err(|_| DhcpError::MalformedDuid)?;
+    Ok((duid.clone(), duid_mac))
+}
+
+/// Translate policy-neutral wire failures into server packet errors.
+fn map_wire_error(error: WireDecodeError) -> DhcpError {
+    match error {
+        WireDecodeError::MalformedPacket(reason) => {
+            DhcpError::InvalidInput(format!("malformed DHCPv6 packet: {reason}"))
+        }
+        WireDecodeError::ClientMessageDecode(error) => DhcpError::PacketDecodeFailure(error),
+        WireDecodeError::MissingRelayMessage => DhcpError::MissingOptionV6(OptionCode::RelayMsg),
+        WireDecodeError::NestedRelay => DhcpError::NestedRelayV6,
+        WireDecodeError::RelayHopCountExceeded(hop_count) => {
+            DhcpError::RelayHopCountExceededV6(hop_count)
+        }
+        WireDecodeError::UnexpectedRelayReply => {
+            DhcpError::UnhandledMessageTypeV6(MessageType::RelayRepl)
+        }
+    }
+}
+
+/// Render opaque relay metadata without introducing lossy UTF-8 collisions.
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(char::from(HEX_DIGITS[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX_DIGITS[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+/// Return the stable DUID-EN used as this server's DHCPv6 identifier.
+fn server_identifier(config: &Config) -> Vec<u8> {
+    let mut identifier = Vec::with_capacity(10);
+    identifier.extend_from_slice(&DUID_EN.to_be_bytes());
+    identifier.extend_from_slice(&NVIDIA_ENTERPRISE_NUMBER.to_be_bytes());
+    identifier.extend_from_slice(&config.dhcp_config.carbide_dhcp_server.octets());
+    identifier
+}
+
+/// Return validated lifetimes for a stateful DHCPv6 response.
+fn stateful_lifetimes(config: &Config) -> Result<(u32, u32), DhcpError> {
+    let preferred_lifetime = config.dhcp_config.dhcpv6_preferred_lifetime_secs;
+    let valid_lifetime = config.dhcp_config.dhcpv6_valid_lifetime_secs;
+    if preferred_lifetime == 0 || valid_lifetime == 0 || preferred_lifetime > valid_lifetime {
+        return Err(DhcpError::InvalidDhcpV6Lifetimes {
+            preferred_lifetime_secs: preferred_lifetime,
+            valid_lifetime_secs: valid_lifetime,
+        });
+    }
+    Ok((preferred_lifetime, valid_lifetime))
+}
+
+/// Reject messages explicitly selecting another server and require selection where mandated.
+fn ensure_server_identifier(message: &Message, config: &Config) -> Result<(), DhcpError> {
+    let mut identifiers = message
+        .opts()
+        .get_all(OptionCode::ServerId)
+        .into_iter()
+        .flatten();
+    let received = match identifiers.next() {
+        Some(DhcpOption::ServerId(identifier)) => Some(identifier),
+        _ => None,
+    };
+    if identifiers.next().is_some() {
+        return Err(DhcpError::InvalidInput(
+            "multiple DHCPv6 ServerId options are unsupported".to_string(),
+        ));
+    }
+
+    if matches!(
+        message.msg_type(),
+        MessageType::Solicit | MessageType::Confirm | MessageType::Rebind
+    ) && received.is_some()
+    {
+        return Err(DhcpError::InvalidInput(format!(
+            "{:?} must not include a DHCPv6 ServerId option",
+            message.msg_type()
+        )));
+    }
+
+    if let Some(received) = received
+        && received != &server_identifier(config)
+    {
+        return Err(DhcpError::NotMyPacket(bytes_to_hex(received)));
+    }
+
+    // These exchanges continue a binding selected from an earlier Advertise.
+    if matches!(
+        message.msg_type(),
+        MessageType::Request | MessageType::Renew | MessageType::Release | MessageType::Decline
+    ) && received.is_none()
+    {
+        return Err(DhcpError::MissingOptionV6(OptionCode::ServerId));
+    }
+    Ok(())
+}
+
+/// Encode a mode-backed address or options response.
+fn encode_mode_reply(
+    request: &DecodedPacketV6,
+    outcome: V6Outcome,
+    config: &Config,
+) -> Result<PacketV6, DhcpError> {
+    let reply_type = reply_type_for(request.message.msg_type());
+    let mut reply = base_reply(request, reply_type, config);
+
+    // The client owns option-39 negotiation flags; its requested name is never trusted.
+    let requested_fqdn_flags = match request.message.opts().get(OptionCode::ClientFqdn) {
+        Some(DhcpOption::Unknown(option)) => option.data().first().copied(),
+        _ => None,
+    };
+
+    match outcome {
+        V6Outcome::Stateful(record) => {
+            add_config_options(&mut reply, Some(&record.fqdn), requested_fqdn_flags, config)?;
+            let association = request
+                .ia_na()?
+                .ok_or(DhcpError::MissingOptionV6(OptionCode::IANA))?;
+            let (preferred_lifetime, valid_lifetime) = stateful_lifetimes(config)?;
+            let address = record.address.parse::<Ipv6Addr>()?;
+            let mut address_options = DhcpOptions::new();
+            address_options.insert(DhcpOption::IAAddr(IAAddr {
+                addr: address,
+                preferred_life: preferred_lifetime,
+                valid_life: valid_lifetime,
+                opts: DhcpOptions::new(),
+            }));
+            reply.opts_mut().insert(DhcpOption::IANA(IANA {
+                id: association.id,
+                t1: 0,
+                t2: 0,
+                opts: address_options,
+            }));
+        }
+        V6Outcome::OptionsOnly(record) => {
+            add_config_options(&mut reply, Some(&record.fqdn), requested_fqdn_flags, config)?;
+        }
+        V6Outcome::NoAddress => {
+            add_config_options(&mut reply, None, requested_fqdn_flags, config)?;
+            let association = request
+                .ia_na()?
+                .ok_or(DhcpError::MissingOptionV6(OptionCode::IANA))?;
+            let status = match request.message.msg_type() {
+                MessageType::Solicit | MessageType::Request => Status::NoAddrsAvail,
+                MessageType::Renew | MessageType::Rebind => Status::NoBinding,
+                other => return Err(DhcpError::UnhandledMessageTypeV6(other)),
+            };
+            let mut association_options = DhcpOptions::new();
+            association_options.insert(status_option(status));
+            reply.opts_mut().insert(DhcpOption::IANA(IANA {
+                id: association.id,
+                t1: 0,
+                t2: 0,
+                opts: association_options,
+            }));
+        }
+    }
+
+    encode_packet(reply, request.relay.as_ref())
+}
+
+/// Encode protocol-local CONFIRM, RELEASE, and DECLINE responses without API mutation.
+fn encode_local_reply(
+    request: &DecodedPacketV6,
+    config: &Config,
+    local_interface: &str,
+) -> Result<Option<PacketV6>, DhcpError> {
+    let status = match request.message.msg_type() {
+        MessageType::Confirm => {
+            let Some(status) = confirm_status(request, config, local_interface)? else {
+                return Ok(None);
+            };
+            status
+        }
+        MessageType::Release | MessageType::Decline => Status::Success,
+        other => return Err(DhcpError::UnhandledMessageTypeV6(other)),
+    };
+    let mut reply = base_reply(request, MessageType::Reply, config);
+    reply.opts_mut().insert(status_option(status));
+    encode_packet(reply, request.relay.as_ref()).map(Some)
+}
+
+/// Determine CONFIRM status when this server has authoritative link knowledge.
+fn confirm_status(
+    request: &DecodedPacketV6,
+    config: &Config,
+    local_interface: &str,
+) -> Result<Option<Status>, DhcpError> {
+    let Some(association) = request.ia_na()? else {
+        return Ok(None);
+    };
+    let addresses = association
+        .opts
+        .iter()
+        .filter_map(|option| match option {
+            DhcpOption::IAAddr(address) => Some(address.addr),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if addresses.is_empty() {
+        return Ok(None);
+    }
+
+    // Controller mode has no host.yaml link authority, so CONFIRM remains
+    // silent before applying the DPU binding-selection rules below.
+    let Some(host_config) = config.host_config.as_ref() else {
+        return Ok(None);
+    };
+
+    let circuit_id = request
+        .circuit_id(Some(local_interface))?
+        .unwrap_or_default();
+    let prefix = host_config
+        .host_ip_addresses
+        .get(&circuit_id)
+        .and_then(|interface| interface.ipv6.as_ref())
+        .and_then(|ipv6| ipv6.prefix.parse::<Ipv6Network>().ok());
+
+    // RFC 8415 requires silence when the server cannot determine whether
+    // the addresses belong to the receiving link.
+    let Some(prefix) = prefix else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        if addresses.iter().all(|address| prefix.contains(*address)) {
+            Status::Success
+        } else {
+            Status::NotOnLink
+        },
+    ))
+}
+
+/// Create the common transaction and identity options for one response.
+fn base_reply(request: &DecodedPacketV6, message_type: MessageType, config: &Config) -> Message {
+    let mut reply = Message::new_with_id(message_type, request.message.xid());
+    reply
+        .opts_mut()
+        .insert(DhcpOption::ClientId(request.duid.clone()));
+    reply
+        .opts_mut()
+        .insert(DhcpOption::ServerId(server_identifier(config)));
+    reply
+}
+
+/// Append configured service options and request-negotiated API-owned naming options.
+fn add_config_options(
+    reply: &mut Message,
+    fqdn: Option<&str>,
+    requested_fqdn_flags: Option<u8>,
+    config: &Config,
+) -> Result<(), DhcpError> {
+    if !config.dhcp_config.carbide_nameservers_v6.is_empty() {
+        reply.opts_mut().insert(DhcpOption::DomainNameServers(
+            config.dhcp_config.carbide_nameservers_v6.clone(),
+        ));
+    }
+    if !config.dhcp_config.carbide_ntpservers_v6.is_empty() {
+        reply.opts_mut().insert(DhcpOption::NtpServer(
+            config
+                .dhcp_config
+                .carbide_ntpservers_v6
+                .iter()
+                .copied()
+                .map(NtpSuboption::ServerAddress)
+                .collect(),
+        ));
+    }
+    if let Some(fqdn) = fqdn.filter(|fqdn| !fqdn.is_empty()) {
+        let encoded_fqdn = encode_domain_name(fqdn)?;
+
+        // Domain search is API-owned and independent of client-FQDN negotiation.
+        if let Some((_, domain)) = fqdn.trim_end_matches('.').split_once('.') {
+            reply
+                .opts_mut()
+                .insert(DhcpOption::Unknown(UnknownOption::new(
+                    OptionCode::DomainSearchList,
+                    encode_domain_name(domain)?,
+                )));
+        }
+
+        // Preserve client negotiation flags while replacing its name with the trusted FQDN.
+        if let Some(flags) = requested_fqdn_flags {
+            let mut client_fqdn = vec![flags];
+            client_fqdn.extend(encoded_fqdn);
+            reply
+                .opts_mut()
+                .insert(DhcpOption::Unknown(UnknownOption::new(
+                    OptionCode::ClientFqdn,
+                    client_fqdn,
+                )));
+        }
+    }
+    Ok(())
+}
+
+/// Encode one DNS name in uncompressed RFC 1035 wire format for DHCPv6 name options.
+fn encode_domain_name(name: &str) -> Result<Vec<u8>, DhcpError> {
+    let mut encoded = Vec::new();
+    for label in name.trim_end_matches('.').split('.') {
+        if label.is_empty() || label.len() > 63 {
+            return Err(DhcpError::InvalidInput(format!(
+                "invalid DHCPv6 domain-name label in {name}"
+            )));
+        }
+        encoded.push(label.len() as u8);
+        encoded.extend_from_slice(label.as_bytes());
+    }
+    encoded.push(0);
+    // The terminating root label counts toward the RFC 1035 255-byte name limit.
+    if encoded.len() > 255 {
+        return Err(DhcpError::InvalidInput(format!(
+            "DHCPv6 domain name exceeds the 255-byte wire limit: {name}"
+        )));
+    }
+    Ok(encoded)
+}
+
+/// Build a DHCPv6 Status Code option with no diagnostic text.
+fn status_option(status: Status) -> DhcpOption {
+    DhcpOption::StatusCode(StatusCode {
+        status,
+        msg: String::new(),
+    })
+}
+
+/// Select ADVERTISE for SOLICIT and REPLY for every subsequent exchange.
+fn reply_type_for(request_type: MessageType) -> MessageType {
+    if request_type == MessageType::Solicit {
+        MessageType::Advertise
+    } else {
+        MessageType::Reply
+    }
+}
+
+/// Encode the inner response and optionally restore its Relay-Reply envelope.
+fn encode_packet(response: Message, relay: Option<&RelayEnvelope>) -> Result<PacketV6, DhcpError> {
+    let message_type = if response.msg_type() == MessageType::Advertise {
+        V6ReplyMessageType::Advertise
+    } else {
+        V6ReplyMessageType::Reply
+    };
+    let mut encoded = Vec::new();
+    response.encode(&mut Encoder::new(&mut encoded))?;
+    if let Some(relay) = relay {
+        encoded = wrap_relay_reply(&encoded, relay)?;
+    }
+    Ok(PacketV6 {
+        encoded_packet: encoded,
+        message_type,
+    })
+}
+
+/// Wrap an encoded client response in the matching one-hop Relay-Reply envelope.
+fn wrap_relay_reply(inner_response: &[u8], relay: &RelayEnvelope) -> Result<Vec<u8>, DhcpError> {
+    let mut response = Vec::new();
+    response.push(RELAY_REPLY);
+    response.push(relay.hop_count);
+    response.extend_from_slice(&relay.link_address.octets());
+    response.extend_from_slice(&relay.peer_address.octets());
+    if let Some(interface_id) = &relay.interface_id {
+        encode_raw_option(&mut response, OptionCode::InterfaceId, interface_id)?;
+    }
+    if let Some(remote_id) = &relay.remote_id {
+        encode_raw_option(&mut response, OptionCode::RemoteId, remote_id)?;
+    }
+    encode_raw_option(&mut response, OptionCode::RelayMsg, inner_response)?;
+    Ok(response)
+}
+
+/// Append one raw DHCPv6 TLV after checking its 16-bit wire length.
+fn encode_raw_option(
+    packet: &mut Vec<u8>,
+    option_code: OptionCode,
+    payload: &[u8],
+) -> Result<(), DhcpError> {
+    let length = u16::try_from(payload.len()).map_err(|_| {
+        DhcpError::InvalidInput(format!("DHCPv6 option {option_code:?} exceeds 65535 bytes"))
+    })?;
+    packet.extend_from_slice(&u16::from(option_code).to_be_bytes());
+    packet.extend_from_slice(&length.to_be_bytes());
+    packet.extend_from_slice(payload);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_rpc_utils::dhcp::DhcpConfig;
+    use carbide_test_support::Outcome::{Fails, Yields};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
+    use rpc::forge_tls_client::ForgeClientConfig;
+
+    use super::*;
+
+    /// Verifies ClientId extraction accepts one valid option and rejects
+    /// missing, malformed, or duplicate options.
+    ///
+    /// This prevents ambiguous or unusable client identity from reaching
+    /// request processing.
+    #[test]
+    fn client_identifier_requires_one_nonempty_option() {
+        let client_id = vec![0, 3, 0, 1, 2, 3, 4, 5, 6, 7];
+        let other_client_id = vec![0, 3, 10, 11, 12, 13, 14, 15, 16, 17];
+
+        scenarios!(run = |identifiers| {
+                let mut message = Message::new_with_id(MessageType::Solicit, [0, 0, 0]);
+                for identifier in identifiers {
+                    message.opts_mut().insert(DhcpOption::ClientId(identifier));
+                }
+                client_identifier(&message)
+                    .map(|(duid, _)| duid)
+                    .map_err(drop)
+            };
+            "valid ClientId" {
+                // One nonempty ClientId provides an unambiguous client identity.
+                vec![client_id.clone()] => Yields(client_id.clone()),
+            }
+            "missing, malformed, or duplicate ClientId" {
+                // An absent ClientId cannot identify a client.
+                vec![] => Fails,
+                // An empty ClientId is structurally malformed.
+                vec![Vec::new()] => Fails,
+                // A type-only ClientId lacks the required identifier octet.
+                vec![vec![0, 3]] => Fails,
+                // A one-byte ClientId cannot contain a DUID type.
+                vec![vec![0]] => Fails,
+                // Repeating the same ClientId is still ambiguous on the wire.
+                vec![client_id.clone(), client_id.clone()] => Fails,
+                // Conflicting ClientIds must not depend on option ordering.
+                vec![client_id, other_client_id] => Fails,
+            }
+        );
+    }
+
+    /// Verifies each DHCPv6 client message enforces its ServerId presence and
+    /// matching policy.
+    ///
+    /// This prevents forbidden, missing, mismatched, or duplicate server
+    /// selection from being accepted.
+    #[test]
+    fn server_identifier_enforces_message_presence_matrix_and_cardinality() {
+        #[derive(Clone, Copy)]
+        enum ServerIds {
+            Absent,
+            ThisServer,
+            OtherServer,
+            DuplicateSame,
+            DuplicateMixed,
+        }
+
+        struct Row {
+            message_type: MessageType,
+            server_ids: ServerIds,
+        }
+
+        let config = Config::new(
+            DhcpConfig::default(),
+            None,
+            67,
+            ForgeClientConfig::new(String::new(), None),
+        );
+        let server_id = server_identifier(&config);
+        let other_server_id = vec![0xff];
+
+        value_scenarios!(run = |Row { message_type, server_ids }| {
+                let mut message = Message::new_with_id(message_type, [0, 0, 0]);
+                let identifiers = match server_ids {
+                    ServerIds::Absent => vec![],
+                    ServerIds::ThisServer => vec![server_id.clone()],
+                    ServerIds::OtherServer => vec![other_server_id.clone()],
+                    ServerIds::DuplicateSame => vec![server_id.clone(), server_id.clone()],
+                    ServerIds::DuplicateMixed => vec![server_id.clone(), other_server_id.clone()],
+                };
+                for identifier in identifiers {
+                    message.opts_mut().insert(DhcpOption::ServerId(identifier));
+                }
+                ensure_server_identifier(&message, &config).is_ok()
+            };
+            "SOLICIT" {
+                // SOLICIT starts server selection and therefore omits ServerId.
+                Row { message_type: MessageType::Solicit, server_ids: ServerIds::Absent } => true,
+                // A SOLICIT must not preselect this server.
+                Row { message_type: MessageType::Solicit, server_ids: ServerIds::ThisServer } => false,
+            }
+            "REQUEST" {
+                // REQUEST commits the server selected by its matching identifier.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::ThisServer } => true,
+                // REQUEST without ServerId has not selected a server.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::Absent } => false,
+                // Another server's identifier must not reach local allocation.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::OtherServer } => false,
+            }
+            "CONFIRM" {
+                // CONFIRM asks any server about the current link and omits ServerId.
+                Row { message_type: MessageType::Confirm, server_ids: ServerIds::Absent } => true,
+                // CONFIRM must remain independent of a previously selected server.
+                Row { message_type: MessageType::Confirm, server_ids: ServerIds::ThisServer } => false,
+            }
+            "RENEW" {
+                // RENEW targets the server that owns the existing binding.
+                Row { message_type: MessageType::Renew, server_ids: ServerIds::ThisServer } => true,
+                // RENEW without ServerId cannot identify its binding owner.
+                Row { message_type: MessageType::Renew, server_ids: ServerIds::Absent } => false,
+                // A RENEW for another server must not mutate local state.
+                Row { message_type: MessageType::Renew, server_ids: ServerIds::OtherServer } => false,
+            }
+            "REBIND" {
+                // REBIND is broadcast after the original server stops responding.
+                Row { message_type: MessageType::Rebind, server_ids: ServerIds::Absent } => true,
+                // REBIND must not remain pinned to the unavailable server.
+                Row { message_type: MessageType::Rebind, server_ids: ServerIds::ThisServer } => false,
+            }
+            "RELEASE" {
+                // RELEASE addresses the server that owns the binding being ended.
+                Row { message_type: MessageType::Release, server_ids: ServerIds::ThisServer } => true,
+                // RELEASE without ServerId cannot identify the binding owner.
+                Row { message_type: MessageType::Release, server_ids: ServerIds::Absent } => false,
+                // Another server's RELEASE must not be acknowledged locally.
+                Row { message_type: MessageType::Release, server_ids: ServerIds::OtherServer } => false,
+            }
+            "DECLINE" {
+                // DECLINE reports an unusable address to the server that supplied it.
+                Row { message_type: MessageType::Decline, server_ids: ServerIds::ThisServer } => true,
+                // DECLINE without ServerId cannot identify the address supplier.
+                Row { message_type: MessageType::Decline, server_ids: ServerIds::Absent } => false,
+                // Another server's declined address is outside local authority.
+                Row { message_type: MessageType::Decline, server_ids: ServerIds::OtherServer } => false,
+            }
+            "INFORMATION-REQUEST" {
+                // A normal multicast INFORMATION-REQUEST omits ServerId.
+                Row { message_type: MessageType::InformationRequest, server_ids: ServerIds::Absent } => true,
+                // A reconfiguration-triggered INFORMATION-REQUEST targets this server.
+                Row { message_type: MessageType::InformationRequest, server_ids: ServerIds::ThisServer } => true,
+                // A targeted request for another server must be discarded locally.
+                Row { message_type: MessageType::InformationRequest, server_ids: ServerIds::OtherServer } => false,
+            }
+            "duplicate ServerId" {
+                // Repeated matching identifiers remain ambiguous and invalid.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::DuplicateSame } => false,
+                // Conflicting duplicate identifiers must not depend on option ordering.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::DuplicateMixed } => false,
+            }
+        );
+    }
+
+    /// Verifies the DNS name's 255-byte limit includes its root but excludes option-39 flags.
+    ///
+    /// This prevents emitting an overlong name or rejecting a legal 256-byte option payload.
+    #[test]
+    fn enforces_dns_name_wire_limit_separately_from_client_fqdn_flags() {
+        // Three maximum labels consume 192 wire bytes, leaving the final label
+        // length, its contents, and the terminating root to establish the boundary.
+        let three_maximum_labels = ["a".repeat(63), "b".repeat(63), "c".repeat(63)].join(".");
+        let maximum_name = format!("{three_maximum_labels}.{}", "d".repeat(61));
+        let overlong_name = format!("{three_maximum_labels}.{}", "d".repeat(62));
+
+        // Keep unrelated options empty so only DNS-name encoding controls the outcome.
+        let config = Config::new(
+            DhcpConfig::default(),
+            None,
+            67,
+            ForgeClientConfig::new(String::new(), None),
+        );
+
+        // Render through the option-39 production path so the flags/name boundary is covered.
+        check_cases(
+            [
+                // The maximum legal DNS name still leaves room for option-39 flags.
+                Case {
+                    scenario: "255-byte DNS wire name",
+                    input: maximum_name,
+                    expect: Yields((256, Some(1), Some(0))),
+                },
+                // One additional DNS octet exceeds the protocol name boundary.
+                Case {
+                    scenario: "256-byte DNS wire name",
+                    input: overlong_name,
+                    expect: Fails,
+                },
+            ],
+            |fqdn| {
+                let mut reply = Message::new_with_id(MessageType::Reply, [0, 0, 0]);
+                add_config_options(&mut reply, Some(&fqdn), Some(1), &config).map_err(drop)?;
+
+                // Return the payload boundary, preserved flags, and terminating root.
+                let payload = match reply.opts().get(OptionCode::ClientFqdn) {
+                    Some(DhcpOption::Unknown(option)) => option.data(),
+                    _ => return Err(()),
+                };
+                Ok((
+                    payload.len(),
+                    payload.first().copied(),
+                    payload.last().copied(),
+                ))
+            },
+        );
+    }
+}

--- a/crates/dhcp-server/src/packet_handler_v6.rs
+++ b/crates/dhcp-server/src/packet_handler_v6.rs
@@ -1,0 +1,978 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! DHCPv6 packet decoding and response encoding for the DPU-side server.
+//!
+//! `dhcproto 0.15` models option 9 exclusively as another `RelayMessage`, but
+//! the innermost option 9 contains a normal client `Message`. The shared
+//! `carbide-dhcpv6` decoder therefore uses a deliberately small raw-TLV parser,
+//! while this server uses dhcproto's typed API for response options.
+
+use std::net::Ipv6Addr;
+use std::sync::Arc;
+
+use carbide_dhcpv6::{
+    DecodeError as WireDecodeError, DecodedPacket as WirePacket, DuidError, DuidMac, RELAY_REPLY,
+    RelayEnvelope, decode as decode_wire_packet, extract_mac_from_duid, extract_mac_from_option79,
+};
+use carbide_instrument::emit;
+use dhcproto::v6::{
+    DhcpOption, DhcpOptions, IAAddr, IANA, Message, MessageType, NtpSuboption, OptionCode, Status,
+    StatusCode, UnknownOption,
+};
+use dhcproto::{Encodable, Encoder};
+use ipnetwork::Ipv6Network;
+use lru::LruCache;
+use rpc::forge::{AddressFamily, DhcpDiscovery, MessageKind};
+use tokio::sync::Mutex;
+
+use crate::cache::CacheEntry;
+use crate::errors::DhcpError;
+use crate::metrics::{DhcpV6RequestReceived, MessageTypeLabel, V6ReplyMessageType};
+use crate::modes::{DhcpMode, V6Outcome};
+use crate::{Config, util};
+
+const DUID_EN: u16 = 2;
+const NVIDIA_ENTERPRISE_NUMBER: u32 = 5703;
+
+#[derive(Debug)]
+struct DecodedPacketV6 {
+    message: Message,
+    relay: Option<RelayEnvelope>,
+    duid: Vec<u8>,
+    duid_mac: DuidMac,
+}
+
+/// An encoded DHCPv6 response and the bounded response type used for metrics.
+#[derive(Debug)]
+pub struct PacketV6 {
+    encoded_packet: Vec<u8>,
+    pub message_type: V6ReplyMessageType,
+}
+
+impl PacketV6 {
+    /// Return the wire bytes for the transport responsible for sending this response.
+    pub fn encoded_packet(&self) -> &[u8] {
+        &self.encoded_packet
+    }
+}
+
+impl DecodedPacketV6 {
+    /// Decode a direct client message or one supported Relay-Forward envelope.
+    fn decode(packet: &[u8]) -> Result<Self, DhcpError> {
+        let WirePacket { message, relay } = decode_wire_packet(packet).map_err(map_wire_error)?;
+
+        let (duid, duid_mac) = client_identifier(&message)?;
+
+        Ok(Self {
+            message,
+            relay,
+            duid,
+            duid_mac,
+        })
+    }
+
+    /// Resolve the authoritative lookup MAC with trusted relay identity taking precedence.
+    fn selected_mac_address(&self) -> Result<String, DhcpError> {
+        let duid_mac = match self.duid_mac {
+            DuidMac::Mac(mac) => Some(mac),
+            DuidMac::NoLinkLayerMac => None,
+        };
+        let relay_mac = self
+            .relay
+            .as_ref()
+            .and_then(|relay| relay.client_link_layer.as_deref())
+            .and_then(extract_mac_from_option79);
+
+        // RFC 6939 identifies the sending link and therefore takes precedence
+        // over a DUID that may have been formed from another permanent NIC.
+        let selected_mac = match (relay_mac, duid_mac) {
+            (Some(relay_mac), Some(duid_mac)) => {
+                if relay_mac != duid_mac {
+                    tracing::warn!(
+                        client_mac_address = %util::u8_to_mac(&relay_mac.bytes()),
+                        duid_mac_address = %util::u8_to_mac(&duid_mac.bytes()),
+                        "DHCPv6 option 79 MAC disagrees with DUID MAC"
+                    );
+                }
+                relay_mac
+            }
+            (Some(relay_mac), None) => relay_mac,
+            (None, Some(duid_mac)) => duid_mac,
+            (None, None) => {
+                tracing::warn!(
+                    relay_link_ip_address = ?self.relay.as_ref().map(|relay| relay.link_address),
+                    "DHCPv6 request has a non-MAC DUID and no RFC 6939 option 79"
+                );
+                return Err(DhcpError::NoMacNoOption79);
+            }
+        };
+
+        Ok(util::u8_to_mac(&selected_mac.bytes()))
+    }
+
+    /// Return the single IA_NA supported by Carbide's one-address API contract.
+    fn ia_na(&self) -> Result<Option<&IANA>, DhcpError> {
+        let mut associations = self
+            .message
+            .opts()
+            .get_all(OptionCode::IANA)
+            .into_iter()
+            .flatten()
+            .filter_map(|option| match option {
+                DhcpOption::IANA(association) => Some(association),
+                _ => None,
+            });
+        let association = associations.next();
+        if associations.next().is_some() {
+            Err(DhcpError::InvalidInput(
+                "multiple DHCPv6 IA_NA options are unsupported".to_string(),
+            ))
+        } else {
+            Ok(association)
+        }
+    }
+
+    /// Return the optional single IAADDR hint carried inside the client's IA_NA.
+    fn desired_address(&self) -> Result<Option<Ipv6Addr>, DhcpError> {
+        let Some(association) = self.ia_na()? else {
+            return Ok(None);
+        };
+        let mut addresses = association
+            .opts
+            .get_all(OptionCode::IAAddr)
+            .into_iter()
+            .flatten()
+            .filter_map(|option| match option {
+                DhcpOption::IAAddr(address) => Some(address.addr),
+                _ => None,
+            });
+        let address = addresses.next();
+        if addresses.next().is_some() {
+            Err(DhcpError::InvalidInput(
+                "multiple DHCPv6 IAADDR options are unsupported".to_string(),
+            ))
+        } else {
+            Ok(address)
+        }
+    }
+
+    /// Select the circuit identifier used by DPU lookup and API cache routing.
+    fn circuit_id(&self, local_interface: Option<&str>) -> Result<Option<String>, DhcpError> {
+        // A DPU listener is bound to one host interface, so that ingress name is
+        // authoritative even when a client supplies a Relay-Forward envelope.
+        if let Some(local_interface) = local_interface {
+            return Ok(Some(local_interface.to_string()));
+        }
+
+        // Controller mode has no local host.yaml authority and preserves the
+        // relay's opaque identifier for API routing.
+        Ok(self
+            .relay
+            .as_ref()
+            .and_then(|relay| relay.interface_id.as_deref())
+            .map(bytes_to_hex))
+    }
+
+    /// Build the family-aware API discovery request for this wire message.
+    fn discovery_request(
+        &self,
+        source_address: Ipv6Addr,
+        local_interface: &str,
+        message_kind: MessageKind,
+        use_local_circuit_id: bool,
+    ) -> Result<DhcpDiscovery, DhcpError> {
+        // Local DPU lookup is keyed by ingress interface. Only the authoritative
+        // controller path needs a MAC for API and cache identity.
+        let mac_address = if use_local_circuit_id {
+            String::new()
+        } else {
+            self.selected_mac_address()?
+        };
+        let relay_address = self
+            .relay
+            .as_ref()
+            .map_or(source_address, |relay| relay.link_address);
+        let vendor_string = match self.message.opts().get(OptionCode::VendorClass) {
+            Some(DhcpOption::VendorClass(vendor)) => vendor
+                .data
+                .iter()
+                .find_map(|value| std::str::from_utf8(value).ok().map(str::to_owned)),
+            _ => None,
+        };
+
+        Ok(DhcpDiscovery {
+            mac_address,
+            relay_address: relay_address.to_string(),
+            vendor_string,
+            link_address: self
+                .relay
+                .as_ref()
+                .map(|relay| relay.link_address.to_string()),
+            circuit_id: self.circuit_id(use_local_circuit_id.then_some(local_interface))?,
+            remote_id: self
+                .relay
+                .as_ref()
+                .and_then(|relay| relay.remote_id.as_deref())
+                .map(bytes_to_hex),
+            desired_address: self.desired_address()?.map(|address| address.to_string()),
+            address_family: Some(AddressFamily::V6 as i32),
+            message_kind: Some(message_kind as i32),
+            duid: Some(self.duid.clone()),
+        })
+    }
+}
+
+/// Process one DHCPv6 request and return no packet when the protocol requires silence.
+pub async fn process_packet(
+    packet: &[u8],
+    source_address: Ipv6Addr,
+    config: &Config,
+    local_interface: &str,
+    handler: &dyn DhcpMode,
+    machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
+) -> Result<Option<PacketV6>, DhcpError> {
+    let decoded = DecodedPacketV6::decode(packet)?;
+    emit(DhcpV6RequestReceived {
+        message_type: MessageTypeLabel::from(decoded.message.msg_type()),
+    });
+
+    let requires_relay = handler.should_be_relayed();
+    // Controller mode trusts its validated relay topology; DPU mode trusts
+    // only the receiving interface and rejects relay-controlled metadata.
+    match (requires_relay, decoded.relay.is_some()) {
+        (true, false) => {
+            return Err(DhcpError::InvalidInput(
+                "controller mode requires a relayed DHCPv6 packet".to_string(),
+            ));
+        }
+        (false, true) => {
+            return Err(DhcpError::InvalidInput(
+                "DPU mode requires a direct DHCPv6 packet".to_string(),
+            ));
+        }
+        _ => {}
+    }
+    ensure_server_identifier(&decoded.message, config)?;
+
+    // TODO(dhcpv6-rapid-commit): Milestone 05 may turn SOLICIT directly into
+    // REPLY when option 14 is present. This milestone always uses ADVERTISE.
+    let wire_type = decoded.message.msg_type();
+    let ia_na = decoded.ia_na()?;
+
+    // IA_TA and IA_PD cannot be represented by the single-address API model.
+    // Reject them before protocol-local replies can acknowledge unsupported state.
+    if decoded.message.opts().get(OptionCode::IATA).is_some()
+        || decoded.message.opts().get(OptionCode::IAPD).is_some()
+    {
+        return Err(DhcpError::UnhandledMessageTypeV6(wire_type));
+    }
+
+    let message_kind = match wire_type {
+        MessageType::Solicit if ia_na.is_some() => MessageKind::V6Solicit,
+        MessageType::Solicit | MessageType::InformationRequest if ia_na.is_none() => {
+            MessageKind::V6InfoRequest
+        }
+        MessageType::Request | MessageType::Renew | MessageType::Rebind if ia_na.is_some() => {
+            MessageKind::V6Request
+        }
+        MessageType::Confirm => {
+            return encode_local_reply(&decoded, config, local_interface);
+        }
+        MessageType::Release | MessageType::Decline => {
+            // Controller mode uses a relay-selected MAC as its authoritative
+            // client identity even when the protocol response remains local.
+            if requires_relay {
+                decoded.selected_mac_address()?;
+            }
+            // DHCPv6 acknowledges RELEASE/DECLINE with a Reply, unlike the
+            // standalone DHCPv4 path. This server has no Kea-style binding
+            // database, so Success acknowledges a validly addressed lease-end
+            // notification; it does not prove an active (DUID, IAID, address)
+            // binding, release the API-owned allocation, or quarantine a
+            // declined address.
+            return encode_local_reply(&decoded, config, local_interface);
+        }
+        MessageType::Solicit | MessageType::Request | MessageType::Renew | MessageType::Rebind => {
+            return Err(DhcpError::MissingOptionV6(OptionCode::IANA));
+        }
+        other => return Err(DhcpError::UnhandledMessageTypeV6(other)),
+    };
+
+    // Stateful controller discovery can allocate, so reject unusable local
+    // lifetime configuration before crossing the API boundary. DPU discovery
+    // is read-only and keeps serving address-less bindings without lifetimes.
+    if requires_relay && message_kind != MessageKind::V6InfoRequest {
+        stateful_lifetimes(config)?;
+    }
+
+    // DPU mode keys direct requests by the receiving interface; controller mode
+    // forwards only relay-provided circuit identity and never invents one.
+    let discovery = decoded.discovery_request(
+        source_address,
+        local_interface,
+        message_kind,
+        !requires_relay,
+    )?;
+    let outcome = handler
+        .discover_dhcp_v6(discovery, config, machine_cache)
+        .await?;
+    let outcome = match (wire_type, outcome) {
+        // A refresh is valid only when the client names the authoritative binding;
+        // no address or a different address has no binding to renew.
+        (MessageType::Renew | MessageType::Rebind, V6Outcome::Stateful(record)) => {
+            match decoded.desired_address()? {
+                Some(desired) if record.address.parse::<Ipv6Addr>()? == desired => {
+                    V6Outcome::Stateful(record)
+                }
+                _ => V6Outcome::NoAddress,
+            }
+        }
+        (_, outcome) => outcome,
+    };
+    encode_mode_reply(&decoded, outcome, config).map(Some)
+}
+
+/// Return and classify the request's single structurally valid ClientId.
+fn client_identifier(message: &Message) -> Result<(Vec<u8>, DuidMac), DhcpError> {
+    let mut identifiers = message
+        .opts()
+        .get_all(OptionCode::ClientId)
+        .into_iter()
+        .flatten();
+    let identifier = identifiers.next();
+    if identifiers.next().is_some() {
+        return Err(DhcpError::InvalidInput(
+            "multiple DHCPv6 ClientId options are unsupported".to_string(),
+        ));
+    }
+
+    let Some(DhcpOption::ClientId(duid)) = identifier else {
+        return Err(DhcpError::MissingOptionV6(OptionCode::ClientId));
+    };
+    let duid_mac = match extract_mac_from_duid(duid) {
+        Ok(duid_mac) => duid_mac,
+        Err(DuidError::Malformed) => return Err(DhcpError::MalformedDuid),
+        Err(DuidError::UnsupportedType) => {
+            let duid_type = duid
+                .get(..2)
+                .and_then(|bytes| <[u8; 2]>::try_from(bytes).ok())
+                .map(u16::from_be_bytes)
+                .ok_or(DhcpError::MalformedDuid)?;
+            return Err(DhcpError::UnsupportedDuidType(duid_type));
+        }
+    };
+    Ok((duid.clone(), duid_mac))
+}
+
+/// Translate policy-neutral wire failures into server packet errors.
+fn map_wire_error(error: WireDecodeError) -> DhcpError {
+    match error {
+        WireDecodeError::MalformedPacket(reason) => {
+            DhcpError::InvalidInput(format!("malformed DHCPv6 packet: {reason}"))
+        }
+        WireDecodeError::ClientMessageDecode(error) => DhcpError::PacketDecodeFailure(error),
+        WireDecodeError::MissingRelayMessage => DhcpError::MissingOptionV6(OptionCode::RelayMsg),
+        WireDecodeError::NestedRelay => DhcpError::NestedRelayV6,
+        WireDecodeError::RelayHopCountExceeded(hop_count) => {
+            DhcpError::RelayHopCountExceededV6(hop_count)
+        }
+        WireDecodeError::UnexpectedRelayReply => {
+            DhcpError::UnhandledMessageTypeV6(MessageType::RelayRepl)
+        }
+    }
+}
+
+/// Render opaque relay metadata without introducing lossy UTF-8 collisions.
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(char::from(HEX_DIGITS[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX_DIGITS[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+/// Return the stable DUID-EN used as this server's DHCPv6 identifier.
+fn server_identifier(config: &Config) -> Vec<u8> {
+    let mut identifier = Vec::with_capacity(10);
+    identifier.extend_from_slice(&DUID_EN.to_be_bytes());
+    identifier.extend_from_slice(&NVIDIA_ENTERPRISE_NUMBER.to_be_bytes());
+    identifier.extend_from_slice(&config.dhcp_config.carbide_dhcp_server.octets());
+    identifier
+}
+
+/// Return validated lifetimes for a stateful DHCPv6 response.
+fn stateful_lifetimes(config: &Config) -> Result<(u32, u32), DhcpError> {
+    let preferred_lifetime = config.dhcp_config.dhcpv6_preferred_lifetime_secs;
+    let valid_lifetime = config.dhcp_config.dhcpv6_valid_lifetime_secs;
+    if preferred_lifetime == 0 || valid_lifetime == 0 || preferred_lifetime > valid_lifetime {
+        return Err(DhcpError::InvalidInput(
+            "DHCPv6 lifetimes must be nonzero with preferred not exceeding valid".to_string(),
+        ));
+    }
+    Ok((preferred_lifetime, valid_lifetime))
+}
+
+/// Reject messages explicitly selecting another server and require selection where mandated.
+fn ensure_server_identifier(message: &Message, config: &Config) -> Result<(), DhcpError> {
+    let mut identifiers = message
+        .opts()
+        .get_all(OptionCode::ServerId)
+        .into_iter()
+        .flatten();
+    let received = match identifiers.next() {
+        Some(DhcpOption::ServerId(identifier)) => Some(identifier),
+        _ => None,
+    };
+    if identifiers.next().is_some() {
+        return Err(DhcpError::InvalidInput(
+            "multiple DHCPv6 ServerId options are unsupported".to_string(),
+        ));
+    }
+
+    if matches!(
+        message.msg_type(),
+        MessageType::Solicit | MessageType::Confirm | MessageType::Rebind
+    ) && received.is_some()
+    {
+        return Err(DhcpError::InvalidInput(format!(
+            "{:?} must not include a DHCPv6 ServerId option",
+            message.msg_type()
+        )));
+    }
+
+    if let Some(received) = received
+        && received != &server_identifier(config)
+    {
+        return Err(DhcpError::NotMyPacket(bytes_to_hex(received)));
+    }
+
+    // These exchanges continue a binding selected from an earlier Advertise.
+    if matches!(
+        message.msg_type(),
+        MessageType::Request | MessageType::Renew | MessageType::Release | MessageType::Decline
+    ) && received.is_none()
+    {
+        return Err(DhcpError::MissingOptionV6(OptionCode::ServerId));
+    }
+    Ok(())
+}
+
+/// Encode a mode-backed address or options response.
+fn encode_mode_reply(
+    request: &DecodedPacketV6,
+    outcome: V6Outcome,
+    config: &Config,
+) -> Result<PacketV6, DhcpError> {
+    let reply_type = reply_type_for(request.message.msg_type());
+    let mut reply = base_reply(request, reply_type, config);
+
+    // The client owns option-39 negotiation flags; its requested name is never trusted.
+    let requested_fqdn_flags = match request.message.opts().get(OptionCode::ClientFqdn) {
+        Some(DhcpOption::Unknown(option)) => option.data().first().copied(),
+        _ => None,
+    };
+
+    match outcome {
+        V6Outcome::Stateful(record) => {
+            add_config_options(&mut reply, Some(&record.fqdn), requested_fqdn_flags, config)?;
+            let association = request
+                .ia_na()?
+                .ok_or(DhcpError::MissingOptionV6(OptionCode::IANA))?;
+            let (preferred_lifetime, valid_lifetime) = stateful_lifetimes(config)?;
+            let address = record.address.parse::<Ipv6Addr>()?;
+            let mut address_options = DhcpOptions::new();
+            address_options.insert(DhcpOption::IAAddr(IAAddr {
+                addr: address,
+                preferred_life: preferred_lifetime,
+                valid_life: valid_lifetime,
+                opts: DhcpOptions::new(),
+            }));
+            reply.opts_mut().insert(DhcpOption::IANA(IANA {
+                id: association.id,
+                t1: 0,
+                t2: 0,
+                opts: address_options,
+            }));
+        }
+        V6Outcome::OptionsOnly(record) => {
+            add_config_options(&mut reply, Some(&record.fqdn), requested_fqdn_flags, config)?;
+        }
+        V6Outcome::NoAddress => {
+            add_config_options(&mut reply, None, requested_fqdn_flags, config)?;
+            let association = request
+                .ia_na()?
+                .ok_or(DhcpError::MissingOptionV6(OptionCode::IANA))?;
+            let status = match request.message.msg_type() {
+                MessageType::Solicit | MessageType::Request => Status::NoAddrsAvail,
+                MessageType::Renew | MessageType::Rebind => Status::NoBinding,
+                other => return Err(DhcpError::UnhandledMessageTypeV6(other)),
+            };
+            let mut association_options = DhcpOptions::new();
+            association_options.insert(status_option(status));
+            reply.opts_mut().insert(DhcpOption::IANA(IANA {
+                id: association.id,
+                t1: 0,
+                t2: 0,
+                opts: association_options,
+            }));
+        }
+    }
+
+    encode_packet(reply, request.relay.as_ref())
+}
+
+/// Encode protocol-local CONFIRM, RELEASE, and DECLINE responses without API mutation.
+fn encode_local_reply(
+    request: &DecodedPacketV6,
+    config: &Config,
+    local_interface: &str,
+) -> Result<Option<PacketV6>, DhcpError> {
+    let status = match request.message.msg_type() {
+        MessageType::Confirm => {
+            let Some(status) = confirm_status(request, config, local_interface)? else {
+                return Ok(None);
+            };
+            status
+        }
+        MessageType::Release | MessageType::Decline => Status::Success,
+        other => return Err(DhcpError::UnhandledMessageTypeV6(other)),
+    };
+    let mut reply = base_reply(request, MessageType::Reply, config);
+    reply.opts_mut().insert(status_option(status));
+    encode_packet(reply, request.relay.as_ref()).map(Some)
+}
+
+/// Determine CONFIRM status when this server has authoritative link knowledge.
+fn confirm_status(
+    request: &DecodedPacketV6,
+    config: &Config,
+    local_interface: &str,
+) -> Result<Option<Status>, DhcpError> {
+    let Some(association) = request.ia_na()? else {
+        return Ok(None);
+    };
+    let addresses = association
+        .opts
+        .iter()
+        .filter_map(|option| match option {
+            DhcpOption::IAAddr(address) => Some(address.addr),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if addresses.is_empty() {
+        return Ok(None);
+    }
+
+    // Controller mode has no host.yaml link authority, so CONFIRM remains
+    // silent before applying the DPU binding-selection rules below.
+    let Some(host_config) = config.host_config.as_ref() else {
+        return Ok(None);
+    };
+
+    let circuit_id = request
+        .circuit_id(Some(local_interface))?
+        .unwrap_or_default();
+    let prefix = host_config
+        .host_ip_addresses
+        .get(&circuit_id)
+        .and_then(|interface| interface.ipv6.as_ref())
+        .and_then(|ipv6| ipv6.prefix.parse::<Ipv6Network>().ok());
+
+    // RFC 8415 requires silence when the server cannot determine whether
+    // the addresses belong to the receiving link.
+    let Some(prefix) = prefix else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        if addresses.iter().all(|address| prefix.contains(*address)) {
+            Status::Success
+        } else {
+            Status::NotOnLink
+        },
+    ))
+}
+
+/// Create the common transaction and identity options for one response.
+fn base_reply(request: &DecodedPacketV6, message_type: MessageType, config: &Config) -> Message {
+    let mut reply = Message::new_with_id(message_type, request.message.xid());
+    reply
+        .opts_mut()
+        .insert(DhcpOption::ClientId(request.duid.clone()));
+    reply
+        .opts_mut()
+        .insert(DhcpOption::ServerId(server_identifier(config)));
+    reply
+}
+
+/// Append configured service options and request-negotiated API-owned naming options.
+fn add_config_options(
+    reply: &mut Message,
+    fqdn: Option<&str>,
+    requested_fqdn_flags: Option<u8>,
+    config: &Config,
+) -> Result<(), DhcpError> {
+    if !config.dhcp_config.carbide_nameservers_v6.is_empty() {
+        reply.opts_mut().insert(DhcpOption::DomainNameServers(
+            config.dhcp_config.carbide_nameservers_v6.clone(),
+        ));
+    }
+    if !config.dhcp_config.carbide_ntpservers_v6.is_empty() {
+        reply.opts_mut().insert(DhcpOption::NtpServer(
+            config
+                .dhcp_config
+                .carbide_ntpservers_v6
+                .iter()
+                .copied()
+                .map(NtpSuboption::ServerAddress)
+                .collect(),
+        ));
+    }
+    if let Some(fqdn) = fqdn.filter(|fqdn| !fqdn.is_empty()) {
+        let encoded_fqdn = encode_domain_name(fqdn)?;
+
+        // Domain search is API-owned and independent of client-FQDN negotiation.
+        if let Some((_, domain)) = fqdn.trim_end_matches('.').split_once('.') {
+            reply
+                .opts_mut()
+                .insert(DhcpOption::Unknown(UnknownOption::new(
+                    OptionCode::DomainSearchList,
+                    encode_domain_name(domain)?,
+                )));
+        }
+
+        // Preserve client negotiation flags while replacing its name with the trusted FQDN.
+        if let Some(flags) = requested_fqdn_flags {
+            let mut client_fqdn = vec![flags];
+            client_fqdn.extend(encoded_fqdn);
+            reply
+                .opts_mut()
+                .insert(DhcpOption::Unknown(UnknownOption::new(
+                    OptionCode::ClientFqdn,
+                    client_fqdn,
+                )));
+        }
+    }
+    Ok(())
+}
+
+/// Encode one DNS name in uncompressed RFC 1035 wire format for DHCPv6 name options.
+fn encode_domain_name(name: &str) -> Result<Vec<u8>, DhcpError> {
+    let mut encoded = Vec::new();
+    for label in name.trim_end_matches('.').split('.') {
+        if label.is_empty() || label.len() > 63 {
+            return Err(DhcpError::InvalidInput(format!(
+                "invalid DHCPv6 domain-name label in {name}"
+            )));
+        }
+        encoded.push(label.len() as u8);
+        encoded.extend_from_slice(label.as_bytes());
+    }
+    encoded.push(0);
+    // The terminating root label counts toward the RFC 1035 255-byte name limit.
+    if encoded.len() > 255 {
+        return Err(DhcpError::InvalidInput(format!(
+            "DHCPv6 domain name exceeds the 255-byte wire limit: {name}"
+        )));
+    }
+    Ok(encoded)
+}
+
+/// Build a DHCPv6 Status Code option with no diagnostic text.
+fn status_option(status: Status) -> DhcpOption {
+    DhcpOption::StatusCode(StatusCode {
+        status,
+        msg: String::new(),
+    })
+}
+
+/// Select ADVERTISE for SOLICIT and REPLY for every subsequent exchange.
+fn reply_type_for(request_type: MessageType) -> MessageType {
+    if request_type == MessageType::Solicit {
+        MessageType::Advertise
+    } else {
+        MessageType::Reply
+    }
+}
+
+/// Encode the inner response and optionally restore its Relay-Reply envelope.
+fn encode_packet(response: Message, relay: Option<&RelayEnvelope>) -> Result<PacketV6, DhcpError> {
+    let message_type = if response.msg_type() == MessageType::Advertise {
+        V6ReplyMessageType::Advertise
+    } else {
+        V6ReplyMessageType::Reply
+    };
+    let mut encoded = Vec::new();
+    response.encode(&mut Encoder::new(&mut encoded))?;
+    if let Some(relay) = relay {
+        encoded = wrap_relay_reply(&encoded, relay)?;
+    }
+    Ok(PacketV6 {
+        encoded_packet: encoded,
+        message_type,
+    })
+}
+
+/// Wrap an encoded client response in the matching one-hop Relay-Reply envelope.
+fn wrap_relay_reply(inner_response: &[u8], relay: &RelayEnvelope) -> Result<Vec<u8>, DhcpError> {
+    let mut response = Vec::new();
+    response.push(RELAY_REPLY);
+    response.push(relay.hop_count);
+    response.extend_from_slice(&relay.link_address.octets());
+    response.extend_from_slice(&relay.peer_address.octets());
+    if let Some(interface_id) = &relay.interface_id {
+        encode_raw_option(&mut response, OptionCode::InterfaceId, interface_id)?;
+    }
+    if let Some(remote_id) = &relay.remote_id {
+        encode_raw_option(&mut response, OptionCode::RemoteId, remote_id)?;
+    }
+    encode_raw_option(&mut response, OptionCode::RelayMsg, inner_response)?;
+    Ok(response)
+}
+
+/// Append one raw DHCPv6 TLV after checking its 16-bit wire length.
+fn encode_raw_option(
+    packet: &mut Vec<u8>,
+    option_code: OptionCode,
+    payload: &[u8],
+) -> Result<(), DhcpError> {
+    let length = u16::try_from(payload.len()).map_err(|_| {
+        DhcpError::InvalidInput(format!("DHCPv6 option {option_code:?} exceeds 65535 bytes"))
+    })?;
+    packet.extend_from_slice(&u16::from(option_code).to_be_bytes());
+    packet.extend_from_slice(&length.to_be_bytes());
+    packet.extend_from_slice(payload);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_rpc_utils::dhcp::DhcpConfig;
+    use carbide_test_support::Outcome::{Fails, Yields};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
+    use rpc::forge_tls_client::ForgeClientConfig;
+
+    use super::*;
+
+    /// Verifies ClientId extraction accepts one valid option and rejects
+    /// missing, malformed, or duplicate options.
+    ///
+    /// This prevents ambiguous or unusable client identity from reaching
+    /// request processing.
+    #[test]
+    fn client_identifier_requires_one_nonempty_option() {
+        let client_id = vec![0, 3, 0, 1, 2, 3, 4, 5, 6, 7];
+        let other_client_id = vec![0, 3, 10, 11, 12, 13, 14, 15, 16, 17];
+
+        scenarios!(run = |identifiers| {
+                let mut message = Message::new_with_id(MessageType::Solicit, [0, 0, 0]);
+                for identifier in identifiers {
+                    message.opts_mut().insert(DhcpOption::ClientId(identifier));
+                }
+                client_identifier(&message)
+                    .map(|(duid, _)| duid)
+                    .map_err(drop)
+            };
+            "valid ClientId" {
+                // One nonempty ClientId provides an unambiguous client identity.
+                vec![client_id.clone()] => Yields(client_id.clone()),
+            }
+            "missing, malformed, or duplicate ClientId" {
+                // An absent ClientId cannot identify a client.
+                vec![] => Fails,
+                // An empty ClientId is structurally malformed.
+                vec![Vec::new()] => Fails,
+                // A type-only ClientId lacks the required identifier octet.
+                vec![vec![0, 3]] => Fails,
+                // A one-byte ClientId cannot contain a DUID type.
+                vec![vec![0]] => Fails,
+                // Repeating the same ClientId is still ambiguous on the wire.
+                vec![client_id.clone(), client_id.clone()] => Fails,
+                // Conflicting ClientIds must not depend on option ordering.
+                vec![client_id, other_client_id] => Fails,
+            }
+        );
+    }
+
+    /// Verifies each DHCPv6 client message enforces its ServerId presence and
+    /// matching policy.
+    ///
+    /// This prevents forbidden, missing, mismatched, or duplicate server
+    /// selection from being accepted.
+    #[test]
+    fn server_identifier_enforces_message_presence_matrix_and_cardinality() {
+        #[derive(Clone, Copy)]
+        enum ServerIds {
+            Absent,
+            ThisServer,
+            OtherServer,
+            DuplicateSame,
+            DuplicateMixed,
+        }
+
+        struct Row {
+            message_type: MessageType,
+            server_ids: ServerIds,
+        }
+
+        let config = Config::new(
+            DhcpConfig::default(),
+            None,
+            67,
+            ForgeClientConfig::new(String::new(), None),
+        );
+        let server_id = server_identifier(&config);
+        let other_server_id = vec![0xff];
+
+        value_scenarios!(run = |Row { message_type, server_ids }| {
+                let mut message = Message::new_with_id(message_type, [0, 0, 0]);
+                let identifiers = match server_ids {
+                    ServerIds::Absent => vec![],
+                    ServerIds::ThisServer => vec![server_id.clone()],
+                    ServerIds::OtherServer => vec![other_server_id.clone()],
+                    ServerIds::DuplicateSame => vec![server_id.clone(), server_id.clone()],
+                    ServerIds::DuplicateMixed => vec![server_id.clone(), other_server_id.clone()],
+                };
+                for identifier in identifiers {
+                    message.opts_mut().insert(DhcpOption::ServerId(identifier));
+                }
+                ensure_server_identifier(&message, &config).is_ok()
+            };
+            "SOLICIT" {
+                // SOLICIT starts server selection and therefore omits ServerId.
+                Row { message_type: MessageType::Solicit, server_ids: ServerIds::Absent } => true,
+                // A SOLICIT must not preselect this server.
+                Row { message_type: MessageType::Solicit, server_ids: ServerIds::ThisServer } => false,
+            }
+            "REQUEST" {
+                // REQUEST commits the server selected by its matching identifier.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::ThisServer } => true,
+                // REQUEST without ServerId has not selected a server.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::Absent } => false,
+                // Another server's identifier must not reach local allocation.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::OtherServer } => false,
+            }
+            "CONFIRM" {
+                // CONFIRM asks any server about the current link and omits ServerId.
+                Row { message_type: MessageType::Confirm, server_ids: ServerIds::Absent } => true,
+                // CONFIRM must remain independent of a previously selected server.
+                Row { message_type: MessageType::Confirm, server_ids: ServerIds::ThisServer } => false,
+            }
+            "RENEW" {
+                // RENEW targets the server that owns the existing binding.
+                Row { message_type: MessageType::Renew, server_ids: ServerIds::ThisServer } => true,
+                // RENEW without ServerId cannot identify its binding owner.
+                Row { message_type: MessageType::Renew, server_ids: ServerIds::Absent } => false,
+                // A RENEW for another server must not mutate local state.
+                Row { message_type: MessageType::Renew, server_ids: ServerIds::OtherServer } => false,
+            }
+            "REBIND" {
+                // REBIND is broadcast after the original server stops responding.
+                Row { message_type: MessageType::Rebind, server_ids: ServerIds::Absent } => true,
+                // REBIND must not remain pinned to the unavailable server.
+                Row { message_type: MessageType::Rebind, server_ids: ServerIds::ThisServer } => false,
+            }
+            "RELEASE" {
+                // RELEASE addresses the server that owns the binding being ended.
+                Row { message_type: MessageType::Release, server_ids: ServerIds::ThisServer } => true,
+                // RELEASE without ServerId cannot identify the binding owner.
+                Row { message_type: MessageType::Release, server_ids: ServerIds::Absent } => false,
+                // Another server's RELEASE must not be acknowledged locally.
+                Row { message_type: MessageType::Release, server_ids: ServerIds::OtherServer } => false,
+            }
+            "DECLINE" {
+                // DECLINE reports an unusable address to the server that supplied it.
+                Row { message_type: MessageType::Decline, server_ids: ServerIds::ThisServer } => true,
+                // DECLINE without ServerId cannot identify the address supplier.
+                Row { message_type: MessageType::Decline, server_ids: ServerIds::Absent } => false,
+                // Another server's declined address is outside local authority.
+                Row { message_type: MessageType::Decline, server_ids: ServerIds::OtherServer } => false,
+            }
+            "INFORMATION-REQUEST" {
+                // A normal multicast INFORMATION-REQUEST omits ServerId.
+                Row { message_type: MessageType::InformationRequest, server_ids: ServerIds::Absent } => true,
+                // A reconfiguration-triggered INFORMATION-REQUEST targets this server.
+                Row { message_type: MessageType::InformationRequest, server_ids: ServerIds::ThisServer } => true,
+                // A targeted request for another server must be discarded locally.
+                Row { message_type: MessageType::InformationRequest, server_ids: ServerIds::OtherServer } => false,
+            }
+            "duplicate ServerId" {
+                // Repeated matching identifiers remain ambiguous and invalid.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::DuplicateSame } => false,
+                // Conflicting duplicate identifiers must not depend on option ordering.
+                Row { message_type: MessageType::Request, server_ids: ServerIds::DuplicateMixed } => false,
+            }
+        );
+    }
+
+    /// Verifies the DNS name's 255-byte limit includes its root but excludes option-39 flags.
+    ///
+    /// This prevents emitting an overlong name or rejecting a legal 256-byte option payload.
+    #[test]
+    fn enforces_dns_name_wire_limit_separately_from_client_fqdn_flags() {
+        // Three maximum labels consume 192 wire bytes, leaving the final label
+        // length, its contents, and the terminating root to establish the boundary.
+        let three_maximum_labels = ["a".repeat(63), "b".repeat(63), "c".repeat(63)].join(".");
+        let maximum_name = format!("{three_maximum_labels}.{}", "d".repeat(61));
+        let overlong_name = format!("{three_maximum_labels}.{}", "d".repeat(62));
+
+        // Keep unrelated options empty so only DNS-name encoding controls the outcome.
+        let config = Config::new(
+            DhcpConfig::default(),
+            None,
+            67,
+            ForgeClientConfig::new(String::new(), None),
+        );
+
+        // Render through the option-39 production path so the flags/name boundary is covered.
+        check_cases(
+            [
+                // The maximum legal DNS name still leaves room for option-39 flags.
+                Case {
+                    scenario: "255-byte DNS wire name",
+                    input: maximum_name,
+                    expect: Yields((256, Some(1), Some(0))),
+                },
+                // One additional DNS octet exceeds the protocol name boundary.
+                Case {
+                    scenario: "256-byte DNS wire name",
+                    input: overlong_name,
+                    expect: Fails,
+                },
+            ],
+            |fqdn| {
+                let mut reply = Message::new_with_id(MessageType::Reply, [0, 0, 0]);
+                add_config_options(&mut reply, Some(&fqdn), Some(1), &config).map_err(drop)?;
+
+                // Return the payload boundary, preserved flags, and terminating root.
+                let payload = match reply.opts().get(OptionCode::ClientFqdn) {
+                    Some(DhcpOption::Unknown(option)) => option.data(),
+                    _ => return Err(()),
+                };
+                Ok((
+                    payload.len(),
+                    payload.first().copied(),
+                    payload.last().copied(),
+                ))
+            },
+        );
+    }
+}

--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -14,6 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::ffi::CString;
+use std::net::{Ipv6Addr, SocketAddrV6};
+use std::time::Duration;
+
 use carbide_dhcp_common::{MachineArchitecture, VendorClass};
 use carbide_instrument::emit;
 use rpc::forge::DhcpRecord;
@@ -27,6 +31,8 @@ use crate::metrics::{
 
 const SOCKET_SETUP_ATTEMPTS: i32 = 10;
 const INTERFACE_BIND_ATTEMPTS: i32 = 10;
+const DHCPV6_LINK_SCOPED_GROUP: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 1, 2);
+const DHCPV6_SITE_SCOPED_GROUP: Ipv6Addr = Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 1, 3);
 
 fn open_configured_socket(
     listen_address: core::net::SocketAddrV4,
@@ -69,6 +75,16 @@ fn interface_bind_next_action(retries_left: i32) -> SocketSetupNextAction {
     } else {
         SocketSetupNextAction::Retry
     }
+}
+
+/// Select the multicast groups required by one DHCPv6 listener policy.
+fn dhcp_v6_multicast_groups(join_site_scoped_group: bool) -> impl Iterator<Item = Ipv6Addr> {
+    [
+        Some(DHCPV6_LINK_SCOPED_GROUP),
+        join_site_scoped_group.then_some(DHCPV6_SITE_SCOPED_GROUP),
+    ]
+    .into_iter()
+    .flatten()
 }
 
 pub(super) fn u8_to_mac(data: &[u8]) -> String {
@@ -122,10 +138,7 @@ pub(super) fn machine_get_filename(
 }
 
 /// Create a UDP socket and set non_blocking, broadcast and other options flag on it.
-pub(super) async fn get_socket(
-    listen_address: core::net::SocketAddrV4,
-    interface: String,
-) -> UdpSocket {
+pub async fn get_socket(listen_address: core::net::SocketAddrV4, interface: String) -> UdpSocket {
     for retry in 0..SOCKET_SETUP_ATTEMPTS {
         // Create a socket2 socket because std and Tokio sockets do not expose
         // the options that must be set before binding.
@@ -167,6 +180,93 @@ pub(super) async fn get_socket(
     panic!("Could not create socket successfully.");
 }
 
+const DHCPV6_SOCKET_SETUP_ATTEMPTS: usize = 10;
+const DHCPV6_SOCKET_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Create a DHCPv6 socket, retrying boundedly while its interface becomes ready.
+///
+/// Every socket joins the link-scoped client/relay/server group. When
+/// `join_site_scoped_group` is true, it also joins the site-scoped server group
+/// used by relay agents.
+pub async fn get_socket_v6(
+    listen_address: SocketAddrV6,
+    interface: &str,
+    join_site_scoped_group: bool,
+) -> Result<UdpSocket, DhcpError> {
+    let mut attempts_remaining = DHCPV6_SOCKET_SETUP_ATTEMPTS;
+    loop {
+        match open_socket_v6(listen_address, interface, join_site_scoped_group) {
+            Ok(socket) => return Ok(socket),
+            Err(error) => {
+                attempts_remaining -= 1;
+                if attempts_remaining == 0 {
+                    return Err(error);
+                }
+
+                // Interface creation and multicast readiness can race server startup.
+                tracing::warn!(
+                    interface_name = interface,
+                    attempts_remaining,
+                    error = %error,
+                    "DHCPv6 socket setup failed, retrying"
+                );
+                tokio::time::sleep(DHCPV6_SOCKET_RETRY_DELAY).await;
+            }
+        }
+    }
+}
+
+/// Perform one DHCPv6 socket setup attempt for the selected interface.
+fn open_socket_v6(
+    listen_address: SocketAddrV6,
+    interface: &str,
+    join_site_scoped_group: bool,
+) -> Result<UdpSocket, DhcpError> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV6,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    )?;
+    socket.set_reuse_address(true)?;
+    socket.set_only_v6(true)?;
+    socket.set_nonblocking(true)?;
+    socket.bind_device(Some(interface.as_bytes()))?;
+
+    // SO_BINDTODEVICE scopes this wildcard listener to the selected interface.
+    // The interface index below selects the same interface for multicast.
+    let interface_index = if_index_for(interface)?;
+    let listen_address = SocketAddrV6::new(
+        *listen_address.ip(),
+        listen_address.port(),
+        listen_address.flowinfo(),
+        interface_index,
+    );
+    socket.bind(&listen_address.into())?;
+
+    // Controller-mode relays may discover servers through the site-scoped
+    // All_DHCP_Servers group. DPU listeners deliberately remain link-local.
+    for group in dhcp_v6_multicast_groups(join_site_scoped_group) {
+        socket.join_multicast_v6(&group, interface_index)?;
+    }
+
+    Ok(UdpSocket::from_std(socket.into())?)
+}
+
+/// Resolve a Linux interface name to the scope index required by IPv6 sockets.
+fn if_index_for(interface: &str) -> Result<u32, DhcpError> {
+    let interface = CString::new(interface)
+        .map_err(|_| DhcpError::InvalidInput("interface name contains a NUL byte".to_string()))?;
+
+    // SAFETY: CString guarantees a valid NUL-terminated pointer for the duration
+    // of the call, and if_nametoindex does not retain it.
+    let interface_index = unsafe { libc::if_nametoindex(interface.as_ptr()) };
+    if interface_index == 0 {
+        Err(std::io::Error::last_os_error().into())
+    } else {
+        Ok(interface_index)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use carbide_test_support::value_scenarios;
@@ -204,5 +304,27 @@ mod tests {
                 0 => SocketSetupNextAction::Panic,
             }
         );
+    }
+
+    /// DHCPv6 listeners always admit link-local discovery, while site-scoped
+    /// relay discovery is included only when requested by the serving mode.
+    #[test]
+    fn multicast_groups_follow_listener_policy() {
+        for (scenario, join_site_scoped_group, expected) in [
+            // Direct-only DPU listeners join only the link-scoped group.
+            ("link scope only", false, vec![DHCPV6_LINK_SCOPED_GROUP]),
+            // Controller listeners also join the relay-to-server group.
+            (
+                "link and site scopes",
+                true,
+                vec![DHCPV6_LINK_SCOPED_GROUP, DHCPV6_SITE_SCOPED_GROUP],
+            ),
+        ] {
+            assert_eq!(
+                dhcp_v6_multicast_groups(join_site_scoped_group).collect::<Vec<_>>(),
+                expected,
+                "{scenario}"
+            );
+        }
     }
 }

--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -14,6 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::ffi::CString;
+use std::net::{Ipv6Addr, SocketAddrV6};
+use std::time::Duration;
+
 use carbide_dhcp_common::{MachineArchitecture, VendorClass};
 use carbide_instrument::emit;
 use rpc::forge::DhcpRecord;
@@ -122,10 +126,7 @@ pub(super) fn machine_get_filename(
 }
 
 /// Create a UDP socket and set non_blocking, broadcast and other options flag on it.
-pub(super) async fn get_socket(
-    listen_address: core::net::SocketAddrV4,
-    interface: String,
-) -> UdpSocket {
+pub async fn get_socket(listen_address: core::net::SocketAddrV4, interface: String) -> UdpSocket {
     for retry in 0..SOCKET_SETUP_ATTEMPTS {
         // Create a socket2 socket because std and Tokio sockets do not expose
         // the options that must be set before binding.
@@ -165,6 +166,82 @@ pub(super) async fn get_socket(
         return UdpSocket::from_std(socket.into()).unwrap();
     }
     panic!("Could not create socket successfully.");
+}
+
+const DHCPV6_SOCKET_SETUP_ATTEMPTS: usize = 10;
+const DHCPV6_SOCKET_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Create a DHCPv6 socket, retrying boundedly while its interface becomes ready.
+pub async fn get_socket_v6(
+    listen_address: SocketAddrV6,
+    interface: &str,
+) -> Result<UdpSocket, DhcpError> {
+    let mut attempts_remaining = DHCPV6_SOCKET_SETUP_ATTEMPTS;
+    loop {
+        match open_socket_v6(listen_address, interface) {
+            Ok(socket) => return Ok(socket),
+            Err(error) => {
+                attempts_remaining -= 1;
+                if attempts_remaining == 0 {
+                    return Err(error);
+                }
+
+                // Interface creation and multicast readiness can race server startup.
+                tracing::warn!(
+                    interface_name = interface,
+                    attempts_remaining,
+                    error = %error,
+                    "DHCPv6 socket setup failed, retrying"
+                );
+                tokio::time::sleep(DHCPV6_SOCKET_RETRY_DELAY).await;
+            }
+        }
+    }
+}
+
+/// Perform one DHCPv6 socket setup attempt for the selected interface.
+fn open_socket_v6(listen_address: SocketAddrV6, interface: &str) -> Result<UdpSocket, DhcpError> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV6,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    )?;
+    socket.set_reuse_address(true)?;
+    socket.set_only_v6(true)?;
+    socket.set_nonblocking(true)?;
+    socket.bind_device(Some(interface.as_bytes()))?;
+
+    // SO_BINDTODEVICE scopes this wildcard listener to the selected interface.
+    // The interface index below selects the same interface for multicast.
+    let interface_index = if_index_for(interface)?;
+    let listen_address = SocketAddrV6::new(
+        *listen_address.ip(),
+        listen_address.port(),
+        listen_address.flowinfo(),
+        interface_index,
+    );
+    socket.bind(&listen_address.into())?;
+
+    // Join the explicit link-local All_DHCP_Relay_Agents_and_Servers group.
+    let relay_group = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 1, 2);
+    socket.join_multicast_v6(&relay_group, interface_index)?;
+
+    Ok(UdpSocket::from_std(socket.into())?)
+}
+
+/// Resolve a Linux interface name to the scope index required by IPv6 sockets.
+fn if_index_for(interface: &str) -> Result<u32, DhcpError> {
+    let interface = CString::new(interface)
+        .map_err(|_| DhcpError::InvalidInput("interface name contains a NUL byte".to_string()))?;
+
+    // SAFETY: CString guarantees a valid NUL-terminated pointer for the duration
+    // of the call, and if_nametoindex does not retain it.
+    let interface_index = unsafe { libc::if_nametoindex(interface.as_ptr()) };
+    if interface_index == 0 {
+        Err(std::io::Error::last_os_error().into())
+    } else {
+        Ok(interface_index)
+    }
 }
 
 #[cfg(test)]

--- a/crates/dhcp-server/tests/common/mod.rs
+++ b/crates/dhcp-server/tests/common/mod.rs
@@ -1,0 +1,272 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Each integration-test binary compiles these helpers independently and uses
+// only the subset relevant to that binary.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+
+use carbide_dhcp_server::cache::{self, CacheEntry};
+use carbide_dhcp_server::{Config, packet_handler_v6};
+use carbide_dhcpv6::RELAY_FORWARD;
+use carbide_rpc_utils::dhcp::{DhcpConfig, HostConfig, InterfaceInfo, InterfaceInfoV6};
+use dhcproto::v6::{
+    DhcpOption, DhcpOptions, IAAddr, IANA, Message, MessageType, OptionCode, Status,
+};
+use dhcproto::{Decodable, Decoder, Encodable, Encoder};
+use lru::LruCache;
+use rpc::forge_tls_client::ForgeClientConfig;
+use tokio::sync::Mutex;
+
+pub(super) const DUID_LL: &[u8] = &[0, 3, 0, 1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee];
+pub(super) const DUID_UUID: &[u8] = &[0, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+pub(super) const IAID: u32 = 0x0102_0304;
+/// Expected DUID-EN from the shared test configuration's loopback server identity.
+///
+/// Keeping this as an independent wire fixture verifies production derivation
+/// without exposing the internal helper solely to integration tests.
+pub(super) const SERVER_IDENTIFIER: &[u8] = &[0, 2, 0, 0, 0x16, 0x47, 127, 0, 0, 1];
+
+/// Provide an isolated machine cache matching the production capacity contract.
+pub(super) fn machine_cache() -> Arc<Mutex<LruCache<String, CacheEntry>>> {
+    Arc::new(Mutex::new(LruCache::new(
+        std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE)
+            .expect("production cache size is nonzero"),
+    )))
+}
+
+/// Build deterministic DPU configuration whose IPv6 block drives packet outcomes.
+pub(super) fn dpu_config(interface: &str, ipv6: InterfaceInfoV6) -> Config {
+    dpu_config_with_bindings(BTreeMap::from([(
+        interface.to_string(),
+        InterfaceInfo {
+            address: Some(Ipv4Addr::new(192, 0, 2, 20)),
+            gateway: Some(Ipv4Addr::new(192, 0, 2, 1)),
+            prefix: Some("192.0.2.0/24".to_string()),
+            fqdn: "host.example.com".to_string(),
+            booturl: None,
+            mtu: Some(9000),
+            ipv6: Some(ipv6),
+        },
+    )]))
+}
+
+/// Build DPU configuration with caller-selected bindings so identity tests can distinguish
+/// authoritative ingress from untrusted relay metadata.
+pub(super) fn dpu_config_with_bindings(
+    host_ip_addresses: BTreeMap<String, InterfaceInfo>,
+) -> Config {
+    // Keep server-wide identity and options fixed so callers vary only binding selection.
+    let host_config = HostConfig {
+        host_interface_id: "0fd6e9a3-06fc-4a22-ad29-aca299677b00"
+            .parse()
+            .expect("test host interface id is valid"),
+        host_ip_addresses,
+    };
+
+    Config::new(
+        base_dhcp_config(None),
+        Some(host_config),
+        67,
+        forge_config(),
+    )
+}
+
+/// Build controller configuration pointing at the supplied mock Forge API.
+pub(super) fn controller_config(api_url: &str) -> Config {
+    controller_config_with_lifetimes(api_url, 3600, 7200)
+}
+
+/// Build controller configuration with explicit DHCPv6 stateful lifetimes.
+pub(super) fn controller_config_with_lifetimes(
+    api_url: &str,
+    preferred_lifetime: u32,
+    valid_lifetime: u32,
+) -> Config {
+    let mut dhcp_config = base_dhcp_config(Some(api_url.to_string()));
+    dhcp_config.dhcpv6_preferred_lifetime_secs = preferred_lifetime;
+    dhcp_config.dhcpv6_valid_lifetime_secs = valid_lifetime;
+    Config::new(dhcp_config, None, 67, forge_config())
+}
+
+/// Build the dual-stack option and lifetime settings shared by v6 packet tests.
+fn base_dhcp_config(api_url: Option<String>) -> DhcpConfig {
+    DhcpConfig {
+        carbide_api_url: api_url,
+        carbide_nameservers_v6: vec!["2001:db8::53".parse().unwrap()],
+        carbide_ntpservers_v6: vec!["2001:db8::123".parse().unwrap()],
+        dhcpv6_preferred_lifetime_secs: 3600,
+        dhcpv6_valid_lifetime_secs: 7200,
+        ..Default::default()
+    }
+}
+
+/// Disable TLS for the loopback mock API used by controller-mode tests.
+fn forge_config() -> ForgeClientConfig {
+    ForgeClientConfig::new(String::new(), None)
+}
+
+/// Build a client DHCPv6 message with optional IA_NA and server selection.
+///
+/// IA_NA is included when `address` is present or the message is SOLICIT or
+/// REQUEST. It is omitted for RENEW and REBIND when `address` is absent.
+pub(super) fn client_message(
+    message_type: MessageType,
+    duid: &[u8],
+    address: Option<Ipv6Addr>,
+    server_id: Option<Vec<u8>>,
+) -> Message {
+    let mut message = Message::new_with_id(message_type, [0xaa, 0xbb, 0xcc]);
+    message
+        .opts_mut()
+        .insert(DhcpOption::ClientId(duid.to_vec()));
+    if let Some(server_id) = server_id {
+        message.opts_mut().insert(DhcpOption::ServerId(server_id));
+    }
+    if address.is_some() || matches!(message_type, MessageType::Solicit | MessageType::Request) {
+        let mut options = DhcpOptions::new();
+        if let Some(address) = address {
+            options.insert(DhcpOption::IAAddr(IAAddr {
+                addr: address,
+                preferred_life: 300,
+                valid_life: 600,
+                opts: DhcpOptions::new(),
+            }));
+        }
+        message.opts_mut().insert(DhcpOption::IANA(IANA {
+            id: IAID,
+            t1: 0,
+            t2: 0,
+            opts: options,
+        }));
+    }
+    message
+}
+
+/// Encode a typed DHCPv6 client message into its wire representation.
+pub(super) fn encode(message: &Message) -> Vec<u8> {
+    let mut packet = Vec::new();
+    message
+        .encode(&mut Encoder::new(&mut packet))
+        .expect("test DHCPv6 message encodes");
+    packet
+}
+
+/// Decode a direct packet response produced by the server packet handler.
+pub(super) fn decode_response(packet: &packet_handler_v6::PacketV6) -> Message {
+    decode_message(packet.encoded_packet())
+}
+
+/// Decode DHCPv6 wire bytes so socket tests verify the received datagram.
+pub(super) fn decode_message(packet: &[u8]) -> Message {
+    Message::decode(&mut Decoder::new(packet)).expect("server DHCPv6 response decodes")
+}
+
+/// Return the single IA_NA carried by a stateful response.
+pub(super) fn response_ia_na(response: &Message) -> &IANA {
+    match response.opts().get(OptionCode::IANA) {
+        Some(DhcpOption::IANA(association)) => association,
+        other => panic!("expected response IA_NA, got {other:?}"),
+    }
+}
+
+/// Assert an IA-specific failure retains IAID and contains no fabricated IAADDR.
+pub(super) fn assert_ia_na_failure(response: &Message, expected_status: Status) {
+    assert!(response.opts().get(OptionCode::StatusCode).is_none());
+    let association = response_ia_na(response);
+    assert_eq!(association.id, IAID);
+    assert!(association.opts.get(OptionCode::IAAddr).is_none());
+    match association.opts.get(OptionCode::StatusCode) {
+        Some(DhcpOption::StatusCode(status)) => {
+            assert_eq!(status.status, expected_status);
+        }
+        other => panic!("expected nested IA_NA status, got {other:?}"),
+    }
+}
+
+/// Return the top-level status carried by a protocol-local response.
+pub(super) fn response_status(response: &Message) -> dhcproto::v6::Status {
+    match response.opts().get(OptionCode::StatusCode) {
+        Some(DhcpOption::StatusCode(status)) => status.status,
+        other => panic!("expected response status, got {other:?}"),
+    }
+}
+
+/// Encode one raw relay option for envelope construction and inspection.
+pub(super) fn raw_option(code: OptionCode, payload: &[u8]) -> Vec<u8> {
+    let mut option = Vec::new();
+    option.extend_from_slice(&u16::from(code).to_be_bytes());
+    option.extend_from_slice(
+        &u16::try_from(payload.len())
+            .expect("test relay option fits on the wire")
+            .to_be_bytes(),
+    );
+    option.extend_from_slice(payload);
+    option
+}
+
+/// Wrap a direct client message in the supported one-hop Relay-Forward shape,
+/// omitting Interface-ID or option 79 when its corresponding payload is empty.
+pub(super) fn relay_forward(inner: &[u8], interface_id: &[u8], option79: &[u8]) -> Vec<u8> {
+    // A relay forwarding a client message initializes the hop count to zero.
+    let mut relay = vec![RELAY_FORWARD, 0];
+    relay.extend_from_slice(&"2001:db8::1".parse::<Ipv6Addr>().unwrap().octets());
+    relay.extend_from_slice(&"fe80::1".parse::<Ipv6Addr>().unwrap().octets());
+    // Empty metadata represents omission. Callers can use raw_option when
+    // they need a distinct zero-length option on the wire.
+    if !interface_id.is_empty() {
+        relay.extend_from_slice(&raw_option(OptionCode::InterfaceId, interface_id));
+    }
+    if !option79.is_empty() {
+        relay.extend_from_slice(&raw_option(OptionCode::ClientLinklayerAddr, option79));
+    }
+    relay.extend_from_slice(&raw_option(OptionCode::RelayMsg, inner));
+    relay
+}
+
+/// Parse one uniquely occurring option from a raw relay envelope.
+pub(super) fn relay_option(packet: &[u8], code: OptionCode) -> &[u8] {
+    let mut options = packet.get(34..).unwrap_or_else(|| {
+        panic!(
+            "malformed relay packet: {} bytes is shorter than the 34-byte header",
+            packet.len()
+        )
+    });
+    while !options.is_empty() {
+        assert!(
+            options.len() >= 4,
+            "malformed relay option header: only {} bytes remain",
+            options.len()
+        );
+        let current = u16::from_be_bytes([options[0], options[1]]);
+        let length = u16::from_be_bytes([options[2], options[3]]) as usize;
+        let remaining = &options[4..];
+        assert!(
+            length <= remaining.len(),
+            "malformed relay option length {length}: only {} payload bytes remain",
+            remaining.len()
+        );
+        let (payload, rest) = remaining.split_at(length);
+        if current == u16::from(code) {
+            return payload;
+        }
+        options = rest;
+    }
+    panic!("relay option {code:?} is absent")
+}

--- a/crates/dhcp-server/tests/common/mod.rs
+++ b/crates/dhcp-server/tests/common/mod.rs
@@ -1,0 +1,270 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Each integration-test binary compiles these helpers independently and uses
+// only the subset relevant to that binary.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+
+use carbide_dhcp_server::cache::{self, CacheEntry};
+use carbide_dhcp_server::{Config, packet_handler_v6};
+use carbide_dhcpv6::RELAY_FORWARD;
+use carbide_rpc_utils::dhcp::{DhcpConfig, HostConfig, InterfaceInfo, InterfaceInfoV6};
+use dhcproto::v6::{
+    DhcpOption, DhcpOptions, IAAddr, IANA, Message, MessageType, OptionCode, Status,
+};
+use dhcproto::{Decodable, Decoder, Encodable, Encoder};
+use lru::LruCache;
+use rpc::forge_tls_client::ForgeClientConfig;
+use tokio::sync::Mutex;
+
+pub const DUID_LL: &[u8] = &[0, 3, 0, 1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee];
+pub const DUID_UUID: &[u8] = &[0, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+pub const IAID: u32 = 0x0102_0304;
+/// Expected DUID-EN from the shared test configuration's loopback server identity.
+///
+/// Keeping this as an independent wire fixture verifies production derivation
+/// without exposing the internal helper solely to integration tests.
+pub const SERVER_IDENTIFIER: &[u8] = &[0, 2, 0, 0, 0x16, 0x47, 127, 0, 0, 1];
+
+/// Provide an isolated machine cache matching the production capacity contract.
+pub fn machine_cache() -> Arc<Mutex<LruCache<String, CacheEntry>>> {
+    Arc::new(Mutex::new(LruCache::new(
+        std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE)
+            .expect("production cache size is nonzero"),
+    )))
+}
+
+/// Build deterministic DPU configuration whose IPv6 block drives packet outcomes.
+pub fn dpu_config(interface: &str, ipv6: InterfaceInfoV6) -> Config {
+    dpu_config_with_bindings(BTreeMap::from([(
+        interface.to_string(),
+        InterfaceInfo {
+            address: Ipv4Addr::new(192, 0, 2, 20),
+            gateway: Ipv4Addr::new(192, 0, 2, 1),
+            prefix: "192.0.2.0/24".to_string(),
+            fqdn: "host.example.com".to_string(),
+            booturl: None,
+            mtu: Some(9000),
+            ipv6: Some(ipv6),
+        },
+    )]))
+}
+
+/// Build DPU configuration with caller-selected bindings so identity tests can distinguish
+/// authoritative ingress from untrusted relay metadata.
+pub fn dpu_config_with_bindings(host_ip_addresses: BTreeMap<String, InterfaceInfo>) -> Config {
+    // Keep server-wide identity and options fixed so callers vary only binding selection.
+    let host_config = HostConfig {
+        host_interface_id: "0fd6e9a3-06fc-4a22-ad29-aca299677b00"
+            .parse()
+            .expect("test host interface id is valid"),
+        host_ip_addresses,
+    };
+
+    Config::new(
+        base_dhcp_config(None),
+        Some(host_config),
+        67,
+        forge_config(),
+    )
+}
+
+/// Build controller configuration pointing at the supplied mock Forge API.
+pub fn controller_config(api_url: &str) -> Config {
+    controller_config_with_lifetimes(api_url, 3600, 7200)
+}
+
+/// Build controller configuration with explicit DHCPv6 stateful lifetimes.
+pub fn controller_config_with_lifetimes(
+    api_url: &str,
+    preferred_lifetime: u32,
+    valid_lifetime: u32,
+) -> Config {
+    let mut dhcp_config = base_dhcp_config(Some(api_url.to_string()));
+    dhcp_config.dhcpv6_preferred_lifetime_secs = preferred_lifetime;
+    dhcp_config.dhcpv6_valid_lifetime_secs = valid_lifetime;
+    Config::new(dhcp_config, None, 67, forge_config())
+}
+
+/// Build the dual-stack option and lifetime settings shared by v6 packet tests.
+fn base_dhcp_config(api_url: Option<String>) -> DhcpConfig {
+    DhcpConfig {
+        carbide_api_url: api_url,
+        carbide_nameservers_v6: vec!["2001:db8::53".parse().unwrap()],
+        carbide_ntpservers_v6: vec!["2001:db8::123".parse().unwrap()],
+        dhcpv6_preferred_lifetime_secs: 3600,
+        dhcpv6_valid_lifetime_secs: 7200,
+        ..Default::default()
+    }
+}
+
+/// Disable TLS for the loopback mock API used by controller-mode tests.
+fn forge_config() -> ForgeClientConfig {
+    ForgeClientConfig::new(String::new(), None)
+}
+
+/// Build a client DHCPv6 message with optional IA_NA and server selection.
+///
+/// IA_NA is included when `address` is present or the message is SOLICIT or
+/// REQUEST. It is omitted for RENEW and REBIND when `address` is absent.
+pub fn client_message(
+    message_type: MessageType,
+    duid: &[u8],
+    address: Option<Ipv6Addr>,
+    server_id: Option<Vec<u8>>,
+) -> Message {
+    let mut message = Message::new_with_id(message_type, [0xaa, 0xbb, 0xcc]);
+    message
+        .opts_mut()
+        .insert(DhcpOption::ClientId(duid.to_vec()));
+    if let Some(server_id) = server_id {
+        message.opts_mut().insert(DhcpOption::ServerId(server_id));
+    }
+    if address.is_some() || matches!(message_type, MessageType::Solicit | MessageType::Request) {
+        let mut options = DhcpOptions::new();
+        if let Some(address) = address {
+            options.insert(DhcpOption::IAAddr(IAAddr {
+                addr: address,
+                preferred_life: 300,
+                valid_life: 600,
+                opts: DhcpOptions::new(),
+            }));
+        }
+        message.opts_mut().insert(DhcpOption::IANA(IANA {
+            id: IAID,
+            t1: 0,
+            t2: 0,
+            opts: options,
+        }));
+    }
+    message
+}
+
+/// Encode a typed DHCPv6 client message into its wire representation.
+pub fn encode(message: &Message) -> Vec<u8> {
+    let mut packet = Vec::new();
+    message
+        .encode(&mut Encoder::new(&mut packet))
+        .expect("test DHCPv6 message encodes");
+    packet
+}
+
+/// Decode a direct packet response produced by the server packet handler.
+pub fn decode_response(packet: &packet_handler_v6::PacketV6) -> Message {
+    decode_message(packet.encoded_packet())
+}
+
+/// Decode DHCPv6 wire bytes so socket tests verify the received datagram.
+pub fn decode_message(packet: &[u8]) -> Message {
+    Message::decode(&mut Decoder::new(packet)).expect("server DHCPv6 response decodes")
+}
+
+/// Return the single IA_NA carried by a stateful response.
+pub fn response_ia_na(response: &Message) -> &IANA {
+    match response.opts().get(OptionCode::IANA) {
+        Some(DhcpOption::IANA(association)) => association,
+        other => panic!("expected response IA_NA, got {other:?}"),
+    }
+}
+
+/// Assert an IA-specific failure retains IAID and contains no fabricated IAADDR.
+pub fn assert_ia_na_failure(response: &Message, expected_status: Status) {
+    assert!(response.opts().get(OptionCode::StatusCode).is_none());
+    let association = response_ia_na(response);
+    assert_eq!(association.id, IAID);
+    assert!(association.opts.get(OptionCode::IAAddr).is_none());
+    match association.opts.get(OptionCode::StatusCode) {
+        Some(DhcpOption::StatusCode(status)) => {
+            assert_eq!(status.status, expected_status);
+        }
+        other => panic!("expected nested IA_NA status, got {other:?}"),
+    }
+}
+
+/// Return the top-level status carried by a protocol-local response.
+pub fn response_status(response: &Message) -> dhcproto::v6::Status {
+    match response.opts().get(OptionCode::StatusCode) {
+        Some(DhcpOption::StatusCode(status)) => status.status,
+        other => panic!("expected response status, got {other:?}"),
+    }
+}
+
+/// Encode one raw relay option for envelope construction and inspection.
+pub fn raw_option(code: OptionCode, payload: &[u8]) -> Vec<u8> {
+    let mut option = Vec::new();
+    option.extend_from_slice(&u16::from(code).to_be_bytes());
+    option.extend_from_slice(
+        &u16::try_from(payload.len())
+            .expect("test relay option fits on the wire")
+            .to_be_bytes(),
+    );
+    option.extend_from_slice(payload);
+    option
+}
+
+/// Wrap a direct client message in the supported one-hop Relay-Forward shape,
+/// omitting Interface-ID or option 79 when its corresponding payload is empty.
+pub fn relay_forward(inner: &[u8], interface_id: &[u8], option79: &[u8]) -> Vec<u8> {
+    // A relay forwarding a client message initializes the hop count to zero.
+    let mut relay = vec![RELAY_FORWARD, 0];
+    relay.extend_from_slice(&"2001:db8::1".parse::<Ipv6Addr>().unwrap().octets());
+    relay.extend_from_slice(&"fe80::1".parse::<Ipv6Addr>().unwrap().octets());
+    // Empty metadata represents omission. Callers can use raw_option when
+    // they need a distinct zero-length option on the wire.
+    if !interface_id.is_empty() {
+        relay.extend_from_slice(&raw_option(OptionCode::InterfaceId, interface_id));
+    }
+    if !option79.is_empty() {
+        relay.extend_from_slice(&raw_option(OptionCode::ClientLinklayerAddr, option79));
+    }
+    relay.extend_from_slice(&raw_option(OptionCode::RelayMsg, inner));
+    relay
+}
+
+/// Parse one uniquely occurring option from a raw relay envelope.
+pub fn relay_option(packet: &[u8], code: OptionCode) -> &[u8] {
+    let mut options = packet.get(34..).unwrap_or_else(|| {
+        panic!(
+            "malformed relay packet: {} bytes is shorter than the 34-byte header",
+            packet.len()
+        )
+    });
+    while !options.is_empty() {
+        assert!(
+            options.len() >= 4,
+            "malformed relay option header: only {} bytes remain",
+            options.len()
+        );
+        let current = u16::from_be_bytes([options[0], options[1]]);
+        let length = u16::from_be_bytes([options[2], options[3]]) as usize;
+        let remaining = &options[4..];
+        assert!(
+            length <= remaining.len(),
+            "malformed relay option length {length}: only {} payload bytes remain",
+            remaining.len()
+        );
+        let (payload, rest) = remaining.split_at(length);
+        if current == u16::from(code) {
+            return payload;
+        }
+        options = rest;
+    }
+    panic!("relay option {code:?} is absent")
+}

--- a/crates/dhcp-server/tests/v6_coexistence_test.rs
+++ b/crates/dhcp-server/tests/v6_coexistence_test.rs
@@ -1,0 +1,206 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::sync::Arc;
+use std::time::Duration;
+
+use carbide_dhcp_server::modes::dpu::Dpu;
+use carbide_dhcp_server::util::{get_socket, get_socket_v6};
+use carbide_dhcp_server::{packet_handler, packet_handler_v6};
+use carbide_rpc_utils::dhcp::InterfaceInfoV6;
+use dhcproto::v4::{
+    DhcpOption as DhcpOptionV4, Message as MessageV4, MessageType as MessageTypeV4,
+    OptionCode as OptionCodeV4,
+};
+use dhcproto::v6::{Message as MessageV6, MessageType as MessageTypeV6};
+use dhcproto::{Decodable, Decoder, Encodable, Encoder};
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+mod common;
+
+use common::{DUID_LL, client_message, dpu_config, encode, machine_cache};
+
+/// Verifies the per-interface v4 and v6 sockets independently serve both families.
+#[tokio::test]
+async fn v4_and_v6_listeners_serve_concurrent_requests() {
+    // Loopback keeps the two production socket paths isolated from external
+    // interfaces while retaining bind-to-device behavior.
+    let config = dpu_config(
+        "lo",
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let v4_listener = Arc::new(
+        get_socket(
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+            "lo".to_string(),
+        )
+        .await,
+    );
+    let v6_listener = Arc::new(
+        get_socket_v6(
+            SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0),
+            "lo",
+            false,
+        )
+        .await
+        .expect("DHCPv6 listener binds"),
+    );
+    let v4_client = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("DHCPv4 client binds");
+    let v6_client = UdpSocket::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
+        .await
+        .expect("DHCPv6 client binds");
+
+    // Build one valid request for each family.
+    let mut discover = MessageV4::new(
+        Ipv4Addr::UNSPECIFIED,
+        Ipv4Addr::UNSPECIFIED,
+        Ipv4Addr::UNSPECIFIED,
+        Ipv4Addr::UNSPECIFIED,
+        &[0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
+    );
+    discover
+        .opts_mut()
+        .insert(DhcpOptionV4::MessageType(MessageTypeV4::Discover));
+    let mut discover_wire = Vec::new();
+    discover
+        .encode(&mut Encoder::new(&mut discover_wire))
+        .expect("DHCPv4 DISCOVER encodes");
+    let solicit_wire = encode(&client_message(MessageTypeV6::Solicit, DUID_LL, None, None));
+
+    // Send both requests before receiving either, exercising simultaneous listeners.
+    v4_client
+        .send_to(
+            &discover_wire,
+            SocketAddrV4::new(
+                Ipv4Addr::LOCALHOST,
+                v4_listener
+                    .local_addr()
+                    .expect("v4 listener address")
+                    .port(),
+            ),
+        )
+        .await
+        .expect("client sends DHCPv4 DISCOVER");
+    v6_client
+        .send_to(
+            &solicit_wire,
+            SocketAddrV6::new(
+                Ipv6Addr::LOCALHOST,
+                v6_listener
+                    .local_addr()
+                    .expect("v6 listener address")
+                    .port(),
+                0,
+                0,
+            ),
+        )
+        .await
+        .expect("client sends DHCPv6 SOLICIT");
+
+    let mut v4_request = vec![0; 2048];
+    let mut v6_request = vec![0; 2048];
+    let (v4_received, v6_received) = tokio::join!(
+        timeout(
+            Duration::from_secs(5),
+            v4_listener.recv_from(&mut v4_request)
+        ),
+        timeout(
+            Duration::from_secs(5),
+            v6_listener.recv_from(&mut v6_request)
+        ),
+    );
+    let (v4_length, v4_source) = v4_received
+        .expect("v4 listener receives before timeout")
+        .expect("v4 listener receives DISCOVER");
+    let (v6_length, v6_source) = v6_received
+        .expect("v6 listener receives before timeout")
+        .expect("v6 listener receives SOLICIT");
+    let SocketAddr::V4(v4_source) = v4_source else {
+        panic!("DHCPv4 listener received a non-IPv4 source");
+    };
+    let SocketAddr::V6(v6_source) = v6_source else {
+        panic!("DHCPv6 listener received a non-IPv6 source");
+    };
+
+    // Process and return each response through its corresponding socket.
+    let mut v4_cache = machine_cache();
+    let v4_response = packet_handler::process_packet(
+        &v4_request[..v4_length],
+        SocketAddr::V4(v4_source),
+        &config,
+        "lo",
+        &Dpu {},
+        &mut v4_cache,
+    )
+    .await
+    .expect("DHCPv4 DISCOVER is served");
+    v4_response
+        .send(v4_source, v4_listener)
+        .await
+        .expect("listener sends DHCPv4 OFFER");
+
+    let mut v6_cache = machine_cache();
+    let v6_response = packet_handler_v6::process_packet(
+        &v6_request[..v6_length],
+        *v6_source.ip(),
+        &config,
+        "lo",
+        &Dpu {},
+        &mut v6_cache,
+    )
+    .await
+    .expect("DHCPv6 SOLICIT is valid")
+    .expect("DHCPv6 SOLICIT is served");
+    v6_listener
+        .send_to(v6_response.encoded_packet(), v6_source)
+        .await
+        .expect("listener sends DHCPv6 ADVERTISE");
+
+    // Both clients must receive the correct family-specific response.
+    let mut offer_wire = vec![0; 2048];
+    let mut advertise_wire = vec![0; 2048];
+    let (offer, advertise) = tokio::join!(
+        timeout(Duration::from_secs(5), v4_client.recv_from(&mut offer_wire)),
+        timeout(
+            Duration::from_secs(5),
+            v6_client.recv_from(&mut advertise_wire)
+        ),
+    );
+    let (offer_length, _) = offer
+        .expect("v4 client receives before timeout")
+        .expect("v4 client receives OFFER");
+    let (advertise_length, _) = advertise
+        .expect("v6 client receives before timeout")
+        .expect("v6 client receives ADVERTISE");
+    let offer = MessageV4::decode(&mut Decoder::new(&offer_wire[..offer_length]))
+        .expect("DHCPv4 OFFER decodes");
+    let advertise = MessageV6::decode(&mut Decoder::new(&advertise_wire[..advertise_length]))
+        .expect("DHCPv6 ADVERTISE decodes");
+
+    assert_eq!(
+        offer.opts().get(OptionCodeV4::MessageType),
+        Some(&DhcpOptionV4::MessageType(MessageTypeV4::Offer))
+    );
+    assert_eq!(advertise.msg_type(), MessageTypeV6::Advertise);
+}

--- a/crates/dhcp-server/tests/v6_coexistence_test.rs
+++ b/crates/dhcp-server/tests/v6_coexistence_test.rs
@@ -1,0 +1,202 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::sync::Arc;
+use std::time::Duration;
+
+use carbide_dhcp_server::modes::dpu::Dpu;
+use carbide_dhcp_server::util::{get_socket, get_socket_v6};
+use carbide_dhcp_server::{packet_handler, packet_handler_v6};
+use carbide_rpc_utils::dhcp::InterfaceInfoV6;
+use dhcproto::v4::{
+    DhcpOption as DhcpOptionV4, Message as MessageV4, MessageType as MessageTypeV4,
+    OptionCode as OptionCodeV4,
+};
+use dhcproto::v6::{Message as MessageV6, MessageType as MessageTypeV6};
+use dhcproto::{Decodable, Decoder, Encodable, Encoder};
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+mod common;
+
+use common::{DUID_LL, client_message, dpu_config, encode, machine_cache};
+
+/// Verifies the per-interface v4 and v6 sockets independently serve both families.
+#[tokio::test]
+async fn v4_and_v6_listeners_serve_concurrent_requests() {
+    // Loopback keeps the two production socket paths isolated from external
+    // interfaces while retaining bind-to-device behavior.
+    let config = dpu_config(
+        "lo",
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let v4_listener = Arc::new(
+        get_socket(
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+            "lo".to_string(),
+        )
+        .await,
+    );
+    let v6_listener = Arc::new(
+        get_socket_v6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0), "lo")
+            .await
+            .expect("DHCPv6 listener binds"),
+    );
+    let v4_client = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("DHCPv4 client binds");
+    let v6_client = UdpSocket::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
+        .await
+        .expect("DHCPv6 client binds");
+
+    // Build one valid request for each family.
+    let mut discover = MessageV4::new(
+        Ipv4Addr::UNSPECIFIED,
+        Ipv4Addr::UNSPECIFIED,
+        Ipv4Addr::UNSPECIFIED,
+        Ipv4Addr::UNSPECIFIED,
+        &[0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
+    );
+    discover
+        .opts_mut()
+        .insert(DhcpOptionV4::MessageType(MessageTypeV4::Discover));
+    let mut discover_wire = Vec::new();
+    discover
+        .encode(&mut Encoder::new(&mut discover_wire))
+        .expect("DHCPv4 DISCOVER encodes");
+    let solicit_wire = encode(&client_message(MessageTypeV6::Solicit, DUID_LL, None, None));
+
+    // Send both requests before receiving either, exercising simultaneous listeners.
+    v4_client
+        .send_to(
+            &discover_wire,
+            SocketAddrV4::new(
+                Ipv4Addr::LOCALHOST,
+                v4_listener
+                    .local_addr()
+                    .expect("v4 listener address")
+                    .port(),
+            ),
+        )
+        .await
+        .expect("client sends DHCPv4 DISCOVER");
+    v6_client
+        .send_to(
+            &solicit_wire,
+            SocketAddrV6::new(
+                Ipv6Addr::LOCALHOST,
+                v6_listener
+                    .local_addr()
+                    .expect("v6 listener address")
+                    .port(),
+                0,
+                0,
+            ),
+        )
+        .await
+        .expect("client sends DHCPv6 SOLICIT");
+
+    let mut v4_request = vec![0; 2048];
+    let mut v6_request = vec![0; 2048];
+    let (v4_received, v6_received) = tokio::join!(
+        timeout(
+            Duration::from_secs(5),
+            v4_listener.recv_from(&mut v4_request)
+        ),
+        timeout(
+            Duration::from_secs(5),
+            v6_listener.recv_from(&mut v6_request)
+        ),
+    );
+    let (v4_length, v4_source) = v4_received
+        .expect("v4 listener receives before timeout")
+        .expect("v4 listener receives DISCOVER");
+    let (v6_length, v6_source) = v6_received
+        .expect("v6 listener receives before timeout")
+        .expect("v6 listener receives SOLICIT");
+    let SocketAddr::V4(v4_source) = v4_source else {
+        panic!("DHCPv4 listener received a non-IPv4 source");
+    };
+    let SocketAddr::V6(v6_source) = v6_source else {
+        panic!("DHCPv6 listener received a non-IPv6 source");
+    };
+
+    // Process and return each response through its corresponding socket.
+    let mut v4_cache = machine_cache();
+    let v4_response = packet_handler::process_packet(
+        &v4_request[..v4_length],
+        SocketAddr::V4(v4_source),
+        &config,
+        "lo",
+        &Dpu {},
+        &mut v4_cache,
+    )
+    .await
+    .expect("DHCPv4 DISCOVER is served");
+    v4_response
+        .send(v4_source, v4_listener)
+        .await
+        .expect("listener sends DHCPv4 OFFER");
+
+    let mut v6_cache = machine_cache();
+    let v6_response = packet_handler_v6::process_packet(
+        &v6_request[..v6_length],
+        *v6_source.ip(),
+        &config,
+        "lo",
+        &Dpu {},
+        &mut v6_cache,
+    )
+    .await
+    .expect("DHCPv6 SOLICIT is valid")
+    .expect("DHCPv6 SOLICIT is served");
+    v6_listener
+        .send_to(v6_response.encoded_packet(), v6_source)
+        .await
+        .expect("listener sends DHCPv6 ADVERTISE");
+
+    // Both clients must receive the correct family-specific response.
+    let mut offer_wire = vec![0; 2048];
+    let mut advertise_wire = vec![0; 2048];
+    let (offer, advertise) = tokio::join!(
+        timeout(Duration::from_secs(5), v4_client.recv_from(&mut offer_wire)),
+        timeout(
+            Duration::from_secs(5),
+            v6_client.recv_from(&mut advertise_wire)
+        ),
+    );
+    let (offer_length, _) = offer
+        .expect("v4 client receives before timeout")
+        .expect("v4 client receives OFFER");
+    let (advertise_length, _) = advertise
+        .expect("v6 client receives before timeout")
+        .expect("v6 client receives ADVERTISE");
+    let offer = MessageV4::decode(&mut Decoder::new(&offer_wire[..offer_length]))
+        .expect("DHCPv4 OFFER decodes");
+    let advertise = MessageV6::decode(&mut Decoder::new(&advertise_wire[..advertise_length]))
+        .expect("DHCPv6 ADVERTISE decodes");
+
+    assert_eq!(
+        offer.opts().get(OptionCodeV4::MessageType),
+        Some(&DhcpOptionV4::MessageType(MessageTypeV4::Offer))
+    );
+    assert_eq!(advertise.msg_type(), MessageTypeV6::Advertise);
+}

--- a/crates/dhcp-server/tests/v6_controller_mode_test.rs
+++ b/crates/dhcp-server/tests/v6_controller_mode_test.rs
@@ -1,0 +1,307 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::convert::Infallible;
+use std::net::Ipv6Addr;
+use std::sync::{Arc, Mutex};
+
+use carbide_dhcp_server::errors::DhcpError;
+use carbide_dhcp_server::modes::controller::Controller;
+use carbide_dhcp_server::packet_handler_v6::process_packet;
+use carbide_dhcpv6::RELAY_REPLY;
+use dhcproto::v6::{DhcpOption, Message, MessageType, OptionCode};
+use dhcproto::{Decodable, Decoder};
+use futures::stream;
+use http_body_util::combinators::UnsyncBoxBody;
+use http_body_util::{BodyExt, StreamBody};
+use hyper::body::{Bytes, Frame, Incoming};
+use hyper::server::conn::http2;
+use hyper::service::service_fn;
+use hyper::{Request, Response, header};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use prost::Message as _;
+use rpc::forge::{AddressFamily, BuildInfo, DhcpDiscovery, DhcpRecord};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+mod common;
+
+use common::{
+    DUID_UUID, client_message, controller_config, controller_config_with_lifetimes, encode,
+    machine_cache, relay_forward, relay_option, response_ia_na,
+};
+
+const OPTION79: &[u8] = &[0, 1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee];
+
+/// Minimal Forge mock supporting only client initialization and DiscoverDhcp.
+struct MockDiscoverDhcpApi {
+    url: String,
+    discoveries: Arc<Mutex<Vec<DhcpDiscovery>>>,
+    shutdown: Option<oneshot::Sender<()>>,
+    server: Option<JoinHandle<()>>,
+}
+
+impl MockDiscoverDhcpApi {
+    /// Start an isolated HTTP/2 gRPC endpoint without linking the Kea hook crate.
+    async fn start() -> Self {
+        // Bind before spawning so the returned URL is immediately usable.
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("mock Forge listener binds");
+        let address = listener.local_addr().expect("mock listener has an address");
+        let discoveries = Arc::new(Mutex::new(Vec::new()));
+        let server_discoveries = discoveries.clone();
+        let (shutdown, shutdown_rx) = oneshot::channel();
+
+        // One connection serves the Version probe and test DiscoverDhcp call.
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("mock accepts a client");
+            let connection = http2::Builder::new(TokioExecutor::new()).serve_connection(
+                TokioIo::new(stream),
+                service_fn(move |request| mock_forge_request(request, server_discoveries.clone())),
+            );
+            tokio::pin!(connection);
+            tokio::select! {
+                result = connection.as_mut() => {
+                    result.expect("mock serves the gRPC connection");
+                }
+                _ = shutdown_rx => {
+                    connection.as_mut().graceful_shutdown();
+                    connection
+                        .await
+                        .expect("mock gracefully closes the gRPC connection");
+                }
+            }
+        });
+
+        Self {
+            url: format!("http://{address}"),
+            discoveries,
+            shutdown: Some(shutdown),
+            server: Some(server),
+        }
+    }
+
+    /// Return the loopback URL consumed by the production Forge client.
+    fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Stop the mock, surface task failures, and return its observed requests.
+    async fn shutdown(mut self) -> Vec<DhcpDiscovery> {
+        let shutdown_sent = match self.shutdown.take() {
+            Some(shutdown) => shutdown.send(()).is_ok(),
+            None => true,
+        };
+        self.server
+            .take()
+            .expect("mock server task is present")
+            .await
+            .expect("mock server task did not panic");
+        assert!(
+            shutdown_sent,
+            "mock shutdown receiver closed before the explicit signal"
+        );
+        self.discoveries
+            .lock()
+            .expect("mock discoveries lock is available")
+            .clone()
+    }
+}
+
+impl Drop for MockDiscoverDhcpApi {
+    fn drop(&mut self) {
+        if let Some(server) = self.server.take() {
+            server.abort();
+        }
+    }
+}
+
+/// Handle the two Forge methods used by controller-mode discovery.
+async fn mock_forge_request(
+    request: Request<Incoming>,
+    discoveries: Arc<Mutex<Vec<DhcpDiscovery>>>,
+) -> Result<Response<UnsyncBoxBody<Bytes, Infallible>>, Infallible> {
+    let response = match request.uri().path() {
+        "/forge.Forge/Version" => grpc_response(BuildInfo::default()),
+        "/forge.Forge/DiscoverDhcp" => {
+            // Strip the gRPC frame and retain the request for contract assertions.
+            let body = request
+                .into_body()
+                .collect()
+                .await
+                .expect("DiscoverDhcp request body is readable")
+                .to_bytes();
+            let payload = body.get(5..).expect("DiscoverDhcp has a gRPC frame");
+            let discovery = DhcpDiscovery::decode(payload).expect("DiscoverDhcp request decodes");
+            discoveries
+                .lock()
+                .expect("mock discoveries lock is available")
+                .push(discovery.clone());
+
+            // Return only the fields consumed by the DHCPv6 response encoder.
+            grpc_response(DhcpRecord {
+                fqdn: "host.example.com".to_string(),
+                mac_address: discovery.mac_address,
+                address: "2001:db8::ee".to_string(),
+                prefix: "2001:db8::/64".to_string(),
+                ..Default::default()
+            })
+        }
+        path => panic!("unexpected mock Forge method: {path}"),
+    };
+    Ok(response)
+}
+
+/// Encode one protobuf response with the gRPC data and status frames tonic expects.
+fn grpc_response(message: impl prost::Message) -> Response<UnsyncBoxBody<Bytes, Infallible>> {
+    // Prefix the protobuf with the standard uncompressed gRPC frame header.
+    let mut data = Vec::with_capacity(5 + message.encoded_len());
+    data.push(0);
+    data.extend_from_slice(
+        &u32::try_from(message.encoded_len())
+            .expect("test response fits in a gRPC frame")
+            .to_be_bytes(),
+    );
+    message
+        .encode(&mut data)
+        .expect("mock gRPC response encodes");
+
+    // Complete the response with an OK status trailer.
+    let mut trailers = hyper::HeaderMap::new();
+    trailers.insert(
+        header::HeaderName::from_static("grpc-status"),
+        header::HeaderValue::from_static("0"),
+    );
+    let body = StreamBody::new(stream::iter([
+        Ok::<_, Infallible>(Frame::data(Bytes::from(data))),
+        Ok(Frame::trailers(trailers)),
+    ]))
+    .boxed_unsync();
+
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/grpc+tonic")
+        .body(body)
+        .expect("mock gRPC response is valid")
+}
+
+/// Verifies controller mode forwards selected v6 identity and restores the relay envelope.
+#[tokio::test]
+async fn relayed_solicit_round_trips_through_controller_api() {
+    let api = MockDiscoverDhcpApi::start().await;
+    let config = controller_config(api.url());
+    let inner = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let request = relay_forward(&inner, b"swp1", OPTION79);
+    let mut cache = machine_cache();
+
+    // A non-MAC DUID is valid here because the trusted relay supplies option 79.
+    let packet = process_packet(
+        &request,
+        "fe80::100".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await;
+    let discoveries = api.shutdown().await;
+    let packet = packet
+        .expect("relayed controller SOLICIT is valid")
+        .expect("relayed controller SOLICIT is served");
+
+    // The response preserves relay routing metadata and wraps an ADVERTISE.
+    assert_eq!(packet.encoded_packet()[0], RELAY_REPLY);
+    assert_eq!(
+        relay_option(packet.encoded_packet(), OptionCode::InterfaceId),
+        b"swp1"
+    );
+    let response = Message::decode(&mut Decoder::new(relay_option(
+        packet.encoded_packet(),
+        OptionCode::RelayMsg,
+    )))
+    .expect("inner ADVERTISE decodes");
+    assert_eq!(response.msg_type(), MessageType::Advertise);
+    match response_ia_na(&response).opts.get(OptionCode::IAAddr) {
+        Some(DhcpOption::IAAddr(address)) => {
+            assert_eq!(address.addr, "2001:db8::ee".parse::<Ipv6Addr>().unwrap());
+        }
+        other => panic!("expected controller IAADDR, got {other:?}"),
+    }
+
+    // The API observes the transport-selected MAC and complete family-aware contract.
+    assert_eq!(discoveries.len(), 1);
+    let discovery = &discoveries[0];
+    assert_eq!(discovery.address_family, Some(AddressFamily::V6 as i32));
+    assert_eq!(discovery.duid.as_deref(), Some(DUID_UUID));
+    assert_eq!(discovery.mac_address, "02:aa:bb:cc:dd:ee");
+    assert_eq!(discovery.circuit_id.as_deref(), Some("73777031"));
+    assert_eq!(discovery.link_address.as_deref(), Some("2001:db8::1"));
+}
+
+/// Verifies controller CONFIRM without optional Interface-ID remains silent.
+#[tokio::test]
+async fn relayed_confirm_without_link_knowledge_is_ignored() {
+    let config = controller_config("http://[::1]:1");
+    let inner = encode(&client_message(
+        MessageType::Confirm,
+        DUID_UUID,
+        Some("2001:db8::20".parse().unwrap()),
+        None,
+    ));
+    let request = relay_forward(&inner, &[], OPTION79);
+    let mut cache = machine_cache();
+
+    // CONFIRM bypasses the API, so omitting relay Interface-ID must preserve silence.
+    let response = process_packet(
+        &request,
+        "fe80::100".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await
+    .expect("relayed CONFIRM is valid");
+    assert!(response.is_none());
+}
+
+/// Invalid stateful lifetimes fail locally before controller discovery can allocate.
+#[tokio::test]
+async fn invalid_stateful_lifetimes_fail_before_controller_discovery() {
+    // An unreachable API makes any accidental discovery call observable as a transport error.
+    let config = controller_config_with_lifetimes("http://[::1]:1", 0, 7200);
+    let inner = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let request = relay_forward(&inner, b"swp1", OPTION79);
+    let mut cache = machine_cache();
+
+    let result = process_packet(
+        &request,
+        "fe80::100".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(DhcpError::InvalidInput(error))
+            if error == "DHCPv6 lifetimes must be nonzero with preferred not exceeding valid"
+    ));
+}

--- a/crates/dhcp-server/tests/v6_controller_mode_test.rs
+++ b/crates/dhcp-server/tests/v6_controller_mode_test.rs
@@ -1,0 +1,309 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::convert::Infallible;
+use std::net::Ipv6Addr;
+use std::sync::{Arc, Mutex};
+
+use carbide_dhcp_server::errors::DhcpError;
+use carbide_dhcp_server::modes::controller::Controller;
+use carbide_dhcp_server::packet_handler_v6::process_packet;
+use carbide_dhcpv6::RELAY_REPLY;
+use dhcproto::v6::{DhcpOption, Message, MessageType, OptionCode};
+use dhcproto::{Decodable, Decoder};
+use futures::stream;
+use http_body_util::combinators::UnsyncBoxBody;
+use http_body_util::{BodyExt, StreamBody};
+use hyper::body::{Bytes, Frame, Incoming};
+use hyper::server::conn::http2;
+use hyper::service::service_fn;
+use hyper::{Request, Response, header};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use prost::Message as _;
+use rpc::forge::{AddressFamily, BuildInfo, DhcpDiscovery, DhcpRecord};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+mod common;
+
+use common::{
+    DUID_UUID, client_message, controller_config, controller_config_with_lifetimes, encode,
+    machine_cache, relay_forward, relay_option, response_ia_na,
+};
+
+const OPTION79: &[u8] = &[0, 1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee];
+
+/// Minimal Forge mock supporting only client initialization and DiscoverDhcp.
+struct MockDiscoverDhcpApi {
+    url: String,
+    discoveries: Arc<Mutex<Vec<DhcpDiscovery>>>,
+    shutdown: Option<oneshot::Sender<()>>,
+    server: Option<JoinHandle<()>>,
+}
+
+impl MockDiscoverDhcpApi {
+    /// Start an isolated HTTP/2 gRPC endpoint without linking the Kea hook crate.
+    async fn start() -> Self {
+        // Bind before spawning so the returned URL is immediately usable.
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("mock Forge listener binds");
+        let address = listener.local_addr().expect("mock listener has an address");
+        let discoveries = Arc::new(Mutex::new(Vec::new()));
+        let server_discoveries = discoveries.clone();
+        let (shutdown, shutdown_rx) = oneshot::channel();
+
+        // One connection serves the Version probe and test DiscoverDhcp call.
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("mock accepts a client");
+            let connection = http2::Builder::new(TokioExecutor::new()).serve_connection(
+                TokioIo::new(stream),
+                service_fn(move |request| mock_forge_request(request, server_discoveries.clone())),
+            );
+            tokio::pin!(connection);
+            tokio::select! {
+                result = connection.as_mut() => {
+                    result.expect("mock serves the gRPC connection");
+                }
+                _ = shutdown_rx => {
+                    connection.as_mut().graceful_shutdown();
+                    connection
+                        .await
+                        .expect("mock gracefully closes the gRPC connection");
+                }
+            }
+        });
+
+        Self {
+            url: format!("http://{address}"),
+            discoveries,
+            shutdown: Some(shutdown),
+            server: Some(server),
+        }
+    }
+
+    /// Return the loopback URL consumed by the production Forge client.
+    fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Stop the mock, surface task failures, and return its observed requests.
+    async fn shutdown(mut self) -> Vec<DhcpDiscovery> {
+        let shutdown_sent = match self.shutdown.take() {
+            Some(shutdown) => shutdown.send(()).is_ok(),
+            None => true,
+        };
+        self.server
+            .take()
+            .expect("mock server task is present")
+            .await
+            .expect("mock server task did not panic");
+        assert!(
+            shutdown_sent,
+            "mock shutdown receiver closed before the explicit signal"
+        );
+        self.discoveries
+            .lock()
+            .expect("mock discoveries lock is available")
+            .clone()
+    }
+}
+
+impl Drop for MockDiscoverDhcpApi {
+    fn drop(&mut self) {
+        if let Some(server) = self.server.take() {
+            server.abort();
+        }
+    }
+}
+
+/// Handle the two Forge methods used by controller-mode discovery.
+async fn mock_forge_request(
+    request: Request<Incoming>,
+    discoveries: Arc<Mutex<Vec<DhcpDiscovery>>>,
+) -> Result<Response<UnsyncBoxBody<Bytes, Infallible>>, Infallible> {
+    let response = match request.uri().path() {
+        "/forge.Forge/Version" => grpc_response(BuildInfo::default()),
+        "/forge.Forge/DiscoverDhcp" => {
+            // Strip the gRPC frame and retain the request for contract assertions.
+            let body = request
+                .into_body()
+                .collect()
+                .await
+                .expect("DiscoverDhcp request body is readable")
+                .to_bytes();
+            let payload = body.get(5..).expect("DiscoverDhcp has a gRPC frame");
+            let discovery = DhcpDiscovery::decode(payload).expect("DiscoverDhcp request decodes");
+            discoveries
+                .lock()
+                .expect("mock discoveries lock is available")
+                .push(discovery.clone());
+
+            // Return only the fields consumed by the DHCPv6 response encoder.
+            grpc_response(DhcpRecord {
+                fqdn: "host.example.com".to_string(),
+                mac_address: discovery.mac_address,
+                address: "2001:db8::ee".to_string(),
+                prefix: "2001:db8::/64".to_string(),
+                ..Default::default()
+            })
+        }
+        path => panic!("unexpected mock Forge method: {path}"),
+    };
+    Ok(response)
+}
+
+/// Encode one protobuf response with the gRPC data and status frames tonic expects.
+fn grpc_response(message: impl prost::Message) -> Response<UnsyncBoxBody<Bytes, Infallible>> {
+    // Prefix the protobuf with the standard uncompressed gRPC frame header.
+    let mut data = Vec::with_capacity(5 + message.encoded_len());
+    data.push(0);
+    data.extend_from_slice(
+        &u32::try_from(message.encoded_len())
+            .expect("test response fits in a gRPC frame")
+            .to_be_bytes(),
+    );
+    message
+        .encode(&mut data)
+        .expect("mock gRPC response encodes");
+
+    // Complete the response with an OK status trailer.
+    let mut trailers = hyper::HeaderMap::new();
+    trailers.insert(
+        header::HeaderName::from_static("grpc-status"),
+        header::HeaderValue::from_static("0"),
+    );
+    let body = StreamBody::new(stream::iter([
+        Ok::<_, Infallible>(Frame::data(Bytes::from(data))),
+        Ok(Frame::trailers(trailers)),
+    ]))
+    .boxed_unsync();
+
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/grpc+tonic")
+        .body(body)
+        .expect("mock gRPC response is valid")
+}
+
+/// Verifies controller mode forwards selected v6 identity and restores the relay envelope.
+#[tokio::test]
+async fn relayed_solicit_round_trips_through_controller_api() {
+    let api = MockDiscoverDhcpApi::start().await;
+    let config = controller_config(api.url());
+    let inner = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let request = relay_forward(&inner, b"swp1", OPTION79);
+    let mut cache = machine_cache();
+
+    // A non-MAC DUID is valid here because the trusted relay supplies option 79.
+    let packet = process_packet(
+        &request,
+        "fe80::100".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await;
+    let discoveries = api.shutdown().await;
+    let packet = packet
+        .expect("relayed controller SOLICIT is valid")
+        .expect("relayed controller SOLICIT is served");
+
+    // The response preserves relay routing metadata and wraps an ADVERTISE.
+    assert_eq!(packet.encoded_packet()[0], RELAY_REPLY);
+    assert_eq!(
+        relay_option(packet.encoded_packet(), OptionCode::InterfaceId),
+        b"swp1"
+    );
+    let response = Message::decode(&mut Decoder::new(relay_option(
+        packet.encoded_packet(),
+        OptionCode::RelayMsg,
+    )))
+    .expect("inner ADVERTISE decodes");
+    assert_eq!(response.msg_type(), MessageType::Advertise);
+    match response_ia_na(&response).opts.get(OptionCode::IAAddr) {
+        Some(DhcpOption::IAAddr(address)) => {
+            assert_eq!(address.addr, "2001:db8::ee".parse::<Ipv6Addr>().unwrap());
+        }
+        other => panic!("expected controller IAADDR, got {other:?}"),
+    }
+
+    // The API observes the transport-selected MAC and complete family-aware contract.
+    assert_eq!(discoveries.len(), 1);
+    let discovery = &discoveries[0];
+    assert_eq!(discovery.address_family, Some(AddressFamily::V6 as i32));
+    assert_eq!(discovery.duid.as_deref(), Some(DUID_UUID));
+    assert_eq!(discovery.mac_address, "02:aa:bb:cc:dd:ee");
+    assert_eq!(discovery.circuit_id.as_deref(), Some("73777031"));
+    assert_eq!(discovery.link_address.as_deref(), Some("2001:db8::1"));
+}
+
+/// Verifies controller CONFIRM without optional Interface-ID remains silent.
+#[tokio::test]
+async fn relayed_confirm_without_link_knowledge_is_ignored() {
+    let config = controller_config("http://[::1]:1");
+    let inner = encode(&client_message(
+        MessageType::Confirm,
+        DUID_UUID,
+        Some("2001:db8::20".parse().unwrap()),
+        None,
+    ));
+    let request = relay_forward(&inner, &[], OPTION79);
+    let mut cache = machine_cache();
+
+    // CONFIRM bypasses the API, so omitting relay Interface-ID must preserve silence.
+    let response = process_packet(
+        &request,
+        "fe80::100".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await
+    .expect("relayed CONFIRM is valid");
+    assert!(response.is_none());
+}
+
+/// Invalid stateful lifetimes fail locally before controller discovery can allocate.
+#[tokio::test]
+async fn invalid_stateful_lifetimes_fail_before_controller_discovery() {
+    // An unreachable API makes any accidental discovery call observable as a transport error.
+    let config = controller_config_with_lifetimes("http://[::1]:1", 0, 7200);
+    let inner = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let request = relay_forward(&inner, b"swp1", OPTION79);
+    let mut cache = machine_cache();
+
+    let result = process_packet(
+        &request,
+        "fe80::100".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(DhcpError::InvalidDhcpV6Lifetimes {
+            preferred_lifetime_secs: 0,
+            valid_lifetime_secs: 7200,
+        })
+    ));
+}

--- a/crates/dhcp-server/tests/v6_identity_and_relay_policy_test.rs
+++ b/crates/dhcp-server/tests/v6_identity_and_relay_policy_test.rs
@@ -1,0 +1,386 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::BTreeMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use carbide_dhcp_server::errors::DhcpError;
+use carbide_dhcp_server::modes::controller::Controller;
+use carbide_dhcp_server::modes::dpu::Dpu;
+use carbide_dhcp_server::packet_handler_v6::process_packet;
+use carbide_rpc_utils::dhcp::{InterfaceInfo, InterfaceInfoV6};
+use dhcproto::v6::{DhcpOption, DhcpOptions, IAPD, IATA, MessageType, OptionCode, Status};
+
+mod common;
+
+use common::{
+    DUID_UUID, SERVER_IDENTIFIER, client_message, controller_config, decode_message,
+    decode_response, dpu_config_with_bindings, encode, machine_cache, relay_forward, relay_option,
+    response_ia_na, response_status,
+};
+
+const OPTION79: &[u8] = &[0, 1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee];
+
+/// Provide stateful DPU configuration so identity policy is the only rejection under test.
+fn config() -> carbide_dhcp_server::Config {
+    // Give the receiving interface a complete production-shaped binding.
+    let ingress = InterfaceInfo {
+        address: Ipv4Addr::new(192, 0, 2, 20),
+        gateway: Ipv4Addr::new(192, 0, 2, 1),
+        prefix: "192.0.2.0/24".to_string(),
+        fqdn: "host.example.com".to_string(),
+        booturl: None,
+        mtu: Some(9000),
+        ipv6: Some(InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        }),
+    };
+
+    // Vary only IPv6 so a foreign binding selection is visible in the reply.
+    let mut foreign = ingress.clone();
+    foreign.ipv6 = Some(InterfaceInfoV6 {
+        address: Some("2001:db8:1::20".parse().unwrap()),
+        prefix: "2001:db8:1::/64".to_string(),
+    });
+
+    dpu_config_with_bindings(BTreeMap::from([
+        ("eth0".to_string(), ingress),
+        ("eth1".to_string(), foreign),
+    ]))
+}
+
+/// Verifies DPU mode accepts opaque client identity because ingress interface selects the binding.
+#[tokio::test]
+async fn direct_non_mac_duid_uses_ingress_interface() {
+    let config = config();
+    let request = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let mut cache = machine_cache();
+
+    // DPU lookup is keyed by ingress interface, so a non-MAC DUID must not block service.
+    let packet = process_packet(
+        &request,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("non-MAC DUID request is valid")
+    .expect("configured ingress interface serves a non-MAC DUID");
+
+    // An Advertise alone would not prove which configured interface supplied the binding.
+    let response = decode_response(&packet);
+    assert_eq!(response.msg_type(), MessageType::Advertise);
+    match response_ia_na(&response).opts.get(OptionCode::IAAddr) {
+        Some(DhcpOption::IAAddr(address)) => {
+            assert_eq!(address.addr, "2001:db8::20".parse::<Ipv6Addr>().unwrap());
+        }
+        other => panic!("expected eth0 IAAddr, got {other:?}"),
+    }
+}
+
+/// Verifies DPU ingress selection does not bypass generic DUID validation.
+#[tokio::test]
+async fn direct_malformed_duid_is_rejected_before_ingress_lookup() {
+    let config = config();
+    let request = encode(&client_message(MessageType::Solicit, &[0], None, None));
+    let mut cache = machine_cache();
+
+    let error = process_packet(
+        &request,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect_err("malformed DUID must fail before DPU binding selection");
+    assert!(matches!(error, DhcpError::MalformedDuid));
+}
+
+/// Verifies DPU mode rejects Relay-Forward before relay metadata can influence local service.
+#[tokio::test]
+async fn dpu_rejects_relay_forward() {
+    let config = config();
+    let inner = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let request = relay_forward(&inner, b"eth1", &[]);
+    let mut cache = machine_cache();
+
+    let error = process_packet(
+        &request,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect_err("DPU mode must reject relayed DHCPv6");
+    assert!(matches!(
+        error,
+        DhcpError::InvalidInput(message)
+            if message == "DPU mode requires a direct DHCPv6 packet"
+    ));
+}
+
+/// Verifies controller-local lease-end replies require a relay-selected MAC because they skip
+/// authoritative discovery before returning a protocol-local success.
+#[tokio::test]
+async fn controller_lease_end_messages_require_selected_mac_identity() {
+    let config = controller_config("http://[::1]:1");
+    let server_id = SERVER_IDENTIFIER.to_vec();
+
+    for message_type in [MessageType::Release, MessageType::Decline] {
+        // Include the selected server and IA_NA so identity is the only rejection.
+        let inner = encode(&client_message(
+            message_type,
+            DUID_UUID,
+            Some("2001:db8::20".parse().unwrap()),
+            Some(server_id.clone()),
+        ));
+        let request_without_identity = relay_forward(&inner, b"swp1", &[]);
+        let mut cache = machine_cache();
+
+        // Controller mode must not acknowledge a lease-end message without a MAC source.
+        let error = process_packet(
+            &request_without_identity,
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Controller {},
+            &mut cache,
+        )
+        .await
+        .expect_err("controller lease-end identity requires a usable MAC source");
+        assert!(matches!(error, DhcpError::NoMacNoOption79));
+
+        let request_with_identity = relay_forward(&inner, b"swp1", OPTION79);
+        let mut cache = machine_cache();
+
+        // A trusted relay MAC satisfies the identity gate without invoking discovery.
+        let packet = process_packet(
+            &request_with_identity,
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Controller {},
+            &mut cache,
+        )
+        .await
+        .expect("relay option 79 provides controller lease-end identity")
+        .expect("controller returns a local lease-end reply");
+        let response = decode_message(relay_option(packet.encoded_packet(), OptionCode::RelayMsg));
+        assert_eq!(response.msg_type(), MessageType::Reply);
+        assert_eq!(response_status(&response), Status::Success);
+    }
+}
+
+/// Verifies DPU lease-end replies remain ingress-scoped because local serving does not need
+/// a MAC-bearing DUID or relay-supplied option 79.
+#[tokio::test]
+async fn dpu_lease_end_messages_keep_ingress_identity_policy() {
+    let config = config();
+    let server_id = SERVER_IDENTIFIER.to_vec();
+
+    for message_type in [MessageType::Release, MessageType::Decline] {
+        // Include the selected server and IA_NA to exercise the complete local reply path.
+        let request = encode(&client_message(
+            message_type,
+            DUID_UUID,
+            Some("2001:db8::20".parse().unwrap()),
+            Some(server_id.clone()),
+        ));
+        let mut cache = machine_cache();
+
+        // DPU mode keys identity by ingress interface, so the non-MAC DUID remains valid.
+        let packet = process_packet(
+            &request,
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Dpu {},
+            &mut cache,
+        )
+        .await
+        .expect("DPU lease-end identity is ingress-scoped")
+        .expect("DPU returns a local lease-end reply");
+        let response = decode_response(&packet);
+        assert_eq!(response.msg_type(), MessageType::Reply);
+        assert_eq!(response_status(&response), Status::Success);
+    }
+}
+
+/// Unsupported address-association types are rejected before protocol-local replies.
+#[tokio::test]
+async fn local_replies_do_not_acknowledge_temporary_or_prefix_associations() {
+    #[derive(Clone, Copy)]
+    enum Association {
+        Temporary,
+        PrefixDelegation,
+    }
+
+    let config = config();
+    for (scenario, message_type, association) in [
+        // CONFIRM cannot validate temporary-address state this server does not own.
+        (
+            "CONFIRM with IA_TA",
+            MessageType::Confirm,
+            Association::Temporary,
+        ),
+        // RELEASE must not claim that an unsupported delegated prefix was released.
+        (
+            "RELEASE with IA_PD",
+            MessageType::Release,
+            Association::PrefixDelegation,
+        ),
+        // DECLINE must not claim that an unsupported temporary address was quarantined.
+        (
+            "DECLINE with IA_TA",
+            MessageType::Decline,
+            Association::Temporary,
+        ),
+    ] {
+        let server_id = matches!(message_type, MessageType::Release | MessageType::Decline)
+            .then(|| SERVER_IDENTIFIER.to_vec());
+        let mut message = client_message(
+            message_type,
+            DUID_UUID,
+            Some("2001:db8::20".parse().unwrap()),
+            server_id,
+        );
+        match association {
+            Association::Temporary => {
+                message.opts_mut().insert(DhcpOption::IATA(IATA {
+                    id: 7,
+                    opts: DhcpOptions::new(),
+                }));
+            }
+            Association::PrefixDelegation => message.opts_mut().insert(DhcpOption::IAPD(IAPD {
+                id: 7,
+                t1: 0,
+                t2: 0,
+                opts: DhcpOptions::new(),
+            })),
+        }
+        let request = encode(&message);
+        let mut cache = machine_cache();
+
+        let error = process_packet(
+            &request,
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Dpu {},
+            &mut cache,
+        )
+        .await
+        .expect_err("unsupported association must not receive a local success reply");
+        assert!(
+            matches!(&error, DhcpError::UnhandledMessageTypeV6(actual) if *actual == message_type),
+            "{scenario} returned {error:?}"
+        );
+    }
+}
+
+/// Verifies controller identity requires relay option 79 for valid DUIDs without Ethernet MACs.
+#[tokio::test]
+async fn controller_non_mac_duids_require_relay_identity() {
+    let config = controller_config("http://[::1]:1");
+    let request = relay_forward(
+        &encode(&client_message(MessageType::Solicit, DUID_UUID, None, None)),
+        b"swp1",
+        &[],
+    );
+    let mut cache = machine_cache();
+
+    // A valid non-MAC DUID still cannot select an authoritative API row.
+    let error = process_packet(
+        &request,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await
+    .expect_err("controller identity requires a usable MAC source");
+    assert!(matches!(error, DhcpError::NoMacNoOption79));
+
+    let unknown = relay_forward(
+        &encode(&client_message(
+            MessageType::Solicit,
+            &[0, 99, 0, 1, 2, 3],
+            None,
+            None,
+        )),
+        b"swp1",
+        &[],
+    );
+
+    // Unknown DUID types are valid opaque identities and use the same option-79 fallback.
+    let error = process_packet(
+        &unknown,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await
+    .expect_err("controller identity requires a usable MAC source");
+    assert!(matches!(error, DhcpError::NoMacNoOption79));
+}
+
+/// Verifies nested and multi-hop relay shapes are rejected before segment selection.
+#[tokio::test]
+async fn unsupported_relay_depth_is_rejected() {
+    let config = config();
+    let inner = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let nested = relay_forward(&relay_forward(&inner, b"swp1", OPTION79), b"swp2", OPTION79);
+    let mut cache = machine_cache();
+
+    // Nested relay precedence is intentionally undefined in this one-hop milestone.
+    let error = process_packet(
+        &nested,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect_err("nested relay must be rejected");
+    assert!(matches!(error, DhcpError::NestedRelayV6));
+
+    // A nonzero count requires another relay envelope, which this decoder rejects.
+    let mut nonzero_hop = relay_forward(&inner, b"swp1", OPTION79);
+    nonzero_hop[1] = 1;
+    let error = process_packet(
+        &nonzero_hop,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect_err("nonzero relay hop count must be rejected");
+    assert!(matches!(error, DhcpError::RelayHopCountExceededV6(1)));
+}

--- a/crates/dhcp-server/tests/v6_identity_and_relay_policy_test.rs
+++ b/crates/dhcp-server/tests/v6_identity_and_relay_policy_test.rs
@@ -1,0 +1,469 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::BTreeMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use carbide_dhcp_server::errors::DhcpError;
+use carbide_dhcp_server::modes::controller::Controller;
+use carbide_dhcp_server::modes::dpu::Dpu;
+use carbide_dhcp_server::packet_handler_v6::process_packet;
+use carbide_rpc_utils::dhcp::{InterfaceInfo, InterfaceInfoV6};
+use dhcproto::v6::{DhcpOption, DhcpOptions, IANA, IAPD, IATA, MessageType, OptionCode, Status};
+
+mod common;
+
+use common::{
+    DUID_UUID, SERVER_IDENTIFIER, client_message, controller_config, decode_message,
+    decode_response, dpu_config_with_bindings, encode, machine_cache, relay_forward, relay_option,
+    response_ia_na, response_status,
+};
+
+const OPTION79: &[u8] = &[0, 1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee];
+
+/// Provide stateful DPU configuration so identity policy is the only rejection under test.
+fn config() -> carbide_dhcp_server::Config {
+    // Give the receiving interface a complete production-shaped binding.
+    let ingress = InterfaceInfo {
+        address: Some(Ipv4Addr::new(192, 0, 2, 20)),
+        gateway: Some(Ipv4Addr::new(192, 0, 2, 1)),
+        prefix: Some("192.0.2.0/24".to_string()),
+        fqdn: "host.example.com".to_string(),
+        booturl: None,
+        mtu: Some(9000),
+        ipv6: Some(InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        }),
+    };
+
+    // Vary only IPv6 so a foreign binding selection is visible in the reply.
+    let mut foreign = ingress.clone();
+    foreign.ipv6 = Some(InterfaceInfoV6 {
+        address: Some("2001:db8:1::20".parse().unwrap()),
+        prefix: "2001:db8:1::/64".to_string(),
+    });
+
+    dpu_config_with_bindings(BTreeMap::from([
+        ("eth0".to_string(), ingress),
+        ("eth1".to_string(), foreign),
+    ]))
+}
+
+/// Verifies DPU mode accepts opaque client identity because ingress interface selects the binding.
+#[tokio::test]
+async fn direct_non_mac_duid_uses_ingress_interface() {
+    let config = config();
+    let request = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let mut cache = machine_cache();
+
+    // DPU lookup is keyed by ingress interface, so a non-MAC DUID must not block service.
+    let packet = process_packet(
+        &request,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("non-MAC DUID request is valid")
+    .expect("configured ingress interface serves a non-MAC DUID");
+
+    // An Advertise alone would not prove which configured interface supplied the binding.
+    let response = decode_response(&packet);
+    assert_eq!(response.msg_type(), MessageType::Advertise);
+    match response_ia_na(&response).opts.get(OptionCode::IAAddr) {
+        Some(DhcpOption::IAAddr(address)) => {
+            assert_eq!(address.addr, "2001:db8::20".parse::<Ipv6Addr>().unwrap());
+        }
+        other => panic!("expected eth0 IAAddr, got {other:?}"),
+    }
+}
+
+/// Verifies DPU ingress selection does not bypass generic DUID validation.
+#[tokio::test]
+async fn direct_malformed_duid_is_rejected_before_ingress_lookup() {
+    let config = config();
+    let request = encode(&client_message(MessageType::Solicit, &[0], None, None));
+    let mut cache = machine_cache();
+
+    let error = process_packet(
+        &request,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect_err("malformed DUID must fail before DPU binding selection");
+    assert!(matches!(error, DhcpError::MalformedDuid));
+}
+
+/// Verifies DPU mode rejects Relay-Forward before relay metadata can influence local service.
+#[tokio::test]
+async fn dpu_rejects_relay_forward() {
+    let config = config();
+    let inner = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let request = relay_forward(&inner, b"eth1", &[]);
+    let mut cache = machine_cache();
+
+    let error = process_packet(
+        &request,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect_err("DPU mode must reject relayed DHCPv6");
+    assert!(matches!(
+        error,
+        DhcpError::InvalidInput(message)
+            if message == "DPU mode requires a direct DHCPv6 packet"
+    ));
+}
+
+/// Verifies controller-local lease-end replies require a relay-selected MAC because they skip
+/// authoritative discovery before returning a protocol-local success.
+#[tokio::test]
+async fn controller_lease_end_messages_require_selected_mac_identity() {
+    let config = controller_config("http://[::1]:1");
+    let server_id = SERVER_IDENTIFIER.to_vec();
+
+    for message_type in [MessageType::Release, MessageType::Decline] {
+        // Include the selected server and IA_NA so identity is the only rejection.
+        let inner = encode(&client_message(
+            message_type,
+            DUID_UUID,
+            Some("2001:db8::20".parse().unwrap()),
+            Some(server_id.clone()),
+        ));
+        let request_without_identity = relay_forward(&inner, b"swp1", &[]);
+        let mut cache = machine_cache();
+
+        // Controller mode must not acknowledge a lease-end message without a MAC source.
+        let error = process_packet(
+            &request_without_identity,
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Controller {},
+            &mut cache,
+        )
+        .await
+        .expect_err("controller lease-end identity requires a usable MAC source");
+        assert!(matches!(error, DhcpError::NoMacNoOption79));
+
+        let request_with_identity = relay_forward(&inner, b"swp1", OPTION79);
+        let mut cache = machine_cache();
+
+        // A trusted relay MAC satisfies the identity gate without invoking discovery.
+        let packet = process_packet(
+            &request_with_identity,
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Controller {},
+            &mut cache,
+        )
+        .await
+        .expect("relay option 79 provides controller lease-end identity")
+        .expect("controller returns a local lease-end reply");
+        let response = decode_message(relay_option(packet.encoded_packet(), OptionCode::RelayMsg));
+        assert_eq!(response.msg_type(), MessageType::Reply);
+        assert_eq!(response_status(&response), Status::Success);
+    }
+}
+
+/// Verifies DPU lease-end replies remain ingress-scoped because local serving does not need
+/// a MAC-bearing DUID or relay-supplied option 79.
+#[tokio::test]
+async fn dpu_lease_end_messages_keep_ingress_identity_policy() {
+    let config = config();
+    let server_id = SERVER_IDENTIFIER.to_vec();
+
+    for message_type in [MessageType::Release, MessageType::Decline] {
+        // Include the selected server and IA_NA to exercise the complete local reply path.
+        let request = encode(&client_message(
+            message_type,
+            DUID_UUID,
+            Some("2001:db8::20".parse().unwrap()),
+            Some(server_id.clone()),
+        ));
+        let mut cache = machine_cache();
+
+        // DPU mode keys identity by ingress interface, so the non-MAC DUID remains valid.
+        let packet = process_packet(
+            &request,
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Dpu {},
+            &mut cache,
+        )
+        .await
+        .expect("DPU lease-end identity is ingress-scoped")
+        .expect("DPU returns a local lease-end reply");
+        let response = decode_response(&packet);
+        assert_eq!(response.msg_type(), MessageType::Reply);
+        assert_eq!(response_status(&response), Status::Success);
+    }
+}
+
+/// RELEASE and DECLINE identify the address whose lease-end notification is
+/// being acknowledged even though the standalone server does not verify or
+/// mutate authoritative binding state.
+#[tokio::test]
+async fn lease_end_messages_require_an_identifiable_address() {
+    #[derive(Clone, Copy)]
+    enum Association {
+        Absent,
+        Empty,
+    }
+
+    let config = config();
+    for (scenario, message_type, association, expected_option) in [
+        // RELEASE without IA_NA does not identify even an IAID.
+        (
+            "RELEASE without IA_NA",
+            MessageType::Release,
+            Association::Absent,
+            OptionCode::IANA,
+        ),
+        // RELEASE with an empty IA_NA does not identify a lease to release.
+        (
+            "RELEASE without IAADDR",
+            MessageType::Release,
+            Association::Empty,
+            OptionCode::IAAddr,
+        ),
+        // DECLINE without IA_NA does not identify even an IAID.
+        (
+            "DECLINE without IA_NA",
+            MessageType::Decline,
+            Association::Absent,
+            OptionCode::IANA,
+        ),
+        // DECLINE with an empty IA_NA does not identify a suspect address.
+        (
+            "DECLINE without IAADDR",
+            MessageType::Decline,
+            Association::Empty,
+            OptionCode::IAAddr,
+        ),
+    ] {
+        let mut message = client_message(
+            message_type,
+            DUID_UUID,
+            None,
+            Some(SERVER_IDENTIFIER.to_vec()),
+        );
+        if matches!(association, Association::Empty) {
+            message.opts_mut().insert(DhcpOption::IANA(IANA {
+                id: 7,
+                t1: 0,
+                t2: 0,
+                opts: DhcpOptions::new(),
+            }));
+        }
+        let mut cache = machine_cache();
+
+        let error = process_packet(
+            &encode(&message),
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Dpu {},
+            &mut cache,
+        )
+        .await
+        .expect_err(scenario);
+        assert!(
+            matches!(error, DhcpError::MissingOptionV6(option) if option == expected_option),
+            "{scenario}: {error:?}"
+        );
+    }
+}
+
+/// Unsupported address-association types are rejected before protocol-local replies.
+#[tokio::test]
+async fn local_replies_do_not_acknowledge_temporary_or_prefix_associations() {
+    #[derive(Clone, Copy)]
+    enum Association {
+        Temporary,
+        PrefixDelegation,
+    }
+
+    let config = config();
+    for (scenario, message_type, association) in [
+        // CONFIRM cannot validate temporary-address state this server does not own.
+        (
+            "CONFIRM with IA_TA",
+            MessageType::Confirm,
+            Association::Temporary,
+        ),
+        // RELEASE must not claim that an unsupported delegated prefix was released.
+        (
+            "RELEASE with IA_PD",
+            MessageType::Release,
+            Association::PrefixDelegation,
+        ),
+        // DECLINE must not claim that an unsupported temporary address was quarantined.
+        (
+            "DECLINE with IA_TA",
+            MessageType::Decline,
+            Association::Temporary,
+        ),
+    ] {
+        let server_id = matches!(message_type, MessageType::Release | MessageType::Decline)
+            .then(|| SERVER_IDENTIFIER.to_vec());
+        let mut message = client_message(
+            message_type,
+            DUID_UUID,
+            Some("2001:db8::20".parse().unwrap()),
+            server_id,
+        );
+        let expected_option = match association {
+            Association::Temporary => {
+                message.opts_mut().insert(DhcpOption::IATA(IATA {
+                    id: 7,
+                    opts: DhcpOptions::new(),
+                }));
+                OptionCode::IATA
+            }
+            Association::PrefixDelegation => {
+                message.opts_mut().insert(DhcpOption::IAPD(IAPD {
+                    id: 7,
+                    t1: 0,
+                    t2: 0,
+                    opts: DhcpOptions::new(),
+                }));
+                OptionCode::IAPD
+            }
+        };
+        let request = encode(&message);
+        let mut cache = machine_cache();
+
+        let error = process_packet(
+            &request,
+            "fe80::20".parse().unwrap(),
+            &config,
+            "eth0",
+            &Dpu {},
+            &mut cache,
+        )
+        .await
+        .expect_err("unsupported association must not receive a local success reply");
+        assert!(
+            matches!(
+                &error,
+                DhcpError::UnsupportedAddressAssociationV6(actual)
+                    if *actual == expected_option
+            ),
+            "{scenario} returned {error:?}"
+        );
+    }
+}
+
+/// Verifies controller identity requires relay option 79 for valid DUIDs without Ethernet MACs.
+#[tokio::test]
+async fn controller_non_mac_duids_require_relay_identity() {
+    let config = controller_config("http://[::1]:1");
+    let request = relay_forward(
+        &encode(&client_message(MessageType::Solicit, DUID_UUID, None, None)),
+        b"swp1",
+        &[],
+    );
+    let mut cache = machine_cache();
+
+    // A valid non-MAC DUID still cannot select an authoritative API row.
+    let error = process_packet(
+        &request,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await
+    .expect_err("controller identity requires a usable MAC source");
+    assert!(matches!(error, DhcpError::NoMacNoOption79));
+
+    let unknown = relay_forward(
+        &encode(&client_message(
+            MessageType::Solicit,
+            &[0, 99, 0, 1, 2, 3],
+            None,
+            None,
+        )),
+        b"swp1",
+        &[],
+    );
+
+    // Unknown DUID types are valid opaque identities and use the same option-79 fallback.
+    let error = process_packet(
+        &unknown,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Controller {},
+        &mut cache,
+    )
+    .await
+    .expect_err("controller identity requires a usable MAC source");
+    assert!(matches!(error, DhcpError::NoMacNoOption79));
+}
+
+/// Verifies nested and multi-hop relay shapes are rejected before segment selection.
+#[tokio::test]
+async fn unsupported_relay_depth_is_rejected() {
+    let config = config();
+    let inner = encode(&client_message(MessageType::Solicit, DUID_UUID, None, None));
+    let nested = relay_forward(&relay_forward(&inner, b"swp1", OPTION79), b"swp2", OPTION79);
+    let mut cache = machine_cache();
+
+    // Nested relay precedence is intentionally undefined in this one-hop milestone.
+    let error = process_packet(
+        &nested,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect_err("nested relay must be rejected");
+    assert!(matches!(error, DhcpError::NestedRelayV6));
+
+    // A nonzero count requires another relay envelope, which this decoder rejects.
+    let mut nonzero_hop = relay_forward(&inner, b"swp1", OPTION79);
+    nonzero_hop[1] = 1;
+    let error = process_packet(
+        &nonzero_hop,
+        "fe80::20".parse().unwrap(),
+        &config,
+        "eth0",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect_err("nonzero relay hop count must be rejected");
+    assert!(matches!(error, DhcpError::RelayHopCountExceededV6(1)));
+}

--- a/crates/dhcp-server/tests/v6_listener_test.rs
+++ b/crates/dhcp-server/tests/v6_listener_test.rs
@@ -1,0 +1,472 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::sync::Arc;
+use std::time::Duration;
+
+use carbide_dhcp_server::modes::dpu::Dpu;
+use carbide_dhcp_server::packet_handler_v6::process_packet;
+use carbide_dhcp_server::util::get_socket_v6;
+use carbide_rpc_utils::dhcp::InterfaceInfoV6;
+use carbide_test_support::Outcome::Yields;
+use carbide_test_support::{Case, check_cases_async};
+use dhcproto::v6::{
+    DhcpOption, IANA, MessageType, NtpSuboption, OptionCode, Status, UnknownOption,
+};
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+mod common;
+
+use common::{
+    DUID_LL, IAID, SERVER_IDENTIFIER, assert_ia_na_failure, client_message, decode_message,
+    decode_response, dpu_config, encode, machine_cache, response_ia_na, response_status,
+};
+
+const INTERFACE: &str = "eth0";
+
+/// Verifies a stateful SOLICIT preserves IAID and returns the configured address and server ID.
+#[tokio::test]
+async fn stateful_solicit_returns_advertise_with_binding_identity() {
+    // Loopback exercises the production bind-to-device and multicast setup
+    // without depending on an environment-specific interface name.
+    let config = dpu_config(
+        "lo",
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let request = client_message(MessageType::Solicit, DUID_LL, None, None);
+    let listener = Arc::new(
+        get_socket_v6(
+            SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0),
+            "lo",
+            false,
+        )
+        .await
+        .expect("DHCPv6 listener binds to loopback"),
+    );
+    let client = UdpSocket::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
+        .await
+        .expect("DHCPv6 client binds");
+    let destination = SocketAddrV6::new(
+        Ipv6Addr::LOCALHOST,
+        listener.local_addr().expect("listener address").port(),
+        0,
+        0,
+    );
+
+    // Send through the production socket setup so bind-to-device and
+    // multicast membership are exercised before packet handling.
+    client
+        .send_to(&encode(&request), destination)
+        .await
+        .expect("client sends SOLICIT");
+    let mut request_buffer = vec![0; 2048];
+    let (length, source) = timeout(
+        Duration::from_secs(5),
+        listener.recv_from(&mut request_buffer),
+    )
+    .await
+    .expect("listener receives before timeout")
+    .expect("listener receives SOLICIT");
+    let SocketAddr::V6(source) = source else {
+        panic!("DHCPv6 listener received a non-IPv6 source");
+    };
+    let mut cache = machine_cache();
+
+    let packet = process_packet(
+        &request_buffer[..length],
+        *source.ip(),
+        &config,
+        "lo",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("stateful SOLICIT is valid")
+    .expect("stateful SOLICIT receives a response");
+    listener
+        .send_to(packet.encoded_packet(), source)
+        .await
+        .expect("listener sends ADVERTISE");
+
+    // Decode what the client actually received from the UDP socket.
+    let mut response_buffer = vec![0; 2048];
+    let (length, _) = timeout(
+        Duration::from_secs(5),
+        client.recv_from(&mut response_buffer),
+    )
+    .await
+    .expect("client receives before timeout")
+    .expect("client receives ADVERTISE");
+    let response = decode_message(&response_buffer[..length]);
+
+    // The response binds the client's IAID to the configured /128 and identifies this server.
+    assert_eq!(response.msg_type(), MessageType::Advertise);
+    assert_eq!(
+        response.opts().get(OptionCode::ServerId),
+        Some(&DhcpOption::ServerId(SERVER_IDENTIFIER.to_vec()))
+    );
+    let association = response_ia_na(&response);
+    assert_eq!(association.id, IAID);
+    match association.opts.get(OptionCode::IAAddr) {
+        Some(DhcpOption::IAAddr(address)) => {
+            assert_eq!(address.addr, "2001:db8::20".parse::<Ipv6Addr>().unwrap());
+            assert_eq!(address.preferred_life, 3600);
+            assert_eq!(address.valid_life, 7200);
+        }
+        other => panic!("expected advertised IAADDR, got {other:?}"),
+    }
+}
+
+/// Verifies stateful and options-only replies use trusted names and client-controlled flags.
+///
+/// This prevents client-supplied hostnames and absent option-39 requests from influencing replies.
+#[tokio::test]
+async fn fqdn_options_follow_client_negotiation_and_api_ownership() {
+    // The configured name is trusted and has a parent distinct from the client-supplied name.
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+
+    check_cases_async(
+        [
+            // Without option 39, only the API-owned search domain is returned.
+            Case {
+                scenario: "absent client FQDN",
+                input: (MessageType::Solicit, None),
+                expect: Yields((vec!["example.com.".to_string()], None)),
+            },
+            // An empty option 39 cannot request an echoed client FQDN.
+            Case {
+                scenario: "empty client FQDN",
+                input: (MessageType::InformationRequest, Some(Vec::new())),
+                expect: Yields((vec!["example.com.".to_string()], None)),
+            },
+            // A requested option 39 preserves flags but replaces the untrusted name.
+            Case {
+                scenario: "requested client FQDN",
+                input: (
+                    MessageType::InformationRequest,
+                    Some(b"\x01\x06client\x07invalid\0".to_vec()),
+                ),
+                expect: Yields((
+                    vec!["example.com.".to_string()],
+                    Some(b"\x01\x04host\x07example\x03com\0".to_vec()),
+                )),
+            },
+        ],
+        |(message_type, client_fqdn)| {
+            let config = config.clone();
+            async move {
+                // Vary only client option 39 so the API-owned name remains authoritative.
+                let mut request = client_message(message_type, DUID_LL, None, None);
+                if let Some(client_fqdn) = client_fqdn {
+                    request
+                        .opts_mut()
+                        .insert(DhcpOption::Unknown(UnknownOption::new(
+                            OptionCode::ClientFqdn,
+                            client_fqdn,
+                        )));
+                }
+                let mut cache = machine_cache();
+
+                let response = process_packet(
+                    &encode(&request),
+                    "fe80::20".parse().unwrap(),
+                    &config,
+                    INTERFACE,
+                    &Dpu {},
+                    &mut cache,
+                )
+                .await
+                .map_err(|error| error.to_string())?
+                .ok_or_else(|| format!("{message_type:?} produced no DHCPv6 response"))?;
+                let response = decode_response(&response);
+
+                // Return decoded wire values so every case pins both naming options.
+                let domain_search = match response.opts().get(OptionCode::DomainSearchList) {
+                    Some(DhcpOption::DomainSearchList(domains)) => domains
+                        .iter()
+                        .map(|domain| domain.to_ascii())
+                        .collect::<Vec<_>>(),
+                    other => panic!("expected domain-search option, got {other:?}"),
+                };
+                let client_fqdn = match response.opts().get(OptionCode::ClientFqdn) {
+                    Some(DhcpOption::Unknown(option)) => Some(option.data().to_vec()),
+                    None => None,
+                    other => panic!("expected raw client-FQDN option, got {other:?}"),
+                };
+
+                Ok::<_, String>((domain_search, client_fqdn))
+            }
+        },
+    )
+    .await;
+}
+
+/// Verifies DPU CONFIRM replies only when its configured prefix provides link knowledge.
+#[tokio::test]
+async fn dpu_confirm_with_known_prefix_returns_success() {
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let request = client_message(
+        MessageType::Confirm,
+        DUID_LL,
+        Some("2001:db8::99".parse().unwrap()),
+        None,
+    );
+    let mut cache = machine_cache();
+
+    // A configured DPU prefix is authoritative for the receiving link.
+    let response = process_packet(
+        &encode(&request),
+        "fe80::20".parse().unwrap(),
+        &config,
+        INTERFACE,
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("CONFIRM is valid")
+    .expect("known-link CONFIRM receives a response");
+    assert_eq!(
+        response_status(&decode_response(&response)),
+        Status::Success
+    );
+}
+
+/// Verifies a SLAAC-only interface refuses stateful allocation but still serves v6 options.
+#[tokio::test]
+async fn slaac_only_interface_separates_stateful_and_information_requests() {
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: None,
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+
+    // A stateful SOLICIT cannot invent a /128 from the interface's SLAAC prefix.
+    let solicit = client_message(MessageType::Solicit, DUID_LL, None, None);
+    let mut cache = machine_cache();
+    let advertise = process_packet(
+        &encode(&solicit),
+        "fe80::20".parse().unwrap(),
+        &config,
+        INTERFACE,
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("SLAAC-only SOLICIT is valid")
+    .expect("SLAAC-only SOLICIT receives a status response");
+    let advertise = decode_response(&advertise);
+    assert_eq!(advertise.msg_type(), MessageType::Advertise);
+    assert_ia_na_failure(&advertise, Status::NoAddrsAvail);
+
+    // INFORMATION-REQUEST remains useful and carries both configured v6 option families.
+    let information = client_message(MessageType::InformationRequest, DUID_LL, None, None);
+    let response = process_packet(
+        &encode(&information),
+        "fe80::20".parse().unwrap(),
+        &config,
+        INTERFACE,
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("SLAAC-only information request is valid")
+    .expect("SLAAC-only information request is served");
+    let response = decode_response(&response);
+    assert_eq!(response.msg_type(), MessageType::Reply);
+    assert!(response.opts().get(OptionCode::IANA).is_none());
+    assert_eq!(
+        response.opts().get(OptionCode::DomainNameServers),
+        Some(&DhcpOption::DomainNameServers(vec![
+            "2001:db8::53".parse().unwrap()
+        ]))
+    );
+    assert_eq!(
+        response.opts().get(OptionCode::NtpServer),
+        Some(&DhcpOption::NtpServer(vec![NtpSuboption::ServerAddress(
+            "2001:db8::123".parse().unwrap()
+        )]))
+    );
+}
+
+/// Verifies RENEW for a different /128 returns NoBinding instead of replacing the binding.
+#[tokio::test]
+async fn renew_for_unknown_address_returns_no_binding() {
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let renew = client_message(
+        MessageType::Renew,
+        DUID_LL,
+        Some("2001:db8::99".parse().unwrap()),
+        Some(SERVER_IDENTIFIER.to_vec()),
+    );
+    let mut cache = machine_cache();
+
+    // The wire message type remains available after API lookup and selects NoBinding.
+    let response = process_packet(
+        &encode(&renew),
+        "fe80::20".parse().unwrap(),
+        &config,
+        INTERFACE,
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("unknown RENEW is valid")
+    .expect("unknown RENEW receives a status response");
+    assert_ia_na_failure(&decode_response(&response), Status::NoBinding);
+}
+
+/// Verifies empty IA_NA refreshes return NoBinding because no address identifies a binding.
+#[tokio::test]
+async fn addressless_renew_and_rebind_return_no_binding() {
+    // Configure one authoritative address shared by both refresh message types.
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    check_cases_async(
+        [
+            // RENEW selects this server but carries no address to identify a binding.
+            Case {
+                scenario: "Renew",
+                input: (MessageType::Renew, Some(SERVER_IDENTIFIER.to_vec())),
+                expect: Yields(()),
+            },
+            // REBIND omits ServerId and likewise carries no address-bearing binding.
+            Case {
+                scenario: "Rebind",
+                input: (MessageType::Rebind, None),
+                expect: Yields(()),
+            },
+        ],
+        |(message_type, server_id)| {
+            let config = config.clone();
+            async move {
+                // An empty IA_NA carries an IAID but identifies no renewable address.
+                let mut refresh = client_message(message_type, DUID_LL, None, server_id);
+                refresh.opts_mut().insert(DhcpOption::IANA(IANA {
+                    id: IAID,
+                    t1: 0,
+                    t2: 0,
+                    opts: Default::default(),
+                }));
+                let mut cache = machine_cache();
+
+                let response = process_packet(
+                    &encode(&refresh),
+                    "fe80::20".parse().unwrap(),
+                    &config,
+                    INTERFACE,
+                    &Dpu {},
+                    &mut cache,
+                )
+                .await
+                .map_err(|error| error.to_string())?
+                .ok_or_else(|| format!("{message_type:?} produced no DHCPv6 response"))?;
+                assert_ia_na_failure(&decode_response(&response), Status::NoBinding);
+                Ok::<_, String>(())
+            }
+        },
+    )
+    .await;
+}
+
+/// Verifies SLAAC-only state reports the message-specific IA_NA failure
+/// without fabricating an IAAddr.
+#[tokio::test]
+async fn slaac_only_binding_returns_message_specific_failure() {
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: None,
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let server_id = SERVER_IDENTIFIER.to_vec();
+
+    check_cases_async(
+        [
+            // Initial allocation cannot provide an address from SLAAC-only state.
+            Case {
+                scenario: "Request returns NoAddrsAvail",
+                input: (MessageType::Request, Status::NoAddrsAvail),
+                expect: Yields(()),
+            },
+            // Refresh cannot match an address-bearing binding in SLAAC-only state.
+            Case {
+                scenario: "Renew returns NoBinding",
+                input: (MessageType::Renew, Status::NoBinding),
+                expect: Yields(()),
+            },
+        ],
+        |(message_type, expected_status)| {
+            let config = config.clone();
+            let server_id = server_id.clone();
+            async move {
+                let request = client_message(
+                    message_type,
+                    DUID_LL,
+                    Some("2001:db8::99".parse().unwrap()),
+                    Some(server_id),
+                );
+                let mut cache = machine_cache();
+
+                let response = process_packet(
+                    &encode(&request),
+                    "fe80::20".parse().unwrap(),
+                    &config,
+                    INTERFACE,
+                    &Dpu {},
+                    &mut cache,
+                )
+                .await
+                .map_err(|error| error.to_string())?
+                .ok_or_else(|| format!("{message_type:?} produced no DHCPv6 response"))?;
+                assert_ia_na_failure(&decode_response(&response), expected_status);
+                Ok::<_, String>(())
+            }
+        },
+    )
+    .await;
+}

--- a/crates/dhcp-server/tests/v6_listener_test.rs
+++ b/crates/dhcp-server/tests/v6_listener_test.rs
@@ -1,0 +1,468 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::sync::Arc;
+use std::time::Duration;
+
+use carbide_dhcp_server::modes::dpu::Dpu;
+use carbide_dhcp_server::packet_handler_v6::process_packet;
+use carbide_dhcp_server::util::get_socket_v6;
+use carbide_rpc_utils::dhcp::InterfaceInfoV6;
+use carbide_test_support::Outcome::Yields;
+use carbide_test_support::{Case, check_cases_async};
+use dhcproto::v6::{
+    DhcpOption, IANA, MessageType, NtpSuboption, OptionCode, Status, UnknownOption,
+};
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+mod common;
+
+use common::{
+    DUID_LL, IAID, SERVER_IDENTIFIER, assert_ia_na_failure, client_message, decode_message,
+    decode_response, dpu_config, encode, machine_cache, response_ia_na, response_status,
+};
+
+const INTERFACE: &str = "eth0";
+
+/// Verifies a stateful SOLICIT preserves IAID and returns the configured address and server ID.
+#[tokio::test]
+async fn stateful_solicit_returns_advertise_with_binding_identity() {
+    // Loopback exercises the production bind-to-device and multicast setup
+    // without depending on an environment-specific interface name.
+    let config = dpu_config(
+        "lo",
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let request = client_message(MessageType::Solicit, DUID_LL, None, None);
+    let listener = Arc::new(
+        get_socket_v6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0), "lo")
+            .await
+            .expect("DHCPv6 listener binds to loopback"),
+    );
+    let client = UdpSocket::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
+        .await
+        .expect("DHCPv6 client binds");
+    let destination = SocketAddrV6::new(
+        Ipv6Addr::LOCALHOST,
+        listener.local_addr().expect("listener address").port(),
+        0,
+        0,
+    );
+
+    // Send through the production socket setup so bind-to-device and
+    // multicast membership are exercised before packet handling.
+    client
+        .send_to(&encode(&request), destination)
+        .await
+        .expect("client sends SOLICIT");
+    let mut request_buffer = vec![0; 2048];
+    let (length, source) = timeout(
+        Duration::from_secs(5),
+        listener.recv_from(&mut request_buffer),
+    )
+    .await
+    .expect("listener receives before timeout")
+    .expect("listener receives SOLICIT");
+    let SocketAddr::V6(source) = source else {
+        panic!("DHCPv6 listener received a non-IPv6 source");
+    };
+    let mut cache = machine_cache();
+
+    let packet = process_packet(
+        &request_buffer[..length],
+        *source.ip(),
+        &config,
+        "lo",
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("stateful SOLICIT is valid")
+    .expect("stateful SOLICIT receives a response");
+    listener
+        .send_to(packet.encoded_packet(), source)
+        .await
+        .expect("listener sends ADVERTISE");
+
+    // Decode what the client actually received from the UDP socket.
+    let mut response_buffer = vec![0; 2048];
+    let (length, _) = timeout(
+        Duration::from_secs(5),
+        client.recv_from(&mut response_buffer),
+    )
+    .await
+    .expect("client receives before timeout")
+    .expect("client receives ADVERTISE");
+    let response = decode_message(&response_buffer[..length]);
+
+    // The response binds the client's IAID to the configured /128 and identifies this server.
+    assert_eq!(response.msg_type(), MessageType::Advertise);
+    assert_eq!(
+        response.opts().get(OptionCode::ServerId),
+        Some(&DhcpOption::ServerId(SERVER_IDENTIFIER.to_vec()))
+    );
+    let association = response_ia_na(&response);
+    assert_eq!(association.id, IAID);
+    match association.opts.get(OptionCode::IAAddr) {
+        Some(DhcpOption::IAAddr(address)) => {
+            assert_eq!(address.addr, "2001:db8::20".parse::<Ipv6Addr>().unwrap());
+            assert_eq!(address.preferred_life, 3600);
+            assert_eq!(address.valid_life, 7200);
+        }
+        other => panic!("expected advertised IAADDR, got {other:?}"),
+    }
+}
+
+/// Verifies stateful and options-only replies use trusted names and client-controlled flags.
+///
+/// This prevents client-supplied hostnames and absent option-39 requests from influencing replies.
+#[tokio::test]
+async fn fqdn_options_follow_client_negotiation_and_api_ownership() {
+    // The configured name is trusted and has a parent distinct from the client-supplied name.
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+
+    check_cases_async(
+        [
+            // Without option 39, only the API-owned search domain is returned.
+            Case {
+                scenario: "absent client FQDN",
+                input: (MessageType::Solicit, None),
+                expect: Yields((vec!["example.com.".to_string()], None)),
+            },
+            // An empty option 39 cannot request an echoed client FQDN.
+            Case {
+                scenario: "empty client FQDN",
+                input: (MessageType::InformationRequest, Some(Vec::new())),
+                expect: Yields((vec!["example.com.".to_string()], None)),
+            },
+            // A requested option 39 preserves flags but replaces the untrusted name.
+            Case {
+                scenario: "requested client FQDN",
+                input: (
+                    MessageType::InformationRequest,
+                    Some(b"\x01\x06client\x07invalid\0".to_vec()),
+                ),
+                expect: Yields((
+                    vec!["example.com.".to_string()],
+                    Some(b"\x01\x04host\x07example\x03com\0".to_vec()),
+                )),
+            },
+        ],
+        |(message_type, client_fqdn)| {
+            let config = config.clone();
+            async move {
+                // Vary only client option 39 so the API-owned name remains authoritative.
+                let mut request = client_message(message_type, DUID_LL, None, None);
+                if let Some(client_fqdn) = client_fqdn {
+                    request
+                        .opts_mut()
+                        .insert(DhcpOption::Unknown(UnknownOption::new(
+                            OptionCode::ClientFqdn,
+                            client_fqdn,
+                        )));
+                }
+                let mut cache = machine_cache();
+
+                let response = process_packet(
+                    &encode(&request),
+                    "fe80::20".parse().unwrap(),
+                    &config,
+                    INTERFACE,
+                    &Dpu {},
+                    &mut cache,
+                )
+                .await
+                .map_err(|error| error.to_string())?
+                .ok_or_else(|| format!("{message_type:?} produced no DHCPv6 response"))?;
+                let response = decode_response(&response);
+
+                // Return decoded wire values so every case pins both naming options.
+                let domain_search = match response.opts().get(OptionCode::DomainSearchList) {
+                    Some(DhcpOption::DomainSearchList(domains)) => domains
+                        .iter()
+                        .map(|domain| domain.to_ascii())
+                        .collect::<Vec<_>>(),
+                    other => panic!("expected domain-search option, got {other:?}"),
+                };
+                let client_fqdn = match response.opts().get(OptionCode::ClientFqdn) {
+                    Some(DhcpOption::Unknown(option)) => Some(option.data().to_vec()),
+                    None => None,
+                    other => panic!("expected raw client-FQDN option, got {other:?}"),
+                };
+
+                Ok::<_, String>((domain_search, client_fqdn))
+            }
+        },
+    )
+    .await;
+}
+
+/// Verifies DPU CONFIRM replies only when its configured prefix provides link knowledge.
+#[tokio::test]
+async fn dpu_confirm_with_known_prefix_returns_success() {
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let request = client_message(
+        MessageType::Confirm,
+        DUID_LL,
+        Some("2001:db8::99".parse().unwrap()),
+        None,
+    );
+    let mut cache = machine_cache();
+
+    // A configured DPU prefix is authoritative for the receiving link.
+    let response = process_packet(
+        &encode(&request),
+        "fe80::20".parse().unwrap(),
+        &config,
+        INTERFACE,
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("CONFIRM is valid")
+    .expect("known-link CONFIRM receives a response");
+    assert_eq!(
+        response_status(&decode_response(&response)),
+        Status::Success
+    );
+}
+
+/// Verifies a SLAAC-only interface refuses stateful allocation but still serves v6 options.
+#[tokio::test]
+async fn slaac_only_interface_separates_stateful_and_information_requests() {
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: None,
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+
+    // A stateful SOLICIT cannot invent a /128 from the interface's SLAAC prefix.
+    let solicit = client_message(MessageType::Solicit, DUID_LL, None, None);
+    let mut cache = machine_cache();
+    let advertise = process_packet(
+        &encode(&solicit),
+        "fe80::20".parse().unwrap(),
+        &config,
+        INTERFACE,
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("SLAAC-only SOLICIT is valid")
+    .expect("SLAAC-only SOLICIT receives a status response");
+    let advertise = decode_response(&advertise);
+    assert_eq!(advertise.msg_type(), MessageType::Advertise);
+    assert_ia_na_failure(&advertise, Status::NoAddrsAvail);
+
+    // INFORMATION-REQUEST remains useful and carries both configured v6 option families.
+    let information = client_message(MessageType::InformationRequest, DUID_LL, None, None);
+    let response = process_packet(
+        &encode(&information),
+        "fe80::20".parse().unwrap(),
+        &config,
+        INTERFACE,
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("SLAAC-only information request is valid")
+    .expect("SLAAC-only information request is served");
+    let response = decode_response(&response);
+    assert_eq!(response.msg_type(), MessageType::Reply);
+    assert!(response.opts().get(OptionCode::IANA).is_none());
+    assert_eq!(
+        response.opts().get(OptionCode::DomainNameServers),
+        Some(&DhcpOption::DomainNameServers(vec![
+            "2001:db8::53".parse().unwrap()
+        ]))
+    );
+    assert_eq!(
+        response.opts().get(OptionCode::NtpServer),
+        Some(&DhcpOption::NtpServer(vec![NtpSuboption::ServerAddress(
+            "2001:db8::123".parse().unwrap()
+        )]))
+    );
+}
+
+/// Verifies RENEW for a different /128 returns NoBinding instead of replacing the binding.
+#[tokio::test]
+async fn renew_for_unknown_address_returns_no_binding() {
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let renew = client_message(
+        MessageType::Renew,
+        DUID_LL,
+        Some("2001:db8::99".parse().unwrap()),
+        Some(SERVER_IDENTIFIER.to_vec()),
+    );
+    let mut cache = machine_cache();
+
+    // The wire message type remains available after API lookup and selects NoBinding.
+    let response = process_packet(
+        &encode(&renew),
+        "fe80::20".parse().unwrap(),
+        &config,
+        INTERFACE,
+        &Dpu {},
+        &mut cache,
+    )
+    .await
+    .expect("unknown RENEW is valid")
+    .expect("unknown RENEW receives a status response");
+    assert_ia_na_failure(&decode_response(&response), Status::NoBinding);
+}
+
+/// Verifies empty IA_NA refreshes return NoBinding because no address identifies a binding.
+#[tokio::test]
+async fn addressless_renew_and_rebind_return_no_binding() {
+    // Configure one authoritative address shared by both refresh message types.
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: Some("2001:db8::20".parse().unwrap()),
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    check_cases_async(
+        [
+            // RENEW selects this server but carries no address to identify a binding.
+            Case {
+                scenario: "Renew",
+                input: (MessageType::Renew, Some(SERVER_IDENTIFIER.to_vec())),
+                expect: Yields(()),
+            },
+            // REBIND omits ServerId and likewise carries no address-bearing binding.
+            Case {
+                scenario: "Rebind",
+                input: (MessageType::Rebind, None),
+                expect: Yields(()),
+            },
+        ],
+        |(message_type, server_id)| {
+            let config = config.clone();
+            async move {
+                // An empty IA_NA carries an IAID but identifies no renewable address.
+                let mut refresh = client_message(message_type, DUID_LL, None, server_id);
+                refresh.opts_mut().insert(DhcpOption::IANA(IANA {
+                    id: IAID,
+                    t1: 0,
+                    t2: 0,
+                    opts: Default::default(),
+                }));
+                let mut cache = machine_cache();
+
+                let response = process_packet(
+                    &encode(&refresh),
+                    "fe80::20".parse().unwrap(),
+                    &config,
+                    INTERFACE,
+                    &Dpu {},
+                    &mut cache,
+                )
+                .await
+                .map_err(|error| error.to_string())?
+                .ok_or_else(|| format!("{message_type:?} produced no DHCPv6 response"))?;
+                assert_ia_na_failure(&decode_response(&response), Status::NoBinding);
+                Ok::<_, String>(())
+            }
+        },
+    )
+    .await;
+}
+
+/// Verifies SLAAC-only state reports the message-specific IA_NA failure
+/// without fabricating an IAAddr.
+#[tokio::test]
+async fn slaac_only_binding_returns_message_specific_failure() {
+    let config = dpu_config(
+        INTERFACE,
+        InterfaceInfoV6 {
+            address: None,
+            prefix: "2001:db8::/64".to_string(),
+        },
+    );
+    let server_id = SERVER_IDENTIFIER.to_vec();
+
+    check_cases_async(
+        [
+            // Initial allocation cannot provide an address from SLAAC-only state.
+            Case {
+                scenario: "Request returns NoAddrsAvail",
+                input: (MessageType::Request, Status::NoAddrsAvail),
+                expect: Yields(()),
+            },
+            // Refresh cannot match an address-bearing binding in SLAAC-only state.
+            Case {
+                scenario: "Renew returns NoBinding",
+                input: (MessageType::Renew, Status::NoBinding),
+                expect: Yields(()),
+            },
+        ],
+        |(message_type, expected_status)| {
+            let config = config.clone();
+            let server_id = server_id.clone();
+            async move {
+                let request = client_message(
+                    message_type,
+                    DUID_LL,
+                    Some("2001:db8::99".parse().unwrap()),
+                    Some(server_id),
+                );
+                let mut cache = machine_cache();
+
+                let response = process_packet(
+                    &encode(&request),
+                    "fe80::20".parse().unwrap(),
+                    &config,
+                    INTERFACE,
+                    &Dpu {},
+                    &mut cache,
+                )
+                .await
+                .map_err(|error| error.to_string())?
+                .ok_or_else(|| format!("{message_type:?} produced no DHCPv6 response"))?;
+                assert_ia_na_failure(&decode_response(&response), expected_status);
+                Ok::<_, String>(())
+            }
+        },
+    )
+    .await;
+}

--- a/crates/dhcp/Cargo.toml
+++ b/crates/dhcp/Cargo.toml
@@ -36,6 +36,7 @@ carbide-dhcp-common = { path = "../dhcp-common" }
 carbide-instrument = { path = "../instrument" }
 carbide-rpc = { path = "../rpc" }
 carbide-tls = { path = "../tls" }
+carbide-dhcpv6 = { path = "../dhcpv6" }
 metrics-endpoint = { path = "../metrics-endpoint" }
 
 [features]

--- a/crates/dhcp/src/discovery_v6.rs
+++ b/crates/dhcp/src/discovery_v6.rs
@@ -16,33 +16,25 @@
  */
 //! DHCPv6 decode and identity selection for the Kea hook.
 //!
-//! This module is intentionally not a general DHCPv6 implementation. Kea still
-//! owns the DHCP state machine and `dhcproto` decodes normal client messages;
-//! the local raw parsing is limited to the hook boundary where we must recover
-//! one-hop relay metadata, enforce relay trust rules, and select the client
-//! identity before calling the Carbide API. Kea may provide that relay metadata
-//! as a side-channel after unwrapping the packet, or leave it in the raw wire
-//! bytes, so this module handles both shapes with the same policy.
+//! Kea owns the DHCP state machine, while `carbide-dhcpv6` owns policy-neutral
+//! wire decoding. This adapter adds Kea's relay side-channel, message policy,
+//! and authoritative client-identity selection before calling the Carbide API.
+//! Kea may provide relay metadata through that side channel after unwrapping
+//! the packet, or leave it in the raw wire bytes, so both shapes are supported.
 
 use std::ffi::CString;
 use std::net::Ipv6Addr;
 
+#[cfg(test)]
+use carbide_dhcpv6::{DUID_MAX_LENGTH, DuidError};
+use carbide_dhcpv6::{
+    DecodeError as WireDecodeError, DecodedPacket as WirePacket, DuidMac, RELAY_FORWARD,
+    RELAY_REPLY, decode as decode_wire_packet, decode_client_message, extract_mac_from_duid,
+    extract_mac_from_option79,
+};
 use dhcproto::v6::{DhcpOption, Message, MessageType, OptionCode};
-use dhcproto::{Decodable, Decoder};
 use mac_address::MacAddress;
 use rpc::forge as rpc;
-
-const DHCPV6_RELAY_FORW: u8 = 12;
-const DHCPV6_RELAY_REPL: u8 = 13;
-const DUID_LLT: u16 = 1;
-const DUID_EN: u16 = 2;
-const DUID_LL: u16 = 3;
-const DUID_UUID: u16 = 4;
-const HTYPE_ETHERNET: u16 = 1;
-const ETHERNET_MAC_LEN: usize = 6;
-const DUID_EN_MIN_LEN: usize = 7;
-const DUID_MAX_LEN: usize = 128;
-const DUID_UUID_LEN: usize = 18;
 
 /// Supplemental relay metadata from Kea when it has already unwrapped the relay envelope.
 #[derive(Debug, Default, Clone)]
@@ -84,25 +76,6 @@ pub(super) enum V6DecodeError {
     UnsupportedMessage(MessageType),
 }
 
-/// Result of parsing a DUID for a link-layer identity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DuidMac {
-    Mac(MacAddress),
-    NoLinkLayerMac,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DuidError {
-    Malformed,
-    UnsupportedType,
-}
-
-#[derive(Debug)]
-struct RawOption<'a> {
-    code: u16,
-    data: &'a [u8],
-}
-
 /// Decode a DHCPv6 packet without any Kea-provided relay fallback metadata.
 #[cfg(test)]
 fn decode(packet: &[u8]) -> Result<V6Discovery, V6DecodeError> {
@@ -119,8 +92,8 @@ pub(super) fn decode_with_relay_context(
     }
 
     let decoded = match packet.first().copied() {
-        Some(DHCPV6_RELAY_FORW) => decode_relay_forward(packet)?,
-        Some(DHCPV6_RELAY_REPL) => {
+        Some(RELAY_FORWARD) => decode_relay_forward(packet)?,
+        Some(RELAY_REPLY) => {
             return Err(V6DecodeError::UnsupportedMessage(MessageType::RelayRepl));
         }
         Some(_) => decode_direct(packet, relay_context)?,
@@ -128,38 +101,6 @@ pub(super) fn decode_with_relay_context(
     };
 
     select_identity(decoded)
-}
-
-/// Extract an Ethernet MAC from a DUID-LL or DUID-LLT byte string.
-fn extract_mac_from_duid(duid: &[u8]) -> Result<DuidMac, DuidError> {
-    // Kea caps DUIDs at RFC 8415's 128-byte maximum.
-    if duid.len() < 2 || duid.len() > DUID_MAX_LEN {
-        return Err(DuidError::Malformed);
-    }
-
-    let duid_type = u16::from_be_bytes([duid[0], duid[1]]);
-    match duid_type {
-        DUID_LLT => parse_link_layer_duid(&duid[2..], 4),
-        DUID_LL => parse_link_layer_duid(&duid[2..], 0),
-        DUID_EN if duid.len() >= DUID_EN_MIN_LEN => Ok(DuidMac::NoLinkLayerMac),
-        DUID_UUID if duid.len() == DUID_UUID_LEN => Ok(DuidMac::NoLinkLayerMac),
-        DUID_EN | DUID_UUID => Err(DuidError::Malformed),
-        _ => Err(DuidError::UnsupportedType),
-    }
-}
-
-/// Parse RFC 6939 option 79 and return an Ethernet MAC when it carries one.
-fn extract_mac_from_option79(payload: &[u8]) -> Option<MacAddress> {
-    if payload.len() != 2 + ETHERNET_MAC_LEN {
-        return None;
-    }
-
-    let htype = u16::from_be_bytes([payload[0], payload[1]]);
-    (htype == HTYPE_ETHERNET).then(|| {
-        MacAddress::new([
-            payload[2], payload[3], payload[4], payload[5], payload[6], payload[7],
-        ])
-    })
 }
 
 /// Return a newly allocated MAC string extracted from a DHCPv6 DUID.
@@ -203,27 +144,6 @@ pub unsafe extern "C" fn carbide_free_mac_string(mac: *mut libc::c_char) {
     }
 }
 
-/// Parse the link-layer payload portion shared by DUID-LL and DUID-LLT.
-fn parse_link_layer_duid(bytes: &[u8], payload_offset: usize) -> Result<DuidMac, DuidError> {
-    if bytes.len() < 2 + payload_offset + ETHERNET_MAC_LEN {
-        return Err(DuidError::Malformed);
-    }
-
-    let htype = u16::from_be_bytes([bytes[0], bytes[1]]);
-    if htype != HTYPE_ETHERNET {
-        return Err(DuidError::UnsupportedType);
-    }
-
-    let mac = &bytes[2 + payload_offset..];
-    if mac.len() != ETHERNET_MAC_LEN {
-        return Err(DuidError::Malformed);
-    }
-
-    Ok(DuidMac::Mac(MacAddress::new([
-        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
-    ])))
-}
-
 #[derive(Debug)]
 struct DecodedV6 {
     message: Message,
@@ -235,7 +155,9 @@ struct DecodedV6 {
 
 /// Decode a client packet while preserving Kea-provided relay metadata.
 fn decode_direct(packet: &[u8], relay_context: &RelayContext) -> Result<DecodedV6, V6DecodeError> {
-    if relay_context.hop_count > 1 {
+    // Once Kea strips the relay envelope, a nonzero hop count cannot be proven
+    // to fit the supported one-envelope topology, so fail closed.
+    if relay_context.hop_count != 0 {
         return Err(V6DecodeError::RelayHopCountExceeded(
             relay_context.hop_count,
         ));
@@ -243,8 +165,7 @@ fn decode_direct(packet: &[u8], relay_context: &RelayContext) -> Result<DecodedV
 
     // Kea may have stripped the relay envelope already; keep its relay fields
     // only as fallback metadata and let the packet body drive message parsing.
-    let message =
-        Message::decode(&mut Decoder::new(packet)).map_err(|_| V6DecodeError::MalformedPacket)?;
+    let message = decode_client_message(packet).map_err(map_wire_error)?;
     Ok(DecodedV6 {
         message,
         relay_link: relay_context.link_address,
@@ -254,55 +175,35 @@ fn decode_direct(packet: &[u8], relay_context: &RelayContext) -> Result<DecodedV
     })
 }
 
-/// Decode one relay-forward envelope and its direct client message.
-///
-/// `dhcproto` handles the inner client message, but relay envelopes need a
-/// narrow raw-TLV pass here. In `dhcproto 0.15`, option 9 is modeled as another
-/// `RelayMessage`; for our authoritative path it normally carries a direct
-/// client message, and nested relay is intentionally rejected by policy.
+/// Decode one relay-forward envelope through the shared wire codec.
 fn decode_relay_forward(packet: &[u8]) -> Result<DecodedV6, V6DecodeError> {
-    if packet.len() < 34 {
-        return Err(V6DecodeError::MalformedPacket);
-    }
-    let hop_count = packet[1];
-    if hop_count > 1 {
-        return Err(V6DecodeError::RelayHopCountExceeded(hop_count));
-    }
-
-    let link_address = Ipv6Addr::from(
-        <[u8; 16]>::try_from(&packet[2..18]).map_err(|_| V6DecodeError::MalformedPacket)?,
-    );
-    let options = parse_raw_options(&packet[34..])?;
-    let relay_messages = options
-        .iter()
-        .filter(|option| option.code == u16::from(OptionCode::RelayMsg))
-        .map(|option| option.data)
-        .collect::<Vec<_>>();
-    // Kea keeps only one decoded Relay Message for later processing. Reject
-    // duplicates so identity selection cannot observe a different client.
-    let relay_message = match relay_messages.as_slice() {
-        [relay_message] => *relay_message,
-        _ => return Err(V6DecodeError::MalformedPacket),
-    };
-
-    // Nested relay is deliberately unsupported because segment selection would
-    // otherwise need a clear policy for which relay link-address wins.
-    if matches!(
-        relay_message.first().copied(),
-        Some(DHCPV6_RELAY_FORW) | Some(DHCPV6_RELAY_REPL)
-    ) {
-        return Err(V6DecodeError::NestedRelay);
-    }
-
-    let message = Message::decode(&mut Decoder::new(relay_message))
-        .map_err(|_| V6DecodeError::MalformedPacket)?;
+    let WirePacket { message, relay } = decode_wire_packet(packet).map_err(map_wire_error)?;
+    let relay = relay.ok_or(V6DecodeError::MalformedPacket)?;
     Ok(DecodedV6 {
         message,
-        relay_link: Some(link_address),
-        interface_id: raw_option_bytes(&options, OptionCode::InterfaceId),
-        remote_id: raw_option_bytes(&options, OptionCode::RemoteId),
-        client_link_layer: raw_option_bytes(&options, OptionCode::ClientLinklayerAddr),
+        relay_link: Some(relay.link_address),
+        interface_id: relay.interface_id,
+        remote_id: relay.remote_id,
+        client_link_layer: relay.client_link_layer,
     })
+}
+
+/// Translate policy-neutral wire failures into Kea hook outcomes.
+fn map_wire_error(error: WireDecodeError) -> V6DecodeError {
+    match error {
+        // The Kea boundary has one stable malformed-packet outcome for
+        // structural, client-decode, and missing-envelope failures.
+        WireDecodeError::MalformedPacket(_)
+        | WireDecodeError::ClientMessageDecode(_)
+        | WireDecodeError::MissingRelayMessage => V6DecodeError::MalformedPacket,
+        WireDecodeError::NestedRelay => V6DecodeError::NestedRelay,
+        WireDecodeError::RelayHopCountExceeded(hop_count) => {
+            V6DecodeError::RelayHopCountExceeded(hop_count)
+        }
+        WireDecodeError::UnexpectedRelayReply => {
+            V6DecodeError::UnsupportedMessage(MessageType::RelayRepl)
+        }
+    }
 }
 
 /// Select the MAC identity and transport fields sent to the Carbide API.
@@ -439,37 +340,6 @@ fn vendor_class(options: &dhcproto::v6::DhcpOptions) -> Option<String> {
     }
 }
 
-/// Parse raw DHCPv6 option TLVs from a relay envelope.
-fn parse_raw_options(mut bytes: &[u8]) -> Result<Vec<RawOption<'_>>, V6DecodeError> {
-    let mut options = Vec::new();
-    while !bytes.is_empty() {
-        if bytes.len() < 4 {
-            return Err(V6DecodeError::MalformedPacket);
-        }
-
-        let code = u16::from_be_bytes([bytes[0], bytes[1]]);
-        let len = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
-        bytes = &bytes[4..];
-        if bytes.len() < len {
-            return Err(V6DecodeError::MalformedPacket);
-        }
-
-        let (data, rest) = bytes.split_at(len);
-        options.push(RawOption { code, data });
-        bytes = rest;
-    }
-
-    Ok(options)
-}
-
-/// Return an owned copy of one raw relay option payload.
-fn raw_option_bytes(options: &[RawOption<'_>], code: OptionCode) -> Option<Vec<u8>> {
-    options
-        .iter()
-        .find(|option| option.code == u16::from(code))
-        .map(|option| option.data.to_vec())
-}
-
 #[cfg(test)]
 mod tests {
     use dhcproto::v6::{DhcpOption, IAAddr, IANA, IAPD, IATA, UnknownOption};
@@ -572,18 +442,28 @@ mod tests {
             DuidMac::NoLinkLayerMac
         );
         assert_eq!(
-            extract_mac_from_duid(&duid_en(DUID_MAX_LEN)).unwrap(),
+            extract_mac_from_duid(&duid_en(DUID_MAX_LENGTH)).unwrap(),
             DuidMac::NoLinkLayerMac
         );
         assert_eq!(
             extract_mac_from_duid(DUID_UUID).unwrap(),
             DuidMac::NoLinkLayerMac
         );
+        assert_eq!(
+            extract_mac_from_duid(&[0, 99, 0, 1, 2, 3]).unwrap(),
+            DuidMac::NoLinkLayerMac
+        );
+        // A valid non-Ethernet DUID-LL is still a usable DHCP identity even
+        // though this Ethernet-specific helper cannot extract its address.
+        assert_eq!(
+            extract_mac_from_duid(&[0, 3, 0, 32, 2, 0, 0, 0, 0, 1]).unwrap(),
+            DuidMac::NoLinkLayerMac
+        );
     }
 
     #[test]
     fn rejects_malformed_duids() {
-        // Truncated and unknown DUID forms cannot safely identify the client.
+        // Truncated DUID forms cannot safely identify the client.
         assert_eq!(extract_mac_from_duid(&[0]), Err(DuidError::Malformed));
         assert_eq!(
             extract_mac_from_duid(&[0, 2, 0, 0, 0, 1]),
@@ -594,23 +474,15 @@ mod tests {
             Err(DuidError::Malformed)
         );
         assert_eq!(
-            extract_mac_from_duid(&duid_en(DUID_MAX_LEN + 1)),
+            extract_mac_from_duid(&duid_en(DUID_MAX_LENGTH + 1)),
             Err(DuidError::Malformed)
-        );
-        assert_eq!(
-            extract_mac_from_duid(&[0, 99, 0, 1, 2, 3]),
-            Err(DuidError::UnsupportedType)
-        );
-        assert_eq!(
-            extract_mac_from_duid(&[0, 3, 0, 32, 2, 0, 0, 0, 0, 1]),
-            Err(DuidError::UnsupportedType)
         );
     }
 
     #[test]
     fn parses_option79_ethernet_mac() {
-        // Option 79 is decoded as Unknown by dhcproto, so we hand-parse the
-        // link-layer type and address payload here.
+        // Option 79 is decoded as Unknown by dhcproto, so the shared decoder
+        // hand-parses its link-layer type and address payload.
         assert_eq!(
             extract_mac_from_option79(OPTION79),
             Some("02:aa:bb:cc:dd:ee".parse().unwrap())
@@ -637,7 +509,7 @@ mod tests {
         // A one-hop relay supplies segment metadata and option 79; option 79
         // wins over the MAC embedded in DUID-LL/LLT.
         let inner = encode_message(client_message(MessageType::Solicit, true, DUID_LL));
-        let decoded = decode(&relay_forward(&inner, 1)).unwrap();
+        let decoded = decode(&relay_forward(&inner, 0)).unwrap();
 
         assert_eq!(decoded.selected_mac, "02:aa:bb:cc:dd:ee".parse().unwrap());
         assert_eq!(
@@ -662,7 +534,7 @@ mod tests {
             &packet,
             &RelayContext {
                 relay_count: 1,
-                hop_count: 1,
+                hop_count: 0,
                 link_address: Some("2001:db8::10".parse().unwrap()),
                 interface_id: Some(b"swp1".to_vec()),
                 remote_id: None,
@@ -676,6 +548,36 @@ mod tests {
         assert_eq!(
             message_kind_for(decoded.message_type, decoded.has_ia_na),
             Some(rpc::MessageKind::V6InfoRequest)
+        );
+    }
+
+    /// Verifies Kea's unwrapped relay representation preserves the shared
+    /// single-envelope rule that only a zero hop count can carry a client.
+    #[test]
+    fn rejects_unwrapped_packet_with_nonzero_hop_count() {
+        // Supply an ordinary client body exactly as Kea does after removing
+        // the outer Relay-Forward envelope.
+        let packet = encode_message(client_message(
+            MessageType::InformationRequest,
+            false,
+            DUID_LL,
+        ));
+
+        // A nonzero count implies another relay envelope, which this
+        // compatibility representation cannot preserve.
+        assert_eq!(
+            decode_with_relay_context(
+                &packet,
+                &RelayContext {
+                    relay_count: 1,
+                    hop_count: 1,
+                    link_address: Some("2001:db8::10".parse().unwrap()),
+                    interface_id: Some(b"swp1".to_vec()),
+                    remote_id: None,
+                    client_link_layer: None,
+                },
+            ),
+            Err(V6DecodeError::RelayHopCountExceeded(1))
         );
     }
 
@@ -713,32 +615,29 @@ mod tests {
         let inner = encode_message(client_message(MessageType::Solicit, true, DUID_UUID));
 
         assert_eq!(
-            decode(&relay_forward(&inner, 1)).unwrap().selected_mac,
+            decode(&relay_forward(&inner, 0)).unwrap().selected_mac,
             "02:aa:bb:cc:dd:ee".parse().unwrap()
         );
     }
 
     #[test]
     fn drops_malformed_duid_even_with_relay_option79() {
-        // Relay option 79 only helps valid non-MAC DUIDs; malformed or
-        // unhandled DUID forms are unsupported before MAC selection.
+        // Relay option 79 only helps valid non-MAC DUIDs; malformed DUID forms
+        // are rejected before MAC selection.
         let truncated = encode_message(client_message(
             MessageType::Solicit,
             true,
             &[0, 4, 0, 1, 2, 3],
         ));
-        let non_ethernet = encode_message(client_message(
-            MessageType::Solicit,
-            true,
-            &[0, 3, 0, 32, 2, 0, 0, 0, 0, 1],
-        ));
+        let missing_link_layer_address =
+            encode_message(client_message(MessageType::Solicit, true, &[0, 3, 0, 32]));
 
         assert_eq!(
-            decode(&relay_forward(&truncated, 1)),
+            decode(&relay_forward(&truncated, 0)),
             Err(V6DecodeError::UnsupportedDuid)
         );
         assert_eq!(
-            decode(&relay_forward(&non_ethernet, 1)),
+            decode(&relay_forward(&missing_link_layer_address, 0)),
             Err(V6DecodeError::UnsupportedDuid)
         );
     }
@@ -889,29 +788,29 @@ mod tests {
     #[test]
     fn drops_oversized_duid_en_even_with_relay_option79() {
         // Relay option 79 may supply the MAC, but the DUID still has to fit
-        // Kea and RFC 8415 length limits.
+        // Kea and RFC 9915 length limits.
         let inner = encode_message(client_message(
             MessageType::Solicit,
             true,
-            &duid_en(DUID_MAX_LEN + 1),
+            &duid_en(DUID_MAX_LENGTH + 1),
         ));
 
         assert_eq!(
-            decode(&relay_forward(&inner, 1)),
+            decode(&relay_forward(&inner, 0)),
             Err(V6DecodeError::UnsupportedDuid)
         );
     }
 
     #[test]
-    fn rejects_nested_or_multi_hop_relay() {
+    fn rejects_nested_or_nonzero_hop_relay() {
         // Multi-hop relay handling needs an explicit segment precedence rule,
         // so this milestone rejects it instead of serving silently.
         let inner = encode_message(client_message(MessageType::Solicit, true, DUID_LL));
-        let nested = relay_forward(&relay_forward(&inner, 1), 1);
+        let nested = relay_forward(&relay_forward(&inner, 0), 0);
 
         assert_eq!(
-            decode(&relay_forward(&inner, 2)),
-            Err(V6DecodeError::RelayHopCountExceeded(2))
+            decode(&relay_forward(&inner, 1)),
+            Err(V6DecodeError::RelayHopCountExceeded(1))
         );
         assert_eq!(decode(&nested), Err(V6DecodeError::NestedRelay));
     }

--- a/crates/dhcp/src/discovery_v6.rs
+++ b/crates/dhcp/src/discovery_v6.rs
@@ -16,33 +16,25 @@
  */
 //! DHCPv6 decode and identity selection for the Kea hook.
 //!
-//! This module is intentionally not a general DHCPv6 implementation. Kea still
-//! owns the DHCP state machine and `dhcproto` decodes normal client messages;
-//! the local raw parsing is limited to the hook boundary where we must recover
-//! one-hop relay metadata, enforce relay trust rules, and select the client
-//! identity before calling the Carbide API. Kea may provide that relay metadata
-//! as a side-channel after unwrapping the packet, or leave it in the raw wire
-//! bytes, so this module handles both shapes with the same policy.
+//! Kea owns the DHCP state machine, while `carbide-dhcpv6` owns policy-neutral
+//! wire decoding. This adapter adds Kea's relay side-channel, message policy,
+//! and authoritative client-identity selection before calling the Carbide API.
+//! Kea may provide relay metadata through that side channel after unwrapping
+//! the packet, or leave it in the raw wire bytes, so both shapes are supported.
 
 use std::ffi::CString;
 use std::net::Ipv6Addr;
 
+#[cfg(test)]
+use carbide_dhcpv6::{DUID_MAX_LENGTH, DuidError};
+use carbide_dhcpv6::{
+    DecodeError as WireDecodeError, DecodedPacket as WirePacket, DuidMac, RELAY_FORWARD,
+    RELAY_REPLY, decode as decode_wire_packet, decode_client_message, extract_mac_from_duid,
+    extract_mac_from_option79,
+};
 use dhcproto::v6::{DhcpOption, Message, MessageType, OptionCode};
-use dhcproto::{Decodable, Decoder};
 use mac_address::MacAddress;
 use rpc::forge as rpc;
-
-const DHCPV6_RELAY_FORW: u8 = 12;
-const DHCPV6_RELAY_REPL: u8 = 13;
-const DUID_LLT: u16 = 1;
-const DUID_EN: u16 = 2;
-const DUID_LL: u16 = 3;
-const DUID_UUID: u16 = 4;
-const HTYPE_ETHERNET: u16 = 1;
-const ETHERNET_MAC_LEN: usize = 6;
-const DUID_EN_MIN_LEN: usize = 7;
-const DUID_MAX_LEN: usize = 128;
-const DUID_UUID_LEN: usize = 18;
 
 /// Supplemental relay metadata from Kea when it has already unwrapped the relay envelope.
 #[derive(Debug, Default, Clone)]
@@ -84,25 +76,6 @@ pub(super) enum V6DecodeError {
     UnsupportedMessage(MessageType),
 }
 
-/// Result of parsing a DUID for a link-layer identity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DuidMac {
-    Mac(MacAddress),
-    NoLinkLayerMac,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DuidError {
-    Malformed,
-    UnsupportedType,
-}
-
-#[derive(Debug)]
-struct RawOption<'a> {
-    code: u16,
-    data: &'a [u8],
-}
-
 /// Decode a DHCPv6 packet without any Kea-provided relay fallback metadata.
 #[cfg(test)]
 fn decode(packet: &[u8]) -> Result<V6Discovery, V6DecodeError> {
@@ -119,8 +92,8 @@ pub(super) fn decode_with_relay_context(
     }
 
     let decoded = match packet.first().copied() {
-        Some(DHCPV6_RELAY_FORW) => decode_relay_forward(packet)?,
-        Some(DHCPV6_RELAY_REPL) => {
+        Some(RELAY_FORWARD) => decode_relay_forward(packet)?,
+        Some(RELAY_REPLY) => {
             return Err(V6DecodeError::UnsupportedMessage(MessageType::RelayRepl));
         }
         Some(_) => decode_direct(packet, relay_context)?,
@@ -128,38 +101,6 @@ pub(super) fn decode_with_relay_context(
     };
 
     select_identity(decoded)
-}
-
-/// Extract an Ethernet MAC from a DUID-LL or DUID-LLT byte string.
-fn extract_mac_from_duid(duid: &[u8]) -> Result<DuidMac, DuidError> {
-    // Kea caps DUIDs at RFC 8415's 128-byte maximum.
-    if duid.len() < 2 || duid.len() > DUID_MAX_LEN {
-        return Err(DuidError::Malformed);
-    }
-
-    let duid_type = u16::from_be_bytes([duid[0], duid[1]]);
-    match duid_type {
-        DUID_LLT => parse_link_layer_duid(&duid[2..], 4),
-        DUID_LL => parse_link_layer_duid(&duid[2..], 0),
-        DUID_EN if duid.len() >= DUID_EN_MIN_LEN => Ok(DuidMac::NoLinkLayerMac),
-        DUID_UUID if duid.len() == DUID_UUID_LEN => Ok(DuidMac::NoLinkLayerMac),
-        DUID_EN | DUID_UUID => Err(DuidError::Malformed),
-        _ => Err(DuidError::UnsupportedType),
-    }
-}
-
-/// Parse RFC 6939 option 79 and return an Ethernet MAC when it carries one.
-fn extract_mac_from_option79(payload: &[u8]) -> Option<MacAddress> {
-    if payload.len() != 2 + ETHERNET_MAC_LEN {
-        return None;
-    }
-
-    let htype = u16::from_be_bytes([payload[0], payload[1]]);
-    (htype == HTYPE_ETHERNET).then(|| {
-        MacAddress::new([
-            payload[2], payload[3], payload[4], payload[5], payload[6], payload[7],
-        ])
-    })
 }
 
 /// Return a newly allocated MAC string extracted from a DHCPv6 DUID.
@@ -199,27 +140,6 @@ pub unsafe extern "C" fn carbide_free_mac_string(mac: *mut libc::c_char) {
     }
 }
 
-/// Parse the link-layer payload portion shared by DUID-LL and DUID-LLT.
-fn parse_link_layer_duid(bytes: &[u8], payload_offset: usize) -> Result<DuidMac, DuidError> {
-    if bytes.len() < 2 + payload_offset + ETHERNET_MAC_LEN {
-        return Err(DuidError::Malformed);
-    }
-
-    let htype = u16::from_be_bytes([bytes[0], bytes[1]]);
-    if htype != HTYPE_ETHERNET {
-        return Err(DuidError::UnsupportedType);
-    }
-
-    let mac = &bytes[2 + payload_offset..];
-    if mac.len() != ETHERNET_MAC_LEN {
-        return Err(DuidError::Malformed);
-    }
-
-    Ok(DuidMac::Mac(MacAddress::new([
-        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
-    ])))
-}
-
 #[derive(Debug)]
 struct DecodedV6 {
     message: Message,
@@ -231,7 +151,9 @@ struct DecodedV6 {
 
 /// Decode a client packet while preserving Kea-provided relay metadata.
 fn decode_direct(packet: &[u8], relay_context: &RelayContext) -> Result<DecodedV6, V6DecodeError> {
-    if relay_context.hop_count > 1 {
+    // Once Kea strips the relay envelope, a nonzero hop count cannot be proven
+    // to fit the supported one-envelope topology, so fail closed.
+    if relay_context.hop_count != 0 {
         return Err(V6DecodeError::RelayHopCountExceeded(
             relay_context.hop_count,
         ));
@@ -239,8 +161,7 @@ fn decode_direct(packet: &[u8], relay_context: &RelayContext) -> Result<DecodedV
 
     // Kea may have stripped the relay envelope already; keep its relay fields
     // only as fallback metadata and let the packet body drive message parsing.
-    let message =
-        Message::decode(&mut Decoder::new(packet)).map_err(|_| V6DecodeError::MalformedPacket)?;
+    let message = decode_client_message(packet).map_err(map_wire_error)?;
     Ok(DecodedV6 {
         message,
         relay_link: relay_context.link_address,
@@ -250,55 +171,35 @@ fn decode_direct(packet: &[u8], relay_context: &RelayContext) -> Result<DecodedV
     })
 }
 
-/// Decode one relay-forward envelope and its direct client message.
-///
-/// `dhcproto` handles the inner client message, but relay envelopes need a
-/// narrow raw-TLV pass here. In `dhcproto 0.15`, option 9 is modeled as another
-/// `RelayMessage`; for our authoritative path it normally carries a direct
-/// client message, and nested relay is intentionally rejected by policy.
+/// Decode one relay-forward envelope through the shared wire codec.
 fn decode_relay_forward(packet: &[u8]) -> Result<DecodedV6, V6DecodeError> {
-    if packet.len() < 34 {
-        return Err(V6DecodeError::MalformedPacket);
-    }
-    let hop_count = packet[1];
-    if hop_count > 1 {
-        return Err(V6DecodeError::RelayHopCountExceeded(hop_count));
-    }
-
-    let link_address = Ipv6Addr::from(
-        <[u8; 16]>::try_from(&packet[2..18]).map_err(|_| V6DecodeError::MalformedPacket)?,
-    );
-    let options = parse_raw_options(&packet[34..])?;
-    let relay_messages = options
-        .iter()
-        .filter(|option| option.code == u16::from(OptionCode::RelayMsg))
-        .map(|option| option.data)
-        .collect::<Vec<_>>();
-    // Kea keeps only one decoded Relay Message for later processing. Reject
-    // duplicates so identity selection cannot observe a different client.
-    let relay_message = match relay_messages.as_slice() {
-        [relay_message] => *relay_message,
-        _ => return Err(V6DecodeError::MalformedPacket),
-    };
-
-    // Nested relay is deliberately unsupported because segment selection would
-    // otherwise need a clear policy for which relay link-address wins.
-    if matches!(
-        relay_message.first().copied(),
-        Some(DHCPV6_RELAY_FORW) | Some(DHCPV6_RELAY_REPL)
-    ) {
-        return Err(V6DecodeError::NestedRelay);
-    }
-
-    let message = Message::decode(&mut Decoder::new(relay_message))
-        .map_err(|_| V6DecodeError::MalformedPacket)?;
+    let WirePacket { message, relay } = decode_wire_packet(packet).map_err(map_wire_error)?;
+    let relay = relay.ok_or(V6DecodeError::MalformedPacket)?;
     Ok(DecodedV6 {
         message,
-        relay_link: Some(link_address),
-        interface_id: raw_option_bytes(&options, OptionCode::InterfaceId),
-        remote_id: raw_option_bytes(&options, OptionCode::RemoteId),
-        client_link_layer: raw_option_bytes(&options, OptionCode::ClientLinklayerAddr),
+        relay_link: Some(relay.link_address),
+        interface_id: relay.interface_id,
+        remote_id: relay.remote_id,
+        client_link_layer: relay.client_link_layer,
     })
+}
+
+/// Translate policy-neutral wire failures into Kea hook outcomes.
+fn map_wire_error(error: WireDecodeError) -> V6DecodeError {
+    match error {
+        // The Kea boundary has one stable malformed-packet outcome for
+        // structural, client-decode, and missing-envelope failures.
+        WireDecodeError::MalformedPacket(_)
+        | WireDecodeError::ClientMessageDecode(_)
+        | WireDecodeError::MissingRelayMessage => V6DecodeError::MalformedPacket,
+        WireDecodeError::NestedRelay => V6DecodeError::NestedRelay,
+        WireDecodeError::RelayHopCountExceeded(hop_count) => {
+            V6DecodeError::RelayHopCountExceeded(hop_count)
+        }
+        WireDecodeError::UnexpectedRelayReply => {
+            V6DecodeError::UnsupportedMessage(MessageType::RelayRepl)
+        }
+    }
 }
 
 /// Select the MAC identity and transport fields sent to the Carbide API.
@@ -435,37 +336,6 @@ fn vendor_class(options: &dhcproto::v6::DhcpOptions) -> Option<String> {
     }
 }
 
-/// Parse raw DHCPv6 option TLVs from a relay envelope.
-fn parse_raw_options(mut bytes: &[u8]) -> Result<Vec<RawOption<'_>>, V6DecodeError> {
-    let mut options = Vec::new();
-    while !bytes.is_empty() {
-        if bytes.len() < 4 {
-            return Err(V6DecodeError::MalformedPacket);
-        }
-
-        let code = u16::from_be_bytes([bytes[0], bytes[1]]);
-        let len = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
-        bytes = &bytes[4..];
-        if bytes.len() < len {
-            return Err(V6DecodeError::MalformedPacket);
-        }
-
-        let (data, rest) = bytes.split_at(len);
-        options.push(RawOption { code, data });
-        bytes = rest;
-    }
-
-    Ok(options)
-}
-
-/// Return an owned copy of one raw relay option payload.
-fn raw_option_bytes(options: &[RawOption<'_>], code: OptionCode) -> Option<Vec<u8>> {
-    options
-        .iter()
-        .find(|option| option.code == u16::from(code))
-        .map(|option| option.data.to_vec())
-}
-
 #[cfg(test)]
 mod tests {
     use dhcproto::v6::{DhcpOption, IAAddr, IANA, IAPD, IATA, UnknownOption};
@@ -568,18 +438,22 @@ mod tests {
             DuidMac::NoLinkLayerMac
         );
         assert_eq!(
-            extract_mac_from_duid(&duid_en(DUID_MAX_LEN)).unwrap(),
+            extract_mac_from_duid(&duid_en(DUID_MAX_LENGTH)).unwrap(),
             DuidMac::NoLinkLayerMac
         );
         assert_eq!(
             extract_mac_from_duid(DUID_UUID).unwrap(),
             DuidMac::NoLinkLayerMac
         );
+        assert_eq!(
+            extract_mac_from_duid(&[0, 99, 0, 1, 2, 3]).unwrap(),
+            DuidMac::NoLinkLayerMac
+        );
     }
 
     #[test]
     fn rejects_malformed_duids() {
-        // Truncated and unknown DUID forms cannot safely identify the client.
+        // Truncated and unsupported link-layer DUID forms cannot safely identify the client.
         assert_eq!(extract_mac_from_duid(&[0]), Err(DuidError::Malformed));
         assert_eq!(
             extract_mac_from_duid(&[0, 2, 0, 0, 0, 1]),
@@ -590,12 +464,8 @@ mod tests {
             Err(DuidError::Malformed)
         );
         assert_eq!(
-            extract_mac_from_duid(&duid_en(DUID_MAX_LEN + 1)),
+            extract_mac_from_duid(&duid_en(DUID_MAX_LENGTH + 1)),
             Err(DuidError::Malformed)
-        );
-        assert_eq!(
-            extract_mac_from_duid(&[0, 99, 0, 1, 2, 3]),
-            Err(DuidError::UnsupportedType)
         );
         assert_eq!(
             extract_mac_from_duid(&[0, 3, 0, 32, 2, 0, 0, 0, 0, 1]),
@@ -605,8 +475,8 @@ mod tests {
 
     #[test]
     fn parses_option79_ethernet_mac() {
-        // Option 79 is decoded as Unknown by dhcproto, so we hand-parse the
-        // link-layer type and address payload here.
+        // Option 79 is decoded as Unknown by dhcproto, so the shared decoder
+        // hand-parses its link-layer type and address payload.
         assert_eq!(
             extract_mac_from_option79(OPTION79),
             Some("02:aa:bb:cc:dd:ee".parse().unwrap())
@@ -633,7 +503,7 @@ mod tests {
         // A one-hop relay supplies segment metadata and option 79; option 79
         // wins over the MAC embedded in DUID-LL/LLT.
         let inner = encode_message(client_message(MessageType::Solicit, true, DUID_LL));
-        let decoded = decode(&relay_forward(&inner, 1)).unwrap();
+        let decoded = decode(&relay_forward(&inner, 0)).unwrap();
 
         assert_eq!(decoded.selected_mac, "02:aa:bb:cc:dd:ee".parse().unwrap());
         assert_eq!(
@@ -658,7 +528,7 @@ mod tests {
             &packet,
             &RelayContext {
                 relay_count: 1,
-                hop_count: 1,
+                hop_count: 0,
                 link_address: Some("2001:db8::10".parse().unwrap()),
                 interface_id: Some(b"swp1".to_vec()),
                 remote_id: None,
@@ -672,6 +542,36 @@ mod tests {
         assert_eq!(
             message_kind_for(decoded.message_type, decoded.has_ia_na),
             Some(rpc::MessageKind::V6InfoRequest)
+        );
+    }
+
+    /// Verifies Kea's unwrapped relay representation preserves the shared
+    /// single-envelope rule that only a zero hop count can carry a client.
+    #[test]
+    fn rejects_unwrapped_packet_with_nonzero_hop_count() {
+        // Supply an ordinary client body exactly as Kea does after removing
+        // the outer Relay-Forward envelope.
+        let packet = encode_message(client_message(
+            MessageType::InformationRequest,
+            false,
+            DUID_LL,
+        ));
+
+        // A nonzero count implies another relay envelope, which this
+        // compatibility representation cannot preserve.
+        assert_eq!(
+            decode_with_relay_context(
+                &packet,
+                &RelayContext {
+                    relay_count: 1,
+                    hop_count: 1,
+                    link_address: Some("2001:db8::10".parse().unwrap()),
+                    interface_id: Some(b"swp1".to_vec()),
+                    remote_id: None,
+                    client_link_layer: None,
+                },
+            ),
+            Err(V6DecodeError::RelayHopCountExceeded(1))
         );
     }
 
@@ -709,7 +609,7 @@ mod tests {
         let inner = encode_message(client_message(MessageType::Solicit, true, DUID_UUID));
 
         assert_eq!(
-            decode(&relay_forward(&inner, 1)).unwrap().selected_mac,
+            decode(&relay_forward(&inner, 0)).unwrap().selected_mac,
             "02:aa:bb:cc:dd:ee".parse().unwrap()
         );
     }
@@ -730,11 +630,11 @@ mod tests {
         ));
 
         assert_eq!(
-            decode(&relay_forward(&truncated, 1)),
+            decode(&relay_forward(&truncated, 0)),
             Err(V6DecodeError::UnsupportedDuid)
         );
         assert_eq!(
-            decode(&relay_forward(&non_ethernet, 1)),
+            decode(&relay_forward(&non_ethernet, 0)),
             Err(V6DecodeError::UnsupportedDuid)
         );
     }
@@ -885,29 +785,29 @@ mod tests {
     #[test]
     fn drops_oversized_duid_en_even_with_relay_option79() {
         // Relay option 79 may supply the MAC, but the DUID still has to fit
-        // Kea and RFC 8415 length limits.
+        // Kea and RFC 9915 length limits.
         let inner = encode_message(client_message(
             MessageType::Solicit,
             true,
-            &duid_en(DUID_MAX_LEN + 1),
+            &duid_en(DUID_MAX_LENGTH + 1),
         ));
 
         assert_eq!(
-            decode(&relay_forward(&inner, 1)),
+            decode(&relay_forward(&inner, 0)),
             Err(V6DecodeError::UnsupportedDuid)
         );
     }
 
     #[test]
-    fn rejects_nested_or_multi_hop_relay() {
+    fn rejects_nested_or_nonzero_hop_relay() {
         // Multi-hop relay handling needs an explicit segment precedence rule,
         // so this milestone rejects it instead of serving silently.
         let inner = encode_message(client_message(MessageType::Solicit, true, DUID_LL));
-        let nested = relay_forward(&relay_forward(&inner, 1), 1);
+        let nested = relay_forward(&relay_forward(&inner, 0), 0);
 
         assert_eq!(
-            decode(&relay_forward(&inner, 2)),
-            Err(V6DecodeError::RelayHopCountExceeded(2))
+            decode(&relay_forward(&inner, 1)),
+            Err(V6DecodeError::RelayHopCountExceeded(1))
         );
         assert_eq!(decode(&nested), Err(V6DecodeError::NestedRelay));
     }

--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -134,8 +134,7 @@ void add_ia_na_status6(Pkt6Ptr query6_ptr, Pkt6Ptr response6_ptr,
 }
 
 void record_dropped_v6_request(const char *reason) {
-  // Preserve the shared v4/v6 counter while emitting the required v6 series.
-  carbide_increment_dropped_requests(reason);
+  // DHCPv6 has its own metric family; the unsuffixed counter remains DHCPv4.
   carbide_increment_dropped_v6_requests(reason);
 }
 
@@ -1198,7 +1197,7 @@ int pkt6_receive(CalloutHandle &handle) {
   Pkt6Ptr query6_ptr;
   handle.getArgument("query6", query6_ptr);
 
-  carbide_increment_total_requests();
+  carbide_increment_v6_requests(query6_ptr ? query6_ptr->getType() : 0);
 
   if (!query6_ptr) {
     LOG_ERROR(logger, "LOG_CARBIDE_PKT6_RECEIVE: missing query6 argument");

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -464,7 +464,7 @@ pub unsafe extern "C" fn carbide_set_config_metrics_endpoint(endpoint: *const c_
     }
 }
 
-/// Increments counter for total number of requests
+/// Increments the legacy DHCPv4 request counter.
 ///
 /// # Safety
 ///
@@ -474,7 +474,18 @@ pub unsafe extern "C" fn carbide_increment_total_requests() {
     metrics::increment_total_requests();
 }
 
-/// Increments counter for number of dropped or refused requests. The reason
+/// Increments the DHCPv6 request counter, labelled by the request's message
+/// type. `message_type` is the raw DHCPv6 message-type code reported by Kea.
+///
+/// # Safety
+///
+/// None
+#[unsafe(no_mangle)]
+pub extern "C" fn carbide_increment_v6_requests(message_type: u8) {
+    metrics::increment_v6_requests(metrics::V6RequestMessageType::from(message_type));
+}
+
+/// Increments the legacy DHCPv4 dropped-or-refused request counter. The reason
 /// string is mapped onto the bounded [`metrics::DropReason`] taxonomy; a
 /// string outside the taxonomy (or a null / non-UTF-8 input) is bucketed as
 /// `Unknown` so the metric's label domain stays closed.
@@ -522,7 +533,7 @@ pub extern "C" fn carbide_increment_v6_reply_sent(message_type: u8) {
     metrics::increment_v6_reply_sent(metrics::V6ReplyMessageType::from(message_type));
 }
 
-/// Increments counter for number of dropped DHCPv6 requests.
+/// Increments the DHCPv6 dropped-or-refused request counter.
 ///
 /// # Safety
 ///

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -446,7 +446,7 @@ pub unsafe extern "C" fn carbide_set_config_metrics_endpoint(endpoint: *const c_
     }
 }
 
-/// Increments counter for total number of requests
+/// Increments the legacy DHCPv4 request counter.
 ///
 /// # Safety
 ///
@@ -456,7 +456,18 @@ pub unsafe extern "C" fn carbide_increment_total_requests() {
     metrics::increment_total_requests();
 }
 
-/// Increments counter for number of dropped or refused requests. The reason
+/// Increments the DHCPv6 request counter, labelled by the request's message
+/// type. `message_type` is the raw DHCPv6 message-type code reported by Kea.
+///
+/// # Safety
+///
+/// None
+#[unsafe(no_mangle)]
+pub extern "C" fn carbide_increment_v6_requests(message_type: u8) {
+    metrics::increment_v6_requests(metrics::V6RequestMessageType::from(message_type));
+}
+
+/// Increments the legacy DHCPv4 dropped-or-refused request counter. The reason
 /// string is mapped onto the bounded [`metrics::DropReason`] taxonomy; a
 /// string outside the taxonomy (or a null / non-UTF-8 input) is bucketed as
 /// `Unknown` so the metric's label domain stays closed.
@@ -502,7 +513,7 @@ pub extern "C" fn carbide_increment_v6_reply_sent(message_type: u8) {
     metrics::increment_v6_reply_sent(metrics::V6ReplyMessageType::from(message_type));
 }
 
-/// Increments counter for number of dropped DHCPv6 requests.
+/// Increments the DHCPv6 dropped-or-refused request counter.
 ///
 /// # Safety
 ///

--- a/crates/dhcp/src/metrics.rs
+++ b/crates/dhcp/src/metrics.rs
@@ -21,13 +21,12 @@
 //! The counters are `carbide-instrument` events declared with `log = off`:
 //! the Kea process installs no tracing subscriber, so the C++ `LOG_ERROR`
 //! lines in `callouts.cc` remain the log side and the events move only the
-//! metric. The two request counters declare their existing exposed Prometheus
-//! series names directly, so the names and the `reason` label key that
-//! existing dashboards select on stay byte-identical. The certificate-expiry
-//! gauge is point-in-time state, not an occurrence, and stays on the
-//! observable-gauge pattern. `metrics_server` installs the metrics endpoint's
-//! Prometheus-only meter provider, so there is no separate OTLP instrument-name
-//! contract for these counters.
+//! metric. The DHCPv4 counters retain their existing exposed Prometheus names
+//! and `reason` label values, while DHCPv6 traffic uses explicit v6 metric
+//! names. The certificate-expiry gauge is point-in-time state, not an
+//! occurrence, and stays on the observable-gauge pattern. `metrics_server`
+//! installs the metrics endpoint's Prometheus-only meter provider, so there is
+//! no separate OTLP instrument-name contract for these counters.
 
 use std::ops::Deref;
 use std::sync::Arc;
@@ -68,6 +67,36 @@ impl From<u8> for ReplyMessageType {
             2 => Self::Offer, // DHCPOFFER
             5 => Self::Ack,   // DHCPACK
             6 => Self::Nak,   // DHCPNAK
+            _ => Self::Other,
+        }
+    }
+}
+
+/// The DHCPv6 message type of an incoming client request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(super) enum V6RequestMessageType {
+    Solicit,
+    Request,
+    Confirm,
+    Renew,
+    Rebind,
+    Release,
+    Decline,
+    InformationRequest,
+    Other,
+}
+
+impl From<u8> for V6RequestMessageType {
+    fn from(message_type_code: u8) -> Self {
+        match message_type_code {
+            1 => Self::Solicit,
+            3 => Self::Request,
+            4 => Self::Confirm,
+            5 => Self::Renew,
+            6 => Self::Rebind,
+            8 => Self::Release,
+            9 => Self::Decline,
+            11 => Self::InformationRequest,
             _ => Self::Other,
         }
     }
@@ -215,7 +244,7 @@ impl From<&str> for DropReason {
 }
 
 /// Why the DHCPv6 hook dropped a request, as the bounded `reason` label on
-/// `carbide_dropped_v6_requests_total`.
+/// `carbide_dhcp_v6_requests_dropped_total`.
 ///
 /// These labels intentionally follow the existing DHCPv6 snake_case contract,
 /// except `NonRelayedPacket`, which is shared with the v4 drop path.
@@ -291,7 +320,7 @@ impl From<&str> for V6DropReason {
     }
 }
 
-/// A DHCP request reached the hook's `pkt4_receive` callout, whatever becomes
+/// A DHCPv4 request reached the hook's `pkt4_receive` callout, whatever becomes
 /// of it next.
 #[derive(Event)]
 #[event(
@@ -300,11 +329,11 @@ impl From<&str> for V6DropReason {
     component = "carbide-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of DHCP requests received."
+    describe = "Number of DHCPv4 requests received."
 )]
 struct DhcpRequestReceived;
 
-/// The hook dropped or refused a DHCP request. This counts refusal events,
+/// The hook dropped or refused a DHCPv4 request. This counts refusal events,
 /// not packets: an exchange that fails at more than one callout (a refused
 /// lease selection and then a missing machine at send time) counts each site.
 #[derive(Event)]
@@ -314,29 +343,44 @@ struct DhcpRequestReceived;
     component = "carbide-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of DHCP requests dropped or refused, by reason."
+    describe = "Number of DHCPv4 requests dropped or refused, by reason."
 )]
 struct DhcpRequestDropped {
     #[label]
     reason: DropReason,
 }
 
+/// A DHCPv6 request reached the hook's `pkt6_receive` callout.
+#[derive(Event)]
+#[event(
+    event_name = "kea_dhcp_v6_request_received",
+    metric_name = "carbide_dhcp_v6_requests_total",
+    component = "carbide-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of DHCPv6 requests received, by DHCP message type."
+)]
+struct DhcpV6RequestReceived {
+    #[label]
+    message_type: V6RequestMessageType,
+}
+
 /// The DHCPv6 hook dropped a packet before Kea could safely answer it.
 #[derive(Event)]
 #[event(
     event_name = "kea_dhcp_v6_request_dropped",
-    metric_name = "carbide_dropped_v6_requests_total",
+    metric_name = "carbide_dhcp_v6_requests_dropped_total",
     component = "carbide-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of dropped DHCPv6 requests, by reason."
+    describe = "Number of DHCPv6 requests dropped or refused, by reason."
 )]
 struct DhcpV6RequestDropped {
     #[label]
     reason: V6DropReason,
 }
 
-/// A fully assembled DHCP reply left `pkt4_send` for transmission: an `offer`
+/// A fully assembled DHCPv4 reply left `pkt4_send` for transmission: an `offer`
 /// proposes a lease, an `ack` commits one, a `nak` refuses one.
 ///
 /// Unlike the two request counters this metric is new, so it uses the
@@ -348,7 +392,7 @@ struct DhcpV6RequestDropped {
     component = "carbide-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of DHCP replies sent, by reply message type."
+    describe = "Number of DHCPv4 replies sent, by reply message type."
 )]
 struct DhcpReplySent {
     #[label]
@@ -532,6 +576,13 @@ pub(super) fn increment_total_requests() {
     }
 }
 
+/// Increment the DHCPv6 request counter for an incoming message type.
+pub(super) fn increment_v6_requests(message_type: V6RequestMessageType) {
+    if metrics_initialized() {
+        emit(DhcpV6RequestReceived { message_type });
+    }
+}
+
 pub(super) fn increment_dropped_requests(reason: DropReason) {
     if metrics_initialized() {
         emit(DhcpRequestDropped { reason });
@@ -646,6 +697,77 @@ mod tests {
                 },
             ],
             ReplyMessageType::from,
+        );
+    }
+
+    /// Verifies Kea's raw DHCPv6 request codes map onto the bounded request
+    /// labels exposed by the v6 request metric.
+    #[test]
+    fn v6_request_message_type_maps_dhcpv6_request_codes_and_buckets_the_rest() {
+        check_values(
+            [
+                // SOLICIT starts DHCPv6 allocation and keeps its own metric label.
+                Check {
+                    scenario: "SOLICIT (1)",
+                    input: 1u8,
+                    expect: V6RequestMessageType::Solicit,
+                },
+                // REQUEST commits an advertised binding and remains independently visible.
+                Check {
+                    scenario: "REQUEST (3)",
+                    input: 3,
+                    expect: V6RequestMessageType::Request,
+                },
+                // CONFIRM checks link validity without being folded into allocation traffic.
+                Check {
+                    scenario: "CONFIRM (4)",
+                    input: 4,
+                    expect: V6RequestMessageType::Confirm,
+                },
+                // RENEW targets the current server and keeps its refresh identity.
+                Check {
+                    scenario: "RENEW (5)",
+                    input: 5,
+                    expect: V6RequestMessageType::Renew,
+                },
+                // REBIND is a distinct refresh after the original server is unavailable.
+                Check {
+                    scenario: "REBIND (6)",
+                    input: 6,
+                    expect: V6RequestMessageType::Rebind,
+                },
+                // RELEASE ends a binding and must remain observable as lease-end traffic.
+                Check {
+                    scenario: "RELEASE (8)",
+                    input: 8,
+                    expect: V6RequestMessageType::Release,
+                },
+                // DECLINE reports an unusable address separately from RELEASE.
+                Check {
+                    scenario: "DECLINE (9)",
+                    input: 9,
+                    expect: V6RequestMessageType::Decline,
+                },
+                // INFORMATION-REQUEST carries only configuration options.
+                Check {
+                    scenario: "INFORMATION-REQUEST (11)",
+                    input: 11,
+                    expect: V6RequestMessageType::InformationRequest,
+                },
+                // RELAY-FORWARD is an envelope and must not impersonate a client request.
+                Check {
+                    scenario: "RELAY-FORWARD (12) is an outer wire envelope",
+                    input: 12,
+                    expect: V6RequestMessageType::Other,
+                },
+                // Unrecognized codes share the bounded fallback instead of adding cardinality.
+                Check {
+                    scenario: "unknown code buckets as other",
+                    input: 250,
+                    expect: V6RequestMessageType::Other,
+                },
+            ],
+            V6RequestMessageType::from,
         );
     }
 
@@ -934,6 +1056,9 @@ mod tests {
             emit(DhcpRequestDropped {
                 reason: DropReason::TooManyFailuresError,
             });
+            emit(DhcpV6RequestReceived {
+                message_type: V6RequestMessageType::Confirm,
+            });
             emit(DhcpV6RequestDropped {
                 reason: V6DropReason::NestedRelay,
             });
@@ -959,7 +1084,14 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dropped_v6_requests_total",
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "confirm")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "nested_relay")]
             ),
             1.0
@@ -1000,6 +1132,7 @@ mod tests {
             crate::carbide_increment_dropped_requests(c"NonRelayedPacket".as_ptr());
             crate::carbide_increment_dropped_v6_requests(c"nested_relay".as_ptr());
         }
+        crate::carbide_increment_v6_requests(4);
         crate::carbide_increment_reply_sent(5);
         crate::carbide_increment_v6_reply_sent(7);
         assert_eq!(
@@ -1015,7 +1148,14 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dropped_v6_requests_total",
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "confirm")]
+            ),
+            0.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "nested_relay")]
             ),
             0.0
@@ -1043,6 +1183,7 @@ mod tests {
             crate::carbide_increment_dropped_v6_requests(c"nested_relay".as_ptr());
             crate::carbide_increment_dropped_v6_requests(c"not_a_v6_reason".as_ptr());
         }
+        crate::carbide_increment_v6_requests(4); // DHCPV6_CONFIRM
         crate::carbide_increment_reply_sent(5); // DHCPACK
         crate::carbide_increment_v6_reply_sent(7); // DHCPV6_REPLY
 
@@ -1066,14 +1207,21 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dropped_v6_requests_total",
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "confirm")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "nested_relay")]
             ),
             1.0
         );
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dropped_v6_requests_total",
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "unknown")]
             ),
             1.0

--- a/crates/dhcp/src/metrics.rs
+++ b/crates/dhcp/src/metrics.rs
@@ -21,13 +21,12 @@
 //! The counters are `carbide-instrument` events declared with `log = off`:
 //! the Kea process installs no tracing subscriber, so the C++ `LOG_ERROR`
 //! lines in `callouts.cc` remain the log side and the events move only the
-//! metric. The two request counters declare their existing exposed Prometheus
-//! series names directly, so the names and the `reason` label key that
-//! existing dashboards select on stay byte-identical. The certificate-expiry
-//! gauge is point-in-time state, not an occurrence, and stays on the
-//! observable-gauge pattern. `metrics_server` installs the metrics endpoint's
-//! Prometheus-only meter provider, so there is no separate OTLP instrument-name
-//! contract for these counters.
+//! metric. The DHCPv4 counters retain their existing exposed Prometheus names
+//! and `reason` label values, while DHCPv6 traffic uses explicit v6 metric
+//! names. The certificate-expiry gauge is point-in-time state, not an
+//! occurrence, and stays on the observable-gauge pattern. `metrics_server`
+//! installs the metrics endpoint's Prometheus-only meter provider, so there is
+//! no separate OTLP instrument-name contract for these counters.
 
 use std::ops::Deref;
 use std::sync::Arc;
@@ -68,6 +67,36 @@ impl From<u8> for ReplyMessageType {
             2 => Self::Offer, // DHCPOFFER
             5 => Self::Ack,   // DHCPACK
             6 => Self::Nak,   // DHCPNAK
+            _ => Self::Other,
+        }
+    }
+}
+
+/// The DHCPv6 message type of an incoming client request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(super) enum V6RequestMessageType {
+    Solicit,
+    Request,
+    Confirm,
+    Renew,
+    Rebind,
+    Release,
+    Decline,
+    InformationRequest,
+    Other,
+}
+
+impl From<u8> for V6RequestMessageType {
+    fn from(message_type_code: u8) -> Self {
+        match message_type_code {
+            1 => Self::Solicit,
+            3 => Self::Request,
+            4 => Self::Confirm,
+            5 => Self::Renew,
+            6 => Self::Rebind,
+            8 => Self::Release,
+            9 => Self::Decline,
+            11 => Self::InformationRequest,
             _ => Self::Other,
         }
     }
@@ -215,7 +244,7 @@ impl From<&str> for DropReason {
 }
 
 /// Why the DHCPv6 hook dropped a request, as the bounded `reason` label on
-/// `carbide_dropped_v6_requests_total`.
+/// `carbide_dhcp_v6_requests_dropped_total`.
 ///
 /// These labels intentionally follow the existing DHCPv6 snake_case contract,
 /// except `NonRelayedPacket`, which is shared with the v4 drop path.
@@ -291,7 +320,7 @@ impl From<&str> for V6DropReason {
     }
 }
 
-/// A DHCP request reached the hook's `pkt4_receive` callout, whatever becomes
+/// A DHCPv4 request reached the hook's `pkt4_receive` callout, whatever becomes
 /// of it next.
 #[derive(Event)]
 #[event(
@@ -300,11 +329,11 @@ impl From<&str> for V6DropReason {
     component = "carbide-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of DHCP requests received."
+    describe = "Number of DHCPv4 requests received."
 )]
 struct DhcpRequestReceived;
 
-/// The hook dropped or refused a DHCP request. This counts refusal events,
+/// The hook dropped or refused a DHCPv4 request. This counts refusal events,
 /// not packets: an exchange that fails at more than one callout (a refused
 /// lease selection and then a missing machine at send time) counts each site.
 #[derive(Event)]
@@ -314,29 +343,44 @@ struct DhcpRequestReceived;
     component = "carbide-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of DHCP requests dropped or refused, by reason."
+    describe = "Number of DHCPv4 requests dropped or refused, by reason."
 )]
 struct DhcpRequestDropped {
     #[label]
     reason: DropReason,
 }
 
+/// A DHCPv6 request reached the hook's `pkt6_receive` callout.
+#[derive(Event)]
+#[event(
+    event_name = "kea_dhcp_v6_request_received",
+    metric_name = "carbide_dhcp_v6_requests_total",
+    component = "carbide-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of DHCPv6 requests received, by DHCP message type."
+)]
+struct DhcpV6RequestReceived {
+    #[label]
+    message_type: V6RequestMessageType,
+}
+
 /// The DHCPv6 hook dropped a packet before Kea could safely answer it.
 #[derive(Event)]
 #[event(
     event_name = "kea_dhcp_v6_request_dropped",
-    metric_name = "carbide_dropped_v6_requests_total",
+    metric_name = "carbide_dhcp_v6_requests_dropped_total",
     component = "carbide-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of dropped DHCPv6 requests, by reason."
+    describe = "Number of DHCPv6 requests dropped or refused, by reason."
 )]
 struct DhcpV6RequestDropped {
     #[label]
     reason: V6DropReason,
 }
 
-/// A fully assembled DHCP reply left `pkt4_send` for transmission: an `offer`
+/// A fully assembled DHCPv4 reply left `pkt4_send` for transmission: an `offer`
 /// proposes a lease, an `ack` commits one, a `nak` refuses one.
 ///
 /// Unlike the two request counters this metric is new, so it uses the
@@ -348,7 +392,7 @@ struct DhcpV6RequestDropped {
     component = "carbide-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of DHCP replies sent, by reply message type."
+    describe = "Number of DHCPv4 replies sent, by reply message type."
 )]
 struct DhcpReplySent {
     #[label]
@@ -532,6 +576,13 @@ pub(super) fn increment_total_requests() {
     }
 }
 
+/// Increment the DHCPv6 request counter for an incoming message type.
+pub(super) fn increment_v6_requests(message_type: V6RequestMessageType) {
+    if metrics_initialized() {
+        emit(DhcpV6RequestReceived { message_type });
+    }
+}
+
 pub(super) fn increment_dropped_requests(reason: DropReason) {
     if metrics_initialized() {
         emit(DhcpRequestDropped { reason });
@@ -646,6 +697,77 @@ mod tests {
                 },
             ],
             ReplyMessageType::from,
+        );
+    }
+
+    /// Verifies Kea's raw DHCPv6 request codes map onto the bounded request
+    /// labels exposed by the v6 request metric.
+    #[test]
+    fn v6_request_message_type_maps_dhcpv6_request_codes_and_buckets_the_rest() {
+        check_values(
+            [
+                // SOLICIT starts DHCPv6 allocation and keeps its own metric label.
+                Check {
+                    scenario: "SOLICIT (1)",
+                    input: 1u8,
+                    expect: V6RequestMessageType::Solicit,
+                },
+                // REQUEST commits an advertised binding and remains independently visible.
+                Check {
+                    scenario: "REQUEST (3)",
+                    input: 3,
+                    expect: V6RequestMessageType::Request,
+                },
+                // CONFIRM checks link validity without being folded into allocation traffic.
+                Check {
+                    scenario: "CONFIRM (4)",
+                    input: 4,
+                    expect: V6RequestMessageType::Confirm,
+                },
+                // RENEW targets the current server and keeps its refresh identity.
+                Check {
+                    scenario: "RENEW (5)",
+                    input: 5,
+                    expect: V6RequestMessageType::Renew,
+                },
+                // REBIND is a distinct refresh after the original server is unavailable.
+                Check {
+                    scenario: "REBIND (6)",
+                    input: 6,
+                    expect: V6RequestMessageType::Rebind,
+                },
+                // RELEASE ends a binding and must remain observable as lease-end traffic.
+                Check {
+                    scenario: "RELEASE (8)",
+                    input: 8,
+                    expect: V6RequestMessageType::Release,
+                },
+                // DECLINE reports an unusable address separately from RELEASE.
+                Check {
+                    scenario: "DECLINE (9)",
+                    input: 9,
+                    expect: V6RequestMessageType::Decline,
+                },
+                // INFORMATION-REQUEST carries only configuration options.
+                Check {
+                    scenario: "INFORMATION-REQUEST (11)",
+                    input: 11,
+                    expect: V6RequestMessageType::InformationRequest,
+                },
+                // RELAY-FORWARD is an envelope and must not impersonate a client request.
+                Check {
+                    scenario: "RELAY-FORWARD (12) is an outer wire envelope",
+                    input: 12,
+                    expect: V6RequestMessageType::Other,
+                },
+                // Unrecognized codes share the bounded fallback instead of adding cardinality.
+                Check {
+                    scenario: "unknown code buckets as other",
+                    input: 250,
+                    expect: V6RequestMessageType::Other,
+                },
+            ],
+            V6RequestMessageType::from,
         );
     }
 
@@ -932,6 +1054,9 @@ mod tests {
             emit(DhcpRequestDropped {
                 reason: DropReason::TooManyFailuresError,
             });
+            emit(DhcpV6RequestReceived {
+                message_type: V6RequestMessageType::Confirm,
+            });
             emit(DhcpV6RequestDropped {
                 reason: V6DropReason::NestedRelay,
             });
@@ -957,7 +1082,14 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dropped_v6_requests_total",
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "confirm")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "nested_relay")]
             ),
             1.0
@@ -996,6 +1128,7 @@ mod tests {
             crate::carbide_increment_dropped_requests(c"NonRelayedPacket".as_ptr());
             crate::carbide_increment_dropped_v6_requests(c"nested_relay".as_ptr());
         }
+        crate::carbide_increment_v6_requests(4);
         crate::carbide_increment_reply_sent(5);
         crate::carbide_increment_v6_reply_sent(7);
         assert_eq!(
@@ -1011,7 +1144,14 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dropped_v6_requests_total",
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "confirm")]
+            ),
+            0.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "nested_relay")]
             ),
             0.0
@@ -1037,6 +1177,7 @@ mod tests {
             crate::carbide_increment_dropped_v6_requests(c"nested_relay".as_ptr());
             crate::carbide_increment_dropped_v6_requests(c"not_a_v6_reason".as_ptr());
         }
+        crate::carbide_increment_v6_requests(4); // DHCPV6_CONFIRM
         crate::carbide_increment_reply_sent(5); // DHCPACK
         crate::carbide_increment_v6_reply_sent(7); // DHCPV6_REPLY
 
@@ -1060,14 +1201,21 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dropped_v6_requests_total",
+                "carbide_dhcp_v6_requests_total",
+                &[("message_type", "confirm")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "nested_relay")]
             ),
             1.0
         );
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dropped_v6_requests_total",
+                "carbide_dhcp_v6_requests_dropped_total",
                 &[("reason", "unknown")]
             ),
             1.0

--- a/crates/dhcp/tests/common/mod.rs
+++ b/crates/dhcp/tests/common/mod.rs
@@ -93,7 +93,7 @@ fn hook_library_path() -> String {
 pub(super) fn v6_drop_metric_value(endpoint: SocketAddr, reason: &str) -> f64 {
     labeled_counter_value(
         endpoint,
-        "carbide_dropped_v6_requests_total",
+        "carbide_dhcp_v6_requests_dropped_total",
         "reason",
         reason,
     )
@@ -109,7 +109,7 @@ pub(super) fn wait_for_v6_drop_metric_at_least(
 ) -> bool {
     wait_for_labeled_counter_at_least(
         endpoint,
-        "carbide_dropped_v6_requests_total",
+        "carbide_dhcp_v6_requests_dropped_total",
         "reason",
         reason,
         minimum,

--- a/crates/dhcp/tests/common/mod.rs
+++ b/crates/dhcp/tests/common/mod.rs
@@ -87,7 +87,7 @@ fn scrape_metrics(endpoint: SocketAddr) -> Option<String> {
 /// Return the parsed DHCPv6 dropped-request counter value for a reason label.
 #[allow(dead_code)]
 fn drop_counter_value(metrics: &str, reason: &str) -> f64 {
-    let prefix = format!("carbide_dropped_v6_requests_total{{reason=\"{reason}\"}} ");
+    let prefix = format!("carbide_dhcp_v6_requests_dropped_total{{reason=\"{reason}\"}} ");
     metrics
         .lines()
         .filter_map(|line| line.strip_prefix(&prefix))

--- a/crates/dhcpv6/Cargo.toml
+++ b/crates/dhcpv6/Cargo.toml
@@ -14,15 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-lease_time_secs: 604800  # Seconds
-renewal_time_secs: 3600  # Seconds
-rebinding_time_secs: 432000  # Seconds
-dhcpv6_preferred_lifetime_secs: 3600  # Seconds
-dhcpv6_valid_lifetime_secs: 7200  # Seconds
-carbide_nameservers:
-  - 10.217.126.20
-carbide_api_url: https://carbide-api.forge-system.svc.cluster.local:1079
-carbide_ntpservers:
-  - 10.180.37.3
-carbide_provisioning_server_ipv4: 10.217.126.17
-carbide_dhcp_server: 10.217.126.16
+[package]
+name = "carbide-dhcpv6"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Shared DHCPv6 wire-decoding primitives for NVIDIA Infra Controller"
+
+[dependencies]
+dhcproto = { workspace = true }
+mac_address = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
+[lints]
+workspace = true

--- a/crates/dhcpv6/src/lib.rs
+++ b/crates/dhcpv6/src/lib.rs
@@ -1,0 +1,957 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Policy-neutral DHCPv6 wire decoding shared by the Kea hook and standalone server.
+//!
+//! `dhcproto 0.15` models relay option 9 as another relay message even when its
+//! payload is an ordinary client message. This crate therefore performs a
+//! narrow raw-TLV pass over one relay envelope and delegates client-message
+//! decoding to `dhcproto`.
+
+use std::net::Ipv6Addr;
+
+use dhcproto::v6::{DhcpOption, Message, MessageType, OptionCode, UnknownOption};
+use dhcproto::{Decodable, Decoder, Encodable, Encoder};
+use mac_address::MacAddress;
+
+/// DHCPv6 message type for a Relay-Forward envelope.
+pub const RELAY_FORWARD: u8 = 12;
+
+/// DHCPv6 message type for a Relay-Reply envelope.
+pub const RELAY_REPLY: u8 = 13;
+
+const DUID_LLT: u16 = 1;
+const DUID_EN: u16 = 2;
+const DUID_LL: u16 = 3;
+const DUID_UUID: u16 = 4;
+const HARDWARE_TYPE_ETHERNET: u16 = 1;
+const ETHERNET_MAC_LENGTH: usize = 6;
+const DUID_EN_MIN_LENGTH: usize = 7;
+const DUID_TYPE_LENGTH: usize = 2;
+const DUID_MIN_LENGTH: usize = DUID_TYPE_LENGTH + 1;
+/// Maximum complete DUID length permitted by RFC 9915.
+pub const DUID_MAX_LENGTH: usize = DUID_TYPE_LENGTH + 128;
+const DUID_UUID_LENGTH: usize = 18;
+
+/// Metadata retained from one supported DHCPv6 Relay-Forward envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelayEnvelope {
+    pub hop_count: u8,
+    pub link_address: Ipv6Addr,
+    pub peer_address: Ipv6Addr,
+    pub interface_id: Option<Vec<u8>>,
+    pub remote_id: Option<Vec<u8>>,
+    pub client_link_layer: Option<Vec<u8>>,
+}
+
+/// A decoded client message and its optional one-hop relay envelope.
+#[derive(Debug)]
+pub struct DecodedPacket {
+    pub message: Message,
+    pub relay: Option<RelayEnvelope>,
+}
+
+/// Structural failures encountered before serving policy is applied.
+#[derive(Debug, thiserror::Error)]
+pub enum DecodeError {
+    #[error("malformed DHCPv6 packet: {0}")]
+    MalformedPacket(&'static str),
+    #[error("DHCPv6 decode failed: {0}")]
+    ClientMessageDecode(#[source] dhcproto::error::DecodeError),
+    #[error("missing DHCPv6 relay-message option")]
+    MissingRelayMessage,
+    #[error("nested DHCPv6 relay packet")]
+    NestedRelay,
+    #[error("unsupported DHCPv6 relay hop count {0}")]
+    RelayHopCountExceeded(u8),
+    #[error("unexpected DHCPv6 relay-reply request")]
+    UnexpectedRelayReply,
+}
+
+/// Result of parsing a DUID for an Ethernet identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuidMac {
+    Mac(MacAddress),
+    NoLinkLayerMac,
+}
+
+/// Why generic DUID structural validation failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuidError {
+    /// The DUID violates its structural or length constraints.
+    Malformed,
+}
+
+// These are defensive service limits rather than DHCPv6 wire-format limits.
+// Legitimate messages use shallow option trees with far fewer options.
+const MAX_CLIENT_OPTION_NESTING_DEPTH: usize = 8;
+const MAX_CLIENT_OPTIONS: usize = 256;
+
+#[derive(Debug)]
+struct RawOption<'data> {
+    code: u16,
+    data: &'data [u8],
+    encoded: &'data [u8],
+}
+
+/// Decode one direct client message or one supported Relay-Forward envelope.
+pub fn decode(packet: &[u8]) -> Result<DecodedPacket, DecodeError> {
+    match packet.first().copied() {
+        Some(RELAY_FORWARD) => decode_relay_forward(packet),
+        Some(RELAY_REPLY) => Err(DecodeError::UnexpectedRelayReply),
+        Some(_) => Ok(DecodedPacket {
+            message: decode_client_message(packet)?,
+            relay: None,
+        }),
+        None => Err(DecodeError::MalformedPacket("empty packet")),
+    }
+}
+
+/// Classify the client message type with bounded work for ingress metrics.
+///
+/// Direct messages use their first octet. For one Relay-Forward envelope, the
+/// first relay-message option supplies the client type. Malformed, empty, or
+/// excessively option-rich relay envelopes retain the outer relay type and are
+/// therefore reported through the caller's bounded `other` label.
+pub fn request_message_type(packet: &[u8]) -> MessageType {
+    let outer_type = MessageType::from(packet.first().copied().unwrap_or_default());
+    if outer_type != MessageType::RelayForw {
+        return outer_type;
+    }
+
+    relay_message_type(packet).unwrap_or(outer_type)
+}
+
+/// Find the encapsulated client type without allocating or fully decoding.
+fn relay_message_type(packet: &[u8]) -> Option<MessageType> {
+    let mut options = packet.get(34..)?;
+    for _ in 0..MAX_CLIENT_OPTIONS {
+        if options.is_empty() {
+            return None;
+        }
+        let header = options.get(..4)?;
+        let option_code = u16::from_be_bytes([header[0], header[1]]);
+        let payload_length = u16::from_be_bytes([header[2], header[3]]) as usize;
+        let encoded_length = 4usize.checked_add(payload_length)?;
+        let payload = options.get(4..encoded_length)?;
+        if OptionCode::from(option_code) == OptionCode::RelayMsg {
+            return payload.first().copied().map(MessageType::from);
+        }
+        options = options.get(encoded_length..)?;
+    }
+    None
+}
+
+/// Decode an ordinary client message after validating all option TLV boundaries.
+pub fn decode_client_message(packet: &[u8]) -> Result<Message, DecodeError> {
+    let options = packet
+        .get(4..)
+        .ok_or(DecodeError::MalformedPacket("truncated client header"))?;
+    let options = parse_raw_options(options)?;
+
+    // dhcproto stops at the first undecodable option, so validate each option
+    // independently before allowing its lossy option-list decoder to run.
+    validate_client_options(&options)?;
+
+    // dhcproto incorrectly interprets vendor-private suboption codes as global
+    // DHCPv6 option codes. Decode the standard options without option 17, then
+    // retain each validated vendor payload as an opaque option.
+    let sanitized_packet = options
+        .iter()
+        .any(|option| OptionCode::from(option.code) == OptionCode::VendorOpts)
+        .then(|| {
+            let mut sanitized = Vec::with_capacity(packet.len());
+            sanitized.extend_from_slice(&packet[..4]);
+            for option in &options {
+                if OptionCode::from(option.code) != OptionCode::VendorOpts {
+                    sanitized.extend_from_slice(option.encoded);
+                }
+            }
+            sanitized
+        });
+    let decode_packet = sanitized_packet.as_deref().unwrap_or(packet);
+    let mut message = Message::decode(&mut Decoder::new(decode_packet))
+        .map_err(DecodeError::ClientMessageDecode)?;
+
+    for option in options
+        .iter()
+        .filter(|option| OptionCode::from(option.code) == OptionCode::VendorOpts)
+    {
+        message
+            .opts_mut()
+            .insert(DhcpOption::Unknown(UnknownOption::new(
+                OptionCode::VendorOpts,
+                option.data.to_vec(),
+            )));
+    }
+    Ok(message)
+}
+
+/// Extract an Ethernet MAC from a supported DUID, or classify a valid non-MAC DUID.
+pub fn extract_mac_from_duid(duid: &[u8]) -> Result<DuidMac, DuidError> {
+    // RFC 9915 requires a two-octet type followed by 1 through 128 octets.
+    if !(DUID_MIN_LENGTH..=DUID_MAX_LENGTH).contains(&duid.len()) {
+        return Err(DuidError::Malformed);
+    }
+
+    let duid_type = u16::from_be_bytes([duid[0], duid[1]]);
+    match duid_type {
+        DUID_LLT => parse_link_layer_duid(&duid[2..], 4),
+        DUID_LL => parse_link_layer_duid(&duid[2..], 0),
+        DUID_EN if duid.len() >= DUID_EN_MIN_LENGTH => Ok(DuidMac::NoLinkLayerMac),
+        DUID_UUID if duid.len() == DUID_UUID_LENGTH => Ok(DuidMac::NoLinkLayerMac),
+        DUID_EN | DUID_UUID => Err(DuidError::Malformed),
+        _ => Ok(DuidMac::NoLinkLayerMac),
+    }
+}
+
+/// Parse RFC 6939 option 79 and return its Ethernet MAC when supported.
+pub fn extract_mac_from_option79(payload: &[u8]) -> Option<MacAddress> {
+    if payload.len() != 2 + ETHERNET_MAC_LENGTH {
+        return None;
+    }
+
+    let hardware_type = u16::from_be_bytes([payload[0], payload[1]]);
+    (hardware_type == HARDWARE_TYPE_ETHERNET).then(|| {
+        MacAddress::new([
+            payload[2], payload[3], payload[4], payload[5], payload[6], payload[7],
+        ])
+    })
+}
+
+/// Decode one Relay-Forward envelope and its direct client payload.
+fn decode_relay_forward(packet: &[u8]) -> Result<DecodedPacket, DecodeError> {
+    if packet.len() < 34 {
+        return Err(DecodeError::MalformedPacket("truncated relay header"));
+    }
+
+    let hop_count = packet[1];
+    // A relay forwarding a direct client message uses zero; a nonzero value
+    // implies an outer relay envelope that this one-envelope decoder rejects.
+    if hop_count != 0 {
+        return Err(DecodeError::RelayHopCountExceeded(hop_count));
+    }
+    let link_address = Ipv6Addr::from(
+        <[u8; 16]>::try_from(&packet[2..18])
+            .map_err(|_| DecodeError::MalformedPacket("invalid relay link-address"))?,
+    );
+    let peer_address = Ipv6Addr::from(
+        <[u8; 16]>::try_from(&packet[18..34])
+            .map_err(|_| DecodeError::MalformedPacket("invalid relay peer-address"))?,
+    );
+    let options = parse_raw_options(&packet[34..])?;
+
+    // Each consumer processes one client per envelope. Reject duplicates so
+    // identity selection and response handling cannot observe different clients.
+    let relay_message = unique_raw_option(&options, OptionCode::RelayMsg)?
+        .ok_or(DecodeError::MissingRelayMessage)?;
+
+    // Segment precedence and reply chaining are undefined for nested relays in
+    // both current consumers, so reject instead of selecting an inner relay.
+    if matches!(
+        relay_message.first().copied(),
+        Some(RELAY_FORWARD) | Some(RELAY_REPLY)
+    ) {
+        return Err(DecodeError::NestedRelay);
+    }
+
+    Ok(DecodedPacket {
+        message: decode_client_message(relay_message)?,
+        relay: Some(RelayEnvelope {
+            hop_count,
+            link_address,
+            peer_address,
+            interface_id: owned_unique_raw_option(&options, OptionCode::InterfaceId)?,
+            remote_id: owned_unique_raw_option(&options, OptionCode::RemoteId)?,
+            client_link_layer: owned_unique_raw_option(&options, OptionCode::ClientLinklayerAddr)?,
+        }),
+    })
+}
+
+/// Parse the link-layer payload shared by DUID-LL and DUID-LLT.
+fn parse_link_layer_duid(bytes: &[u8], time_length: usize) -> Result<DuidMac, DuidError> {
+    let link_layer_offset = 2 + time_length;
+    if bytes.len() <= link_layer_offset {
+        return Err(DuidError::Malformed);
+    }
+
+    let hardware_type = u16::from_be_bytes([bytes[0], bytes[1]]);
+    if hardware_type != HARDWARE_TYPE_ETHERNET {
+        return Ok(DuidMac::NoLinkLayerMac);
+    }
+
+    let mac = &bytes[link_layer_offset..];
+    if mac.len() != ETHERNET_MAC_LENGTH {
+        return Err(DuidError::Malformed);
+    }
+
+    Ok(DuidMac::Mac(MacAddress::new([
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
+    ])))
+}
+
+/// Parse a sequence of DHCPv6 option TLVs without interpreting their payloads.
+fn parse_raw_options(mut bytes: &[u8]) -> Result<Vec<RawOption<'_>>, DecodeError> {
+    let mut options = Vec::new();
+    while !bytes.is_empty() {
+        if bytes.len() < 4 {
+            return Err(DecodeError::MalformedPacket("truncated option header"));
+        }
+        let code = u16::from_be_bytes([bytes[0], bytes[1]]);
+        let length = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
+        if bytes.len() - 4 < length {
+            return Err(DecodeError::MalformedPacket("truncated option payload"));
+        }
+        let encoded_length = 4 + length;
+        let (encoded, remaining) = bytes.split_at(encoded_length);
+        options.push(RawOption {
+            code,
+            data: &encoded[4..],
+            encoded,
+        });
+        bytes = remaining;
+    }
+    Ok(options)
+}
+
+/// Reject semantically invalid client options before dhcproto can panic or
+/// silently truncate its decoded option list.
+fn validate_client_options(options: &[RawOption<'_>]) -> Result<(), DecodeError> {
+    // Complete the resource-budget pass before invoking dhcproto anywhere in
+    // the attacker-controlled option tree.
+    let mut option_count = 0;
+    validate_client_option_budget(options, 0, &mut option_count)?;
+    validate_client_option_semantics(options)
+}
+
+/// Bound attacker-controlled option-tree depth and size before typed decoding.
+fn validate_client_option_budget(
+    options: &[RawOption<'_>],
+    depth: usize,
+    option_count: &mut usize,
+) -> Result<(), DecodeError> {
+    if depth > MAX_CLIENT_OPTION_NESTING_DEPTH {
+        return Err(DecodeError::MalformedPacket(
+            "client option nesting limit exceeded",
+        ));
+    }
+
+    for option in options {
+        *option_count += 1;
+        if *option_count > MAX_CLIENT_OPTIONS {
+            return Err(DecodeError::MalformedPacket(
+                "client option count limit exceeded",
+            ));
+        }
+
+        if OptionCode::from(option.code) == OptionCode::VendorOpts {
+            if depth != 0 {
+                return Err(DecodeError::MalformedPacket(
+                    "vendor-specific option in nested client option",
+                ));
+            }
+            let vendor_payload = option.data.get(4..).ok_or(DecodeError::MalformedPacket(
+                "invalid vendor-specific option",
+            ))?;
+            for _ in parse_raw_options(vendor_payload)? {
+                *option_count += 1;
+                if *option_count > MAX_CLIENT_OPTIONS {
+                    return Err(DecodeError::MalformedPacket(
+                        "client option count limit exceeded",
+                    ));
+                }
+            }
+            continue;
+        }
+
+        if let Some(nested) = nested_option_payload(option)? {
+            let nested_options = parse_raw_options(nested)?;
+            if !nested_options.is_empty() {
+                validate_client_option_budget(&nested_options, depth + 1, option_count)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate every bounded option in isolation before whole-message decoding.
+fn validate_client_option_semantics(options: &[RawOption<'_>]) -> Result<(), DecodeError> {
+    for option in options {
+        // Vendor suboption codes are enterprise-local and have no global
+        // OptionCode semantics. Their framing was validated by the budget pass.
+        if OptionCode::from(option.code) == OptionCode::VendorOpts {
+            continue;
+        }
+
+        let nested = nested_option_payload(option)?;
+
+        // Validate nested DHCP option containers before their parent decoder
+        // can consume bytes from a following malformed child option.
+        if let Some(nested) = nested {
+            validate_client_option_semantics(&parse_raw_options(nested)?)?;
+        }
+
+        // Isolating one TLV prevents a short option from borrowing bytes from
+        // its successor. Full consumption rejects fixed-size length mismatches.
+        let mut decoder = Decoder::new(option.encoded);
+        let decoded = DhcpOption::decode(&mut decoder).map_err(DecodeError::ClientMessageDecode)?;
+        if !decoder.buffer().is_empty() {
+            return Err(DecodeError::MalformedPacket("invalid client option length"));
+        }
+
+        // Several dhcproto container decoders stop successfully at a malformed
+        // child. A shorter round trip proves that bytes were silently omitted.
+        let mut encoded = Vec::with_capacity(option.encoded.len());
+        decoded
+            .encode(&mut Encoder::new(&mut encoded))
+            .map_err(|_| DecodeError::MalformedPacket("unencodable client option"))?;
+        if encoded.len() != option.encoded.len() {
+            return Err(DecodeError::MalformedPacket(
+                "partially decoded client option",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Return the nested option area for a DHCPv6 container option.
+fn nested_option_payload<'data>(
+    option: &RawOption<'data>,
+) -> Result<Option<&'data [u8]>, DecodeError> {
+    let offset = match OptionCode::from(option.code) {
+        OptionCode::IANA | OptionCode::IAPD => 12,
+        OptionCode::IATA => 4,
+        OptionCode::IAAddr => 24,
+        OptionCode::IAPrefix => 25,
+        // Relay Message is valid in a relay envelope, not inside the
+        // ordinary client message validated by this function.
+        OptionCode::RelayMsg => {
+            return Err(DecodeError::MalformedPacket(
+                "relay-message option in client message",
+            ));
+        }
+        _ => return Ok(None),
+    };
+
+    option
+        .data
+        .get(offset..)
+        .map(Some)
+        .ok_or(DecodeError::MalformedPacket("invalid client option"))
+}
+
+/// Return one raw option payload while rejecting ambiguous duplicates.
+fn unique_raw_option<'data>(
+    options: &[RawOption<'data>],
+    option_code: OptionCode,
+) -> Result<Option<&'data [u8]>, DecodeError> {
+    let mut matches = options
+        .iter()
+        .filter(|option| option.code == u16::from(option_code))
+        .map(|option| option.data);
+    let value = matches.next();
+    if matches.next().is_some() {
+        Err(DecodeError::MalformedPacket("duplicate relay option"))
+    } else {
+        Ok(value)
+    }
+}
+
+/// Return an owned raw option payload while retaining duplicate validation.
+fn owned_unique_raw_option(
+    options: &[RawOption<'_>],
+    option_code: OptionCode,
+) -> Result<Option<Vec<u8>>, DecodeError> {
+    unique_raw_option(options, option_code).map(|value| value.map(|value| value.to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    const DIRECT_SOLICIT: &[u8] = &[1, 0, 0, 1];
+
+    /// Encode one raw option so malformed-packet tests control its declared
+    /// payload independently of dhcproto's typed encoder.
+    fn raw_option(option_code: OptionCode, payload: &[u8]) -> Vec<u8> {
+        let mut option = Vec::new();
+        option.extend_from_slice(&u16::from(option_code).to_be_bytes());
+        option.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+        option.extend_from_slice(payload);
+        option
+    }
+
+    /// Build an ambiguous relay envelope so duplicate-option rejection is
+    /// exercised before either consumer can select different metadata.
+    fn relay_forward_with_duplicate_option(option_code: OptionCode) -> Vec<u8> {
+        let mut packet = vec![RELAY_FORWARD, 0];
+        packet.extend_from_slice(&[0; 32]);
+        packet.extend(raw_option(option_code, b"first"));
+        packet.extend(raw_option(option_code, b"second"));
+        packet.extend(raw_option(OptionCode::RelayMsg, DIRECT_SOLICIT));
+        packet
+    }
+
+    /// Build a structurally valid one-hop Relay-Forward around an arbitrary
+    /// payload so relay-boundary tests vary only the encapsulated message.
+    fn relay_forward(inner: &[u8]) -> Vec<u8> {
+        let mut packet = vec![RELAY_FORWARD, 0];
+        packet.extend_from_slice(&[0; 32]);
+        packet.extend(raw_option(OptionCode::RelayMsg, inner));
+        packet
+    }
+
+    /// Build an unregistered opaque DUID of an exact length so boundary tests
+    /// remain independent of registered type-specific layouts.
+    fn opaque_duid(length: usize) -> Vec<u8> {
+        let mut duid = vec![0, 99];
+        duid.resize(length, 0xaa);
+        duid
+    }
+
+    /// Build a client message with an exact nested IA_TA depth so the
+    /// resource-boundary test does not depend on dhcproto's typed encoder.
+    fn client_message_with_option_nesting(nesting_depth: usize) -> Vec<u8> {
+        let mut option = raw_option(OptionCode::Unknown(65_000), &[]);
+        for _ in 0..nesting_depth {
+            let mut payload = vec![0; 4];
+            payload.extend(option);
+            option = raw_option(OptionCode::IATA, &payload);
+        }
+
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        packet.extend(option);
+        packet
+    }
+
+    /// Build one opaque vendor container with an exact number of framed
+    /// enterprise-local suboptions.
+    fn client_message_with_vendor_option_count(option_count: usize) -> Vec<u8> {
+        let mut vendor_payload = 5703u32.to_be_bytes().to_vec();
+        for _ in 0..option_count {
+            vendor_payload.extend(raw_option(OptionCode::Unknown(65_000), &[]));
+        }
+
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        packet.extend(raw_option(OptionCode::VendorOpts, &vendor_payload));
+        packet
+    }
+
+    /// Build a client message with an exact number of independent options so
+    /// the count limit is exercised without adding nesting.
+    fn client_message_with_option_count(option_count: usize) -> Vec<u8> {
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        for _ in 0..option_count {
+            packet.extend(raw_option(OptionCode::Unknown(65_000), &[]));
+        }
+        packet
+    }
+
+    /// Verifies generic DUID validation accepts exactly the complete-length
+    /// range defined by RFC 9915, independent of registered DUID type.
+    #[test]
+    fn validates_duid_length_boundaries() {
+        check_values(
+            [
+                // A type code without identifier data is incomplete.
+                Check {
+                    scenario: "type-only DUID",
+                    input: opaque_duid(DUID_MIN_LENGTH - 1),
+                    expect: Err(DuidError::Malformed),
+                },
+                // The shortest opaque DUID has one identifier octet.
+                Check {
+                    scenario: "minimum-length opaque DUID",
+                    input: opaque_duid(DUID_MIN_LENGTH),
+                    expect: Ok(DuidMac::NoLinkLayerMac),
+                },
+                // The longest opaque DUID has 128 identifier octets.
+                Check {
+                    scenario: "maximum-length opaque DUID",
+                    input: opaque_duid(DUID_MAX_LENGTH),
+                    expect: Ok(DuidMac::NoLinkLayerMac),
+                },
+                // One octet beyond the RFC limit is malformed.
+                Check {
+                    scenario: "oversized opaque DUID",
+                    input: opaque_duid(DUID_MAX_LENGTH + 1),
+                    expect: Err(DuidError::Malformed),
+                },
+            ],
+            |duid| extract_mac_from_duid(&duid),
+        );
+    }
+
+    /// Structurally complete link-layer DUIDs remain valid identities when
+    /// their hardware address cannot be interpreted as an Ethernet MAC.
+    #[test]
+    fn classifies_non_ethernet_link_layer_duids_as_non_mac_identities() {
+        check_values(
+            [
+                // DUID-LL accepts a variable-length InfiniBand address.
+                Check {
+                    scenario: "non-Ethernet DUID-LL",
+                    input: {
+                        let mut duid = DUID_LL.to_be_bytes().to_vec();
+                        duid.extend_from_slice(&32u16.to_be_bytes());
+                        duid.extend_from_slice(&[0xaa; 20]);
+                        duid
+                    },
+                    expect: Ok(DuidMac::NoLinkLayerMac),
+                },
+                // DUID-LLT applies the same identity policy after its time field.
+                Check {
+                    scenario: "non-Ethernet DUID-LLT",
+                    input: {
+                        let mut duid = DUID_LLT.to_be_bytes().to_vec();
+                        duid.extend_from_slice(&32u16.to_be_bytes());
+                        duid.extend_from_slice(&1234u32.to_be_bytes());
+                        duid.extend_from_slice(&[0xbb; 20]);
+                        duid
+                    },
+                    expect: Ok(DuidMac::NoLinkLayerMac),
+                },
+                // A DUID-LL still needs at least one link-layer-address octet.
+                Check {
+                    scenario: "DUID-LL without link-layer address",
+                    input: {
+                        let mut duid = DUID_LL.to_be_bytes().to_vec();
+                        duid.extend_from_slice(&32u16.to_be_bytes());
+                        duid
+                    },
+                    expect: Err(DuidError::Malformed),
+                },
+                // A DUID-LLT must not end at its fixed hardware and time fields.
+                Check {
+                    scenario: "DUID-LLT without link-layer address",
+                    input: {
+                        let mut duid = DUID_LLT.to_be_bytes().to_vec();
+                        duid.extend_from_slice(&32u16.to_be_bytes());
+                        duid.extend_from_slice(&1234u32.to_be_bytes());
+                        duid
+                    },
+                    expect: Err(DuidError::Malformed),
+                },
+            ],
+            |duid| extract_mac_from_duid(&duid),
+        );
+    }
+
+    /// Ingress classification extracts direct and one-hop client message types
+    /// without applying the full DHCPv6 decoder or allocating option storage.
+    #[test]
+    fn classifies_request_message_type_with_bounded_relay_inspection() {
+        check_values(
+            [
+                // Direct traffic exposes its client message type in octet zero.
+                Check {
+                    scenario: "direct Solicit",
+                    input: DIRECT_SOLICIT.to_vec(),
+                    expect: MessageType::Solicit,
+                },
+                // Relay traffic uses the first octet of its relay-message payload.
+                Check {
+                    scenario: "relayed Request",
+                    input: relay_forward(&[u8::from(MessageType::Request), 0, 0, 1]),
+                    expect: MessageType::Request,
+                },
+                // A malformed relay stays in the bounded catch-all metric label.
+                Check {
+                    scenario: "truncated Relay-Forward",
+                    input: vec![RELAY_FORWARD],
+                    expect: MessageType::RelayForw,
+                },
+            ],
+            |packet| request_message_type(&packet),
+        );
+    }
+
+    /// Verifies incomplete client-option TLVs cannot be silently ignored.
+    ///
+    /// This prevents a partially decoded client message from reaching either
+    /// the Kea hook or standalone DHCPv6 policy.
+    #[test]
+    fn rejects_incomplete_client_option_tlvs() {
+        check_values(
+            [
+                // An incomplete header cannot identify an option or its payload.
+                Check {
+                    scenario: "truncated option header",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend_from_slice(&[0, 1, 0]);
+                        packet
+                    },
+                    expect: true,
+                },
+                // A complete header must not claim bytes beyond the datagram.
+                Check {
+                    scenario: "truncated option payload",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend_from_slice(&[0, 1, 0, 2, 0xaa]);
+                        packet
+                    },
+                    expect: true,
+                },
+            ],
+            |packet| {
+                matches!(
+                    decode_client_message(&packet),
+                    Err(DecodeError::MalformedPacket(_))
+                )
+            },
+        );
+    }
+
+    /// Verifies semantically malformed options fail closed instead of panicking
+    /// or disappearing from dhcproto's successfully decoded message.
+    ///
+    /// This protects both the standalone task boundary and Kea's C ABI from
+    /// attacker-controlled option payloads.
+    #[test]
+    fn rejects_semantically_invalid_client_options() {
+        check_values(
+            [
+                // A short Vendor Class must not borrow the following TLV header
+                // and underflow its declared length.
+                Check {
+                    scenario: "zero-length Vendor Class",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend(raw_option(OptionCode::VendorClass, &[]));
+                        packet.extend(raw_option(OptionCode::RapidCommit, &[]));
+                        packet
+                    },
+                    expect: true,
+                },
+                // A fixed-size IA_NA payload must not disappear with every
+                // otherwise valid option that follows it.
+                Check {
+                    scenario: "short IA_NA",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend(raw_option(OptionCode::IANA, &[]));
+                        packet.extend(raw_option(OptionCode::RapidCommit, &[]));
+                        packet
+                    },
+                    expect: true,
+                },
+                // A truncated length-prefixed class value is otherwise decoded
+                // as an empty option with its malformed bytes discarded.
+                Check {
+                    scenario: "truncated User Class value",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend(raw_option(OptionCode::UserClass, &[0, 2, 0xaa]));
+                        packet
+                    },
+                    expect: true,
+                },
+                // Nested IA_NA options need the same isolation as top-level
+                // options because dhcproto recursively uses its lossy decoder.
+                Check {
+                    scenario: "zero-length nested Vendor Class",
+                    input: {
+                        let mut association = vec![0; 12];
+                        association.extend(raw_option(OptionCode::VendorClass, &[]));
+                        association.extend(raw_option(OptionCode::RapidCommit, &[]));
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend(raw_option(OptionCode::IANA, &association));
+                        packet
+                    },
+                    expect: true,
+                },
+            ],
+            |packet| {
+                matches!(
+                    decode_client_message(&packet),
+                    Err(DecodeError::MalformedPacket(_)) | Err(DecodeError::ClientMessageDecode(_))
+                )
+            },
+        );
+    }
+
+    /// Verifies enterprise-local vendor suboption codes remain opaque even
+    /// when they collide with globally registered DHCPv6 option codes.
+    #[test]
+    fn preserves_opaque_vendor_suboptions() {
+        // Private code 3 collides with IA_NA, but its one-byte payload has only
+        // the vendor-defined meaning and must not be decoded as an IA_NA.
+        let private_suboption = raw_option(OptionCode::IANA, &[0xaa]);
+        let mut vendor_payload = 5703u32.to_be_bytes().to_vec();
+        vendor_payload.extend(private_suboption);
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        packet.extend(raw_option(OptionCode::VendorOpts, &vendor_payload));
+
+        let message = decode_client_message(&packet).expect("opaque vendor suboption is accepted");
+        match message.opts().get(OptionCode::VendorOpts) {
+            Some(DhcpOption::Unknown(option)) => {
+                assert_eq!(option.data(), vendor_payload);
+            }
+            other => panic!("expected opaque vendor-specific option, got {other:?}"),
+        }
+    }
+
+    /// Verifies vendor-private payloads still obey their own TLV framing.
+    #[test]
+    fn rejects_truncated_vendor_suboptions() {
+        let mut vendor_payload = 5703u32.to_be_bytes().to_vec();
+        // The private suboption declares two bytes but supplies only one.
+        vendor_payload.extend_from_slice(&[0, 3, 0, 2, 0xaa]);
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        packet.extend(raw_option(OptionCode::VendorOpts, &vendor_payload));
+
+        assert!(matches!(
+            decode_client_message(&packet),
+            Err(DecodeError::MalformedPacket("truncated option payload"))
+        ));
+    }
+
+    /// Verifies attacker-controlled option trees are accepted through the
+    /// explicit service budget and rejected immediately beyond either bound.
+    #[test]
+    fn enforces_client_option_resource_budget() {
+        check_values(
+            [
+                // The deepest supported option tree remains available to clients.
+                Check {
+                    scenario: "maximum nesting depth",
+                    input: client_message_with_option_nesting(MAX_CLIENT_OPTION_NESTING_DEPTH),
+                    expect: true,
+                },
+                // One additional container is rejected before typed decoding recurses.
+                Check {
+                    scenario: "nesting depth above limit",
+                    input: client_message_with_option_nesting(MAX_CLIENT_OPTION_NESTING_DEPTH + 1),
+                    expect: false,
+                },
+                // The maximum bounded number of shallow options remains accepted.
+                Check {
+                    scenario: "maximum option count",
+                    input: client_message_with_option_count(MAX_CLIENT_OPTIONS),
+                    expect: true,
+                },
+                // One additional option is rejected before any typed option decode.
+                Check {
+                    scenario: "option count above limit",
+                    input: client_message_with_option_count(MAX_CLIENT_OPTIONS + 1),
+                    expect: false,
+                },
+                // One vendor container plus 255 private suboptions meets the limit.
+                Check {
+                    scenario: "maximum vendor suboption count",
+                    input: client_message_with_vendor_option_count(MAX_CLIENT_OPTIONS - 1),
+                    expect: true,
+                },
+                // A vendor container and 256 private suboptions exceed the limit.
+                Check {
+                    scenario: "vendor suboption count above limit",
+                    input: client_message_with_vendor_option_count(MAX_CLIENT_OPTIONS),
+                    expect: false,
+                },
+            ],
+            |packet| decode_client_message(&packet).is_ok(),
+        );
+    }
+
+    /// Verifies single-valued relay identity and routing options reject
+    /// ambiguous duplicates.
+    ///
+    /// This ensures the Kea hook and standalone server cannot select different
+    /// metadata from the same Relay-Forward envelope.
+    #[test]
+    fn rejects_duplicate_single_valued_relay_options() {
+        check_values(
+            [
+                // Repeated Interface-ID values make segment selection ambiguous.
+                Check {
+                    scenario: "duplicate Interface-ID",
+                    input: OptionCode::InterfaceId,
+                    expect: true,
+                },
+                // Repeated Remote-ID values make relay identity ambiguous.
+                Check {
+                    scenario: "duplicate Remote-ID",
+                    input: OptionCode::RemoteId,
+                    expect: true,
+                },
+                // Repeated option 79 values make MAC selection ambiguous.
+                Check {
+                    scenario: "duplicate Client Link-Layer Address",
+                    input: OptionCode::ClientLinklayerAddr,
+                    expect: true,
+                },
+            ],
+            |option_code| {
+                matches!(
+                    decode(&relay_forward_with_duplicate_option(option_code)),
+                    Err(DecodeError::MalformedPacket("duplicate relay option"))
+                )
+            },
+        );
+    }
+
+    /// Verifies the shared decoder owns relay-header, hop-count, and nesting
+    /// boundaries independently of its Kea and standalone-server adapters.
+    #[test]
+    fn rejects_unsupported_relay_boundaries() {
+        check_values(
+            [
+                // A Relay-Forward must contain its complete 34-byte fixed header.
+                Check {
+                    scenario: "truncated relay header",
+                    input: {
+                        let mut packet = relay_forward(DIRECT_SOLICIT);
+                        packet.truncate(33);
+                        packet
+                    },
+                    expect: "malformed DHCPv6 packet: truncated relay header".to_string(),
+                },
+                // A direct client payload is valid only in the first relay envelope.
+                Check {
+                    scenario: "nonzero hop count",
+                    input: {
+                        let mut packet = relay_forward(DIRECT_SOLICIT);
+                        packet[1] = 1;
+                        packet
+                    },
+                    expect: "unsupported DHCPv6 relay hop count 1".to_string(),
+                },
+                // A nested Relay-Forward has undefined routing precedence here.
+                Check {
+                    scenario: "nested Relay-Forward",
+                    input: relay_forward(&[RELAY_FORWARD]),
+                    expect: "nested DHCPv6 relay packet".to_string(),
+                },
+                // A nested Relay-Reply is also invalid as a client payload.
+                Check {
+                    scenario: "nested Relay-Reply",
+                    input: relay_forward(&[RELAY_REPLY]),
+                    expect: "nested DHCPv6 relay packet".to_string(),
+                },
+            ],
+            |packet| {
+                decode(&packet)
+                    .expect_err("unsupported relay boundary must fail")
+                    .to_string()
+            },
+        );
+    }
+}

--- a/crates/dhcpv6/src/lib.rs
+++ b/crates/dhcpv6/src/lib.rs
@@ -1,0 +1,837 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Policy-neutral DHCPv6 wire decoding shared by the Kea hook and standalone server.
+//!
+//! `dhcproto 0.15` models relay option 9 as another relay message even when its
+//! payload is an ordinary client message. This crate therefore performs a
+//! narrow raw-TLV pass over one relay envelope and delegates client-message
+//! decoding to `dhcproto`.
+
+use std::net::Ipv6Addr;
+
+use dhcproto::v6::{DhcpOption, Message, OptionCode, UnknownOption};
+use dhcproto::{Decodable, Decoder, Encodable, Encoder};
+use mac_address::MacAddress;
+
+/// DHCPv6 message type for a Relay-Forward envelope.
+pub const RELAY_FORWARD: u8 = 12;
+
+/// DHCPv6 message type for a Relay-Reply envelope.
+pub const RELAY_REPLY: u8 = 13;
+
+const DUID_LLT: u16 = 1;
+const DUID_EN: u16 = 2;
+const DUID_LL: u16 = 3;
+const DUID_UUID: u16 = 4;
+const HARDWARE_TYPE_ETHERNET: u16 = 1;
+const ETHERNET_MAC_LENGTH: usize = 6;
+const DUID_EN_MIN_LENGTH: usize = 7;
+const DUID_TYPE_LENGTH: usize = 2;
+const DUID_MIN_LENGTH: usize = DUID_TYPE_LENGTH + 1;
+/// Maximum complete DUID length permitted by RFC 9915.
+pub const DUID_MAX_LENGTH: usize = DUID_TYPE_LENGTH + 128;
+const DUID_UUID_LENGTH: usize = 18;
+
+/// Metadata retained from one supported DHCPv6 Relay-Forward envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelayEnvelope {
+    pub hop_count: u8,
+    pub link_address: Ipv6Addr,
+    pub peer_address: Ipv6Addr,
+    pub interface_id: Option<Vec<u8>>,
+    pub remote_id: Option<Vec<u8>>,
+    pub client_link_layer: Option<Vec<u8>>,
+}
+
+/// A decoded client message and its optional one-hop relay envelope.
+#[derive(Debug)]
+pub struct DecodedPacket {
+    pub message: Message,
+    pub relay: Option<RelayEnvelope>,
+}
+
+/// Structural failures encountered before serving policy is applied.
+#[derive(Debug, thiserror::Error)]
+pub enum DecodeError {
+    #[error("malformed DHCPv6 packet: {0}")]
+    MalformedPacket(&'static str),
+    #[error("DHCPv6 decode failed: {0}")]
+    ClientMessageDecode(#[source] dhcproto::error::DecodeError),
+    #[error("missing DHCPv6 relay-message option")]
+    MissingRelayMessage,
+    #[error("nested DHCPv6 relay packet")]
+    NestedRelay,
+    #[error("unsupported DHCPv6 relay hop count {0}")]
+    RelayHopCountExceeded(u8),
+    #[error("unexpected DHCPv6 relay-reply request")]
+    UnexpectedRelayReply,
+}
+
+/// Result of parsing a DUID for an Ethernet identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuidMac {
+    Mac(MacAddress),
+    NoLinkLayerMac,
+}
+
+/// Why a DUID cannot provide a supported identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuidError {
+    Malformed,
+    UnsupportedType,
+}
+
+// These are defensive service limits rather than DHCPv6 wire-format limits.
+// Legitimate messages use shallow option trees with far fewer options.
+const MAX_CLIENT_OPTION_NESTING_DEPTH: usize = 8;
+const MAX_CLIENT_OPTIONS: usize = 256;
+
+#[derive(Debug)]
+struct RawOption<'data> {
+    code: u16,
+    data: &'data [u8],
+    encoded: &'data [u8],
+}
+
+/// Decode one direct client message or one supported Relay-Forward envelope.
+pub fn decode(packet: &[u8]) -> Result<DecodedPacket, DecodeError> {
+    match packet.first().copied() {
+        Some(RELAY_FORWARD) => decode_relay_forward(packet),
+        Some(RELAY_REPLY) => Err(DecodeError::UnexpectedRelayReply),
+        Some(_) => Ok(DecodedPacket {
+            message: decode_client_message(packet)?,
+            relay: None,
+        }),
+        None => Err(DecodeError::MalformedPacket("empty packet")),
+    }
+}
+
+/// Decode an ordinary client message after validating all option TLV boundaries.
+pub fn decode_client_message(packet: &[u8]) -> Result<Message, DecodeError> {
+    let options = packet
+        .get(4..)
+        .ok_or(DecodeError::MalformedPacket("truncated client header"))?;
+    let options = parse_raw_options(options)?;
+
+    // dhcproto stops at the first undecodable option, so validate each option
+    // independently before allowing its lossy option-list decoder to run.
+    validate_client_options(&options)?;
+
+    // dhcproto incorrectly interprets vendor-private suboption codes as global
+    // DHCPv6 option codes. Decode the standard options without option 17, then
+    // retain each validated vendor payload as an opaque option.
+    let sanitized_packet = options
+        .iter()
+        .any(|option| OptionCode::from(option.code) == OptionCode::VendorOpts)
+        .then(|| {
+            let mut sanitized = Vec::with_capacity(packet.len());
+            sanitized.extend_from_slice(&packet[..4]);
+            for option in &options {
+                if OptionCode::from(option.code) != OptionCode::VendorOpts {
+                    sanitized.extend_from_slice(option.encoded);
+                }
+            }
+            sanitized
+        });
+    let decode_packet = sanitized_packet.as_deref().unwrap_or(packet);
+    let mut message = Message::decode(&mut Decoder::new(decode_packet))
+        .map_err(DecodeError::ClientMessageDecode)?;
+
+    for option in options
+        .iter()
+        .filter(|option| OptionCode::from(option.code) == OptionCode::VendorOpts)
+    {
+        message
+            .opts_mut()
+            .insert(DhcpOption::Unknown(UnknownOption::new(
+                OptionCode::VendorOpts,
+                option.data.to_vec(),
+            )));
+    }
+    Ok(message)
+}
+
+/// Extract an Ethernet MAC from a supported DUID, or classify a valid non-MAC DUID.
+pub fn extract_mac_from_duid(duid: &[u8]) -> Result<DuidMac, DuidError> {
+    // RFC 9915 requires a two-octet type followed by 1 through 128 octets.
+    if !(DUID_MIN_LENGTH..=DUID_MAX_LENGTH).contains(&duid.len()) {
+        return Err(DuidError::Malformed);
+    }
+
+    let duid_type = u16::from_be_bytes([duid[0], duid[1]]);
+    match duid_type {
+        DUID_LLT => parse_link_layer_duid(&duid[2..], 4),
+        DUID_LL => parse_link_layer_duid(&duid[2..], 0),
+        DUID_EN if duid.len() >= DUID_EN_MIN_LENGTH => Ok(DuidMac::NoLinkLayerMac),
+        DUID_UUID if duid.len() == DUID_UUID_LENGTH => Ok(DuidMac::NoLinkLayerMac),
+        DUID_EN | DUID_UUID => Err(DuidError::Malformed),
+        _ => Ok(DuidMac::NoLinkLayerMac),
+    }
+}
+
+/// Parse RFC 6939 option 79 and return its Ethernet MAC when supported.
+pub fn extract_mac_from_option79(payload: &[u8]) -> Option<MacAddress> {
+    if payload.len() != 2 + ETHERNET_MAC_LENGTH {
+        return None;
+    }
+
+    let hardware_type = u16::from_be_bytes([payload[0], payload[1]]);
+    (hardware_type == HARDWARE_TYPE_ETHERNET).then(|| {
+        MacAddress::new([
+            payload[2], payload[3], payload[4], payload[5], payload[6], payload[7],
+        ])
+    })
+}
+
+/// Decode one Relay-Forward envelope and its direct client payload.
+fn decode_relay_forward(packet: &[u8]) -> Result<DecodedPacket, DecodeError> {
+    if packet.len() < 34 {
+        return Err(DecodeError::MalformedPacket("truncated relay header"));
+    }
+
+    let hop_count = packet[1];
+    // A relay forwarding a direct client message uses zero; a nonzero value
+    // implies an outer relay envelope that this one-envelope decoder rejects.
+    if hop_count != 0 {
+        return Err(DecodeError::RelayHopCountExceeded(hop_count));
+    }
+    let link_address = Ipv6Addr::from(
+        <[u8; 16]>::try_from(&packet[2..18])
+            .map_err(|_| DecodeError::MalformedPacket("invalid relay link-address"))?,
+    );
+    let peer_address = Ipv6Addr::from(
+        <[u8; 16]>::try_from(&packet[18..34])
+            .map_err(|_| DecodeError::MalformedPacket("invalid relay peer-address"))?,
+    );
+    let options = parse_raw_options(&packet[34..])?;
+
+    // Each consumer processes one client per envelope. Reject duplicates so
+    // identity selection and response handling cannot observe different clients.
+    let relay_message = unique_raw_option(&options, OptionCode::RelayMsg)?
+        .ok_or(DecodeError::MissingRelayMessage)?;
+
+    // Segment precedence and reply chaining are undefined for nested relays in
+    // both current consumers, so reject instead of selecting an inner relay.
+    if matches!(
+        relay_message.first().copied(),
+        Some(RELAY_FORWARD) | Some(RELAY_REPLY)
+    ) {
+        return Err(DecodeError::NestedRelay);
+    }
+
+    Ok(DecodedPacket {
+        message: decode_client_message(relay_message)?,
+        relay: Some(RelayEnvelope {
+            hop_count,
+            link_address,
+            peer_address,
+            interface_id: owned_unique_raw_option(&options, OptionCode::InterfaceId)?,
+            remote_id: owned_unique_raw_option(&options, OptionCode::RemoteId)?,
+            client_link_layer: owned_unique_raw_option(&options, OptionCode::ClientLinklayerAddr)?,
+        }),
+    })
+}
+
+/// Parse the link-layer payload shared by DUID-LL and DUID-LLT.
+fn parse_link_layer_duid(bytes: &[u8], time_length: usize) -> Result<DuidMac, DuidError> {
+    if bytes.len() < 2 + time_length + ETHERNET_MAC_LENGTH {
+        return Err(DuidError::Malformed);
+    }
+
+    let hardware_type = u16::from_be_bytes([bytes[0], bytes[1]]);
+    if hardware_type != HARDWARE_TYPE_ETHERNET {
+        return Err(DuidError::UnsupportedType);
+    }
+
+    let mac = &bytes[2 + time_length..];
+    if mac.len() != ETHERNET_MAC_LENGTH {
+        return Err(DuidError::Malformed);
+    }
+
+    Ok(DuidMac::Mac(MacAddress::new([
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
+    ])))
+}
+
+/// Parse a sequence of DHCPv6 option TLVs without interpreting their payloads.
+fn parse_raw_options(mut bytes: &[u8]) -> Result<Vec<RawOption<'_>>, DecodeError> {
+    let mut options = Vec::new();
+    while !bytes.is_empty() {
+        if bytes.len() < 4 {
+            return Err(DecodeError::MalformedPacket("truncated option header"));
+        }
+        let code = u16::from_be_bytes([bytes[0], bytes[1]]);
+        let length = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
+        if bytes.len() - 4 < length {
+            return Err(DecodeError::MalformedPacket("truncated option payload"));
+        }
+        let encoded_length = 4 + length;
+        let (encoded, remaining) = bytes.split_at(encoded_length);
+        options.push(RawOption {
+            code,
+            data: &encoded[4..],
+            encoded,
+        });
+        bytes = remaining;
+    }
+    Ok(options)
+}
+
+/// Reject semantically invalid client options before dhcproto can panic or
+/// silently truncate its decoded option list.
+fn validate_client_options(options: &[RawOption<'_>]) -> Result<(), DecodeError> {
+    // Complete the resource-budget pass before invoking dhcproto anywhere in
+    // the attacker-controlled option tree.
+    let mut option_count = 0;
+    validate_client_option_budget(options, 0, &mut option_count)?;
+    validate_client_option_semantics(options)
+}
+
+/// Bound attacker-controlled option-tree depth and size before typed decoding.
+fn validate_client_option_budget(
+    options: &[RawOption<'_>],
+    depth: usize,
+    option_count: &mut usize,
+) -> Result<(), DecodeError> {
+    if depth > MAX_CLIENT_OPTION_NESTING_DEPTH {
+        return Err(DecodeError::MalformedPacket(
+            "client option nesting limit exceeded",
+        ));
+    }
+
+    for option in options {
+        *option_count += 1;
+        if *option_count > MAX_CLIENT_OPTIONS {
+            return Err(DecodeError::MalformedPacket(
+                "client option count limit exceeded",
+            ));
+        }
+
+        if OptionCode::from(option.code) == OptionCode::VendorOpts {
+            if depth != 0 {
+                return Err(DecodeError::MalformedPacket(
+                    "vendor-specific option in nested client option",
+                ));
+            }
+            let vendor_payload = option.data.get(4..).ok_or(DecodeError::MalformedPacket(
+                "invalid vendor-specific option",
+            ))?;
+            for _ in parse_raw_options(vendor_payload)? {
+                *option_count += 1;
+                if *option_count > MAX_CLIENT_OPTIONS {
+                    return Err(DecodeError::MalformedPacket(
+                        "client option count limit exceeded",
+                    ));
+                }
+            }
+            continue;
+        }
+
+        if let Some(nested) = nested_option_payload(option)? {
+            let nested_options = parse_raw_options(nested)?;
+            if !nested_options.is_empty() {
+                validate_client_option_budget(&nested_options, depth + 1, option_count)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate every bounded option in isolation before whole-message decoding.
+fn validate_client_option_semantics(options: &[RawOption<'_>]) -> Result<(), DecodeError> {
+    for option in options {
+        // Vendor suboption codes are enterprise-local and have no global
+        // OptionCode semantics. Their framing was validated by the budget pass.
+        if OptionCode::from(option.code) == OptionCode::VendorOpts {
+            continue;
+        }
+
+        let nested = nested_option_payload(option)?;
+
+        // Validate nested DHCP option containers before their parent decoder
+        // can consume bytes from a following malformed child option.
+        if let Some(nested) = nested {
+            validate_client_option_semantics(&parse_raw_options(nested)?)?;
+        }
+
+        // Isolating one TLV prevents a short option from borrowing bytes from
+        // its successor. Full consumption rejects fixed-size length mismatches.
+        let mut decoder = Decoder::new(option.encoded);
+        let decoded = DhcpOption::decode(&mut decoder).map_err(DecodeError::ClientMessageDecode)?;
+        if !decoder.buffer().is_empty() {
+            return Err(DecodeError::MalformedPacket("invalid client option length"));
+        }
+
+        // Several dhcproto container decoders stop successfully at a malformed
+        // child. A shorter round trip proves that bytes were silently omitted.
+        let mut encoded = Vec::with_capacity(option.encoded.len());
+        decoded
+            .encode(&mut Encoder::new(&mut encoded))
+            .map_err(|_| DecodeError::MalformedPacket("unencodable client option"))?;
+        if encoded.len() != option.encoded.len() {
+            return Err(DecodeError::MalformedPacket(
+                "partially decoded client option",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Return the nested option area for a DHCPv6 container option.
+fn nested_option_payload<'data>(
+    option: &RawOption<'data>,
+) -> Result<Option<&'data [u8]>, DecodeError> {
+    let offset = match OptionCode::from(option.code) {
+        OptionCode::IANA | OptionCode::IAPD => 12,
+        OptionCode::IATA => 4,
+        OptionCode::IAAddr => 24,
+        OptionCode::IAPrefix => 25,
+        // Relay Message is valid in a relay envelope, not inside the
+        // ordinary client message validated by this function.
+        OptionCode::RelayMsg => {
+            return Err(DecodeError::MalformedPacket(
+                "relay-message option in client message",
+            ));
+        }
+        _ => return Ok(None),
+    };
+
+    option
+        .data
+        .get(offset..)
+        .map(Some)
+        .ok_or(DecodeError::MalformedPacket("invalid client option"))
+}
+
+/// Return one raw option payload while rejecting ambiguous duplicates.
+fn unique_raw_option<'data>(
+    options: &[RawOption<'data>],
+    option_code: OptionCode,
+) -> Result<Option<&'data [u8]>, DecodeError> {
+    let mut matches = options
+        .iter()
+        .filter(|option| option.code == u16::from(option_code))
+        .map(|option| option.data);
+    let value = matches.next();
+    if matches.next().is_some() {
+        Err(DecodeError::MalformedPacket("duplicate relay option"))
+    } else {
+        Ok(value)
+    }
+}
+
+/// Return an owned raw option payload while retaining duplicate validation.
+fn owned_unique_raw_option(
+    options: &[RawOption<'_>],
+    option_code: OptionCode,
+) -> Result<Option<Vec<u8>>, DecodeError> {
+    unique_raw_option(options, option_code).map(|value| value.map(|value| value.to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    const DIRECT_SOLICIT: &[u8] = &[1, 0, 0, 1];
+
+    /// Encode one raw option so malformed-packet tests control its declared
+    /// payload independently of dhcproto's typed encoder.
+    fn raw_option(option_code: OptionCode, payload: &[u8]) -> Vec<u8> {
+        let mut option = Vec::new();
+        option.extend_from_slice(&u16::from(option_code).to_be_bytes());
+        option.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+        option.extend_from_slice(payload);
+        option
+    }
+
+    /// Build an ambiguous relay envelope so duplicate-option rejection is
+    /// exercised before either consumer can select different metadata.
+    fn relay_forward_with_duplicate_option(option_code: OptionCode) -> Vec<u8> {
+        let mut packet = vec![RELAY_FORWARD, 0];
+        packet.extend_from_slice(&[0; 32]);
+        packet.extend(raw_option(option_code, b"first"));
+        packet.extend(raw_option(option_code, b"second"));
+        packet.extend(raw_option(OptionCode::RelayMsg, DIRECT_SOLICIT));
+        packet
+    }
+
+    /// Build a structurally valid one-hop Relay-Forward around an arbitrary
+    /// payload so relay-boundary tests vary only the encapsulated message.
+    fn relay_forward(inner: &[u8]) -> Vec<u8> {
+        let mut packet = vec![RELAY_FORWARD, 0];
+        packet.extend_from_slice(&[0; 32]);
+        packet.extend(raw_option(OptionCode::RelayMsg, inner));
+        packet
+    }
+
+    /// Build an unregistered opaque DUID of an exact length so boundary tests
+    /// remain independent of registered type-specific layouts.
+    fn opaque_duid(length: usize) -> Vec<u8> {
+        let mut duid = vec![0, 99];
+        duid.resize(length, 0xaa);
+        duid
+    }
+
+    /// Build a client message with an exact nested IA_TA depth so the
+    /// resource-boundary test does not depend on dhcproto's typed encoder.
+    fn client_message_with_option_nesting(nesting_depth: usize) -> Vec<u8> {
+        let mut option = raw_option(OptionCode::Unknown(65_000), &[]);
+        for _ in 0..nesting_depth {
+            let mut payload = vec![0; 4];
+            payload.extend(option);
+            option = raw_option(OptionCode::IATA, &payload);
+        }
+
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        packet.extend(option);
+        packet
+    }
+
+    /// Build one opaque vendor container with an exact number of framed
+    /// enterprise-local suboptions.
+    fn client_message_with_vendor_option_count(option_count: usize) -> Vec<u8> {
+        let mut vendor_payload = 5703u32.to_be_bytes().to_vec();
+        for _ in 0..option_count {
+            vendor_payload.extend(raw_option(OptionCode::Unknown(65_000), &[]));
+        }
+
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        packet.extend(raw_option(OptionCode::VendorOpts, &vendor_payload));
+        packet
+    }
+
+    /// Build a client message with an exact number of independent options so
+    /// the count limit is exercised without adding nesting.
+    fn client_message_with_option_count(option_count: usize) -> Vec<u8> {
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        for _ in 0..option_count {
+            packet.extend(raw_option(OptionCode::Unknown(65_000), &[]));
+        }
+        packet
+    }
+
+    /// Verifies generic DUID validation accepts exactly the complete-length
+    /// range defined by RFC 9915, independent of registered DUID type.
+    #[test]
+    fn validates_duid_length_boundaries() {
+        check_values(
+            [
+                // A type code without identifier data is incomplete.
+                Check {
+                    scenario: "type-only DUID",
+                    input: opaque_duid(DUID_MIN_LENGTH - 1),
+                    expect: Err(DuidError::Malformed),
+                },
+                // The shortest opaque DUID has one identifier octet.
+                Check {
+                    scenario: "minimum-length opaque DUID",
+                    input: opaque_duid(DUID_MIN_LENGTH),
+                    expect: Ok(DuidMac::NoLinkLayerMac),
+                },
+                // The longest opaque DUID has 128 identifier octets.
+                Check {
+                    scenario: "maximum-length opaque DUID",
+                    input: opaque_duid(DUID_MAX_LENGTH),
+                    expect: Ok(DuidMac::NoLinkLayerMac),
+                },
+                // One octet beyond the RFC limit is malformed.
+                Check {
+                    scenario: "oversized opaque DUID",
+                    input: opaque_duid(DUID_MAX_LENGTH + 1),
+                    expect: Err(DuidError::Malformed),
+                },
+            ],
+            |duid| extract_mac_from_duid(&duid),
+        );
+    }
+
+    /// Verifies incomplete client-option TLVs cannot be silently ignored.
+    ///
+    /// This prevents a partially decoded client message from reaching either
+    /// the Kea hook or standalone DHCPv6 policy.
+    #[test]
+    fn rejects_incomplete_client_option_tlvs() {
+        check_values(
+            [
+                // An incomplete header cannot identify an option or its payload.
+                Check {
+                    scenario: "truncated option header",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend_from_slice(&[0, 1, 0]);
+                        packet
+                    },
+                    expect: true,
+                },
+                // A complete header must not claim bytes beyond the datagram.
+                Check {
+                    scenario: "truncated option payload",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend_from_slice(&[0, 1, 0, 2, 0xaa]);
+                        packet
+                    },
+                    expect: true,
+                },
+            ],
+            |packet| {
+                matches!(
+                    decode_client_message(&packet),
+                    Err(DecodeError::MalformedPacket(_))
+                )
+            },
+        );
+    }
+
+    /// Verifies semantically malformed options fail closed instead of panicking
+    /// or disappearing from dhcproto's successfully decoded message.
+    ///
+    /// This protects both the standalone task boundary and Kea's C ABI from
+    /// attacker-controlled option payloads.
+    #[test]
+    fn rejects_semantically_invalid_client_options() {
+        check_values(
+            [
+                // A short Vendor Class must not borrow the following TLV header
+                // and underflow its declared length.
+                Check {
+                    scenario: "zero-length Vendor Class",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend(raw_option(OptionCode::VendorClass, &[]));
+                        packet.extend(raw_option(OptionCode::RapidCommit, &[]));
+                        packet
+                    },
+                    expect: true,
+                },
+                // A fixed-size IA_NA payload must not disappear with every
+                // otherwise valid option that follows it.
+                Check {
+                    scenario: "short IA_NA",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend(raw_option(OptionCode::IANA, &[]));
+                        packet.extend(raw_option(OptionCode::RapidCommit, &[]));
+                        packet
+                    },
+                    expect: true,
+                },
+                // A truncated length-prefixed class value is otherwise decoded
+                // as an empty option with its malformed bytes discarded.
+                Check {
+                    scenario: "truncated User Class value",
+                    input: {
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend(raw_option(OptionCode::UserClass, &[0, 2, 0xaa]));
+                        packet
+                    },
+                    expect: true,
+                },
+                // Nested IA_NA options need the same isolation as top-level
+                // options because dhcproto recursively uses its lossy decoder.
+                Check {
+                    scenario: "zero-length nested Vendor Class",
+                    input: {
+                        let mut association = vec![0; 12];
+                        association.extend(raw_option(OptionCode::VendorClass, &[]));
+                        association.extend(raw_option(OptionCode::RapidCommit, &[]));
+                        let mut packet = DIRECT_SOLICIT.to_vec();
+                        packet.extend(raw_option(OptionCode::IANA, &association));
+                        packet
+                    },
+                    expect: true,
+                },
+            ],
+            |packet| {
+                matches!(
+                    decode_client_message(&packet),
+                    Err(DecodeError::MalformedPacket(_)) | Err(DecodeError::ClientMessageDecode(_))
+                )
+            },
+        );
+    }
+
+    /// Verifies enterprise-local vendor suboption codes remain opaque even
+    /// when they collide with globally registered DHCPv6 option codes.
+    #[test]
+    fn preserves_opaque_vendor_suboptions() {
+        // Private code 3 collides with IA_NA, but its one-byte payload has only
+        // the vendor-defined meaning and must not be decoded as an IA_NA.
+        let private_suboption = raw_option(OptionCode::IANA, &[0xaa]);
+        let mut vendor_payload = 5703u32.to_be_bytes().to_vec();
+        vendor_payload.extend(private_suboption);
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        packet.extend(raw_option(OptionCode::VendorOpts, &vendor_payload));
+
+        let message = decode_client_message(&packet).expect("opaque vendor suboption is accepted");
+        match message.opts().get(OptionCode::VendorOpts) {
+            Some(DhcpOption::Unknown(option)) => {
+                assert_eq!(option.data(), vendor_payload);
+            }
+            other => panic!("expected opaque vendor-specific option, got {other:?}"),
+        }
+    }
+
+    /// Verifies vendor-private payloads still obey their own TLV framing.
+    #[test]
+    fn rejects_truncated_vendor_suboptions() {
+        let mut vendor_payload = 5703u32.to_be_bytes().to_vec();
+        // The private suboption declares two bytes but supplies only one.
+        vendor_payload.extend_from_slice(&[0, 3, 0, 2, 0xaa]);
+        let mut packet = DIRECT_SOLICIT.to_vec();
+        packet.extend(raw_option(OptionCode::VendorOpts, &vendor_payload));
+
+        assert!(matches!(
+            decode_client_message(&packet),
+            Err(DecodeError::MalformedPacket("truncated option payload"))
+        ));
+    }
+
+    /// Verifies attacker-controlled option trees are accepted through the
+    /// explicit service budget and rejected immediately beyond either bound.
+    #[test]
+    fn enforces_client_option_resource_budget() {
+        check_values(
+            [
+                // The deepest supported option tree remains available to clients.
+                Check {
+                    scenario: "maximum nesting depth",
+                    input: client_message_with_option_nesting(MAX_CLIENT_OPTION_NESTING_DEPTH),
+                    expect: true,
+                },
+                // One additional container is rejected before typed decoding recurses.
+                Check {
+                    scenario: "nesting depth above limit",
+                    input: client_message_with_option_nesting(MAX_CLIENT_OPTION_NESTING_DEPTH + 1),
+                    expect: false,
+                },
+                // The maximum bounded number of shallow options remains accepted.
+                Check {
+                    scenario: "maximum option count",
+                    input: client_message_with_option_count(MAX_CLIENT_OPTIONS),
+                    expect: true,
+                },
+                // One additional option is rejected before any typed option decode.
+                Check {
+                    scenario: "option count above limit",
+                    input: client_message_with_option_count(MAX_CLIENT_OPTIONS + 1),
+                    expect: false,
+                },
+                // One vendor container plus 255 private suboptions meets the limit.
+                Check {
+                    scenario: "maximum vendor suboption count",
+                    input: client_message_with_vendor_option_count(MAX_CLIENT_OPTIONS - 1),
+                    expect: true,
+                },
+                // A vendor container and 256 private suboptions exceed the limit.
+                Check {
+                    scenario: "vendor suboption count above limit",
+                    input: client_message_with_vendor_option_count(MAX_CLIENT_OPTIONS),
+                    expect: false,
+                },
+            ],
+            |packet| decode_client_message(&packet).is_ok(),
+        );
+    }
+
+    /// Verifies single-valued relay identity and routing options reject
+    /// ambiguous duplicates.
+    ///
+    /// This ensures the Kea hook and standalone server cannot select different
+    /// metadata from the same Relay-Forward envelope.
+    #[test]
+    fn rejects_duplicate_single_valued_relay_options() {
+        check_values(
+            [
+                // Repeated Interface-ID values make segment selection ambiguous.
+                Check {
+                    scenario: "duplicate Interface-ID",
+                    input: OptionCode::InterfaceId,
+                    expect: true,
+                },
+                // Repeated Remote-ID values make relay identity ambiguous.
+                Check {
+                    scenario: "duplicate Remote-ID",
+                    input: OptionCode::RemoteId,
+                    expect: true,
+                },
+                // Repeated option 79 values make MAC selection ambiguous.
+                Check {
+                    scenario: "duplicate Client Link-Layer Address",
+                    input: OptionCode::ClientLinklayerAddr,
+                    expect: true,
+                },
+            ],
+            |option_code| {
+                matches!(
+                    decode(&relay_forward_with_duplicate_option(option_code)),
+                    Err(DecodeError::MalformedPacket("duplicate relay option"))
+                )
+            },
+        );
+    }
+
+    /// Verifies the shared decoder owns relay-header, hop-count, and nesting
+    /// boundaries independently of its Kea and standalone-server adapters.
+    #[test]
+    fn rejects_unsupported_relay_boundaries() {
+        check_values(
+            [
+                // A Relay-Forward must contain its complete 34-byte fixed header.
+                Check {
+                    scenario: "truncated relay header",
+                    input: {
+                        let mut packet = relay_forward(DIRECT_SOLICIT);
+                        packet.truncate(33);
+                        packet
+                    },
+                    expect: "malformed DHCPv6 packet: truncated relay header".to_string(),
+                },
+                // A direct client payload is valid only in the first relay envelope.
+                Check {
+                    scenario: "nonzero hop count",
+                    input: {
+                        let mut packet = relay_forward(DIRECT_SOLICIT);
+                        packet[1] = 1;
+                        packet
+                    },
+                    expect: "unsupported DHCPv6 relay hop count 1".to_string(),
+                },
+                // A nested Relay-Forward has undefined routing precedence here.
+                Check {
+                    scenario: "nested Relay-Forward",
+                    input: relay_forward(&[RELAY_FORWARD]),
+                    expect: "nested DHCPv6 relay packet".to_string(),
+                },
+                // A nested Relay-Reply is also invalid as a client payload.
+                Check {
+                    scenario: "nested Relay-Reply",
+                    input: relay_forward(&[RELAY_REPLY]),
+                    expect: "nested DHCPv6 relay packet".to_string(),
+                },
+            ],
+            |packet| {
+                decode(&packet)
+                    .expect_err("unsupported relay boundary must fail")
+                    .to_string()
+            },
+        );
+    }
+}

--- a/crates/rpc-utils/src/dhcp.rs
+++ b/crates/rpc-utils/src/dhcp.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use carbide_uuid::UuidConversionError;
 use carbide_uuid::machine::MachineInterfaceId;
-use ipnetwork::Ipv4Network;
+use ipnetwork::{Ipv4Network, Ipv6Network};
 use rpc::InterfaceFunctionType;
 use rpc::errors::RpcDataConversionError;
 use rpc::forge::ManagedHostNetworkConfigResponse;
@@ -44,6 +44,10 @@ pub struct DhcpConfig {
     pub carbide_nameservers_v6: Vec<Ipv6Addr>,
     #[serde(default)]
     pub carbide_ntpservers_v6: Vec<Ipv6Addr>,
+    /// Optional DHCPv6 server-address configuration.
+    ///
+    /// Listener admission does not depend on it, and sockets bind `[::]:547`
+    /// per interface.
     #[serde(default)]
     pub carbide_dhcp_server_v6: Option<Ipv6Addr>,
     #[serde(default)]
@@ -213,6 +217,22 @@ impl TryFrom<::rpc::forge::FlatInterfaceConfig> for InterfaceInfo {
     type Error = DhcpDataError;
     fn try_from(value: ::rpc::forge::FlatInterfaceConfig) -> Result<Self, Self::Error> {
         let gateway = Ipv4Network::from_str(&value.gateway)?.ip();
+        let ipv6 = value
+            .ipv6_interface_config
+            .map(|ipv6| -> Result<InterfaceInfoV6, DhcpDataError> {
+                // An empty address preserves an explicitly enabled SLAAC-only
+                // prefix without manufacturing a stateful host binding.
+                let prefix = Ipv6Network::from_str(&ipv6.interface_prefix)?;
+                Ok(InterfaceInfoV6 {
+                    address: if ipv6.ip.is_empty() {
+                        None
+                    } else {
+                        Some(ipv6.ip.parse()?)
+                    },
+                    prefix: prefix.to_string(),
+                })
+            })
+            .transpose()?;
 
         Ok(InterfaceInfo {
             address: value.ip.parse()?,
@@ -221,7 +241,7 @@ impl TryFrom<::rpc::forge::FlatInterfaceConfig> for InterfaceInfo {
             fqdn: value.fqdn,
             booturl: value.booturl,
             mtu: value.mtu,
-            ipv6: None,
+            ipv6,
         })
     }
 }
@@ -331,8 +351,8 @@ mod tests {
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{scenarios, value_scenarios};
     use rpc::forge::{
-        FlatInterfaceConfig, InterfaceFunctionType, ManagedHostNetworkConfigResponse,
-        VpcVirtualizationType,
+        FlatInterfaceConfig, FlatInterfaceIpv6Config, InterfaceFunctionType,
+        ManagedHostNetworkConfigResponse, VpcVirtualizationType,
     };
 
     use super::*;
@@ -391,6 +411,24 @@ mod tests {
             mtu: Some(9000),
             ..Default::default()
         }
+    }
+
+    /// Build a valid IPv4 interface with caller-selected flattened IPv6 data.
+    fn interface_config_with_ipv6(address: &str, prefix: &str) -> FlatInterfaceConfig {
+        let mut config = interface_config(
+            InterfaceFunctionType::Physical,
+            200,
+            None,
+            true,
+            "192.0.2.20",
+            "192.0.2.1/24",
+        );
+        config.ipv6_interface_config = Some(FlatInterfaceIpv6Config {
+            ip: address.to_string(),
+            interface_prefix: prefix.to_string(),
+            svi_ip: None,
+        });
+        config
     }
 
     fn host_network_config(
@@ -468,6 +506,15 @@ mod tests {
     ) -> Result<InterfaceSummary, &'static str> {
         InterfaceInfo::try_from(config)
             .map(summarize_interface)
+            .map_err(dhcp_error_kind)
+    }
+
+    /// Convert only the IPv6 sidecar so table cases remain focused on its contract.
+    fn summarize_flat_interface_ipv6(
+        config: FlatInterfaceConfig,
+    ) -> Result<Option<InterfaceInfoV6>, &'static str> {
+        InterfaceInfo::try_from(config)
+            .map(|interface| interface.ipv6)
             .map_err(dhcp_error_kind)
     }
 
@@ -762,6 +809,40 @@ mod tests {
         let old_interface: InterfaceInfo =
             serde_json::from_str(old_wire).expect("old interface deserializes");
         assert_eq!(old_interface.ipv6, None);
+    }
+
+    /// Verifies flattened IPv6 data is validated before becoming the
+    /// host.yaml sidecar consumed by DHCP.
+    #[test]
+    fn converts_flat_interface_ipv6_config() {
+        scenarios!(summarize_flat_interface_ipv6:
+            "valid IPv6 interface configuration" {
+                // A stateful address and its validated prefix are both retained.
+                interface_config_with_ipv6(
+                    "2001:db8::20",
+                    "2001:db8::/64",
+                ) => Yields(Some(InterfaceInfoV6 {
+                    address: Some("2001:db8::20".parse().unwrap()),
+                    prefix: "2001:db8::/64".to_string(),
+                })),
+                // An explicit prefix without an address remains SLAAC-only.
+                interface_config_with_ipv6(
+                    "",
+                    "2001:db8:1::/64",
+                ) => Yields(Some(InterfaceInfoV6 {
+                    address: None,
+                    prefix: "2001:db8:1::/64".to_string(),
+                })),
+            }
+
+            "invalid IPv6 interface prefix" {
+                // Malformed prefixes fail conversion instead of reaching packet handling.
+                interface_config_with_ipv6(
+                    "2001:db8::20",
+                    "not-an-ipv6-prefix",
+                ) => FailsWith("ip-network"),
+            }
+        );
     }
 
     #[test]

--- a/crates/rpc-utils/src/dhcp.rs
+++ b/crates/rpc-utils/src/dhcp.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use carbide_uuid::UuidConversionError;
 use carbide_uuid::machine::MachineInterfaceId;
-use ipnetwork::Ipv4Network;
+use ipnetwork::{Ipv4Network, Ipv6Network};
 use rpc::InterfaceFunctionType;
 use rpc::errors::RpcDataConversionError;
 use rpc::forge::ManagedHostNetworkConfigResponse;
@@ -44,6 +44,10 @@ pub struct DhcpConfig {
     pub carbide_nameservers_v6: Vec<Ipv6Addr>,
     #[serde(default)]
     pub carbide_ntpservers_v6: Vec<Ipv6Addr>,
+    /// Optional DHCPv6 server-address configuration.
+    ///
+    /// Listener admission does not depend on it, and sockets bind `[::]:547`
+    /// per interface.
     #[serde(default)]
     pub carbide_dhcp_server_v6: Option<Ipv6Addr>,
     #[serde(default)]
@@ -198,7 +202,8 @@ impl HostConfig {
     }
 }
 
-// This conversion continues to consume the compatibility fields during the address-list rollout.
+// This conversion continues to consume the IPv4 compatibility fields during
+// the address-list rollout.
 #[allow(deprecated)]
 impl TryFrom<::rpc::forge::FlatInterfaceConfig> for InterfaceInfo {
     type Error = DhcpDataError;
@@ -217,6 +222,27 @@ impl TryFrom<::rpc::forge::FlatInterfaceConfig> for InterfaceInfo {
             }
         };
 
+        let ipv6 = value
+            .addresses
+            .iter()
+            .find(|address| address.address_family == i32::from(::rpc::forge::AddressFamily::V6))
+            // Routing-only loopback or SVI data does not configure DHCP on this interface.
+            .filter(|address| !address.ip.is_empty() || !address.interface_prefix.is_empty())
+            .map(|ipv6| -> Result<InterfaceInfoV6, DhcpDataError> {
+                // An empty address preserves an explicitly enabled SLAAC-only
+                // prefix without manufacturing a stateful host binding.
+                let prefix = Ipv6Network::from_str(&ipv6.interface_prefix)?;
+                Ok(InterfaceInfoV6 {
+                    address: if ipv6.ip.is_empty() {
+                        None
+                    } else {
+                        Some(ipv6.ip.parse()?)
+                    },
+                    prefix: prefix.to_string(),
+                })
+            })
+            .transpose()?;
+
         Ok(InterfaceInfo {
             address,
             gateway,
@@ -224,7 +250,7 @@ impl TryFrom<::rpc::forge::FlatInterfaceConfig> for InterfaceInfo {
             fqdn: value.fqdn,
             booturl: value.booturl,
             mtu: value.mtu,
-            ipv6: None,
+            ipv6,
         })
     }
 }
@@ -334,8 +360,8 @@ mod tests {
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{scenarios, value_scenarios};
     use rpc::forge::{
-        FlatInterfaceConfig, InterfaceFunctionType, ManagedHostNetworkConfigResponse,
-        VpcVirtualizationType,
+        AddressFamily, FlatInterfaceConfig, InterfaceAddressConfig, InterfaceFunctionType,
+        ManagedHostNetworkConfigResponse, VpcVirtualizationType,
     };
 
     use super::*;
@@ -398,6 +424,20 @@ mod tests {
         }
     }
 
+    /// Build caller-selected family-neutral IPv6 interface data.
+    fn interface_config_with_ipv6(address: &str, prefix: &str) -> FlatInterfaceConfig {
+        FlatInterfaceConfig {
+            addresses: vec![InterfaceAddressConfig {
+                address_family: AddressFamily::V6.into(),
+                ip: address.to_string(),
+                interface_prefix: prefix.to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// Build deprecated compatibility input without IPv4 addressing.
     #[allow(deprecated)]
     fn ipv6_only_interface_config() -> FlatInterfaceConfig {
         let mut config =
@@ -481,6 +521,15 @@ mod tests {
     ) -> Result<InterfaceSummary, &'static str> {
         InterfaceInfo::try_from(config)
             .map(summarize_interface)
+            .map_err(dhcp_error_kind)
+    }
+
+    /// Convert only the IPv6 sidecar so table cases remain focused on its contract.
+    fn summarize_flat_interface_ipv6(
+        config: FlatInterfaceConfig,
+    ) -> Result<Option<InterfaceInfoV6>, &'static str> {
+        InterfaceInfo::try_from(config)
+            .map(|interface| interface.ipv6)
             .map_err(dhcp_error_kind)
     }
 
@@ -804,6 +853,58 @@ mod tests {
         assert_eq!(ipv6_only_interface.address, None);
         assert_eq!(ipv6_only_interface.gateway, None);
         assert_eq!(ipv6_only_interface.prefix, None);
+    }
+
+    /// Verifies family-neutral IPv6 data is validated before becoming the
+    /// host.yaml sidecar consumed by DHCP.
+    #[test]
+    fn converts_family_neutral_ipv6_config() {
+        scenarios!(summarize_flat_interface_ipv6:
+            "valid IPv6 interface configuration" {
+                // A stateful address and its validated prefix are both retained.
+                interface_config_with_ipv6(
+                    "2001:db8::20",
+                    "2001:db8::/64",
+                ) => Yields(Some(InterfaceInfoV6 {
+                    address: Some("2001:db8::20".parse().unwrap()),
+                    prefix: "2001:db8::/64".to_string(),
+                })),
+                // An explicit prefix without an address remains SLAAC-only.
+                interface_config_with_ipv6(
+                    "",
+                    "2001:db8:1::/64",
+                ) => Yields(Some(InterfaceInfoV6 {
+                    address: None,
+                    prefix: "2001:db8:1::/64".to_string(),
+                })),
+                // An operator loopback alone does not enable DHCPv6 on the host interface.
+                FlatInterfaceConfig {
+                    addresses: vec![InterfaceAddressConfig {
+                        address_family: AddressFamily::V6.into(),
+                        tenant_vrf_loopback_ip: Some("2001:db8::3".to_string()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                } => Yields(None),
+                // An SVI address alone belongs to routing and cannot configure DHCPv6.
+                FlatInterfaceConfig {
+                    addresses: vec![InterfaceAddressConfig {
+                        address_family: AddressFamily::V6.into(),
+                        svi_ip: Some("2001:db8::4".to_string()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                } => Yields(None),
+            }
+
+            "invalid IPv6 interface prefix" {
+                // Malformed prefixes fail conversion instead of reaching packet handling.
+                interface_config_with_ipv6(
+                    "2001:db8::20",
+                    "not-an-ipv6-prefix",
+                ) => FailsWith("ip-network"),
+            }
+        );
     }
 
     #[test]

--- a/deploy/DNS.md
+++ b/deploy/DNS.md
@@ -4,7 +4,17 @@
 
 NICo (ncx-infrastructure-controller) depends on a set of well-known hostnames in the `.nico` DNS zone. These names are resolved by DPU agents, host PXE loaders, and other in-band management components at runtime. Several of these hostnames are **compiled into binaries or embedded shell scripts** and cannot be changed without rebuilding the software.
 
-Before deploying NICo, you must configure DNS A records that resolve each `.nico` hostname to the appropriate service virtual IP (VIP) on your out-of-band (OOB) management network. A site-local recursive resolver (Unbound or equivalent) running on your site controller is the recommended approach.
+Before deploying NICo, you must configure DNS A records that resolve each
+`.nico` hostname to the appropriate service virtual IP (VIP) on your
+out-of-band (OOB) management network. Configure AAAA records for services that
+must be discovered over IPv6; in particular, DHCPv6 option 56 requires an AAAA
+record for the NTP hostname. A site-local recursive resolver (Unbound or
+equivalent) running on your site controller is the recommended approach.
+
+Stock DPU-agent images query `carbide-ntp.forge`. The rebranded
+`nico-ntp.nico` name applies only to images built to use that name. These are
+distinct hostnames, not suffix substitutions; configure the exact name queried
+by the deployed agent, or serve both aliases during a mixed-image transition.
 
 ---
 
@@ -15,7 +25,7 @@ Before deploying NICo, you must configure DNS A records that resolve each `.nico
 | `nico-api.nico` | 443 | gRPC / TLS | DPU agents, admin CLI, PXE service, DHCP plugin, FMDS, health probe | `nico-api` pod | NICo gRPC API |
 | `nico-pxe.nico` | 80 | HTTP | DPU agents, iPXE clients | `nico-pxe` pod | iPXE scripts, cloud-init payloads, boot artifacts, internal APT |
 | `nico-static-pxe.nico` | 80 | HTTP | Host PXE loader (scout) | `nico-static-pxe` pod | Static boot files: `scout.squashfs`, `scout.efi`, BFB images |
-| `nico-ntp.nico` | 123 | UDP (NTP) | DPU agents, managed hosts (DHCP option 42) | `nico-ntp` pods | NTP time synchronisation |
+| `carbide-ntp.forge` (stock) or `nico-ntp.nico` (rebranded image) | 123 | UDP (NTP) | DPU agents, managed hosts (DHCP options 42 and 56) | `nico-ntp` pods or operator NTP service | NTP time synchronisation |
 | `unbound.nico` | 53 | UDP / TCP (DNS) | DPU agents, managed hosts (DHCP option 6) | `nico-unbound` pod | Site-local recursive DNS resolver |
 | `otel-receiver.nico` | 443 | gRPC / TLS (OTLP) | DPU otel-collector sidecars | otel-receiver service | OpenTelemetry ingestion endpoint |
 | `socks.nico` | 1888 | SOCKS5 | DPU agent extension service pods | SOCKS5 proxy service | Outbound HTTP/HTTPS proxy for DPU-hosted workloads |
@@ -79,22 +89,34 @@ Serves pre-built, version-controlled boot assets used during host bring-up. Unli
 
 ---
 
-### `nico-ntp.nico` — NTP Service
+### `carbide-ntp.forge` / `nico-ntp.nico` — NTP Service
 
 **Port:** 123 (UDP)  
 **Protocol:** NTP  
 **In-cluster addresses:** `nico-ntp-1.nico-ntp.nico-system.svc.cluster.local`, `nico-ntp-2.nico-ntp.nico-system.svc.cluster.local`, `nico-ntp-3.nico-ntp.nico-system.svc.cluster.local`
 
-Provides NTP time synchronisation for DPU agents and managed hosts. The service is backed by three pods for redundancy; configure multiple DNS A records for `nico-ntp.nico` pointing to each pod's VIP.
+Provides NTP time synchronisation for DPU agents and managed hosts. The bundled
+service is backed by three pods for redundancy. Configure multiple DNS A
+records pointing to its IPv4 VIPs. To advertise the service through DHCPv6
+option 56, also configure one or more AAAA records pointing to reachable IPv6
+NTP endpoints.
 
 **Consumers:**
-- `nico-agent` (DPU agent) — resolves `nico-ntp.nico` at startup to discover NTP server addresses; the resolved addresses are also pushed to managed hosts via DHCP option 42
+- `nico-agent` (DPU agent) — stock images resolve `carbide-ntp.forge` at startup to discover NTP server addresses; images rebuilt with the rebranded name resolve `nico-ntp.nico`. IPv4 and IPv6 results are advertised to managed hosts through DHCP options 42 and 56, respectively
 
-**Configurability:** The DPU agent resolves `nico-ntp.nico` directly via DNS (`crates/agent/src/main_loop.rs`). **This lookup is not overridable via config in the compiled agent.**
+**Configurability:** The stock DPU agent resolves `carbide-ntp.forge` directly
+via DNS (`crates/agent/src/util.rs`). **This lookup is not overridable via
+config in the compiled agent.** Using `nico-ntp.nico` requires an image rebuilt
+with that hostname.
 
-> **Warning:** `nico-ntp.nico` is hardcoded in the compiled `nico-agent` binary (`crates/agent/src/main_loop.rs`). This DNS record must exist and resolve correctly on the OOB network. Changing this hostname requires rebuilding the DPU agent.
+> **Warning:** `carbide-ntp.forge` is hardcoded in the stock `nico-agent`
+> binary. That exact DNS record must resolve correctly on the OOB network.
+> Changing the hostname requires rebuilding the DPU agent.
 
-**Multiple A records (recommended):** Configure one A record per NTP pod instance to provide redundancy. Clients will receive all addresses and select among them.
+**Multiple records (recommended):** Configure one A record per IPv4 NTP pod
+instance to provide redundancy. Configure one or more AAAA records when using
+the DHCPv6 option-56 fallback. Clients receive every address from the matching
+family and select among them.
 
 ---
 
@@ -173,7 +195,7 @@ What it resolves:
 
 | Query | How it's answered |
 |---|---|
-| `nico-api.nico`, `nico-pxe.nico`, `nico-static-pxe.nico`, `nico-ntp.nico`, `socks.nico`, `otel-receiver.nico` | Served locally by Unbound from `local_data.conf` |
+| `nico-api.nico`, `nico-pxe.nico`, `nico-static-pxe.nico`, the deployed agent's exact NTP hostname, `socks.nico`, `otel-receiver.nico` | Served locally by Unbound from `local_data.conf` |
 | Names in the site domain (e.g., a `<machine-id>` record under `initial_domain_name`) | Reaches `nico-dns` via upstream delegation of the site zone to the `nico-dns` VIPs, or via an explicit forward zone in Unbound |
 | External names (package mirrors, public NTP fallbacks, etc.) | Unbound forwards or recurses to the upstream resolver configured in `forwarders.conf` |
 
@@ -189,7 +211,7 @@ A managed host that has been ingested but not yet allocated to a tenant remains 
 
 What it resolves:
 
-- The same set of `.nico` service names as DPU agents — for example, `nico-pxe.nico` for cloud-init userdata and the internal APT repository, `nico-ntp.nico` for time synchronisation, `nico-api.nico` for any in-band tooling that targets the NICo API.
+- The same service endpoints as DPU agents — for example, `nico-pxe.nico` for cloud-init userdata and the internal APT repository, the NTP hostname compiled into the deployed agent for time synchronisation, and `nico-api.nico` for any in-band tooling that targets the NICo API.
 - The host's own hostname and other site-zone records, through the same delegation or forward-zone path that DPU agents use.
 - External names, through Unbound's upstream forwarder.
 
@@ -212,7 +234,7 @@ For both client types:
 | `nico-api.nico` | Default value only (`crates/host-support/src/agent_config.rs`, config defaults across services) | **Yes** — override via `NICO_API_URL` env var or config file |
 | `nico-pxe.nico` | Compiled into `nico-agent` (`crates/agent/src/main_loop.rs`) | **No** — requires rebuilding `nico-agent` |
 | `nico-static-pxe.nico` | Embedded in host boot scripts (`pxe/common_files/scout-loader-rclocal`, `pxe/common_files/check-scout-updates.sh`) | **No** — requires rebuilding host boot images |
-| `nico-ntp.nico` | Compiled into `nico-agent` (`crates/agent/src/main_loop.rs`) | **No** — requires rebuilding `nico-agent` |
+| `carbide-ntp.forge` (stock) / `nico-ntp.nico` (rebranded image) | Compiled into `nico-agent` (`crates/agent/src/util.rs`) | **No** — requires rebuilding `nico-agent` |
 | `unbound.nico` | Not compiled into binaries; distributed via DHCP option 6 | **Yes** — update DHCP server configuration |
 | `otel-receiver.nico` | otel-collector config YAML (`bluefield/charts/nico-otelcol/files/otel_config.yaml`, etc.) | **Yes** — update otel-collector config files and redeploy |
 | `socks.nico` | Compiled into `nico-agent` (`crates/agent/src/extension_services/k8s_pod_handler.rs`) | **No** — requires rebuilding `nico-agent` |
@@ -223,13 +245,26 @@ For both client types:
 
 ### Using Unbound (`local_data.conf`)
 
-Populate `deploy/files/unbound/local_data.conf` with the site controller VIP for each service and apply the changes to your cluster. Each entry in that file includes a comment describing the service, its port, and any hardcoded-hostname warnings. The Unbound pod will restart automatically once the updated ConfigMap is live.
+For Helm deployments, populate `unbound.localData` with each service VIP. The
+chart renders IPv4 literals as A records and IPv6 literals as AAAA records. For
+the legacy Kustomize deployment, populate
+`deploy/files/unbound/local_data.conf`; its checked-in placeholders cover the
+IPv4 service VIPs and both NTP hostname aliases, so add a site-specific AAAA
+entry for `carbide-ntp.forge` when stock agents use the DHCPv6 option-56
+fallback. Add the corresponding `nico-ntp.nico` record only for rebranded
+images. The Unbound pod restarts automatically once the generated ConfigMap
+changes.
 
 ### Using Other DNS Providers
 
-Any DNS server that can serve authoritative responses for the `.nico` zone on your OOB management network is supported. Create A records for each hostname listed above pointing to the appropriate VIP.
+Any DNS server that can serve authoritative responses for the required `.nico`
+and `.forge` names on your OOB management network is supported. Create A
+records for each applicable hostname and an AAAA record for the exact NTP
+hostname queried by the deployed agent when DHCPv6 option 56 is required.
 
-> **Note:** `.nico` is not a publicly registered TLD. It is used exclusively on the isolated OOB management network and should not be forwarded to upstream public resolvers. Configure your DNS server to treat `.nico` as a locally authoritative zone with no upstream forwarding.
+> **Note:** `.nico` and `.forge` are private service zones in this deployment.
+> They should not be forwarded to public resolvers. Configure your DNS server
+> to answer the required names locally with no upstream forwarding.
 
 ---
 
@@ -239,10 +274,17 @@ After configuring DNS, verify that all records resolve correctly from a host or 
 
 ```bash
 for name in nico-api.nico nico-pxe.nico nico-static-pxe.nico \
-            nico-ntp.nico unbound.nico otel-receiver.nico socks.nico; do
+            unbound.nico otel-receiver.nico socks.nico; do
     printf "%-30s -> %s\n" "$name" "$(dig +short "$name" @<UNBOUND_VIP> || echo 'FAILED')"
 done
+
+# Stock agent: both results are required for dual-stack NTP fallback.
+dig +short A carbide-ntp.forge @<UNBOUND_VIP>
+dig +short AAAA carbide-ntp.forge @<UNBOUND_VIP>
 ```
+
+For an image rebuilt to query `nico-ntp.nico`, replace the complete
+`carbide-ntp.forge` hostname in both commands. Do not replace only its TLD.
 
 Verify reachability on expected ports:
 
@@ -257,7 +299,7 @@ curl -sf --max-time 5 http://nico-pxe.nico/ -o /dev/null && echo "nico-pxe OK" |
 curl -sf --max-time 5 http://nico-static-pxe.nico/ -o /dev/null && echo "nico-static-pxe OK" || echo "nico-static-pxe FAILED"
 
 # NTP
-ntpdate -q nico-ntp.nico
+ntpdate -q carbide-ntp.forge
 
 # DNS resolver (should return a result for an external name)
 dig +short +timeout=3 example.com @unbound.nico

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -52,7 +52,7 @@ The templates in `deploy/files/` are mounted into services and must be filled wi
 - `deploy/files/nico-api/admin_root_cert_pem` – place the PEM‑encoded root CA chain used to authenticate NICo admins (matches the CA trusted by the admin CLI). Generate this from your CA and keep private keys elsewhere.
 - `deploy/files/nico-api/nico-api-site-config.toml` – set site identifiers (`ENVIRONMENT_NAME`, `SITE_DOMAIN_NAME`), admin network pool and gateway, service VIPs (API, DHCP, DNS, PXE, SSH console, NGINX/proxy, Unbound), tenant overlay prefixes, and IPMI pools/names for controllers and managed hosts. Ensure service VIPs come from your chosen /27 (or equivalent) VIP pool and that IPMI pools each have a gateway and unique network name.
 - `deploy/files/unbound/forwarders.conf` – list upstream recursive DNS endpoints reachable from the cluster. Use IPs for resolvers allowed to recurse for your site.
-- `deploy/files/unbound/local_data.conf` – defines static DNS A records for NICo services, including all `.nico` service endpoints (API, PXE, static PXE, NTP, Unbound, otel-receiver, and SOCKS proxy) and any additional site-specific names (e.g., `api-<ENVIRONMENT_NAME>.<SITE_DOMAIN_NAME>`). Map each hostname to the corresponding service VIP you selected above. Several `.nico` hostnames are hardcoded in compiled binaries and must resolve correctly before DPU agents can start. See [`.nico` DNS Zone — Service Endpoint Reference](DNS.md) for the full list of hostnames, required ports, and which entries are hardcoded.
+- `deploy/files/unbound/local_data.conf` – defines static DNS A and AAAA records for NICo services, including the `.nico` service endpoints, the stock agent's `carbide-ntp.forge` name, and any additional site-specific names (e.g., `api-<ENVIRONMENT_NAME>.<SITE_DOMAIN_NAME>`). Map each hostname to the corresponding service VIP you selected. Add an AAAA record for the exact NTP hostname queried by the deployed agent when DHCPv6 option 56 should advertise an IPv6 NTP fallback. Several hostnames are hardcoded in compiled binaries and must resolve correctly before DPU agents can start. See [`.nico` DNS Zone — Service Endpoint Reference](DNS.md) for the full list of hostnames, required ports, and which entries are hardcoded.
 - `deploy/files/kea_config.json` – provide the Kea DHCPv4 configuration tailored to your admin/tenant networks, including option definitions, subnets, pools, and relay settings. Reference the same service IPs used elsewhere and ensure leases align with the admin network pool.
 - `deploy/files/vtysh.conf` – FRRouting vtysh shell configuration. Align hostname and service addresses here with the FRR service IPs chosen from your service VIP pool.
 
@@ -289,7 +289,8 @@ The container runs `dockurr/chrony` and reads `NTP_SERVERS` / `NTP_DIRECTIVES` f
    kubectl apply -k deploy/nico-base/ntp -n <NICO_NAMESPACE>
    ```
 
-3. Hand out the `nico-ntp` pod hostnames via DHCP option 42 or node configs.
+3. Hand out the `nico-ntp` pod addresses via DHCP option 42 for IPv4, DHCP
+   option 56 for IPv6, or node configs.
 
 ---
 

--- a/deploy/files/unbound/local_data.conf
+++ b/deploy/files/unbound/local_data.conf
@@ -17,13 +17,23 @@ server:
     #          pxe/common_files/check-scout-updates.sh
     local-data: "nico-static-pxe.nico 300 IN A {{ NICO_STATIC_PXE_IP }}"
 
-    # nico-ntp.nico — NTP service
-    # Port 123 (UDP). Accessed by DPU agents; distributed to managed hosts via DHCP option 42.
-    # WARNING: hardcoded in crates/agent/src/main_loop.rs
-    # Three A records for redundancy — one per NTP pod.
+    # carbide-ntp.forge / nico-ntp.nico — NTP service
+    # Port 123 (UDP). Accessed by DPU agents; IPv4 and IPv6 addresses are
+    # distributed to managed hosts via DHCP options 42 and 56, respectively.
+    # WARNING: stock agents resolve carbide-ntp.forge in crates/agent/src/util.rs.
+    # Keep the nico-ntp.nico aliases for images rebuilt with the rebranded name.
+    # Three A records for redundancy — one per NTP pod and hostname.
+    local-data: "carbide-ntp.forge 300 IN A {{ NICO_NTP_SERVERS_IP_0 }}"
+    local-data: "carbide-ntp.forge 300 IN A {{ NICO_NTP_SERVERS_IP_1 }}"
+    local-data: "carbide-ntp.forge 300 IN A {{ NICO_NTP_SERVERS_IP_2 }}"
     local-data: "nico-ntp.nico 300 IN A {{ NICO_NTP_SERVERS_IP_0 }}"
     local-data: "nico-ntp.nico 300 IN A {{ NICO_NTP_SERVERS_IP_1 }}"
     local-data: "nico-ntp.nico 300 IN A {{ NICO_NTP_SERVERS_IP_2 }}"
+    # Add one or more site-specific AAAA records when DHCPv6 option 56 should
+    # advertise an NTP fallback. The stock hostname is required; add the
+    # rebranded alias when serving images built to query it, for example:
+    # local-data: "carbide-ntp.forge 300 IN AAAA 2001:db8::123"
+    # local-data: "nico-ntp.nico 300 IN AAAA 2001:db8::123"
 
     # unbound.nico — Recursive DNS resolver
     # Port 53 (UDP/TCP). Distributed to DPU agents and managed hosts as the

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -55,12 +55,15 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_database_transaction_rollback_failures_total</td><td>counter</td><td>Number of database transaction rollback failures, by trigger.</td></tr>
 <tr><td>carbide_db_pool_idle_conns</td><td>gauge</td><td>Number of idle connections in the carbide database pool</td></tr>
 <tr><td>carbide_db_pool_total_conns</td><td>gauge</td><td>Number of (active + idle) connections in the carbide database pool</td></tr>
-<tr><td>carbide_dhcp_dropped_requests_total</td><td>counter</td><td>Number of DHCP packets dropped without a reply, by drop reason.</td></tr>
-<tr><td>carbide_dhcp_replies_sent_total</td><td>counter</td><td>Number of DHCP replies sent, by reply message type.</td></tr>
-<tr><td>carbide_dhcp_requests_total</td><td>counter</td><td>Number of DHCP packets received and decoded, by DHCP message type.</td></tr>
+<tr><td>carbide_dhcp_dropped_requests_total</td><td>counter</td><td>Number of DHCPv4 packets dropped without a reply, by drop reason.</td></tr>
+<tr><td>carbide_dhcp_replies_sent_total</td><td>counter</td><td>Number of DHCPv4 replies sent, by reply message type.</td></tr>
+<tr><td>carbide_dhcp_requests_total</td><td>counter</td><td>Number of DHCPv4 packets received and decoded, by DHCP message type.</td></tr>
 <tr><td>carbide_dhcp_socket_setup_failures_total</td><td>counter</td><td>Number of DHCP socket setup failures, by operation and next action.</td></tr>
 <tr><td>carbide_dhcp_timestamp_file_failures_total</td><td>counter</td><td>Number of DHCP timestamp file failures, by operation</td></tr>
+<tr><td>carbide_dhcp_v6_listener_unavailable_total</td><td>counter</td><td>Number of DHCPv6 listeners made unavailable by socket setup failure, by reason.</td></tr>
 <tr><td>carbide_dhcp_v6_replies_sent_total</td><td>counter</td><td>Number of DHCPv6 replies sent, by response message type.</td></tr>
+<tr><td>carbide_dhcp_v6_requests_dropped_total</td><td>counter</td><td>Number of DHCPv6 requests dropped or refused, by reason.</td></tr>
+<tr><td>carbide_dhcp_v6_requests_total</td><td>counter</td><td>Number of DHCPv6 requests received, by DHCP message type.</td></tr>
 <tr><td>carbide_dns_negative_cache_hit_count_total</td><td>counter</td><td>Number of negative DNS cache hits, by response code</td></tr>
 <tr><td>carbide_dns_negative_cache_miss_count_total</td><td>counter</td><td>Number of negative DNS cache misses, by response code</td></tr>
 <tr><td>carbide_dns_queries_total</td><td>counter</td><td>Number of DNS queries received, by query type</td></tr>
@@ -77,7 +80,6 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dpu_uefi_password_setup_skips_total</td><td>counter</td><td>Number of DPU UEFI password setup operations skipped, by reason.</td></tr>
 <tr><td>carbide_dpus_healthy_count</td><td>gauge</td><td>Number of DPUs in the system that have reported healthy in the last report. Healthy does not imply up - the report from the DPU might be outdated.</td></tr>
 <tr><td>carbide_dpus_up_count</td><td>gauge</td><td>Number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
-<tr><td>carbide_dropped_v6_requests_total</td><td>counter</td><td>Number of dropped DHCPv6 requests, by reason.</td></tr>
 <tr><td>carbide_dsx_event_bus_publish_count_total</td><td>counter</td><td>Number of MQTT publish attempts</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_alerts_detected_total</td><td>counter</td><td>Number of leak alerts detected</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_dedup_skipped_total</td><td>counter</td><td>Number of messages skipped due to deduplication</td></tr>

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -55,12 +55,15 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_database_transaction_rollback_failures_total</td><td>counter</td><td>Number of database transaction rollback failures, by trigger.</td></tr>
 <tr><td>carbide_db_pool_idle_conns</td><td>gauge</td><td>Number of idle connections in the carbide database pool</td></tr>
 <tr><td>carbide_db_pool_total_conns</td><td>gauge</td><td>Number of (active + idle) connections in the carbide database pool</td></tr>
-<tr><td>carbide_dhcp_dropped_requests_total</td><td>counter</td><td>Number of DHCP packets dropped without a reply, by drop reason.</td></tr>
-<tr><td>carbide_dhcp_replies_sent_total</td><td>counter</td><td>Number of DHCP replies sent, by reply message type.</td></tr>
-<tr><td>carbide_dhcp_requests_total</td><td>counter</td><td>Number of DHCP packets received and decoded, by DHCP message type.</td></tr>
+<tr><td>carbide_dhcp_dropped_requests_total</td><td>counter</td><td>Number of DHCPv4 packets dropped without a reply, by drop reason.</td></tr>
+<tr><td>carbide_dhcp_replies_sent_total</td><td>counter</td><td>Number of DHCPv4 replies sent, by reply message type.</td></tr>
+<tr><td>carbide_dhcp_requests_total</td><td>counter</td><td>Number of DHCPv4 packets received and decoded, by DHCP message type.</td></tr>
 <tr><td>carbide_dhcp_socket_setup_failures_total</td><td>counter</td><td>Number of DHCP socket setup failures, by operation and next action.</td></tr>
 <tr><td>carbide_dhcp_timestamp_file_failures_total</td><td>counter</td><td>Number of DHCP timestamp file failures, by operation</td></tr>
+<tr><td>carbide_dhcp_v6_listener_unavailable_total</td><td>counter</td><td>Number of DHCPv6 listeners made unavailable by socket setup failure, by reason.</td></tr>
 <tr><td>carbide_dhcp_v6_replies_sent_total</td><td>counter</td><td>Number of DHCPv6 replies sent, by response message type.</td></tr>
+<tr><td>carbide_dhcp_v6_requests_dropped_total</td><td>counter</td><td>Number of DHCPv6 requests dropped or refused, by reason.</td></tr>
+<tr><td>carbide_dhcp_v6_requests_total</td><td>counter</td><td>Number of DHCPv6 requests received, by DHCP message type.</td></tr>
 <tr><td>carbide_dns_negative_cache_hit_count_total</td><td>counter</td><td>Number of negative DNS cache hits, by response code</td></tr>
 <tr><td>carbide_dns_negative_cache_miss_count_total</td><td>counter</td><td>Number of negative DNS cache misses, by response code</td></tr>
 <tr><td>carbide_dns_queries_total</td><td>counter</td><td>Number of DNS queries received, by query type</td></tr>
@@ -76,7 +79,6 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dpu_uefi_password_setup_skips_total</td><td>counter</td><td>Number of DPU UEFI password setup operations skipped, by reason.</td></tr>
 <tr><td>carbide_dpus_healthy_count</td><td>gauge</td><td>Number of DPUs in the system that have reported healthy in the last report. Healthy does not imply up - the report from the DPU might be outdated.</td></tr>
 <tr><td>carbide_dpus_up_count</td><td>gauge</td><td>Number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
-<tr><td>carbide_dropped_v6_requests_total</td><td>counter</td><td>Number of dropped DHCPv6 requests, by reason.</td></tr>
 <tr><td>carbide_dsx_event_bus_publish_count_total</td><td>counter</td><td>Number of MQTT publish attempts</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_alerts_detected_total</td><td>counter</td><td>Number of leak alerts detected</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_dedup_skipped_total</td><td>counter</td><td>Number of messages skipped due to deduplication</td></tr>

--- a/helm/charts/unbound/templates/configmap.yaml
+++ b/helm/charts/unbound/templates/configmap.yaml
@@ -39,7 +39,11 @@ data:
     {{- $name := .name }}
     {{- $ttl := .ttl | default 300 }}
     {{- range .addresses }}
+    {{- if contains ":" (toString .) }}
+        local-data: "{{ $name }} {{ $ttl }} IN AAAA {{ . }}"
+    {{- else }}
         local-data: "{{ $name }} {{ $ttl }} IN A {{ . }}"
+    {{- end }}
     {{- end }}
     {{- end }}
   {{- end }}

--- a/helm/charts/unbound/tests/local_data_test.yaml
+++ b/helm/charts/unbound/tests/local_data_test.yaml
@@ -1,4 +1,4 @@
-suite: unbound local DNS A records (localData)
+suite: unbound local DNS records (localData)
 templates:
   - configmap.yaml
 release:
@@ -35,6 +35,20 @@ tests:
       - matchRegex:
           path: data["local_data.conf"]
           pattern: 'local-data: "nico-ntp\.nico 60 IN A 10\.0\.0\.4"'
+
+  - it: renders IPv6 addresses as AAAA records
+    documentIndex: 1
+    set:
+      localData:
+        - name: carbide-ntp.forge
+          addresses: ["10.0.0.2", "2001:db8::2"]
+    asserts:
+      - matchRegex:
+          path: data["local_data.conf"]
+          pattern: 'local-data: "carbide-ntp\.forge 300 IN A 10\.0\.0\.2"'
+      - matchRegex:
+          path: data["local_data.conf"]
+          pattern: 'local-data: "carbide-ntp\.forge 300 IN AAAA 2001:db8::2"'
 
   - it: supports a legacy alias resolving to the same address
     documentIndex: 1

--- a/helm/charts/unbound/values.yaml
+++ b/helm/charts/unbound/values.yaml
@@ -60,7 +60,8 @@ env:
   BROKEN_DNSSEC: "1"
   UNBOUND_CONTROL_DIR: /etc/unbound/keys
 
-# Local DNS A records served to managed hosts and DPUs. Rendered into a
+# Local DNS A and AAAA records served to managed hosts and DPUs. IPv4 and IPv6
+# address literals render as A and AAAA records, respectively, in the
 # local_data.conf file that unbound includes from local.conf.d. Names and IPs
 # are environment-specific, so this is empty by default — populate per site.
 localData: []
@@ -69,8 +70,10 @@ localData: []
 #     addresses: ["10.0.0.1"]
 #   - name: carbide-api.forge        # legacy alias → same address
 #     addresses: ["10.0.0.1"]
-#   - name: nico-ntp.nico            # multiple addresses are supported
-#     addresses: ["10.0.0.2", "10.0.0.3", "10.0.0.4"]
+#   - name: carbide-ntp.forge         # exact hostname queried by stock agents
+#     addresses: ["10.0.0.2", "10.0.0.3", "2001:db8::2"]
+#   - name: nico-ntp.nico             # optional alias for rebranded images
+#     addresses: ["10.0.0.2", "10.0.0.3", "2001:db8::2"]
 
 # Local config files for unbound
 localConfig:


### PR DESCRIPTION
This PR adds native DHCPv6 serving alongside the existing DHCPv4 path in dhcp-server. This enables dual-stack bare-metal provisioning in both DPU and Controller modes without changing DHCPv4 admission or requiring a separate DHCPv6 process.

  The dhcp-server now...

  - Runs an interface-bound DHCPv6 listener on `[::]:547` and joins `ff02::1:2` for every configured interface.
  - Handles direct and one-hop relayed DHCPv6 traffic, including stateful address assignment, stateless options, CONFIRM, RELEASE, DECLINE, RENEW, and REBIND:
    - DPU mode accepts direct DHCPv6 only.
    - Controller mode accepts one-hop relayed DHCPv6 only.
    - DHCPv4 behavior is unchanged.
    - Shared relay decoding remains available to controller mode and Kea.
  - Enforces DHCPv6 identity, ServerId, relay, and IA_NA validation at the packet boundary.
  - Returns correctly nested `NoAddrsAvail` and `NoBinding` status responses when no stateful address is available.
  - Supplies IPv6 DNS, NTP, domain-search, and requested Client FQDN options.
  - Uses DPU ingress as the authoritative local binding identity while Controller mode forwards discovery through the existing API.
  - Retries transient socket setup failures and supervises IPv4 and IPv6 listeners so IPv6 unavailability remains nonfatal without masking an IPv4 failure.
  - Shares policy-neutral DHCPv6 wire and identity decoding with the existing Kea path, preventing the two implementations from drifting. This intentionally hardens malformed TLVs and duplicate relay metadata by rejecting them rather than partially or ambiguously decoding them.

  The agent-side configuration conversion now preserves available IPv6 interface and service data. DHCPv4 behavior remains enabled and independently covered.

  ## Related issues

  Closes #2386
  Part of #2413

  ## Type of Change

  - [x] **Add** - New feature or capability
  - [ ] **Change** - Changes in existing functionality
  - [ ] **Fix** - Bug fixes
  - [ ] **Remove** - Removed features or deprecated functionality
  - [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

  ## Breaking Changes

  - [ ] **This PR contains breaking changes**

  ## Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [ ] Manual testing performed
  - [ ] No testing required (docs, internal refactor, etc.)

  ## Additional Notes

  - DHCPv6 listeners start unconditionally for configured interfaces. The optional DPU IPv6 loopback address is not a listener address or feature gate.
  - Admin-segment IPv6 configuration production remains owned by the later overlay milestone; this PR provides the DHCPv6 transport and serving seam.
  - Identity-free Information-request remains unsupported: the standalone server still requires ClientId and includes it in the response.
  - As with the pre-existing DHCPv4 implementation, detached packet-processing tasks can outlive a configuration reload generation. A future fix should address generation ownership for both protocol families together.

<details>
<summary>Deeper Dive</summary>

# Behavioral overview

## Scope and conclusion

The branch turns the standalone Rust DHCP server into a dual-stack service. It adds one DHCPv6 listener per configured interface, a bounded shared DHCPv6 wire decoder, DPU-local and Controller/API-backed DHCPv6 policy, dual-stack agent configuration, family-separated metrics, and deployment guidance for IPv6 NTP discovery.

The central promise is:

- DHCPv4 continues to use its existing serving path.
- DHCPv6 is attempted independently on every configured interface.
- DPU mode serves directly attached clients from interface-local configuration.
- Controller mode serves only one-hop relayed clients through the existing Forge `DiscoverDhcp` API.
- Malformed, ambiguous, cross-mode, or unsupported traffic fails closed.
- DHCPv6 listener failure does not take down otherwise healthy DHCPv4 service.

There is deliberately no DHCPv6 runtime feature gate in this milestone. Deployment controls when the new binary is rolled out; neither `loopback_ip_v6` nor `carbide_dhcp_server_v6` enables or disables the listener.

## Serving topology and transport

For every configured interface, the process now creates:

- the existing DHCPv4 listener; and
- a DHCPv6 listener bound to `[::]:547`, scoped to that interface with `SO_BINDTODEVICE` and configured as IPv6-only.

The IPv6 socket joins `ff02::1:2` on the selected interface. Controller mode also joins the site-scoped server group `ff05::1:3`; DPU mode does not, because its trust boundary is direct-client traffic only.

Transport admission is strict:

- a direct DHCPv6 client message must originate from UDP port 546;
- a Relay-Forward must originate from UDP port 547; and
- a reply is sent to the exact, validated UDP source address and port.

Wrong-port datagrams are counted as received and then dropped as invalid. The port check belongs to the real listener transport; tests or library callers that invoke `process_packet` directly bypass it.

IPv4 and IPv6 have separate 128-permit admission semaphores. Heavy or stalled IPv6 work therefore cannot consume DHCPv4's packet permits. Each semaphore is shared by all interfaces for its address family.

The IPv6 listener uses a full 65,535-byte receive buffer rather than the DHCPv4/BOOTP minimum-size rules. Accepted packet work runs in detached Tokio tasks, as DHCPv4 packet work already does.

## Mode and identity boundaries

| Mode | Accepted topology | Binding/lookup authority | Client identity policy |
|---|---|---|---|
| DPU | Direct client messages only | The receiving interface selects the `host.yaml` entry | ClientId must be structurally valid, but it need not contain an Ethernet MAC |
| Controller | One Relay-Forward envelope only | Relay metadata is forwarded to `DiscoverDhcp`; Interface-ID is preserved when present and the local interface is not substituted | RFC 6939 option 79 MAC takes precedence, then an Ethernet DUID MAC; a valid non-MAC DUID without a usable option 79 is rejected |

If option 79 and the DUID contain different Ethernet MACs, option 79 wins and the discrepancy is logged. DPU mode rejects relay-controlled metadata rather than allowing it to select another local interface.

Every currently supported message requires exactly one structurally valid ClientId. ServerId is also validated for uniqueness and message-specific presence:

- forbidden on Solicit, Confirm, and Rebind;
- required and matching on Request, Renew, Release, and Decline; and
- optional on Information-request, but required to match when present.

## DHCPv6 message behavior

| Client message | New server behavior | API/state effect | Important limits |
|---|---|---|---|
| Solicit with IA_NA | Returns Advertise with the authoritative IAAddr, or IA_NA/`NoAddrsAvail` when the binding is SLAAC-only/addressless | DPU reads `host.yaml`; Controller performs `V6Solicit` discovery | Rapid Commit is ignored; no direct Reply |
| Solicit without IA_NA | Treats it as information-only and returns an options-only Advertise | DPU reads local options; Controller performs `V6InfoRequest` | Still requires ClientId |
| Request with IA_NA | Returns Reply with the authoritative IAAddr, or IA_NA/`NoAddrsAvail` | Uses `V6Request`; Controller may allocate through the API | Matching ServerId is mandatory |
| Renew with IA_NA | Returns Reply only when the client IAAddr equals the authoritative address; otherwise IA_NA/`NoBinding` | Uses `V6Request` before the returned address is compared | Matching ServerId is mandatory; missing IAAddr yields `NoBinding` |
| Rebind with IA_NA | Same address validation and `NoBinding` behavior as Renew | Uses `V6Request` before the returned address is compared | ServerId must be absent |
| Confirm | DPU returns top-level `Success` when all named addresses are on its configured prefix, `NotOnLink` otherwise; the server is silent if link membership cannot be determined | No API call and no allocation mutation | Controller has no local link authority and is silent |
| Release | Returns a top-level `Success` Reply after envelope, identity, IA_NA, and IAAddr validation | No API call; does not release an API-owned allocation | Acknowledges a validly addressed notification, not proof of an active binding |
| Decline | Returns a top-level `Success` Reply after envelope, identity, IA_NA, and IAAddr validation | No API call; does not quarantine the address | Same acknowledgement-only limitation as Release |
| Information-request without IA_NA | Returns an options-only Reply | DPU reads local options; Controller performs uncached `V6InfoRequest` | Identity-free Information-request is not supported |
| IA_TA, IA_PD, unsupported message types, inbound Relay-Reply | Rejects the packet | None | Temporary addresses, prefix delegation, and server-side Relay-Reply input are outside this milestone |

The server supports at most one IA_NA and, where a single address is required, one IAAddr. Address-less failures are associated with the client's IA_NA and IAID rather than emitted as an unrelated top-level status.

## Response contents

Stateful replies carry:

- the authoritative IPv6 address;
- configured preferred and valid lifetimes;
- T1 and T2 set to zero, leaving renewal timing to the client;
- configured IPv6 DNS servers in option 23; and
- configured IPv6 NTP servers in option 56.

The agent currently writes preferred and valid lifetimes of 3,600 and 7,200 seconds. Stateful lifetimes must both be nonzero and preferred must not exceed valid. Controller requests are rejected before an allocating API call if this configuration is invalid.

DNS and NTP options are emitted when configured; the client's Option Request Option is not used to filter them. For a trusted host/API FQDN:

- the suffix is emitted as Domain Search option 24;
- Client FQDN option 39 is emitted only if the client supplied it;
- the client's first flags byte is preserved, but its requested name is replaced by the authoritative FQDN; and
- DNS label and 255-byte total wire-name limits are enforced.

Addressless/SLAAC responses still receive DNS and NTP configuration, but do not receive a fabricated `/128`, IAAddr, or trusted host FQDN.

This branch does not provide router advertisements, a DHCPv6 default-router option, prefix delegation, temporary-address allocation, Server Unicast, Rapid Commit, MTU/boot options over DHCPv6, or a standalone lease database. SLAAC still depends on an external RA producer.

## Shared wire-decoding contract

The new `carbide-dhcpv6` crate is the policy-neutral owner of DHCPv6 decoding for both the standalone server and the existing Kea hook adapter. It accepts a direct client message or exactly one Relay-Forward envelope.

The decoder promises to reject before policy execution:

- incomplete client or relay headers and incomplete option TLVs;
- a missing or duplicate Relay Message;
- duplicate Interface-ID, Remote-ID, or client link-layer options;
- nested Relay-Forward/Relay-Reply payloads;
- any nonzero hop count in the supported single-envelope model; and
- option structures exceeding a depth of 8 or 256 total options/suboptions.

Vendor-specific child TLVs are framing-checked and resource-counted, but their private option codes and payload semantics remain opaque.

Complete DUIDs must be 3 through 130 octets. Valid Ethernet DUID-LL/LLT values can yield a MAC. Valid DUID-EN, DUID-UUID, non-Ethernet link-layer, and unregistered DUID types remain acceptable opaque identities rather than being rejected merely because a MAC cannot be extracted.

Reusing this decoder in Kea is an intentional, ledger-approved exception to the original Milestone 04 “no Kea hook changes” scope. Conforming direct and one-hop traffic retains the established Kea policy; malformed or ambiguous traffic is now handled consistently and more strictly at the shared boundary. Kea-specific policy, API mapping, logging, and drop classification remain in the Kea integration crate.

## Agent and configuration behavior

The shared DHCP configuration now carries IPv6 DNS servers, IPv6 NTP servers, an optional IPv6 server-address field, and DHCPv6 preferred/valid lifetimes. The optional server-address field is currently informational and remains unset by the agent; it neither chooses the socket address nor gates startup.

The agent's file-backed and gRPC-backed update paths now produce equivalent IPv6 DHCP data. Both paths:

- split discovered DNS and NTP addresses by family while retaining order;
- set the fixed 3,600/7,200-second DHCPv6 lifetimes; and
- translate the family-neutral V6 interface entry into `InterfaceInfo.ipv6`.

An IPv6 interface entry with an address becomes stateful. An entry with a valid IPv6 `interface_prefix` but an empty address is the explicit SLAAC-only shape. The prefix must parse as an IPv6 network. The deprecated `ipv6_interface_config` sidecar is not a supported rolling-upgrade source for this pre-production DHCPv6 path; current producers must use the family-neutral `addresses` representation.

The existing IPv4 prerequisites remain: agent-generated DHCP configuration still needs the managed-host IPv4 loopback and an IPv4 PXE address. IPv6 support does not relax those constraints.

Old serialized DHCP configuration remains deserializable because new fields have defaults. Its IPv4 behavior is preserved, but omitted DHCPv6 lifetimes default to zero, so it cannot produce a stateful DHCPv6 address response until valid lifetimes are supplied.

## NTP and DNS operational behavior

NTP precedence is evaluated independently per family:

- valid site-provided addresses replace service-discovered addresses only for the same family; and
- when a family has no valid site address, its service-discovered fallback is retained.

The production `siteConfig.ntp_servers` type is IPv4-only. In practice it can override DHCPv4 option 42 but cannot suppress or populate the IPv6 option-56 fallback.

At agent startup, service discovery resolves the exact, compiled hostname `carbide-ntp.forge` and retains all returned A and AAAA addresses. Resolution failure is nonfatal and leaves that fallback empty. These service addresses are not refreshed by a DHCP configuration reload; changing their DNS records requires the agent to rebuild them, normally by restarting the agent.

For DHCPv6 option 56 to contain the discovered fallback:

- the resolver visible to the agent must return an AAAA answer for the exact hostname its image uses;
- that IPv6 address must be reachable as an NTP endpoint by the managed host; and
- rebranded images that query `nico-ntp.nico` need that complete alternate name configured, not merely a substituted TLD.

The Unbound Helm chart now renders IPv4 `localData.addresses` as A records and IPv6 literals as AAAA records. `localData` remains empty by default.

Operational caveat: a DPF/containerized agent uses the pod's resolver and the chart sets `dnsPolicy: ClusterFirst`. Therefore, putting `carbide-ntp.forge` only in Core Unbound does not by itself guarantee that the agent can resolve it; cluster DNS must serve or forward that name to the appropriate resolver. The branch documentation currently describes DPU-agent resolution more narrowly than this runtime behavior.

## Controller API and caching behavior

Controller-mode DHCPv6 uses the existing Forge `DiscoverDhcp` API and a local 60-second LRU cache for stateful discovery. Information-only requests bypass that stateful cache so an options-only record cannot poison address-bearing lookups.

Client construction, cache work, and the Controller API operation are covered by a five-second DHCPv6 deadline. A timeout produces no response, releases the packet permit, and is classified as a `fetch_machine_error` drop. This prevents an API outage from tying up all DHCPv6 permits for the RPC client's much longer default retry policy.

The deadline bounds local waiting; it cannot guarantee rollback if the remote API committed an allocation before cancellation became visible.

## Reload, failure, and lifecycle promises

DHCPv6 listeners join the same immutable configuration generation as DHCPv4. On a changed configuration reload, the server stages the files, cancels and awaits the receive-loop tasks, promotes the staged files, and starts a new generation. An unchanged update skips the restart. `StopServer` stops the DHCP generation while leaving the gRPC control service available for a later restart.

The gRPC update response means the request was validated and queued; it does not mean the asynchronous listener transition has already completed.

IPv6 socket establishment and recreation each use ten attempts separated by two seconds and are interruptible by generation cancellation. If all attempts fail:

- that IPv6 listener becomes unavailable;
- the failure is logged and counted;
- DHCPv4 and other healthy listeners continue; and
- the failed IPv6 listener is not continuously respawned—it needs a later generation/reload to try again.

Listener supervision preserves healthy IPv4 siblings when one IPv4 interface listener exits, while logging the partial failure. When the last IPv4 listener exits, the generation is failed and its IPv6 listeners are cancelled. An IPv6 listener exit or panic remains nonfatal to IPv4.

The metrics endpoint's `/health` and `/ready` endpoints report process liveness, not DHCP serving readiness. They can remain healthy when an IPv6 listener is unavailable; operators must use the listener-unavailable metric and logs for that condition.

## Observability contract

Packet metrics are separated by address family:

- existing unsuffixed `carbide_dhcp_requests_total`, `carbide_dhcp_dropped_requests_total`, and `carbide_dhcp_replies_sent_total` remain DHCPv4-only; and
- DHCPv6 uses `carbide_dhcp_v6_requests_total`, `carbide_dhcp_v6_requests_dropped_total`, and `carbide_dhcp_v6_replies_sent_total`.

DHCPv6 requests are counted at listener ingress, before rate limiting, source port checks, identity validation, or full decoding. Drops therefore remain a subset of received traffic even for overload and malformed identities. The reply counter records successful sends, not merely encoded responses.

Drop labels use a bounded DHCPv6-specific reason vocabulary, including rate limit, invalid packet, relay nesting/hop count, identity, unsupported message, API, and send failures. Kea and the standalone server emit the same metric family, while retaining path-appropriate bounded reason mappings. Consumers must explicitly sum v4 and v6 series for a cross-family total.

`carbide_dhcp_v6_listener_unavailable_total` distinguishes initial socket setup from socket recreation failure. Successfully processed DPU-side DHCPv6 traffic also updates the existing family-neutral “last DHCP request seen” timestamp after the send attempt, including when that send fails; it is not an acknowledgement that the client received the response.

The obsolete pre-production DHCPv6 drop series was removed without an alias. This is an accepted compatibility break because DHCPv6 metrics are not yet a production-consumed contract. Existing IPv4 metric names and labels do not change.

## Compatibility promises

### DHCPv4

- DHCPv4 packet parsing, allocation, reply construction, configured listen address, and wire behavior remain on the existing path.
- IPv6 traffic does not enter the established unsuffixed IPv4 metrics.
- DHCPv4 and DHCPv6 cannot starve one another's admission permits.
- An unavailable DHCPv6 stack cannot by itself terminate DHCPv4.
- The IPv4 handler deliberately continues rejecting IPv6 prefixes until the IPv6 path reaches the separately planned parity boundary.

The branch does refine IPv4 listener supervision: partial multi-interface loss keeps healthy siblings and reload control alive, but total loss of all IPv4 listeners is no longer masked by an always-running IPv6 sibling.

### Pre-production DHCPv6

There is no promise of rolling compatibility with the deprecated IPv6 sidecar or the removed old DHCPv6 metric name. Those interfaces were not in production. Valid Kea DHCPv6 behavior is intended to remain compatible, subject to the shared decoder's explicit fail-closed hardening and broader acceptance of standards-conforming opaque DUID types.

## Explicit limits and deferred risks

The following are part of the current boundary, not hidden implementation details:

- **Identity-free Information-request remains unresolved.** The standalone server still requires ClientId even though RFC DHCPv6 permits an identity-free form. The implementation code-review ledger requires this to be called out in future reviews.
- **In-flight tasks are not generation-owned.** A detached v4 or v6 packet task can retain an old socket/configuration and send one stale response after reload or stop. The five-second Controller deadline narrows but does not eliminate this exposure.
- **An empty-interface update preserves the previous generation.** This pre-existing IPv4 lifecycle behavior now also preserves its IPv6 listeners.
- **Controller refresh is not lookup-only.** On a cold/expired cache, Renew/Rebind can reach allocating `V6Request` API behavior before the local IAAddr comparison returns `NoBinding`.
- **Release/Decline are acknowledgement-only.** They do not validate a durable lease association, release API state, or quarantine a declined address.
- **ServerId depends on IPv4 configuration.** The DUID-EN suffix is derived from `carbide_dhcp_server`; changing that IPv4 value on reload changes the DHCPv6 ServerId. Affected clients are expected to reconcile through Rebind.
- **Listener startup is unconditional and fixed-port.** There is no runtime rollout gate or configurable DHCPv6 bind address/port.
- **IPv6 listener failure is only partially self-healing.** Bounded recreation is provided after a receive error, but exhaustion requires a later reload to retry.
- **Health is not readiness.** Process health endpoints do not prove that any particular DHCP listener is active.
- **The protocol scope is deliberately narrow.** It excludes multi-hop relay chains, prefix delegation, temporary addresses, Rapid Commit, RA, durable standalone lease state, and identity-free Information-request.

## Deployment requirements and non-promises

The process or container must be able to:

- see each configured interface in its network namespace;
- bind privileged UDP port 547;
- apply `SO_BINDTODEVICE` and multicast membership on that interface;
- receive the required link/site-scoped multicast traffic; and
- pass UDP 546/547 through firewall and namespace policy.

DPU clients must be directly attached from the DHCP server's trust perspective and use source port 546. Controller relays must send one-envelope, zero-hop-count Relay-Forward traffic from source port 547. The controller does not fabricate a relay Interface-ID from the receiving interface.

This branch supplies listener and protocol behavior, not a guarantee that a particular DPF/container deployment has the required interface attachment, capabilities, multicast routing, firewall policy, or cluster-DNS forwarding. Those must be established by deployment configuration.

These changes do not promise:

  - Rapid Commit.
  - Multi-hop relay support.
  - IA_TA or prefix delegation.
  - A standalone binding database.
  - API lease release or decline quarantine from RELEASE/DECLINE.
  - Stable packet-task draining across reload. In-flight IPv4 or IPv6 tasks may still finish using the old generation.
  - A non-allocating Controller lookup for RENEW/REBIND. On a cold cache, discovery can allocate before the returned address is checked.
  - Identity-free Information-request. This remains unresolved: every standalone DHCPv6 request currently requires ClientId.
  - Pure IPv6 host configuration.
  - Runtime enablement through loopback_ip_v6 or carbide_dhcp_server_v6.


</details>