### PR TITLE
fix(rest-api): Retrieve Site runtime config with inventory, update controller version

### DIFF
--- a/rest-api/site-workflow/pkg/activity/site.go
+++ b/rest-api/site-workflow/pkg/activity/site.go
@@ -39,7 +39,9 @@ func (msi *ManageSiteConfigInventory) DiscoverSiteConfigInventory(ctx context.Co
 		return cClient.ErrCoreGrpcClientNotConnected
 	}
 
-	buildInfo, err := grpcClient.GrpcServiceClient().Version(ctx, &corev1.VersionRequest{})
+	buildInfo, err := grpcClient.GrpcServiceClient().Version(ctx, &corev1.VersionRequest{
+		DisplayConfig: true,
+	})
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to retrieve Site runtime config using Core gRPC API")
 		return err

--- a/rest-api/site-workflow/pkg/activity/site_test.go
+++ b/rest-api/site-workflow/pkg/activity/site_test.go
@@ -61,6 +61,8 @@ func TestManageSiteConfigInventory_DiscoverSiteConfigInventory(t *testing.T) {
 
 	buildInfo, ok := tc.Calls[0].Arguments[4].(*corev1.BuildInfo)
 	require.True(t, ok)
+	require.NotNil(t, buildInfo.GetRuntimeConfig(),
+		"Version request must set DisplayConfig, Core omits the runtime config without it")
 	assert.Equal(t, siteFabricPrefixes, buildInfo.GetRuntimeConfig().GetSiteFabricPrefixes())
 }
 

