### PR TITLE
fix(agent): parse interface indexes above 255

### DIFF
--- a/crates/agent/src/dpu/link.rs
+++ b/crates/agent/src/dpu/link.rs
@@ -24,7 +24,7 @@ use crate::pretty_cmd;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct IpLink {
-    pub ifindex: u8,
+    pub ifindex: u32,
     pub ifname: Option<String>,
     pub flags: Vec<String>,
     pub mtu: u32,
@@ -71,5 +71,23 @@ impl IpLink {
             let fout = String::from_utf8_lossy(&output.stdout).to_string();
             Ok(fout)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IpLink;
+    use crate::dpu::interface::IpInterface;
+
+    const IP_LINK_OUT: &str = r#"[{"ifindex":256,"ifname":"pf0vf51","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":9216,"qdisc":"mq","operstate":"UP","linkmode":"DEFAULT","group":"default","txqlen":128,"link_type":"ether","address":"26:97:d8:57:c8:31","broadcast":"ff:ff:ff:ff:ff:ff","addr_info":[]}]"#;
+
+    #[test]
+    fn test_parse_ifindex_above_u8_max() -> eyre::Result<()> {
+        let links: Vec<IpLink> = serde_json::from_str(IP_LINK_OUT)?;
+        assert_eq!(links[0].ifindex, 256);
+
+        let interfaces: Vec<IpInterface> = serde_json::from_str(IP_LINK_OUT)?;
+        assert_eq!(interfaces[0].link.ifindex, 256);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Widen `IpLink.ifindex` from `u8` to `u32` so the DPU agent can deserialize Linux interface indexes above 255 without exiting its main loop.

Without this fix, any DPU with an interface index greater than or equal to 256 crash-loops `forge-dpu-agent` roughly every 90 seconds. The agent exits its main loop before reporting network status, so instance updates never leave Configuring. Creating and deleting interfaces drives indexes upward, so long-lived DPUs can reach this state regardless of how many interfaces they hold at once.

Add regression coverage for both direct `IpLink` parsing and the flattened `IpInterface` address-reconciliation path using the boundary value 256.

`ifindex` is not read anywhere in production code; its only previous reference was a test assertion. Widening the field therefore cannot change behavior beyond allowing the parse to succeed.

A `release/v2.1` backport will follow after this change merges.

## Related issues

Fixes #4872

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Targeted Linux regression test passed.
- `carbide-agent` suite: 202 passed and 2 container-environment failures; both failures reproduce unchanged on `upstream/main`.
- Pinned nightly formatting passed.
- Clippy passed for all `carbide-agent` targets with warnings denied.
