### PR TITLE
fix(ci): enforce Fern token permission policies

### DIFF
--- a/.github/ci/check-fern-docs-ci-permissions.sh
+++ b/.github/ci/check-fern-docs-ci-permissions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-fern-docs-ci-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/fern-docs-ci.yml}"
+
+# Fern validation only reads the checked-out documentation sources.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Fern docs (check)" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=read"

--- a/.github/ci/check-fern-docs-preview-build-permissions.sh
+++ b/.github/ci/check-fern-docs-preview-build-permissions.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-fern-docs-preview-build-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/fern-docs-preview-build.yml}"
+
+# The build workflow only reads sources and uploads an artifact. The privileged
+# pull request comment lives in the companion workflow.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Preview Fern Docs: Build" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=read"

--- a/.github/ci/check-publish-fern-docs-permissions.sh
+++ b/.github/ci/check-publish-fern-docs-permissions.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-publish-fern-docs-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/publish-fern-docs.yml}"
+
+# Publishing authenticates with DOCS_FERN_TOKEN; the GitHub token only needs
+# repository read access.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Publish Fern Docs" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=read"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,15 @@ jobs:
       - name: Check Stale PRs token permissions
         run: bash .github/ci/check-stale-ci-permissions.sh
 
+      - name: Check Fern docs (check) token permissions
+        run: bash .github/ci/check-fern-docs-ci-permissions.sh
+
+      - name: "Check Preview Fern Docs: Build token permissions"
+        run: bash .github/ci/check-fern-docs-preview-build-permissions.sh
+
+      - name: Check Publish Fern Docs token permissions
+        run: bash .github/ci/check-publish-fern-docs-permissions.sh
+
       - name: Check Core CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh core
 


### PR DESCRIPTION
The three read-only Fern documentation workflows already limit their GitHub tokens to `contents: read`, and GitHub applies that restriction at runtime. However, our repository policy check does not yet watch those declarations for drift. This PR enrolls all three workflows in the shared checker so any future permission change requires an explicit policy update and review. Runtime permissions remain unchanged.

The write-scoped preview-comment workflow needs its permissions narrowed to the exact job that writes comments before the shared checker can adopt it, so that authority change stays in a separate follow-up.

Primary callouts are:

- **Expected green-run effect:** Effectively none. This adds three small shell policy checks to the existing `changes` job.
- **What it really buys us:** The read-only Fern documentation workflow family cannot gain new token access without an explicit policy update and review.

## What changed

- Added one small policy wrapper for each read-only Fern workflow.
- Registered the existing `contents: read` contract for each workflow's single job.
- Ran all three checks beside the existing permission-policy checks in Core CI.
- Left the Fern workflows, generic checker, and runtime token permissions unchanged.

## Testing

- Shared permission-checker self-test: 60 fixtures passed.
- The existing permission-policy checks and all three new Fern workflow checks passed.
- Bash syntax, ShellCheck 0.11.0, Actionlint 1.7.12, and `git diff --check` passed.
- `cargo make check-format-nightly` passed.
- `cargo make clippy` passed.
- `cargo make carbide-lints` passed.
- Local CodeRabbit and Claude reviews completed with no in-scope correctness findings remaining.
- Hosted checks passed both final aggregate gates on the exact PR head. Core's first attempt hit a pre-existing database concurrency-test flake; the failed-jobs-only retry passed the same test with 384 tests passed and zero failed, then `core-ci-pass` succeeded.

Closes #4853

Part of #4572.
