### PR TITLE
docs: clarify retained address lifetime

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -62,7 +62,8 @@ Add a DPU OS interface with a fixed IP:
     --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
     --interfaces '[{\"mac_address\":\"02:00:00:00:20:01\",\"role\":\"dpu_os\",\"ip_allocation\":\"fixed\",\"fixed_ip\":\"192.0.2.10\"}]'
 
-Retain the BMC's auto-allocated DHCP address as a static one (never expires):
+Retain the BMC's auto-allocated DHCP address as static for the lifetime of its
+machine-interface record:
     $ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
     --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
     --bmc-ip-allocation retained
@@ -189,7 +190,7 @@ pub(crate) struct Args {
         long = "bmc-ip-allocation",
         value_name = "BMC_IP_ALLOCATION",
         value_enum,
-        help = "Per-host control over how this BMC's IP is assigned and retained. `auto` (default): infer from `--bmc-ip-address` -- a configured address is `fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that may expire and change; `fixed`: the operator-specified `--bmc-ip-address` (static); `retained`: an auto-allocated address pinned as static (never expires). Unset defers to the server default (`auto`)."
+        help = "Per-host control over how this BMC's IP is assigned and retained. `auto` (default): infer from `--bmc-ip-address` -- a configured address is `fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that may expire and change; `fixed`: the operator-specified `--bmc-ip-address` (static); `retained`: an auto-allocated DHCP address that stays static for the lifetime of its machine-interface record. Unset defers to the server default (`auto`)."
     )]
     bmc_ip_allocation: Option<BmcIpAllocationType>,
 

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -72,7 +72,8 @@ Change the per-host DPU policy:
     $ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
     --dpu-policy ignore
 
-Retain the BMC's auto-allocated DHCP address as a static one (never expires):
+Retain the BMC's auto-allocated DHCP address as static for the lifetime of its
+machine-interface record:
     $ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
     --bmc-ip-allocation retained
 
@@ -209,7 +210,7 @@ pub(crate) struct Args {
         value_name = "BMC_IP_ALLOCATION",
         value_enum,
         group = "group",
-        help = "Per-host control over how this BMC's IP is assigned and retained. `auto` (default): infer from `--bmc-ip-address` -- a configured address is `fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that may expire and change; `fixed`: the operator-specified `--bmc-ip-address` (static); `retained`: an auto-allocated address pinned as static (never expires). Unset preserves the existing per-host value."
+        help = "Per-host control over how this BMC's IP is assigned and retained. `auto` (default): infer from `--bmc-ip-address` -- a configured address is `fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that may expire and change; `fixed`: the operator-specified `--bmc-ip-address` (static); `retained`: an auto-allocated DHCP address that stays static for the lifetime of its machine-interface record. Unset preserves the existing per-host value."
     )]
     pub(super) bmc_ip_allocation: Option<BmcIpAllocationType>,
 

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -99,7 +99,8 @@ where
 ///   treated as `Fixed`, no address is treated as `Retained`.
 /// - `Dynamic`: a normal DHCP lease that may expire and change.
 /// - `Fixed`: the operator-specified `bmc_ip_address` (static).
-/// - `Retained`: an auto-allocated address pinned as Static (never expires).
+/// - `Retained`: an auto-allocated DHCP address that stays static for the
+///   lifetime of its machine-interface record.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
 #[sqlx(type_name = "bmc_ip_allocation_t", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6334,8 +6334,8 @@ enum DpuMode {
 //   a configured address is treated as FIXED, no address is treated as RETAINED.
 // - BMC_IP_ALLOCATION_TYPE_DYNAMIC: a normal DHCP lease that may expire and change.
 // - BMC_IP_ALLOCATION_TYPE_FIXED: the operator-specified `bmc_ip_address` (static).
-// - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated address pinned as Static
-//   (never expires).
+// - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated DHCP address that stays
+//   static for the lifetime of its machine-interface record.
 //
 // On create, omission and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On
 // single and batch update, omission preserves the effective Host BMC policy,

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -2864,8 +2864,8 @@ func (DpuMode) EnumDescriptor() ([]byte, []int) {
 //     a configured address is treated as FIXED, no address is treated as RETAINED.
 //   - BMC_IP_ALLOCATION_TYPE_DYNAMIC: a normal DHCP lease that may expire and change.
 //   - BMC_IP_ALLOCATION_TYPE_FIXED: the operator-specified `bmc_ip_address` (static).
-//   - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated address pinned as Static
-//     (never expires).
+//   - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated DHCP address that stays
+//     static for the lifetime of its machine-interface record.
 //
 // On create, omission and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On
 // single and batch update, omission preserves the effective Host BMC policy,

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -6335,8 +6335,8 @@ enum DpuMode {
 //   a configured address is treated as FIXED, no address is treated as RETAINED.
 // - BMC_IP_ALLOCATION_TYPE_DYNAMIC: a normal DHCP lease that may expire and change.
 // - BMC_IP_ALLOCATION_TYPE_FIXED: the operator-specified `bmc_ip_address` (static).
-// - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated address pinned as Static
-//   (never expires).
+// - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated DHCP address that stays
+//   static for the lifetime of its machine-interface record.
 //
 // On create, omission and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On
 // single and batch update, omission preserves the effective Host BMC policy,


### PR DESCRIPTION
A Retained BMC address becomes Static for the lifetime of its machine-interface record. Calling it non-expiring made it sound like the address was saved for reuse after that interface was deleted and re-ingested, which it is not.

So, this updates the `nico-admin-cli expected-machine {add,patch}` help, the model Rustdoc, and the protobuf comments to name the actual lifetime. The checked-in REST protobuf mirrors are regenerated from the updated source. CLI arguments, protobuf wire values, and allocation behavior all stay the same.

## Related issues

- #4836
- #3491

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p nico-admin-cli` (427 passed)
- Rendered and inspected `nico-admin-cli expected-machine add --help`
- Rendered and inspected `nico-admin-cli expected-machine patch --help`
- Regenerated the REST Core protobuf snapshots and Go bindings, then verified the worktree stayed clean
- `cargo make format-nightly`
- `cargo make clippy`
- Cached Carbide-lints workflow

## Additional Notes

The generated `nico-admin-cli` reference under `docs/` stays in the separate docs-only #4151 / #4418 so the code and documentation review paths remain independent.
