### PR TITLE
feat(dpu): otel tracing support

### DIFF
--- a/bluefield/charts/nico-otelcol/files/otel_config.yaml
+++ b/bluefield/charts/nico-otelcol/files/otel_config.yaml
@@ -5,6 +5,12 @@ extensions:
     fsync: true
 
 receivers:
+  # OTLP receiver for DPU workloads to emit tracing spans
+  otlp/workloads:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+
   filelog/doca:
     include:
       - /var/log/doca/hbn/frr/frr.log
@@ -243,8 +249,11 @@ processors:
   batch/metrics-disk:
     send_batch_size: 8192
     timeout: 75s
+  batch/traces:
+    send_batch_size: 8192
+    timeout: 5s
   fileresource:
-    file_paths: 
+    file_paths:
       - /run/otelcol-contrib/machine-id
       - /run/otelcol-contrib/host-machine-id
     poll_interval: 5s
@@ -325,6 +334,11 @@ processors:
       - key: component
         value: transceiver-exporter
         action: upsert
+  resource/traces-workloads:
+    attributes:
+      - key: component
+        value: dpu-workloads
+        action: upsert
   resourcedetection:
     # Add hostname at the resource level
     detectors: ["system"]
@@ -399,6 +413,15 @@ exporters:
 
 service:
   pipelines:
+    traces/workloads:
+      receivers: [otlp/workloads]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - fileresource
+        - resource/traces-workloads
+        - batch/traces
+      exporters: [otlp/site]
     logs/nico-dpu-agent:
       receivers: [filelog/nico-dpu-agent]
       processors:

--- a/bluefield/otel/ocb-generated/go.mod
+++ b/bluefield/otel/ocb-generated/go.mod
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/collector/processor/batchprocessor v0.155.0
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.155.0
 	go.opentelemetry.io/collector/receiver v1.61.0
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.155.0
 	go.opentelemetry.io/collector/service v0.155.0
 	golang.org/x/sys v0.46.0
 	puntstatsreceiver v0.0.1
@@ -321,6 +322,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.155.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.155.0 // indirect
 	go.opentelemetry.io/collector/internal/memorylimiter v0.155.0 // indirect
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.155.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.155.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.61.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.155.0 // indirect

--- a/bluefield/otel/otel_config.yaml
+++ b/bluefield/otel/otel_config.yaml
@@ -14,13 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
----
 extensions:
   file_storage/cursors:
     directory: /var/lib/otelcol-contrib/cursors
     fsync: true
 
 receivers:
+  # OTLP receiver for DPU workloads to emit tracing spans
+  otlp/workloads:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+
   filelog/doca:
     include:
       - /var/log/doca/hbn/frr/frr.log
@@ -240,6 +245,9 @@ processors:
   batch/metrics-disk:
     send_batch_size: 8192
     timeout: 75s
+  batch/traces:
+    send_batch_size: 8192
+    timeout: 5s
   fileresource:
     file_paths:
       - /run/otelcol-contrib/machine-id
@@ -322,6 +330,11 @@ processors:
       - key: component
         value: transceiver-exporter
         action: upsert
+  resource/traces-workloads:
+    attributes:
+      - key: component
+        value: dpu-workloads
+        action: upsert
   resource/punt-stats:
     attributes:
       - key: component
@@ -400,6 +413,16 @@ exporters:
 
 service:
   pipelines:
+    # Traces pipeline for DPU workloads (eg, ovnkube-node)
+    traces/workloads:
+      receivers: [otlp/workloads]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - fileresource
+        - resource/traces-workloads
+        - batch/traces
+      exporters: [otlp/site]
     logs/journald:
       receivers: [journald/forge-dpu-agent]
       processors:

--- a/bluefield/otel/otelcol_builder_config_yaml.txt
+++ b/bluefield/otel/otelcol_builder_config_yaml.txt
@@ -41,6 +41,8 @@ receivers:
   - gomod:
       github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v${VERSION}
   - gomod:
