### PR TITLE
fix(credential-rotation): when rotating a managed host's BMC credential, prevent site explorer from exploring the managed host's BMCs while the rotation is in progress

### DIFF
--- a/crates/api-core/src/tests/power_shelf_state_controller/bmc_rotation.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/bmc_rotation.rs
@@ -56,7 +56,6 @@ use crate::tests::common::api_fixtures::{TestEnv, create_test_env};
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const BMC: CredentialRotationType = CredentialRotationType::Bmc;
-const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
 
 /// Stand in for site-explorer acknowledging every pending BMC suppression -- the
 /// barrier the rotation gate waits on before changing a credential. This test
@@ -64,16 +63,22 @@ const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExpl
 /// pass itself.
 async fn ack_all_site_explorer_suppressions(pool: &sqlx::PgPool) {
     let mut conn = pool.acquire().await.expect("acquire connection");
-    let macs: Vec<MacAddress> =
-        db::bmc_suppression::find_all_by_subsystem(&mut *conn, SITE_EXPLORER)
-            .await
-            .expect("read suppressions")
-            .into_iter()
-            .map(|s| s.bmc_mac_address)
-            .collect();
-    db::bmc_suppression::acknowledge_unacknowledged(&mut conn, &macs, SITE_EXPLORER)
-        .await
-        .expect("acknowledge suppressions");
+    let macs: Vec<MacAddress> = db::bmc_suppression::find_all_by_subsystem(
+        &mut *conn,
+        BmcSuppressionSubsystem::SiteExplorer,
+    )
+    .await
+    .expect("read suppressions")
+    .into_iter()
+    .map(|s| s.bmc_mac_address)
+    .collect();
+    db::bmc_suppression::acknowledge_unacknowledged(
+        &mut conn,
+        &macs,
+        BmcSuppressionSubsystem::SiteExplorer,
+    )
+    .await
+    .expect("acknowledge suppressions");
 }
 
 fn per_device_key(mac: MacAddress) -> CredentialKey {
@@ -684,6 +689,148 @@ async fn force_request_converges_quarantined_pmc_when_disabled(pool: sqlx::PgPoo
     assert!(
         !power_shelf.bmc_credential_rotation_requested,
         "the one-shot force request must be cleared after a settled forced rotation"
+    );
+
+    Ok(())
+}
+
+/// When the PMC password change lands but persisting the new per-device secret
+/// to the store fails, the hardware is AHEAD of the store. The power shelf must
+/// hold in `RotatingBmc` (keeping the site-explorer suppression) rather than
+/// settling to Ready with a stale stored secret, and keep retrying until the
+/// store reconciles.
+#[crate::sqlx_test]
+async fn store_persist_failure_holds_in_rotating_bmc_until_reconciled(
+    pool: sqlx::PgPool,
+) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+
+    let power_shelf_id = common::api_fixtures::site_explorer::new_power_shelf(
+        &env,
+        Some("BMC Rotation Store-Lag Test Power Shelf".to_string()),
+        Some(5000),
+        Some(240),
+        Some("Data Center A, Rack 1".to_string()),
+    )
+    .await?;
+    let pmc_mac = seed_pmc_endpoint(&pool, power_shelf_id).await?;
+    move_to_ready(&pool, &power_shelf_id).await?;
+    stage_lagging_pmc(&env, &pool, pmc_mac).await?;
+
+    // Enter RotatingBmc, let the gate record the suppression, and acknowledge it.
+    run_power_shelf_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        power_shelf_services(&env, &pool, true),
+    )
+    .await; // Ready -> RotatingBmc
+    run_power_shelf_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        power_shelf_services(&env, &pool, true),
+    )
+    .await; // gate records the suppression and waits
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // The store write now fails: the hardware change will land but the persist
+    // will not, leaving the PMC ahead of the store.
+    env.test_credential_manager
+        .set_set_credentials_failure(true);
+
+    // The password change succeeds on the hardware but the persist fails, so the
+    // shelf holds in RotatingBmc instead of returning to Ready.
+    run_power_shelf_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        power_shelf_services(&env, &pool, true),
+    )
+    .await;
+    let power_shelf = load_power_shelf(&pool, &power_shelf_id).await?;
+    assert!(
+        matches!(
+            power_shelf.controller_state.value,
+            PowerShelfControllerState::RotatingBmc { .. }
+        ),
+        "a persist failure must hold in RotatingBmc, got {:?}",
+        power_shelf.controller_state.value,
+    );
+    assert!(
+        db::bmc_suppression::is_suppressed(&pool, pmc_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?,
+        "the rotation suppression must be retained while the store lags"
+    );
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, BMC, pmc_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            !status.converged,
+            "hardware ahead of store is not converged"
+        );
+        assert!(
+            !status.quarantined,
+            "a persist failure must not record a backoff"
+        );
+    }
+    assert_eq!(
+        env.redfish_sim.user_password("root").as_deref(),
+        Some("new"),
+        "the hardware change must have landed even though the persist failed"
+    );
+    assert_eq!(
+        env.test_credential_manager
+            .get_credentials(&per_device_key(pmc_mac))
+            .await
+            .expect("reading the per-device secret should succeed")
+            .expect("per-device secret should still be set"),
+        creds("root", "old"),
+        "the stored secret must still lag after the failed persist"
+    );
+
+    // The store becomes writable again: the next tick reconciles and returns to
+    // Ready.
+    env.test_credential_manager
+        .set_set_credentials_failure(false);
+    run_power_shelf_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        power_shelf_services(&env, &pool, true),
+    )
+    .await;
+    let power_shelf = load_power_shelf(&pool, &power_shelf_id).await?;
+    assert!(
+        matches!(
+            power_shelf.controller_state.value,
+            PowerShelfControllerState::Ready
+        ),
+        "expected Ready once the store reconciles, got {:?}",
+        power_shelf.controller_state.value,
+    );
+    assert!(
+        !db::bmc_suppression::is_suppressed(&pool, pmc_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?,
+        "resume must delete the rotation suppression once reconciled"
+    );
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, BMC, pmc_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            status.converged,
+            "device should converge once the store reconciles"
+        );
+        assert_eq!(status.current_version, Some(1));
+    }
+    assert_eq!(
+        env.test_credential_manager
+            .get_credentials(&per_device_key(pmc_mac))
+            .await
+            .expect("reading the per-device secret should succeed")
+            .expect("per-device secret should still be set"),
+        creds("root", "new"),
+        "the store is reconciled to the new password once the write succeeds"
     );
 
     Ok(())

