### PR TITLE
fix(health): limit concurrent Redfish calls per BMC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7857,6 +7857,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e07bc4a5ae977451c3a89314ddeb2418d5d5a92595a0b28bbfced0de5132b9"
 dependencies = [
+ "async-lock",
  "bytes",
  "futures-core",
  "futures-util",

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -83,6 +83,7 @@ nv-redfish = { workspace = true, features = [
   "chassis",
   "computer-systems",
   "event-service",
+  "http-extras",
   "log-services",
   "managers",
   "memory",

--- a/crates/health/README.md
+++ b/crates/health/README.md
@@ -119,9 +119,10 @@ For a faster fault-injection loop, copy
 run hardware health with the copied file:
 
 ```toml
+bmc_request_concurrency = 4
+
 [collectors.sensors]
 sensor_fetch_interval = "5s"
-sensor_fetch_concurrency = 4
 include_sensor_thresholds = true
 ```
 

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -20,6 +20,9 @@ shard = 0
 shards_count = 1
 
 cache_size = 100
+# Maximum concurrent Redfish operations per BMC. Must be greater than zero. Default: 1.
+# Changes take effect after restarting carbide-health.
+bmc_request_concurrency = 1
 bmc_proxy_url = "http://proxy.example.com:8080"
 
 endpoint_discovery_interval = "5m"

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -20,9 +20,10 @@ shard = 0
 shards_count = 1
 
 cache_size = 100
-# Maximum concurrent Redfish operations per BMC. Must be greater than zero. Default: 1.
+# Maximum concurrent Redfish operations per BMC, including collector fan-out.
+# Must be greater than zero. Default: 4.
 # Changes take effect after restarting carbide-health.
-bmc_request_concurrency = 1
+bmc_request_concurrency = 4
 bmc_proxy_url = "http://proxy.example.com:8080"
 
 endpoint_discovery_interval = "5m"
@@ -216,12 +217,10 @@ log_mode = "unreachable"
 
 [collectors.sensors]
 sensor_fetch_interval = "1m"
-sensor_fetch_concurrency = 10
 include_sensor_thresholds = true
 
 [collectors.metrics]
 fetch_interval = "2m"
-fetch_concurrency = 4
 
 # Redfish telemetry service: pre-aggregated metric reports, one GET per report
 # instead of one per resource. Published under the `hw_telemetry` series name so
@@ -281,9 +280,6 @@ exclude_services = ["Journal"]
 [collectors.logs.sse]
 initial_backoff = "1s"
 max_backoff = "30s"
-# Maximum number of concurrent Redfish GET requests used to fetch EventRecord
-# resources referenced by @odata.id in SSE notifications.
-event_record_fetch_concurrency = 4
 
 # required when
 # mode = "periodic"; must not be set when mode = "sse"

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -22,6 +22,7 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::net::IpAddr;
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -295,6 +296,7 @@ pub struct ApiEndpointSource {
     reqwest: ReqwestClient,
     proxy_url: Option<Url>,
     cache_size: usize,
+    bmc_request_concurrency: NonZeroUsize,
     bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     bmc_client_cache: Mutex<HashMap<MacAddress, CachedBmcClient>>,
 }
@@ -314,11 +316,30 @@ impl ApiEndpointSource {
         cache_size: usize,
         bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     ) -> Self {
+        Self::new_with_request_concurrency(
+            api,
+            reqwest,
+            proxy_url,
+            cache_size,
+            NonZeroUsize::MIN,
+            bmc_latency_metrics,
+        )
+    }
+
+    pub(crate) fn new_with_request_concurrency(
+        api: Arc<ApiClientWrapper>,
+        reqwest: ReqwestClient,
+        proxy_url: Option<Url>,
+        cache_size: usize,
+        bmc_request_concurrency: NonZeroUsize,
+        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
+    ) -> Self {
         Self {
             api,
             reqwest,
             proxy_url,
             cache_size,
+            bmc_request_concurrency,
             bmc_latency_metrics,
             bmc_client_cache: Mutex::new(HashMap::new()),
         }
@@ -621,6 +642,7 @@ impl ApiEndpointSource {
                     provider,
                     self.proxy_url.clone(),
                     self.cache_size,
+                    self.bmc_request_concurrency,
                     bmc_latency_instrumentation,
                 )?))
             })?
@@ -812,6 +834,7 @@ mod tests {
             provider,
             None,
             10,
+            NonZeroUsize::MIN,
             None,
         )?))
     }

--- a/crates/health/src/bmc.rs
+++ b/crates/health/src/bmc.rs
@@ -16,6 +16,7 @@
  */
 
 use std::any::{Any, type_name};
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
@@ -27,7 +28,7 @@ use futures::TryStreamExt;
 use http::HeaderMap;
 use http::header::{self, InvalidHeaderValue};
 use nv_redfish::bmc_http::reqwest::{BmcError, Client as ReqwestClient};
