### PR TITLE
ci(rest): build Go binary artifacts using structured manifest

### DIFF
--- a/.github/ci/rest-command-bundles.md
+++ b/.github/ci/rest-command-bundles.md
@@ -1,0 +1,211 @@
+# REST command bundle contract
+
+REST has 11 standalone command names, while the production Linux images also
+need `nicocli` and `nico-mcp`. Building each command in its own job repeated the
+same checkout and Go setup, and it left the Docker builds with no checked bundle
+they could reuse.
+
+So, [`rest-command-manifest.json`](rest-command-manifest.json) is the one list of
+REST commands this workflow may build. One job builds everything for a target,
+checks each binary, and uploads one archive with the exact build record a later
+job needs.
+
+## What can be built
+
+The source manifest is an object with exactly three required fields:
+
+- `schema_version` is the integer `1`.
+- `targets` is a non-empty array. Each entry has the non-empty strings `name`,
+  `goos`, and `goarch`; `name` must be the literal `<goos>-<goarch>` value, and
+  target names must be unique. The supported names are exactly `linux-amd64`,
+  `linux-arm64`, and `darwin-arm64`.
+- `outputs` is a non-empty array. Each entry has `name`, `package`, `target`,
+  `cgo_enabled`, `ldflags`, and `output`. The command name uses lowercase
+  letters, numbers, and internal hyphens. `package` starts with `./`, contains
+  no empty, `.`, or `..` path components, cannot escape through a symlink, and
+  names an existing directory under `--repo-root`. `target` names a declared
+  target, `cgo_enabled` is a Boolean, `ldflags` is an array of non-empty
+  strings, and `output` is exactly `bin/<name>`.
+
+`cgo_enabled: true` sets `CGO_ENABLED=1`; `false` sets it to `0`. Command names
+and `output` paths must be unique within one target. Every target needs at least
+one output and produces one `rest-command-bundle-<target>.tar.gz` archive;
+source-manifest order becomes resolved-manifest command order. Unknown fields
+and unsafe paths fail validation.
+
+Linker flags may use only `${VERSION}`, `${SHORT_SHA}`,
+`${BUILD_TIME_LEGACY}`, and `${BUILD_TIME_RFC3339}`. Any other dollar form is
+rejected; literal-dollar escaping is unsupported, and a backslash does not
+escape a token.
+
+The checked-in inventory has three deliberate boundaries:
+
+- Linux amd64 and Linux arm64 each build 13 commands. The ten production image
+  entrypoints are `api`, `migrations`, `sitemgr`, `workflow`, `site-agent`,
+  `credsmgr`, `flow`, `psm`, `nsm`, and `nico-mcp`. They use the same settings
+  and metadata fields as their production Dockerfiles. Bundle timestamps use
+  canonical UTC values rather than inheriting a runner's local timezone. The
+  API image also contains `nicocli`; both `nicocli` and `nico-mcp` are
+  Linux-only bundle outputs.
+- `mock-core` and `mock-flow` keep the previous standalone behavior. The native
+  Linux amd64 builds use CGO, while the cross-compiled Linux arm64 builds do
+  not. That amd64 target therefore needs a working C compiler; build metadata,
+  rather than `file` wording, verifies its `CGO_ENABLED=1` setting.
+- Darwin arm64 keeps the previous 11-command standalone contract. The API,
+  site-agent, and flow commands keep their runtime version metadata without
+  acquiring Linux static-linker flags or new CLI/MCP builds.
+
+All three targets build `api`, `migrations`, `sitemgr`, `workflow`,
+`site-agent`, `mock-core`, `mock-flow`, `credsmgr`, `flow`, `psm`, and `nsm`.
+The two Linux targets also build `nicocli` and `nico-mcp`. The independent
+command-contract test pins the exact package, target, CGO, linker-flag, and
+output inventory; the source manifest remains the canonical machine-readable
+list.
+
+The supported transition boundary is
+[CICD-08](https://github.com/NVIDIA/infra-controller/issues/4582). Until that
+issue changes image packaging to consume these bundles, the production
+Dockerfiles contain a second copy of the Linux service build settings. Keeping
+the two copies aligned is a review responsibility during this transition;
+CICD-08 removes the duplicate build recipe by making packaging consume these
+bundles.
+
+## Commands
+
+`rest_command_bundle.py` has three subcommands. Each accepts optional
+`--manifest PATH`, which defaults to the adjacent
+`.github/ci/rest-command-manifest.json`, and `--repo-root PATH`, which defaults
+to the repository's `rest-api/` directory. Relative path arguments resolve
+from the current working directory; `--repo-root` does not rebase the other
+paths. Absolute paths are accepted.
+
+- `check` has no additional flags. It validates the source manifest and package
+  directories, writes no files, and prints the output and target counts.
+- `build` requires `--target`, `--output-dir`, `--version`,
+  `--build-timestamp`, `--candidate-sha`, and `--short-sha`; `--allow-dirty` is
+  optional. It validates the checkout, compiles and inspects every command for
+  one target, creates the output directory when missing, publishes the three
+  bundle files, and prints build progress plus the verified output count and
+  archive size. An existing output directory must be empty. The accepted
+  targets are `linux-amd64`, `linux-arm64`, and `darwin-arm64`.
+- `verify` requires `--target`, `--bundle`, `--checksum`,
+  `--resolved-manifest`, `--version`, `--build-timestamp`, `--candidate-sha`,
+  and `--short-sha`; `--allow-dirty` is optional. It reads and verifies the
+  three bundle files for a declared target, uses a temporary directory for
+  binary inspection, removes that directory on exit, and prints the verified
+  archive path. The bundle cannot choose its expected identity.
+
+Each subcommand rejects flags owned by another subcommand. In particular,
+`check` rejects `--allow-dirty`, `build` rejects the verify-only bundle path
+flags, and `verify` rejects `--output-dir`. An undeclared target fails in
+`build` or `verify`; there is no target flag for `check`.
+
+The version starts with a letter or number and otherwise accepts only letters,
+numbers, periods, underscores, and hyphens. The build timestamp uses UTC
+`YYYY-MM-DDTHH:MM:SSZ`. The candidate SHA is exactly 40 lowercase hexadecimal
+characters, while the short SHA is its 7- to 12-character prefix. Because that
+timestamp is also written into the gzip header, it must fall between
+`1970-01-01T00:00:00Z` and `2106-02-07T06:28:15Z`, inclusive.
+
+Only `build` and `verify` accept `--allow-dirty`. By default, `build` rejects
+tracked or untracked changes anywhere in the repository worktree, and `verify`
+rejects a resolved manifest with `source_dirty: true`. The flag permits that
+state for local validation. CI does not pass it.
+
+`build` stages the three bundle files inside the output directory, verifies
+them there, and publishes the resolved manifest and checksum before atomically
+renaming the archive into place. A failed build, verification, or publication
+normally removes staged and partially published files so the output directory
+is empty for a retry. If cleanup itself fails, the error names each path it
+could not remove.
+
+All three commands require Python 3.10 or newer. `build` also requires Git,
+[Go 1.26.4 or newer](../../rest-api/go.mod), and the `file` utility; `verify` requires Go
+and `file`. Building `linux-amd64` also requires a C compiler for `mock-core`
+and `mock-flow`. CI checks the Python minimum, selects the module's minimum Go
+1.26.4, and checks `file --version` before compiling. A contract, command, tool,
+or verification failure prints `error: <message>` to standard error and exits
+with status 1. Argument parsing and missing required flags print `usage:` and
+exit with status 2.
+
+## Bundle files
+
+For a target such as `linux-amd64`, `build` writes:
+
+- `rest-command-bundle-linux-amd64.tar.gz`;
+- `rest-command-bundle-linux-amd64.tar.gz.sha256`; and
+- `rest-command-bundle-linux-amd64.manifest.json`.
+
+The UTF-8 checksum sidecar contains exactly one LF-terminated line: one
+lowercase SHA-256 digest, two spaces, the archive filename, and the final LF.
+The producer writes a level-9 gzip stream with no stored filename or optional
+header fields and with the build timestamp as its gzip timestamp. It contains a
+PAX-format tar stream ordered as `manifest.json`, `SHA256SUMS`, and then binary
+paths sorted by name. Those two metadata files use mode `0644`; every
+`bin/<name>` entry uses mode `0755`. All members are regular relative files with
+UID and GID `0`, empty owner and group names, and the build timestamp as their
+modification time.
+
+The binary checksum file uses the same digest and two-space format, with one
+LF-terminated line for every command, `/`-separated relative paths, source
+inventory sorted by path, and no extra entries. The resolved and embedded
+manifests use UTF-8 JSON with sorted object keys, two-space indentation, and one
+final newline; non-ASCII characters are escaped. No required field is omitted.
+
+The resolved manifest records string values for the source-manifest SHA-256,
+requested candidate and short SHA, version, and build timestamp; a Boolean
+`source_dirty`; the exact target object; and a non-empty command array. Each
+command entry records string values for its name, package, output, import path,
+Go version, `file` description, SHA-256, and VCS settings; a Boolean CGO choice;
+a positive integer size; and a possibly empty array whose linker-flag entries
+are non-empty strings.
+
+The flat VCS keys are always present and non-empty. `vcs_modified` records Go's
+`vcs.modified` value or `unknown` when Go omits it. `vcs_revision` records the
+candidate SHA only when Go reports that exact revision; otherwise it is
+`unavailable`. Verification rejects every other revision value. Go normally
+records the repository revision for this module; the fallback keeps the bundle
+contract explicit in environments where those settings are unavailable.
+
+The producer and its unit test own the PAX writer choice. The standalone
+verifier accepts any readable tar encoding, but still enforces the canonical
+JSON bytes, gzip header and timestamp, member order, ownership, timestamps,
+modes, paths, inventory, and contents described above.
+
+## Embedded metadata
+
+The Linux and Darwin `api` and `site-agent` builds set `metadata.Version` to
+`--version` and `metadata.BuildTime` to `YYYY-MM-DD HH:MM:SS`. Their `flow`
+builds set `metadata.Version` to `--version`, `metadata.BuildTime` to
+`YYYY-MM-DDTHH:MM:SSZ`, and `metadata.GitCommit` to `--short-sha`. Their full Go
+symbol paths live in the source manifest and are pinned by the command-contract
+test. Darwin builds omit only the Linux static-linker and stripping flags.
+
+`go version -m -json` exposes linker flags as one aggregate setting. Missing,
+extra, or reordered flags fail verification, unrelated build settings are
+ignored, and the last value wins if Go reports one setting key more than once.
+Every resolved `-X` value must also appear in the binary. The script does not
+maintain a second allowlist of `-X` destinations; the source manifest and its
+independent contract test own those destinations.
+
+## What verification checks
+
+The verifier starts from the checked-in source manifest and the identity the
+caller supplied. From there it checks:
+
+- the archive sidecar and exact archive inventory;
+- the byte-for-byte match between the external and embedded resolved manifest;
+- safe paths, regular-file types, exact modes, sizes, and checksums;
+- package import paths, `GOOS`, `GOARCH`, `CGO_ENABLED`, and linker flags from
+  `go version -m -json`;
+- physical architecture and CGO-disabled Linux static linkage from `file -b`;
+  and
+- every metadata value supplied through a `-X` linker flag.
+
+Go normally records `vcs.revision` in these binaries. Before compiling, the
+builder confirms that Git `HEAD` is the requested candidate and rejects a dirty
+checkout unless local validation explicitly passes `--allow-dirty`. The
+resolved manifest records that source check and uses `unavailable` only when Go
+omits the VCS setting. The standalone verifier checks the recorded candidate,
+build contract, binary metadata, checksums, and file inventory, but it cannot
+cryptographically prove which source tree produced the binaries.

--- a/.github/ci/rest-command-manifest.json
+++ b/.github/ci/rest-command-manifest.json
@@ -1,0 +1,418 @@
+{
+  "schema_version": 1,
+  "targets": [
+    {
+      "name": "linux-amd64",
+      "goos": "linux",
+      "goarch": "amd64"
+    },
+    {
+      "name": "linux-arm64",
+      "goos": "linux",
+      "goarch": "arm64"
+    },
+    {
+      "name": "darwin-arm64",
+      "goos": "darwin",
+      "goarch": "arm64"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "api",
+      "package": "./api/cmd/api",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.BuildTime=${BUILD_TIME_LEGACY}"
+      ],
+      "output": "bin/api"
+    },
+    {
+      "name": "migrations",
+      "package": "./db/cmd/migrations",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/migrations"
+    },
+    {
+      "name": "sitemgr",
+      "package": "./site-manager/cmd/sitemgr",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/sitemgr"
+    },
+    {
+      "name": "workflow",
+      "package": "./workflow/cmd/workflow",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/workflow"
+    },
+    {
+      "name": "site-agent",
+      "package": "./site-agent/cmd/site-agent",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata.BuildTime=${BUILD_TIME_LEGACY}"
+      ],
+      "output": "bin/site-agent"
+    },
+    {
+      "name": "mock-core",
+      "package": "./site-agent/cmd/mock-core",
+      "target": "linux-amd64",
+      "cgo_enabled": true,
+      "ldflags": [],
+      "output": "bin/mock-core"
+    },
+    {
+      "name": "mock-flow",
+      "package": "./site-agent/cmd/mock-flow",
+      "target": "linux-amd64",
+      "cgo_enabled": true,
+      "ldflags": [],
+      "output": "bin/mock-flow"
+    },
+    {
+      "name": "credsmgr",
+      "package": "./cert-manager/cmd/credsmgr",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/credsmgr"
+    },
+    {
+      "name": "flow",
+      "package": "./flow",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.BuildTime=${BUILD_TIME_RFC3339}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.GitCommit=${SHORT_SHA}"
+      ],
+      "output": "bin/flow"
+    },
+    {
+      "name": "psm",
+      "package": "./powershelf-manager",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static"
+      ],
+      "output": "bin/psm"
+    },
+    {
+      "name": "nsm",
+      "package": "./nvswitch-manager",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static"
+      ],
+      "output": "bin/nsm"
+    },
+    {
+      "name": "nicocli",
+      "package": "./cli/cmd/cli",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/nicocli"
+    },
+    {
+      "name": "nico-mcp",
+      "package": "./mcp/cmd/nico-mcp",
+      "target": "linux-amd64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/nico-mcp"
+    },
+    {
+      "name": "api",
+      "package": "./api/cmd/api",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.BuildTime=${BUILD_TIME_LEGACY}"
+      ],
+      "output": "bin/api"
+    },
+    {
+      "name": "migrations",
+      "package": "./db/cmd/migrations",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/migrations"
+    },
+    {
+      "name": "sitemgr",
+      "package": "./site-manager/cmd/sitemgr",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/sitemgr"
+    },
+    {
+      "name": "workflow",
+      "package": "./workflow/cmd/workflow",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/workflow"
+    },
+    {
+      "name": "site-agent",
+      "package": "./site-agent/cmd/site-agent",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata.BuildTime=${BUILD_TIME_LEGACY}"
+      ],
+      "output": "bin/site-agent"
+    },
+    {
+      "name": "mock-core",
+      "package": "./site-agent/cmd/mock-core",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/mock-core"
+    },
+    {
+      "name": "mock-flow",
+      "package": "./site-agent/cmd/mock-flow",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/mock-flow"
+    },
+    {
+      "name": "credsmgr",
+      "package": "./cert-manager/cmd/credsmgr",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/credsmgr"
+    },
+    {
+      "name": "flow",
+      "package": "./flow",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.BuildTime=${BUILD_TIME_RFC3339}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.GitCommit=${SHORT_SHA}"
+      ],
+      "output": "bin/flow"
+    },
+    {
+      "name": "psm",
+      "package": "./powershelf-manager",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static"
+      ],
+      "output": "bin/psm"
+    },
+    {
+      "name": "nsm",
+      "package": "./nvswitch-manager",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static"
+      ],
+      "output": "bin/nsm"
+    },
+    {
+      "name": "nicocli",
+      "package": "./cli/cmd/cli",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/nicocli"
+    },
+    {
+      "name": "nico-mcp",
+      "package": "./mcp/cmd/nico-mcp",
+      "target": "linux-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-extldflags=-static",
+        "-w",
+        "-s"
+      ],
+      "output": "bin/nico-mcp"
+    },
+    {
+      "name": "api",
+      "package": "./api/cmd/api",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.BuildTime=${BUILD_TIME_LEGACY}"
+      ],
+      "output": "bin/api"
+    },
+    {
+      "name": "migrations",
+      "package": "./db/cmd/migrations",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/migrations"
+    },
+    {
+      "name": "sitemgr",
+      "package": "./site-manager/cmd/sitemgr",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/sitemgr"
+    },
+    {
+      "name": "workflow",
+      "package": "./workflow/cmd/workflow",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/workflow"
+    },
+    {
+      "name": "site-agent",
+      "package": "./site-agent/cmd/site-agent",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-X=github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata.BuildTime=${BUILD_TIME_LEGACY}"
+      ],
+      "output": "bin/site-agent"
+    },
+    {
+      "name": "mock-core",
+      "package": "./site-agent/cmd/mock-core",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/mock-core"
+    },
+    {
+      "name": "mock-flow",
+      "package": "./site-agent/cmd/mock-flow",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/mock-flow"
+    },
+    {
+      "name": "credsmgr",
+      "package": "./cert-manager/cmd/credsmgr",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/credsmgr"
+    },
+    {
+      "name": "flow",
+      "package": "./flow",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.Version=${VERSION}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.BuildTime=${BUILD_TIME_RFC3339}",
+        "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.GitCommit=${SHORT_SHA}"
+      ],
+      "output": "bin/flow"
+    },
+    {
+      "name": "psm",
+      "package": "./powershelf-manager",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/psm"
+    },
+    {
+      "name": "nsm",
+      "package": "./nvswitch-manager",
+      "target": "darwin-arm64",
+      "cgo_enabled": false,
+      "ldflags": [],
+      "output": "bin/nsm"
+    }
+  ]
+}

