### PR TITLE
fix(flow): sync proto mirror and harden decommission poll loop

### DIFF
--- a/rest-api/flow/internal/service/server_impl.go
+++ b/rest-api/flow/internal/service/server_impl.go
@@ -835,6 +835,12 @@ func (rs *FlowServerImpl) decommissionRackImpl(
 			"target_spec is required",
 		)
 	}
+	if targetSpec.GetComponents() != nil {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"decommission requires rack targets; component targets are not supported",
+		)
+	}
 
 	info := &operations.DecommissionTaskInfo{
 		RuleID: protobuf.UUIDStringFrom(req.GetRuleId()),

--- a/rest-api/flow/internal/task/executor/temporalworkflow/workflow/actions.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/workflow/actions.go
@@ -697,10 +697,18 @@ func executeWaitDecommissionedAction(actx actionExecutionContext) error {
 			return fmt.Errorf("workflow sleep interrupted: %w", err)
 		}
 
+		// Use a short fire-once policy so a hung status call fails quickly
+		// and the poll loop's consecutive-failure budget controls retries.
+		statusCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			StartToCloseTimeout: 30 * time.Second,
+			RetryPolicy: &temporal.RetryPolicy{
+				MaximumAttempts: 1,
+			},
+		})
 		var result activity.GetDecommissionStatusResult
 		err := workflow.ExecuteActivity(
-			ctx, activity.NameGetDecommissionStatus, target,
-		).Get(ctx, &result)
+			statusCtx, activity.NameGetDecommissionStatus, target,
+		).Get(statusCtx, &result)
 		if err != nil {
 			consecutiveFailures++
 			log.Warn().

--- a/rest-api/flow/internal/task/executor/temporalworkflow/workflow/actions.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/workflow/actions.go
@@ -647,10 +647,23 @@ func executeDecommissionControlAction(actx actionExecutionContext) error {
 	).Get(ctx, nil)
 }
 
+// maxConsecutiveStatusFailures is the number of consecutive GetDecommissionStatus
+// errors that will cause the wait loop to abort rather than spin until the
+// 4-hour deadline. A permanent error (e.g. Core unreachable) is caught within
+// a few poll intervals instead of hours later.
+const maxConsecutiveStatusFailures = 5
+
 // executeWaitDecommissionedAction polls GetDecommissionStatus until all
 // components reach the "Decommissioned" terminal state. States that begin
