### PR TITLE
feat(dpu-agent): configure machine identity sign proxy

### DIFF
--- a/bluefield/charts/nico-dpu-agent/templates/configmap.yaml
+++ b/bluefield/charts/nico-dpu-agent/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- with .Values.fmds.sign_proxy_url }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nico-dpu-agent.fullname" $ }}-config
+  labels:
+    {{- include "nico-dpu-agent.labels" $ | nindent 4 }}
+data:
+  config.toml: |
+    [machine-identity]
+    sign-proxy-url = {{ . | quote }}
+{{- end }}

--- a/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
@@ -9,6 +9,10 @@
 {{- $bootstrapCaObjectKey = get $bootstrapCaObject "key" -}}
 {{- end -}}
 {{- $certsDir := .Values.certsDir | default "/opt/nico" -}}
+{{- $podAnnotations := .Values.serviceDaemonSet.annotations -}}
+{{- if .Values.fmds.sign_proxy_url -}}
+{{- $podAnnotations = omit $podAnnotations "checksum/machine-identity-config" -}}
+{{- end -}}
 {{- if not (has $bootstrapCaSource (list "legacy_download" "mounted")) -}}
 {{- fail (printf "bootstrapCa.source must be one of legacy_download or mounted; got %q" $bootstrapCaSource) -}}
 {{- end -}}
@@ -60,8 +64,11 @@ spec:
   template:
     metadata:
       annotations:
-        {{- with .Values.serviceDaemonSet.annotations }}
+        {{- with $podAnnotations }}
           {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.fmds.sign_proxy_url }}
+        checksum/machine-identity-config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
         {{- end }}
       labels:
         {{- include "nico-dpu-agent.selectorLabels" . | nindent 8 }}
@@ -131,6 +138,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
+            {{- with .Values.fmds.sign_proxy_url }}
+            - "--config-path=/etc/forge/config.toml"
+            {{- end }}
             - run
             - "--hbn-config-mode=nvue-rest"
             - "--agent-platform-type=containerized"
@@ -182,12 +192,23 @@ spec:
                   name: {{ .Values.hbn.nvue_credentials_secret_name }}
                   key: {{ .Values.hbn.nvue_password_key }}
           volumeMounts:
+            {{- with .Values.fmds.sign_proxy_url }}
+            - name: agent-config
+              mountPath: /etc/forge/config.toml
+              subPath: config.toml
+              readOnly: true
+            {{- end }}
             - name: nico-certs
               mountPath: {{ .Values.certsDir | default "/opt/nico" }}
             - name: hw-cache
               mountPath: /data
               readOnly: true
       volumes:
+        {{- with .Values.fmds.sign_proxy_url }}
+        - name: agent-config
+          configMap:
+            name: {{ include "nico-dpu-agent.fullname" $ }}-config
+        {{- end }}
         - name: nico-certs
           hostPath:
             path: {{ .Values.certsDir | default "/opt/nico" }}

--- a/bluefield/charts/nico-dpu-agent/tests/machine_identity_configmap_test.yaml
+++ b/bluefield/charts/nico-dpu-agent/tests/machine_identity_configmap_test.yaml
@@ -1,0 +1,14 @@
+suite: machine identity ConfigMap
+templates:
+  - configmap.yaml
+tests:
+  - it: renders the existing agent configuration format
+    set:
+      fmds:
+        sign_proxy_url: http://dsx-imds.dpf-operator-system.svc.cluster.local:8080
+    asserts:
+      - equal:
+          path: data["config.toml"]
+          value: |
+            [machine-identity]
+            sign-proxy-url = "http://dsx-imds.dpf-operator-system.svc.cluster.local:8080"

--- a/bluefield/charts/nico-dpu-agent/tests/machine_identity_test.yaml
+++ b/bluefield/charts/nico-dpu-agent/tests/machine_identity_test.yaml
@@ -1,0 +1,44 @@
+suite: machine identity configuration
+templates:
+  - daemonset.yaml
+tests:
+  - it: uses the Forge signer by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --config-path=/etc/forge/config.toml
+
+  - it: mounts the configured agent file
+    set:
+      image:
+        repository: test
+        tag: test
+      fmds:
+        sign_proxy_url: http://dsx-imds.dpf-operator-system.svc.cluster.local:8080
+      serviceDaemonSet:
+        annotations:
+          checksum/machine-identity-config: user-value
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --config-path=/etc/forge/config.toml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: agent-config
+            mountPath: /etc/forge/config.toml
+            subPath: config.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: agent-config
+            configMap:
+              name: RELEASE-NAME-config
+      - notEqual:
+          path: spec.template.metadata.annotations["checksum/machine-identity-config"]
+          value: user-value

