### PR TITLE
docs: pull our documentation and comment guidance into STYLE_GUIDE.md

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -22,6 +22,108 @@ review. For example, a PR that lands protobuf changes but without any code using
 guesswork during review: If we can't see how the code will be used, we are just guessing at what the best API
 contract will be. Landing both changes together means we can look at it all holistically.
 
+## Documentation and comments
+
+Use documentation to make contracts available where readers look for them. Use comments to preserve reasoning that
+code cannot express.
+
+### Public contracts
+
+Document every new public declaration covered below. Use Rust documentation comments (`///` on declarations and `//!`
+for module or crate documentation) by default. When a change alters an existing public contract, add or update its
+documentation in the same change.
+
+Here, public means reachable from another crate through a public path or re-export. At minimum, document:
+
+- Crates and public modules
+- Public structs, enums, traits, and type aliases
+- Public functions, associated functions, methods, constants, statics, and exported macros
+- Public fields and enum variants, including the meaning of variant payloads
+- Public associated types and associated constants
+
+A public re-export may rely on the target declaration's documentation when rustdoc exposes it at the re-exported path.
+Document any additional contract introduced by an alias or new module placement.
+
+An `impl` block does not need its own documentation. Document public inherent methods individually. A trait
+implementation inherits the trait's shared contract; document any caller-visible behavior specific to the
+implementation on the implementing type or relevant method.
+
+Every declaration and member listed above needs at least one concise sentence stating its purpose, even when its name
+and type are descriptive. Keep that sentence brief; do not pad a simple contract with a line-by-line translation.
+
+Some derive macros consume declaration comments as interface text. For Clap-derived commands, arguments, or values,
+write `help` or `about` metadata as the public contract, or write the `///` comment as deliberate CLI help. Do not add
+duplicate rustdoc that silently changes rendered help.
+
+Document behavior that a signature cannot express:
+
+- Semantics, accepted values, formats, units, and bounds
+- Defaults and omission behavior
+- Invariants, state transitions, and mutation, ownership, or lifetime rules
+- Side effects and conditions that change the result or produce a meaningful error
+
+Do not hand-edit generated declarations. Put their contract in the generator-owned source and verify that it reaches
+the generated public surface. When a public wrapper is the supported interface, keep the raw generated declarations
+internal and document the wrapper instead.
+
+Treat this as the repository minimum. Component owners and reviewers can ask for documentation of additional internal
+declarations or more detail, but do not waive the public baseline.
+
+For commands, configuration, APIs, Helm values, and other operator-facing interfaces, put the contract in its
+authoritative source and make it available on the rendered surface readers use. Documentation near an implementation
+does not replace the interface's own CLI help, gRPC or REST API reference, Helm values, or operator documentation. The
+declaration itself can be authoritative when generation consumes it. Protobuf field comments, for example, own
+generated API documentation. Follow the repository's
+[documentation review checklist](AGENTS.md#documentation-review) to verify interface contracts and generated output.
+
+### Implementation rationale
+
+Add an ordinary `//` comment when safely changing the code depends on context that its names, types, and control flow do
+not reveal:
+
+- The invariant a block preserves
+- Why an `unsafe` block is sound, in an adjacent `// SAFETY:` comment
+- The protocol or compatibility constraint behind an unusual choice
+- An ordering dependency or non-local consequence that a reader would otherwise have to reconstruct across files or
+  systems
+- Why an apparently simpler alternative would violate the current contract
+
+Write comments for the code and contract as they exist. Put PR narration, former behavior, and approaches tried and
+abandoned in review or commit history. Do not preserve implementation prompts or review conversations in source
+comments.
+
+If a past decision still imposes a compatibility constraint, state the current constraint and its support boundary.
+Current limitations and deliberately unsupported behavior are part of the present contract; document them when readers
+need them to use or change the code safely. Explain a tempting alternative through the current invariant it would
+violate. Do not narrate what the code already says.
+
+### Commented-out code
+
+Delete commented-out executable code and obsolete local declarations by default.
+
+A commented-out field declaration is acceptable as a short schema inventory when a database, wire format, or similar
+external representation provides fields that the local type intentionally does not map:
+
+```rust
+#[derive(serde::Deserialize)]
+struct GetResponse {
+    id: String,
+    // Available from the API response but intentionally unmapped:
+    // modified_at: String,
+}
+```
+
+Keep the inventory beside the mapped fields. Verify each field name and type against the authoritative schema or an
+exercised payload. Do not use this exception for speculative fields, removed local fields, implementations, or control
+flow.
+
+Explain compatibility or staged-rollout boundaries in prose, including the support boundary or tracked work. If
+dormant code must land in phases, follow the exception under [A note on dead code](#a-note-on-dead-code). Do not leave
+executable code commented out.
+
+Apply this rule to new code. Clean up existing commented-out code when nearby work makes that change safe and
+reviewable.
+
 ## Lints and Warnings
 
 We enable all clippy lints by default, and treat all warnings as errors. If a warning or clippy lint is firing for
@@ -45,8 +147,8 @@ Other common places where we've seen `#[allow(dead_code)]` that are not necessar
   underscore to hint that it's not supposed to be read
 - If a field is only used if certain crate features are enabled, prefer `#[cfg(feature = "feature")]` to only
   include it when that feature is being used.
-- If a field isn't currently used, but you want to leave it around as documentation on what fields could exist (like an
-  unused database column, or unused JSON field), comment it out.
+- If a database, wire format, or similar external representation provides fields that the type intentionally leaves
+  unmapped, use the [commented-out field inventory](#commented-out-code) exception instead of adding dead fields.
 - Otherwise, strongly consider deleting the code.
 
 For binaries, add the following to the beginning of your main.rs:


### PR DESCRIPTION
_This continues the style-guide series from https://github.com/NVIDIA/infra-controller/pull/4608, https://github.com/NVIDIA/infra-controller/pull/4648, https://github.com/NVIDIA/infra-controller/pull/4739, https://github.com/NVIDIA/infra-controller/pull/4641, and https://github.com/NVIDIA/infra-controller/pull/4783._

This is an attempt to capture the general NICo maintainer design principles and guidance around public contracts and implementation comments for the codebase. This change is derived from the pre-OSS review corpus as a whole -- years of MRs and tens of thousands of comments and discussions. As such, it leans into the guiding design decisions and principles used to define and grow the project into the product we have today.

**The idea is to ensure we capture our core principles in `STYLE_GUIDE.md`.** If any of those principles have changed, we should capture that too, ensuring we don't lose sight of why decisions were made as the codebase evolves with new contributors, human and agentic alike.

**For this change specifically, I focused on putting documentation where its readers actually find it.** The search through previous reviews surfaced discussions related to:

- Rust public contracts and rustdoc.
- Field semantics, units, defaults, and ownership rules.
- Generated and operator-facing interfaces.
- Rationale, invariants, and protocol constraints.
- Commented-out field inventories, executable code, and compatibility boundaries.

This pulls out the recurring parts:

- Document every new public Rust declaration covered by the baseline, using rustdoc by default and declaration metadata
  when it owns generated interface text.
- Update the documentation when a public contract changes.
- Give each covered declaration at least one concise sentence stating its purpose; keep simple contracts brief instead
  of omitting them or translating the code line by line.
- Document semantics, values, units, defaults, invariants, ownership, side effects, and errors instead of restating names.
- Keep operator-facing contracts in their authoritative source and make them available on the rendered surface readers use.
- Use ordinary comments for non-obvious reasoning about the current code, not narration, former behavior, abandoned
  approaches, implementation prompts, or review conversations.
- Delete commented-out executable code and obsolete declarations. Allow commented field declarations only as a narrow
  inventory of fields an external representation actually provides but the local type intentionally leaves unmapped.
  Use prose for compatibility and staged-rollout boundaries, and follow the existing phased-development dead-code
  exception when dormant code must land.

### What Changed After Review

Follow-up review sharpened one important boundary: "self-explanatory item" was too subjective to be useful.

The updated guidance now:

- Defines public as reachable from another crate.
- Sets a documentation floor for every new public declaration and member.
- Keeps `impl` blocks free of redundant prose.
- Lets component owners and reviewers require documentation for internal declarations or more detail without lowering
  the public baseline.

The procedural interface and generated-output checks stay in `AGENTS.md`, so `STYLE_GUIDE.md` can state the design
principle without duplicating the whole review checklist.

Review also clarified two comment boundaries:

- Comments can document current limitations and deliberately unsupported behavior, but they should not preserve former
  behavior, abandoned approaches, implementation prompts, or review conversations. If an earlier decision still
  imposes a compatibility constraint, the comment states the constraint that still applies.
- A short commented-out field declaration can document a field that an external database, wire format, or API actually
  provides but the local type intentionally leaves unmapped. That exception does not extend to speculative fields or
  abandoned code.

Again, we can always adjust this now or later. The hope is that we don't lose the reasoning behind why we made certain decisions to get us where we are now, and can continue using that reasoning to help drive future decisions.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4627

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Validated with `cargo make format-nightly`, `cargo make clippy`, the cached Carbide-lints workflow, `rumdl`, `git diff --check`, and a Pandoc render. No tests were run because this is a documentation-only change.

<details>
<summary>Model Findings Overview</summary>

All three local reviews completed against the same stable pre-fix tree.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 1 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 5 | 4 | 1 |
| **Total** | **6** | **5** | **1** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- `STYLE_GUIDE.md`: The feature-gate wording contradicted the existing phased-development dead-code
   exception. **Resolution:** The comment rule now links to that exception when dormant code must land in phases.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- `STYLE_GUIDE.md`: The feature-gate wording contradicted the phased-development exception. **Resolution:**
   The guidance now links to the existing exception.
2. **Adopted** -- `STYLE_GUIDE.md`: Generated-interface ownership was repeated three times. **Resolution:** The general
   rule, Clap-specific rule, and protobuf example now each appear once.
3. **Adopted** -- `STYLE_GUIDE.md`: The schema-inventory example did not visibly identify an externally mapped type.
   **Resolution:** The example now includes its `serde::Deserialize` derive.
4. **Adopted** -- `STYLE_GUIDE.md`: The commented-out-code rule could read as a repository-wide cleanup mandate.
   **Resolution:** The rule applies to new code and asks for existing cleanup only when nearby work makes it safe.
5. **Declined** -- `STYLE_GUIDE.md`: State that the public-documentation baseline is not lint-enforced. **Reason:** Tool
   enforcement is procedural state, while this section records the durable review standard for new and changed APIs.

</details>
