### PR TITLE
patch(v2.1): Disable REST Docker build CI cache export to reduce churn

### DIFF
--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -174,7 +174,13 @@ jobs:
             CARBIDE_BUILD_HELM_VERSION=${{ inputs.helm_version }}
           tags: ${{ steps.docker-tags.outputs.arch_tag }}
           cache-from: type=gha,scope=${{ inputs.service_name }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.service_name }}-${{ matrix.arch }}
+          # Nothing on this branch exports. Actions cache entries are ref-scoped,
+          # so every cherry-pick pull request and every release tag wrote its own
+          # mode=max copy of ten services on two architectures: 18.3 GB from one
+          # pull request and 9.1 GB from the v2.1.0-rc.2 tag, in a 150 GB pool
+          # shared with main. A release branch may read the default branch's
+          # entries, so cache-from above still starts these builds warm.
+          cache-to: ''
           labels: |
             org.opencontainers.image.title=${{ inputs.service_name }}
             org.opencontainers.image.version=${{ inputs.semantic_version }}


### PR DESCRIPTION
`release/v2.1` pipeline runs are exporting REST images to GitHub Action cache, filling it up and evicting crucial cache.

This PR brings aligns caching strategy with `main`

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)