### PR TITLE
fix(ci): enforce image scan token permissions

### DIFF
--- a/.github/ci/check-image-scan-ci-permissions.sh
+++ b/.github/ci/check-image-scan-ci-permissions.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-image-scan-ci-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/image-scan.yml}"
+
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "NICo Image Scan" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "actions=read,contents=read"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,9 @@ jobs:
       - name: Check Publish Fern Docs token permissions
         run: bash .github/ci/check-publish-fern-docs-permissions.sh
 
+      - name: Check Image Scan token permissions
+        run: bash .github/ci/check-image-scan-ci-permissions.sh
+
       - name: Check Core CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh core
 


### PR DESCRIPTION
`NICo Image Scan` runs after Core CI and downloads the scan-target artifacts that identify which published images need vulnerability scanning. Now, its GitHub token is intentionally limited to reading repository contents and the triggering run's Actions artifacts, **but** CI did not verify that permission.

This PR enrolls `Image Scan` in the shared permission checker, so any future token-permission change fails CI until reviewers explicitly approve the new policy. Runtime permissions are unchanged.

## Related issues

Closes #4846.

Part of #4572.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Shared permission-checker fixtures
- All workflow-specific permission-policy checks, including the new Image Scan check
- Bash syntax and ShellCheck
- Actionlint
- Full Core formatting, Clippy, and custom-lint gates

## Expected green-run effect

Effectively none. This adds one small shell policy check to the existing `changes` job.

## What it really buys us

Image Scan permission changes now fail CI until the new access is reviewed and added to its explicit policy.
