### PR TITLE
patch(v2.0): Disable Core/REST Docker build CI cache export to reduce churn

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -177,7 +177,13 @@ jobs:
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
           cache-from: type=gha
-          cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
+          # Nothing on this branch exports. Actions cache entries are ref-scoped,
+          # so every cherry-pick pull request and every release tag wrote its own
+          # mode=max copy into a 150 GB pool shared with main, evicting the
+          # sccache objects the Rust builds read. A release branch may read the
+          # default branch's entries, so cache-from above still starts these
+          # builds warm.
+          cache-to: ''
 
       # Scan the image the build step just loaded into the daemon — no rebuild.
       # Only runs when the image is actually loaded (load=true and not pushing,

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -155,7 +155,13 @@ jobs:
             CARBIDE_BUILD_HELM_VERSION=${{ inputs.helm_version }}
           tags: ${{ steps.docker-tags.outputs.arch_tag }}
           cache-from: type=gha,scope=${{ inputs.service_name }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.service_name }}-${{ matrix.arch }}
+          # Nothing on this branch exports. Actions cache entries are ref-scoped,
+          # so every cherry-pick pull request and every release tag wrote its own
+          # mode=max copy of ten services on two architectures into a 150 GB pool
+          # shared with main, evicting the sccache objects the Rust builds read.
+          # A release branch may read the default branch's entries, so cache-from
+          # above still starts these builds warm.
+          cache-to: ''
           labels: |
             org.opencontainers.image.title=${{ inputs.service_name }}
             org.opencontainers.image.version=${{ inputs.semantic_version }}


### PR DESCRIPTION
`release/v2.0` pipeline runs are exporting Core/REST images to GitHub Action cache, filling it up and evicting crucial cache.

This PR brings aligns caching strategy with `main`

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)