### PR TITLE
patch(2.0): update refs to actions 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -910,7 +910,7 @@ jobs:
           fetch-depth: 0  # Full history for secret scanning
 
       - name: Run TruffleHog Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
           extra-args: '--results=verified,unknown --only-verified'
           post-pr-comment: 'false'
@@ -932,7 +932,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run CodeQL Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@20dc10dda4fa9f8f0380a47cd9a7800d3da3dcf3
+        # Bounded separately from the job so a hang fails this step by name and
+        # still lets the post steps run, rather than the runner being killed
+        # mid-flight with no attribution.
+        timeout-minutes: 15
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/codeql-scan@20dc10dda4fa9f8f0380a47cd9a7800d3da3dcf3
         with:
           languages: 'rust'
           build-mode: 'none'
@@ -1186,7 +1190,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Helm chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: helm
           lint: 'true'
@@ -1203,7 +1207,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push Helm chart to NGC
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: helm
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -1223,7 +1227,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Helm prereqs chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: helm-prereqs
           lint: 'true'
@@ -1240,7 +1244,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push Helm prereqs chart to NGC
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: helm-prereqs
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -1414,28 +1418,28 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate nico-otelcol chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-otelcol
           lint: 'true'
           template: 'true'
 
       - name: Validate nico-dpu-agent chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-dpu-agent
           lint: 'true'
           template: 'true'
 
       - name: Validate nico-dhcp-server chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-dhcp-server
           lint: 'true'
           template: 'true'
 
       - name: Validate nico-fmds chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-fmds
           lint: 'true'
@@ -1452,7 +1456,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push nico-otelcol chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-otelcol
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -1463,7 +1467,7 @@ jobs:
           ngc-duplicate: fail
 
       - name: Package and push nico-dpu-agent chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-dpu-agent
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -1474,7 +1478,7 @@ jobs:
           ngc-duplicate: fail
 
       - name: Package and push nico-dhcp-server chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-dhcp-server
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -1485,7 +1489,7 @@ jobs:
           ngc-duplicate: fail
 
       - name: Package and push nico-fmds chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-fmds
           chart-version: ${{ needs.prepare.outputs.helm_version }}
@@ -1583,7 +1587,7 @@ jobs:
     needs:
       - prepare
       - build-release-container-x86_64
-    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@760d2d7964b479fde431cd3e0b980bc6b6a26ccd
+    uses: dsx-ai-factory/dsx-github-actions/.github/workflows/promote-image.yml@760d2d7964b479fde431cd3e0b980bc6b6a26ccd
     with:
       source: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide
       source_tag: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1622,7 +1622,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan-aggregate@739847ddf00fda38916504ef84e1f504eac3158f
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/security-container-scan-aggregate@739847ddf00fda38916504ef84e1f504eac3158f
         with:
           post-pr-comment: 'true'
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Grype vulnerability scan
         if: ${{ inputs.scan && inputs.load && !inputs.push && steps.build.outcome == 'success' }}
         continue-on-error: true
-        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@739847ddf00fda38916504ef84e1f504eac3158f
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/security-container-scan@739847ddf00fda38916504ef84e1f504eac3158f
         with:
           image: ${{ inputs.image_name }}:${{ inputs.image_tag }}
           fail-on: critical

--- a/.github/workflows/notify-build-status.yml
+++ b/.github/workflows/notify-build-status.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Notify Slack - Build Success
         if: steps.analyze.outputs.status == 'success' && inputs.notify-on-success
