### PR TITLE
feat(health): add structured OTLP health-report attributes

### DIFF
--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -51,8 +51,12 @@ hyper-util = { workspace = true, features = [
 ] }
 mac_address = { workspace = true }
 metrics-endpoint = { path = "../metrics-endpoint" }
-opentelemetry-proto = { workspace = true, default_features = false, features = ["gen-tonic", "logs", "metrics"] }
 opentelemetry = { workspace = true }
+opentelemetry-proto = { workspace = true, default-features = false, features = [
+  "gen-tonic",
+  "logs",
+  "metrics",
+] }
 prometheus = { workspace = true }
 reqwest = { workspace = true, features = ["query", "json", "rustls"] }
 rustls = { workspace = true }

--- a/crates/health/README.md
+++ b/crates/health/README.md
@@ -1,0 +1,136 @@
+# Hardware Health Service
+
+The `carbide-health` package builds the `forge-hw-health` binary. The deployed
+component is named `nico-hardware-health`.
+
+The quickest local test runs the service against the repository's HTTPS
+Redfish simulator. The supplied configuration uses one static BMC endpoint,
+enables tracing and Prometheus output, and disables NICo API discovery and all
+health-report sinks. No NICo API server, database, or Kubernetes cluster is
+needed for this workflow.
+
+## Prerequisites
+
+- Run every command from the repository root.
+- Install `cargo` and the Rust toolchain pinned by
+  [`rust-toolchain.toml`](../../rust-toolchain.toml).
+- Make sure TCP ports `1266` and `9009` are free.
+
+The first `cargo run` builds its binary and dependencies, so it can take
+several minutes.
+
+## Run against `bmc-mock`
+
+Start the mock BMC in one terminal:
+
+```bash
+cargo run -p bmc-mock
+```
+
+Wait for the mock BMC to report that it is listening on `0.0.0.0:1266`. Access the mock BMC's logs with the following command:
+
+
+In a second terminal, start hardware health with the local-test
+configuration:
+
+```bash
+cargo run -p carbide-health --bin forge-hw-health -- \
+  crates/health/example/config.bmc-mock.toml
+```
+
+The argument after `--` is the configuration-file path. Always pass this path
+for the standalone test: running without it uses defaults that enable NICo API
+discovery and health-report sinks.
+
+To include debug logs from the hardware-health crate, set `RUST_LOG` when
+starting it:
+
+```bash
+RUST_LOG=carbide_health=debug \
+  cargo run -p carbide-health --bin forge-hw-health -- \
+  crates/health/example/config.bmc-mock.toml
+```
+
+## Verify collection
+
+Use a third terminal to query the listener on port 9009:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:9009/livez
+curl --fail --silent --show-error http://127.0.0.1:9009/metrics \
+  | rg '^carbide_'
+curl --fail --silent --show-error http://127.0.0.1:9009/telemetry \
+  | rg '^carbide_hardware_health_'
+```
+
+The expected results are:
+
+- `/livez` returns `ok`. This proves that the HTTP listener is running; it
+  does not prove that a BMC collection succeeded.
+- `/metrics` contains service-level discovery, collector, and process metrics.
+- `/telemetry` contains per-sensor gauges after the first discovery and sensor
+  collection pass. The default sensor poll interval is 60 seconds.
+
+The tracing sink is also enabled, so the hardware-health terminal shows
+endpoint discovery, collector events, and any collection errors.
+
+## Inject an unhealthy sensor
+
+`bmc-mock` supports runtime response injection. The following rule changes the
+first temperature sensor in the default mock profile to a critical reading:
+
+```bash
+curl --fail --insecure --silent --show-error \
+  --request POST \
+  --header 'content-type: application/json' \
+  --data '{
+    "id": "hot-temperature",
+    "selector": {
+      "OdataId": "/redfish/v1/Chassis/Chassis_0/Sensors/Temperature_1"
+    },
+    "action": {
+      "JsonMerge": {
+        "Reading": 100,
+        "Status": {"Health": "Critical"}
+      }
+    }
+  }' \
+  https://127.0.0.1:1266/injection/rules
+```
+
+After the next sensor poll, inspect the affected telemetry and the
+hardware-health logs:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:9009/telemetry \
+  | rg 'sensor_name="Temperature 1"'
+```
+
+Remove all injection rules to restore normal mock readings:
+
+```bash
+curl --fail --insecure --silent --show-error \
+  --request DELETE \
+  https://127.0.0.1:1266/injection/rules
+```
+
+For a faster fault-injection loop, copy
+[`config.bmc-mock.toml`](example/config.bmc-mock.toml), add this section, and
+run hardware health with the copied file:
+
+```toml
+[collectors.sensors]
+sensor_fetch_interval = "5s"
+sensor_fetch_concurrency = 4
+include_sensor_thresholds = true
+```
+
+## Stop the test
+
+Press Ctrl-C in the hardware-health terminal and then in the `bmc-mock`
+terminal. Mock injection rules are held in memory and are discarded when
+`bmc-mock` exits.
+
+For the complete configuration surface, including real BMC endpoints,
+additional collectors, OTLP, and NICo API sinks, see
+[`config.example.toml`](example/config.example.toml).

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -116,10 +116,10 @@ flush_interval = "2s"
 # latest-wins per endpoint while the drain is backed up.
 include_diagnostics = false
 