--- a/bluefield/charts/nico-dpu-agent/values.yaml
+++ b/bluefield/charts/nico-dpu-agent/values.yaml
@@ -67,3 +67,5 @@ dhcp_server:
 fmds:
   # Will be updated in dpf_services.rs
   service_name: ""
+  # Empty keeps NICo's Forge signer.
+  sign_proxy_url: ""

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -605,10 +605,21 @@ events, so consumers handle them identically.
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `false` | Enable DPF Kubernetes deployment. |
 | `dpu_agent_bootstrap_ca` | `DpfDpuAgentBootstrapCa` | `legacy_download` | Bootstrap trust for the containerized DPU agent. Supports `legacy_download` and `mounted`, as described in the following examples. |
-| `services` | `Box<DpfMandatoryServicesConfig>` | built-in mandatory-service defaults | Helm chart, image, and pull-secret settings for the six mandatory DPF services. |
+| `services` | `Box<DpfMandatoryServicesConfig>` | built-in mandatory-service defaults | Helm chart, image, pull-secret, and `extra_helm_values` settings for the six mandatory DPF services. |
 | `docker_image_pull_secret` | `Option<String>` | — | Override for the Kubernetes `imagePullSecrets` entry used to pull mandatory-service images (applied to every mandatory service except `dts` and `doca_hbn`, which take a pull secret only from their per-service config). |
 | `proxy` | `Option<DpfProxyDetails>` | — | Proxy configuration for the DPU. When set, containerd on the DPU routes outbound HTTPS traffic through it. |
 | `deployments` | `DpfDeploymentsConfig` | *(default)* | Per-generation DPUDeployment configurations. BF3 is always present with defaults; BF4 variants are opt-in. BF4 Astra gets default Weave DHCP agent, Weave flow controller, and Xplane services; `extra_services` can replace any of those definitions. |
+
+Each entry under `[dpf.services]` accepts a chart-native `extra_helm_values` table. NICo
+deep-merges it over generated `DPUServiceTemplate` values. Nested scalars and arrays
+replace generated values. DPF applies NICo's deployment-specific
+`DPUServiceConfiguration` values after the template values.
+Top-level and per-deployment service fields both overlay the service's built-in defaults.
+
+```toml
+[dpf.services.dpu_agent.extra_helm_values.fmds]
+sign_proxy_url = "http://dsx-imds.dpf-operator-system.svc.cluster.local:8080"
+```
 
 Omitting `[dpf.dpu_agent_bootstrap_ca]` preserves the historical download URL.
 Use the following configuration to retain download mode while overriding the

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -47,6 +47,7 @@ use chrono::Duration;
 use db::host_naming::HostNamingStrategyKind;
 use duration_str::{deserialize_duration, deserialize_duration_chrono};
 use figment::Figment;
+use figment::providers::Serialized;
 use health_report::HealthAlertClassification;
 use ipnetwork::{IpNetwork, Ipv4Network};
 use itertools::Itertools;