-        uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
         with:
           slack-bot-token: ${{ secrets.slack-bot-token }}
           channel-id: ${{ inputs.channel-id }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Notify Slack - Partial Failure
         if: steps.analyze.outputs.status == 'partial' && inputs.notify-on-partial
-        uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
         with:
           slack-bot-token: ${{ secrets.slack-bot-token }}
           channel-id: ${{ inputs.channel-id }}
@@ -259,7 +259,7 @@ jobs:
 
       - name: Notify Slack - Build Failure
         if: steps.analyze.outputs.status == 'failure' && inputs.notify-on-failure
-        uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/slack-notify@2eeda375a465badd24f229e68c62ac98c0561c6a # v1.4.1
         with:
           slack-bot-token: ${{ secrets.slack-bot-token }}
           channel-id: ${{ inputs.channel-id }}

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -123,7 +123,7 @@ jobs:
     needs:
       - prepare
       - approve-promotion
-    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
+    uses: dsx-ai-factory/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
       source: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide
       source_tag: ${{ needs.prepare.outputs.version }}
@@ -142,7 +142,7 @@ jobs:
     needs:
       - prepare
       - approve-promotion
-    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
+    uses: dsx-ai-factory/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
       source: nvcr.io/0837451325059433/carbide-dev/carbide-release-artifacts-aarch64
       source_tag: ${{ needs.prepare.outputs.version }}
@@ -161,7 +161,7 @@ jobs:
     needs:
       - prepare
       - approve-promotion
-    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
+    uses: dsx-ai-factory/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
       source: nvcr.io/0837451325059433/carbide-dev/carbide-release-artifacts-x86_64
       source_tag: ${{ needs.prepare.outputs.version }}
@@ -186,7 +186,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push Helm prereqs chart to production NGC
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: helm-prereqs
           chart-version: ${{ needs.prepare.outputs.helm_version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Push Git Tag
-        uses: NVIDIA/dsx-github-actions/.github/actions/git-tag@95e609360851cfc141918c2c21e57762d77394ac
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/git-tag@95e609360851cfc141918c2c21e57762d77394ac
         with:
           tag: ${{ needs.fetch-new-version.outputs.version }}
       - name: Release

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -391,6 +391,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan-aggregate@739847ddf00fda38916504ef84e1f504eac3158f
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/security-container-scan-aggregate@739847ddf00fda38916504ef84e1f504eac3158f
         with:
           post-pr-comment: 'true'

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Grype vulnerability scan
         if: matrix.arch == 'amd64'
         continue-on-error: true
-        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@739847ddf00fda38916504ef84e1f504eac3158f
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:
           image: ${{ steps.docker-tags.outputs.arch_tag }}
           fail-on: critical
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload binary artifact with semantic version
         if: inputs.push_enabled == true
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
           display-name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload binary artifact with latest tag
         if: inputs.is_main_branch == 'true' && inputs.push_enabled == true
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
           display-name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
@@ -291,7 +291,7 @@ jobs:
             | gzip > "artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz"
 
       - name: Upload Docker image artifact with semantic version
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-image
           display-name: ${{ inputs.service_name }}-image
@@ -303,7 +303,7 @@ jobs:
 
       - name: Upload Docker image artifact with latest tag
         if: inputs.is_main_branch == 'true'
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-image
           display-name: ${{ inputs.service_name }}-image

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run TruffleHog Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@f435aa6bf125fe6f9e5ac438f8cef75f90e29a2b
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/trufflehog-scan@f435aa6bf125fe6f9e5ac438f8cef75f90e29a2b
         with:
           extra-args: '--results=verified,unknown --only-verified'
           post-pr-comment: 'true'

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Helm chart
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: ${{ matrix.chart }}
           lint: 'true'
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push Helm chart to NGC
-        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: ${{ matrix.chart }}
           chart-version: ${{ inputs.chart_version }}

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -20,8 +20,8 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
-        # Refer to https://github.com/NVIDIA/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
+        # Refer to https://github.com/dsx-ai-factory/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
         with:
           days-before-issue-stale: '-1'
           days-before-pr-stale: '30'


### PR DESCRIPTION
Backports #4895

The repo `NVIDIA/dsx-github-actions` was transferred to `dsx-ai-factory/dsx-github-actions`. GitHub Actions resolves 
action/workflow references differently depending on where they appear in a workflow file:

- **Job-level reusable workflow calls** (`jobs.<id>.uses:`) are resolved at parse time. If the target can't be found, GitHub rejects the entire workflow file before any jobs run — this is what caused the hard failure in `ci.yaml` ([run
31631294473](https://github.com/NVIDIA/infra-controller/actions/runs/31631294473).
- **Step-level action references** (`steps[*].uses:`) are resolved at runtime. GitHub still follows HTTP redirects for these, so workflows like `rest-ci.yml` that only had step-level references continued to trigger and pass despite the stale org name.

Because step-level references silently kept working via redirect, the breakage was not uniform — only workflows with job-level reusable workflow calls hard-failed. This PR updates all references regardless of kind for consistency and to avoid relying on redirect behavior that GitHub can revoke at any time.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