-use nv_redfish::bmc_http::{CacheSettings, HttpBmc, HttpClient};
+use nv_redfish::bmc_http::{CacheSettings, ConcurrencyLimitedBmc, HttpBmc, HttpClient};
 use nv_redfish::core::query::{ExpandQuery, FilterQuery};
 use nv_redfish::core::upload::{MultipartUpdateRequest, UploadReader};
 use nv_redfish::core::{
@@ -196,12 +197,14 @@ pub(crate) fn bmc_latency_endpoint_labels(
 }
 
 pub struct BmcClient {
-    inner: HttpBmc<InstrumentedHttpClient>,
+    /// Enforces this endpoint's configured Redfish operation limit.
+    inner: ConcurrencyLimitedBmc<HttpBmc<InstrumentedHttpClient>>,
     addr: BmcAddr,
     provider: Arc<dyn CredentialProvider>,
     credential_generation: AtomicU64,
     init: OnceCell<()>,
     refresh_lock: Mutex<()>,
+
     circuit: StdMutex<CircuitState>,
     /// Lock-free fast-path hint mirroring `circuit`: `false` iff the circuit is
     /// `Closed`. Lets the healthy request path (the overwhelmingly common case)
@@ -226,6 +229,7 @@ impl BmcClient {
         provider: Arc<dyn CredentialProvider>,
         proxy_url: Option<Url>,
         cache_size: usize,
+        request_concurrency: NonZeroUsize,
         bmc_latency_instrumentation: Option<BmcLatencyInstrumentation>,
     ) -> Result<Self, HealthError> {
         let server_address = bmc_server_address(&addr);
@@ -251,7 +255,9 @@ impl BmcClient {
             placeholder,
             CacheSettings::with_capacity(cache_size),
             headers,
-        );
+        )
+        .with_request_concurrency_limit(request_concurrency);
+
         Ok(Self {
             inner,
             addr,
@@ -1290,6 +1296,8 @@ mod tests {
     use crate::endpoint::BmcAddr;
     use crate::metrics::BmcLatencyAttribute;
 
+    const TEST_REQUEST_CONCURRENCY: NonZeroUsize = NonZeroUsize::MIN;
+
     struct CountingProvider {
         calls: Arc<AtomicUsize>,
         delay: Option<Duration>,
@@ -1366,6 +1374,34 @@ mod tests {
             .expect("reqwest client builds")
     }
 
+    fn reqwest_with_timeout(timeout: Duration) -> ReqwestClient {
+        ReqwestClient::with_params(
+            ReqwestClientParams::new()
+                .accept_invalid_certs(true)
+                .timeout(timeout),
+        )
+        .expect("reqwest client builds")
+    }
+
+    fn test_bmc(
+        reqwest: ReqwestClient,
+        addr: BmcAddr,
+        provider: Arc<dyn CredentialProvider>,
+        proxy_url: Option<Url>,
+        cache_size: usize,
+        bmc_latency_instrumentation: Option<BmcLatencyInstrumentation>,
+    ) -> Result<BmcClient, HealthError> {
+        BmcClient::new(
+            reqwest,
+            addr,
+            provider,
+            proxy_url,
+            cache_size,
+            TEST_REQUEST_CONCURRENCY,
+            bmc_latency_instrumentation,
+        )
+    }
+
     fn bmc_status_error(status: http::StatusCode) -> BmcError {
         BmcError::InvalidResponse {
             url: Url::parse("https://127.0.0.1/redfish/v1").expect("valid url"),
@@ -1381,7 +1417,7 @@ mod tests {
             },
             None,
         );
-        BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("constructor ok")
+        test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("constructor ok")
     }
 
     fn dummy_error() -> HealthError {
@@ -1428,9 +1464,8 @@ mod tests {
             port: Some(port),
             mac: MacAddress::from_str("00:11:22:33:44:55").expect("mac"),
         };
-        let client = Arc::new(
-            BmcClient::new(reqwest(), addr, provider, None, 10, None).expect("constructor ok"),
-        );
+        let client =
+            Arc::new(test_bmc(reqwest(), addr, provider, None, 10, None).expect("constructor ok"));
 
         assert_eq!(
             client.collector_sweep(),
@@ -1447,6 +1482,86 @@ mod tests {
             CollectorSweep::Skip,
             "a genuine connect failure must be classified as a connection error and open the breaker"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn request_concurrency_limits_parallel_transport_attempts() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+
+        let proxy_url = Url::parse(&format!(
+            "http://{}",
+            listener.local_addr().expect("listener address")
+        ))
+        .expect("test proxy URL");
+
+        let (provider, _) = CountingProvider::new(
+            BmcCredentials::SessionToken {
+                token: "t".to_string(),
+            },
+            None,
+        );
+
+        let client = Arc::new(
+            BmcClient::new(
+                reqwest_with_timeout(Duration::from_millis(200)),
+                test_addr(),
+                provider,
+                Some(proxy_url),
+                10,
+                NonZeroUsize::MIN,
+                None,
+            )
+            .expect("constructor succeeds"),
+        );
+
+        client.ensure_credentials().await.expect("credentials load");
+
+        let first_client = Arc::clone(&client);
+
+        let first = tokio::spawn(async move {
+            first_client
+                .inner
+                .get::<nv_redfish::schema::service_root::ServiceRoot>(&ODataId::from(
+                    "/redfish/v1/".to_string(),
+                ))
+                .await
+        });
+
+        let (_first_connection, _) =
+            tokio::time::timeout(Duration::from_secs(1), listener.accept())
+                .await
+                .expect("first request reaches transport")
+                .expect("accept first request");
+
+        let second_client = Arc::clone(&client);
+
+        let second = tokio::spawn(async move {
+            second_client
+                .inner
+                .get::<nv_redfish::schema::service_root::ServiceRoot>(&ODataId::from(
+                    "/redfish/v1/".to_string(),
+                ))
+                .await
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err(),
+            "second request must wait while the first holds the only permit"
+        );
+
+        assert!(first.await.expect("first task joins").is_err());
+
+        let (_second_connection, _) =
+            tokio::time::timeout(Duration::from_secs(1), listener.accept())
+                .await
+                .expect("second request reaches transport after permit release")
+                .expect("accept second request");
+
+        assert!(second.await.expect("second task joins").is_err());
     }
 
     #[test]
@@ -1643,7 +1758,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None)
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None)
             .expect("constructor succeeds");
 
         assert_eq!(
@@ -1667,7 +1782,7 @@ mod tests {
             Some(Duration::from_millis(50)),
         );
         let client =
-            Arc::new(BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok"));
+            Arc::new(test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok"));
 
         let mut handles = Vec::new();
         for _ in 0..16 {
@@ -1711,7 +1826,7 @@ mod tests {
         let provider = Arc::new(FlakyProvider {
             attempts: AtomicUsize::new(0),
         });
-        let client = BmcClient::new(reqwest(), test_addr(), provider.clone(), None, 10, None)
+        let client = test_bmc(reqwest(), test_addr(), provider.clone(), None, 10, None)
             .expect("constructor succeeds");
 
         assert!(client.ensure_credentials().await.is_err());
@@ -1730,7 +1845,7 @@ mod tests {
             Some(Duration::from_millis(50)),
         );
         let client =
-            Arc::new(BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok"));
+            Arc::new(test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok"));
         client.ensure_credentials().await.expect("init ok");
         assert_eq!(calls.load(AtomicOrdering::SeqCst), 1);
 
@@ -1791,7 +1906,7 @@ mod tests {
             handed_out: StdMutex::new(Vec::new()),
             calls: calls.clone(),
         });
-        let client = BmcClient::new(reqwest(), test_addr(), provider.clone(), None, 10, None)
+        let client = test_bmc(reqwest(), test_addr(), provider.clone(), None, 10, None)
             .expect("constructor ok");
 
         client.ensure_credentials().await.expect("init ok");
@@ -1825,7 +1940,7 @@ mod tests {
         }
 
         let client = Arc::new(
-            BmcClient::new(
+            test_bmc(
                 reqwest(),
                 test_addr(),
                 Arc::new(HangingProvider),
@@ -1863,7 +1978,7 @@ mod tests {
         }
 
         let client = Arc::new(
-            BmcClient::new(
+            test_bmc(
                 reqwest(),
                 test_addr(),
                 Arc::new(HangingProvider),
@@ -1895,7 +2010,7 @@ mod tests {
             },
             None,
         );
-        let recovered = BmcClient::new(reqwest(), test_addr(), recovery_provider, None, 10, None)
+        let recovered = test_bmc(reqwest(), test_addr(), recovery_provider, None, 10, None)
             .expect("constructor ok");
         recovered.ensure_credentials().await.expect("recovery ok");
         assert_eq!(recovery_calls.load(AtomicOrdering::SeqCst), 1);
@@ -1943,7 +2058,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(auth_error()), Ok("body")]);
 
         let value = client
@@ -1969,7 +2084,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(HealthError::HttpError(
             "request failed with HTTP 404".to_string(),
         ))]);
@@ -1997,7 +2112,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(auth_error()), Err(auth_error())]);
 
         client
@@ -2040,7 +2155,7 @@ mod tests {
         let provider = Arc::new(InitOnceThenFailingProvider {
             calls: AtomicUsize::new(0),
         });
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(auth_error())]);
 
         let error = client
@@ -2070,7 +2185,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let attempts = Arc::new(AtomicUsize::new(0));
@@ -2115,7 +2230,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
 
         let (first, first_attempts) = scripted_op(vec![Err(auth_error()), Err(auth_error())]);
         client
@@ -2159,7 +2274,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let generation = client.credential_generation.load(Ordering::Acquire);
@@ -2193,7 +2308,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let stale_generation = client.credential_generation.load(Ordering::Acquire) - 1;
@@ -2224,7 +2339,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let observed = client.credential_generation.load(Ordering::Acquire);
@@ -2264,7 +2379,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let attempts = Arc::new(AtomicUsize::new(0));
@@ -2306,7 +2421,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, _) = scripted_op(vec![
             Err(auth_error()),
             Err(HealthError::HttpError("HTTP 500".to_string())),
@@ -2337,7 +2452,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(forbidden_error()), Err(forbidden_error())]);
 
         client
@@ -2367,7 +2482,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
+        let client = test_bmc(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, _) = scripted_op(vec![Err(auth_error()), Err(auth_error())]);
 
         client
@@ -2556,7 +2671,7 @@ mod tests {
                 ),
             )
         });
-        let client = BmcClient::new(
+        let client = test_bmc(
             reqwest(),
             test_addr(),
             provider,

--- a/crates/health/src/collectors/discovery.rs
+++ b/crates/health/src/collectors/discovery.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -31,14 +32,16 @@ use crate::endpoint::BmcEndpoint;
 /// Configuration for the entity discovery collector
 pub struct EntityDiscoveryCollectorConfig<B: Bmc> {
     pub(crate) shared: SharedInventory<B>,
-    pub discovery_concurrency: usize,
+
+    /// Bounds local fan-out to the endpoint Redfish operation limit.
+    pub request_concurrency: NonZeroUsize,
 }
 
 pub struct EntityDiscoveryCollector<B: Bmc> {
     endpoint: Arc<BmcEndpoint>,
     bmc: Arc<B>,
     shared: SharedInventory<B>,
-    discovery_concurrency: usize,
+    request_concurrency: usize,
     generation: u64,
 }
 
@@ -54,7 +57,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for EntityDiscoveryCollector<B> {
             endpoint,
             bmc,
             shared: config.shared,
-            discovery_concurrency: config.discovery_concurrency.max(1),
+            request_concurrency: config.request_concurrency.get(),
             generation: 0,
         })
     }
@@ -177,7 +180,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
                 let metric = processor.metrics_sensor_links().await;
                 (processor, env, metric)
             })
-            .buffer_unordered(self.discovery_concurrency)
+            .buffer_unordered(self.request_concurrency)
             .collect()
             .await;
 
@@ -222,7 +225,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
                 let sensors = memory.environment_sensor_links().await;
                 (memory, sensors)
             })
-            .buffer_unordered(self.discovery_concurrency)
+            .buffer_unordered(self.request_concurrency)
             .collect()
             .await;
 
@@ -270,7 +273,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
                     let sensors = drive.environment_sensor_links().await;
                     (drive, sensors)
                 })
-                .buffer_unordered(self.discovery_concurrency)
+                .buffer_unordered(self.request_concurrency)
                 .collect()
                 .await;
 
@@ -312,7 +315,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
                 let sensors = ps.metrics_sensor_links().await;
                 (ps, sensors)
             })
