### PR TITLE
feat(flow): decouple expected-inventory identity from chassis labels

### DIFF
--- a/rest-api/flow/internal/db/migrations/20260811120000_component_identity_key.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260811120000_component_identity_key.down.sql
@@ -1,0 +1,23 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- The duplicate host BMC rows the up migration deleted are not restored:
+-- the bmc table has no soft-delete and the rows carried no state beyond the
+-- MAC/IP the mirror re-derives from Core.
+--
+-- Both SET NOT NULL statements fail if any row mirrored while the column was
+-- nullable still carries a NULL. Such rows need a manufacturer / serial (or
+-- deletion) before the schema can be narrowed again.
+ALTER TABLE rack
+    ALTER COLUMN serial_number SET NOT NULL;
+
+ALTER TABLE component
+    ALTER COLUMN manufacturer SET NOT NULL,
+    ALTER COLUMN serial_number SET NOT NULL;
+
+DROP INDEX IF EXISTS bmc_one_host_per_component_idx;
+
+DROP INDEX IF EXISTS component_identity_key_idx;
+
+ALTER TABLE component
+    DROP COLUMN identity_key;

--- a/rest-api/flow/internal/db/migrations/20260811120000_component_identity_key.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260811120000_component_identity_key.down.sql
@@ -1,14 +1,12 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- The duplicate host BMC rows the up migration deleted are not restored:
--- the bmc table has no soft-delete and the rows carried no state beyond the
--- MAC/IP the mirror re-derives from Core.
+-- The host BMC rows the up migration deleted are not restored.
 --
--- Both SET NOT NULL statements fail if any row mirrored while the column was
--- nullable still carries a NULL. Such rows need a manufacturer / serial (or
--- deletion) before the schema can be narrowed again.
+-- Both SET NOT NULL statements fail if a row still carries a NULL, which needs
+-- a manufacturer / serial (or deletion) before the schema can be narrowed.
 ALTER TABLE rack
+    ALTER COLUMN manufacturer SET NOT NULL,
     ALTER COLUMN serial_number SET NOT NULL;
 
 ALTER TABLE component

--- a/rest-api/flow/internal/db/migrations/20260811120000_component_identity_key.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260811120000_component_identity_key.up.sql
@@ -1,0 +1,61 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Give component an explicit identity column so the expected-inventory mirror
+-- has one authoritative match key instead of deriving identity from whichever
+-- descriptive columns happen to be populated.
+--
+-- identity_key holds the value of the current derivation (see
+-- identityKeyForSpec). The derivation is expected to change; the schema
+-- deliberately says nothing about what composes the value so that a change
+-- is a backfill rather than a migration of constraints and match logic.
+--
+-- Nullable, with a partial unique index, because the three ingestion gRPC
+-- paths (CreateExpectedRack, AddComponent, PatchRack) create components
+-- outside the mirror and have no derivation to apply.
+--
+-- Unique globally rather than per type. identity_key is a denormalised copy of
+-- a value that is already unique at its source -- today bmc.mac_address, a
+-- primary key -- but the copy inherits none of that, so only the index makes
+-- the column carry the guarantee its value already has. Scoping it by type
+-- would instead permit one MAC under two component types, which no valid
+-- inventory can produce; a Core payload that reports one aborts the type's
+-- reconciliation with a named constraint error, which is the right response to
+-- input that broken and far easier to spot than the component the mirror would
+-- otherwise duplicate.
+ALTER TABLE component
+    ADD COLUMN identity_key character varying;
+
+CREATE UNIQUE INDEX component_identity_key_idx
+    ON component (identity_key)
+    WHERE identity_key IS NOT NULL;
+
+-- The derivation reads a component's host BMC, so the 1:1 it assumes has to
+-- be real. Extra type='Host' rows are an ingestion bug that
+-- planBMCReconciliation already hard-deletes on the next mirror cycle; this
+-- brings that cleanup forward so the index can be created. Keeping the lowest
+-- MAC is arbitrary but deterministic — the mirror re-attaches whichever MAC
+-- Core reports on the next cycle regardless of which row survives here.
+DELETE FROM bmc a
+    USING bmc b
+    WHERE a.type = 'Host'
+      AND b.type = 'Host'
+      AND a.component_id = b.component_id
+      AND a.mac_address > b.mac_address;
+
+CREATE UNIQUE INDEX bmc_one_host_per_component_idx
+    ON bmc (component_id)
+    WHERE type = 'Host';
+
+-- With identity in its own column, manufacturer and serial are descriptive
+-- metadata, so a Core site whose chassis labels are incomplete no longer has
+-- its rows skipped. UNIQUE (manufacturer, serial_number) stays: Postgres
+-- treats NULLs as distinct, so incomplete rows simply stop occupying a slot,
+-- and GetRackInfoBySerial / GetComponentInfoBySerial keep their
+-- at-most-one-match guarantee for fully-labelled rows.
+ALTER TABLE component
+    ALTER COLUMN manufacturer DROP NOT NULL,
+    ALTER COLUMN serial_number DROP NOT NULL;
+
+ALTER TABLE rack
+    ALTER COLUMN serial_number DROP NOT NULL;

--- a/rest-api/flow/internal/db/migrations/20260811120000_component_identity_key.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260811120000_component_identity_key.up.sql
@@ -1,28 +1,9 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- Give component an explicit identity column so the expected-inventory mirror
--- has one authoritative match key instead of deriving identity from whichever
--- descriptive columns happen to be populated.
---
--- identity_key holds the value of the current derivation (see
--- identityKeyForSpec). The derivation is expected to change; the schema
--- deliberately says nothing about what composes the value so that a change
--- is a backfill rather than a migration of constraints and match logic.
---
--- Nullable, with a partial unique index, because the three ingestion gRPC
--- paths (CreateExpectedRack, AddComponent, PatchRack) create components
--- outside the mirror and have no derivation to apply.
---
--- Unique globally rather than per type. identity_key is a denormalised copy of
--- a value that is already unique at its source -- today bmc.mac_address, a
--- primary key -- but the copy inherits none of that, so only the index makes
--- the column carry the guarantee its value already has. Scoping it by type
--- would instead permit one MAC under two component types, which no valid
--- inventory can produce; a Core payload that reports one aborts the type's
--- reconciliation with a named constraint error, which is the right response to
--- input that broken and far easier to spot than the component the mirror would
--- otherwise duplicate.
+-- identity_key is the identity the expected-inventory mirror matches a Core row
+-- against. The schema only enforces that it is unique; what composes the value
+-- is the mirror's to define.
 ALTER TABLE component
     ADD COLUMN identity_key character varying;
 
@@ -30,12 +11,8 @@ CREATE UNIQUE INDEX component_identity_key_idx
     ON component (identity_key)
     WHERE identity_key IS NOT NULL;
 
--- The derivation reads a component's host BMC, so the 1:1 it assumes has to
--- be real. Extra type='Host' rows are an ingestion bug that
--- planBMCReconciliation already hard-deletes on the next mirror cycle; this
--- brings that cleanup forward so the index can be created. Keeping the lowest
--- MAC is arbitrary but deterministic — the mirror re-attaches whichever MAC
--- Core reports on the next cycle regardless of which row survives here.
+-- A component has at most one host BMC. Delete the duplicates an ingestion bug
+-- allowed so the index can be created; the lowest MAC survives.
 DELETE FROM bmc a
     USING bmc b
     WHERE a.type = 'Host'
@@ -47,15 +24,13 @@ CREATE UNIQUE INDEX bmc_one_host_per_component_idx
     ON bmc (component_id)
     WHERE type = 'Host';
 
--- With identity in its own column, manufacturer and serial are descriptive
--- metadata, so a Core site whose chassis labels are incomplete no longer has
--- its rows skipped. UNIQUE (manufacturer, serial_number) stays: Postgres
--- treats NULLs as distinct, so incomplete rows simply stop occupying a slot,
--- and GetRackInfoBySerial / GetComponentInfoBySerial keep their
--- at-most-one-match guarantee for fully-labelled rows.
+-- manufacturer and serial_number are descriptive metadata now, not identity.
+-- UNIQUE (manufacturer, serial_number) stays useful because Postgres treats
+-- NULLs as distinct: an incomplete row occupies no slot.
 ALTER TABLE component
     ALTER COLUMN manufacturer DROP NOT NULL,
     ALTER COLUMN serial_number DROP NOT NULL;
 
 ALTER TABLE rack
+    ALTER COLUMN manufacturer DROP NOT NULL,
     ALTER COLUMN serial_number DROP NOT NULL;

