### PR TITLE
fix(helm/nico-api): strip stale spiffe_trust_domain from site TOML

### DIFF
--- a/helm/charts/nico-api/templates/configmap.yaml
+++ b/helm/charts/nico-api/templates/configmap.yaml
@@ -43,10 +43,17 @@ data:
   # The built-in config (carbide-api-config.toml) always renders it from
   # global.spiffe.trustDomain, so a stale "forge.local" in a migrated site
   # overlay cannot silently override it and cause bare HTTP 403s (issue #3666).
-  # Operators who need a non-default trust domain should set
-  # global.spiffe.trustDomain in their helm values instead.
+  #
+  # UPGRADE NOTE: If your site TOML contains spiffe_trust_domain, set
+  # global.spiffe.trustDomain to the same value in your helm values before
+  # upgrading. The key will be stripped from the site TOML and the chart
+  # value will take effect.
+  #
+  # The regex covers both TOML string forms (double-quoted and single-quoted
+  # literal strings). Bare (unquoted) values are not valid TOML for strings
+  # and are not expected in practice.
   {{- $raw := .Values.siteConfig.nicoApiSiteConfig | default "" }}
-  {{- $siteConfig := regexReplaceAll `(?m)^\s*spiffe_trust_domain\s*=\s*"[^"]*"\s*$` $raw "" }}
+  {{- $siteConfig := regexReplaceAll `(?m)^\s*spiffe_trust_domain\s*=\s*["'][^"']*["']\s*$` $raw "" }}
   carbide-api-site-config.toml: {{ $siteConfig | quote }}
   nico-api-site-config.toml:    {{ $siteConfig | quote }}
 {{- with .Values.siteConfig.adminRootCertPem }}

--- a/helm/charts/nico-api/templates/configmap.yaml
+++ b/helm/charts/nico-api/templates/configmap.yaml
@@ -53,7 +53,7 @@ data:
   # literal strings). Bare (unquoted) values are not valid TOML for strings
   # and are not expected in practice.
   {{- $raw := .Values.siteConfig.nicoApiSiteConfig | default "" }}
-  {{- $siteConfig := regexReplaceAll `(?m)^\s*spiffe_trust_domain\s*=\s*["'][^"']*["']\s*$` $raw "" }}
+  {{- $siteConfig := regexReplaceAll `(?m)^\s*spiffe_trust_domain\s*=\s*["'][^"']*["'][^\n]*$` $raw "" }}
   carbide-api-site-config.toml: {{ $siteConfig | quote }}
   nico-api-site-config.toml:    {{ $siteConfig | quote }}
 {{- with .Values.siteConfig.adminRootCertPem }}

--- a/helm/charts/nico-api/templates/configmap.yaml
+++ b/helm/charts/nico-api/templates/configmap.yaml
@@ -38,8 +38,17 @@ metadata:
     {{- include "nico-api.labels" . | nindent 4 }}
 data:
   # Both filenames populated for dual carbide/nico image support.
-  carbide-api-site-config.toml: {{ .Values.siteConfig.nicoApiSiteConfig | default "" | quote }}
-  nico-api-site-config.toml:    {{ .Values.siteConfig.nicoApiSiteConfig | default "" | quote }}
+  #
+  # spiffe_trust_domain is stripped from the site TOML before rendering.
+  # The built-in config (carbide-api-config.toml) always renders it from
+  # global.spiffe.trustDomain, so a stale "forge.local" in a migrated site
+  # overlay cannot silently override it and cause bare HTTP 403s (issue #3666).
+  # Operators who need a non-default trust domain should set
+  # global.spiffe.trustDomain in their helm values instead.
+  {{- $raw := .Values.siteConfig.nicoApiSiteConfig | default "" }}
+  {{- $siteConfig := regexReplaceAll `(?m)^\s*spiffe_trust_domain\s*=\s*"[^"]*"\s*$` $raw "" }}
+  carbide-api-site-config.toml: {{ $siteConfig | quote }}
+  nico-api-site-config.toml:    {{ $siteConfig | quote }}
 {{- with .Values.siteConfig.adminRootCertPem }}
   admin_root_cert_pem: |
     {{- . | nindent 4 }}

--- a/helm/charts/nico-api/tests/auth_test.yaml
+++ b/helm/charts/nico-api/tests/auth_test.yaml
@@ -50,3 +50,36 @@ tests:
       - matchRegex:
           path: data["casbin-policy.csv"]
           pattern: 'g, spiffe-service-id/carbide-dns, nico-dns'
+
+  - it: strips stale spiffe_trust_domain from the site TOML (issue 3666)
+    documentIndex: 1
+    set:
+      siteConfig:
+        enabled: true
+        nicoApiSiteConfig: |
+          [auth.trust]
+          spiffe_trust_domain = "forge.local"
+          some_other_key = "preserved"
+    asserts:
+      - notMatchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'spiffe_trust_domain'
+      - matchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'some_other_key = "preserved"'
+
+  - it: leaves site TOML untouched when spiffe_trust_domain is absent
+    documentIndex: 1
+    set:
+      siteConfig:
+        enabled: true
+        nicoApiSiteConfig: |
+          [auth.trust]
+          some_other_key = "value"
+    asserts:
+      - matchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'some_other_key = "value"'
+      - notMatchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'spiffe_trust_domain'