@@ -1461,20 +1462,42 @@ fn default_dpf_node_label_key() -> String {
 /// testing/dev purpose).
 /// There are following mandatory services:
 /// dpu-agent, fmds, dhcp-server, doca-hbn, dts and otel.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct DpfMandatoryServicesConfig {
-    #[serde(default = "crate::dpf_services::default_dts_service")]
     pub dts: DpfServiceConfig,
-    #[serde(default = "crate::dpf_services::default_doca_hbn_service")]
     pub doca_hbn: DpfServiceConfig,
-    #[serde(default = "crate::dpf_services::default_dpu_agent_service")]
     pub dpu_agent: DpfServiceConfig,
-    #[serde(default = "crate::dpf_services::default_dhcp_server_service")]
     pub dhcp_server: DpfServiceConfig,
-    #[serde(default = "crate::dpf_services::default_fmds_service")]
     pub fmds: DpfServiceConfig,
-    #[serde(default = "crate::dpf_services::default_otelcol_service")]
     pub otel: DpfServiceConfig,
+}
+
+impl<'de> Deserialize<'de> for DpfMandatoryServicesConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // `#[serde(default)]` only handles an absent `services` field. For a present,
+        // partial table, start with every service default and overlay the supplied fields.
+        let configured = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let mut services = Self::default();
+        for (name, configured) in configured {
+            let service = match name.as_str() {
+                "dts" => &mut services.dts,
+                "doca_hbn" => &mut services.doca_hbn,
+                "dpu_agent" => &mut services.dpu_agent,
+                "dhcp_server" => &mut services.dhcp_server,
+                "fmds" => &mut services.fmds,
+                "otel" => &mut services.otel,
+                _ => continue,
+            };
+            *service = Figment::from(Serialized::defaults(std::mem::take(service)))
+                .merge(Serialized::defaults(configured))
+                .extract()
+                .map_err(serde::de::Error::custom)?;
+        }
+        Ok(services)
+    }
 }
 
 impl Default for DpfMandatoryServicesConfig {
@@ -1564,6 +1587,10 @@ pub struct DpfServiceConfig {
     /// `imagePullSecrets` entry is emitted in the service's Helm values.
     #[serde(default)]
     pub docker_image_pull_secret: Option<String>,
+    /// Chart-native values deep-merged over NICo's generated template values.
+    /// Tables merge recursively. Scalars and arrays replace generated values.
+    #[serde(default)]
+    pub extra_helm_values: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 /// Per-deployment DPF configuration for named entries under `[dpf.deployments]`.
@@ -5851,6 +5878,87 @@ object_kind = "secret"
         .unwrap_err();
 
         assert!(error.to_string().contains("unknown field `object_kind`"));
+    }
+
+    #[test]
+    fn empty_dpf_service_uses_its_defaults() {
+        let config = toml::from_str::<DpfConfig>("[services.dpu_agent]").unwrap();
+        let expected_agent = crate::dpf_services::default_dpu_agent_service();
+        let expected_fmds = crate::dpf_services::default_fmds_service();
+
+        assert_eq!(config.services.dpu_agent.name, expected_agent.name);
+        assert_eq!(
+            config.services.dpu_agent.helm_chart,
+            expected_agent.helm_chart
+        );
+        assert_eq!(config.services.fmds.name, expected_fmds.name);
+    }
+
+    #[test]
+    fn top_level_dpf_service_overlays_its_defaults() {
+        let config = toml::from_str::<DpfConfig>(
+            r#"
+[services.dpu_agent]
+helm_version = "configured-version"
+
+[services.dpu_agent.extra_helm_values.fmds]
+sign_proxy_url = "http://dsx-imds.dpf-operator-system.svc.cluster.local:8080"
+"#,
+        )
+        .unwrap();
+        let expected = crate::dpf_services::default_dpu_agent_service();
+
+        assert_eq!(config.services.dpu_agent.name, expected.name);
+        assert_eq!(
+            config.services.dpu_agent.docker_repo_url,
+            expected.docker_repo_url
+        );
+        assert_eq!(config.services.dpu_agent.helm_version, "configured-version");
+        assert_eq!(
+            config.services.dpu_agent.extra_helm_values.unwrap()["fmds"]["sign_proxy_url"],
+            "http://dsx-imds.dpf-operator-system.svc.cluster.local:8080"
+        );
+    }
+
+    #[test]
+    fn dpf_service_helm_values_require_a_table() {
+        for value in ["true", "[\"value\"]"] {
+            let config = format!("[services.dpu_agent]\nextra_helm_values = {value}\n");
+
+            assert!(toml::from_str::<DpfConfig>(&config).is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn deployment_dpf_service_overlays_its_defaults() {
+        let config = toml::from_str::<DpfConfig>(
+            r#"
+[deployments.bf4_generic]
+flavor_name = "bf4-flavor"
+deployment_name = "bf4-deployment"
+node_label_key = "carbide.nvidia.com/bf4"
+
+[deployments.bf4_generic.services.dpu_agent]
+helm_version = "configured-version"
+
+[deployments.bf4_generic.services.dpu_agent.extra_helm_values.fmds]
+sign_proxy_url = "http://bf4-dsx-imds.dpf-operator-system.svc.cluster.local:8080"
+
+[deployments.bf4_generic.services.fmds]
+"#,
+        )
+        .unwrap();
+        let services = config.deployments.bf4_generic.unwrap().services.unwrap();
+        let expected_agent = crate::dpf_services::default_dpu_agent_service();
+        let expected_fmds = crate::dpf_services::default_fmds_service();
+
+        assert_eq!(services.dpu_agent.name, expected_agent.name);
+        assert_eq!(services.dpu_agent.helm_version, "configured-version");
+        assert_eq!(services.fmds.name, expected_fmds.name);
+        assert_eq!(
+            services.dpu_agent.extra_helm_values.unwrap()["fmds"]["sign_proxy_url"],
+            "http://bf4-dsx-imds.dpf-operator-system.svc.cluster.local:8080"
+        );
     }
 
     #[test]

--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -173,6 +173,7 @@ pub(crate) fn default_dts_service() -> DpfServiceConfig {
         docker_repo_url: String::new(),
         docker_image_tag: String::new(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -185,6 +186,7 @@ pub(crate) fn default_doca_hbn_service() -> DpfServiceConfig {
         docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_HBN_SERVICE_IMAGE_NAME}"),
         docker_image_tag: DOCA_HBN_SERVICE_IMAGE_TAG.to_string(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -197,6 +199,7 @@ pub(crate) fn default_dpu_agent_service() -> DpfServiceConfig {
         docker_repo_url: format!("{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{DPU_AGENT_SERVICE_IMAGE_NAME}"),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -211,6 +214,7 @@ pub(crate) fn default_dhcp_server_service() -> DpfServiceConfig {
         ),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -223,6 +227,7 @@ pub(crate) fn default_fmds_service() -> DpfServiceConfig {
         docker_repo_url: format!("{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{FMDS_SERVICE_IMAGE_NAME}"),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -237,6 +242,7 @@ pub(crate) fn default_otelcol_service() -> DpfServiceConfig {
         ),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -251,6 +257,7 @@ pub(crate) fn default_doca_weave_dhcp_agent_service() -> DpfServiceConfig {
         ),
         docker_image_tag: DOCA_WEAVE_DHCP_AGENT_SERVICE_IMAGE_TAG.to_string(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -265,6 +272,7 @@ pub(crate) fn default_doca_weave_flow_controller_service() -> DpfServiceConfig {
         ),
         docker_image_tag: DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_IMAGE_TAG.to_string(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -277,6 +285,7 @@ pub(crate) fn default_doca_xplane_service() -> DpfServiceConfig {
         docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_XPLANE_SERVICE_IMAGE_NAME}"),
         docker_image_tag: DOCA_XPLANE_SERVICE_IMAGE_TAG.to_string(),
         docker_image_pull_secret: None,
+        extra_helm_values: None,
     }
 }
 
@@ -296,6 +305,34 @@ fn apply_image_pull_secrets(helm_values: &mut serde_json::Value, cfg: &DpfServic
             "imagePullSecrets".to_string(),
             serde_json::json!([{ "name": secret }]),
         );
+}
+
+fn merge_helm_values(
+    base: &mut serde_json::Map<String, serde_json::Value>,
+    overlay: &serde_json::Map<String, serde_json::Value>,
+) {
+    for (key, value) in overlay {
+        match (base.get_mut(key), value) {
+            (Some(serde_json::Value::Object(base)), serde_json::Value::Object(overlay)) => {
+                merge_helm_values(base, overlay);
+            }
+            _ => {
+                base.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+fn apply_helm_values(helm_values: &mut serde_json::Value, cfg: &DpfServiceConfig) {
+    apply_image_pull_secrets(helm_values, cfg);
+    if let Some(overlay) = &cfg.extra_helm_values {
+        merge_helm_values(
+            helm_values
+                .as_object_mut()
+                .expect("generated Helm values must be an object"),
+            overlay,
+        );
+    }
 }
 
 /// DOCA HBN service definition.
@@ -321,7 +358,7 @@ pub fn doca_hbn_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             },
         }
     });
-    apply_image_pull_secrets(&mut helm_values, cfg);
+    apply_helm_values(&mut helm_values, cfg);
     ServiceDefinition {
         helm_values: Some(helm_values),
 
@@ -349,7 +386,7 @@ pub fn dts_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     let mut helm_values = serde_json::json!({
         "exposedPorts": { "ports": { "httpserverport": true } }
     });
-    apply_image_pull_secrets(&mut helm_values, cfg);
+    apply_helm_values(&mut helm_values, cfg);
     ServiceDefinition {
         helm_values: Some(helm_values),
         config_ports: None,
@@ -378,8 +415,6 @@ fn dpu_agent_helm_values(
             "nvue_password_key": "password",
         }
     });
-    apply_image_pull_secrets(&mut values, cfg);
-
     let bootstrap_ca_values = match bootstrap_ca {
         DpfDpuAgentBootstrapCa::LegacyDownload { url: None } => None,
         DpfDpuAgentBootstrapCa::LegacyDownload { url: Some(url) } => Some(serde_json::json!({
@@ -409,6 +444,7 @@ fn dpu_agent_helm_values(
             .expect("DPU agent Helm values are an object")
             .insert("bootstrapCa".to_string(), bootstrap_ca_values);
     }
+    apply_helm_values(&mut values, cfg);
 
     values
 }
@@ -453,7 +489,7 @@ pub fn dhcp_server_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             "tag": cfg.docker_image_tag,
         }
     });
-    apply_image_pull_secrets(&mut helm_values, cfg);
+    apply_helm_values(&mut helm_values, cfg);
     ServiceDefinition {
         helm_values: Some(helm_values),
 
@@ -486,7 +522,7 @@ pub fn fmds_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             "tag": cfg.docker_image_tag,
         }
     });
-    apply_image_pull_secrets(&mut helm_values, cfg);
+    apply_helm_values(&mut helm_values, cfg);
     ServiceDefinition {
         helm_values: Some(helm_values),
 
@@ -519,7 +555,7 @@ pub fn otelcol_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             "tag": cfg.docker_image_tag,
         }
     });
-    apply_image_pull_secrets(&mut helm_values, cfg);
+    apply_helm_values(&mut helm_values, cfg);
     ServiceDefinition {
         helm_values: Some(helm_values),
         service_daemon_set_annotations: Some(BTreeMap::new()),
@@ -551,7 +587,7 @@ pub fn doca_weave_dhcp_agent_service(cfg: &DpfServiceConfig) -> ServiceDefinitio
             }
         }
     });
-    apply_image_pull_secrets(&mut helm_values, cfg);
+    apply_helm_values(&mut helm_values, cfg);
     ServiceDefinition {
         helm_values: Some(helm_values),
         config_values: Some(serde_json::json!({
@@ -635,7 +671,7 @@ pub fn doca_weave_flow_controller_service(cfg: &DpfServiceConfig) -> ServiceDefi
             }
         }
     });
-    apply_image_pull_secrets(&mut helm_values, cfg);
+    apply_helm_values(&mut helm_values, cfg);
     ServiceDefinition {
         helm_values: Some(helm_values),
         config_values: Some(serde_json::json!({
@@ -663,7 +699,7 @@ pub fn doca_xplane_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             "tag": cfg.docker_image_tag,
         }
     });
-    apply_image_pull_secrets(&mut helm_values, cfg);
+    apply_helm_values(&mut helm_values, cfg);
     ServiceDefinition {
         helm_values: Some(helm_values),
         ..ServiceDefinition::new(
@@ -708,13 +744,70 @@ pub fn mandatory_services(
 mod tests {
     use carbide_dpf::sdk::build_dpu_interfaces_vec;
     use carbide_dpf::types::DpuServiceInterfaceTemplateType;
-    use carbide_dpf::{build_service_configuration, build_service_interface};
+    use carbide_dpf::{
+        build_service_configuration, build_service_interface, build_service_template,
+    };
     use carbide_test_support::value_scenarios;
     use url::Url;
 
     use super::*;
 
     const TEST_NS: &str = "dpf-operator-system";
+
+    #[test]
+    fn helm_value_tables_merge_recursively() {
+        let mut values = serde_json::json!({
+            "image": {
+                "repository": "generated",
+                "tag": "generated",
+            }
+        });
+
+        let overlay = serde_json::json!({
+            "image": { "tag": "configured" },
+            "fmds": { "sign_proxy_url": "http://dsx-imds" },
+        });
+        merge_helm_values(
+            values.as_object_mut().unwrap(),
+            overlay.as_object().unwrap(),
+        );
+
+        assert_eq!(
+            values,
+            serde_json::json!({
+                "image": {
+                    "repository": "generated",
+                    "tag": "configured",
+                },
+                "fmds": { "sign_proxy_url": "http://dsx-imds" },
+            })
+        );
+    }
+
+    #[test]
+    fn helm_value_scalars_and_arrays_replace_generated_values() {
+        let mut values = serde_json::json!({
+            "enabled": false,
+            "tolerations": [{ "key": "generated" }],
+        });
+
+        let overlay = serde_json::json!({
+            "enabled": true,
+            "tolerations": [{ "key": "configured" }],
+        });
+        merge_helm_values(
+            values.as_object_mut().unwrap(),
+            overlay.as_object().unwrap(),
+        );
+
+        assert_eq!(
+            values,
+            serde_json::json!({
+                "enabled": true,
+                "tolerations": [{ "key": "configured" }],
+            })
+        );
+    }
 
     #[test]
     fn dpu_agent_bootstrap_ca_helm_values_follow_site_policy() {
@@ -877,6 +970,31 @@ mod tests {
             agent.helm_values.unwrap()["imagePullSecrets"],
             serde_json::json!([{ "name": "nico-pull-secret" }])
         );
+    }
+
+    #[test]
+    fn dpu_agent_template_merges_extra_helm_values() {
+        let mut config = default_dpu_agent_service();
+        config.extra_helm_values = serde_json::json!({
+            "fmds": {
+                "sign_proxy_url": "http://dsx-imds.dpf-operator-system.svc.cluster.local:8080"
+            },
+            "image": {
+                "tag": "configured-tag"
+            }
+        })
+        .as_object()
+        .cloned();
+        let service = dpu_agent_service(&config, &DpfDpuAgentBootstrapCa::default());
+        let template = build_service_template(&service, TEST_NS, "");
+        let values = template.spec.helm_chart.values.unwrap();
+
+        assert_eq!(
+            values["fmds"]["sign_proxy_url"],
+            "http://dsx-imds.dpf-operator-system.svc.cluster.local:8080"
+        );
+        assert_eq!(values["image"]["repository"], config.docker_repo_url);
+        assert_eq!(values["image"]["tag"], "configured-tag");
     }
 
     // ---- weave services ----

--- a/crates/host-support/src/agent_config.rs
+++ b/crates/host-support/src/agent_config.rs
@@ -68,10 +68,11 @@ pub struct MachineConfigFromPxe {
 ///
 /// This is what we READ from /etc/forge/config.toml. In prod most of the fields will default.
 /// We only implement Serialize for unit tests.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentConfig {
     #[serde(default, rename = "forge-system")]
     pub forge_system: ForgeSystemConfig,
+    #[serde(default)]
     pub machine: MachineConfig,
     #[serde(default, rename = "metadata-service")]
     pub metadata_service: MetadataServiceConfig,
@@ -789,12 +790,12 @@ sign-timeout-secs = 9
                 MID_SECTION => Yields(()),
             }
 
-            "completely empty config is rejected (a required field is missing)" {
-                "" => Fails,
+            "completely empty config uses defaults" {
+                "" => Yields(()),
             }
 
-            "unknown top-level key is rejected (deny_unknown_fields)" {
-                "totally-unknown-key = 5\n" => Fails,
+            "unknown top-level key is ignored" {
+                "totally-unknown-key = 5\n" => Yields(()),
             }
 
             "interface-id not a uuid fails" {
@@ -817,6 +818,17 @@ sign-timeout-secs = 9
                 "[fmds-armos-networking.config]\naddresses = [\"not-a-cidr\"]\n" => Fails,
             }
         );
+    }
+
+    #[test]
+    fn machine_identity_only_uses_agent_defaults() {
+        let url = "http://dsx-imds.dpf-operator-system.svc.cluster.local:8080";
+        let actual: AgentConfig =
+            toml::from_str(&format!("[machine-identity]\nsign-proxy-url = {url:?}\n")).unwrap();
+        let mut expected = AgentConfig::default();
+        expected.machine_identity.sign_proxy_url = Some(url.to_string());
+
+        assert_eq!(actual, expected);
     }
 
     // Field-level assertions on the FULL parse: each original `assert_eq!` becomes

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -661,6 +661,30 @@ docker_image_pull_secret = "dpf-pull-secret"       # optional; omit for a public
 `docker_image_pull_secret` is optional per service and defaults to none: omitting
 it renders no `imagePullSecrets` for that service (public-registry pulls). Set it to
 a Kubernetes image-pull Secret name when the service is served from a private registry.
+Use `extra_helm_values` for other chart settings.
+
+#### Helm value overlays
+
+`extra_helm_values` uses keys from the selected chart's `values.yaml`. NICo merges
+them over its generated template values. Deployment-specific
+`DPUServiceConfiguration` values take precedence.
+
+Notes:
+
+- Tables merge recursively.
+- Nested scalars and arrays replace generated values.
+- Omitted keys keep their generated values.
+
+Set the DPU agent machine identity proxy with a key similar to the following:
+
+```toml
+[dpf.services.dpu_agent.extra_helm_values.fmds]
+sign_proxy_url = "http://dsx-imds.dpf-operator-system.svc.cluster.local:8080"
+```
+
+The DPU agent's generated `dhcp_server.service_name`, `fmds.service_name`, and
+`hbn.nvue_https_address` are deployment-specific and take precedence over these
+template overlays.
 
 #### Per-deployment configuration (`[dpf.deployments.*]`)
 
@@ -721,9 +745,10 @@ versions by adding a `[dpf.deployments.<name>.services]` block with the same six
 sub-tables as `[dpf.services]` (`dts`, `doca_hbn`, `dpu_agent`, `dhcp_server`,
 `fmds`, `otel`). This override **replaces** the inherited set for that
 deployment; any service sub-table you omit falls back to its **built-in
-default**, *not* to the top-level `[dpf.services]` value, so specify all six
-when using it. The top-level `docker_image_pull_secret` still applies on top of
-the resolved set (every service except `dts` and `doca_hbn`).
+default**, *not* to the top-level `[dpf.services]` value. Fields omitted from a
+configured service also use that service's built-in defaults. The top-level
+`docker_image_pull_secret` still applies on top of the resolved set (every
+service except `dts` and `doca_hbn`).
 
 ```toml
 # Pin a BF4-specific HBN chart/image while keeping the other services on defaults.
@@ -734,7 +759,6 @@ helm_chart               = "doca-hbn"
 helm_version             = "3.4.0"
 docker_repo_url          = "nvcr.io/nvidia/doca/doca_hbn"
 docker_image_tag         = "3.4.0-doca3.4.0"
-# ...plus dts, dpu_agent, dhcp_server, fmds, and otel sub-tables.
 ```
 
 BF4 Astra includes three built-in deployment-specific services with no


### PR DESCRIPTION
Backports #4563

The DPU agent already accepts a machine identity sign proxy URL through `AgentConfig`, but its chart did not expose it. This adds the chart input and lets each NICo DPF service supply an `extra_helm_values` table.

Service configuration now resolves consistently at the top level and per deployment:

- An absent or empty services table uses every built-in service default.
- A partial service table overlays only its supplied fields on that service's built-in default.
- `extra_helm_values` must be a table. Nested tables merge recursively, while nested scalars and arrays replace generated values.
- Deployment-specific `DPUServiceConfiguration` values are applied last and take precedence over template values.

## Related issues

None.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

- Added tests for empty and partial service configuration at top-level and per-deployment paths.
- Added tests for recursive table merging, nested scalar and array replacement, and rejection of non-table overlay roots.
- Added a parsing test proving a machine-identity-only file equals `AgentConfig::default()` plus the proxy URL.
- `helm lint bluefield/charts/nico-dpu-agent`
- Rendered the default chart and confirmed it does not add a config file.
- Rendered with `fmds.sign_proxy_url` and verified the authoritative checksum, argument, mount, ConfigMap, and parsed TOML value.
- `cargo fmt --all -- --check`
- Local Rust test builds stop on macOS-only platform failures in `procfs`, `libudev-sys`, and `tss-esapi-sys`. Linux CI performs the Rust validation.

