### PR TITLE
fix(agent): compare all HBN inputs before skipping apply

### DIFF
--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -38,6 +38,7 @@ use forge_certs::cert_renewal::ClientCertRenewer;
 use forge_dpu_remediation::remediation::{MachineInfo, RemediationExecutor};
 use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
+use prost::Message as _;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -488,21 +489,20 @@ struct IterationResult {
     loop_period: std::time::Duration,
 }
 
-/// `CurrentNetworkVersion` tracks the versions we last successfully applied,
-/// mostly so we can avoid hitting the HBN update methods more frequently than
-/// needed.
+/// `CurrentNetworkVersion` tracks the response inputs we last applied so the
+/// agent can skip an HBN update only when the explicit versions match and the
+/// current response still describes the same HBN behavior.
 #[derive(Debug, Default)]
 struct CurrentNetworkVersion {
     managed_host_config_version: Option<String>,
     instance_network_config_version: Option<String>,
-    // This hashes over a bunch of unversioned fields from the API.
-    unversioned_fields_hash: Option<u64>,
+    rendered_inputs_hash: Option<u64>,
 }
 
 impl CurrentNetworkVersion {
-    // Return whether our stored version matches the specific config.
-    fn matches_versions_from(&self, conf: impl AsRef<ManagedHostNetworkConfigResponse>) -> bool {
-        let conf = conf.as_ref();
+    /// Returns whether the explicit versions and HBN inputs from the response
+    /// match the last successful network reconciliation.
+    fn matches_versions_from(&self, conf: &ManagedHostNetworkConfigResponse) -> bool {
         let managed_host_config_version = get_non_empty_str(&conf.managed_host_config_version);
         let instance_network_config_version =
             get_non_empty_str(&conf.instance_network_config_version);
@@ -510,14 +510,12 @@ impl CurrentNetworkVersion {
         let config_versions_identical = self.managed_host_config_version.as_deref()
             == managed_host_config_version
             && self.instance_network_config_version.as_deref() == instance_network_config_version;
-        match (config_versions_identical, self.unversioned_fields_hash) {
-            (true, Some(unversioned_fields_hash)) => {
-                if unversioned_fields_hash == Self::hash_unversioned_fields(conf) {
+        match (config_versions_identical, self.rendered_inputs_hash) {
+            (true, Some(rendered_inputs_hash)) => {
+                if rendered_inputs_hash == Self::hash_rendered_inputs(conf) {
                     true
                 } else {
-                    tracing::info!(
-                        "An unversioned field in ManagedHostNetworkConfigResponse has changed"
-                    );
+                    tracing::info!("Rendered network inputs changed without a version change");
                     false
                 }
             }
@@ -526,88 +524,168 @@ impl CurrentNetworkVersion {
         }
     }
 
-    fn update_from(&mut self, conf: impl AsRef<ManagedHostNetworkConfigResponse>) {
-        let conf = conf.as_ref();
+    /// Records the versions and HBN inputs from the response after network
+    /// reconciliation succeeds.
+    fn update_from(&mut self, conf: &ManagedHostNetworkConfigResponse) {
         self.managed_host_config_version =
             get_non_empty_str(&conf.managed_host_config_version).map(String::from);
         self.instance_network_config_version =
             get_non_empty_str(&conf.instance_network_config_version).map(String::from);
-        self.unversioned_fields_hash
-            .replace(Self::hash_unversioned_fields(conf));
+        self.rendered_inputs_hash
+            .replace(Self::hash_rendered_inputs(conf));
     }
 
-    // Some of the fields aren't covered by any of the ConfigVersions that we
-    // receive from the API, so let's try to catch changes in these so that we
-    // don't skip a needed config update.
-    fn hash_unversioned_fields(conf: &ManagedHostNetworkConfigResponse) -> u64 {
+    /// Builds the one local fingerprint used to decide whether HBN rendering
+    /// can be skipped. Starting with the complete response makes new protobuf
+    /// fields part of the comparison by default; we remove only fields that
+    /// cannot affect HBN rendering, then normalize collections whose order does
+    /// not change HBN behavior. A future protobuf map field must be normalized
+    /// explicitly because its encoded iteration order is not stable.
+    fn hash_rendered_inputs(conf: &ManagedHostNetworkConfigResponse) -> u64 {
+        // TODO(chet): Eventually, Core should bump a version whenever any of
+        // these HBN inputs change, and then we can drop this fingerprint.
+        // Parent VPC policies can affect a lot of DPUs at once, though.
+        // Updating every instance would turn one VPC change into a lot of
+        // writes, and the version would say the instance changed when it
+        // didn't. This probably needs its own version.
+        let mut canonical = conf.clone();
+        Self::remove_non_rendered_inputs(&mut canonical);
+        Self::normalize_set_like_inputs(&mut canonical);
+
         let mut hasher = DefaultHasher::new();
-        let h = &mut hasher;
-
-        conf.additional_route_target_imports.hash(h);
-        conf.anycast_site_prefixes.hash(h);
-        conf.asn.hash(h);
-        conf.bgp_leaf_session_password.hash(h);
-        conf.common_internal_route_target.hash(h);
-        conf.datacenter_asn.hash(h);
-        conf.deny_prefixes.hash(h);
-        conf.deprecated_deny_prefixes.hash(h);
-        conf.dhcp_servers.hash(h);
-        conf.internet_l3_vni.hash(h);
-        // `managed_host_config_version` normally follows machine-group updates,
-        // but that relies on the DPU already being attached to its host. Hash
-        // the nested config so a missed fan-out cannot hide a DPU-specific change.
-        conf.managed_host_config.hash(h);
-        conf.network_security_policy_overrides.hash(h);
-        conf.ntp_servers.hash(h);
-        conf.remote_id.hash(h);
-        conf.route_servers.hash(h);
-        conf.site_global_vpc_vni.hash(h);
-        conf.stateful_acls_enabled.hash(h);
-        conf.tenant_host_asn.hash(h);
-        conf.vni_device.hash(h);
-        conf.vpc_isolation_behavior.hash(h);
-
-        conf.dpu_extension_services
-            .iter()
-            .for_each(|dpu_extension_service| {
-                dpu_extension_service.removed.hash(h);
-                dpu_extension_service.service_id.hash(h);
-                // We can probably ignore the other fields, assuming good
-                // behavior from the versioning.
-            });
-
-        let hash_routing_profile = |routing_profile: &rpc::RoutingProfile,
-                                    h: &mut DefaultHasher| {
-            routing_profile.accepted_leaks_from_underlay.hash(h);
-            routing_profile.allowed_anycast_prefixes.hash(h);
-            routing_profile.leak_default_route_from_underlay.hash(h);
-            routing_profile.leak_tenant_host_routes_to_underlay.hash(h);
-            routing_profile.route_target_imports.hash(h);
-            routing_profile.route_targets_on_exports.hash(h);
-            routing_profile.tenant_leak_communities_accepted.hash(h);
-        };
-
-        if let Some(routing_profile) = &conf.routing_profile {
-            hash_routing_profile(routing_profile, h);
-        }
-
-        // Parent VPC profile changes do not increment either version supplied
-        // to the agent, so hash every interface's resolved profile explicitly.
-        // TODO: Consider replacing this fallback hash with explicit invalidation
-        // by incrementing every affected instance's network-config or config
-        // version, or by introducing a dedicated dependency version. Fan-out
-        // updates could contend at scale, and changing an instance version is
-        // misleading when only its parent VPC policy changed.
-        conf.tenant_interfaces.len().hash(h);
-        for interface in &conf.tenant_interfaces {
-            interface.internal_uuid.hash(h);
-            interface.vpc_routing_profile.is_some().hash(h);
-            if let Some(routing_profile) = &interface.vpc_routing_profile {
-                hash_routing_profile(routing_profile, h);
-            }
-        }
+        canonical.encode_to_vec().hash(&mut hasher);
 
         hasher.finish()
+    }
+
+    /// Removes response fields that do not affect HBN rendering. The
+    /// fingerprint starts with the complete response, so a new protobuf field
+    /// remains part of the comparison until we deliberately exclude it here.
+    fn remove_non_rendered_inputs(config: &mut ManagedHostNetworkConfigResponse) {
+        // These versions are compared directly before the fingerprint.
+        config.managed_host_config_version.clear();
+        config.instance_network_config_version.clear();
+
+        // Instance payload fields feed status and metadata paths, not network
+        // rendering.
+        config.instance_id = None;
+        config.instance = None;
+
+        // The pinger type is read once when the agent starts. A runtime change
+        // cannot affect HBN rendering and still requires an agent restart.
+        config.dpu_network_pinger_type = None;
+
+        // These inputs have separate owners that run independently of the HBN
+        // comparison.
+        config.min_dpu_functioning_links = None;
+        config.dpu_extension_services.clear();
+        config.astra_config = None;
+        config.use_admin_network_changed = None;
+
+        // DHCP is reconciled before this HBN skip decision on every iteration.
+        config.ntp_servers.clear();
+
+        // `host_interface_id` helps resolve the host machine ID when the agent
+        // starts, but a later change does not affect HBN rendering.
+        config.host_interface_id = None;
+
+        // Nothing in the agent reads the deprecated deny-prefix list anymore.
+        config.deprecated_deny_prefixes.clear();
+
+        // DHCP is always enabled; this deprecated flag no longer controls
+        // rendering.
+        config.enable_dhcp = false;
+    }
+
+    /// `normalize_set_like_inputs` sorts inputs that HBN treats as sets, but
+    /// preserves relative order anywhere HBN cares about it.
+    fn normalize_set_like_inputs(config: &mut ManagedHostNetworkConfigResponse) {
+        config.dhcp_servers.sort_unstable();
+        config.route_servers.sort_unstable();
+        config.deny_prefixes.sort_unstable();
+        config.site_fabric_prefixes.sort_unstable();
+        config.anycast_site_prefixes.sort_unstable();
+        config
+            .additional_route_target_imports
+            .sort_by_key(|route_target| (route_target.asn, route_target.vni));
+
+        if let Some(admin_interface) = &mut config.admin_interface {
+            Self::normalize_interface(admin_interface);
+        }
+        for interface in &mut config.tenant_interfaces {
+            Self::normalize_interface(interface);
+        }
+
+        for rule in &mut config.network_security_policy_overrides {
+            Self::normalize_security_group_rule(rule);
+        }
+        Self::normalize_security_group_rule_order(&mut config.network_security_policy_overrides);
+
+        if let Some(routing_profile) = &mut config.routing_profile {
+            Self::normalize_routing_profile(routing_profile);
+        }
+    }
+
+    /// Orders prefix-policy entries by their only rendered value.
+    fn sort_prefix_entries(entries: &mut [rpc::PrefixFilterPolicyEntry]) {
+        entries.sort_by(|left, right| left.prefix.cmp(&right.prefix));
+    }
+
+    /// `normalize_interface` sorts the set-like inputs inside one interface
+    /// without changing the surrounding interface order.
+    fn normalize_interface(interface: &mut rpc::FlatInterfaceConfig) {
+        interface.vpc_prefixes.sort_unstable();
+        interface.vpc_peer_prefixes.sort_unstable();
+        interface.vpc_peer_vnis.sort_unstable();
+
+        if let Some(routing_profile) = &mut interface.vpc_routing_profile {
+            Self::normalize_routing_profile(routing_profile);
+        }
+        if let Some(routing_profile) = &mut interface.interface_routing_profile {
+            Self::sort_prefix_entries(&mut routing_profile.allowed_anycast_prefixes);
+        }
+        if let Some(network_security_group) = &mut interface.network_security_group {
+            for rule in &mut network_security_group.rules {
+                Self::normalize_security_group_rule(rule);
+            }
+            Self::normalize_security_group_rule_order(&mut network_security_group.rules);
+        }
+    }
+
+    /// `normalize_routing_profile` sorts collections whose order does not
+    /// change routing behavior.
+    fn normalize_routing_profile(routing_profile: &mut rpc::RoutingProfile) {
+        routing_profile
+            .route_target_imports
+            .sort_by_key(|route_target| (route_target.asn, route_target.vni));
+        routing_profile
+            .route_targets_on_exports
+            .sort_by_key(|route_target| (route_target.asn, route_target.vni));
+        Self::sort_prefix_entries(&mut routing_profile.accepted_leaks_from_underlay);
+        Self::sort_prefix_entries(&mut routing_profile.allowed_anycast_prefixes);
+    }
+
+    /// `normalize_security_group_rule` sorts the resolved source and
+    /// destination prefixes for one security-group rule.
+    fn normalize_security_group_rule(rule: &mut rpc::ResolvedNetworkSecurityGroupRule) {
+        rule.src_prefixes.sort_unstable();
+        rule.dst_prefixes.sort_unstable();
+    }
+
+    /// The renderer partitions rules by direction and address family, then
+    /// stable-sorts each partition by priority. Mirror that behavior without
+    /// erasing the meaningful relative order of equal-priority rules.
+    fn normalize_security_group_rule_order(rules: &mut [rpc::ResolvedNetworkSecurityGroupRule]) {
+        rules.sort_by_key(|rule| {
+            rule.rule.as_ref().map(|attributes| {
+                (
+                    attributes.direction()
+                        == rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress,
+                    attributes.ipv6,
+                    attributes.priority,
+                )
+            })
+        });
     }
 }
 
@@ -1630,93 +1708,651 @@ ATF: v2.2(release):4.9.3-")
 mod test {
     use super::*;
 
-    /// Verifies the supplemental cache hash tracks every interface's parent
-    /// VPC profile and stable identity so non-first changes trigger rendering.
-    #[test]
-    fn test_current_network_version_hashes_all_vpc_routing_profiles() {
-        use carbide_test_support::value_scenarios;
-
-        /// Selects the non-first interface mutation applied after caching.
-        #[derive(Clone, Copy, Debug)]
-        enum InterfaceChange {
-            Unchanged,
-            Profile,
-            ProfilePresence,
-            Identity,
+    /// Builds a routing profile with multiple entries in each set-like
+    /// collection used by the fingerprint tests.
+    fn comparison_routing_profile() -> rpc::RoutingProfile {
+        rpc::RoutingProfile {
+            route_target_imports: vec![
+                ::rpc::common::RouteTarget {
+                    asn: 65_001,
+                    vni: 101,
+                },
+                ::rpc::common::RouteTarget {
+                    asn: 65_002,
+                    vni: 102,
+                },
+            ],
+            route_targets_on_exports: vec![
+                ::rpc::common::RouteTarget {
+                    asn: 65_003,
+                    vni: 103,
+                },
+                ::rpc::common::RouteTarget {
+                    asn: 65_004,
+                    vni: 104,
+                },
+            ],
+            leak_default_route_from_underlay: false,
+            leak_tenant_host_routes_to_underlay: false,
+            tenant_leak_communities_accepted: false,
+            accepted_leaks_from_underlay: vec![
+                rpc::PrefixFilterPolicyEntry {
+                    prefix: "10.0.0.0/8".to_string(),
+                },
+                rpc::PrefixFilterPolicyEntry {
+                    prefix: "172.16.0.0/12".to_string(),
+                },
+            ],
+            allowed_anycast_prefixes: vec![
+                rpc::PrefixFilterPolicyEntry {
+                    prefix: "192.0.2.0/24".to_string(),
+                },
+                rpc::PrefixFilterPolicyEntry {
+                    prefix: "198.51.100.0/24".to_string(),
+                },
+            ],
         }
+    }
 
-        value_scenarios!(run = |change| {
-            let first_profile = rpc::RoutingProfile {
-                leak_default_route_from_underlay: true,
+    /// Builds a resolved rule with nested prefix sets and caller-selected ID,
+    /// priority, and action.
+    fn comparison_security_group_rule(
+        id: &str,
+        priority: u32,
+        action: rpc::NetworkSecurityGroupRuleAction,
+    ) -> rpc::ResolvedNetworkSecurityGroupRule {
+        rpc::ResolvedNetworkSecurityGroupRule {
+            rule: Some(rpc::NetworkSecurityGroupRuleAttributes {
+                id: Some(id.to_string()),
+                direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
+                protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny.into(),
+                action: action.into(),
+                priority,
+                source_net: Some(
+                    rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                        "0.0.0.0/0".to_string(),
+                    ),
+                ),
+                destination_net: Some(
+                    rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                        "0.0.0.0/0".to_string(),
+                    ),
+                ),
                 ..Default::default()
-            };
-            let second_profile = rpc::RoutingProfile::default();
-            let mut conf = Arc::new(ManagedHostNetworkConfigResponse {
-                managed_host_config_version: "managed-v1".to_string(),
-                instance_network_config_version: "instance-v1".to_string(),
-                // Preserve the compatibility field derived from the first
-                // interface so only per-interface hashing can catch changes.
-                routing_profile: Some(first_profile.clone()),
-                tenant_interfaces: vec![
-                    rpc::FlatInterfaceConfig {
-                        internal_uuid: Some(::rpc::common::Uuid {
-                            value: "first-interface".to_string(),
-                        }),
-                        vpc_routing_profile: Some(first_profile),
-                        ..Default::default()
+            }),
+            src_prefixes: vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()],
+            dst_prefixes: vec!["192.0.2.0/24".to_string(), "198.51.100.0/24".to_string()],
+        }
+    }
+
+    /// Builds an interface that exercises every nested collection normalized
+    /// by the fingerprint.
+    fn comparison_interface(id: &str, vlan_id: u32, vni: u32) -> rpc::FlatInterfaceConfig {
+        rpc::FlatInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical.into(),
+            vlan_id,
+            vni,
+            gateway: "10.0.0.1/24".to_string(),
+            ip: "10.0.0.2".to_string(),
+            interface_prefix: "10.0.0.0/31".to_string(),
+            virtual_function_id: None,
+            vpc_prefixes: vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()],
+            prefix: "10.0.0.0/24".to_string(),
+            fqdn: format!("{id}.example.test"),
+            booturl: Some("http://boot.example.test/ipxe".to_string()),
+            vpc_vni: vni + 1_000,
+            svi_ip: Some("10.0.0.1".to_string()),
+            tenant_vrf_loopback_ip: Some("10.0.0.3".to_string()),
+            is_l2_segment: false,
+            vpc_peer_prefixes: vec!["192.0.2.0/24".to_string(), "198.51.100.0/24".to_string()],
+            vpc_peer_vnis: vec![2_001, 2_002],
+            mtu: Some(9_000),
+            ipv6_interface_config: Some(rpc::FlatInterfaceIpv6Config {
+                ip: "2001:db8::1".to_string(),
+                interface_prefix: "2001:db8::/127".to_string(),
+                svi_ip: Some("2001:db8::".to_string()),
+            }),
+            vpc_routing_profile: Some(comparison_routing_profile()),
+            interface_routing_profile: Some(rpc::FlatInterfaceRoutingProfile {
+                allowed_anycast_prefixes: vec![
+                    rpc::PrefixFilterPolicyEntry {
+                        prefix: "203.0.113.0/25".to_string(),
                     },
-                    rpc::FlatInterfaceConfig {
-                        internal_uuid: Some(::rpc::common::Uuid {
-                            value: "second-interface".to_string(),
-                        }),
-                        vpc_routing_profile: Some(second_profile),
-                        ..Default::default()
+                    rpc::PrefixFilterPolicyEntry {
+                        prefix: "203.0.113.128/25".to_string(),
                     },
                 ],
-                ..Default::default()
-            });
-            let mut current = CurrentNetworkVersion::default();
-            current.update_from(&conf);
+            }),
+            network_security_group: Some(rpc::FlatInterfaceNetworkSecurityGroupConfig {
+                id: format!("nsg-{id}"),
+                version: "nsg-v1".to_string(),
+                source: rpc::NetworkSecurityGroupSource::NsgSourceVpc.into(),
+                rules: vec![
+                    comparison_security_group_rule(
+                        "first-rule",
+                        100,
+                        rpc::NetworkSecurityGroupRuleAction::NsgRuleActionPermit,
+                    ),
+                    comparison_security_group_rule(
+                        "second-rule",
+                        200,
+                        rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny,
+                    ),
+                ],
+                stateful_egress: false,
+            }),
+            internal_uuid: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+        }
+    }
 
-            // Change only the second interface while leaving both compared
-            // configuration versions and the compatibility profile untouched.
-            let second_interface = &mut Arc::get_mut(&mut conf)
-                .expect("network configuration must not be shared")
-                .tenant_interfaces[1];
-            match change {
-                InterfaceChange::Unchanged => {}
-                InterfaceChange::Profile => {
-                    second_interface
+    /// Builds one populated response shared by the rendered, non-HBN, and
+    /// ordering comparison cases.
+    fn comparison_network_config() -> ManagedHostNetworkConfigResponse {
+        ManagedHostNetworkConfigResponse {
+            asn: 65_000,
+            dhcp_servers: vec!["10.10.0.1".to_string(), "10.10.0.2".to_string()],
+            vni_device: "vxlan48".to_string(),
+            managed_host_config: Some(rpc::ManagedHostNetworkConfig {
+                loopback_ip: "10.20.0.1".to_string(),
+                quarantine_state: None,
+                loopback_ip_v6: Some("2001:db8:ffff::1".to_string()),
+            }),
+            managed_host_config_version: "managed-v1".to_string(),
+            use_admin_network: false,
+            admin_interface: Some(comparison_interface("admin", 10, 100)),
+            tenant_interfaces: vec![
+                comparison_interface("first-interface", 20, 200),
+                comparison_interface("second-interface", 30, 300),
+            ],
+            instance_network_config_version: "instance-v1".to_string(),
+            network_virtualization_type: Some(rpc::VpcVirtualizationType::Fnn.into()),
+            vpc_vni: Some(1_000),
+            route_servers: vec!["10.30.0.1".to_string(), "10.30.0.2".to_string()],
+            remote_id: "dpu-remote-id".to_string(),
+            deprecated_deny_prefixes: vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()],
+            deny_prefixes: vec!["100.64.0.0/10".to_string(), "169.254.0.0/16".to_string()],
+            site_fabric_prefixes: vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()],
+            vpc_isolation_behavior: rpc::VpcIsolationBehaviorType::VpcIsolationMutual.into(),
+            stateful_acls_enabled: true,
+            ntp_servers: vec!["10.40.0.1".to_string(), "10.40.0.2".to_string()],
+            enable_dhcp: true,
+            host_interface_id: Some("60cef902-9779-4666-8362-c9bb4b37185f".to_string()),
+            is_primary_dpu: true,
+            internet_l3_vni: Some(4_000),
+            datacenter_asn: 65_100,
+            common_internal_route_target: Some(::rpc::common::RouteTarget {
+                asn: 65_200,
+                vni: 5_000,
+            }),
+            additional_route_target_imports: vec![
+                ::rpc::common::RouteTarget {
+                    asn: 65_201,
+                    vni: 5_001,
+                },
+                ::rpc::common::RouteTarget {
+                    asn: 65_202,
+                    vni: 5_002,
+                },
+            ],
+            network_security_policy_overrides: vec![
+                comparison_security_group_rule(
+                    "first-override",
+                    10,
+                    rpc::NetworkSecurityGroupRuleAction::NsgRuleActionPermit,
+                ),
+                comparison_security_group_rule(
+                    "second-override",
+                    20,
+                    rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny,
+                ),
+            ],
+            routing_profile: Some(comparison_routing_profile()),
+            anycast_site_prefixes: vec!["192.0.2.0/24".to_string(), "198.51.100.0/24".to_string()],
+            tenant_host_asn: Some(65_300),
+            site_global_vpc_vni: Some(6_000),
+            bgp_leaf_session_password: Some("leaf-password".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Selects the unchanged baseline or one response mutation that should
+    /// invalidate the HBN skip decision.
+    #[derive(Clone, Copy, Debug)]
+    enum RenderedInputChange {
+        Unchanged,
+        ManagedVersion,
+        InstanceVersion,
+        ManagedHostLoopback,
+        DenyPrefix,
+        SiteFabricPrefix,
+        AdminInterfaceVni,
+        TenantInterfaceVni,
+        TenantVpcPrefix,
+        TenantPeerPrefix,
+        TenantPeerVni,
+        VpcRoutingProfile,
+        InterfaceRoutingProfile,
+        NetworkSecurityGroup,
+        NetworkSecurityPolicyOverride,
+        NetworkVirtualizationType,
+        PrimaryDpu,
+    }
+
+    impl RenderedInputChange {
+        /// Applies the selected case to the shared response.
+        fn apply(self, config: &mut ManagedHostNetworkConfigResponse) {
+            match self {
+                Self::Unchanged => {}
+                Self::ManagedVersion => config.managed_host_config_version.push_str("-changed"),
+                Self::InstanceVersion => {
+                    config.instance_network_config_version.push_str("-changed")
+                }
+                Self::ManagedHostLoopback => {
+                    config
+                        .managed_host_config
+                        .as_mut()
+                        .expect("comparison fixture has managed-host config")
+                        .loopback_ip = "10.20.0.2".to_string();
+                }
+                Self::DenyPrefix => config.deny_prefixes.push("192.0.2.0/24".to_string()),
+                Self::SiteFabricPrefix => {
+                    config
+                        .site_fabric_prefixes
+                        .push("192.168.0.0/16".to_string());
+                }
+                Self::AdminInterfaceVni => {
+                    config
+                        .admin_interface
+                        .as_mut()
+                        .expect("comparison fixture has an admin interface")
+                        .vni += 1;
+                }
+                Self::TenantInterfaceVni => config.tenant_interfaces[1].vni += 1,
+                Self::TenantVpcPrefix => {
+                    config.tenant_interfaces[1]
+                        .vpc_prefixes
+                        .push("192.168.0.0/16".to_string());
+                }
+                Self::TenantPeerPrefix => {
+                    config.tenant_interfaces[1]
+                        .vpc_peer_prefixes
+                        .push("203.0.113.0/24".to_string());
+                }
+                Self::TenantPeerVni => config.tenant_interfaces[1].vpc_peer_vnis.push(2_003),
+                Self::VpcRoutingProfile => {
+                    config.tenant_interfaces[1]
                         .vpc_routing_profile
                         .as_mut()
-                        .expect("second interface profile")
+                        .expect("comparison fixture has a VPC routing profile")
                         .leak_default_route_from_underlay = true;
                 }
-                InterfaceChange::ProfilePresence => {
-                    second_interface.vpc_routing_profile = None;
+                Self::InterfaceRoutingProfile => {
+                    config.tenant_interfaces[1]
+                        .interface_routing_profile
+                        .as_mut()
+                        .expect("comparison fixture has an interface routing profile")
+                        .allowed_anycast_prefixes
+                        .push(rpc::PrefixFilterPolicyEntry {
+                            prefix: "100.64.0.0/10".to_string(),
+                        });
                 }
-                InterfaceChange::Identity => {
-                    second_interface.internal_uuid = Some(::rpc::common::Uuid {
-                        value: "replacement-interface".to_string(),
-                    });
+                Self::NetworkSecurityGroup => {
+                    config.tenant_interfaces[1]
+                        .network_security_group
+                        .as_mut()
+                        .expect("comparison fixture has a network security group")
+                        .stateful_egress = true;
                 }
+                Self::NetworkSecurityPolicyOverride => {
+                    config.network_security_policy_overrides[1]
+                        .src_prefixes
+                        .push("100.64.0.0/10".to_string());
+                }
+                Self::NetworkVirtualizationType => {
+                    config.network_virtualization_type =
+                        Some(rpc::VpcVirtualizationType::EthernetVirtualizer.into());
+                }
+                Self::PrimaryDpu => config.is_primary_dpu = false,
             }
+        }
+    }
 
-            current.matches_versions_from(&conf)
+    /// A new agent process must render once before it can use the HBN skip
+    /// cache; no response may match an uninitialized fingerprint.
+    #[test]
+    fn current_network_version_never_matches_before_first_update() {
+        let config = comparison_network_config();
+
+        assert!(!CurrentNetworkVersion::default().matches_versions_from(&config));
+    }
+
+    /// Every input consumed by HBN must invalidate the cache, and either
+    /// explicit version must do the same.
+    #[test]
+    fn current_network_version_detects_rendered_input_changes() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(run = |change| {
+            let mut config = comparison_network_config();
+            let mut current = CurrentNetworkVersion::default();
+            current.update_from(&config);
+            change.apply(&mut config);
+            current.matches_versions_from(&config)
         };
-            "unchanged interface state" {
-                // Identical interface profiles and identities remain cached.
-                InterfaceChange::Unchanged => true,
+            "unchanged configuration" {
+                RenderedInputChange::Unchanged => true,
             }
-            "non-first interface changes" {
-                // A changed parent VPC profile must invalidate the cached render.
-                InterfaceChange::Profile => false,
-                // Profile presence is meaningful even when all present fields
-                // would otherwise have default values.
-                InterfaceChange::ProfilePresence => false,
-                // Interface identity prevents profiles from being silently
-                // reassociated with a different port.
-                InterfaceChange::Identity => false,
+            "version changes" {
+                RenderedInputChange::ManagedVersion => false,
+                RenderedInputChange::InstanceVersion => false,
+            }
+            "top-level rendering inputs" {
+                RenderedInputChange::ManagedHostLoopback => false,
+                RenderedInputChange::DenyPrefix => false,
+                RenderedInputChange::SiteFabricPrefix => false,
+                RenderedInputChange::NetworkVirtualizationType => false,
+                RenderedInputChange::PrimaryDpu => false,
+            }
+            "interface rendering inputs" {
+                RenderedInputChange::AdminInterfaceVni => false,
+                RenderedInputChange::TenantInterfaceVni => false,
+                RenderedInputChange::TenantVpcPrefix => false,
+                RenderedInputChange::TenantPeerPrefix => false,
+                RenderedInputChange::TenantPeerVni => false,
+                RenderedInputChange::VpcRoutingProfile => false,
+                RenderedInputChange::InterfaceRoutingProfile => false,
+                RenderedInputChange::NetworkSecurityGroup => false,
+                RenderedInputChange::NetworkSecurityPolicyOverride => false,
+            }
+        );
+    }
+
+    /// `SetLikeInputReordering` lists the response collections this test
+    /// reverses to prove member order does not trigger another HBN apply.
+    #[derive(Clone, Copy, Debug)]
+    enum SetLikeInputReordering {
+        DhcpServers,
+        RouteServers,
+        SiteFabricPrefixes,
+        AdminInterfaceVpcPrefixes,
+        TenantVpcPrefixes,
+        TenantPeerPrefixes,
+        TenantPeerVnis,
+        AdditionalRouteTargets,
+        TopLevelRoutingProfileRouteTargets,
+        VpcRouteTargets,
+        InterfaceAnycastPrefixes,
+        NetworkSecurityGroupRules,
+        NetworkSecurityGroupRulePrefixes,
+        NetworkSecurityPolicyOverrides,
+    }
+
+    impl SetLikeInputReordering {
+        /// Reverses the selected collection without changing its members.
+        fn apply(self, config: &mut ManagedHostNetworkConfigResponse) {
+            match self {
+                Self::DhcpServers => config.dhcp_servers.reverse(),
+                Self::RouteServers => config.route_servers.reverse(),
+                Self::SiteFabricPrefixes => config.site_fabric_prefixes.reverse(),
+                Self::AdminInterfaceVpcPrefixes => config
+                    .admin_interface
+                    .as_mut()
+                    .expect("comparison fixture has an admin interface")
+                    .vpc_prefixes
+                    .reverse(),
+                Self::TenantVpcPrefixes => config.tenant_interfaces[0].vpc_prefixes.reverse(),
+                Self::TenantPeerPrefixes => {
+                    config.tenant_interfaces[0].vpc_peer_prefixes.reverse();
+                }
+                Self::TenantPeerVnis => config.tenant_interfaces[0].vpc_peer_vnis.reverse(),
+                Self::AdditionalRouteTargets => {
+                    config.additional_route_target_imports.reverse();
+                }
+                Self::TopLevelRoutingProfileRouteTargets => config
+                    .routing_profile
+                    .as_mut()
+                    .expect("comparison fixture has a top-level routing profile")
+                    .route_target_imports
+                    .reverse(),
+                Self::VpcRouteTargets => {
+                    config.tenant_interfaces[0]
+                        .vpc_routing_profile
+                        .as_mut()
+                        .expect("comparison fixture has a VPC routing profile")
+                        .route_target_imports
+                        .reverse();
+                }
+                Self::InterfaceAnycastPrefixes => {
+                    config.tenant_interfaces[0]
+                        .interface_routing_profile
+                        .as_mut()
+                        .expect("comparison fixture has an interface routing profile")
+                        .allowed_anycast_prefixes
+                        .reverse();
+                }
+                Self::NetworkSecurityGroupRules => {
+                    config.tenant_interfaces[0]
+                        .network_security_group
+                        .as_mut()
+                        .expect("comparison fixture has a network security group")
+                        .rules
+                        .reverse();
+                }
+                Self::NetworkSecurityGroupRulePrefixes => {
+                    config.tenant_interfaces[0]
+                        .network_security_group
+                        .as_mut()
+                        .expect("comparison fixture has a network security group")
+                        .rules[0]
+                        .src_prefixes
+                        .reverse();
+                }
+                Self::NetworkSecurityPolicyOverrides => {
+                    config.network_security_policy_overrides.reverse();
+                }
+            }
+        }
+    }
+
+    /// Reordering set-like inputs must not cause an unnecessary HBN update.
+    #[test]
+    fn current_network_version_ignores_set_like_input_order() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(run = |reordering| {
+            let mut config = comparison_network_config();
+            let mut current = CurrentNetworkVersion::default();
+            current.update_from(&config);
+            reordering.apply(&mut config);
+            current.matches_versions_from(&config)
+        };
+            "top-level sets" {
+                SetLikeInputReordering::DhcpServers => true,
+                SetLikeInputReordering::RouteServers => true,
+                SetLikeInputReordering::SiteFabricPrefixes => true,
+                SetLikeInputReordering::AdditionalRouteTargets => true,
+                SetLikeInputReordering::TopLevelRoutingProfileRouteTargets => true,
+                SetLikeInputReordering::NetworkSecurityPolicyOverrides => true,
+            }
+            "interface sets" {
+                SetLikeInputReordering::AdminInterfaceVpcPrefixes => true,
+                SetLikeInputReordering::TenantVpcPrefixes => true,
+                SetLikeInputReordering::TenantPeerPrefixes => true,
+                SetLikeInputReordering::TenantPeerVnis => true,
+                SetLikeInputReordering::VpcRouteTargets => true,
+                SetLikeInputReordering::InterfaceAnycastPrefixes => true,
+                SetLikeInputReordering::NetworkSecurityGroupRules => true,
+                SetLikeInputReordering::NetworkSecurityGroupRulePrefixes => true,
+            }
+        );
+    }
+
+    /// Selects one collection whose relative order changes HBN behavior.
+    #[derive(Clone, Copy, Debug)]
+    enum OrderSensitiveInputReordering {
+        TenantInterfaces,
+        EqualPriorityNetworkSecurityGroupRules,
+        EqualPriorityNetworkSecurityPolicyOverrides,
+    }
+
+    impl OrderSensitiveInputReordering {
+        /// Makes the security-rule cases depend on stable equal-priority
+        /// ordering before their entries are reversed.
+        fn prepare(self, config: &mut ManagedHostNetworkConfigResponse) {
+            match self {
+                Self::TenantInterfaces => {}
+                Self::EqualPriorityNetworkSecurityGroupRules => {
+                    let rules = &mut config.tenant_interfaces[0]
+                        .network_security_group
+                        .as_mut()
+                        .expect("comparison fixture has a network security group")
+                        .rules;
+                    let priority = rules[0]
+                        .rule
+                        .as_ref()
+                        .expect("comparison fixture has rule attributes")
+                        .priority;
+                    rules[1]
+                        .rule
+                        .as_mut()
+                        .expect("comparison fixture has rule attributes")
+                        .priority = priority;
+                }
+                Self::EqualPriorityNetworkSecurityPolicyOverrides => {
+                    let priority = config.network_security_policy_overrides[0]
+                        .rule
+                        .as_ref()
+                        .expect("comparison fixture has rule attributes")
+                        .priority;
+                    config.network_security_policy_overrides[1]
+                        .rule
+                        .as_mut()
+                        .expect("comparison fixture has rule attributes")
+                        .priority = priority;
+                }
+            }
+        }
+
+        /// Reverses the selected order-sensitive collection.
+        fn apply(self, config: &mut ManagedHostNetworkConfigResponse) {
+            match self {
+                Self::TenantInterfaces => config.tenant_interfaces.reverse(),
+                Self::EqualPriorityNetworkSecurityGroupRules => config.tenant_interfaces[0]
+                    .network_security_group
+                    .as_mut()
+                    .expect("comparison fixture has a network security group")
+                    .rules
+                    .reverse(),
+                Self::EqualPriorityNetworkSecurityPolicyOverrides => {
+                    config.network_security_policy_overrides.reverse();
+                }
+            }
+        }
+    }
+
+    /// Interface order and equal-priority rule order must remain part of the
+    /// fingerprint because the renderer preserves both.
+    #[test]
+    fn current_network_version_preserves_semantically_significant_order() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(run = |reordering| {
+            let mut config = comparison_network_config();
+            reordering.prepare(&mut config);
+            let mut current = CurrentNetworkVersion::default();
+            current.update_from(&config);
+            reordering.apply(&mut config);
+            current.matches_versions_from(&config)
+        };
+            "first-match interface order" {
+                OrderSensitiveInputReordering::TenantInterfaces => false,
+            }
+            "equal-priority security rule order" {
+                OrderSensitiveInputReordering::EqualPriorityNetworkSecurityGroupRules => false,
+                OrderSensitiveInputReordering::EqualPriorityNetworkSecurityPolicyOverrides => false,
+            }
+        );
+    }
+
+    /// `NonHbnInputChange` lists the response fields this test changes to
+    /// prove they stay out of the HBN fingerprint.
+    #[derive(Clone, Copy, Debug)]
+    enum NonHbnInputChange {
+        NetworkPingerType,
+        MinimumFunctioningLinks,
+        InstanceId,
+        InstancePayload,
+        DeprecatedDhcpFlag,
+        DeprecatedDenyPrefixes,
+        NtpServers,
+        HostInterfaceId,
+        ExtensionServices,
+        AstraConfig,
+        AdminNetworkTransition,
+    }
+
+    impl NonHbnInputChange {
+        /// Applies the selected non-HBN change to the shared response.
+        fn apply(self, config: &mut ManagedHostNetworkConfigResponse) {
+            match self {
+                Self::NetworkPingerType => {
+                    config.dpu_network_pinger_type = Some("icmp".to_string());
+                }
+                Self::MinimumFunctioningLinks => config.min_dpu_functioning_links = Some(1),
+                Self::InstanceId => config.instance_id = Some(Default::default()),
+                Self::InstancePayload => config.instance = Some(Default::default()),
+                Self::DeprecatedDhcpFlag => config.enable_dhcp = false,
+                Self::DeprecatedDenyPrefixes => config
+                    .deprecated_deny_prefixes
+                    .push("192.0.2.0/24".to_string()),
+                Self::NtpServers => config.ntp_servers.push("10.40.0.3".to_string()),
+                Self::HostInterfaceId => {
+                    config.host_interface_id =
+                        Some("7340b4f5-1721-4dd3-8fc3-9f91a4c29f61".to_string());
+                }
+                Self::ExtensionServices => {
+                    config
+                        .dpu_extension_services
+                        .push(rpc::ManagedHostDpuExtensionServiceConfig {
+                            service_id: "extension-service".to_string(),
+                            ..Default::default()
+                        });
+                }
+                Self::AstraConfig => config.astra_config = Some(rpc::AstraConfig::default()),
+                Self::AdminNetworkTransition => config.use_admin_network_changed = Some(true),
+            }
+        }
+    }
+
+    /// Inputs used outside HBN, read only at startup, or deprecated must not
+    /// retrigger HBN.
+    #[test]
+    fn current_network_version_ignores_non_hbn_inputs() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(run = |change| {
+            let mut config = comparison_network_config();
+            let mut current = CurrentNetworkVersion::default();
+            current.update_from(&config);
+            change.apply(&mut config);
+            current.matches_versions_from(&config)
+        };
+            "inputs applied outside HBN rendering" {
+                NonHbnInputChange::MinimumFunctioningLinks => true,
+                NonHbnInputChange::ExtensionServices => true,
+                NonHbnInputChange::AstraConfig => true,
+                NonHbnInputChange::AdminNetworkTransition => true,
+            }
+            "startup, status, DHCP-only, and deprecated inputs" {
+                NonHbnInputChange::NetworkPingerType => true,
+                NonHbnInputChange::InstanceId => true,
+                NonHbnInputChange::InstancePayload => true,
+                NonHbnInputChange::HostInterfaceId => true,
+                NonHbnInputChange::NtpServers => true,
+                NonHbnInputChange::DeprecatedDenyPrefixes => true,
+                NonHbnInputChange::DeprecatedDhcpFlag => true,
             }
         );
     }
@@ -1788,42 +2424,6 @@ mod test {
                     virtualization_type: VpcVirtualizationType::Flat,
                     managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
                 } => false,
-            }
-        );
-    }
-
-    #[test]
-    fn test_current_network_version_hashes_nested_managed_host_config() {
-        use carbide_test_support::value_scenarios;
-
-        value_scenarios!(run = |managed_host_config| {
-            let mut conf = Arc::new(ManagedHostNetworkConfigResponse {
-                managed_host_config: Some(rpc::ManagedHostNetworkConfig {
-                    loopback_ip: "10.0.0.1".to_string(),
-                    loopback_ip_v6: None,
-                    quarantine_state: None,
-                }),
-                managed_host_config_version: "managed-v1".to_string(),
-                instance_network_config_version: "instance-v1".to_string(),
-                ..Default::default()
-            });
-            let mut current = CurrentNetworkVersion::default();
-            current.update_from(&conf);
-            Arc::get_mut(&mut conf).unwrap().managed_host_config = managed_host_config;
-            current.matches_versions_from(&conf)
-        };
-            "nested config changes invalidate the cache" {
-                Some(rpc::ManagedHostNetworkConfig {
-                    loopback_ip: "10.0.0.2".to_string(),
-                    loopback_ip_v6: None,
-                    quarantine_state: None,
-                }) => false,
-                Some(rpc::ManagedHostNetworkConfig {
-                    loopback_ip: "10.0.0.1".to_string(),
-                    loopback_ip_v6: Some("2001:db8::1".to_string()),
-                    quarantine_state: None,
-                }) => false,
-                None => false,
             }
         );
     }


### PR DESCRIPTION
The agent uses Core version fields to decide when HBN rendering and apply can be skipped, but some rendering inputs are not covered by those versions. The existing fallback hash hand-picked a subset, so a SitePrefix isolation change or another omitted nested input could leave HBN stale even though the desired response changed.

This builds a fingerprint from the complete managed host network response, removes only fields that cannot affect HBN, and normalizes collections using the renderer's own ordering approach.

Because the fingerprint starts from the complete response, future protobuf fields participate by default. Only fields proven not to affect HBN are cleared explicitly, and DHCP remains on its existing unconditional reconciliation path.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3893

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Passed the five focused comparison tests, all 203 `carbide-agent` library tests, nightly formatting, full-workspace Clippy, and custom Carbide lints.


Closes #3893

