### PR TITLE
cherry-pick(v2.0): lenovo-ami/dell ingestion and scaling issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.21#63431424e2f5eea93e3df7eb41f0b2b3e98f72fb"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.21.1#c625c1b85b081b8ee3f4da1dd5753cf27cdd3ee4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.21.1#c625c1b85b081b8ee3f4da1dd5753cf27cdd3ee4"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.21.3#469c80f489c8d5f4c7603fe3a73f81577b6bb04a"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.21.1" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.21.3" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-mts-rc04" }
 ansi-to-html = "0.2.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.21" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.21.1" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-mts-rc04" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -18,13 +18,14 @@
 use std::collections::HashMap;
 
 use carbide_network::virtualization::VpcVirtualizationType;
+use carbide_uuid::domain::DomainId;
 use carbide_uuid::vpc::VpcId;
 use db::dns::domain;
 use db::network_segment::reconcile_network_defs;
 use db::vpc::{self};
 use db::{ObjectColumnFilter, Transaction, dpu_agent_upgrade_policy, network_segment};
 use itertools::Itertools;
-use model::dns::NewDomain;
+use model::dns::{Domain, NewDomain};
 use model::firmware::AgentUpgradePolicyChoice;
 use model::machine::upgrade_policy::AgentUpgradePolicy;
 use model::metadata::Metadata;
@@ -62,30 +63,84 @@ pub async fn create_initial_domain(
         Ok(false)
     }
 }
