### PR TITLE
fix(flow): preserve expected component descriptions

### DIFF
--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
@@ -493,13 +493,8 @@ func mirrorExpectedComponents(
 			// tombstone row — bun otherwise appends "deleted_at IS NULL" to
 			// the UPDATE and the resurrect would silently match zero rows.
 			p.toUpdate[i].UpdatedAt = now
-			if _, err := tx.NewUpdate().
-				Model(&p.toUpdate[i]).
-				Column("name", "model", "description", "manufacturer", "serial_number", "slot_id",
-					"tray_index", "host_id", "rack_id", "deleted_at", "updated_at").
-				WhereAllWithDeleted().
-				Where("id = ?", p.toUpdate[i].ID).
-				Exec(ctx); err != nil {
+			expectedDescription, _ := p.toUpdate[i].Description[expectedDescriptionKey].(string)
+			if err := updateMirroredComponent(ctx, tx, &p.toUpdate[i], expectedDescription); err != nil {
 				return fmt.Errorf("update component %q: %w", p.toUpdate[i].SerialNumber, err)
 			}
 			ops := p.toUpdateBMCs[i]
@@ -557,6 +552,42 @@ func mirrorExpectedComponents(
 	result.updated = len(p.toUpdate)
 	result.softDeleted = softDeleted
 	return result
+}
+
+// updateMirroredComponent persists mirror-owned scalar fields and changes only
+// Core's reserved description key against the current database value. Keeping
+// the JSONB mutation in SQL prevents a stale reconciliation snapshot from
+// replacing runtime or operator entries written after the snapshot was read.
+func updateMirroredComponent(ctx context.Context, idb bun.IDB, component *model.Component, expectedDescription string) error {
+	var rackID any
+	if component.RackID != uuid.Nil {
+		rackID = component.RackID
+	}
+	query := idb.NewUpdate().
+		Model((*model.Component)(nil)).
+		Set("name = ?", component.Name).
+		Set("model = ?", component.Model).
+		Set("manufacturer = ?", component.Manufacturer).
+		Set("serial_number = ?", component.SerialNumber).
+		Set("slot_id = ?", component.SlotID).
+		Set("tray_index = ?", component.TrayIndex).
+		Set("host_id = ?", component.HostID).
+		Set("rack_id = ?", rackID).
+		Set("deleted_at = ?", component.DeletedAt).
+		Set("updated_at = ?", component.UpdatedAt).
+		WhereAllWithDeleted().
+		Where("id = ?", component.ID)
+	if expectedDescription == "" {
+		query.Set("description = NULLIF((CASE WHEN jsonb_typeof(description) = 'object' THEN description ELSE '{}'::jsonb END) - ?::text, '{}'::jsonb)", expectedDescriptionKey)
+	} else {
+		query.Set(
+			"description = jsonb_set(CASE WHEN jsonb_typeof(description) = 'object' THEN description ELSE '{}'::jsonb END, ARRAY[?::text], to_jsonb(?::text), true)",
+			expectedDescriptionKey,
+			expectedDescription,
+		)
+	}
+	_, err := query.Exec(ctx)
+	return err
 }
 
 // specValid rejects a Core row carrying no BMC MAC address. The MAC is the

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
@@ -37,6 +37,7 @@ const (
 	labelComponentSlotID       = "slot_id"
 	labelComponentTrayIdx      = "tray_idx"
 	labelComponentHostID       = "host_id"
+	expectedDescriptionKey     = "expected_description"
 )
 
 // expectedComponentSpec is the normalised view of one Core expected_* row.
@@ -54,6 +55,7 @@ type expectedComponentSpec struct {
 	SerialNumber   string
 	Model          string
 	Name           string
+	Description    string
 	SlotID         int
 	TrayIndex      int
 	HostID         int
@@ -98,6 +100,7 @@ func machineDetailToSpec(d nicoapi.ExpectedMachineDetail) expectedComponentSpec 
 		Type:           devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
 		SerialNumber:   d.ChassisSerialNumber,
 		Name:           d.Name,
+		Description:    d.Description,
 		RackExternalID: d.RackID,
 		BMC: expectedBMCSpec{
 			MACAddress: d.BMCMACAddress,
@@ -113,6 +116,7 @@ func switchDetailToSpec(d nicoapi.ExpectedSwitchDetail) expectedComponentSpec {
 		Type:           devicetypes.ComponentTypeToString(devicetypes.ComponentTypeNVSwitch),
 		SerialNumber:   d.SwitchSerialNumber,
 		Name:           d.Name,
+		Description:    d.Description,
 		RackExternalID: d.RackID,
 		BMC: expectedBMCSpec{
 			MACAddress: d.BMCMACAddress,
@@ -128,6 +132,7 @@ func powerShelfDetailToSpec(d nicoapi.ExpectedPowerShelfDetail) expectedComponen
 		Type:           devicetypes.ComponentTypeToString(devicetypes.ComponentTypePowerShelf),
 		SerialNumber:   d.ShelfSerialNumber,
 		Name:           d.Name,
+		Description:    d.Description,
 		RackExternalID: d.RackID,
 		BMC: expectedBMCSpec{
 			MACAddress: d.BMCMACAddress,
@@ -490,7 +495,7 @@ func mirrorExpectedComponents(
 			p.toUpdate[i].UpdatedAt = now
 			if _, err := tx.NewUpdate().
 				Model(&p.toUpdate[i]).
-				Column("name", "model", "manufacturer", "serial_number", "slot_id",
+				Column("name", "model", "description", "manufacturer", "serial_number", "slot_id",
 					"tray_index", "host_id", "rack_id", "deleted_at", "updated_at").
 				WhereAllWithDeleted().
 				Where("id = ?", p.toUpdate[i].ID).
@@ -662,11 +667,31 @@ func componentFromSpec(s expectedComponentSpec, rackID uuid.UUID) model.Componen
 		Manufacturer: s.Manufacturer,
 		SerialNumber: s.SerialNumber,
 		Model:        s.Model,
+		Description:  componentDescriptionWithExpected(nil, s.Description),
 		SlotID:       s.SlotID,
 		TrayIndex:    s.TrayIndex,
 		HostID:       s.HostID,
 		RackID:       rackID,
 	}
+}
+
+// componentDescriptionWithExpected returns a copy with only Core's reserved
+// description key changed. An empty expected description removes that key,
+// while values owned by runtime sync or operators remain untouched.
+func componentDescriptionWithExpected(existing map[string]any, expected string) map[string]any {
+	description := make(map[string]any, len(existing)+1)
+	for key, value := range existing {
+		description[key] = value
+	}
+	if expected == "" {
+		delete(description, expectedDescriptionKey)
+	} else {
+		description[expectedDescriptionKey] = expected
+	}
+	if len(description) == 0 {
+		return nil
+	}
+	return description
 }
 
 // applyComponentChanges copies mirror-managed fields from desired into
@@ -682,6 +707,7 @@ func componentFromSpec(s expectedComponentSpec, rackID uuid.UUID) model.Componen
 func applyComponentChanges(existing, desired *model.Component, spec expectedComponentSpec) {
 	existing.Name = desired.Name
 	existing.Model = desired.Model
+	existing.Description = componentDescriptionWithExpected(existing.Description, spec.Description)
 	existing.RackID = desired.RackID
 	if existing.Manufacturer == "" {
 		existing.Manufacturer = desired.Manufacturer
@@ -721,6 +747,14 @@ func diffComponentFields(existing, desired *model.Component, spec expectedCompon
 	}
 	if existing.SerialNumber == "" && desired.SerialNumber != "" {
 		diffs = append(diffs, fieldChange{"serial_number", existing.SerialNumber, desired.SerialNumber})
+	}
+	existingDescription, hasExpectedDescription := existing.Description[expectedDescriptionKey]
+	if spec.Description == "" {
+		if hasExpectedDescription {
+			diffs = append(diffs, fieldChange{expectedDescriptionKey, fmt.Sprint(existingDescription), ""})
+		}
+	} else if current, ok := existingDescription.(string); !ok || current != spec.Description {
+		diffs = append(diffs, fieldChange{expectedDescriptionKey, fmt.Sprint(existingDescription), spec.Description})
 	}
 	if !spec.preserveFields["slot_id"] && existing.SlotID != desired.SlotID {
 		diffs = append(diffs, fieldChange{"slot_id", strconv.Itoa(existing.SlotID), strconv.Itoa(desired.SlotID)})

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component_test.go
@@ -85,6 +85,7 @@ func TestMachineDetailToSpec(t *testing.T) {
 	assert.Equal(t, "SN-001", s.SerialNumber)
 	assert.Equal(t, "Foxconn", s.Manufacturer)
 	assert.Equal(t, "MGX-Compute-Gen2", s.Model)
+	assert.Equal(t, "compute node", s.Description)
 	assert.Equal(t, 5, s.SlotID)
 	assert.Equal(t, 1, s.TrayIndex)
 	assert.Equal(t, 3, s.HostID)
@@ -97,20 +98,24 @@ func TestSwitchDetailToSpec_TypeIsNVSwitch(t *testing.T) {
 	s := switchDetailToSpec(nicoapi.ExpectedSwitchDetail{
 		SwitchSerialNumber: "SW-1",
 		BMCMACAddress:      "00:00:00:00:00:01",
+		Description:        "fabric switch",
 		Labels:             map[string]string{labelComponentManufacturer: "NVIDIA"},
 	})
 	assert.Equal(t, devicetypes.ComponentTypeToString(devicetypes.ComponentTypeNVSwitch), s.Type)
 	assert.Equal(t, "SW-1", s.SerialNumber)
+	assert.Equal(t, "fabric switch", s.Description)
 }
 
 func TestPowerShelfDetailToSpec_TypeIsPowerShelf(t *testing.T) {
 	s := powerShelfDetailToSpec(nicoapi.ExpectedPowerShelfDetail{
 		ShelfSerialNumber: "PS-1",
 		BMCMACAddress:     "00:00:00:00:00:02",
+		Description:       "power shelf",
 		Labels:            map[string]string{labelComponentManufacturer: "NVIDIA"},
 	})
 	assert.Equal(t, devicetypes.ComponentTypeToString(devicetypes.ComponentTypePowerShelf), s.Type)
 	assert.Equal(t, "PS-1", s.SerialNumber)
+	assert.Equal(t, "power shelf", s.Description)
 }
 
 func TestSpecValid(t *testing.T) {
@@ -260,6 +265,7 @@ func TestComponentFromSpec(t *testing.T) {
 		SerialNumber: "SN-1",
 		Model:        "MGX",
 		Name:         "node-1",
+		Description:  "compute node",
 		SlotID:       5,
 		TrayIndex:    1,
 		HostID:       3,
@@ -270,6 +276,7 @@ func TestComponentFromSpec(t *testing.T) {
 	assert.Equal(t, "Foxconn", c.Manufacturer)
 	assert.Equal(t, "SN-1", c.SerialNumber)
 	assert.Equal(t, "MGX", c.Model)
+	assert.Equal(t, map[string]any{expectedDescriptionKey: "compute node"}, c.Description)
 	assert.Empty(t, c.FirmwareVersion, "firmware_version is owned by runtime sync, mirror must leave it unset")
 	assert.Equal(t, 5, c.SlotID)
 	assert.Equal(t, 1, c.TrayIndex)
@@ -306,6 +313,45 @@ func TestDiffComponentFields(t *testing.T) {
 		desired.FirmwareVersion = "2.0"
 		assert.Empty(t, diffComponentFields(base(), desired, expectedComponentSpec{}))
 	})
+
+	for _, tc := range []struct {
+		name        string
+		existing    map[string]any
+		expected    string
+		wantChanged bool
+	}{
+		{
+			name:        "new expected description is detected",
+			expected:    "new description",
+			wantChanged: true,
+		},
+		{
+			name:     "unchanged expected description produces no diff",
+			existing: map[string]any{expectedDescriptionKey: "same", "operator": "keep"},
+			expected: "same",
+		},
+		{
+			name:        "cleared expected description is detected",
+			existing:    map[string]any{expectedDescriptionKey: "old", "operator": "keep"},
+			wantChanged: true,
+		},
+		{
+			name:     "unrelated description entries do not produce a diff",
+			existing: map[string]any{"operator": "keep"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			existing := base()
+			existing.Description = tc.existing
+			diffs := diffComponentFields(existing, base(), expectedComponentSpec{Description: tc.expected})
+			if tc.wantChanged {
+				require.Len(t, diffs, 1)
+				assert.Equal(t, expectedDescriptionKey, diffs[0].field)
+			} else {
+				assert.Empty(t, diffs)
+			}
+		})
+	}
 
 	for name, mutate := range map[string]func(*model.Component){
 		"name":       func(c *model.Component) { c.Name = "n2" },
@@ -351,6 +397,10 @@ func TestApplyComponentChanges_DoesNotTouchIdentityOrRuntimeFields(t *testing.T)
 		Model:        "old-model",
 		RackID:       rackA,
 		ComponentID:  &extID, // runtime-owned, must not be touched
+		Description: map[string]any{
+			"nvos_ip":  "10.0.0.2",
+			"operator": "keep",
+		},
 	}
 	desired := &model.Component{
 		Name:   "new",
@@ -358,7 +408,7 @@ func TestApplyComponentChanges_DoesNotTouchIdentityOrRuntimeFields(t *testing.T)
 		RackID: rackB,
 	}
 
-	applyComponentChanges(existing, desired, expectedComponentSpec{})
+	applyComponentChanges(existing, desired, expectedComponentSpec{Description: "Core description"})
 
 	assert.Equal(t, "new", existing.Name)
 	assert.Equal(t, "new-model", existing.Model)
@@ -368,6 +418,24 @@ func TestApplyComponentChanges_DoesNotTouchIdentityOrRuntimeFields(t *testing.T)
 	assert.Equal(t, "SN-1", existing.SerialNumber, "SerialNumber is identity")
 	require.NotNil(t, existing.ComponentID)
 	assert.Equal(t, "runtime-id", *existing.ComponentID, "external_id is runtime-owned")
+	assert.Equal(t, "10.0.0.2", existing.Description["nvos_ip"], "runtime-owned description entry must survive")
+	assert.Equal(t, "keep", existing.Description["operator"], "operator-owned description entry must survive")
+	assert.Equal(t, "Core description", existing.Description[expectedDescriptionKey])
+}
+
+func TestComponentDescriptionWithExpected(t *testing.T) {
+	existing := map[string]any{
+		expectedDescriptionKey: "old",
+		"operator":             "keep",
+	}
+
+	updated := componentDescriptionWithExpected(existing, "new")
+	assert.Equal(t, map[string]any{expectedDescriptionKey: "new", "operator": "keep"}, updated)
+	assert.Equal(t, "old", existing[expectedDescriptionKey], "helper must not mutate the input map")
+
+	cleared := componentDescriptionWithExpected(updated, "")
+	assert.Equal(t, map[string]any{"operator": "keep"}, cleared)
+	assert.Nil(t, componentDescriptionWithExpected(map[string]any{expectedDescriptionKey: "old"}, ""))
 }
 
 func TestApplyComponentChanges_PreservedFieldsKeepFlowValue(t *testing.T) {

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -539,6 +539,63 @@ func TestMirrorComponents_DescriptionLifecycle(t *testing.T) {
 	}
 }
 
+func TestUpdateMirroredComponent_PreservesRuntimeWriteAfterReconciliationRead(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		expectedDescription string
+		wantExpected        bool
+	}{
+		{"set expected description", "updated description", true},
+		{"clear expected description", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, pool := mirrorTestPool(t)
+			component := model.Component{
+				Type:         compType(),
+				Manufacturer: "Mfg",
+				SerialNumber: "INTERLEAVE-" + tc.name,
+				Name:         "before",
+				Description: map[string]any{
+					expectedDescriptionKey: "initial description",
+					"operator":             "keep",
+				},
+			}
+			require.NoError(t, component.Create(ctx, pool.DB))
+
+			var reconciliationSnapshot model.Component
+			require.NoError(t, pool.DB.NewSelect().Model(&reconciliationSnapshot).Where("id = ?", component.ID).Scan(ctx))
+
+			// Simulate runtime sync committing after reconciliation read the row
+			// but before the mirror writes its planned update.
+			_, err := pool.DB.NewUpdate().
+				Model((*model.Component)(nil)).
+				Set(
+					"description = jsonb_set(COALESCE(description, '{}'::jsonb), ARRAY[?::text], to_jsonb(?::text), true)",
+					nvosIPDescriptionKey,
+					"10.0.0.2",
+				).
+				Where("id = ?", component.ID).
+				Exec(ctx)
+			require.NoError(t, err)
+
+			reconciliationSnapshot.Name = "after"
+			reconciliationSnapshot.UpdatedAt = time.Now()
+			require.NoError(t, updateMirroredComponent(ctx, pool.DB, &reconciliationSnapshot, tc.expectedDescription))
+
+			var updated model.Component
+			require.NoError(t, pool.DB.NewSelect().Model(&updated).Where("id = ?", component.ID).Scan(ctx))
+			assert.Equal(t, "after", updated.Name)
+			assert.Equal(t, "10.0.0.2", updated.Description[nvosIPDescriptionKey])
+			assert.Equal(t, "keep", updated.Description["operator"])
+			if tc.wantExpected {
+				assert.Equal(t, tc.expectedDescription, updated.Description[expectedDescriptionKey])
+			} else {
+				assert.NotContains(t, updated.Description, expectedDescriptionKey)
+			}
+		})
+	}
+}
+
 // #11: a successful but empty Core response soft-deletes all Flow components
 // of the type.
 func TestMirrorComponents_EmptyCoreSoftDeletesAll(t *testing.T) {

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -480,6 +480,65 @@ func compType() string {
 	return devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)
 }
 
+func TestMirrorComponents_DescriptionLifecycle(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		componentType devicetypes.ComponentType
+		serial        string
+		mac           string
+	}{
+		{"ExpectedMachine", devicetypes.ComponentTypeCompute, "DESC-COMPUTE", "aa:bb:cc:dd:ef:01"},
+		{"ExpectedSwitch", devicetypes.ComponentTypeNVSwitch, "DESC-SWITCH", "aa:bb:cc:dd:ef:02"},
+		{"ExpectedPowerShelf", devicetypes.ComponentTypePowerShelf, "DESC-POWER", "aa:bb:cc:dd:ef:03"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, pool := mirrorTestPool(t)
+			componentType := devicetypes.ComponentTypeToString(tc.componentType)
+			spec := expectedComponentSpec{
+				Type:         componentType,
+				Manufacturer: "Mfg",
+				SerialNumber: tc.serial,
+				Name:         tc.serial,
+				Description:  "initial description",
+				BMC:          expectedBMCSpec{MACAddress: tc.mac},
+			}
+
+			mirrorExpectedComponents(ctx, pool, componentType, []expectedComponentSpec{spec}, map[string]uuid.UUID{})
+
+			loadComponent := func() model.Component {
+				var component model.Component
+				err := pool.DB.NewSelect().Model(&component).
+					Where("manufacturer = ? AND serial_number = ?", spec.Manufacturer, spec.SerialNumber).
+					Scan(ctx)
+				require.NoError(t, err)
+				return component
+			}
+
+			component := loadComponent()
+			assert.Equal(t, "initial description", component.Description[expectedDescriptionKey])
+
+			component.Description["operator"] = "keep"
+			component.Description["nvos_ip"] = "10.0.0.2"
+			_, err := pool.DB.NewUpdate().Model(&component).Column("description").WherePK().Exec(ctx)
+			require.NoError(t, err)
+
+			spec.Description = "updated description"
+			mirrorExpectedComponents(ctx, pool, componentType, []expectedComponentSpec{spec}, map[string]uuid.UUID{})
+			component = loadComponent()
+			assert.Equal(t, "updated description", component.Description[expectedDescriptionKey])
+			assert.Equal(t, "keep", component.Description["operator"])
+			assert.Equal(t, "10.0.0.2", component.Description["nvos_ip"])
+
+			spec.Description = ""
+			mirrorExpectedComponents(ctx, pool, componentType, []expectedComponentSpec{spec}, map[string]uuid.UUID{})
+			component = loadComponent()
+			assert.NotContains(t, component.Description, expectedDescriptionKey)
+			assert.Equal(t, "keep", component.Description["operator"])
+			assert.Equal(t, "10.0.0.2", component.Description["nvos_ip"])
+		})
+	}
+}
+
 // #11: a successful but empty Core response soft-deletes all Flow components
 // of the type.
 func TestMirrorComponents_EmptyCoreSoftDeletesAll(t *testing.T) {


### PR DESCRIPTION
## Summary

Preserve Core descriptions for `ExpectedMachine`, `ExpectedSwitch`, and `ExpectedPowerShelf` when Flow mirrors expected inventory.

The Core-owned value is stored under the reserved `expected_description` key so expected reconciliation can create, update, or clear it without replacing runtime- or operator-owned description entries.

Fixes #4353.

## Root cause

The Core API detail models already exposed descriptions, but the Flow normalization and persistence paths omitted them. Consequently, new mirrored components lost their descriptions and existing components never received description changes.

The description column is also shared with runtime metadata such as the NVSwitch `nvos_ip`, so replacing the entire JSON map would have caused data loss.

## Changes

- Carry descriptions through normalization for `ExpectedMachine`, `ExpectedSwitch`, and `ExpectedPowerShelf`.
- Store the expected description under the reserved `expected_description` key.
- Merge updates into the existing description map, preserving runtime and operator keys.
- Remove only `expected_description` when Core clears the value.
- Add unit coverage for conversion, change detection, merging, and clearing.
- Add PostgreSQL-backed insert, change, clear, and merge coverage for every component type.

## Validation

- `make test-flow`
- `go vet ./flow/internal/scheduler/jobs/inventorysync`
- `git diff --check`

The full Flow suite was rerun after rebasing onto current upstream `main`.

## Note

This is an attempt at fully automated issue resolution using Codex.