--- a/.github/ci/rest_command_bundle.py
+++ b/.github/ci/rest_command_bundle.py
@@ -1,0 +1,1283 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build and verify the REST command artifacts for one target.
+
+The checked-in manifest owns the build contract. ``build`` turns that contract
+into one archive, checksum, and resolved manifest; ``verify`` reopens those
+files and checks them without trusting the archive to describe itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from string import Template
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+TOKEN_RE = re.compile(r"\$\{([A-Z][A-Z0-9_]*)\}")
+ALLOWED_TOKENS = {
+    "BUILD_TIME_LEGACY",
+    "BUILD_TIME_RFC3339",
+    "SHORT_SHA",
+    "VERSION",
+}
+NAME_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
+SHORT_SHA_RE = re.compile(r"[0-9a-f]{7,12}")
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+VERSION_RE = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9._-]*")
+BUILD_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
+DEFAULT_MANIFEST = Path(__file__).resolve().with_name("rest-command-manifest.json")
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[2] / "rest-api"
+PHYSICAL_ARCHITECTURE_MARKERS = {
+    "linux-amd64": ("ELF 64-bit", "x86-64"),
+    "linux-arm64": ("ELF 64-bit", "ARM aarch64"),
+    "darwin-arm64": ("Mach-O 64-bit", "arm64"),
+}
+STATIC_LINUX_LINKAGE_MARKERS = ("statically linked", "static-pie linked")
+
+
+class BundleError(RuntimeError):
+    """``BundleError`` turns a bad contract, build, or bundle into one CLI error."""
+
+
+@dataclass(frozen=True)
+class Target:
+    """``Target`` maps a manifest name to one Go OS and architecture pair."""
+
+    name: str
+    goos: str
+    goarch: str
+
+
+@dataclass(frozen=True)
+class CommandBuild:
+    """``CommandBuild`` is one command's complete contract for one target."""
+
+    name: str
+    package: str
+    target: str
+    cgo_enabled: bool
+    ldflags: tuple[str, ...]
+    archive_path: str
+
+
+@dataclass(frozen=True)
+class SourceManifest:
+    """``SourceManifest`` is the validated contract loaded from checked-in JSON."""
+
+    targets: dict[str, Target]
+    outputs: tuple[CommandBuild, ...]
+    sha256: str
+
+
+@dataclass(frozen=True)
+class BinaryInspection:
+    """``BinaryInspection`` records facts read back from one compiled command."""
+
+    go_version: str
+    vcs_modified: str
+    vcs_revision: str
+    file_description: str
+
+
+def sha256_bytes(value: bytes) -> str:
+    """Return the lowercase SHA-256 digest for an in-memory value."""
+
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    """Hash `path` in bounded chunks so file size does not set memory use."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_keys(value: dict[str, Any], expected: set[str], context: str) -> None:
+    """Reject missing or unknown object fields at a named contract boundary."""
+
+    actual = set(value)
+    if actual != expected:
+        raise BundleError(
+            f"{context} keys must be {sorted(expected)}, got {sorted(actual)}"
+        )
+
+
+def require_string(value: Any, field: str) -> str:
+    """Return one safe, nonempty single-line string or reject `field`."""
+
+    if not isinstance(value, str) or not value:
+        raise BundleError(f"{field} must be a non-empty string")
+    if "\n" in value or "\r" in value or "\0" in value:
+        raise BundleError(f"{field} must be a single-line string without NUL bytes")
+    return value
+
+
+def parse_target(value: Any, index: int) -> Target:
+    """Validate one source-manifest target and return its typed form."""
+
+    if not isinstance(value, dict):
+        raise BundleError(f"targets[{index}] must be an object")
+    require_keys(value, {"name", "goos", "goarch"}, f"targets[{index}]")
+    name = require_string(value["name"], f"targets[{index}].name")
+    goos = require_string(value["goos"], f"targets[{index}].goos")
+    goarch = require_string(value["goarch"], f"targets[{index}].goarch")
+    if name != f"{goos}-{goarch}":
+        raise BundleError(
+            f"targets[{index}].name must be {goos}-{goarch}, got {name}"
+        )
+    if name not in PHYSICAL_ARCHITECTURE_MARKERS:
+        raise BundleError(f"targets[{index}] is not supported: {name}")
+    return Target(name=name, goos=goos, goarch=goarch)
+
+
+def parse_output(value: Any, index: int, repo_root: Path) -> CommandBuild:
+    """Validate one command declaration without allowing paths outside REST."""
+
+    if not isinstance(value, dict):
+        raise BundleError(f"outputs[{index}] must be an object")
+    require_keys(
+        value,
+        {"name", "package", "target", "cgo_enabled", "ldflags", "output"},
+        f"outputs[{index}]",
+    )
+    name = require_string(value["name"], f"outputs[{index}].name")
+    if NAME_RE.fullmatch(name) is None:
+        raise BundleError(f"outputs[{index}].name is not a safe command name: {name}")
+
+    package = require_string(value["package"], f"outputs[{index}].package")
+    package_parts = package.removeprefix("./").split("/")
+    if not package.startswith("./") or any(
+        part in {"", ".", ".."} for part in package_parts
+    ):
+        raise BundleError(
+            f"outputs[{index}].package must be a normalized relative ./ path: {package}"
+        )
+    package_dir = repo_root.joinpath(*package_parts).resolve()
+    try:
+        package_dir.relative_to(repo_root)
+    except ValueError as error:
+        raise BundleError(
+            f"outputs[{index}].package escapes the repository: {package}"
+        ) from error
+    if not package_dir.is_dir():
+        raise BundleError(f"outputs[{index}].package does not exist: {package}")
+
+    target = require_string(value["target"], f"outputs[{index}].target")
+    if not isinstance(value["cgo_enabled"], bool):
+        raise BundleError(f"outputs[{index}].cgo_enabled must be a boolean")
+
+    raw_ldflags = value["ldflags"]
+    if not isinstance(raw_ldflags, list) or not all(
+        isinstance(flag, str) for flag in raw_ldflags
+    ):
+        raise BundleError(f"outputs[{index}].ldflags must be a list of strings")
+    for flag in raw_ldflags:
+        require_string(flag, f"outputs[{index}].ldflags")
+        if flag == "-X" or flag.startswith("-X "):
+            raise BundleError(
+                f"outputs[{index}].ldflags must use the -X=name=value form: {flag}"
+            )
+        tokens = set(TOKEN_RE.findall(flag))
+        unknown = tokens - ALLOWED_TOKENS
+        if unknown:
+            raise BundleError(
+                f"outputs[{index}].ldflags uses unknown tokens: {sorted(unknown)}"
+            )
+        if "$" in TOKEN_RE.sub("", flag):
+            raise BundleError(
+                f"outputs[{index}].ldflags contains an invalid template token: {flag}"
+            )
+
+    output = require_string(value["output"], f"outputs[{index}].output")
+    if output != f"bin/{name}":
+        raise BundleError(
+            f"outputs[{index}].output must be bin/{name}, got {output}"
+        )
+
+    return CommandBuild(
+        name=name,
+        package=package,
+        target=target,
+        cgo_enabled=value["cgo_enabled"],
+        ldflags=tuple(raw_ldflags),
+        archive_path=output,
+    )
+
+
+def load_source_manifest(path: Path, repo_root: Path) -> SourceManifest:
+    """Load the source manifest and reject contracts the builder cannot enforce."""
+
+    repo_root = repo_root.resolve()
+    manifest_bytes = path.read_bytes()
+    try:
+        manifest_data = json.loads(manifest_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise BundleError(f"invalid JSON in {path}: {error}") from error
+    if not isinstance(manifest_data, dict):
+        raise BundleError("manifest root must be an object")
+    require_keys(
+        manifest_data, {"schema_version", "targets", "outputs"}, "manifest"
+    )
+    schema_version = manifest_data["schema_version"]
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != SCHEMA_VERSION
+    ):
+        raise BundleError(
+            f"manifest schema_version must be integer {SCHEMA_VERSION}, "
+            f"got {schema_version!r}"
+        )
+    if not isinstance(manifest_data["targets"], list) or not manifest_data["targets"]:
+        raise BundleError("manifest targets must be a non-empty list")
+    if not isinstance(manifest_data["outputs"], list) or not manifest_data["outputs"]:
+        raise BundleError("manifest outputs must be a non-empty list")
+
+    targets: dict[str, Target] = {}
+    for index, raw_target in enumerate(manifest_data["targets"]):
+        target = parse_target(raw_target, index)
+        if target.name in targets:
+            raise BundleError(f"duplicate target: {target.name}")
+        targets[target.name] = target
+
+    outputs: list[CommandBuild] = []
+    identities: set[tuple[str, str]] = set()
+    paths: set[tuple[str, str]] = set()
+    used_targets: set[str] = set()
+    for index, raw_output in enumerate(manifest_data["outputs"]):
+        output = parse_output(raw_output, index, repo_root)
+        if output.target not in targets:
+            raise BundleError(
+                f"outputs[{index}].target is not declared: {output.target}"
+            )
+        identity = (output.target, output.name)
+        if identity in identities:
+            raise BundleError(f"duplicate target/name pair: {identity}")
+        identities.add(identity)
+        output_path = (output.target, output.archive_path)
+        if output_path in paths:
+            raise BundleError(f"duplicate target/output pair: {output_path}")
+        paths.add(output_path)
+        used_targets.add(output.target)
+        outputs.append(output)
+    unused_targets = set(targets) - used_targets
+    if unused_targets:
+        raise BundleError(f"targets have no outputs: {sorted(unused_targets)}")
+
+    return SourceManifest(
+        targets=targets,
+        outputs=tuple(outputs),
+        sha256=sha256_bytes(manifest_bytes),
+    )
+
+
+def parse_build_timestamp(value: str) -> datetime:
+    """Parse the canonical UTC timestamp and require gzip's supported range."""
+
+    require_string(value, "build timestamp")
+    if BUILD_TIMESTAMP_RE.fullmatch(value) is None:
+        raise BundleError(
+            f"build timestamp must use UTC RFC3339 seconds, got {value}"
+        )
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as error:
+        raise BundleError(
+            f"build timestamp must use UTC RFC3339 seconds, got {value}"
+        ) from error
+    timestamp = parsed.replace(tzinfo=timezone.utc)
+    gzip_seconds = int(timestamp.timestamp())
+    if not 0 <= gzip_seconds <= 0xFFFFFFFF:
+        raise BundleError(
+            "build timestamp must fit the gzip timestamp range "
+            "1970-01-01T00:00:00Z through 2106-02-07T06:28:15Z"
+        )
+    return timestamp
+
+
+def validate_identity(version: str, candidate_sha: str, short_sha: str) -> None:
+    """Require a safe version and one internally consistent commit identity."""
+
+    require_string(version, "version")
+    if VERSION_RE.fullmatch(version) is None:
+        raise BundleError(
+            "version must start with an alphanumeric character and contain only "
+            "letters, numbers, periods, underscores, or hyphens"
+        )
+    if FULL_SHA_RE.fullmatch(candidate_sha) is None:
+        raise BundleError("candidate SHA must be 40 lowercase hexadecimal characters")
+    if SHORT_SHA_RE.fullmatch(short_sha) is None:
+        raise BundleError("short SHA must be 7 to 12 lowercase hexadecimal characters")
+    if not candidate_sha.startswith(short_sha):
+        raise BundleError("short SHA does not match the candidate SHA")
+
+
+def resolve_ldflags(output: CommandBuild, values: dict[str, str]) -> tuple[str, ...]:
+    """Substitute the allowed build values into one command's linker flags."""
+
+    resolved: list[str] = []
+    for flag in output.ldflags:
+        try:
+            value = Template(flag).substitute(values)
+        except (KeyError, ValueError) as error:
+            raise BundleError(
+                f"cannot resolve ldflags for {output.target}/{output.name}: {error}"
+            ) from error
+        require_string(value, f"resolved ldflag for {output.target}/{output.name}")
+        resolved.append(value)
+    return tuple(resolved)
+
+
+def command_output(command: list[str], cwd: Path) -> str:
+    """Run a read-only inspection command and convert failures to BundleError."""
+
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "command failed").strip()
+        raise BundleError(f"{' '.join(command)}: {detail}") from error
+    except OSError as error:
+        raise BundleError(f"cannot run {command[0]}: {error}") from error
+    return result.stdout.strip()
+
+
+def module_path(repo_root: Path) -> str:
+    """Read the Go module path that turns package paths into import paths."""
+
+    for line in (repo_root / "go.mod").read_text(encoding="utf-8").splitlines():
+        if line.startswith("module "):
+            return line.removeprefix("module ").strip()
+    raise BundleError(f"module declaration not found in {repo_root / 'go.mod'}")
+
+
+def expected_import_path(module: str, package: str) -> str:
+    """Return the full Go import path for a normalized local package."""
+
+    suffix = package.removeprefix("./")
+    return f"{module}/{suffix}"
+
+
+def build_info(path: Path, repo_root: Path) -> dict[str, Any]:
+    """Read structured Go build metadata back from one compiled command."""
+
+    raw = command_output(["go", "version", "-m", "-json", str(path)], repo_root)
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise BundleError(f"invalid build info for {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise BundleError(f"build info for {path} is not an object")
+    return value
+
+
+def metadata_values(ldflags: Iterable[str]) -> tuple[str, ...]:
+    """Extract values from the supported `-X=name=value` linker-flag form."""
+
+    values: list[str] = []
+    for flag in ldflags:
+        if not flag.startswith("-X="):
+            if flag == "-X" or flag.startswith("-X "):
+                raise BundleError(
+                    f"-X linker flags must use the -X=name=value form: {flag}"
+                )
+            continue
+        assignment = flag.removeprefix("-X=")
+        _, separator, value = assignment.partition("=")
+        if not separator or not value:
+            raise BundleError(f"invalid -X linker flag: {flag}")
+        values.append(value)
+    return tuple(values)
+
+
+def validate_file_description(
+    description: str,
+    target: Target,
+    output: CommandBuild,
+) -> None:
+    """Check the architecture and linkage facts reported by ``file``.
+
+    ``file`` has used both ``statically linked`` and ``static-pie linked`` for
+    valid static ELF binaries. The contract cares about that fact, not which
+    libmagic wording the runner happens to use.
+    """
+
+    architecture_markers = PHYSICAL_ARCHITECTURE_MARKERS.get(target.name)
+    if architecture_markers is None:
+        raise BundleError(f"no physical architecture check for {target.name}")
+    missing = [marker for marker in architecture_markers if marker not in description]
+    if missing:
+        raise BundleError(
+            f"{output.name} has wrong file type {description!r}; missing {missing}"
+        )
+
+    # CGO_ENABLED=1 does not promise dynamic linkage. The build-info check owns
+    # that setting; only CGO-disabled Linux commands promise a static file.
+    if target.goos != "linux" or output.cgo_enabled:
+        return
+
+    if not any(marker in description for marker in STATIC_LINUX_LINKAGE_MARKERS):
+        raise BundleError(
+            f"{output.name} has wrong file type {description!r}; expected one of "
+            f"{list(STATIC_LINUX_LINKAGE_MARKERS)}"
+        )
+
+
+def inspect_binary(
+    path: Path,
+    repo_root: Path,
+    target: Target,
+    output: CommandBuild,
+    ldflags: tuple[str, ...],
+    candidate_sha: str,
+    import_path: str,
+) -> BinaryInspection:
+    """Read a binary back and confirm the compiler honored its build contract."""
+
+    go_build_info = build_info(path, repo_root)
+    if go_build_info.get("Path") != import_path:
+        raise BundleError(
+            f"{output.name} package is {go_build_info.get('Path')}, "
+            f"expected {import_path}"
+        )
+    settings = {
+        setting.get("Key"): setting.get("Value")
+        for setting in go_build_info.get("Settings", [])
+        if isinstance(setting, dict)
+    }
+    expected_settings = {
+        "CGO_ENABLED": "1" if output.cgo_enabled else "0",
+        "GOARCH": target.goarch,
+        "GOOS": target.goos,
+    }
+    for key, expected in expected_settings.items():
+        if settings.get(key) != expected:
+            raise BundleError(
+                f"{output.name} {key} is {settings.get(key)!r}, expected {expected!r}"
+            )
+    vcs_revision = settings.get("vcs.revision")
+    # Go normally records the repository revision for this module. Keep the
+    # fallback for environments where those settings are unavailable;
+    # ``build_bundle`` still checks the exact Git HEAD and source state first.
+    if vcs_revision is not None and vcs_revision != candidate_sha:
+        raise BundleError(
+            f"{output.name} vcs.revision is {vcs_revision!r}, expected {candidate_sha!r}"
+        )
+    recorded_ldflags = tuple(shlex.split(settings.get("-ldflags", "")))
+    if recorded_ldflags != ldflags:
+        raise BundleError(
+            f"{output.name} ldflags are {recorded_ldflags!r}, expected {ldflags!r}"
+        )
+
+    file_description = command_output(["file", "-b", str(path)], repo_root)
+    validate_file_description(file_description, target, output)
+
+    embedded_values = metadata_values(ldflags)
+    if embedded_values:
+        binary = path.read_bytes()
+        missing_values = [
+            value for value in embedded_values if value.encode() not in binary
+        ]
+        if missing_values:
+            raise BundleError(
+                f"{output.name} is missing linker metadata values: {missing_values}"
+            )
+
+    go_version = go_build_info.get("GoVersion")
+    if not isinstance(go_version, str) or not go_version:
+        raise BundleError(f"{output.name} build info has no GoVersion")
+
+    return BinaryInspection(
+        go_version=go_version,
+        vcs_modified=settings.get("vcs.modified", "unknown"),
+        vcs_revision=vcs_revision or "unavailable",
+        file_description=file_description,
+    )
+
+
+def canonical_json(value: Any) -> bytes:
+    """Encode stable, human-readable JSON with one trailing newline."""
+
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def write_tar_member(
+    archive: tarfile.TarFile,
+    name: str,
+    value: bytes,
+    mode: int,
+    mtime: int,
+) -> None:
+    """Write one byte-backed member with deterministic ownership and time."""
+
+    header = tarfile.TarInfo(name=name)
+    header.size = len(value)
+    header.mode = mode
+    header.mtime = mtime
+    header.uid = 0
+    header.gid = 0
+    header.uname = ""
+    header.gname = ""
+    archive.addfile(header, fileobj=io.BytesIO(value))
+
+
+def create_bundle(
+    path: Path,
+    manifest: bytes,
+    checksums: bytes,
+    binaries: dict[str, bytes],
+    mtime: int,
+) -> None:
+    """Write a deterministic archive from the resolved contract and binaries."""
+
+    try:
+        with path.open("wb") as destination:
+            with gzip.GzipFile(
+                filename="",
+                mode="wb",
+                compresslevel=9,
+                fileobj=destination,
+                mtime=mtime,
+            ) as compressed:
+                with tarfile.open(fileobj=compressed, mode="w") as archive:
+                    write_tar_member(archive, "manifest.json", manifest, 0o644, mtime)
+                    write_tar_member(archive, "SHA256SUMS", checksums, 0o644, mtime)
+                    for name in sorted(binaries):
+                        write_tar_member(archive, name, binaries[name], 0o755, mtime)
+    except (tarfile.TarError, OSError) as error:
+        raise BundleError(f"cannot write bundle {path}: {error}") from error
+
+
+def publish_bundle_files(
+    staged_paths: Iterable[Path],
+    output_dir: Path,
+) -> dict[str, Path]:
+    """Publish verified files from same-filesystem staging or leave none behind."""
+
+    published: list[Path] = []
+    final_paths: dict[str, Path] = {}
+    try:
+        for staged_path in staged_paths:
+            final_path = output_dir / staged_path.name
+            staged_path.replace(final_path)
+            published.append(final_path)
+            final_paths[staged_path.name] = final_path
+    except OSError as error:
+        cleanup_errors: list[str] = []
+        for final_path in reversed(published):
+            try:
+                final_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_error:
+                cleanup_errors.append(f"{final_path}: {cleanup_error}")
+        if cleanup_errors:
+            raise BundleError(
+                "cannot publish bundle files and cannot clean partial output: "
+                + "; ".join(cleanup_errors)
+            ) from error
+        raise BundleError(f"cannot publish bundle files: {error}") from error
+    return final_paths
+
+
+def validate_gzip_header(path: Path, expected_mtime: int) -> None:
+    """Require the deterministic gzip header written by ``create_bundle``."""
+
+    with path.open("rb") as source:
+        header = source.read(10)
+    if len(header) != 10 or header[:3] != b"\x1f\x8b\x08":
+        raise BundleError("bundle is not a gzip stream")
+    if header[3] != 0:
+        raise BundleError("bundle gzip header has unexpected optional fields")
+    if int.from_bytes(header[4:8], "little") != expected_mtime:
+        raise BundleError("bundle gzip timestamp does not match the build timestamp")
+    if header[8] != 2:
+        raise BundleError("bundle gzip header does not record level-9 compression")
+
+
+def read_bundle(
+    path: Path,
+    expected_mtime: int | None = None,
+) -> dict[str, tuple[bytes, int]]:
+    """Read only deterministic, safe, regular members and retain their modes."""
+
+    entries: dict[str, tuple[bytes, int]] = {}
+    member_names: list[str] = []
+    try:
+        with tarfile.open(path, mode="r:gz") as archive:
+            for member in archive.getmembers():
+                member_path = PurePosixPath(member.name)
+                if (
+                    member.name in entries
+                    or member_path.is_absolute()
+                    or ".." in member_path.parts
+                    or not member.isfile()
+                    or member.mode & ~0o777
+                ):
+                    raise BundleError(f"unsafe or duplicate bundle member: {member.name}")
+                if (
+                    member.uid != 0
+                    or member.gid != 0
+                    or member.uname != ""
+                    or member.gname != ""
+                ):
+                    raise BundleError(
+                        f"bundle member has non-normalized ownership: {member.name}"
+                    )
+                if expected_mtime is not None and member.mtime != expected_mtime:
+                    raise BundleError(
+                        f"bundle member has the wrong timestamp: {member.name}"
+                    )
+                source = archive.extractfile(member)
+                if source is None:
+                    raise BundleError(f"cannot read bundle member: {member.name}")
+                member_names.append(member.name)
+                entries[member.name] = (source.read(), member.mode)
+    except (tarfile.TarError, OSError) as error:
+        raise BundleError(f"cannot read bundle {path}: {error}") from error
+    metadata_names = {"manifest.json", "SHA256SUMS"}
+    if metadata_names.issubset(member_names):
+        expected_order = ["manifest.json", "SHA256SUMS"] + sorted(
+            name for name in member_names if name not in metadata_names
+        )
+        if member_names != expected_order:
+            raise BundleError("bundle members are not in deterministic order")
+    return entries
+
+
+def parse_checksums(value: bytes) -> dict[str, str]:
+    """Parse the strict GNU-style checksum inventory embedded in a bundle."""
+
+    checksums: dict[str, str] = {}
+    if not value.endswith(b"\n") or b"\r" in value:
+        raise BundleError("SHA256SUMS must use LF-terminated lines")
+    try:
+        lines = value.decode("utf-8").splitlines()
+    except UnicodeDecodeError as error:
+        raise BundleError("SHA256SUMS is not UTF-8") from error
+    for line in lines:
+        digest, separator, name = line.partition("  ")
+        if not separator or HASH_RE.fullmatch(digest) is None or name in checksums:
+            raise BundleError(f"invalid SHA256SUMS line: {line!r}")
+        checksums[name] = digest
+    return checksums
+
+
+def parse_sidecar(value: str, bundle_name: str) -> str:
+    """Return the digest from the archive's exact one-line checksum sidecar."""
+
+    if not value.endswith("\n") or "\r" in value:
+        raise BundleError("bundle checksum sidecar must use one LF-terminated line")
+    lines = value.splitlines()
+    if len(lines) != 1:
+        raise BundleError("bundle checksum sidecar must contain exactly one line")
+    digest, separator, name = lines[0].partition("  ")
+    if not separator or HASH_RE.fullmatch(digest) is None or name != bundle_name:
+        raise BundleError("bundle checksum sidecar is invalid")
+    return digest
+
+
+def validate_resolved_manifest(
+    resolved_manifest: Any,
+    source_manifest: SourceManifest,
+    repo_root: Path,
+    expected_target: str,
+    expected_version: str,
+    expected_build_timestamp: str,
+    expected_candidate: str,
+    expected_short_sha: str,
+    expected_source_dirty: bool | None,
+) -> tuple[Target, list[dict[str, Any]]]:
+    """Check a resolved manifest against the source contract and expected build."""
+
+    if not isinstance(resolved_manifest, dict):
+        raise BundleError("resolved manifest root must be an object")
+    require_keys(
+        resolved_manifest,
+        {
+            "build_timestamp",
+            "candidate_sha",
+            "outputs",
+            "schema_version",
+            "short_sha",
+            "source_dirty",
+            "source_manifest_sha256",
+            "target",
+            "version",
+        },
+        "resolved manifest",
+    )
+    schema_version = resolved_manifest["schema_version"]
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != SCHEMA_VERSION
+    ):
+        raise BundleError("resolved manifest has an unsupported schema")
+    validate_identity(expected_version, expected_candidate, expected_short_sha)
+    timestamp = parse_build_timestamp(expected_build_timestamp)
+    # An uploaded manifest cannot define its own identity. Require every
+    # run-specific value to match the candidate the caller asked us to verify.
+    exact_identity = {
+        "build_timestamp": expected_build_timestamp,
+        "candidate_sha": expected_candidate,
+        "short_sha": expected_short_sha,
+        "source_manifest_sha256": source_manifest.sha256,
+        "version": expected_version,
+    }
+    for field, expected in exact_identity.items():
+        if resolved_manifest[field] != expected:
+            raise BundleError(
+                f"resolved manifest {field} is {resolved_manifest[field]!r}, "
+                f"expected {expected!r}"
+            )
+    if not isinstance(resolved_manifest["source_dirty"], bool):
+        raise BundleError("resolved manifest source_dirty must be a boolean")
+    if (
+        expected_source_dirty is not None
+        and resolved_manifest["source_dirty"] is not expected_source_dirty
+    ):
+        raise BundleError(
+            "resolved manifest source_dirty does not match the expected source state"
+        )
+
+    # Resolve the target from the checked-in manifest, then require the uploaded
+    # target object to say exactly the same thing.
+    if expected_target not in source_manifest.targets:
+        raise BundleError(
+            f"requested target is not in the source manifest: {expected_target}"
+        )
+    target = source_manifest.targets[expected_target]
+    expected_target_value = {
+        "goarch": target.goarch,
+        "goos": target.goos,
+        "name": target.name,
+    }
+    if resolved_manifest["target"] != expected_target_value:
+        raise BundleError(
+            f"resolved manifest target is {resolved_manifest['target']!r}, "
+            f"expected {expected_target_value!r}"
+        )
+
+    resolved_outputs = resolved_manifest["outputs"]
+    if not isinstance(resolved_outputs, list) or not resolved_outputs:
+        raise BundleError("resolved manifest outputs must be a non-empty list")
+    expected_commands = [
+        output for output in source_manifest.outputs if output.target == expected_target
+    ]
+    if len(resolved_outputs) != len(expected_commands):
+        raise BundleError(
+            f"resolved manifest has {len(resolved_outputs)} outputs, "
+            f"expected {len(expected_commands)}"
+        )
+
+    template_values = {
+        "BUILD_TIME_LEGACY": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "BUILD_TIME_RFC3339": timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "SHORT_SHA": expected_short_sha,
+        "VERSION": expected_version,
+    }
+    go_module_path = module_path(repo_root)
+    output_keys = {
+        "cgo_enabled",
+        "file_description",
+        "go_version",
+        "import_path",
+        "ldflags",
+        "name",
+        "output",
+        "package",
+        "sha256",
+        "size",
+        "vcs_modified",
+        "vcs_revision",
+    }
+    # Each output is checked in source-manifest order. That makes a missing,
+    # reordered, or relabeled binary fail before any archive path is used.
+    validated_outputs: list[dict[str, Any]] = []
+    for index, (raw_output, expected_command) in enumerate(
+        zip(resolved_outputs, expected_commands, strict=True)
+    ):
+        context = f"resolved manifest outputs[{index}]"
+        if not isinstance(raw_output, dict):
+            raise BundleError(f"{context} must be an object")
+        require_keys(raw_output, output_keys, context)
+        exact_contract = {
+            "cgo_enabled": expected_command.cgo_enabled,
+            "import_path": expected_import_path(
+                go_module_path, expected_command.package
+            ),
+            "ldflags": list(resolve_ldflags(expected_command, template_values)),
+            "name": expected_command.name,
+            "output": expected_command.archive_path,
+            "package": expected_command.package,
+        }
+        for field, expected in exact_contract.items():
+            if raw_output[field] != expected:
+                raise BundleError(
+                    f"{context}.{field} is {raw_output[field]!r}, expected {expected!r}"
+                )
+        for field in (
+            "file_description",
+            "go_version",
+            "import_path",
+            "name",
+            "output",
+            "package",
+            "sha256",
+            "vcs_modified",
+            "vcs_revision",
+        ):
+            require_string(raw_output[field], f"{context}.{field}")
+        if NAME_RE.fullmatch(raw_output["name"]) is None:
+            raise BundleError(f"{context}.name is unsafe: {raw_output['name']!r}")
+        if HASH_RE.fullmatch(raw_output["sha256"]) is None:
+            raise BundleError(f"{context}.sha256 must be a lowercase SHA-256 digest")
+        if (
+            not isinstance(raw_output["size"], int)
+            or isinstance(raw_output["size"], bool)
+            or raw_output["size"] <= 0
+        ):
+            raise BundleError(f"{context}.size must be a positive integer")
+        if not isinstance(raw_output["ldflags"], list) or not all(
+            isinstance(flag, str) and flag for flag in raw_output["ldflags"]
+        ):
+            raise BundleError(f"{context}.ldflags must be a list of strings")
+        if not isinstance(raw_output["cgo_enabled"], bool):
+            raise BundleError(f"{context}.cgo_enabled must be a boolean")
+        if raw_output["vcs_revision"] not in {expected_candidate, "unavailable"}:
+            raise BundleError(
+                f"{context}.vcs_revision does not match the candidate"
+            )
+        validated_outputs.append(raw_output)
+    return target, validated_outputs
+
+
+def verify_bundle(
+    bundle_path: Path,
+    checksum_path: Path,
+    manifest_path: Path,
+    source_manifest: SourceManifest,
+    repo_root: Path,
+    expected_target: str,
+    expected_version: str,
+    expected_build_timestamp: str,
+    expected_candidate: str,
+    expected_short_sha: str,
+    expected_source_dirty: bool | None,
+) -> None:
+    """Verify one uploaded bundle without trusting its embedded declarations."""
+
+    try:
+        checksum_text = checksum_path.read_bytes().decode()
+    except UnicodeDecodeError as error:
+        raise BundleError("bundle checksum sidecar is not UTF-8") from error
+    expected_bundle_hash = parse_sidecar(checksum_text, bundle_path.name)
+    actual_bundle_hash = sha256_file(bundle_path)
+    if actual_bundle_hash != expected_bundle_hash:
+        raise BundleError(
+            f"bundle checksum is {actual_bundle_hash}, expected {expected_bundle_hash}"
+        )
+
+    resolved_manifest_bytes = manifest_path.read_bytes()
+    try:
+        resolved_manifest = json.loads(resolved_manifest_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise BundleError(f"resolved manifest is invalid JSON: {error}") from error
+    if canonical_json(resolved_manifest) != resolved_manifest_bytes:
+        raise BundleError("resolved manifest does not use canonical JSON encoding")
+    target, resolved_outputs = validate_resolved_manifest(
+        resolved_manifest,
+        source_manifest,
+        repo_root,
+        expected_target,
+        expected_version,
+        expected_build_timestamp,
+        expected_candidate,
+        expected_short_sha,
+        expected_source_dirty,
+    )
+
+    expected_mtime = int(parse_build_timestamp(expected_build_timestamp).timestamp())
+    validate_gzip_header(bundle_path, expected_mtime)
+    entries = read_bundle(bundle_path, expected_mtime)
+    expected_names = {"manifest.json", "SHA256SUMS"}
+    expected_names.update(output["output"] for output in resolved_outputs)
+    if set(entries) != expected_names:
+        raise BundleError(
+            f"bundle members are {sorted(entries)}, expected {sorted(expected_names)}"
+        )
+    # The sidecar and embedded manifests must be byte-for-byte identical. There
+    # is one claimed build contract, rather than an external and internal copy
+    # that can quietly disagree.
+    if entries["manifest.json"] != (resolved_manifest_bytes, 0o644):
+        raise BundleError("embedded manifest differs from the external manifest")
+    if entries["SHA256SUMS"][1] != 0o644:
+        raise BundleError("SHA256SUMS must have mode 0644")
+
+    checksums = parse_checksums(entries["SHA256SUMS"][0])
+    expected_checksum_names = {output["output"] for output in resolved_outputs}
+    if set(checksums) != expected_checksum_names:
+        raise BundleError("SHA256SUMS does not list the exact binary inventory")
+
+    with tempfile.TemporaryDirectory(prefix="rest-command-verify-") as temp:
+        temp_root = Path(temp)
+        for index, raw_output in enumerate(resolved_outputs):
+            name = raw_output["output"]
+            binary_bytes, mode = entries[name]
+            if mode != 0o755:
+                raise BundleError(f"{name} must have mode 0755, got {mode:o}")
+            digest = sha256_bytes(binary_bytes)
+            if digest != checksums[name] or digest != raw_output["sha256"]:
+                raise BundleError(f"{name} checksum does not match its manifest")
+            if len(binary_bytes) != raw_output["size"]:
+                raise BundleError(f"{name} size does not match its manifest")
+
+            # ``go version -m`` and ``file`` inspect filesystem paths. Use a
+            # verifier-owned name so an archive member can never choose where
+            # its bytes are written.
+            binary = temp_root / f"output-{index}"
+            binary.write_bytes(binary_bytes)
+            binary.chmod(0o755)
+            command = CommandBuild(
+                name=raw_output["name"],
+                package=raw_output["package"],
+                target=expected_target,
+                cgo_enabled=raw_output["cgo_enabled"],
+                ldflags=tuple(raw_output["ldflags"]),
+                archive_path=name,
+            )
+            validate_file_description(
+                raw_output["file_description"], target, command
+            )
+            inspection = inspect_binary(
+                binary,
+                repo_root,
+                target,
+                command,
+                command.ldflags,
+                expected_candidate,
+                raw_output["import_path"],
+            )
+            validate_recorded_inspection(name, raw_output, inspection)
+
+
+def validate_recorded_inspection(
+    name: str,
+    recorded: dict[str, Any],
+    inspection: BinaryInspection,
+) -> None:
+    """Require the resolved build record to match the reopened binary exactly."""
+
+    for field in (
+        "file_description",
+        "go_version",
+        "vcs_modified",
+        "vcs_revision",
+    ):
+        detail = getattr(inspection, field)
+        if recorded[field] != detail:
+            raise BundleError(
+                f"{name} {field} is {recorded[field]!r}, expected {detail!r}"
+            )
+
+
+def build_bundle(args: argparse.Namespace) -> None:
+    """Build, package, and independently reopen one target's complete inventory."""
+
+    repo_root = args.repo_root.resolve()
+    manifest = load_source_manifest(args.manifest.resolve(), repo_root)
+    if args.target not in manifest.targets:
+        raise BundleError(f"target is not declared in the manifest: {args.target}")
+    target = manifest.targets[args.target]
+    target_commands = [
+        command for command in manifest.outputs if command.target == args.target
+    ]
+    timestamp = parse_build_timestamp(args.build_timestamp)
+    validate_identity(args.version, args.candidate_sha, args.short_sha)
+
+    # The candidate label is only honest when it names this exact checkout.
+    # CI rejects all source changes; local validation can opt in and records
+    # that the source was dirty in the resolved manifest.
+    actual_sha = command_output(["git", "rev-parse", "HEAD"], repo_root)
+    if actual_sha != args.candidate_sha:
+        raise BundleError(
+            f"checked-out candidate is {actual_sha}, expected {args.candidate_sha}"
+        )
+    source_status = command_output(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"], repo_root
+    )
+    source_dirty = bool(source_status)
+    if source_dirty and not args.allow_dirty:
+        raise BundleError(
+            "the repository worktree has tracked or untracked changes anywhere in the "
+            f"checkout; refusing to label it as candidate {args.candidate_sha}"
+        )
+    template_values = {
+        "BUILD_TIME_LEGACY": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "BUILD_TIME_RFC3339": timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "SHORT_SHA": args.short_sha,
+        "VERSION": args.version,
+    }
+    go_module_path = module_path(repo_root)
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if any(output_dir.iterdir()):
+        raise BundleError(f"output directory must be empty: {output_dir}")
+    stem = f"rest-command-bundle-{target.name}"
+
+    with tempfile.TemporaryDirectory(prefix="rest-command-build-") as temp:
+        temp_root = Path(temp)
+        bin_root = temp_root / "bin"
+        bin_root.mkdir()
+        resolved_outputs: list[dict[str, Any]] = []
+        binary_contents: dict[str, bytes] = {}
+        for command in target_commands:
+            binary = bin_root / command.name
+            ldflags = resolve_ldflags(command, template_values)
+            go_build_command = ["go", "build", "-o", str(binary)]
+            if ldflags:
+                go_build_command.extend(["-ldflags", shlex.join(ldflags)])
+            go_build_command.append(command.package)
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "CGO_ENABLED": "1" if command.cgo_enabled else "0",
+                    "GOARCH": target.goarch,
+                    "GOOS": target.goos,
+                }
+            )
+            print(f"Building {command.name} for {target.name}", flush=True)
+            try:
+                subprocess.run(
+                    go_build_command,
+                    cwd=repo_root,
+                    env=environment,
+                    check=True,
+                )
+            except subprocess.CalledProcessError as error:
+                raise BundleError(
+                    f"go build failed for {target.name}/{command.name}"
+                ) from error
+            binary.chmod(0o755)
+            import_path = expected_import_path(go_module_path, command.package)
+            inspection = inspect_binary(
+                binary,
+                repo_root,
+                target,
+                command,
+                ldflags,
+                args.candidate_sha,
+                import_path,
+            )
+            binary_bytes = binary.read_bytes()
+            binary_contents[command.archive_path] = binary_bytes
+            resolved_outputs.append(
+                {
+                    "cgo_enabled": command.cgo_enabled,
+                    "file_description": inspection.file_description,
+                    "go_version": inspection.go_version,
+                    "import_path": import_path,
+                    "ldflags": list(ldflags),
+                    "name": command.name,
+                    "output": command.archive_path,
+                    "package": command.package,
+                    "sha256": sha256_bytes(binary_bytes),
+                    "size": len(binary_bytes),
+                    "vcs_modified": inspection.vcs_modified,
+                    "vcs_revision": inspection.vcs_revision,
+                }
+            )
+
+        resolved_manifest = {
+            "build_timestamp": args.build_timestamp,
+            "candidate_sha": args.candidate_sha,
+            "outputs": resolved_outputs,
+            "schema_version": SCHEMA_VERSION,
+            "short_sha": args.short_sha,
+            "source_manifest_sha256": manifest.sha256,
+            "source_dirty": source_dirty,
+            "target": {
+                "goarch": target.goarch,
+                "goos": target.goos,
+                "name": target.name,
+            },
+            "version": args.version,
+        }
+        manifest_bytes = canonical_json(resolved_manifest)
+        checksum_bytes = "".join(
+            f"{sha256_bytes(binary_contents[name])}  {name}\n"
+            for name in sorted(binary_contents)
+        ).encode()
+        with tempfile.TemporaryDirectory(
+            prefix=".rest-command-stage-", dir=output_dir
+        ) as stage:
+            stage_root = Path(stage)
+            staged_bundle = stage_root / f"{stem}.tar.gz"
+            staged_checksum = stage_root / f"{stem}.tar.gz.sha256"
+            staged_manifest = stage_root / f"{stem}.manifest.json"
+            create_bundle(
+                staged_bundle,
+                manifest_bytes,
+                checksum_bytes,
+                binary_contents,
+                int(timestamp.timestamp()),
+            )
+            staged_manifest.write_bytes(manifest_bytes)
+            staged_checksum.write_text(
+                f"{sha256_file(staged_bundle)}  {staged_bundle.name}\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+
+            verify_bundle(
+                staged_bundle,
+                staged_checksum,
+                staged_manifest,
+                manifest,
+                repo_root,
+                target.name,
+                args.version,
+                args.build_timestamp,
+                args.candidate_sha,
+                args.short_sha,
+                source_dirty,
+            )
+            # Publish the archive last so a consumer never sees it before its
+            # resolved manifest and checksum sidecar are ready.
+            final_paths = publish_bundle_files(
+                (staged_manifest, staged_checksum, staged_bundle), output_dir
+            )
+
+    bundle_path = final_paths[staged_bundle.name]
+    print(
+        f"Verified {len(target_commands)} outputs in {bundle_path} "
+        f"({bundle_path.stat().st_size} bytes)",
+        flush=True,
+    )
+
+
+def check_manifest(args: argparse.Namespace) -> None:
+    """Validate the checked-in source contract without compiling commands."""
+
+    manifest = load_source_manifest(args.manifest.resolve(), args.repo_root.resolve())
+    print(
+        f"Validated {len(manifest.outputs)} outputs across "
+        f"{len(manifest.targets)} targets"
+    )
+
+
+def verify_existing_bundle(args: argparse.Namespace) -> None:
+    """Verify supplied bundle files against the checked-in source contract."""
+
+    validate_identity(args.version, args.candidate_sha, args.short_sha)
+    repo_root = args.repo_root.resolve()
+    manifest = load_source_manifest(args.manifest.resolve(), repo_root)
+    verify_bundle(
+        args.bundle.resolve(),
+        args.checksum.resolve(),
+        args.resolved_manifest.resolve(),
+        manifest,
+        repo_root,
+        args.target,
+        args.version,
+        args.build_timestamp,
+        args.candidate_sha,
+        args.short_sha,
+        None if args.allow_dirty else False,
+    )
+    print(f"Verified {args.bundle}")
+
+
+def parser() -> argparse.ArgumentParser:
+    """Define the check, build, and verify command-line contracts."""
+
+    result = argparse.ArgumentParser(
+        description="Build and verify exact REST command bundles."
+    )
+    subparsers = result.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check", help="validate the source manifest")
+    check.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    check.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
+    check.set_defaults(function=check_manifest)
+
+    build = subparsers.add_parser("build", help="build and verify one target bundle")
+    build.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    build.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
+    build.add_argument("--target", required=True)
+    build.add_argument("--output-dir", type=Path, required=True)
+    build.add_argument("--version", required=True)
+    build.add_argument("--build-timestamp", required=True)
+    build.add_argument("--candidate-sha", required=True)
+    build.add_argument("--short-sha", required=True)
+    build.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="allow local validation from a dirty checkout and record that fact",
+    )
+    build.set_defaults(function=build_bundle)
+
+    verify = subparsers.add_parser("verify", help="verify one existing target bundle")
+    verify.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    verify.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
+    verify.add_argument("--target", required=True)
+    verify.add_argument("--bundle", type=Path, required=True)
+    verify.add_argument("--checksum", type=Path, required=True)
+    verify.add_argument("--resolved-manifest", type=Path, required=True)
+    verify.add_argument("--version", required=True)
+    verify.add_argument("--build-timestamp", required=True)
+    verify.add_argument("--candidate-sha", required=True)
+    verify.add_argument("--short-sha", required=True)
+    verify.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="allow a bundle whose resolved manifest records a dirty source checkout",
+    )
+    verify.set_defaults(function=verify_existing_bundle)
+    return result
+
+
+def main() -> int:
+    """Run the selected command and present contract failures consistently."""
+
+    args = parser().parse_args()
+    try:
+        args.function(args)
+    except (BundleError, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/ci/test_rest_command_bundle.py
+++ b/.github/ci/test_rest_command_bundle.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep the REST command manifest and bundle format honest at their boundaries."""
+
+from __future__ import annotations
+
+import copy
+import gzip
+import io
+import json
+import re
+import shlex
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+
+CI_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = CI_DIR.parents[1]
+REST_API_DIR = REPOSITORY_ROOT / "rest-api"
+sys.path.insert(0, str(CI_DIR))
+
+import rest_command_bundle as bundle  # noqa: E402
+
+
+class ManifestTest(unittest.TestCase):
+    """``ManifestTest`` pins the complete source-controlled build contract."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.path = CI_DIR / "rest-command-manifest.json"
+        cls.value = json.loads(cls.path.read_text())
+        cls.manifest = bundle.load_source_manifest(cls.path, REST_API_DIR)
+
+    def test_cli_defaults_follow_the_ci_helper_location(self) -> None:
+        args = bundle.parser().parse_args(("check",))
+
+        self.assertEqual(args.manifest, CI_DIR / "rest-command-manifest.json")
+        self.assertEqual(args.repo_root, REST_API_DIR)
+
+    def test_exact_build_contract(self) -> None:
+        # Keep this inventory independent from `rest-command-manifest.json`.
+        # Any package, target, CGO, or linker-flag change should require an
+        # explicit test change that a reviewer can see.
+        packages = {
+            "api": "./api/cmd/api",
+            "credsmgr": "./cert-manager/cmd/credsmgr",
+            "flow": "./flow",
+            "migrations": "./db/cmd/migrations",
+            "mock-core": "./site-agent/cmd/mock-core",
+            "mock-flow": "./site-agent/cmd/mock-flow",
+            "nico-mcp": "./mcp/cmd/nico-mcp",
+            "nicocli": "./cli/cmd/cli",
+            "nsm": "./nvswitch-manager",
+            "psm": "./powershelf-manager",
+            "site-agent": "./site-agent/cmd/site-agent",
+            "sitemgr": "./site-manager/cmd/sitemgr",
+            "workflow": "./workflow/cmd/workflow",
+        }
+        static_stripped = ("-extldflags=-static", "-w", "-s")
+        static_only = ("-extldflags=-static",)
+        metadata_flags = {
+            "api": (
+                "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.Version=${VERSION}",
+                "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.BuildTime=${BUILD_TIME_LEGACY}",
+            ),
+            "site-agent": (
+                "-X=github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata.Version=${VERSION}",
+                "-X=github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata.BuildTime=${BUILD_TIME_LEGACY}",
+            ),
+            "flow": (
+                "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.Version=${VERSION}",
+                "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.BuildTime=${BUILD_TIME_RFC3339}",
+                "-X=github.com/NVIDIA/infra-controller/rest-api/flow/pkg/metadata.GitCommit=${SHORT_SHA}",
+            ),
+        }
+        linux_flags = {
+            "api": static_stripped + metadata_flags["api"],
+            "migrations": static_stripped,
+            "sitemgr": static_stripped,
+            "workflow": static_stripped,
+            "site-agent": static_stripped + metadata_flags["site-agent"],
+            "mock-core": (),
+            "mock-flow": (),
+            "credsmgr": static_stripped,
+            "flow": static_only + metadata_flags["flow"],
+            "nicocli": static_stripped,
+            "nico-mcp": static_stripped,
+            "psm": static_only,
+            "nsm": static_only,
+        }
+        common = set(packages) - {"nicocli", "nico-mcp"}
+        inventories = {
+            "linux-amd64": set(packages),
+            "linux-arm64": set(packages),
+            "darwin-arm64": common,
+        }
+        target_specs = {
+            "linux-amd64": ("linux", "amd64"),
+            "linux-arm64": ("linux", "arm64"),
+            "darwin-arm64": ("darwin", "arm64"),
+        }
+
+        self.assertEqual(set(self.manifest.targets), set(target_specs))
+        self.assertEqual(len(self.manifest.outputs), 37)
+        for name, (goos, goarch) in target_specs.items():
+            with self.subTest(target=name):
+                target = self.manifest.targets[name]
+                self.assertEqual((target.goos, target.goarch), (goos, goarch))
+                actual = {
+                    output.name
+                    for output in self.manifest.outputs
+                    if output.target == name
+                }
+                self.assertEqual(actual, inventories[name])
+
+        for output in self.manifest.outputs:
+            with self.subTest(target=output.target, name=output.name):
+                self.assertEqual(output.package, packages[output.name])
+                self.assertEqual(output.archive_path, f"bin/{output.name}")
+                expected_cgo = (
+                    output.target == "linux-amd64"
+                    and output.name in {"mock-core", "mock-flow"}
+                )
+                self.assertEqual(output.cgo_enabled, expected_cgo)
+                expected_flags = (
+                    linux_flags[output.name]
+                    if output.target.startswith("linux-")
+                    else metadata_flags.get(output.name, ())
+                )
+                self.assertEqual(output.ldflags, expected_flags)
+
+    def test_ldflags_keep_space_delimited_metadata_in_one_argument(self) -> None:
+        output = self.output("linux-amd64", "api")
+        values = {
+            "BUILD_TIME_LEGACY": "2026-08-05 12:34:56",
+            "BUILD_TIME_RFC3339": "2026-08-05T12:34:56Z",
+            "SHORT_SHA": "1234567",
+            "VERSION": "pull-request-4581-1234567",
+        }
+        resolved = bundle.resolve_ldflags(output, values)
+        self.assertEqual(tuple(shlex.split(shlex.join(resolved))), resolved)
+        self.assertIn(
+            "-X=github.com/NVIDIA/infra-controller/rest-api/api/pkg/metadata.BuildTime=2026-08-05 12:34:56",
+            resolved,
+        )
+
+    def test_space_separated_metadata_flag_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            bundle.BundleError, "must use the -X=name=value form"
+        ):
+            bundle.metadata_values(("-X metadata.Version=1.2.3",))
+
+    def test_invalid_manifest_cases(self) -> None:
+        def set_unsupported_target(value: dict[str, Any]) -> None:
+            targets = value["targets"]
+            outputs = value["outputs"]
+            target = next(
+                target for target in targets if target["name"] == "linux-amd64"
+            )
+            target.update(name="linux-s390x", goarch="s390x")
+            for output in outputs:
+                if output["target"] == "linux-amd64":
+                    output["target"] = "linux-s390x"
+
+        cases = {
+            "duplicate output": (
+                lambda value: value["outputs"].append(
+                    copy.deepcopy(value["outputs"][0])
+                ),
+                "duplicate target/name pair",
+            ),
+            "missing target": (
+                lambda value: value["outputs"][0].__setitem__(
+                    "target", "linux-s390x"
+                ),
+                "outputs[0].target is not declared: linux-s390x",
+            ),
+            "unsupported target": (
+                set_unsupported_target,
+                "is not supported: linux-s390x",
+            ),
+            "unsafe output": (
+                lambda value: value["outputs"][0].__setitem__("output", "../api"),
+                "outputs[0].output must be bin/api, got ../api",
+            ),
+            "trailing command hyphen": (
+                lambda value: value["outputs"][0].update(
+                    name="api-", output="bin/api-"
+                ),
+                "outputs[0].name is not a safe command name: api-",
+            ),
+            "unknown token": (
+                lambda value: value["outputs"][0]["ldflags"].append(
+                    "-X=example.Value=${UNKNOWN}"
+                ),
+                "outputs[0].ldflags uses unknown tokens",
+            ),
+            "space-separated metadata flag": (
+                lambda value: value["outputs"][0]["ldflags"].append(
+                    "-X metadata.Version=1.2.3"
+                ),
+                "outputs[0].ldflags must use the -X=name=value form",
+            ),
+            "boolean schema version": (
+                lambda value: value.__setitem__("schema_version", True),
+                "manifest schema_version must be integer 1, got True",
+            ),
+            "floating-point schema version": (
+                lambda value: value.__setitem__("schema_version", 1.0),
+                "manifest schema_version must be integer 1, got 1.0",
+            ),
+            "missing package": (
+                lambda value: value["outputs"][0].__setitem__(
+                    "package", "./not-a-package"
+                ),
+                "outputs[0].package does not exist: ./not-a-package",
+            ),
+            "absolute package suffix": (
+                lambda value: value["outputs"][0].__setitem__("package", ".//tmp"),
+                "outputs[0].package must be a normalized relative ./ path: .//tmp",
+            ),
+            "string cgo": (
+                lambda value: value["outputs"][0].__setitem__("cgo_enabled", "0"),
+                "outputs[0].cgo_enabled must be a boolean",
+            ),
+        }
+        for name, (mutate, expected_error) in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temp:
+                value = copy.deepcopy(self.value)
+                mutate(value)
+                path = Path(temp) / "manifest.json"
+                path.write_text(json.dumps(value))
+                with self.assertRaisesRegex(
+                    bundle.BundleError, re.escape(expected_error)
+                ):
+                    bundle.load_source_manifest(path, REST_API_DIR)
+
+    def output(self, target: str, name: str) -> bundle.CommandBuild:
+        return next(
+            output
+            for output in self.manifest.outputs
+            if output.target == target and output.name == name
+        )
+
+
+class BundleFormatTest(unittest.TestCase):
+    """``BundleFormatTest`` checks archive reproducibility and fail-closed reads."""
+
+    def test_build_timestamp_is_canonical_and_fits_gzip(self) -> None:
+        self.assertEqual(
+            bundle.parse_build_timestamp("2026-08-05T12:34:56Z").isoformat(),
+            "2026-08-05T12:34:56+00:00",
+        )
+        invalid = (
+            "2026-8-5T1:2:3Z",
+            "1969-12-31T23:59:59Z",
+            "2106-02-07T06:28:16Z",
+        )
+        for timestamp in invalid:
+            with self.subTest(timestamp=timestamp), self.assertRaises(
+                bundle.BundleError
+            ):
+                bundle.parse_build_timestamp(timestamp)
+
+    def test_file_description_accepts_known_static_wording(self) -> None:
+        target = bundle.Target("linux-amd64", "linux", "amd64")
+        command = bundle.CommandBuild(
+            name="api",
+            package="./api/cmd/api",
+            target=target.name,
+            cgo_enabled=False,
+            ldflags=(),
+            archive_path="bin/api",
+        )
+        cases = (
+            "ELF 64-bit LSB executable, x86-64, statically linked",
+            "ELF 64-bit LSB pie executable, x86-64, static-pie linked",
+        )
+        for file_description in cases:
+            with self.subTest(file_description=file_description):
+                bundle.validate_file_description(file_description, target, command)
+
+    def test_file_description_rejects_wrong_linkage(self) -> None:
+        target = bundle.Target("linux-arm64", "linux", "arm64")
+        command = bundle.CommandBuild(
+            name="api",
+            package="./api/cmd/api",
+            target=target.name,
+            cgo_enabled=False,
+            ldflags=(),
+            archive_path="bin/api",
+        )
+        with self.assertRaises(bundle.BundleError):
+            bundle.validate_file_description(
+                "ELF 64-bit LSB executable, ARM aarch64, dynamically linked",
+                target,
+                command,
+            )
+
+    def test_file_description_accepts_darwin_arm64(self) -> None:
+        target = bundle.Target("darwin-arm64", "darwin", "arm64")
+        command = bundle.CommandBuild(
+            name="api",
+            package="./api/cmd/api",
+            target=target.name,
+            cgo_enabled=False,
+            ldflags=(),
+            archive_path="bin/api",
+        )
+        bundle.validate_file_description(
+            "Mach-O 64-bit arm64 executable", target, command
+        )
+
+    def test_file_description_rejects_wrong_architecture(self) -> None:
+        target = bundle.Target("darwin-arm64", "darwin", "arm64")
+        command = bundle.CommandBuild(
+            name="api",
+            package="./api/cmd/api",
+            target=target.name,
+            cgo_enabled=False,
+            ldflags=(),
+            archive_path="bin/api",
+        )
+        with self.assertRaisesRegex(
+            bundle.BundleError, re.escape("missing ['arm64']")
+        ):
+            bundle.validate_file_description(
+                "Mach-O 64-bit x86_64 executable", target, command
+            )
+
+    def test_cgo_file_description_does_not_assume_linkage(self) -> None:
+        target = bundle.Target("linux-amd64", "linux", "amd64")
+        command = bundle.CommandBuild(
+            name="mock-core",
+            package="./site-agent/cmd/mock-core",
+            target=target.name,
+            cgo_enabled=True,
+            ldflags=(),
+            archive_path="bin/mock-core",
+        )
+        descriptions = (
+            "ELF 64-bit LSB executable, x86-64, dynamically linked",
+            "ELF 64-bit LSB executable, x86-64, statically linked",
+        )
+        for description in descriptions:
+            with self.subTest(description=description):
+                bundle.validate_file_description(description, target, command)
+
+    def test_missing_external_tool_names_the_command(self) -> None:
+        missing = FileNotFoundError(2, "No such file or directory", "file")
+        with mock.patch.object(bundle.subprocess, "run", side_effect=missing):
+            with self.assertRaisesRegex(bundle.BundleError, "cannot run file"):
+                bundle.command_output(["file", "--version"], REST_API_DIR)
+
+    def test_recorded_file_description_matches_reopened_binary(self) -> None:
+        target = bundle.Target("linux-amd64", "linux", "amd64")
+        command = bundle.CommandBuild(
+            name="api",
+            package="./api/cmd/api",
+            target=target.name,
+            cgo_enabled=False,
+            ldflags=(),
+            archive_path="bin/api",
+        )
+        recorded = {
+            "file_description": "ELF 64-bit, x86-64, statically linked",
+            "go_version": "go1.26.4",
+            "vcs_modified": "unknown",
+            "vcs_revision": "unavailable",
+        }
+        inspection = bundle.BinaryInspection(
+            go_version="go1.26.4",
+            vcs_modified="unknown",
+            vcs_revision="unavailable",
+            file_description=(
+                "ELF 64-bit, x86-64, statically linked, stripped"
+            ),
+        )
+        bundle.validate_file_description(
+            recorded["file_description"], target, command
+        )
+        bundle.validate_file_description(
+            inspection.file_description, target, command
+        )
+        with self.assertRaisesRegex(bundle.BundleError, "file_description"):
+            bundle.validate_recorded_inspection("api", recorded, inspection)
+
+    def test_bundle_is_deterministic_and_preserves_modes(self) -> None:
+        manifest = b'{"schema_version": 1}\n'
+        binaries = {"bin/api": b"api", "bin/workflow": b"workflow"}
+        checksums = b"a" * 64 + b"  bin/api\n" + b"b" * 64 + b"  bin/workflow\n"
+        timestamp = 1_786_000_000
+        with tempfile.TemporaryDirectory() as temp:
+            first = Path(temp) / "first.tar.gz"
+            second = Path(temp) / "second.tar.gz"
+            bundle.create_bundle(first, manifest, checksums, binaries, timestamp)
+            bundle.create_bundle(second, manifest, checksums, binaries, timestamp)
+            archive_bytes = first.read_bytes()
+            self.assertEqual(archive_bytes, second.read_bytes())
+            self.assertEqual(archive_bytes[:2], b"\x1f\x8b")
+            self.assertEqual(archive_bytes[3] & 0x08, 0)
+            self.assertEqual(int.from_bytes(archive_bytes[4:8], "little"), timestamp)
+            self.assertEqual(archive_bytes[8], 2)
+
+            with tarfile.open(first, mode="r:gz") as archive:
+                members = archive.getmembers()
+            self.assertEqual(
+                [member.name for member in members],
+                ["manifest.json", "SHA256SUMS", "bin/api", "bin/workflow"],
+            )
+            for member in members:
+                with self.subTest(member=member.name):
+                    self.assertEqual(member.uid, 0)
+                    self.assertEqual(member.gid, 0)
+                    self.assertEqual(member.uname, "")
+                    self.assertEqual(member.gname, "")
+                    self.assertEqual(member.mtime, timestamp)
+
+            entries = bundle.read_bundle(first)
+            self.assertEqual(entries["manifest.json"], (manifest, 0o644))
+            self.assertEqual(entries["SHA256SUMS"], (checksums, 0o644))
+            self.assertEqual(entries["bin/api"], (b"api", 0o755))
+            self.assertEqual(entries["bin/workflow"], (b"workflow", 0o755))
+
+    def test_publish_failure_removes_partial_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            output_dir = Path(temp) / "output"
+            stage_dir = output_dir / "stage"
+            stage_dir.mkdir(parents=True)
+            manifest = stage_dir / "manifest.json"
+            missing = stage_dir / "missing.sha256"
+            archive = stage_dir / "bundle.tar.gz"
+            manifest.write_text("manifest")
+            archive.write_text("archive")
+
+            with self.assertRaisesRegex(bundle.BundleError, "cannot publish"):
+                bundle.publish_bundle_files(
+                    (manifest, missing, archive), output_dir
+                )
+
+            self.assertFalse((output_dir / manifest.name).exists())
+            self.assertFalse((output_dir / archive.name).exists())
+
+    def test_canonical_json_is_stable(self) -> None:
+        value = {"z": 1, "a": {"enabled": True}}
+        self.assertEqual(
+            bundle.canonical_json(value),
+            b'{\n  "a": {\n    "enabled": true\n  },\n  "z": 1\n}\n',
+        )
+
+    def test_bundle_rejects_unsafe_members(self) -> None:
+        cases = {
+            "path traversal": self.regular_member("../api", b"api"),
+            "setuid mode": self.regular_member("bin/api", b"api", 0o4755),
+            "symbolic link": self.symlink_member("bin/api", "/tmp/api"),
+        }
+        for name, member in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temp:
+                path = Path(temp) / "bundle.tar.gz"
+                self.write_archive(path, [member])
+                with self.assertRaises(bundle.BundleError):
+                    bundle.read_bundle(path)
+
+    def test_checksum_parsers_fail_closed(self) -> None:
+        valid = "a" * 64
+        self.assertEqual(
+            bundle.parse_checksums(f"{valid}  bin/api\n".encode()),
+            {"bin/api": valid},
+        )
+        self.assertEqual(
+            bundle.parse_sidecar(f"{valid}  bundle.tar.gz\n", "bundle.tar.gz"),
+            valid,
+        )
+        invalid_checksums = [
+            f"{valid}  bin/api".encode(),
+            f"{valid}  bin/api\r\n".encode(),
+            b"not-a-checksum  bin/api\n",
+            f"{valid} bin/api\n".encode(),
+            f"{valid}  bin/api\n{valid}  bin/api\n".encode(),
+        ]
+        for value in invalid_checksums:
+            with self.subTest(value=value), self.assertRaises(bundle.BundleError):
+                bundle.parse_checksums(value)
+        invalid_sidecars = [
+            f"{valid}  bundle.tar.gz",
+            f"{valid}  bundle.tar.gz\r\n",
+            f"{valid}  another.tar.gz\n",
+            f"{valid}  bundle.tar.gz\n{valid}  bundle.tar.gz\n",
+        ]
+        for value in invalid_sidecars:
+            with self.subTest(value=value), self.assertRaises(bundle.BundleError):
+                bundle.parse_sidecar(value, "bundle.tar.gz")
+
+    def test_resolved_manifest_matches_authoritative_contract(self) -> None:
+        source = bundle.load_source_manifest(
+            CI_DIR / "rest-command-manifest.json", REST_API_DIR
+        )
+        candidate = "1" * 40
+        short_sha = candidate[:8]
+        version = "pull-request-4581-11111111"
+        timestamp = "2026-08-05T12:34:56Z"
+        value = self.resolved_manifest(
+            source, "linux-amd64", version, timestamp, candidate, short_sha
+        )
+        target, outputs = bundle.validate_resolved_manifest(
+            value,
+            source,
+            REST_API_DIR,
+            "linux-amd64",
+            version,
+            timestamp,
+            candidate,
+            short_sha,
+            False,
+        )
+        self.assertEqual(target, source.targets["linux-amd64"])
+        self.assertEqual(len(outputs), 13)
+
+        cases = {
+            "wrong target": (
+                lambda changed: changed["target"].__setitem__(
+                    "name", "linux-arm64"
+                ),
+                "resolved manifest target is",
+            ),
+            "wrong candidate": (
+                lambda changed: changed.__setitem__("candidate_sha", "2" * 40),
+                "resolved manifest candidate_sha is",
+            ),
+            "missing output": (
+                lambda changed: changed["outputs"].pop(),
+                "resolved manifest has 12 outputs, expected 13",
+            ),
+            "relabeled output": (
+                lambda changed: changed["outputs"][0].__setitem__(
+                    "name", "../../escape"
+                ),
+                "resolved manifest outputs[0].name is '../../escape', expected 'api'",
+            ),
+            "wrong ldflags": (
+                lambda changed: changed["outputs"][0].__setitem__("ldflags", []),
+                "resolved manifest outputs[0].ldflags is [], expected",
+            ),
+            "wrong source manifest": (
+                lambda changed: changed.__setitem__(
+                    "source_manifest_sha256", "3" * 64
+                ),
+                "resolved manifest source_manifest_sha256 is",
+            ),
+            "boolean schema version": (
+                lambda changed: changed.__setitem__("schema_version", True),
+                "resolved manifest has an unsupported schema",
+            ),
+            "floating-point schema version": (
+                lambda changed: changed.__setitem__("schema_version", 1.0),
+                "resolved manifest has an unsupported schema",
+            ),
+        }
+        for name, (mutate, expected_error) in cases.items():
+            with self.subTest(name=name):
+                changed = copy.deepcopy(value)
+                mutate(changed)
+                with self.assertRaisesRegex(
+                    bundle.BundleError, re.escape(expected_error)
+                ):
+                    bundle.validate_resolved_manifest(
+                        changed,
+                        source,
+                        REST_API_DIR,
+                        "linux-amd64",
+                        version,
+                        timestamp,
+                        candidate,
+                        short_sha,
+                        False,
+                    )
+
+    @staticmethod
+    def resolved_manifest(
+        source: bundle.SourceManifest,
+        target_name: str,
+        version: str,
+        timestamp: str,
+        candidate: str,
+        short_sha: str,
+    ) -> dict[str, object]:
+        parsed_timestamp = bundle.parse_build_timestamp(timestamp)
+        values = {
+            "BUILD_TIME_LEGACY": parsed_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            "BUILD_TIME_RFC3339": timestamp,
+            "SHORT_SHA": short_sha,
+            "VERSION": version,
+        }
+        module = bundle.module_path(REST_API_DIR)
+        outputs = []
+        for output in source.outputs:
+            if output.target != target_name:
+                continue
+            outputs.append(
+                {
+                    "cgo_enabled": output.cgo_enabled,
+                    "file_description": "test binary",
+                    "go_version": "go1.26.4",
+                    "import_path": bundle.expected_import_path(module, output.package),
+                    "ldflags": list(bundle.resolve_ldflags(output, values)),
+                    "name": output.name,
+                    "output": output.archive_path,
+                    "package": output.package,
+                    "sha256": "a" * 64,
+                    "size": 1,
+                    "vcs_modified": "unknown",
+                    "vcs_revision": "unavailable",
+                }
+            )
+        target = source.targets[target_name]
+        return {
+            "build_timestamp": timestamp,
+            "candidate_sha": candidate,
+            "outputs": outputs,
+            "schema_version": 1,
+            "short_sha": short_sha,
+            "source_dirty": False,
+            "source_manifest_sha256": source.sha256,
+            "target": {
+                "goarch": target.goarch,
+                "goos": target.goos,
+                "name": target.name,
+            },
+            "version": version,
+        }
+
+    @staticmethod
+    def regular_member(
+        name: str, value: bytes, mode: int = 0o755
+    ) -> tuple[tarfile.TarInfo, bytes]:
+        member = tarfile.TarInfo(name)
+        member.size = len(value)
+        member.mode = mode
+        return member, value
+
+    @staticmethod
+    def symlink_member(name: str, target: str) -> tuple[tarfile.TarInfo, bytes]:
+        member = tarfile.TarInfo(name)
+        member.type = tarfile.SYMTYPE
+        member.linkname = target
+        return member, b""
+
+    @staticmethod
+    def write_archive(
+        path: Path, members: list[tuple[tarfile.TarInfo, bytes]]
+    ) -> None:
+        with path.open("wb") as destination:
+            with gzip.GzipFile(filename="", mode="wb", fileobj=destination, mtime=0) as zipped:
+                with tarfile.open(fileobj=zipped, mode="w") as archive:
+                    for member, value in members:
+                        archive.addfile(member, io.BytesIO(value))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/rest-build-binaries.yml
+++ b/.github/workflows/rest-build-binaries.yml
@@ -5,18 +5,55 @@ name: Build Go Binaries
 
 on:
   workflow_dispatch:
+    inputs:
+      identity_source:
+        description: 'Source for the manual build identity'
+        required: true
+        default: 'selected-ref'
+        type: choice
+        options:
+          - 'selected-ref'
+      runner:
+        description: 'Runner type for the build jobs'
+        required: false
+        default: 'linux-amd64-cpu4'
+        type: string
+      upload_artifact:
+        description: 'Whether to upload target bundles'
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
-        runner:
-          description: 'Runner type for the build job'
-          required: false
-          default: 'linux-amd64-cpu4'
-          type: string
-        upload_artifact:
-          description: 'Whether to upload artifacts'
-          required: false
-          default: false
-          type: boolean
+      runner:
+        description: 'Runner type for the build jobs'
+        required: false
+        default: 'linux-amd64-cpu4'
+        type: string
+      upload_artifact:
+        description: 'Whether to upload target bundles'
+        required: false
+        default: false
+        type: boolean
+      binary_version:
+        description: 'Version embedded in production command binaries'
+        required: true
+        type: string
+      build_timestamp:
+        description: 'UTC RFC3339 timestamp embedded in production command binaries'
+        required: true
+        type: string
+      short_sha:
+        description: 'Short candidate SHA embedded in flow'
+        required: true
+        type: string
+      full_sha:
+        description: 'Full candidate SHA recorded in each target manifest'
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -26,47 +63,84 @@ env:
   GO_VERSION: "1.26.4"
 
 jobs:
