### PR TITLE
fix(rest-postgres): increase postgres PVC storage to 10Gi

### DIFF
--- a/rest-api/deploy/INSTALLATION.md
+++ b/rest-api/deploy/INSTALLATION.md
@@ -170,7 +170,7 @@ A single-replica PostgreSQL 14 StatefulSet that hosts all databases for the NICo
 | `base/postgres/namespace.yaml` | `postgres` namespace |
 | `base/postgres/admin-creds.yaml` | Secret `admin-creds` — postgres superuser password |
 | `base/postgres/init-configmap.yaml` | ConfigMap `postgres-init` — SQL init script |
-| `base/postgres/statefulset.yaml` | StatefulSet `postgres` — `postgres:14.4-alpine`, 1Gi PVC |
+| `base/postgres/statefulset.yaml` | StatefulSet `postgres` — `postgres:14.4-alpine`, 10Gi PVC |
 | `base/postgres/service.yaml` | ClusterIP Service on port 5432 — DNS: `postgres.postgres` |
 | `base/postgres/adminer.yaml` | Optional Adminer web UI |
 

--- a/rest-api/deploy/kustomize/base/postgres/statefulset.yaml
+++ b/rest-api/deploy/kustomize/base/postgres/statefulset.yaml
@@ -76,4 +76,4 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 1Gi
+            storage: 10Gi


### PR DESCRIPTION
The `postgres` StatefulSet in `rest-api/deploy/kustomize/base/postgres/` requests
a 1Gi PVC. Despite the `nico_rest` database moving to `nico-pg-cluster` in #3081,
this StatefulSet is still deployed on every reference install — `helm-prereqs/setup.sh`
Phase 7c applies it and waits for its rollout — and `postgres-0` remains the single
backing store for Temporal (`temporal` + `temporal_visibility`) and Keycloak
(`keycloak`), plus nico-rest-api and the workflow workers in the standalone
kustomize path and in local kind dev.

Temporal history and visibility are the fastest-growing tables in the stack, so
1Gi is undersized for anything past a short smoke test and because Keycloak
shares the volume, filling it takes out authentication along with workflow
execution. This raises the `volumeClaimTemplates` request to 10Gi, matching the
baseline the project already uses for PostgreSQL: `helm-prereqs/values.yaml` sets
`postgresql.volumeSize: "10Gi"` for `nico-pg-cluster`.

The manifest table in `rest-api/deploy/INSTALLATION.md` described the PVC as 1Gi
and is updated in the same commit. Scope is the storage request only, no change
to StorageClass, access modes, image, or any other field.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

Deployed on a 3-node cluster via `helm-prereqs/setup.sh`; `postgres-0` in the
`postgres` namespace comes up with the 10Gi PVC bound, and the Temporal and
Keycloak databases initialise as before.

Manifest-level checks: `kubectl kustomize deploy/kustomize/base/postgres` renders
`storage: 10Gi` with the `postgres-data` claim still matching the container's
`volumeMount`, and all seven overlays build cleanly. No overlay patches
`volumeClaimTemplates`, so nothing overrides the new value.

## Additional Notes
Are we moving nico-rest component databases to HA pg-cluster in `setup.sh` script? Even if yes, this change doesn't break it.