### PR TITLE
fix(nico-dhcp): memory leak 

### DIFF
--- a/crates/dhcp/src/kea_logger.rs
+++ b/crates/dhcp/src/kea_logger.rs
@@ -69,15 +69,18 @@ impl log::Log for KeaLogger {
             ))
             .unwrap();
 
+            let ptr = text.into_raw();
             unsafe {
                 use Level::*;
                 match record.metadata().level() {
-                    Trace => kea_log_generic_debug(KEA_DEBUGLEVEL_TRACE, text.into_raw()),
-                    Debug => kea_log_generic_debug(KEA_DEBUGLEVEL_DEBUG, text.into_raw()),
-                    Info => kea_log_generic_info(text.into_raw()),
-                    Warn => kea_log_generic_warn(text.into_raw()),
-                    Error => kea_log_generic_error(text.into_raw()),
+                    Trace => kea_log_generic_debug(KEA_DEBUGLEVEL_TRACE, ptr),
+                    Debug => kea_log_generic_debug(KEA_DEBUGLEVEL_DEBUG, ptr),
+                    Info => kea_log_generic_info(ptr),
+                    Warn => kea_log_generic_warn(ptr),
+                    Error => kea_log_generic_error(ptr),
                 }
+                // retake pointer to free memory
+                let _ = CString::from_raw(ptr);
             }
         }
     }


### PR DESCRIPTION
## Problem 
The `nico-dhcp` memory usage constantly grows over time due to misuse of [into_raw](https://doc.rust-lang.org/beta/std/ffi/struct.CString.html#method.into_raw) function. 

## FIx
Use approach recommended in official documentation ([example](https://doc.rust-lang.org/beta/std/ffi/struct.CString.html#examples-4))

"**The pointer which this function returns must be returned to Rust and reconstituted using CString::from_raw to be properly deallocated.**"



## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)