-            .buffer_unordered(self.discovery_concurrency)
+            .buffer_unordered(self.request_concurrency)
             .collect()
             .await;
 

--- a/crates/health/src/collectors/entity_metrics.rs
+++ b/crates/health/src/collectors/entity_metrics.rs
@@ -16,6 +16,7 @@
  */
 
 use std::borrow::Cow;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -766,7 +767,9 @@ fn power_supply_metric_fields(m: &PowerSupplyMetrics) -> Vec<MetricField> {
 pub struct MetricsCollectorConfig<B: Bmc> {
     pub data_sink: Option<Arc<dyn DataSink>>,
     pub(crate) shared: SharedInventory<B>,
-    pub fetch_concurrency: usize,
+
+    /// Bounds local fan-out to the endpoint Redfish operation limit.
+    pub request_concurrency: NonZeroUsize,
 }
 
 pub struct MetricsCollector<B: Bmc> {
@@ -774,7 +777,7 @@ pub struct MetricsCollector<B: Bmc> {
     event_context: EventContext,
     shared: SharedInventory<B>,
     data_sink: Option<Arc<dyn DataSink>>,
-    fetch_concurrency: usize,
+    request_concurrency: usize,
 }
 
 impl<B: Bmc + 'static> PeriodicCollector<B> for MetricsCollector<B> {
@@ -791,7 +794,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for MetricsCollector<B> {
             event_context,
             shared: config.shared,
             data_sink: config.data_sink,
-            fetch_concurrency: config.fetch_concurrency.max(1),
+            request_concurrency: config.request_concurrency.get(),
         })
     }
 
