### PR TITLE
docs: capture state-controller durability in STYLE_GUIDE.md

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -537,6 +537,13 @@ its own fencing, idempotency, or a reconciliation protocol proven safe when exec
 also does not replace atomic SQL, version predicates, or constraints for writers that do not participate in the same
 work key.
 
+### State-controller recovery boundaries
+
+Transactions cannot make external side effects atomic. State-controller work that crosses database and external system
+boundaries must persist a recovery point and avoid holding database transactions open across external I/O. Make repeated
+or overlapping external work safe through fencing, idempotency, or reconciliation. For controller-model background, see
+[Reliable State Handling](docs/architecture/state_handling.md).
+
 ## Database wrappers
 
 - Type definitions: The code in `crates/api-db` is intended to wrap database calls, whereas `crates/api-model` should


### PR DESCRIPTION
_This continues the style-guide series from https://github.com/NVIDIA/infra-controller/pull/4608, https://github.com/NVIDIA/infra-controller/pull/4648, https://github.com/NVIDIA/infra-controller/pull/4739, https://github.com/NVIDIA/infra-controller/pull/4641, and https://github.com/NVIDIA/infra-controller/pull/4783._

This is the `STYLE_GUIDE.md` half of the state-controller durability guidance from #4623.

**Transactions cannot make external side effects atomic.** State-controller work that crosses database and external-system boundaries needs a durable recovery point, must avoid holding database transactions open across external I/O, and needs fencing, idempotency, or reconciliation when work can repeat or overlap.

The short rule has its own scan point beside the existing long-running work-lock contract and links to the repository's current state-handling page for controller-model background. The detailed `docs/architecture/state_handling.md` refresh is in https://github.com/NVIDIA/infra-controller/pull/4867 so it can move through the technical-writer queue separately.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4623

Documentation companion: https://github.com/NVIDIA/infra-controller/pull/4867

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Validated with `cargo make format-nightly`, `cargo make clippy`, the cached Carbide-lints workflow, `rumdl`, `git diff --check`, and a Pandoc render. No tests were run because this is a documentation-only change.