+
+#[derive(Debug, PartialEq, Eq)]
+enum SeedNetworkDomainSelection {
+    Selected(DomainId),
+    NoForwardDomain,
+    Ambiguous(Vec<String>),
+}
+
+/// Select the forward domain used to parent config-seeded network segments.
+///
+/// Reverse-DNS zones share the domains table and must not make a sole forward
+/// domain appear ambiguous.
+fn select_seed_network_domain(
+    domains: &[Domain],
+    configured_domain_name: Option<&str>,
+) -> SeedNetworkDomainSelection {
+    let forward_domains = domains
+        .iter()
+        .filter(|domain| {
+            let name = domain.name.trim_end_matches('.');
+            !matches!(name, "in-addr.arpa" | "ip6.arpa")
+                && !name.ends_with(".in-addr.arpa")
+                && !name.ends_with(".ip6.arpa")
+        })
+        .collect_vec();
+
+    if let Some(domain_name) = configured_domain_name {
+        let configured_domains = forward_domains
+            .iter()
+            .filter(|domain| domain.name == domain_name)
+            .collect_vec();
+        if let [domain] = configured_domains.as_slice() {
+            return SeedNetworkDomainSelection::Selected(domain.id);
+        }
+    }
+
+    match forward_domains.as_slice() {
+        [] => SeedNetworkDomainSelection::NoForwardDomain,
+        [domain] => SeedNetworkDomainSelection::Selected(domain.id),
+        domains => SeedNetworkDomainSelection::Ambiguous(
+            domains
+                .iter()
+                .map(|domain| domain.name.clone())
+                .sorted()
+                .collect(),
+        ),
+    }
+}
+
 pub async fn create_initial_networks(
     api: &Api,
     db_pool: &Pool<Postgres>,
     networks: &HashMap<String, NetworkDefinition>,
 ) -> Result<(), CarbideError> {
     let mut txn = Transaction::begin(db_pool).await?;
-    let all_domains = db::dns::domain::find_by(
+    let domains = db::dns::domain::find_by(
         &mut txn,
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;
-    if all_domains.is_empty() {
-        tracing::warn!("No domain configured, skipping initial network creation");
-        return Ok(());
-    }
-    if all_domains.len() > 1 {
-        // We only create initial networks if we only have a single domain - usually created
-        // as initial_domain_name in config file.
-        // Having multiple domains is fine, it means we probably created the network much
-        // earlier.
-        tracing::info!("Multiple domains, skipping initial network creation");
-        return Ok(());
-    }
-    let domain_id = all_domains[0].id;
+    let domain_id = match select_seed_network_domain(
+        &domains,
+        api.runtime_config.initial_domain_name.as_deref(),
+    ) {
+        SeedNetworkDomainSelection::Selected(domain_id) => domain_id,
+        SeedNetworkDomainSelection::NoForwardDomain => {
+            tracing::warn!("No forward domain configured, skipping initial network creation");
+            return Ok(());
+        }
+        SeedNetworkDomainSelection::Ambiguous(forward_domains) => {
+            tracing::warn!(
+                ?forward_domains,
+                configured_domain_name = ?api.runtime_config.initial_domain_name,
+                "Multiple forward domains, skipping initial network creation",
+            );
+            return Ok(());
+        }
+    };
     reconcile_network_defs(&mut txn, networks).await?;
 
     for (name, def) in networks {
@@ -493,4 +548,137 @@ pub(crate) async fn create_admin_vpc(
     txn.commit().await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+    use chrono::Utc;
+
+    use super::*;
+
+    struct DomainSelectionCase {
+        domains: Vec<Domain>,
+        configured_domain_name: Option<&'static str>,
+    }
+
+    fn domain_id(id: u128) -> DomainId {
+        uuid::Uuid::from_u128(id).into()
+    }
+
+    fn domain(id: u128, name: &str) -> Domain {
+        let timestamp = Utc::now();
+        Domain {
+            id: domain_id(id),
+            name: name.to_string(),
+            created: timestamp,
+            updated: timestamp,
+            deleted: None,
+            soa: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn seed_network_domain_selection_distinguishes_forward_and_reverse_domains() {
+        check_values(
+            [
+                Check {
+                    scenario: "no domains are available",
+                    input: DomainSelectionCase {
+                        domains: vec![],
+                        configured_domain_name: None,
+                    },
+                    expect: SeedNetworkDomainSelection::NoForwardDomain,
+                },
+                Check {
+                    scenario: "the configured domain wins among multiple forward domains",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "legacy.example"),
+                            domain(2, "0.20.172.in-addr.arpa"),
+                            domain(3, "site.example"),
+                        ],
+                        configured_domain_name: Some("site.example"),
+                    },
+                    expect: SeedNetworkDomainSelection::Selected(domain_id(3)),
+                },
+                Check {
+                    scenario: "a renamed configured domain falls back to the sole forward domain",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "renamed.example"),
+                            domain(2, "0.20.172.in-addr.arpa"),
+                        ],
+                        configured_domain_name: Some("site.example"),
+                    },
+                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                },
+                Check {
+                    scenario: "an API-created domain works without initial_domain_name",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "api-created.example"),
+                            domain(2, "0.20.172.in-addr.arpa"),
+                            domain(3, "0.0.ip6.arpa"),
+                        ],
+                        configured_domain_name: None,
+                    },
+                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                },
+                Check {
+                    scenario: "reverse domains alone do not become the forward domain",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "0.20.172.in-addr.arpa"),
+                            domain(2, "0.0.ip6.arpa."),
+                        ],
+                        configured_domain_name: None,
+                    },
+                    expect: SeedNetworkDomainSelection::NoForwardDomain,
+                },
+                Check {
+                    scenario: "a configured reverse domain does not override the forward domain",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "site.example"),
+                            domain(2, "0.20.172.in-addr.arpa"),
+                        ],
+                        configured_domain_name: Some("0.20.172.in-addr.arpa"),
+                    },
+                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                },
+                Check {
+                    scenario: "multiple forward domains without a configured match are ambiguous",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "one.example"),
+                            domain(2, "two.example"),
+                            domain(3, "0.20.172.in-addr.arpa"),
+                        ],
+                        configured_domain_name: None,
+                    },
+                    expect: SeedNetworkDomainSelection::Ambiguous(vec![
+                        "one.example".to_string(),
+                        "two.example".to_string(),
+                    ]),
+                },
+                Check {
+                    scenario: "duplicate configured domains are ambiguous",
+                    input: DomainSelectionCase {
+                        domains: vec![domain(1, "site.example"), domain(2, "site.example")],
+                        configured_domain_name: Some("site.example"),
+                    },
+                    expect: SeedNetworkDomainSelection::Ambiguous(vec![
+                        "site.example".to_string(),
+                        "site.example".to_string(),
+                    ]),
+                },
+            ],
+            |DomainSelectionCase {
+                 domains,
+                 configured_domain_name,
+             }| { select_seed_network_domain(&domains, configured_domain_name) },
+        );
+    }
 }

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -188,6 +188,10 @@ pub async fn discover_dhcp(
     api: &Api,
     request: Request<rpc::DhcpDiscovery>,
 ) -> Result<Response<rpc::DhcpRecord>, CarbideError> {
+    // Admission permit BEFORE the first transaction: the interface/address
+    // lookups below can wait on segment advisory locks, so a waiter here
+    // pins a pool connection exactly like the allocation path does.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     let rpc::DhcpDiscovery {
@@ -455,6 +459,9 @@ pub async fn discover_dhcp(
 
     txn.commit().await?;
 
+    // Permit from the top of discover_dhcp is still held here; the earlier
+    // transaction committed, but the allocation path below takes the same
+    // segment locks, so one permit covers the whole request.
     let mut txn = api.txn_begin().await?;
 
     let mut record: rpc::DhcpRecord = db::dhcp_record::find_by_mac_address(

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -615,6 +615,9 @@ pub(crate) async fn admin_force_delete_machine(
         }
     }
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
     let mut machines_to_clear_credentials = Vec::new();
 

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -115,6 +115,9 @@ pub(crate) async fn discover_machine(
         None
     };
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
     tracing::debug!(
         ?remote_ip,

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -151,6 +151,9 @@ async fn set_primary_interface_core(
         .into());
     }
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     let interface_map =

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -57,10 +57,12 @@ use model::hardware_info::TpmEkCertificate;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
-    BiosConfigInfo, BiosConfigState, CleanupContext, CleanupState, DpuDiscoveringState,
+    BiosConfigInfo, BiosConfigState, CleanupContext,
+    CleanupState, CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState,
     DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
     HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode, MachineState,
-    MachineValidatingState, ManagedHostState, MeasuringState, PowerState, SetBootOrderInfo,
+    MachineValidatingState, ManagedHostState, MeasuringState, PowerState, SecureEraseBossState,
+    SetBootOrderInfo,
     SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea, ValidationState,
 };
 use model::machine_validation::MachineValidationState;
@@ -1221,6 +1223,80 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
     assert!(matches!(
         host.current_state(),
         ManagedHostState::WaitingForCleanup { .. }
+    ));
+}
+
+#[crate::sqlx_test]
+async fn test_dell_boss_initial_discovery_skips_lockdown_states(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    env.redfish_sim
+        .set_boss_controller_id(Some("RAID.Slot.1".to_string()));
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    db::machine::advance(
+        &host,
+        &mut txn,
+        &ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::Init,
+            cleanup_context: CleanupContext::InitialDiscovery,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::SecureEraseBoss {
+                secure_erase_boss_context,
+            },
+            cleanup_context: CleanupContext::InitialDiscovery,
+        } if secure_erase_boss_context.boss_controller_id == "RAID.Slot.1"
+            && secure_erase_boss_context.secure_erase_jid.is_none()
+            && secure_erase_boss_context.secure_erase_boss_state
+                == SecureEraseBossState::SecureEraseBoss
+            && secure_erase_boss_context.iteration == Some(0)
+    ));
+
+    db::machine::advance(
+        &host,
+        &mut txn,
+        &ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::CreateBossVolume {
+                create_boss_volume_context: CreateBossVolumeContext {
+                    boss_controller_id: "RAID.Slot.1".to_string(),
+                    create_boss_volume_jid: Some("boss-job-1".to_string()),
+                    create_boss_volume_state: CreateBossVolumeState::WaitForJobCompletion,
+                    iteration: Some(0),
+                },
+            },
+            cleanup_context: CleanupContext::InitialDiscovery,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.redfish_sim
+        .set_job_state_sequence(vec![libredfish::JobState::Completed]);
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery,
+        }
     ));
 }
 

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -57,13 +57,12 @@ use model::hardware_info::TpmEkCertificate;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
-    BiosConfigInfo, BiosConfigState, CleanupContext,
-    CleanupState, CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState,
-    DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
-    HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode, MachineState,
-    MachineValidatingState, ManagedHostState, MeasuringState, PowerState, SecureEraseBossState,
-    SetBootOrderInfo,
-    SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea, ValidationState,
+    BiosConfigInfo, BiosConfigState, CleanupContext, CleanupState, CreateBossVolumeContext,
+    CreateBossVolumeState, DpuDiscoveringState, DpuInitState, DpuReprovisionStates, FailureCause,
+    FailureDetails, FailureSource, HostPlatformConfigurationState, InstallDpuOsState,
+    InstanceState, LockdownMode, MachineState, MachineValidatingState, ManagedHostState,
+    MeasuringState, PowerState, SecureEraseBossState, SetBootOrderInfo, SetBootOrderState,
+    SetSecureBootState, SpdmMeasuringState, StateMachineArea, ValidationState,
 };
 use model::machine_validation::MachineValidationState;
 use model::network_segment::NetworkSegmentType;

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -560,7 +560,7 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     let env =
         create_test_env_with_overrides(db_pool.clone(), TestEnvOverrides::no_network_segments())
             .await;
