### PR TITLE
docs(admin-cli): clarify expected machine option behavior

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -151,7 +151,7 @@ pub(crate) struct Args {
     #[clap(
         long = "default_pause_ingestion_and_poweron",
         value_name = "DEFAULT_PAUSE_INGESTION_AND_POWERON",
-        help = "Optional flag to pause machine's ingestion and power on. False - don't pause, true - will pause it. The actual mutable state is stored in explored_endpoints."
+        help = "Initial pause state applied when the BMC endpoint for this machine is first explored. `true` pauses ingestion and automatic power-on; `false` pauses neither. Defaults to `false`."
     )]
     default_pause_ingestion_and_poweron: Option<bool>,
 
@@ -159,7 +159,7 @@ pub(crate) struct Args {
         long,
         action = clap::ArgAction::Set,
         value_name = "DPF_ENABLED",
-        help = "DPF enable/disable for this machine. Default is updated as true.",
+        help = "Whether DPF is enabled for this machine. Defaults to true.",
     )]
     dpf_enabled: Option<bool>,
 
@@ -190,7 +190,7 @@ pub(crate) struct Args {
         long = "bmc-ip-allocation",
         value_name = "BMC_IP_ALLOCATION",
         value_enum,
-        help = "Per-host control over how this BMC's IP is assigned and retained. `auto` (default): infer from `--bmc-ip-address` -- a configured address is `fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that may expire and change; `fixed`: the operator-specified `--bmc-ip-address` (static); `retained`: an auto-allocated DHCP address that stays static for the lifetime of its machine-interface record. Unset defers to the server default (`auto`)."
+        help = "Per-host control over IP assignment and retention for this BMC. `auto` (default): infer from `--bmc-ip-address` -- a configured address is `fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that may expire and change; `fixed`: the operator-specified `--bmc-ip-address` (static); `retained`: an auto-allocated DHCP address that stays static for the lifetime of its machine-interface record. Unset defers to the server default (`auto`)."
     )]
     bmc_ip_allocation: Option<BmcIpAllocationType>,
 

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -168,7 +168,7 @@ pub(crate) struct Args {
     #[clap(
         long = "default_pause_ingestion_and_poweron",
         value_name = "DEFAULT_PAUSE_INGESTION_AND_POWERON",
-        help = "Optional flag to pause machine's ingestion and power on. False - don't pause, true - will pause it. The actual mutable state is stored in explored_endpoints."
+        help = "Initial pause state applied when the BMC endpoint for this machine is first explored. `true` pauses ingestion and automatic power-on; `false` pauses neither. Omit to preserve the existing Expected Machine value. Changes do not affect an endpoint that has already been explored."
     )]
     pub(super) default_pause_ingestion_and_poweron: Option<bool>,
 
@@ -176,7 +176,7 @@ pub(crate) struct Args {
         long,
         action = clap::ArgAction::Set,
         value_name = "DPF_ENABLED",
-        help = "DPF enable/disable for this machine. Default is updated as true.",
+        help = "Whether DPF is enabled for this machine. Omit to preserve the existing value.",
     )]
     pub(super) dpf_enabled: Option<bool>,
 
@@ -210,7 +210,7 @@ pub(crate) struct Args {
         value_name = "BMC_IP_ALLOCATION",
         value_enum,
         group = "group",
-        help = "Per-host control over how this BMC's IP is assigned and retained. `auto` (default): infer from `--bmc-ip-address` -- a configured address is `fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that may expire and change; `fixed`: the operator-specified `--bmc-ip-address` (static); `retained`: an auto-allocated DHCP address that stays static for the lifetime of its machine-interface record. Unset preserves the existing per-host value."
+        help = "Per-host control over IP assignment and retention for this BMC. `auto` (default): infer from `--bmc-ip-address` -- a configured address is `fixed`, no address is `retained`; `dynamic`: a normal DHCP lease that may expire and change; `fixed`: the operator-specified `--bmc-ip-address` (static); `retained`: an auto-allocated DHCP address that stays static for the lifetime of its machine-interface record. Unset preserves the existing per-host value."
     )]
     pub(super) bmc_ip_allocation: Option<BmcIpAllocationType>,
 
@@ -219,7 +219,7 @@ pub(crate) struct Args {
         visible_alias = "host_nics",
         value_name = "INTERFACES",
         group = "group",
-        help = "Interfaces as a JSON array of ExpectedInterface objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc|host_bmc|unspecified and ip_allocation=dynamic|fixed|retained|unspecified. network_segment_type uses protobuf enum numbers: tenant=0, admin=1, underlay=2, host_inband=3. Replaces the machine's full interface list. For a matching stored MAC, omitting role preserves the stored role; role=unspecified resets it to host. Omitting ip_allocation preserves the stored policy when the presence of fixed_ip is unchanged; ip_allocation=unspecified resets it to fixed_ip inference. Omitting any other optional interface field, including network_segment_type, clears its stored value."
+        help = "Interfaces as a JSON array of ExpectedInterface objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc|host_bmc|unspecified and ip_allocation=dynamic|fixed|retained|unspecified. network_segment_type uses protobuf enum numbers: tenant=0, admin=1, underlay=2, host_inband=3. Replaces the full interface list for the machine. For a matching stored MAC, omitting role preserves the stored role; role=unspecified resets it to host. Omitting ip_allocation preserves the stored policy when the presence of fixed_ip is unchanged; ip_allocation=unspecified resets it to fixed_ip inference. Omitting any other optional interface field, including network_segment_type, clears its stored value."
     )]
     pub(super) interfaces: Option<String>,
 


### PR DESCRIPTION
Keep Expected Machine help grammatical in both the live CLI and generated reference pages.

The roff-to-Markdown conversion drops apostrophes, so phrases such as `machine's` render incorrectly. This rephrases those options without apostrophes and documents the actual initial-only pause semantics plus the different DPF behavior for add and patch.

## Related issues

- https://github.com/NVIDIA/infra-controller/issues/4894
- Documentation companion: https://github.com/NVIDIA/infra-controller/pull/4418

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Verified the live `nico-admin-cli expected-machine add --help` and `patch --help` contracts, then rendered the affected pages through the Bookworm roff/Pandoc pipeline. The generated reference updates remain isolated in the docs-only #4418 PR.

Validation also included nightly formatting, full workspace Clippy, custom Carbide lints, and the focused `nico-admin-cli` tests.