--- a/rest-api/flow/internal/db/model/component.go
+++ b/rest-api/flow/internal/db/model/component.go
@@ -26,20 +26,13 @@ type Component struct {
 	Name string    `bun:"name"`
 	Type string    `bun:"type,type:varchar(16),default:'Compute'"`
 	// IdentityKey is what the expected-inventory mirror matches a Core row
-	// against, made unique by component_identity_key_idx. It is empty (SQL
-	// NULL, which the partial index exempts) on components created by the
-	// ingestion gRPC paths, which have no Core row to mirror.
-	//
-	// The schema deliberately says nothing about what composes the value:
-	// changing the derivation has to stay a backfill rather than a reshaping
-	// of constraints. See identityKeyForSpec in the inventorysync package for
-	// the current derivation and the procedure a change requires.
+	// against, made unique by the partial index component_identity_key_idx.
+	// Empty (SQL NULL, which the index exempts) on components created by the
+	// ingestion gRPC paths. identityKeyForSpec defines the value.
 	IdentityKey string `bun:"identity_key,nullzero"`
-	// Manufacturer and SerialNumber are descriptive metadata, not identity, so
-	// a Core row with incomplete chassis labels is still mirrored. Empty
-	// string maps to SQL NULL via nullzero, and UNIQUE (manufacturer,
-	// serial_number) keeps protecting fully-labelled rows because Postgres
-	// treats NULLs as distinct.
+	// Manufacturer and SerialNumber are descriptive metadata, not identity.
+	// Empty string maps to SQL NULL via nullzero, so an incomplete pair
+	// occupies no slot in component_manufacturer_serial_idx.
 	Manufacturer    string         `bun:"manufacturer,nullzero,unique:component_manufacturer_serial_idx"`
 	Model           string         `bun:"model"`
 	SerialNumber    string         `bun:"serial_number,nullzero,unique:component_manufacturer_serial_idx"`

--- a/rest-api/flow/internal/db/model/component.go
+++ b/rest-api/flow/internal/db/model/component.go
@@ -22,12 +22,27 @@ import (
 type Component struct {
 	bun.BaseModel `bun:"table:component,alias:c"`
 
-	ID              uuid.UUID      `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	Name            string         `bun:"name"`
-	Type            string         `bun:"type,type:varchar(16),default:'Compute'"`
-	Manufacturer    string         `bun:"manufacturer,notnull,unique:component_manufacturer_serial_idx"`
+	ID   uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	Name string    `bun:"name"`
+	Type string    `bun:"type,type:varchar(16),default:'Compute'"`
+	// IdentityKey is what the expected-inventory mirror matches a Core row
+	// against, made unique by component_identity_key_idx. It is empty (SQL
+	// NULL, which the partial index exempts) on components created by the
+	// ingestion gRPC paths, which have no Core row to mirror.
+	//
+	// The schema deliberately says nothing about what composes the value:
+	// changing the derivation has to stay a backfill rather than a reshaping
+	// of constraints. See identityKeyForSpec in the inventorysync package for
+	// the current derivation and the procedure a change requires.
+	IdentityKey string `bun:"identity_key,nullzero"`
+	// Manufacturer and SerialNumber are descriptive metadata, not identity, so
+	// a Core row with incomplete chassis labels is still mirrored. Empty
+	// string maps to SQL NULL via nullzero, and UNIQUE (manufacturer,
+	// serial_number) keeps protecting fully-labelled rows because Postgres
+	// treats NULLs as distinct.
+	Manufacturer    string         `bun:"manufacturer,nullzero,unique:component_manufacturer_serial_idx"`
 	Model           string         `bun:"model"`
-	SerialNumber    string         `bun:"serial_number,notnull,notnull,unique:component_manufacturer_serial_idx"`
+	SerialNumber    string         `bun:"serial_number,nullzero,unique:component_manufacturer_serial_idx"`
 	Description     map[string]any `bun:"description,type:jsonb,json_use_number"`
 	FirmwareVersion string         `bun:"firmware_version,nullzero"`
 	// RackID is uuid.Nil when the component has been ingested but is not yet
@@ -55,6 +70,12 @@ func (cd *Component) Create(ctx context.Context, idb bun.IDB) error {
 	return err
 }
 
+// Get looks the component up by ID, or by (manufacturer, serial_number) when
+// no ID is set. Both columns are nullable, so a component the
+// expected-inventory mirror stored without one of those labels is not
+// addressable this way and reports sql.ErrNoRows; look it up by ID or Host
+// BMC MAC instead. component_manufacturer_serial_idx still guarantees at most
+// one match whenever both values are supplied.
 func (cd *Component) Get(
 	ctx context.Context,
 	idb bun.IDB,

--- a/rest-api/flow/internal/db/model/rack.go
+++ b/rest-api/flow/internal/db/model/rack.go
@@ -24,10 +24,14 @@ var defaultRackPagination = dbquery.Pagination{
 type Rack struct {
 	bun.BaseModel `bun:"table:rack,alias:r"`
 
-	ID           uuid.UUID      `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	Name         string         `bun:"name,notnull,unique:rack_name_idx"`
-	Manufacturer string         `bun:"manufacturer,notnull,unique:rack_manufacturer_serial_idx"`
-	SerialNumber string         `bun:"serial_number,notnull,unique:rack_manufacturer_serial_idx"`
+	ID           uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	Name         string    `bun:"name,notnull,unique:rack_name_idx"`
+	Manufacturer string    `bun:"manufacturer,notnull,unique:rack_manufacturer_serial_idx"`
+	// SerialNumber is nullable so expected-inventory can mirror Core racks
+	// that have a stable external_id but no chassis serial yet. Empty string
+	// maps to SQL NULL via nullzero; UNIQUE (manufacturer, serial_number)
+	// still protects serial-bearing rows (Postgres treats NULLs as distinct).
+	SerialNumber string         `bun:"serial_number,nullzero,unique:rack_manufacturer_serial_idx"`
 	Description  map[string]any `bun:"description,type:jsonb,json_use_number"`
 	Location     map[string]any `bun:"location,type:jsonb"`
 	NVLDomainID  uuid.UUID      `bun:"nvldomain_id,type:uuid"`
@@ -73,6 +77,12 @@ func (rd *Rack) Create(ctx context.Context, idb bun.IDB) error {
 	return err
 }
 
+// Get looks the rack up by ID, or by (manufacturer, serial_number) when no ID
+// is set. serial_number is nullable, so a rack the expected-inventory mirror
+// stored without a chassis serial is not addressable this way and reports
+// sql.ErrNoRows; look it up by ID or external_id instead.
+// rack_manufacturer_serial_idx still guarantees at most one match whenever
+// both values are supplied.
 func (rd *Rack) Get(
 	ctx context.Context,
 	idb bun.IDB,

--- a/rest-api/flow/internal/db/model/rack.go
+++ b/rest-api/flow/internal/db/model/rack.go
@@ -24,13 +24,13 @@ var defaultRackPagination = dbquery.Pagination{
 type Rack struct {
 	bun.BaseModel `bun:"table:rack,alias:r"`
 
-	ID           uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	Name         string    `bun:"name,notnull,unique:rack_name_idx"`
-	Manufacturer string    `bun:"manufacturer,notnull,unique:rack_manufacturer_serial_idx"`
-	// SerialNumber is nullable so expected-inventory can mirror Core racks
-	// that have a stable external_id but no chassis serial yet. Empty string
-	// maps to SQL NULL via nullzero; UNIQUE (manufacturer, serial_number)
-	// still protects serial-bearing rows (Postgres treats NULLs as distinct).
+	ID   uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	Name string    `bun:"name,notnull,unique:rack_name_idx"`
+	// Manufacturer and SerialNumber are descriptive chassis labels, not
+	// identity: a mirrored rack is identified by ExternalID (Core's rack_id).
+	// Empty string maps to SQL NULL via nullzero, so an incomplete pair
+	// occupies no slot in rack_manufacturer_serial_idx.
+	Manufacturer string         `bun:"manufacturer,nullzero,unique:rack_manufacturer_serial_idx"`
 	SerialNumber string         `bun:"serial_number,nullzero,unique:rack_manufacturer_serial_idx"`
 	Description  map[string]any `bun:"description,type:jsonb,json_use_number"`
 	Location     map[string]any `bun:"location,type:jsonb"`
@@ -78,11 +78,8 @@ func (rd *Rack) Create(ctx context.Context, idb bun.IDB) error {
 }
 
 // Get looks the rack up by ID, or by (manufacturer, serial_number) when no ID
-// is set. serial_number is nullable, so a rack the expected-inventory mirror
-// stored without a chassis serial is not addressable this way and reports
-// sql.ErrNoRows; look it up by ID or external_id instead.
-// rack_manufacturer_serial_idx still guarantees at most one match whenever
-// both values are supplied.
+// is set. Both chassis columns are nullable, so a rack stored without one of
+// them reports sql.ErrNoRows here — look it up by ID or external_id instead.
 func (rd *Rack) Get(
 	ctx context.Context,
 	idb bun.IDB,

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror.go
@@ -21,16 +21,17 @@ import (
 // well-behaved (mostly updates, no surprises) or alarming (large delete
 // counts).
 type mirrorResult struct {
-	resource         string
-	pulled           int
-	inserted         int
-	updated          int
-	adopted          int
-	resurrected      int
-	softDeleted      int
-	legacyExempt     int
-	skippedNoIDOrKey int
-	skippedNameTaken int
+	resource           string
+	pulled             int
+	inserted           int
+	updated            int
+	adopted            int
+	resurrected        int
+	softDeleted        int
+	legacyExempt       int
+	skippedNoIDOrKey   int
+	skippedNameTaken   int
+	skippedSerialTaken int
 }
 
 func (r mirrorResult) log() {
@@ -45,6 +46,7 @@ func (r mirrorResult) log() {
 		Int("legacy_exempt", r.legacyExempt).
 		Int("skipped_invalid", r.skippedNoIDOrKey).
 		Int("skipped_name_taken", r.skippedNameTaken).
+		Int("skipped_serial_taken", r.skippedSerialTaken).
 		Msgf("Expected-inventory mirror: %s", r.resource)
 }
 
@@ -140,11 +142,76 @@ func loadRackIDByExternalID(ctx context.Context, idb bun.IDB) (map[string]uuid.U
 }
 
 // rackNaturalKey joins manufacturer and serial number with a NUL byte. NUL
-// can't appear inside either component, so this is collision-free without
-// having to escape. Used by both the rack and component mirrors to key
-// "is this row already known" maps off the shared (manufacturer, serial)
-// pair, so it lives here next to the orchestrator rather than in either
+// can't appear inside either value, so this is collision-free without having
+// to escape. Both mirrors key maps off the shared (manufacturer, serial) pair,
+// so it lives here next to the orchestrator rather than in either
 // type-specific file.
+//
+// The pair is no longer what either mirror identifies a row by — components
+// match on identity_key and racks on external_id. It survives as the
+// *_manufacturer_serial_idx unique constraint over descriptive labels, so what
+// these keys mostly track now is which rows own which slot of that index, plus
+// a fallback for specs whose identity resolves to nothing.
 func rackNaturalKey(manufacturer, serialNumber string) string {
 	return manufacturer + "\x00" + serialNumber
+}
+
+// naturalKeySlotTaken reports whether writing this (manufacturer, serial_number)
+// pair would land on a unique-index slot belonging to a different row: one
+// already in the table (owners, tombstones included), or one the current cycle
+// has already queued a write for (claimed). Both matter because a cycle plans
+// every write before it opens the transaction, so two planned writes can
+// collide with each other without either colliding with stored state.
+func naturalKeySlotTaken(owners map[string]uuid.UUID, claimed map[string]struct{}, manufacturer, serialNumber string, selfID uuid.UUID) bool {
+	naturalKey := naturalKeyOrEmpty(manufacturer, serialNumber)
+	if naturalKey == "" {
+		return false
+	}
+	if naturalKeyTakenByOther(owners, manufacturer, serialNumber, selfID) {
+		return true
+	}
+	_, planned := claimed[naturalKey]
+	return planned
+}
+
+// naturalKeyOrEmpty returns the (manufacturer, serial_number) index key, or ""
+// when either half is absent. Such a pair stores a SQL NULL, which Postgres
+// treats as distinct from every other value, so it occupies no slot and
+// identifies nothing.
+func naturalKeyOrEmpty(manufacturer, serialNumber string) string {
+	if manufacturer == "" || serialNumber == "" {
+		return ""
+	}
+	return rackNaturalKey(manufacturer, serialNumber)
+}
+
+// claimNaturalKeySlot records a pair the cycle has queued a write for. A pair with
+// an empty half is not recorded: it stores a SQL NULL, which Postgres treats
+// as distinct from every other value, so it occupies no slot.
+func claimNaturalKeySlot(claimed map[string]struct{}, manufacturer, serialNumber string) {
+	if naturalKey := naturalKeyOrEmpty(manufacturer, serialNumber); naturalKey != "" {
+		claimed[naturalKey] = struct{}{}
+	}
+}
+
+// naturalKeyTakenByOther reports whether some row other than selfID already
+// occupies the (manufacturer, serial_number) slot in the table's unique index.
+// Pass uuid.Nil as selfID for an INSERT. Callers that also have to account for
+// writes queued earlier in the same cycle want naturalKeySlotTaken instead.
+//
+// Both mirrors need this because they write the serial column: the component
+// mirror matches on identity_key and the rack mirror on external_id, so the row
+// they matched can legitimately carry a different serial from the one Core now
+// reports. Blindly writing Core's value would abort the whole reconciliation
+// transaction, and since the unique index covers soft-deleted rows, owners must
+// include tombstones.
+//
+// An empty manufacturer or serial occupies no slot at all — Postgres treats
+// NULLs as distinct — so those can never collide and return false.
+func naturalKeyTakenByOther(owners map[string]uuid.UUID, manufacturer, serialNumber string, selfID uuid.UUID) bool {
+	if manufacturer == "" || serialNumber == "" {
+		return false
+	}
+	owner, ok := owners[rackNaturalKey(manufacturer, serialNumber)]
+	return ok && owner != selfID
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror.go
@@ -141,17 +141,12 @@ func loadRackIDByExternalID(ctx context.Context, idb bun.IDB) (map[string]uuid.U
 	return out, nil
 }
 
-// rackNaturalKey joins manufacturer and serial number with a NUL byte. NUL
-// can't appear inside either value, so this is collision-free without having
-// to escape. Both mirrors key maps off the shared (manufacturer, serial) pair,
-// so it lives here next to the orchestrator rather than in either
-// type-specific file.
+// rackNaturalKey joins manufacturer and serial number with a NUL byte, which
+// cannot appear inside either value, so no escaping is needed.
 //
-// The pair is no longer what either mirror identifies a row by — components
-// match on identity_key and racks on external_id. It survives as the
-// *_manufacturer_serial_idx unique constraint over descriptive labels, so what
-// these keys mostly track now is which rows own which slot of that index, plus
-// a fallback for specs whose identity resolves to nothing.
+// The pair identifies nothing now — components match on identity_key and racks
+// on external_id. It survives as the *_manufacturer_serial_idx unique
+// constraint, so these keys track which row owns which slot of that index.
 func rackNaturalKey(manufacturer, serialNumber string) string {
 	return manufacturer + "\x00" + serialNumber
 }
@@ -159,9 +154,8 @@ func rackNaturalKey(manufacturer, serialNumber string) string {
 // naturalKeySlotTaken reports whether writing this (manufacturer, serial_number)
 // pair would land on a unique-index slot belonging to a different row: one
 // already in the table (owners, tombstones included), or one the current cycle
-// has already queued a write for (claimed). Both matter because a cycle plans
-// every write before it opens the transaction, so two planned writes can
-// collide with each other without either colliding with stored state.
+// has already queued (claimed). A cycle plans every write before opening the
+// transaction, so two planned writes can collide with each other alone.
 func naturalKeySlotTaken(owners map[string]uuid.UUID, claimed map[string]struct{}, manufacturer, serialNumber string, selfID uuid.UUID) bool {
 	naturalKey := naturalKeyOrEmpty(manufacturer, serialNumber)
 	if naturalKey == "" {
@@ -185,9 +179,8 @@ func naturalKeyOrEmpty(manufacturer, serialNumber string) string {
 	return rackNaturalKey(manufacturer, serialNumber)
 }
 
-// claimNaturalKeySlot records a pair the cycle has queued a write for. A pair with
-// an empty half is not recorded: it stores a SQL NULL, which Postgres treats
-// as distinct from every other value, so it occupies no slot.
+// claimNaturalKeySlot records a pair the cycle has queued a write for. A pair
+// with an empty half occupies no slot, so it is not recorded.
 func claimNaturalKeySlot(claimed map[string]struct{}, manufacturer, serialNumber string) {
 	if naturalKey := naturalKeyOrEmpty(manufacturer, serialNumber); naturalKey != "" {
 		claimed[naturalKey] = struct{}{}
@@ -199,15 +192,12 @@ func claimNaturalKeySlot(claimed map[string]struct{}, manufacturer, serialNumber
 // Pass uuid.Nil as selfID for an INSERT. Callers that also have to account for
 // writes queued earlier in the same cycle want naturalKeySlotTaken instead.
 //
-// Both mirrors need this because they write the serial column: the component
-// mirror matches on identity_key and the rack mirror on external_id, so the row
-// they matched can legitimately carry a different serial from the one Core now
-// reports. Blindly writing Core's value would abort the whole reconciliation
-// transaction, and since the unique index covers soft-deleted rows, owners must
-// include tombstones.
+// Both mirrors need this because neither matches on the serial any more, so the
+// row they did match can carry a different serial from the one Core reports.
+// Writing it blindly would abort the whole reconciliation transaction. The
+// unique index covers soft-deleted rows, so owners must include tombstones.
 //
-// An empty manufacturer or serial occupies no slot at all — Postgres treats
-// NULLs as distinct — so those can never collide and return false.
+// A pair with an empty half occupies no slot and never collides.
 func naturalKeyTakenByOther(owners map[string]uuid.UUID, manufacturer, serialNumber string, selfID uuid.UUID) bool {
 	if manufacturer == "" || serialNumber == "" {
 		return false

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
@@ -234,15 +234,11 @@ func pullExpectedPowerShelves(ctx context.Context, c nicoapi.Client) (rows []nic
 // component type against the supplied normalised specs. Every Core row and
 // every Flow row is reduced to one identity (identityKeyForSpec /
 // identityKeyForComponent) and matched on that; the chassis labels are only
-// consulted for rows no identity matched, and only when no other spec claims
-// them, so the two indexes can never compete for one row. Resurrect behaviour
-// is symmetrical to the rack mirror so transient Core absence doesn't cause
-// UUID churn.
+// consulted for a row no identity matched and no other spec claims.
 //
-// A matched row keeps its UUID while manufacturer / serial are updated as
-// metadata, so a write can land on a (manufacturer, serial_number) pair some
-// other row already holds. Those writes are skipped rather than attempted;
-// see naturalKeySlotTaken.
+// A matched row keeps its UUID while manufacturer / serial are rewritten as
+// metadata, so a write can land on a pair another row holds; those are skipped
+// rather than attempted (naturalKeySlotTaken).
 //
 // rackIDByExtID resolves a Core rack_id string (e.g. "a12") to the Flow rack
 // UUID. A spec whose RackExternalID can't be resolved is mirrored with a NULL
@@ -275,22 +271,14 @@ func mirrorExpectedComponents(
 		return result
 	}
 
-	// flowByIdentityKey is the primary match index: one key per row, so nothing
-	// can disagree with it. Rows the mirror has never written an identity for
-	// fall back to the derivation, landing under the same key a Core spec
-	// produces, so they are adopted rather than duplicated. Two rows cannot
-	// collide here while the derivation reads the host BMC, since
-	// bmc.mac_address is a primary key.
+	// flowByIdentityKey is the primary match index. A row the mirror never
+	// wrote an identity for falls back to the derivation, landing under the
+	// same key a Core spec produces, so it is adopted rather than duplicated.
 	//
 	// flowByNaturalKey backs the fallback for a spec whose identity matches
-	// nothing. A component whose identity legitimately changed (a replaced BMC
-	// board) or that never had one (ingestion-gRPC rows with no host BMC)
-	// would otherwise be re-inserted, and the insert would then be refused
-	// forever by the (manufacturer, serial_number) slot the old row — or its
-	// tombstone — still occupies. Adopting keeps the UUID and unsticks it.
-	//
-	// naturalKeyOwners covers soft-deleted rows too: component_manufacturer_serial_idx
-	// is a full unique constraint, so a tombstone still occupies its slot.
+	// nothing — a replaced BMC board, or a row that never had an identity.
+	// Re-inserting instead stays refused forever by the (manufacturer,
+	// serial_number) slot the old row, or its tombstone, still occupies.
 	flowByIdentityKey := make(map[string]*model.Component, len(existing))
 	flowByNaturalKey := make(map[string]*model.Component, len(existing))
 	naturalKeyOwners := make(map[string]uuid.UUID, len(existing))
@@ -306,11 +294,9 @@ func mirrorExpectedComponents(
 	}
 
 	// Which Flow rows some spec claims by identity. Resolved up front because
-	// the natural-key fallback has to distinguish "this row is spoken for" from
-	// "this row is unmatched", and a single pass cannot know that until it has
-	// seen every spec. Without it the fallback could steal a row from a spec
-	// later in the slice — the ordering bug that made the previous
-	// serial-keyed matching unpredictable.
+	// the natural-key fallback cannot tell "spoken for" from "unmatched" until
+	// every spec has been seen, and would otherwise steal a row from a later
+	// spec.
 	claimedByIdentity := make(map[uuid.UUID]struct{}, len(specs))
 	for _, s := range specs {
 		if key := identityKeyForSpec(s); key != "" {
@@ -329,16 +315,10 @@ func mirrorExpectedComponents(
 	}
 	var p plan
 
-	// seenIdentityKeys: every identity Core is still reporting this cycle,
-	// recorded BEFORE any validity / dedup skip so the delete phase never
-	// drops a row Core still lists. plannedIdentityKeys: identities already
-	// queued, so a Core-side duplicate is dropped here instead of aborting the
-	// transaction on component_identity_key_idx.
-	// plannedNaturalKeys: (manufacturer, serial) pairs this cycle has already
-	// queued a write for. Identity no longer runs through that pair, but the
-	// mirror still writes it and component_manufacturer_serial_idx still
-	// guards it, so two writes planned in the same cycle have to be kept off
-	// the same slot.
+	// seenIdentityKeys records every identity Core still reports, BEFORE any
+	// skip, so the delete phase never drops a row Core still lists. The two
+	// planned* sets keep writes queued in one cycle off a single slot in
+	// component_identity_key_idx / component_manufacturer_serial_idx.
 	seenIdentityKeys := make(map[string]struct{}, len(specs))
 	plannedIdentityKeys := make(map[string]struct{}, len(specs))
 	plannedNaturalKeys := make(map[string]struct{}, len(specs))
@@ -394,11 +374,10 @@ func mirrorExpectedComponents(
 
 		cur, matched := flowByIdentityKey[key]
 		if !matched {
-			// Identity resolves to nothing, but the chassis labels point at a
-			// row no other spec claims: same component, new identity. Adopt it
-			// so the UUID survives and the write isn't blocked by the natural
-			// key it already holds. At most one candidate exists —
-			// component_manufacturer_serial_idx is unique.
+			// No identity match, but the chassis labels point at a row no
+			// other spec claims: same component, new identity. Adopt it so the
+			// UUID survives and the write isn't blocked by the natural key that
+			// row already holds.
 			if naturalKey := naturalKeyOrEmpty(desired.Manufacturer, desired.SerialNumber); naturalKey != "" {
 				if byNaturalKey, ok := flowByNaturalKey[naturalKey]; ok {
 					_, claimed := claimedByIdentity[byNaturalKey.ID]
@@ -411,11 +390,9 @@ func mirrorExpectedComponents(
 		}
 
 		if matched {
-			// Identity matched, but manufacturer/serial are metadata the
-			// mirror also writes, and Core's pair may already belong to a
-			// different row. Attempting it would abort the whole type's
-			// transaction on component_manufacturer_serial_idx every cycle,
-			// so skip the write and leave both rows for an operator.
+			// Core's manufacturer/serial may already belong to a different row.
+			// Attempting the write would abort the whole type's transaction
+			// every cycle, so skip it and leave both rows for an operator.
 			if naturalKeySlotTaken(naturalKeyOwners, plannedNaturalKeys, desired.Manufacturer, desired.SerialNumber, cur.ID) {
 				log.Warn().
 					Str("type", componentType).
@@ -465,8 +442,7 @@ func mirrorExpectedComponents(
 		}
 
 		// A new identity can still arrive carrying a (manufacturer, serial)
-		// some other row holds, or that another spec in this same cycle has
-		// already queued. Same reasoning as the update path above.
+		// another row holds, or one this cycle already queued.
 		if naturalKeySlotTaken(naturalKeyOwners, plannedNaturalKeys, desired.Manufacturer, desired.SerialNumber, uuid.Nil) {
 			log.Warn().
 				Str("type", componentType).
@@ -585,12 +561,9 @@ func mirrorExpectedComponents(
 		return nil
 	}); err != nil {
 		log.Error().Err(err).Str("type", componentType).Msg("Expected-inventory mirror: component reconciliation transaction failed; mirror is no-op this cycle")
-		// Tx rolled back: every per-spec decision logged above represents
-		// intent, not committed state. Strip success-side counters so the
-		// summary log line reflects what actually landed. pulled and the
-		// skipped_* counters survive: pulled is input size and the skips are
-		// decided before we ever opened the tx, so neither is invalidated by
-		// the rollback.
+		// Tx rolled back, so the per-spec decisions logged above are intent,
+		// not committed state. pulled and the skipped_* counters survive the
+		// strip: both are decided before the tx opened.
 		result.resurrected = 0
 		result.adopted = 0
 		return result
@@ -602,46 +575,29 @@ func mirrorExpectedComponents(
 	return result
 }
 
-// specValid rejects rows missing the Host BMC MAC. That MAC is the stable
-// 1:1 component identity (bmc PK guard). Manufacturer and serial_number are
-// optional mirror-managed metadata and may be NULL in the component table.
+// specValid rejects a Core row the mirror cannot derive an identity for.
 func specValid(s expectedComponentSpec) bool {
 	return identityKeyForSpec(s) != ""
 }
 
-// identityKeyForSpec derives the value stored in component.identity_key for a
-// Core expected component, or "" when Core supplied nothing the mirror can
-// identify the row by. Today that is the host BMC MAC: it is 1:1 with a
-// component, it is the bmc table's primary key, and unlike the chassis labels
-// Core always reports it.
+// identityKeyForSpec derives component.identity_key for a Core expected
+// component, or "" when Core supplied nothing to identify the row by. Today
+// that is the host BMC MAC, which Core always reports and which is 1:1 with a
+// component.
 //
-// This derivation is deliberately the only place the identity rule appears,
-// because it is expected to change — to a compound key, or to a Core-supplied
-// id — without reshaping the schema, the unique index, or the reconciliation
-// below.
-//
-// Changing it is not just an edit here. identity_key carries no marker of
-// which derivation produced it, so old and new values are indistinguishable
-// in the column, and during a rolling deploy two versions would write
-// different keys for the same component and collide on
-// component_identity_key_idx, aborting the cycle. A change therefore
-// ships in three steps: first a release whose matching accepts both the old
-// and the new value, then a migration that re-derives identity_key for every
-// row, then the switch to writing the new value (and a later release dropping
-// the compatibility branch).
+// Redefining it is not a local edit: identity_key records no marker of which
+// derivation wrote it, so during a rolling deploy two versions would write
+// different keys for one component and collide. A change ships as a release
+// that accepts both values, then a backfill, then the switch.
 func identityKeyForSpec(s expectedComponentSpec) string {
 	return s.BMC.MACAddress
 }
 
 // identityKeyForComponent returns the identity a stored row answers to: the
 // persisted value once the mirror has written one, otherwise what the current
-// derivation makes of the row itself. The second case is how rows created
-// before identity_key existed — or by the ingestion gRPC paths — get adopted
-// instead of duplicated.
-//
-// It also constrains identityKeyForSpec: a derivation has to be computable
-// from a Flow row and not only from a Core spec, or adoption has nothing to
-// match on.
+// derivation makes of the row itself. That fallback is how rows predating
+// identity_key, or created by the ingestion gRPC paths, get adopted instead of
+// duplicated — so a derivation has to be computable from a Flow row too.
 func identityKeyForComponent(c *model.Component) string {
 	if c.IdentityKey != "" {
 		return c.IdentityKey
@@ -673,9 +629,8 @@ func resolveRackID(s expectedComponentSpec, rackIDByExtID map[string]uuid.UUID) 
 func componentFromSpec(s expectedComponentSpec, rackID uuid.UUID) model.Component {
 	name := s.Name
 	if name == "" {
-		// Component.Name is part of the user-visible identity but the table
-		// doesn't enforce non-empty. Prefer Core serial, then Host BMC MAC,
-		// so inserts stay labelled when Core omits the name.
+		// Prefer Core's serial, then the host BMC MAC, so a component stays
+		// labelled when Core omits the name.
 		switch {
 		case s.SerialNumber != "":
 			name = s.SerialNumber
@@ -699,12 +654,10 @@ func componentFromSpec(s expectedComponentSpec, rackID uuid.UUID) model.Componen
 // applyComponentChanges copies mirror-managed fields from desired into
 // existing. Type stays immutable (per-type reconciliation scope). Runtime
 // (ComponentID, PowerState, FirmwareVersion), lifecycle (Status, IngestedAt)
-// and audit timestamps are intentionally not touched. Manufacturer and
-// serial_number are mirror-managed metadata now that Host BMC MAC owns
-// identity — Core may fill a missing manufacturer on a later cycle. Fields
-// named in spec.preserveFields are also skipped — those are the columns
-// whose Core labels were malformed and so should keep Flow's existing value
-// rather than be overwritten with the parseLabelInt fallback zero.
+// and audit timestamps are intentionally not touched. Manufacturer and serial
+// are rewritten as metadata, so Core can fill a missing one later. Fields named
+// in spec.preserveFields are skipped — their Core labels were malformed, so
+// Flow's existing value beats the parseLabelInt fallback zero.
 func applyComponentChanges(existing, desired *model.Component, spec expectedComponentSpec) {
 	existing.Name = desired.Name
 	existing.IdentityKey = desired.IdentityKey
@@ -736,9 +689,8 @@ func diffComponentFields(existing, desired *model.Component, spec expectedCompon
 	if existing.Name != desired.Name {
 		diffs = append(diffs, fieldChange{"name", existing.Name, desired.Name})
 	}
-	// Changes only on the two paths the identity index cannot match: adopting
-	// a row that has no identity yet, and re-keying one whose identity moved
-	// (a replaced BMC board). An identity match by definition agrees already.
+	// Only differs when adopting a row that has no identity yet, or re-keying
+	// one whose identity moved; an identity match already agrees.
 	if existing.IdentityKey != desired.IdentityKey {
 		diffs = append(diffs, fieldChange{"identity_key", existing.IdentityKey, desired.IdentityKey})
 	}
@@ -782,10 +734,8 @@ func logComponentChanges(componentType string, id uuid.UUID, serial string, diff
 }
 
 // bmcOps captures the set of writes the mirror plans against the BMC table
-// for one component. The deletes slice is kept plural even though
-// bmc_one_host_per_component_idx now makes several type='Host' rows
-// impossible: the reconciliation also runs against rows written before that
-// index existed.
+// for one component. deletes stays plural because the reconciliation also runs
+// against rows written before bmc_one_host_per_component_idx existed.
 type bmcOps struct {
 	insert  *model.BMC
 	update  *model.BMC
@@ -946,9 +896,8 @@ func equalOptionalString(a, b *string) bool {
 }
 
 // hostBMCMac returns the Host BMC MAC for a component, or "" when none is
-// attached. At most one can match: bmc_one_host_per_component_idx enforces
-// the 1:1. DPU / other BMC types are ignored so they cannot become the
-// expected-inventory identity.
+// attached. bmc_one_host_per_component_idx makes the match unambiguous; DPU
+// and other BMC types are ignored.
 func hostBMCMac(c *model.Component) string {
 	if c == nil {
 		return ""

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
@@ -231,10 +231,18 @@ func pullExpectedPowerShelves(ctx context.Context, c nicoapi.Client) (rows []nic
 }
 
 // mirrorExpectedComponents reconciles Flow's component table for a single
-// component type against the supplied normalised specs. Matching key is
-// (manufacturer, serial_number), the same unique key Flow's ingestion path
-// already enforces; resurrect behaviour is symmetrical to the rack mirror so
-// transient Core absence doesn't cause UUID churn.
+// component type against the supplied normalised specs. Every Core row and
+// every Flow row is reduced to one identity (identityKeyForSpec /
+// identityKeyForComponent) and matched on that; the chassis labels are only
+// consulted for rows no identity matched, and only when no other spec claims
+// them, so the two indexes can never compete for one row. Resurrect behaviour
+// is symmetrical to the rack mirror so transient Core absence doesn't cause
+// UUID churn.
+//
+// A matched row keeps its UUID while manufacturer / serial are updated as
+// metadata, so a write can land on a (manufacturer, serial_number) pair some
+// other row already holds. Those writes are skipped rather than attempted;
+// see naturalKeySlotTaken.
 //
 // rackIDByExtID resolves a Core rack_id string (e.g. "a12") to the Flow rack
 // UUID. A spec whose RackExternalID can't be resolved is mirrored with a NULL
@@ -267,10 +275,49 @@ func mirrorExpectedComponents(
 		return result
 	}
 
-	flowBySerial := make(map[string]*model.Component, len(existing))
+	// flowByIdentityKey is the primary match index: one key per row, so nothing
+	// can disagree with it. Rows the mirror has never written an identity for
+	// fall back to the derivation, landing under the same key a Core spec
+	// produces, so they are adopted rather than duplicated. Two rows cannot
+	// collide here while the derivation reads the host BMC, since
+	// bmc.mac_address is a primary key.
+	//
+	// flowByNaturalKey backs the fallback for a spec whose identity matches
+	// nothing. A component whose identity legitimately changed (a replaced BMC
+	// board) or that never had one (ingestion-gRPC rows with no host BMC)
+	// would otherwise be re-inserted, and the insert would then be refused
+	// forever by the (manufacturer, serial_number) slot the old row — or its
+	// tombstone — still occupies. Adopting keeps the UUID and unsticks it.
+	//
+	// naturalKeyOwners covers soft-deleted rows too: component_manufacturer_serial_idx
+	// is a full unique constraint, so a tombstone still occupies its slot.
+	flowByIdentityKey := make(map[string]*model.Component, len(existing))
+	flowByNaturalKey := make(map[string]*model.Component, len(existing))
+	naturalKeyOwners := make(map[string]uuid.UUID, len(existing))
 	for i := range existing {
 		c := &existing[i]
-		flowBySerial[rackNaturalKey(c.Manufacturer, c.SerialNumber)] = c
+		if key := identityKeyForComponent(c); key != "" {
+			flowByIdentityKey[key] = c
+		}
+		if naturalKey := naturalKeyOrEmpty(c.Manufacturer, c.SerialNumber); naturalKey != "" {
+			flowByNaturalKey[naturalKey] = c
+			naturalKeyOwners[naturalKey] = c.ID
+		}
+	}
+
+	// Which Flow rows some spec claims by identity. Resolved up front because
+	// the natural-key fallback has to distinguish "this row is spoken for" from
+	// "this row is unmatched", and a single pass cannot know that until it has
+	// seen every spec. Without it the fallback could steal a row from a spec
+	// later in the slice — the ordering bug that made the previous
+	// serial-keyed matching unpredictable.
+	claimedByIdentity := make(map[uuid.UUID]struct{}, len(specs))
+	for _, s := range specs {
+		if key := identityKeyForSpec(s); key != "" {
+			if c, ok := flowByIdentityKey[key]; ok {
+				claimedByIdentity[c.ID] = struct{}{}
+			}
+		}
 	}
 
 	type plan struct {
@@ -282,25 +329,25 @@ func mirrorExpectedComponents(
 	}
 	var p plan
 
-	// seenKeys: every (manufacturer, serial) Core is still reporting this
-	// cycle, recorded BEFORE any validity / dedup skip. The delete phase
-	// treats a row whose key is absent from this set as "Core dropped it".
-	// plannedKeys: keys we've already queued an insert/update for, used to
-	// drop Core duplicates before they hit the (manufacturer, serial)
-	// unique index and roll back the whole type's transaction.
-	seenKeys := make(map[string]struct{}, len(specs))
-	plannedKeys := make(map[string]struct{}, len(specs))
+	// seenIdentityKeys: every identity Core is still reporting this cycle,
+	// recorded BEFORE any validity / dedup skip so the delete phase never
+	// drops a row Core still lists. plannedIdentityKeys: identities already
+	// queued, so a Core-side duplicate is dropped here instead of aborting the
+	// transaction on component_identity_key_idx.
+	// plannedNaturalKeys: (manufacturer, serial) pairs this cycle has already
+	// queued a write for. Identity no longer runs through that pair, but the
+	// mirror still writes it and component_manufacturer_serial_idx still
+	// guards it, so two writes planned in the same cycle have to be kept off
+	// the same slot.
+	seenIdentityKeys := make(map[string]struct{}, len(specs))
+	plannedIdentityKeys := make(map[string]struct{}, len(specs))
+	plannedNaturalKeys := make(map[string]struct{}, len(specs))
+	touchedIDs := make(map[uuid.UUID]struct{}, len(specs))
 
 	for _, s := range specs {
-		// Record the natural key as "still reported by Core" as early as
-		// possible. The key needs only (manufacturer, serial); a missing
-		// BMC MAC is a partial-row blip, not an absence, so it must not
-		// let the delete phase soft-delete a row Core is still listing.
-		keyDerivable := s.Manufacturer != "" && s.SerialNumber != ""
-		var key string
-		if keyDerivable {
-			key = rackNaturalKey(s.Manufacturer, s.SerialNumber)
-			seenKeys[key] = struct{}{}
+		key := identityKeyForSpec(s)
+		if key != "" {
+			seenIdentityKeys[key] = struct{}{}
 		}
 
 		if !specValid(s) {
@@ -309,23 +356,20 @@ func mirrorExpectedComponents(
 				Str("serial", s.SerialNumber).
 				Str("manufacturer", s.Manufacturer).
 				Str("bmc_mac", s.BMC.MACAddress).
-				Msg("Expected-inventory mirror: skipping Core expected component missing required identity (manufacturer / serial / BMC MAC); row preserved if its key is still reported")
+				Msg("Expected-inventory mirror: skipping Core expected component the mirror cannot derive an identity for; a component it could not match back to Core on a later cycle would be worse than the gap")
 			result.skippedNoIDOrKey++
 			continue
 		}
 
-		// specValid guarantees manufacturer and serial are set, so key is
-		// populated here. Drop Core duplicates: planning the same key twice
-		// would queue two INSERTs that collide on the unique index.
-		if _, planned := plannedKeys[key]; planned {
+		if _, planned := plannedIdentityKeys[key]; planned {
 			log.Warn().
 				Str("type", componentType).
-				Str("manufacturer", s.Manufacturer).
+				Str("identity_key", key).
 				Str("serial", s.SerialNumber).
-				Msg("Expected-inventory mirror: Core returned duplicate spec for this component; skipping the later occurrence to avoid a unique-constraint abort (Cloud REST is producing duplicates)")
+				Msg("Expected-inventory mirror: Core returned two expected components with the same identity; skipping the later occurrence (Core-side duplicate)")
 			continue
 		}
-		plannedKeys[key] = struct{}{}
+		plannedIdentityKeys[key] = struct{}{}
 
 		rackID, ok := resolveRackID(s, rackIDByExtID)
 		if !ok {
@@ -346,8 +390,50 @@ func mirrorExpectedComponents(
 		}
 
 		desired := componentFromSpec(s, rackID)
+		desired.IdentityKey = key
 
-		if cur, ok := flowBySerial[key]; ok {
+		cur, matched := flowByIdentityKey[key]
+		if !matched {
+			// Identity resolves to nothing, but the chassis labels point at a
+			// row no other spec claims: same component, new identity. Adopt it
+			// so the UUID survives and the write isn't blocked by the natural
+			// key it already holds. At most one candidate exists —
+			// component_manufacturer_serial_idx is unique.
+			if naturalKey := naturalKeyOrEmpty(desired.Manufacturer, desired.SerialNumber); naturalKey != "" {
+				if byNaturalKey, ok := flowByNaturalKey[naturalKey]; ok {
+					_, claimed := claimedByIdentity[byNaturalKey.ID]
+					_, touched := touchedIDs[byNaturalKey.ID]
+					if !claimed && !touched {
+						cur, matched = byNaturalKey, true
+					}
+				}
+			}
+		}
+
+		if matched {
+			// Identity matched, but manufacturer/serial are metadata the
+			// mirror also writes, and Core's pair may already belong to a
+			// different row. Attempting it would abort the whole type's
+			// transaction on component_manufacturer_serial_idx every cycle,
+			// so skip the write and leave both rows for an operator.
+			if naturalKeySlotTaken(naturalKeyOwners, plannedNaturalKeys, desired.Manufacturer, desired.SerialNumber, cur.ID) {
+				log.Warn().
+					Str("type", componentType).
+					Str("identity_key", key).
+					Str("manufacturer", desired.Manufacturer).
+					Str("serial", desired.SerialNumber).
+					Str("component_id", cur.ID.String()).
+					Msg("Expected-inventory mirror: Core's manufacturer/serial for this component is already held by a different Flow row; skipping this update to avoid a unique-constraint abort (operator must resolve the duplicate serial)")
+				result.skippedSerialTaken++
+				touchedIDs[cur.ID] = struct{}{}
+				continue
+			}
+			claimNaturalKeySlot(plannedNaturalKeys, desired.Manufacturer, desired.SerialNumber)
+
+			if cur.IdentityKey == "" {
+				result.adopted++
+			}
+
 			candidate := *cur
 			needUpdate := false
 			if candidate.DeletedAt != nil {
@@ -357,6 +443,7 @@ func mirrorExpectedComponents(
 				log.Info().
 					Str("type", componentType).
 					Str("serial", candidate.SerialNumber).
+					Str("bmc_mac", s.BMC.MACAddress).
 					Str("component_id", candidate.ID.String()).
 					Msg("Expected-inventory mirror: resurrecting soft-deleted component")
 			}
@@ -373,8 +460,24 @@ func mirrorExpectedComponents(
 				p.toUpdate = append(p.toUpdate, candidate)
 				p.toUpdateBMCs = append(p.toUpdateBMCs, bmcOps)
 			}
+			touchedIDs[candidate.ID] = struct{}{}
 			continue
 		}
+
+		// A new identity can still arrive carrying a (manufacturer, serial)
+		// some other row holds, or that another spec in this same cycle has
+		// already queued. Same reasoning as the update path above.
+		if naturalKeySlotTaken(naturalKeyOwners, plannedNaturalKeys, desired.Manufacturer, desired.SerialNumber, uuid.Nil) {
+			log.Warn().
+				Str("type", componentType).
+				Str("identity_key", key).
+				Str("manufacturer", desired.Manufacturer).
+				Str("serial", desired.SerialNumber).
+				Msg("Expected-inventory mirror: Core's manufacturer/serial is already held by a different Flow component; skipping this insert to avoid a unique-constraint abort (operator must resolve the duplicate serial)")
+			result.skippedSerialTaken++
+			continue
+		}
+		claimNaturalKeySlot(plannedNaturalKeys, desired.Manufacturer, desired.SerialNumber)
 
 		p.toInsert = append(p.toInsert, desired)
 		p.toInsertBMCs = append(p.toInsertBMCs, model.BMC{
@@ -384,6 +487,7 @@ func mirrorExpectedComponents(
 		})
 		log.Info().
 			Str("type", componentType).
+			Str("identity_key", key).
 			Str("serial", desired.SerialNumber).
 			Str("manufacturer", desired.Manufacturer).
 			Msg("Expected-inventory mirror: inserting new component from Core")
@@ -394,8 +498,13 @@ func mirrorExpectedComponents(
 		if c.DeletedAt != nil {
 			continue
 		}
-		if _, seen := seenKeys[rackNaturalKey(c.Manufacturer, c.SerialNumber)]; seen {
+		if _, touched := touchedIDs[c.ID]; touched {
 			continue
+		}
+		if key := identityKeyForComponent(c); key != "" {
+			if _, seen := seenIdentityKeys[key]; seen {
+				continue
+			}
 		}
 		p.toDelete = append(p.toDelete, *c)
 		log.Info().
@@ -438,7 +547,7 @@ func mirrorExpectedComponents(
 			p.toUpdate[i].UpdatedAt = now
 			if _, err := tx.NewUpdate().
 				Model(&p.toUpdate[i]).
-				Column("name", "model", "slot_id", "tray_index", "host_id", "rack_id", "deleted_at", "updated_at").
+				Column("name", "identity_key", "manufacturer", "serial_number", "model", "slot_id", "tray_index", "host_id", "rack_id", "deleted_at", "updated_at").
 				WhereAllWithDeleted().
 				Where("id = ?", p.toUpdate[i].ID).
 				Exec(ctx); err != nil {
@@ -478,11 +587,12 @@ func mirrorExpectedComponents(
 		log.Error().Err(err).Str("type", componentType).Msg("Expected-inventory mirror: component reconciliation transaction failed; mirror is no-op this cycle")
 		// Tx rolled back: every per-spec decision logged above represents
 		// intent, not committed state. Strip success-side counters so the
-		// summary log line reflects what actually landed. pulled and
-		// skippedNoIDOrKey survive: pulled is input size; skippedNoIDOrKey
-		// is decided before we ever opened the tx, so neither is
-		// invalidated by the rollback.
+		// summary log line reflects what actually landed. pulled and the
+		// skipped_* counters survive: pulled is input size and the skips are
+		// decided before we ever opened the tx, so neither is invalidated by
+		// the rollback.
 		result.resurrected = 0
+		result.adopted = 0
 		return result
 	}
 
@@ -492,11 +602,51 @@ func mirrorExpectedComponents(
 	return result
 }
 
-// specValid rejects rows missing fields the mirror needs to construct a row
-// that both inserts cleanly (Component.Manufacturer / SerialNumber are
-// NOT NULL and form a unique index) and reconciles BMC (MAC is BMC PK).
+// specValid rejects rows missing the Host BMC MAC. That MAC is the stable
+// 1:1 component identity (bmc PK guard). Manufacturer and serial_number are
+// optional mirror-managed metadata and may be NULL in the component table.
 func specValid(s expectedComponentSpec) bool {
-	return s.Manufacturer != "" && s.SerialNumber != "" && s.BMC.MACAddress != ""
+	return identityKeyForSpec(s) != ""
+}
+
+// identityKeyForSpec derives the value stored in component.identity_key for a
+// Core expected component, or "" when Core supplied nothing the mirror can
+// identify the row by. Today that is the host BMC MAC: it is 1:1 with a
+// component, it is the bmc table's primary key, and unlike the chassis labels
+// Core always reports it.
+//
+// This derivation is deliberately the only place the identity rule appears,
+// because it is expected to change — to a compound key, or to a Core-supplied
+// id — without reshaping the schema, the unique index, or the reconciliation
+// below.
+//
+// Changing it is not just an edit here. identity_key carries no marker of
+// which derivation produced it, so old and new values are indistinguishable
+// in the column, and during a rolling deploy two versions would write
+// different keys for the same component and collide on
+// component_identity_key_idx, aborting the cycle. A change therefore
+// ships in three steps: first a release whose matching accepts both the old
+// and the new value, then a migration that re-derives identity_key for every
+// row, then the switch to writing the new value (and a later release dropping
+// the compatibility branch).
+func identityKeyForSpec(s expectedComponentSpec) string {
+	return s.BMC.MACAddress
+}
+
+// identityKeyForComponent returns the identity a stored row answers to: the
+// persisted value once the mirror has written one, otherwise what the current
+// derivation makes of the row itself. The second case is how rows created
+// before identity_key existed — or by the ingestion gRPC paths — get adopted
+// instead of duplicated.
+//
+// It also constrains identityKeyForSpec: a derivation has to be computable
+// from a Flow row and not only from a Core spec, or adoption has nothing to
+// match on.
+func identityKeyForComponent(c *model.Component) string {
+	if c.IdentityKey != "" {
+		return c.IdentityKey
+	}
+	return hostBMCMac(c)
 }
 
 // resolveRackID translates Core's rack_id string into the Flow Rack.ID
@@ -524,9 +674,14 @@ func componentFromSpec(s expectedComponentSpec, rackID uuid.UUID) model.Componen
 	name := s.Name
 	if name == "" {
 		// Component.Name is part of the user-visible identity but the table
-		// doesn't enforce non-empty; matching Flow's lenient default keeps
-		// inserts safe when Core omits the name.
-		name = s.SerialNumber
+		// doesn't enforce non-empty. Prefer Core serial, then Host BMC MAC,
+		// so inserts stay labelled when Core omits the name.
+		switch {
+		case s.SerialNumber != "":
+			name = s.SerialNumber
+		default:
+			name = s.BMC.MACAddress
+		}
 	}
 	return model.Component{
 		Name:         name,
@@ -542,14 +697,19 @@ func componentFromSpec(s expectedComponentSpec, rackID uuid.UUID) model.Componen
 }
 
 // applyComponentChanges copies mirror-managed fields from desired into
-// existing. Identity (Manufacturer/SerialNumber/Type), runtime (ComponentID,
-// PowerState, FirmwareVersion), lifecycle (Status, IngestedAt) and audit
-// (CreatedAt, UpdatedAt) are intentionally not touched. Fields named in
-// spec.preserveFields are also skipped — those are the columns whose Core
-// labels were malformed and so should keep Flow's existing value rather
-// than be overwritten with the parseLabelInt fallback zero.
+// existing. Type stays immutable (per-type reconciliation scope). Runtime
+// (ComponentID, PowerState, FirmwareVersion), lifecycle (Status, IngestedAt)
+// and audit timestamps are intentionally not touched. Manufacturer and
+// serial_number are mirror-managed metadata now that Host BMC MAC owns
+// identity — Core may fill a missing manufacturer on a later cycle. Fields
+// named in spec.preserveFields are also skipped — those are the columns
+// whose Core labels were malformed and so should keep Flow's existing value
+// rather than be overwritten with the parseLabelInt fallback zero.
 func applyComponentChanges(existing, desired *model.Component, spec expectedComponentSpec) {
 	existing.Name = desired.Name
+	existing.IdentityKey = desired.IdentityKey
+	existing.Manufacturer = desired.Manufacturer
+	existing.SerialNumber = desired.SerialNumber
 	existing.Model = desired.Model
 	existing.RackID = desired.RackID
 	if !spec.preserveFields["slot_id"] {
@@ -575,6 +735,18 @@ func diffComponentFields(existing, desired *model.Component, spec expectedCompon
 	var diffs []fieldChange
 	if existing.Name != desired.Name {
 		diffs = append(diffs, fieldChange{"name", existing.Name, desired.Name})
+	}
+	// Changes only on the two paths the identity index cannot match: adopting
+	// a row that has no identity yet, and re-keying one whose identity moved
+	// (a replaced BMC board). An identity match by definition agrees already.
+	if existing.IdentityKey != desired.IdentityKey {
+		diffs = append(diffs, fieldChange{"identity_key", existing.IdentityKey, desired.IdentityKey})
+	}
+	if existing.Manufacturer != desired.Manufacturer {
+		diffs = append(diffs, fieldChange{"manufacturer", existing.Manufacturer, desired.Manufacturer})
+	}
+	if existing.SerialNumber != desired.SerialNumber {
+		diffs = append(diffs, fieldChange{"serial_number", existing.SerialNumber, desired.SerialNumber})
 	}
 	if existing.Model != desired.Model {
 		diffs = append(diffs, fieldChange{"model", existing.Model, desired.Model})
@@ -610,10 +782,10 @@ func logComponentChanges(componentType string, id uuid.UUID, serial string, diff
 }
 
 // bmcOps captures the set of writes the mirror plans against the BMC table
-// for one component. The deletes slice can be longer than one entry: a
-// well-formed component carries exactly one type='Host' BMC, but ingestion
-// bugs and data drift can leave several, and the mirror hard-deletes the
-// stale ones so Core's "exactly one host BMC" view is enforced.
+// for one component. The deletes slice is kept plural even though
+// bmc_one_host_per_component_idx now makes several type='Host' rows
+// impossible: the reconciliation also runs against rows written before that
+// index existed.
 type bmcOps struct {
 	insert  *model.BMC
 	update  *model.BMC
@@ -771,6 +943,23 @@ func equalOptionalString(a, b *string) bool {
 		return false
 	}
 	return *a == *b
+}
+
+// hostBMCMac returns the Host BMC MAC for a component, or "" when none is
+// attached. At most one can match: bmc_one_host_per_component_idx enforces
+// the 1:1. DPU / other BMC types are ignored so they cannot become the
+// expected-inventory identity.
+func hostBMCMac(c *model.Component) string {
+	if c == nil {
+		return ""
+	}
+	hostType := devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)
+	for i := range c.BMCs {
+		if c.BMCs[i].Type == hostType {
+			return c.BMCs[i].MacAddress
+		}
+	}
+	return ""
 }
 
 // getAllComponentsByTypeIncludingDeleted loads every row of the given type,

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component_test.go
@@ -121,17 +121,104 @@ func TestSpecValid(t *testing.T) {
 	}
 	assert.True(t, specValid(base), "complete spec should be valid")
 
-	for name, mutate := range map[string]func(*expectedComponentSpec){
-		"missing manufacturer": func(s *expectedComponentSpec) { s.Manufacturer = "" },
-		"missing serial":       func(s *expectedComponentSpec) { s.SerialNumber = "" },
-		"missing bmc mac":      func(s *expectedComponentSpec) { s.BMC.MACAddress = "" },
-	} {
-		t.Run(name, func(t *testing.T) {
-			s := base
-			mutate(&s)
-			assert.False(t, specValid(s))
-		})
-	}
+	t.Run("missing manufacturer is still valid (Host BMC MAC is the identity)", func(t *testing.T) {
+		s := base
+		s.Manufacturer = ""
+		assert.True(t, specValid(s))
+	})
+	t.Run("missing serial is still valid (Host BMC MAC is the identity)", func(t *testing.T) {
+		s := base
+		s.SerialNumber = ""
+		assert.True(t, specValid(s))
+	})
+	t.Run("missing bmc mac is invalid", func(t *testing.T) {
+		s := base
+		s.BMC.MACAddress = ""
+		assert.False(t, specValid(s))
+	})
+}
+
+func TestHostBMCMac(t *testing.T) {
+	hostType := devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)
+	dpuType := devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU)
+
+	t.Run("nil component", func(t *testing.T) {
+		assert.Empty(t, hostBMCMac(nil))
+	})
+	t.Run("no BMCs", func(t *testing.T) {
+		assert.Empty(t, hostBMCMac(&model.Component{}))
+	})
+	t.Run("dpu only is ignored", func(t *testing.T) {
+		c := &model.Component{BMCs: []model.BMC{{MacAddress: "aa:bb:cc:dd:ee:50", Type: dpuType}}}
+		assert.Empty(t, hostBMCMac(c))
+	})
+	t.Run("returns host MAC and ignores dpu", func(t *testing.T) {
+		c := &model.Component{BMCs: []model.BMC{
+			{MacAddress: "aa:bb:cc:dd:ee:50", Type: dpuType},
+			{MacAddress: "aa:bb:cc:dd:ee:01", Type: hostType},
+		}}
+		assert.Equal(t, "aa:bb:cc:dd:ee:01", hostBMCMac(c))
+	})
+}
+
+func TestIdentityKeyForSpec(t *testing.T) {
+	t.Run("derives from the host BMC MAC", func(t *testing.T) {
+		s := expectedComponentSpec{
+			Manufacturer: "Foxconn",
+			SerialNumber: "SN-1",
+			BMC:          expectedBMCSpec{MACAddress: "aa:bb:cc:dd:ee:ff"},
+		}
+		assert.Equal(t, "aa:bb:cc:dd:ee:ff", identityKeyForSpec(s))
+	})
+	t.Run("chassis labels do not contribute", func(t *testing.T) {
+		bare := expectedComponentSpec{BMC: expectedBMCSpec{MACAddress: "aa:bb:cc:dd:ee:ff"}}
+		labelled := expectedComponentSpec{
+			Manufacturer: "Foxconn",
+			SerialNumber: "SN-1",
+			Model:        "MGX",
+			BMC:          expectedBMCSpec{MACAddress: "aa:bb:cc:dd:ee:ff"},
+		}
+		assert.Equal(t, identityKeyForSpec(bare), identityKeyForSpec(labelled))
+	})
+	t.Run("no host BMC MAC yields no identity", func(t *testing.T) {
+		s := expectedComponentSpec{Manufacturer: "Foxconn", SerialNumber: "SN-1"}
+		assert.Empty(t, identityKeyForSpec(s))
+	})
+}
+
+func TestIdentityKeyForComponent(t *testing.T) {
+	hostType := devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)
+
+	t.Run("persisted value wins over the derivation", func(t *testing.T) {
+		c := &model.Component{
+			IdentityKey: "stored",
+			BMCs:        []model.BMC{{MacAddress: "aa:bb:cc:dd:ee:01", Type: hostType}},
+		}
+		assert.Equal(t, "stored", identityKeyForComponent(c))
+	})
+	t.Run("falls back to the derivation so unadopted rows still match", func(t *testing.T) {
+		c := &model.Component{BMCs: []model.BMC{{MacAddress: "aa:bb:cc:dd:ee:01", Type: hostType}}}
+		assert.Equal(t, "aa:bb:cc:dd:ee:01", identityKeyForComponent(c))
+	})
+	t.Run("no identity at all", func(t *testing.T) {
+		assert.Empty(t, identityKeyForComponent(&model.Component{}))
+	})
+
+	// Adoption depends on both sides agreeing, so a derivation change that
+	// updates only identityKeyForSpec would silently duplicate every row.
+	t.Run("agrees with identityKeyForSpec for a row the mirror just created", func(t *testing.T) {
+		s := expectedComponentSpec{
+			Manufacturer: "Foxconn",
+			SerialNumber: "SN-1",
+			BMC:          expectedBMCSpec{MACAddress: "aa:bb:cc:dd:ee:02"},
+		}
+		stored := &model.Component{
+			Manufacturer: s.Manufacturer,
+			SerialNumber: s.SerialNumber,
+			BMCs:         []model.BMC{{MacAddress: s.BMC.MACAddress, Type: hostType}},
+		}
+		assert.Equal(t, identityKeyForSpec(s), identityKeyForComponent(stored))
+	})
 }
 
 func TestResolveRackID(t *testing.T) {
@@ -185,6 +272,17 @@ func TestComponentFromSpec_NameFallsBackToSerial(t *testing.T) {
 	assert.Equal(t, "SN-1", c.Name, "empty Core name should fall back to serial so notnull-checks downstream don't trip")
 }
 
+func TestComponentFromSpec_NameFallsBackToHostBMCMac(t *testing.T) {
+	s := expectedComponentSpec{
+		Type: "Compute",
+		BMC:  expectedBMCSpec{MACAddress: "aa:bb:cc:dd:ee:ff"},
+	}
+	c := componentFromSpec(s, uuid.Nil)
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", c.Name, "empty Core name and serial should fall back to Host BMC MAC")
+	assert.Empty(t, c.SerialNumber)
+	assert.Empty(t, c.Manufacturer)
+}
+
 func TestDiffComponentFields(t *testing.T) {
 	rackA := uuid.New()
 	rackB := uuid.New()
@@ -210,12 +308,14 @@ func TestDiffComponentFields(t *testing.T) {
 	})
 
 	for name, mutate := range map[string]func(*model.Component){
-		"name":       func(c *model.Component) { c.Name = "n2" },
-		"model":      func(c *model.Component) { c.Model = "m2" },
-		"slot_id":    func(c *model.Component) { c.SlotID = 9 },
-		"tray_index": func(c *model.Component) { c.TrayIndex = 9 },
-		"host_id":    func(c *model.Component) { c.HostID = 9 },
-		"rack_id":    func(c *model.Component) { c.RackID = rackB },
+		"name":          func(c *model.Component) { c.Name = "n2" },
+		"manufacturer":  func(c *model.Component) { c.Manufacturer = "other" },
+		"serial_number": func(c *model.Component) { c.SerialNumber = "SN-2" },
+		"model":         func(c *model.Component) { c.Model = "m2" },
+		"slot_id":       func(c *model.Component) { c.SlotID = 9 },
+		"tray_index":    func(c *model.Component) { c.TrayIndex = 9 },
+		"host_id":       func(c *model.Component) { c.HostID = 9 },
+		"rack_id":       func(c *model.Component) { c.RackID = rackB },
 	} {
 		t.Run("change in "+name+" is detected", func(t *testing.T) {
 			desired := base()
@@ -239,7 +339,7 @@ func TestDiffComponentFields(t *testing.T) {
 	})
 }
 
-func TestApplyComponentChanges_DoesNotTouchIdentityOrRuntimeFields(t *testing.T) {
+func TestApplyComponentChanges_UpdatesMetadataPreservesRuntime(t *testing.T) {
 	id := uuid.New()
 	rackA := uuid.New()
 	rackB := uuid.New()
@@ -248,26 +348,28 @@ func TestApplyComponentChanges_DoesNotTouchIdentityOrRuntimeFields(t *testing.T)
 		ID:           id,
 		Name:         "old",
 		Type:         "Compute",
-		Manufacturer: "Foxconn",
+		Manufacturer: "",
 		SerialNumber: "SN-1",
 		Model:        "old-model",
 		RackID:       rackA,
 		ComponentID:  &extID, // runtime-owned, must not be touched
 	}
 	desired := &model.Component{
-		Name:   "new",
-		Model:  "new-model",
-		RackID: rackB,
+		Name:         "new",
+		Manufacturer: "Foxconn",
+		SerialNumber: "SN-2",
+		Model:        "new-model",
+		RackID:       rackB,
 	}
 
 	applyComponentChanges(existing, desired, expectedComponentSpec{})
 
 	assert.Equal(t, "new", existing.Name)
+	assert.Equal(t, "Foxconn", existing.Manufacturer, "manufacturer is mirror-managed metadata once Host BMC owns identity")
+	assert.Equal(t, "SN-2", existing.SerialNumber, "serial is mirror-managed metadata once Host BMC owns identity")
 	assert.Equal(t, "new-model", existing.Model)
 	assert.Equal(t, rackB, existing.RackID)
-	assert.Equal(t, "Compute", existing.Type, "Type is identity; mirror must not touch")
-	assert.Equal(t, "Foxconn", existing.Manufacturer, "Manufacturer is identity")
-	assert.Equal(t, "SN-1", existing.SerialNumber, "SerialNumber is identity")
+	assert.Equal(t, "Compute", existing.Type, "Type scopes the reconciliation; mirror must not touch")
 	require.NotNil(t, existing.ComponentID)
 	assert.Equal(t, "runtime-id", *existing.ComponentID, "external_id is runtime-owned")
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -190,6 +190,66 @@ func TestMirrorRacks_NullSerialDistinctByExternalID(t *testing.T) {
 	assert.Equal(t, 4, n, "four NULL-serial racks with distinct external_ids must all insert")
 }
 
+// Chassis labels are metadata, not identity, so a Core site that has labelled
+// neither is still mirrored rather than skipped. Both racks store NULL for
+// both columns and stay distinct on external_id.
+func TestMirrorRacks_NoChassisLabelsStillMirrored(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		{RackID: "a12", Name: "rack-a12"},
+		{RackID: "b07", Name: "rack-b07"},
+	})
+
+	n, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).
+		Where("manufacturer IS NULL").
+		Where("serial_number IS NULL").
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "racks with no chassis labels must mirror, distinguished by external_id")
+}
+
+// A Core row with no rack_id has no identity the mirror could match it back to
+// on a later cycle, so it is skipped even when both chassis labels are present.
+func TestMirrorRacks_NoRackIDSkipped(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	result := mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		{Name: "orphan", Labels: map[string]string{
+			labelChassisManufacturer: "NVIDIA",
+			labelChassisSerialNumber: "SN-ORPHAN",
+		}},
+	})
+
+	assert.Equal(t, 1, result.skippedNoIDOrKey)
+	n, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, n, "a rack with no rack_id must not be inserted")
+}
+
+// A site that labels its chassis after the rack was first mirrored gets both
+// labels backfilled in place, keeping the UUID.
+func TestMirrorRacks_ChassisLabelsBackfilled(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		{RackID: "a12", Name: "rack-a12"},
+	})
+	var before model.Rack
+	require.NoError(t, pool.DB.NewSelect().Model(&before).Where("external_id = ?", "a12").Scan(ctx))
+	require.Empty(t, before.Manufacturer)
+	require.Empty(t, before.SerialNumber)
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		coreRack("a12", "NVIDIA", "SN-A12"),
+	})
+
+	after, err := (&model.Rack{ID: before.ID}).Get(ctx, pool.DB, false)
+	require.NoError(t, err)
+	assert.Equal(t, "NVIDIA", after.Manufacturer, "backfill must keep the UUID and fill both labels")
+	assert.Equal(t, "SN-A12", after.SerialNumber)
+}
+
 // A NULL-serial rack matched by external_id whose newly-reported serial is
 // already held by another rack (here a tombstone, which still occupies the
 // unique slot) must be skipped, not written: the write would abort the whole

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -166,6 +166,61 @@ func TestMirrorRacks_DuplicateChassisNoAbort(t *testing.T) {
 	assert.Equal(t, 1, n, "exactly one rack inserted; the duplicate is dropped, not a constraint abort")
 }
 
+// Racks with manufacturer but no serial, each with a distinct rack_id, must
+// all insert. Postgres treats NULL serials as distinct under
+// UNIQUE (manufacturer, serial_number), and matching is by external_id.
+func TestMirrorRacks_NullSerialDistinctByExternalID(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	core := make([]nicoapi.ExpectedRackDetail, 0, 4)
+	for _, id := range []string{"a12", "b07", "c03", "d09"} {
+		core = append(core, nicoapi.ExpectedRackDetail{
+			RackID: id,
+			Name:   "rack-" + id,
+			Labels: map[string]string{labelChassisManufacturer: "NVIDIA"},
+		})
+	}
+	mirrorExpectedRacks(ctx, pool, core)
+
+	n, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).
+		Where("manufacturer = ?", "NVIDIA").
+		Where("serial_number IS NULL").
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n, "four NULL-serial racks with distinct external_ids must all insert")
+}
+
+// A NULL-serial rack matched by external_id whose newly-reported serial is
+// already held by another rack (here a tombstone, which still occupies the
+// unique slot) must be skipped, not written: the write would abort the whole
+// rack transaction and take every other rack down with it, every cycle.
+func TestMirrorRacks_SerialTakenByTombstoneSkipsUpdate(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	holder := model.Rack{Name: "holder", Manufacturer: "NVIDIA", SerialNumber: "SN-CLASH"}
+	require.NoError(t, holder.Create(ctx, pool.DB))
+	require.NoError(t, holder.Delete(ctx, pool.DB))
+
+	target := model.Rack{Name: "rack-a12", Manufacturer: "NVIDIA", ExternalID: strPtr("a12")}
+	require.NoError(t, target.Create(ctx, pool.DB))
+	other := model.Rack{Name: "rack-b07", Manufacturer: "NVIDIA", ExternalID: strPtr("b07")}
+	require.NoError(t, other.Create(ctx, pool.DB))
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		coreRack("a12", "NVIDIA", "SN-CLASH"),
+		{RackID: "b07", Name: "rack-b07-renamed", Labels: map[string]string{labelChassisManufacturer: "NVIDIA"}},
+	})
+
+	gotTarget, err := (&model.Rack{ID: target.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Empty(t, gotTarget.SerialNumber, "must not write a serial another rack already holds")
+	assert.Nil(t, gotTarget.DeletedAt, "a skipped update must not cascade into a soft-delete")
+
+	gotOther, err := (&model.Rack{ID: other.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Equal(t, "rack-b07-renamed", gotOther.Name, "the colliding rack must not block unrelated racks in the same cycle")
+}
+
 // #8: an empty Core description must not wipe operator-set rack metadata.
 func TestMirrorRacks_EmptyDescriptionPreserved(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
@@ -362,8 +417,212 @@ func TestRunInventoryOne_DriftTablePreservedOnRPCFailure(t *testing.T) {
 	assert.Equal(t, 1, n, "drift table must not be wiped when an actual-sync RPC failed")
 }
 
-// #4: duplicate component specs must not abort the transaction on the
-// (manufacturer, serial) unique index.
+// A row the mirror has never written an identity_key for must be adopted via
+// the derivation rather than duplicated, and the adoption must persist so the
+// next cycle matches on the stored value.
+func TestMirrorComponents_AdoptsRowWithoutIdentityKey(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	legacy := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-LEGACY"}
+	require.NoError(t, legacy.Create(ctx, pool.DB))
+	require.Empty(t, legacy.IdentityKey, "fixture must start unadopted")
+	hostBMC := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:60",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		ComponentID: legacy.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&hostBMC).Exec(ctx)
+	require.NoError(t, err)
+
+	spec := computeSpec("Mfg", "C-LEGACY", "aa:bb:cc:dd:ee:60")
+	mirrorExpectedComponents(ctx, pool, compType(), []expectedComponentSpec{spec}, map[string]uuid.UUID{})
+
+	got, err := (&model.Component{ID: legacy.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt, "adoption must not soft-delete the row it adopted")
+	assert.Equal(t, "aa:bb:cc:dd:ee:60", got.IdentityKey, "adoption must persist the derived identity")
+
+	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("type = ?", compType()).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "the unadopted row must be reused, not duplicated")
+}
+
+// A replaced BMC board changes the component's identity. Re-inserting would
+// be refused forever by the (manufacturer, serial) slot the old row still
+// occupies, so the fallback must adopt it and re-key it in place.
+func TestMirrorComponents_ReplacedBMCReKeysInPlace(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	c := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-REKEY"}
+	require.NoError(t, c.Create(ctx, pool.DB))
+	oldBMC := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:80",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		ComponentID: c.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&oldBMC).Exec(ctx)
+	require.NoError(t, err)
+	mirrorExpectedComponents(ctx, pool, compType(),
+		[]expectedComponentSpec{computeSpec("Mfg", "C-REKEY", "aa:bb:cc:dd:ee:80")},
+		map[string]uuid.UUID{})
+
+	// Same chassis, new BMC board.
+	mirrorExpectedComponents(ctx, pool, compType(),
+		[]expectedComponentSpec{computeSpec("Mfg", "C-REKEY", "aa:bb:cc:dd:ee:81")},
+		map[string]uuid.UUID{})
+
+	got, err := (&model.Component{ID: c.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt, "re-keying must not soft-delete the component")
+	assert.Equal(t, "aa:bb:cc:dd:ee:81", got.IdentityKey, "identity must follow the new BMC")
+
+	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("type = ?", compType()).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "a BMC swap must not leave a second component behind")
+}
+
+// The natural-key fallback must never take a row another spec claims by
+// identity, whatever order the specs arrive in.
+func TestMirrorComponents_FallbackYieldsToIdentityClaim(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	// Held by identity aa:bb:cc:dd:ee:90, and also the only holder of
+	// (Mfg, C-CONTESTED).
+	held := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-CONTESTED"}
+	require.NoError(t, held.Create(ctx, pool.DB))
+	hostBMC := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:90",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		ComponentID: held.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&hostBMC).Exec(ctx)
+	require.NoError(t, err)
+
+	// The contender is listed first, so a single-pass fallback would let it
+	// steal the row before the identity match is ever considered.
+	mirrorExpectedComponents(ctx, pool, compType(), []expectedComponentSpec{
+		computeSpec("Mfg", "C-CONTESTED", "aa:bb:cc:dd:ee:91"),
+		computeSpec("Mfg", "C-CONTESTED", "aa:bb:cc:dd:ee:90"),
+	}, map[string]uuid.UUID{})
+
+	got, err := (&model.Component{ID: held.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt)
+	assert.Equal(t, "aa:bb:cc:dd:ee:90", got.IdentityKey, "the identity claim must win over the label fallback")
+}
+
+// Identity is the host BMC MAC, so the same serial under two manufacturers is
+// two components. The previous serial-keyed dedup silently dropped the second.
+func TestMirrorComponents_SameSerialDifferentManufacturerBothInsert(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	mirrorExpectedComponents(ctx, pool, compType(), []expectedComponentSpec{
+		computeSpec("MfgA", "C-SHARED", "aa:bb:cc:dd:ee:61"),
+		computeSpec("MfgB", "C-SHARED", "aa:bb:cc:dd:ee:62"),
+	}, map[string]uuid.UUID{})
+
+	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("serial_number = ?", "C-SHARED").Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "a shared serial under distinct manufacturers is two legitimate components")
+}
+
+// Same, for the klamath-style rows Core reports without a manufacturer label:
+// the pair stores a NULL, so it occupies no unique-index slot at all.
+func TestMirrorComponents_SameSerialNoManufacturerBothInsert(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	mirrorExpectedComponents(ctx, pool, compType(), []expectedComponentSpec{
+		computeSpec("", "C-UNLABELLED", "aa:bb:cc:dd:ee:63"),
+		computeSpec("", "C-UNLABELLED", "aa:bb:cc:dd:ee:64"),
+	}, map[string]uuid.UUID{})
+
+	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("serial_number = ?", "C-UNLABELLED").Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "unlabelled rows sharing a serial must not collapse onto one key")
+}
+
+// The delete phase keys off identity, so a Flow row Core no longer reports is
+// soft-deleted even while some other component Core still reports happens to
+// carry the same serial. Keying deletes off serial kept such rows alive
+// forever.
+func TestMirrorComponents_SharedSerialDoesNotShieldAbsentComponent(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	gone := model.Component{Type: compType(), Manufacturer: "MfgA", SerialNumber: "C-TWIN"}
+	require.NoError(t, gone.Create(ctx, pool.DB))
+	hostBMC := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:65",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		ComponentID: gone.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&hostBMC).Exec(ctx)
+	require.NoError(t, err)
+
+	// Core reports a different component that shares the serial but not the
+	// identity of the row above.
+	mirrorExpectedComponents(ctx, pool, compType(), []expectedComponentSpec{
+		computeSpec("MfgB", "C-TWIN", "aa:bb:cc:dd:ee:66"),
+	}, map[string]uuid.UUID{})
+
+	got, err := (&model.Component{ID: gone.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.NotNil(t, got.DeletedAt, "a component Core stopped reporting must be soft-deleted regardless of who else holds its serial")
+}
+
+// identity_key is a denormalised copy of a value that is unique at its source,
+// so the index has to be global. Scoped by type it would admit one MAC under
+// two component types, which no valid inventory produces.
+func TestComponent_IdentityKeyUniqueAcrossTypes(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	first := model.Component{Type: compType(), Name: "c1", IdentityKey: "aa:bb:cc:dd:ee:a0"}
+	require.NoError(t, first.Create(ctx, pool.DB))
+
+	second := model.Component{
+		Type:        devicetypes.ComponentTypeToString(devicetypes.ComponentTypeNVSwitch),
+		Name:        "c2",
+		IdentityKey: "aa:bb:cc:dd:ee:a0",
+	}
+	require.Error(t, second.Create(ctx, pool.DB), "one identity must not appear under two component types")
+
+	// NULL is exempt, so the ingestion gRPC paths stay unconstrained.
+	for _, name := range []string{"no-identity-1", "no-identity-2"} {
+		c := model.Component{Type: compType(), Name: name}
+		require.NoError(t, c.Create(ctx, pool.DB), "rows without an identity must not collide")
+	}
+}
+
+// bmc_one_host_per_component_idx makes the 1:1 the identity derivation assumes
+// enforceable rather than conventional, so hostBMCMac can never have to pick
+// between candidates.
+func TestBMC_SecondHostBMCPerComponentRejected(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	c := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-1TO1"}
+	require.NoError(t, c.Create(ctx, pool.DB))
+
+	hostType := devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)
+	first := model.BMC{MacAddress: "aa:bb:cc:dd:ee:70", Type: hostType, ComponentID: c.ID}
+	_, err := pool.DB.NewInsert().Model(&first).Exec(ctx)
+	require.NoError(t, err)
+
+	second := model.BMC{MacAddress: "aa:bb:cc:dd:ee:71", Type: hostType, ComponentID: c.ID}
+	_, err = pool.DB.NewInsert().Model(&second).Exec(ctx)
+	require.Error(t, err, "a component must not be able to hold two host BMCs")
+
+	// A DPU BMC is outside the partial index and stays allowed.
+	dpu := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:72",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU),
+		ComponentID: c.ID,
+	}
+	_, err = pool.DB.NewInsert().Model(&dpu).Exec(ctx)
+	require.NoError(t, err, "the index must only constrain host BMCs")
+}
+
+// #4: duplicate component specs must not abort the transaction. The two specs
+// carry distinct identities, so it is the (manufacturer, serial) pair they
+// share that has to be kept off one unique-index slot.
 func TestMirrorComponents_DuplicateSpecNoAbort(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
@@ -375,5 +634,104 @@ func TestMirrorComponents_DuplicateSpecNoAbort(t *testing.T) {
 
 	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("serial_number = ?", "C-DUP").Count(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 1, n, "exactly one component inserted; the duplicate spec is dropped")
+	assert.Equal(t, 1, n, "exactly one component inserted; the duplicate serial is dropped")
+}
+
+// Missing manufacturer is allowed: identity_key carries the identity, so the
+// chassis labels are free to be incomplete.
+func TestMirrorComponents_MissingManufacturerInserts(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	spec := computeSpec("", "C-NO-MFR", "aa:bb:cc:dd:ee:30")
+	mirrorExpectedComponents(ctx, pool, compType(), []expectedComponentSpec{spec}, map[string]uuid.UUID{})
+
+	got, err := model.GetComponentByBMCMAC(ctx, pool.DB, "aa:bb:cc:dd:ee:30")
+	require.NoError(t, err)
+	assert.Empty(t, got.Manufacturer)
+	assert.Equal(t, "C-NO-MFR", got.SerialNumber)
+	require.Len(t, got.BMCs, 1)
+	assert.Equal(t, "aa:bb:cc:dd:ee:30", got.BMCs[0].MacAddress)
+}
+
+// Missing serial is allowed once identity comes from elsewhere. Several such
+// rows must not collapse: Postgres treats the NULL serials as distinct under
+// component_manufacturer_serial_idx.
+func TestMirrorComponents_NullSerialDistinctByHostBMCMac(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	specs := []expectedComponentSpec{
+		{Type: compType(), BMC: expectedBMCSpec{MACAddress: "aa:bb:cc:dd:ee:31"}},
+		{Type: compType(), BMC: expectedBMCSpec{MACAddress: "aa:bb:cc:dd:ee:32"}},
+		{Type: compType(), BMC: expectedBMCSpec{MACAddress: "aa:bb:cc:dd:ee:33"}},
+	}
+	mirrorExpectedComponents(ctx, pool, compType(), specs, map[string]uuid.UUID{})
+
+	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).
+		Where("type = ?", compType()).
+		Where("serial_number IS NULL").
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n, "three NULL-serial components with distinct Host BMC MACs must all insert")
+}
+
+// Identity is independent of the chassis labels, so Core renaming a serial
+// updates the existing row in place instead of inserting a duplicate.
+func TestMirrorComponents_MatchByHostBMCMac(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	c := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-OLD"}
+	require.NoError(t, c.Create(ctx, pool.DB))
+	hostBMC := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:40",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		ComponentID: c.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&hostBMC).Exec(ctx)
+	require.NoError(t, err)
+
+	spec := computeSpec("Mfg", "C-NEW", "aa:bb:cc:dd:ee:40")
+	mirrorExpectedComponents(ctx, pool, compType(), []expectedComponentSpec{spec}, map[string]uuid.UUID{})
+
+	got, err := (&model.Component{ID: c.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt)
+	assert.Equal(t, "C-NEW", got.SerialNumber, "Host BMC match must update serial metadata in place")
+
+	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("type = ?", compType()).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "must not insert a second component for the same Host BMC MAC")
+}
+
+// Identity and (manufacturer, serial) can disagree: identity matches one row
+// while Core's serial belongs to another. The write must be skipped so a
+// single conflicting component doesn't roll back the type's whole cycle.
+func TestMirrorComponents_SerialTakenByOtherComponentSkipsUpdate(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	holder := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-CLASH"}
+	require.NoError(t, holder.Create(ctx, pool.DB))
+
+	target := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-TARGET"}
+	require.NoError(t, target.Create(ctx, pool.DB))
+	hostBMC := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:50",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		ComponentID: target.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&hostBMC).Exec(ctx)
+	require.NoError(t, err)
+
+	mirrorExpectedComponents(ctx, pool, compType(), []expectedComponentSpec{
+		computeSpec("Mfg", "C-CLASH", "aa:bb:cc:dd:ee:50"),
+		computeSpec("Mfg", "C-FRESH", "aa:bb:cc:dd:ee:51"),
+	}, map[string]uuid.UUID{})
+
+	gotTarget, err := (&model.Component{ID: target.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Equal(t, "C-TARGET", gotTarget.SerialNumber, "must not write a serial another component already holds")
+	assert.Nil(t, gotTarget.DeletedAt, "a skipped update must not cascade into a soft-delete")
+
+	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("serial_number = ?", "C-FRESH").Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "the colliding component must not block unrelated components in the same cycle")
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
@@ -57,12 +57,12 @@ func pullExpectedRacks(
 // expected_racks view. The algorithm is, in order:
 //
 //  1. Index every Flow rack — including soft-deleted ones — by external_id
-//     (mirror-owned) and by (manufacturer, serial_number) (the natural key
-//     shared with Core). Including soft-deleted rows is what makes
+//     (mirror-owned) and by (manufacturer, serial_number) when serial is
+//     present (the natural key shared with Core). NULL-serial racks match
+//     only via external_id. Including soft-deleted rows is what makes
 //     resurrection work: a rack that briefly disappeared from Core and came
 //     back keeps its UUID, and a re-insert would otherwise collide on the
-//     (manufacturer, serial_number) unique index that the soft-deleted row
-//     still occupies.
+//     unique indexes the soft-deleted row still occupies.
 //
 //  2. For each Core row, find the matching Flow row preferring external_id
 //     and falling back to (manufacturer, serial_number) to adopt rows that
@@ -95,12 +95,24 @@ func mirrorExpectedRacks(
 
 	flowByExtID := make(map[string]*model.Rack, len(flowRacks))
 	flowBySerial := make(map[string]*model.Rack, len(flowRacks))
+	// naturalKeyOwners covers soft-deleted rows too: rack_manufacturer_serial_idx
+	// is a full unique constraint, so a tombstone still occupies its slot.
+	naturalKeyOwners := make(map[string]uuid.UUID, len(flowRacks))
 	for i := range flowRacks {
 		r := &flowRacks[i]
 		if r.ExternalID != nil && *r.ExternalID != "" {
 			flowByExtID[*r.ExternalID] = r
 		}
-		flowBySerial[rackNaturalKey(r.Manufacturer, r.SerialNumber)] = r
+		if r.Manufacturer != "" && r.SerialNumber != "" {
+			naturalKeyOwners[rackNaturalKey(r.Manufacturer, r.SerialNumber)] = r.ID
+		}
+		// Only index serial-bearing rows. Empty/NULL serials are not a
+		// natural key — matching those goes exclusively through external_id
+		// so klamath-style manufacturer=NVIDIA / serial=NULL racks do not
+		// collapse onto one map entry.
+		if r.SerialNumber != "" {
+			flowBySerial[rackNaturalKey(r.Manufacturer, r.SerialNumber)] = r
+		}
 	}
 
 	type plan struct {
@@ -138,11 +150,13 @@ func mirrorExpectedRacks(
 	// cycle; the delete phase skips them so a rack_id rename (update to the
 	// new external_id) isn't immediately undone by a soft-delete keyed off
 	// the stale in-memory external_id. plannedSerial: natural keys already
-	// queued, to drop Core duplicates before they collide on the
-	// (manufacturer, serial) unique index.
+	// queued for serial-bearing racks. plannedExtID: external_ids already
+	// queued so duplicate Core rack_ids (or multiple NULL-serial racks
+	// sharing a manufacturer) cannot collide.
 	seenExtID := make(map[string]struct{}, len(coreRacks))
 	touchedIDs := make(map[uuid.UUID]struct{}, len(coreRacks))
 	plannedSerial := make(map[string]struct{}, len(coreRacks))
+	plannedExtID := make(map[string]struct{}, len(coreRacks))
 
 	for _, cr := range coreRacks {
 		// Record the rack_id as "still reported" before any skip below.
@@ -152,15 +166,14 @@ func mirrorExpectedRacks(
 
 		built, ok := buildRackFromCore(cr)
 		if !ok {
-			// Required fields (manufacturer / serial) missing in Core's labels;
-			// inserting would violate NOT NULL or the (manufacturer, serial)
-			// unique constraint. Skip the write, but the rack_id is already in
-			// seenExtID so we don't soft-delete an existing Flow rack over a
-			// transient label gap.
+			// Required identity missing: need manufacturer, plus either a
+			// chassis serial or a Core rack_id (external_id). Skip the
+			// write, but the rack_id is already in seenExtID so we don't
+			// soft-delete an existing Flow rack over a transient label gap.
 			log.Warn().
 				Str("rack_id", cr.RackID).
 				Str("name", cr.Name).
-				Msg("Expected-inventory mirror: skipping Core expected rack missing chassis manufacturer or serial-number labels; existing Flow rack preserved")
+				Msg("Expected-inventory mirror: skipping Core expected rack missing chassis manufacturer, and lacking both serial-number and rack_id; existing Flow rack preserved")
 			result.skippedNoIDOrKey++
 			continue
 		}
@@ -174,19 +187,30 @@ func mirrorExpectedRacks(
 				Msg("Expected-inventory mirror: Core expected rack has no rack_id; rack will be mirrored but components can't reference it")
 		}
 
-		// Drop Core duplicates: planning the same chassis twice would queue a
-		// second INSERT that collides on the (manufacturer, serial) unique
-		// index and roll back the whole rack mirror.
-		natKey := rackNaturalKey(built.Manufacturer, built.SerialNumber)
-		if _, planned := plannedSerial[natKey]; planned {
-			log.Warn().
-				Str("rack_id", cr.RackID).
-				Str("manufacturer", built.Manufacturer).
-				Str("serial", built.SerialNumber).
-				Msg("Expected-inventory mirror: Core returned duplicate expected racks for the same chassis; skipping the later occurrence")
-			continue
+		// Drop Core duplicates before they collide on unique indexes.
+		if cr.RackID != "" {
+			if _, planned := plannedExtID[cr.RackID]; planned {
+				log.Warn().
+					Str("rack_id", cr.RackID).
+					Str("manufacturer", built.Manufacturer).
+					Str("serial", built.SerialNumber).
+					Msg("Expected-inventory mirror: Core returned duplicate expected racks for the same rack_id; skipping the later occurrence")
+				continue
+			}
+			plannedExtID[cr.RackID] = struct{}{}
 		}
-		plannedSerial[natKey] = struct{}{}
+		if built.SerialNumber != "" {
+			naturalKey := rackNaturalKey(built.Manufacturer, built.SerialNumber)
+			if _, planned := plannedSerial[naturalKey]; planned {
+				log.Warn().
+					Str("rack_id", cr.RackID).
+					Str("manufacturer", built.Manufacturer).
+					Str("serial", built.SerialNumber).
+					Msg("Expected-inventory mirror: Core returned duplicate expected racks for the same chassis; skipping the later occurrence")
+				continue
+			}
+			plannedSerial[naturalKey] = struct{}{}
+		}
 
 		// Prefer external_id match (already adopted on a previous cycle).
 		// Empty rack_ids never hit flowByExtID by construction.
@@ -201,6 +225,20 @@ func mirrorExpectedRacks(
 			if patched := rackUpdatedFromCore(&candidate, &built); patched != nil {
 				candidate = *patched
 				needUpdate = true
+			}
+			// rackUpdatedFromCore fills a previously-NULL serial, which can
+			// land on a (manufacturer, serial) pair another rack — including
+			// a tombstone — already holds. Writing it anyway would abort the
+			// whole rack transaction every cycle.
+			if needUpdate && naturalKeyTakenByOther(naturalKeyOwners, candidate.Manufacturer, candidate.SerialNumber, existing.ID) {
+				log.Warn().
+					Str("rack_id", cr.RackID).
+					Str("manufacturer", candidate.Manufacturer).
+					Str("rack_serial", candidate.SerialNumber).
+					Msg("Expected-inventory mirror: Core's chassis serial for this rack_id is already held by a different Flow rack; skipping this update to avoid a unique-constraint abort (operator must resolve the duplicate chassis)")
+				result.skippedSerialTaken++
+				touchedIDs[existing.ID] = struct{}{}
+				continue
 			}
 			if needUpdate && nameTakenByOtherLiveRack(liveByName, candidate.Name, existing.ID) {
 				log.Warn().
@@ -221,32 +259,34 @@ func mirrorExpectedRacks(
 
 		// Fall back to natural key (legacy ingestion-gRPC rows the mirror has
 		// never adopted; adopt by writing external_id alongside any deltas).
-		// A serial match that's also soft-deleted gets resurrected at the
-		// same time — see the function-level comment for why this matters.
-		if existing, ok := flowBySerial[natKey]; ok {
-			candidate := *existing
-			candidate.ExternalID = built.ExternalID
-			if candidate.DeletedAt != nil {
-				candidate.DeletedAt = nil
-				result.resurrected++
-			}
-			if patched := rackUpdatedFromCore(&candidate, &built); patched != nil {
-				candidate = *patched
-			}
-			if nameTakenByOtherLiveRack(liveByName, candidate.Name, existing.ID) {
-				log.Warn().
-					Str("rack_id", cr.RackID).
-					Str("name", candidate.Name).
-					Str("rack_serial", candidate.SerialNumber).
-					Msg("Expected-inventory mirror: Core rack name already held by a different live Flow rack; skipping this adoption to avoid a unique-name abort (operator must resolve the duplicate name)")
-				result.skippedNameTaken++
+		// Only serial-bearing rows participate — NULL serial has no natural key.
+		if built.SerialNumber != "" {
+			naturalKey := rackNaturalKey(built.Manufacturer, built.SerialNumber)
+			if existing, ok := flowBySerial[naturalKey]; ok {
+				candidate := *existing
+				candidate.ExternalID = built.ExternalID
+				if candidate.DeletedAt != nil {
+					candidate.DeletedAt = nil
+					result.resurrected++
+				}
+				if patched := rackUpdatedFromCore(&candidate, &built); patched != nil {
+					candidate = *patched
+				}
+				if nameTakenByOtherLiveRack(liveByName, candidate.Name, existing.ID) {
+					log.Warn().
+						Str("rack_id", cr.RackID).
+						Str("name", candidate.Name).
+						Str("rack_serial", candidate.SerialNumber).
+						Msg("Expected-inventory mirror: Core rack name already held by a different live Flow rack; skipping this adoption to avoid a unique-name abort (operator must resolve the duplicate name)")
+					result.skippedNameTaken++
+					touchedIDs[existing.ID] = struct{}{}
+					continue
+				}
+				p.toUpdate = append(p.toUpdate, candidate)
 				touchedIDs[existing.ID] = struct{}{}
+				result.adopted++
 				continue
 			}
-			p.toUpdate = append(p.toUpdate, candidate)
-			touchedIDs[existing.ID] = struct{}{}
-			result.adopted++
-			continue
 		}
 
 		if nameTakenByOtherLiveRack(liveByName, built.Name, uuid.Nil) {
@@ -327,7 +367,7 @@ func mirrorExpectedRacks(
 			p.toUpdate[i].UpdatedAt = now
 			if _, err := tx.NewUpdate().
 				Model(&p.toUpdate[i]).
-				Column("name", "description", "location", "external_id", "deleted_at", "updated_at").
+				Column("name", "serial_number", "description", "location", "external_id", "deleted_at", "updated_at").
 				WhereAllWithDeleted().
 				Where("id = ?", p.toUpdate[i].ID).
 				Exec(ctx); err != nil {
@@ -344,9 +384,9 @@ func mirrorExpectedRacks(
 		log.Error().Err(err).Msg("Expected-inventory mirror: rack reconciliation transaction failed; mirror is no-op this cycle")
 		// Tx rolled back: per-spec decisions logged above describe intent,
 		// not committed state. Strip success-side counters so the summary
-		// log reflects what actually landed (nothing). pulled,
-		// skippedNoIDOrKey and legacyExempt survive: they're decided
-		// before the tx opened and aren't invalidated by the rollback.
+		// log reflects what actually landed (nothing). pulled, the skipped_*
+		// counters and legacyExempt survive: they're decided before the tx
+		// opened and aren't invalidated by the rollback.
 		result.resurrected = 0
 		result.adopted = 0
 		return result
@@ -413,8 +453,12 @@ func getAllRacksIncludingDeleted(ctx context.Context, idb bun.IDB) ([]model.Rack
 // flowBySerialInCore is a small helper: it scans Core's racks and returns
 // whether any of them shares this Flow rack's (manufacturer, serial_number).
 // Used to suppress the "legacy not in Core" warn for rows that the adoption
-// path will pick up on this same cycle.
+// path will pick up on this same cycle. Rows with an empty serial have no
+// natural key and never match here.
 func flowBySerialInCore(r *model.Rack, coreRacks []nicoapi.ExpectedRackDetail) (string, bool) {
+	if r.SerialNumber == "" {
+		return "", false
+	}
 	want := rackNaturalKey(r.Manufacturer, r.SerialNumber)
 	for _, cr := range coreRacks {
 		manufacturer := cr.Labels[labelChassisManufacturer]
@@ -430,13 +474,18 @@ func flowBySerialInCore(r *model.Rack, coreRacks []nicoapi.ExpectedRackDetail) (
 }
 
 // buildRackFromCore translates one Core ExpectedRackDetail into the Flow Rack
-// shape the mirror will insert. Returns false if the Core row is missing
-// fields that Flow's rack table requires (manufacturer / serial_number are
-// NOT NULL and form a unique key).
+// shape the mirror will insert. Returns false when the Core row lacks a usable
+// identity: manufacturer is always required (NOT NULL), and at least one of
+// chassis serial-number or Core rack_id must be present. Serial may be empty
+// when rack_id is set — UNIQUE (manufacturer, serial_number) treats NULLs as
+// distinct, and external_id is the stable match key in that case.
 func buildRackFromCore(cr nicoapi.ExpectedRackDetail) (model.Rack, bool) {
 	manufacturer := cr.Labels[labelChassisManufacturer]
 	serial := cr.Labels[labelChassisSerialNumber]
-	if manufacturer == "" || serial == "" {
+	if manufacturer == "" {
+		return model.Rack{}, false
+	}
+	if serial == "" && cr.RackID == "" {
 		return model.Rack{}, false
 	}
 
@@ -513,10 +562,12 @@ func rackLocationFromLabels(labels map[string]string) map[string]any {
 }
 
 // rackUpdatedFromCore returns a copy of `existing` with mirror-managed fields
-// overwritten from `fromCore`. It deliberately does not touch identity
-// (manufacturer / serial_number), lifecycle (status / ingested_at), or fields
-// the mirror has no opinion on (nvldomain_id is out of scope for this PR; the
-// runtime sync owns it).
+// overwritten from `fromCore`. It deliberately does not rewrite manufacturer
+// (still part of the natural key for serial-bearing rows), lifecycle
+// (status / ingested_at), or fields the mirror has no opinion on
+// (nvldomain_id is out of scope; the runtime sync owns it). Serial may be
+// filled in when Core later supplies a chassis serial for a rack that was
+// first mirrored by external_id alone.
 //
 // Returns nil when no patchable field changed so the caller can skip a no-op
 // UPDATE.
@@ -526,6 +577,13 @@ func rackUpdatedFromCore(existing, fromCore *model.Rack) *model.Rack {
 
 	if fromCore.Name != "" && existing.Name != fromCore.Name {
 		patched.Name = fromCore.Name
+		changed = true
+	}
+	// Fill a previously-NULL serial once Core starts reporting one. Never
+	// clear a populated serial back to empty — that would drop the natural
+	// key for no good reason if Core momentarily omits the label.
+	if existing.SerialNumber == "" && fromCore.SerialNumber != "" {
+		patched.SerialNumber = fromCore.SerialNumber
 		changed = true
 	}
 	// Only overwrite Description / Location when Core actually carries a

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
@@ -57,18 +57,19 @@ func pullExpectedRacks(
 // expected_racks view. The algorithm is, in order:
 //
 //  1. Index every Flow rack — including soft-deleted ones — by external_id
-//     (mirror-owned) and by (manufacturer, serial_number) when serial is
-//     present (the natural key shared with Core). NULL-serial racks match
-//     only via external_id. Including soft-deleted rows is what makes
-//     resurrection work: a rack that briefly disappeared from Core and came
-//     back keeps its UUID, and a re-insert would otherwise collide on the
-//     unique indexes the soft-deleted row still occupies.
+//     (the identity, mirror-owned) and by (manufacturer, serial_number) when
+//     both labels are present. Incompletely-labelled racks match only via
+//     external_id. Including soft-deleted rows is what makes resurrection
+//     work: a rack that briefly left Core keeps its UUID, and a re-insert
+//     would collide on the indexes the soft-deleted row still occupies.
 //
 //  2. For each Core row, find the matching Flow row preferring external_id
 //     and falling back to (manufacturer, serial_number) to adopt rows that
 //     predate the mirror. New rows are inserted. A matched row that's
 //     currently soft-deleted is resurrected by clearing deleted_at;
-//     mirror-managed fields are updated alongside on real deltas.
+//     mirror-managed fields are updated alongside on real deltas. A Core row
+//     can carry a chassis pair another row already holds; those writes are
+//     skipped rather than attempted (naturalKeyTakenByOther).
 //
 //  3. Live Flow rows whose external_id is set but no longer appear in Core
 //     are soft-deleted (including the case where Core returned zero racks —
@@ -103,15 +104,12 @@ func mirrorExpectedRacks(
 		if r.ExternalID != nil && *r.ExternalID != "" {
 			flowByExtID[*r.ExternalID] = r
 		}
-		if r.Manufacturer != "" && r.SerialNumber != "" {
-			naturalKeyOwners[rackNaturalKey(r.Manufacturer, r.SerialNumber)] = r.ID
-		}
-		// Only index serial-bearing rows. Empty/NULL serials are not a
-		// natural key — matching those goes exclusively through external_id
-		// so klamath-style manufacturer=NVIDIA / serial=NULL racks do not
-		// collapse onto one map entry.
-		if r.SerialNumber != "" {
-			flowBySerial[rackNaturalKey(r.Manufacturer, r.SerialNumber)] = r
+		// Only index fully-labelled rows. Racks sharing a manufacturer with
+		// no serial must not collapse onto one entry; they match on
+		// external_id alone.
+		if naturalKey := naturalKeyOrEmpty(r.Manufacturer, r.SerialNumber); naturalKey != "" {
+			flowBySerial[naturalKey] = r
+			naturalKeyOwners[naturalKey] = r.ID
 		}
 	}
 
@@ -149,10 +147,8 @@ func mirrorExpectedRacks(
 	// touchedIDs: Flow rack UUIDs the match path adopted / updated this
 	// cycle; the delete phase skips them so a rack_id rename (update to the
 	// new external_id) isn't immediately undone by a soft-delete keyed off
-	// the stale in-memory external_id. plannedSerial: natural keys already
-	// queued for serial-bearing racks. plannedExtID: external_ids already
-	// queued so duplicate Core rack_ids (or multiple NULL-serial racks
-	// sharing a manufacturer) cannot collide.
+	// the stale in-memory external_id. plannedSerial and plannedExtID keep
+	// writes queued in one cycle off a single slot in their unique indexes.
 	seenExtID := make(map[string]struct{}, len(coreRacks))
 	touchedIDs := make(map[uuid.UUID]struct{}, len(coreRacks))
 	plannedSerial := make(map[string]struct{}, len(coreRacks))
@@ -166,41 +162,28 @@ func mirrorExpectedRacks(
 
 		built, ok := buildRackFromCore(cr)
 		if !ok {
-			// Required identity missing: need manufacturer, plus either a
-			// chassis serial or a Core rack_id (external_id). Skip the
-			// write, but the rack_id is already in seenExtID so we don't
-			// soft-delete an existing Flow rack over a transient label gap.
+			// No rack_id, so nothing the mirror could match this row back to
+			// on a later cycle.
 			log.Warn().
-				Str("rack_id", cr.RackID).
 				Str("name", cr.Name).
-				Msg("Expected-inventory mirror: skipping Core expected rack missing chassis manufacturer, and lacking both serial-number and rack_id; existing Flow rack preserved")
+				Str("rack_profile_id", cr.RackProfileID).
+				Msg("Expected-inventory mirror: skipping Core expected rack with no rack_id; existing Flow rack preserved")
 			result.skippedNoIDOrKey++
 			continue
 		}
 
-		if cr.RackID == "" {
+		// Drop Core duplicates before they collide on unique indexes.
+		if _, planned := plannedExtID[cr.RackID]; planned {
 			log.Warn().
-				Str("rack_profile_id", cr.RackProfileID).
-				Str("name", cr.Name).
+				Str("rack_id", cr.RackID).
 				Str("manufacturer", built.Manufacturer).
 				Str("serial", built.SerialNumber).
-				Msg("Expected-inventory mirror: Core expected rack has no rack_id; rack will be mirrored but components can't reference it")
+				Msg("Expected-inventory mirror: Core returned duplicate expected racks for the same rack_id; skipping the later occurrence")
+			continue
 		}
+		plannedExtID[cr.RackID] = struct{}{}
 
-		// Drop Core duplicates before they collide on unique indexes.
-		if cr.RackID != "" {
-			if _, planned := plannedExtID[cr.RackID]; planned {
-				log.Warn().
-					Str("rack_id", cr.RackID).
-					Str("manufacturer", built.Manufacturer).
-					Str("serial", built.SerialNumber).
-					Msg("Expected-inventory mirror: Core returned duplicate expected racks for the same rack_id; skipping the later occurrence")
-				continue
-			}
-			plannedExtID[cr.RackID] = struct{}{}
-		}
-		if built.SerialNumber != "" {
-			naturalKey := rackNaturalKey(built.Manufacturer, built.SerialNumber)
+		if naturalKey := naturalKeyOrEmpty(built.Manufacturer, built.SerialNumber); naturalKey != "" {
 			if _, planned := plannedSerial[naturalKey]; planned {
 				log.Warn().
 					Str("rack_id", cr.RackID).
@@ -213,8 +196,7 @@ func mirrorExpectedRacks(
 		}
 
 		// Prefer external_id match (already adopted on a previous cycle).
-		// Empty rack_ids never hit flowByExtID by construction.
-		if existing, ok := flowByExtID[cr.RackID]; ok && cr.RackID != "" {
+		if existing, ok := flowByExtID[cr.RackID]; ok {
 			candidate := *existing
 			needUpdate := false
 			if candidate.DeletedAt != nil {
@@ -259,9 +241,9 @@ func mirrorExpectedRacks(
 
 		// Fall back to natural key (legacy ingestion-gRPC rows the mirror has
 		// never adopted; adopt by writing external_id alongside any deltas).
-		// Only serial-bearing rows participate — NULL serial has no natural key.
-		if built.SerialNumber != "" {
-			naturalKey := rackNaturalKey(built.Manufacturer, built.SerialNumber)
+		// Only fully-labelled rows participate — a pair with either half
+		// absent has no natural key.
+		if naturalKey := naturalKeyOrEmpty(built.Manufacturer, built.SerialNumber); naturalKey != "" {
 			if existing, ok := flowBySerial[naturalKey]; ok {
 				candidate := *existing
 				candidate.ExternalID = built.ExternalID
@@ -367,7 +349,7 @@ func mirrorExpectedRacks(
 			p.toUpdate[i].UpdatedAt = now
 			if _, err := tx.NewUpdate().
 				Model(&p.toUpdate[i]).
-				Column("name", "serial_number", "description", "location", "external_id", "deleted_at", "updated_at").
+				Column("name", "manufacturer", "serial_number", "description", "location", "external_id", "deleted_at", "updated_at").
 				WhereAllWithDeleted().
 				Where("id = ?", p.toUpdate[i].ID).
 				Exec(ctx); err != nil {
@@ -382,11 +364,9 @@ func mirrorExpectedRacks(
 		return nil
 	}); err != nil {
 		log.Error().Err(err).Msg("Expected-inventory mirror: rack reconciliation transaction failed; mirror is no-op this cycle")
-		// Tx rolled back: per-spec decisions logged above describe intent,
-		// not committed state. Strip success-side counters so the summary
-		// log reflects what actually landed (nothing). pulled, the skipped_*
-		// counters and legacyExempt survive: they're decided before the tx
-		// opened and aren't invalidated by the rollback.
+		// Tx rolled back, so the decisions logged above are intent, not
+		// committed state. pulled, the skipped_* counters and legacyExempt
+		// survive the strip: all are decided before the tx opened.
 		result.resurrected = 0
 		result.adopted = 0
 		return result
@@ -453,20 +433,16 @@ func getAllRacksIncludingDeleted(ctx context.Context, idb bun.IDB) ([]model.Rack
 // flowBySerialInCore is a small helper: it scans Core's racks and returns
 // whether any of them shares this Flow rack's (manufacturer, serial_number).
 // Used to suppress the "legacy not in Core" warn for rows that the adoption
-// path will pick up on this same cycle. Rows with an empty serial have no
-// natural key and never match here.
+// path will pick up on this same cycle. A row missing either chassis label has
+// no natural key and never matches here.
 func flowBySerialInCore(r *model.Rack, coreRacks []nicoapi.ExpectedRackDetail) (string, bool) {
-	if r.SerialNumber == "" {
+	want := naturalKeyOrEmpty(r.Manufacturer, r.SerialNumber)
+	if want == "" {
 		return "", false
 	}
-	want := rackNaturalKey(r.Manufacturer, r.SerialNumber)
 	for _, cr := range coreRacks {
-		manufacturer := cr.Labels[labelChassisManufacturer]
-		serial := cr.Labels[labelChassisSerialNumber]
-		if manufacturer == "" || serial == "" {
-			continue
-		}
-		if rackNaturalKey(manufacturer, serial) == want {
+		got := naturalKeyOrEmpty(cr.Labels[labelChassisManufacturer], cr.Labels[labelChassisSerialNumber])
+		if got != "" && got == want {
 			return cr.RackID, true
 		}
 	}
@@ -474,47 +450,29 @@ func flowBySerialInCore(r *model.Rack, coreRacks []nicoapi.ExpectedRackDetail) (
 }
 
 // buildRackFromCore translates one Core ExpectedRackDetail into the Flow Rack
-// shape the mirror will insert. Returns false when the Core row lacks a usable
-// identity: manufacturer is always required (NOT NULL), and at least one of
-// chassis serial-number or Core rack_id must be present. Serial may be empty
-// when rack_id is set — UNIQUE (manufacturer, serial_number) treats NULLs as
-// distinct, and external_id is the stable match key in that case.
+// shape the mirror will insert. rack_id is the identity and the only thing
+// required; a rack whose chassis is unlabelled is still mirrored.
+//
+// Core validates that rack_id is present but not that it is non-empty, so the
+// guard stays even though a rack without one should not reach here.
 func buildRackFromCore(cr nicoapi.ExpectedRackDetail) (model.Rack, bool) {
-	manufacturer := cr.Labels[labelChassisManufacturer]
-	serial := cr.Labels[labelChassisSerialNumber]
-	if manufacturer == "" {
-		return model.Rack{}, false
-	}
-	if serial == "" && cr.RackID == "" {
+	if cr.RackID == "" {
 		return model.Rack{}, false
 	}
 
 	name := cr.Name
 	if name == "" {
-		// Flow's rack.name is NOT NULL with a unique index. Fall back to
-		// Core's stable rack_id first (operator-meaningful), then to
-		// manufacturer-serial so the row is still insertable when Core has
-		// neither. Operators can always rename later via the existing rack
-		// PATCH path.
-		switch {
-		case cr.RackID != "":
-			name = cr.RackID
-		default:
-			name = manufacturer + "-" + serial
-		}
+		// rack.name is NOT NULL and the chassis labels may supply nothing.
+		// rack_id is operator-meaningful; a PATCH can rename later.
+		name = cr.RackID
 	}
 
+	extID := cr.RackID
 	r := model.Rack{
 		Name:         name,
-		Manufacturer: manufacturer,
-		SerialNumber: serial,
-	}
-	// Leave ExternalID NULL when Core has no rack_id. Storing an empty
-	// string would still hit the partial unique index (which excludes NULL
-	// but not the empty string), so two such racks would collide.
-	if cr.RackID != "" {
-		extID := cr.RackID
-		r.ExternalID = &extID
+		Manufacturer: cr.Labels[labelChassisManufacturer],
+		SerialNumber: cr.Labels[labelChassisSerialNumber],
+		ExternalID:   &extID,
 	}
 
 	if desc := rackDescriptionFromLabels(cr.Labels, cr.Description); len(desc) > 0 {
@@ -562,12 +520,9 @@ func rackLocationFromLabels(labels map[string]string) map[string]any {
 }
 
 // rackUpdatedFromCore returns a copy of `existing` with mirror-managed fields
-// overwritten from `fromCore`. It deliberately does not rewrite manufacturer
-// (still part of the natural key for serial-bearing rows), lifecycle
-// (status / ingested_at), or fields the mirror has no opinion on
-// (nvldomain_id is out of scope; the runtime sync owns it). Serial may be
-// filled in when Core later supplies a chassis serial for a rack that was
-// first mirrored by external_id alone.
+// overwritten from `fromCore`. It deliberately does not rewrite lifecycle
+// (status / ingested_at) or fields the mirror has no opinion on (nvldomain_id
+// is out of scope; the runtime sync owns it).
 //
 // Returns nil when no patchable field changed so the caller can skip a no-op
 // UPDATE.
@@ -579,9 +534,14 @@ func rackUpdatedFromCore(existing, fromCore *model.Rack) *model.Rack {
 		patched.Name = fromCore.Name
 		changed = true
 	}
-	// Fill a previously-NULL serial once Core starts reporting one. Never
-	// clear a populated serial back to empty — that would drop the natural
-	// key for no good reason if Core momentarily omits the label.
+	// Fill a previously-NULL chassis label once Core reports one, but never
+	// clear a populated one: a momentary omission on Core's side would vacate
+	// the (manufacturer, serial_number) slot and drop the row out of
+	// GetRackInfoBySerial.
+	if existing.Manufacturer == "" && fromCore.Manufacturer != "" {
+		patched.Manufacturer = fromCore.Manufacturer
+		changed = true
+	}
 	if existing.SerialNumber == "" && fromCore.SerialNumber != "" {
 		patched.SerialNumber = fromCore.SerialNumber
 		changed = true

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
@@ -105,20 +105,39 @@ func TestBuildRackFromCore(t *testing.T) {
 			},
 		},
 		{
-			name: "missing manufacturer is unusable",
+			name: "missing manufacturer is usable (chassis labels are metadata)",
 			in: nicoapi.ExpectedRackDetail{
 				RackID: "c01",
 				Labels: map[string]string{
 					labelChassisSerialNumber: "SN-C01",
 				},
 			},
-			wantOK: false,
+			wantOK: true,
+			assertRow: func(t *testing.T, r model.Rack) {
+				assert.Empty(t, r.Manufacturer)
+				assert.Equal(t, "SN-C01", r.SerialNumber)
+				require.NotNil(t, r.ExternalID)
+				assert.Equal(t, "c01", *r.ExternalID)
+			},
 		},
 		{
-			name: "missing serial without rack_id is unusable",
+			name: "neither chassis label is usable; rack_id alone is the identity",
+			in: nicoapi.ExpectedRackDetail{
+				RackID: "c03",
+			},
+			wantOK: true,
+			assertRow: func(t *testing.T, r model.Rack) {
+				assert.Empty(t, r.Manufacturer)
+				assert.Empty(t, r.SerialNumber)
+				assert.Equal(t, "c03", r.Name)
+			},
+		},
+		{
+			name: "no rack_id is unusable even with complete chassis labels",
 			in: nicoapi.ExpectedRackDetail{
 				Labels: map[string]string{
 					labelChassisManufacturer: "Foxconn",
+					labelChassisSerialNumber: "SN-C04",
 				},
 			},
 			wantOK: false,
@@ -157,9 +176,9 @@ func TestBuildRackFromCore(t *testing.T) {
 			},
 		},
 		{
-			name: "missing rack_id yields nil ExternalID (NULL in DB) so partial unique index stays clean",
+			name: "missing name falls back to rack_id rather than the chassis labels",
 			in: nicoapi.ExpectedRackDetail{
-				Name: "noext",
+				RackID: "e01",
 				Labels: map[string]string{
 					labelChassisManufacturer: "Foxconn",
 					labelChassisSerialNumber: "SN-E01",
@@ -167,22 +186,7 @@ func TestBuildRackFromCore(t *testing.T) {
 			},
 			wantOK: true,
 			assertRow: func(t *testing.T, r model.Rack) {
-				assert.Nil(t, r.ExternalID)
-				assert.Equal(t, "noext", r.Name)
-			},
-		},
-		{
-			name: "missing both rack_id and name falls back to manufacturer-serial",
-			in: nicoapi.ExpectedRackDetail{
-				Labels: map[string]string{
-					labelChassisManufacturer: "Foxconn",
-					labelChassisSerialNumber: "SN-F01",
-				},
-			},
-			wantOK: true,
-			assertRow: func(t *testing.T, r model.Rack) {
-				assert.Equal(t, "Foxconn-SN-F01", r.Name)
-				assert.Nil(t, r.ExternalID)
+				assert.Equal(t, "e01", r.Name)
 			},
 		},
 	}
@@ -272,6 +276,24 @@ func TestRackUpdatedFromCore(t *testing.T) {
 		fromCore.SerialNumber = ""
 		assert.Nil(t, rackUpdatedFromCore(existing, &fromCore))
 		assert.Equal(t, "SN-1", existing.SerialNumber)
+	})
+
+	t.Run("fills NULL manufacturer when Core later reports one", func(t *testing.T) {
+		existing := base()
+		existing.Manufacturer = ""
+		fromCore := *base()
+		fromCore.Manufacturer = "NVIDIA"
+		got := rackUpdatedFromCore(existing, &fromCore)
+		require.NotNil(t, got)
+		assert.Equal(t, "NVIDIA", got.Manufacturer)
+	})
+
+	t.Run("does not clear an existing manufacturer when Core omits it", func(t *testing.T) {
+		existing := base()
+		fromCore := *base()
+		fromCore.Manufacturer = ""
+		assert.Nil(t, rackUpdatedFromCore(existing, &fromCore))
+		assert.Equal(t, "Foxconn", existing.Manufacturer)
 	})
 
 	t.Run("empty name in fromCore does not clobber existing name", func(t *testing.T) {

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
@@ -24,6 +24,36 @@ func TestRackNaturalKeyIsCollisionFree(t *testing.T) {
 	assert.NotEqual(t, a, b, "manufacturer/serial collisions must be impossible")
 }
 
+func TestNaturalKeyTakenByOther(t *testing.T) {
+	self := uuid.New()
+	other := uuid.New()
+	owners := map[string]uuid.UUID{
+		rackNaturalKey("NVIDIA", "SN-1"): other,
+		rackNaturalKey("NVIDIA", "SN-2"): self,
+	}
+
+	tests := []struct {
+		name         string
+		manufacturer string
+		serial       string
+		selfID       uuid.UUID
+		want         bool
+	}{
+		{name: "held by another row", manufacturer: "NVIDIA", serial: "SN-1", selfID: self, want: true},
+		{name: "held by another row on insert", manufacturer: "NVIDIA", serial: "SN-1", selfID: uuid.Nil, want: true},
+		{name: "held by the row itself", manufacturer: "NVIDIA", serial: "SN-2", selfID: self, want: false},
+		{name: "unclaimed key", manufacturer: "NVIDIA", serial: "SN-9", selfID: self, want: false},
+		{name: "empty serial occupies no slot", manufacturer: "NVIDIA", serial: "", selfID: uuid.Nil, want: false},
+		{name: "empty manufacturer occupies no slot", manufacturer: "", serial: "SN-1", selfID: uuid.Nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := naturalKeyTakenByOther(owners, tt.manufacturer, tt.serial, tt.selfID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestBuildRackFromCore(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -85,14 +115,30 @@ func TestBuildRackFromCore(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name: "missing serial is unusable",
+			name: "missing serial without rack_id is unusable",
 			in: nicoapi.ExpectedRackDetail{
-				RackID: "c02",
 				Labels: map[string]string{
 					labelChassisManufacturer: "Foxconn",
 				},
 			},
 			wantOK: false,
+		},
+		{
+			name: "missing serial with rack_id is usable (external_id is the identity)",
+			in: nicoapi.ExpectedRackDetail{
+				RackID: "c02",
+				Labels: map[string]string{
+					labelChassisManufacturer: "NVIDIA",
+				},
+			},
+			wantOK: true,
+			assertRow: func(t *testing.T, r model.Rack) {
+				assert.Equal(t, "c02", r.Name)
+				assert.Equal(t, "NVIDIA", r.Manufacturer)
+				assert.Empty(t, r.SerialNumber)
+				require.NotNil(t, r.ExternalID)
+				assert.Equal(t, "c02", *r.ExternalID)
+			},
 		},
 		{
 			name: "no description/location labels leaves jsonb columns nil",
@@ -208,6 +254,24 @@ func TestRackUpdatedFromCore(t *testing.T) {
 		require.NotNil(t, got)
 		require.NotNil(t, got.ExternalID)
 		assert.Equal(t, "a12", *got.ExternalID)
+	})
+
+	t.Run("fills NULL serial when Core later reports one", func(t *testing.T) {
+		existing := base()
+		existing.SerialNumber = ""
+		fromCore := *base()
+		fromCore.SerialNumber = "SN-FILLED"
+		got := rackUpdatedFromCore(existing, &fromCore)
+		require.NotNil(t, got)
+		assert.Equal(t, "SN-FILLED", got.SerialNumber)
+	})
+
+	t.Run("does not clear an existing serial when Core omits it", func(t *testing.T) {
+		existing := base()
+		fromCore := *base()
+		fromCore.SerialNumber = ""
+		assert.Nil(t, rackUpdatedFromCore(existing, &fromCore))
+		assert.Equal(t, "SN-1", existing.SerialNumber)
 	})
 
 	t.Run("empty name in fromCore does not clobber existing name", func(t *testing.T) {


### PR DESCRIPTION
Flow's `component` and `rack` tables use `UNIQUE (manufacturer, serial_number)` as row identity, and the expected-inventory mirror matches Core rows to Flow rows by that pair. Sites whose chassis labels are incomplete therefore have rows skipped entirely — one deployment reports four racks as `manufacturer=NVIDIA` with no serial, so all four are dropped. Relaxing the check alone would be worse: the four would collapse onto one key and three would be silently discarded as duplicate chassis.
- Adds `component.identity_key`, a nullable column with a global partial unique index, that the mirror matches on instead of the chassis labels. `identityKeyForSpec` is the single derivation, currently the host BMC MAC — 1:1 with a component, already the `bmc` table's primary key, and always reported by Core. The schema says nothing about what composes the value, so redefining it is a backfill rather than a constraint migration; the doc comment records the rolling-deploy hazard, since old and new values are indistinguishable in the column.
- `rack_id` becomes a mirrored rack's sole identity. `buildRackFromCore` now requires only `rack_id` and no longer skips a rack whose chassis is unlabelled, and `rackUpdatedFromCore` fills a label once Core starts reporting one without ever clearing a populated one.
- Drops `NOT NULL` from `manufacturer` and `serial_number` on both tables. `UNIQUE (manufacturer, serial_number)` stays: Postgres treats NULLs as distinct, so an incomplete row occupies no index slot and `GetComponentInfoBySerial` / `GetRackInfoBySerial` keep their at-most-one-match guarantee for fully-labelled rows. A lookup by `(NULL, serial)` or `(mfr, NULL)` returns `sql.ErrNoRows`, which the model doc comments now state.
- A matched row keeps its UUID while its labels are refreshed as metadata, so a write can land on a `(manufacturer, serial_number)` pair another row — or its tombstone — already holds. `naturalKeySlotTaken` skips and counts those writes rather than letting one collision abort the whole reconciliation transaction and roll back every other row in the cycle.
- Adds `bmc_one_host_per_component_idx`, a partial unique index enforcing one host BMC per component. The up migration first deletes extra `type='Host'` rows, keeping the lowest MAC; these are an ingestion bug `planBMCReconciliation` already hard-deletes on the next cycle. `AddComponent` callers that pass two host BMCs for one component now get a unique violation instead of silently creating both.

## Related issues 
Closes #4966

## Type of Change 
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes 
- [ ] **This PR contains breaking changes**

## Testing 
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes 