--- a/helm/charts/nico-api/tests/auth_test.yaml
+++ b/helm/charts/nico-api/tests/auth_test.yaml
@@ -101,12 +101,29 @@ tests:
           path: data["nico-api-site-config.toml"]
           pattern: 'other_key = "kept"'
 
-  - it: round-trip — built-in config still uses global.spiffe.trustDomain after site TOML is stripped
+  - it: also strips spiffe_trust_domain with an inline TOML comment
+    documentIndex: 1
+    set:
+      siteConfig:
+        enabled: true
+        nicoApiSiteConfig: |
+          [auth.trust]
+          spiffe_trust_domain = "forge.local" # migrated from carbide
+          other_key = "kept"
+    asserts:
+      - notMatchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'spiffe_trust_domain'
+      - matchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'other_key = "kept"'
+
+  - it: round-trip — built-in config uses global.spiffe.trustDomain not the stale site value
     documentIndex: 0
     set:
       global:
         spiffe:
-          trustDomain: forge.local
+          trustDomain: nico.local
       siteConfig:
         enabled: true
         nicoApiSiteConfig: |
@@ -115,4 +132,20 @@ tests:
     asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
-          pattern: 'spiffe_trust_domain = "forge\.local"'
+          pattern: 'spiffe_trust_domain = "nico\.local"'
+
+  - it: round-trip — site config does not contain spiffe_trust_domain after stripping
+    documentIndex: 1
+    set:
+      global:
+        spiffe:
+          trustDomain: nico.local
+      siteConfig:
+        enabled: true
+        nicoApiSiteConfig: |
+          [auth.trust]
+          spiffe_trust_domain = "forge.local"
+    asserts:
+      - notMatchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'spiffe_trust_domain'

--- a/helm/charts/nico-api/tests/auth_test.yaml
+++ b/helm/charts/nico-api/tests/auth_test.yaml
@@ -83,3 +83,36 @@ tests:
       - notMatchRegex:
           path: data["nico-api-site-config.toml"]
           pattern: 'spiffe_trust_domain'
+
+  - it: also strips single-quoted spiffe_trust_domain (TOML literal string form)
+    documentIndex: 1
+    set:
+      siteConfig:
+        enabled: true
+        nicoApiSiteConfig: |
+          [auth.trust]
+          spiffe_trust_domain = 'forge.local'
+          other_key = "kept"
+    asserts:
+      - notMatchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'spiffe_trust_domain'
+      - matchRegex:
+          path: data["nico-api-site-config.toml"]
+          pattern: 'other_key = "kept"'
+
+  - it: round-trip — built-in config still uses global.spiffe.trustDomain after site TOML is stripped
+    documentIndex: 0
+    set:
+      global:
+        spiffe:
+          trustDomain: forge.local
+      siteConfig:
+        enabled: true
+        nicoApiSiteConfig: |
+          [auth.trust]
+          spiffe_trust_domain = "forge.local"
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'spiffe_trust_domain = "forge\.local"'


### PR DESCRIPTION
Closes #3666.

When an operator migrates from carbide to NICo 2.0, their site config TOML often retains `spiffe_trust_domain = "forge.local"` from the old deployment. Because the site TOML is a Figment overlay loaded after the built-in config, this stale value overrides `global.spiffe.trustDomain` and breaks every in-cluster service client with a bare HTTP 403 (`Request denied: [TrustedCertificate]` in nico-api logs).

## Root cause

The built-in `carbide-api-config.toml` already renders `spiffe_trust_domain` from `global.spiffe.trustDomain` under `[auth.trust]`. But `siteConfig.nicoApiSiteConfig` is passed verbatim into the ConfigMap, so a stale value in the operator's TOML takes precedence and silently overrides the chart's authoritative value.

## Fix

Strip `spiffe_trust_domain = "..."` from `siteConfig.nicoApiSiteConfig` at helm render time using `regexReplaceAll`. Both double-quoted (`"forge.local"`) and single-quoted (`'forge.local'`) TOML string forms are handled. All other keys in the `[auth.trust]` section are preserved. With the key absent from the site TOML, the built-in config's `global.spiffe.trustDomain` value takes effect.

## Upgrade note

> **Before upgrading**, if your site TOML contains `spiffe_trust_domain`, add `global.spiffe.trustDomain: <your-domain>` to your helm values. The key will be stripped from the site TOML on the next helm upgrade; without the values override the chart default (`nico.local`) would take effect instead.

This is already documented in the upgrade guide (PR #4261). Operators who already set `global.spiffe.trustDomain` in their values are unaffected.

## Related issues

Closes #3666

## Type of Change

- [x] **Fix** - Bug fixes

## Breaking Changes

- [ ] **This PR contains breaking changes**

No breaking changes for correctly-configured deployments. Operators with `spiffe_trust_domain` only in their site TOML (not in `global.spiffe.trustDomain`) should follow the upgrade note above.

## Testing

- [x] Unit tests added/updated

`helm unittest helm/charts/nico-api -f tests/auth_test.yaml` — 6 tests pass:
- Existing: defaults to nico.local, flips to forge.local via values
- New: stale double-quoted value stripped + sibling keys preserved
- New: single-quoted value also stripped
- New: absent key leaves TOML unchanged
- New: round-trip — built-in config still renders `forge.local` from `global.spiffe.trustDomain` after site TOML is stripped