-# Include per-alert detail on health report records for this target. Health
-# report records otherwise carry only alert and success counts. When enabled,
-# each record with alerts gains a `health_report.alerts` attribute holding a
-# JSON array of up to 64 alerts; a truncated record also carries
+# Include per-alert detail on health report records for this target. Records
+# otherwise carry routing fields, counts, and structured successes without the
+# alert attributes. When enabled, each record with alerts carries the first 64
+# alerts in report order; only a report with more than 64 alerts also carries
 # `health_report.alerts.dropped` with the number omitted.
 include_alert_details = false
 #

--- a/crates/health/src/otlp/convert.rs
+++ b/crates/health/src/otlp/convert.rs
@@ -18,12 +18,14 @@
 use std::collections::HashMap;
 use std::time::SystemTime;
 
-use opentelemetry::{Key, Value};
+use opentelemetry::logs::AnyValue;
+use opentelemetry::{Key, KeyValue};
+use opentelemetry_proto::transform::common::tonic::Attributes;
 use serde::Serialize;
 
 use super::collector_logs::ExportLogsServiceRequest;
 use super::collector_metrics::ExportMetricsServiceRequest;
-use super::common::{AnyValue, KeyValue};
+use super::common::KeyValue as OtlpKeyValue;
 use super::logs::{LogRecord as OtlpLogRecord, ResourceLogs, ScopeLogs, SeverityNumber};
 use super::metrics::{
     Gauge as OtlpGauge, Metric as OtlpMetric, NumberDataPoint, ResourceMetrics, ScopeMetrics,
@@ -31,7 +33,10 @@ use super::metrics::{
 };
 use super::resource::Resource;
 use crate::endpoint::SwitchEndpointRole;
-use crate::sink::{CollectorEvent, EventContext, HealthReportAlert, MetricSample};
+use crate::sink::{
+    CollectorEvent, EventContext, HealthReport, HealthReportAlert, HealthReportSuccess,
+    MetricSample,
+};
 
 /// Maximum alerts serialized into the `health_report.alerts` attribute.
 ///
@@ -40,6 +45,17 @@ use crate::sink::{CollectorEvent, EventContext, HealthReportAlert, MetricSample}
 /// which the drain retries before dropping the whole batch. Truncating here
 /// keeps one degraded endpoint from taking unrelated records down with it.
 const MAX_SERIALIZED_ALERTS: usize = 64;
+
+const HEALTH_REPORT_SCHEMA_VERSION: &str = "v1";
+const HEALTH_REPORT_SCHEMA_VERSION_KEY: &str = "health_report.schema_version";
+const HEALTH_REPORT_SOURCE_KEY: &str = "health_report.source";
+const HEALTH_REPORT_TARGET_KEY: &str = "health_report.target";
+const HEALTH_REPORT_OBSERVED_AT_KEY: &str = "health_report.observed_at";
+const HEALTH_REPORT_SUCCESS_COUNT_KEY: &str = "health_report.success_count";
+const HEALTH_REPORT_ALERT_COUNT_KEY: &str = "health_report.alert_count";
+const HEALTH_REPORT_SUCCESSES_KEY: &str = "health_report.successes";
+const HEALTH_REPORT_SUCCESS_PROBE_ID_KEY: &str = "probe_id";
+const HEALTH_REPORT_SUCCESS_TARGET_KEY: &str = "target";
 
 fn severity_text_to_number(severity: &str) -> i32 {
     match severity.to_uppercase().as_str() {
@@ -55,6 +71,14 @@ fn severity_text_to_number(severity: &str) -> i32 {
 
 fn resource_group_key(context: &EventContext) -> String {
     format!("{}|{}", context.endpoint_key, context.collector_type)
+}
+
+/// Lowers [`KeyValue`] attributes onto the wire.
+///
+/// [`Attributes`] is opentelemetry-proto's newtype over the OTLP attribute list;
+/// it owns the [`KeyValue`] conversion, so this only unwraps it.
+fn otlp_attributes(attributes: impl IntoIterator<Item = KeyValue>) -> Vec<OtlpKeyValue> {
+    Attributes::from(attributes).0
 }
 
 fn resource_attributes(context: &EventContext) -> Vec<KeyValue> {
@@ -135,18 +159,91 @@ fn convert_log(log: &crate::sink::LogRecord, observed_nanos: u64) -> OtlpLogReco
     let attributes = log
         .attributes
         .iter()
-        .map(|(k, v)| KeyValue::new(k.to_string(), v.clone()))
-        .collect();
+        .map(|(k, v)| KeyValue::new(k.to_string(), v.clone()));
 
     OtlpLogRecord {
         time_unix_nano: observed_nanos,
         observed_time_unix_nano: observed_nanos,
         severity_number: severity_text_to_number(&log.severity),
         severity_text: log.severity.clone(),
-        body: Some(log.body.clone().into_any_value()),
-        attributes,
+        body: Some(AnyValue::from(log.body.clone()).into()),
+        attributes: otlp_attributes(attributes),
         ..Default::default()
     }
+}
+
+/// One passing probe, as a nested kvlist under `health_report.successes`.
+fn health_report_success_value(success: &HealthReportSuccess) -> AnyValue {
+    let mut entries = HashMap::from([(
+        Key::from_static_str(HEALTH_REPORT_SUCCESS_PROBE_ID_KEY),
+        AnyValue::from(success.probe_id.as_str()),
+    )]);
+    if let Some(target) = &success.target {
+        entries.insert(
+            Key::from_static_str(HEALTH_REPORT_SUCCESS_TARGET_KEY),
+            AnyValue::from(target.clone()),
+        );
+    }
+
+    AnyValue::Map(Box::new(entries))
+}
+
+/// The versioned `health_report.*` attribute contract.
+///
+/// Scalar routing fields let a consumer filter without parsing the summary body;
+/// `health_report.successes` carries the passing probes as nested kvlists.
+fn health_report_attributes(report: &HealthReport) -> Vec<(&'static str, AnyValue)> {
+    let successes = report
+        .successes
+        .iter()
+        .map(health_report_success_value)
+        .collect();
+
+    let mut attributes = vec![
+        ("event.type", AnyValue::from("health_report")),
+        (
+            HEALTH_REPORT_SCHEMA_VERSION_KEY,
+            AnyValue::from(HEALTH_REPORT_SCHEMA_VERSION),
+        ),
+        (
+            HEALTH_REPORT_SOURCE_KEY,
+            AnyValue::from(report.source.as_str()),
+        ),
+        (
+            HEALTH_REPORT_SUCCESS_COUNT_KEY,
+            AnyValue::from(i64::try_from(report.successes.len()).unwrap_or(i64::MAX)),
+        ),
+        (
+            HEALTH_REPORT_ALERT_COUNT_KEY,
+            AnyValue::from(i64::try_from(report.alerts.len()).unwrap_or(i64::MAX)),
+        ),
+        (
+            HEALTH_REPORT_SUCCESSES_KEY,
+            AnyValue::ListAny(Box::new(successes)),
+        ),
+    ];
+    if let Some(target) = report.target {
+        attributes.push((HEALTH_REPORT_TARGET_KEY, AnyValue::from(target.as_str())));
+    }
+    if let Some(observed_at) = &report.observed_at {
+        attributes.push((
+            HEALTH_REPORT_OBSERVED_AT_KEY,
+            AnyValue::from(observed_at.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)),
+        ));
+    }
+
+    attributes
+}
+
+/// When the report was observed, falling back to the export time for reports
+/// without an observation time or dated before the Unix epoch.
+fn health_report_event_time(report: &HealthReport, fallback_nanos: u64) -> u64 {
+    report
+        .observed_at
+        .as_ref()
+        .and_then(chrono::DateTime::timestamp_nanos_opt)
+        .and_then(|nanos| u64::try_from(nanos).ok())
+        .unwrap_or(fallback_nanos)
 }
 
 /// Alert detail as it appears inside the `health_report.alerts` JSON array.
@@ -168,7 +265,7 @@ struct AlertDetail<'a> {
 ///
 /// Returns no attributes when serialization fails so a malformed report costs
 /// only the detail, not the record.
-fn alert_detail_attributes(alerts: &[HealthReportAlert]) -> Vec<KeyValue> {
+fn alert_detail_attributes(alerts: &[HealthReportAlert]) -> Vec<(&'static str, AnyValue)> {
     let details: Vec<AlertDetail<'_>> = alerts
         .iter()
         .take(MAX_SERIALIZED_ALERTS)
@@ -197,13 +294,13 @@ fn alert_detail_attributes(alerts: &[HealthReportAlert]) -> Vec<KeyValue> {
         }
     };
 
-    let mut attributes = vec![KeyValue::new("health_report.alerts", json)];
+    let mut attributes = vec![("health_report.alerts", AnyValue::from(json))];
     let dropped = alerts.len().saturating_sub(MAX_SERIALIZED_ALERTS);
 
     if dropped > 0 {
-        attributes.push(KeyValue::new(
+        attributes.push((
             "health_report.alerts.dropped",
-            i64::try_from(dropped).unwrap_or(i64::MAX),
+            AnyValue::from(i64::try_from(dropped).unwrap_or(i64::MAX)),
         ));
     }
 
@@ -230,19 +327,20 @@ fn convert_event(
                 "WARN"
             };
 
-            let mut attributes = vec![KeyValue::new("event.type", "health_report".to_string())];
+            let mut attributes = health_report_attributes(report);
 
             if include_alert_details && !report.alerts.is_empty() {
                 attributes.extend(alert_detail_attributes(&report.alerts));
             }
 
             Some(OtlpLogRecord {
-                time_unix_nano: observed_nanos,
+                time_unix_nano: health_report_event_time(report, observed_nanos),
                 observed_time_unix_nano: observed_nanos,
                 severity_number: severity_text_to_number(severity),
                 severity_text: severity.to_string(),
-                body: Some(body.into_any_value()),
-                attributes,
+                body: Some(AnyValue::from(body).into()),
+
+                attributes: attributes.into_iter().collect::<Attributes>().0,
                 ..Default::default()
             })
         }
@@ -253,8 +351,8 @@ fn convert_event(
                 observed_time_unix_nano: observed_nanos,
                 severity_number: SeverityNumber::Info as i32,
                 severity_text: "INFO".to_string(),
-                body: Some(body.into_any_value()),
-                attributes: vec![KeyValue::new("event.type", "firmware".to_string())],
+                body: Some(AnyValue::from(body).into()),
+                attributes: otlp_attributes([KeyValue::new("event.type", "firmware")]),
                 ..Default::default()
             })
         }
@@ -295,9 +393,8 @@ pub fn build_export_request(
         .into_values()
         .map(|(attrs, records)| ResourceLogs {
             resource: Some(Resource {
-                attributes: attrs,
-                dropped_attributes_count: 0,
-                entity_refs: vec![],
+                attributes: otlp_attributes(attrs),
+                ..Default::default()
             }),
             scope_logs: vec![ScopeLogs {
                 scope: None,
@@ -331,14 +428,13 @@ pub fn build_metrics_export_request(
         // switch.serial_number, switch.ip). VictoriaMetrics flattens resource
         // attributes onto every series, so promoting them onto the datapoint too
         // only duplicates the same value under a second (underscore) label name.
-        let attributes: Vec<KeyValue> = sample
+        let attributes = sample
             .labels
             .iter()
-            .map(|(k, v)| KeyValue::new(k.to_string(), v.clone()))
-            .collect();
+            .map(|(k, v)| KeyValue::new(k.to_string(), v.clone()));
 
         let data_point = NumberDataPoint {
-            attributes,
+            attributes: otlp_attributes(attributes),
             time_unix_nano: observed_nanos,
             value: Some(number_data_point::Value::AsDouble(sample.value)),
             ..Default::default()
@@ -370,9 +466,8 @@ pub fn build_metrics_export_request(
         .into_values()
         .map(|(attrs, metrics)| ResourceMetrics {
             resource: Some(Resource {
-                attributes: attrs,
-                dropped_attributes_count: 0,
-                entity_refs: vec![],
+                attributes: otlp_attributes(attrs),
+                ..Default::default()
             }),
             scope_metrics: vec![ScopeMetrics {
                 scope: None,
@@ -386,63 +481,29 @@ pub fn build_metrics_export_request(
     ExportMetricsServiceRequest { resource_metrics }
 }
 
-/// Convenience trait to make opentelemetry-proto's AnyValue easier to work with
-///
-/// opentelemetry-proto's [`AnyValue`] implements `From` from [`opentelemetry::Value`], but it's
-/// opentelemetry::Value tself that has multiple convenient `From` impls for things like String,
-/// u32, etc. So convert first through [`opentelemetry::Value`], then into opentelemetry_proto's
-/// [`AnyValue`].
-trait IntoAnyValue {
-    fn into_any_value(self) -> AnyValue;
-}
-
-impl<T> IntoAnyValue for T
-where
-    T: Into<Value>,
-{
-    fn into_any_value(self) -> AnyValue {
-        AnyValue::from(self.into())
-    }
-}
-
-/// Convenience trait: A `new` function for opentelemetry_proto's [`KeyValue`], leveraging
-/// [`opentelemetry::Key`] and [`opentelemetry::Value`]'s existing `From` implementations to make
-/// constructing KeyValues easier.
-/// convert to an opentelemetry_proto [`AnyValue`]
-trait NewFromKeyAndValue {
-    fn new(key: impl Into<Key>, value: impl Into<Value>) -> Self;
-}
-
-impl NewFromKeyAndValue for KeyValue {
-    fn new(key: impl Into<Key>, value: impl Into<Value>) -> Self {
-        KeyValue {
-            key: key.into().to_string(),
-            value: Some(AnyValue::from(value.into())),
-            key_strindex: 0,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
     use std::net::{IpAddr, Ipv4Addr};
     use std::str::FromStr;
 
+    use carbide_test_support::value_scenarios;
     use carbide_uuid::nvlink::NvLinkDomainId;
     use carbide_uuid::power_shelf::PowerShelfId;
     use carbide_uuid::rack::RackId;
     use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
+    use chrono::{TimeZone, Utc};
     use mac_address::MacAddress;
-    use opentelemetry_proto::tonic::common::v1::any_value;
 
     use super::*;
     use crate::endpoint::{
         BmcAddr, EndpointMetadata, MachineData, PowerShelfData, SharedSystemUuid, SwitchData,
         SwitchEndpointRole,
     };
+    use crate::otlp::common::{AnyValue as OtlpAnyValue, any_value};
     use crate::sink::{
-        Classification, HealthReport, HealthReportAlert, LogRecord, Probe, ReportSource,
+        Classification, HealthReport, HealthReportAlert, HealthReportSuccess, HealthReportTarget,
+        LogRecord, Probe, ReportSource,
     };
 
     fn test_context() -> EventContext {
@@ -467,7 +528,13 @@ mod tests {
         SwitchId::new(SwitchIdSource::Tpm, hash, SwitchType::NvLink)
     }
 
-    fn attr_value<'a>(attrs: &'a [KeyValue], key: &str) -> Option<&'a str> {
+    /// Resource attributes as an export carries them, so assertions read the
+    /// same wire form the collector receives.
+    fn otlp_resource_attributes(context: &EventContext) -> Vec<OtlpKeyValue> {
+        otlp_attributes(resource_attributes(context))
+    }
+
+    fn attr_value<'a>(attrs: &'a [OtlpKeyValue], key: &str) -> Option<&'a str> {
         attrs
             .iter()
             .find(|attr| attr.key == key)
@@ -478,7 +545,7 @@ mod tests {
             })
     }
 
-    fn attr_int_value(attrs: &[KeyValue], key: &str) -> Option<i64> {
+    fn attr_int_value(attrs: &[OtlpKeyValue], key: &str) -> Option<i64> {
         attrs
             .iter()
             .find(|attr| attr.key == key)
@@ -489,7 +556,7 @@ mod tests {
             })
     }
 
-    fn attr_bool_value(attrs: &[KeyValue], key: &str) -> Option<bool> {
+    fn attr_bool_value(attrs: &[OtlpKeyValue], key: &str) -> Option<bool> {
         attrs
             .iter()
             .find(|attr| attr.key == key)
@@ -498,6 +565,37 @@ mod tests {
                 any_value::Value::BoolValue(value) => Some(*value),
                 _ => None,
             })
+    }
+
+    /// The record's body when it is a string, the only body shape the health
+    /// crate emits.
+    fn body_value(record: &OtlpLogRecord) -> Option<&str> {
+        match record.body.as_ref()?.value.as_ref()? {
+            any_value::Value::StringValue(value) => Some(value.as_str()),
+            _ => None,
+        }
+    }
+
+    fn any_array_value(value: &OtlpAnyValue) -> Option<&[OtlpAnyValue]> {
+        match value.value.as_ref()? {
+            any_value::Value::ArrayValue(value) => Some(value.values.as_slice()),
+            _ => None,
+        }
+    }
+
+    fn any_kvlist_value(value: &OtlpAnyValue) -> Option<&[OtlpKeyValue]> {
+        match value.value.as_ref()? {
+            any_value::Value::KvlistValue(value) => Some(value.values.as_slice()),
+            _ => None,
+        }
+    }
+
+    fn attr_array_value<'a>(attrs: &'a [OtlpKeyValue], key: &str) -> Option<&'a [OtlpAnyValue]> {
+        attrs
+            .iter()
+            .find(|attr| attr.key == key)
+            .and_then(|attr| attr.value.as_ref())
+            .and_then(any_array_value)
     }
 
     #[test]
@@ -531,7 +629,7 @@ mod tests {
             rack_id: Some(RackId::new("RACK_1")),
         };
 
-        let attrs = resource_attributes(&context);
+        let attrs = otlp_resource_attributes(&context);
 
         assert_eq!(attr_value(&attrs, "rack.id"), Some("RACK_1"));
         assert_eq!(attr_value(&attrs, "site"), Some("rno-dev7"));
@@ -574,7 +672,7 @@ mod tests {
             rack_id: None,
         };
 
-        let attrs = resource_attributes(&context);
+        let attrs = otlp_resource_attributes(&context);
 
         assert_eq!(attr_value(&attrs, "machine.id"), None);
         assert_eq!(attr_value(&attrs, "component.type"), Some("compute_node"));
@@ -614,7 +712,7 @@ mod tests {
             rack_id: Some(RackId::new("RACK_2")),
         };
 
-        let attrs = resource_attributes(&context);
+        let attrs = otlp_resource_attributes(&context);
 
         assert_eq!(
             attr_value(&attrs, "switch.id"),
@@ -658,7 +756,7 @@ mod tests {
             rack_id: Some(RackId::new("RACK_2")),
         };
 
-        let attrs = resource_attributes(&context);
+        let attrs = otlp_resource_attributes(&context);
 
         assert_eq!(attr_value(&attrs, "bmc.endpoint"), None);
         assert_eq!(attr_value(&attrs, "bmc.ip"), None);
@@ -827,7 +925,7 @@ mod tests {
             rack_id: Some(RackId::new("RACK_4")),
         };
 
-        let attrs = resource_attributes(&context);
+        let attrs = otlp_resource_attributes(&context);
 
         assert_eq!(attr_value(&attrs, "component.type"), Some("power_shelf"));
         assert_eq!(attr_value(&attrs, "rack.id"), Some("RACK_4"));
@@ -885,7 +983,7 @@ mod tests {
         let records = &request.resource_logs[0].scope_logs[0].log_records;
         let record = &records[0];
 
-        assert_eq!(record.body, Some(body.into_any_value()));
+        assert_eq!(body_value(record), Some(body));
         assert_eq!(
             attr_value(&record.attributes, "redfish.diagnostic_data.type"),
             Some("cper")
@@ -905,6 +1003,34 @@ mod tests {
         ];
         let request = build_export_request(&batch, false);
         assert!(request.resource_logs.is_empty());
+    }
+
+    #[test]
+    fn health_report_attribute_keys_are_stable() {
+        assert_eq!(
+            [
+                HEALTH_REPORT_SCHEMA_VERSION_KEY,
+                HEALTH_REPORT_SOURCE_KEY,
+                HEALTH_REPORT_TARGET_KEY,
+                HEALTH_REPORT_OBSERVED_AT_KEY,
+                HEALTH_REPORT_SUCCESS_COUNT_KEY,
+                HEALTH_REPORT_ALERT_COUNT_KEY,
+                HEALTH_REPORT_SUCCESSES_KEY,
+                HEALTH_REPORT_SUCCESS_PROBE_ID_KEY,
+                HEALTH_REPORT_SUCCESS_TARGET_KEY,
+            ],
+            [
+                "health_report.schema_version",
+                "health_report.source",
+                "health_report.target",
+                "health_report.observed_at",
+                "health_report.success_count",
+                "health_report.alert_count",
+                "health_report.successes",
+                "probe_id",
+                "target",
+            ]
+        );
     }
 
     fn sensor_alert() -> HealthReportAlert {
@@ -954,15 +1080,28 @@ mod tests {
         assert_eq!(record.severity_text, "WARN");
     }
 
-    /// Guards the flag-off record against any change from the alert detail work.
+    /// Guards the per-target policy: scalar evidence remains available while
+    /// free-form alert detail stays absent when the flag is disabled.
     #[test]
     fn health_report_omits_alert_details_when_disabled() {
         let record = health_report_record(vec![sensor_alert()], false);
 
-        assert_eq!(record.attributes.len(), 1);
         assert_eq!(
             attr_value(&record.attributes, "event.type"),
             Some("health_report")
+        );
+        assert_eq!(
+            attr_value(&record.attributes, HEALTH_REPORT_SCHEMA_VERSION_KEY),
+            Some("v1")
+        );
+        assert_eq!(
+            attr_int_value(&record.attributes, HEALTH_REPORT_ALERT_COUNT_KEY),
+            Some(1)
+        );
+        assert_eq!(attr_value(&record.attributes, "health_report.alerts"), None);
+        assert_eq!(
+            attr_int_value(&record.attributes, "health_report.alerts.dropped"),
+            None
         );
     }
 
@@ -987,8 +1126,8 @@ mod tests {
         assert_eq!(record.severity_text, "WARN");
         assert_eq!(record.severity_number, SeverityNumber::Warn as i32);
         assert_eq!(
-            record.body,
-            Some("health report: 2 alerts, 0 ok (source: BmcSensors)".into_any_value())
+            body_value(&record),
+            Some("health report: 2 alerts, 0 ok (source: BmcSensors)")
         );
         assert_eq!(
             attr_value(&record.attributes, "event.type"),
@@ -1030,8 +1169,11 @@ mod tests {
     fn health_report_without_alerts_omits_alert_details() {
         let record = health_report_record(vec![], true);
 
-        assert_eq!(record.attributes.len(), 1);
         assert_eq!(attr_value(&record.attributes, "health_report.alerts"), None);
+        assert_eq!(
+            attr_int_value(&record.attributes, HEALTH_REPORT_ALERT_COUNT_KEY),
+            Some(0)
+        );
     }
 
     #[test]
@@ -1068,6 +1210,167 @@ mod tests {
         assert_eq!(
             attr_int_value(&record.attributes, "health_report.alerts.dropped"),
             Some(3)
+        );
+    }
+
+    #[test]
+    fn health_report_converts_with_structured_evidence() {
+        let ctx = test_context();
+        let observed_at = Utc
+            .with_ymd_and_hms(2026, 7, 31, 12, 34, 56)
+            .single()
+            .expect("valid timestamp");
+        let report = CollectorEvent::HealthReport(
+            HealthReport {
+                source: ReportSource::NvueLeakage,
+                target: Some(HealthReportTarget::Switch),
+                observed_at: Some(observed_at),
+                successes: vec![HealthReportSuccess {
+                    probe_id: Probe::NvueLeakage,
+                    target: Some("LEAK1".to_string()),
+                }],
+                alerts: vec![HealthReportAlert {
+                    probe_id: Probe::NvueLeakage,
+                    target: Some("LEAK2".to_string()),
+                    message: "NVUE leakage sensor LEAK2 reports leak".to_string(),
+                    classifications: vec![Classification::Leak, Classification::SensorFailure],
+                }],
+            }
+            .into(),
+        );
+
+        let request = build_export_request(&[(ctx, report)], true);
+        let records = &request.resource_logs[0].scope_logs[0].log_records;
+        let record = &records[0];
+        let attrs = record.attributes.as_slice();
+
+        assert_eq!(record.severity_text, "WARN");
+        assert_eq!(
+            body_value(record),
+            Some("health report: 1 alerts, 1 ok (source: NvueLeakage)")
+        );
+        assert_eq!(attr_value(attrs, "event.type"), Some("health_report"));
+        assert_eq!(
+            record.time_unix_nano,
+            u64::try_from(
+                observed_at
+                    .timestamp_nanos_opt()
+                    .expect("timestamp has nanoseconds")
+            )
+            .expect("timestamp is after the Unix epoch")
+        );
+        assert_eq!(
+            attr_value(attrs, HEALTH_REPORT_SCHEMA_VERSION_KEY),
+            Some("v1")
+        );
+        assert_eq!(
+            attr_value(attrs, HEALTH_REPORT_SOURCE_KEY),
+            Some("nvue-leakage")
+        );
+        assert_eq!(attr_value(attrs, HEALTH_REPORT_TARGET_KEY), Some("switch"));
+        assert_eq!(
+            attr_value(attrs, HEALTH_REPORT_OBSERVED_AT_KEY),
+            Some("2026-07-31T12:34:56.000000000Z")
+        );
+        assert_eq!(
+            attr_int_value(attrs, HEALTH_REPORT_SUCCESS_COUNT_KEY),
+            Some(1)
+        );
+        assert_eq!(
+            attr_int_value(attrs, HEALTH_REPORT_ALERT_COUNT_KEY),
+            Some(1)
+        );
+
+        let successes =
+            attr_array_value(attrs, HEALTH_REPORT_SUCCESSES_KEY).expect("success array");
+        let success = any_kvlist_value(&successes[0]).expect("structured success");
+        assert_eq!(
+            attr_value(success, HEALTH_REPORT_SUCCESS_PROBE_ID_KEY),
+            Some("NvueLeakage")
+        );
+        assert_eq!(
+            attr_value(success, HEALTH_REPORT_SUCCESS_TARGET_KEY),
+            Some("LEAK1")
+        );
+
+        let alerts = alert_details(record);
+        let alert = &alerts[0];
+        assert_eq!(alert["probe_id"], "NvueLeakage");
+        assert_eq!(alert["target"], "LEAK2");
+        assert_eq!(alert["message"], "NVUE leakage sensor LEAK2 reports leak");
+        assert_eq!(
+            alert["classifications"],
+            serde_json::json!(["Leak", "SensorFailure"])
+        );
+        assert_eq!(attr_int_value(attrs, "health_report.alerts.dropped"), None);
+    }
+
+    /// Export timestamp handed to `convert_event` so timestamp expectations stay
+    /// independent of the wall clock.
+    const EXPORT_NANOS: u64 = 1_784_500_000_000_000_000;
+
+    #[derive(Debug, PartialEq)]
+    struct RecordTimestamps {
+        time_unix_nano: u64,
+        observed_time_unix_nano: u64,
+    }
+
+    fn health_report_timestamps(observed_at: Option<chrono::DateTime<Utc>>) -> RecordTimestamps {
+        let event = CollectorEvent::HealthReport(
+            HealthReport {
+                source: ReportSource::BmcSensors,
+                target: Some(HealthReportTarget::Machine),
+                observed_at,
+                successes: vec![HealthReportSuccess {
+                    probe_id: Probe::Sensor,
+                    target: Some("Temp1".to_string()),
+                }],
+                alerts: vec![],
+            }
+            .into(),
+        );
+        let record = convert_event(&event, EXPORT_NANOS, false).expect("health report converts");
+
+        RecordTimestamps {
+            time_unix_nano: record.time_unix_nano,
+            observed_time_unix_nano: record.observed_time_unix_nano,
+        }
+    }
+
+    #[test]
+    fn health_report_event_time_prefers_the_observation_time() {
+        let observed_at = Utc
+            .with_ymd_and_hms(2026, 7, 31, 12, 34, 56)
+            .single()
+            .expect("valid timestamp");
+        let observed_nanos = u64::try_from(
+            observed_at
+                .timestamp_nanos_opt()
+                .expect("timestamp has nanoseconds"),
+        )
+        .expect("timestamp is after the Unix epoch");
+
+        value_scenarios!(health_report_timestamps:
+            "observation time present" {
+                Some(observed_at) => RecordTimestamps {
+                    time_unix_nano: observed_nanos,
+                    observed_time_unix_nano: EXPORT_NANOS,
+                },
+            }
+
+            "observation time absent" {
+                None => RecordTimestamps {
+                    time_unix_nano: EXPORT_NANOS,
+                    observed_time_unix_nano: EXPORT_NANOS,
+                },
+            }
+
+            "observation time before the Unix epoch" {
+                Utc.with_ymd_and_hms(1969, 12, 31, 23, 59, 59).single() => RecordTimestamps {
+                    time_unix_nano: EXPORT_NANOS,
+                    observed_time_unix_nano: EXPORT_NANOS,
+                },
+            }
         );
     }
 

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -42,6 +42,17 @@ pub enum HealthReportTarget {
     Switch,
 }
 
+impl HealthReportTarget {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Machine => "machine",
+            Self::PowerShelf => "power-shelf",
+            Self::Rack => "rack",
+            Self::Switch => "switch",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct EventContext {
     pub endpoint_key: String,
@@ -862,6 +873,28 @@ mod tests {
 
             "GPU inventory" {
                 ReportSource::GpuInventory => "gpu-inventory",
+            }
+        );
+    }
+
+    #[test]
+    fn report_target_strings() {
+        value_scenarios!(
+            run = HealthReportTarget::as_str;
+            "machine" {
+                HealthReportTarget::Machine => "machine",
+            }
+
+            "power shelf" {
+                HealthReportTarget::PowerShelf => "power-shelf",
+            }
+
+            "rack" {
+                HealthReportTarget::Rack => "rack",
+            }
+
+            "switch" {
+                HealthReportTarget::Switch => "switch",
             }
         );
     }

--- a/docs/architecture/health_aggregation.md
+++ b/docs/architecture/health_aggregation.md
@@ -284,6 +284,56 @@ The publishing sinks expose that inventory context using the conventions of the 
 - `[sinks.otlp]` adds the string resource attributes `collector.type` and either `bmc.endpoint` and `bmc.ip`, or `switch.endpoint` and `switch.ip` for host-side switch collection. Typed inventory adds the strings `component.type` and, when present, `rack.id`. _Machine_ metadata attributes are the strings `machine.id`, `system.uuid`, `machine.serial`, `driver.version`, and `nvlink.domain.uuid`, plus the integers `machine.slot_number` and `machine.tray_index`. _Switch_ metadata attributes are the strings `switch.id`, `switch.serial_number`, `switch.endpoint_role`, and `nvlink.domain.uuid`, the boolean `switch.is_primary`, and the integers `switch.slot_number` and `switch.tray_index`. Static endpoint custom labels are string resource attributes and keep their configured names.
 - `[sinks.health_report]`, `[sinks.rack_health_report]`, `[sinks.switch_health_report]`, and `[sinks.power_shelf_health_report]` use the same event context when submitting assessed health reports back to NICo API. The persisted `HealthReport` and `HealthProbeAlert` schemas remain the probe success/alert model described above.
 
+#### OTLP health-report log contract
+
+OTLP health-report logs keep the existing human-readable summary body and add a
+versioned structured attribute contract. Match `health_report.schema_version`
+against `v1` before decoding `health_report.successes`. Per-alert detail keeps
+the existing opt-in JSON representation controlled by the target's
+`include_alert_details` setting, which defaults to `false`; consequently,
+`health_report.alerts` and `health_report.alerts.dropped` are absent unless
+details are enabled. If the schema version is missing or unsupported, consumers
+retain the human-readable summary body, ignore the structured `health_report.*`
+attributes, and do not reject the record. This fallback emits no warning. 
+Additional fields may be present besides the minimum ones listed below.
+
+| Attribute | OTLP type | Presence | Value |
+| --------- | --------- | -------- | ----- |
+| `event.type` | string | Always | Always `health_report`. |
+| `health_report.alerts` | string | Conditional | JSON array containing the first 64 alert objects in report order. Present only when `include_alert_details = true` and the report has alerts. |
+| `health_report.alerts.dropped` | int | Conditional | Number of alerts after the first 64 that were omitted from `health_report.alerts`; present only when details are enabled and the report has more than 64 alerts. |
+| `health_report.alert_count` | `int_value` (signed 64-bit) | Always | Number of alerts in the report, including any omitted from `health_report.alerts`, bounded to `0..=i64::MAX`. |
+| `health_report.observed_at` | string | Optional | Observation time as RFC 3339 UTC with nanosecond precision, for example `2026-07-31T12:34:56.000000000Z`. Omitted when the report carries no observation time. |
+| `health_report.schema_version` | string | Always | `v1` for the contract documented here. |
+| `health_report.source` | string | Always | The collector that assessed the report: `bmc-sensors`, `bmc-events`, `bmc-leak-detectors`, `tray-leak-detection`, `rack-leak-detection`, `nvue-leakage`, or `gpu-inventory`. |
+| `health_report.success_count` | `int_value` (signed 64-bit) | Always | Number of entries in `health_report.successes`, bounded to `0..=i64::MAX`. |
+| `health_report.successes` | array of `kvlist` | Always | One entry per succeeded probe, empty when the report has none. |
+| `health_report.target` | string | Optional | The kind of inventory object assessed: `machine`, `power-shelf`, `rack`, or `switch`. Omitted when the report names no target. |
+
+`health_report.success_count` equals the length of `health_report.successes`
+while that length is representable as `i64`, and otherwise saturates at
+`i64::MAX`. `health_report.alert_count` applies the same bound and is available
+regardless of the alert-detail setting. For representable counts, when
+`health_report.alerts` is present, the alert count equals the JSON array length
+plus `health_report.alerts.dropped`, treating an absent dropped count as zero.
+
+Every `health_report.successes` entry carries at least these fields:
+
+| Field | OTLP type | Presence | Value |
+| --------- | --------- | -------- | ----- |
+| `probe_id` | string | Always | The probe that ran: `BmcSensor`, `IntrusionSensorTriggered`, `BmcLeakDetection`, `NvueLeakage`, or `SkuValidation`. See [Health probe IDs](health/health_probe_ids.md) for the shared probe-ID catalogue. |
+| `target` | string | Optional | The probed component, such as a sensor or leak-detector ID. Omitted when the probe ID fully describes what was tested. |
+
+When `health_report.alerts` is present, every JSON object carries the same
+`probe_id` and optional `target` fields, plus at least these fields:
+
+| Field | JSON type | Presence | Value |
+| --------- | --------- | -------- | ----- |
+| `message` | string | Always | Human-readable description of the alert. |
+| `classifications` | array of string | Always | Zero or more of `SensorOk`, `SensorWarning`, `SensorCritical`, `SensorFatal`, `SensorFailure`, `PreventAllocations`, `Leak`, and `LeakDetector`. Refer to [Health alert classifications](health/health_alert_classifications.md) for the classifications NICo interprets. Unlike reports for the NICo API, this array carries only the classifications the collector raised, without the `Hardware` marker. |
+
+The two record timestamps are set by different clocks. `time_unix_nano` is never zero: it is the report's own observation time if it is representable as Unix nanoseconds, and otherwise the export time. `observed_time_unix_nano` is always the export time. These keep export order recoverable for reports whose observation time is older or absent.
+
 ### BMC inventory monitoring
 
 The Site Explorer process within NICo Core periodically queries all Host and DPU BMCs in order to record certain BMC properties (e.g. components within a host and firmware versions).

--- a/docs/operations/monitoring-health.md
+++ b/docs/operations/monitoring-health.md
@@ -271,16 +271,19 @@ For leak-related events, look for:
 report_source=tray-leak-detection
 ```
 
-Health report records exported over OTLP carry only these counts by default.
-Setting `include_alert_details = true` on a `[[sinks.otlp.targets]]` entry adds
-a `health_report.alerts` attribute holding a JSON array of the individual
-alerts, each with `probe_id`, `message`, `classifications`, and `target` when
-the alert names one. The setting is per target, so a debugging destination can
-receive detail while a long-term store receives only counts. At most 64 alerts
-are serialized per record; a truncated record also carries
-`health_report.alerts.dropped` with the number omitted. Note that `probe_id`
-uses health API probe names, so OOB GPU inventory alerts appear as
-`SkuValidation` to dedup with the in-band SKU alerts.
+Health report records exported over OTLP carry versioned routing fields, counts, and structured success entries by default. Refer to the [OTLP health-report log contract](../architecture/health_aggregation.md#otlp-health-report-log-contract) for the complete attribute schema.
+
+Keep the following in mind when configuring health report records:
+
+* The per-target `include_alert_details` setting defaults to `false`. This omits `health_report.alerts` and `health_report.alerts.dropped`. Set `include_alert_details` to `true` on a `[[sinks.otlp.targets]]` entry to add `health_report.alerts` when the report has alerts.
+
+* _The setting is per-target_. This means that, for example, a debugging destination can receive detail, while a long-term store receives the routing, count, and success evidence without needing to store free-form alert messages.
+
+* The JSON array in `health_report.alerts` contains the first 64 alerts in report order, each with `probe_id`, `message`, `classifications`, and `target` if the alert names one.
+
+* `health_report.alerts.dropped` appears only when details are enabled _and_ the report has more than 64 alerts. It contains the number of omitted alerts beyond those first 64.
+
+* Probe IDs use health API names: for example, OOB GPU inventory alerts appear as `SkuValidation` to deduplicate with the in-band SKU alerts.
 
 ## DPU Health Checks
 


### PR DESCRIPTION
Health reports reached OTLP as a prose summary body and a single event.type attribute, so consumers had to parse free text to recover the source, probe results, and alert classifications behind a report.

Emit a versioned health_report.* attribute contract alongside the unchanged summary body: scalar routing fields plus nested successes and alerts that preserve probe IDs, targets, messages, and classifications. The record now carries the report's own observation time when it has one, leaving observed_time_unix_nano as the export time.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4508

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
AI generated PR with tweaks and reading by a human

