### PR TITLE
docs(machine-a-tron): correct DPU factory credential source

### DIFF
--- a/docs/development/machine-a-tron-deployment.md
+++ b/docs/development/machine-a-tron-deployment.md
@@ -204,14 +204,24 @@ which fails the check (`vault does not have a valid password entry`) — they
 must be re-seeded with any non-empty password. `machines/bmc/site/root` is not
 seeded at all; without it every run aborts with `MissingCredentials`.
 
-Beyond the preconditions, the **credential rotation flow** requires this exact
-chain (all handled by `setup-machine-a-tron.sh` Phase 4):
+For the default BlueField-3 simulation, the **credential rotation flow**
+requires this exact chain, which `setup-machine-a-tron.sh` Phase 4 handles:
 
 | Vault path | Value | Why |
 |------------|-------|-----|
 | `machines/all_hosts/factory_default/bmc-metadata-items/dell` | `root`/`factory_password` | Host BMC factory default (mock's `DUMMY_FACTORY_PASSWORD`). Path segment is **lowercase** `dell` — `BMCVendor`'s `Display` impl lowercases. |
-| `machines/all_dpus/factory_default/bmc-metadata-items/root` | `root`/`0penBmc` | DPU BMC factory default (mock's `DUMMY_FACTORY_DPU_PASSWORD`) — note it differs from the host factory password. |
+| `machines/all_dpus/factory_default/bmc-metadata-items/root` | `root`/`0penBmc` | Legacy DPU BMC catch-all (`DpuModel::Unknown`). Matches `DpuModel::default_factory_credentials()` for BF2, BF3, and unidentified models. `bmc-mock` uses that source for the BF3 account it creates; site-explorer uses it for its final fallback. It differs from the host factory password. |
 | `machines/bmc/site/root` | `root`/&lt;distinct&gt; | Rotation target. **Must differ from both factory passwords**, or the rotation is a no-op and the mock rejects with `403 Factory-default password must be changed` forever. |
+
+<Note title="BlueField-4 factory credentials">
+The machine-a-tron hardware types `dell_poweredge_r760_bf4` and `nvidia_dgx_vr`
+use BlueField-4 DPUs with `admin`/`0penBmc` factory credentials. site-explorer
+checks the model-specific entry, then the `root` catch-all, then the built-in
+per-model default. Because Phase 4 seeds the catch-all but not the model entry,
+seed `machines/all_dpus/factory_default/bmc-metadata-items/bf4` with the BF4
+credentials before using either type. Otherwise, site-explorer attempts the
+`root` username and a `401 Unauthorized` latches `AvoidLockout`.
+</Note>
 
 site-explorer logs into each BMC with its factory default, rotates the password
 to the site root value, then proceeds — using the wrong factory password (or a

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -164,10 +164,15 @@ BMC_USERNAME="${BMC_USERNAME:-root}"
 # no-op and the mock keeps rejecting with "Factory-default password must be
 # changed" (403) forever.
 BMC_PASSWORD="${BMC_PASSWORD:-NicoSiteRoot1}"
-# Factory defaults HARDCODED in the bmc-mock binary (crates/bmc-mock/src/lib.rs):
-#   host BMCs:  DUMMY_FACTORY_PASSWORD     = "factory_password"
-#   DPU BMCs:   DUMMY_FACTORY_DPU_PASSWORD = "0penBmc"
-# Do not change unless the mock changes.
+# Factory defaults used by this simulation:
+#   host BMCs:  `bmc_mock::DUMMY_FACTORY_PASSWORD` = "factory_password"
+#   DPU BMCs:   `bmc_vendor::DpuModel::default_factory_credentials()` is shared
+#               by `bmc-mock` and site-explorer
+# site-explorer checks a model-specific entry, the catch-all seeded below, then
+# its per-model code fallback. This catch-all matches BF2/BF3 and unrecognized
+# models (`root`/`0penBmc`). BF4 needs a model-specific `bf4` entry for its
+# `admin` username.
+# Do not change unless those factory defaults change.
 FACTORY_HOST_BMC_PASSWORD="factory_password"
 FACTORY_DPU_BMC_PASSWORD="0penBmc"
 # Vendor path segment for the host factory cred. LOWERCASE is required: the

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -81,18 +81,19 @@ vault:
         UsernamePassword:
           username: "root"
           password: "0penBmc"
-    ## Per-model DPU BMC factory-default OVERRIDES (optional).
+    ## Per-model DPU BMC factory-default entries.
     ##
-    ## Not seeded by default: site-explorer already falls back to each model's
-    ## publicly-documented factory default in code (DpuModel::default_factory_credentials
-    ## — BlueField-4 = admin/0penBmc, earlier generations = root/0penBmc, matching the
-    ## "root" catch-all above). Only add a per-model entry here to override that default
-    ## for a site whose DPUs ship with a non-standard factory password.
+    ## site-explorer checks a model-specific entry, then the catch-all above,
+    ## then its per-model code fallback. A standard BF4 site therefore needs
+    ## the `bf4` entry below; uncomment this block to seed it with the shown
+    ## factory credentials.
+    ## Change the values only when a site's BF4 DPUs ship with non-standard
+    ## factory credentials.
     # - path: "machines/all_dpus/factory_default/bmc-metadata-items/bf4"
     #   data:
     #     UsernamePassword:
     #       username: "admin"
-    #       password: ""          # SITE SECRET: this site's BF4 factory password
+    #       password: "0penBmc"
     - path: "machines/all_dpus/factory_default/uefi-metadata-items/auth"
       data:
         UsernamePassword:


### PR DESCRIPTION
The Machine-a-tron deployment guide and setup script still pointed at `DUMMY_FACTORY_DPU_PASSWORD`, but that constant went away when the DPU defaults moved to `DpuModel::default_factory_credentials()`.

This updates both stale references to the shared per-model source, corrects the adjacent `values.yaml` guidance for the same lookup order, and calls out that the legacy `root` Vault entry matches the default BlueField-3 simulation while BlueField-4 uses `admin`. The active Vault paths, seeded values, and rotation behavior are unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4633.
Part of https://github.com/NVIDIA/infra-controller/issues/4550.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `bash -n helm-prereqs/setup-machine-a-tron.sh`
- `rumdl check --config docs/.rumdl.toml AGENTS.md docs/development/machine-a-tron-deployment.md`
- Stale `DUMMY_FACTORY_DPU_PASSWORD` reference sweep
- `npx --yes --package fern-api@5.89.1 fern docs md check`
- `npx --yes --package fern-api@5.89.1 fern check`
- `helm lint helm-prereqs`
- `helm template nico-prereqs helm-prereqs --show-only templates/vault-config-job.yaml`
- `cargo make format-nightly`
- `cargo make clippy`
- Cached Carbide-lints workflow from `refresh_carbide_lints.md`

## Additional Notes

The setup-script and `values.yaml` changes update comments only. They do not enable the BF4 seed or change active Vault paths, credential values, or rotation behavior.

Closes #4633