@@ -828,7 +831,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for MetricsCollector<B> {
             .collect();
 
         let processed: usize = stream::iter(futures)
-            .buffer_unordered(self.fetch_concurrency)
+            .buffer_unordered(self.request_concurrency)
             .collect::<Vec<usize>>()
             .await
             .into_iter()
@@ -1633,7 +1636,7 @@ mod tests {
             MetricsCollectorConfig {
                 data_sink,
                 shared: Arc::new(arc_swap::ArcSwapOption::empty()),
-                fetch_concurrency: 1,
+                request_concurrency: NonZeroUsize::MIN,
             },
         )
         .expect("metrics collector should build");

--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -16,6 +16,7 @@
  */
 
 use std::borrow::Cow;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -73,15 +74,14 @@ pub struct SseLogCollectorConfig {
     /// Attach Redfish diagnostic payloads to emitted log records.
     pub include_diagnostics: bool,
 
-    /// Maximum number of concurrent Redfish GET requests used to fetch
-    /// referenced event records.
-    pub event_record_fetch_concurrency: usize,
+    /// Bounds event-record resolution to the endpoint Redfish operation limit.
+    pub request_concurrency: NonZeroUsize,
 }
 
 pub struct SseLogCollector<B: Bmc> {
     bmc: Arc<B>,
     include_diagnostics: bool,
-    event_record_fetch_concurrency: usize,
+    request_concurrency: usize,
 }
 
 #[async_trait]
@@ -96,7 +96,7 @@ impl<B: Bmc + 'static> StreamingCollector<B> for SseLogCollector<B> {
         Ok(Self {
             bmc,
             include_diagnostics: config.include_diagnostics,
-            event_record_fetch_concurrency: config.event_record_fetch_concurrency.max(1),
+            request_concurrency: config.request_concurrency.get(),
         })
     }
 
@@ -107,7 +107,7 @@ impl<B: Bmc + 'static> StreamingCollector<B> for SseLogCollector<B> {
             sse_stream,
             Arc::clone(&self.bmc),
             self.include_diagnostics,
-            self.event_record_fetch_concurrency,
+            self.request_concurrency,
         );
 
         Ok(StreamingConnectResult::Connected(event_stream))
@@ -122,13 +122,13 @@ fn map_event_stream<'a, B, S>(
     sse_stream: S,
     bmc: Arc<B>,
     include_diagnostics: bool,
-    event_record_fetch_concurrency: usize,
+    request_concurrency: usize,
 ) -> EventStream<'a>
 where
     B: Bmc + 'static,
     S: futures::Stream<Item = Result<EventStreamPayload, HealthError>> + Send + 'a,
 {
-    let fetch_permits = Arc::new(Semaphore::new(event_record_fetch_concurrency));
+    let fetch_permits = Arc::new(Semaphore::new(request_concurrency));
 
     sse_stream
         .map(move |result| {
@@ -144,7 +144,7 @@ where
                 .await
             }
         })
-        .buffered(event_record_fetch_concurrency)
+        .buffered(request_concurrency)
         .flat_map(futures::stream::iter)
         .boxed()
 }
@@ -649,7 +649,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn event_record_fetch_concurrency_limits_get_requests() {
+    async fn request_concurrency_limits_event_record_gets() {
         let first_path = "/redfish/v1/EventService/Events/records/hung";
         let second_path = "/redfish/v1/EventService/Events/records/waiting";
         let first_request_started = Arc::new(tokio::sync::Notify::new());

--- a/crates/health/src/collectors/sensors.rs
+++ b/crates/health/src/collectors/sensors.rs
@@ -16,6 +16,7 @@
  */
 
 use std::borrow::Cow;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -94,7 +95,10 @@ struct SensorProjection {
 pub struct SensorCollectorConfig<B: Bmc> {
     pub data_sink: Option<Arc<dyn DataSink>>,
     pub(crate) shared: SharedInventory<B>,
-    pub sensor_fetch_concurrency: usize,
+
+    /// Bounds local fan-out to the endpoint Redfish operation limit.
+    pub request_concurrency: NonZeroUsize,
+
     pub include_sensor_thresholds: bool,
 }
 
@@ -104,7 +108,7 @@ pub struct SensorCollector<B: Bmc> {
     event_context: EventContext,
     shared: SharedInventory<B>,
     data_sink: Option<Arc<dyn DataSink>>,
-    sensor_fetch_concurrency: usize,
+    request_concurrency: usize,
     include_sensor_thresholds: bool,
 }
 
@@ -122,7 +126,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
             event_context,
             shared: config.shared,
             data_sink: config.data_sink,
-            sensor_fetch_concurrency: config.sensor_fetch_concurrency.max(1),
+            request_concurrency: config.request_concurrency.get(),
             include_sensor_thresholds: config.include_sensor_thresholds,
         })
     }
@@ -202,7 +206,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
         let futures: Vec<_> = fetches.take(sensor_limit.unwrap_or(usize::MAX)).collect();
 
         let processed: usize = stream::iter(futures)
-            .buffer_unordered(self.sensor_fetch_concurrency)
+            .buffer_unordered(self.request_concurrency)
             .collect::<Vec<usize>>()
             .await
             .into_iter()
@@ -495,7 +499,6 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::*;
-    use crate::bmc::BmcClient;
     use crate::collectors::inventory::EntityInventory;
     use crate::endpoint::test_support::{mac, test_endpoint};
 