-  # One job per target, not per command. A single-command job still compiles
-  # the whole dependency graph behind that command, and pays a minute or more
-  # of queue, checkout and toolchain setup on top of it. Grouping a target's
-  # commands into one job shares that graph through GOCACHE instead: from a
-  # cold cache the first command takes about 14 seconds and the remaining ten
-  # about 17 seconds combined.
+  resolve-manual-identity:
+    name: Resolve Manual Build Identity
+    # This single-option input exists only for direct dispatch. Reusable callers
+    # cannot set it and must supply the four required identity inputs instead.
+    if: inputs.identity_source == 'selected-ref'
+    runs-on: ${{ inputs.runner || 'linux-amd64-cpu4' }}
+    outputs:
+      binary_version: ${{ steps.identity.outputs.binary_version }}
+      build_timestamp: ${{ steps.identity.outputs.build_timestamp }}
+      short_sha: ${{ steps.identity.outputs.short_sha }}
+      full_sha: ${{ steps.identity.outputs.full_sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Resolve identity
+        id: identity
+        env:
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          full_sha=$(git rev-parse HEAD)
+          short_sha=$(git rev-parse --short HEAD)
+          semantic_version=$(git describe --tags --first-parent --always)
+          branch_name=$(printf '%s' "${REF_NAME}" | sed 's/[^a-zA-Z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//')
+
+          # Keep this manual-only precedence aligned with
+          # rest-prepare-build-info.yml's normal CI identity.
+          if [ "${REF}" = "refs/heads/main" ]; then
+            binary_version=${semantic_version}
+          elif [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            binary_version=${REF_NAME}
+          elif [ -n "${branch_name}" ]; then
+            binary_version=${branch_name}-${short_sha}
+          else
+            echo "::error::cannot derive a binary version from ${REF_NAME}"
+            exit 1
+          fi
+          build_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          if [[ ! "${binary_version}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+            echo "::error::derived binary version is not safe: ${binary_version}"
+            exit 1
+          fi
+          {
+            echo "binary_version=${binary_version}"
+            echo "build_timestamp=${build_timestamp}"
+            echo "short_sha=${short_sha}"
+            echo "full_sha=${full_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
   build-binaries:
     name: Build Binaries (${{ matrix.target }})
-    # All three targets build on the amd64 runner, as they did when this was
-    # keyed by command. That keeps the existing CGO behaviour: linux-amd64 is
-    # native so cgo is on, and the two cross-compiled targets have it off.
-    runs-on: ${{ inputs.runner }}
+    needs: resolve-manual-identity
+    if: >-
+      ${{ !cancelled() &&
+          (needs.resolve-manual-identity.result == 'success' ||
+           needs.resolve-manual-identity.result == 'skipped') }}
+    runs-on: ${{ inputs.runner || 'linux-amd64-cpu4' }}
+    timeout-minutes: 30
+    env:
+      TARGET: ${{ matrix.target }}
+      BINARY_VERSION: ${{ inputs.identity_source == 'selected-ref' && needs.resolve-manual-identity.outputs.binary_version || inputs.binary_version }}
+      BUILD_TIMESTAMP: ${{ inputs.identity_source == 'selected-ref' && needs.resolve-manual-identity.outputs.build_timestamp || inputs.build_timestamp }}
+      SHORT_SHA: ${{ inputs.identity_source == 'selected-ref' && needs.resolve-manual-identity.outputs.short_sha || inputs.short_sha }}
+      FULL_SHA: ${{ inputs.identity_source == 'selected-ref' && needs.resolve-manual-identity.outputs.full_sha || inputs.full_sha }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: linux-amd64
-            goos: linux
-            goarch: amd64
-          - target: linux-arm64
-            goos: linux
-            goarch: arm64
-          - target: darwin-arm64
-            goos: darwin
-            goarch: arm64
-    env:
-      # `<name> <package>` per line, and the declaration of what gets released.
-      # Single source for both the build loop and the verification loop, so the
-      # two cannot drift.
-      COMMANDS: |
-        api ./api/cmd/api
-        migrations ./db/cmd/migrations
-        sitemgr ./site-manager/cmd/sitemgr
-        workflow ./workflow/cmd/workflow
-        site-agent ./site-agent/cmd/site-agent
-        mock-core ./site-agent/cmd/mock-core
-        mock-flow ./site-agent/cmd/mock-flow
-        credsmgr ./cert-manager/cmd/credsmgr
-        flow ./flow
-        psm ./powershelf-manager
-        nsm ./nvswitch-manager
+        target:
+          - linux-amd64
+          - linux-arm64
+          - darwin-arm64
 
     steps:
       - name: Checkout code
@@ -81,69 +155,75 @@ jobs:
           cache: true
           cache-dependency-path: rest-api/go.sum
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       - name: Download dependencies
         run: go mod download
 
-      - name: Build commands for ${{ matrix.target }}
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          TARGET: ${{ matrix.target }}
+      - name: Validate bundle prerequisites and identity
         run: |
           set -euo pipefail
-          mkdir -p dist
-          while read -r name package; do
-            [ -n "${name}" ] || continue
-            go build -o "dist/${name}-${TARGET}" "${package}"
-          done <<< "${COMMANDS}"
 
-      # A per-command job could not silently produce nothing, because the build
-      # step was the job. Looping can, so every declared command is checked for a
-      # file that exists and was built for this target.
-      #
-      # What this cannot do is notice a command missing from COMMANDS, because
-      # COMMANDS is the declaration of what to ship. It needs to be maintained
-      # when new packages are added or removed.
-      - name: Verify ${{ matrix.target }} inventory and architecture
-        env:
-          GOOS_WANT: ${{ matrix.goos }}
-          GOARCH_WANT: ${{ matrix.goarch }}
-          TARGET: ${{ matrix.target }}
+          python3 -c 'import sys; sys.exit("error: Python 3.10 or newer is required") if sys.version_info < (3, 10) else None'
+
+          # `file` is part of the existing REST image-runner contract. Check it
+          # before compilation because the bundle verifier needs it afterward.
+          file --version
+
+          actual_full_sha=$(git rev-parse HEAD)
+          if [ "${FULL_SHA}" != "${actual_full_sha}" ]; then
+            echo "::error::requested candidate ${FULL_SHA} does not match checkout ${actual_full_sha}"
+            exit 1
+          fi
+          if [[ "${actual_full_sha}" != "${SHORT_SHA}"* ]]; then
+            echo "::error::short candidate ${SHORT_SHA} is not a prefix of ${actual_full_sha}"
+            exit 1
+          fi
+          if [[ ! "${BINARY_VERSION}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+            echo "::error::binary version is not safe: ${BINARY_VERSION}"
+            exit 1
+          fi
+          if [[ ! "${BUILD_TIMESTAMP}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+            echo "::error::build timestamp must use UTC RFC3339 seconds: ${BUILD_TIMESTAMP}"
+            exit 1
+          fi
+
+      - name: Build and verify ${{ matrix.target }} bundle
+        run: |
+          python3 ../.github/ci/rest_command_bundle.py build \
+            --target "${TARGET}" \
+            --output-dir "build/rest-command-bundles/${TARGET}" \
+            --version "${BINARY_VERSION}" \
+            --build-timestamp "${BUILD_TIMESTAMP}" \
+            --candidate-sha "${FULL_SHA}" \
+            --short-sha "${SHORT_SHA}"
+
+      - name: Record ${{ matrix.target }} bundle
         run: |
           set -euo pipefail
-          binaries=()
-          while read -r name _; do
-            [ -n "${name}" ] || continue
-            binary="dist/${name}-${TARGET}"
-            [ -f "${binary}" ] || { echo "::error::${binary} was not produced"; exit 1; }
-            # `go version -m` reports the settings the toolchain recorded, so
-            # this reads Mach-O and ELF alike and does not depend on how the
-            # runner's `file` database happens to word things. CGO_ENABLED is
-            # deliberately not asserted: it is on for the native target and off
-            # for the cross-compiled ones, which is the pre-existing behaviour.
-            settings=$(go version -m "${binary}")
-            for want in "GOOS=${GOOS_WANT}" "GOARCH=${GOARCH_WANT}"; do
-              grep -qE "^[[:space:]]*build[[:space:]]+${want}$" <<< "${settings}" \
-                || { echo "::error::${binary} was not built for ${want}"; exit 1; }
-            done
-            binaries+=("${binary}")
-          done <<< "${COMMANDS}"
-          # Catches COMMANDS collapsing to nothing -- an easy YAML block-scalar
-          # mistake that would otherwise upload an empty artifact and pass. A
-          # count compared against COMMANDS itself could not catch this, since
-          # both sides would be zero.
-          [ "${#binaries[@]}" -gt 0 ] \
-            || { echo "::error::COMMANDS declared no binaries for ${TARGET}"; exit 1; }
-          # Named explicitly rather than globbed, so the checksum file cannot
-          # pick itself up on a runner that kept the previous workspace.
-          sha256sum "${binaries[@]}" > "dist/SHA256SUMS-${TARGET}"
-          echo "verified ${#binaries[@]} ${TARGET} binaries"
 
-      - name: Upload ${{ matrix.target }} binaries
+          bundle="build/rest-command-bundles/${TARGET}/rest-command-bundle-${TARGET}.tar.gz"
+          {
+            echo "### REST command bundle: ${TARGET}"
+            echo ""
+            echo "- Candidate: \`${FULL_SHA}\`"
+            echo "- Version: \`${BINARY_VERSION}\`"
+            echo "- Bundle bytes: \`$(stat -c %s "${bundle}")\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload ${{ matrix.target }} bundle
         if: inputs.upload_artifact == true
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target }}-binaries
-          # Also picks up SHA256SUMS-<target>, which matches the same suffix.
-          path: rest-api/dist/*-${{ matrix.target }}
+          name: rest-command-bundle-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            rest-api/build/rest-command-bundles/${{ matrix.target }}/rest-command-bundle-${{ matrix.target }}.tar.gz
+            rest-api/build/rest-command-bundles/${{ matrix.target }}/rest-command-bundle-${{ matrix.target }}.tar.gz.sha256
+            rest-api/build/rest-command-bundles/${{ matrix.target }}/rest-command-bundle-${{ matrix.target }}.manifest.json
+          if-no-files-found: error
+          # The bundle is already gzip-compressed; another deflate pass only burns runner time.
+          compression-level: 0
           retention-days: 7

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -48,6 +48,9 @@ jobs:
           filters: |
             rest_api:
               - 'rest-api/**'
+              - '.github/ci/rest-command-*'
+              - '.github/ci/rest_command_bundle.py'
+              - '.github/ci/test_rest_command_bundle.py'
               - '.github/workflows/rest-*.yml'
               - 'helm/rest/**'
             core_proto:
@@ -106,6 +109,10 @@ jobs:
       - prepare
     with:
       upload_artifact: true
+      binary_version: ${{ needs.prepare.outputs.binary_version }}
+      build_timestamp: ${{ needs.prepare.outputs.build_timestamp }}
+      short_sha: ${{ needs.prepare.outputs.short_sha }}
+      full_sha: ${{ needs.prepare.outputs.full_sha }}
     uses: ./.github/workflows/rest-build-binaries.yml
 
   security-secret-scan:

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -32,6 +32,11 @@ jobs:
           cache: true
           cache-dependency-path: rest-api/go.sum
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Download dependencies
         run: go mod download
 
@@ -51,6 +56,9 @@ jobs:
             git -P diff --name-only
             exit 1
           fi
+
+      - name: Check REST command bundle contract
+        run: make check-command-bundle
 
   lint-go:
     name: Lint Go

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -21,6 +21,12 @@ on:
       full_sha:
         description: "Full SHA of the current commit"
         value: ${{ jobs.prepare.outputs.full_sha }}
+      binary_version:
+        description: "Version embedded in production REST command binaries"
+        value: ${{ jobs.prepare.outputs.binary_version }}
+      build_timestamp:
+        description: "UTC RFC3339 timestamp embedded in production REST command binaries"
+        value: ${{ jobs.prepare.outputs.build_timestamp }}
       target_registry:
         description: "Target NVCR registry path"
         value: ${{ jobs.prepare.outputs.target_registry }}
@@ -54,6 +60,8 @@ jobs:
       semantic_version: ${{ steps.generate-version.outputs.semantic_version }}
       short_sha: ${{ steps.generate-version.outputs.short_sha }}
       full_sha: ${{ steps.generate-version.outputs.full_sha }}
+      binary_version: ${{ steps.generate-version.outputs.binary_version }}
+      build_timestamp: ${{ steps.generate-version.outputs.build_timestamp }}
       target_registry: ${{ steps.generate-version.outputs.target_registry }}
       target_ngc_path: ${{ steps.generate-version.outputs.target_ngc_path }}
       branch_name: ${{ steps.generate-version.outputs.branch_name }}
@@ -110,22 +118,40 @@ jobs:
           fi
           target_registry="${target_registry%/}"
 
-          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${GITHUB_REF_NAME}"
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
           BRANCH_SHA_TAG="${BRANCH_NAME}-${SHORT_SHA}"
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             IS_MAIN_BRANCH="true"
           else
             IS_MAIN_BRANCH="false"
           fi
 
-          REF_NAME="${{ github.ref_name }}"
+          REF_NAME="${GITHUB_REF_NAME}"
           if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
             RELEASE_TAG="${REF_NAME}"
           else
             RELEASE_TAG=""
           fi
+
+          # Keep this precedence aligned with the manual-only resolver in
+          # rest-build-binaries.yml.
+          if [ "${IS_MAIN_BRANCH}" = "true" ]; then
+            BINARY_VERSION="${SEMANTIC_VERSION}"
+          elif [ -n "${RELEASE_TAG}" ]; then
+            BINARY_VERSION="${RELEASE_TAG}"
+          elif [ -n "${BRANCH_NAME}" ]; then
+            BINARY_VERSION="${BRANCH_SHA_TAG}"
+          else
+            echo "::error::cannot derive a binary version from ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          if [[ ! "${BINARY_VERSION}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+            echo "::error::derived binary version is not safe: ${BINARY_VERSION}"
+            exit 1
+          fi
+          BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           if printf '%s' "${COMMIT_MESSAGE}" | grep -q "push-container"; then
             PUSH_REQUESTED="true"
@@ -133,38 +159,47 @@ jobs:
             PUSH_REQUESTED="false"
           fi
 
-          echo "semantic_version=$SEMANTIC_VERSION" >> $GITHUB_OUTPUT
-          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
-          echo "full_sha=$FULL_SHA" >> $GITHUB_OUTPUT
-          echo "target_registry=$target_registry" >> $GITHUB_OUTPUT
-          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
-            echo "target_ngc_path=${target_registry#*/}" >> $GITHUB_OUTPUT
-          else
+          # Helm chart version: strip leading `v`, then for non-exact-tag commits replace the
+          # last `-` with `.` to align with core helm_version (e.g. `v1.6.0-3-gabc1234` -> `1.6.0-3.gabc1234`).
+          HELM_VERSION="${RAW_VERSION#v}"
+          if [[ "$RAW_VERSION" =~ -g[0-9a-f]+$ ]]; then
+            HELM_VERSION="${HELM_VERSION%-*}.${HELM_VERSION##*-}"
+          fi
+
+          if [ "${GITHUB_REPOSITORY}" != "NVIDIA/infra-controller" ]; then
             case "${NGC_PATH_OVERRIDE%/}" in
               "0837451325059433/carbide-dev"|"0837451325059433/carbide")
                 echo "::error::this repository must not publish helm/resources to the canonical NGC path"
                 exit 1;;
             esac
-            echo "target_ngc_path=${NGC_PATH_OVERRIDE:-}" >> $GITHUB_OUTPUT
           fi
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "branch_sha_tag=$BRANCH_SHA_TAG" >> $GITHUB_OUTPUT
-          echo "is_main_branch=$IS_MAIN_BRANCH" >> $GITHUB_OUTPUT
-          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
-          echo "push_requested=$PUSH_REQUESTED" >> $GITHUB_OUTPUT
 
-          # Helm chart version: strip leading `v`, then for non-exact-tag commits replace the
-          # last `-` with `.` to align with core helm_version (e.g. `v1.6.0-3-gabc1234` -> `1.6.0-3.gabc1234`).
-          HELM_VERSION="${RAW_VERSION#v}"
-          if [[ "$RAW_VERSION" =~ -g[0-9a-f]+$ ]]; then
-            HELM_VERSION=$(echo "$HELM_VERSION" | sed 's/\(.*\)-/\1./')
-          fi
-          echo "helm_version=$HELM_VERSION" >> $GITHUB_OUTPUT
+          {
+            echo "semantic_version=${SEMANTIC_VERSION}"
+            echo "short_sha=${SHORT_SHA}"
+            echo "full_sha=${FULL_SHA}"
+            echo "binary_version=${BINARY_VERSION}"
+            echo "build_timestamp=${BUILD_TIMESTAMP}"
+            echo "target_registry=${target_registry}"
+            if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
+              echo "target_ngc_path=${target_registry#*/}"
+            else
+              echo "target_ngc_path=${NGC_PATH_OVERRIDE:-}"
+            fi
+            echo "branch_name=${BRANCH_NAME}"
+            echo "branch_sha_tag=${BRANCH_SHA_TAG}"
+            echo "is_main_branch=${IS_MAIN_BRANCH}"
+            echo "release_tag=${RELEASE_TAG}"
+            echo "push_requested=${PUSH_REQUESTED}"
+            echo "helm_version=${HELM_VERSION}"
+          } >> "${GITHUB_OUTPUT}"
 
           echo "Generated build information:"
           echo "  SEMANTIC_VERSION: $SEMANTIC_VERSION"
           echo "  SHORT_SHA: $SHORT_SHA"
           echo "  FULL_SHA: $FULL_SHA"
+          echo "  BINARY_VERSION: $BINARY_VERSION"
+          echo "  BUILD_TIMESTAMP: $BUILD_TIMESTAMP"
           echo "  TARGET_REGISTRY: $target_registry"
           echo "  BRANCH_NAME: $BRANCH_NAME"
           echo "  BRANCH_SHA_TAG: $BRANCH_SHA_TAG"
@@ -174,18 +209,36 @@ jobs:
           echo "  HELM_VERSION: $HELM_VERSION"
 
       - name: Generate build summary
+        env:
+          SUMMARY_SEMANTIC_VERSION: ${{ steps.generate-version.outputs.semantic_version }}
+          SUMMARY_SHORT_SHA: ${{ steps.generate-version.outputs.short_sha }}
+          SUMMARY_BINARY_VERSION: ${{ steps.generate-version.outputs.binary_version }}
+          SUMMARY_BUILD_TIMESTAMP: ${{ steps.generate-version.outputs.build_timestamp }}
+          SUMMARY_FULL_SHA: ${{ steps.generate-version.outputs.full_sha }}
+          SUMMARY_REF_NAME: ${{ github.ref_name }}
+          SUMMARY_BRANCH_NAME: ${{ steps.generate-version.outputs.branch_name }}
+          SUMMARY_BRANCH_SHA_TAG: ${{ steps.generate-version.outputs.branch_sha_tag }}
+          SUMMARY_IS_MAIN_BRANCH: ${{ steps.generate-version.outputs.is_main_branch }}
+          SUMMARY_RELEASE_TAG: ${{ steps.generate-version.outputs.release_tag }}
+          SUMMARY_PUSH_REQUESTED: ${{ steps.generate-version.outputs.push_requested }}
+          SUMMARY_HELM_VERSION: ${{ steps.generate-version.outputs.helm_version }}
+          SUMMARY_TARGET_REGISTRY: ${{ steps.generate-version.outputs.target_registry }}
         run: |
-          echo "# Build Information Generated" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "## Version Details" >> $GITHUB_STEP_SUMMARY
-          echo "- **Semantic Version**: \`${{ steps.generate-version.outputs.semantic_version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Short SHA**: \`${{ steps.generate-version.outputs.short_sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Full SHA**: \`${{ steps.generate-version.outputs.full_sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch**: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch Name (sanitized)**: \`${{ steps.generate-version.outputs.branch_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch-SHA Tag**: \`${{ steps.generate-version.outputs.branch_sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Is Main Branch**: \`${{ steps.generate-version.outputs.is_main_branch }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release Tag**: \`${{ steps.generate-version.outputs.release_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Push Requested**: \`${{ steps.generate-version.outputs.push_requested }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Helm Version**: \`${{ steps.generate-version.outputs.helm_version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Target Registry**: \`${{ steps.generate-version.outputs.target_registry }}\`" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+
+          {
+            printf '%s\n' "# Build Information Generated" "" "## Version Details"
+            printf '%s\n' "- **Semantic Version**: \`${SUMMARY_SEMANTIC_VERSION}\`"
+            printf '%s\n' "- **Short SHA**: \`${SUMMARY_SHORT_SHA}\`"
+            printf '%s\n' "- **Binary Version**: \`${SUMMARY_BINARY_VERSION}\`"
+            printf '%s\n' "- **Build Timestamp**: \`${SUMMARY_BUILD_TIMESTAMP}\`"
+            printf '%s\n' "- **Full SHA**: \`${SUMMARY_FULL_SHA}\`"
+            printf '%s\n' "- **Branch**: \`${SUMMARY_REF_NAME}\`"
+            printf '%s\n' "- **Branch Name (sanitized)**: \`${SUMMARY_BRANCH_NAME}\`"
+            printf '%s\n' "- **Branch-SHA Tag**: \`${SUMMARY_BRANCH_SHA_TAG}\`"
+            printf '%s\n' "- **Is Main Branch**: \`${SUMMARY_IS_MAIN_BRANCH}\`"
+            printf '%s\n' "- **Release Tag**: \`${SUMMARY_RELEASE_TAG}\`"
+            printf '%s\n' "- **Push Requested**: \`${SUMMARY_PUSH_REQUESTED}\`"
+            printf '%s\n' "- **Helm Version**: \`${SUMMARY_HELM_VERSION}\`"
+            printf '%s\n' "- **Target Registry**: \`${SUMMARY_TARGET_REGISTRY}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/rest-api/Makefile
+++ b/rest-api/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: test postgres-up postgres-down ensure-postgres postgres-wait clean check-source-headers fix-source-headers
+.PHONY: test postgres-up postgres-down ensure-postgres postgres-wait clean check-source-headers fix-source-headers check-command-bundle
 .PHONY: build docker-build docker-build-local
 .PHONY: test-ipam test-site-agent test-site-manager test-workflow test-db test-api test-auth test-common test-cert-manager test-site-workflow test-flow test-powershelf-manager test-nvswitch-manager test-proto migrate core-mock-server-build core-mock-server-start core-mock-server-stop flow-mock-server-build flow-mock-server-start flow-mock-server-stop
 .PHONY: validate-openapi preview-openapi generate-client
@@ -108,6 +108,11 @@ check-source-headers:
 
 fix-source-headers:
 	python3 scripts/check_source_headers.py --fix
+
+check-command-bundle:
+	python3 -c 'import sys; sys.exit("error: Python 3.10 or newer is required") if sys.version_info < (3, 10) else None'
+	python3 -B ../.github/ci/test_rest_command_bundle.py
+	python3 -B ../.github/ci/rest_command_bundle.py check
 
 ensure-postgres:
 	@docker inspect $(POSTGRES_CONTAINER_NAME) > /dev/null 2>&1 || $(MAKE) postgres-up


### PR DESCRIPTION
#4644 got the important first move in here. @thossain-nv changed REST from one runner per command to one build job per target, which removed repeated setup work and gave us the parallel build layout we wanted. We have now had several days of that model running on `main`, and it has been a good baseline to build from.

This PR is a direct follow-up on top of #4644. It keeps target scheduling in `.github/workflows/rest-build-binaries.yml` and adds the contract the next pipeline stage needs. `.github/ci/rest-command-manifest.json` defines what each job builds, the settings it uses, and the files packaging is allowed to consume. The bundle helper then checks the candidate identity and source state, verifies the complete inventory and binary metadata, and uploads one checked bundle with its checksum and resolved manifest.

That split is important: #4644 owns the parallelization, while this PR makes the build results safe to reuse. Once #4582 consumes these bundles, the image jobs can package the binaries already built and checked here instead of keeping a second build list and compiling the same services again inside Docker. This PR deliberately leaves those Dockerfiles alone so we can review and measure the producer contract before changing its consumers.

- **Expected green-run effect:** #4644 already delivered the direct wall-time win from consolidating the jobs, so this PR is not expected to make the required REST check materially faster by itself. The added verification has added about a minute in the hosted comparisons so far, while stored artifact data fell by about 21%. The larger time savings need to be measured in #4582 after packaging stops recompiling.
- **What it really buys us:** one source-controlled agreement between build and packaging. Both stages use the same command inventory, compiler and linker settings, candidate identity, filenames, and checksums, so we can build once, verify once, and hand that exact result to the next stage without letting workflow and Docker build lists drift apart.

## Measured result

This compares [#4644's final hosted REST run](https://github.com/NVIDIA/infra-controller/actions/runs/31133621873) with [#4618's rebased exact-head REST run](https://github.com/NVIDIA/infra-controller/actions/runs/31525247039):

| Metric | #4644 | This PR | Change |
|---|---:|---:|---:|
| Target-build lane wall time | `2m50s` | `4m03s` | `+1m13s` |
| Summed build runner time | `8m18s` | `11m28s` | `+3m10s` |
| Uploaded artifact data | `739.8 MB` | `582.8 MB` | `-21.2%` |

Several days of successful `main` runs put #4644's target-build lane around three minutes, so the broader sample reaches the same conclusion: this PR adds verification time instead of another direct lane speedup. Other REST lanes varied between runs, so we are not treating full-workflow time as a performance result from this change.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4581

Part of https://github.com/NVIDIA/infra-controller/issues/4572

Prepares https://github.com/NVIDIA/infra-controller/issues/4582

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Exact head `5d8614aab8c7ccfdf470dcd0762f73a18b3df00f` passed the 19 command-bundle tests under Python 3.10.20, every target bundle build, verification, and upload job, and both the `rest-ci-pass` and `core-ci-pass` gates.

## Additional Notes

Go normally records `vcs.revision` in these binaries. The builder verifies the exact Git `HEAD` and a clean source tree before compilation; the resolved manifest uses `unavailable` only when the build environment omits that setting.

This PR intentionally leaves the production Dockerfiles unchanged. #4582 is where those image builds switch to the checked Linux bundles, so the producer contract and its consumer can be reviewed and measured separately.

Closes #4581