### PR TITLE
feat: Reduce machine inventory size by filtering irrelevant network interfaces

### DIFF
--- a/crates/scout/src/register.rs
+++ b/crates/scout/src/register.rs
@@ -26,6 +26,19 @@ use tss_esapi::handles::KeyHandle;
 
 use crate::{CarbideClientError, attestation as attest, platform, tpm};
 
+// Mellanox SFs and VFs that have no real MAC address report "ch:64" from udev
+// (carbide_network::MELLANOX_SF_VF_MAC_ADDRESS_IN). VFs additionally appear under
+// a "virtfn" sysfs path segment. Neither is useful to the host inventory model.
+fn is_auxiliary_interface(nic: &::rpc::machine_discovery::NetworkInterface) -> bool {
+    let is_sf_or_vf_mac = nic.mac_address == "ch:64";
+    let is_vf_path = nic
+        .pci_properties
+        .as_ref()
+        .map(|p| p.path.contains("virtfn"))
+        .unwrap_or(false);
+    is_sf_or_vf_mac || is_vf_path
+}
+
 pub(super) async fn run(
     forge_api: &str,
     root_ca: String,
@@ -34,6 +47,9 @@ pub(super) async fn run(
     tpm_path: &str,
 ) -> Result<(MachineId, Option<uuid::Uuid>), CarbideClientError> {
     let mut hardware_info = enumerate_hardware()?;
+    hardware_info
+        .network_interfaces
+        .retain(|nic| !is_auxiliary_interface(nic));
     info!("Successfully enumerated hardware");
 
     // Missing TPM EK material must not be treated as DPU detection. DPUs are
@@ -201,4 +217,136 @@ pub(super) async fn run(
     }
 
     Ok((machine_id, interface_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use ::rpc::machine_discovery::{NetworkInterface, PciDeviceProperties};
+
+    use super::*;
+
+    fn pci(path: &str) -> Option<PciDeviceProperties> {
+        Some(PciDeviceProperties {
+            vendor: "Mellanox Technologies".to_string(),
+            device: "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller".to_string(),
+            path: path.to_string(),
+            numa_node: 0,
+            description: None,
+            slot: Some("0000:08:00.0".to_string()),
+        })
+    }
+
+    fn nic(mac: &str, path: &str) -> NetworkInterface {
+        NetworkInterface {
+            mac_address: mac.to_string(),
+            pci_properties: pci(path),
+        }
+    }
+
+    // DPU physical functions exposed to the host have real MACs and a direct sysfs
+    // path (no "virtfn" segment). They must survive the filter so the inventory model
+    // retains evidence that the machine has a DPU.
+    #[test]
+    fn dpu_pf_is_kept() {
+        let iface = nic(
+            "a0:88:c2:00:11:22",
+            "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/enp8s0f0np0",
+        );
+        assert!(!is_auxiliary_interface(&iface));
+    }
+
+    #[test]
+    fn second_dpu_pf_port_is_kept() {
+        let iface = nic(
+            "a0:88:c2:00:11:23",
+            "/devices/pci0000:00/0000:00:1c.4/0000:08:00.1/net/enp8s0f1np1",
+        );
+        assert!(!is_auxiliary_interface(&iface));
+    }
+
+    // Regular host NICs (non-DPU Ethernet controllers) must also be kept.
+    #[test]
+    fn regular_host_nic_is_kept() {
+        let iface = nic(
+            "b4:96:91:aa:bb:cc",
+            "/devices/pci0000:00/0000:00:01.0/0000:01:00.0/net/eth0",
+        );
+        assert!(!is_auxiliary_interface(&iface));
+    }
+
+    // SFs (scalable functions) report "ch:64" from udev when they have no real MAC.
+    #[test]
+    fn sf_with_sentinel_mac_is_filtered() {
+        let iface = nic(
+            "ch:64",
+            "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/en_sf0",
+        );
+        assert!(is_auxiliary_interface(&iface));
+    }
+
+    // VFs appear under a "virtfn" sysfs path segment regardless of their MAC.
+    #[test]
+    fn vf_with_virtfn_path_is_filtered() {
+        let iface = nic(
+            "a0:88:c2:00:11:30",
+            "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/virtfn0/net/eth1",
+        );
+        assert!(is_auxiliary_interface(&iface));
+    }
+
+    // VFs that also carry the sentinel MAC are caught by either predicate.
+    #[test]
+    fn vf_with_sentinel_mac_and_virtfn_path_is_filtered() {
+        let iface = nic(
+            "ch:64",
+            "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/virtfn3/net/eth3",
+        );
+        assert!(is_auxiliary_interface(&iface));
+    }
+
+    // Exercises the unwrap_or(false) in the virtfn path check: absent pci_properties
+    // does not cause a false positive when the interface does not also carry
+    // the sentinel MAC.
+    #[test]
+    fn no_pci_properties_with_real_mac_is_kept() {
+        let iface = NetworkInterface {
+            mac_address: "de:ad:be:ef:00:01".to_string(),
+            pci_properties: None,
+        };
+        assert!(!is_auxiliary_interface(&iface));
+    }
+
+    // Verify end-to-end that retain keeps exactly the expected interfaces when a
+    // mixed list is filtered — DPU PFs survive, SFs and VFs are removed.
+    #[test]
+    fn retain_keeps_pfs_removes_sfs_and_vfs() {
+        let mut nics = vec![
+            nic(
+                "a0:88:c2:00:11:22",
+                "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/enp8s0f0np0",
+            ),
+            nic(
+                "ch:64",
+                "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/en_sf0",
+            ),
+            nic(
+                "ch:64",
+                "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/en_sf1",
+            ),
+            nic(
+                "a0:88:c2:00:11:23",
+                "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/virtfn0/net/eth1",
+            ),
+            nic(
+                "a0:88:c2:00:11:24",
+                "/devices/pci0000:00/0000:00:1c.4/0000:08:00.1/net/enp8s0f1np1",
+            ),
+        ];
+
+        nics.retain(|nic| !is_auxiliary_interface(nic));
+
+        assert_eq!(nics.len(), 2);
+        assert_eq!(nics[0].mac_address, "a0:88:c2:00:11:22");
+        assert_eq!(nics[1].mac_address, "a0:88:c2:00:11:24");
+    }
 }

--- a/crates/scout/src/register.rs
+++ b/crates/scout/src/register.rs
@@ -34,7 +34,10 @@ fn is_auxiliary_interface(nic: &::rpc::machine_discovery::NetworkInterface) -> b
     let is_vf_path = nic
         .pci_properties
         .as_ref()
-        .map(|p| p.path.contains("virtfn"))
+        .map(|p| {
+            let pci_portion = p.path.split("/net/").next().unwrap_or("");
+            pci_portion.contains("virtfn")
+        })
         .unwrap_or(false);
     is_sf_or_vf_mac || is_vf_path
 }
@@ -302,6 +305,17 @@ mod tests {
             "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/virtfn3/net/eth3",
         );
         assert!(is_auxiliary_interface(&iface));
+    }
+
+    // An interface whose name happens to contain "virtfn" (after /net/) is not a VF
+    // and must not be filtered — only a "virtfn" sysfs segment before /net/ indicates a VF.
+    #[test]
+    fn interface_named_virtfn_with_real_mac_is_kept() {
+        let iface = nic(
+            "b4:96:91:aa:bb:cc",
+            "/devices/pci0000:00/0000:00:01.0/0000:01:00.0/net/virtfn0",
+        );
+        assert!(!is_auxiliary_interface(&iface));
     }
 
     // Exercises the unwrap_or(false) in the virtfn path check: absent pci_properties

--- a/crates/scout/src/register.rs
+++ b/crates/scout/src/register.rs
@@ -26,11 +26,16 @@ use tss_esapi::handles::KeyHandle;
 
 use crate::{CarbideClientError, attestation as attest, platform, tpm};
 
-// Mellanox SFs and VFs that have no real MAC address report "ch:64" from udev
-// (carbide_network::MELLANOX_SF_VF_MAC_ADDRESS_IN). VFs additionally appear under
-// a "virtfn" sysfs path segment. Neither is useful to the host inventory model.
+// Sentinel MAC reported by udev for Mellanox SFs and VFs that have no real MAC
+// address. Mirrors carbide_network::MELLANOX_SF_VF_MAC_ADDRESS_IN without
+// adding that crate as a dependency.
+const MELLANOX_SF_VF_MAC_ADDRESS_IN: &str = "ch:64";
+
+// Mellanox SFs and VFs that have no real MAC address report the sentinel above from udev.
+// VFs additionally appear under a "virtfn" sysfs path segment.
+// Neither is useful to the host inventory model.
 fn is_auxiliary_interface(nic: &::rpc::machine_discovery::NetworkInterface) -> bool {
-    let is_sf_or_vf_mac = nic.mac_address == "ch:64";
+    let is_sf_or_vf_mac = nic.mac_address == MELLANOX_SF_VF_MAC_ADDRESS_IN;
     let is_vf_path = nic
         .pci_properties
         .as_ref()
@@ -277,11 +282,11 @@ mod tests {
         assert!(!is_auxiliary_interface(&iface));
     }
 
-    // SFs (scalable functions) report "ch:64" from udev when they have no real MAC.
+    // SFs (scalable functions) report the sentinel MAC from udev when they have no real MAC.
     #[test]
     fn sf_with_sentinel_mac_is_filtered() {
         let iface = nic(
-            "ch:64",
+            MELLANOX_SF_VF_MAC_ADDRESS_IN,
             "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/en_sf0",
         );
         assert!(is_auxiliary_interface(&iface));
@@ -301,7 +306,7 @@ mod tests {
     #[test]
     fn vf_with_sentinel_mac_and_virtfn_path_is_filtered() {
         let iface = nic(
-            "ch:64",
+            MELLANOX_SF_VF_MAC_ADDRESS_IN,
             "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/virtfn3/net/eth3",
         );
         assert!(is_auxiliary_interface(&iface));
@@ -340,11 +345,11 @@ mod tests {
                 "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/enp8s0f0np0",
             ),
             nic(
-                "ch:64",
+                MELLANOX_SF_VF_MAC_ADDRESS_IN,
                 "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/en_sf0",
             ),
             nic(
-                "ch:64",
+                MELLANOX_SF_VF_MAC_ADDRESS_IN,
                 "/devices/pci0000:00/0000:00:1c.4/0000:08:00.0/net/en_sf1",
             ),
             nic(


### PR DESCRIPTION
For better scaling, this PR reduces the amount of network interface data transmitted and persisted by filtering out interfaces that are not useful to the host inventory model. It reuses the existing filtering approach for InfiniBand interfaces by excluding interfaces that have

1. the MELLANOX_SF_VF_MAC_ADDRESS_IN sentinel mac_address indicating that the interface has no real MAC address, OR
2. `virtfn` PCI path that indicates a virtual function (VF) regardless of mac address

The filter is applied in scout. BMC-facing interfaces are already excluded by the existing filter in `enumerate_hardware_inner()` before they reach scout's filter.

## Related issues

https://github.com/NVIDIA/infra-controller/issues/2936

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The migration path for existing machines that already have oversized network interface inventory would be to trigger re-discovery.