-    let networks = HashMap::from([
+    let mut networks = HashMap::from([
         (
             "admin".to_string(),
             NetworkDefinition {
@@ -612,6 +612,10 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     let admin = db::network_segment::find_by_name(&mut txn, "admin").await?;
     assert_eq!(admin.config.mtu, 9000);
     assert_eq!(admin.config.segment_type, NetworkSegmentType::Admin);
+    let initial_domain_id = admin
+        .config
+        .subdomain_id
+        .expect("config-seeded network should use the forward domain");
 
     let underlay = db::network_segment::find_by_name(&mut txn, "DEV1-C09-IPMI-01").await?;
     assert_eq!(underlay.config.mtu, 1500);
@@ -624,6 +628,19 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
         NetworkSegmentType::HostInband
     );
     assert_eq!(host_inband.config.vpc_id, None);
+    // These extra domain rows reproduce the state that previously disabled later seeding.
+    for reverse_domain in [
+        "254.254.254.169.in-addr.arpa",
+        "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.ip6.arpa",
+    ] {
+        assert_eq!(
+            db::dns::domain::find_by_name(txn.as_mut(), reverse_domain)
+                .await?
+                .len(),
+            1,
+            "static assignment reverse domain should exist"
+        );
+    }
     txn.commit().await?;
 
     // Now create them again. It should succeed but not create any more
@@ -652,6 +669,28 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
         num_before, num_after,
         "second create_initial_networks should not have created any segments"
     );
+
+    networks.insert(
+        "DEV1-C09-IPMI-02".to_string(),
+        NetworkDefinition {
+            segment_type: NetworkDefinitionSegmentType::Underlay,
+            prefix: "172.99.0.64/27".parse().unwrap(),
+            prefix_v6: None,
+            gateway: "172.99.0.65".parse().unwrap(),
+            dhcpv6_link_address: None,
+            mtu: 1500,
+            reserve_first: 5,
+            allocation_strategy: Default::default(),
+            vpc_name: None,
+        },
+    );
+    crate::db_init::create_initial_networks(&env.api, &env.pool, &networks).await?;
+
+    let mut txn = db_pool.begin().await?;
+    let added = db::network_segment::find_by_name(&mut txn, "DEV1-C09-IPMI-02").await?;
+    assert_eq!(added.config.subdomain_id, Some(initial_domain_id));
+    txn.commit().await?;
+
     Ok(())
 }
 

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -1394,6 +1394,38 @@ async fn lock_network_segment_exclusive(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+static ADMIN_LOCK_ADMISSION: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
+    std::sync::OnceLock::new();
+
+/// Admission gate for the `lock_all_admin_segments` flows. The admin-segment
+/// advisory locks serialize those transactions anyway; without a gate, every
+/// waiter parks *inside* an open transaction, pinning a pool connection while
+/// blocked on the lock. At fleet-ingestion scale that queue grows past
+/// Postgres `max_connections` and the whole system wedges (registration,
+/// exploration, and the state controllers all starve; see the 4,500-host
+/// ingestion wedge). Acquire this permit BEFORE opening the transaction and
+/// hold it until commit/rollback, so excess waiters queue in memory instead
+/// of on connections. Permits: `ADMIN_LOCK_ADMISSION` env var, default 16.
+pub async fn admin_lock_admission() -> tokio::sync::OwnedSemaphorePermit {
+    let sem = ADMIN_LOCK_ADMISSION.get_or_init(|| {
+        // Clamp to a sane range: 0 would deadlock every gated flow, and a
+        // value at or above the pool size defeats the gate's purpose (the
+        // waiters it is meant to keep off connections would all be admitted).
+        const DEFAULT_PERMITS: usize = 16;
+        const MAX_PERMITS: usize = 256;
+        let permits = std::env::var("ADMIN_LOCK_ADMISSION")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|n| n.clamp(1, MAX_PERMITS))
+            .unwrap_or(DEFAULT_PERMITS);
+        std::sync::Arc::new(tokio::sync::Semaphore::new(permits))
+    });
+    sem.clone()
+        .acquire_owned()
+        .await
+        .expect("admin-lock admission semaphore is never closed")
+}
+
 pub async fn allocate_svi_ip(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -344,13 +344,16 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         hw_type: Option<hw::HwType>,
     ) -> Result<Vec<ModelEthernetInterface>, Error<B>> {
         let is_bluefield = hw_type == Some(hw::HwType::Bluefield);
-        let mut result = self.ethernet_interfaces.iter()
+        let mut result = self
+            .ethernet_interfaces
+            .iter()
             .map(|iface| {
                 let mac_address = iface
                     .mac_address()
                     .map(|addr| {
-                        deserialize_input_mac_to_address(addr.as_str())
-                            .map_err(|e| Error::InvalidValue(format!("MAC address not valid: {addr} (err: {e})")))
+                        deserialize_input_mac_to_address(addr.as_str()).map_err(|e| {
+                            Error::InvalidValue(format!("MAC address not valid: {addr} (err: {e})"))
+                        })
                     })
                     .transpose()
                     .or_else(|err| {
@@ -388,7 +391,8 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     link_status: iface.link_status().map(|s| format!("{s:?}")),
                     uefi_device_path,
                 })
-            }).collect::<Result<Vec<_>, _>>()?;
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         if is_bluefield
             && !result.iter().any(|iface| {

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -343,6 +343,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         &self,
         hw_type: Option<hw::HwType>,
     ) -> Result<Vec<ModelEthernetInterface>, Error<B>> {
+        let is_bluefield = hw_type == Some(hw::HwType::Bluefield);
         let mut result = self.ethernet_interfaces.iter()
             .map(|iface| {
                 let mac_address = iface
@@ -353,15 +354,18 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     })
                     .transpose()
                     .or_else(|err| {
-                        if iface
-                            .interface_enabled().is_some_and(|is_enabled| !is_enabled)
+                        if is_bluefield
+                            || iface
+                                .interface_enabled()
+                                .is_some_and(|is_enabled| !is_enabled)
                         {
-                            // disabled interfaces sometimes populate the MAC address with junk,
-                            // ignore this error and create the interface with an empty mac address
-                            // in the exploration report
+                            // Some BlueField firmware and disabled interfaces can populate
+                            // MACAddress with junk. Keep the interface but omit its invalid MAC.
                             tracing::debug!(
-                                "could not parse MAC address for a disabled interface {} (link_status: {:#?}): {err}",
-                                iface.id(), iface.link_status()
+                                interface_id = %iface.id(),
+                                link_status = ?iface.link_status(),
+                                error = %err,
+                                "ignoring invalid system interface MAC address"
                             );
                             Ok(None)
                         } else {
@@ -386,7 +390,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                 })
             }).collect::<Result<Vec<_>, _>>()?;
 
-        if hw_type.is_some_and(|v| v == hw::HwType::Bluefield)
+        if is_bluefield
             && !result.iter().any(|iface| {
                 iface
                     .id

--- a/crates/bmc-explorer/src/hw/dell.rs
+++ b/crates/bmc-explorer/src/hw/dell.rs
@@ -17,7 +17,7 @@
 
 use crate::hw::BiosAttr;
 
-pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 13] = [
+pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 14] = [
     BiosAttr::new_str("InBandManageabilityInterface", "Disabled"),
     BiosAttr::new_str("UefiVariableAccess", "Standard"),
     BiosAttr::new_any_str("SerialComm", &["OnConRedirAuto", "OnConRedir"]), // Second is legacy
@@ -30,5 +30,6 @@ pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 13] = [
     BiosAttr::new_str("Tpm2Hierarchy", "Enabled"), // Setup puts "Clear" here.
     BiosAttr::new_str("Tpm2Algorithm", "SHA256"),
     BiosAttr::new_str("HttpDev1EnDis", "Enabled"),
+    BiosAttr::new_str("HttpDev1TlsMode", "None"),
     BiosAttr::new_str("PxeDev1EnDis", "Disabled"),
 ];

--- a/crates/bmc-explorer/tests/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield3_explore.rs
@@ -49,6 +49,48 @@ async fn explore_bluefield3_baseline() {
 }
 
 #[test]
+async fn explore_bluefield3_ignores_invalid_system_interface_mac() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+    h.state.injection.put(vec![bmc_mock::injection::Rule {
+        id: "invalid_system_interface_mac".into(),
+        selector: bmc_mock::injection::Selector::Path {
+            method: Some("GET".into()),
+            glob: "/redfish/v1/Systems/Bluefield/EthernetInterfaces/oob_net0".into(),
+        },
+        action: bmc_mock::injection::Action::JsonMerge(serde_json::json!({
+            "Id": "eth0",
+            "InterfaceEnabled": true,
+            "LinkStatus": "LinkDown",
+            "MACAddress": "00:00:11:e7:fe:80:00:00:00:00:00:00:02:00:00:03:00:18:00:01",
+        })),
+        remaining: None,
+    }]);
+
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .unwrap();
+    let system = report.systems.first().expect("systems must be present");
+    let eth0 = system
+        .ethernet_interfaces
+        .iter()
+        .find(|interface| interface.id.as_deref() == Some("eth0"))
+        .expect("invalid interface must be preserved");
+    let oob = system
+        .ethernet_interfaces
+        .iter()
+        .find(|interface| interface.id.as_deref() == Some("oob_net0"))
+        .expect("OOB interface must be preserved");
+
+    assert_eq!(eth0.mac_address, None);
+    assert!(oob.mac_address.is_some(), "valid OOB MAC must be preserved");
+    assert!(system.base_mac.is_some(), "DPU base MAC must be preserved");
+    assert!(
+        report.dpu_pairing_serial_number().is_some(),
+        "DPU pairing serial number must be preserved"
+    );
+}
+
+#[test]
 async fn explore_bluefield3_without_system_eth_interfaces() {
     let settings = DpuSettings {
         exposes_oob_eth: false,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1007,12 +1007,18 @@ impl MachineStateHandler {
                                 .await
                                 .map_err(|e| redfish_error("get_boss_controller", e))?
                         {
+                            let secure_erase_boss_state = match cleanup_context {
+                                CleanupContext::Deprovision => SecureEraseBossState::UnlockHost,
+                                CleanupContext::InitialDiscovery => {
+                                    SecureEraseBossState::SecureEraseBoss
+                                }
+                            };
                             let next_state = waiting_for_cleanup_state(
                                 CleanupState::SecureEraseBoss {
                                     secure_erase_boss_context: SecureEraseBossContext {
                                         boss_controller_id,
                                         secure_erase_jid: None,
-                                        secure_erase_boss_state: SecureEraseBossState::UnlockHost,
+                                        secure_erase_boss_state,
                                         iteration: Some(0),
                                     },
                                 },
@@ -1039,10 +1045,12 @@ impl MachineStateHandler {
 
                         match secure_erase_boss_context.secure_erase_boss_state {
                             SecureEraseBossState::UnlockHost => {
-                                redfish_client
-                                    .set_idrac_lockdown(EnabledDisabled::Disabled)
-                                    .await
-                                    .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                if matches!(cleanup_context, CleanupContext::Deprovision) {
+                                    redfish_client
+                                        .set_idrac_lockdown(EnabledDisabled::Disabled)
+                                        .await
+                                        .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                }
 
                                 let next_state = waiting_for_cleanup_state(
                                     CleanupState::SecureEraseBoss {
@@ -1222,10 +1230,12 @@ impl MachineStateHandler {
                                 .await
                             }
                             CreateBossVolumeState::LockHost => {
-                                redfish_client
-                                    .set_idrac_lockdown(EnabledDisabled::Enabled)
-                                    .await
-                                    .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                if matches!(cleanup_context, CleanupContext::Deprovision) {
+                                    redfish_client
+                                        .set_idrac_lockdown(EnabledDisabled::Enabled)
+                                        .await
+                                        .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                }
 
                                 let next_state = post_cleanup_state(*cleanup_context);
 
@@ -10017,24 +10027,30 @@ async fn wait_for_boss_controller_job_to_complete(
         // The job has completed; transition to next step in host cleanup
         libredfish::JobState::Completed => {
             // healthy path
-            let cleanup_state = match secure_erase_boss_controller {
+            let next_state = match (secure_erase_boss_controller, cleanup_context) {
                 // now that we have finished doing a secure erase of the BOSS controller
                 // we can do a standard secure erase of the remaining drives through the /usr/sbin/nvme tool
-                true => CleanupState::HostCleanup {
-                    boss_controller_id: Some(boss_controller_id),
-                },
-                // now that we have recreated the R1 volume on top of the BOSS controller, we can lock the host back down again.
-                false => CleanupState::CreateBossVolume {
-                    create_boss_volume_context: CreateBossVolumeContext {
-                        boss_controller_id,
-                        create_boss_volume_jid: None,
-                        create_boss_volume_state: CreateBossVolumeState::LockHost,
-                        iteration: Some(iterations),
+                (true, _) => waiting_for_cleanup_state(
+                    CleanupState::HostCleanup {
+                        boss_controller_id: Some(boss_controller_id),
                     },
-                },
+                    cleanup_context,
+                ),
+                // now that we have recreated the R1 volume on top of the BOSS controller, we can lock the host back down again.
+                (false, CleanupContext::Deprovision) => waiting_for_cleanup_state(
+                    CleanupState::CreateBossVolume {
+                        create_boss_volume_context: CreateBossVolumeContext {
+                            boss_controller_id,
+                            create_boss_volume_jid: None,
+                            create_boss_volume_state: CreateBossVolumeState::LockHost,
+                            iteration: Some(iterations),
+                        },
+                    },
+                    cleanup_context,
+                ),
+                (false, CleanupContext::InitialDiscovery) => post_cleanup_state(cleanup_context),
             };
 
-            let next_state = waiting_for_cleanup_state(cleanup_state, cleanup_context);
             Ok(StateHandlerOutcome::transition(next_state))
         }
         // The job has failed; handle error

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -290,7 +290,7 @@ pub fn redact_password(err: libredfish::RedfishError, password: &str) -> libredf
         | RfError::NoHeader
         | RfError::Lockdown
         | RfError::MissingVendor
-        | RfError::PasswordChangeRequired
+        | RfError::PasswordChangeRequired { .. }
         | RfError::FileError(_)
         | RfError::UserNotFound(_)
         | RfError::NotSupported(_)

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -57,6 +57,7 @@ struct RedfishSimState {
     machine_setup_bios_job_id: Option<String>,
     is_bios_setup: Option<bool>,
     default_lockdown: Option<EnabledDisabled>,
+    boss_controller_id: Option<String>,
     job_state_sequence: VecDeque<JobState>,
     /// Offset (in seconds) applied to the BMC `DateTime` returned by
     /// `get_manager`, relative to the controller's `Utc::now()`. Defaults to 0
@@ -183,6 +184,10 @@ impl RedfishSim {
 
     pub fn set_job_state_sequence(&self, states: Vec<JobState>) {
         self.state.lock().unwrap().job_state_sequence = VecDeque::from(states);
+    }
+
+    pub fn set_boss_controller_id(&self, boss_controller_id: Option<String>) {
+        self.state.lock().unwrap().boss_controller_id = boss_controller_id;
     }
 
     pub fn set_is_bios_setup(&self, ready: bool) {
@@ -1451,7 +1456,7 @@ impl Redfish for RedfishSimClient {
     fn get_boss_controller<'a>(
         &'a self,
     ) -> libredfish::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { Ok(None) })
+        Box::pin(async move { Ok(self.state.lock().unwrap().boss_controller_id.clone()) })
     }
 
     fn decommission_storage_controller<'a>(

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -154,6 +154,9 @@ impl MachineCreator {
                 None
             };
 
+        // Admission permit BEFORE the transaction: waiters on the admin-segment
+        // advisory lock must queue in memory, not on open pool connections.
+        let _admin_admission = db::machine_interface::admin_lock_admission().await;
         let mut txn = Transaction::begin(pool).await?;
 
         // Zero-dpu case: If the explored host had no DPUs, we can create the machine now

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -234,21 +234,27 @@ impl RedfishClient {
                     .map_err(|err| redact_password(err, curr_password.as_str()))
                     .map_err(map_redfish_error)?;
             }
-            // Vikings and Lenovo GB300s (both still detected as AMI here).
-            // Resolve the admin account by username, and fall back to the conventional
-            // id "2" only when reads are blocked by `PasswordChangeRequired` (Viking factory state).
+            // AMI-based BMCs, including Vikings and Lenovo GB300s.
+            // Resolve the admin account by username. If reads are blocked by
+            // `PasswordChangeRequired`, use its account URI or fall back to id "2".
             // Any other error propagates.
             //
             // https://docs.nvidia.com/dgx/dgxh100-user-guide/redfish-api-supp.html
-            RedfishVendor::AMI | RedfishVendor::LenovoGB300 => {
+            RedfishVendor::AMI | RedfishVendor::LenovoAMI | RedfishVendor::LenovoGB300 => {
                 match client
                     .change_password(curr_user.as_str(), new_password.as_str())
                     .await
                 {
                     Ok(()) => {}
-                    Err(libredfish::RedfishError::PasswordChangeRequired) => {
+                    Err(libredfish::RedfishError::PasswordChangeRequired { account_uri }) => {
+                        // For example: /redfish/v1/AccountService/Accounts/4
+                        let account_id = account_uri
+                            .as_deref()
+                            .and_then(|uri| uri.rsplit_once('/').map(|(_, id)| id))
+                            .filter(|id| !id.is_empty())
+                            .unwrap_or("2");
                         client
-                            .change_password_by_id("2", new_password.as_str())
+                            .change_password_by_id(account_id, new_password.as_str())
                             .await
                             .map_err(|err| redact_password(err, new_password.as_str()))
                             .map_err(|err| redact_password(err, curr_password.as_str()))
@@ -262,10 +268,7 @@ impl RedfishClient {
                     }
                 }
             }
-            RedfishVendor::LenovoAMI
-            | RedfishVendor::Supermicro
-            | RedfishVendor::Dell
-            | RedfishVendor::Hpe => {
+            RedfishVendor::Supermicro | RedfishVendor::Dell | RedfishVendor::Hpe => {
                 client
                     .change_password(curr_user.as_str(), new_password.as_str())
                     .await


### PR DESCRIPTION
This PR backports several fixes into `v2.0`:

- Keep network seeding working after reverse-DNS creation.
- Bound admin-segment lock admission to prevent PostgreSQL connection exhaustion.
- Tolerate malformed BlueField system-interface MACs.
- Prevent Dell initial discovery from enabling lockdown before UEFI setup.
- Verify Dell HTTP boot TLS configuration.
- Use the BMC-provided account URI during AMI password rotation.
- Limit AMI NTP configuration to two servers and accept asynchronous 202 Accepted responses.
- Update libredfish to the v2.0 maintenance tag `v0.44.21.3`.

## Related issues

- #4710
- #4816
- #4815
- #4704
- #4724
- #4756
- #4297
- #4342

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
