### PR TITLE
fix(flow): find untracked hosts when expected inventory is empty

### DIFF
--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
@@ -25,6 +25,19 @@ func isMachineComponentType(t string) bool {
 	return t == devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)
 }
 
+// filterHostMachineDetails returns the Core machine records that represent
+// hosts. A Flow compute component can own both Host and DPU BMC rows, but only
+// the HOST MachineDetail represents that expected compute in actual inventory.
+func filterHostMachineDetails(machineDetails []nicoapi.MachineDetail) []nicoapi.MachineDetail {
+	hostMachineDetails := make([]nicoapi.MachineDetail, 0, len(machineDetails))
+	for _, detail := range machineDetails {
+		if detail.MachineType == corev1.MachineType_HOST.String() {
+			hostMachineDetails = append(hostMachineDetails, detail)
+		}
+	}
+	return hostMachineDetails
+}
+
 // ---------------------------------------------------------------------------
 // syncMachines: sync machine components against NICo
 // ---------------------------------------------------------------------------
@@ -38,7 +51,8 @@ func isMachineComponentType(t string) bool {
 //
 // Flow:
 //  1. DB: get all compute components (with BMCs)
-//  2. NICo GetMachines: fetch all machine details (linking, firmware, state, missing_in_expected)
+//  2. NICo GetMachines: fetch runtime inventory and keep the HOST details used
+//     for linking, direct writes, and missing_in_expected detection
 //  3. Link by BMC MAC (from step 2 data) → direct-write external_id
 //  4. NICo GetPowerStates: direct-write power_state
 //  5. Direct-write firmware_version (from step 2 data)
@@ -61,28 +75,29 @@ func syncMachines(
 		return 0, nil, false
 	}
 
-	if len(components) == 0 {
-		return 0, nil, true
-	}
-
-	// Step 2: Fetch all machine details from NICo. This is the single source
-	// for BMC-MAC linking, firmware_version, controller_state, and
-	// missing_in_expected detection — a failure here means we can't trust this
-	// cycle, so preserve prior state rather than writing a partial view.
+	// Step 2: Fetch all machine details from NICo, even when Flow has no expected
+	// compute components. The empty expected set still needs an authoritative
+	// Core query so discovered hosts become missing_in_expected drift, while an
+	// RPC failure remains distinguishable from a successful empty inventory.
+	// This is also the single source for BMC-MAC linking, firmware_version,
+	// controller_state, and missing_in_expected detection — a failure here means
+	// we can't trust this cycle, so preserve prior state rather than writing a
+	// partial view.
 	allMachineDetails, err := nicoClient.GetMachines(ctx)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve machine details from NICo: %v", err)
 		return 0, nil, false
 	}
-	received = len(allMachineDetails)
+	hostMachineDetails := filterHostMachineDetails(allMachineDetails)
+	received = len(hostMachineDetails)
 
 	detailByID := make(map[string]nicoapi.MachineDetail)
-	for _, d := range allMachineDetails {
+	for _, d := range hostMachineDetails {
 		detailByID[d.MachineID] = d
 	}
 
 	// Step 3: Direct-write external_id by BMC MAC matching
-	syncMachineIDs(ctx, pool, allMachineDetails, components)
+	syncMachineIDs(ctx, pool, hostMachineDetails, components)
 
 	// Re-read components to pick up any external_id updates
 	allComponents, err := model.GetAllComponents(ctx, pool.DB)
@@ -109,7 +124,7 @@ func syncMachines(
 	}
 
 	if len(machineIDs) == 0 {
-		return received, buildDriftsForUnmatchedComponents(components, allMachineDetails), true
+		return received, buildDriftsForUnmatchedComponents(components, hostMachineDetails), true
 	}
 
 	// Step 4: Direct-write power_state (requires separate NICo API)
@@ -184,7 +199,7 @@ func syncMachines(
 	}
 
 	// Detect missing_in_expected: machines in NICo but not in local DB
-	for _, detail := range allMachineDetails {
+	for _, detail := range hostMachineDetails {
 		if _, found := componentsByExternalID[detail.MachineID]; !found {
 			extID := detail.MachineID
 			drifts = append(drifts, model.ComponentDrift{
@@ -203,11 +218,11 @@ func syncMachines(
 
 // buildDriftsForUnmatchedComponents returns missing_in_actual drifts for all
 // components that have no external_id, plus missing_in_expected drifts for
-// every NICo machine (since no DB component has an external_id, none can
+// every NICo host machine (since no DB component has an external_id, none can
 // match).
 func buildDriftsForUnmatchedComponents(
 	components []model.Component,
-	allMachineDetails []nicoapi.MachineDetail,
+	hostMachineDetails []nicoapi.MachineDetail,
 ) []model.ComponentDrift {
 	now := time.Now()
 	var drifts []model.ComponentDrift
@@ -222,7 +237,7 @@ func buildDriftsForUnmatchedComponents(
 			})
 		}
 	}
-	for _, detail := range allMachineDetails {
+	for _, detail := range hostMachineDetails {
 		extID := detail.MachineID
 		drifts = append(drifts, model.ComponentDrift{
 			ComponentID: nil,
@@ -236,26 +251,22 @@ func buildDriftsForUnmatchedComponents(
 }
 
 // syncMachineIDs matches components by BMC MAC address against pre-fetched NICo
-// machine details and direct-writes the external_id. BMC MAC is the stable
-// identity Core populates on the discovered machine (Machine.bmc_info.mac,
-// surfaced as MachineDetail.BmcMac), so linking no longer depends on serial
-// number.
+// host machine details and direct-writes the external_id. Callers must filter
+// the Core response to HOST records first. BMC MAC is the stable identity Core
+// populates on the discovered machine (Machine.bmc_info.mac, surfaced as
+// MachineDetail.BmcMac), so linking no longer depends on serial number.
 func syncMachineIDs(
 	ctx context.Context,
 	pool *cdb.Session,
-	allDetails []nicoapi.MachineDetail,
+	hostMachineDetails []nicoapi.MachineDetail,
 	components []model.Component,
 ) {
-	// Index discovered machines by normalized BMC MAC → Core MachineId.
-	// Restrict to HOST machines: a compute component owns both a host BMC and
-	// a DPU BMC, and Core exposes the DPU as its own MachineDetail whose BmcMac
-	// is that DPU BMC. Including DPUs here would let a compute component's DPU
-	// BMC resolve to the DPU's machine id instead of the host's.
+	// Index discovered host machines by normalized BMC MAC → Core MachineId.
+	// A compute component can also own an auxiliary DPU BMC. Keeping DPU machine
+	// details out of this index prevents that BMC from replacing the component's
+	// external_id with the DPU machine ID.
 	machineIDByBmcMac := make(map[string]string)
-	for _, cur := range allDetails {
-		if cur.MachineType != corev1.MachineType_HOST.String() {
-			continue
-		}
+	for _, cur := range hostMachineDetails {
 		if cur.BmcMac != "" && cur.MachineID != "" {
 			machineIDByBmcMac[utils.NormalizeMAC(cur.BmcMac)] = cur.MachineID
 		}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine_test.go
@@ -4,17 +4,238 @@
 package inventorysync
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
 
 // ptr is a generic helper that returns a pointer to the given value.
 // Useful for constructing test structs with pointer fields (e.g. *int32, *string).
 func ptr[T any](v T) *T { return &v }
+
+// failGetMachinesClient wraps a working mock client and fails GetMachines.
+type failGetMachinesClient struct {
+	nicoapi.Client
+}
+
+// GetMachines makes failGetMachinesClient fail only the actual-inventory query
+// while its embedded mock client continues to serve the other sync RPCs.
+func (c *failGetMachinesClient) GetMachines(_ context.Context) ([]nicoapi.MachineDetail, error) {
+	return nil, errors.New("boom")
+}
+
+func TestFilterHostMachineDetails(t *testing.T) {
+	testCases := []struct {
+		name               string
+		machineDetails     []nicoapi.MachineDetail
+		expectedMachineIDs []string
+	}{
+		{
+			name:               "no machines",
+			expectedMachineIDs: []string{},
+		},
+		{
+			name: "host machines",
+			machineDetails: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String()},
+				{MachineID: "host-2", MachineType: corev1.MachineType_HOST.String()},
+			},
+			expectedMachineIDs: []string{"host-1", "host-2"},
+		},
+		{
+			name: "mixed host and DPU machines",
+			machineDetails: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String()},
+				{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String()},
+				{MachineID: "host-2", MachineType: corev1.MachineType_HOST.String()},
+			},
+			expectedMachineIDs: []string{"host-1", "host-2"},
+		},
+		{
+			name: "DPU machines",
+			machineDetails: []nicoapi.MachineDetail{
+				{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String()},
+			},
+			expectedMachineIDs: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hostMachineDetails := filterHostMachineDetails(tc.machineDetails)
+			machineIDs := make([]string, 0, len(hostMachineDetails))
+			for _, detail := range hostMachineDetails {
+				machineIDs = append(machineIDs, detail.MachineID)
+			}
+
+			assert.Equal(t, tc.expectedMachineIDs, machineIDs)
+		})
+	}
+}
+
+func TestSyncMachines(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		machineDetails             []nicoapi.MachineDetail
+		expectedHostBmcMac         string
+		expectedDpuBmcMac          string
+		expectedPersistedMachineID string
+		expectedReceived           int
+		expectedExternalIDs        []string
+	}{
+		{
+			name:                "empty expected and actual inventory",
+			expectedExternalIDs: []string{},
+		},
+		{
+			name: "empty expected inventory with host and DPU actual inventory",
+			machineDetails: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String()},
+				{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String()},
+				{MachineID: "host-2", MachineType: corev1.MachineType_HOST.String()},
+			},
+			expectedReceived:    2,
+			expectedExternalIDs: []string{"host-1", "host-2"},
+		},
+		{
+			name: "matched expected host with orphan host and DPU actual inventory",
+			machineDetails: []nicoapi.MachineDetail{
+				{MachineID: "expected-host", MachineType: corev1.MachineType_HOST.String(), BmcMac: "aa:bb:cc:dd:ee:81"},
+				{MachineID: "orphan-host", MachineType: corev1.MachineType_HOST.String()},
+				{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String(), BmcMac: "aa:bb:cc:dd:ee:82"},
+			},
+			expectedHostBmcMac:         "aa:bb:cc:dd:ee:81",
+			expectedDpuBmcMac:          "aa:bb:cc:dd:ee:82",
+			expectedPersistedMachineID: "expected-host",
+			expectedReceived:           2,
+			expectedExternalIDs:        []string{"orphan-host"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, pool := mirrorTestPool(t)
+			client := nicoapi.NewMockClient()
+			for _, detail := range tc.machineDetails {
+				client.AddMachine(detail)
+			}
+			var expectedComponent model.Component
+			if tc.expectedHostBmcMac != "" {
+				expectedComponent = model.Component{
+					Type:         devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
+					Manufacturer: "TestMfg",
+					SerialNumber: "expected-host",
+				}
+				require.NoError(t, expectedComponent.Create(ctx, pool.DB))
+				createTestBMC(ctx, t, pool, expectedComponent.ID, tc.expectedHostBmcMac)
+			}
+			if tc.expectedDpuBmcMac != "" {
+				dpuBMC := model.BMC{
+					MacAddress:  tc.expectedDpuBmcMac,
+					ComponentID: expectedComponent.ID,
+					Type:        "DPU",
+				}
+				_, err := pool.DB.NewInsert().Model(&dpuBMC).Exec(ctx)
+				require.NoError(t, err)
+			}
+
+			received, drifts, rpcOK := syncMachines(ctx, pool, client)
+
+			assert.True(t, rpcOK)
+			assert.Equal(t, tc.expectedReceived, received)
+			reportedExternalIDs := make([]string, 0, len(drifts))
+			for _, drift := range drifts {
+				assert.Equal(t, model.DriftTypeMissingInExpected, drift.DriftType)
+				assert.Nil(t, drift.ComponentID)
+				require.NotNil(t, drift.ExternalID)
+				reportedExternalIDs = append(reportedExternalIDs, *drift.ExternalID)
+			}
+			assert.ElementsMatch(t, tc.expectedExternalIDs, reportedExternalIDs)
+
+			if tc.expectedPersistedMachineID != "" {
+				var persisted model.Component
+				err := pool.DB.NewSelect().Model(&persisted).Where("id = ?", expectedComponent.ID).Scan(ctx)
+				require.NoError(t, err)
+				require.NotNil(t, persisted.ComponentID)
+				assert.Equal(t, tc.expectedPersistedMachineID, *persisted.ComponentID)
+			}
+		})
+	}
+}
+
+func TestRunInventoryOne(t *testing.T) {
+	t.Run("final expected compute deletion keeps orphan host drift", func(t *testing.T) {
+		ctx, pool := mirrorTestPool(t)
+		client := nicoapi.NewMockClient()
+
+		const hostMachineID = "host-after-expected-delete"
+		const hostBmcMac = "aa:bb:cc:dd:ee:91"
+		client.AddMachine(nicoapi.MachineDetail{
+			MachineID:   hostMachineID,
+			MachineType: corev1.MachineType_HOST.String(),
+			BmcMac:      hostBmcMac,
+		})
+
+		component := model.Component{
+			Type:         devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
+			Manufacturer: "TestMfg",
+			SerialNumber: "expected-host-to-delete",
+		}
+		require.NoError(t, component.Create(ctx, pool.DB))
+		createTestBMC(ctx, t, pool, component.ID, hostBmcMac)
+
+		runInventoryOne(ctx, pool, client, false)
+		drifts, err := model.GetAllDrifts(ctx, pool.DB)
+		require.NoError(t, err)
+		assert.Empty(t, drifts)
+
+		require.NoError(t, component.Delete(ctx, pool.DB))
+		runInventoryOne(ctx, pool, client, false)
+
+		drifts, err = model.GetAllDrifts(ctx, pool.DB)
+		require.NoError(t, err)
+		require.Len(t, drifts, 1)
+		assert.Equal(t, model.DriftTypeMissingInExpected, drifts[0].DriftType)
+		assert.Nil(t, drifts[0].ComponentID)
+		require.NotNil(t, drifts[0].ExternalID)
+		assert.Equal(t, hostMachineID, *drifts[0].ExternalID)
+	})
+
+	t.Run("Core query failure preserves prior orphan host drift", func(t *testing.T) {
+		ctx, pool := mirrorTestPool(t)
+
+		// With no expected compute rows, `syncMachines` still queries Core.
+		// Keeping a reliable orphan-host result here proves that a failed call
+		// remains different from a successful, empty actual inventory.
+		externalID := "host-from-prior-cycle"
+		existing := model.ComponentDrift{
+			ExternalID: &externalID,
+			DriftType:  model.DriftTypeMissingInExpected,
+			Diffs:      []model.FieldDiff{},
+			CheckedAt:  time.Now(),
+		}
+		_, err := pool.DB.NewInsert().Model(&existing).Exec(ctx)
+		require.NoError(t, err)
+
+		client := &failGetMachinesClient{Client: nicoapi.NewMockClient()}
+		runInventoryOne(ctx, pool, client, false)
+
+		drifts, err := model.GetAllDrifts(ctx, pool.DB)
+		require.NoError(t, err)
+		require.Len(t, drifts, 1, "drift table must not be wiped when an actual-sync RPC failed")
+		require.NotNil(t, drifts[0].ExternalID)
+		assert.Equal(t, externalID, *drifts[0].ExternalID)
+	})
+}
 
 func TestCompareMachineFieldsForDrift_NoMismatch(t *testing.T) {
 	expected := &model.Component{

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -5,10 +5,8 @@ package inventorysync
 
 import (
 	"context"
-	"errors"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -21,16 +19,6 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 )
-
-// failGetMachinesClient wraps the production mock and forces the machine
-// actual-sync RPC to fail, so runActualSync reports allRPCOK=false.
-type failGetMachinesClient struct {
-	nicoapi.Client
-}
-
-func (c *failGetMachinesClient) GetMachines(_ context.Context) ([]nicoapi.MachineDetail, error) {
-	return nil, errors.New("boom")
-}
 
 // These tests exercise the mirror's write paths against a real database —
 // the half that pure-function tests can't reach and where the
@@ -502,33 +490,6 @@ func TestMirrorComponents_EvictRefusesNonHostBMC(t *testing.T) {
 	b, err := (&model.Component{Manufacturer: "Mfg", SerialNumber: "C-B"}).Get(ctx, pool.DB)
 	require.NoError(t, err)
 	assert.Empty(t, b.BMCs, "B's host BMC insert must be skipped, not steal the DPU MAC")
-}
-
-// #10: when an actual-sync RPC fails, the component_drift table must be left
-// intact rather than wiped with a partial view.
-func TestRunInventoryOne_DriftTablePreservedOnRPCFailure(t *testing.T) {
-	ctx, pool := mirrorTestPool(t)
-
-	// A compute component so syncMachines reaches GetMachines (which fails).
-	c := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-DRIFT-1"}
-	require.NoError(t, c.Create(ctx, pool.DB))
-
-	// A pre-existing drift row that must survive the failed cycle.
-	existing := model.ComponentDrift{
-		ComponentID: &c.ID,
-		DriftType:   model.DriftTypeMissingInActual,
-		Diffs:       []model.FieldDiff{},
-		CheckedAt:   time.Now(),
-	}
-	_, err := pool.DB.NewInsert().Model(&existing).Exec(ctx)
-	require.NoError(t, err)
-
-	client := &failGetMachinesClient{Client: nicoapi.NewMockClient()}
-	runInventoryOne(ctx, pool, client, false)
-
-	n, err := pool.DB.NewSelect().Model((*model.ComponentDrift)(nil)).Count(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n, "drift table must not be wiped when an actual-sync RPC failed")
 }
 
 // #4: two specs reporting the same manufacturer and serial must not abort the

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
@@ -172,9 +172,9 @@ func TestSyncFirmwareVersion(t *testing.T) {
 }
 
 // TestSyncMachineIDs_DpuBmcNotLinked verifies that a compute component owning
-// both a host BMC and a DPU BMC links to the HOST machine id, never the DPU's.
-// Core exposes the DPU as its own MachineDetail whose BmcMac is the DPU BMC, so
-// without the host-only filter the component could resolve to the DPU machine.
+// both a host BMC and a DPU BMC links to the HOST machine ID, never the DPU's.
+// Core exposes the DPU as its own `MachineDetail`, so matching the unfiltered
+// response could resolve the component to the DPU machine.
 func TestSyncMachineIDs_DpuBmcNotLinked(t *testing.T) {
 	ctx := context.Background()
 
@@ -218,7 +218,7 @@ func TestSyncMachineIDs_DpuBmcNotLinked(t *testing.T) {
 	components, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeCompute)
 	assert.Nil(t, err)
 
-	syncMachineIDs(ctx, pool, allDetails, components)
+	syncMachineIDs(ctx, pool, filterHostMachineDetails(allDetails), components)
 
 	var updated model.Component
 	err = pool.DB.NewSelect().Model(&updated).Where("id = ?", comp.ID).Scan(ctx)


### PR DESCRIPTION
Flow keeps a drift report comparing the hosts Cloud expects with the hosts Core discovers. As it stood, removing the final expected host made Flow stop asking Core for machines altogether. Hosts still visible to Core then disappeared from the report, while DPU records could sometimes be reported as unexpected hosts.

So, machine sync now asks Core what is present even when Cloud expects zero hosts, and it builds the report from `HOST` machine records only. If Core cannot answer, Flow keeps the last reliable report instead of replacing it with an empty one.

Key updates include:

- Untracked hosts remain visible after the final expected host is removed.
- DPUs are excluded from host matching and drift reporting.
- A valid empty response and a failed Core request remain meaningfully different.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4356

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Closes #4356
