### PR TITLE
fix: skip globally owned addresses during IPv6 allocation

### DIFF
--- a/crates/api-core/src/dhcp/v6.rs
+++ b/crates/api-core/src/dhcp/v6.rs
@@ -80,6 +80,13 @@ pub(super) async fn observe_slaac_address(
         return Ok(());
     };
 
+    // TODO(chet): Serialize same-interface IPv6 selection and replacement
+    // across SLAAC observation, static assignment, and stateful DHCPv6. The
+    // `unique_address_family_on_interface` index keeps us from storing two IPv6
+    // rows for one interface, but it does not decide which concurrent writer
+    // should win. The losing writer currently returns a database error and
+    // aborts its DHCP transaction.
+    //
     // A stateful/static IPv6 address already owns this interface family.
     if db::machine_interface_address::has_address_for_family(
         &mut *txn,
@@ -95,8 +102,8 @@ pub(super) async fn observe_slaac_address(
     if let Some(address) = slaac_gua_from_eui64(prefix, mac) {
         let address = IpAddr::V6(address);
 
-        // The shared insert is the ownership boundary for both visible and
-        // concurrent owners.
+        // The shared insert enforces global ownership of this exact address,
+        // including concurrent claims from another interface.
         db::machine_interface_address::insert(
             &mut *txn,
             interface_id,

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -3670,13 +3670,15 @@ where
     // though in the case of machine interfaces, its probably
     // always going to just be a /32.
     //
-    // used_ips returns the used (or allocated) IPs for machine
-    // interfaces in a given network segment.
+    // used_ips returns globally owned machine-interface addresses contained by
+    // this segment's prefixes. Filtering by the owning interface's segment
+    // would miss a static assignment that predates its containing managed
+    // prefix.
     //
-    // More specifically, this is intended to specifically
-    // target the `address` column of the `machine_interface_addresses`
-    // table, in which a single /32 is stored (although, as an
-    // `inet`, it could techincally also have a prefix length).
+    // More specifically, this targets the `address` column of the
+    // `machine_interface_addresses` table, where
+    // `machine_interface_addresses_host_address_check` permits only /32 or
+    // /128 host addresses.
     async fn used_ips(&self, txn: &mut DB) -> Result<Vec<IpAddr>, DatabaseError> {
         // IpAddrContainer is a small private struct used
         // for binding the result of the subsequent SQL
@@ -3687,11 +3689,16 @@ where
             address: IpAddr,
         }
 
+        // Machine-interface addresses are normalized to host addresses, so
+        // these inclusive prefix bounds are the same as subnet containment and
+        // can use the btree index behind `machine_interface_addresses_address_key`.
         let query = "
-SELECT address FROM machine_interface_addresses
-INNER JOIN machine_interfaces ON machine_interfaces.id = machine_interface_addresses.interface_id
-INNER JOIN network_segments ON machine_interfaces.segment_id = network_segments.id
-WHERE network_segments.id = $1::uuid";
+SELECT mia.address
+FROM network_prefixes np
+JOIN machine_interface_addresses mia
+  ON mia.address BETWEEN host(network(np.prefix))::inet
+                     AND host(broadcast(np.prefix))::inet
+WHERE np.segment_id = $1::uuid";
 
         let containers: Vec<IpAddrContainer> = sqlx::query_as(query)
             .bind(self.segment_id)

--- a/crates/api-db/src/machine_interface/ip_allocator.rs
+++ b/crates/api-db/src/machine_interface/ip_allocator.rs
@@ -252,6 +252,110 @@ async fn test_machine_interface_create_with_ipv6_prefix(
     Ok(())
 }
 
+/// An address can still belong to an interface on `static-assignments` when a
+/// managed prefix is added around it later. Both initial DHCPv6 allocation and
+/// family recovery must skip that address even though its owning interface
+/// remains on a different segment.
+#[crate::sqlx_test]
+async fn test_ipv6_allocation_skips_address_owned_outside_managed_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+
+    let static_assignments = db::network_segment::persist(
+        NewNetworkSegment {
+            name: db::network_segment::STATIC_ASSIGNMENTS_SEGMENT_NAME.to_string(),
+            subdomain_id: None,
+            vpc_id: None,
+            mtu: 1500,
+            prefixes: vec![NewNetworkPrefix {
+                prefix: "169.254.254.254/32".parse()?,
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 1,
+            }],
+            vlan_id: None,
+            vni: None,
+            segment_type: NetworkSegmentType::Underlay,
+            id: uuid::Uuid::new_v4().into(),
+            can_stretch: Some(false),
+            allocation_strategy: AllocationStrategy::Reserved,
+        },
+        &mut txn,
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+    let occupied_address: IpAddr = "2001:db8:4801::2".parse()?;
+    db::machine_interface::preallocate_machine_interface(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:48:01")?,
+        occupied_address,
+        None,
+    )
+    .await?;
+
+    let owner = db::machine_interface_address::find_by_address(txn.as_mut(), occupied_address)
+        .await?
+        .expect("static IPv6 owner should exist");
+    assert_eq!(owner.segment_id, static_assignments.id);
+    let owner_interface_id = owner.id;
+
+    // Add the managed prefix after the static reservation. Its first DHCP
+    // candidate is already owned by the interface on `static-assignments`.
+    let managed_segment = db::network_segment::persist(
+        NewNetworkSegment {
+            name: "IPV6-GLOBAL-OWNER".to_string(),
+            subdomain_id: None,
+            vpc_id: None,
+            mtu: 1500,
+            prefixes: vec![NewNetworkPrefix {
+                prefix: "2001:db8:4801::/112".parse()?,
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 2,
+            }],
+            vlan_id: None,
+            vni: None,
+            segment_type: NetworkSegmentType::Underlay,
+            id: uuid::Uuid::new_v4().into(),
+            can_stretch: Some(false),
+            allocation_strategy: AllocationStrategy::Dynamic,
+        },
+        &mut txn,
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+    let next_available_address: IpAddr = "2001:db8:4801::3".parse()?;
+
+    let interface = db::machine_interface::create(
+        &mut txn,
+        std::slice::from_ref(&managed_segment),
+        &MacAddress::from_str("aa:bb:cc:dd:48:02")?,
+        true,
+        AddressSelectionStrategy::NextAvailableIp,
+        None,
+    )
+    .await?;
+    assert_eq!(interface.addresses, vec![next_available_address]);
+
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    let recovered = db::machine_interface::allocate_address_for_family(
+        &mut txn,
+        interface.id,
+        &managed_segment,
+        IpAddressFamily::Ipv6,
+    )
+    .await?;
+    assert_eq!(recovered, vec![next_available_address]);
+
+    let owner = db::machine_interface_address::find_by_address(txn.as_mut(), occupied_address)
+        .await?
+        .expect("static IPv6 owner should remain unchanged");
+    assert_eq!(owner.id, owner_interface_id);
+
+    Ok(())
+}
+
 /// Verify that a dual-stack segment (IPv4 + IPv6 prefixes) allocates one
 /// address from each family, and that the hostname is derived from the IPv4
 /// address (more human-readable).


### PR DESCRIPTION
Machine-interface addresses are globally unique, but the IPv6 allocator only counted addresses owned by interfaces already assigned to the candidate segment. If a static assignment was created before a containing managed prefix, the allocator could keep selecting that unavailable address instead of moving to the next free one.

So, `UsedAdminNetworkIpResolver` now derives its used set from every globally owned address inside the candidate segment's prefix bounds, regardless of the owning interface's segment. The inclusive bounds use the existing `UNIQUE(address)` btree index, so this does not need another database migration or a site-wide table scan. Both initial IPv6 allocation and later address-family recovery now skip the occupied address.

The separate same-interface race between SLAAC, static assignment, and stateful DHCPv6 remains documented for follow-up; this PR does not change which writer should win that race.

## Related issues

- #4837
- #3491

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-api-db test_ipv6_allocation_skips_address_owned_outside_managed_segment --lib -- --nocapture`
- `cargo test -p carbide-api-db --lib` (364 passed)
- `cargo make format-nightly`
- `cargo make clippy`
- Cached Carbide-lints workflow

## Additional Notes

This uses the host-address normalization and global address-ownership constraint added by #4801. There is no database migration in this PR.