@@ -1070,39 +1073,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn fetch_concurrency_cases() {
-        check_values(
-            [
-                Check {
-                    scenario: "zero concurrency is normalized",
-                    input: 0,
-                    expect: 1,
-                },
-                Check {
-                    scenario: "configured concurrency is retained",
-                    input: 8,
-                    expect: 8,
-                },
-            ],
-            |sensor_fetch_concurrency| {
-                let endpoint = Arc::new(test_endpoint(mac("00:11:22:33:44:55")));
-                let collector = SensorCollector::<BmcClient>::new_runner(
-                    endpoint.bmc().clone(),
-                    endpoint,
-                    SensorCollectorConfig {
-                        data_sink: None,
-                        shared: Arc::new(ArcSwapOption::empty()),
-                        sensor_fetch_concurrency,
-                        include_sensor_thresholds: false,
-                    },
-                )
-                .expect("sensor collector");
-                collector.sensor_fetch_concurrency
-            },
-        );
-    }
-
     #[derive(Clone, Copy)]
     enum CollectionCase {
         MissingInventory,
@@ -1175,7 +1145,7 @@ mod tests {
             event_context: EventContext::from_endpoint(endpoint.as_ref(), "sensor_collector"),
             shared: shared.clone(),
             data_sink: Some(sink.clone()),
-            sensor_fetch_concurrency: 2,
+            request_concurrency: 2,
             include_sensor_thresholds: true,
         };
 

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -18,6 +18,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
 use std::net::{IpAddr, SocketAddr};
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -28,6 +29,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
 use crate::metrics::BmcLatencyAttribute;
+
+const DEFAULT_BMC_REQUEST_CONCURRENCY: NonZeroUsize = NonZeroUsize::MIN;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -55,6 +58,10 @@ pub struct Config {
     /// Maximum cache size per BMC, uses etags
     pub cache_size: usize,
 
+    /// Maximum concurrent Redfish operations per BMC. Changes take effect when
+    /// the service restarts and rebuilds BMC clients.
+    pub bmc_request_concurrency: NonZeroUsize,
+
     /// Interval between BMC endpoint discovery iterations.
     #[serde(with = "humantime_serde")]
     pub endpoint_discovery_interval: Duration,
@@ -76,6 +83,7 @@ impl Default for Config {
             shard: 0,
             shards_count: 1,
             cache_size: 100,
+            bmc_request_concurrency: DEFAULT_BMC_REQUEST_CONCURRENCY,
             endpoint_discovery_interval: Duration::from_secs(300),
             bmc_proxy_url: None,
         }
@@ -2351,6 +2359,7 @@ mod tests {
         assert_eq!(config.shards_count, 1);
 
         assert_eq!(config.cache_size, 100);
+        assert_eq!(config.bmc_request_concurrency.get(), 1);
         assert_eq!(config.endpoint_discovery_interval, Duration::from_secs(300));
 
         if let Configurable::Enabled(ref nvue) = config.collectors.nvue {
@@ -2378,6 +2387,7 @@ mod tests {
     fn test_static_only_config() {
         let toml_content = r#"
 endpoint_discovery_interval = "1m"
+bmc_request_concurrency = 2
 
 [[endpoint_sources.static_bmc_endpoints]]
 ip = "192.168.1.100"
@@ -2414,6 +2424,8 @@ cache_size = 50
         assert!(!config.sinks.health_report.is_enabled());
 
         assert_eq!(config.endpoint_sources.static_bmc_endpoints.len(), 1);
+        assert_eq!(config.bmc_request_concurrency.get(), 2);
+
         assert_eq!(
             config.endpoint_sources.static_bmc_endpoints[0].ip,
             "192.168.1.100".parse::<IpAddr>().unwrap()
@@ -3278,6 +3290,7 @@ reload_interval = "30s"
         assert_eq!(config.shard, 0);
         assert_eq!(config.shards_count, 1);
         assert_eq!(config.cache_size, 100);
+        assert_eq!(config.bmc_request_concurrency.get(), 1);
         assert_eq!(config.metrics.endpoint, "0.0.0.0:9009");
         assert!(!config.metrics.enable_bmc_latency_metrics);
         assert_eq!(
@@ -3298,6 +3311,16 @@ reload_interval = "30s"
         } else {
             panic!("health report sink should be enabled by default");
         }
+    }
+
+    #[test]
+    fn zero_bmc_request_concurrency_is_rejected() {
+        let result = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Toml::string("bmc_request_concurrency = 0"))
+            .extract::<Config>();
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -26,11 +26,12 @@ use figment::Figment;
 use figment::providers::{Env, Format, Serialized, Toml};
 use rustls_pki_types::DnsName;
 use serde::{Deserialize, Deserializer, Serialize};
+use tokio::sync::Semaphore;
 use url::Url;
 
 use crate::metrics::BmcLatencyAttribute;
 
-const DEFAULT_BMC_REQUEST_CONCURRENCY: NonZeroUsize = NonZeroUsize::MIN;
+const DEFAULT_BMC_REQUEST_CONCURRENCY: NonZeroUsize = NonZeroUsize::MIN.saturating_add(3);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -58,8 +59,10 @@ pub struct Config {
     /// Maximum cache size per BMC, uses etags
     pub cache_size: usize,
 
-    /// Maximum concurrent Redfish operations per BMC. Changes take effect when
-    /// the service restarts and rebuilds BMC clients.
+    /// Maximum concurrent Redfish operations per BMC, including collector
+    /// fan-out. Changes take effect when the service restarts and rebuilds BMC
+    /// clients. The value must not exceed [`Semaphore::MAX_PERMITS`], which
+    /// bounds SSE event-record buffering.
     pub bmc_request_concurrency: NonZeroUsize,
 
     /// Interval between BMC endpoint discovery iterations.
@@ -1054,6 +1057,7 @@ pub struct DiscoveryConfig {
     #[serde(with = "humantime_serde")]
     pub refresh_interval: Duration,
 
+    /// Maximum endpoints whose system identities are resolved concurrently.
     pub discovery_concurrency: usize,
 }
 
@@ -1071,15 +1075,12 @@ impl Default for DiscoveryConfig {
 pub struct MetricsCollectorConfig {
     #[serde(with = "humantime_serde")]
     pub fetch_interval: Duration,
-
-    pub fetch_concurrency: usize,
 }
 
 impl Default for MetricsCollectorConfig {
     fn default() -> Self {
         Self {
             fetch_interval: Duration::from_secs(120),
-            fetch_concurrency: 4,
         }
     }
 }
@@ -1180,9 +1181,6 @@ pub struct SensorCollectorConfig {
     #[serde(with = "humantime_serde")]
     pub sensor_fetch_interval: Duration,
 
-    /// Number of concurrent sensor fetches.
-    pub sensor_fetch_concurrency: usize,
-
     /// Include sensor thresholds in the metrics attributes.
     pub include_sensor_thresholds: bool,
 }
@@ -1191,7 +1189,6 @@ impl Default for SensorCollectorConfig {
     fn default() -> Self {
         Self {
             sensor_fetch_interval: Duration::from_secs(60),
-            sensor_fetch_concurrency: 4,
             include_sensor_thresholds: true,
         }
     }
@@ -1289,10 +1286,6 @@ pub struct SseLogConfig {
     /// Maximum retry backoff after repeated streaming connection failures.
     #[serde(with = "humantime_serde")]
     pub max_backoff: Duration,
-
-    /// Maximum number of concurrent Redfish GET requests used to fetch
-    /// `EventRecord` resources referenced by `@odata.id` in SSE notifications.
-    pub event_record_fetch_concurrency: usize,
 }
 
 impl Default for SseLogConfig {
@@ -1300,7 +1293,6 @@ impl Default for SseLogConfig {
         Self {
             initial_backoff: Duration::from_secs(1),
             max_backoff: Duration::from_secs(30),
-            event_record_fetch_concurrency: 4,
         }
     }
 }
@@ -1318,13 +1310,6 @@ impl SseLogConfig {
         if self.max_backoff < self.initial_backoff {
             return Err(
                 "[collectors.logs.sse].max_backoff must be greater than or equal to initial_backoff"
-                    .to_string(),
-            );
-        }
-
-        if self.event_record_fetch_concurrency == 0 {
-            return Err(
-                "[collectors.logs.sse].event_record_fetch_concurrency must be greater than 0"
                     .to_string(),
             );
         }
@@ -1906,6 +1891,13 @@ impl Config {
             return Err("endpoint_discovery_interval must be greater than 0".to_string());
         }
 
+        if self.bmc_request_concurrency.get() > Semaphore::MAX_PERMITS {
+            return Err(format!(
+                "bmc_request_concurrency must not exceed {}",
+                Semaphore::MAX_PERMITS
+            ));
+        }
+
         self.metrics.validate()?;
 
         if let Configurable::Enabled(rate_limit) = &self.rate_limit
@@ -2308,12 +2300,6 @@ mod tests {
         assert_eq!(reachability.timeout, Duration::from_secs(3));
         assert_eq!(reachability.log_mode, ReachabilityLogMode::Unreachable);
 
-        if let Configurable::Enabled(ref sensors) = config.collectors.sensors {
-            assert_eq!(sensors.sensor_fetch_concurrency, 10);
-        } else {
-            panic!("sensors empty")
-        }
-
         if let Configurable::Enabled(ref logs) = config.collectors.logs {
             assert_eq!(logs.mode, LogCollectionMode::Auto);
             let auto = logs.auto.as_ref().expect("example config sets [auto]");
@@ -2331,7 +2317,6 @@ mod tests {
             let sse = logs.sse_or_default();
             assert_eq!(sse.initial_backoff, Duration::from_secs(1));
             assert_eq!(sse.max_backoff, Duration::from_secs(30));
-            assert_eq!(sse.event_record_fetch_concurrency, 4);
             assert!(logs.validate().is_ok());
         } else {
             panic!("logs empty")
@@ -2359,7 +2344,7 @@ mod tests {
         assert_eq!(config.shards_count, 1);
 
         assert_eq!(config.cache_size, 100);
-        assert_eq!(config.bmc_request_concurrency.get(), 1);
+        assert_eq!(config.bmc_request_concurrency.get(), 4);
         assert_eq!(config.endpoint_discovery_interval, Duration::from_secs(300));
 
         if let Configurable::Enabled(ref nvue) = config.collectors.nvue {
@@ -2403,7 +2388,6 @@ enabled = false
 
 [collectors.sensors]
 sensor_fetch_interval = "30s"
-sensor_fetch_concurrency = 5
 include_sensor_thresholds = false
 
 [metrics]
@@ -2594,6 +2578,12 @@ username = "root"
                 Box::new(Config::default()) => Yields(()),
 
                 config_with(|config| {
+                    config.bmc_request_concurrency =
+                        NonZeroUsize::new(Semaphore::MAX_PERMITS)
+                            .expect("Tokio supports at least one semaphore permit");
+                }) => Yields(()),
+
+                config_with(|config| {
                     config.collectors.logs =
                         Configurable::Enabled(LogsCollectorConfig::default());
                 }) => Yields(()),
@@ -2637,6 +2627,15 @@ username = "root"
                 }) => FailsWith(
                     "endpoint_discovery_interval must be greater than 0".to_string()
                 ),
+
+                config_with(|config| {
+                    config.bmc_request_concurrency =
+                        NonZeroUsize::new(Semaphore::MAX_PERMITS + 1)
+                            .expect("the value above Tokio's maximum remains nonzero");
+                }) => FailsWith(format!(
+                    "bmc_request_concurrency must not exceed {}",
+                    Semaphore::MAX_PERMITS
+                )),
 
                 config_with(|config| {
                     config.metrics.enable_bmc_latency_metrics = true;
@@ -3290,7 +3289,7 @@ reload_interval = "30s"
         assert_eq!(config.shard, 0);
         assert_eq!(config.shards_count, 1);
         assert_eq!(config.cache_size, 100);
-        assert_eq!(config.bmc_request_concurrency.get(), 1);
+        assert_eq!(config.bmc_request_concurrency.get(), 4);
         assert_eq!(config.metrics.endpoint, "0.0.0.0:9009");
         assert!(!config.metrics.enable_bmc_latency_metrics);
         assert_eq!(
@@ -4453,19 +4452,8 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
                 SseLogConfig {
                     initial_backoff: Duration::from_secs(30),
                     max_backoff: Duration::from_secs(1),
-                    ..SseLogConfig::default()
                 } => FailsWith(
                     "[collectors.logs.sse].max_backoff must be greater than or equal to initial_backoff"
-                        .to_string()
-                ),
-            }
-
-            "zero event record fetch concurrency" {
-                SseLogConfig {
-                    event_record_fetch_concurrency: 0,
-                    ..SseLogConfig::default()
-                } => FailsWith(
-                    "[collectors.logs.sse].event_record_fetch_concurrency must be greater than 0"
                         .to_string()
                 ),
             }
@@ -4608,7 +4596,6 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
                     sse: Some(SseLogConfig {
                         initial_backoff: Duration::from_secs(30),
                         max_backoff: Duration::from_secs(1),
-                        ..SseLogConfig::default()
                     }),
                     ..LogsCollectorConfig::default()
                 } => FailsWith(
@@ -4664,21 +4651,18 @@ mode = "sse"
 [sse]
 initial_backoff = "2s"
 max_backoff = "1m"
-event_record_fetch_concurrency = 8
 "# => Yields(LogsConfigProjection {
                     mode: LogCollectionMode::Sse,
                     validation: Ok(()),
                     configured_sse: Some(SseLogConfig {
                         initial_backoff: Duration::from_secs(2),
                         max_backoff: Duration::from_secs(60),
-                        event_record_fetch_concurrency: 8,
                     }),
                     configured_periodic: None,
                     configured_auto: None,
                     effective_sse: SseLogConfig {
                         initial_backoff: Duration::from_secs(2),
                         max_backoff: Duration::from_secs(60),
-                        event_record_fetch_concurrency: 8,
                     },
                     effective_periodic: PeriodicLogConfig::default(),
                     effective_auto_periodic: PeriodicLogConfig::default(),
@@ -4758,14 +4742,12 @@ max_backoff = "45s"
                     configured_sse: Some(SseLogConfig {
                         initial_backoff: Duration::from_secs(3),
                         max_backoff: Duration::from_secs(45),
-                        ..SseLogConfig::default()
                     }),
                     configured_periodic: None,
                     configured_auto: None,
                     effective_sse: SseLogConfig {
                         initial_backoff: Duration::from_secs(3),
                         max_backoff: Duration::from_secs(45),
-                        ..SseLogConfig::default()
                     },
                     effective_periodic: PeriodicLogConfig::default(),
                     effective_auto_periodic: PeriodicLogConfig::default(),
@@ -4789,9 +4771,9 @@ max_backoff = "45s"
     #[test]
     fn test_sse_log_config_defaults() {
         let defaults = SseLogConfig::default();
+
         assert_eq!(defaults.initial_backoff, Duration::from_secs(1));
         assert_eq!(defaults.max_backoff, Duration::from_secs(30));
-        assert_eq!(defaults.event_record_fetch_concurrency, 4);
     }
 
     #[test]

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -17,6 +17,7 @@
 
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -262,6 +263,7 @@ pub struct DiscoveryLoopContext {
     pub(crate) discovery_iteration_histogram: Histogram,
     pub(crate) discovery_endpoint_fetch_histogram: Histogram,
     pub(crate) limiter: Arc<dyn RateLimiter>,
+    pub(crate) bmc_request_concurrency: NonZeroUsize,
     pub(crate) metrics_manager: Arc<MetricsManager>,
     pub(crate) discovery_config: DiscoveryConfig,
     pub(crate) sensors_config: Configurable<SensorCollectorOptions>,
@@ -352,6 +354,7 @@ impl DiscoveryLoopContext {
             discovery_iteration_histogram,
             discovery_endpoint_fetch_histogram,
             limiter,
+            bmc_request_concurrency: config.bmc_request_concurrency,
             metrics_manager,
             discovery_config: config.collectors.discovery.clone(),
             sensors_config: config.collectors.sensors.clone(),

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -1347,6 +1347,7 @@ mod tests {
                 Arc::new(FailingProvider),
                 None,
                 10,
+                std::num::NonZeroUsize::MIN,
                 None,
             )
             .expect("constructor succeeds"),

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -196,7 +196,7 @@ fn spawn_generic_redfish_collectors(
             bmc.clone(),
             EntityDiscoveryCollectorConfig {
                 shared,
-                discovery_concurrency: ctx.discovery_config.discovery_concurrency,
+                request_concurrency: ctx.bmc_request_concurrency,
             },
             CollectorStartContext {
                 limiter: ctx.limiter.clone(),
@@ -238,7 +238,7 @@ fn spawn_generic_redfish_collectors(
             SensorCollectorConfig {
                 data_sink: data_sink.clone(),
                 shared,
-                sensor_fetch_concurrency: sensor_cfg.sensor_fetch_concurrency,
+                request_concurrency: ctx.bmc_request_concurrency,
                 include_sensor_thresholds: sensor_cfg.include_sensor_thresholds,
             },
             CollectorStartContext {
@@ -281,7 +281,7 @@ fn spawn_generic_redfish_collectors(
             MetricsCollectorConfig {
                 data_sink: data_sink.clone(),
                 shared,
-                fetch_concurrency: metrics_cfg.fetch_concurrency,
+                request_concurrency: ctx.bmc_request_concurrency,
             },
             CollectorStartContext {
                 limiter: ctx.limiter.clone(),
@@ -397,7 +397,7 @@ fn spawn_generic_redfish_collectors(
                         bmc.clone(),
                         SseLogCollectorConfig {
                             include_diagnostics: ctx.logs_include_diagnostics,
-                            event_record_fetch_concurrency: sse_cfg.event_record_fetch_concurrency,
+                            request_concurrency: ctx.bmc_request_concurrency,
                         },
                         data_sink,
                         StreamingCollectorStartContext {
@@ -434,7 +434,7 @@ fn spawn_generic_redfish_collectors(
                         bmc.clone(),
                         SseLogCollectorConfig {
                             include_diagnostics: ctx.logs_include_diagnostics,
-                            event_record_fetch_concurrency: sse_cfg.event_record_fetch_concurrency,
+                            request_concurrency: ctx.bmc_request_concurrency,
                         },
                         data_sink,
                         StreamingCollectorStartContext {

--- a/crates/health/src/endpoint/cluster.rs
+++ b/crates/health/src/endpoint/cluster.rs
@@ -16,6 +16,7 @@
  */
 
 use std::net::IpAddr;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use carbide_uuid::rack::RackId;
@@ -295,6 +296,7 @@ pub struct ClusterEndpointSource {
     reqwest: ReqwestClient,
     proxy_url: Option<Url>,
     cache_size: usize,
+    bmc_request_concurrency: NonZeroUsize,
     bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
 }
 
@@ -306,11 +308,30 @@ impl ClusterEndpointSource {
         cache_size: usize,
         bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     ) -> Self {
+        Self::from_config_with_request_concurrency(
+            cfg,
+            reqwest,
+            proxy_url,
+            cache_size,
+            NonZeroUsize::MIN,
+            bmc_latency_metrics,
+        )
+    }
+
+    pub(crate) fn from_config_with_request_concurrency(
+        cfg: ClusterEndpointSourceConfig,
+        reqwest: &ReqwestClient,
+        proxy_url: Option<&Url>,
+        cache_size: usize,
+        bmc_request_concurrency: NonZeroUsize,
+        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
+    ) -> Self {
         Self {
             cfg,
             reqwest: reqwest.clone(),
             proxy_url: proxy_url.cloned(),
             cache_size,
+            bmc_request_concurrency,
             bmc_latency_metrics,
         }
     }
@@ -327,6 +348,7 @@ impl ClusterEndpointSource {
             &self.reqwest,
             self.proxy_url.as_ref(),
             self.cache_size,
+            self.bmc_request_concurrency,
             self.bmc_latency_metrics.clone(),
         );
         tracing::info!(endpoint_count = endpoints.len(), "Loaded cluster endpoints");
@@ -401,6 +423,7 @@ fn build_endpoints(
     reqwest: &ReqwestClient,
     proxy_url: Option<&Url>,
     cache_size: usize,
+    bmc_request_concurrency: NonZeroUsize,
     bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
 ) -> Vec<Arc<BmcEndpoint>> {
     let mut endpoints = Vec::with_capacity(nodes.len());
@@ -442,6 +465,7 @@ fn build_endpoints(
             provider,
             proxy_url.cloned(),
             cache_size,
+            bmc_request_concurrency,
             bmc_latency_instrumentation,
         ) {
             Ok(c) => Arc::new(c),

--- a/crates/health/src/endpoint/mod.rs
+++ b/crates/health/src/endpoint/mod.rs
@@ -54,8 +54,16 @@ pub(crate) mod test_support {
     ) -> BmcEndpoint {
         let provider = Arc::new(FixedCredentialProvider::new(creds));
         let bmc = Arc::new(
-            BmcClient::new(reqwest(), addr.clone(), provider, None, 10, None)
-                .expect("fixed-credential BmcClient construction is infallible"),
+            BmcClient::new(
+                reqwest(),
+                addr.clone(),
+                provider,
+                None,
+                10,
+                std::num::NonZeroUsize::MIN,
+                None,
+            )
+            .expect("fixed-credential BmcClient construction is infallible"),
         );
         BmcEndpoint {
             addr,

--- a/crates/health/src/endpoint/sources.rs
+++ b/crates/health/src/endpoint/sources.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -70,6 +71,24 @@ impl StaticEndpointSource {
         reqwest: &ReqwestClient,
         proxy_url: Option<&Url>,
         cache_size: usize,
+        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
+    ) -> Self {
+        Self::from_config_with_request_concurrency(
+            configs,
+            reqwest,
+            proxy_url,
+            cache_size,
+            NonZeroUsize::MIN,
+            bmc_latency_metrics,
+        )
+    }
+
+    pub(crate) fn from_config_with_request_concurrency(
+        configs: &[StaticBmcEndpoint],
+        reqwest: &ReqwestClient,
+        proxy_url: Option<&Url>,
+        cache_size: usize,
+        bmc_request_concurrency: NonZeroUsize,
         bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     ) -> Self {
         let mut endpoints = Vec::with_capacity(configs.len());
@@ -204,6 +223,7 @@ impl StaticEndpointSource {
                 provider,
                 proxy_url.cloned(),
                 cache_size,
+                bmc_request_concurrency,
                 bmc_latency_instrumentation,
             ) {
                 Ok(client) => Arc::new(client),

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -150,11 +150,12 @@ fn build_endpoint_wiring(
     let mut sources: Vec<Arc<dyn EndpointSource>> = Vec::new();
 
     if !config.endpoint_sources.static_bmc_endpoints.is_empty() {
-        let static_source = StaticEndpointSource::from_config(
+        let static_source = StaticEndpointSource::from_config_with_request_concurrency(
             config.endpoint_sources.static_bmc_endpoints.as_slice(),
             &reqwest,
             config.bmc_proxy_url.as_ref(),
             config.cache_size,
+            config.bmc_request_concurrency,
             bmc_latency_metrics.clone(),
         );
         sources.push(Arc::new(static_source));
@@ -167,22 +168,24 @@ fn build_endpoint_wiring(
             source_cfg.client_key.clone(),
             &source_cfg.api_url,
         ));
-        let endpoint_source = Arc::new(ApiEndpointSource::new(
+        let endpoint_source = Arc::new(ApiEndpointSource::new_with_request_concurrency(
             api_client,
             reqwest.clone(),
             config.bmc_proxy_url.clone(),
             config.cache_size,
+            config.bmc_request_concurrency,
             bmc_latency_metrics.clone(),
         ));
         sources.push(endpoint_source as Arc<dyn EndpointSource>);
     }
 
     if let Configurable::Enabled(ref source_cfg) = config.endpoint_sources.cluster {
-        let cluster_source = ClusterEndpointSource::from_config(
+        let cluster_source = ClusterEndpointSource::from_config_with_request_concurrency(
             source_cfg.clone(),
             &reqwest,
             config.bmc_proxy_url.as_ref(),
             config.cache_size,
+            config.bmc_request_concurrency,
             bmc_latency_metrics,
         );
         sources.push(Arc::new(cluster_source));

--- a/docs/architecture/redfish_workflow.md
+++ b/docs/architecture/redfish_workflow.md
@@ -239,8 +239,11 @@ Sensors (temperature, fan speed, power consumption, current draw) are collected 
 | Config Parameter | Default | Description |
 |---|---|---|
 | `sensor_fetch_interval` | 60 seconds | How often sensors are polled |
-| `sensor_fetch_concurrency` | 10 | Maximum concurrent BMC sensor queries |
 | `include_sensor_thresholds` | true | Whether to include threshold values |
+
+Sensor, entity discovery, entity metrics, and SSE event-record fetches use the
+global `bmc_request_concurrency` limit. It defaults to four concurrent Redfish
+operations per BMC.
 
 Sensor data is read from:
 ```

--- a/docs/operations/monitoring-health.md
+++ b/docs/operations/monitoring-health.md
@@ -124,17 +124,16 @@ Collector defaults from the example config:
 
 | Area | Parameter | Example value | Meaning |
 |---|---:|---|---|
+| Redfish | `bmc_request_concurrency` | `4` | Maximum number of concurrent Redfish operations per BMC. |
 | Rate limiting | `bucket_burst` | `200` | Burst size for outbound requests. |
 | Rate limiting | `bucket_replenish` | `"35ms"` | Token replenish interval. |
 | Sensor collector | `sensor_fetch_interval` | `"1m"` | Sensor polling cadence. |
 | Sensor collector | `rediscover_interval` | `"5m"` | Sensor inventory rediscovery cadence. |
 | Sensor collector | `state_refresh_interval` | `"30m"` | Broader BMC state refresh cadence. |
-| Sensor collector | `sensor_fetch_concurrency` | `10` | Concurrent sensor fetch limit. |
 | Sensor collector | `include_sensor_thresholds` | `true` | Include BMC threshold data when available. |
 | Entity discovery | `refresh_interval` | `"5m"` | Redfish entity inventory rediscovery cadence. |
-| Entity discovery | `discovery_concurrency` | `4` | Concurrent per-BMC discovery limit. |
+| Entity discovery | `discovery_concurrency` | `1` | Concurrent endpoint identity resolutions. |
 | Entity metrics collector | `fetch_interval` | `"2m"` | Entity metrics polling cadence. |
-| Entity metrics collector | `fetch_concurrency` | `4` | Concurrent per-entity metric fetch limit. |
 | Firmware collector | `firmware_refresh_interval` | `"30m"` | Firmware refresh cadence. |
 | Logs collector | `mode` | `"sse"` | Preferred BMC log collection mode. |
 | NMX-C collector | `grpc_port` | `9370` | Switch-host NMX-C gRPC endpoint port. |
@@ -204,7 +203,6 @@ section to the hardware health service config to enable it:
 ```toml
 [collectors.metrics]
 fetch_interval = "2m"     # default
-fetch_concurrency = 4     # default; parallel per-entity fetches
 ```
 
 What it collects, per entity type discovered on the BMC:


### PR DESCRIPTION
Limit concurrent Redfish calls per BMC client and endpoint so collectors sharing an endpoint do not overload the BMC. Requests to different endpoints remain independently limited. `bmc_request_concurrency` defaults to `1` and accepts a non-zero value.

Also removed redundant BMC collector-specific concurrency settings.

## Related issues

Supports #4751

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)