### PR TITLE
feat(flow): Add action execution foundation

### DIFF
--- a/rest-api/flow/internal/converter/dao/event_action_execution.go
+++ b/rest-api/flow/internal/converter/dao/event_action_execution.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dao
+
+import (
+	"fmt"
+	"time"
+
+	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+)
+
+// EventActionExecutionTo converts a domain execution to a database model.
+func EventActionExecutionTo(
+	execution *eventrule.Execution,
+) (*dbmodel.EventActionExecution, error) {
+	if err := execution.Validate(); err != nil {
+		return nil, err
+	}
+
+	var nextAttemptAt *time.Time
+	if !execution.NextAttemptAt.IsZero() {
+		next := execution.NextAttemptAt
+		nextAttemptAt = &next
+	}
+	return &dbmodel.EventActionExecution{
+		ID:             execution.ID,
+		EventID:        execution.EventID,
+		RuleID:         execution.RuleID,
+		ActionID:       execution.ActionID,
+		CorrelationKey: execution.CorrelationKey,
+		Status:         string(execution.Status),
+		Reason:         string(execution.Reason),
+		Observations:   execution.Observations,
+		Attempts:       execution.Attempts,
+		StatusMessage:  execution.StatusMessage,
+		FirstClaimedAt: execution.FirstClaimedAt,
+		UpdatedAt:      execution.UpdatedAt,
+		NextAttemptAt:  nextAttemptAt,
+	}, nil
+}
+
+// EventActionExecutionFrom converts a database model to a domain execution.
+func EventActionExecutionFrom(
+	persisted *dbmodel.EventActionExecution,
+) (*eventrule.Execution, error) {
+	if persisted == nil {
+		return nil, nil
+	}
+
+	var nextAttemptAt time.Time
+	if persisted.NextAttemptAt != nil {
+		nextAttemptAt = *persisted.NextAttemptAt
+	}
+	execution := &eventrule.Execution{
+		ExecutionState: eventrule.ExecutionState{
+			Status:        eventrule.ExecutionStatus(persisted.Status),
+			Reason:        eventrule.ExecutionReason(persisted.Reason),
+			StatusMessage: persisted.StatusMessage,
+			NextAttemptAt: nextAttemptAt,
+		},
+		ID:             persisted.ID,
+		EventID:        persisted.EventID,
+		RuleID:         persisted.RuleID,
+		ActionID:       persisted.ActionID,
+		CorrelationKey: persisted.CorrelationKey,
+		Observations:   persisted.Observations,
+		Attempts:       persisted.Attempts,
+		FirstClaimedAt: persisted.FirstClaimedAt,
+		UpdatedAt:      persisted.UpdatedAt,
+	}
+	if err := execution.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %w", eventrule.ErrInvalidPersistedExecution, err)
+	}
+	return execution, nil
+}

--- a/rest-api/flow/internal/converter/dao/event_action_execution_test.go
+++ b/rest-api/flow/internal/converter/dao/event_action_execution_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dao
+
+import (
+	"testing"
+	"time"
+
+	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventActionExecutionRoundTrip(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	base := eventrule.Execution{
+		ExecutionState: eventrule.ExecutionState{Status: eventrule.ExecutionStatusClaimed},
+		ID:             uuid.New(), EventID: uuid.New(), RuleID: uuid.New(), ActionID: "notify",
+		CorrelationKey: "incident-1", Observations: 2, Attempts: 1,
+		FirstClaimedAt: now, UpdatedAt: now.Add(time.Second),
+	}
+	tests := map[string]eventrule.Execution{
+		"claimed":   executionWithStatus(base, eventrule.ExecutionStatusClaimed),
+		"submitted": executionWithStatus(base, eventrule.ExecutionStatusSubmitted),
+		"completed": executionWithStatus(base, eventrule.ExecutionStatusCompleted),
+		"skipped": func() eventrule.Execution {
+			execution := executionWithStatus(base, eventrule.ExecutionStatusSkipped)
+			execution.Reason = eventrule.ExecutionReasonNoTargets
+			return execution
+		}(),
+		"deferred": func() eventrule.Execution {
+			execution := executionWithStatus(base, eventrule.ExecutionStatusDeferred)
+			execution.Reason = eventrule.ExecutionReasonAttemptFailed
+			execution.StatusMessage = "temporarily unavailable"
+			execution.NextAttemptAt = now.Add(time.Minute)
+			return execution
+		}(),
+		"failed": func() eventrule.Execution {
+			execution := executionWithStatus(base, eventrule.ExecutionStatusFailed)
+			execution.StatusMessage = "permanent failure"
+			return execution
+		}(),
+	}
+	completed := tests["completed"]
+	completed.StatusMessage = "action completed"
+	tests["completed"] = completed
+	for name, execution := range tests {
+		t.Run(name, func(t *testing.T) {
+			persisted, err := EventActionExecutionTo(&execution)
+			require.NoError(t, err)
+			roundTripped, err := EventActionExecutionFrom(persisted)
+			require.NoError(t, err)
+			require.Equal(t, &execution, roundTripped)
+		})
+	}
+}
+
+func TestEventActionExecutionToRejectsInvalidDomain(t *testing.T) {
+	tests := map[string]*eventrule.Execution{
+		"nil":        nil,
+		"invalid id": {ExecutionState: eventrule.ExecutionState{Status: eventrule.ExecutionStatusClaimed}},
+	}
+	for name, execution := range tests {
+		t.Run(name, func(t *testing.T) {
+			persisted, err := EventActionExecutionTo(execution)
+			require.Error(t, err)
+			require.Nil(t, persisted)
+		})
+	}
+}
+
+func TestEventActionExecutionFrom(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	valid, err := EventActionExecutionTo(&eventrule.Execution{
+		ExecutionState: eventrule.ExecutionState{Status: eventrule.ExecutionStatusClaimed},
+		ID:             uuid.New(), EventID: uuid.New(), RuleID: uuid.New(), ActionID: "notify",
+		Observations: 1, Attempts: 1,
+		FirstClaimedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		persisted *dbmodel.EventActionExecution
+		mutate    func(*dbmodel.EventActionExecution)
+		wantNil   bool
+		wantErr   string
+	}{
+		"nil": {wantNil: true},
+		"unknown status": {
+			persisted: valid,
+			mutate:    func(execution *dbmodel.EventActionExecution) { execution.Status = "unknown" },
+			wantErr:   "unknown execution status",
+		},
+		"missing action id": {
+			persisted: valid,
+			mutate:    func(execution *dbmodel.EventActionExecution) { execution.ActionID = "" },
+			wantErr:   "event rule action id is empty",
+		},
+		"deferred without next attempt": {
+			persisted: valid,
+			mutate: func(execution *dbmodel.EventActionExecution) {
+				execution.Status = string(eventrule.ExecutionStatusDeferred)
+				execution.Reason = string(eventrule.ExecutionReasonAttemptFailed)
+				execution.StatusMessage = "temporary failure"
+			},
+			wantErr: "deferred execution requires next attempt time",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var persisted *dbmodel.EventActionExecution
+			if test.persisted != nil {
+				mutated := *test.persisted
+				persisted = &mutated
+				test.mutate(persisted)
+			}
+			execution, err := EventActionExecutionFrom(persisted)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, test.wantNil, execution == nil)
+				return
+			}
+			require.ErrorIs(t, err, eventrule.ErrInvalidPersistedExecution)
+			require.ErrorContains(t, err, test.wantErr)
+			require.Nil(t, execution)
+		})
+	}
+}
+
+func executionWithStatus(
+	execution eventrule.Execution,
+	status eventrule.ExecutionStatus,
+) eventrule.Execution {
+	execution.Status = status
+	return execution
+}

