### PR TITLE
fix(api-web): show stale health-alert filters in the Health dropdown

### DIFF
--- a/crates/api-web/src/managed_host.rs
+++ b/crates/api-web/src/managed_host.rs
@@ -429,6 +429,7 @@ pub(super) async fn show_html(
 
     let active_health_alerts_filter = params
         .remove("health-alerts-filter")
+        .filter(|value| !value.is_empty())
         .unwrap_or("all".to_string());
     let active_maintenance_filter = params
         .remove("maintenance-filter")
@@ -590,6 +591,12 @@ pub(super) async fn show_html(
 
     let states: Vec<String> = states.into_iter().sorted_unstable().collect();
 
+    if !matches!(
+        active_health_alerts_filter.as_str(),
+        "all" | "healthy" | "unhealthy"
+    ) {
+        health_alert_ids.insert(active_health_alerts_filter.clone());
+    }
     let health_alert_ids: Vec<String> = health_alert_ids.into_iter().sorted_unstable().collect();
 
     let gpus: Vec<String> = gpus

--- a/crates/api-web/src/tests/managed_host.rs
+++ b/crates/api-web/src/tests/managed_host.rs
@@ -633,6 +633,43 @@ async fn test_managed_host_health_alert_filter_empty_state(pool: sqlx::PgPool) -
     let body_str = std::str::from_utf8(&body_bytes).expect("Invalid UTF-8 in body");
 
     assert!(body_str.contains("No machines match the selected filters."));
+    assert!(
+        body_str.contains(r#"<option value="SomeAlertNoOneHas" selected>"#),
+        "expected the stale alert ID to appear as a selected dropdown option"
+    );
 
     Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_empty_health_alert_filter_is_unfiltered(pool: sqlx::PgPool) {
+    let env = TestEnv::new(pool).await;
+    let mh = env.create_ready_managed_host(1).await.0;
+
+    let app = make_test_app(&env.test_harness);
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri("/admin/managed-host?health-alerts-filter=")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body_str = std::str::from_utf8(&body_bytes).expect("Invalid UTF-8 in body");
+
+    assert!(
+        !body_str.contains(r#"<option value="" selected>"#),
+        "expected an empty health-alert filter not to render a blank selected option"
+    );
+    assert!(body_str.contains("All Managed Hosts (1)"));
+    assert!(body_str.contains(&mh.host.id.to_string()));
 }


### PR DESCRIPTION
The managed-host page builds its Health dropdown from alert IDs present
in the current inventory, while the request handler applies the
`health-alerts-filter` query value independently. Nothing reconciles the
two.

When a bookmarked or shared URL names an alert that is no longer active,
the server still applies the filter and returns zero hosts—but no
`<option>` matches the active value. No option is marked selected, so
the browser displays the first option, `All`. The page then shows
`Filtered Managed Hosts (0)` beneath a control that appears to claim no
filter is applied.

That contradiction is misleading during triage: an empty page under
`All` reads as “there are no hosts” rather than “this page is filtered
to an alert nothing currently has.” The control provides no visible
indication that the URL still contains another filter value.

To reproduce, load
`/admin/managed-host?health-alerts-filter=<alert-id>` while that alert is
active and confirm it is selected. Clear the health report providing
the alert, then reload the same URL. The heading reports zero matches
while the dropdown displays `All`.

Fix this by inserting the active filter into the option set when it is
not one of the built-in values (`all`, `healthy`, or `unhealthy`). The
dropdown can then display the value actually being applied. The
existing `HashSet` deduplicates the value when the alert is also live,
sorting remains unchanged, and the server-side filter predicate is
untouched. The page still shows zero matches, but it now identifies the
active filter.

A present-but-empty value is normalized to `all`, matching an omitted
parameter, so it neither filters out every host nor creates a blank
selected option.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Both regressions were verified red-then-green on Linux with PostgreSQL
before the rebase. Final verification was repeated after rebasing onto
`349a2b110` with Rust 1.97.1.

Before the stale-filter fix, with only its new assertion applied:

```text
cargo test --locked -p carbide-api-web managed_host_health_alert -- --nocapture

1 passed; 1 failed; 0 ignored; 0 measured; 58 filtered out
```

`test_managed_host_health_alert_exact_filter` passed, while
`test_managed_host_health_alert_filter_empty_state` failed on the new
assertion. This confirmed the regression independently of the build and
database environment.

Before the empty-value normalization, the new focused test also ran and
failed at its intended assertion:

```text
cargo test --locked -p carbide-api-web \
  test_managed_host_empty_health_alert_filter_is_unfiltered \
  -- --nocapture

expected an empty health-alert filter not to render a blank selected option
```

After both fixes, the empty-value regression passed:

```text
cargo test --locked -p carbide-api-web \
  test_managed_host_empty_health_alert_filter_is_unfiltered \
  -- --nocapture

1 passed; 0 failed; 0 ignored; 0 measured; 60 filtered out
```

The existing health-alert tests also passed:

```text
cargo test --locked -p carbide-api-web managed_host_health_alert -- --nocapture

2 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out
```

Full package suite:

```text
cargo test --locked -p carbide-api-web

61 passed; 0 failed
Doc-tests: 0 passed; 0 failed
```

CI-equivalent Clippy:

```text
cargo make --no-workspace clippy-flow

cargo clippy --locked --all-targets --all-features
Exit status: 0
```

Clippy produced no warnings involving either changed file.

Formatting:

```text
cargo fmt --all -- --check
```

Passed.

Hosted Core CI also passed for PR head `1151556dd` in
[run 31676733184](https://github.com/NVIDIA/infra-controller/actions/runs/31676733184):

```text
Detect Core CI Gate: passed
core-ci-pass: passed
```

The extended stale-filter test covers both halves of that contract: the
no-match message and a selected option for the stale value. The
empty-value test confirms the normal unfiltered heading, a visible host,
and the absence of a blank selected option.

## Additional Notes

The active filter originates from the query string and is therefore
attacker-controlled. It was already used in server-side filter
comparisons and, when pagination controls are rendered, included in
pagination links through `ActiveFilters::to_query_params()` and
`pages_footer.html`. This change adds another render location: the
dropdown option's value and label. Askama HTML-escapes each template
interpolation, preventing the value from being interpreted as markup.
The existing pagination-link query construction is unchanged.

`health_alert_ids` is populated from every fetched machine before the
active filters are applied, so adding the stale active value does not
otherwise change which options appear.
