### PR TITLE
fix(setup): make core image name configurable

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -74,18 +74,20 @@ Everything in this step must be done **before** running `setup.sh`. Skipping any
 export KUBECONFIG=/path/to/kubeconfig          # your cluster kubeconfig
 export REGISTRY_PULL_SECRET=<pull-secret-or-api-key>  # your registry pull credential
 export NICO_IMAGE_REGISTRY=my-registry.example.com/nico  # base registry for all NICo images
+export NICO_CORE_IMAGE_NAME=nico                   # optional; defaults to nico
 export NICO_CORE_IMAGE_TAG=<nico-core-image-tag>  # e.g. v2025.12.30-rc1
 export NICO_REST_IMAGE_TAG=<nico-rest-image-tag>      # e.g. v1.0.4
 ```
 
-`NICO_IMAGE_REGISTRY` is used for both NICo Core (`<registry>/nvmetal-carbide`) and NICo REST (`<registry>/nico-rest-*`). Push all images to this registry before running setup.
+`NICO_IMAGE_REGISTRY` is used for both NICo Core (`<registry>/<NICO_CORE_IMAGE_NAME>`) and NICo REST (`<registry>/nico-rest-*`). `NICO_CORE_IMAGE_NAME` defaults to `nico`, matching the image produced by `make images`; set it to `nvmetal-carbide` when deploying a legacy image. Push all images to this registry before running setup.
 
 Obtain an NGC API key at [ngc.nvidia.com](https://ngc.nvidia.com) → **API Keys** → **Generate Personal Key**.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `REGISTRY_PULL_SECRET` | **Yes** | Pull secret and API key for your image registry. Used to create the image pull secret for both NICo Core and NICo REST. |
-| `NICO_IMAGE_REGISTRY` | **Yes** | Base image registry for all NICo images (e.g. `my-registry.example.com/nico`). Used for NICo Core (`<registry>/nvmetal-carbide`) and NICo REST (`<registry>/nico-rest-*`). |
+| `NICO_IMAGE_REGISTRY` | **Yes** | Base image registry for all NICo images (e.g. `my-registry.example.com/nico`). Used for NICo Core and NICo REST (`<registry>/nico-rest-*`). |
+| `NICO_CORE_IMAGE_NAME` | No | NICo Core image name under `NICO_IMAGE_REGISTRY`. Defaults to `nico`; use `nvmetal-carbide` for legacy images. |
 | `NICO_CORE_IMAGE_TAG` | **Yes** | NICo Core image tag (e.g. `v2025.12.30`). |
 | `NICO_REST_IMAGE_TAG` | **Yes** | NICo REST image tag (e.g. `v1.0.4`). |
 | `KUBECONFIG` | **Yes** | Path to your cluster kubeconfig. |

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -99,6 +99,7 @@ The tables below summarize the keys that must be set per site.
 | `REGISTRY_PULL_SECRET` | No | **Raw** NGC API key or registry password (e.g. `nvapi-...`). This value is passed verbatim as the docker password — do **not** point it at a file path or a JSON dockerconfig. Leave unset for public, preloaded, or externally managed image pulls. |
 | `REGISTRY_PULL_USERNAME` | No | Username for generated pull secrets. Defaults to `$oauthtoken` (correct for `nvcr.io` API-key auth). |
 | `NICO_IMAGE_REGISTRY` | Yes, unless `--skip-core --skip-rest` | Base image registry for all NICo images (e.g. `my-registry.example.com/nico`) |
+| `NICO_CORE_IMAGE_NAME` | No | NICo Core image name under `NICO_IMAGE_REGISTRY`. Defaults to `nico`, matching `make images`; use `nvmetal-carbide` for legacy images. |
 | `NICO_CORE_IMAGE_TAG` | Yes, unless `--skip-core` | NICo Core image tag (e.g. `v2025.12.30-rc1`) |
 | `NICO_REST_IMAGE_TAG` | Yes, unless `--skip-rest` | NICo REST image tag (e.g. `v1.0.4`) |
 | `NICO_SITE_UUID` | No | Stable UUID for this site. If unset, `setup.sh` tries to reuse the UUID from a prior install (site-agent ConfigMap). If that fails, it adopts an existing REST site with the same name, or mints a UUID and seeds the site record itself. |

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -34,6 +34,8 @@
 #   9. NICo REST source/charts   — in-tree rest-api/ and helm/rest/ are present
 #
 # Configurable:
+#   NICO_CORE_IMAGE_NAME  — NICo Core image name under NICO_IMAGE_REGISTRY
+#                           (default: nico; use nvmetal-carbide for legacy images)
 #   PREFLIGHT_CHECK_IMAGE — image used for per-node pod checks (default: busybox:1.36)
 #                           Override for air-gapped clusters:
 #                           export PREFLIGHT_CHECK_IMAGE=my-registry.example.com/busybox:1.36
@@ -91,6 +93,7 @@ fi
 
 ERRORS=()
 WARNINGS=()
+NICO_CORE_IMAGE_NAME="${NICO_CORE_IMAGE_NAME:-nico}"
 
 _CORE_VALUES_CFG="${CORE_VALUES:-${SCRIPT_DIR}/values/nico-core.yaml}"
 _CORE_VALUES_LABEL="${CORE_VALUES:-values/nico-core.yaml}"
@@ -171,6 +174,14 @@ _UUID_RE='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-
 # NICO_IMAGE_REGISTRY must not include a protocol prefix
 if [[ -n "${NICO_IMAGE_REGISTRY:-}" ]] && [[ "${NICO_IMAGE_REGISTRY}" =~ ^https?:// ]]; then
     ERRORS+=("NICO_IMAGE_REGISTRY must not include a protocol prefix — remove 'https://' or 'http://'")
+fi
+
+# NICO_CORE_IMAGE_NAME is appended to NICO_IMAGE_REGISTRY as one repository
+# path component. Reject full paths and tags so the resulting reference is
+# unambiguous and remains under the configured registry prefix.
+if [[ "${SKIP_CORE:-false}" != "true" ]] && \
+   [[ ! "${NICO_CORE_IMAGE_NAME}" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+    ERRORS+=("NICO_CORE_IMAGE_NAME='${NICO_CORE_IMAGE_NAME}' is not a valid image name — use one lowercase path component without a tag (e.g. nico or nvmetal-carbide)")
 fi
 
 # NICO_SITE_UUID must be a valid UUID if set (used as Temporal namespace + CLUSTER_ID)

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -32,6 +32,8 @@
 #                         NICo REST tag. Example: v1.0.4
 #
 # Optional environment:
+#   NICO_CORE_IMAGE_NAME   NICo Core image name under NICO_IMAGE_REGISTRY.
+#                         Default: nico. Use nvmetal-carbide for legacy images.
 #   REGISTRY_PULL_SECRET   Registry password/API key. If unset, setup does not
 #                          create image pull secrets; images must be public,
 #                          preloaded, or use existing imagePullSecrets.
@@ -463,7 +465,7 @@ else
         helm upgrade --install nico ./helm
         --namespace nico-system
         -f "${_CORE_VALUES_ARG}"
-        --set-string "global.image.repository=${NICO_IMAGE_REGISTRY}/nvmetal-carbide"
+        --set-string "global.image.repository=${NICO_IMAGE_REGISTRY}/${NICO_CORE_IMAGE_NAME}"
         --set-string "global.image.tag=${NICO_CORE_IMAGE_TAG}"
         --timeout 600s --wait
     )
@@ -508,7 +510,7 @@ else
     echo "    ${_CORE_VALUES_FILE}"
     echo ""
     echo "  Key fields:"
-    echo "    global.image.repository   — ${NICO_IMAGE_REGISTRY}/nvmetal-carbide"
+    echo "    global.image.repository   — ${NICO_IMAGE_REGISTRY}/${NICO_CORE_IMAGE_NAME}"
     echo "    global.image.tag          — ${NICO_CORE_IMAGE_TAG}"
     echo "    nico-api.hostname      — your site hostname"
     echo "    nico-api.siteConfig    — site-specific network/pool/IB config"

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -7,9 +7,10 @@
 ## EXAMPLE/placeholder tokens.
 ##
 ## Image registry and tag are injected at install time via --set flags:
-##   --set global.image.repository=<your-registry>/nvmetal-carbide
+##   --set global.image.repository=<your-registry>/<core-image-name>
 ##   --set global.image.tag=<tag>
-## In setup.sh these come from NICO_IMAGE_REGISTRY and NICO_CORE_IMAGE_TAG.
+## In setup.sh these come from NICO_IMAGE_REGISTRY, NICO_CORE_IMAGE_NAME
+## (default: nico), and NICO_CORE_IMAGE_TAG.
 ## =============================================================================
 
 global:
@@ -380,7 +381,7 @@ nico-pxe:
   ## Boot artifacts (ipxe.efi, BFB, OS images) — REQUIRED or DPU/host HTTP boot 404s and
   ## falls back to the local OS (never re-images). These init containers populate the
   ## /boot-artifacts/blobs/internal volume that nico-pxe serves at /public/blobs/internal.
-  ## Pin the images to the same build/registry as nvmetal-carbide.
+  ## Pin the images to the same build/registry as the NICo Core image.
   ## NOTE: the aarch64 image ships /aarch64 + /apt (NOT /firmware) — copying a missing dir crash-loops the init.
   bootArtifactContainers: []
   # bootArtifactContainers:


### PR DESCRIPTION
Align the setup workflow with the NICo Core image produced by `make images`, while retaining an explicit compatibility override for legacy image names.

## Related issues

Closes #4666

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `bash -n helm-prereqs/setup.sh helm-prereqs/preflight.sh`
- `git diff --check`
- `make help`
- valid `nico` and `nvmetal-carbide` image names, plus rejection of a full tagged image path

## Additional Notes

`NICO_CORE_IMAGE_NAME` defaults to `nico`, matching the local build. Set it to `nvmetal-carbide` when deploying legacy CI or NGC images. Standalone and setup-driven preflight checks resolve and validate the same value.