--- a/rest-api/site-workflow/pkg/grpc/client/testing.go
+++ b/rest-api/site-workflow/pkg/grpc/client/testing.go
@@ -71,7 +71,8 @@ func (mcgsc *MockCoreGrpcServiceClient) Version(ctx context.Context, in *corev1.
 	// Core reports the runtime config only when the request asks for it, so a
 	// caller that omits DisplayConfig gets BuildInfo with no RuntimeConfig.
 	if in.GetDisplayConfig() {
-		if siteFabricPrefixes, ok := ctx.Value("siteFabricPrefixes").([]string); ok {
+		siteFabricPrefixes, ok := ctx.Value("siteFabricPrefixes").([]string)
+		if ok {
 			out.RuntimeConfig = &corev1.RuntimeConfig{
 				SiteFabricPrefixes: siteFabricPrefixes,
 			}

--- a/rest-api/site-workflow/pkg/grpc/client/testing.go
+++ b/rest-api/site-workflow/pkg/grpc/client/testing.go
@@ -68,9 +68,13 @@ type MockCoreGrpcServiceClient struct {
 func (mcgsc *MockCoreGrpcServiceClient) Version(ctx context.Context, in *corev1.VersionRequest, opts ...grpc.CallOption) (*corev1.BuildInfo, error) {
 	out := new(corev1.BuildInfo)
 	out.BuildVersion = "1.0.0"
-	if siteFabricPrefixes, ok := ctx.Value("siteFabricPrefixes").([]string); ok {
-		out.RuntimeConfig = &corev1.RuntimeConfig{
-			SiteFabricPrefixes: siteFabricPrefixes,
+	// Core reports the runtime config only when the request asks for it, so a
+	// caller that omits DisplayConfig gets BuildInfo with no RuntimeConfig.
+	if in.GetDisplayConfig() {
+		if siteFabricPrefixes, ok := ctx.Value("siteFabricPrefixes").([]string); ok {
+			out.RuntimeConfig = &corev1.RuntimeConfig{
+				SiteFabricPrefixes: siteFabricPrefixes,
+			}
 		}
 	}
 	return out, nil

--- a/rest-api/workflow/pkg/activity/site/site.go
+++ b/rest-api/workflow/pkg/activity/site/site.go
@@ -17,8 +17,11 @@ import (
 	tOperatorv1 "go.temporal.io/api/operatorservice/v1"
 	tWorkflowv1 "go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 
-	cloudutils "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
+
+	ccu "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/ipam"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
@@ -37,7 +40,28 @@ const (
 
 	// Number of days before cert expiration when rotation should be triggered
 	rotationBufferDays = 10
+
+	// Site fabric IP block constants
+	siteFabricIPBlockDescription = "Automatically created from Site fabric prefix"
+
+	// Site fabric IP block name prefix
+	siteFabricIPBlockNamePrefix = "site-fabric"
+
+	// Site fabric IP block ready message
+	siteFabricIPBlockReadyMsg = "IP Block is ready for use"
 )
+
+// siteFabricIPBlocksLockID derives the advisory lock that serializes Site
+// fabric IP Block creation for a Site. It is shared with the activity's tests,
+// which acquire the same lock to exercise contention handling.
+func getSiteFabricIPBlockLockID(dbSite *cdbm.Site) uint64 {
+	return cdb.GetAdvisoryLockIDFromString(fmt.Sprintf(
+		"site-fabric-ip-blocks:%s:%s:%s",
+		dbSite.InfrastructureProviderID.String(),
+		dbSite.ID.String(),
+		cdbm.IPBlockRoutingTypeDatacenterOnly,
+	))
+}
 
 // ManageSite is an activity wrapper for managing Site lifecycle that allows
 // injecting DB access
@@ -49,6 +73,41 @@ type ManageSite struct {
 }
 
 // Activity functions
+
+// UpdateSiteMetadataInDB is a Temporal activity that updates the Site metadata in the DB.
+func (mst ManageSite) UpdateSiteInDB(ctx context.Context, siteID uuid.UUID, buildInfo *corev1.BuildInfo) error {
+	logger := log.With().Str("Activity", "UpdateSiteMetadataInDB").Str("Site ID", siteID.String()).Logger()
+
+	logger.Info().Msg("starting activity")
+
+	siteDAO := cdbm.NewSiteDAO(mst.dbSession)
+	site, err := siteDAO.GetByID(ctx, nil, siteID, nil, false)
+	if err != nil {
+		if err == cdb.ErrDoesNotExist {
+			// If Site is not found, return a non-retryable error to prevent the workflow from retrying
+			logger.Warn().Err(err).Msg("received Config inventory for unknown or deleted Site")
+			return temporal.NewNonRetryableApplicationError("Site not found", "Site not found", err)
+		}
+
+		logger.Error().Err(err).Msg("failed to retrieve Site by ID, DB error")
+		return err
+	}
+
+	// Update build version for Site
+	siteControllerVersion := buildInfo.GetBuildVersion()
+	if siteControllerVersion != "" && (site.SiteControllerVersion == nil || (site.SiteControllerVersion != nil && *site.SiteControllerVersion != siteControllerVersion)) {
+		_, err = siteDAO.Update(ctx, nil, cdbm.SiteUpdateInput{
+			SiteID:                site.ID,
+			SiteControllerVersion: &siteControllerVersion,
+		})
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to update Site controller version in DB")
+			return err
+		}
+	}
+
+	return nil
+}
 
 // DeleteSiteComponentsFromDB is a Temporal activity that initiates delete for instance type, machine,
 // machine interface, machine capability, operating system site association, instance, subnet, vpc, vpc peering, vpc prefix,
@@ -99,7 +158,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 
 	// Delete Instance Types
 	// Check for Instance Types associated with Site
-	its, _, err := itDAO.GetAll(ctx, nil, cdbm.InstanceTypeFilterInput{SiteIDs: []uuid.UUID{siteID}}, nil, nil, cloudutils.GetPtr(cdbp.TotalLimit), nil)
+	its, _, err := itDAO.GetAll(ctx, nil, cdbm.InstanceTypeFilterInput{SiteIDs: []uuid.UUID{siteID}}, nil, nil, ccu.GetPtr(cdbp.TotalLimit), nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving Instance Types for Site from DB")
 		return err
@@ -130,7 +189,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 			SiteIDs:        []uuid.UUID{siteID},
 			ExcludeDerived: true,
 		},
-		cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)},
+		cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)},
 		nil,
 	)
 	if err != nil {
@@ -149,7 +208,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 
 	// Delete Instances
 	// Check that Instance exists
-	instances, _, err := instanceDAO.GetAll(ctx, nil, cdbm.InstanceFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	instances, _, err := instanceDAO.GetAll(ctx, nil, cdbm.InstanceFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Instances from DB by Site ID")
 		return err
@@ -202,7 +261,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 
 	// Delete Machines
 	// Check if Machines exist
-	mcs, _, err := mDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	mcs, _, err := mDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("error retrieving Machine for Site from DB")
 		return err
@@ -216,7 +275,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 			cdbm.MachineInterfaceFilterInput{
 				MachineIDs: []string{mc.ID},
 			},
-			cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)},
+			cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)},
 			nil,
 		)
 		if serr != nil {
@@ -234,7 +293,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 		}
 
 		// Get Machine Capability records from the db
-		mcbs, _, serr := mcDAO.GetAll(ctx, nil, []string{mc.ID}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, cloudutils.GetPtr(cdbp.TotalLimit), nil)
+		mcbs, _, serr := mcDAO.GetAll(ctx, nil, []string{mc.ID}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, ccu.GetPtr(cdbp.TotalLimit), nil)
 		if serr != nil {
 			logger.Error().Err(serr).Msg("error retrieving MachineCapabilities for Site's machine from DB")
 			return serr
@@ -258,7 +317,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 
 	// Delete Subnets
 	// Check if Subnets exist
-	subnets, _, err := subnetDAO.GetAll(ctx, nil, cdbm.SubnetFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, []string{})
+	subnets, _, err := subnetDAO.GetAll(ctx, nil, cdbm.SubnetFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, []string{})
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Subnets from DB by Site ID")
 		return err
@@ -274,7 +333,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete VPC Prefixes
-	vpcPrefixes, _, err := vpfxDAO.GetAll(ctx, nil, cdbm.VpcPrefixFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	vpcPrefixes, _, err := vpfxDAO.GetAll(ctx, nil, cdbm.VpcPrefixFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve VPC Prefixes from DB by Site ID")
 		return err
@@ -290,7 +349,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete VPC Peerings
-	vpps, _, err := vpDAO.GetAll(ctx, nil, cdbm.VpcPeeringFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	vpps, _, err := vpDAO.GetAll(ctx, nil, cdbm.VpcPeeringFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve VPC Peerings from DB by Site ID")
 		return err
@@ -306,7 +365,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 
 	// Delete VPCs
 	// Check if VPCs exist
-	vpcs, _, err := vpcDAO.GetAll(ctx, nil, cdbm.VpcFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	vpcs, _, err := vpcDAO.GetAll(ctx, nil, cdbm.VpcFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve VPCs from DB by Site ID")
 		return err
@@ -328,7 +387,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 		cdbm.InfiniBandPartitionFilterInput{
 			SiteIDs: []uuid.UUID{siteID},
 		},
-		cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)},
+		cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)},
 		nil,
 	)
 	if err != nil {
@@ -346,7 +405,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete NVLink Logical Partitions
-	nvllps, _, err := nvllpDAO.GetAll(ctx, nil, cdbm.NVLinkLogicalPartitionFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	nvllps, _, err := nvllpDAO.GetAll(ctx, nil, cdbm.NVLinkLogicalPartitionFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve NVLink Logical Partitions from DB by Site ID")
 		return err
@@ -361,7 +420,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete SSH Key Group Site Associations
-	skgsas, _, err := skgsaDAO.GetAll(ctx, nil, cdbm.SSHKeyGroupSiteAssociationFilterInput{SiteID: &siteID}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	skgsas, _, err := skgsaDAO.GetAll(ctx, nil, cdbm.SSHKeyGroupSiteAssociationFilterInput{SiteID: &siteID}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve SSH Key Group Site Associations from DB")
 		return err
@@ -378,7 +437,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	// Delete SSH Key Group Instance Associations
 	skgias, _, err := skgiaDAO.GetAll(ctx, nil, cdbm.SSHKeyGroupInstanceAssociationFilterInput{
 		SiteIDs: []uuid.UUID{siteID},
-	}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve SSH Key Group Instance Associations from DB")
 		return err
@@ -393,7 +452,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete Network Security Groups
-	nsgs, _, err := nsgDAO.GetAll(ctx, nil, cdbm.NetworkSecurityGroupFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	nsgs, _, err := nsgDAO.GetAll(ctx, nil, cdbm.NetworkSecurityGroupFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Network Security Groups from DB by Site ID")
 		return err
@@ -411,7 +470,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete operating system site associations.
-	ossas, _, err := ossaDAO.GetAll(ctx, nil, cdbm.OperatingSystemSiteAssociationFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	ossas, _, err := ossaDAO.GetAll(ctx, nil, cdbm.OperatingSystemSiteAssociationFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Operating System Site Associations from DB by Site ID")
 		return err
@@ -426,7 +485,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete DPU Extension Service Deployments
-	desds, _, err := desdDAO.GetAll(ctx, nil, cdbm.DpuExtensionServiceDeploymentFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	desds, _, err := desdDAO.GetAll(ctx, nil, cdbm.DpuExtensionServiceDeploymentFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve DPU Extension Service Deployments from DB by Site ID")
 		return err
@@ -441,7 +500,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete Skus
-	skus, _, err := skuDAO.GetAll(ctx, nil, cdbm.SkuFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)})
+	skus, _, err := skuDAO.GetAll(ctx, nil, cdbm.SkuFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)})
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Skus from DB by Site ID")
 		return err
@@ -456,7 +515,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete Expected Switches
-	ess, _, err := esDAO.GetAll(ctx, nil, cdbm.ExpectedSwitchFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	ess, _, err := esDAO.GetAll(ctx, nil, cdbm.ExpectedSwitchFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Expected Switches from DB by Site ID")
 		return err
@@ -471,7 +530,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete Expected Power Shelves
-	epss, _, err := epsDAO.GetAll(ctx, nil, cdbm.ExpectedPowerShelfFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	epss, _, err := epsDAO.GetAll(ctx, nil, cdbm.ExpectedPowerShelfFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Expected Power Shelves from DB by Site ID")
 		return err
@@ -486,7 +545,7 @@ func (mst ManageSite) DeleteSiteComponentsFromDB(ctx context.Context, siteID uui
 	}
 
 	// Delete Expected Machines
-	ems, _, err := emDAO.GetAll(ctx, nil, cdbm.ExpectedMachineFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	ems, _, err := emDAO.GetAll(ctx, nil, cdbm.ExpectedMachineFilterInput{SiteIDs: []uuid.UUID{siteID}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Expected Machines from DB by Site ID")
 		return err
@@ -520,7 +579,7 @@ func (mst ManageSite) MonitorInventoryReceiptForAllSites(ctx context.Context) er
 	// Get all Sites
 	siteDAO := cdbm.NewSiteDAO(mst.dbSession)
 
-	sites, _, err := siteDAO.GetAll(ctx, nil, cdbm.SiteFilterInput{Statuses: []string{string(cdbm.SiteStatusRegistered)}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	sites, _, err := siteDAO.GetAll(ctx, nil, cdbm.SiteFilterInput{Statuses: []string{string(cdbm.SiteStatusRegistered)}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Sites from DB")
 		return err
@@ -575,7 +634,7 @@ func (mst ManageSite) MonitorInventoryReceiptForAllSites(ctx context.Context) er
 
 			// Set Site status to error
 			errMsg := fmt.Sprintf("Site hasn't received inventory for longer than threshold period of: %v minutes", SiteInventoryReceiptThreshold.Minutes())
-			serr := mst.updateSiteStatusInDB(ctx, nil, site.ID, cloudutils.GetPtr(cdbm.SiteStatusError), &errMsg)
+			serr := mst.updateSiteStatusInDB(ctx, nil, site.ID, ccu.GetPtr(cdbm.SiteStatusError), &errMsg)
 			if serr != nil {
 				logger.Error().Err(serr).Msg("error updating Site status in DB")
 				return serr
@@ -597,7 +656,7 @@ func (mst ManageSite) GetAllSiteIDs(ctx context.Context) ([]uuid.UUID, error) {
 	// Get all Sites
 	siteDAO := cdbm.NewSiteDAO(mst.dbSession)
 
-	sites, _, err := siteDAO.GetAll(ctx, nil, cdbm.SiteFilterInput{}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	sites, _, err := siteDAO.GetAll(ctx, nil, cdbm.SiteFilterInput{}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to retrieve Sites from DB")
 		return nil, err
@@ -641,7 +700,7 @@ func (mst ManageSite) CheckOTPExpirationAndRenewForAllSites(ctx context.Context)
 	logger.Info().Msg("starting activity")
 
 	stDAO := cdbm.NewSiteDAO(mst.dbSession)
-	sites, _, err := stDAO.GetAll(ctx, nil, cdbm.SiteFilterInput{Statuses: []string{cdbm.SiteStatusRegistered}}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	sites, _, err := stDAO.GetAll(ctx, nil, cdbm.SiteFilterInput{Statuses: []string{cdbm.SiteStatusRegistered}}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("Error retrieving Site from DB")
 		return err
@@ -679,7 +738,7 @@ func (mst ManageSite) CheckOTPExpirationAndRenewForAllSites(ctx context.Context)
 			}
 
 			// Encrypt the new OTP with the siteID
-			encryptedOTP := cloudutils.EncryptData([]byte(*newOTP), site.ID.String())
+			encryptedOTP := ccu.EncryptData([]byte(*newOTP), site.ID.String())
 			// Base64 encode the encrypted OTP
 			base64EncodedEncryptedOTP := base64.StdEncoding.EncodeToString(encryptedOTP)
 
@@ -780,7 +839,7 @@ func (mst ManageSite) DeleteOrphanedSiteTemporalNamespaces(ctx context.Context) 
 
 	// Get existing Site IDs
 	stDAO := cdbm.NewSiteDAO(mst.dbSession)
-	sites, count, err := stDAO.GetAll(ctx, nil, cdbm.SiteFilterInput{}, cdbp.PageInput{Limit: cloudutils.GetPtr(cdbp.TotalLimit)}, nil)
+	sites, count, err := stDAO.GetAll(ctx, nil, cdbm.SiteFilterInput{}, cdbp.PageInput{Limit: ccu.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to retrieve Sites from DB")
 		return fmt.Errorf("failed to get sites from DB: %w", err)
@@ -830,22 +889,6 @@ func (mst ManageSite) DeleteOrphanedSiteTemporalNamespaces(ctx context.Context) 
 	return nil
 }
 
-// NewManageSite returns a new ManageSite activity
-func NewManageSite(dbSession *cdb.Session, siteClientPool *sc.ClientPool, tc client.Client, cfg *config.Config) ManageSite {
-	return ManageSite{
-		dbSession:      dbSession,
-		siteClientPool: siteClientPool,
-		tc:             tc,
-		cfg:            cfg,
-	}
-}
-
-const (
-	siteFabricIPBlockDescription = "Automatically created from Site fabric prefix"
-	siteFabricIPBlockNamePrefix  = "site-fabric"
-	siteFabricIPBlockReadyMsg    = "IP Block is ready for use"
-)
-
 // UpdateIPBlocksInDBFromFabricPrefixes creates Site-level DatacenterOnly IP
 // Blocks for the fabric prefixes reported by the Site as part of its Site
 // Config inventory. Existing root IP Blocks for the same provider, Site,
@@ -892,7 +935,7 @@ func (mst ManageSite) UpdateIPBlocksInDBFromFabricPrefixes(ctx context.Context, 
 	statusDetailDAO := cdbm.NewStatusDetailDAO(mst.dbSession)
 
 	err = cdb.WithTx(ctx, mst.dbSession, func(tx *cdb.Tx) error {
-		if derr := tx.AcquireAdvisoryLock(ctx, siteFabricIPBlocksLockID(dbSite), false); derr != nil {
+		if derr := tx.AcquireAdvisoryLock(ctx, getSiteFabricIPBlockLockID(dbSite), false); derr != nil {
 			logger.Error().Err(derr).Msg("failed to acquire advisory lock for Site fabric IP Blocks")
 			return derr
 		}
@@ -914,7 +957,7 @@ func (mst ManageSite) UpdateIPBlocksInDBFromFabricPrefixes(ctx context.Context, 
 					RoutingTypes:   []string{cdbm.IPBlockRoutingTypeDatacenterOnly},
 					ExcludeDerived: true,
 				},
-				cdbp.PageInput{Limit: cloudutils.GetPtr(1)},
+				cdbp.PageInput{Limit: ccu.GetPtr(1)},
 				nil,
 			)
 			if derr != nil {
@@ -951,7 +994,7 @@ func (mst ManageSite) UpdateIPBlocksInDBFromFabricPrefixes(ctx context.Context, 
 
 			createdIPBlock, derr := ipBlockDAO.Create(ctx, tx, cdbm.IPBlockCreateInput{
 				Name:                     name,
-				Description:              cloudutils.GetPtr(siteFabricIPBlockDescription),
+				Description:              ccu.GetPtr(siteFabricIPBlockDescription),
 				SiteID:                   dbSite.ID,
 				InfrastructureProviderID: dbSite.InfrastructureProviderID,
 				RoutingType:              cdbm.IPBlockRoutingTypeDatacenterOnly,
@@ -972,7 +1015,7 @@ func (mst ManageSite) UpdateIPBlocksInDBFromFabricPrefixes(ctx context.Context, 
 				cdbm.StatusDetailCreateInput{
 					EntityID: createdIPBlock.ID.String(),
 					Status:   cdbm.IPBlockStatusReady,
-					Message:  cloudutils.GetPtr(siteFabricIPBlockReadyMsg),
+					Message:  ccu.GetPtr(siteFabricIPBlockReadyMsg),
 				},
 			); derr != nil {
 				logger.Error().Err(derr).Msg("error creating Site fabric IPBlock StatusDetail in DB")
@@ -997,14 +1040,12 @@ func (mst ManageSite) UpdateIPBlocksInDBFromFabricPrefixes(ctx context.Context, 
 	return nil
 }
 
-// siteFabricIPBlocksLockID derives the advisory lock that serializes Site
-// fabric IP Block creation for a Site. It is shared with the activity's tests,
-// which acquire the same lock to exercise contention handling.
-func siteFabricIPBlocksLockID(dbSite *cdbm.Site) uint64 {
-	return cdb.GetAdvisoryLockIDFromString(fmt.Sprintf(
-		"site-fabric-ip-blocks:%s:%s:%s",
-		dbSite.InfrastructureProviderID.String(),
-		dbSite.ID.String(),
-		cdbm.IPBlockRoutingTypeDatacenterOnly,
-	))
+// NewManageSite returns a new ManageSite activity
+func NewManageSite(dbSession *cdb.Session, siteClientPool *sc.ClientPool, tc client.Client, cfg *config.Config) ManageSite {
+	return ManageSite{
+		dbSession:      dbSession,
+		siteClientPool: siteClientPool,
+		tc:             tc,
+		cfg:            cfg,
+	}
 }

--- a/rest-api/workflow/pkg/activity/site/site.go
+++ b/rest-api/workflow/pkg/activity/site/site.go
@@ -935,7 +935,8 @@ func (mst ManageSite) UpdateIPBlocksInDBFromFabricPrefixes(ctx context.Context, 
 	statusDetailDAO := cdbm.NewStatusDetailDAO(mst.dbSession)
 
 	err = cdb.WithTx(ctx, mst.dbSession, func(tx *cdb.Tx) error {
-		if derr := tx.AcquireAdvisoryLock(ctx, getSiteFabricIPBlockLockID(dbSite), false); derr != nil {
+		derr := tx.AcquireAdvisoryLock(ctx, getSiteFabricIPBlockLockID(dbSite), false)
+		if derr != nil {
 			logger.Error().Err(derr).Msg("failed to acquire advisory lock for Site fabric IP Blocks")
 			return derr
 		}

--- a/rest-api/workflow/pkg/activity/site/site_test.go
+++ b/rest-api/workflow/pkg/activity/site/site_test.go
@@ -6,6 +6,7 @@ package site
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,7 @@ import (
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	cdbu "github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/internal/config"
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
@@ -31,6 +33,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/uptrace/bun/extra/bundebug"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 
 	tnsv1 "go.temporal.io/api/namespace/v1"
@@ -1235,6 +1238,115 @@ func TestManageSite_DeleteSiteComponentsFromDB_NewResources(t *testing.T) {
 	assertPresent("ssh_key_association (intentionally not cleaned)", &cdbm.SSHKeyAssociation{}, "ska.id", site1Resources.sshKeyAssocID)
 }
 
+func TestManageSite_UpdateSiteInDB(t *testing.T) {
+	ctx := context.Background()
+	resources := setupSiteFabricIPBlockTest(t)
+	mst := NewManageSite(resources.dbSession, nil, nil, nil)
+	siteDAO := cdbm.NewSiteDAO(resources.dbSession)
+
+	createSite := func(t *testing.T, version *string) *cdbm.Site {
+		t.Helper()
+		site := &cdbm.Site{
+			ID:                       uuid.New(),
+			Name:                     "test-site-" + uuid.NewString(),
+			DisplayName:              cutil.GetPtr("Test"),
+			Org:                      "test",
+			InfrastructureProviderID: resources.provider.ID,
+			SiteControllerVersion:    version,
+			SiteAgentVersion:         cutil.GetPtr("1.0.0"),
+			IsInfinityEnabled:        true,
+			Status:                   cdbm.SiteStatusRegistered,
+			CreatedBy:                resources.user.ID,
+		}
+		_, err := resources.dbSession.DB.NewInsert().Model(site).Exec(ctx)
+		require.NoError(t, err)
+		return site
+	}
+
+	tests := []struct {
+		name             string
+		existingVersion  *string
+		buildInfo        *corev1.BuildInfo
+		wantVersion      *string
+		wantErr          bool
+		wantNonRetryable bool
+		useUnknownSiteID bool
+	}{
+		{
+			name:            "sets version when site has none",
+			existingVersion: nil,
+			buildInfo:       &corev1.BuildInfo{BuildVersion: "1.2.3"},
+			wantVersion:     cutil.GetPtr("1.2.3"),
+		},
+		{
+			name:            "updates version when different",
+			existingVersion: cutil.GetPtr("1.0.0"),
+			buildInfo:       &corev1.BuildInfo{BuildVersion: "2.0.0"},
+			wantVersion:     cutil.GetPtr("2.0.0"),
+		},
+		{
+			name:            "no-op when reported version matches stored version",
+			existingVersion: cutil.GetPtr("1.0.0"),
+			buildInfo:       &corev1.BuildInfo{BuildVersion: "1.0.0"},
+			wantVersion:     cutil.GetPtr("1.0.0"),
+		},
+		{
+			name:            "preserves stored version when build info omits it",
+			existingVersion: cutil.GetPtr("1.0.0"),
+			buildInfo:       &corev1.BuildInfo{},
+			wantVersion:     cutil.GetPtr("1.0.0"),
+		},
+		{
+			name:            "no-op when site and build info both lack a version",
+			existingVersion: nil,
+			buildInfo:       &corev1.BuildInfo{},
+			wantVersion:     nil,
+		},
+		{
+			name:             "unknown site returns non-retryable error",
+			buildInfo:        &corev1.BuildInfo{BuildVersion: "1.2.3"},
+			wantErr:          true,
+			wantNonRetryable: true,
+			useUnknownSiteID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			site := createSite(t, tt.existingVersion)
+
+			siteID := site.ID
+			if tt.useUnknownSiteID {
+				siteID = uuid.New()
+			}
+
+			err := mst.UpdateSiteInDB(ctx, siteID, tt.buildInfo)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantNonRetryable {
+					var applicationErr *temporal.ApplicationError
+					require.ErrorAs(t, err, &applicationErr)
+					assert.True(t, applicationErr.NonRetryable())
+					assert.Equal(t, "Site not found", applicationErr.Type())
+					assert.True(t, errors.Is(applicationErr.Unwrap(), cdb.ErrDoesNotExist))
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			got, err := siteDAO.GetByID(ctx, nil, site.ID, nil, false)
+			require.NoError(t, err)
+			if tt.wantVersion == nil {
+				assert.Nil(t, got.SiteControllerVersion)
+				return
+			}
+			require.NotNil(t, got.SiteControllerVersion)
+			assert.Equal(t, *tt.wantVersion, *got.SiteControllerVersion)
+		})
+	}
+}
+
 type siteFabricIPBlockTestResources struct {
 	dbSession *cdb.Session
 	user      *cdbm.User
@@ -1407,7 +1519,7 @@ func TestManageSite_UpdateIPBlocksInDBFromFabricPrefixes_ReturnsErrorWhenFabricB
 	mst := NewManageSite(resources.dbSession, nil, nil, nil)
 
 	err := cdb.WithTx(ctx, resources.dbSession, func(tx *cdb.Tx) error {
-		require.NoError(t, tx.AcquireAdvisoryLock(ctx, siteFabricIPBlocksLockID(resources.site), false))
+		require.NoError(t, tx.AcquireAdvisoryLock(ctx, getSiteFabricIPBlockLockID(resources.site), false))
 
 		derr := mst.UpdateIPBlocksInDBFromFabricPrefixes(ctx, resources.site.ID, []string{"10.0.0.0/16"})
 		assert.ErrorIs(t, derr, cdb.ErrXactAdvisoryLockFailed)

--- a/rest-api/workflow/pkg/workflow/site/update.go
+++ b/rest-api/workflow/pkg/workflow/site/update.go
@@ -4,27 +4,34 @@
 package site
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/rs/zerolog/log"
 
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	"github.com/google/uuid"
-	temporallog "go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	siteActivity "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/activity/site"
+
+	cwm "github.com/NVIDIA/infra-controller/rest-api/workflow/internal/metrics"
 )
 
 // UpdateSiteConfigInventory applies the Site Config inventory reported by the
 // Site Agent. Today that inventory carries the Site fabric prefixes, from which
 // the workflow creates the matching Site-level IP Blocks.
 func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, buildInfo *corev1.BuildInfo) error {
-	logger := temporallog.With(workflow.GetLogger(ctx), "Workflow", "UpdateSiteConfigInventory", "SiteID", siteIDStr)
-	logger.Info("starting workflow")
+	logger := log.With().Str("Workflow", "UpdateSiteConfigInventory").Str("SiteID", siteIDStr).Logger()
+
+	startTime := time.Now()
+
+	logger.Info().Msg("starting workflow")
 
 	siteID, err := uuid.Parse(siteIDStr)
 	if err != nil {
-		logger.Error("invalid Site ID", "Error", err)
+		logger.Warn().Err(err).Msg(fmt.Sprintf("workflow triggered with invalid site ID: %s", siteID))
 		return err
 	}
 
@@ -40,14 +47,28 @@ func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, buildInfo
 	ctx = workflow.WithActivityOptions(ctx, options)
 
 	var manageSite siteActivity.ManageSite
-	siteFabricPrefixes := buildInfo.GetRuntimeConfig().GetSiteFabricPrefixes()
 
-	err = workflow.ExecuteActivity(ctx, manageSite.UpdateIPBlocksInDBFromFabricPrefixes, siteID, siteFabricPrefixes).Get(ctx, nil)
+	err = workflow.ExecuteActivity(ctx, manageSite.UpdateSiteInDB, siteID, buildInfo).Get(ctx, nil)
 	if err != nil {
-		logger.Error("failed to execute UpdateIPBlocksInDBFromFabricPrefixes activity", "Error", err)
-		return err
+		logger.Warn().Err(err).Msg("failed to execute UpdateSiteMetadataInDB activity")
 	}
 
-	logger.Info("completing workflow")
-	return nil
+	siteFabricPrefixes := buildInfo.GetRuntimeConfig().GetSiteFabricPrefixes()
+	err = workflow.ExecuteActivity(ctx, manageSite.UpdateIPBlocksInDBFromFabricPrefixes, siteID, siteFabricPrefixes).Get(ctx, nil)
+	if err != nil {
+		logger.Warn().Err(err).Msg("failed to execute UpdateIPBlocksInDBFromFabricPrefixes activity")
+	}
+
+	// Record latency for this inventory call
+	var inventoryMetricsManager cwm.ManageInventoryMetrics
+
+	serr := workflow.ExecuteActivity(ctx, inventoryMetricsManager.RecordLatency, siteID, "UpdateSiteConfigInventory", err != nil, time.Since(startTime)).Get(ctx, nil)
+	if serr != nil {
+		logger.Warn().Err(serr).Msg("failed to execute activity: RecordLatency")
+	}
+
+	logger.Info().Msg("completing workflow")
+
+	// Return original error from inventory activity, if any
+	return err
 }

--- a/rest-api/workflow/pkg/workflow/site/update.go
+++ b/rest-api/workflow/pkg/workflow/site/update.go
@@ -25,13 +25,13 @@ import (
 func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, buildInfo *corev1.BuildInfo) error {
 	logger := log.With().Str("Workflow", "UpdateSiteConfigInventory").Str("SiteID", siteIDStr).Logger()
 
-	startTime := time.Now()
+	startTime := workflow.Now(ctx)
 
 	logger.Info().Msg("starting workflow")
 
 	siteID, err := uuid.Parse(siteIDStr)
 	if err != nil {
-		logger.Warn().Err(err).Msg(fmt.Sprintf("workflow triggered with invalid site ID: %s", siteID))
+		logger.Warn().Err(err).Msg(fmt.Sprintf("workflow triggered with invalid site ID: %s", siteIDStr))
 		return err
 	}
 
@@ -62,7 +62,7 @@ func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, buildInfo
 	// Record latency for this inventory call
 	var inventoryMetricsManager cwm.ManageInventoryMetrics
 
-	serr := workflow.ExecuteActivity(ctx, inventoryMetricsManager.RecordLatency, siteID, "UpdateSiteConfigInventory", err != nil, time.Since(startTime)).Get(ctx, nil)
+	serr := workflow.ExecuteActivity(ctx, inventoryMetricsManager.RecordLatency, siteID, "UpdateSiteConfigInventory", err != nil, workflow.Now(ctx).Sub(startTime)).Get(ctx, nil)
 	if serr != nil {
 		logger.Warn().Err(serr).Msg("failed to execute activity: RecordLatency")
 	}

--- a/rest-api/workflow/pkg/workflow/site/update_test.go
+++ b/rest-api/workflow/pkg/workflow/site/update_test.go
@@ -14,6 +14,7 @@ import (
 	"go.temporal.io/sdk/testsuite"
 
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
+	cwm "github.com/NVIDIA/infra-controller/rest-api/workflow/internal/metrics"
 	siteActivity "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/activity/site"
 )
 
@@ -33,17 +34,25 @@ func (s *UpdateSiteConfigInventoryWorkflowTestSuite) AfterTest(suiteName, testNa
 
 func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInventoryWorkflow_Success() {
 	var siteManager siteActivity.ManageSite
+	var metricsManager cwm.ManageInventoryMetrics
 
 	siteID := uuid.New()
 	prefixes := []string{"10.0.0.0/16", "2001:db8::/64"}
 	buildInfo := &corev1.BuildInfo{
+		BuildVersion: "1.2.3",
 		RuntimeConfig: &corev1.RuntimeConfig{
 			SiteFabricPrefixes: prefixes,
 		},
 	}
 
+	s.env.RegisterActivity(siteManager.UpdateSiteInDB)
+	s.env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo).Return(nil)
+
 	s.env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
 	s.env.OnActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes, mock.Anything, siteID, prefixes).Return(nil)
+
+	s.env.RegisterActivity(metricsManager.RecordLatency)
+	s.env.OnActivity(metricsManager.RecordLatency, mock.Anything, siteID, "UpdateSiteConfigInventory", false, mock.Anything).Return(nil)
 
 	s.env.ExecuteWorkflow(UpdateSiteConfigInventory, siteID.String(), buildInfo)
 	s.True(s.env.IsWorkflowCompleted())
@@ -52,17 +61,25 @@ func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInvent
 
 func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInventoryWorkflow_ActivityFails() {
 	var siteManager siteActivity.ManageSite
+	var metricsManager cwm.ManageInventoryMetrics
 
 	siteID := uuid.New()
 	prefixes := []string{"10.0.0.0/16"}
 	buildInfo := &corev1.BuildInfo{
+		BuildVersion: "1.2.3",
 		RuntimeConfig: &corev1.RuntimeConfig{
 			SiteFabricPrefixes: prefixes,
 		},
 	}
 
+	s.env.RegisterActivity(siteManager.UpdateSiteInDB)
+	s.env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo).Return(nil)
+
 	s.env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
 	s.env.OnActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes, mock.Anything, siteID, prefixes).Return(errors.New("failed to update Site IP Blocks"))
+
+	s.env.RegisterActivity(metricsManager.RecordLatency)
+	s.env.OnActivity(metricsManager.RecordLatency, mock.Anything, siteID, "UpdateSiteConfigInventory", true, mock.Anything).Return(nil).Maybe()
 
 	s.env.ExecuteWorkflow(UpdateSiteConfigInventory, siteID.String(), buildInfo)
 	s.True(s.env.IsWorkflowCompleted())
@@ -72,6 +89,35 @@ func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInvent
 	var applicationErr *temporal.ApplicationError
 	s.True(errors.As(err, &applicationErr))
 	s.Equal("failed to update Site IP Blocks", applicationErr.Error())
+}
+
+func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInventoryWorkflow_UpdateSiteInDBFailsContinues() {
+	var siteManager siteActivity.ManageSite
+	var metricsManager cwm.ManageInventoryMetrics
+
+	siteID := uuid.New()
+	prefixes := []string{"10.0.0.0/16"}
+	buildInfo := &corev1.BuildInfo{
+		BuildVersion: "1.2.3",
+		RuntimeConfig: &corev1.RuntimeConfig{
+			SiteFabricPrefixes: prefixes,
+		},
+	}
+
+	// UpdateSiteInDB failures are logged and do not stop the workflow from
+	// creating Site fabric IP Blocks from the reported prefixes.
+	s.env.RegisterActivity(siteManager.UpdateSiteInDB)
+	s.env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo).Return(errors.New("failed to update Site metadata"))
+
+	s.env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
+	s.env.OnActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes, mock.Anything, siteID, prefixes).Return(nil)
+
+	s.env.RegisterActivity(metricsManager.RecordLatency)
+	s.env.OnActivity(metricsManager.RecordLatency, mock.Anything, siteID, "UpdateSiteConfigInventory", false, mock.Anything).Return(nil)
+
+	s.env.ExecuteWorkflow(UpdateSiteConfigInventory, siteID.String(), buildInfo)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 }
 
 func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInventoryWorkflow_InvalidSiteID() {

--- a/rest-api/workflow/pkg/workflow/site/update_test.go
+++ b/rest-api/workflow/pkg/workflow/site/update_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 
@@ -18,114 +19,128 @@ import (
 	siteActivity "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/activity/site"
 )
 
-type UpdateSiteConfigInventoryWorkflowTestSuite struct {
-	suite.Suite
-	testsuite.WorkflowTestSuite
-	env *testsuite.TestWorkflowEnvironment
-}
+func TestUpdateSiteConfigInventory(t *testing.T) {
+	type testCase struct {
+		name                 string
+		siteIDStr            string
+		prefixes             []string
+		buildVersion         string
+		updateSiteInDBErr    error
+		updateIPBlocksErr    error
+		wantErr              bool
+		wantErrContains      string
+		expectUpdateSiteInDB bool
+		expectUpdateIPBlocks bool
+		expectRecordLatency  bool
+		recordLatencyFailed  bool
+	}
 
-func (s *UpdateSiteConfigInventoryWorkflowTestSuite) SetupTest() {
-	s.env = s.NewTestWorkflowEnvironment()
-}
-
-func (s *UpdateSiteConfigInventoryWorkflowTestSuite) AfterTest(suiteName, testName string) {
-	s.env.AssertExpectations(s.T())
-}
-
-func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInventoryWorkflow_Success() {
-	var siteManager siteActivity.ManageSite
-	var metricsManager cwm.ManageInventoryMetrics
-
-	siteID := uuid.New()
-	prefixes := []string{"10.0.0.0/16", "2001:db8::/64"}
-	buildInfo := &corev1.BuildInfo{
-		BuildVersion: "1.2.3",
-		RuntimeConfig: &corev1.RuntimeConfig{
-			SiteFabricPrefixes: prefixes,
+	tests := []testCase{
+		{
+			name:                 "Success",
+			prefixes:             []string{"10.0.0.0/16", "2001:db8::/64"},
+			buildVersion:         "1.2.3",
+			expectUpdateSiteInDB: true,
+			expectUpdateIPBlocks: true,
+			expectRecordLatency:  true,
+		},
+		{
+			name:                 "ActivityFails",
+			prefixes:             []string{"10.0.0.0/16"},
+			buildVersion:         "1.2.3",
+			updateIPBlocksErr:    errors.New("failed to update Site IP Blocks"),
+			wantErr:              true,
+			wantErrContains:      "failed to update Site IP Blocks",
+			expectUpdateSiteInDB: true,
+			expectUpdateIPBlocks: true,
+			expectRecordLatency:  true,
+			recordLatencyFailed:  true,
+		},
+		{
+			// UpdateSiteInDB failures are logged and do not stop the workflow
+			// from creating Site fabric IP Blocks from the reported prefixes.
+			name:                 "UpdateSiteInDBFailsContinues",
+			prefixes:             []string{"10.0.0.0/16"},
+			buildVersion:         "1.2.3",
+			updateSiteInDBErr:    errors.New("failed to update Site metadata"),
+			expectUpdateSiteInDB: true,
+			expectUpdateIPBlocks: true,
+			expectRecordLatency:  true,
+		},
+		{
+			name:      "InvalidSiteID",
+			siteIDStr: "not-a-site-id",
+			wantErr:   true,
 		},
 	}
 
-	s.env.RegisterActivity(siteManager.UpdateSiteInDB)
-	s.env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo).Return(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ts testsuite.WorkflowTestSuite
+			env := ts.NewTestWorkflowEnvironment()
+			t.Cleanup(func() {
+				env.AssertExpectations(t)
+			})
 
-	s.env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
-	s.env.OnActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes, mock.Anything, siteID, prefixes).Return(nil)
+			siteIDStr := tt.siteIDStr
+			var siteID uuid.UUID
+			if siteIDStr == "" {
+				siteID = uuid.New()
+				siteIDStr = siteID.String()
+			}
 
-	s.env.RegisterActivity(metricsManager.RecordLatency)
-	s.env.OnActivity(metricsManager.RecordLatency, mock.Anything, siteID, "UpdateSiteConfigInventory", false, mock.Anything).Return(nil)
+			buildInfo := &corev1.BuildInfo{
+				BuildVersion: tt.buildVersion,
+			}
+			if tt.prefixes != nil {
+				buildInfo.RuntimeConfig = &corev1.RuntimeConfig{
+					SiteFabricPrefixes: tt.prefixes,
+				}
+			}
 
-	s.env.ExecuteWorkflow(UpdateSiteConfigInventory, siteID.String(), buildInfo)
-	s.True(s.env.IsWorkflowCompleted())
-	s.NoError(s.env.GetWorkflowError())
-}
+			var siteManager siteActivity.ManageSite
+			var metricsManager cwm.ManageInventoryMetrics
 
-func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInventoryWorkflow_ActivityFails() {
-	var siteManager siteActivity.ManageSite
-	var metricsManager cwm.ManageInventoryMetrics
+			if tt.expectUpdateSiteInDB {
+				env.RegisterActivity(siteManager.UpdateSiteInDB)
+				env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo).Return(tt.updateSiteInDBErr)
+			}
+			if tt.expectUpdateIPBlocks {
+				env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
+				env.OnActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes, mock.Anything, siteID, tt.prefixes).Return(tt.updateIPBlocksErr)
+			}
+			if tt.expectRecordLatency {
+				env.RegisterActivity(metricsManager.RecordLatency)
+				onLatency := env.OnActivity(
+					metricsManager.RecordLatency,
+					mock.Anything,
+					siteID,
+					"UpdateSiteConfigInventory",
+					tt.recordLatencyFailed,
+					mock.Anything,
+				).Return(nil)
+				if tt.recordLatencyFailed {
+					onLatency.Maybe()
+				}
+			}
 
-	siteID := uuid.New()
-	prefixes := []string{"10.0.0.0/16"}
-	buildInfo := &corev1.BuildInfo{
-		BuildVersion: "1.2.3",
-		RuntimeConfig: &corev1.RuntimeConfig{
-			SiteFabricPrefixes: prefixes,
-		},
+			env.ExecuteWorkflow(UpdateSiteConfigInventory, siteIDStr, buildInfo)
+			require.True(t, env.IsWorkflowCompleted())
+
+			err := env.GetWorkflowError()
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			if tt.wantErrContains == "" {
+				return
+			}
+
+			var applicationErr *temporal.ApplicationError
+			require.True(t, errors.As(err, &applicationErr))
+			assert.Equal(t, tt.wantErrContains, applicationErr.Error())
+		})
 	}
-
-	s.env.RegisterActivity(siteManager.UpdateSiteInDB)
-	s.env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo).Return(nil)
-
-	s.env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
-	s.env.OnActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes, mock.Anything, siteID, prefixes).Return(errors.New("failed to update Site IP Blocks"))
-
-	s.env.RegisterActivity(metricsManager.RecordLatency)
-	s.env.OnActivity(metricsManager.RecordLatency, mock.Anything, siteID, "UpdateSiteConfigInventory", true, mock.Anything).Return(nil).Maybe()
-
-	s.env.ExecuteWorkflow(UpdateSiteConfigInventory, siteID.String(), buildInfo)
-	s.True(s.env.IsWorkflowCompleted())
-	err := s.env.GetWorkflowError()
-	s.Error(err)
-
-	var applicationErr *temporal.ApplicationError
-	s.True(errors.As(err, &applicationErr))
-	s.Equal("failed to update Site IP Blocks", applicationErr.Error())
-}
-
-func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInventoryWorkflow_UpdateSiteInDBFailsContinues() {
-	var siteManager siteActivity.ManageSite
-	var metricsManager cwm.ManageInventoryMetrics
-
-	siteID := uuid.New()
-	prefixes := []string{"10.0.0.0/16"}
-	buildInfo := &corev1.BuildInfo{
-		BuildVersion: "1.2.3",
-		RuntimeConfig: &corev1.RuntimeConfig{
-			SiteFabricPrefixes: prefixes,
-		},
-	}
-
-	// UpdateSiteInDB failures are logged and do not stop the workflow from
-	// creating Site fabric IP Blocks from the reported prefixes.
-	s.env.RegisterActivity(siteManager.UpdateSiteInDB)
-	s.env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo).Return(errors.New("failed to update Site metadata"))
-
-	s.env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
-	s.env.OnActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes, mock.Anything, siteID, prefixes).Return(nil)
-
-	s.env.RegisterActivity(metricsManager.RecordLatency)
-	s.env.OnActivity(metricsManager.RecordLatency, mock.Anything, siteID, "UpdateSiteConfigInventory", false, mock.Anything).Return(nil)
-
-	s.env.ExecuteWorkflow(UpdateSiteConfigInventory, siteID.String(), buildInfo)
-	s.True(s.env.IsWorkflowCompleted())
-	s.NoError(s.env.GetWorkflowError())
-}
-
-func (s *UpdateSiteConfigInventoryWorkflowTestSuite) Test_UpdateSiteConfigInventoryWorkflow_InvalidSiteID() {
-	s.env.ExecuteWorkflow(UpdateSiteConfigInventory, "not-a-site-id", &corev1.BuildInfo{})
-	s.True(s.env.IsWorkflowCompleted())
-	s.Error(s.env.GetWorkflowError())
-}
-
-func TestUpdateSiteConfigInventoryWorkflowTestSuite(t *testing.T) {
-	suite.Run(t, new(UpdateSiteConfigInventoryWorkflowTestSuite))
 }


### PR DESCRIPTION
Site config inventory is currently only returning build info and not runtime config. Auto-creation of Provider IP Blocks requires the Fabric prefixes from runtime config, this PR ensures runtime config is fetched.

In addition the PR saves Core/Site Controller version in Site entry in REST DB, which gets exposed in Site API object. This'll help find any version differences between REST/Site.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/2085

## Type of Change
- [x] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated