### PR TITLE
cherry-pick(v2.1): lenovo-ami/dell ingestion and scaling issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6840,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.4#7772f48f934805c66dab7f1a68c5fbaf6f781295"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.5#c79aa49ea21a8e3e161eb9f6154f331162b79b2d"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6840,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.3#b199e7bebeb8238fe1440f110d06affba5b6b799"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.4#7772f48f934805c66dab7f1a68c5fbaf6f781295"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.3" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.4" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.0" }
 ansi-to-html = "0.2.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.4" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.5" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.0" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -454,6 +454,10 @@ pub async fn discover_dhcp(
     api: &Api,
     request: Request<rpc::DhcpDiscovery>,
 ) -> Result<Response<rpc::DhcpRecord>, CarbideError> {
+    // Admission permit BEFORE the first transaction: the interface/address
+    // lookups below can wait on segment advisory locks, so a waiter here
+    // pins a pool connection exactly like the allocation path does.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     let rpc::DhcpDiscovery {
@@ -887,6 +891,9 @@ pub async fn discover_dhcp(
         return Ok(Response::new(record));
     }
 
+    // Permit from the top of discover_dhcp is still held here; the earlier
+    // transaction committed, but the allocation path below takes the same
+    // segment locks, so one permit covers the whole request.
     let mut txn = api.txn_begin().await?;
 
     let record = db::dhcp_record::find_by_mac_address(

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -638,6 +638,9 @@ pub(crate) async fn admin_force_delete_machine(
         }
     }
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
     let mut machines_to_clear_credentials = Vec::new();
 

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -103,6 +103,9 @@ pub(crate) async fn discover_machine(
         None
     };
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     // Advisory-lock the admin segments before any machine-interface row

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -132,6 +132,9 @@ async fn set_primary_interface_core(
         .into());
     }
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     // Site Explorer takes these locks before it changes interface ownership.

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -58,12 +58,12 @@ use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     BiosConfigInfo, BiosConfigState, BomValidating, BomValidatingContext, CleanupContext,
-    CleanupState, DpuDiscoveringState, DpuInitState, DpuReprovisionStates, FailureCause,
-    FailureDetails, FailureSource, HostPlatformConfigurationState, InstallDpuOsState,
-    InstanceState, LockdownMode, MachineState, MachineValidatingState, MachineValidationContext,
-    ManagedHostState, MeasuringState, PowerState, ReadyBootConfigState,
-    ReadyBootConfigTerminalFailure, SetBootOrderInfo, SetBootOrderState, SetSecureBootState,
-    SpdmMeasuringState, StateMachineArea, ValidationState,
+    CleanupState, CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState,
+    DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
+    HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode, MachineState,
+    MachineValidatingState, MachineValidationContext, ManagedHostState, MeasuringState, PowerState,
+    ReadyBootConfigState, ReadyBootConfigTerminalFailure, SecureEraseBossState, SetBootOrderInfo,
+    SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea, ValidationState,
 };
 use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::machine_validation::MachineValidationState;
@@ -1042,6 +1042,80 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
     assert!(matches!(
         host.current_state(),
         ManagedHostState::WaitingForCleanup { .. }
+    ));
+}
+
+#[crate::sqlx_test]
+async fn test_dell_boss_initial_discovery_skips_lockdown_states(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    env.redfish_sim
+        .set_boss_controller_id(Some("RAID.Slot.1".to_string()));
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    db::machine::advance(
+        &host,
+        &mut txn,
+        &ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::Init,
+            cleanup_context: CleanupContext::InitialDiscovery,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::SecureEraseBoss {
+                secure_erase_boss_context,
+            },
+            cleanup_context: CleanupContext::InitialDiscovery,
+        } if secure_erase_boss_context.boss_controller_id == "RAID.Slot.1"
+            && secure_erase_boss_context.secure_erase_jid.is_none()
+            && secure_erase_boss_context.secure_erase_boss_state
+                == SecureEraseBossState::SecureEraseBoss
+            && secure_erase_boss_context.iteration == Some(0)
+    ));
+
+    db::machine::advance(
+        &host,
+        &mut txn,
+        &ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::CreateBossVolume {
+                create_boss_volume_context: CreateBossVolumeContext {
+                    boss_controller_id: "RAID.Slot.1".to_string(),
+                    create_boss_volume_jid: Some("boss-job-1".to_string()),
+                    create_boss_volume_state: CreateBossVolumeState::WaitForJobCompletion,
+                    iteration: Some(0),
+                },
+            },
+            cleanup_context: CleanupContext::InitialDiscovery,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.redfish_sim
+        .set_job_state_sequence(vec![libredfish::JobState::Completed]);
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery,
+        }
     ));
 }
 

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2324,6 +2324,38 @@ pub async fn lock_all_admin_segments(txn: &mut PgConnection) -> DatabaseResult<(
     lock_network_segments_exclusive(txn, &segment_ids).await
 }
 