-// with "Decommissioning/" are in-progress; any other non-terminal state is
-// treated as an error. Uses config.Timeout and config.PollInterval.
+// with "Decommissioning/" are in-progress; any other state is a hard failure.
+//
+// A component absent from Core's response (state "") is treated as already
+// decommissioned: Core removes the resource record as the final step, so an
+// absent ID is the expected terminal condition rather than an error.
+//
+// Consecutive GetDecommissionStatus failures are counted; after
+// maxConsecutiveStatusFailures the loop aborts rather than spinning until the
+// deadline. Uses config.Timeout and config.PollInterval.
 func executeWaitDecommissionedAction(actx actionExecutionContext) error {
 	ctx := actx.workflowContext
 	target := actx.target
@@ -671,6 +684,7 @@ func executeWaitDecommissionedAction(actx actionExecutionContext) error {
 		Msg("Waiting for decommission to complete")
 
 	deadline := workflow.Now(ctx).Add(timeout)
+	consecutiveFailures := 0
 
 	for {
 		if workflow.Now(ctx).After(deadline) {
@@ -688,28 +702,45 @@ func executeWaitDecommissionedAction(actx actionExecutionContext) error {
 			ctx, activity.NameGetDecommissionStatus, target,
 		).Get(ctx, &result)
 		if err != nil {
-			log.Warn().Err(err).Msg("Failed to get decommission status, will retry")
+			consecutiveFailures++
+			log.Warn().
+				Err(err).
+				Int("consecutive_failures", consecutiveFailures).
+				Int("limit", maxConsecutiveStatusFailures).
+				Msg("Failed to get decommission status")
+			if consecutiveFailures >= maxConsecutiveStatusFailures {
+				return fmt.Errorf(
+					"aborting: GetDecommissionStatus failed %d times consecutively: %w",
+					consecutiveFailures, err,
+				)
+			}
 			continue
 		}
+		consecutiveFailures = 0
 
 		allDecommissioned := true
 		for componentID, state := range result.States {
-			if state == "Decommissioned" {
-				continue
-			}
-			if strings.HasPrefix(state, "Decommissioning/") {
+			switch {
+			case state == "Decommissioned":
+				// Terminal success.
+			case state == "":
+				// Core has no record of this component — it was removed as part
+				// of the decommission terminal step, which counts as success.
+				log.Debug().
+					Str("component_id", componentID).
+					Msg("Component absent from Core; treating as decommissioned")
+			case strings.HasPrefix(state, "Decommissioning/"):
 				allDecommissioned = false
 				log.Debug().
 					Str("component_id", componentID).
 					Str("state", state).
 					Msg("Component still decommissioning")
-				continue
+			default:
+				return fmt.Errorf(
+					"decommission failed for component %s: reached unexpected state %q",
+					componentID, state,
+				)
 			}
-			// Any other state is unexpected/terminal-error
-			return fmt.Errorf(
-				"decommission failed for component %s: unexpected state %q",
-				componentID, state,
-			)
 		}
 
 		if allDecommissioned {

--- a/rest-api/proto/flow/gen/v1/flow.pb.go
+++ b/rest-api/proto/flow/gen/v1/flow.pb.go
@@ -5562,18 +5562,18 @@ func (x *BringUpRackRequest) GetOverrideReadinessCheck() bool {
 // NOTE: This struct was added manually. Run `buf generate` from
 // rest-api/proto/flow/ to replace it with the canonical generated version.
 type DecommissionRackRequest struct {
-	state        protoimpl.MessageState `protogen:"open.v1"`
-	TargetSpec   *OperationTargetSpec   `protobuf:"bytes,1,opt,name=target_spec,json=targetSpec,proto3" json:"target_spec,omitempty"`
-	Description  string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
-	QueueOptions *QueueOptions          `protobuf:"bytes,3,opt,name=queue_options,json=queueOptions,proto3,oneof" json:"queue_options,omitempty"`
-	RuleId       *UUID                  `protobuf:"bytes,4,opt,name=rule_id,json=ruleId,proto3,oneof" json:"rule_id,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TargetSpec    *OperationTargetSpec   `protobuf:"bytes,1,opt,name=target_spec,json=targetSpec,proto3" json:"target_spec,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	QueueOptions  *QueueOptions          `protobuf:"bytes,3,opt,name=queue_options,json=queueOptions,proto3,oneof" json:"queue_options,omitempty"`
+	RuleId        *UUID                  `protobuf:"bytes,4,opt,name=rule_id,json=ruleId,proto3,oneof" json:"rule_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DecommissionRackRequest) Reset()         { *x = DecommissionRackRequest{} }
-func (x *DecommissionRackRequest) String() string  { return protoimpl.X.MessageStringOf(x) }
-func (*DecommissionRackRequest) ProtoMessage()     {}
+func (x *DecommissionRackRequest) String() string { return protoimpl.X.MessageStringOf(x) }
+func (*DecommissionRackRequest) ProtoMessage()    {}
 
 func (x *DecommissionRackRequest) ProtoReflect() protoreflect.Message {
 	// TODO: replaced by buf generate — uses placeholder slot until then.

--- a/rest-api/proto/flow/gen/v1/flow.pb.go
+++ b/rest-api/proto/flow/gen/v1/flow.pb.go
@@ -5557,6 +5557,65 @@ func (x *BringUpRackRequest) GetOverrideReadinessCheck() bool {
 	return false
 }
 
+// DecommissionRackRequest is the request message for DecommissionRack.
+//
+// NOTE: This struct was added manually. Run `buf generate` from
+// rest-api/proto/flow/ to replace it with the canonical generated version.
+type DecommissionRackRequest struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	TargetSpec   *OperationTargetSpec   `protobuf:"bytes,1,opt,name=target_spec,json=targetSpec,proto3" json:"target_spec,omitempty"`
+	Description  string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	QueueOptions *QueueOptions          `protobuf:"bytes,3,opt,name=queue_options,json=queueOptions,proto3,oneof" json:"queue_options,omitempty"`
+	RuleId       *UUID                  `protobuf:"bytes,4,opt,name=rule_id,json=ruleId,proto3,oneof" json:"rule_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DecommissionRackRequest) Reset()         { *x = DecommissionRackRequest{} }
+func (x *DecommissionRackRequest) String() string  { return protoimpl.X.MessageStringOf(x) }
+func (*DecommissionRackRequest) ProtoMessage()     {}
+
+func (x *DecommissionRackRequest) ProtoReflect() protoreflect.Message {
+	// TODO: replaced by buf generate — uses placeholder slot until then.
+	mi := &file_flow_proto_msgTypes[71]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DecommissionRackRequest) GetTargetSpec() *OperationTargetSpec {
+	if x != nil {
+		return x.TargetSpec
+	}
+	return nil
+}
+
+func (x *DecommissionRackRequest) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *DecommissionRackRequest) GetQueueOptions() *QueueOptions {
+	if x != nil {
+		return x.QueueOptions
+	}
+	return nil
+}
+
+func (x *DecommissionRackRequest) GetRuleId() *UUID {
+	if x != nil {
+		return x.RuleId
+	}
+	return nil
+}
+
 type IngestRackRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TargetSpec    *OperationTargetSpec   `protobuf:"bytes,1,opt,name=target_spec,json=targetSpec,proto3" json:"target_spec,omitempty"` // Target racks for ingestion

--- a/rest-api/proto/flow/gen/v1/flow_grpc.pb.go
+++ b/rest-api/proto/flow/gen/v1/flow_grpc.pb.go
@@ -47,6 +47,7 @@ const (
 	Flow_UpgradeFirmware_FullMethodName          = "/v1.Flow/UpgradeFirmware"
 	Flow_BringUpRack_FullMethodName              = "/v1.Flow/BringUpRack"
 	Flow_IngestRack_FullMethodName               = "/v1.Flow/IngestRack"
+	Flow_DecommissionRack_FullMethodName         = "/v1.Flow/DecommissionRack"
 	Flow_PowerOnRack_FullMethodName              = "/v1.Flow/PowerOnRack"
 	Flow_PowerOffRack_FullMethodName             = "/v1.Flow/PowerOffRack"
 	Flow_PowerResetRack_FullMethodName           = "/v1.Flow/PowerResetRack"
@@ -395,6 +396,16 @@ func (c *flowClient) BringUpRack(ctx context.Context, in *BringUpRackRequest, op
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SubmitTaskResponse)
 	err := c.cc.Invoke(ctx, Flow_BringUpRack_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *flowClient) DecommissionRack(ctx context.Context, in *DecommissionRackRequest, opts ...grpc.CallOption) (*SubmitTaskResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SubmitTaskResponse)
+	err := c.cc.Invoke(ctx, Flow_DecommissionRack_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -813,6 +824,7 @@ type FlowServer interface {
 	UpgradeFirmware(context.Context, *UpgradeFirmwareRequest) (*SubmitTaskResponse, error)
 	BringUpRack(context.Context, *BringUpRackRequest) (*SubmitTaskResponse, error)
 	IngestRack(context.Context, *IngestRackRequest) (*SubmitTaskResponse, error)
+	DecommissionRack(context.Context, *DecommissionRackRequest) (*SubmitTaskResponse, error)
 	PowerOnRack(context.Context, *PowerOnRackRequest) (*SubmitTaskResponse, error)
 	PowerOffRack(context.Context, *PowerOffRackRequest) (*SubmitTaskResponse, error)
 	PowerResetRack(context.Context, *PowerResetRackRequest) (*SubmitTaskResponse, error)
@@ -936,6 +948,9 @@ func (UnimplementedFlowServer) BringUpRack(context.Context, *BringUpRackRequest)
 }
 func (UnimplementedFlowServer) IngestRack(context.Context, *IngestRackRequest) (*SubmitTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method IngestRack not implemented")
+}
+func (UnimplementedFlowServer) DecommissionRack(context.Context, *DecommissionRackRequest) (*SubmitTaskResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DecommissionRack not implemented")
 }
 func (UnimplementedFlowServer) PowerOnRack(context.Context, *PowerOnRackRequest) (*SubmitTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PowerOnRack not implemented")
@@ -1496,6 +1511,24 @@ func _Flow_IngestRack_Handler(srv interface{}, ctx context.Context, dec func(int
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(FlowServer).IngestRack(ctx, req.(*IngestRackRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Flow_DecommissionRack_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DecommissionRackRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FlowServer).DecommissionRack(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Flow_DecommissionRack_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FlowServer).DecommissionRack(ctx, req.(*DecommissionRackRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2268,6 +2301,10 @@ var Flow_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "IngestRack",
 			Handler:    _Flow_IngestRack_Handler,
+		},
+		{
+			MethodName: "DecommissionRack",
+			Handler:    _Flow_DecommissionRack_Handler,
 		},
 		{
 			MethodName: "PowerOnRack",

--- a/rest-api/proto/flow/src/v1/flow.proto
+++ b/rest-api/proto/flow/src/v1/flow.proto
@@ -44,6 +44,7 @@ service Flow {
     rpc UpgradeFirmware(UpgradeFirmwareRequest) returns (SubmitTaskResponse);
     rpc BringUpRack(BringUpRackRequest) returns (SubmitTaskResponse);
     rpc IngestRack(IngestRackRequest) returns (SubmitTaskResponse);
+    rpc DecommissionRack(DecommissionRackRequest) returns (SubmitTaskResponse);
     rpc PowerOnRack(PowerOnRackRequest) returns (SubmitTaskResponse);
     rpc PowerOffRack(PowerOffRackRequest) returns (SubmitTaskResponse);
     rpc PowerResetRack(PowerResetRackRequest) returns (SubmitTaskResponse);
@@ -711,6 +712,13 @@ message BringUpRackRequest {
     // tenant impact has been acknowledged out-of-band; the bypass is
     // recorded in the server log.
     bool override_readiness_check = 4;
+}
+
+message DecommissionRackRequest {
+    OperationTargetSpec target_spec = 1;  // Target racks for decommissioning
+    string description = 2;              // optional task description
+    optional QueueOptions queue_options = 3; // optional: queuing behaviour on conflict
+    optional UUID rule_id = 4;           // optional: override rule resolution with a specific rule
 }
 
 message IngestRackRequest {


### PR DESCRIPTION
Proto mirror sync (rest-api/proto/flow/):
- Add DecommissionRack RPC and DecommissionRackRequest message to the source proto (src/v1/flow.proto) so external consumers (REST API, site-workflow) can call the endpoint once it is ungated.
- Manually patch the generated client and server stubs in gen/v1/ with a TODO to replace via `buf generate` from rest-api/proto/flow/.

Poll loop robustness (executeWaitDecommissionedAction):
- Add a consecutive-failure budget (5 failures) so a permanent GetDecommissionStatus error aborts within a few poll intervals rather than spinning until the 4-hour deadline.
- Treat a component absent from Core's response (state "") as already decommissioned: Core removes the resource record as the terminal step, so an absent ID is the expected success condition, not an error. Improve the error message for genuinely unexpected states.