### PR TITLE
chore(api-db): remove the legacy update_admin_network stored procedure

### DIFF
--- a/crates/api-db/migrations/20260810142348_drop_update_admin_network.sql
+++ b/crates/api-db/migrations/20260810142348_drop_update_admin_network.sql
@@ -1,0 +1,6 @@
+-- This operator-only IPv4 renumbering helper predates multi-prefix admin
+-- segments and has no service callers. It created a persistent scratch table
+-- at runtime; remove any copy left by its last manual invocation.
+DROP PROCEDURE IF EXISTS public.update_admin_network(uuid, inet, inet);
+
+DROP TABLE IF EXISTS public.tmp_network_range_placeholder;


### PR DESCRIPTION
`update_admin_network` was added as a manually invoked IPv4 admin network renumbering helper and was never exposed through NICo. Its original notes recommended deleting it after it was no longer needed, and the last matching environment change we found was in April 2025.

The procedure has no service callers today, and its single-prefix and single-address assumptions no longer match dual-stack interfaces or the current hostname model. This migration removes the installed procedure and any persistent scratch table left by its last invocation while keeping migration history unchanged.

## Related issues

- Closes #4794
- Part of #3491

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated the migration filename, applied the migration through an existing SQLx database test, and ran focused Clippy for `carbide-api-db`.

## Additional Notes

The known deployment that used this helper ran migrations with a database role that can remove its scratch table. An environment that manually invoked the procedure with an unrelated table owner may need that owner to remove `tmp_network_range_placeholder` before upgrading.

This should merge before #4150 adds global machine-interface address uniqueness.