--- a/crates/api-core/src/tests/power_shelf_state_controller/bmc_rotation.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/bmc_rotation.rs
@@ -43,6 +43,7 @@ use db::credential_rotation::{
 use db::power_shelf as db_power_shelf;
 use mac_address::MacAddress;
 use model::allocation_type::AllocationType;
+use model::bmc_suppression::BmcSuppressionSubsystem;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
 use state_controller::config::IterationConfig;
 use state_controller::controller::StateController;
@@ -55,6 +56,25 @@ use crate::tests::common::api_fixtures::{TestEnv, create_test_env};
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const BMC: CredentialRotationType = CredentialRotationType::Bmc;
+const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
+
+/// Stand in for site-explorer acknowledging every pending BMC suppression -- the
+/// barrier the rotation gate waits on before changing a credential. This test
+/// drives only the power-shelf controller, so it plays the site-explorer ack
+/// pass itself.
+async fn ack_all_site_explorer_suppressions(pool: &sqlx::PgPool) {
+    let mut conn = pool.acquire().await.expect("acquire connection");
+    let macs: Vec<MacAddress> =
+        db::bmc_suppression::find_all_by_subsystem(&mut *conn, SITE_EXPLORER)
+            .await
+            .expect("read suppressions")
+            .into_iter()
+            .map(|s| s.bmc_mac_address)
+            .collect();
+    db::bmc_suppression::acknowledge_unacknowledged(&mut conn, &macs, SITE_EXPLORER)
+        .await
+        .expect("acknowledge suppressions");
+}
 
 fn per_device_key(mac: MacAddress) -> CredentialKey {
     CredentialKey::BmcCredentials {
@@ -293,7 +313,30 @@ async fn ready_power_shelf_converges_pmc_to_site_target(pool: sqlx::PgPool) -> T
         power_shelf.controller_state.value,
     );
 
-    // Iteration 2: the rotation converges the device and returns to Ready.
+    // Iteration 2: the gate records a site-explorer suppression for the PMC and
+    // waits for its acknowledgement before touching the credential, so the shelf
+    // stays in RotatingBmc and nothing is rotated yet.
+    run_power_shelf_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        power_shelf_services(&env, &pool, true),
+    )
+    .await;
+    let power_shelf = load_power_shelf(&pool, &power_shelf_id).await?;
+    assert!(
+        matches!(
+            power_shelf.controller_state.value,
+            PowerShelfControllerState::RotatingBmc { .. }
+        ),
+        "rotation must wait in RotatingBmc until site-explorer acknowledges, got {:?}",
+        power_shelf.controller_state.value,
+    );
+
+    // Site-explorer acknowledges the suppression (its skip barrier).
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // Iteration 3: with the barrier satisfied, the rotation converges the device
+    // and returns to Ready.
     run_power_shelf_controller_with_services(
         pool.clone(),
         env.api.work_lock_manager_handle.clone(),
@@ -408,7 +451,27 @@ async fn failing_pmc_rotation_returns_to_ready_and_quarantines(pool: sqlx::PgPoo
         power_shelf.controller_state.value,
     );
 
-    // Iteration 2: the rotation attempt fails; the engine quarantines the device
+    // Iteration 2: the gate records a site-explorer suppression and waits for its
+    // acknowledgement, so the shelf stays in RotatingBmc before any rotation is
+    // attempted.
+    run_power_shelf_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        power_shelf_services(&env, &pool, true),
+    )
+    .await;
+    let power_shelf = load_power_shelf(&pool, &power_shelf_id).await?;
+    assert!(
+        matches!(
+            power_shelf.controller_state.value,
+            PowerShelfControllerState::RotatingBmc { .. }
+        ),
+        "rotation must wait in RotatingBmc until site-explorer acknowledges, got {:?}",
+        power_shelf.controller_state.value,
+    );
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // Iteration 3: the rotation attempt fails; the engine quarantines the device
     // and the handler settles back to Ready (RotatingBmc is not terminal).
     run_power_shelf_controller_with_services(
         pool.clone(),
@@ -569,7 +632,26 @@ async fn force_request_converges_quarantined_pmc_when_disabled(pool: sqlx::PgPoo
         power_shelf.controller_state.value,
     );
 
-    // Iteration 2: the forced tick bypasses backoff, converges the device, and
+    // Iteration 2: even a forced rotation first gates on site-explorer, so it
+    // waits in RotatingBmc until the suppression is acknowledged.
+    run_power_shelf_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        power_shelf_services(&env, &pool, false),
+    )
+    .await;
+    let power_shelf = load_power_shelf(&pool, &power_shelf_id).await?;
+    assert!(
+        matches!(
+            power_shelf.controller_state.value,
+            PowerShelfControllerState::RotatingBmc { .. }
+        ),
+        "a forced rotation must still wait for site-explorer acknowledgement, got {:?}",
+        power_shelf.controller_state.value,
+    );
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // Iteration 3: the forced tick bypasses backoff, converges the device, and
     // returns to Ready.
     run_power_shelf_controller_with_services(
         pool.clone(),

--- a/crates/api-core/src/tests/switch_state_controller/bmc_rotation.rs
+++ b/crates/api-core/src/tests/switch_state_controller/bmc_rotation.rs
@@ -32,6 +32,7 @@ use db::credential_rotation::{
 };
 use db::switch as db_switch;
 use mac_address::MacAddress;
+use model::bmc_suppression::BmcSuppressionSubsystem;
 use model::switch::{Switch, SwitchControllerState};
 
 use super::fixtures::switch::transition_switch_controller_state;
@@ -41,6 +42,25 @@ use crate::tests::common::api_fixtures::create_test_env;
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const BMC: CredentialRotationType = CredentialRotationType::Bmc;
+const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
+
+/// Stand in for site-explorer acknowledging every pending BMC suppression -- the
+/// barrier the rotation gate waits on before changing a credential. This test
+/// drives only the switch controller, so it plays the site-explorer ack pass
+/// itself.
+async fn ack_all_site_explorer_suppressions(pool: &sqlx::PgPool) {
+    let mut conn = pool.acquire().await.expect("acquire connection");
+    let macs: Vec<MacAddress> =
+        db::bmc_suppression::find_all_by_subsystem(&mut *conn, SITE_EXPLORER)
+            .await
+            .expect("read suppressions")
+            .into_iter()
+            .map(|s| s.bmc_mac_address)
+            .collect();
+    db::bmc_suppression::acknowledge_unacknowledged(&mut conn, &macs, SITE_EXPLORER)
+        .await
+        .expect("acknowledge suppressions");
+}
 
 fn per_device_key(mac: MacAddress) -> CredentialKey {
     CredentialKey::BmcCredentials {
@@ -168,7 +188,30 @@ async fn ready_switch_converges_bmc_to_site_target(pool: sqlx::PgPool) -> TestRe
         switch.controller_state.value,
     );
 
-    // Iteration 2: the rotation converges the device and returns to Ready.
+    // Iteration 2: the gate records a site-explorer suppression for the switch
+    // BMC and waits for its acknowledgement before touching the credential, so
+    // the switch stays in RotatingBmc and nothing is rotated yet.
+    run_switch_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        switch_services(&env, &pool, true),
+    )
+    .await;
+    let switch = load_switch(&pool, &switch_id).await?;
+    assert!(
+        matches!(
+            switch.controller_state.value,
+            SwitchControllerState::RotatingBmc { .. }
+        ),
+        "rotation must wait in RotatingBmc until site-explorer acknowledges, got {:?}",
+        switch.controller_state.value,
+    );
+
+    // Site-explorer acknowledges the suppression (its skip barrier).
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // Iteration 3: with the barrier satisfied, the rotation converges the device
+    // and returns to Ready.
     run_switch_controller_with_services(
         pool.clone(),
         env.api.work_lock_manager_handle.clone(),

--- a/crates/api-core/src/tests/switch_state_controller/bmc_rotation.rs
+++ b/crates/api-core/src/tests/switch_state_controller/bmc_rotation.rs
@@ -42,7 +42,6 @@ use crate::tests::common::api_fixtures::create_test_env;
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const BMC: CredentialRotationType = CredentialRotationType::Bmc;
-const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
 
 /// Stand in for site-explorer acknowledging every pending BMC suppression -- the
 /// barrier the rotation gate waits on before changing a credential. This test
@@ -50,16 +49,22 @@ const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExpl
 /// itself.
 async fn ack_all_site_explorer_suppressions(pool: &sqlx::PgPool) {
     let mut conn = pool.acquire().await.expect("acquire connection");
-    let macs: Vec<MacAddress> =
-        db::bmc_suppression::find_all_by_subsystem(&mut *conn, SITE_EXPLORER)
-            .await
-            .expect("read suppressions")
-            .into_iter()
-            .map(|s| s.bmc_mac_address)
-            .collect();
-    db::bmc_suppression::acknowledge_unacknowledged(&mut conn, &macs, SITE_EXPLORER)
-        .await
-        .expect("acknowledge suppressions");
+    let macs: Vec<MacAddress> = db::bmc_suppression::find_all_by_subsystem(
+        &mut *conn,
+        BmcSuppressionSubsystem::SiteExplorer,
+    )
+    .await
+    .expect("read suppressions")
+    .into_iter()
+    .map(|s| s.bmc_mac_address)
+    .collect();
+    db::bmc_suppression::acknowledge_unacknowledged(
+        &mut conn,
+        &macs,
+        BmcSuppressionSubsystem::SiteExplorer,
+    )
+    .await
+    .expect("acknowledge suppressions");
 }
 
 fn per_device_key(mac: MacAddress) -> CredentialKey {
@@ -252,6 +257,164 @@ async fn ready_switch_converges_bmc_to_site_target(pool: sqlx::PgPool) -> TestRe
         persisted,
         creds("root", "new"),
         "per-device secret should be rotated to the new password"
+    );
+
+    Ok(())
+}
+
+/// When the switch BMC password change lands but persisting the new per-device
+/// secret to the store fails, the hardware is AHEAD of the store. The switch
+/// must hold in `RotatingBmc` (keeping the site-explorer suppression) rather
+/// than settling to Ready with a stale stored secret, and keep retrying until
+/// the store reconciles.
+#[crate::sqlx_test]
+async fn switch_store_persist_failure_holds_in_rotating_bmc_until_reconciled(
+    pool: sqlx::PgPool,
+) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+
+    let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
+    let bmc_mac = db_switch::find_switch_endpoints_by_ids(&pool, &[switch_id])
+        .await?
+        .first()
+        .expect("switch endpoint row")
+        .bmc_mac;
+
+    {
+        let mut txn = pool.begin().await?;
+        transition_switch_controller_state(txn.as_mut(), &switch_id, SwitchControllerState::Ready)
+            .await?;
+        txn.commit().await?;
+    }
+
+    env.redfish_sim.seed_user("root", "old");
+    env.test_credential_manager
+        .set_credentials(&per_device_key(bmc_mac), &creds("root", "old"))
+        .await
+        .expect("staging the per-device secret should succeed");
+    {
+        let mut conn = pool.acquire().await?;
+        record_device_converged(&mut conn, bmc_mac, BMC).await?;
+        set_next_target_version(&mut conn, BMC, 0, serde_json::json!({}))
+            .await?
+            .expect("target must advance from version 0");
+    }
+    env.test_credential_manager
+        .set_credentials(&rotate_to_key(1), &creds("root", "new"))
+        .await
+        .expect("staging the rotate-to secret should succeed");
+
+    // Enter RotatingBmc, let the gate record the suppression, and acknowledge it.
+    run_switch_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        switch_services(&env, &pool, true),
+    )
+    .await; // Ready -> RotatingBmc
+    run_switch_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        switch_services(&env, &pool, true),
+    )
+    .await; // gate records the suppression and waits
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // The store write now fails: the hardware change will land but the persist
+    // will not, leaving the BMC ahead of the store.
+    env.test_credential_manager
+        .set_set_credentials_failure(true);
+
+    // The password change succeeds on the hardware but the persist fails, so the
+    // switch holds in RotatingBmc instead of returning to Ready.
+    run_switch_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        switch_services(&env, &pool, true),
+    )
+    .await;
+    let switch = load_switch(&pool, &switch_id).await?;
+    assert!(
+        matches!(
+            switch.controller_state.value,
+            SwitchControllerState::RotatingBmc { .. }
+        ),
+        "a persist failure must hold in RotatingBmc, got {:?}",
+        switch.controller_state.value,
+    );
+    assert!(
+        db::bmc_suppression::is_suppressed(&pool, bmc_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?,
+        "the rotation suppression must be retained while the store lags"
+    );
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, BMC, bmc_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            !status.converged,
+            "hardware ahead of store is not converged"
+        );
+        assert!(
+            !status.quarantined,
+            "a persist failure must not record a backoff"
+        );
+    }
+    assert_eq!(
+        env.redfish_sim.user_password("root").as_deref(),
+        Some("new"),
+        "the hardware change must have landed even though the persist failed"
+    );
+    assert_eq!(
+        env.test_credential_manager
+            .get_credentials(&per_device_key(bmc_mac))
+            .await
+            .expect("reading the per-device secret should succeed")
+            .expect("per-device secret should still be set"),
+        creds("root", "old"),
+        "the stored secret must still lag after the failed persist"
+    );
+
+    // The store becomes writable again: the next tick reconciles and returns to
+    // Ready.
+    env.test_credential_manager
+        .set_set_credentials_failure(false);
+    run_switch_controller_with_services(
+        pool.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        switch_services(&env, &pool, true),
+    )
+    .await;
+    let switch = load_switch(&pool, &switch_id).await?;
+    assert!(
+        matches!(switch.controller_state.value, SwitchControllerState::Ready),
+        "expected Ready once the store reconciles, got {:?}",
+        switch.controller_state.value,
+    );
+    assert!(
+        !db::bmc_suppression::is_suppressed(&pool, bmc_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?,
+        "resume must delete the rotation suppression once reconciled"
+    );
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, BMC, bmc_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            status.converged,
+            "device should converge once the store reconciles"
+        );
+        assert_eq!(status.current_version, Some(1));
+    }
+    assert_eq!(
+        env.test_credential_manager
+            .get_credentials(&per_device_key(bmc_mac))
+            .await
+            .expect("reading the per-device secret should succeed")
+            .expect("per-device secret should still be set"),
+        creds("root", "new"),
+        "the store is reconciled to the new password once the write succeeds"
     );
 
     Ok(())

