### PR TITLE
Fix(admin-cli): support `nvlink-info` for GB300

### DIFF
--- a/crates/admin-cli/src/machine/nvlink_info/cmd.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/cmd.rs
@@ -221,15 +221,16 @@ pub(super) async fn handle_nvlink_info_populate(
         let gpu_slot_id = gpu_json
             .get("loc")
             .and_then(|loc| {
-                loc.get("location")
-                    .and_then(|location| location.get("slot_id"))
-                    .and_then(|v| v.as_i64())
-                    .or_else(|| loc.get("slot_id").and_then(|v| v.as_i64()))
+                loc.get("slot_id").and_then(|v| v.as_i64()).or_else(|| {
+                    loc.get("location")
+                        .and_then(|location| location.get("slot_id"))
+                        .and_then(|v| v.as_i64())
+                })
             })
             .map(|v| v as i32)
             .ok_or_else(|| {
                 CarbideCliError::GenericError(
-                    "GPU entry missing loc.location.slot_id or loc.slot_id in NMX-C GPU list response"
+                    "GPU entry missing loc.slot_id or loc.location.slot_id in NMX-C GPU list response"
                         .to_string(),
                 )
             })?;

--- a/crates/admin-cli/src/machine/nvlink_info/cmd.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/cmd.rs
@@ -221,16 +221,15 @@ pub(super) async fn handle_nvlink_info_populate(
         let gpu_slot_id = gpu_json
             .get("loc")
             .and_then(|loc| {
-                loc.get("slot_id").or_else(|| {
-                    loc.get("location")
-                        .and_then(|location| location.get("slot_id"))
-                })
+                loc.get("location")
+                    .and_then(|location| location.get("slot_id"))
+                    .and_then(|v| v.as_i64())
+                    .or_else(|| loc.get("slot_id").and_then(|v| v.as_i64()))
             })
-            .and_then(|v| v.as_i64())
             .map(|v| v as i32)
             .ok_or_else(|| {
                 CarbideCliError::GenericError(
-                    "GPU entry missing loc.slot_id or loc.location.slot_id in NMX-C GPU list response"
+                    "GPU entry missing loc.location.slot_id or loc.slot_id in NMX-C GPU list response"
                         .to_string(),
                 )
             })?;

--- a/crates/admin-cli/src/machine/nvlink_info/cmd.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/cmd.rs
@@ -18,6 +18,7 @@
 use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_utils::none_if_empty::NoneIfEmpty;
+use model::hardware_info::gpu_name_indicates_mnnvl;
 
 use super::args::{NvlinkInfoArgs, NvlinkInfoPopulateArgs};
 use crate::errors::{CarbideCliError, CarbideCliResult};
@@ -30,12 +31,19 @@ pub(super) async fn handle_nvlink_info_show(
 ) -> CarbideCliResult<()> {
     let machine = api_client.get_machine(args.machine_id).await?;
 
-    // Check if this is an MNNVL machine (GB200)
+    // Check if this is an MNNVL machine (GB200|GB300)
     let is_mnnvl = machine
         .discovery_info
         .as_ref()
-        .and_then(|info| info.dmi_data.as_ref())
-        .map(|dmi| dmi.product_name.contains("GB200"))
+        .map(|info| {
+            info.dmi_data
+                .as_ref()
+                .is_some_and(|dmi| gpu_name_indicates_mnnvl(&dmi.product_name))
+                || info
+                    .gpus
+                    .iter()
+                    .any(|gpu| gpu_name_indicates_mnnvl(&gpu.name))
+        })
         .unwrap_or(false);
 
     if !is_mnnvl {
@@ -69,12 +77,19 @@ pub(super) async fn handle_nvlink_info_populate(
     let machine = api_client.get_machine(args.machine_id).await?;
     let update_db = args.update_db;
 
-    // Check if this is an MNNVL machine (GB200)
+    // Check if this is an MNNVL machine (GB200|GB300)
     let is_mnnvl = machine
         .discovery_info
         .as_ref()
-        .and_then(|info| info.dmi_data.as_ref())
-        .map(|dmi| dmi.product_name.contains("GB200"))
+        .map(|info| {
+            info.dmi_data
+                .as_ref()
+                .is_some_and(|dmi| gpu_name_indicates_mnnvl(&dmi.product_name))
+                || info
+                    .gpus
+                    .iter()
+                    .any(|gpu| gpu_name_indicates_mnnvl(&gpu.name))
+        })
         .unwrap_or(false);
 
     if !is_mnnvl {
@@ -202,14 +217,21 @@ pub(super) async fn handle_nvlink_info_populate(
                     "GPU entry missing gpu_uid in NMX-C GPU list response".to_string(),
                 )
             })?;
+
         let gpu_slot_id = gpu_json
             .get("loc")
-            .and_then(|loc| loc.get("slot_id"))
+            .and_then(|loc| {
+                loc.get("slot_id").or_else(|| {
+                    loc.get("location")
+                        .and_then(|location| location.get("slot_id"))
+                })
+            })
             .and_then(|v| v.as_i64())
             .map(|v| v as i32)
             .ok_or_else(|| {
                 CarbideCliError::GenericError(
-                    "GPU entry missing loc.slot_id in NMX-C GPU list response".to_string(),
+                    "GPU entry missing loc.slot_id or loc.location.slot_id in NMX-C GPU list response"
+                        .to_string(),
                 )
             })?;
 

--- a/crates/admin-cli/src/machine/nvlink_info/cmd.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/cmd.rs
@@ -16,13 +16,37 @@
  */
 
 use ::rpc::admin_cli::OutputFormat;
-use ::rpc::forge as forgerpc;
+use ::rpc::{Machine, forge as forgerpc};
 use carbide_utils::none_if_empty::NoneIfEmpty;
+use carbide_uuid::machine::MachineId;
 use model::hardware_info::gpu_name_indicates_mnnvl;
 
 use super::args::{NvlinkInfoArgs, NvlinkInfoPopulateArgs};
 use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
+
+/// Returns an error unless the machine's discovery info identifies MNNVL hardware (GB200|GB300|VR NVL)
+#[allow(deprecated)]
+fn ensure_mnnvl_machine(machine: &Machine, machine_id: MachineId) -> CarbideCliResult<()> {
+    let is_mnnvl = machine.discovery_info.as_ref().is_some_and(|info| {
+        info.dmi_data
+            .as_ref()
+            .is_some_and(|dmi| gpu_name_indicates_mnnvl(&dmi.product_name))
+            || info
+                .gpus
+                .iter()
+                .any(|gpu| gpu_name_indicates_mnnvl(&gpu.name))
+    });
+
+    if !is_mnnvl {
+        return Err(CarbideCliError::GenericError(format!(
+            "Machine {} is not an MNNVL machine",
+            machine_id
+        )));
+    }
+
+    Ok(())
+}
 
 #[allow(deprecated)]
 pub(super) async fn handle_nvlink_info_show(
@@ -31,27 +55,7 @@ pub(super) async fn handle_nvlink_info_show(
 ) -> CarbideCliResult<()> {
     let machine = api_client.get_machine(args.machine_id).await?;
 
-    // Check if this is an MNNVL machine (GB200|GB300)
-    let is_mnnvl = machine
-        .discovery_info
-        .as_ref()
-        .map(|info| {
-            info.dmi_data
-                .as_ref()
-                .is_some_and(|dmi| gpu_name_indicates_mnnvl(&dmi.product_name))
-                || info
-                    .gpus
-                    .iter()
-                    .any(|gpu| gpu_name_indicates_mnnvl(&gpu.name))
-        })
-        .unwrap_or(false);
-
-    if !is_mnnvl {
-        return Err(CarbideCliError::GenericError(format!(
-            "Machine {} is not an MNNVL machine",
-            args.machine_id
-        )));
-    }
+    ensure_mnnvl_machine(&machine, args.machine_id)?;
 
     match machine.nvlink_info {
         Some(nvlink_info) => {
@@ -77,27 +81,7 @@ pub(super) async fn handle_nvlink_info_populate(
     let machine = api_client.get_machine(args.machine_id).await?;
     let update_db = args.update_db;
 
-    // Check if this is an MNNVL machine (GB200|GB300)
-    let is_mnnvl = machine
-        .discovery_info
-        .as_ref()
-        .map(|info| {
-            info.dmi_data
-                .as_ref()
-                .is_some_and(|dmi| gpu_name_indicates_mnnvl(&dmi.product_name))
-                || info
-                    .gpus
-                    .iter()
-                    .any(|gpu| gpu_name_indicates_mnnvl(&gpu.name))
-        })
-        .unwrap_or(false);
-
-    if !is_mnnvl {
-        return Err(CarbideCliError::GenericError(format!(
-            "Machine {} is not an MNNVL machine",
-            args.machine_id
-        )));
-    }
+    ensure_mnnvl_machine(&machine, args.machine_id)?;
 
     let bmc_ip = machine
         .bmc_info


### PR DESCRIPTION
`machine nvlink-info show` and `machine nvlink-info populate` are part of the NVLink partitioning workflow.
Neither worked against Supermicro GB300.

Fixed two problems:

1. Both commands gated on `dmi_data.product_name` containing "GB200", so GB300
   was rejected with "Machine <id> is not an MNNVL machine". Matching that field
   alone is not enough either - on SMC GB300 it doesn't contain the "GB300"
   string, so detection now also matches on `gpu.name`.
2. `populate` read `slot_id` at `loc.slot_id` and failed with "GPU entry missing
   loc.slot_id in NMX-C GPU list response". For GB300 it lives at `loc.location.slot_id`. 

Both changes are backward compatible but tested only against GB300.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4700

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


