### PR TITLE
feat(ufm-mock): Mock of UFM service integrated with machine-a-tron

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,7 @@ name = "carbide-ib-fabric"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "axum",
  "base64",
  "carbide-api-db",
  "carbide-api-model",
@@ -2222,6 +2223,7 @@ dependencies = [
  "carbide-secrets",
  "carbide-test-support",
  "carbide-tls",
+ "carbide-ufm-mock",
  "carbide-utils",
  "carbide-uuid",
  "chrono",
@@ -2435,6 +2437,7 @@ dependencies = [
  "carbide-rpc",
  "carbide-test-support",
  "carbide-tls",
+ "carbide-ufm-mock",
  "carbide-utils",
  "carbide-uuid",
  "carbide-version",
@@ -2448,6 +2451,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "mac_address",
+ "metrics-endpoint",
  "rand 0.10.1",
  "ratatui",
  "reqwest 0.13.4",
@@ -3384,6 +3388,33 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tonic",
+]
+
+[[package]]
+name = "carbide-ufm-mock"
+version = "0.0.1"
+dependencies = [
+ "axum",
+ "axum-server",
+ "carbide-axum-utils",
+ "carbide-utils",
+ "clap",
+ "duration-str",
+ "eyre",
+ "figment",
+ "futures",
+ "metrics-endpoint",
+ "opentelemetry 0.32.0",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1421,6 +1421,7 @@ where
         ipmi_reachable_port: None,
         hw_mac_address_ranges: None,
         mac_address_pool: None,
+        ufm_mock: Default::default(),
     };
 
     let (provisionable_handles, mat_handle) = api_test_helper::machine_a_tron::run_local(

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -181,6 +181,7 @@ async fn run_machine_a_tron_racks_test(
         ipmi_reachable_port: None,
         hw_mac_address_ranges: None,
         mac_address_pool: None,
+        ufm_mock: Default::default(),
     };
 
     let (provisionable_handles, mat_handle) = api_test_helper::machine_a_tron::run_local(

--- a/crates/axum-utils/src/injection/middleware.rs
+++ b/crates/axum-utils/src/injection/middleware.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use axum::body::Body;
-use axum::extract::{Request, State};
+use axum::extract::{OriginalUri, Request, State};
 use axum::response::Response;
 use axum::routing::any;
 
@@ -35,7 +35,14 @@ pub fn injection_router(inner: Router, store: Arc<InjectionStore>) -> Router {
 
 async fn process(State(mut state): State<InjectionMiddleware>, request: Request<Body>) -> Response {
     let method = request.method().clone();
-    let path = request.uri().path().to_string();
+    // Axum strips the mounting prefix from `request.uri()` inside a nested router and preserves
+    // the client-visible URI in `OriginalUri`. Injection selectors describe external paths, so
+    // prefer the original path when the two differ and fall back for non-nested routers.
+    let path = request
+        .extensions()
+        .get::<OriginalUri>()
+        .map_or_else(|| request.uri().path(), |uri| uri.0.path())
+        .to_string();
     if let Some(response) = state.store.pre_handle(&method, &path).await {
         return response;
     }

--- a/crates/bmc-mock/src/infiniband.rs
+++ b/crates/bmc-mock/src/infiniband.rs
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::fmt;
+
+/// An InfiniBand port GUID in network byte order.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Guid([u8; 8]);
+
+impl From<[u8; 8]> for Guid {
+    fn from(bytes: [u8; 8]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<Guid> for [u8; 8] {
+    fn from(guid: Guid) -> Self {
+        guid.0
+    }
+}
+
+impl fmt::Display for Guid {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::Guid;
+
+    #[test]
+    fn display_is_normalized_hexadecimal() {
+        check_values(
+            [
+                Check {
+                    scenario: "leading zeroes",
+                    input: Guid::from([0, 0, 0, 0, 0, 0, 0, 1]),
+                    expect: "0000000000000001".to_string(),
+                },
+                Check {
+                    scenario: "lowercase hexadecimal",
+                    input: Guid::from([0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10]),
+                    expect: "fedcba9876543210".to_string(),
+                },
+            ],
+            |guid| guid.to_string(),
+        );
+    }
+}

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -30,6 +30,7 @@ mod bmc_state;
 mod combined_server;
 mod http;
 mod hw;
+pub mod infiniband;
 mod json;
 pub mod mac_address_pool;
 mod machine_info;

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 
+use crate::infiniband::Guid;
 use crate::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use crate::redfish::update_service::UpdateServiceConfig;
 use crate::{DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HardwareType, hw, redfish};
@@ -381,15 +382,14 @@ impl HostMachineInfo {
             .or(self.non_dpu_mac_address)
     }
 
-    pub fn infiniband_port_guids(&self) -> Vec<String> {
+    pub fn infiniband_port_guids(&self) -> Vec<Guid> {
         let [b0, b1, b2, b3, b4, b5] = self.hw_mac_addr_pool.base().bytes();
         (0..self.hw_type.infiniband_port_count())
             .map(|interface_index| {
                 let interface_index = u16::try_from(interface_index)
                     .expect("mock hardware models have fewer than 65536 InfiniBand interfaces");
                 let [b6, b7] = interface_index.to_be_bytes();
-                let guid = u64::from_be_bytes([b0, b1, b2, b3, b4, b5, b6, b7]);
-                format!("{guid:016x}")
+                Guid::from([b0, b1, b2, b3, b4, b5, b6, b7])
             })
             .collect()
     }

--- a/crates/ib-fabric/Cargo.toml
+++ b/crates/ib-fabric/Cargo.toml
@@ -52,11 +52,13 @@ url = { workspace = true }
 
 [dev-dependencies]
 # Self-dependency so the crate's own tests see the `test-support` fakes.
+axum = { workspace = true }
 carbide-ib-fabric = { path = ".", features = ["test-support"] }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
 figment = { features = ["env", "test", "toml"], workspace = true }
 tempfile = { workspace = true }
+ufm-mock = { package = "carbide-ufm-mock", path = "../ufm-mock" }
 
 [lints]
 workspace = true

--- a/crates/ib-fabric/src/ib/rest.rs
+++ b/crates/ib-fabric/src/ib/rest.rs
@@ -427,8 +427,65 @@ impl From<PortMembership> for IBPortMembership {
 #[cfg(test)]
 mod tests {
     use model::errors::ModelError;
+    use opentelemetry::global;
+    use ufm_mock::{
+        InfinibandPortState, InventoryMachine, InventoryPort, InventorySnapshot, UfmAuthToken,
+        UfmMock, UfmMockConfig,
+    };
 
     use super::*;
+
+    #[tokio::test]
+    async fn rest_client_is_compatible_with_the_ufm_mock() {
+        let auth_token = UfmAuthToken::new("test-token".to_string()).unwrap();
+        let ufm_mock = UfmMock::new(
+            &UfmMockConfig::default(),
+            &auth_token,
+            &global::meter("ib-fabric-ufm-mock-compatibility-test"),
+        )
+        .unwrap();
+        ufm_mock
+            .apply_inventory(InventorySnapshot {
+                inventory_id: "inventory-a".into(),
+                epoch_id: "epoch-a".into(),
+                generation: 1.into(),
+                machines: vec![InventoryMachine {
+                    mat_id: "mat-a".into(),
+                    machine_id: None,
+                    infiniband_ports: Some(vec![InventoryPort {
+                        guid: "0000000000000001".parse().unwrap(),
+                        state: InfinibandPortState::Active,
+                    }]),
+                }],
+            })
+            .unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, ufm_mock.router()).await.unwrap();
+        });
+        let client = new_client(&format!("http://{address}"), "test-token").unwrap();
+
+        assert_eq!(client.versions().await.unwrap().ufm_version, "6.18.0");
+        assert_eq!(client.find_ib_port(None).await.unwrap().len(), 1);
+        let partitions = client
+            .get_ib_networks(GetPartitionOptions {
+                include_guids_data: true,
+                include_qos_conf: false,
+            })
+            .await
+            .unwrap();
+        assert!(
+            partitions[&0x7fff]
+                .associated_guids
+                .as_ref()
+                .unwrap()
+                .is_empty()
+        );
+
+        server.abort();
+        assert!(server.await.unwrap_err().is_cancelled());
+    }
 
     #[test]
     fn ib_rest_type_conversion() {

--- a/crates/machine-a-tron/Cargo.toml
+++ b/crates/machine-a-tron/Cargo.toml
@@ -76,6 +76,8 @@ carbide-version = { path = "../version" }
 carbide-uuid = { path = "../uuid" }
 carbide-network = { path = "../network" }
 carbide-utils = { path = "../utils", features = ["test-support"] }
+metrics-endpoint = { path = "../metrics-endpoint" }
+ufm-mock = { package = "carbide-ufm-mock", path = "../ufm-mock" }
 
 [dev-dependencies]
 carbide-test-support = { path = "../test-support" }

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -34,6 +34,7 @@ use rpc::forge_tls_client::ForgeClientConfig;
 use rpc::protos::forge_api_client::ForgeApiClient;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use ufm_mock::UfmMockConfig;
 use uuid::Uuid;
 
 use crate::BmcRegistrationMode;
@@ -497,10 +498,23 @@ pub struct MachineATronConfig {
     /// inventories are aggregated must use non-overlapping ranges.
     #[serde(default)]
     pub hw_mac_address_ranges: Option<MacAddressRangesConfig>,
+
+    /// Optional UFM API hosted on the machine-a-tron control listener.
+    ///
+    /// Unlike standalone execution, the hosted mock may consume machine-a-tron's control state
+    /// directly when `include_local_inventory` is enabled. Configured static sources are still
+    /// polled and can be combined with that local inventory. A present section is activated only
+    /// when its explicit `enabled` flag is set.
+    #[serde(default)]
+    pub ufm_mock: Option<UfmMockConfig>,
 }
 
 impl MachineATronConfig {
     pub fn validate(&self) -> eyre::Result<()> {
+        if let Some(ufm_mock) = self.ufm_mock.as_ref() {
+            ufm_mock.validate()?;
+        }
+
         if let DhcpType::UdpRelay {
             server_address,
             listen_address,

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -27,14 +27,16 @@ use bmc_mock::injection::{InjectionStore, Rule, RuleId};
 use carbide_uuid::rack::RackId;
 use chrono::{SecondsFormat, Utc};
 use tower::Service;
+use ufm_mock::{
+    EpochId, Generation, InventoryId, InventoryMachine as UfmInventoryMachine, InventoryPort,
+    InventoryProvider, InventorySnapshot, MachineId, MatId,
+};
 
 use crate::device_simulator::SimulatorLifecycle;
 use crate::simulator_registry::SimulatorRegistry;
-use crate::status::{
-    DeviceKind, DeviceStatus, DeviceStatusConfig, DevicesStatusResponse, InfinibandPortStatus,
-};
+use crate::status::{DeviceKind, DeviceStatus, DeviceStatusConfig, DevicesStatusResponse};
 
-pub fn append(router: Router, control_state: ControlState) -> Router {
+pub fn append(router: Option<Router>, control_state: ControlState) -> Router {
     Router::new()
         .route("/", get(get_machines_ui))
         .route("/machines/status", get(get_machines_status))
@@ -64,25 +66,25 @@ pub struct ControlState {
 
 #[derive(Debug)]
 struct InventoryVersion {
-    inventory_id: String,
-    epoch_id: String,
-    generation: u64,
+    inventory_id: InventoryId,
+    epoch_id: EpochId,
+    generation: Generation,
     snapshot: Vec<InventoryMachine>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct InventoryMachine {
-    mat_id: String,
-    machine_id: Option<String>,
+    mat_id: MatId,
+    machine_id: Option<MachineId>,
     hardware_type: Option<HardwareType>,
-    infiniband_ports: Vec<InfinibandPortStatus>,
+    infiniband_ports: Vec<InventoryPort>,
 }
 
 impl ControlState {
     pub fn new(
         simulators: SimulatorRegistry,
         status_config: DeviceStatusConfig,
-        inventory_id: String,
+        inventory_id: InventoryId,
     ) -> Self {
         let devices = Self::collect_statuses(&simulators, &status_config);
         Self {
@@ -90,8 +92,10 @@ impl ControlState {
             status_config,
             inventory_version: Arc::new(Mutex::new(InventoryVersion {
                 inventory_id,
-                epoch_id: Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true),
-                generation: 1,
+                epoch_id: Utc::now()
+                    .to_rfc3339_opts(SecondsFormat::Nanos, true)
+                    .into(),
+                generation: Generation::INITIAL,
                 snapshot: Self::inventory_snapshot(&devices),
             })),
         }
@@ -108,7 +112,7 @@ impl ControlState {
             version.snapshot = snapshot;
             version.generation = version
                 .generation
-                .checked_add(1)
+                .checked_next()
                 .expect("inventory generation cannot overflow during one process epoch");
         }
 
@@ -136,11 +140,20 @@ impl ControlState {
             .iter()
             .filter(|device| device.device_kind == DeviceKind::Machine)
             .map(|device| {
-                let mut infiniband_ports = device.infiniband_ports.clone().unwrap_or_default();
-                infiniband_ports.sort_by(|left, right| left.guid.cmp(&right.guid));
+                let mut infiniband_ports = device
+                    .infiniband_ports
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|port| InventoryPort {
+                        guid: port.guid,
+                        state: port.state,
+                    })
+                    .collect::<Vec<_>>();
+                infiniband_ports.sort_by_key(|port| port.guid);
                 InventoryMachine {
-                    mat_id: device.mat_id.clone(),
-                    machine_id: device.machine_id.clone(),
+                    mat_id: device.mat_id.as_str().into(),
+                    machine_id: device.machine_id.as_deref().map(MachineId::from),
                     hardware_type: device.hardware_type,
                     infiniband_ports,
                 }
@@ -155,9 +168,41 @@ impl ControlState {
     }
 }
 
+// This adapter connects machine-a-tron's live control state to the hosted UFM mock. It lets the
+// mock consume the same in-process inventory when `include_local_inventory` is enabled, without
+// polling machine-a-tron over HTTP.
+impl InventoryProvider for ControlState {
+    fn inventory_snapshot(&self) -> InventorySnapshot {
+        let status = self.devices_status();
+        InventorySnapshot {
+            inventory_id: status.inventory_id,
+            epoch_id: status.epoch_id,
+            generation: status.generation,
+            machines: status
+                .devices
+                .into_iter()
+                .filter(|device| device.device_kind == DeviceKind::Machine)
+                .map(|device| UfmInventoryMachine {
+                    mat_id: MatId::from(device.mat_id),
+                    machine_id: device.machine_id.map(MachineId::from),
+                    infiniband_ports: device.infiniband_ports.map(|ports| {
+                        ports
+                            .into_iter()
+                            .map(|port| InventoryPort {
+                                guid: port.guid,
+                                state: port.state,
+                            })
+                            .collect()
+                    }),
+                })
+                .collect(),
+        }
+    }
+}
+
 #[derive(Clone)]
 struct ControlRouter {
-    inner: Router,
+    inner: Option<Router>,
     control_state: ControlState,
 }
 
@@ -245,7 +290,10 @@ fn device_not_found() -> Response {
 }
 
 async fn process(State(mut state): State<ControlRouter>, request: Request<Body>) -> Response {
-    call_inner_router(&mut state.inner, request).await
+    let Some(inner) = state.inner.as_mut() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    call_inner_router(inner, request).await
 }
 
 async fn call_inner_router(router: &mut Router, request: Request<Body>) -> Response {
@@ -284,7 +332,7 @@ mod tests {
         ControlState::new(
             SimulatorRegistry::try_from_handles(handles).unwrap(),
             DeviceStatusConfig::new(1266),
-            "mat-06:00:00:00:00:00".to_string(),
+            "mat-06:00:00:00:00:00".into(),
         )
     }
 
@@ -322,13 +370,13 @@ mod tests {
                 .build()
                 .unwrap(),
             DeviceStatusConfig::new(1266),
-            "mat-06:00:00:00:00:00".to_string(),
+            "mat-06:00:00:00:00:00".into(),
         )
     }
 
     #[tokio::test]
     async fn machines_status_does_not_require_bmc_routes() {
-        let router = append(Router::new(), control_state(Vec::new()));
+        let router = append(None, control_state(Vec::new()));
 
         let response = router
             .oneshot(
@@ -356,7 +404,7 @@ mod tests {
     #[tokio::test]
     async fn machines_ui_returns_html() {
         let router = append(
-            Router::new().route("/redfish/v1", get(|| async { "bmc" })),
+            Some(Router::new().route("/redfish/v1", get(|| async { "bmc" }))),
             control_state(Vec::new()),
         );
 
@@ -387,10 +435,7 @@ mod tests {
             }),
         );
         let without_ipmi = DeviceHandle::for_control_test(Vec::new(), None);
-        let router = append(
-            Router::new(),
-            control_state(vec![first, second, without_ipmi]),
-        );
+        let router = append(None, control_state(vec![first, second, without_ipmi]));
 
         let response = router
             .oneshot(
@@ -416,7 +461,7 @@ mod tests {
     async fn rack_status_projects_devices_from_machines_status() {
         let handle = DeviceHandle::for_control_test(Vec::new(), None);
         let mat_id = handle.mat_id().to_string();
-        let router = append(Router::new(), rack_control_state(handle));
+        let router = append(None, rack_control_state(handle));
 
         let machines_response = router
             .clone()
@@ -475,7 +520,7 @@ mod tests {
 
     #[tokio::test]
     async fn rack_status_requires_known_rack() {
-        let router = append(Router::new(), control_state(Vec::new()));
+        let router = append(None, control_state(Vec::new()));
 
         let response = router
             .oneshot(
@@ -499,7 +544,7 @@ mod tests {
         let first_id = first.mat_id().to_string();
         let second_id = second.mat_id().to_string();
         let router = append(
-            Router::new(),
+            None,
             rack_control_state_for(
                 vec![first, second],
                 vec![
@@ -528,7 +573,7 @@ mod tests {
 
     #[tokio::test]
     async fn bmc_injection_rules_require_known_device() {
-        let router = append(Router::new(), control_state(Vec::new()));
+        let router = append(None, control_state(Vec::new()));
 
         let get_response = router
             .clone()
@@ -584,7 +629,7 @@ mod tests {
             .unwrap();
         let dpu = DpuMachineHandle::for_control_test(dpu_id, Some(observed_dpu_id));
         let host = DeviceHandle::for_control_test(vec![dpu], None);
-        let router = append(Router::new(), control_state(vec![host.clone()]));
+        let router = append(None, control_state(vec![host.clone()]));
 
         let response = router
             .clone()
@@ -624,7 +669,7 @@ mod tests {
     #[tokio::test]
     async fn unmatched_paths_forward_to_inner_router() {
         let router = append(
-            Router::new().route("/redfish/v1", get(|| async { "bmc" })),
+            Some(Router::new().route("/redfish/v1", get(|| async { "bmc" }))),
             control_state(Vec::new()),
         );
 
@@ -641,5 +686,22 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(&body[..], b"bmc");
+    }
+
+    #[tokio::test]
+    async fn unmatched_paths_return_not_found_without_inner_router() {
+        let router = append(None, control_state(Vec::new()));
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/redfish/v1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/crates/machine-a-tron/src/device_handle.rs
+++ b/crates/machine-a-tron/src/device_handle.rs
@@ -24,15 +24,14 @@ use carbide_uuid::machine::MachineId;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::PersistedDevice;
 use crate::api_client::ApiClient;
 use crate::dpu_machine::DpuMachineHandle;
 use crate::host_machine::MachineHandle;
-use crate::machine_state_machine::InfinibandPortState;
 use crate::power_shelf_simulator::PowerShelfHandle;
 use crate::status::{DeviceKind, DeviceStatus, DeviceStatusConfig};
 use crate::switch_simulator::SwitchHandle;
 use crate::tui::UiUpdate;
+use crate::{Guid, InfinibandPortState, PersistedDevice};
 
 #[derive(Debug, Clone)]
 enum DeviceHandleInner {
@@ -157,7 +156,7 @@ impl DeviceHandle {
 
     pub fn set_infiniband_port_state(
         &self,
-        guid: &str,
+        guid: Guid,
         state: InfinibandPortState,
     ) -> eyre::Result<()> {
         match &self.0 {

--- a/crates/machine-a-tron/src/discovery_info.rs
+++ b/crates/machine-a-tron/src/discovery_info.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use bmc_mock::infiniband::Guid;
 use bmc_mock::mac_address_pool::MacAddressPool;
 use bmc_mock::{DpuMachineInfo, HardwareType, HostMachineInfo, MachineInfo};
 use carbide_utils::arch::CpuArchitecture;
@@ -723,7 +724,7 @@ fn gb200_gpus() -> Vec<Gpu> {
 }
 
 fn gb200_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInterface> {
-    let guids: [String; 4] = host
+    let guids: [Guid; 4] = host
         .infiniband_port_guids()
         .try_into()
         .expect("GB200 has four InfiniBand interfaces");
@@ -747,7 +748,7 @@ fn gb200_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInterfac
                     description: Some("MT2910 Family [ConnectX-7]".into()),
                     slot: Some(format!("{domain}:03:00.0")),
                 }),
-                guid,
+                guid: guid.to_string(),
             }
         })
         .collect()
@@ -827,7 +828,7 @@ fn cx8_network_interface(
 }
 
 fn dgx_h100_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInterface> {
-    let guids: [String; 8] = host
+    let guids: [Guid; 8] = host
         .infiniband_port_guids()
         .try_into()
         .expect("DGX H100 has eight InfiniBand interfaces");
@@ -859,7 +860,7 @@ fn dgx_h100_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInter
                 description: Some("MT2910 Family [ConnectX-7]".into()),
                 slot: Some(format!("0000:{:02x}:00.0", bus + 3)),
             }),
-            guid,
+            guid: guid.to_string(),
         }
     })
     .collect()

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -38,14 +38,12 @@ use crate::api_client::ApiClient;
 use crate::config::{self, MachineATronContext, MachineConfig, PersistedDevice};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay};
 use crate::dpu_machine::{DpuMachine, DpuMachineHandle};
-use crate::machine_state_machine::{
-    InfinibandPortState, LiveState, MachineStateMachine, PersistedMachine,
-};
-use crate::saturating_add_duration_to_instant;
+use crate::machine_state_machine::{LiveState, MachineStateMachine, PersistedMachine};
 use crate::status::{
     BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, EndpointStatus, InfinibandPortStatus,
 };
 use crate::tui::{HostDetails, UiUpdate};
+use crate::{Guid, InfinibandPortState, saturating_add_duration_to_instant};
 
 pub(super) struct HostMachine {
     mat_id: Uuid,
@@ -741,33 +739,26 @@ impl MachineHandle {
 
     pub(super) fn set_infiniband_port_state(
         &self,
-        guid: &str,
+        guid: Guid,
         state: InfinibandPortState,
     ) -> eyre::Result<()> {
         let mut live_state = self.0.live_state.write().unwrap();
         let port_state = live_state
             .infiniband_port_states
-            .get_mut(guid)
-            .ok_or_else(|| eyre::eyre!("InfiniBand port {guid} not found"))?;
+            .get_mut(&guid)
+            .ok_or_else(|| eyre::eyre!("infiniband port {guid} not found"))?;
         *port_state = state;
         Ok(())
     }
 
     pub(super) fn status(&self, config: &DeviceStatusConfig) -> DeviceStatus {
         let live_state = self.0.live_state.read().unwrap();
-        let infiniband_ports = self
-            .0
-            .host_info
-            .infiniband_port_guids()
-            .into_iter()
-            .map(|guid| InfinibandPortStatus {
-                state: *live_state
-                    .infiniband_port_states
-                    .get(&guid)
-                    .expect("live InfiniBand state initialized from static machine info"),
-                guid,
-            })
+        let mut infiniband_ports = live_state
+            .infiniband_port_states
+            .iter()
+            .map(|(&guid, &state)| InfinibandPortStatus { guid, state })
             .collect::<Vec<_>>();
+        infiniband_ports.sort_by_key(|port| port.guid);
         DeviceStatus {
             mat_id: self.0.mat_id.to_string(),
             device_kind: DeviceKind::Machine,

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -61,7 +61,7 @@ pub use device_simulator::{
 pub use dhcp_wrapper::{DhcpClient, UdpDhcpService};
 pub use dpu_machine::DpuMachineHandle;
 pub use machine_a_tron::{AppEvent, MachineATron};
-pub use machine_state_machine::{BmcRegistrationMode, InfinibandPortState};
+pub use machine_state_machine::BmcRegistrationMode;
 pub use mock_ssh_server::{
     Credentials as MockSshCredentials, MockSshServerHandle, PromptBehavior,
     spawn as spawn_mock_ssh_server,
@@ -73,6 +73,7 @@ pub use status::{
 };
 pub use tui::{Tui, UiUpdate};
 pub use tui_host_logs::TuiHostLogs;
+pub use ufm_mock::{Guid, InfinibandPortState};
 
 /// Add a Duration to an Instant, defaulting to a time in the far future if there is an overflow.
 /// This allows using Duration::MAX and being able to add it to Instant::now(), which overflows by

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -50,16 +50,9 @@ use crate::machine_state_machine::MachineStateError::MissingMachineId;
 use crate::machine_utils::{
     PxeError, PxeResponse, forge_agent_control, get_validation_id, send_pxe_boot_request,
 };
-use crate::{PersistedDevice, PersistedDpuMachine};
+use crate::{Guid, InfinibandPortState, PersistedDevice, PersistedDpuMachine};
 
 type DpuDhcpRelayHandle = oneshot::Sender<()>;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum InfinibandPortState {
-    Active,
-    Down,
-}
 
 // RFC 2131 section 4.1's Ethernet example starts at four seconds, doubles to a
 // 64-second base, and adds uniform jitter from -1 through +1 second.
@@ -260,7 +253,7 @@ pub(super) struct LiveState {
     pub(super) api_state: String,
     pub(super) tpm_ek_certificate: Option<Vec<u8>>,
     pub(super) ssh_host_key: Option<String>,
-    pub(super) infiniband_port_states: HashMap<String, InfinibandPortState>,
+    pub(super) infiniband_port_states: HashMap<Guid, InfinibandPortState>,
     /// For a DPU machine, whether its BlueField has flipped to NIC mode. Lets the
     /// owning host observe the flip through the DPU handle and converge (detach
     /// its DPU DHCP relay). Always false for a host machine.
@@ -305,7 +298,10 @@ impl LiveState {
             MachineInfo::Host(host) => host
                 .infiniband_port_guids()
                 .into_iter()
-                .map(|guid| (guid, InfinibandPortState::Active))
+                .map(|guid| {
+                    let bytes: [u8; 8] = guid.into();
+                    (Guid::from(bytes), InfinibandPortState::Active)
+                })
                 .collect(),
             MachineInfo::Dpu(_) => HashMap::new(),
         };

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -16,6 +16,8 @@
  */
 #![cfg_attr(not(test), deny(dead_code_pub_in_binary))]
 
+mod ufm_mock;
+
 use std::borrow::Cow;
 use std::error::Error;
 use std::path::{Path, PathBuf};
@@ -47,6 +49,8 @@ use tokio::sync::mpsc;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, registry};
+
+use crate::ufm_mock::HostedUfmMock;
 
 fn init_log(
     filename: &Option<String>,
@@ -91,6 +95,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let fig = Figment::new().merge(Toml::file(config_path));
     let app_config: MachineATronConfig = fig.extract()?;
     app_config.validate()?;
+    let ufm_config = app_config.ufm_mock.clone();
     let tui_host_logs = if app_config.tui_enabled {
         Some(TuiHostLogs::start_new(100))
     } else {
@@ -224,8 +229,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let control_state = ControlState::new(
         simulators.clone(),
         DeviceStatusConfig::new(bmc_mock_port),
-        inventory_id,
+        inventory_id.into(),
     );
+    // Hosted mode mounts the shared UFM mock router on machine-a-tron's control server. Its
+    // ControlState can be injected as an in-process inventory provider; the standalone binary
+    // initializes the same mock without this provider and relies on configured HTTP sources.
+    let hosted_ufm = HostedUfmMock::start(ufm_config, &control_state)?;
+    let ufm_router = hosted_ufm.as_ref().map(HostedUfmMock::router);
     let certs_dir = app_context
         .bmc_mock_certs_dir
         .as_ref()
@@ -240,7 +250,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             BmcRegistrationMode::BackingInstance(bmc_mock_registry) => {
                 let server_config = bmc_mock::tls::server_config(certs_dir.clone())?;
                 let bmc_router = bmc_mock::combined_router(bmc_mock_registry.clone());
-                let router = append_control_routes(bmc_router, control_state.clone());
+                let bmc_router = match ufm_router.clone() {
+                    Some(ufm_router) => ufm_router.merge(bmc_router),
+                    None => bmc_router,
+                };
+                let router = append_control_routes(Some(bmc_router), control_state.clone());
                 let bmc_https_mock = bmc_mock::CombinedServer::run_router(
                     "bmc-mock",
                     router,
@@ -276,7 +290,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
             BmcRegistrationMode::None(_) => {
                 let server_config = bmc_mock::tls::server_config(certs_dir)?;
-                let router = append_control_routes(axum::Router::new(), control_state);
+                let router = append_control_routes(ufm_router, control_state);
                 let control_server = bmc_mock::CombinedServer::run_router(
                     "machine-a-tron-control",
                     router,
@@ -323,6 +337,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let mat_result = mat.run(simulators, tui_event_tx.clone(), app_rx).await;
+
+    if let Some(hosted_ufm) = hosted_ufm {
+        hosted_ufm.shutdown().await?;
+    }
 
     if let Some(tui_handle) = tui_handle {
         if let Some(tui_quit_tx) = tui_quit_tx.as_ref() {

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -17,12 +17,13 @@
 use bmc_mock::HardwareType;
 use bmc_mock::ipmi_sim::IpmiEndpoint;
 use serde::Serialize;
+use ufm_mock::{EpochId, Generation, InventoryId};
 
-use crate::machine_state_machine::InfinibandPortState;
+use crate::{Guid, InfinibandPortState};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct InfinibandPortStatus {
-    pub guid: String,
+    pub guid: Guid,
     pub state: InfinibandPortState,
 }
 
@@ -73,9 +74,9 @@ impl DeviceStatusConfig {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DevicesStatusResponse {
-    pub inventory_id: String,
-    pub epoch_id: String,
-    pub generation: u64,
+    pub inventory_id: InventoryId,
+    pub epoch_id: EpochId,
+    pub generation: Generation,
     #[serde(rename = "machines")]
     pub devices: Vec<DeviceStatus>,
 }

--- a/crates/machine-a-tron/src/ufm_mock.rs
+++ b/crates/machine-a-tron/src/ufm_mock.rs
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use ::ufm_mock::{InventoryProvider, UfmAuthToken, UfmMock, UfmMockConfig};
+use axum::Router;
+use machine_a_tron::ControlState;
+use metrics_endpoint::{
+    MetricsEndpointConfig, MetricsSetup, new_metrics_setup, run_metrics_endpoint_with_cancellation,
+};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+pub(super) struct HostedUfmMock {
+    router: Router,
+    cancellation: CancellationToken,
+    reconciliation: JoinHandle<()>,
+    metrics_task: Option<JoinHandle<()>>,
+    metrics_setup: MetricsSetup,
+}
+
+impl HostedUfmMock {
+    pub(super) fn start(
+        config: Option<UfmMockConfig>,
+        control_state: &ControlState,
+    ) -> eyre::Result<Option<Self>> {
+        let Some(config) = config.filter(|config| config.enabled) else {
+            return Ok(None);
+        };
+
+        tracing::info!("Enabling hosted UFM mock");
+        let auth_token = UfmAuthToken::from_environment()?;
+        let metrics_setup = new_metrics_setup("carbide-ufm-mock", "carbide", false)?;
+        let ufm = UfmMock::new(&config, &auth_token, &metrics_setup.meter)?;
+        let local_provider = config
+            .include_local_inventory
+            .then(|| Arc::new(control_state.clone()) as Arc<dyn InventoryProvider>);
+        let cancellation = CancellationToken::new();
+        let reconciliation =
+            ufm.start_reconciliation(config.inventory, local_provider, cancellation.child_token());
+        let metrics_task = config.metrics_address.map(|address| {
+            let metrics_config = MetricsEndpointConfig {
+                address,
+                registry: metrics_setup.registry.clone(),
+                health_controller: Some(metrics_setup.health_controller.clone()),
+                additional_prefix: None,
+            };
+            let cancellation = cancellation.child_token();
+            tokio::spawn(async move {
+                if let Err(error) =
+                    run_metrics_endpoint_with_cancellation(&metrics_config, cancellation).await
+                {
+                    tracing::error!(error = %error, "Hosted UFM metrics endpoint stopped");
+                }
+            })
+        });
+
+        Ok(Some(Self {
+            router: ufm.router(),
+            cancellation,
+            reconciliation,
+            metrics_task,
+            metrics_setup,
+        }))
+    }
+
+    pub(super) fn router(&self) -> Router {
+        self.router.clone()
+    }
+
+    pub(super) async fn shutdown(self) -> eyre::Result<()> {
+        self.cancellation.cancel();
+        self.reconciliation.await?;
+        if let Some(metrics_task) = self.metrics_task {
+            metrics_task.await?;
+        }
+        drop(self.metrics_setup);
+        Ok(())
+    }
+}

--- a/crates/ufm-mock/Cargo.toml
+++ b/crates/ufm-mock/Cargo.toml
@@ -1,0 +1,58 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "carbide-ufm-mock"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[lib]
+name = "ufm_mock"
+
+[[bin]]
+name = "ufm-mock"
+path = "src/main.rs"
+
+[dependencies]
+axum = { workspace = true }
+axum-server = { features = ["tls-rustls"], workspace = true }
+carbide-axum-utils = { path = "../axum-utils" }
+carbide-utils = { path = "../utils" }
+clap = { features = ["derive"], workspace = true }
+duration-str = { workspace = true }
+eyre = { workspace = true }
+figment = { features = ["toml"], workspace = true }
+futures = { workspace = true }
+metrics-endpoint = { path = "../metrics-endpoint" }
+opentelemetry = { workspace = true }
+reqwest = { default-features = false, features = ["json", "rustls"], workspace = true }
+serde = { features = ["derive"], workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { features = ["env-filter"], workspace = true }
+url = { features = ["serde"], workspace = true }
+
+[dev-dependencies]
+tower = { features = ["util"], workspace = true }
+
+[lints]
+workspace = true

--- a/crates/ufm-mock/src/auth.rs
+++ b/crates/ufm-mock/src/auth.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub const UFM_MOCK_AUTH_TOKEN_ENV: &str = "UFM_MOCK_AUTH_TOKEN";
+
+/// Authentication token passed separately from non-secret UFM mock configuration.
+///
+/// The type deliberately does not implement `Debug`, `Display`, or `AsRef<str>`. Code that needs
+/// the token value must explicitly call [`Self::expose_secret`].
+pub struct UfmAuthToken(String);
+
+impl UfmAuthToken {
+    /// Reads the token from [`UFM_MOCK_AUTH_TOKEN_ENV`].
+    pub fn from_environment() -> eyre::Result<Self> {
+        let token = std::env::var(UFM_MOCK_AUTH_TOKEN_ENV).map_err(|error| {
+            eyre::eyre!("could not read {UFM_MOCK_AUTH_TOKEN_ENV} environment variable: {error}")
+        })?;
+        Self::new(token)
+    }
+
+    pub fn new(token: String) -> eyre::Result<Self> {
+        eyre::ensure!(
+            !token.is_empty(),
+            "UFM authentication token must not be empty"
+        );
+        Ok(Self(token))
+    }
+
+    /// Explicitly exposes the token to code that must construct an authorization header.
+    pub fn expose_secret(&self) -> &str {
+        &self.0
+    }
+}

--- a/crates/ufm-mock/src/config.rs
+++ b/crates/ufm-mock/src/config.rs
@@ -1,0 +1,240 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use carbide_utils::config::as_std_duration;
+use duration_str::deserialize_duration;
+use serde::{Deserialize, Serialize};
+
+/// Configuration shared by the UFM mock library and its standalone binary.
+///
+/// Machine-a-tron embeds the mock into its control server and may combine its in-process
+/// inventory with remote [`InventoryConfig::static_sources`]. The standalone binary owns its
+/// listener and has no in-process inventory, so it relies exclusively on the configured static
+/// sources.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+pub struct UfmMockConfig {
+    /// Activates a configured mock when it is embedded into another process.
+    ///
+    /// Keeping this separate from the presence of the configuration allows deployments to stage
+    /// a complete UFM section without starting it. The standalone binary sets this to `true`
+    /// because launching that binary is itself the activation decision.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Includes inventory supplied directly by the embedding process.
+    ///
+    /// Machine-a-tron uses its control state as the local provider. Standalone execution has no
+    /// local provider, so this setting has no effect there.
+    #[serde(default)]
+    pub include_local_inventory: bool,
+    #[serde(default)]
+    pub metrics_address: Option<SocketAddr>,
+    #[serde(default)]
+    pub fabric: FabricConfig,
+    #[serde(default)]
+    pub inventory: InventoryConfig,
+}
+
+impl UfmMockConfig {
+    pub fn validate(&self) -> eyre::Result<()> {
+        eyre::ensure!(
+            !self.inventory.poll_interval.is_zero(),
+            "ufm_mock.inventory.poll_interval must be nonzero"
+        );
+        eyre::ensure!(
+            !self.inventory.request_timeout.is_zero(),
+            "ufm_mock.inventory.request_timeout must be nonzero"
+        );
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct FabricConfig {
+    #[serde(default = "default_ufm_version")]
+    pub ufm_version: String,
+    #[serde(default)]
+    pub sm_config: SmConfig,
+}
+
+impl Default for FabricConfig {
+    fn default() -> Self {
+        Self {
+            ufm_version: default_ufm_version(),
+            sm_config: SmConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct SmConfig {
+    #[serde(default = "default_subnet_prefix")]
+    pub subnet_prefix: String,
+    #[serde(default = "default_m_key")]
+    pub m_key: String,
+    #[serde(default = "default_sm_sa_key")]
+    pub sm_key: String,
+    #[serde(default = "default_sm_sa_key")]
+    pub sa_key: String,
+    #[serde(default)]
+    pub m_key_per_port: bool,
+}
+
+impl Default for SmConfig {
+    fn default() -> Self {
+        Self {
+            subnet_prefix: default_subnet_prefix(),
+            m_key: default_m_key(),
+            sm_key: default_sm_sa_key(),
+            sa_key: default_sm_sa_key(),
+            m_key_per_port: false,
+        }
+    }
+}
+
+/// Inventory reconciliation settings used in both hosted and standalone execution.
+///
+/// Static sources are polled in either mode. A hosted mock may additionally receive an
+/// in-process [`crate::InventoryProvider`], while they are the only inventory sources available
+/// to the standalone binary.
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct InventoryConfig {
+    #[serde(
+        default = "default_poll_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub poll_interval: Duration,
+    #[serde(
+        default = "default_request_timeout",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub request_timeout: Duration,
+    #[serde(
+        default = "default_failure_grace_period",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub failure_grace_period: Duration,
+    #[serde(default)]
+    pub failure_action: FailureAction,
+    #[serde(default)]
+    pub static_sources: Vec<InventorySourceConfig>,
+}
+
+impl Default for InventoryConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: default_poll_interval(),
+            request_timeout: default_request_timeout(),
+            failure_grace_period: default_failure_grace_period(),
+            failure_action: FailureAction::default(),
+            static_sources: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureAction {
+    #[default]
+    MarkDown,
+    Remove,
+}
+
+/// A machine-a-tron inventory endpoint parsed and validated while loading configuration.
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct InventorySourceConfig {
+    /// URL returning an [`crate::InventorySnapshot`] as JSON.
+    pub url: url::Url,
+    #[serde(default)]
+    pub ca_cert_path: Option<PathBuf>,
+    #[serde(default)]
+    pub insecure_skip_verify: bool,
+}
+
+/// Top-level configuration for the standalone UFM mock process.
+///
+/// Listener and TLS settings belong to the standalone process. The flattened [`UfmMockConfig`]
+/// is shared with hosted mode, although standalone initialization always activates the mock and
+/// cannot provide local machine-a-tron inventory. Its authentication token comes from
+/// [`crate::UFM_MOCK_AUTH_TOKEN_ENV`], not this configuration.
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct StandaloneConfig {
+    #[serde(default = "default_listen_address")]
+    pub listen_address: SocketAddr,
+    #[serde(default)]
+    pub tls: Option<TlsConfig>,
+    #[serde(flatten)]
+    pub mock: UfmMockConfig,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct TlsConfig {
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+}
+
+fn default_ufm_version() -> String {
+    "6.18.0".to_string()
+}
+
+fn default_subnet_prefix() -> String {
+    "0xfe80000000000000".to_string()
+}
+
+fn default_m_key() -> String {
+    "0x0000000000000000".to_string()
+}
+
+fn default_sm_sa_key() -> String {
+    "0x0000000000000001".to_string()
+}
+
+fn default_poll_interval() -> Duration {
+    Duration::from_secs(2)
+}
+
+fn default_request_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_failure_grace_period() -> Duration {
+    Duration::from_secs(30)
+}
+
+fn default_listen_address() -> SocketAddr {
+    "0.0.0.0:9888".parse().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InventorySourceConfig;
+
+    #[test]
+    fn rejects_invalid_inventory_source_url_during_deserialization() {
+        let result = serde_json::from_value::<InventorySourceConfig>(serde_json::json!({
+            "url": "not a URL"
+        }));
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/ufm-mock/src/http.rs
+++ b/crates/ufm-mock/src/http.rs
@@ -1,0 +1,381 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Path, Query, Request, State};
+use axum::http::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::{HeaderValue, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post, put};
+use axum::{Json, Router};
+use carbide_axum_utils::injection::{InjectionStore, injection_router, management_router};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::auth::UfmAuthToken;
+use crate::state::{BindRequest, Fabric, FabricError, PartitionKey, QosRequest, UnbindRequest};
+
+#[derive(Clone)]
+pub(crate) struct HttpState {
+    fabric: Fabric,
+    auth_header: HeaderValue,
+}
+
+impl HttpState {
+    pub(crate) fn new(fabric: Fabric, auth_token: &UfmAuthToken) -> eyre::Result<Self> {
+        let auth_header = HeaderValue::from_str(&format!("Basic {}", auth_token.expose_secret()))?;
+        Ok(Self {
+            fabric,
+            auth_header,
+        })
+    }
+
+    pub(crate) fn router(self, injection: Arc<InjectionStore>) -> Router {
+        let routes = Router::new()
+            .route("/app/ufm_version", get(version))
+            .route("/app/smconf", get(sm_config))
+            .route("/resources/ports", get(ports))
+            .route("/resources/pkeys", get(partitions).post(bind))
+            .route("/resources/pkeys/{pkey}", get(partition))
+            .route("/actions/remove_guids_from_pkey", post(unbind))
+            .route("/resources/pkeys/qos_conf", put(update_qos))
+            .with_state(self.clone());
+        let routes = injection_router(routes, Arc::clone(&injection))
+            .route_layer(middleware::from_fn_with_state(self, authorize));
+        Router::new()
+            .merge(management_router(injection))
+            .nest("/ufmRestV3", routes)
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PartitionQuery {
+    #[serde(default)]
+    guids_data: bool,
+    #[serde(default)]
+    qos_conf: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct VersionResponse<'a> {
+    ufm_release_version: &'a str,
+}
+
+async fn version(State(state): State<HttpState>) -> Response {
+    json_response(
+        StatusCode::OK,
+        &VersionResponse {
+            ufm_release_version: state.fabric.version(),
+        },
+    )
+}
+
+async fn sm_config(State(state): State<HttpState>) -> Response {
+    json_response(StatusCode::OK, state.fabric.sm_config())
+}
+
+async fn ports(State(state): State<HttpState>) -> Response {
+    let fabric = state.fabric.read();
+    json_response(StatusCode::OK, &fabric.ports())
+}
+
+async fn partitions(
+    State(state): State<HttpState>,
+    Query(query): Query<PartitionQuery>,
+) -> Response {
+    let fabric = state.fabric.read();
+    json_response(
+        StatusCode::OK,
+        &fabric.partitions(query.guids_data, query.qos_conf),
+    )
+}
+
+async fn partition(
+    State(state): State<HttpState>,
+    Path(pkey): Path<PartitionKey>,
+    Query(query): Query<PartitionQuery>,
+) -> Response {
+    let fabric = state.fabric.read();
+    match fabric.partition(pkey, query.guids_data, query.qos_conf) {
+        Ok(Some(partition)) => json_response(StatusCode::OK, &partition),
+        Ok(None) => json_response(StatusCode::OK, &json!({})),
+        Err(error) => error_response(error),
+    }
+}
+
+async fn bind(State(state): State<HttpState>, Json(request): Json<BindRequest>) -> Response {
+    match state.fabric.bind(request) {
+        Ok(()) => json_response(StatusCode::OK, &json!({})),
+        Err(error) => error_response(error),
+    }
+}
+
+async fn unbind(State(state): State<HttpState>, Json(request): Json<UnbindRequest>) -> Response {
+    state.fabric.unbind(request);
+    json_response(StatusCode::OK, &json!({}))
+}
+
+async fn update_qos(State(state): State<HttpState>, Json(request): Json<QosRequest>) -> Response {
+    match state.fabric.update_qos(request) {
+        Ok(()) => json_response(StatusCode::OK, &json!({})),
+        Err(error) => error_response(error),
+    }
+}
+
+async fn authorize(State(state): State<HttpState>, request: Request, next: Next) -> Response {
+    let mut response = if request.headers().get(AUTHORIZATION) != Some(&state.auth_header) {
+        (StatusCode::UNAUTHORIZED, "invalid UFM authorization token").into_response()
+    } else {
+        next.run(request).await
+    };
+
+    response
+        .headers_mut()
+        .insert("x-ufm-mock", HeaderValue::from_static("carbide-ufm-mock"));
+    response
+}
+
+fn error_response(error: FabricError) -> Response {
+    let status = match error {
+        FabricError::PartitionNotFound(_) | FabricError::PortNotFound(_) => StatusCode::NOT_FOUND,
+        FabricError::InvalidInventoryIdentity => StatusCode::BAD_REQUEST,
+    };
+    json_response(status, &json!({ "error": error.to_string() }))
+}
+
+fn json_response<T: Serialize>(status: StatusCode, value: &T) -> Response {
+    match serde_json::to_vec(value) {
+        Ok(body) => Response::builder()
+            .status(status)
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_LENGTH, body.len())
+            .body(Body::from(body))
+            .expect("static response headers must be valid"),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to serialize UFM response: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::config::FabricConfig;
+    use crate::inventory::{
+        InfinibandPortState, InventoryMachine, InventoryPort, InventorySnapshot,
+    };
+
+    fn test_router() -> Router {
+        let fabric = Fabric::new(FabricConfig::default());
+        fabric
+            .reconcile(
+                InventorySnapshot {
+                    inventory_id: "inventory-a".into(),
+                    epoch_id: "epoch-a".into(),
+                    generation: 1.into(),
+                    machines: vec![InventoryMachine {
+                        mat_id: "mat-a".into(),
+                        machine_id: Some("machine-a".into()),
+                        infiniband_ports: Some(vec![InventoryPort {
+                            guid: "0x1".parse().unwrap(),
+                            state: InfinibandPortState::Active,
+                        }]),
+                    }],
+                },
+                crate::inventory::InventoryLease::FIRST_REMOTE,
+            )
+            .unwrap();
+        let auth_token = UfmAuthToken::new("test-token".to_string()).unwrap();
+        HttpState::new(fabric, &auth_token)
+            .unwrap()
+            .router(Arc::new(InjectionStore::new()))
+    }
+
+    fn authorized_request(method: &str, uri: &str, body: Body) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(AUTHORIZATION, "Basic test-token")
+            .header(CONTENT_TYPE, "application/json")
+            .body(body)
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn requires_the_basic_token_used_by_rest_ib_fabric() {
+        let response = test_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/ufmRestV3/app/ufm_version")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn shared_injection_rules_apply_to_ufm_routes_and_can_be_cleared() {
+        let router = test_router();
+        let rule = json!({
+            "id": "version-unavailable",
+            "selector": {
+                "Path": {
+                    "method": "GET",
+                    "glob": "/ufmRestV3/app/ufm_version"
+                }
+            },
+            "action": { "Status": 503 }
+        });
+
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/Injection/rules")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(rule.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = router
+            .clone()
+            .oneshot(authorized_request(
+                "GET",
+                "/ufmRestV3/app/ufm_version",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response.headers().get("x-ufm-mock"),
+            Some(&HeaderValue::from_static("carbide-ufm-mock"))
+        );
+
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/Injection/rules")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from("[]"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = router
+            .oneshot(authorized_request(
+                "GET",
+                "/ufmRestV3/app/ufm_version",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn exposes_ports_and_mutable_partition_membership_in_ufm_v3_shape() {
+        let router = test_router();
+        let response = router
+            .clone()
+            .oneshot(authorized_request(
+                "GET",
+                "/ufmRestV3/resources/ports?sys_type=Computer",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(body[0]["guid"], "0000000000000001");
+        assert_eq!(body[0]["systemID"], "0000000000000001");
+        assert_eq!(body[0]["logical_state"], "Active");
+
+        let response = router
+            .clone()
+            .oneshot(authorized_request(
+                "GET",
+                "/ufmRestV3/resources/pkeys?guids_data=true",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(body["0x7fff"]["partition"], "management");
+        assert_eq!(body["0x7fff"]["guids"], json!([]));
+
+        let response = router
+            .clone()
+            .oneshot(authorized_request(
+                "POST",
+                "/ufmRestV3/resources/pkeys",
+                Body::from(
+                    serde_json::to_vec(&json!({
+                        "pkey": "1",
+                        "ip_over_ib": false,
+                        "membership": "full",
+                        "index0": true,
+                        "guids": ["0000000000000001"]
+                    }))
+                    .unwrap(),
+                ),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = router
+            .oneshot(authorized_request(
+                "GET",
+                "/ufmRestV3/resources/pkeys/1?guids_data=true&qos_conf=true",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(body["partition"], "api_pkey_0x1");
+        assert_eq!(body["guids"][0]["membership"], "full");
+        assert_eq!(body["qos_conf"]["rate_limit"], 2.5);
+    }
+}

--- a/crates/ufm-mock/src/inventory.rs
+++ b/crates/ufm-mock/src/inventory.rs
@@ -1,0 +1,275 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
+pub struct InventoryId(String);
+
+impl AsRef<str> for InventoryId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for InventoryId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for InventoryId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl fmt::Display for InventoryId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_ref())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
+pub struct EpochId(String);
+
+impl AsRef<str> for EpochId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for EpochId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for EpochId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl fmt::Display for EpochId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_ref())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
+pub struct MatId(String);
+
+impl AsRef<str> for MatId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for MatId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for MatId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl fmt::Display for MatId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_ref())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
+pub struct MachineId(String);
+
+impl AsRef<str> for MachineId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for MachineId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for MachineId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl fmt::Display for MachineId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_ref())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
+pub struct Generation(u64);
+
+impl Generation {
+    pub const INITIAL: Self = Self(1);
+
+    pub fn checked_next(self) -> Option<Self> {
+        self.0.checked_add(1).map(Self)
+    }
+}
+
+impl From<u64> for Generation {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Guid(u64);
+
+impl fmt::Display for Guid {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{:016x}", self.0)
+    }
+}
+
+impl FromStr for Guid {
+    type Err = InvalidGuid;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let hex = value.strip_prefix("0x").unwrap_or(value);
+        u64::from_str_radix(hex, 16)
+            .map(Self)
+            .map_err(|_| InvalidGuid(value.to_string()))
+    }
+}
+
+impl From<u64> for Guid {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<[u8; 8]> for Guid {
+    fn from(bytes: [u8; 8]) -> Self {
+        Self(u64::from_be_bytes(bytes))
+    }
+}
+
+impl Serialize for Guid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for Guid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error("invalid InfiniBand GUID {0}")]
+pub struct InvalidGuid(String);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct InventoryLease(u64);
+
+impl InventoryLease {
+    pub(crate) const LOCAL: Self = Self(0);
+    pub(crate) const FIRST_REMOTE: Self = Self(1);
+
+    pub(crate) fn checked_next(self) -> Option<Self> {
+        self.0.checked_add(1).map(Self)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct InventorySnapshot {
+    pub inventory_id: InventoryId,
+    pub epoch_id: EpochId,
+    pub generation: Generation,
+    #[serde(rename = "machines")]
+    pub machines: Vec<InventoryMachine>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct InventoryMachine {
+    pub mat_id: MatId,
+    #[serde(default)]
+    pub machine_id: Option<MachineId>,
+    #[serde(default)]
+    pub infiniband_ports: Option<Vec<InventoryPort>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct InventoryPort {
+    pub guid: Guid,
+    pub state: InfinibandPortState,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum InfinibandPortState {
+    Active,
+    Down,
+}
+
+impl InfinibandPortState {
+    pub(crate) fn physical_state(self) -> &'static str {
+        match self {
+            Self::Active => "Link Up",
+            Self::Down => "Link Down",
+        }
+    }
+
+    pub(crate) fn logical_state(self) -> &'static str {
+        match self {
+            Self::Active => "Active",
+            Self::Down => "Down",
+        }
+    }
+}
+
+/// Supplies inventory without HTTP when the mock is embedded into another process.
+///
+/// Machine-a-tron implements this trait using its control state. The standalone UFM mock does
+/// not have a local provider and obtains inventory from configured HTTP sources instead.
+pub trait InventoryProvider: Send + Sync {
+    fn inventory_snapshot(&self) -> InventorySnapshot;
+}

--- a/crates/ufm-mock/src/lib.rs
+++ b/crates/ufm-mock/src/lib.rs
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod auth;
+mod config;
+mod http;
+mod inventory;
+mod metrics;
+mod reconcile;
+mod state;
+
+use std::sync::Arc;
+
+pub use auth::{UFM_MOCK_AUTH_TOKEN_ENV, UfmAuthToken};
+use axum::Router;
+use carbide_axum_utils::injection::InjectionStore;
+pub use config::{
+    FabricConfig, FailureAction, InventoryConfig, InventorySourceConfig, SmConfig,
+    StandaloneConfig, TlsConfig, UfmMockConfig,
+};
+pub use inventory::{
+    EpochId, Generation, Guid, InfinibandPortState, InvalidGuid, InventoryId, InventoryMachine,
+    InventoryPort, InventoryProvider, InventorySnapshot, MachineId, MatId,
+};
+use opentelemetry::metrics::Meter;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::http::HttpState;
+use crate::metrics::Metrics;
+use crate::state::Fabric;
+
+/// UFM mock shared by hosted and standalone execution.
+///
+/// Construction creates topology state and HTTP routes but does not choose where inventory comes
+/// from. The embedding process makes that choice when it starts reconciliation.
+#[derive(Clone)]
+pub struct UfmMock {
+    fabric: Fabric,
+    http: HttpState,
+    injection: Arc<InjectionStore>,
+    metrics: Metrics,
+}
+
+impl UfmMock {
+    /// Creates a mock from non-secret configuration and a separately supplied authentication
+    /// token.
+    pub fn new(
+        config: &UfmMockConfig,
+        auth_token: &UfmAuthToken,
+        meter: &Meter,
+    ) -> eyre::Result<Self> {
+        let metrics = Metrics::new(meter);
+        let fabric = Fabric::new(config.fabric.clone());
+        let injection = Arc::new(InjectionStore::new());
+        let http = HttpState::new(fabric.clone(), auth_token)?;
+        Ok(Self {
+            fabric,
+            http,
+            injection,
+            metrics,
+        })
+    }
+
+    pub fn router(&self) -> Router {
+        self.http.clone().router(Arc::clone(&self.injection))
+    }
+
+    /// Starts reconciliation for configured HTTP sources and an optional in-process source.
+    ///
+    /// Machine-a-tron passes its control state as `local_provider` when local inventory is
+    /// enabled. The standalone binary passes `None`, leaving configured static HTTP sources as
+    /// its only source of inventory.
+    pub fn start_reconciliation(
+        &self,
+        config: InventoryConfig,
+        local_provider: Option<Arc<dyn InventoryProvider>>,
+        cancellation: CancellationToken,
+    ) -> JoinHandle<()> {
+        reconcile::start(
+            self.fabric.clone(),
+            self.metrics.clone(),
+            config,
+            local_provider,
+            cancellation,
+        )
+    }
+
+    pub fn apply_inventory(&self, snapshot: InventorySnapshot) -> eyre::Result<()> {
+        let outcome = self
+            .fabric
+            .reconcile(snapshot, inventory::InventoryLease::LOCAL)?;
+        self.metrics.record_reconciliation(outcome.metric_label());
+        Ok(())
+    }
+}

--- a/crates/ufm-mock/src/main.rs
+++ b/crates/ufm-mock/src/main.rs
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![cfg_attr(not(test), deny(dead_code_pub_in_binary))]
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use figment::Figment;
+use figment::providers::{Format, Toml};
+use metrics_endpoint::{
+    MetricsEndpointConfig, new_metrics_setup, run_metrics_endpoint_with_cancellation,
+};
+use tokio_util::sync::CancellationToken;
+use tracing_subscriber::EnvFilter;
+use ufm_mock::{StandaloneConfig, UfmAuthToken, UfmMock};
+
+#[derive(Debug, Parser)]
+#[command(name = "ufm-mock")]
+struct Args {
+    #[arg(help = "UFM mock TOML configuration file")]
+    config_file: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init()
+        .map_err(|error| eyre::eyre!(error.to_string()))?;
+
+    let args = Args::parse();
+    let mut config: StandaloneConfig = Figment::new()
+        .merge(Toml::file(&args.config_file))
+        .extract()?;
+    // Hosted execution uses `enabled` to activate an optional configured section. Launching the
+    // standalone binary is itself the activation decision.
+    config.mock.enabled = true;
+    config.mock.validate()?;
+
+    let auth_token = UfmAuthToken::from_environment()?;
+    let metrics_setup = new_metrics_setup("carbide-ufm-mock", "carbide", false)?;
+    let ufm_mock = UfmMock::new(&config.mock, &auth_token, &metrics_setup.meter)?;
+    let cancellation = CancellationToken::new();
+    // Standalone execution has no machine-a-tron control state to use as an in-process provider.
+    // Reconciliation therefore obtains inventory only from `inventory.static_sources`.
+    let reconciliation = ufm_mock.start_reconciliation(
+        config.mock.inventory.clone(),
+        None,
+        cancellation.child_token(),
+    );
+
+    let metrics_task = config.mock.metrics_address.map(|address| {
+        let metrics_config = MetricsEndpointConfig {
+            address,
+            registry: metrics_setup.registry,
+            health_controller: Some(metrics_setup.health_controller),
+            additional_prefix: None,
+        };
+        let metrics_cancellation = cancellation.child_token();
+        tokio::spawn(async move {
+            if let Err(error) =
+                run_metrics_endpoint_with_cancellation(&metrics_config, metrics_cancellation).await
+            {
+                tracing::error!(error = %error, "UFM mock metrics endpoint stopped");
+            }
+        })
+    });
+    let _metrics_guard = metrics_setup.meter_provider;
+
+    let signal_cancellation = cancellation.clone();
+    tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            signal_cancellation.cancel();
+        }
+    });
+
+    tracing::info!(
+        address = %config.listen_address,
+        "Starting UFM mock"
+    );
+    let server_result = if let Some(tls) = config.tls {
+        let tls = axum_server::tls_rustls::RustlsConfig::from_pem_file(tls.cert_path, tls.key_path)
+            .await?;
+        let handle = axum_server::Handle::new();
+        let shutdown_handle = handle.clone();
+        let shutdown = cancellation.clone();
+        tokio::spawn(async move {
+            shutdown.cancelled().await;
+            shutdown_handle.graceful_shutdown(Some(std::time::Duration::from_secs(10)));
+        });
+        axum_server::bind_rustls(config.listen_address, tls)
+            .handle(handle)
+            .serve(ufm_mock.router().into_make_service())
+            .await
+            .map_err(eyre::Report::from)
+    } else {
+        let listener = tokio::net::TcpListener::bind(config.listen_address).await?;
+        axum::serve(listener, ufm_mock.router())
+            .with_graceful_shutdown(cancellation.clone().cancelled_owned())
+            .await
+            .map_err(eyre::Report::from)
+    };
+
+    cancellation.cancel();
+    reconciliation.await?;
+    if let Some(metrics_task) = metrics_task {
+        metrics_task.await?;
+    }
+    server_result
+}

--- a/crates/ufm-mock/src/metrics.rs
+++ b/crates/ufm-mock/src/metrics.rs
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Counter, Meter};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Metrics {
+    reconciliation: Counter<u64>,
+}
+
+impl Metrics {
+    pub(crate) fn new(meter: &Meter) -> Self {
+        Self {
+            reconciliation: meter
+                .u64_counter("carbide_ufm_mock_inventory_reconciliations_total")
+                .with_description("Inventory reconciliation attempts by outcome.")
+                .build(),
+        }
+    }
+
+    pub(crate) fn record_reconciliation(&self, outcome: &'static str) {
+        self.reconciliation
+            .add(1, &[KeyValue::new("outcome", outcome)]);
+    }
+}

--- a/crates/ufm-mock/src/reconcile/inventory_source.rs
+++ b/crates/ufm-mock/src/reconcile/inventory_source.rs
@@ -1,0 +1,176 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Semaphore;
+use url::Url;
+
+use crate::config::InventorySourceConfig;
+use crate::inventory::{InventoryId, InventoryLease, InventorySnapshot};
+
+pub(super) struct PolledInventorySource {
+    url: Url,
+    client: Option<reqwest::Client>,
+    client_error: Option<String>,
+    known_inventory_id: Option<InventoryId>,
+    lease: InventoryLease,
+    failure_since: Option<Instant>,
+    failure_applied: bool,
+}
+
+pub(super) enum PollOutcome {
+    ClientUnavailable,
+    Succeeded {
+        snapshot: InventorySnapshot,
+        previous_inventory_id: Option<InventoryId>,
+    },
+    Failed(String),
+}
+
+pub(super) enum SourceFailure<'a> {
+    ClientConfiguration(String),
+    Inventory {
+        inventory_id: &'a InventoryId,
+        lease: InventoryLease,
+    },
+}
+
+pub(super) struct LogSource<'a>(pub(super) &'a PolledInventorySource);
+
+impl fmt::Display for LogSource<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0.url.as_str())
+    }
+}
+
+impl PolledInventorySource {
+    pub(super) fn new(
+        source: InventorySourceConfig,
+        timeout: Duration,
+        lease: InventoryLease,
+    ) -> Self {
+        match build_client(&source, timeout) {
+            Ok(client) => Self {
+                url: source.url,
+                client: Some(client),
+                client_error: None,
+                known_inventory_id: None,
+                lease,
+                failure_since: None,
+                failure_applied: false,
+            },
+            Err(error) => Self {
+                url: source.url,
+                client: None,
+                client_error: Some(error.to_string()),
+                known_inventory_id: None,
+                lease,
+                failure_since: Some(Instant::now()),
+                failure_applied: false,
+            },
+        }
+    }
+
+    pub(super) fn lease(&self) -> InventoryLease {
+        self.lease
+    }
+
+    pub(super) fn take_failure(
+        &mut self,
+        now: Instant,
+        grace_period: Duration,
+    ) -> Option<SourceFailure<'_>> {
+        if self.failure_applied {
+            return None;
+        }
+        if let Some(error) = self.client_error.take() {
+            self.failure_applied = true;
+            return Some(SourceFailure::ClientConfiguration(error));
+        }
+        if !self
+            .failure_since
+            .is_some_and(|start| now.duration_since(start) >= grace_period)
+        {
+            return None;
+        }
+        self.failure_applied = true;
+        self.known_inventory_id
+            .as_ref()
+            .map(|inventory_id| SourceFailure::Inventory {
+                inventory_id,
+                lease: self.lease,
+            })
+    }
+
+    pub(super) async fn poll(mut self, request_semaphore: Arc<Semaphore>) -> (Self, PollOutcome) {
+        let Some(client) = self.client.as_ref() else {
+            return (self, PollOutcome::ClientUnavailable);
+        };
+        let _permit = request_semaphore
+            .acquire_owned()
+            .await
+            .expect("inventory request semaphore must remain open");
+        let result = client
+            .get(self.url.as_str())
+            .send()
+            .await
+            .and_then(reqwest::Response::error_for_status);
+        let outcome = match result {
+            Ok(response) => response
+                .json::<InventorySnapshot>()
+                .await
+                .map_err(|error| error.to_string()),
+            Err(error) => Err(error.to_string()),
+        };
+        let outcome = match outcome {
+            Ok(snapshot) => {
+                let previous_inventory_id = self
+                    .known_inventory_id
+                    .replace(snapshot.inventory_id.clone())
+                    .filter(|inventory_id| inventory_id != &snapshot.inventory_id);
+                self.failure_since = None;
+                self.failure_applied = false;
+                PollOutcome::Succeeded {
+                    snapshot,
+                    previous_inventory_id,
+                }
+            }
+            Err(error) => {
+                self.failure_since.get_or_insert_with(Instant::now);
+                PollOutcome::Failed(error)
+            }
+        };
+        (self, outcome)
+    }
+}
+
+fn build_client(
+    source: &InventorySourceConfig,
+    timeout: Duration,
+) -> eyre::Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
+        .timeout(timeout)
+        .danger_accept_invalid_certs(source.insecure_skip_verify);
+    if let Some(path) = source.ca_cert_path.as_ref() {
+        let certificate = reqwest::Certificate::from_pem(&std::fs::read(path)?)?;
+        builder = builder.add_root_certificate(certificate);
+    }
+    Ok(builder.build()?)
+}

--- a/crates/ufm-mock/src/reconcile/mod.rs
+++ b/crates/ufm-mock/src/reconcile/mod.rs
@@ -1,0 +1,154 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod inventory_source;
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use futures::future::join_all;
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use self::inventory_source::{LogSource, PollOutcome, PolledInventorySource, SourceFailure};
+use crate::config::InventoryConfig;
+use crate::inventory::{InventoryLease, InventoryProvider, InventorySnapshot};
+use crate::metrics::Metrics;
+use crate::state::Fabric;
+
+const MAX_CONCURRENT_INVENTORY_REQUESTS: usize = 8;
+
+pub(crate) fn start(
+    fabric: Fabric,
+    metrics: Metrics,
+    config: InventoryConfig,
+    local_provider: Option<Arc<dyn InventoryProvider>>,
+    cancellation: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(error) = run(fabric, metrics, config, local_provider, cancellation).await {
+            tracing::error!(error = %error, "UFM inventory reconciliation stopped");
+        }
+    })
+}
+
+async fn run(
+    fabric: Fabric,
+    metrics: Metrics,
+    config: InventoryConfig,
+    local_provider: Option<Arc<dyn InventoryProvider>>,
+    cancellation: CancellationToken,
+) -> eyre::Result<()> {
+    let InventoryConfig {
+        poll_interval,
+        request_timeout,
+        failure_grace_period,
+        failure_action,
+        static_sources,
+    } = config;
+    let mut next_lease = InventoryLease::FIRST_REMOTE;
+    let mut sources = static_sources
+        .into_iter()
+        .map(|config_source| {
+            let lease = next_lease;
+            next_lease = next_lease.checked_next().expect("inventory lease overflow");
+            PolledInventorySource::new(config_source, request_timeout, lease)
+        })
+        .collect::<Vec<_>>();
+
+    let mut interval = tokio::time::interval(poll_interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let request_semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_INVENTORY_REQUESTS));
+
+    loop {
+        tokio::select! {
+            _ = cancellation.cancelled() => return Ok(()),
+            _ = interval.tick() => {}
+        }
+
+        if let Some(provider) = local_provider.as_ref() {
+            let snapshot = provider.inventory_snapshot();
+            record_reconciliation(&fabric, &metrics, snapshot, InventoryLease::LOCAL);
+        }
+
+        let requests = sources
+            .drain(..)
+            .map(|source| source.poll(Arc::clone(&request_semaphore)));
+        let polled_sources = join_all(requests).await;
+
+        for (source, outcome) in polled_sources {
+            match outcome {
+                PollOutcome::ClientUnavailable => {}
+                PollOutcome::Succeeded {
+                    snapshot,
+                    previous_inventory_id,
+                } => {
+                    if let Some(previous_id) = previous_inventory_id.as_ref() {
+                        fabric.source_failed(
+                            previous_id,
+                            source.lease(),
+                            crate::config::FailureAction::Remove,
+                        );
+                    }
+                    record_reconciliation(&fabric, &metrics, snapshot, source.lease());
+                }
+                PollOutcome::Failed(error) => {
+                    tracing::warn!(source = %LogSource(&source), error, "Could not poll machine-a-tron inventory");
+                    metrics.record_reconciliation("poll_failed");
+                }
+            }
+            sources.push(source);
+        }
+
+        let now = Instant::now();
+        for source in &mut sources {
+            match source.take_failure(now, failure_grace_period) {
+                Some(SourceFailure::ClientConfiguration(error)) => {
+                    tracing::warn!(source = %LogSource(source), error, "Could not configure inventory HTTP client");
+                    metrics.record_reconciliation("client_configuration_failed");
+                }
+                Some(SourceFailure::Inventory {
+                    inventory_id,
+                    lease,
+                }) => {
+                    fabric.source_failed(inventory_id, lease, failure_action.clone());
+                    metrics.record_reconciliation(match failure_action {
+                        crate::config::FailureAction::MarkDown => "source_marked_down",
+                        crate::config::FailureAction::Remove => "source_removed",
+                    });
+                }
+                None => {}
+            }
+        }
+    }
+}
+
+fn record_reconciliation(
+    fabric: &Fabric,
+    metrics: &Metrics,
+    snapshot: InventorySnapshot,
+    lease: InventoryLease,
+) {
+    match fabric.reconcile(snapshot, lease) {
+        Ok(outcome) => metrics.record_reconciliation(outcome.metric_label()),
+        Err(error) => {
+            tracing::warn!(error = %error, "Rejected machine-a-tron inventory snapshot");
+            metrics.record_reconciliation("invalid_snapshot");
+        }
+    }
+}

--- a/crates/ufm-mock/src/state.rs
+++ b/crates/ufm-mock/src/state.rs
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod partitions;
+mod ports;
+mod reconciliation;
+#[cfg(test)]
+mod tests;
+mod types;
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+pub(crate) use types::{
+    BindRequest, Fabric, FabricError, FabricRead, PartitionKey, QosRequest, UnbindRequest,
+};
+use types::{DEFAULT_PARTITION_KEY, FabricState, Partition, PartitionQos};
+#[cfg(test)]
+use types::{PortMembership, ReconcileOutcome};
+
+use crate::config::FabricConfig;
+
+impl Fabric {
+    pub(crate) fn new(config: FabricConfig) -> Self {
+        let default_partition = Partition {
+            name: "management".into(),
+            ip_over_ib: true,
+            qos: PartitionQos::default(),
+            members: HashMap::new(),
+        };
+        let inner = FabricState {
+            candidates: HashMap::new(),
+            ports: HashMap::new(),
+            sources: HashMap::new(),
+            partitions: HashMap::from([(DEFAULT_PARTITION_KEY, default_partition)]),
+            next_lid: 1,
+        };
+        Self {
+            config: Arc::new(config),
+            inner: Arc::new(RwLock::new(inner)),
+        }
+    }
+
+    pub(crate) fn version(&self) -> &str {
+        &self.config.ufm_version
+    }
+
+    pub(crate) fn sm_config(&self) -> &crate::config::SmConfig {
+        &self.config.sm_config
+    }
+
+    pub(crate) fn read(&self) -> FabricRead<'_> {
+        FabricRead {
+            state: self.inner.read().expect("fabric lock poisoned"),
+        }
+    }
+}

--- a/crates/ufm-mock/src/state/partitions.rs
+++ b/crates/ufm-mock/src/state/partitions.rs
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::{BTreeMap, HashMap};
+
+use super::types::{
+    BindRequest, DEFAULT_PARTITION_KEY, Fabric, FabricError, FabricRead, Partition, PartitionData,
+    PartitionKey, PartitionQos, PortConfig, PortConfigData, PortMembership, QosRequest,
+    UnbindRequest,
+};
+
+impl Fabric {
+    pub(crate) fn bind(&self, request: BindRequest) -> Result<(), FabricError> {
+        let key = request.pkey;
+        let guids = request.guids;
+        let mut state = self.inner.write().expect("fabric lock poisoned");
+        for guid in &guids {
+            if !state.ports.contains_key(guid) {
+                return Err(FabricError::PortNotFound(*guid));
+            }
+        }
+        let partition = state.partitions.entry(key).or_insert_with(|| Partition {
+            name: format!("api_pkey_{key}").into(),
+            ip_over_ib: request.ip_over_ib,
+            qos: PartitionQos::default(),
+            members: HashMap::new(),
+        });
+        partition.ip_over_ib = request.ip_over_ib;
+        for guid in guids {
+            partition.members.insert(
+                guid,
+                PortConfig {
+                    membership: request.membership,
+                    index0: request.index0,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn unbind(&self, request: UnbindRequest) {
+        let key = request.pkey;
+        let guids = request.guids;
+        let mut state = self.inner.write().expect("fabric lock poisoned");
+        let Some(partition) = state.partitions.get_mut(&key) else {
+            return;
+        };
+        for guid in guids {
+            partition.members.remove(&guid);
+        }
+        if key != DEFAULT_PARTITION_KEY && partition.members.is_empty() {
+            state.partitions.remove(&key);
+        }
+    }
+
+    pub(crate) fn update_qos(&self, request: QosRequest) -> Result<(), FabricError> {
+        let key = request.pkey;
+        let mut state = self.inner.write().expect("fabric lock poisoned");
+        let partition = state
+            .partitions
+            .get_mut(&key)
+            .ok_or(FabricError::PartitionNotFound(key))?;
+        partition.qos = PartitionQos {
+            mtu_limit: request.mtu_limit,
+            service_level: request.service_level,
+            rate_limit: request.rate_limit,
+        };
+        Ok(())
+    }
+}
+
+impl FabricRead<'_> {
+    pub(crate) fn partitions(
+        &self,
+        include_guids: bool,
+        include_qos: bool,
+    ) -> BTreeMap<&PartitionKey, PartitionData<'_>> {
+        self.state
+            .partitions
+            .iter()
+            .map(|(key, partition)| {
+                (
+                    key,
+                    partition_data(*key, partition, include_guids, include_qos),
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn partition(
+        &self,
+        key: PartitionKey,
+        include_guids: bool,
+        include_qos: bool,
+    ) -> Result<Option<PartitionData<'_>>, FabricError> {
+        Ok(self
+            .state
+            .partitions
+            .get(&key)
+            .map(|partition| partition_data(key, partition, include_guids, include_qos)))
+    }
+}
+
+fn partition_data(
+    key: PartitionKey,
+    partition: &Partition,
+    include_guids: bool,
+    include_qos: bool,
+) -> PartitionData<'_> {
+    static DEFAULT_MEMBERSHIP: PortMembership = PortMembership::Limited;
+
+    let mut members = partition.members.iter().collect::<Vec<_>>();
+    members.sort_by_key(|(guid, _)| *guid);
+    PartitionData {
+        partition: partition.name.as_ref(),
+        ip_over_ib: &partition.ip_over_ib,
+        qos_conf: include_qos.then_some(&partition.qos),
+        guids: include_guids.then(|| {
+            members
+                .into_iter()
+                .map(|(guid, config)| PortConfigData {
+                    guid,
+                    membership: &config.membership,
+                    index0: &config.index0,
+                })
+                .collect()
+        }),
+        membership: (key == DEFAULT_PARTITION_KEY).then_some(&DEFAULT_MEMBERSHIP),
+    }
+}

--- a/crates/ufm-mock/src/state/ports.rs
+++ b/crates/ufm-mock/src/state/ports.rs
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::types::{FabricRead, PortData, PortName};
+
+impl FabricRead<'_> {
+    pub(crate) fn ports(&self) -> Vec<PortData<'_>> {
+        let mut ports = self
+            .state
+            .ports
+            .iter()
+            .map(|(guid, port)| {
+                let system_name = port
+                    .candidate
+                    .machine_id
+                    .as_ref()
+                    .map(AsRef::as_ref)
+                    .unwrap_or_else(|| port.candidate.mat_id.as_ref());
+                PortData {
+                    guid,
+                    name: PortName(guid),
+                    system_id: guid,
+                    lid: &port.lid,
+                    dname: port.candidate.mat_id.as_ref(),
+                    system_name,
+                    physical_state: port.candidate.state.physical_state(),
+                    logical_state: port.candidate.state.logical_state(),
+                }
+            })
+            .collect::<Vec<_>>();
+        ports.sort_by(|left, right| left.guid.cmp(right.guid));
+        ports
+    }
+}

--- a/crates/ufm-mock/src/state/reconciliation.rs
+++ b/crates/ufm-mock/src/state/reconciliation.rs
@@ -1,0 +1,211 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
+
+use super::types::{
+    DEFAULT_PARTITION_KEY, Fabric, FabricError, FabricState, PortCandidate, PortRecord,
+    ReconcileOutcome, SourceState,
+};
+use crate::config::FailureAction;
+use crate::inventory::{Guid, InfinibandPortState, InventoryId, InventoryLease, InventorySnapshot};
+
+impl Fabric {
+    pub(crate) fn reconcile(
+        &self,
+        snapshot: InventorySnapshot,
+        lease: InventoryLease,
+    ) -> Result<ReconcileOutcome, FabricError> {
+        if snapshot.inventory_id.as_ref().is_empty() || snapshot.epoch_id.as_ref().is_empty() {
+            return Err(FabricError::InvalidInventoryIdentity);
+        }
+
+        let mut advertised = HashMap::new();
+        for machine in snapshot.machines {
+            for port in machine.infiniband_ports.unwrap_or_default() {
+                advertised.insert(
+                    port.guid,
+                    PortCandidate {
+                        mat_id: machine.mat_id.clone(),
+                        machine_id: machine.machine_id.clone(),
+                        state: port.state,
+                    },
+                );
+            }
+        }
+
+        let mut state = self.inner.write().expect("fabric lock poisoned");
+        if let Some(previous) = state.sources.get_mut(&snapshot.inventory_id)
+            && previous.epoch_id == snapshot.epoch_id
+            && !previous.failed
+        {
+            if previous.generation == snapshot.generation {
+                previous.lease = lease;
+                return Ok(ReconcileOutcome::Duplicate);
+            }
+            if previous.generation > snapshot.generation {
+                return Ok(ReconcileOutcome::Stale);
+            }
+        }
+
+        let previous_guids = state
+            .sources
+            .get(&snapshot.inventory_id)
+            .map(|source| source.guids.clone())
+            .unwrap_or_default();
+        let new_guids = advertised.keys().copied().collect::<BTreeSet<_>>();
+        let affected = previous_guids
+            .union(&new_guids)
+            .copied()
+            .collect::<Vec<_>>();
+
+        for guid in &previous_guids {
+            if let Some(candidates) = state.candidates.get_mut(guid) {
+                candidates.remove(&snapshot.inventory_id);
+            }
+        }
+        for (guid, candidate) in advertised {
+            state
+                .candidates
+                .entry(guid)
+                .or_default()
+                .insert(snapshot.inventory_id.clone(), candidate);
+        }
+        state.sources.insert(
+            snapshot.inventory_id,
+            SourceState {
+                epoch_id: snapshot.epoch_id,
+                generation: snapshot.generation,
+                guids: new_guids,
+                failed: false,
+                lease,
+            },
+        );
+        refresh_ports(&mut state, affected);
+        Ok(ReconcileOutcome::Applied)
+    }
+
+    pub(crate) fn source_failed(
+        &self,
+        inventory_id: &InventoryId,
+        lease: InventoryLease,
+        action: FailureAction,
+    ) {
+        let mut state = self.inner.write().expect("fabric lock poisoned");
+        let Some(source) = state.sources.get(inventory_id) else {
+            return;
+        };
+        if source.lease != lease || source.failed {
+            return;
+        }
+        let guids = source.guids.iter().copied().collect::<Vec<_>>();
+        match action {
+            FailureAction::MarkDown => {
+                if let Some(source) = state.sources.get_mut(inventory_id) {
+                    source.failed = true;
+                }
+                for guid in &guids {
+                    if let Some(candidate) = state
+                        .candidates
+                        .get_mut(guid)
+                        .and_then(|candidates| candidates.get_mut(inventory_id))
+                    {
+                        candidate.state = InfinibandPortState::Down;
+                    }
+                }
+            }
+            FailureAction::Remove => {
+                state.sources.remove(inventory_id);
+                for guid in &guids {
+                    if let Some(candidates) = state.candidates.get_mut(guid) {
+                        candidates.remove(inventory_id);
+                    }
+                }
+            }
+        }
+        refresh_ports(&mut state, guids);
+    }
+}
+
+fn refresh_ports(state: &mut FabricState, guids: Vec<Guid>) {
+    for guid in guids {
+        let winner = state
+            .candidates
+            .get(&guid)
+            .and_then(|candidates| candidates.first_key_value())
+            .map(|(owner, candidate)| (owner.clone(), candidate.clone()));
+        match winner {
+            Some((owner, candidate)) => {
+                if let Some(port) = state.ports.get_mut(&guid) {
+                    port.owner = owner;
+                    port.candidate = candidate;
+                } else {
+                    let lid = state.next_lid;
+                    state.next_lid = state
+                        .next_lid
+                        .checked_add(1)
+                        .expect("LID allocation overflow");
+                    state.ports.insert(
+                        guid,
+                        PortRecord {
+                            owner,
+                            candidate,
+                            lid,
+                        },
+                    );
+                }
+            }
+            None => {
+                state.candidates.remove(&guid);
+                state.ports.remove(&guid);
+                for partition in state.partitions.values_mut() {
+                    partition.members.remove(&guid);
+                }
+                state.partitions.retain(|key, partition| {
+                    *key == DEFAULT_PARTITION_KEY || !partition.members.is_empty()
+                });
+            }
+        }
+    }
+
+    for (guid, candidates) in &state.candidates {
+        if candidates.len() > 1 {
+            tracing::warn!(
+                %guid,
+                inventories = %LogCandidates(candidates),
+                winner = %candidates.first_key_value().expect("conflicting candidates must have a winner").0,
+                "InfiniBand GUID is advertised by multiple inventories"
+            );
+        }
+    }
+}
+
+struct LogCandidates<'a>(&'a BTreeMap<InventoryId, PortCandidate>);
+
+impl fmt::Display for LogCandidates<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[")?;
+        for (index, inventory_id) in self.0.keys().enumerate() {
+            if index > 0 {
+                formatter.write_str(", ")?;
+            }
+            write!(formatter, "{inventory_id}")?;
+        }
+        formatter.write_str("]")
+    }
+}

--- a/crates/ufm-mock/src/state/tests.rs
+++ b/crates/ufm-mock/src/state/tests.rs
@@ -1,0 +1,248 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::*;
+use crate::inventory::{
+    Guid, InfinibandPortState, InventoryLease, InventoryMachine, InventoryPort, InventorySnapshot,
+};
+
+fn fabric() -> Fabric {
+    Fabric::new(FabricConfig::default())
+}
+
+fn snapshot(
+    inventory_id: &str,
+    generation: u64,
+    machines: Vec<InventoryMachine>,
+) -> InventorySnapshot {
+    InventorySnapshot {
+        inventory_id: inventory_id.into(),
+        epoch_id: "epoch-1".into(),
+        generation: generation.into(),
+        machines,
+    }
+}
+
+fn machine(mat_id: &str, guid: &str, state: InfinibandPortState) -> InventoryMachine {
+    InventoryMachine {
+        mat_id: mat_id.into(),
+        machine_id: None,
+        infiniband_ports: Some(vec![InventoryPort {
+            guid: guid.parse().unwrap(),
+            state,
+        }]),
+    }
+}
+
+fn lease(value: u64) -> InventoryLease {
+    (1..value).fold(InventoryLease::FIRST_REMOTE, |lease, _| {
+        lease.checked_next().unwrap()
+    })
+}
+
+#[test]
+fn live_updates_preserve_partition_membership_and_complete_snapshots_remove_ports() {
+    let fabric = fabric();
+    fabric
+        .reconcile(
+            snapshot(
+                "inventory-a",
+                1,
+                vec![machine(
+                    "mat-a",
+                    "0000000000000001",
+                    InfinibandPortState::Active,
+                )],
+            ),
+            lease(1),
+        )
+        .unwrap();
+    fabric
+        .bind(BindRequest {
+            pkey: "1".parse().unwrap(),
+            ip_over_ib: false,
+            membership: PortMembership::Full,
+            index0: true,
+            guids: vec!["0000000000000001".parse().unwrap()],
+        })
+        .unwrap();
+
+    fabric
+        .reconcile(
+            snapshot(
+                "inventory-a",
+                2,
+                vec![machine(
+                    "mat-a",
+                    "0000000000000001",
+                    InfinibandPortState::Down,
+                )],
+            ),
+            lease(1),
+        )
+        .unwrap();
+
+    {
+        let fabric = fabric.read();
+        assert_eq!(fabric.ports()[0].logical_state, "Down");
+        let partition = fabric
+            .partition("1".parse().unwrap(), true, true)
+            .unwrap()
+            .unwrap();
+        let members = partition.guids.unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].guid, &Guid::from(1));
+        assert_eq!(members[0].membership, &PortMembership::Full);
+        assert!(*members[0].index0);
+    }
+
+    fabric
+        .reconcile(snapshot("inventory-a", 3, Vec::new()), lease(1))
+        .unwrap();
+
+    let fabric = fabric.read();
+    assert!(fabric.ports().is_empty());
+    assert!(
+        fabric
+            .partition("1".parse().unwrap(), true, true)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn lower_inventory_id_wins_guid_conflict_regardless_of_arrival_order() {
+    let fabric = fabric();
+    fabric
+        .reconcile(
+            snapshot(
+                "inventory-z",
+                1,
+                vec![machine(
+                    "mat-z",
+                    "0000000000000001",
+                    InfinibandPortState::Down,
+                )],
+            ),
+            lease(1),
+        )
+        .unwrap();
+    fabric
+        .reconcile(
+            snapshot(
+                "inventory-a",
+                1,
+                vec![machine(
+                    "mat-a",
+                    "0000000000000001",
+                    InfinibandPortState::Active,
+                )],
+            ),
+            lease(2),
+        )
+        .unwrap();
+
+    let fabric = fabric.read();
+    let ports = fabric.ports();
+    let port = &ports[0];
+    assert_eq!(port.dname, "mat-a");
+    assert_eq!(port.logical_state, "Active");
+}
+
+#[test]
+fn stale_generation_does_not_replace_newer_state() {
+    let fabric = fabric();
+    fabric
+        .reconcile(
+            snapshot(
+                "inventory-a",
+                2,
+                vec![machine(
+                    "mat-a",
+                    "0000000000000001",
+                    InfinibandPortState::Active,
+                )],
+            ),
+            lease(1),
+        )
+        .unwrap();
+
+    let outcome = fabric
+        .reconcile(snapshot("inventory-a", 1, Vec::new()), lease(1))
+        .unwrap();
+
+    assert_eq!(outcome, ReconcileOutcome::Stale);
+    assert_eq!(fabric.read().ports().len(), 1);
+}
+
+#[test]
+fn reconciles_four_ports_for_4500_machines() {
+    let fabric = fabric();
+    let machines = (0_u64..4_500)
+        .map(|machine_index| InventoryMachine {
+            mat_id: format!("mat-{machine_index}").into(),
+            machine_id: None,
+            infiniband_ports: Some(
+                (0_u64..4)
+                    .map(|port_index| InventoryPort {
+                        guid: Guid::from(machine_index * 4 + port_index + 1),
+                        state: InfinibandPortState::Active,
+                    })
+                    .collect(),
+            ),
+        })
+        .collect();
+
+    fabric
+        .reconcile(snapshot("inventory-scale", 1, machines), lease(1))
+        .unwrap();
+
+    let fabric = fabric.read();
+    assert_eq!(fabric.ports().len(), 18_000);
+    assert_eq!(
+        fabric
+            .partition("0x7fff".parse().unwrap(), true, false)
+            .unwrap()
+            .unwrap()
+            .guids
+            .unwrap()
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn guid_display_is_normalized() {
+    assert_eq!(
+        "0x1".parse::<Guid>().unwrap().to_string(),
+        "0000000000000001"
+    );
+    assert_eq!(
+        "AABB".parse::<Guid>().unwrap().to_string(),
+        "000000000000aabb"
+    );
+}
+
+#[test]
+fn unbind_is_idempotent_for_an_absent_guid() {
+    let fabric = fabric();
+
+    fabric.unbind(UnbindRequest {
+        pkey: "1".parse().unwrap(),
+        guids: vec![Guid::from(1)],
+    });
+}

--- a/crates/ufm-mock/src/state/types.rs
+++ b/crates/ufm-mock/src/state/types.rs
@@ -1,0 +1,282 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
+use std::str::FromStr;
+use std::sync::{Arc, RwLock, RwLockReadGuard};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+
+use crate::config::FabricConfig;
+use crate::inventory::{
+    EpochId, Generation, Guid, InfinibandPortState, InventoryId, InventoryLease, MachineId, MatId,
+};
+
+pub(super) const DEFAULT_PARTITION_KEY: PartitionKey = PartitionKey(0x7fff);
+
+#[derive(Clone, Debug)]
+pub(crate) struct Fabric {
+    pub(super) config: Arc<FabricConfig>,
+    pub(super) inner: Arc<RwLock<FabricState>>,
+}
+
+#[derive(Debug)]
+pub(super) struct FabricState {
+    pub(super) candidates: HashMap<Guid, BTreeMap<InventoryId, PortCandidate>>,
+    pub(super) ports: HashMap<Guid, PortRecord>,
+    pub(super) sources: HashMap<InventoryId, SourceState>,
+    pub(super) partitions: HashMap<PartitionKey, Partition>,
+    pub(super) next_lid: i32,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PortCandidate {
+    pub(super) mat_id: MatId,
+    pub(super) machine_id: Option<MachineId>,
+    pub(super) state: InfinibandPortState,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PortRecord {
+    pub(super) owner: InventoryId,
+    pub(super) candidate: PortCandidate,
+    pub(super) lid: i32,
+}
+
+#[derive(Debug)]
+pub(super) struct SourceState {
+    pub(super) epoch_id: EpochId,
+    pub(super) generation: Generation,
+    pub(super) guids: BTreeSet<Guid>,
+    pub(super) failed: bool,
+    pub(super) lease: InventoryLease,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Partition {
+    pub(super) name: PartitionName,
+    pub(super) ip_over_ib: bool,
+    pub(super) qos: PartitionQos,
+    pub(super) members: HashMap<Guid, PortConfig>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PartitionName(String);
+
+impl AsRef<str> for PartitionName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for PartitionName {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for PartitionName {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub(crate) struct PartitionQos {
+    pub mtu_limit: u16,
+    pub service_level: u8,
+    pub rate_limit: f32,
+}
+
+impl Default for PartitionQos {
+    fn default() -> Self {
+        Self {
+            mtu_limit: 2,
+            service_level: 0,
+            rate_limit: 2.5,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum PortMembership {
+    Limited,
+    Full,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PortConfig {
+    pub(super) membership: PortMembership,
+    pub(super) index0: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct PortData<'a> {
+    pub(super) guid: &'a Guid,
+    pub(super) name: PortName<'a>,
+    #[serde(rename = "systemID")]
+    pub(super) system_id: &'a Guid,
+    pub(super) lid: &'a i32,
+    pub(super) dname: &'a str,
+    pub(super) system_name: &'a str,
+    pub(super) physical_state: &'static str,
+    pub(super) logical_state: &'static str,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct PortName<'a>(pub(super) &'a Guid);
+
+impl fmt::Display for PortName<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}_1", self.0)
+    }
+}
+
+impl Serialize for PortName<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct PartitionKey(u16);
+
+impl fmt::Display for PartitionKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "0x{:x}", self.0)
+    }
+}
+
+impl FromStr for PartitionKey {
+    type Err = InvalidPartitionKey;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let parsed = if let Some(value) = value.strip_prefix("0x") {
+            u16::from_str_radix(value, 16)
+        } else {
+            value.parse()
+        }
+        .map_err(|_| InvalidPartitionKey(value.to_string()))?;
+        if parsed > DEFAULT_PARTITION_KEY.0 {
+            return Err(InvalidPartitionKey(value.to_string()));
+        }
+        Ok(Self(parsed))
+    }
+}
+
+impl Serialize for PartitionKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for PartitionKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error("invalid partition key {0}")]
+pub(crate) struct InvalidPartitionKey(String);
+
+#[derive(Debug, Serialize)]
+pub(super) struct PortConfigData<'a> {
+    pub(super) guid: &'a Guid,
+    pub(super) membership: &'a PortMembership,
+    pub(super) index0: &'a bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct PartitionData<'a> {
+    pub(super) partition: &'a str,
+    pub(super) ip_over_ib: &'a bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) qos_conf: Option<&'a PartitionQos>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) guids: Option<Vec<PortConfigData<'a>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) membership: Option<&'static PortMembership>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct BindRequest {
+    pub pkey: PartitionKey,
+    pub ip_over_ib: bool,
+    pub membership: PortMembership,
+    pub index0: bool,
+    pub guids: Vec<Guid>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct UnbindRequest {
+    pub pkey: PartitionKey,
+    pub guids: Vec<Guid>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct QosRequest {
+    pub pkey: PartitionKey,
+    pub mtu_limit: u16,
+    pub service_level: u8,
+    pub rate_limit: f32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReconcileOutcome {
+    Applied,
+    Duplicate,
+    Stale,
+}
+
+impl ReconcileOutcome {
+    pub(crate) fn metric_label(self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::Duplicate => "duplicate",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum FabricError {
+    #[error("partition {0} does not exist")]
+    PartitionNotFound(PartitionKey),
+    #[error("InfiniBand port {0} does not exist")]
+    PortNotFound(Guid),
+    #[error("inventory_id and epoch_id must not be empty")]
+    InvalidInventoryIdentity,
+}
+
+pub(crate) struct FabricRead<'a> {
+    pub(super) state: RwLockReadGuard<'a, FabricState>,
+}

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -34,6 +34,32 @@ as nico-machine-a-tron. The controller does not support a separate namespace.
 
 **Default:** Override Mode (controller disabled, single pod).
 
+## UFM mock
+
+Machine-a-tron hosts a UFM-compatible mock on its existing HTTPS listener. The
+mock is enabled by default and exposes only the InfiniBand inventory belonging
+to that machine-a-tron process. Point the default NICo IB fabric at the same
+Service used for the machine-a-tron control and Redfish APIs, with
+`/ufmRestV3` as the UFM API path.
+
+The generated Secret contains the HTTP Basic credential accepted by the mock.
+Set `ufmMock.authToken`, or set `ufmMock.existingAuthSecret` to a Secret whose
+`token` key contains the credential.
+
+Disable the embedded mock when InfiniBand simulation is not needed or when an
+external fabric mock is managed separately:
+
+```yaml
+ufmMock:
+  enabled: false
+```
+
+For the default `mat-0` pod and chart name, the endpoint is
+`https://nico-machine-a-tron-mat-0-bmc-mock.<namespace>.svc.cluster.local:1266`.
+The chart does not aggregate InfiniBand inventory across multiple
+machine-a-tron pods. A full `configFiles.matConfigs` override owns the complete
+MAT configuration, including its `[ufm_mock]` section.
+
 ---
 
 ## Mode 1: Override Mode (Development)

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -42,9 +42,9 @@ to that machine-a-tron process. Point the default NICo IB fabric at the same
 Service used for the machine-a-tron control and Redfish APIs, with
 `/ufmRestV3` as the UFM API path.
 
-The generated Secret contains the HTTP Basic credential accepted by the mock.
-Set `ufmMock.authToken`, or set `ufmMock.existingAuthSecret` to a Secret whose
-`token` key contains the credential.
+The chart generates a 24-character HTTP Basic credential, stores it in a
+Secret, and preserves it across Helm upgrades. Set `ufmMock.existingAuthSecret`
+to use an externally managed Secret whose `token` key contains the credential.
 
 Disable the embedded mock when InfiniBand simulation is not needed or when an
 external fabric mock is managed separately:

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -106,6 +106,13 @@ data:
     {{- end }}
     api_refresh_interval = {{ $root.Values.machineATron.apiRefreshInterval | quote }}
 
+    [ufm_mock]
+    enabled = {{ $root.Values.ufmMock.enabled }}
+    {{- if $root.Values.ufmMock.enabled }}
+    include_local_inventory = true
+    metrics_address = "[::]:{{ $root.Values.service.metrics.port }}"
+    {{- end }}
+
     {{/*
     MAC Address Pool Configuration
     Each pod gets a unique base address: basePrefix:podIndex:00:00:00

--- a/helm/charts/nico-machine-a-tron/templates/deployment.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: UFM_MOCK_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ default (printf "%s-ufm-mock-auth" $baseName) $root.Values.ufmMock.existingAuthSecret }}
+                  name: {{ $root.Values.ufmMock.existingAuthSecret | default (printf "%s-ufm-mock-auth" $baseName) | quote }}
                   key: token
           {{- end }}
           ports:

--- a/helm/charts/nico-machine-a-tron/templates/deployment.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/deployment.yaml
@@ -62,10 +62,23 @@ spec:
             {{- toYaml $root.Values.command | nindent 12 }}
           args:
             - "/app/mat.toml"
+          {{- if $root.Values.ufmMock.enabled }}
+          env:
+            - name: UFM_MOCK_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-ufm-mock-auth" $baseName) $root.Values.ufmMock.existingAuthSecret }}
+                  key: token
+          {{- end }}
           ports:
             - name: redfish
               containerPort: {{ $root.Values.service.bmcMock.port }}
               protocol: TCP
+            {{- if $root.Values.ufmMock.enabled }}
+            - name: metrics
+              containerPort: {{ $root.Values.service.metrics.port }}
+              protocol: TCP
+            {{- end }}
             {{- if $root.Values.machineATron.mockBmcSshServer }}
             - name: ssh
               containerPort: {{ $root.Values.machineATron.mockBmcSshPort }}

--- a/helm/charts/nico-machine-a-tron/templates/metrics-service.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/metrics-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ufmMock.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
     - port: {{ .Values.service.metrics.port }}
       name: metrics
       protocol: TCP
+{{- end }}

--- a/helm/charts/nico-machine-a-tron/templates/service-monitor.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.ufmMock.enabled .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/helm/charts/nico-machine-a-tron/templates/ufm-mock-auth.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/ufm-mock-auth.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.ufmMock.enabled (not .Values.ufmMock.existingAuthSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nico-machine-a-tron.name" . }}-ufm-mock-auth
+  namespace: {{ include "nico-machine-a-tron.namespace" . }}
+  labels:
+    {{- include "nico-machine-a-tron.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ required "ufmMock.authToken is required when the UFM mock is enabled" .Values.ufmMock.authToken | quote }}
+{{- end }}

--- a/helm/charts/nico-machine-a-tron/templates/ufm-mock-auth.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/ufm-mock-auth.yaml
@@ -1,12 +1,18 @@
 {{- if and .Values.ufmMock.enabled (not .Values.ufmMock.existingAuthSecret) }}
+{{- $secretName := printf "%s-ufm-mock-auth" (include "nico-machine-a-tron.name" .) }}
+{{- $token := randAlphaNum 24 }}
+{{- $existing := lookup "v1" "Secret" (include "nico-machine-a-tron.namespace" .) $secretName }}
+{{- if and $existing $existing.data (hasKey $existing.data "token") }}
+{{- $token = index $existing.data "token" | b64dec }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "nico-machine-a-tron.name" . }}-ufm-mock-auth
+  name: {{ $secretName }}
   namespace: {{ include "nico-machine-a-tron.namespace" . }}
   labels:
     {{- include "nico-machine-a-tron.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  token: {{ required "ufmMock.authToken is required when the UFM mock is enabled" .Values.ufmMock.authToken | quote }}
+  token: {{ $token | quote }}
 {{- end }}

--- a/helm/charts/nico-machine-a-tron/tests/ufm_mock_auth_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/ufm_mock_auth_test.yaml
@@ -1,0 +1,25 @@
+suite: UFM mock authentication tests
+templates:
+  - ufm-mock-auth.yaml
+tests:
+  - it: should generate a 24-character authentication token
+    asserts:
+      - matchRegex:
+          path: stringData.token
+          pattern: ^[A-Za-z0-9]{24}$
+
+  - it: should not create a Secret when an existing Secret is configured
+    set:
+      ufmMock:
+        existingAuthSecret: existing-ufm-auth
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create a Secret when the UFM mock is disabled
+    set:
+      ufmMock:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -137,6 +137,13 @@ serviceMonitor:
   interval: 30s
   scrapeTimeout: 25s
 
+## UFM-compatible API mock hosted by each machine-a-tron process on its existing
+## HTTPS listener. Disable it for simulations that do not need InfiniBand.
+ufmMock:
+  enabled: true
+  authToken: "Welcome123"
+  existingAuthSecret: ""
+
 ## =============================================================================
 ## Machine-a-tron Core Settings (shared across all pods)
 ## =============================================================================

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -141,7 +141,8 @@ serviceMonitor:
 ## HTTPS listener. Disable it for simulations that do not need InfiniBand.
 ufmMock:
   enabled: true
-  authToken: "Welcome123"
+  ## Use an existing Secret with a `token` key. When unset, the chart creates
+  ## a Secret with a random token and preserves it across Helm upgrades.
   existingAuthSecret: ""
 
 ## =============================================================================


### PR DESCRIPTION
Machine-a-tron models InfiniBand hardware, but local environments previously lacked a UFM endpoint, so they could not exercise NICo’s production UFM REST path.

This PR adds a stateful UFM mock and embeds it into machine-a-tron. It:
- Publishes deterministic InfiniBand inventory from `/machines/status`.
- Implements the UFM REST v3 operations used by `RestIBFabric`.
- Reconciles port state and partition membership across inventory updates.
- Supports Basic authentication, metrics, and fault injection.
- Enables InfiniBand by default in localdev and the MAT Helm chart.
- Supports Helm opt-out with `ufmMock.enabled=false`.

The MAT container contains only the `machine-a-tron` executable; the UFM mock is linked as a library. Standalone scale deployment is outside this PR.

## Related issues

Closes: #3528 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

