### PR TITLE
ci: repin dsx GitHub Actions after org transfer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1358,7 +1358,7 @@ jobs:
           fi
 
       - name: Run TruffleHog Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
           base: ${{ steps.scan-range.outputs.base }}
           head: ${{ steps.scan-range.outputs.head }}
@@ -1390,7 +1390,7 @@ jobs:
         # still lets the post steps run, rather than the runner being killed
         # mid-flight with no attribution.
         timeout-minutes: 15
-        uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@20dc10dda4fa9f8f0380a47cd9a7800d3da3dcf3
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/codeql-scan@20dc10dda4fa9f8f0380a47cd9a7800d3da3dcf3
         with:
           languages: 'rust'
           build-mode: 'none'
@@ -1725,7 +1725,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate Helm chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: helm
           lint: 'true'
@@ -1745,7 +1745,7 @@ jobs:
 
       - name: Package and push Helm chart to NGC
         if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: helm
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -1767,7 +1767,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate Helm prereqs chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: helm-prereqs
           lint: 'true'
@@ -1787,7 +1787,7 @@ jobs:
 
       - name: Package and push Helm prereqs chart to NGC
         if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: helm-prereqs
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -1994,28 +1994,28 @@ jobs:
           persist-credentials: false
 
       - name: Validate nico-otelcol chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-otelcol
           lint: 'true'
           template: 'true'
 
       - name: Validate nico-dpu-agent chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-dpu-agent
           lint: 'true'
           template: 'true'
 
       - name: Validate nico-dhcp-server chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-dhcp-server
           lint: 'true'
           template: 'true'
 
       - name: Validate nico-fmds chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-fmds
           lint: 'true'
@@ -2035,7 +2035,7 @@ jobs:
 
       - name: Package and push nico-otelcol chart
         if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-otelcol
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -2047,7 +2047,7 @@ jobs:
 
       - name: Package and push nico-dpu-agent chart
         if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-dpu-agent
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -2059,7 +2059,7 @@ jobs:
 
       - name: Package and push nico-dhcp-server chart
         if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-dhcp-server
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -2071,7 +2071,7 @@ jobs:
 
       - name: Package and push nico-fmds chart
         if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-fmds
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -2173,7 +2173,7 @@ jobs:
     needs:
       - prepare
       - build-release-container-x86_64
-    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@760d2d7964b479fde431cd3e0b980bc6b6a26ccd
+    uses: dsx-ai-factory/dsx-github-actions/.github/workflows/promote-image.yml@760d2d7964b479fde431cd3e0b980bc6b6a26ccd
     with:
       source: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide
       source_tag: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Grype vulnerability scan
         id: scan
         continue-on-error: true
-        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:
           image: ${{ matrix.target.image }}
           fail-on: critical

--- a/.github/workflows/notify-build-status.yml
+++ b/.github/workflows/notify-build-status.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Notify Slack - Build Success
         if: steps.analyze.outputs.status == 'success' && inputs.notify-on-success