--- a/crates/api-db/src/bmc_suppression.rs
+++ b/crates/api-db/src/bmc_suppression.rs
@@ -55,6 +55,66 @@ pub async fn upsert(
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
+/// Ensures a suppression request exists for the MAC without clobbering an
+/// existing one.
+///
+/// Unlike [`upsert`], a conflicting row is preserved verbatim -- including its
+/// `reason`, `requested_at`, and `acknowledged_at` -- so a rotation-owned
+/// request never overwrites (and can never later delete) an operator's
+/// decommissioning request for the same BMC. When no row exists, one is
+/// inserted with the supplied reason.
+pub async fn ensure_present(
+    txn: &mut PgConnection,
+    input: &NewBmcSuppression,
+) -> DatabaseResult<BmcSuppression> {
+    const QUERY: &str = "INSERT INTO bmc_suppressions (
+        bmc_mac_address,
+        subsystem,
+        reason
+    ) VALUES ($1, $2, $3)
+    ON CONFLICT (bmc_mac_address, subsystem) DO UPDATE SET
+        reason = bmc_suppressions.reason
+    RETURNING
+        bmc_mac_address,
+        subsystem,
+        reason,
+        requested_at,
+        acknowledged_at";
+
+    sqlx::query_as(QUERY)
+        .bind(input.bmc_mac_address)
+        .bind(input.subsystem)
+        .bind(&input.reason)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+/// Returns the suppression rows for the selected BMC MAC addresses in
+/// `subsystem`. Missing MACs are simply absent from the result.
+pub async fn find_many(
+    db: impl DbReader<'_>,
+    bmc_mac_addresses: &[MacAddress],
+    subsystem: BmcSuppressionSubsystem,
+) -> DatabaseResult<Vec<BmcSuppression>> {
+    const QUERY: &str = "SELECT
+        bmc_mac_address,
+        subsystem,
+        reason,
+        requested_at,
+        acknowledged_at
+    FROM bmc_suppressions
+    WHERE bmc_mac_address = ANY($1) AND subsystem = $2
+    ORDER BY bmc_mac_address";
+
+    sqlx::query_as(QUERY)
+        .bind(bmc_mac_addresses)
+        .bind(subsystem)
+        .fetch_all(db)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
 /// Returns an active suppression request, if one exists.
 pub async fn find(
     db: impl DbReader<'_>,
@@ -206,14 +266,40 @@ pub async fn delete_many(
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
+/// Deletes a subsystem's suppression requests for a set of BMC MACs, but only
+/// rows whose `reason` matches.
+///
+/// Scoping the delete by reason lets an automated owner (e.g. BMC credential
+/// rotation) clean up exactly the rows it created without removing a request
+/// another owner (e.g. an operator decommissioning) may hold for the same BMC.
+/// Returns the number of rows removed.
+pub async fn delete_many_with_reason(
+    txn: &mut PgConnection,
+    bmc_mac_addresses: &[MacAddress],
+    subsystem: BmcSuppressionSubsystem,
+    reason: &str,
+) -> DatabaseResult<u64> {
+    const QUERY: &str = "DELETE FROM bmc_suppressions
+        WHERE bmc_mac_address = ANY($1) AND subsystem = $2 AND reason = $3";
+
+    sqlx::query(QUERY)
+        .bind(bmc_mac_addresses)
+        .bind(subsystem)
+        .bind(reason)
+        .execute(txn)
+        .await
+        .map(|result| result.rows_affected())
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
 #[cfg(test)]
 mod tests {
     use mac_address::MacAddress;
     use model::bmc_suppression::{BmcSuppressionSubsystem, NewBmcSuppression};
 
     use super::{
-        acknowledge, acknowledge_unacknowledged, delete, delete_many, find, find_all_by_subsystem,
-        is_suppressed, upsert,
+        acknowledge, acknowledge_unacknowledged, delete, delete_many, delete_many_with_reason,
+        ensure_present, find, find_all_by_subsystem, find_many, is_suppressed, upsert,
     };
 
     const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
@@ -413,6 +499,116 @@ mod tests {
         .await
         .unwrap();
         assert!(recreated.acknowledged_at.is_none());
+    }
+
+    #[crate::sqlx_test]
+    async fn ensure_present_preserves_an_existing_request(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        // An operator decommissioning request already exists and is acknowledged.
+        upsert(
+            txn.as_mut(),
+            &upsert_input(1, SITE_EXPLORER, "decommissioning"),
+        )
+        .await
+        .unwrap();
+        assert!(
+            acknowledge(txn.as_mut(), mac(1), SITE_EXPLORER)
+                .await
+                .unwrap()
+        );
+        let operator = find(txn.as_mut(), mac(1), SITE_EXPLORER)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // A rotation-owned ensure must not clobber reason or acknowledgement.
+        let ensured = ensure_present(
+            txn.as_mut(),
+            &upsert_input(1, SITE_EXPLORER, "bmc_credential_rotation"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(ensured, operator);
+        assert_eq!(ensured.reason, "decommissioning");
+        assert!(ensured.acknowledged_at.is_some());
+
+        // When absent, ensure_present inserts with the supplied reason.
+        let created = ensure_present(
+            txn.as_mut(),
+            &upsert_input(2, SITE_EXPLORER, "bmc_credential_rotation"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(created.reason, "bmc_credential_rotation");
+        assert!(created.acknowledged_at.is_none());
+    }
+
+    #[crate::sqlx_test]
+    async fn find_many_returns_selected_rows(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        for (last, subsystem) in [(1, SITE_EXPLORER), (2, SITE_EXPLORER), (3, DHCP)] {
+            upsert(txn.as_mut(), &upsert_input(last, subsystem, "reason"))
+                .await
+                .unwrap();
+        }
+
+        let found = find_many(txn.as_mut(), &[mac(1), mac(2), mac(3)], SITE_EXPLORER)
+            .await
+            .unwrap();
+        assert_eq!(
+            found
+                .iter()
+                .map(|suppression| suppression.bmc_mac_address)
+                .collect::<Vec<_>>(),
+            vec![mac(1), mac(2)],
+        );
+        assert!(found.iter().all(|s| s.acknowledged_at.is_none()));
+    }
+
+    #[crate::sqlx_test]
+    async fn delete_many_with_reason_only_removes_matching_rows(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        // mac(1): operator-owned; mac(2) and mac(3): rotation-owned.
+        upsert(
+            txn.as_mut(),
+            &upsert_input(1, SITE_EXPLORER, "decommissioning"),
+        )
+        .await
+        .unwrap();
+        for last in [2, 3] {
+            ensure_present(
+                txn.as_mut(),
+                &upsert_input(last, SITE_EXPLORER, "bmc_credential_rotation"),
+            )
+            .await
+            .unwrap();
+        }
+
+        let removed = delete_many_with_reason(
+            txn.as_mut(),
+            &[mac(1), mac(2), mac(3)],
+            SITE_EXPLORER,
+            "bmc_credential_rotation",
+        )
+        .await
+        .unwrap();
+        assert_eq!(removed, 2);
+
+        // Operator request survives; rotation requests are gone.
+        assert!(
+            find(txn.as_mut(), mac(1), SITE_EXPLORER)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            find_many(txn.as_mut(), &[mac(2), mac(3)], SITE_EXPLORER)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[crate::sqlx_test]

--- a/crates/api-model/src/machine/slas.rs
+++ b/crates/api-model/src/machine/slas.rs
@@ -64,8 +64,10 @@ pub const VALIDATION: Duration = Duration::from_secs(30 * 60);
 pub const MAINTENANCE: Duration = Duration::from_secs(5 * 60);
 
 // BMC credential rotation. A single synchronous Redfish password change
-// per device (host + each DPU); generous enough to absorb a slow BMC plus the
-// engine's short per-device backoff without tripping the SLA on the first retry.
+// per device (host + each DPU); generous enough to absorb the up-to-5-minute
+// site-explorer pause handshake (its `SITE_EXPLORER_PAUSE_BUDGET`) that precedes
+// the change, a slow BMC, and the engine's short per-device backoff without
+// tripping the SLA on the first retry.
 pub const ROTATING_BMC: Duration = Duration::from_secs(15 * 60);
 
 // Host UEFI credential rotation. Applying a new UEFI password

--- a/crates/api-model/src/power_shelf/slas.rs
+++ b/crates/api-model/src/power_shelf/slas.rs
@@ -37,8 +37,10 @@ pub(super) const DELETING: u64 = 300; // 5 minutes
 pub(super) const MAINTENANCE: u64 = 300; // 5 minutes
 
 /// SLA for PowerShelf BMC (PMC) credential rotation in seconds. Generous enough
-/// to absorb a slow BMC plus the rotation engine's short per-device backoff
-/// without tripping the SLA on the first retry.
+/// to absorb the up-to-5-minute site-explorer pause handshake (its
+/// `SITE_EXPLORER_PAUSE_BUDGET`) that precedes the change, a slow BMC, and the
+/// rotation engine's short per-device backoff without tripping the SLA on the
+/// first retry.
 pub(super) const ROTATING_BMC: u64 = 15 * 60; // 15 minutes
 
 /// SLA for PowerShelf rack-level reprovisioning (firmware wait) in seconds

--- a/crates/api-model/src/switch/slas.rs
+++ b/crates/api-model/src/switch/slas.rs
@@ -40,6 +40,8 @@ pub(super) const DELETING: u64 = 300; // 5 minutes
 pub(super) const MAINTENANCE: u64 = 300; // 5 minutes
 
 /// SLA for Switch BMC credential rotation in seconds. Generous enough to absorb
-/// a slow BMC plus the rotation engine's short per-device backoff without
-/// tripping the SLA on the first retry.
+/// the up-to-5-minute site-explorer pause handshake (its
+/// `SITE_EXPLORER_PAUSE_BUDGET`) that precedes the change, a slow BMC, and the
+/// rotation engine's short per-device backoff without tripping the SLA on the
+/// first retry.
 pub(super) const ROTATING_BMC: u64 = 15 * 60; // 15 minutes

--- a/crates/credential-rotation/src/lib.rs
+++ b/crates/credential-rotation/src/lib.rs
@@ -221,10 +221,24 @@ pub enum RotateOutcome {
     /// The device is at the target version (just rotated, or already there).
     /// The controller transitions back to its steady (`Ready`) state.
     Converged,
-    /// The attempt failed; a backoff window was recorded. The controller
-    /// returns to steady state and its entry guard skips this device (it reads
-    /// as `quarantined`) until `until` passes.
+    /// The attempt failed *before* the hardware password changed (or the change
+    /// itself failed), so the stored per-device secret still authenticates the
+    /// BMC. A backoff window was recorded. The controller returns to steady
+    /// state and its entry guard skips this device (it reads as `quarantined`)
+    /// until `until` passes.
     Quarantined { until: DateTime<Utc> },
+    /// The BMC reached the rotate-to password but persisting the new per-device
+    /// secret to the credential store failed: the hardware is AHEAD of the
+    /// store (the BMC is on the new password while the store still serves the
+    /// old one). The device is intentionally left **not quarantined and not
+    /// converged**, so it keeps reading as `needs_rotation` and the engine's
+    /// change-then-verify recovery re-persists and converges on a later tick.
+    ///
+    /// The controller must **remain in its rotation state** (keeping the device
+    /// suppressed from site-explorer and out of the allocatable pool) and
+    /// re-tick until the store write succeeds -- reconciliation is retried every
+    /// sweep rather than backed off, and is never abandoned.
+    CredentialStoreReconcilePending,
     /// Nothing to do: no rotation row for this device (not under management, or
     /// the row was torn down). The controller transitions back without acting.
     NoWork,
@@ -412,6 +426,34 @@ pub enum BmcRotationTick {
     /// At least one device hit a transient bookkeeping failure. The controller
     /// should retry the tick, bounded by the state's retry budget.
     Retry,
+    /// At least one device changed its hardware password but the credential
+    /// store persist has not yet succeeded (hardware ahead of the stored
+    /// secret). The controller must **remain** in its rotation state -- keeping
+    /// the device suppressed and out of the allocatable pool -- and wait; a
+    /// later tick's change-then-verify recovery re-persists and converges once
+    /// the store write succeeds. Dominates `Retry` and `Settled` (see
+    /// [`BmcRotationTick::merge`]) so a mixed multi-device tick never leaves the
+    /// rotation state while any device's hardware is ahead of its store.
+    WaitForCredentialStoreReconcile,
+}
+
+impl BmcRotationTick {
+    /// Fold two device outcomes into one tick outcome, strongest wins:
+    /// `WaitForCredentialStoreReconcile` > `Retry` > `Settled`. Holding for a lagging store
+    /// dominates a transient retry so the bounded transient budget can never
+    /// `GaveUp` out of the rotation state (returning the device to an
+    /// allocatable, un-suppressed steady state) while a device's hardware is
+    /// ahead of its stored secret.
+    pub fn merge(self, other: Self) -> Self {
+        use BmcRotationTick::*;
+        match (self, other) {
+            (WaitForCredentialStoreReconcile, _) | (_, WaitForCredentialStoreReconcile) => {
+                WaitForCredentialStoreReconcile
+            }
+            (Retry, _) | (_, Retry) => Retry,
+            (Settled, Settled) => Settled,
+        }
+    }
 }
 
 /// What a state controller should do after one BMC-rotation tick, independent of
@@ -435,6 +477,14 @@ pub enum RotationStep {
     GaveUp,
     /// Re-enter the rotation state carrying this incremented retry count.
     Retry { retry_count: u32 },
+    /// A device's hardware is ahead of its stored secret (the credential-store
+    /// persist is still pending): **remain** in the rotation state and wait for
+    /// a later tick to reconcile the store. Unlike `Retry` this does *not*
+    /// consume the transient-retry budget -- it is a legitimate hold, not a
+    /// bookkeeping error -- and unlike `Settled`/`GaveUp` it must not resume
+    /// site-explorer or clear a force request, so the device stays suppressed
+    /// and non-allocatable until the store write succeeds.
+    WaitForCredentialStoreReconcile,
 }
 
 /// Fold one tick outcome and the current retry count into the next
@@ -451,6 +501,12 @@ pub fn advance(
 ) -> RotationStep {
     match tick {
         BmcRotationTick::Settled => RotationStep::Settled,
+        // A store-reconcile hold is budget-neutral: it is a legitimate wait for
+        // the credential store, not a transient bookkeeping error, so it neither
+        // advances nor exhausts the retry count.
+        BmcRotationTick::WaitForCredentialStoreReconcile => {
+            RotationStep::WaitForCredentialStoreReconcile
+        }
         BmcRotationTick::Retry => {
             let next = retry_count + 1;
             if next >= MAX_BMC_ROTATION_RETRIES {
@@ -519,6 +575,57 @@ mod retry_seam_tests {
                 OBJECT_ID
             ),
             RotationStep::GaveUp
+        ));
+    }
+
+    #[test]
+    fn advance_holds_for_store_reconcile_without_consuming_budget() {
+        // A store-reconcile hold is budget-neutral: it maps straight to
+        // `WaitForCredentialStoreReconcile` regardless of retry count, so waiting for the
+        // credential store never exhausts the transient-retry budget and can
+        // never `GaveUp` out of the rotation state (which would return the device
+        // to an allocatable, un-suppressed steady state while its hardware is
+        // ahead of the store).
+        for count in [0, MAX_BMC_ROTATION_RETRIES - 1, MAX_BMC_ROTATION_RETRIES] {
+            assert!(matches!(
+                advance(
+                    BmcRotationTick::WaitForCredentialStoreReconcile,
+                    count,
+                    OBJECT_ID
+                ),
+                RotationStep::WaitForCredentialStoreReconcile
+            ));
+        }
+    }
+
+    #[test]
+    fn merge_folds_device_outcomes_strongest_wins() {
+        use BmcRotationTick::*;
+        // WaitForCredentialStoreReconcile dominates everything so a mixed multi-device tick
+        // holds; Retry dominates Settled; Settled only survives when both are.
+        assert!(matches!(Settled.merge(Settled), Settled));
+        assert!(matches!(Settled.merge(Retry), Retry));
+        assert!(matches!(Retry.merge(Settled), Retry));
+        assert!(matches!(Retry.merge(Retry), Retry));
+        assert!(matches!(
+            Settled.merge(WaitForCredentialStoreReconcile),
+            WaitForCredentialStoreReconcile
+        ));
+        assert!(matches!(
+            WaitForCredentialStoreReconcile.merge(Settled),
+            WaitForCredentialStoreReconcile
+        ));
+        assert!(matches!(
+            Retry.merge(WaitForCredentialStoreReconcile),
+            WaitForCredentialStoreReconcile
+        ));
+        assert!(matches!(
+            WaitForCredentialStoreReconcile.merge(Retry),
+            WaitForCredentialStoreReconcile
+        ));
+        assert!(matches!(
+            WaitForCredentialStoreReconcile.merge(WaitForCredentialStoreReconcile),
+            WaitForCredentialStoreReconcile
         ));
     }
 }
@@ -746,7 +853,7 @@ pub async fn rotate_bmc(
             }
             Ok(RotateOutcome::Converged)
         }
-        Err(redacted) => {
+        Err(ConvergeError::DeviceFault(redacted)) => {
             let until = backoff_until(status.rotate_attempts, Utc::now());
             let mut conn = db_pool.acquire().await?;
             increment_rotate_attempt(&mut conn, mac, BMC, &redacted, until).await?;
@@ -756,6 +863,26 @@ pub async fn rotate_bmc(
                 redacted,
             ));
             Ok(RotateOutcome::Quarantined { until })
+        }
+        // The hardware reached the target but the store write failed: the BMC is
+        // ahead of the stored secret. Deliberately record *no* backoff and leave
+        // the row not-converged / not-quarantined, so it keeps reading as
+        // `needs_rotation` and the change-then-verify recovery re-persists on a
+        // later tick. The crash marker stays set (we never promoted). The
+        // controller holds in its rotation state until the store reconciles, so
+        // reconciliation is retried every sweep and never abandoned.
+        Err(ConvergeError::CredentialStoreWriteFailed(redacted)) => {
+            // A transient hold, not a terminal result: a plain log rather than a
+            // metric series. The device keeps reading as `needs_rotation`, so the
+            // retry is observable through the existing rotation-state gauges; a
+            // dedicated counter can follow if operators need to trend it.
+            tracing::warn!(
+                %mac,
+                target_version,
+                error = %redacted,
+                "BMC reached the rotate-to password but persisting the new per-device secret failed; holding rotation until the credential store reconciles"
+            );
+            Ok(RotateOutcome::CredentialStoreReconcilePending)
         }
     }
 }
@@ -770,6 +897,33 @@ enum CredentialConvergence {
     /// attempt changed the hardware and crashed before recording success, and
     /// this tick reconciled it. Carries the (redacted) change error for context.
     Recovered { change_error: String },
+}
+
+/// Where a convergence attempt failed, so the caller can tell a *device* fault
+/// (quarantine + backoff; the stored secret still authenticates the BMC) from a
+/// credential-store *persist* failure that lands after the hardware already
+/// changed (hardware AHEAD of the store; hold and reconcile rather than
+/// quarantine). Both carry an already-redacted reason.
+#[derive(Debug)]
+enum ConvergeError {
+    /// The attempt failed before (or at) the hardware change: the stored
+    /// per-device secret still authenticates the BMC, so the device is safe to
+    /// return to steady state after a backoff.
+    DeviceFault(String),
+    /// The hardware reached the rotate-to password but persisting the new
+    /// per-device secret to the credential store failed: the BMC is on the new
+    /// password while the store still serves the old one.
+    CredentialStoreWriteFailed(String),
+}
+
+/// Every pre-persist failure in [`converge_bmc_password`] is a device fault: the
+/// hardware has not (confirmed) moved, so the stored secret is still
+/// authoritative. Only the final store write is special-cased to
+/// [`ConvergeError::CredentialStoreWriteFailed`] explicitly.
+impl From<String> for ConvergeError {
+    fn from(reason: String) -> Self {
+        Self::DeviceFault(reason)
+    }
 }
 
 impl CredentialConvergence {
@@ -795,7 +949,7 @@ async fn converge_bmc_password(
     redfish_pool: &dyn RedfishClientPool,
     bmc: &BmcRotationTarget,
     rotate_to_version: u32,
-) -> Result<CredentialConvergence, String> {
+) -> Result<CredentialConvergence, ConvergeError> {
     let per_device_key = CredentialKey::BmcCredentials {
         credential_type: BmcCredentialType::BmcRoot {
             bmc_mac_address: bmc.device_mac,
@@ -859,10 +1013,15 @@ async fn converge_bmc_password(
         .set_credentials(&per_device_key, &updated)
         .await
         .map_err(|e| {
-            redact(
+            // This is the one failure that leaves the hardware ahead of the
+            // store: the password change already succeeded above, so a failed
+            // persist means the BMC is on the new password while the store still
+            // serves the old one. Surface it distinctly so the caller holds and
+            // reconciles instead of quarantining.
+            ConvergeError::CredentialStoreWriteFailed(redact(
                 format!("persist per-device BMC secret: {e}"),
                 &[&current_password, &new_password],
-            )
+            ))
         })?;
 
     Ok(convergence)
@@ -1513,6 +1672,100 @@ mod tests {
         assert!(
             bmc_accepts(&redfish, "new").await,
             "the BMC must now be on the rotate-TO password"
+        );
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn rotate_bmc_holds_for_store_reconcile_when_persist_fails_then_converges(pool: PgPool) {
+        // Fault-injection: the BMC accepts the new password but persisting the
+        // new per-device secret to the store fails. The hardware is now AHEAD of
+        // the store.  The engine must NOT quarantine: it reports `CredentialStoreReconcilePending`,
+        // leaves the row not-converged / not-quarantined (so it keeps reading as
+        // `needs_rotation`), and the stored secret still lags. A later tick with
+        // the store writable then recovers (the rotate-to value already authenticates)
+        // and converges, reconciling the store -- reconciliation is never abandoned.
+        seed_device_behind_target(&pool, 1).await;
+        let cm = TestCredentialManager::default();
+        cm.set_credentials(&per_device_key(), &creds("root", "old"))
+            .await
+            .unwrap();
+        cm.set_credentials(&rotate_to_key(1), &creds("root", "new"))
+            .await
+            .unwrap();
+        // The BMC is on the per-device secret ("old"), so the hardware change
+        // old -> new succeeds; only the store write is made to fail.
+        let redfish = bmc_on_password("old");
+        cm.set_set_credentials_failure(true);
+
+        let outcome = rotate_bmc(&pool, &cm, &redfish, &target(), false)
+            .await
+            .expect("a store-persist failure is not a transient engine error");
+
+        assert_eq!(
+            outcome,
+            RotateOutcome::CredentialStoreReconcilePending,
+            "a persist failure after the hardware changed must hold for reconcile, not quarantine"
+        );
+
+        let status = status_of(&pool).await;
+        assert!(
+            !status.converged,
+            "hardware ahead of store is not converged"
+        );
+        assert!(
+            !status.quarantined,
+            "a persist failure must NOT record a backoff; the device stays eligible so the persist is retried every sweep"
+        );
+        assert_eq!(
+            status.current_version,
+            Some(0),
+            "the convergence marker must not advance while the store lags"
+        );
+        assert_eq!(
+            status.rotating_to_version,
+            Some(1),
+            "the crash marker stays set (we never promoted) so recovery re-enters"
+        );
+        // Hardware is on the new password, but the stored secret still lags.
+        assert!(
+            bmc_accepts(&redfish, "new").await,
+            "the hardware change must have landed even though the persist failed"
+        );
+        assert_eq!(
+            cm.get_credentials(&per_device_key())
+                .await
+                .unwrap()
+                .unwrap(),
+            creds("root", "old"),
+            "the stored secret must still lag after the failed persist"
+        );
+
+        // The store becomes writable again: the next tick's change-then-verify
+        // recovery re-persists and converges, reconciling hardware and store.
+        cm.set_set_credentials_failure(false);
+        let metrics = MetricsCapture::start();
+        let outcome = rotate_bmc(&pool, &cm, &redfish, &target(), false)
+            .await
+            .expect("the reconciling tick must not raise a transient engine error");
+
+        assert_eq!(outcome, RotateOutcome::Converged);
+        assert_eq!(
+            rotation_result_deltas(&metrics),
+            [0.0, 1.0, 0.0],
+            "reconciling an already-changed BMC counts as a recovery"
+        );
+        drop(metrics);
+        let status = status_of(&pool).await;
+        assert!(status.converged);
+        assert_eq!(status.current_version, Some(1));
+        assert_eq!(status.rotating_to_version, None);
+        assert_eq!(
+            cm.get_credentials(&per_device_key())
+                .await
+                .unwrap()
+                .unwrap(),
+            creds("root", "new"),
+            "the store is reconciled to the new password once the write succeeds"
         );
     }
 

--- a/crates/credential-rotation/src/lib.rs
+++ b/crates/credential-rotation/src/lib.rs
@@ -101,6 +101,8 @@ use model::power_shelf::PowerShelf;
 use model::switch::Switch;
 use sqlx::PgPool;
 
+pub mod site_explorer_pause;
+
 /// All work in this crate is the `bmc` credential family.
 const BMC: CredentialRotationType = CredentialRotationType::Bmc;
 

--- a/crates/credential-rotation/src/site_explorer_pause.rs
+++ b/crates/credential-rotation/src/site_explorer_pause.rs
@@ -1,0 +1,268 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Pause site-explorer probing of a BMC while its credentials are rotated.
+//!
+//! Site-explorer authenticates BMCs directly and, on a 401, persists a sticky
+//! `Unauthorized` latch (`AvoidLockout`) in `explored_endpoints` that blocks
+//! allocations and never self-heals. During rotation there is a window where the
+//! hardware carries the new password but Vault still has the old one; a probe in
+//! that window 401s and latches.
+//!
+//! To close that window, a controller records a
+//! [`BmcSuppressionSubsystem::SiteExplorer`] suppression for the BMC MAC and
+//! waits until site-explorer has *acknowledged* it before changing any
+//! credential. Site-explorer stamps `acknowledged_at` only after it has claimed
+//! the endpoint idle at the top of its single-flight iteration, so an
+//! acknowledged suppression is an exact "site-explorer has observed this, no
+//! probe is in flight, and every future probe skips this MAC" barrier. With the
+//! probe held off, no latch can form, so nothing needs to be cleared on the
+//! happy path; the controller simply deletes its suppression when it returns to
+//! a steady state.
+//!
+//! This module is state-machine-neutral so the machine-, switch-, and
+//! power-shelf-controllers share one implementation. The whole gate is
+//! re-derived from the suppression row each tick (its `requested_at` is the
+//! wait-budget clock and its `acknowledged_at` is the barrier), so callers need
+//! no new persisted sub-state.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use db::DatabaseError;
+use mac_address::MacAddress;
+use model::bmc_suppression::{BmcSuppressionSubsystem, NewBmcSuppression};
+use sqlx::{PgConnection, PgPool};
+
+/// The `reason` stamped on suppressions this module owns. Deletes are scoped to
+/// it so a rotation never removes an operator's (differently-reasoned)
+/// suppression for the same BMC.
+pub const ROTATION_SUPPRESSION_REASON: &str = "bmc_credential_rotation";
+
+/// How long a controller waits for site-explorer to acknowledge the suppression
+/// before proceeding anyway.
+///
+/// The wait normally resolves within one site-explorer iteration. The budget is
+/// a backstop for a disabled or unavailable site-explorer, which can never
+/// acknowledge and also can never latch -- so proceeding after the budget is
+/// safe. It is deliberately several site-explorer run intervals long so a busy
+/// or briefly-contended explorer is never cut short.
+pub const SITE_EXPLORER_PAUSE_BUDGET: Duration = Duration::from_secs(300);
+
+/// Whether the caller may change credentials now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateDecision {
+    /// Site-explorer has acknowledged the suppression (or the wait budget is
+    /// exhausted): the caller may proceed with the rotation this tick.
+    Proceed,
+    /// Site-explorer has not yet acknowledged the suppression and the budget
+    /// remains: the caller must wait and re-check on a later sweep.
+    Wait,
+}
+
+/// Ensure every in-scope BMC MAC is suppressed for site-explorer and report
+/// whether it is safe to change credentials this tick.
+///
+/// Idempotent: re-running each tick preserves an existing suppression (including
+/// an operator's, whose `reason` is never overwritten) and its timestamps. An
+/// empty `macs` (nothing addressable to rotate) is always [`GateDecision::Proceed`].
+pub async fn gate_before_rotation(
+    pool: &PgPool,
+    macs: &[MacAddress],
+) -> Result<GateDecision, DatabaseError> {
+    if macs.is_empty() {
+        return Ok(GateDecision::Proceed);
+    }
+
+    let mut txn = pool
+        .begin()
+        .await
+        .map_err(|e| DatabaseError::query("begin bmc rotation gate transaction", e))?;
+    for mac in macs {
+        db::bmc_suppression::ensure_present(
+            &mut txn,
+            &NewBmcSuppression {
+                bmc_mac_address: *mac,
+                subsystem: BmcSuppressionSubsystem::SiteExplorer,
+                reason: ROTATION_SUPPRESSION_REASON.to_string(),
+            },
+        )
+        .await?;
+    }
+    let rows =
+        db::bmc_suppression::find_many(&mut *txn, macs, BmcSuppressionSubsystem::SiteExplorer)
+            .await?;
+    txn.commit()
+        .await
+        .map_err(|e| DatabaseError::query("commit bmc rotation gate transaction", e))?;
+
+    let all_acknowledged = macs.iter().all(|mac| {
+        rows.iter()
+            .any(|row| row.bmc_mac_address == *mac && row.acknowledged_at.is_some())
+    });
+    if all_acknowledged {
+        return Ok(GateDecision::Proceed);
+    }
+
+    // Escape hatch for a disabled/unavailable site-explorer that will never
+    // acknowledge: proceed once every still-unacknowledged suppression has itself
+    // outlived the pause budget. Measured as the *newest* unacknowledged
+    // `requested_at` -- once that has aged past the budget, so has every older
+    // one. Acknowledged rows are excluded so an operator suppression with a
+    // days-old `requested_at` (already acknowledged) cannot short-circuit the
+    // wait for a freshly inserted, still-unacknowledged rotation suppression.
+    let newest_unacknowledged = rows
+        .iter()
+        .filter(|row| row.acknowledged_at.is_none())
+        .map(|row| row.requested_at)
+        .max();
+    if let Some(newest_unacknowledged) = newest_unacknowledged {
+        let waited = Utc::now().signed_duration_since(newest_unacknowledged);
+        let budget = chrono::Duration::from_std(SITE_EXPLORER_PAUSE_BUDGET)
+            .expect("SITE_EXPLORER_PAUSE_BUDGET fits in chrono::Duration");
+        if waited > budget {
+            tracing::warn!(
+                waited_secs = waited.num_seconds(),
+                "proceeding with BMC rotation without site-explorer acknowledgement: pause \
+                 budget exceeded (site-explorer disabled or unavailable?)"
+            );
+            return Ok(GateDecision::Proceed);
+        }
+    }
+
+    Ok(GateDecision::Wait)
+}
+
+/// Delete the suppressions this module created for `macs`, releasing
+/// site-explorer to resume probing.
+///
+/// Reason-scoped, so an operator suppression for the same BMC is left intact.
+/// The delete is issued on the caller's transaction so it commits atomically
+/// with the state transition that ends the rotation.
+pub async fn resume_after_rotation(
+    txn: &mut PgConnection,
+    macs: &[MacAddress],
+) -> Result<(), DatabaseError> {
+    if macs.is_empty() {
+        return Ok(());
+    }
+    db::bmc_suppression::delete_many_with_reason(
+        txn,
+        macs,
+        BmcSuppressionSubsystem::SiteExplorer,
+        ROTATION_SUPPRESSION_REASON,
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use mac_address::MacAddress;
+    use model::bmc_suppression::{BmcSuppressionSubsystem, NewBmcSuppression};
+    use sqlx::PgPool;
+
+    use super::{GateDecision, gate_before_rotation, resume_after_rotation};
+
+    const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
+
+    fn mac(last: u8) -> MacAddress {
+        MacAddress::new([0x02, 0, 0, 0, 0, last])
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn an_empty_scope_proceeds(pool: PgPool) {
+        assert_eq!(
+            gate_before_rotation(&pool, &[]).await.unwrap(),
+            GateDecision::Proceed
+        );
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn waits_until_every_mac_is_acknowledged(pool: PgPool) {
+        let macs = [mac(1), mac(2)];
+
+        // First pass records the suppressions; nothing is acknowledged yet.
+        assert_eq!(
+            gate_before_rotation(&pool, &macs).await.unwrap(),
+            GateDecision::Wait
+        );
+
+        // Acknowledging only one leaves the gate waiting.
+        let mut txn = pool.begin().await.unwrap();
+        assert!(
+            db::bmc_suppression::acknowledge(&mut txn, mac(1), SITE_EXPLORER)
+                .await
+                .unwrap()
+        );
+        txn.commit().await.unwrap();
+        assert_eq!(
+            gate_before_rotation(&pool, &macs).await.unwrap(),
+            GateDecision::Wait
+        );
+
+        // Once site-explorer has acknowledged both, the gate proceeds.
+        let mut txn = pool.begin().await.unwrap();
+        assert!(
+            db::bmc_suppression::acknowledge(&mut txn, mac(2), SITE_EXPLORER)
+                .await
+                .unwrap()
+        );
+        txn.commit().await.unwrap();
+        assert_eq!(
+            gate_before_rotation(&pool, &macs).await.unwrap(),
+            GateDecision::Proceed
+        );
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn resume_removes_only_rotation_owned_suppressions(pool: PgPool) {
+        // Rotation owns mac(1); an operator owns mac(2).
+        gate_before_rotation(&pool, &[mac(1)]).await.unwrap();
+        let mut txn = pool.begin().await.unwrap();
+        db::bmc_suppression::upsert(
+            &mut txn,
+            &NewBmcSuppression {
+                bmc_mac_address: mac(2),
+                subsystem: SITE_EXPLORER,
+                reason: "decommissioning".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        txn.commit().await.unwrap();
+
+        let mut txn = pool.begin().await.unwrap();
+        resume_after_rotation(&mut txn, &[mac(1), mac(2)])
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        assert!(
+            db::bmc_suppression::find(&pool, mac(1), SITE_EXPLORER)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            db::bmc_suppression::find(&pool, mac(2), SITE_EXPLORER)
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+}

--- a/crates/credential-rotation/src/site_explorer_pause.rs
+++ b/crates/credential-rotation/src/site_explorer_pause.rs
@@ -178,8 +178,6 @@ mod tests {
 
     use super::{GateDecision, gate_before_rotation, resume_after_rotation};
 
-    const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
-
     fn mac(last: u8) -> MacAddress {
         MacAddress::new([0x02, 0, 0, 0, 0, last])
     }
@@ -205,9 +203,13 @@ mod tests {
         // Acknowledging only one leaves the gate waiting.
         let mut txn = pool.begin().await.unwrap();
         assert!(
-            db::bmc_suppression::acknowledge(&mut txn, mac(1), SITE_EXPLORER)
-                .await
-                .unwrap()
+            db::bmc_suppression::acknowledge(
+                &mut txn,
+                mac(1),
+                BmcSuppressionSubsystem::SiteExplorer
+            )
+            .await
+            .unwrap()
         );
         txn.commit().await.unwrap();
         assert_eq!(
@@ -218,9 +220,13 @@ mod tests {
         // Once site-explorer has acknowledged both, the gate proceeds.
         let mut txn = pool.begin().await.unwrap();
         assert!(
-            db::bmc_suppression::acknowledge(&mut txn, mac(2), SITE_EXPLORER)
-                .await
-                .unwrap()
+            db::bmc_suppression::acknowledge(
+                &mut txn,
+                mac(2),
+                BmcSuppressionSubsystem::SiteExplorer
+            )
+            .await
+            .unwrap()
         );
         txn.commit().await.unwrap();
         assert_eq!(
@@ -238,7 +244,7 @@ mod tests {
             &mut txn,
             &NewBmcSuppression {
                 bmc_mac_address: mac(2),
-                subsystem: SITE_EXPLORER,
+                subsystem: BmcSuppressionSubsystem::SiteExplorer,
                 reason: "decommissioning".to_string(),
             },
         )
@@ -253,13 +259,13 @@ mod tests {
         txn.commit().await.unwrap();
 
         assert!(
-            db::bmc_suppression::find(&pool, mac(1), SITE_EXPLORER)
+            db::bmc_suppression::find(&pool, mac(1), BmcSuppressionSubsystem::SiteExplorer)
                 .await
                 .unwrap()
                 .is_none()
         );
         assert!(
-            db::bmc_suppression::find(&pool, mac(2), SITE_EXPLORER)
+            db::bmc_suppression::find(&pool, mac(2), BmcSuppressionSubsystem::SiteExplorer)
                 .await
                 .unwrap()
                 .is_some()

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1180,6 +1180,21 @@ impl MachineStateHandler {
                 // enabled, any lagging host or DPU BMC -- handled together.
                 let tick = rotation::rotate_managed_host_bmcs(ctx.services, mh_snapshot).await;
                 match advance(tick, *retry_count, host_machine_id) {
+                    // A BMC changed its hardware password but the per-device
+                    // secret persist has not yet succeeded: hold in RotatingBmc
+                    // (site-explorer stays suppressed, and the `Ready`-only
+                    // allocation gate keeps the host non-allocatable) and re-tick.
+                    // Do NOT resume site-explorer and do NOT clear a force
+                    // request -- the rotation has not finished. The engine leaves
+                    // the device `needs_rotation`, so a later tick's
+                    // change-then-verify recovery re-persists and converges; the
+                    // hold's upper bound is the state's time-in-state SLA.
+                    RotationStep::WaitForCredentialStoreReconcile => Ok(StateHandlerOutcome::wait(
+                        "BMC hardware changed but the per-device secret persist has not yet \
+                         succeeded; holding rotation (site-explorer suppressed, host \
+                         non-allocatable) until the credential store reconciles"
+                            .to_string(),
+                    )),
                     step @ (RotationStep::Settled | RotationStep::GaveUp) => {
                         // Both terminal steps return to Ready. Only a settled tick
                         // clears a one-shot force request: the forced attempt

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -26,6 +26,7 @@ use std::sync::{Arc, Mutex};
 use attestation::{
     handle_spdm_attestation_failed_recovery, handle_spdm_poll_state, handle_spdm_trigger_state,
 };
+use carbide_credential_rotation::site_explorer_pause::{self, GateDecision};
 use carbide_credential_rotation::{RotationStep, advance};
 use carbide_firmware::{FirmwareConfig, FirmwareConfigSnapshot, FirmwareDownloader};
 use carbide_redfish::boot_interface::BootInterfaceTarget;
@@ -1156,6 +1157,24 @@ impl MachineStateHandler {
             }
 
             ManagedHostState::RotatingBmc { retry_count } => {
+                // Hold site-explorer off every BMC of this managed host and wait
+                // until it has acknowledged, before changing any credential. This
+                // closes the window in which a probe could hit new-hardware /
+                // old-Vault and persist the sticky `AvoidLockout` latch.
+                let bmc_macs: Vec<_> = rotation::managed_host_bmc_endpoints(mh_snapshot)
+                    .map(|e| e.device_mac)
+                    .collect();
+                if matches!(
+                    site_explorer_pause::gate_before_rotation(&ctx.services.db_pool, &bmc_macs)
+                        .await?,
+                    GateDecision::Wait
+                ) {
+                    return Ok(StateHandlerOutcome::wait(
+                        "waiting for site-explorer to acknowledge the BMC rotation suppression"
+                            .to_string(),
+                    ));
+                }
+
                 // One tick converges every BMC that needs work: force-requested
                 // devices (bypassing backoff) and, when site-wide rotation is
                 // enabled, any lagging host or DPU BMC -- handled together.
@@ -1171,13 +1190,16 @@ impl MachineStateHandler {
                         // attempt cleanly running, so we leave the flag set and let
                         // the entry guard re-attempt on a later sweep rather than
                         // silently drop the operator's request.
-                        let mut txn = None;
+                        // Resume site-explorer atomically with the return to Ready,
+                        // so its skip window ends exactly when the rotation does; a
+                        // settled tick also clears the one-shot force flag in the same
+                        // transaction.
+                        let mut txn = ctx.services.db_pool.begin().await?;
                         if matches!(step, RotationStep::Settled) {
-                            txn = rotation::clear_forced_bmc_requests(ctx.services, mh_snapshot)
-                                .await?;
+                            rotation::clear_forced_bmc_requests(&mut txn, mh_snapshot).await?;
                         }
-                        Ok(StateHandlerOutcome::transition(ManagedHostState::Ready)
-                            .with_txn_opt(txn))
+                        site_explorer_pause::resume_after_rotation(&mut txn, &bmc_macs).await?;
+                        Ok(StateHandlerOutcome::transition(ManagedHostState::Ready).with_txn(txn))
                     }
                     RotationStep::Retry { retry_count } => Ok(StateHandlerOutcome::transition(
                         ManagedHostState::RotatingBmc { retry_count },

--- a/crates/machine-controller/src/handler/rotation.rs
+++ b/crates/machine-controller/src/handler/rotation.rs
@@ -37,7 +37,7 @@
 use carbide_credential_rotation::{BmcEndpoint, BmcRotationTick, RotateOutcome, rotate_bmc};
 use carbide_uuid::machine::MachineId;
 use model::machine::{Machine, ManagedHostStateSnapshot};
-use sqlx::PgTransaction;
+use sqlx::PgConnection;
 use state_controller::state_handler::StateHandlerError;
 
 use crate::context::MachineStateHandlerServices;
@@ -45,7 +45,12 @@ use crate::context::MachineStateHandlerServices;
 /// The host BMC followed by each DPU BMC that exposes both a MAC and an IP. A
 /// device missing either cannot be keyed or reached, so it is skipped (the
 /// entry guard likewise never selects it).
-fn managed_host_bmc_endpoints(
+///
+/// This is also the set site-explorer is paused on for the duration of a
+/// rotation and resumed on when it ends -- a superset of the devices any single
+/// tick actually rotates, so a force flag that appears mid-rotation is already
+/// covered and the resume set always matches what was suppressed.
+pub(crate) fn managed_host_bmc_endpoints(
     mh: &ManagedHostStateSnapshot,
 ) -> impl Iterator<Item = BmcEndpoint> + '_ {
     std::iter::once(&mh.host_snapshot)
@@ -161,28 +166,22 @@ fn forced_bmc_machine_ids(mh: &ManagedHostStateSnapshot) -> impl Iterator<Item =
 }
 
 /// Clear the one-shot force-converge flag on exactly the machines that carried a
-/// pending request *in this snapshot*, returning the transaction to commit with
-/// the state transition. Returns `None` when nothing was forced, so the common
-/// passive path performs no write.
+/// pending request *in this snapshot*, writing into the caller's transaction so
+/// the clear commits atomically with the state transition.
 ///
 /// Only the observed-forced machines are cleared -- never the whole managed host
 /// -- so a request that lands mid-tick (after this snapshot was read, hence not
 /// acted on this tick) survives for the next sweep instead of being silently
-/// dropped. Call this only on a settled tick, where the forced attempt genuinely
-/// fired.
+/// dropped. When nothing was forced this is a no-op. Call this only on a settled
+/// tick, where the forced attempt genuinely fired.
 pub(crate) async fn clear_forced_bmc_requests(
-    services: &MachineStateHandlerServices,
+    txn: &mut PgConnection,
     mh: &ManagedHostStateSnapshot,
-) -> Result<Option<PgTransaction<'static>>, StateHandlerError> {
-    let mut forced_machine_ids = forced_bmc_machine_ids(mh).peekable();
-    if forced_machine_ids.peek().is_none() {
-        return Ok(None);
+) -> Result<(), StateHandlerError> {
+    for machine_id in forced_bmc_machine_ids(mh) {
+        db::machine::clear_bmc_credential_rotation_requested(&mut *txn, machine_id).await?;
     }
-    let mut txn = services.db_pool.begin().await?;
-    for machine_id in forced_machine_ids {
-        db::machine::clear_bmc_credential_rotation_requested(&mut txn, machine_id).await?;
-    }
-    Ok(Some(txn))
+    Ok(())
 }
 
 /// Rotate a single BMC endpoint toward the staged target. `force` bypasses the

--- a/crates/machine-controller/src/handler/rotation.rs
+++ b/crates/machine-controller/src/handler/rotation.rs
@@ -119,15 +119,13 @@ pub(crate) async fn rotate_managed_host_bmcs(
         }
         match BmcEndpoint::from_machine(machine) {
             Some(endpoint) => {
-                if matches!(
-                    rotate_endpoint(services, endpoint, force).await,
-                    BmcRotationTick::Retry
-                ) {
-                    // One transient bookkeeping failure asks the whole tick to
-                    // retry; the other endpoints still ran, and their per-device
-                    // rows persist.
-                    tick = BmcRotationTick::Retry;
-                }
+                // Fold each device outcome in, strongest wins: a store-reconcile
+                // hold or a transient retry from any one BMC carries the whole
+                // tick (the other endpoints still ran, and their per-device rows
+                // persist). `merge` keeps a lagging store dominant so the tick
+                // never settles out of the rotation state while any BMC's
+                // hardware is ahead of its stored secret.
+                tick = tick.merge(rotate_endpoint(services, endpoint, force).await);
             }
             // A forced request announces a missing BMC so its one-shot flag
             // still clears; a passive sweep silently skips an unaddressable
@@ -218,6 +216,13 @@ async fn rotate_endpoint(
                 "BMC rotation attempt failed; quarantined until backoff elapses"
             );
             BmcRotationTick::Settled
+        }
+        Ok(RotateOutcome::CredentialStoreReconcilePending) => {
+            tracing::warn!(
+                mac = %target.device_mac,
+                "BMC hardware changed but the per-device secret persist failed; holding rotation until the credential store reconciles"
+            );
+            BmcRotationTick::WaitForCredentialStoreReconcile
         }
         Ok(RotateOutcome::NoWork) => BmcRotationTick::Settled,
         Err(e) => {

--- a/crates/machine-controller/tests/integration/bmc_rotation.rs
+++ b/crates/machine-controller/tests/integration/bmc_rotation.rs
@@ -41,7 +41,6 @@ use model::test_support::ManagedHostConfig;
 use crate::env::Env;
 
 const BMC: CredentialRotationType = CredentialRotationType::Bmc;
-const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
 
 /// Stand in for site-explorer acknowledging every pending BMC suppression -- the
 /// barrier the rotation gate waits on before changing a credential. The
@@ -49,16 +48,22 @@ const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExpl
 /// site-explorer ack pass itself.
 async fn ack_all_site_explorer_suppressions(pool: &PgPool) {
     let mut conn = pool.acquire().await.expect("acquire connection");
-    let macs: Vec<MacAddress> =
-        db::bmc_suppression::find_all_by_subsystem(&mut *conn, SITE_EXPLORER)
-            .await
-            .expect("read suppressions")
-            .into_iter()
-            .map(|s| s.bmc_mac_address)
-            .collect();
-    db::bmc_suppression::acknowledge_unacknowledged(&mut conn, &macs, SITE_EXPLORER)
-        .await
-        .expect("acknowledge suppressions");
+    let macs: Vec<MacAddress> = db::bmc_suppression::find_all_by_subsystem(
+        &mut *conn,
+        BmcSuppressionSubsystem::SiteExplorer,
+    )
+    .await
+    .expect("read suppressions")
+    .into_iter()
+    .map(|s| s.bmc_mac_address)
+    .collect();
+    db::bmc_suppression::acknowledge_unacknowledged(
+        &mut conn,
+        &macs,
+        BmcSuppressionSubsystem::SiteExplorer,
+    )
+    .await
+    .expect("acknowledge suppressions");
 }
 
 fn per_device_key(mac: MacAddress) -> CredentialKey {
@@ -180,7 +185,8 @@ async fn ready_host_converges_bmc_to_site_target(
         mh.host.machine().await.state.value,
     );
     assert!(
-        db::bmc_suppression::is_suppressed(&pool, host_mac, SITE_EXPLORER).await?,
+        db::bmc_suppression::is_suppressed(&pool, host_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?,
         "the gate should record a site-explorer suppression for the host BMC"
     );
     {
@@ -208,7 +214,8 @@ async fn ready_host_converges_bmc_to_site_target(
 
     // The rotation suppression is deleted on the return to Ready.
     assert!(
-        !db::bmc_suppression::is_suppressed(&pool, host_mac, SITE_EXPLORER).await?,
+        !db::bmc_suppression::is_suppressed(&pool, host_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?,
         "resume must delete the rotation suppression on return to Ready"
     );
 
@@ -264,6 +271,156 @@ async fn stage_lagging_bmc(
     cm.set_credentials(&rotate_to_key(1), &creds("root", "new"))
         .await
         .expect("staging the rotate-to secret should succeed");
+    Ok(())
+}
+
+/// When the BMC password change lands but persisting the new per-device secret
+/// to the store fails, the hardware is AHEAD of the store. The host must hold in
+/// `RotatingBmc` (staying non-allocatable and keeping the site-explorer
+/// suppression) rather than settling to Ready with a stale stored secret, and it
+/// must keep retrying until the store reconciles -- reconciliation is never
+/// abandoned.
+#[sqlx_test]
+async fn store_persist_failure_holds_in_rotating_bmc_until_reconciled(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cm = Arc::new(TestCredentialManager::default());
+    let mut env = Env::builder(pool.clone())
+        .with_credential_manager(cm.clone())
+        .configure_runtime(|c| c.bmc_rotation_enabled = true)
+        .build()
+        .await;
+
+    let domain = env.test_harness.test_domain().await;
+    let network_controller = env.test_harness.network_controller();
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    network_controller.create_admin_segment(&domain).await;
+    let site_explorer = env.test_harness.default_test_site_explorer();
+    let mh = env
+        .test_harness
+        .managed_host_builder(&site_explorer, underlay_segment)
+        .with_config(ManagedHostConfig::default())
+        .build()
+        .await
+        .0;
+    mh.advance_to_converged_ready().await;
+
+    let host_mac = mh
+        .host
+        .machine()
+        .await
+        .status
+        .bmc_info
+        .mac
+        .expect("fixture host should have a BMC MAC");
+    env.redfish_sim.seed_user("root", "old");
+    stage_lagging_bmc(&pool, &cm, host_mac).await?;
+
+    // Drive up to the converging tick: enter RotatingBmc, let the gate record the
+    // suppression, and acknowledge it.
+    env.run_single_iteration().await; // Ready -> RotatingBmc
+    env.run_single_iteration().await; // gate records the suppression and waits
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // The store write now fails: the hardware change will land but the persist
+    // will not, leaving the BMC ahead of the store.
+    cm.set_set_credentials_failure(true);
+
+    // Iteration 3: the password change succeeds on the hardware but the persist
+    // fails, so the host holds in RotatingBmc instead of returning to Ready.
+    env.run_single_iteration().await;
+    assert!(
+        matches!(
+            mh.host.machine().await.state.value,
+            ManagedHostState::RotatingBmc { .. }
+        ),
+        "a persist failure must hold in RotatingBmc (non-allocatable), got {:?}",
+        mh.host.machine().await.state.value,
+    );
+    // The site-explorer suppression is retained across the hold -- we must not
+    // resume probing a BMC whose stored secret still lags the hardware.
+    assert!(
+        db::bmc_suppression::is_suppressed(&pool, host_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?,
+        "the rotation suppression must be retained while the store lags"
+    );
+    // The device is neither converged nor quarantined: it stays eligible so the
+    // persist is retried every sweep rather than backed off.
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, BMC, host_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            !status.converged,
+            "hardware ahead of store is not converged"
+        );
+        assert!(
+            !status.quarantined,
+            "a persist failure must not record a backoff"
+        );
+    }
+    // The hardware carries the new password, but the store still lags.
+    assert_eq!(
+        env.redfish_sim.user_password("root").as_deref(),
+        Some("new"),
+        "the hardware change must have landed even though the persist failed"
+    );
+    assert_eq!(
+        cm.get_credentials(&per_device_key(host_mac))
+            .await
+            .expect("reading the per-device secret should succeed")
+            .expect("per-device secret should still be set"),
+        creds("root", "old"),
+        "the stored secret must still lag after the failed persist"
+    );
+
+    // Iteration 4: still failing -> still holding (the hold is not a bounded
+    // transient retry; it persists until the store reconciles).
+    env.run_single_iteration().await;
+    assert!(
+        matches!(
+            mh.host.machine().await.state.value,
+            ManagedHostState::RotatingBmc { .. }
+        ),
+        "the hold must persist across sweeps while the store keeps failing, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+
+    // The store becomes writable again: the next tick's change-then-verify
+    // recovery re-persists and converges, and the host returns to Ready.
+    cm.set_set_credentials_failure(false);
+    env.run_single_iteration().await;
+    assert!(
+        matches!(mh.host.machine().await.state.value, ManagedHostState::Ready),
+        "expected Ready once the store reconciles, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+    assert!(
+        !db::bmc_suppression::is_suppressed(&pool, host_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?,
+        "resume must delete the rotation suppression once reconciled"
+    );
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, BMC, host_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            status.converged,
+            "device should converge once the store reconciles"
+        );
+        assert_eq!(status.current_version, Some(1));
+    }
+    assert_eq!(
+        cm.get_credentials(&per_device_key(host_mac))
+            .await
+            .expect("reading the per-device secret should succeed")
+            .expect("per-device secret should still be set"),
+        creds("root", "new"),
+        "the store is reconciled to the new password once the write succeeds"
+    );
+
     Ok(())
 }
 
@@ -485,7 +642,7 @@ async fn rotation_preserves_an_operator_suppression(
             &mut conn,
             &NewBmcSuppression {
                 bmc_mac_address: host_mac,
-                subsystem: SITE_EXPLORER,
+                subsystem: BmcSuppressionSubsystem::SiteExplorer,
                 reason: "decommissioning".to_string(),
             },
         )
@@ -512,9 +669,10 @@ async fn rotation_preserves_an_operator_suppression(
             .expect("device rotation row should exist");
         assert!(status.converged, "device should have rotated");
     }
-    let operator = db::bmc_suppression::find(&pool, host_mac, SITE_EXPLORER)
-        .await?
-        .expect("operator suppression must survive the rotation");
+    let operator =
+        db::bmc_suppression::find(&pool, host_mac, BmcSuppressionSubsystem::SiteExplorer)
+            .await?
+            .expect("operator suppression must survive the rotation");
     assert_eq!(
         operator.reason, "decommissioning",
         "the operator's suppression reason must be preserved"

--- a/crates/machine-controller/tests/integration/bmc_rotation.rs
+++ b/crates/machine-controller/tests/integration/bmc_rotation.rs
@@ -34,12 +34,32 @@ use db::credential_rotation::{
     record_device_converged, set_next_target_version,
 };
 use mac_address::MacAddress;
+use model::bmc_suppression::{BmcSuppressionSubsystem, NewBmcSuppression};
 use model::machine::ManagedHostState;
 use model::test_support::ManagedHostConfig;
 
 use crate::env::Env;
 
 const BMC: CredentialRotationType = CredentialRotationType::Bmc;
+const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
+
+/// Stand in for site-explorer acknowledging every pending BMC suppression -- the
+/// barrier the rotation gate waits on before changing a credential. The
+/// integration harness drives only the machine controller, so a test plays the
+/// site-explorer ack pass itself.
+async fn ack_all_site_explorer_suppressions(pool: &PgPool) {
+    let mut conn = pool.acquire().await.expect("acquire connection");
+    let macs: Vec<MacAddress> =
+        db::bmc_suppression::find_all_by_subsystem(&mut *conn, SITE_EXPLORER)
+            .await
+            .expect("read suppressions")
+            .into_iter()
+            .map(|s| s.bmc_mac_address)
+            .collect();
+    db::bmc_suppression::acknowledge_unacknowledged(&mut conn, &macs, SITE_EXPLORER)
+        .await
+        .expect("acknowledge suppressions");
+}
 
 fn per_device_key(mac: MacAddress) -> CredentialKey {
     CredentialKey::BmcCredentials {
@@ -147,12 +167,49 @@ async fn ready_host_converges_bmc_to_site_target(
         mh.host.machine().await.state.value,
     );
 
-    // Iteration 2: the rotation converges the device and returns to Ready.
+    // Iteration 2: the gate records a site-explorer suppression for the host BMC
+    // and waits for its acknowledgement before touching the credential, so the
+    // host stays in RotatingBmc and nothing is rotated yet.
+    env.run_single_iteration().await;
+    assert!(
+        matches!(
+            mh.host.machine().await.state.value,
+            ManagedHostState::RotatingBmc { .. }
+        ),
+        "rotation must wait in RotatingBmc until site-explorer acknowledges, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+    assert!(
+        db::bmc_suppression::is_suppressed(&pool, host_mac, SITE_EXPLORER).await?,
+        "the gate should record a site-explorer suppression for the host BMC"
+    );
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, BMC, host_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            !status.converged,
+            "the credential must not change before site-explorer acknowledges"
+        );
+    }
+
+    // Site-explorer acknowledges the suppression (its skip barrier).
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // Iteration 3: with the barrier satisfied, the rotation converges the device
+    // and returns to Ready.
     env.run_single_iteration().await;
     assert!(
         matches!(mh.host.machine().await.state.value, ManagedHostState::Ready),
         "expected Ready once rotation settles, got {:?}",
         mh.host.machine().await.state.value,
+    );
+
+    // The rotation suppression is deleted on the return to Ready.
+    assert!(
+        !db::bmc_suppression::is_suppressed(&pool, host_mac, SITE_EXPLORER).await?,
+        "resume must delete the rotation suppression on return to Ready"
     );
 
     // The device is converged at the target, and the per-device secret is the
@@ -336,7 +393,20 @@ async fn force_request_converges_quarantined_bmc_when_disabled(
         mh.host.machine().await.state.value,
     );
 
-    // Iteration 2: the forced tick bypasses backoff, converges the device, and
+    // Iteration 2: even a forced rotation first gates on site-explorer, so it
+    // waits in RotatingBmc until the suppression is acknowledged.
+    env.run_single_iteration().await;
+    assert!(
+        matches!(
+            mh.host.machine().await.state.value,
+            ManagedHostState::RotatingBmc { .. }
+        ),
+        "a forced rotation must still wait for site-explorer acknowledgement, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+    ack_all_site_explorer_suppressions(&pool).await;
+
+    // Iteration 3: the forced tick bypasses backoff, converges the device, and
     // returns to Ready.
     env.run_single_iteration().await;
     assert!(
@@ -365,6 +435,90 @@ async fn force_request_converges_quarantined_bmc_when_disabled(
         .expect("reading the per-device secret should succeed")
         .expect("per-device secret should still be set");
     assert_eq!(persisted, creds("root", "new"));
+
+    Ok(())
+}
+
+/// An operator's decommission suppression on the host BMC must survive a
+/// rotation: the gate preserves it (never overwrites its reason) and the resume
+/// deletes only the rotation-reason row, so the operator suppression remains.
+#[sqlx_test]
+async fn rotation_preserves_an_operator_suppression(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cm = Arc::new(TestCredentialManager::default());
+    let mut env = Env::builder(pool.clone())
+        .with_credential_manager(cm.clone())
+        .configure_runtime(|c| c.bmc_rotation_enabled = true)
+        .build()
+        .await;
+
+    let domain = env.test_harness.test_domain().await;
+    let network_controller = env.test_harness.network_controller();
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    network_controller.create_admin_segment(&domain).await;
+    let site_explorer = env.test_harness.default_test_site_explorer();
+    let mh = env
+        .test_harness
+        .managed_host_builder(&site_explorer, underlay_segment)
+        .with_config(ManagedHostConfig::default())
+        .build()
+        .await
+        .0;
+    mh.advance_to_converged_ready().await;
+
+    let host_mac = mh
+        .host
+        .machine()
+        .await
+        .status
+        .bmc_info
+        .mac
+        .expect("fixture host should have a BMC MAC");
+    env.redfish_sim.seed_user("root", "old");
+    stage_lagging_bmc(&pool, &cm, host_mac).await?;
+
+    // An operator has independently suppressed this BMC for decommissioning.
+    {
+        let mut conn = pool.acquire().await?;
+        db::bmc_suppression::upsert(
+            &mut conn,
+            &NewBmcSuppression {
+                bmc_mac_address: host_mac,
+                subsystem: SITE_EXPLORER,
+                reason: "decommissioning".to_string(),
+            },
+        )
+        .await?;
+    }
+
+    // Drive the gated rotation to completion.
+    env.run_single_iteration().await; // Ready -> RotatingBmc
+    env.run_single_iteration().await; // gate records the suppression and waits
+    ack_all_site_explorer_suppressions(&pool).await;
+    env.run_single_iteration().await; // barrier satisfied -> rotate -> Ready
+    assert!(
+        matches!(mh.host.machine().await.state.value, ManagedHostState::Ready),
+        "the rotation should settle back to Ready, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+
+    // The device rotated, yet the operator's suppression survives with its
+    // reason intact -- the resume only removed rotation-owned rows.
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, BMC, host_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(status.converged, "device should have rotated");
+    }
+    let operator = db::bmc_suppression::find(&pool, host_mac, SITE_EXPLORER)
+        .await?
+        .expect("operator suppression must survive the rotation");
+    assert_eq!(
+        operator.reason, "decommissioning",
+        "the operator's suppression reason must be preserved"
+    );
 
     Ok(())
 }

--- a/crates/power-shelf-controller/src/rotating_bmc.rs
+++ b/crates/power-shelf-controller/src/rotating_bmc.rs
@@ -41,6 +41,7 @@
 //! A BMC password change never touches the power shelf's power delivery, so this
 //! is safe in `Ready`.
 
+use carbide_credential_rotation::site_explorer_pause::{self, GateDecision};
 use carbide_credential_rotation::{
     BmcEndpoint, BmcRotationTick, RotateOutcome, RotationStep, advance, rotate_bmc,
 };
@@ -95,8 +96,26 @@ pub async fn handle_rotating_bmc(
     ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
     let force = power_shelf.bmc_credential_rotation_requested;
+    let endpoint = BmcEndpoint::from_power_shelf(power_shelf);
 
-    let tick = match BmcEndpoint::from_power_shelf(power_shelf) {
+    // Hold site-explorer off the PMC and wait until it has acknowledged, before
+    // changing the credential. This closes the window in which a probe could hit
+    // new-hardware / old-Vault and persist the sticky `AvoidLockout` latch. An
+    // unaddressable power shelf has nothing to suppress (empty scope).
+    let bmc_macs: Vec<_> = endpoint
+        .as_ref()
+        .map(|e| vec![e.device_mac])
+        .unwrap_or_default();
+    if matches!(
+        site_explorer_pause::gate_before_rotation(&ctx.services.db_pool, &bmc_macs).await?,
+        GateDecision::Wait
+    ) {
+        return Ok(StateHandlerOutcome::wait(
+            "waiting for site-explorer to acknowledge the BMC rotation suppression".to_string(),
+        ));
+    }
+
+    let tick = match endpoint {
         Some(endpoint) => rotate_power_shelf_bmc(ctx.services, endpoint, force).await,
         // A forced request announces a missing PMC so its one-shot flag still
         // clears; a passive sweep silently settles an unaddressable power shelf
@@ -127,7 +146,17 @@ pub async fn handle_rotating_bmc(
             } else {
                 None
             };
-            Ok(StateHandlerOutcome::transition(PowerShelfControllerState::Ready).with_txn_opt(txn))
+            // Resume site-explorer atomically with the return to Ready, so its
+            // skip window ends exactly when the rotation does.
+            let mut resume_txn = match txn {
+                Some(txn) => txn,
+                None => ctx.services.db_pool.begin().await?,
+            };
+            site_explorer_pause::resume_after_rotation(&mut resume_txn, &bmc_macs).await?;
+            Ok(
+                StateHandlerOutcome::transition(PowerShelfControllerState::Ready)
+                    .with_txn(resume_txn),
+            )
         }
         RotationStep::Retry { retry_count } => Ok(StateHandlerOutcome::transition(
             PowerShelfControllerState::RotatingBmc { retry_count },

--- a/crates/power-shelf-controller/src/rotating_bmc.rs
+++ b/crates/power-shelf-controller/src/rotating_bmc.rs
@@ -132,6 +132,19 @@ pub async fn handle_rotating_bmc(
     };
 
     match advance(tick, retry_count, power_shelf_id) {
+        // The PMC changed its hardware password but the per-device secret persist
+        // has not yet succeeded: hold in RotatingBmc (site-explorer stays
+        // suppressed) and re-tick. Do NOT resume site-explorer and do NOT clear a
+        // force request -- the rotation has not finished. The engine leaves the
+        // device `needs_rotation`, so a later tick's change-then-verify recovery
+        // re-persists and converges; the hold's upper bound is the state's
+        // time-in-state SLA.
+        RotationStep::WaitForCredentialStoreReconcile => Ok(StateHandlerOutcome::wait(
+            "PMC's credential changed but persisting the new credential to the credential store \
+             has not yet succeeded; holding rotation (site-explorer suppressed) until the \
+             credential store reconciles"
+                .to_string(),
+        )),
         step @ (RotationStep::Settled | RotationStep::GaveUp) => {
             // Only a settled tick clears a one-shot force request: the forced
             // attempt genuinely fired. GaveUp exhausted the transient-retry
@@ -199,6 +212,13 @@ async fn rotate_power_shelf_bmc(
                 "power shelf BMC (PMC) rotation attempt failed; quarantined until backoff elapses"
             );
             BmcRotationTick::Settled
+        }
+        Ok(RotateOutcome::CredentialStoreReconcilePending) => {
+            tracing::warn!(
+                mac = %target.device_mac,
+                "PMC's credential changed but persisting the new credential to the credential store failed; holding rotation until the credential store reconciles"
+            );
+            BmcRotationTick::WaitForCredentialStoreReconcile
         }
         Ok(RotateOutcome::NoWork) => BmcRotationTick::Settled,
         Err(e) => {

--- a/crates/secrets/src/test_support/credentials.rs
+++ b/crates/secrets/src/test_support/credentials.rs
@@ -31,6 +31,7 @@ pub struct TestCredentialManager {
     fallback_credentials: Option<Credentials>,
     pub set_credentials_sleep_time_ms: AtomicU32,
     delete_credentials_failure: AtomicBool,
+    set_credentials_failure: AtomicBool,
 }
 
 impl TestCredentialManager {
@@ -42,6 +43,7 @@ impl TestCredentialManager {
             fallback_credentials: Some(fallback_credentials),
             set_credentials_sleep_time_ms: Default::default(),
             delete_credentials_failure: Default::default(),
+            set_credentials_failure: Default::default(),
         }
     }
 
@@ -49,6 +51,14 @@ impl TestCredentialManager {
     /// credential.
     pub fn set_delete_credentials_failure(&self, fail: bool) {
         self.delete_credentials_failure
+            .store(fail, atomic::Ordering::Release);
+    }
+
+    /// Makes `set_credentials` return an error without persisting the credential.
+    /// Models a credential-store write failure (e.g. Vault unreachable) so the
+    /// caller can exercise a persist-failure path without touching a real store.
+    pub fn set_set_credentials_failure(&self, fail: bool) {
+        self.set_credentials_failure
             .store(fail, atomic::Ordering::Release);
     }
 }
@@ -88,6 +98,11 @@ impl CredentialWriter for TestCredentialManager {
             .load(atomic::Ordering::Acquire);
         if sleep_ms > 0 {
             tokio::time::sleep(std::time::Duration::from_millis(sleep_ms as _)).await;
+        }
+        if self.set_credentials_failure.load(atomic::Ordering::Acquire) {
+            return Err(SecretsError::GenericError(eyre::eyre!(
+                "test credential set failure"
+            )));
         }
         let mut data = self.credentials.lock().await;
         data.insert(key.to_key_str().to_string(), credentials.clone());

--- a/crates/switch-controller/src/rotating_bmc.rs
+++ b/crates/switch-controller/src/rotating_bmc.rs
@@ -126,6 +126,20 @@ pub async fn handle_rotating_bmc(
     };
 
     match advance(tick, retry_count, switch_id) {
+        // The switch BMC changed its hardware password but the per-device secret
+        // persist has not yet succeeded: hold in RotatingBmc (site-explorer stays
+        // suppressed, and the `Ready`-only allocation gate keeps the switch out
+        // of service) and re-tick. Do NOT resume site-explorer and do NOT clear a
+        // force request -- the rotation has not finished. The engine leaves the
+        // device `needs_rotation`, so a later tick's change-then-verify recovery
+        // re-persists and converges; the hold's upper bound is the state's
+        // time-in-state SLA.
+        RotationStep::WaitForCredentialStoreReconcile => Ok(StateHandlerOutcome::wait(
+            "switch BMC hardware changed but the per-device secret persist has not yet \
+             succeeded; holding rotation (site-explorer suppressed) until the credential \
+             store reconciles"
+                .to_string(),
+        )),
         step @ (RotationStep::Settled | RotationStep::GaveUp) => {
             // Only a settled tick clears a one-shot force request: the forced
             // attempt genuinely fired. GaveUp exhausted the transient-retry
@@ -189,6 +203,13 @@ async fn rotate_switch_bmc(
                 "switch BMC rotation attempt failed; quarantined until backoff elapses"
             );
             BmcRotationTick::Settled
+        }
+        Ok(RotateOutcome::CredentialStoreReconcilePending) => {
+            tracing::warn!(
+                mac = %target.device_mac,
+                "switch BMC hardware changed but the per-device secret persist failed; holding rotation until the credential store reconciles"
+            );
+            BmcRotationTick::WaitForCredentialStoreReconcile
         }
         Ok(RotateOutcome::NoWork) => BmcRotationTick::Settled,
         Err(e) => {

--- a/crates/switch-controller/src/rotating_bmc.rs
+++ b/crates/switch-controller/src/rotating_bmc.rs
@@ -35,6 +35,7 @@
 //! A BMC password change never touches the switch data plane, so this is safe in
 //! `Ready`.
 
+use carbide_credential_rotation::site_explorer_pause::{self, GateDecision};
 use carbide_credential_rotation::{
     BmcEndpoint, BmcRotationTick, RotateOutcome, RotationStep, advance, rotate_bmc,
 };
@@ -89,8 +90,26 @@ pub async fn handle_rotating_bmc(
     ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<SwitchControllerState>, StateHandlerError> {
     let force = switch.bmc_credential_rotation_requested;
+    let endpoint = BmcEndpoint::from_switch(switch);
 
-    let tick = match BmcEndpoint::from_switch(switch) {
+    // Hold site-explorer off the switch BMC and wait until it has acknowledged,
+    // before changing the credential. This closes the window in which a probe
+    // could hit new-hardware / old-Vault and persist the sticky `AvoidLockout`
+    // latch. An unaddressable switch has nothing to suppress (empty scope).
+    let bmc_macs: Vec<_> = endpoint
+        .as_ref()
+        .map(|e| vec![e.device_mac])
+        .unwrap_or_default();
+    if matches!(
+        site_explorer_pause::gate_before_rotation(&ctx.services.db_pool, &bmc_macs).await?,
+        GateDecision::Wait
+    ) {
+        return Ok(StateHandlerOutcome::wait(
+            "waiting for site-explorer to acknowledge the BMC rotation suppression".to_string(),
+        ));
+    }
+
+    let tick = match endpoint {
         Some(endpoint) => rotate_switch_bmc(ctx.services, endpoint, force).await,
         // A forced request announces a missing BMC so its one-shot flag still
         // clears; a passive sweep silently settles an unaddressable switch (the
@@ -119,7 +138,14 @@ pub async fn handle_rotating_bmc(
                 db::switch::clear_bmc_credential_rotation_requested(&mut t, *switch_id).await?;
                 txn = Some(t);
             }
-            Ok(StateHandlerOutcome::transition(SwitchControllerState::Ready).with_txn_opt(txn))
+            // Resume site-explorer atomically with the return to Ready, so its
+            // skip window ends exactly when the rotation does.
+            let mut resume_txn = match txn.take() {
+                Some(txn) => txn,
+                None => ctx.services.db_pool.begin().await?,
+            };
+            site_explorer_pause::resume_after_rotation(&mut resume_txn, &bmc_macs).await?;
+            Ok(StateHandlerOutcome::transition(SwitchControllerState::Ready).with_txn(resume_txn))
         }
         RotationStep::Retry { retry_count } => Ok(StateHandlerOutcome::transition(
             SwitchControllerState::RotatingBmc { retry_count },


### PR DESCRIPTION
A BMC credential rotation could leave the BMC in an AvoidLockout state set by site explorer during the window where the hardware has the new password but Vault still serves the old one.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