+      go.opentelemetry.io/collector/receiver/otlpreceiver v${VERSION}
+  - gomod:
       github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v${VERSION}
   - gomod: puntstatsreceiver v${PUNTSTATS_VERSION}
 

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -9,7 +9,7 @@ How NICo component tracing works, what it covers, how to turn it on and off and 
 - **nico-api** (the `carbide-api` binary) is NICo's primary tracing source and the subject of this
   document. **nico-dns** also emits traces, but with a separate simpler always-on setup.
   **nico-bmc-proxy** emits traces for each proxied BMC request when configured (see
-  [nico-bmc-proxy tracing](#16-nico-bmc-proxy-tracing)).
+  [nico-bmc-proxy tracing](#nico-bmc-proxy-tracing)).
 - **nico-api traces are off by default**; two things must both be true before any spans are emitted:
   - An OTLP endpoint is configured at startup, either in the nico-api config TOML:
 
@@ -36,13 +36,13 @@ How NICo component tracing works, what it covers, how to turn it on and off and 
 - nico-api **propagates W3C trace context** at its network boundaries: it reads `traceparent`/
   `tracestate` from inbound REST and gRPC requests and continues that trace, injecting the same
   headers into its outbound requests. Propagation links traces across services, but does not by itself
-  enable recording (see [W3C trace-context propagation](#17-w3c-trace-context-propagation)).
+  enable recording (see [W3C trace-context propagation](#w3c-trace-context-propagation)).
 
 ---
 
 ## 1. How tracing works
 
-### 1.1 Which components emit traces
+### Which components emit traces
 
 The following binaries build an OTLP span exporter:
 
@@ -51,16 +51,16 @@ The following binaries build an OTLP span exporter:
 - **nico-dns** (`crates/dns/src/main.rs`) - a separate, much simpler **always-on** setup.
 - **nico-bmc-proxy** (`crates/bmc-proxy/src/setup.rs`) - one span per proxied BMC request, off by
   default behind endpoint plus `[tracing] enabled` (see
-  [nico-bmc-proxy tracing](#16-nico-bmc-proxy-tracing)).
+  [nico-bmc-proxy tracing](#nico-bmc-proxy-tracing)).
 
 The other binaries (nico-pxe, nico-dhcp, nico-hardware-health, nico-ssh-console-rs, and
 nico-dsx-exchange-consumer) carry the OpenTelemetry crates in the workspace but do not build a span
 exporter, so they do not emit traces.
 
 Unless noted otherwise, the rest of this document describes **nico-api** tracing.
-nico-dns differs as described in [1.5](#15-nico-dns-tracing-separate-and-always-on).
+nico-dns differs as described in [NICO DNS tracing](#nico-dns-tracing-separate-and-always-on).
 
-### 1.2 What operations are covered
+### What operations are covered
 
 nico-api links many library crates in-process and the `#[tracing::instrument]` spans live in
 those crates. When tracing is enabled, the instrumented operations are:
@@ -81,7 +81,7 @@ provisioning/reconcile loops, power control and firmware updates against the BMC
 backends, plus the database work underneath them - which maps directly to the EPIC's
 "time on a given state of the machine, nodes stuck" need.
 
-### 1.3 How spans are selected (sampler)
+### How spans are selected (sampler)
 
 nico-api uses a custom `CarbideSpanSampler`:
 
@@ -94,17 +94,17 @@ nico-api uses a custom `CarbideSpanSampler`:
   it is captured - **except tokio spans, which are always dropped** (they leak and would exhaust memory).
 - For a span parented to a **remote** (ingress-extracted) trace, the decision stays local: an inbound `sampled`
   flag does not override `tracing_enabled` (see
-  [W3C trace-context propagation](#17-w3c-trace-context-propagation)).
+  [W3C trace-context propagation](#w3c-trace-context-propagation)).
 - The exporter resource is `service.name = carbide-api`; the tracer is named `carbide`.
 
-### 1.4 How traces leave nico-api
+### How traces leave nico-api
 
 nico-api pushes spans over **OTLP/gRPC** to a collector endpoint you configure. It does not
 discover or get injected with anything - it simply connects out to the endpoint from
 `[tracing] otlp_endpoint` or, if set, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. The environment
 variable overrides the TOML value. The transport details: gRPC-only, plaintext.
 
-### 1.5 nico-dns tracing (separate and always-on)
+### nico-dns tracing (separate and always-on)
 
 nico-dns has its own tracing setup (`crates/dns/src/main.rs`), independent of and simpler than
 nico-api's:
@@ -121,7 +121,7 @@ nico-api's:
 - **Resource / output:** `service.name = carbide-dns`; logs are JSON on stdout (not logfmt).
 - **Same transport constraints:** OTLP/gRPC, plaintext (`with_tonic`, no `tls` feature)
 
-### 1.6 nico-bmc-proxy tracing
+### nico-bmc-proxy tracing
 
 nico-bmc-proxy traces each proxied Redfish request through the BMC credential proxy
 (`crates/bmc-proxy/src/bmc_proxy.rs`). It follows the same W3C propagation model as nico-api
@@ -165,7 +165,7 @@ Point this at the same collector nico-api uses: spans only join into one trace i
 hop's exporter reaches the same backend. The components stay distinguishable by their
 `service.name`.
 
-### 1.7 W3C trace-context propagation
+### W3C trace-context propagation
 
 nico-api accepts and produces **W3C Trace Context** headers (`traceparent` and `tracestate`) at its
 network boundaries, so a request already traced by another service stays one trace as it passes
@@ -194,7 +194,7 @@ through nico-api. The standard `TraceContextPropagator` is installed once at sta
     this hop. **This is a known limitation.**
 - **Scope.** Trace context only (`traceparent` or `tracestate`).
 
-### 1.8 Adding a new network client
+### Adding a new network client
 
 Propagation is automatic on ingress but opt-in on egress. Keep the following in mind when adding code:
 
@@ -246,7 +246,7 @@ OTLP exporter is built.
  └───────────────────────────────┘                  └─────────────────────────────────────┘
 ```
 
-### 2.1 Deploy-time configuration
+### Deploy-time configuration
 
 **(a) A traces backend.** Anything that accepts OTLP traces: e.g. Tempo, Jaeger, Grafana Cloud,
 Datadog, Elastic APM or another OTEL collector acting as a gateway.
@@ -357,7 +357,7 @@ Notes:
 - Configuring only the endpoint puts the plumbing in place but does **not** start emission on its
   own. `enabled` must also be true.
 
-### 2.2 Enable / Disable Policy
+### Enable / Disable Policy
 
 With the endpoint configured, emission is controlled by `[tracing] enabled`, which defaults
 **off**:
@@ -389,7 +389,7 @@ Leaving tracing **off** in steady state is the intended operating mode. If you n
 control, set `allow_runtime_changes = false` and change `[tracing] enabled` through the config file
 plus a pod roll.
 
-### 2.3 Do I need to restart nico-api?
+### Do I need to restart nico-api?
 
 It depends on which part you are changing:
 
@@ -413,7 +413,7 @@ the plumbing is cheap while tracing is toggled off. Keep `enabled = false` and
 `allow_runtime_changes = true` for debug-on-demand environments, or set
 `allow_runtime_changes = false` when the config file should be the only control plane for tracing.
 
-### 2.4 Verifying it works
+### Verifying it works
 
 1. `[tracing] otlp_endpoint` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is set on nico-api and points
    at the collector's gRPC endpoint.
@@ -437,7 +437,7 @@ which of three states nico-api is in:
 | Endpoint **set**, tracing **disabled** | **Near-zero** (small per-span bookkeeping) | None | Layer is installed but the sampler drops everything; nothing is recorded or exported. |
 | Endpoint set, tracing **enabled** | **Significant** | Yes | Full recording + serialization + export. This is the "resource-intensive" mode. |
 
-### 3.1 When tracing is ON
+### When tracing is ON
 
 This is the expensive mode the dev team warns about:
 
@@ -449,7 +449,7 @@ This is the expensive mode the dev team warns about:
 - Mitigate with `tail_sampling` at the collector (keep errors/slow traces, sample the rest) and -
   most importantly - **only enable it during an active investigation**, then turn it back off.
 
-### 3.2 When the endpoint is set but tracing is OFF
+### When the endpoint is set but tracing is OFF
 
 This is the common steady state if you follow the recommendation to leave the endpoint configured
 with `[tracing] enabled = false`, or after disabling tracing dynamically. The overhead here is
@@ -466,7 +466,7 @@ with `[tracing] enabled = false`, or after disabling tracing dynamically. The ov
 - Net: a small, roughly constant per-span CPU cost - negligible next to the "on" mode, but not
   the literal zero you get with the endpoint unset.
 
-### 3.3 Practical guidance
+### Practical guidance
 
 - Leave `[tracing] otlp_endpoint` configured and keep tracing **off** in steady state - cheap and
   avoids a pod roll when you need traces.
@@ -497,10 +497,64 @@ annotation involved for traces
 | Sidecar injected but still no traces | Endpoint not set, or points somewhere other than `localhost:4317` | Set `[tracing] otlp_endpoint = "http://localhost:4317"` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4317` on nico-api |
 | Traces reach the collector but not the backend | Collector exporter endpoint/TLS wrong | Check the exporter config; for remote backends configure TLS/mTLS on the collector |
 | Sudden resource/latency spike on nico-api | Tracing left on | `nico-admin-cli set tracing-enabled false`, or set `[tracing] enabled = false` and roll nico-api if runtime changes are disabled |
-| Spans arrive but request trees look sparse | Only spans marked with `carbide.trace_root` start a recorded trace (see [1.3](#13-how-spans-are-selected-sampler)) | Confirm the operation starts at a marked root span |
+| Spans arrive but request trees look sparse | Only spans marked with `carbide.trace_root` start a recorded trace (see [Span Sampler](#how-spans-are-selected-sampler)) | Confirm the operation starts at a marked root span |
 
 ---
 
-## 6. References
+## 6. DPU workload tracing
+
+DPU workloads (such as ovnkube-node) can emit OpenTelemetry tracing spans through the DPU's
+otelcol-contrib collector. The collector provides a localhost-only OTLP/gRPC receiver that
+forwards spans to the site-level OpenTelemetry receiver using the DPU's mTLS credentials.
+
+### Endpoint configuration
+
+| Setting | Value |
+|---------|-------|
+| Protocol | OTLP/gRPC |
+| Endpoint | `127.0.0.1:4317` |
+| TLS | Not required (loopback only) |
+
+### Workload configuration
+
+Configure your workload's OpenTelemetry exporter to send spans to the local collector:
+
+```bash
+# Environment variables (standard OTLP configuration)
+OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
+OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+```
+
+For Kubernetes workloads running on DPUs managed by DPF:
+
+```yaml
+# Pod spec environment variables
+env:
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://127.0.0.1:4317"
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: "grpc"
+```
+
+### Security
+
+- The OTLP receiver binds only to loopback (`127.0.0.1`), preventing external access
+- Workloads do not need access to DPU mTLS credentials
+- The collector authenticates to the site-level receiver using existing mTLS configuration
+
+### Resource attributes
+
+Spans exported through this pipeline include:
+
+| Attribute | Source | Description |
+|-----------|--------|-------------|
+| `host.name` | `resourcedetection` | DPU hostname |
+| `machine.id` | `fileresource` | NICo machine ID |
+| `host.machine.id` | `fileresource` | Host machine ID |
+| `component` | `resource/traces-workloads` | Set to `dpu-workloads` |
+
+---
+
+## 7. References
 
 - [NICo core metrics catalogue](core_metrics.md) - includes `carbide_api_tracing_spans_open`.

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -543,7 +543,7 @@ workloads like ovnkube-node that also use `hostNetwork: true`. Workloads in pod
 network namespaces cannot reach this endpoint.
 </Note>
 
-### 6.4 Security
+### Security
 
 - The OTLP receiver binds only to loopback (`127.0.0.1`), preventing access from outside the node
 - Loopback does not authenticate callers - any process in the host network namespace can send spans

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -521,8 +521,8 @@ Configure your workload's OpenTelemetry exporter to send spans to the local coll
 
 ```bash
 # Environment variables (standard OTLP configuration)
-OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
-OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
+export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
 ```
 
 For Kubernetes workloads running on DPUs managed by DPF:
@@ -536,9 +536,17 @@ env:
     value: "grpc"
 ```
 
-### Security
+<Note>
+The nico-otelcol DaemonSet runs with `hostNetwork: true`, so the loopback endpoint
+`127.0.0.1:4317` is reachable only from the host network namespace. This works for
+workloads like ovnkube-node that also use `hostNetwork: true`. Workloads in pod
+network namespaces cannot reach this endpoint.
+</Note>
 
-- The OTLP receiver binds only to loopback (`127.0.0.1`), preventing external access
+### 6.4 Security
+
+- The OTLP receiver binds only to loopback (`127.0.0.1`), preventing access from outside the node
+- Loopback does not authenticate callers - any process in the host network namespace can send spans
 - Workloads do not need access to DPU mTLS credentials
 - The collector authenticates to the site-level receiver using existing mTLS configuration
 


### PR DESCRIPTION
- Adds tracing support to the DPF nico-otelcol and non-DPF otel collectors. DPU workloads (eg. ovnkube-node) can emit otel tracing spans without direct access to mTLS credentials
- Adds a localhost only OTLP/gRPC receiver and a traces pipeline that forwards spans to the site level otel receiver

## Related issues
- Closes #4276

## Type of Change
- [x] **Add** - New feature or capability

## Testing
- [x] Manual testing performed