-        uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
         with:
           slack-bot-token: ${{ secrets.slack-bot-token }}
           channel-id: ${{ inputs.channel-id }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Notify Slack - Partial Failure
         if: steps.analyze.outputs.status == 'partial' && inputs.notify-on-partial
-        uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
         with:
           slack-bot-token: ${{ secrets.slack-bot-token }}
           channel-id: ${{ inputs.channel-id }}
@@ -259,7 +259,7 @@ jobs:
 
       - name: Notify Slack - Build Failure
         if: steps.analyze.outputs.status == 'failure' && inputs.notify-on-failure
-        uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
         with:
           slack-bot-token: ${{ secrets.slack-bot-token }}
           channel-id: ${{ inputs.channel-id }}

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -149,7 +149,7 @@ jobs:
     needs:
       - prepare
       - approve-promotion
-    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
+    uses: dsx-ai-factory/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
       source: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide
       source_tag: ${{ needs.prepare.outputs.version }}
@@ -168,7 +168,7 @@ jobs:
     needs:
       - prepare
       - approve-promotion
-    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
+    uses: dsx-ai-factory/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
       source: ${{ needs.prepare.outputs.image_registry }}/carbide-release-artifacts-aarch64
       source_tag: ${{ needs.prepare.outputs.version }}
@@ -187,7 +187,7 @@ jobs:
     needs:
       - prepare
       - approve-promotion
-    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
+    uses: dsx-ai-factory/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
       source: ${{ needs.prepare.outputs.image_registry }}/carbide-release-artifacts-x86_64
       source_tag: ${{ needs.prepare.outputs.version }}
@@ -214,7 +214,7 @@ jobs:
           persist-credentials: false
 
       - name: Package and push Helm prereqs chart to production NGC
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: helm-prereqs
           chart-version: ${{ needs.prepare.outputs.helm_version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Push Git Tag
-        uses: NVIDIA/dsx-github-actions/.github/actions/git-tag@95e609360851cfc141918c2c21e57762d77394ac
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/git-tag@95e609360851cfc141918c2c21e57762d77394ac
         with:
           tag: ${{ needs.fetch-new-version.outputs.version }}
       - name: Release

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Grype vulnerability scan
         if: matrix.arch == 'amd64' && github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:
           image: ${{ steps.docker-tags.outputs.arch_tag }}
           fail-on: critical
@@ -237,7 +237,7 @@ jobs:
 
       - name: Upload binary artifact with semantic version
         if: inputs.push_enabled == true && inputs.ngc_path != ''
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
           display-name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
@@ -249,7 +249,7 @@ jobs:
 
       - name: Upload binary artifact with latest tag
         if: inputs.is_main_branch == 'true' && inputs.push_enabled == true && inputs.ngc_path != ''
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
           display-name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
@@ -335,7 +335,7 @@ jobs:
 
       - name: Upload Docker image artifact with semantic version
         if: inputs.ngc_path != ''
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-image
           display-name: ${{ inputs.service_name }}-image
@@ -347,7 +347,7 @@ jobs:
 
       - name: Upload Docker image artifact with latest tag
         if: inputs.is_main_branch == 'true' && inputs.ngc_path != ''
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-image
           display-name: ${{ inputs.service_name }}-image

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -130,7 +130,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/ci/resolve-secret-scan-range.sh >> "$GITHUB_OUTPUT"
       - name: Run TruffleHog Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@f435aa6bf125fe6f9e5ac438f8cef75f90e29a2b
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/trufflehog-scan@f435aa6bf125fe6f9e5ac438f8cef75f90e29a2b
         with:
           base: ${{ steps.scan-range.outputs.base }}
           head: ${{ steps.scan-range.outputs.head }}

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate Helm chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: ${{ matrix.chart }}
           lint: 'true'
@@ -75,7 +75,7 @@ jobs:
 
       - name: Package and push Helm chart to NGC
         if: ${{ inputs.ngc_path != '' }}
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: ${{ matrix.chart }}
           chart-version: ${{ inputs.chart_version }}

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -20,8 +20,8 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
-        # Refer to https://github.com/NVIDIA/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
+        # Refer to https://github.com/dsx-ai-factory/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
         with:
           days-before-issue-stale: '-1'
           days-before-pr-stale: '30'


### PR DESCRIPTION
## Summary

- update `dsx-github-actions` references from `NVIDIA` to `dsx-ai-factory`
- preserve all existing action paths and immutable refs

## Context

The shared actions repository is being transferred as tracked by [NVBug 6528755](https://nvbugspro.nvidia.com/bug/6528755). GitHub redirects keep old references working, but explicit repinning removes the redirect dependency and keeps repository references current.

## Validation

- confirmed no `NVIDIA/dsx-github-actions` references remain
- reviewed the diff to confirm only the repository owner/path changed
- `git diff --check`
- `actionlint` reports only existing custom-runner and shellcheck findings outside this path-only change

## Merge timing

Merge after `NVIDIA/dsx-github-actions` has been transferred to `dsx-ai-factory/dsx-github-actions`.