+static ADMIN_LOCK_ADMISSION: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
+    std::sync::OnceLock::new();
+
+/// Admission gate for the `lock_all_admin_segments` flows. The admin-segment
+/// advisory locks serialize those transactions anyway; without a gate, every
+/// waiter parks *inside* an open transaction, pinning a pool connection while
+/// blocked on the lock. At fleet-ingestion scale that queue grows past
+/// Postgres `max_connections` and the whole system wedges (registration,
+/// exploration, and the state controllers all starve; see the 4,500-host
+/// ingestion wedge). Acquire this permit BEFORE opening the transaction and
+/// hold it until commit/rollback, so excess waiters queue in memory instead
+/// of on connections. Permits: `ADMIN_LOCK_ADMISSION` env var, default 16.
+pub async fn admin_lock_admission() -> tokio::sync::OwnedSemaphorePermit {
+    let sem = ADMIN_LOCK_ADMISSION.get_or_init(|| {
+        // Clamp to a sane range: 0 would deadlock every gated flow, and a
+        // value at or above the pool size defeats the gate's purpose (the
+        // waiters it is meant to keep off connections would all be admitted).
+        const DEFAULT_PERMITS: usize = 16;
+        const MAX_PERMITS: usize = 256;
+        let permits = std::env::var("ADMIN_LOCK_ADMISSION")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|n| n.clamp(1, MAX_PERMITS))
+            .unwrap_or(DEFAULT_PERMITS);
+        std::sync::Arc::new(tokio::sync::Semaphore::new(permits))
+    });
+    sem.clone()
+        .acquire_owned()
+        .await
+        .expect("admin-lock admission semaphore is never closed")
+}
+
 pub async fn allocate_svi_ip(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -402,6 +402,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         &self,
         hw_type: Option<hw::HwType>,
     ) -> Result<Vec<ModelEthernetInterface>, Error<B>> {
+        let is_bluefield = hw_type == Some(hw::HwType::Bluefield);
         let mut result = self
             .ethernet_interfaces
             .iter()
@@ -415,18 +416,18 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     })
                     .transpose()
                     .or_else(|err| {
-                        if iface
-                            .interface_enabled()
-                            .is_some_and(|is_enabled| !is_enabled)
+                        if is_bluefield
+                            || iface
+                                .interface_enabled()
+                                .is_some_and(|is_enabled| !is_enabled)
                         {
-                            // disabled interfaces sometimes populate the MAC address with junk,
-                            // ignore this error and create the interface with an empty mac address
-                            // in the exploration report
+                            // Some BlueField firmware and disabled interfaces can populate
+                            // MACAddress with junk. Keep the interface but omit its invalid MAC.
                             tracing::debug!(
                                 interface_id = %iface.id(),
                                 link_status = ?iface.link_status(),
                                 error = %err,
-                                "could not parse MAC address for a disabled interface"
+                                "ignoring invalid system interface MAC address"
                             );
                             Ok(None)
                         } else {
@@ -452,7 +453,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        if hw_type.is_some_and(|v| v == hw::HwType::Bluefield)
+        if is_bluefield
             && !result.iter().any(|iface| {
                 iface
                     .id

--- a/crates/bmc-explorer/src/hw/dell.rs
+++ b/crates/bmc-explorer/src/hw/dell.rs
@@ -17,7 +17,7 @@
 
 use crate::hw::BiosAttr;
 
-pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 13] = [
+pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 14] = [
     BiosAttr::new_str("InBandManageabilityInterface", "Disabled"),
     BiosAttr::new_str("UefiVariableAccess", "Standard"),
     BiosAttr::new_any_str("SerialComm", &["OnConRedirAuto", "OnConRedir"]), // Second is legacy
@@ -30,5 +30,6 @@ pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 13] = [
     BiosAttr::new_str("Tpm2Hierarchy", "Enabled"), // Setup puts "Clear" here.
     BiosAttr::new_str("Tpm2Algorithm", "SHA256"),
     BiosAttr::new_str("HttpDev1EnDis", "Enabled"),
+    BiosAttr::new_str("HttpDev1TlsMode", "None"),
     BiosAttr::new_str("PxeDev1EnDis", "Disabled"),
 ];

--- a/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
@@ -68,6 +68,48 @@ async fn explore_bluefield3_preserves_oem_mode_and_base_mac() {
 }
 
 #[test]
+async fn explore_bluefield3_ignores_invalid_system_interface_mac() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+    h.state.injection.put(vec![bmc_mock::injection::Rule {
+        id: "invalid_system_interface_mac".into(),
+        selector: bmc_mock::injection::Selector::Path {
+            method: Some("GET".into()),
+            glob: "/redfish/v1/Systems/Bluefield/EthernetInterfaces/oob_net0".into(),
+        },
+        action: bmc_mock::injection::Action::JsonMerge(serde_json::json!({
+            "Id": "eth0",
+            "InterfaceEnabled": true,
+            "LinkStatus": "LinkDown",
+            "MACAddress": "00:00:11:e7:fe:80:00:00:00:00:00:00:02:00:00:03:00:18:00:01",
+        })),
+        remaining: None,
+    }]);
+
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .unwrap();
+    let system = report.systems.first().expect("systems must be present");
+    let eth0 = system
+        .ethernet_interfaces
+        .iter()
+        .find(|interface| interface.id.as_deref() == Some("eth0"))
+        .expect("invalid interface must be preserved");
+    let oob = system
+        .ethernet_interfaces
+        .iter()
+        .find(|interface| interface.id.as_deref() == Some("oob_net0"))
+        .expect("OOB interface must be preserved");
+
+    assert_eq!(eth0.mac_address, None);
+    assert!(oob.mac_address.is_some(), "valid OOB MAC must be preserved");
+    assert!(system.base_mac.is_some(), "DPU base MAC must be preserved");
+    assert!(
+        report.dpu_pairing_serial_number().is_some(),
+        "DPU pairing serial number must be preserved"
+    );
+}
+
+#[test]
 async fn explore_bluefield3_without_system_eth_interfaces() {
     let settings = DpuSettings {
         exposes_oob_eth: false,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1205,12 +1205,18 @@ impl MachineStateHandler {
                                 .await
                                 .map_err(|e| redfish_error("get_boss_controller", e))?
                         {
+                            let secure_erase_boss_state = match cleanup_context {
+                                CleanupContext::Deprovision => SecureEraseBossState::UnlockHost,
+                                CleanupContext::InitialDiscovery => {
+                                    SecureEraseBossState::SecureEraseBoss
+                                }
+                            };
                             let next_state = waiting_for_cleanup_state(
                                 CleanupState::SecureEraseBoss {
                                     secure_erase_boss_context: SecureEraseBossContext {
                                         boss_controller_id,
                                         secure_erase_jid: None,
-                                        secure_erase_boss_state: SecureEraseBossState::UnlockHost,
+                                        secure_erase_boss_state,
                                         iteration: Some(0),
                                     },
                                 },
@@ -1237,10 +1243,12 @@ impl MachineStateHandler {
 
                         match secure_erase_boss_context.secure_erase_boss_state {
                             SecureEraseBossState::UnlockHost => {
-                                redfish_client
-                                    .set_idrac_lockdown(EnabledDisabled::Disabled)
-                                    .await
-                                    .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                if matches!(cleanup_context, CleanupContext::Deprovision) {
+                                    redfish_client
+                                        .set_idrac_lockdown(EnabledDisabled::Disabled)
+                                        .await
+                                        .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                }
 
                                 let next_state = waiting_for_cleanup_state(
                                     CleanupState::SecureEraseBoss {
@@ -1420,10 +1428,12 @@ impl MachineStateHandler {
                                 .await
                             }
                             CreateBossVolumeState::LockHost => {
-                                redfish_client
-                                    .set_idrac_lockdown(EnabledDisabled::Enabled)
-                                    .await
-                                    .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                if matches!(cleanup_context, CleanupContext::Deprovision) {
+                                    redfish_client
+                                        .set_idrac_lockdown(EnabledDisabled::Enabled)
+                                        .await
+                                        .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                }
 
                                 let next_state = post_cleanup_state(*cleanup_context);
 
@@ -11680,24 +11690,30 @@ async fn wait_for_boss_controller_job_to_complete(
         // The job has completed; transition to next step in host cleanup
         libredfish::JobState::Completed => {
             // healthy path
-            let cleanup_state = match secure_erase_boss_controller {
+            let next_state = match (secure_erase_boss_controller, cleanup_context) {
                 // now that we have finished doing a secure erase of the BOSS controller
                 // we can do a standard secure erase of the remaining drives through the /usr/sbin/nvme tool
-                true => CleanupState::HostCleanup {
-                    boss_controller_id: Some(boss_controller_id),
-                },
-                // now that we have recreated the R1 volume on top of the BOSS controller, we can lock the host back down again.
-                false => CleanupState::CreateBossVolume {
-                    create_boss_volume_context: CreateBossVolumeContext {
-                        boss_controller_id,
-                        create_boss_volume_jid: None,
-                        create_boss_volume_state: CreateBossVolumeState::LockHost,
-                        iteration: Some(iterations),
+                (true, _) => waiting_for_cleanup_state(
+                    CleanupState::HostCleanup {
+                        boss_controller_id: Some(boss_controller_id),
                     },
-                },
+                    cleanup_context,
+                ),
+                // now that we have recreated the R1 volume on top of the BOSS controller, we can lock the host back down again.
+                (false, CleanupContext::Deprovision) => waiting_for_cleanup_state(
+                    CleanupState::CreateBossVolume {
+                        create_boss_volume_context: CreateBossVolumeContext {
+                            boss_controller_id,
+                            create_boss_volume_jid: None,
+                            create_boss_volume_state: CreateBossVolumeState::LockHost,
+                            iteration: Some(iterations),
+                        },
+                    },
+                    cleanup_context,
+                ),
+                (false, CleanupContext::InitialDiscovery) => post_cleanup_state(cleanup_context),
             };
 
-            let next_state = waiting_for_cleanup_state(cleanup_state, cleanup_context);
             Ok(StateHandlerOutcome::transition(next_state))
         }
         // The job has failed; handle error

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -409,21 +409,27 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                     .map_err(|err| redact_password(err, curr_password.as_str()))
                     .map_err(RedfishClientCreationError::RedfishError)?;
             }
-            // Vikings and Lenovo GB300s (both still detected as AMI here).
-            // Resolve the admin account by username, and fall back to the conventional
-            // id "2" only when reads are blocked by `PasswordChangeRequired` (Viking factory state).
+            // AMI-based BMCs, including Vikings and Lenovo GB300s.
+            // Resolve the admin account by username. If reads are blocked by
+            // `PasswordChangeRequired`, use its account URI or fall back to id "2".
             // Any other error propagates.
             //
             // https://docs.nvidia.com/dgx/dgxh100-user-guide/redfish-api-supp.html
-            RedfishVendor::AMI | RedfishVendor::LenovoGB300 => {
+            RedfishVendor::AMI | RedfishVendor::LenovoAMI | RedfishVendor::LenovoGB300 => {
                 match client
                     .change_password(curr_user.as_str(), new_password.as_str())
                     .await
                 {
                     Ok(()) => {}
-                    Err(libredfish::RedfishError::PasswordChangeRequired) => {
+                    Err(libredfish::RedfishError::PasswordChangeRequired { account_uri }) => {
+                        // For example: /redfish/v1/AccountService/Accounts/4
+                        let account_id = account_uri
+                            .as_deref()
+                            .and_then(|uri| uri.rsplit_once('/').map(|(_, id)| id))
+                            .filter(|id| !id.is_empty())
+                            .unwrap_or("2");
                         client
-                            .change_password_by_id("2", new_password.as_str())
+                            .change_password_by_id(account_id, new_password.as_str())
                             .await
                             .map_err(|err| redact_password(err, new_password.as_str()))
                             .map_err(|err| redact_password(err, curr_password.as_str()))
@@ -437,10 +443,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                     }
                 }
             }
-            RedfishVendor::LenovoAMI
-            | RedfishVendor::Supermicro
-            | RedfishVendor::Dell
-            | RedfishVendor::Hpe => {
+            RedfishVendor::Supermicro | RedfishVendor::Dell | RedfishVendor::Hpe => {
                 client
                     .change_password(curr_user.as_str(), new_password.as_str())
                     .await
@@ -727,7 +730,7 @@ pub fn redact_passwords(
         | RfError::NoHeader
         | RfError::Lockdown
         | RfError::MissingVendor
-        | RfError::PasswordChangeRequired
+        | RfError::PasswordChangeRequired { .. }
         | RfError::FileError(_)
         | RfError::UserNotFound(_)
         | RfError::NotSupported(_)
@@ -1067,7 +1070,7 @@ mod tests {
         let sim = RedfishSim::default();
         sim.seed_user("root", "factory_pass");
         sim.seed_user("2", "factory_pass");
-        sim.set_password_change_required(true);
+        sim.set_password_change_required(true, None);
 
         sim.set_bmc_root_password(
             "127.0.0.1",
@@ -1081,6 +1084,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_bmc_root_password_ami_uses_account_uri() {
+        let sim = RedfishSim::default();
+        sim.seed_user("root", "factory_pass");
+        sim.seed_user("4", "factory_pass");
+        sim.set_password_change_required(true, Some("/redfish/v1/AccountService/Accounts/4"));
+
+        sim.set_bmc_root_password(
+            "127.0.0.1",
+            Some(443),
+            RedfishVendor::AMI,
+            Credentials::new("root", "factory_pass"),
+            "site_pass".to_string(),
+        )
+        .await
+        .expect("AMI rotation should use the account URI");
+
+        assert_eq!(sim.user_password("4").as_deref(), Some("site_pass"));
+    }
+
+    #[tokio::test]
     async fn set_bmc_root_password_ami_dispatches_to_id_two_after_password_change_required() {
         // Same factory state, but account id "2" is absent: the fallback's
         // `change_password_by_id("2")` fails with `UserNotFound("2")`, proving
@@ -1088,7 +1111,7 @@ mod tests {
         // (rather than swallowing the error or dispatching elsewhere).
         let sim = RedfishSim::default();
         sim.seed_user("root", "factory_pass");
-        sim.set_password_change_required(true);
+        sim.set_password_change_required(true, None);
 
         let err = sim
             .set_bmc_root_password(

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -58,6 +58,7 @@ struct RedfishSimState {
     machine_setup_bios_job_id: Option<String>,
     is_bios_setup: Option<bool>,
     default_lockdown: Option<EnabledDisabled>,
+    boss_controller_id: Option<String>,
     /// Override whether `lockdown_bmc` changes the observed state. `None`
     /// preserves the normal successful behavior; `Some(false)` models a BMC
     /// accepting the write without applying the requested policy.
@@ -284,6 +285,10 @@ impl RedfishSim {
 
     pub fn set_job_state_sequence(&self, states: Vec<JobState>) {
         self.state.lock().unwrap().job_state_sequence = VecDeque::from(states);
+    }
+
+    pub fn set_boss_controller_id(&self, boss_controller_id: Option<String>) {
+        self.state.lock().unwrap().boss_controller_id = boss_controller_id;
     }
 
     pub fn set_is_bios_setup(&self, ready: bool) {
@@ -1880,7 +1885,7 @@ impl Redfish for RedfishSimClient {
     fn get_boss_controller<'a>(
         &'a self,
     ) -> libredfish::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { Ok(None) })
+        Box::pin(async move { Ok(self.state.lock().unwrap().boss_controller_id.clone()) })
     }
 
     fn decommission_storage_controller<'a>(

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -78,6 +78,8 @@ struct RedfishSimState {
     /// change-on-first-use has been done -- the case the `AMI`/`LenovoGB300`
     /// rotation path handles by retrying `change_password_by_id("2")`.
     password_change_required: bool,
+    /// Optional account URI returned with [`RedfishError::PasswordChangeRequired`].
+    password_change_required_account_uri: Option<String>,
     /// When set, overrides the `Vendor` field returned by `get_service_root`.
     /// Tests set it to an unrecognized value to force `probe_bmc_vendor` down
     /// the Chassis `Manufacturer` fallback path.
@@ -368,8 +370,14 @@ impl RedfishSim {
     /// [`RedfishError::PasswordChangeRequired`], modeling a factory BMC that
     /// blocks it until change-on-first-use. `change_password_by_id` still
     /// succeeds, so this exercises the `AMI`/`LenovoGB300` rotation fallback.
-    pub fn set_password_change_required(&self, required: bool) {
-        self.state.lock().unwrap().password_change_required = required;
+    pub fn set_password_change_required(&self, required: bool, account_uri: Option<&str>) {
+        let mut state = self.state.lock().unwrap();
+        state.password_change_required = required;
+        state.password_change_required_account_uri = if required {
+            account_uri.map(str::to_string)
+        } else {
+            None
+        };
     }
 
     /// Enable opt-in authentication enforcement (see [`RedfishSimState::enforce_auth`]):
@@ -856,7 +864,9 @@ impl Redfish for RedfishSimClient {
                 });
             }
             if state.password_change_required {
-                return Err(RedfishError::PasswordChangeRequired);
+                return Err(RedfishError::PasswordChangeRequired {
+                    account_uri: state.password_change_required_account_uri.clone(),
+                });
             }
             self.authorize(&state, "AccountService/Accounts")?;
             if !state.users.contains_key(&s_user) {

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -218,6 +218,9 @@ impl MachineCreator {
                 None
             };
 
+        // Admission permit BEFORE the transaction: waiters on the admin-segment
+        // advisory lock must queue in memory, not on open pool connections.
+        let _admin_admission = db::machine_interface::admin_lock_admission().await;
         let mut txn = Transaction::begin(pool).await?;
 
         // Advisory-lock the admin segments before any machine-interface row


### PR DESCRIPTION
This PR backports several fixes into `v2.1`:

- Bound admin-segment lock admission to prevent PostgreSQL connection exhaustion.
- Tolerate malformed BlueField system-interface MACs.
- Prevent Dell initial discovery from enabling lockdown before UEFI setup.
- Verify Dell HTTP boot TLS configuration.
- Allow Dell thermal and airflow fields to be null when reading power state.
- Use the BMC-provided account URI during AMI password rotation.
- Limit AMI NTP configuration to two servers and accept asynchronous `202 Accepted` responses.
- Update libredfish from `v0.46.3` to `v0.46.5`.

## Related issues

- #4710
- #4816
- #4815
- #4704
- #4724
- #4756
- #4297

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The network-seeding fix from #4342 is already present in `v2.1` and was not cherry-picked.