--- a/rest-api/flow/internal/db/model/event_action_execution.go
+++ b/rest-api/flow/internal/db/model/event_action_execution.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+)
+
+// EventActionExecution is the bun model for the event_action_executions table.
+type EventActionExecution struct {
+	bun.BaseModel `bun:"table:event_action_executions,alias:eae"`
+
+	ID             uuid.UUID  `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	EventID        uuid.UUID  `bun:"event_id,type:uuid,notnull"`
+	RuleID         uuid.UUID  `bun:"rule_id,type:uuid,notnull"`
+	ActionID       string     `bun:"action_id,notnull"`
+	CorrelationKey string     `bun:"correlation_key,notnull"`
+	Status         string     `bun:"status,notnull"`
+	Reason         string     `bun:"reason,notnull"`
+	Observations   int        `bun:"observations,notnull"`
+	Attempts       int        `bun:"attempts,notnull"`
+	StatusMessage  string     `bun:"status_message,notnull"`
+	FirstClaimedAt time.Time  `bun:"first_claimed_at,notnull"`
+	UpdatedAt      time.Time  `bun:"updated_at,notnull"`
+	NextAttemptAt  *time.Time `bun:"next_attempt_at"`
+}

--- a/rest-api/flow/internal/eventrule/execution.go
+++ b/rest-api/flow/internal/eventrule/execution.go
@@ -1,0 +1,396 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package eventrule
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrRetryScheduled indicates that an existing execution is not yet eligible
+// to resume.
+var ErrRetryScheduled = errors.New("event action retry is scheduled")
+
+// ExecutionStatus identifies one action execution state.
+type ExecutionStatus string
+
+const (
+	ExecutionStatusClaimed   ExecutionStatus = "claimed"
+	ExecutionStatusSkipped   ExecutionStatus = "skipped"
+	ExecutionStatusDeferred  ExecutionStatus = "deferred"
+	ExecutionStatusSubmitted ExecutionStatus = "submitted"
+	ExecutionStatusCompleted ExecutionStatus = "completed"
+	ExecutionStatusFailed    ExecutionStatus = "failed"
+)
+
+// CanTransitionTo reports whether an execution with this status may transition
+// to the target status.
+func (s ExecutionStatus) CanTransitionTo(target ExecutionStatus) bool {
+	if s != ExecutionStatusClaimed {
+		return false
+	}
+	return target == ExecutionStatusSubmitted ||
+		target == ExecutionStatusCompleted ||
+		target == ExecutionStatusSkipped ||
+		target == ExecutionStatusDeferred ||
+		target == ExecutionStatusFailed
+}
+
+// ExecutionReason identifies the stable reason for an informational execution
+// outcome without expanding the status state machine.
+type ExecutionReason string
+
+const (
+	ExecutionReasonNone          ExecutionReason = ""
+	ExecutionReasonNoTargets     ExecutionReason = "no_targets"
+	ExecutionReasonAttemptFailed ExecutionReason = "attempt_failed"
+)
+
+type executionStateContract struct {
+	reasons               []ExecutionReason
+	requiresNextAttemptAt bool
+}
+
+// ExecutionState contains the status-dependent state of an execution.
+type ExecutionState struct {
+	Status        ExecutionStatus
+	Reason        ExecutionReason
+	StatusMessage string
+	NextAttemptAt time.Time
+}
+
+// Validate checks that the execution state is internally consistent.
+func (s ExecutionState) Validate() error {
+	contract, ok := executionStateContracts[s.Status]
+	if !ok {
+		return fmt.Errorf("unknown execution status %q", s.Status)
+	}
+	return contract.validate(s)
+}
+
+// ValidateTransition checks that the execution state is a valid transition
+// target. Claimed state is established by Claim and cannot be requested through
+// Transition.
+func (s ExecutionState) ValidateTransition() error {
+	if s.Status == ExecutionStatusClaimed {
+		return fmt.Errorf("cannot transition execution to claimed status")
+	}
+	return s.Validate()
+}
+
+// RetryDue reports whether a deferred execution is eligible to be claimed at
+// the given time.
+func (s ExecutionState) RetryDue(now time.Time) bool {
+	return s.Status == ExecutionStatusDeferred &&
+		!s.NextAttemptAt.IsZero() &&
+		!now.Before(s.NextAttemptAt)
+}
+
+var executionStateContracts = map[ExecutionStatus]executionStateContract{
+	ExecutionStatusClaimed: {},
+	ExecutionStatusSkipped: {
+		reasons: []ExecutionReason{ExecutionReasonNoTargets},
+	},
+	ExecutionStatusDeferred: {
+		reasons:               []ExecutionReason{ExecutionReasonAttemptFailed},
+		requiresNextAttemptAt: true,
+	},
+	ExecutionStatusSubmitted: {},
+	ExecutionStatusCompleted: {},
+	ExecutionStatusFailed:    {},
+}
+
+func (c executionStateContract) validate(state ExecutionState) error {
+	if len(c.reasons) == 0 {
+		if state.Reason != ExecutionReasonNone {
+			return fmt.Errorf(
+				"%s execution cannot have reason %q",
+				state.Status,
+				state.Reason,
+			)
+		}
+	} else if !slices.Contains(c.reasons, state.Reason) {
+		return fmt.Errorf(
+			"%s execution requires one of reasons %q",
+			state.Status,
+			c.reasons,
+		)
+	}
+	if c.requiresNextAttemptAt {
+		if state.NextAttemptAt.IsZero() {
+			return fmt.Errorf("%s execution requires next attempt time", state.Status)
+		}
+	} else {
+		if !state.NextAttemptAt.IsZero() {
+			return fmt.Errorf("%s execution cannot have next attempt time", state.Status)
+		}
+	}
+
+	return validateOptionalString("execution status message", state.StatusMessage)
+}
+
+// Execution records the durable processing state for one rule action.
+type Execution struct {
+	ExecutionState
+	ID             uuid.UUID
+	EventID        uuid.UUID
+	RuleID         uuid.UUID
+	ActionID       string
+	CorrelationKey string
+	Observations   int
+	Attempts       int
+	FirstClaimedAt time.Time
+	UpdatedAt      time.Time
+}
+
+// IsOwned reports whether the current execution attempt is owned for
+// processing.
+//
+// TODO: Treating every claimed execution as owned is sufficient for the current
+// single-process in-memory store, which does not need to distinguish competing
+// workers. When the database-backed store is introduced, extend ownership with
+// a claim token and lease expiration, and apply the same fencing semantics to
+// the in-memory store so both implementations satisfy one store contract.
+func (e Execution) IsOwned() bool {
+	return e.Status == ExecutionStatusClaimed
+}
+
+func (e *Execution) recordObservation(now time.Time) {
+	e.Observations++
+	e.UpdatedAt = now
+}
+
+// TryDeduplicate reports whether an observation is within the deduplication
+// window and records it when it is.
+func (e *Execution) TryDeduplicate(dedupe *Dedupe, observedAt time.Time) bool {
+	if dedupe == nil ||
+		!dedupe.WithinWindow(e.FirstClaimedAt, observedAt) {
+		return false
+	}
+
+	e.recordObservation(observedAt)
+
+	return true
+}
+
+// TryClaim records another observation and attempts to acquire an existing
+// execution. It returns the execution only when a due deferred execution is
+// reclaimed, and returns an error when the receiver is nil. ErrRetryScheduled
+// indicates that a deferred execution is not yet due.
+func (e *Execution) TryClaim(now time.Time) (*Execution, error) {
+	if e == nil {
+		return nil, fmt.Errorf("event action execution is nil")
+	}
+
+	e.recordObservation(now)
+
+	if !e.IsOwned() && e.ExecutionState.RetryDue(now) {
+		e.ExecutionState = ExecutionState{Status: ExecutionStatusClaimed}
+		e.Attempts++
+		return e, nil
+	}
+
+	if e.Status == ExecutionStatusDeferred {
+		return nil, fmt.Errorf("%w for %s", ErrRetryScheduled, e.NextAttemptAt)
+	}
+
+	return nil, nil
+}
+
+// TransitionTo validates and applies an execution state transition at the
+// given time.
+func (e *Execution) TransitionTo(state ExecutionState, now time.Time) error {
+	if e == nil {
+		return fmt.Errorf("event action execution is nil")
+	}
+	if !e.IsOwned() {
+		return fmt.Errorf("execution %s is not owned", e.ID)
+	}
+	if err := state.ValidateTransition(); err != nil {
+		return err
+	}
+	if !e.Status.CanTransitionTo(state.Status) {
+		return fmt.Errorf(
+			"execution %s cannot transition from %q to %q",
+			e.ID,
+			e.Status,
+			state.Status,
+		)
+	}
+	if now.IsZero() {
+		return fmt.Errorf("execution transition time is required")
+	}
+	if now.Before(e.FirstClaimedAt) {
+		return fmt.Errorf("execution transition time cannot precede first claimed time")
+	}
+
+	e.ExecutionState = state
+	e.UpdatedAt = now
+	return nil
+}
+
+// Validate checks the durable execution aggregate.
+func (e *Execution) Validate() error {
+	if e == nil {
+		return fmt.Errorf("event action execution is nil")
+	}
+	if e.ID == uuid.Nil {
+		return fmt.Errorf("event action execution id is required")
+	}
+	if e.EventID == uuid.Nil {
+		return fmt.Errorf("event id is required")
+	}
+	if e.RuleID == uuid.Nil {
+		return fmt.Errorf("event rule id is required")
+	}
+	if err := validateRequiredString("event rule action id", e.ActionID); err != nil {
+		return err
+	}
+	if e.Observations <= 0 {
+		return fmt.Errorf("execution observations must be positive")
+	}
+	if e.Attempts <= 0 {
+		return fmt.Errorf("execution attempts must be positive")
+	}
+	if e.FirstClaimedAt.IsZero() {
+		return fmt.Errorf("execution first claimed time is required")
+	}
+	if e.UpdatedAt.IsZero() {
+		return fmt.Errorf("execution updated time is required")
+	}
+	if e.UpdatedAt.Before(e.FirstClaimedAt) {
+		return fmt.Errorf("execution updated time cannot precede first claimed time")
+	}
+
+	return e.ExecutionState.Validate()
+}
+
+// ExecutionClaim identifies one delivery and optional semantic dedupe claim.
+type ExecutionClaim struct {
+	EventID        uuid.UUID
+	RuleID         uuid.UUID
+	ActionID       string
+	CorrelationKey string
+	Dedupe         *Dedupe
+	Now            time.Time
+}
+
+// ExecutionDeliveryKey identifies one rule action for one delivered event.
+type ExecutionDeliveryKey struct {
+	EventID  uuid.UUID
+	RuleID   uuid.UUID
+	ActionID string
+}
+
+// ExecutionSemanticKey identifies one correlated rule action independently of
+// an individual event delivery.
+type ExecutionSemanticKey struct {
+	RuleID         uuid.UUID
+	ActionID       string
+	CorrelationKey string
+}
+
+// DeliveryKey returns the delivery identity represented by the claim.
+func (c ExecutionClaim) DeliveryKey() ExecutionDeliveryKey {
+	return ExecutionDeliveryKey{
+		EventID:  c.EventID,
+		RuleID:   c.RuleID,
+		ActionID: c.ActionID,
+	}
+}
+
+// SemanticKey returns the semantic deduplication identity represented by the
+// claim.
+func (c ExecutionClaim) SemanticKey() ExecutionSemanticKey {
+	return ExecutionSemanticKey{
+		RuleID:         c.RuleID,
+		ActionID:       c.ActionID,
+		CorrelationKey: c.CorrelationKey,
+	}
+}
+
+// NewExecution validates the claim and constructs its initial execution.
+func (c ExecutionClaim) NewExecution() (*Execution, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	return c.NewExecutionUnchecked(), nil
+}
+
+// NewExecutionUnchecked constructs the initial execution without validating
+// the claim. Callers must validate the claim before calling this method.
+func (c ExecutionClaim) NewExecutionUnchecked() *Execution {
+	return &Execution{
+		ExecutionState: ExecutionState{
+			Status: ExecutionStatusClaimed,
+		},
+		ID:             uuid.New(),
+		EventID:        c.EventID,
+		RuleID:         c.RuleID,
+		ActionID:       c.ActionID,
+		CorrelationKey: c.CorrelationKey,
+		Observations:   1,
+		Attempts:       1,
+		FirstClaimedAt: c.Now,
+		UpdatedAt:      c.Now,
+	}
+}
+
+// Validate checks the delivery identity and optional semantic-deduplication
+// fields of an execution claim.
+func (c ExecutionClaim) Validate() error {
+	if c.EventID == uuid.Nil {
+		return fmt.Errorf("event id is required")
+	}
+	if c.RuleID == uuid.Nil {
+		return fmt.Errorf("event rule id is required")
+	}
+	if err := validateRequiredString("event rule action id", c.ActionID); err != nil {
+		return err
+	}
+	if c.Now.IsZero() {
+		return fmt.Errorf("execution claim time is required")
+	}
+	if c.Dedupe != nil {
+		if err := c.Dedupe.Validate(); err != nil {
+			return fmt.Errorf("execution claim dedupe: %w", err)
+		}
+	}
+	if c.Dedupe != nil && c.CorrelationKey == "" {
+		return fmt.Errorf(
+			"correlation key is required by rule %s dedupe policy",
+			c.RuleID,
+		)
+	}
+	return nil
+}
+
+// NewExecutionClaim derives the delivery and optional semantic-deduplication
+// identity for one rule action.
+func NewExecutionClaim(
+	envelope Envelope,
+	rule Rule,
+	actionID string,
+	now time.Time,
+) (ExecutionClaim, error) {
+	claim := ExecutionClaim{
+		EventID:        envelope.ID,
+		RuleID:         rule.ID,
+		ActionID:       actionID,
+		CorrelationKey: envelope.CorrelationKey,
+		Dedupe:         rule.Dedupe.Clone(),
+		Now:            now,
+	}
+
+	if err := claim.Validate(); err != nil {
+		return ExecutionClaim{}, err
+	}
+
+	return claim, nil
+}

--- a/rest-api/flow/internal/eventrule/execution_test.go
+++ b/rest-api/flow/internal/eventrule/execution_test.go
@@ -1,0 +1,785 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package eventrule
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecution_Validate(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	valid := Execution{
+		ExecutionState: ExecutionState{Status: ExecutionStatusClaimed},
+		ID:             uuid.New(), EventID: uuid.New(), RuleID: uuid.New(), ActionID: "notify",
+		Observations: 1, Attempts: 1,
+		FirstClaimedAt: now, UpdatedAt: now,
+	}
+	tests := map[string]struct {
+		execution *Execution
+		mutate    func(*Execution)
+		wantErr   string
+	}{
+		"valid claimed": {execution: &valid},
+		"nil":           {wantErr: "event action execution is nil"},
+		"claimed with status message": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.StatusMessage = "unexpected" },
+		},
+		"missing id": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.ID = uuid.Nil },
+			wantErr:   "event action execution id is required",
+		},
+		"missing event id": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.EventID = uuid.Nil },
+			wantErr:   "event id is required",
+		},
+		"missing rule id": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.RuleID = uuid.Nil },
+			wantErr:   "event rule id is required",
+		},
+		"missing action id": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.ActionID = "" },
+			wantErr:   "event rule action id is empty",
+		},
+		"zero observations": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.Observations = 0 },
+			wantErr:   "execution observations must be positive",
+		},
+		"zero attempts": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.Attempts = 0 },
+			wantErr:   "execution attempts must be positive",
+		},
+		"missing first claimed time": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.FirstClaimedAt = time.Time{} },
+			wantErr:   "execution first claimed time is required",
+		},
+		"missing updated time": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.UpdatedAt = time.Time{} },
+			wantErr:   "execution updated time is required",
+		},
+		"updated before first claim": {
+			execution: &valid,
+			mutate: func(execution *Execution) {
+				execution.UpdatedAt = execution.FirstClaimedAt.Add(-time.Second)
+			},
+			wantErr: "execution updated time cannot precede first claimed time",
+		},
+		"skipped without reason": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.Status = ExecutionStatusSkipped },
+			wantErr:   "skipped execution requires one of reasons",
+		},
+		"deferred without status message": {
+			execution: &valid,
+			mutate: func(execution *Execution) {
+				execution.Status = ExecutionStatusDeferred
+				execution.Reason = ExecutionReasonAttemptFailed
+				execution.NextAttemptAt = now.Add(time.Minute)
+			},
+		},
+		"failed without status message": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.Status = ExecutionStatusFailed },
+		},
+		"unknown status": {
+			execution: &valid,
+			mutate:    func(execution *Execution) { execution.Status = "unknown" },
+			wantErr:   "unknown execution status",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var execution *Execution
+			if test.execution != nil {
+				mutated := *test.execution
+				execution = &mutated
+				if test.mutate != nil {
+					test.mutate(execution)
+				}
+			}
+			err := execution.Validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestExecution_IsOwned(t *testing.T) {
+	tests := map[string]struct {
+		status ExecutionStatus
+		want   bool
+	}{
+		"claimed": {
+			status: ExecutionStatusClaimed,
+			want:   true,
+		},
+		"deferred": {
+			status: ExecutionStatusDeferred,
+		},
+		"completed": {
+			status: ExecutionStatusCompleted,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			execution := Execution{
+				ExecutionState: ExecutionState{Status: test.status},
+			}
+			require.Equal(t, test.want, execution.IsOwned())
+		})
+	}
+}
+
+func TestExecutionState_ValidateTransition(t *testing.T) {
+	tests := map[string]struct {
+		state   ExecutionState
+		wantErr string
+	}{
+		"completed": {
+			state: ExecutionState{Status: ExecutionStatusCompleted},
+		},
+		"claimed": {
+			state:   ExecutionState{Status: ExecutionStatusClaimed},
+			wantErr: "cannot transition execution to claimed status",
+		},
+		"invalid state": {
+			state:   ExecutionState{Status: ExecutionStatusSkipped},
+			wantErr: "skipped execution requires one of reasons",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.state.ValidateTransition()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestExecutionStatus_CanTransitionTo(t *testing.T) {
+	tests := map[string]struct {
+		from ExecutionStatus
+		to   ExecutionStatus
+		want bool
+	}{
+		"claimed to submitted": {
+			from: ExecutionStatusClaimed,
+			to:   ExecutionStatusSubmitted,
+			want: true,
+		},
+		"claimed to completed": {
+			from: ExecutionStatusClaimed,
+			to:   ExecutionStatusCompleted,
+			want: true,
+		},
+		"claimed to skipped": {
+			from: ExecutionStatusClaimed,
+			to:   ExecutionStatusSkipped,
+			want: true,
+		},
+		"claimed to deferred": {
+			from: ExecutionStatusClaimed,
+			to:   ExecutionStatusDeferred,
+			want: true,
+		},
+		"claimed to failed": {
+			from: ExecutionStatusClaimed,
+			to:   ExecutionStatusFailed,
+			want: true,
+		},
+		"claimed to claimed": {
+			from: ExecutionStatusClaimed,
+			to:   ExecutionStatusClaimed,
+		},
+		"completed to claimed": {
+			from: ExecutionStatusCompleted,
+			to:   ExecutionStatusClaimed,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, test.from.CanTransitionTo(test.to))
+		})
+	}
+}
+
+func TestExecution_TransitionTo(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	zero := time.Time{}
+	beforeFirstClaim := now.Add(-time.Second)
+	tests := map[string]struct {
+		execution  *Execution
+		state      ExecutionState
+		transition *time.Time
+		wantErr    string
+	}{
+		"completed": {
+			execution: &Execution{
+				ID:             uuid.New(),
+				ExecutionState: ExecutionState{Status: ExecutionStatusClaimed},
+			},
+			state: ExecutionState{Status: ExecutionStatusCompleted},
+		},
+		"invalid target state": {
+			execution: &Execution{
+				ID:             uuid.New(),
+				ExecutionState: ExecutionState{Status: ExecutionStatusClaimed},
+			},
+			state:   ExecutionState{Status: ExecutionStatusSkipped},
+			wantErr: "skipped execution requires one of reasons",
+		},
+		"missing transition time": {
+			execution: &Execution{
+				ID:             uuid.New(),
+				ExecutionState: ExecutionState{Status: ExecutionStatusClaimed},
+			},
+			state:      ExecutionState{Status: ExecutionStatusCompleted},
+			transition: &zero,
+			wantErr:    "execution transition time is required",
+		},
+		"transition before first claim": {
+			execution: &Execution{
+				ID:             uuid.New(),
+				ExecutionState: ExecutionState{Status: ExecutionStatusClaimed},
+				FirstClaimedAt: now,
+			},
+			state:      ExecutionState{Status: ExecutionStatusCompleted},
+			transition: &beforeFirstClaim,
+			wantErr:    "execution transition time cannot precede first claimed time",
+		},
+		"target with stale next attempt": {
+			execution: &Execution{
+				ID:             uuid.New(),
+				ExecutionState: ExecutionState{Status: ExecutionStatusClaimed},
+			},
+			state: ExecutionState{
+				Status:        ExecutionStatusCompleted,
+				NextAttemptAt: now.Add(time.Minute),
+			},
+			wantErr: "completed execution cannot have next attempt time",
+		},
+		"not owned": {
+			execution: &Execution{
+				ID:             uuid.New(),
+				ExecutionState: ExecutionState{Status: ExecutionStatusCompleted},
+			},
+			state:   ExecutionState{Status: ExecutionStatusFailed},
+			wantErr: "is not owned",
+		},
+		"not owned with invalid target": {
+			execution: &Execution{
+				ID:             uuid.New(),
+				ExecutionState: ExecutionState{Status: ExecutionStatusCompleted},
+			},
+			state:   ExecutionState{Status: ExecutionStatusClaimed},
+			wantErr: "is not owned",
+		},
+		"nil execution": {
+			state:   ExecutionState{Status: ExecutionStatusCompleted},
+			wantErr: "event action execution is nil",
+		},
+		"nil execution with invalid target": {
+			state:   ExecutionState{Status: ExecutionStatusClaimed},
+			wantErr: "event action execution is nil",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			transitionAt := now
+			if test.transition != nil {
+				transitionAt = *test.transition
+			}
+			err := test.execution.TransitionTo(test.state, transitionAt)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.state, test.execution.ExecutionState)
+			require.Equal(t, transitionAt, test.execution.UpdatedAt)
+		})
+	}
+}
+
+func TestExecution_TryClaim(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	nextAttemptAt := now.Add(time.Minute)
+	tests := map[string]struct {
+		execution     *Execution
+		now           time.Time
+		wantExecution bool
+		wantErr       error
+	}{
+		"due deferred execution": {
+			execution: &Execution{
+				ExecutionState: ExecutionState{
+					Status:        ExecutionStatusDeferred,
+					Reason:        ExecutionReasonAttemptFailed,
+					NextAttemptAt: nextAttemptAt,
+				},
+				Observations: 1,
+				Attempts:     1,
+			},
+			now:           nextAttemptAt,
+			wantExecution: true,
+		},
+		"deferred execution not due": {
+			execution: &Execution{
+				ExecutionState: ExecutionState{
+					Status:        ExecutionStatusDeferred,
+					Reason:        ExecutionReasonAttemptFailed,
+					NextAttemptAt: nextAttemptAt,
+				},
+				Observations: 1,
+				Attempts:     1,
+			},
+			now:     now,
+			wantErr: ErrRetryScheduled,
+		},
+		"existing claimed execution": {
+			execution: &Execution{
+				ExecutionState: ExecutionState{Status: ExecutionStatusClaimed},
+				Observations:   1,
+				Attempts:       1,
+			},
+			now: now,
+		},
+		"nil execution": {
+			now:     now,
+			wantErr: errors.New("event action execution is nil"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := test.execution.TryClaim(test.now)
+			if test.wantExecution {
+				require.Same(t, test.execution, result)
+			} else {
+				require.Nil(t, result)
+			}
+			if test.wantErr != nil {
+				require.ErrorContains(t, err, test.wantErr.Error())
+				if errors.Is(test.wantErr, ErrRetryScheduled) {
+					require.ErrorIs(t, err, ErrRetryScheduled)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			if test.execution == nil {
+				return
+			}
+			require.Equal(t, 2, test.execution.Observations)
+			require.Equal(t, test.now, test.execution.UpdatedAt)
+			if test.wantExecution {
+				require.Equal(t, ExecutionStatusClaimed, test.execution.Status)
+				require.Equal(t, 2, test.execution.Attempts)
+			}
+		})
+	}
+}
+
+func TestExecution_TryDeduplicate(t *testing.T) {
+	firstClaimedAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	tests := map[string]struct {
+		dedupe     *Dedupe
+		observedAt time.Time
+		want       bool
+	}{
+		"nil deduplication policy": {
+			observedAt: firstClaimedAt.Add(time.Second),
+		},
+		"within window": {
+			dedupe:     &Dedupe{Window: time.Minute},
+			observedAt: firstClaimedAt.Add(time.Second),
+			want:       true,
+		},
+		"at window boundary": {
+			dedupe:     &Dedupe{Window: time.Minute},
+			observedAt: firstClaimedAt.Add(time.Minute),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			execution := Execution{
+				FirstClaimedAt: firstClaimedAt,
+				UpdatedAt:      firstClaimedAt,
+				Observations:   1,
+			}
+
+			require.Equal(
+				t,
+				test.want,
+				execution.TryDeduplicate(test.dedupe, test.observedAt),
+			)
+			if test.want {
+				require.Equal(t, 2, execution.Observations)
+				require.Equal(t, test.observedAt, execution.UpdatedAt)
+				return
+			}
+			require.Equal(t, 1, execution.Observations)
+			require.Equal(t, firstClaimedAt, execution.UpdatedAt)
+		})
+	}
+}
+
+func TestNewExecutionClaim(t *testing.T) {
+	eventID := uuid.New()
+	ruleID := uuid.New()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	tests := map[string]struct {
+		envelope    Envelope
+		rule        Rule
+		actionID    string
+		now         time.Time
+		want        ExecutionClaim
+		wantMessage string
+	}{
+		"delivery identity without semantic dedupe": {
+			envelope: Envelope{ID: eventID, CorrelationKey: "unused"},
+			rule:     Rule{ID: ruleID},
+			actionID: "notify",
+			now:      now,
+			want: ExecutionClaim{
+				EventID:        eventID,
+				RuleID:         ruleID,
+				ActionID:       "notify",
+				CorrelationKey: "unused",
+				Now:            now,
+			},
+		},
+		"semantic dedupe identity": {
+			envelope: Envelope{ID: eventID, CorrelationKey: "incident-1"},
+			rule: Rule{
+				ID:     ruleID,
+				Policy: Policy{Dedupe: &Dedupe{Window: time.Minute}},
+			},
+			actionID: "notify",
+			now:      now,
+			want: ExecutionClaim{
+				EventID:        eventID,
+				RuleID:         ruleID,
+				ActionID:       "notify",
+				CorrelationKey: "incident-1",
+				Dedupe:         &Dedupe{Window: time.Minute},
+				Now:            now,
+			},
+		},
+		"missing event id": {
+			rule:        Rule{ID: ruleID},
+			actionID:    "notify",
+			now:         now,
+			wantMessage: "event id is required",
+		},
+		"missing rule id": {
+			envelope:    Envelope{ID: eventID},
+			actionID:    "notify",
+			now:         now,
+			wantMessage: "event rule id is required",
+		},
+		"missing action id": {
+			envelope:    Envelope{ID: eventID},
+			rule:        Rule{ID: ruleID},
+			now:         now,
+			wantMessage: "event rule action id is empty",
+		},
+		"missing claim time": {
+			envelope:    Envelope{ID: eventID},
+			rule:        Rule{ID: ruleID},
+			actionID:    "notify",
+			wantMessage: "execution claim time is required",
+		},
+		"dedupe requires correlation key": {
+			envelope: Envelope{ID: eventID},
+			rule: Rule{
+				ID:     ruleID,
+				Policy: Policy{Dedupe: &Dedupe{Window: time.Minute}},
+			},
+			actionID:    "notify",
+			now:         now,
+			wantMessage: "correlation key is required",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			claim, err := NewExecutionClaim(
+				test.envelope,
+				test.rule,
+				test.actionID,
+				test.now,
+			)
+			if test.wantMessage != "" {
+				require.ErrorContains(t, err, test.wantMessage)
+				require.Equal(t, ExecutionClaim{}, claim)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, claim)
+		})
+	}
+}
+
+func TestExecutionClaim_Validate(t *testing.T) {
+	valid := ExecutionClaim{
+		EventID:  uuid.New(),
+		RuleID:   uuid.New(),
+		ActionID: "notify",
+		Now:      time.Now(),
+	}
+	tests := map[string]struct {
+		mutate  func(*ExecutionClaim)
+		wantErr string
+	}{
+		"valid delivery claim": {},
+		"valid semantic dedupe claim": {
+			mutate: func(claim *ExecutionClaim) {
+				claim.CorrelationKey = "incident-1"
+				claim.Dedupe = &Dedupe{Window: time.Minute}
+			},
+		},
+		"negative dedupe window": {
+			mutate:  func(claim *ExecutionClaim) { claim.Dedupe = &Dedupe{Window: -time.Second} },
+			wantErr: "dedupe window must be positive",
+		},
+		"dedupe without correlation key": {
+			mutate:  func(claim *ExecutionClaim) { claim.Dedupe = &Dedupe{Window: time.Minute} },
+			wantErr: "correlation key is required",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			claim := valid
+			if test.mutate != nil {
+				test.mutate(&claim)
+			}
+			err := claim.Validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestExecutionClaim_DeliveryKey(t *testing.T) {
+	claim := ExecutionClaim{
+		EventID:  uuid.New(),
+		RuleID:   uuid.New(),
+		ActionID: "notify",
+	}
+	require.Equal(t, ExecutionDeliveryKey{
+		EventID:  claim.EventID,
+		RuleID:   claim.RuleID,
+		ActionID: claim.ActionID,
+	}, claim.DeliveryKey())
+}
+
+func TestExecutionClaim_SemanticKey(t *testing.T) {
+	claim := ExecutionClaim{
+		RuleID:         uuid.New(),
+		ActionID:       "notify",
+		CorrelationKey: "incident-1",
+	}
+
+	require.Equal(t, ExecutionSemanticKey{
+		RuleID:         claim.RuleID,
+		ActionID:       claim.ActionID,
+		CorrelationKey: claim.CorrelationKey,
+	}, claim.SemanticKey())
+}
+
+func TestExecutionClaim_NewExecution(t *testing.T) {
+	t.Run("invalid claim", func(t *testing.T) {
+		invalid, err := (ExecutionClaim{}).NewExecution()
+		require.Error(t, err)
+		require.Nil(t, invalid)
+	})
+
+	t.Run("valid claim", func(t *testing.T) {
+		now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+		claim := ExecutionClaim{
+			EventID:        uuid.New(),
+			RuleID:         uuid.New(),
+			ActionID:       "notify",
+			CorrelationKey: "incident-1",
+			Now:            now,
+		}
+
+		execution, err := claim.NewExecution()
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, execution.ID)
+		require.Equal(t, claim.EventID, execution.EventID)
+		require.Equal(t, claim.RuleID, execution.RuleID)
+		require.Equal(t, claim.ActionID, execution.ActionID)
+		require.Equal(t, claim.CorrelationKey, execution.CorrelationKey)
+		require.Equal(t, ExecutionStatusClaimed, execution.Status)
+		require.Equal(t, 1, execution.Observations)
+		require.Equal(t, 1, execution.Attempts)
+		require.Equal(t, now, execution.FirstClaimedAt)
+		require.Equal(t, now, execution.UpdatedAt)
+		require.NoError(t, execution.Validate())
+	})
+}
+
+func TestExecutionState_Validate(t *testing.T) {
+	nextAttemptAt := time.Now().Add(time.Minute)
+	tests := map[string]struct {
+		state   ExecutionState
+		wantErr string
+	}{
+		"skipped": {
+			state: ExecutionState{
+				Status: ExecutionStatusSkipped,
+				Reason: ExecutionReasonNoTargets,
+			},
+		},
+		"deferred": {
+			state: ExecutionState{
+				Status:        ExecutionStatusDeferred,
+				Reason:        ExecutionReasonAttemptFailed,
+				StatusMessage: "inventory unavailable",
+				NextAttemptAt: nextAttemptAt,
+			},
+		},
+		"submitted": {
+			state: ExecutionState{Status: ExecutionStatusSubmitted},
+		},
+		"completed": {
+			state: ExecutionState{
+				Status:        ExecutionStatusCompleted,
+				StatusMessage: "action completed",
+			},
+		},
+		"failed": {
+			state: ExecutionState{
+				Status:        ExecutionStatusFailed,
+				StatusMessage: "invalid target",
+			},
+		},
+		"unknown status": {
+			state:   ExecutionState{Status: "unknown"},
+			wantErr: "unknown execution status",
+		},
+		"skipped without reason": {
+			state:   ExecutionState{Status: ExecutionStatusSkipped},
+			wantErr: "skipped execution requires one of reasons",
+		},
+		"deferred without next attempt": {
+			state: ExecutionState{
+				Status:        ExecutionStatusDeferred,
+				Reason:        ExecutionReasonAttemptFailed,
+				StatusMessage: "inventory unavailable",
+			},
+			wantErr: "deferred execution requires next attempt time",
+		},
+		"completed with next attempt": {
+			state: ExecutionState{
+				Status:        ExecutionStatusCompleted,
+				NextAttemptAt: nextAttemptAt,
+			},
+			wantErr: "completed execution cannot have next attempt time",
+		},
+		"submitted with next attempt": {
+			state: ExecutionState{
+				Status:        ExecutionStatusSubmitted,
+				NextAttemptAt: nextAttemptAt,
+			},
+			wantErr: "submitted execution cannot have next attempt time",
+		},
+		"failed with next attempt": {
+			state: ExecutionState{
+				Status:        ExecutionStatusFailed,
+				NextAttemptAt: nextAttemptAt,
+			},
+			wantErr: "failed execution cannot have next attempt time",
+		},
+		"failed without status message": {
+			state: ExecutionState{Status: ExecutionStatusFailed},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.state.Validate()
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestExecutionState_RetryDue(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	tests := map[string]struct {
+		state ExecutionState
+		want  bool
+	}{
+		"deferred before retry time": {
+			state: ExecutionState{
+				Status:        ExecutionStatusDeferred,
+				NextAttemptAt: now.Add(time.Second),
+			},
+		},
+		"deferred at retry time": {
+			state: ExecutionState{
+				Status:        ExecutionStatusDeferred,
+				NextAttemptAt: now,
+			},
+			want: true,
+		},
+		"deferred after retry time": {
+			state: ExecutionState{
+				Status:        ExecutionStatusDeferred,
+				NextAttemptAt: now.Add(-time.Second),
+			},
+			want: true,
+		},
+		"deferred without retry time": {
+			state: ExecutionState{Status: ExecutionStatusDeferred},
+		},
+		"completed": {
+			state: ExecutionState{
+				Status:        ExecutionStatusCompleted,
+				NextAttemptAt: now,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, test.state.RetryDue(now))
+		})
+	}
+}

--- a/rest-api/flow/internal/eventrule/executor/executor.go
+++ b/rest-api/flow/internal/eventrule/executor/executor.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package executor defines the action-execution boundary used by the event
+// processor and implemented by concrete action dispatchers.
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+)
+
+// Target identifies one canonical target for an action.
+type Target struct {
+	Kind eventrule.ResourceKind
+	ID   uuid.UUID
+}
+
+// Validate checks that the target has a supported kind and canonical identity.
+func (t Target) Validate() error {
+	if err := t.Kind.Validate(); err != nil {
+		return err
+	}
+	if t.ID == uuid.Nil {
+		return fmt.Errorf("target id is required")
+	}
+	return nil
+}
+
+// PrepareRequest contains the normalized inputs needed to prepare one action
+// execution.
+type PrepareRequest struct {
+	Execution eventrule.Execution
+	Envelope  eventrule.Envelope
+	Resource  eventrule.ResolvedResource
+	Action    eventrule.Action
+}
+
+// TargetRequest contains the event and task information needed to resolve
+// concrete targets.
+type TargetRequest struct {
+	EventType eventrule.Type
+	Payload   json.RawMessage
+	Resource  eventrule.ResolvedResource
+	Task      eventrule.SubmitTask
+}
+
+// TargetResolver resolves concrete targets for a task action.
+type TargetResolver interface {
+	ResolveTargets(context.Context, TargetRequest) ([]Target, error)
+}
+
+// ExecutionRequest contains an execution and its prepared action inputs.
+type ExecutionRequest struct {
+	Execution eventrule.Execution
+	Action    eventrule.Action
+	Targets   []Target
+}
+
+// Validate checks the execution and action inputs.
+func (r ExecutionRequest) Validate() error {
+	if err := r.Execution.Validate(); err != nil {
+		return fmt.Errorf("execution: %w", err)
+	}
+	if err := r.Action.Validate(); err != nil {
+		return fmt.Errorf("action: %w", err)
+	}
+	for i, target := range r.Targets {
+		if err := target.Validate(); err != nil {
+			return fmt.Errorf("target %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// PreparationResult contains either a request ready for execution or an outcome
+// that completes preparation without execution. Exactly one field is non-nil.
+type PreparationResult struct {
+	Request *ExecutionRequest
+	Outcome *eventrule.ExecutionState
+}
+
+// Validate checks that preparation produced exactly one next step.
+func (p PreparationResult) Validate() error {
+	if (p.Request == nil) == (p.Outcome == nil) {
+		return fmt.Errorf("executor preparation requires exactly one request or outcome")
+	}
+
+	if p.Outcome != nil {
+		return p.Outcome.ValidateTransition()
+	}
+
+	return p.Request.Validate()
+}
+
+// Executor owns action-specific preparation and execution outcome decisions.
+type Executor interface {
+	// Prepare returns a valid result and a nil error. Operational results,
+	// including skipped, deferred, and failed states, are represented by
+	// PreparationResult. A non-nil error means that no valid result was
+	// produced and indicates an executor contract failure.
+	Prepare(context.Context, PrepareRequest) (PreparationResult, error)
+	// Execute may be called multiple times for the same Execution.ID after a
+	// deferred outcome. Implementations that produce external side effects must
+	// use Execution.ID, or stable keys derived from it for partitioned work, to
+	// make repeated calls idempotent and reconcile an ambiguous prior result
+	// before submitting again. Attempts and rotating ownership tokens must not
+	// be used as downstream idempotency identities. Execute returns a valid
+	// outcome and a nil error. Operational failures are represented by deferred
+	// or failed outcomes. A non-nil error means that no valid outcome was
+	// produced and indicates an executor contract failure.
+	Execute(context.Context, ExecutionRequest) (eventrule.ExecutionState, error)
+}

--- a/rest-api/flow/internal/eventrule/executor/executor_test.go
+++ b/rest-api/flow/internal/eventrule/executor/executor_test.go
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreparationResult_Validate(t *testing.T) {
+	validRequest := newValidExecutionRequest(t)
+	tests := map[string]struct {
+		preparation PreparationResult
+		wantErr     string
+	}{
+		"request": {
+			preparation: PreparationResult{Request: &validRequest},
+		},
+		"invalid request": {
+			preparation: PreparationResult{Request: &ExecutionRequest{}},
+			wantErr:     "execution: event action execution id is required",
+		},
+		"outcome": {
+			preparation: PreparationResult{Outcome: &eventrule.ExecutionState{
+				Status: eventrule.ExecutionStatusSkipped,
+				Reason: eventrule.ExecutionReasonNoTargets,
+			}},
+		},
+		"neither": {
+			wantErr: "requires exactly one request or outcome",
+		},
+		"both": {
+			preparation: PreparationResult{
+				Request: &ExecutionRequest{},
+				Outcome: &eventrule.ExecutionState{
+					Status: eventrule.ExecutionStatusSkipped,
+					Reason: eventrule.ExecutionReasonNoTargets,
+				},
+			},
+			wantErr: "requires exactly one request or outcome",
+		},
+		"invalid outcome": {
+			preparation: PreparationResult{Outcome: &eventrule.ExecutionState{
+				Status: eventrule.ExecutionStatusSkipped,
+			}},
+			wantErr: "skipped execution requires one of reasons",
+		},
+		"claimed outcome": {
+			preparation: PreparationResult{Outcome: &eventrule.ExecutionState{
+				Status: eventrule.ExecutionStatusClaimed,
+			}},
+			wantErr: "cannot transition execution to claimed status",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.preparation.Validate()
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestExecutionRequest_Validate(t *testing.T) {
+	valid := newValidExecutionRequest(t)
+	tests := map[string]struct {
+		request ExecutionRequest
+		mutate  func(*ExecutionRequest)
+		wantErr string
+	}{
+		"valid": {request: valid},
+		"invalid execution": {
+			request: valid,
+			mutate:  func(request *ExecutionRequest) { request.Execution.ID = uuid.Nil },
+			wantErr: "execution: event action execution id is required",
+		},
+		"invalid action": {
+			request: valid,
+			mutate:  func(request *ExecutionRequest) { request.Action = eventrule.Action{} },
+			wantErr: "action: action id is empty",
+		},
+		"missing target id": {
+			request: valid,
+			mutate: func(request *ExecutionRequest) {
+				request.Targets = []Target{{Kind: eventrule.ResourceKindComponent}}
+			},
+			wantErr: "target 0: target id is required",
+		},
+		"invalid target kind": {
+			request: valid,
+			mutate: func(request *ExecutionRequest) {
+				request.Targets = []Target{{Kind: "invalid", ID: uuid.New()}}
+			},
+			wantErr: `target 0: unknown resource kind "invalid"`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			request := test.request
+			if test.mutate != nil {
+				test.mutate(&request)
+			}
+			err := request.Validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestTarget_Validate(t *testing.T) {
+	tests := map[string]struct {
+		target  Target
+		wantErr string
+	}{
+		"component": {
+			target: Target{Kind: eventrule.ResourceKindComponent, ID: uuid.New()},
+		},
+		"rack": {
+			target: Target{Kind: eventrule.ResourceKindRack, ID: uuid.New()},
+		},
+		"invalid kind": {
+			target:  Target{Kind: "invalid", ID: uuid.New()},
+			wantErr: `unknown resource kind "invalid"`,
+		},
+		"missing id": {
+			target:  Target{Kind: eventrule.ResourceKindComponent},
+			wantErr: "target id is required",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.target.Validate()
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func newValidExecutionRequest(t *testing.T) ExecutionRequest {
+	t.Helper()
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	execution, err := (eventrule.ExecutionClaim{
+		EventID:  uuid.New(),
+		RuleID:   uuid.New(),
+		ActionID: "noop",
+		Now:      now,
+	}).NewExecution()
+	require.NoError(t, err)
+	return ExecutionRequest{
+		Execution: *execution,
+		Action: eventrule.NewAction(
+			"noop",
+			eventrule.ActionCondition{},
+			eventrule.Noop{},
+		),
+	}
+}

--- a/rest-api/flow/internal/eventrule/policy.go
+++ b/rest-api/flow/internal/eventrule/policy.go
@@ -20,13 +20,29 @@ type Dedupe struct {
 	Window time.Duration
 }
 
+// Clone returns an independent copy of the deduplication policy.
+func (d *Dedupe) Clone() *Dedupe {
+	if d == nil {
+		return nil
+	}
+	cloned := *d
+	return &cloned
+}
+
+// WithinWindow reports whether an observation falls within the deduplication
+// window anchored at the execution's first claim time.
+func (d *Dedupe) WithinWindow(firstClaimedAt, observedAt time.Time) bool {
+	if d == nil {
+		return false
+	}
+	return !observedAt.Before(firstClaimedAt) &&
+		observedAt.Sub(firstClaimedAt) < d.Window
+}
+
 // Clone returns an independent copy of the policy and its mutable data.
 func (p Policy) Clone() Policy {
 	cloned := p
-	if p.Dedupe != nil {
-		dedupe := *p.Dedupe
-		cloned.Dedupe = &dedupe
-	}
+	cloned.Dedupe = p.Dedupe.Clone()
 	cloned.Actions = CloneActions(p.Actions)
 	return cloned
 }

--- a/rest-api/flow/internal/eventrule/policy_test.go
+++ b/rest-api/flow/internal/eventrule/policy_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package eventrule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDedupe_Clone(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var nilDedupe *Dedupe
+		require.Nil(t, nilDedupe.Clone())
+	})
+
+	t.Run("configured policy", func(t *testing.T) {
+		dedupe := &Dedupe{Window: time.Minute}
+		cloned := dedupe.Clone()
+		require.Equal(t, dedupe, cloned)
+		require.NotSame(t, dedupe, cloned)
+	})
+}
+
+func TestDedupe_WithinWindow(t *testing.T) {
+	firstClaimedAt := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	tests := map[string]struct {
+		dedupe     *Dedupe
+		observedAt time.Time
+		want       bool
+	}{
+		"nil policy": {
+			observedAt: firstClaimedAt,
+		},
+		"at first claim": {
+			dedupe:     &Dedupe{Window: time.Minute},
+			observedAt: firstClaimedAt,
+			want:       true,
+		},
+		"immediately before first claim": {
+			dedupe:     &Dedupe{Window: time.Minute},
+			observedAt: firstClaimedAt.Add(-time.Nanosecond),
+		},
+		"far before first claim": {
+			dedupe:     &Dedupe{Window: time.Minute},
+			observedAt: firstClaimedAt.Add(-24 * time.Hour),
+		},
+		"inside window": {
+			dedupe:     &Dedupe{Window: time.Minute},
+			observedAt: firstClaimedAt.Add(time.Minute - time.Nanosecond),
+			want:       true,
+		},
+		"at window boundary": {
+			dedupe:     &Dedupe{Window: time.Minute},
+			observedAt: firstClaimedAt.Add(time.Minute),
+		},
+		"outside window": {
+			dedupe:     &Dedupe{Window: time.Minute},
+			observedAt: firstClaimedAt.Add(time.Minute + time.Nanosecond),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(
+				t,
+				test.want,
+				test.dedupe.WithinWindow(firstClaimedAt, test.observedAt),
+			)
+		})
+	}
+}

--- a/rest-api/flow/internal/eventrule/processor/config.go
+++ b/rest-api/flow/internal/eventrule/processor/config.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package processor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/executor"
+	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
+)
+
+// Config contains the dependencies and runtime settings for a Processor.
+type Config struct {
+	Inventory  inventoryresolver.InventoryReader
+	Rules      RuleResolver
+	Executions eventrule.ExecutionStore
+	Executor   executor.Executor
+
+	Clock func() time.Time
+}
+
+// Validate checks that all required processor dependencies and runtime
+// settings are valid.
+func (c Config) Validate() error {
+	if c.Inventory == nil {
+		return fmt.Errorf("inventory reader is required")
+	}
+	if c.Rules == nil {
+		return fmt.Errorf("rule resolver is required")
+	}
+	if c.Executions == nil {
+		return fmt.Errorf("execution store is required")
+	}
+	if c.Executor == nil {
+		return fmt.Errorf("action executor is required")
+	}
+
+	return nil
+}
+
+func (c Config) clock() func() time.Time {
+	if c.Clock != nil {
+		return c.Clock
+	}
+	return time.Now
+}

--- a/rest-api/flow/internal/eventrule/processor/config_test.go
+++ b/rest-api/flow/internal/eventrule/processor/config_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := map[string]struct {
+		mutate  func(*Config)
+		wantErr string
+	}{
+		"valid": {},
+		"missing inventory reader": {
+			mutate:  func(config *Config) { config.Inventory = nil },
+			wantErr: "inventory reader is required",
+		},
+		"missing rule resolver": {
+			mutate:  func(config *Config) { config.Rules = nil },
+			wantErr: "rule resolver is required",
+		},
+		"missing execution store": {
+			mutate:  func(config *Config) { config.Executions = nil },
+			wantErr: "execution store is required",
+		},
+		"missing action executor": {
+			mutate:  func(config *Config) { config.Executor = nil },
+			wantErr: "action executor is required",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := validProcessorConfig()
+			if test.mutate != nil {
+				test.mutate(&config)
+			}
+
+			err := config.Validate()
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Run("rejects invalid configuration", func(t *testing.T) {
+		processor, err := New(Config{})
+		require.Error(t, err)
+		require.Nil(t, processor)
+	})
+
+	t.Run("defaults clock", func(t *testing.T) {
+		processor, err := New(validProcessorConfig())
+		require.NoError(t, err)
+		require.NotNil(t, processor.now)
+	})
+}

--- a/rest-api/flow/internal/eventrule/processor/enrichment_test.go
+++ b/rest-api/flow/internal/eventrule/processor/enrichment_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
-	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
 	identifier "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/Identifier"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/deviceinfo"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -33,10 +32,11 @@ func TestEnrichComponent(t *testing.T) {
 		nil,
 	)
 	resolved.RackID = rackID
-	processor := New(
-		inventoryresolver.New(&processorInventory{
+	processor := newTestProcessor(
+		t,
+		&processorInventory{
 			components: []*component.Component{&resolved},
-		}),
+		},
 		nil,
 	)
 
@@ -133,7 +133,7 @@ func TestEnrichClassifiesFailures(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			processor := New(inventoryresolver.New(test.inventory), nil)
+			processor := newTestProcessor(t, test.inventory, nil)
 			_, err := processor.enrich(
 				context.Background(),
 				validEnvelope(test.resource),
@@ -151,10 +151,11 @@ func TestEnrichClassifiesFailures(t *testing.T) {
 
 func TestEnrichRackUsesResolvedResourceAsRack(t *testing.T) {
 	rackID := uuid.New()
-	processor := New(
-		inventoryresolver.New(&processorInventory{
+	processor := newTestProcessor(
+		t,
+		&processorInventory{
 			rack: rack.New(deviceinfo.DeviceInfo{ID: rackID}, location.Location{}),
-		}),
+		},
 		nil,
 	)
 

--- a/rest-api/flow/internal/eventrule/processor/execution.go
+++ b/rest-api/flow/internal/eventrule/processor/execution.go
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package processor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/executor"
+	"github.com/google/uuid"
+)
+
+func (p *Processor) processAction(
+	ctx context.Context,
+	prepared preparedEvent,
+	action eventrule.Action,
+) error {
+	// Check action eligibility and construct a validated execution claim.
+	claim, err := p.precheckExecution(prepared, action)
+	if err != nil || claim == nil {
+		return err
+	}
+
+	// Atomically claim the action's delivery and optional semantic-dedupe
+	// identity. A nil preparation request is an accepted duplicate.
+	prepareReq, err := p.claimExecution(ctx, *claim, prepared, action)
+	if err != nil || prepareReq == nil {
+		return err
+	}
+
+	// Prepare the action-specific request or outcome.
+	result, err := p.prepareExecution(ctx, *prepareReq)
+	if err != nil {
+		return err
+	}
+
+	// Execute a prepared request, or carry forward a preparation outcome.
+	outcome, err := p.performExecution(ctx, result)
+	if err != nil {
+		return err
+	}
+
+	// Persist the resulting execution state.
+	return p.persistExecution(ctx, prepareReq.Execution.ID, outcome)
+}
+
+func (p *Processor) precheckExecution(
+	prepared preparedEvent,
+	action eventrule.Action,
+) (*eventrule.ExecutionClaim, error) {
+	if !action.Condition.AppliesTo(
+		prepared.Envelope,
+		prepared.Enriched.ResolvedResource,
+	) {
+		return nil, nil
+	}
+
+	claim, err := eventrule.NewExecutionClaim(
+		prepared.Envelope,
+		*prepared.Rule,
+		action.ID,
+		p.now(),
+	)
+	if err != nil {
+		return nil, terminalError(err)
+	}
+
+	return &claim, nil
+}
+
+func (p *Processor) claimExecution(
+	ctx context.Context,
+	claim eventrule.ExecutionClaim,
+	prepared preparedEvent,
+	action eventrule.Action,
+) (*executor.PrepareRequest, error) {
+	execution, err := p.executions.Claim(ctx, claim)
+	if err != nil || execution == nil {
+		return nil, err
+	}
+
+	return &executor.PrepareRequest{
+		Execution: *execution,
+		Envelope:  prepared.Envelope,
+		Resource:  prepared.Enriched.ResolvedResource,
+		Action:    action,
+	}, nil
+}
+
+func (p *Processor) prepareExecution(
+	ctx context.Context,
+	prepareReq executor.PrepareRequest,
+) (executor.PreparationResult, error) {
+	result, err := p.executor.Prepare(ctx, prepareReq)
+	if err != nil {
+		return executor.PreparationResult{}, terminalError(
+			fmt.Errorf("executor preparation failed: %w", err),
+		)
+	}
+
+	// Defensively validate the result at the executor boundary even though
+	// implementations are required to return a valid result with a nil error.
+	if err := result.Validate(); err != nil {
+		return executor.PreparationResult{}, terminalError(err)
+	}
+
+	return result, nil
+}
+
+func (p *Processor) performExecution(
+	ctx context.Context,
+	result executor.PreparationResult,
+) (eventrule.ExecutionState, error) {
+	// A preparation outcome already represents the resulting state, so no
+	// action execution is needed.
+	if result.Outcome != nil {
+		return *result.Outcome, nil
+	}
+
+	outcome, err := p.executor.Execute(ctx, *result.Request)
+	if err != nil {
+		return eventrule.ExecutionState{}, terminalError(
+			fmt.Errorf("executor execution failed: %w", err),
+		)
+	}
+
+	// Defensively validate the outcome at the executor boundary even though
+	// implementations are required to return a valid outcome with a nil error.
+	if err := outcome.ValidateTransition(); err != nil {
+		return eventrule.ExecutionState{}, terminalError(err)
+	}
+
+	return outcome, nil
+}
+
+func (p *Processor) persistExecution(
+	ctx context.Context,
+	executionID uuid.UUID,
+	outcome eventrule.ExecutionState,
+) error {
+	_, err := p.executions.Transition(ctx, executionID, outcome, p.now().UTC())
+	return err
+}

--- a/rest-api/flow/internal/eventrule/processor/execution_test.go
+++ b/rest-api/flow/internal/eventrule/processor/execution_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package processor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/executor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessor_PerformExecution(t *testing.T) {
+	executorErr := errors.New("executor unavailable")
+	completed := eventrule.ExecutionState{Status: eventrule.ExecutionStatusCompleted}
+	claimed := eventrule.ExecutionState{Status: eventrule.ExecutionStatusClaimed}
+	tests := map[string]struct {
+		result      executor.PreparationResult
+		executor    executor.Executor
+		wantOutcome eventrule.ExecutionState
+		wantErr     error
+		wantMessage string
+	}{
+		"preparation outcome pass-through": {
+			result:      executor.PreparationResult{Outcome: &completed},
+			executor:    executorStub{},
+			wantOutcome: completed,
+		},
+		"valid executor outcome": {
+			result:      executionResult(),
+			executor:    executorStub{outcome: completed},
+			wantOutcome: completed,
+		},
+		"executor error is terminal": {
+			result:      executionResult(),
+			executor:    executorStub{err: executorErr},
+			wantErr:     executorErr,
+			wantMessage: "executor execution failed",
+		},
+		"invalid executor outcome is terminal": {
+			result:      executionResult(),
+			executor:    executorStub{outcome: claimed},
+			wantErr:     ErrTerminal,
+			wantMessage: "cannot transition execution to claimed status",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			processor := &Processor{executor: test.executor}
+			outcome, err := processor.performExecution(
+				context.Background(),
+				test.result,
+			)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+				require.ErrorIs(t, err, ErrTerminal)
+				require.ErrorContains(t, err, test.wantMessage)
+				require.Equal(t, eventrule.ExecutionState{}, outcome)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantOutcome, outcome)
+		})
+	}
+}
+
+func executionResult() executor.PreparationResult {
+	return executor.PreparationResult{Request: &executor.ExecutionRequest{}}
+}
+
+type executorStub struct {
+	outcome eventrule.ExecutionState
+	err     error
+}
+
+func (executorStub) Prepare(
+	context.Context,
+	executor.PrepareRequest,
+) (executor.PreparationResult, error) {
+	return executor.PreparationResult{}, nil
+}
+
+func (e executorStub) Execute(
+	context.Context,
+	executor.ExecutionRequest,
+) (eventrule.ExecutionState, error) {
+	return e.outcome, e.err
+}

--- a/rest-api/flow/internal/eventrule/processor/integration_test.go
+++ b/rest-api/flow/internal/eventrule/processor/integration_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/manager"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/registry"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/store/memory"
-	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/deviceinfo"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/location"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
@@ -41,10 +40,11 @@ func TestProcessorPreparationIntegration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	processor := New(
-		inventoryresolver.New(&processorInventory{
+	processor := newTestProcessor(
+		t,
+		&processorInventory{
 			rack: rack.New(deviceinfo.DeviceInfo{ID: rackID}, location.Location{}),
-		}),
+		},
 		ruleManager,
 	)
 	envelope := eventrule.Envelope{

--- a/rest-api/flow/internal/eventrule/processor/preparation.go
+++ b/rest-api/flow/internal/eventrule/processor/preparation.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package processor
+
+import (
+	"context"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+)
+
+// RuleResolver resolves the effective rule for an event and rack scope.
+// A cache may decorate this interface without changing processing.
+type RuleResolver interface {
+	GetEffective(context.Context, eventrule.Type, uuid.UUID) (*eventrule.Rule, error)
+}
+
+// preparedEvent contains runtime inputs prepared for policy evaluation.
+type preparedEvent struct {
+	Envelope eventrule.Envelope
+	Enriched enrichment
+	Rule     *eventrule.Rule
+}
+
+// prepare enriches an envelope and resolves its effective rule. An absent rule
+// is an accepted no-op represented by a nil preparedEvent.Rule.
+func (p *Processor) prepare(
+	ctx context.Context,
+	envelope eventrule.Envelope,
+) (preparedEvent, error) {
+	if err := envelope.Validate(); err != nil {
+		return preparedEvent{}, terminalError(err)
+	}
+
+	enriched, err := p.enrich(ctx, envelope)
+	if err != nil {
+		return preparedEvent{}, err
+	}
+
+	rule, err := p.rules.GetEffective(
+		ctx,
+		envelope.Type,
+		enriched.ResolvedResource.RackID,
+	)
+	if err != nil {
+		return preparedEvent{}, classifyRuleError(err)
+	}
+
+	return preparedEvent{
+		Envelope: envelope,
+		Enriched: enriched,
+		Rule:     rule,
+	}, nil
+}

--- a/rest-api/flow/internal/eventrule/processor/preparation_test.go
+++ b/rest-api/flow/internal/eventrule/processor/preparation_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
-	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/deviceinfo"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/location"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
@@ -73,7 +72,7 @@ func TestPrepare(t *testing.T) {
 			}
 
 			resolverCalled := false
-			resolver := effectiveRuleResolverFunc(func(
+			resolver := ruleResolverFunc(func(
 				_ context.Context,
 				eventType eventrule.Type,
 				resolvedRackID uuid.UUID,
@@ -83,7 +82,7 @@ func TestPrepare(t *testing.T) {
 				require.Equal(t, rackID, resolvedRackID)
 				return test.rule, test.ruleErr
 			})
-			processor := newRackProcessor(rackID, resolver)
+			processor := newRackProcessor(t, rackID, resolver)
 
 			result, err := processor.prepare(
 				context.Background(),
@@ -111,24 +110,27 @@ func TestPrepare(t *testing.T) {
 }
 
 func newRackProcessor(
+	t *testing.T,
 	rackID uuid.UUID,
-	rules effectiveRuleResolver,
+	rules RuleResolver,
 ) *Processor {
-	return New(
-		inventoryresolver.New(&processorInventory{
+	t.Helper()
+	return newTestProcessor(
+		t,
+		&processorInventory{
 			rack: rack.New(deviceinfo.DeviceInfo{ID: rackID}, location.Location{}),
-		}),
+		},
 		rules,
 	)
 }
 
-type effectiveRuleResolverFunc func(
+type ruleResolverFunc func(
 	context.Context,
 	eventrule.Type,
 	uuid.UUID,
 ) (*eventrule.Rule, error)
 
-func (f effectiveRuleResolverFunc) GetEffective(
+func (f ruleResolverFunc) GetEffective(
 	ctx context.Context,
 	eventType eventrule.Type,
 	rackID uuid.UUID,

--- a/rest-api/flow/internal/eventrule/processor/process_test.go
+++ b/rest-api/flow/internal/eventrule/processor/process_test.go
@@ -1,0 +1,526 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package processor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	eventexecutor "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/executor"
+	memorystore "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/store/memory"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/deviceinfo"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/location"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
+	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	runtimeMaxExecutionAttempts = 3
+	runtimeInitialRetryDelay    = time.Second
+)
+
+func TestProcessor_Process(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	rackID := uuid.New()
+	tests := map[string]struct {
+		rule             *eventrule.Rule
+		targets          []eventexecutor.Target
+		targetErr        error
+		executorErr      error
+		wantErr          error
+		wantStatus       eventrule.ExecutionStatus
+		wantReason       eventrule.ExecutionReason
+		wantExecutions   int
+		wantExecutorRuns int
+	}{
+		"no effective rule is accepted": {},
+		"condition skip creates no execution": {
+			rule: processorRuntimeRule(eventrule.NewAction(
+				"skip",
+				eventrule.ActionCondition{
+					ComponentTypes: []flowtypes.ComponentType{flowtypes.ComponentTypeNVSwitch},
+				},
+				eventrule.Noop{},
+			)),
+		},
+		"noop completes": {
+			rule:             processorRuntimeRule(noopAction("noop")),
+			wantStatus:       eventrule.ExecutionStatusCompleted,
+			wantExecutions:   1,
+			wantExecutorRuns: 1,
+		},
+		"no targets skips submit": {
+			rule:           processorRuntimeRule(submitAction("submit")),
+			wantStatus:     eventrule.ExecutionStatusSkipped,
+			wantReason:     eventrule.ExecutionReasonNoTargets,
+			wantExecutions: 1,
+		},
+		"terminal target error produces failed outcome": {
+			rule:           processorRuntimeRule(submitAction("submit")),
+			targetErr:      terminalError(errors.New("invalid topology")),
+			wantStatus:     eventrule.ExecutionStatusFailed,
+			wantExecutions: 1,
+		},
+		"retryable executor error schedules retry": {
+			rule:             processorRuntimeRule(noopAction("noop")),
+			executorErr:      errors.New("alert service unavailable"),
+			wantStatus:       eventrule.ExecutionStatusDeferred,
+			wantReason:       eventrule.ExecutionReasonAttemptFailed,
+			wantExecutions:   1,
+			wantExecutorRuns: 1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := memorystore.New()
+			var executorRuns int
+			processor := runtimeProcessor(
+				t,
+				rackID,
+				test.rule,
+				store,
+				targetResolverFunc(func(
+					context.Context,
+					eventexecutor.TargetRequest,
+				) ([]eventexecutor.Target, error) {
+					return test.targets, test.targetErr
+				}),
+				actionExecutorFunc(func(
+					context.Context,
+					eventexecutor.ExecutionRequest,
+				) (string, error) {
+					executorRuns++
+					return "result-1", test.executorErr
+				}),
+				&now,
+			)
+
+			err := processor.Process(context.Background(), runtimeEnvelope(rackID))
+			if test.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr.Error())
+				if errors.Is(test.wantErr, ErrTerminal) {
+					require.ErrorIs(t, err, ErrTerminal)
+				}
+			}
+			require.Equal(t, test.wantExecutorRuns, executorRuns)
+			executions, err := store.Executions()
+			require.NoError(t, err)
+			require.Len(t, executions, test.wantExecutions)
+			if test.wantExecutions > 0 {
+				require.Equal(t, test.wantStatus, executions[0].Status)
+				require.Equal(t, test.wantReason, executions[0].Reason)
+			}
+		})
+	}
+
+	t.Run("deduplication", testProcessDeduplication)
+	t.Run("retries and exhausts", testProcessRetriesAndExhausts)
+	t.Run("processes actions independently", testProcessProcessesActionsIndependently)
+	t.Run("concurrent duplicate executes once", testProcessConcurrentDuplicateExecutesOnce)
+}
+
+func testProcessDeduplication(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	rackID := uuid.New()
+	tests := map[string]struct {
+		dedupe        *eventrule.Dedupe
+		secondEventID uuid.UUID
+	}{
+		"delivery duplicate without semantic dedupe": {},
+		"semantic duplicate across event IDs": {
+			dedupe:        &eventrule.Dedupe{Window: time.Minute},
+			secondEventID: uuid.New(),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := memorystore.New()
+			rule := processorRuntimeRule(noopAction("noop"))
+			rule.Dedupe = test.dedupe
+			var runs int
+			processor := runtimeProcessor(
+				t, rackID, rule, store, nil,
+				actionExecutorFunc(func(context.Context, eventexecutor.ExecutionRequest) (string, error) {
+					runs++
+					return "", nil
+				}),
+				&now,
+			)
+			first := runtimeEnvelope(rackID)
+			first.CorrelationKey = "incident-1"
+			second := first
+			if test.secondEventID != uuid.Nil {
+				second.ID = test.secondEventID
+			}
+
+			require.NoError(t, processor.Process(context.Background(), first))
+			require.NoError(t, processor.Process(context.Background(), second))
+			require.Equal(t, 1, runs)
+			executions, err := store.Executions()
+			require.NoError(t, err)
+			require.Len(t, executions, 1)
+			require.Equal(t, 2, executions[0].Observations)
+		})
+	}
+}
+
+func testProcessRetriesAndExhausts(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	rackID := uuid.New()
+	store := memorystore.New()
+	executorErr := errors.New("downstream unavailable")
+	processor := runtimeProcessor(
+		t, rackID, processorRuntimeRule(noopAction("noop")), store, nil,
+		actionExecutorFunc(func(context.Context, eventexecutor.ExecutionRequest) (string, error) {
+			return "", executorErr
+		}),
+		&now,
+	)
+	envelope := runtimeEnvelope(rackID)
+
+	for attempt := 1; attempt <= runtimeMaxExecutionAttempts; attempt++ {
+		err := processor.Process(context.Background(), envelope)
+		require.NoError(t, err)
+		executions, snapshotsErr := store.Executions()
+		require.NoError(t, snapshotsErr)
+		execution := executions[0]
+		require.Equal(t, attempt, execution.Attempts)
+		if attempt < runtimeMaxExecutionAttempts {
+			require.Equal(t, eventrule.ExecutionStatusDeferred, execution.Status)
+			require.Equal(
+				t,
+				now.Add(runtimeRetryDelay(attempt)),
+				execution.NextAttemptAt,
+			)
+			earlyErr := processor.Process(context.Background(), envelope)
+			require.ErrorIs(t, earlyErr, eventrule.ErrRetryScheduled)
+			executions, snapshotsErr = store.Executions()
+			require.NoError(t, snapshotsErr)
+			require.Equal(t, attempt, executions[0].Attempts)
+			now = execution.NextAttemptAt
+		} else {
+			require.Equal(t, eventrule.ExecutionStatusFailed, execution.Status)
+		}
+	}
+}
+
+func testProcessProcessesActionsIndependently(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	rackID := uuid.New()
+	store := memorystore.New()
+	firstErr := errors.New("first action unavailable")
+	var executed []string
+	processor := runtimeProcessor(
+		t,
+		rackID,
+		processorRuntimeRule(noopAction("first"), noopAction("second")),
+		store,
+		nil,
+		actionExecutorFunc(func(
+			_ context.Context,
+			request eventexecutor.ExecutionRequest,
+		) (string, error) {
+			executed = append(executed, request.Action.ID)
+			if request.Action.ID == "first" {
+				return "", firstErr
+			}
+			return "", nil
+		}),
+		&now,
+	)
+
+	err := processor.Process(context.Background(), runtimeEnvelope(rackID))
+	require.NoError(t, err)
+	require.Equal(t, []string{"first", "second"}, executed)
+	executions, snapshotsErr := store.Executions()
+	require.NoError(t, snapshotsErr)
+	require.Len(t, executions, 2)
+	statuses := make(map[string]eventrule.ExecutionStatus, len(executions))
+	for _, execution := range executions {
+		statuses[execution.ActionID] = execution.Status
+	}
+	require.Equal(t, eventrule.ExecutionStatusDeferred, statuses["first"])
+	require.Equal(t, eventrule.ExecutionStatusCompleted, statuses["second"])
+}
+
+func testProcessConcurrentDuplicateExecutesOnce(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	rackID := uuid.New()
+	store := memorystore.New()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var runs atomic.Int32
+	processor := runtimeProcessor(
+		t, rackID, processorRuntimeRule(noopAction("noop")), store, nil,
+		actionExecutorFunc(func(context.Context, eventexecutor.ExecutionRequest) (string, error) {
+			if runs.Add(1) == 1 {
+				close(entered)
+			}
+			<-release
+			return "", nil
+		}),
+		&now,
+	)
+	envelope := runtimeEnvelope(rackID)
+
+	const deliveries = 20
+	start := make(chan struct{})
+	errs := make(chan error, deliveries)
+	var wg sync.WaitGroup
+	for range deliveries {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- processor.Process(context.Background(), envelope)
+		}()
+	}
+	close(start)
+	<-entered
+	close(release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), runs.Load())
+	executions, err := store.Executions()
+	require.NoError(t, err)
+	require.Len(t, executions, 1)
+}
+
+func runtimeProcessor(
+	t *testing.T,
+	rackID uuid.UUID,
+	rule *eventrule.Rule,
+	store eventrule.ExecutionStore,
+	targets eventexecutor.TargetResolver,
+	execute actionExecutorFunc,
+	now *time.Time,
+) *Processor {
+	t.Helper()
+	if targets == nil {
+		targets = targetResolverFunc(func(
+			context.Context,
+			eventexecutor.TargetRequest,
+		) ([]eventexecutor.Target, error) {
+			return nil, nil
+		})
+	}
+	resolver := ruleResolverFunc(func(
+		context.Context,
+		eventrule.Type,
+		uuid.UUID,
+	) (*eventrule.Rule, error) {
+		return rule, nil
+	})
+	processor, err := New(Config{
+		Inventory: &processorInventory{
+			rack: rack.New(deviceinfo.DeviceInfo{ID: rackID}, location.Location{}),
+		},
+		Rules:      resolver,
+		Executions: store,
+		Executor: runtimeExecutor{
+			targets: targets,
+			execute: execute,
+			now:     now,
+		},
+		Clock: func() time.Time { return *now },
+	})
+	require.NoError(t, err)
+	return processor
+}
+
+func newTestProcessor(
+	t *testing.T,
+	inventory *processorInventory,
+	rules RuleResolver,
+) *Processor {
+	t.Helper()
+	if rules == nil {
+		rules = ruleResolverFunc(func(
+			context.Context,
+			eventrule.Type,
+			uuid.UUID,
+		) (*eventrule.Rule, error) {
+			return nil, nil
+		})
+	}
+	processor, err := New(Config{
+		Inventory:  inventory,
+		Rules:      rules,
+		Executions: memorystore.New(),
+		Executor: runtimeExecutor{
+			targets: targetResolverFunc(func(
+				context.Context,
+				eventexecutor.TargetRequest,
+			) ([]eventexecutor.Target, error) {
+				return nil, nil
+			}),
+			execute: func(context.Context, eventexecutor.ExecutionRequest) (string, error) {
+				return "", nil
+			},
+		},
+	})
+	require.NoError(t, err)
+	return processor
+}
+
+func processorRuntimeRule(actions ...eventrule.Action) *eventrule.Rule {
+	return &eventrule.Rule{
+		ID:        uuid.New(),
+		EventType: "test.event",
+		Policy:    eventrule.Policy{Actions: actions},
+	}
+}
+
+func runtimeEnvelope(rackID uuid.UUID) eventrule.Envelope {
+	return eventrule.Envelope{
+		ID:       uuid.New(),
+		Type:     "test.event",
+		Resource: eventrule.Resource{Kind: eventrule.ResourceKindRack, ID: rackID},
+	}
+}
+
+func noopAction(id string) eventrule.Action {
+	return eventrule.NewAction(id, eventrule.ActionCondition{}, eventrule.Noop{})
+}
+
+func submitAction(id string) eventrule.Action {
+	return eventrule.NewAction(id, eventrule.ActionCondition{}, eventrule.SubmitTask{})
+}
+
+type targetResolverFunc func(
+	context.Context,
+	eventexecutor.TargetRequest,
+) ([]eventexecutor.Target, error)
+
+func (f targetResolverFunc) ResolveTargets(
+	ctx context.Context,
+	request eventexecutor.TargetRequest,
+) ([]eventexecutor.Target, error) {
+	return f(ctx, request)
+}
+
+type actionExecutorFunc func(context.Context, eventexecutor.ExecutionRequest) (string, error)
+
+type runtimeExecutor struct {
+	targets eventexecutor.TargetResolver
+	execute actionExecutorFunc
+	now     *time.Time
+}
+
+func (e runtimeExecutor) Prepare(
+	ctx context.Context,
+	request eventexecutor.PrepareRequest,
+) (eventexecutor.PreparationResult, error) {
+	var targets []eventexecutor.Target
+	if request.Action.Spec.Type() == eventrule.ActionTypeSubmitTask {
+		task := request.Action.Spec.(eventrule.SubmitTask)
+		var err error
+		targets, err = e.targets.ResolveTargets(ctx, eventexecutor.TargetRequest{
+			EventType: request.Envelope.Type,
+			Payload:   request.Envelope.Payload,
+			Resource:  request.Resource,
+			Task:      task,
+		})
+		if err != nil {
+			outcome := e.failureOutcome(request.Execution, err)
+			return eventexecutor.PreparationResult{Outcome: &outcome}, nil
+		}
+		if len(targets) == 0 {
+			outcome := eventrule.ExecutionState{
+				Status: eventrule.ExecutionStatusSkipped,
+				Reason: eventrule.ExecutionReasonNoTargets,
+			}
+			return eventexecutor.PreparationResult{Outcome: &outcome}, nil
+		}
+	}
+
+	return eventexecutor.PreparationResult{Request: &eventexecutor.ExecutionRequest{
+		Execution: request.Execution,
+		Action:    request.Action,
+		Targets:   targets,
+	}}, nil
+}
+
+func (e runtimeExecutor) Execute(
+	ctx context.Context,
+	request eventexecutor.ExecutionRequest,
+) (eventrule.ExecutionState, error) {
+	_, err := e.execute(ctx, request)
+	if err != nil {
+		return e.failureOutcome(request.Execution, err), nil
+	}
+
+	status := eventrule.ExecutionStatusCompleted
+	if request.Action.Spec.Type() == eventrule.ActionTypeSubmitTask {
+		status = eventrule.ExecutionStatusSubmitted
+	}
+	return eventrule.ExecutionState{Status: status}, nil
+}
+
+func (e runtimeExecutor) failureOutcome(
+	execution eventrule.Execution,
+	cause error,
+) eventrule.ExecutionState {
+	if errors.Is(cause, ErrTerminal) ||
+		execution.Attempts >= runtimeMaxExecutionAttempts {
+		return eventrule.ExecutionState{
+			Status:        eventrule.ExecutionStatusFailed,
+			StatusMessage: cause.Error(),
+		}
+	}
+
+	now := time.Now()
+	if e.now != nil {
+		now = *e.now
+	}
+	return eventrule.ExecutionState{
+		Status:        eventrule.ExecutionStatusDeferred,
+		Reason:        eventrule.ExecutionReasonAttemptFailed,
+		StatusMessage: cause.Error(),
+		NextAttemptAt: now.Add(runtimeRetryDelay(execution.Attempts)),
+	}
+}
+
+func runtimeRetryDelay(attempt int) time.Duration {
+	return runtimeInitialRetryDelay * time.Duration(1<<max(attempt-1, 0))
+}
+
+func validProcessorConfig() Config {
+	return Config{
+		Inventory: &processorInventory{},
+		Rules: ruleResolverFunc(func(
+			context.Context,
+			eventrule.Type,
+			uuid.UUID,
+		) (*eventrule.Rule, error) {
+			return nil, nil
+		}),
+		Executions: memorystore.New(),
+		Executor: runtimeExecutor{
+			targets: targetResolverFunc(func(
+				context.Context,
+				eventexecutor.TargetRequest,
+			) ([]eventexecutor.Target, error) {
+				return nil, nil
+			}),
+			execute: func(context.Context, eventexecutor.ExecutionRequest) (string, error) {
+				return "", nil
+			},
+		},
+	}
+}

--- a/rest-api/flow/internal/eventrule/processor/processor.go
+++ b/rest-api/flow/internal/eventrule/processor/processor.go
@@ -5,66 +5,52 @@ package processor
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/executor"
 	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
-	"github.com/google/uuid"
 )
-
-// effectiveRuleResolver resolves hierarchical rule precedence. A cache may
-// decorate this interface without changing preparation or processing.
-type effectiveRuleResolver interface {
-	GetEffective(context.Context, eventrule.Type, uuid.UUID) (*eventrule.Rule, error)
-}
-
-// preparedEvent contains runtime inputs prepared for policy evaluation.
-type preparedEvent struct {
-	Envelope eventrule.Envelope
-	Enriched enrichment
-	Rule     *eventrule.Rule
-}
 
 // Processor orchestrates event enrichment, rule selection, and processing.
 type Processor struct {
-	inventory *inventoryresolver.Resolver
-	rules     effectiveRuleResolver
+	inventory  *inventoryresolver.Resolver
+	rules      RuleResolver
+	executions eventrule.ExecutionStore
+	executor   executor.Executor
+	now        func() time.Time
 }
 
 // New constructs an event processor.
-func New(
-	inventory *inventoryresolver.Resolver,
-	rules effectiveRuleResolver,
-) *Processor {
-	return &Processor{inventory: inventory, rules: rules}
+func New(config Config) (*Processor, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &Processor{
+		inventory:  inventoryresolver.New(config.Inventory),
+		rules:      config.Rules,
+		executions: config.Executions,
+		executor:   config.Executor,
+		now:        config.clock(),
+	}, nil
 }
 
-// prepare enriches an envelope and resolves its effective rule. An absent rule
-// is an accepted no-op represented by a nil preparedEvent.Rule.
-func (p *Processor) prepare(
-	ctx context.Context,
-	envelope eventrule.Envelope,
-) (preparedEvent, error) {
-	if err := envelope.Validate(); err != nil {
-		return preparedEvent{}, terminalError(err)
+// Process validates, prepares, and processes every eligible action.
+func (p *Processor) Process(ctx context.Context, envelope eventrule.Envelope) error {
+	prepared, err := p.prepare(ctx, envelope)
+	if err != nil || prepared.Rule == nil {
+		return err
 	}
 
-	enriched, err := p.enrich(ctx, envelope)
-	if err != nil {
-		return preparedEvent{}, err
+	var actionErrors []error
+	for _, action := range prepared.Rule.Actions {
+		if err := p.processAction(ctx, prepared, action); err != nil {
+			actionErrors = append(actionErrors, fmt.Errorf("action %q: %w", action.ID, err))
+		}
 	}
 
-	rule, err := p.rules.GetEffective(
-		ctx,
-		envelope.Type,
-		enriched.ResolvedResource.RackID,
-	)
-	if err != nil {
-		return preparedEvent{}, classifyRuleError(err)
-	}
-
-	return preparedEvent{
-		Envelope: envelope,
-		Enriched: enriched,
-		Rule:     rule,
-	}, nil
+	return errors.Join(actionErrors...)
 }

--- a/rest-api/flow/internal/eventrule/store.go
+++ b/rest-api/flow/internal/eventrule/store.go
@@ -6,6 +6,7 @@ package eventrule
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -17,6 +18,13 @@ var ErrRuleNotFound = errors.New("event rule not found")
 // decoded into a valid domain rule. Retrying without repairing the stored data
 // cannot succeed.
 var ErrInvalidPersistedRule = errors.New("invalid persisted event rule")
+
+// ErrInvalidPersistedExecution identifies persisted execution data that
+// cannot be decoded into a valid domain execution.
+var ErrInvalidPersistedExecution = errors.New("invalid persisted event action execution")
+
+// ErrExecutionNotFound identifies an unsuccessful execution lookup.
+var ErrExecutionNotFound = errors.New("event action execution not found")
 
 // RuleFilter limits rules returned by a store.
 type RuleFilter struct {
@@ -80,4 +88,20 @@ type BindingStore interface {
 	// GetForScope returns the binding for an event type and scope. When no
 	// binding exists, implementations must return (nil, nil).
 	GetForScope(context.Context, Type, Scope) (*Binding, error)
+}
+
+// ExecutionStore owns idempotent claims and action state transitions.
+// Claim atomically creates or resumes an execution. It returns a non-nil
+// execution only when the caller owns processing. It returns (nil, nil) when
+// an existing execution makes the claim an accepted no-op. When an existing
+// retryable execution is not yet eligible to resume, Claim returns an error
+// wrapping ErrRetryScheduled unless persisting the claim's observation or
+// state fails; that persistence error takes precedence and is returned alone.
+// Other non-nil errors report claim failures.
+// Transition validates and atomically persists an execution state transition,
+// returning the canonical stored execution. Transition must return an error
+// wrapping ErrExecutionNotFound when the execution ID does not exist.
+type ExecutionStore interface {
+	Claim(context.Context, ExecutionClaim) (*Execution, error)
+	Transition(context.Context, uuid.UUID, ExecutionState, time.Time) (*Execution, error)
 }

--- a/rest-api/flow/internal/eventrule/store/memory/binding.go
+++ b/rest-api/flow/internal/eventrule/store/memory/binding.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"context"
+	"fmt"
+
+	converterdao "github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/dao"
+	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+)
+
+// Bind stores a rule-to-scope association.
+func (s *Store) Bind(_ context.Context, binding eventrule.Binding) error {
+	if err := binding.Validate(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.bindings[binding.ID]; ok {
+		return fmt.Errorf("event rule binding %s already exists", binding.ID)
+	}
+
+	ruleRecord, ok := s.rules[binding.RuleID]
+	if !ok {
+		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, binding.RuleID)
+	}
+
+	if string(binding.EventType) != ruleRecord.EventType {
+		return fmt.Errorf(
+			"event rule binding event type %q does not match rule event type %q",
+			binding.EventType,
+			ruleRecord.EventType,
+		)
+	}
+
+	// Keep these checks in separate passes so duplicate-scope conflicts take
+	// deterministic precedence over mixed site/rack conflicts regardless of map
+	// iteration order.
+	for _, persisted := range s.bindings {
+		if bindingRecordMatchesScope(persisted, binding.EventType, binding.Scope) {
+			return fmt.Errorf(
+				"event type %q already has a binding for scope %q",
+				binding.EventType,
+				binding.Scope.Type,
+			)
+		}
+	}
+
+	for _, persisted := range s.bindings {
+		if persisted.RuleID == binding.RuleID &&
+			persisted.ScopeType != string(binding.Scope.Type) {
+			return fmt.Errorf("event rule %s cannot mix site and rack bindings", binding.RuleID)
+		}
+	}
+
+	now := s.now().UTC()
+	persisted, err := converterdao.EventRuleBindingTo(binding, now, now)
+	if err != nil {
+		return err
+	}
+	s.bindings[binding.ID] = *persisted
+	return nil
+}
+
+// Unbind deletes one binding.
+func (s *Store) Unbind(_ context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.bindings[id]; !ok {
+		return fmt.Errorf("%w: binding %s", eventrule.ErrRuleNotFound, id)
+	}
+	delete(s.bindings, id)
+	return nil
+}
+
+// GetForScope returns the binding for an event type and scope.
+func (s *Store) GetForScope(
+	_ context.Context,
+	eventType eventrule.Type,
+	scope eventrule.Scope,
+) (*eventrule.Binding, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, persisted := range s.bindings {
+		if bindingRecordMatchesScope(persisted, eventType, scope) {
+			return converterdao.EventRuleBindingFrom(&persisted)
+		}
+	}
+	return nil, nil
+}
+
+func bindingRecordMatchesScope(
+	binding dbmodel.EventRuleBinding,
+	eventType eventrule.Type,
+	scope eventrule.Scope,
+) bool {
+	if binding.EventType != string(eventType) ||
+		binding.ScopeType != string(scope.Type) {
+		return false
+	}
+
+	switch scope.Type {
+	case eventrule.ScopeTypeSite:
+		return binding.ScopeID == nil
+	case eventrule.ScopeTypeRack:
+		return binding.ScopeID != nil && *binding.ScopeID == scope.ID
+	default:
+		return false
+	}
+}

--- a/rest-api/flow/internal/eventrule/store/memory/execution.go
+++ b/rest-api/flow/internal/eventrule/store/memory/execution.go
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	converterdao "github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/dao"
+	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+)
+
+type memoryExecution struct {
+	persisted dbmodel.EventActionExecution
+}
+
+// Claim atomically creates, suppresses, or resumes an action execution.
+func (s *Store) Claim(
+	_ context.Context,
+	claim eventrule.ExecutionClaim,
+) (*eventrule.Execution, error) {
+	if err := claim.Validate(); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if id, exists := s.executionsByDelivery[claim.DeliveryKey()]; exists {
+		return s.claimExisting(id, claim)
+	}
+
+	deduplicated, err := s.dedupeExecution(claim)
+	if err != nil || deduplicated {
+		return nil, err
+	}
+
+	return s.newExecution(claim)
+}
+
+// Transition atomically moves an owned execution to the requested state.
+func (s *Store) Transition(
+	_ context.Context,
+	id uuid.UUID,
+	state eventrule.ExecutionState,
+	now time.Time,
+) (*eventrule.Execution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	execution, err := s.execution(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := execution.TransitionTo(state, now.UTC()); err != nil {
+		return nil, err
+	}
+
+	if err := s.setExecution(execution); err != nil {
+		return nil, err
+	}
+
+	return execution, nil
+}
+
+// Executions returns stable execution snapshots for diagnostics and tests.
+func (s *Store) Executions() ([]eventrule.Execution, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	executions := make([]eventrule.Execution, 0, len(s.executions))
+	for id := range s.executions {
+		execution, err := s.execution(id)
+		if err != nil {
+			return nil, err
+		}
+		executions = append(executions, *execution)
+	}
+
+	slices.SortFunc(executions, func(a, b eventrule.Execution) int {
+		return cmp.Compare(a.ID.String(), b.ID.String())
+	})
+
+	return executions, nil
+}
+
+func (s *Store) execution(id uuid.UUID) (*eventrule.Execution, error) {
+	record := s.executions[id]
+	if record == nil {
+		return nil, fmt.Errorf("%w: %s", eventrule.ErrExecutionNotFound, id)
+	}
+
+	return converterdao.EventActionExecutionFrom(&record.persisted)
+}
+
+func (s *Store) setExecution(execution *eventrule.Execution) error {
+	record := s.executions[execution.ID]
+	if record == nil {
+		return fmt.Errorf("%w: %s", eventrule.ErrExecutionNotFound, execution.ID)
+	}
+
+	persisted, err := converterdao.EventActionExecutionTo(execution)
+	if err != nil {
+		return err
+	}
+	record.persisted = *persisted
+
+	return nil
+}
+
+func (s *Store) claimExisting(
+	id uuid.UUID,
+	claim eventrule.ExecutionClaim,
+) (*eventrule.Execution, error) {
+	execution, err := s.execution(id)
+	if err != nil {
+		return nil, err
+	}
+
+	result, claimErr := execution.TryClaim(claim.Now)
+	if err := s.setExecution(execution); err != nil {
+		return nil, err
+	}
+
+	return result, claimErr
+}
+
+func (s *Store) dedupeExecution(claim eventrule.ExecutionClaim) (bool, error) {
+	if claim.Dedupe == nil {
+		return false, nil
+	}
+
+	executionIDs := s.executionsBySemantic[claim.SemanticKey()]
+	for _, id := range executionIDs {
+		execution, err := s.execution(id)
+		if err != nil {
+			return false, err
+		}
+
+		if !execution.TryDeduplicate(claim.Dedupe, claim.Now) {
+			continue
+		}
+
+		if err := s.setExecution(execution); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (s *Store) newExecution(
+	claim eventrule.ExecutionClaim,
+) (*eventrule.Execution, error) {
+	execution := claim.NewExecutionUnchecked()
+	persisted, err := converterdao.EventActionExecutionTo(execution)
+	if err != nil {
+		return nil, err
+	}
+
+	record := &memoryExecution{persisted: *persisted}
+	s.executions[execution.ID] = record
+	s.executionsByDelivery[claim.DeliveryKey()] = execution.ID
+
+	if claim.Dedupe != nil {
+		semanticKey := claim.SemanticKey()
+		s.executionsBySemantic[semanticKey] = append(
+			s.executionsBySemantic[semanticKey],
+			execution.ID,
+		)
+	}
+
+	return s.execution(execution.ID)
+}

--- a/rest-api/flow/internal/eventrule/store/memory/rule.go
+++ b/rest-api/flow/internal/eventrule/store/memory/rule.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	converterdao "github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/dao"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+)
+
+// GetByID returns one persisted rule.
+func (s *Store) GetByID(_ context.Context, id uuid.UUID) (*eventrule.Rule, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	persisted, ok := s.rules[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+	}
+	return converterdao.EventRuleFrom(&persisted)
+}
+
+// List returns persisted rules matching the filter.
+func (s *Store) List(
+	_ context.Context,
+	filter eventrule.RuleFilter,
+) ([]*eventrule.Rule, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rules := make([]*eventrule.Rule, 0, len(s.rules))
+	for _, persisted := range s.rules {
+		rule, err := converterdao.EventRuleFrom(&persisted)
+		if err != nil {
+			return nil, err
+		}
+		if filter.Matches(rule) {
+			rules = append(rules, rule)
+		}
+	}
+	slices.SortFunc(rules, func(a, b *eventrule.Rule) int {
+		return cmp.Compare(a.ID.String(), b.ID.String())
+	})
+	return rules, nil
+}
+
+// Create stores a new persisted rule.
+func (s *Store) Create(
+	_ context.Context,
+	rule *eventrule.Rule,
+) (*eventrule.Rule, error) {
+	if rule == nil {
+		return nil, errors.New("event rule is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.rules[rule.ID]; ok {
+		return nil, fmt.Errorf("event rule %s already exists", rule.ID)
+	}
+	canonical := rule.Clone()
+	now := s.now().UTC()
+	canonical.CreatedAt = now
+	canonical.UpdatedAt = now
+	persisted, err := converterdao.EventRuleTo(&canonical)
+	if err != nil {
+		return nil, err
+	}
+	s.rules[canonical.ID] = *persisted
+	return &canonical, nil
+}
+
+// UpdateMetadata updates one persisted rule's metadata.
+func (s *Store) UpdateMetadata(
+	_ context.Context,
+	id uuid.UUID,
+	metadata eventrule.RuleMetadata,
+) error {
+	return s.updateRule(id, func(rule *eventrule.Rule) {
+		rule.Name = metadata.Name
+		rule.Description = metadata.Description
+	})
+}
+
+// SetDedupe replaces or clears one persisted rule's deduplication policy.
+func (s *Store) SetDedupe(
+	_ context.Context,
+	id uuid.UUID,
+	dedupe *eventrule.Dedupe,
+) error {
+	return s.updateRule(id, func(rule *eventrule.Rule) {
+		if dedupe == nil {
+			rule.Dedupe = nil
+			return
+		}
+		cloned := *dedupe
+		rule.Dedupe = &cloned
+	})
+}
+
+// ReplaceActions replaces all actions belonging to one persisted rule.
+func (s *Store) ReplaceActions(
+	_ context.Context,
+	id uuid.UUID,
+	actions []eventrule.Action,
+) error {
+	return s.updateRule(id, func(rule *eventrule.Rule) {
+		rule.Actions = eventrule.CloneActions(actions)
+	})
+}
+
+// Delete atomically deletes a persisted rule and all of its bindings.
+func (s *Store) Delete(_ context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.rules[id]; !ok {
+		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+	}
+	bindingIDs := make([]uuid.UUID, 0)
+	for bindingID, persisted := range s.bindings {
+		if persisted.RuleID == id {
+			bindingIDs = append(bindingIDs, bindingID)
+		}
+	}
+	delete(s.rules, id)
+	for _, bindingID := range bindingIDs {
+		delete(s.bindings, bindingID)
+	}
+	return nil
+}
+
+// SetEnabled changes one persisted rule's enabled state.
+func (s *Store) SetEnabled(_ context.Context, id uuid.UUID, enabled bool) error {
+	return s.updateRule(id, func(rule *eventrule.Rule) {
+		rule.Enabled = enabled
+	})
+}
+
+func (s *Store) updateRule(id uuid.UUID, mutate func(*eventrule.Rule)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	persisted, ok := s.rules[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+	}
+	rule, err := converterdao.EventRuleFrom(&persisted)
+	if err != nil {
+		return err
+	}
+	mutate(rule)
+	rule.UpdatedAt = s.now().UTC()
+	updated, err := converterdao.EventRuleTo(rule)
+	if err != nil {
+		return err
+	}
+	s.rules[id] = *updated
+	return nil
+}

--- a/rest-api/flow/internal/eventrule/store/memory/store.go
+++ b/rest-api/flow/internal/eventrule/store/memory/store.go
@@ -1,297 +1,43 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package memory implements event-rule stores using versioned persistence
-// models held in memory.
+// Package memory implements event-rule stores in memory.
 package memory
 
 import (
-	"cmp"
-	"context"
-	"errors"
-	"fmt"
-	"slices"
 	"sync"
 	"time"
 
-	converterdao "github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/dao"
 	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
 	"github.com/google/uuid"
 )
 
-// Store implements rule and binding persistence over in-memory model records.
+// Store implements rule, binding, and execution persistence in memory.
 type Store struct {
-	mu       sync.RWMutex
-	rules    map[uuid.UUID]dbmodel.EventRule
-	bindings map[uuid.UUID]dbmodel.EventRuleBinding
-	now      func() time.Time
+	mu                   sync.RWMutex
+	rules                map[uuid.UUID]dbmodel.EventRule
+	bindings             map[uuid.UUID]dbmodel.EventRuleBinding
+	executions           map[uuid.UUID]*memoryExecution
+	executionsByDelivery map[eventrule.ExecutionDeliveryKey]uuid.UUID
+	executionsBySemantic map[eventrule.ExecutionSemanticKey][]uuid.UUID
+	now                  func() time.Time
 }
 
 // New constructs an empty in-memory store.
 func New() *Store {
 	return &Store{
-		rules:    make(map[uuid.UUID]dbmodel.EventRule),
-		bindings: make(map[uuid.UUID]dbmodel.EventRuleBinding),
-		now:      time.Now,
+		rules:                make(map[uuid.UUID]dbmodel.EventRule),
+		bindings:             make(map[uuid.UUID]dbmodel.EventRuleBinding),
+		executions:           make(map[uuid.UUID]*memoryExecution),
+		executionsByDelivery: make(map[eventrule.ExecutionDeliveryKey]uuid.UUID),
+		executionsBySemantic: make(map[eventrule.ExecutionSemanticKey][]uuid.UUID),
+		now:                  time.Now,
 	}
-}
-
-// GetByID returns one persisted rule.
-func (s *Store) GetByID(_ context.Context, id uuid.UUID) (*eventrule.Rule, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	persisted, ok := s.rules[id]
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
-	}
-	return converterdao.EventRuleFrom(&persisted)
-}
-
-// List returns persisted rules matching the filter.
-func (s *Store) List(
-	_ context.Context,
-	filter eventrule.RuleFilter,
-) ([]*eventrule.Rule, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	rules := make([]*eventrule.Rule, 0, len(s.rules))
-	for _, persisted := range s.rules {
-		rule, err := converterdao.EventRuleFrom(&persisted)
-		if err != nil {
-			return nil, err
-		}
-		if filter.Matches(rule) {
-			rules = append(rules, rule)
-		}
-	}
-	slices.SortFunc(rules, func(a, b *eventrule.Rule) int {
-		return cmp.Compare(a.ID.String(), b.ID.String())
-	})
-	return rules, nil
-}
-
-// Create stores a new persisted rule.
-func (s *Store) Create(
-	_ context.Context,
-	rule *eventrule.Rule,
-) (*eventrule.Rule, error) {
-	if rule == nil {
-		return nil, errors.New("event rule is nil")
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.rules[rule.ID]; ok {
-		return nil, fmt.Errorf("event rule %s already exists", rule.ID)
-	}
-	canonical := rule.Clone()
-	now := s.now().UTC()
-	canonical.CreatedAt = now
-	canonical.UpdatedAt = now
-	persisted, err := converterdao.EventRuleTo(&canonical)
-	if err != nil {
-		return nil, err
-	}
-	s.rules[canonical.ID] = *persisted
-	return &canonical, nil
-}
-
-// UpdateMetadata updates one persisted rule's metadata.
-func (s *Store) UpdateMetadata(
-	_ context.Context,
-	id uuid.UUID,
-	metadata eventrule.RuleMetadata,
-) error {
-	return s.updateRule(id, func(rule *eventrule.Rule) {
-		rule.Name = metadata.Name
-		rule.Description = metadata.Description
-	})
-}
-
-// SetDedupe replaces or clears one persisted rule's deduplication policy.
-func (s *Store) SetDedupe(
-	_ context.Context,
-	id uuid.UUID,
-	dedupe *eventrule.Dedupe,
-) error {
-	return s.updateRule(id, func(rule *eventrule.Rule) {
-		if dedupe == nil {
-			rule.Dedupe = nil
-			return
-		}
-		cloned := *dedupe
-		rule.Dedupe = &cloned
-	})
-}
-
-// ReplaceActions replaces all actions belonging to one persisted rule.
-func (s *Store) ReplaceActions(
-	_ context.Context,
-	id uuid.UUID,
-	actions []eventrule.Action,
-) error {
-	return s.updateRule(id, func(rule *eventrule.Rule) {
-		rule.Actions = eventrule.CloneActions(actions)
-	})
-}
-
-// Delete atomically deletes a persisted rule and all of its bindings.
-func (s *Store) Delete(_ context.Context, id uuid.UUID) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.rules[id]; !ok {
-		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
-	}
-	bindingIDs := make([]uuid.UUID, 0)
-	for bindingID, persisted := range s.bindings {
-		if persisted.RuleID == id {
-			bindingIDs = append(bindingIDs, bindingID)
-		}
-	}
-	delete(s.rules, id)
-	for _, bindingID := range bindingIDs {
-		delete(s.bindings, bindingID)
-	}
-	return nil
-}
-
-// SetEnabled changes one persisted rule's enabled state.
-func (s *Store) SetEnabled(_ context.Context, id uuid.UUID, enabled bool) error {
-	return s.updateRule(id, func(rule *eventrule.Rule) {
-		rule.Enabled = enabled
-	})
-}
-
-// Bind stores a rule-to-scope association.
-func (s *Store) Bind(_ context.Context, binding eventrule.Binding) error {
-	if err := binding.Validate(); err != nil {
-		return err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.bindings[binding.ID]; ok {
-		return fmt.Errorf("event rule binding %s already exists", binding.ID)
-	}
-
-	ruleRecord, ok := s.rules[binding.RuleID]
-	if !ok {
-		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, binding.RuleID)
-	}
-
-	if string(binding.EventType) != ruleRecord.EventType {
-		return fmt.Errorf(
-			"event rule binding event type %q does not match rule event type %q",
-			binding.EventType,
-			ruleRecord.EventType,
-		)
-	}
-
-	for _, persisted := range s.bindings {
-		if persisted.RuleID == binding.RuleID &&
-			persisted.ScopeType != string(binding.Scope.Type) {
-			return fmt.Errorf("event rule %s cannot mix site and rack bindings", binding.RuleID)
-		}
-
-		if bindingRecordMatchesScope(persisted, binding.EventType, binding.Scope) {
-			return fmt.Errorf(
-				"event type %q already has a binding for scope %q",
-				binding.EventType,
-				binding.Scope.Type,
-			)
-		}
-	}
-
-	now := s.now().UTC()
-	persisted, err := converterdao.EventRuleBindingTo(binding, now, now)
-	if err != nil {
-		return err
-	}
-	s.bindings[binding.ID] = *persisted
-	return nil
-}
-
-// Unbind deletes one binding.
-func (s *Store) Unbind(_ context.Context, id uuid.UUID) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.bindings[id]; !ok {
-		return fmt.Errorf("%w: binding %s", eventrule.ErrRuleNotFound, id)
-	}
-	delete(s.bindings, id)
-	return nil
-}
-
-// GetForScope returns the binding for an event type and scope.
-func (s *Store) GetForScope(
-	_ context.Context,
-	eventType eventrule.Type,
-	scope eventrule.Scope,
-) (*eventrule.Binding, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	for _, persisted := range s.bindings {
-		if bindingRecordMatchesScope(persisted, eventType, scope) {
-			return converterdao.EventRuleBindingFrom(&persisted)
-		}
-	}
-	return nil, nil
-}
-
-func bindingRecordMatchesScope(
-	binding dbmodel.EventRuleBinding,
-	eventType eventrule.Type,
-	scope eventrule.Scope,
-) bool {
-	if binding.EventType != string(eventType) ||
-		binding.ScopeType != string(scope.Type) {
-		return false
-	}
-
-	switch scope.Type {
-	case eventrule.ScopeTypeSite:
-		return binding.ScopeID == nil
-	case eventrule.ScopeTypeRack:
-		return binding.ScopeID != nil && *binding.ScopeID == scope.ID
-	default:
-		return false
-	}
-}
-
-func (s *Store) updateRule(id uuid.UUID, mutate func(*eventrule.Rule)) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	persisted, ok := s.rules[id]
-	if !ok {
-		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
-	}
-	rule, err := converterdao.EventRuleFrom(&persisted)
-	if err != nil {
-		return err
-	}
-	mutate(rule)
-	rule.UpdatedAt = s.now().UTC()
-	if err := rule.Validate(); err != nil {
-		return err
-	}
-	updated, err := converterdao.EventRuleTo(rule)
-	if err != nil {
-		return err
-	}
-	s.rules[id] = *updated
-	return nil
 }
 
 var (
-	_ eventrule.RuleStore    = (*Store)(nil)
-	_ eventrule.BindingStore = (*Store)(nil)
+	_ eventrule.RuleStore      = (*Store)(nil)
+	_ eventrule.BindingStore   = (*Store)(nil)
+	_ eventrule.ExecutionStore = (*Store)(nil)
 )

--- a/rest-api/flow/internal/eventrule/store/memory/store_test.go
+++ b/rest-api/flow/internal/eventrule/store/memory/store_test.go
@@ -6,6 +6,7 @@ package memory
 import (
 	"context"
 	"testing"
+	"time"
 
 	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
@@ -15,9 +16,12 @@ import (
 )
 
 func TestStoreContract(t *testing.T) {
-	storetest.RunContract(t, func() (eventrule.RuleStore, eventrule.BindingStore) {
+	storetest.RunRuleBindingContract(t, func() (eventrule.RuleStore, eventrule.BindingStore) {
 		store := New()
 		return store, store
+	})
+	storetest.RunExecutionContract(t, func() eventrule.ExecutionStore {
+		return New()
 	})
 }
 
@@ -56,4 +60,35 @@ func TestBindingScansIgnoreUnrelatedInvalidRecords(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, &binding, found)
 	require.NoError(t, store.Delete(ctx, rule.ID))
+}
+
+func TestStore_ClaimRejectsDanglingIndexes(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	tests := map[string]func(*Store, eventrule.ExecutionClaim){
+		"delivery": func(store *Store, claim eventrule.ExecutionClaim) {
+			store.executionsByDelivery[claim.DeliveryKey()] = uuid.New()
+		},
+		"semantic": func(store *Store, claim eventrule.ExecutionClaim) {
+			store.executionsBySemantic[claim.SemanticKey()] = []uuid.UUID{uuid.New()}
+		},
+	}
+
+	for name, corrupt := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := New()
+			claim := eventrule.ExecutionClaim{
+				EventID:        uuid.New(),
+				RuleID:         uuid.New(),
+				ActionID:       "action",
+				CorrelationKey: "incident-1",
+				Dedupe:         &eventrule.Dedupe{Window: time.Minute},
+				Now:            now,
+			}
+			corrupt(store, claim)
+
+			execution, err := store.Claim(context.Background(), claim)
+			require.ErrorIs(t, err, eventrule.ErrExecutionNotFound)
+			require.Nil(t, execution)
+		})
+	}
 }

--- a/rest-api/flow/internal/eventrule/store/storetest/contract.go
+++ b/rest-api/flow/internal/eventrule/store/storetest/contract.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Factory constructs empty rule and binding stores that share one persistence
-// boundary.
-type Factory func() (eventrule.RuleStore, eventrule.BindingStore)
+// RuleBindingFactory constructs empty rule and binding stores that share one
+// persistence boundary.
+type RuleBindingFactory func() (eventrule.RuleStore, eventrule.BindingStore)
 
-// RunContract executes the shared rule and binding store contract.
-func RunContract(t *testing.T, factory Factory) {
+// RunRuleBindingContract executes the shared rule and binding store contract.
+func RunRuleBindingContract(t *testing.T, factory RuleBindingFactory) {
 	t.Helper()
 	t.Run("rule lifecycle", func(t *testing.T) {
 		testRuleLifecycle(t, factory)
@@ -36,7 +36,7 @@ func RunContract(t *testing.T, factory Factory) {
 	})
 }
 
-func testRuleLifecycle(t *testing.T, factory Factory) {
+func testRuleLifecycle(t *testing.T, factory RuleBindingFactory) {
 	t.Helper()
 	ctx := context.Background()
 	rules, _ := factory()
@@ -132,7 +132,7 @@ func testRuleLifecycle(t *testing.T, factory Factory) {
 	}
 }
 
-func testBindingInvariants(t *testing.T, factory Factory) {
+func testBindingInvariants(t *testing.T, factory RuleBindingFactory) {
 	t.Helper()
 	ctx := context.Background()
 	rules, bindings := factory()
@@ -166,6 +166,10 @@ func testBindingInvariants(t *testing.T, factory Factory) {
 	secondSite := newBinding(second, eventrule.Scope{Type: eventrule.ScopeTypeSite})
 	require.NoError(t, bindings.Bind(ctx, secondSite))
 	require.ErrorContains(t, bindings.Bind(ctx, newBinding(
+		first,
+		eventrule.Scope{Type: eventrule.ScopeTypeSite},
+	)), "already has a binding for scope")
+	require.ErrorContains(t, bindings.Bind(ctx, newBinding(
 		second,
 		eventrule.Scope{Type: eventrule.ScopeTypeSite},
 	)), "already has a binding for scope")
@@ -192,7 +196,7 @@ func testBindingInvariants(t *testing.T, factory Factory) {
 	assert.Nil(t, found)
 }
 
-func testConcurrentBindingConflict(t *testing.T, factory Factory) {
+func testConcurrentBindingConflict(t *testing.T, factory RuleBindingFactory) {
 	t.Helper()
 	ctx := context.Background()
 	rules, bindings := factory()
@@ -220,7 +224,7 @@ func testConcurrentBindingConflict(t *testing.T, factory Factory) {
 	assert.Equal(t, 1, successes)
 }
 
-func testDeleteCascadesBindings(t *testing.T, factory Factory) {
+func testDeleteCascadesBindings(t *testing.T, factory RuleBindingFactory) {
 	t.Helper()
 	ctx := context.Background()
 	rules, bindings := factory()

--- a/rest-api/flow/internal/eventrule/store/storetest/execution_contract.go
+++ b/rest-api/flow/internal/eventrule/store/storetest/execution_contract.go
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package storetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// ExecutionFactory constructs an empty execution store.
+type ExecutionFactory func() eventrule.ExecutionStore
+
+// RunExecutionContract executes the shared execution store contract.
+func RunExecutionContract(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+	t.Run("claim and retry", func(t *testing.T) {
+		testExecutionClaimAndRetry(t, factory)
+	})
+	t.Run("delivery deduplication", func(t *testing.T) {
+		testExecutionDeliveryDeduplication(t, factory)
+	})
+	t.Run("semantic deduplication", func(t *testing.T) {
+		testExecutionSemanticDeduplication(t, factory)
+	})
+	t.Run("semantic deduplication window expiry", func(t *testing.T) {
+		testExecutionSemanticDedupeWindowExpiry(t, factory)
+	})
+	t.Run("transitions", func(t *testing.T) {
+		testExecutionTransitions(t, factory)
+	})
+	t.Run("unknown execution transition", func(t *testing.T) {
+		testUnknownExecutionTransition(t, factory)
+	})
+	t.Run("terminal execution is not owned", func(t *testing.T) {
+		testExecutionOwnership(t, factory)
+	})
+}
+
+func testUnknownExecutionTransition(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+	execution, err := factory().Transition(
+		context.Background(),
+		uuid.New(),
+		eventrule.ExecutionState{Status: eventrule.ExecutionStatusCompleted},
+		time.Now(),
+	)
+	require.ErrorIs(t, err, eventrule.ErrExecutionNotFound)
+	require.Nil(t, execution)
+}
+
+func testExecutionOwnership(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	store := factory()
+	execution, err := store.Claim(ctx, newExecutionClaim(now))
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	transitioned, err := store.Transition(ctx, execution.ID, eventrule.ExecutionState{
+		Status: eventrule.ExecutionStatusCompleted,
+	}, now)
+	require.NoError(t, err)
+	require.NotNil(t, transitioned)
+
+	transitioned, err = store.Transition(ctx, execution.ID, eventrule.ExecutionState{
+		Status: eventrule.ExecutionStatusFailed,
+	}, now.Add(time.Second))
+	require.ErrorContains(t, err, "is not owned")
+	require.Nil(t, transitioned)
+}
+
+func testExecutionClaimAndRetry(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+	ctx := context.Background()
+	firstClaimedAt := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	nextAttemptAt := firstClaimedAt.Add(time.Minute)
+	store := factory()
+	claim := newExecutionClaim(firstClaimedAt)
+
+	execution, err := store.Claim(ctx, claim)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+	require.Equal(t, eventrule.ExecutionStatusClaimed, execution.Status)
+	require.Equal(t, firstClaimedAt, execution.FirstClaimedAt)
+	require.Equal(t, 1, execution.Observations)
+	require.Equal(t, 1, execution.Attempts)
+
+	_, err = store.Transition(ctx, execution.ID, eventrule.ExecutionState{
+		Status:        eventrule.ExecutionStatusDeferred,
+		Reason:        eventrule.ExecutionReasonAttemptFailed,
+		StatusMessage: "inventory unavailable",
+		NextAttemptAt: nextAttemptAt,
+	}, firstClaimedAt.Add(time.Second))
+	require.NoError(t, err)
+
+	claim.Now = nextAttemptAt.Add(-time.Second)
+	execution, err = store.Claim(ctx, claim)
+	require.Nil(t, execution)
+	require.ErrorIs(t, err, eventrule.ErrRetryScheduled)
+
+	claim.Now = nextAttemptAt
+	execution, err = store.Claim(ctx, claim)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+	require.Equal(t, eventrule.ExecutionStatusClaimed, execution.Status)
+	require.Equal(t, eventrule.ExecutionReasonNone, execution.Reason)
+	require.Empty(t, execution.StatusMessage)
+	require.True(t, execution.NextAttemptAt.IsZero())
+	require.Equal(t, firstClaimedAt, execution.FirstClaimedAt)
+	require.Equal(t, 3, execution.Observations)
+	require.Equal(t, 2, execution.Attempts)
+}
+
+func testExecutionDeliveryDeduplication(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	store := factory()
+	claim := newExecutionClaim(now)
+
+	execution, err := store.Claim(ctx, claim)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	claim.Now = now.Add(time.Second)
+	duplicate, err := store.Claim(ctx, claim)
+	require.NoError(t, err)
+	require.Nil(t, duplicate)
+
+	transitioned, err := store.Transition(ctx, execution.ID, eventrule.ExecutionState{
+		Status: eventrule.ExecutionStatusCompleted,
+	}, now.Add(2*time.Second))
+	require.NoError(t, err)
+	require.Equal(t, 2, transitioned.Observations)
+}
+
+func testExecutionSemanticDeduplication(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	store := factory()
+	claim := newExecutionClaim(now)
+	claim.CorrelationKey = "incident-1"
+	claim.Dedupe = &eventrule.Dedupe{Window: time.Minute}
+
+	execution, err := store.Claim(ctx, claim)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	claim.EventID = uuid.New()
+	claim.Now = now.Add(time.Second)
+	duplicate, err := store.Claim(ctx, claim)
+	require.NoError(t, err)
+	require.Nil(t, duplicate)
+
+	transitioned, err := store.Transition(ctx, execution.ID, eventrule.ExecutionState{
+		Status: eventrule.ExecutionStatusCompleted,
+	}, now.Add(2*time.Second))
+	require.NoError(t, err)
+	require.Equal(t, 2, transitioned.Observations)
+}
+
+func testExecutionSemanticDedupeWindowExpiry(
+	t *testing.T,
+	factory ExecutionFactory,
+) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	store := factory()
+	claim := newExecutionClaim(now)
+	claim.CorrelationKey = "incident-1"
+	claim.Dedupe = &eventrule.Dedupe{Window: time.Minute}
+
+	first, err := store.Claim(ctx, claim)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	claim.EventID = uuid.New()
+	claim.Now = now.Add(claim.Dedupe.Window)
+	second, err := store.Claim(ctx, claim)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.NotEqual(t, first.ID, second.ID)
+}
+
+func testExecutionTransitions(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	tests := map[string]struct {
+		state   eventrule.ExecutionState
+		wantErr bool
+	}{
+		"invalid status": {
+			state:   eventrule.ExecutionState{Status: "invalid"},
+			wantErr: true,
+		},
+		"claimed is not a transition target": {
+			state:   eventrule.ExecutionState{Status: eventrule.ExecutionStatusClaimed},
+			wantErr: true,
+		},
+		"completed": {
+			state: eventrule.ExecutionState{Status: eventrule.ExecutionStatusCompleted},
+		},
+		"skipped without reason": {
+			state:   eventrule.ExecutionState{Status: eventrule.ExecutionStatusSkipped},
+			wantErr: true,
+		},
+		"skipped": {
+			state: eventrule.ExecutionState{
+				Status: eventrule.ExecutionStatusSkipped,
+				Reason: eventrule.ExecutionReasonNoTargets,
+			},
+		},
+		"deferred without reason": {
+			state: eventrule.ExecutionState{
+				Status:        eventrule.ExecutionStatusDeferred,
+				NextAttemptAt: now.Add(time.Minute),
+			},
+			wantErr: true,
+		},
+		"deferred without next attempt": {
+			state: eventrule.ExecutionState{
+				Status: eventrule.ExecutionStatusDeferred,
+				Reason: eventrule.ExecutionReasonAttemptFailed,
+			},
+			wantErr: true,
+		},
+		"deferred": {
+			state: eventrule.ExecutionState{
+				Status:        eventrule.ExecutionStatusDeferred,
+				Reason:        eventrule.ExecutionReasonAttemptFailed,
+				NextAttemptAt: now.Add(time.Minute),
+			},
+		},
+		"submitted": {
+			state: eventrule.ExecutionState{Status: eventrule.ExecutionStatusSubmitted},
+		},
+		"failed": {
+			state: eventrule.ExecutionState{Status: eventrule.ExecutionStatusFailed},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			store := factory()
+			execution, err := store.Claim(ctx, newExecutionClaim(now))
+			require.NoError(t, err)
+			require.NotNil(t, execution)
+
+			transitionAt := now.Add(time.Second)
+			transitioned, err := store.Transition(
+				ctx,
+				execution.ID,
+				test.state,
+				transitionAt,
+			)
+			if test.wantErr {
+				require.Error(t, err)
+				require.Nil(t, transitioned)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.state, transitioned.ExecutionState)
+			require.Equal(t, transitionAt, transitioned.UpdatedAt)
+		})
+	}
+}
+
+func newExecutionClaim(now time.Time) eventrule.ExecutionClaim {
+	return eventrule.ExecutionClaim{
+		EventID:  uuid.New(),
+		RuleID:   uuid.New(),
+		ActionID: "action",
+		Now:      now,
+	}
+}


### PR DESCRIPTION
Leakage detection currently polls NICo Core for leaking information and
immediately submits a force power-off task for each affected component.
That is safe as an initial behavior, but it hard-codes both detection
and response in the leak detection job.

We need a pre-defined response at startup, while leaving room for users
to define their own rules later. And the mode should be reusable for
other event families such as thermal alarms, inventory drift, firmware
health events, attestation failures, etc.

We plan to create event rules which decide what to do in response to an
event.

This PR introduces the first phased implementation of durable event-rule
action execution while keeping database-backed ownership fencing out of
this change.
- defines execution identity, state/status/reason contracts, delivery and
   semantic keys, retry timing, ownership, deduplication, claim, and
   transition domain operations
- adds the execution database model and tested DAO conversions without
   introducing a PostgreSQL migration or store
- defines Executor preparation and execution contracts, including result
   validation and operational-outcome handling
- refactors Processor into explicit precheck, claim, prepare, perform, and
   persist stages using full execution and event-envelope requests
- adds the ExecutionStore Claim and Transition contract with delivery
   idempotency, semantic deduplication, deferred retry, observation, and
   attempt behavior
- implements the contract in the in-memory store while persisting db-model
   records and sharing domain decisions with future stores
- splits the in-memory rule, binding, and execution stores into focused files
   and adds reusable store contract tests
- adds table-driven coverage for domain validation, converters, executor
   contracts, processor stages, and execution-store behavior

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

