### PR TITLE
feat(rest-api): Recovery of missing VPC Prefixes from Site inventory

### DIFF
--- a/rest-api/db/pkg/db/ipam/ipam.go
+++ b/rest-api/db/pkg/db/ipam/ipam.go
@@ -109,7 +109,7 @@ func GetIpamUsageForIPBlock(ctx context.Context, ipamDB cipam.Storage, ipBlock *
 	ipamPrefix := ipamer.PrefixFrom(ctx, cidr)
 
 	if ipamPrefix == nil {
-		return nil, errors.New(fmt.Sprintf("did not find prefix for IPBlock: %s", ipBlock.ID.String()))
+		return nil, fmt.Errorf("did not find prefix for IPBlock: %s", ipBlock.ID)
 	}
 
 	// Handle full grant scenario
@@ -144,7 +144,7 @@ func CreateChildIpamEntryForIPBlock(ctx context.Context, tx *cdb.Tx, dbSession *
 	// we can reason better wrt correctness.
 	// TODO: look into implementing full grant in cloud-ipam library.
 	if parentIPBlock.FullGrant {
-		return nil, errors.New(fmt.Sprintf("parent IPBlock : %s already has a full-grant", parentIPBlock.ID.String()))
+		return nil, fmt.Errorf("parent IPBlock %s already has a full grant", parentIPBlock.ID)
 	}
 	ipamer := cipam.NewWithStorage(ipamDB)
 	namespace := GetIpamNamespaceForIPBlock(ctx, parentIPBlock.RoutingType, parentIPBlock.InfrastructureProviderID.String(), parentIPBlock.SiteID.String())
@@ -154,7 +154,7 @@ func CreateChildIpamEntryForIPBlock(ctx context.Context, tx *cdb.Tx, dbSession *
 	if childBlockSize == parentIPBlock.PrefixLength {
 		parentPrefix := ipamer.PrefixFrom(ctx, parentCidr)
 		if parentPrefix == nil {
-			return nil, errors.New(fmt.Sprintf("did not find prefix for parentIPBlock: %s", parentIPBlock.ID.String()))
+			return nil, fmt.Errorf("did not find prefix for parentIPBlock: %s", parentIPBlock.ID)
 		}
 		parentUsage := parentPrefix.Usage()
 		if parentUsage.AcquiredPrefixes > 0 {
@@ -193,7 +193,7 @@ func AcquireSpecificChildIpamEntryForIPBlock(ctx context.Context, tx *cdb.Tx, db
 		return nil, ErrNilIPBlock
 	}
 	if parentIPBlock.FullGrant {
-		return nil, errors.New(fmt.Sprintf("parent IPBlock : %s already has a full-grant", parentIPBlock.ID.String()))
+		return nil, fmt.Errorf("parent IPBlock %s already has a full grant", parentIPBlock.ID)
 	}
 	ipamer := cipam.NewWithStorage(ipamDB)
 	namespace := GetIpamNamespaceForIPBlock(ctx, parentIPBlock.RoutingType, parentIPBlock.InfrastructureProviderID.String(), parentIPBlock.SiteID.String())
@@ -202,7 +202,7 @@ func AcquireSpecificChildIpamEntryForIPBlock(ctx context.Context, tx *cdb.Tx, db
 	// A child equal to the parent is a full grant. That path must go through
 	// CreateChildIpamEntryForIPBlock so the REST DB FullGrant flag stays consistent.
 	if childCidr == parentCidr {
-		return nil, errors.New(fmt.Sprintf("childCidr: %s equals parentCidr for IPBlock: %s, use CreateChildIpamEntryForIPBlock", childCidr, parentIPBlock.ID.String()))
+		return nil, fmt.Errorf("child CIDR %s equals parent CIDR %s for IPBlock %s; use CreateChildIpamEntryForIPBlock", childCidr, parentCidr, parentIPBlock.ID)
 	}
 	childPrefix, err := ipamer.AcquireSpecificChildPrefix(ctx, parentCidr, childCidr)
 	if err != nil {
@@ -226,7 +226,7 @@ func DeleteChildIpamEntryFromCidr(ctx context.Context, tx *cdb.Tx, dbSession *cd
 		// this is a consistency check
 		if parentCidr != childCidr {
 			// this should never happen, ie, in a full grant, parent cidr and child cidr should match
-			return errors.New(fmt.Sprintf("parent IPBlock has full-grant, but childCidr: %s does not match parentCidr: %s", childCidr, parentCidr))
+			return fmt.Errorf("parent IPBlock has full grant, but child CIDR %s does not match parent CIDR %s", childCidr, parentCidr)
 		}
 		ipbDAO := cdbm.NewIPBlockDAO(dbSession)
 		_, err := ipbDAO.Update(
@@ -239,7 +239,7 @@ func DeleteChildIpamEntryFromCidr(ctx context.Context, tx *cdb.Tx, dbSession *cd
 		)
 
 		if err != nil {
-			return errors.New(fmt.Sprintf("unable to update IPBlock's full-grant, ipblock id: %s ", parentIPBlock.ID.String()))
+			return fmt.Errorf("unable to update IPBlock full grant for IPBlock %s", parentIPBlock.ID)
 		}
 		parentIPBlock.FullGrant = false
 		return nil

--- a/rest-api/db/pkg/db/ipam/ipam.go
+++ b/rest-api/db/pkg/db/ipam/ipam.go
@@ -199,6 +199,11 @@ func AcquireSpecificChildIpamEntryForIPBlock(ctx context.Context, tx *cdb.Tx, db
 	namespace := GetIpamNamespaceForIPBlock(ctx, parentIPBlock.RoutingType, parentIPBlock.InfrastructureProviderID.String(), parentIPBlock.SiteID.String())
 	ipamer.SetNamespace(namespace)
 	parentCidr := GetCidrForIPBlock(ctx, parentIPBlock.Prefix, parentIPBlock.PrefixLength)
+	// A child equal to the parent is a full grant. That path must go through
+	// CreateChildIpamEntryForIPBlock so the REST DB FullGrant flag stays consistent.
+	if childCidr == parentCidr {
+		return nil, errors.New(fmt.Sprintf("childCidr: %s equals parentCidr for IPBlock: %s, use CreateChildIpamEntryForIPBlock", childCidr, parentIPBlock.ID.String()))
+	}
 	childPrefix, err := ipamer.AcquireSpecificChildPrefix(ctx, parentCidr, childCidr)
 	if err != nil {
 		return nil, err

--- a/rest-api/db/pkg/db/ipam/ipam.go
+++ b/rest-api/db/pkg/db/ipam/ipam.go
@@ -183,6 +183,29 @@ func CreateChildIpamEntryForIPBlock(ctx context.Context, tx *cdb.Tx, dbSession *
 	return childPrefix, err
 }
 
+// AcquireSpecificChildIpamEntryForIPBlock will create a child ipam entry in the ipam DB for the
+// given parent IP Block, using an exact child cidr instead of letting ipam choose one
+// Note: FullGrant is tracked only in the REST DB, so the ipam DB reports a fully granted parent as
+// empty. The caller must go through this helper (rather than the ipam library directly) so a
+// fully granted parent cannot hand out an overlapping child prefix
+func AcquireSpecificChildIpamEntryForIPBlock(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, ipamDB cipam.Storage, parentIPBlock *cdbm.IPBlock, childCidr string) (*cipam.Prefix, error) {
+	if parentIPBlock == nil {
+		return nil, ErrNilIPBlock
+	}
+	if parentIPBlock.FullGrant {
+		return nil, errors.New(fmt.Sprintf("parent IPBlock : %s already has a full-grant", parentIPBlock.ID.String()))
+	}
+	ipamer := cipam.NewWithStorage(ipamDB)
+	namespace := GetIpamNamespaceForIPBlock(ctx, parentIPBlock.RoutingType, parentIPBlock.InfrastructureProviderID.String(), parentIPBlock.SiteID.String())
+	ipamer.SetNamespace(namespace)
+	parentCidr := GetCidrForIPBlock(ctx, parentIPBlock.Prefix, parentIPBlock.PrefixLength)
+	childPrefix, err := ipamer.AcquireSpecificChildPrefix(ctx, parentCidr, childCidr)
+	if err != nil {
+		return nil, err
+	}
+	return childPrefix, nil
+}
+
 // DeleteChildIpamEntryFromCidr will delete a child ipam entry in the ipam DB
 // given the parent IPBlock, and child cidr
 // Note: FullGrant is a special case when the parentIPBlock has a full grant, and the child

--- a/rest-api/db/pkg/db/ipam/ipam_test.go
+++ b/rest-api/db/pkg/db/ipam/ipam_test.go
@@ -10,12 +10,12 @@ import (
 
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
-	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cdbutil "github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun/extra/bundebug"
 )
 
@@ -34,7 +34,7 @@ func getTestIpamer(t *testing.T, ipamDB cipam.Storage) cipam.Ipamer {
 func getTestIpamDB(t *testing.T, dbSession *db.Session, reset bool) cipam.Storage {
 	if testIpamDB != nil {
 		if reset {
-			testIpamDB.DeleteAllPrefixes(context.Background(), "")
+			require.NoError(t, testIpamDB.DeleteAllPrefixes(context.Background(), ""))
 		}
 		return testIpamDB
 	}
@@ -42,11 +42,11 @@ func getTestIpamDB(t *testing.T, dbSession *db.Session, reset bool) cipam.Storag
 	storage := cipam.NewBunStorage(dbSession.DB, nil)
 
 	// ensure the ipam schema is applied in test db
-	storage.ApplyDbSchema()
+	require.NoError(t, storage.ApplyDbSchema())
 
 	testIpamDB := NewIpamStorage(dbSession.DB, nil)
 	if reset {
-		testIpamDB.DeleteAllPrefixes(context.Background(), "")
+		require.NoError(t, testIpamDB.DeleteAllPrefixes(context.Background(), ""))
 	}
 	return testIpamDB
 }
@@ -463,7 +463,7 @@ func TestCreateChildIpamEntryForIPBlock(t *testing.T) {
 	tests := []struct {
 		name              string
 		parentIPBlock     *cdbm.IPBlock
-		tx                *cdb.Tx
+		tx                *db.Tx
 		childCount        int
 		childPrefixLength int
 		expectedErr       bool
@@ -649,7 +649,7 @@ func TestDeleteChildIpamEntryFromCidr(t *testing.T) {
 	tests := []struct {
 		name           string
 		parentIPBlock  *cdbm.IPBlock
-		tx             *cdb.Tx
+		tx             *db.Tx
 		childCidr      string
 		expectedErr    bool
 		checkFullGrant bool
@@ -753,6 +753,7 @@ func TestAcquireSpecificChildIpamEntryForIPBlock(t *testing.T) {
 		parentIPBlock *cdbm.IPBlock
 		childCidr     string
 		expectedErr   bool
+		expectedError string
 	}{
 		{
 			name:          "success acquiring specific child",
@@ -765,12 +766,17 @@ func TestAcquireSpecificChildIpamEntryForIPBlock(t *testing.T) {
 			parentIPBlock: parent,
 			childCidr:     "10.20.0.0/16",
 			expectedErr:   true,
+			expectedError: fmt.Sprintf(
+				"child CIDR 10.20.0.0/16 equals parent CIDR 10.20.0.0/16 for IPBlock %s; use CreateChildIpamEntryForIPBlock",
+				parent.ID,
+			),
 		},
 		{
 			name:          "failure when parent is fully granted",
 			parentIPBlock: fullGrantParent,
 			childCidr:     "10.21.1.0/24",
 			expectedErr:   true,
+			expectedError: fmt.Sprintf("parent IPBlock %s already has a full grant", fullGrantParent.ID),
 		},
 		{
 			name:          "failure when parent is nil",
@@ -783,6 +789,9 @@ func TestAcquireSpecificChildIpamEntryForIPBlock(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			child, err := AcquireSpecificChildIpamEntryForIPBlock(ctx, nil, dbSession, ipamDB, tc.parentIPBlock, tc.childCidr)
 			assert.Equal(t, tc.expectedErr, err != nil)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+			}
 			if tc.expectedErr {
 				assert.Nil(t, child)
 				return

--- a/rest-api/db/pkg/db/ipam/ipam_test.go
+++ b/rest-api/db/pkg/db/ipam/ipam_test.go
@@ -708,6 +708,91 @@ func TestDeleteChildIpamEntryFromCidr(t *testing.T) {
 	}
 }
 
+func TestAcquireSpecificChildIpamEntryForIPBlock(t *testing.T) {
+	dbSession := cdbutil.GetTestDBSession(t, false)
+	defer dbSession.Close()
+	dbSession.DB.AddQueryHook(bundebug.NewQueryHook(
+		bundebug.WithEnabled(false),
+		bundebug.FromEnv("BUNDEBUG"),
+	))
+	ipamDB := getTestIpamDB(t, dbSession, true)
+	ctx := context.Background()
+	testIpamSetupSchema(t, dbSession)
+
+	ip := testIpamBuildInfrastructureProvider(t, dbSession, "testip-specific")
+	site := testIpamBuildSite(t, dbSession, ip, "testsite-specific")
+
+	parent := &cdbm.IPBlock{
+		RoutingType:              cdbm.IPBlockRoutingTypeDatacenterOnly,
+		InfrastructureProviderID: ip.ID,
+		SiteID:                   site.ID,
+		Prefix:                   "10.20.0.0",
+		PrefixLength:             16,
+		FullGrant:                false,
+		ProtocolVersion:          cdbm.IPBlockProtocolVersionV4,
+	}
+	ipamer := cipam.NewWithStorage(ipamDB)
+	ipamer.SetNamespace(GetIpamNamespaceForIPBlock(ctx, parent.RoutingType, parent.InfrastructureProviderID.String(), parent.SiteID.String()))
+	prefix, err := ipamer.NewPrefix(ctx, "10.20.0.0/16")
+	assert.Nil(t, err)
+	assert.Equal(t, "10.20.0.0/16", prefix.Cidr)
+
+	fullGrantParent := &cdbm.IPBlock{
+		ID:                       uuid.New(),
+		RoutingType:              cdbm.IPBlockRoutingTypeDatacenterOnly,
+		InfrastructureProviderID: ip.ID,
+		SiteID:                   site.ID,
+		Prefix:                   "10.21.0.0",
+		PrefixLength:             16,
+		FullGrant:                true,
+		ProtocolVersion:          cdbm.IPBlockProtocolVersionV4,
+	}
+
+	tests := []struct {
+		name          string
+		parentIPBlock *cdbm.IPBlock
+		childCidr     string
+		expectedErr   bool
+	}{
+		{
+			name:          "success acquiring specific child",
+			parentIPBlock: parent,
+			childCidr:     "10.20.1.0/24",
+			expectedErr:   false,
+		},
+		{
+			name:          "failure when child equals parent",
+			parentIPBlock: parent,
+			childCidr:     "10.20.0.0/16",
+			expectedErr:   true,
+		},
+		{
+			name:          "failure when parent is fully granted",
+			parentIPBlock: fullGrantParent,
+			childCidr:     "10.21.1.0/24",
+			expectedErr:   true,
+		},
+		{
+			name:          "failure when parent is nil",
+			parentIPBlock: nil,
+			childCidr:     "10.20.2.0/24",
+			expectedErr:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			child, err := AcquireSpecificChildIpamEntryForIPBlock(ctx, nil, dbSession, ipamDB, tc.parentIPBlock, tc.childCidr)
+			assert.Equal(t, tc.expectedErr, err != nil)
+			if tc.expectedErr {
+				assert.Nil(t, child)
+				return
+			}
+			assert.NotNil(t, child)
+			assert.Equal(t, tc.childCidr, child.Cidr)
+		})
+	}
+}
+
 // Generic IPAM library tests from the api
 func TestIpamer_NewPrefix(t *testing.T) {
 	// test ipam operations from api

--- a/rest-api/db/pkg/db/model/ipblock.go
+++ b/rest-api/db/pkg/db/model/ipblock.go
@@ -156,6 +156,8 @@ type IPBlockFilterInput struct {
 	ExcludeDerived            bool
 	ExcludeTenantSitePrefixes bool
 	SearchQuery               *string
+	// IncludeDeleted returns soft-deleted rows in addition to active ones.
+	IncludeDeleted bool
 }
 
 // ProviderVisible applies the provider's IPBlock visibility rules to the filter.
@@ -475,6 +477,9 @@ func (ipbsd IPBlockSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter IPBlock
 	ipbs := []IPBlock{}
 
 	query := db.GetIDB(tx, ipbsd.dbSession).NewSelect().Model(&ipbs)
+	if filter.IncludeDeleted {
+		query = query.WhereAllWithDeleted()
+	}
 	query, err := ipbsd.setQueryWithFilter(query, filter, ipblockDAOSpan)
 	if err != nil {
 		return nil, 0, err

--- a/rest-api/db/pkg/db/model/ipblock.go
+++ b/rest-api/db/pkg/db/model/ipblock.go
@@ -6,6 +6,8 @@ package model
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
@@ -94,6 +96,19 @@ type IPBlock struct {
 	Updated                  time.Time               `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted                  *time.Time              `bun:"deleted,soft_delete"`
 	CreatedBy                *uuid.UUID              `bun:"created_by,type:uuid"`
+}
+
+// ContainsPrefix reports whether prefix belongs to this IPBlock.
+func (ipb *IPBlock) ContainsPrefix(prefix netip.Prefix) bool {
+	if ipb == nil {
+		return false
+	}
+
+	ipBlockPrefix, err := netip.ParsePrefix(fmt.Sprintf("%s/%d", ipb.Prefix, ipb.PrefixLength))
+	return err == nil &&
+		ipBlockPrefix.Addr().BitLen() == prefix.Addr().BitLen() &&
+		ipBlockPrefix.Bits() <= prefix.Bits() &&
+		ipBlockPrefix.Contains(prefix.Addr())
 }
 
 // IPBlockCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/ipblock_test.go
+++ b/rest-api/db/pkg/db/model/ipblock_test.go
@@ -644,6 +644,25 @@ func TestIPBlockSQLDAO_GetAll(t *testing.T) {
 		}
 	}
 
+	deletedIPBlock, err := ipbsd.Create(
+		ctx, nil, IPBlockCreateInput{
+			Name:                     "deleted-ip-block",
+			Description:              cutil.GetPtr("description"),
+			SiteID:                   site1.ID,
+			InfrastructureProviderID: ip.ID,
+			RoutingType:              IPBlockRoutingTypePublic,
+			Prefix:                   "203.0.113.0",
+			PrefixLength:             24,
+			ProtocolVersion:          "v4",
+			FullGrant:                false,
+			Status:                   IPBlockStatusReady,
+			CreatedBy:                &user.ID,
+		},
+	)
+	require.NoError(t, err)
+	err = ipbsd.Delete(ctx, nil, deletedIPBlock.ID)
+	require.NoError(t, err)
+
 	dummyUUID := uuid.New()
 
 	// OTEL Spanner configuration
@@ -672,6 +691,7 @@ func TestIPBlockSQLDAO_GetAll(t *testing.T) {
 		expectedError             bool
 		paramRelations            []string
 		verifyChildSpanner        bool
+		includeDeleted            bool
 	}{
 		{
 			desc:                      "GetAll with no filters returns objects",
@@ -971,6 +991,22 @@ func TestIPBlockSQLDAO_GetAll(t *testing.T) {
 			expectedError:             false,
 		},
 		{
+			desc:          "GetAll excludes a soft-deleted IP Block by default",
+			ids:           []uuid.UUID{deletedIPBlock.ID},
+			expectedCount: 0,
+			expectedTotal: cutil.GetPtr(0),
+			expectedError: false,
+		},
+		{
+			desc:           "GetAll includes a soft-deleted IP Block when requested",
+			ids:            []uuid.UUID{deletedIPBlock.ID},
+			includeDeleted: true,
+			expectedCount:  1,
+			expectedTotal:  cutil.GetPtr(1),
+			expectedError:  false,
+			firstEntry:     deletedIPBlock,
+		},
+		{
 			desc:                      "GetAll with site, prefix and prefixLenth returns object",
 			siteIDs:                   []uuid.UUID{site2.ID},
 			infrastructureProviderIDs: []uuid.UUID{ip.ID},
@@ -1018,6 +1054,7 @@ func TestIPBlockSQLDAO_GetAll(t *testing.T) {
 					Statuses:                  tc.statuses,
 					SearchQuery:               tc.searchQuery,
 					IPBlockIDs:                tc.ids,
+					IncludeDeleted:            tc.includeDeleted,
 				},
 				paginator.PageInput{
 					Offset:  tc.offset,

--- a/rest-api/db/pkg/db/model/ipblock_test.go
+++ b/rest-api/db/pkg/db/model/ipblock_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,6 +93,60 @@ func testIPBlockBuildTenant(t *testing.T, dbSession *db.Session, name string) *T
 	_, err := dbSession.DB.NewInsert().Model(tenant).Exec(context.Background())
 	assert.Nil(t, err)
 	return tenant
+}
+
+func TestIPBlock_ContainsPrefix(t *testing.T) {
+	tests := []struct {
+		name             string
+		ipBlock          *IPBlock
+		reportedPrefix   string
+		expectedContains bool
+	}{
+		{
+			name:             "contains a narrower IPv4 prefix",
+			ipBlock:          &IPBlock{Prefix: "10.20.0.0", PrefixLength: 16},
+			reportedPrefix:   "10.20.30.0/24",
+			expectedContains: true,
+		},
+		{
+			name:             "rejects an IPv4 prefix outside the block",
+			ipBlock:          &IPBlock{Prefix: "10.20.0.0", PrefixLength: 16},
+			reportedPrefix:   "10.21.30.0/24",
+			expectedContains: false,
+		},
+		{
+			name:             "rejects a reported prefix wider than the block",
+			ipBlock:          &IPBlock{Prefix: "10.20.16.0", PrefixLength: 20},
+			reportedPrefix:   "10.20.0.0/16",
+			expectedContains: false,
+		},
+		{
+			name:             "rejects a different address family",
+			ipBlock:          &IPBlock{Prefix: "10.20.0.0", PrefixLength: 16},
+			reportedPrefix:   "2001:db8::/64",
+			expectedContains: false,
+		},
+		{
+			name:             "rejects an invalid IPBlock prefix",
+			ipBlock:          &IPBlock{Prefix: "not-an-address", PrefixLength: 16},
+			reportedPrefix:   "10.20.30.0/24",
+			expectedContains: false,
+		},
+		{
+			name:             "rejects a nil IPBlock",
+			ipBlock:          nil,
+			reportedPrefix:   "10.20.30.0/24",
+			expectedContains: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reportedPrefix, err := netip.ParsePrefix(test.reportedPrefix)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedContains, test.ipBlock.ContainsPrefix(reportedPrefix))
+		})
+	}
 }
 
 func TestIPBlockSQLDAO_Create(t *testing.T) {

--- a/rest-api/db/pkg/db/model/vpcprefix.go
+++ b/rest-api/db/pkg/db/model/vpcprefix.go
@@ -215,6 +215,13 @@ type VpcPrefixUpdateInput struct {
 	IsMissingOnSite *bool
 }
 
+// VpcPrefixClearInput input parameters for Clear method
+type VpcPrefixClearInput struct {
+	VpcPrefixID uuid.UUID
+	// Deleted clears the soft-delete timestamp (undelete).
+	Deleted bool
+}
+
 // VpcPrefixFilterInput input parameters for Filter method
 type VpcPrefixFilterInput struct {
 	VpcPrefixIDs  []uuid.UUID
@@ -228,6 +235,8 @@ type VpcPrefixFilterInput struct {
 	SearchQuery   *string
 	Prefixes      []string
 	PrefixLengths []int
+	// IncludeDeleted returns soft-deleted rows in addition to active ones.
+	IncludeDeleted bool
 }
 
 var _ bun.BeforeAppendModelHook = (*VpcPrefix)(nil)
@@ -265,6 +274,8 @@ type VpcPrefixDAO interface {
 	GetAll(ctx context.Context, tx *db.Tx, filter VpcPrefixFilterInput, page paginator.PageInput, includeRelations []string) ([]VpcPrefix, int, error)
 	//
 	Update(ctx context.Context, tx *db.Tx, input VpcPrefixUpdateInput) (*VpcPrefix, error)
+	//
+	Clear(ctx context.Context, tx *db.Tx, input VpcPrefixClearInput) (*VpcPrefix, error)
 	//
 	Delete(ctx context.Context, tx *db.Tx, id uuid.UUID) error
 	//
@@ -368,6 +379,10 @@ func (vpsd VpcPrefixSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter VpcPre
 	vps := []VpcPrefix{}
 
 	query := db.GetIDB(tx, vpsd.dbSession).NewSelect().Model(&vps)
+	// Soft-deleted rows are excluded by default.
+	if filter.IncludeDeleted {
+		query = query.WhereAllWithDeleted()
+	}
 	if filter.VpcPrefixIDs != nil {
 		query = query.Where("vp.id IN (?)", bun.In(filter.VpcPrefixIDs))
 		vpsd.tracerSpan.SetAttribute(vpDAOSpan, "vpc_prefix_ids", filter.VpcPrefixIDs)
@@ -513,6 +528,46 @@ func (vpsd VpcPrefixSQLDAO) Update(ctx context.Context, tx *db.Tx, input VpcPref
 
 	nvp, err := vpsd.GetByID(ctx, tx, vp.ID, nil)
 
+	if err != nil {
+		return nil, err
+	}
+	return nvp, nil
+}
+
+// Clear clears VpcPrefix attributes based on provided arguments
+func (vpsd VpcPrefixSQLDAO) Clear(ctx context.Context, tx *db.Tx, input VpcPrefixClearInput) (*VpcPrefix, error) {
+	ctx, vpDAOSpan := vpsd.tracerSpan.CreateChildInCurrentContext(ctx, "VpcPrefixDAO.Clear")
+	if vpDAOSpan != nil {
+		defer vpDAOSpan.End()
+
+		vpsd.tracerSpan.SetAttribute(vpDAOSpan, "id", input.VpcPrefixID.String())
+	}
+
+	vp := &VpcPrefix{
+		ID: input.VpcPrefixID,
+	}
+	updatedFields := []string{}
+
+	if input.Deleted {
+		vp.Deleted = nil
+		updatedFields = append(updatedFields, "deleted")
+	}
+
+	if len(updatedFields) > 0 {
+		updatedFields = append(updatedFields, "updated")
+
+		query := db.GetIDB(tx, vpsd.dbSession).NewUpdate().Model(vp).Column(updatedFields...).Where("id = ?", input.VpcPrefixID)
+		// Soft-deleted rows are excluded by default; include them when undeleting.
+		if input.Deleted {
+			query = query.WhereAllWithDeleted()
+		}
+		_, err := query.Exec(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	nvp, err := vpsd.GetByID(ctx, tx, vp.ID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/rest-api/db/pkg/db/model/vpcprefix_test.go
+++ b/rest-api/db/pkg/db/model/vpcprefix_test.go
@@ -1278,3 +1278,60 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		})
 	}
 }
+
+func TestVpcPrefixSQLDAO_ClearDeleted(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testVpcPrefixInitDB(t)
+	defer dbSession.Close()
+	testVpcPrefixSetupSchema(t, dbSession)
+
+	ip := testVpcPrefixBuildInfrastructureProvider(t, dbSession, "testIP")
+	site := testVpcPrefixBuildSite(t, dbSession, ip, "testSite")
+	tenant := testVpcPrefixBuildTenant(t, dbSession, "testTenant")
+	user := testVpcPrefixBuildUser(t, dbSession, "testUser")
+	ipBlock := testVpcPrefixBuildIPBlock(t, dbSession, &site.ID, &ip.ID, "ipBlock", &user.ID)
+	vpc := testVpcPrefixBuildVpc(t, dbSession, ip, site, tenant, "testVpc")
+	vpcPrefixDAO := NewVpcPrefixDAO(dbSession)
+
+	vpcPrefix, err := vpcPrefixDAO.Create(ctx, nil, VpcPrefixCreateInput{
+		Name:         "test-clear-deleted",
+		TenantOrg:    "test",
+		SiteID:       site.ID,
+		VpcID:        vpc.ID,
+		TenantID:     tenant.ID,
+		IpBlockID:    &ipBlock.ID,
+		Prefix:       "192.0.2.0/24",
+		PrefixLength: 24,
+		Status:       VpcPrefixStatusError,
+		CreatedBy:    user.ID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, vpcPrefixDAO.Delete(ctx, nil, vpcPrefix.ID))
+
+	t.Run("clears soft-delete marker", func(t *testing.T) {
+		cleared, clearErr := vpcPrefixDAO.Clear(ctx, nil, VpcPrefixClearInput{
+			VpcPrefixID: vpcPrefix.ID,
+			Deleted:     true,
+		})
+		require.NoError(t, clearErr)
+		require.NotNil(t, cleared)
+		assert.Nil(t, cleared.Deleted)
+
+		updated, updateErr := vpcPrefixDAO.Update(ctx, nil, VpcPrefixUpdateInput{
+			VpcPrefixID:     vpcPrefix.ID,
+			Status:          cutil.GetPtr(VpcPrefixStatusReady),
+			IsMissingOnSite: cutil.GetPtr(false),
+		})
+		require.NoError(t, updateErr)
+		assert.Equal(t, VpcPrefixStatusReady, updated.Status)
+		assert.False(t, updated.IsMissingOnSite)
+	})
+
+	t.Run("returns not found for unknown VPC Prefix", func(t *testing.T) {
+		_, clearErr := vpcPrefixDAO.Clear(ctx, nil, VpcPrefixClearInput{
+			VpcPrefixID: uuid.New(),
+			Deleted:     true,
+		})
+		assert.ErrorIs(t, clearErr, db.ErrDoesNotExist)
+	})
+}

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -439,23 +439,25 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		}
 
 		ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
-		prefixLength := reportedPrefix.Bits()
+		reportedPrefixLength := reportedPrefix.Bits()
 
 		// Soft-skips after IPAM mutation must return a non-nil error so WithTxResult
 		// rolls back (e.g. FullGrant=true from CreateChildIpamEntryForIPBlock).
-		if ipBlock.PrefixLength == prefixLength {
-			childPrefix, allocateErr := ipam.CreateChildIpamEntryForIPBlock(ctx, tx, mvp.dbSession, ipamStorage, ipBlock, prefixLength)
-			if allocateErr != nil {
-				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create IPAM entry for VPC Prefix: %w", allocateErr)
-			}
-			if childPrefix.Cidr != reportedVpcPrefix.Prefix {
-				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: allocated Prefix %s differs from Site record %s", childPrefix.Cidr, reportedVpcPrefix.Prefix)
-			}
+		var allocateErr error
+		if ipBlock.PrefixLength == reportedPrefixLength {
+			_, allocateErr = ipam.CreateChildIpamEntryForIPBlock(
+				ctx, tx, mvp.dbSession, ipamStorage, ipBlock, reportedPrefixLength,
+			)
 		} else {
-			_, allocateErr := ipam.AcquireSpecificChildIpamEntryForIPBlock(ctx, tx, mvp.dbSession, ipamStorage, ipBlock, reportedVpcPrefix.Prefix)
-			if allocateErr != nil {
-				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create IPAM entry for VPC Prefix: %w", allocateErr)
-			}
+			_, allocateErr = ipam.AcquireSpecificChildIpamEntryForIPBlock(
+				ctx, tx, mvp.dbSession, ipamStorage, ipBlock, reportedVpcPrefix.Prefix,
+			)
+		}
+		if allocateErr != nil {
+			return nil, fmt.Errorf(
+				"unable to create VPC Prefix found on Site: failed to create IPAM entry for VPC Prefix: %w",
+				allocateErr,
+			)
 		}
 
 		// If the VPC Prefix was soft-deleted, undelete it
@@ -509,7 +511,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			TenantID:     vpc.TenantID,
 			IpBlockID:    &ipBlock.ID,
 			Prefix:       reportedVpcPrefix.Prefix,
-			PrefixLength: prefixLength,
+			PrefixLength: reportedPrefixLength,
 			Status:       cdbm.VpcPrefixStatusReady,
 			CreatedBy:    site.CreatedBy,
 		})

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -406,6 +406,21 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		if lockErr != nil {
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to acquire advisory lock on IP Block, DB error: %w", lockErr)
 		}
+
+		// Refresh FullGrant under the lock; the candidate scan above read it before the
+		// lock, so a concurrent create may have flipped it since. Both IPAM helpers gate
+		// on this flag, and a full grant acquires no child prefix, so the usage check in
+		// CreateChildIpamEntryForIPBlock cannot catch a stale value.
+		freshIPBlock, reloadIPBlockErr := cdbm.NewIPBlockDAO(mvp.dbSession).GetByID(ctx, tx, ipBlock.ID, nil)
+		if reloadIPBlockErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to reload IP Block under advisory lock, DB error: %w", reloadIPBlockErr)
+		}
+		ipBlock = freshIPBlock
+		if ipBlock.FullGrant {
+			logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block %s was fully granted concurrently", ipBlock.ID)
+			return nil, nil
+		}
+
 		ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
 		// Soft-skips after IPAM mutation must return a non-nil error so WithTxResult
 		// rolls back (e.g. FullGrant=true from CreateChildIpamEntryForIPBlock).

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -97,16 +97,10 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 			logger.Error().Msg("received VPC Prefix inventory entry with missing controller ID, skipping")
 			continue
 		}
-		reportedVpcPrefixID := controllerVpcPrefix.GetId().GetValue()
-		slogger := logger.With().Str("VPC Prefix Controller ID", reportedVpcPrefixID).Logger()
-		controllerVpcPrefixID, parseErr := uuid.Parse(reportedVpcPrefixID)
-		if parseErr != nil {
-			slogger.Error().Err(parseErr).Msg("received VPC Prefix inventory entry with invalid controller ID, skipping")
-			continue
-		}
-		controllerVpcPrefixIDStr := controllerVpcPrefixID.String()
 
-		vpcPrefix := existingVpcPrefixIDMap[controllerVpcPrefixIDStr]
+		controllerVpcPrefixID := controllerVpcPrefix.GetId().GetValue()
+		slogger := logger.With().Str("VPC Prefix Controller ID", controllerVpcPrefixID).Logger()
+		vpcPrefix := existingVpcPrefixIDMap[controllerVpcPrefixID]
 
 		// No active REST row for this inventory VPC Prefix: create one or undelete a soft-deleted match,
 		// then fall through so the main inventory loop applies Site-reported status updates.
@@ -193,8 +187,8 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 
 		// If the VpcPrefix was already deleting or deleted, we can remove it from the DB.
 		if vpcPrefix.Status == cdbm.VpcPrefixStatusDeleting || vpcPrefix.Status == cdbm.VpcPrefixStatusDeleted {
-			// The delete helper reloads the IPBlock under its advisory lock.
-			curVpcPrefix, serr := vpcPrefixDAO.GetByID(ctx, nil, vpcPrefix.ID, nil)
+			// Retrieve Subnet with IPBlock
+			curVpcPrefix, serr := vpcPrefixDAO.GetByID(ctx, nil, vpcPrefix.ID, []string{cdbm.IPBlockRelationName})
 			if serr != nil {
 				slogger.Error().Err(serr).Msg("failed to get VPC Prefix from DB")
 				continue
@@ -243,15 +237,6 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 	return nil
 }
 
-func ipBlockContainsPrefix(ctx context.Context, ipBlock *cdbm.IPBlock, prefix netip.Prefix) bool {
-	ipBlockCIDR := ipam.GetCidrForIPBlock(ctx, ipBlock.Prefix, ipBlock.PrefixLength)
-	ipBlockPrefix, err := netip.ParsePrefix(ipBlockCIDR)
-	return err == nil &&
-		ipBlockPrefix.Addr().BitLen() == prefix.Addr().BitLen() &&
-		ipBlockPrefix.Bits() <= prefix.Bits() &&
-		ipBlockPrefix.Contains(prefix.Addr())
-}
-
 // createOrUpdateVpcPrefixFromSite creates a REST VPC Prefix from Site inventory, or undeletes
 // a matching soft-deleted row (and resets Status from Site inventory on undelete).
 // Returns nil when skipped or on failure.
@@ -266,16 +251,18 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		Str("VPC Prefix Controller ID", controllerVpcPrefix.GetId().GetValue()).
 		Logger()
 
-	vpcPrefixID, err := uuid.Parse(controllerVpcPrefix.GetId().GetValue())
+	// Get the controller VPC Prefix ID from the Site inventory
+	controllerVpcPrefixID, err := uuid.Parse(controllerVpcPrefix.GetId().GetValue())
 	if err != nil {
 		logger.Warn().Msgf("unable to create VPC Prefix found on Site: failed to parse VPC Prefix Controller ID, not a valid UUID %s", controllerVpcPrefix.GetId().GetValue())
 		return nil
 	}
 
+	// Get the reported VPC Prefix from the Site inventory
 	reportedVpcPrefix := new(cdbm.VpcPrefix)
 	reportedVpcPrefix.FromProto(controllerVpcPrefix)
 	if reportedVpcPrefix.Name == "" {
-		reportedVpcPrefix.Name = fmt.Sprintf("recovered-%s", vpcPrefixID.String()[:8])
+		reportedVpcPrefix.Name = fmt.Sprintf("recovered-%s", controllerVpcPrefixID.String()[:8])
 	}
 	if reportedVpcPrefix.Prefix == "" {
 		logger.Warn().Msg("unable to create VPC Prefix found on Site: VPC Prefix on Site is reporting empty Prefix")
@@ -295,8 +282,6 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		return nil
 	}
 	reportedVpcPrefix.Prefix = maskedPrefixCIDR
-	prefixLength := reportedPrefix.Bits()
-
 	if reportedVpcPrefix.VpcID == uuid.Nil {
 		logger.Warn().Msg("unable to create VPC Prefix found on Site: VPC Prefix on Site is reporting empty VPC ID")
 		return nil
@@ -327,7 +312,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		// another site would otherwise be invisible here and Create would unique-constraint
 		// fail every inventory cycle.
 		matches, _, reloadErr := vpcPrefixDAO.GetAll(ctx, tx, cdbm.VpcPrefixFilterInput{
-			VpcPrefixIDs:   []uuid.UUID{vpcPrefixID},
+			VpcPrefixIDs:   []uuid.UUID{reportedVpcPrefix.ID},
 			IncludeDeleted: true,
 		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 		if reloadErr != nil {
@@ -340,16 +325,17 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			existingVpcPrefix = &matches[0]
 		}
 
+		// If the VPC Prefix was found in the DB, we need to check if it is valid
 		if existingVpcPrefix != nil {
 			if existingVpcPrefix.SiteID != site.ID {
-				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC Prefix ID already exists under a different Site for VPC Prefix %s", vpcPrefixID)
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC Prefix ID already exists under a different Site for VPC Prefix %s", controllerVpcPrefixID)
 				return nil, nil
 			}
 			if existingVpcPrefix.Deleted == nil {
 				return existingVpcPrefix, nil
 			}
 			if existingVpcPrefix.VpcID != vpc.ID {
-				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC differs in REST cache and Site record for VPC Prefix %s", controllerVpcPrefixID)
 				return nil, nil
 			}
 			if existingVpcPrefix.Org != vpc.Org {
@@ -360,11 +346,14 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			// the cached Prefix/VpcID or DB and IPAM will permanently diverge.
 			existingPrefix, parseErr := netip.ParsePrefix(existingVpcPrefix.Prefix)
 			if parseErr != nil || existingPrefix.Masked().String() != reportedVpcPrefix.Prefix {
-				logger.Warn().Msgf("unable to create VPC Prefix found on Site: prefix differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: prefix differs in REST cache and Site record for VPC Prefix %s", controllerVpcPrefixID)
 				return nil, nil
 			}
 		}
 
+		// Get the IP Block for the VPC Prefix
+		// if existingVpcPrefix is not nil, we use the stored IP Block ID
+		// otherwise we need to find the most specific Ready tenant IPBlock that contains its prefix
 		ipBlockDAO := cdbm.NewIPBlockDAO(mvp.dbSession)
 		var ipBlock *cdbm.IPBlock
 		if existingVpcPrefix != nil {
@@ -391,7 +380,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 				logger.Warn().Msgf("unable to create VPC Prefix found on Site: stored IP Block belongs to a different Tenant for VPC Prefix %s", existingVpcPrefix.ID)
 				return nil, nil
 			}
-			if !ipBlockContainsPrefix(ctx, ipBlock, reportedPrefix) {
+			if !ipBlock.ContainsPrefix(reportedPrefix) {
 				logger.Warn().Msgf("unable to create VPC Prefix found on Site: stored IP Block does not contain Prefix %s for VPC Prefix %s", reportedPrefix, existingVpcPrefix.ID)
 				return nil, nil
 			}
@@ -411,7 +400,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 				candidateIPBlock := &ipBlocks[i]
 				// A fully granted IPBlock is entirely owned by an existing VPC Prefix,
 				// but the IPAM DB reports it as empty and its Status stays Ready.
-				if candidateIPBlock.FullGrant || !ipBlockContainsPrefix(ctx, candidateIPBlock, reportedPrefix) {
+				if candidateIPBlock.FullGrant || !candidateIPBlock.ContainsPrefix(reportedPrefix) {
 					continue
 				}
 				if ipBlock == nil || candidateIPBlock.PrefixLength > ipBlock.PrefixLength {
@@ -440,12 +429,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to reload IP Block under advisory lock, DB error: %w", reloadIPBlockErr)
 		}
 		ipBlock = freshIPBlock
-		if ipBlock.SiteID != site.ID || ipBlock.TenantID == nil || *ipBlock.TenantID != vpc.TenantID ||
-			!ipBlockContainsPrefix(ctx, ipBlock, reportedPrefix) {
-			logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block ownership or Prefix changed while recovering VPC Prefix %s", vpcPrefixID)
-			return nil, nil
-		}
-		if existingVpcPrefix == nil && ipBlock.Status != cdbm.IPBlockStatusReady {
+		if ipBlock.Status != cdbm.IPBlockStatusReady {
 			logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block %s is no longer Ready", ipBlock.ID)
 			return nil, nil
 		}
@@ -455,6 +439,8 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		}
 
 		ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
+		prefixLength := reportedPrefix.Bits()
+
 		// Soft-skips after IPAM mutation must return a non-nil error so WithTxResult
 		// rolls back (e.g. FullGrant=true from CreateChildIpamEntryForIPBlock).
 		if ipBlock.PrefixLength == prefixLength {
@@ -472,6 +458,8 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			}
 		}
 
+		// If the VPC Prefix was soft-deleted, undelete it
+		// reuse the existing VPC Prefix ID and Status from the Site inventory to avoid creating a new VPC Prefix
 		if existingVpcPrefix != nil {
 			// Soft-deleted rows almost always carry Status=Deleting (set by the REST
 			// delete path before soft-delete). Clear only nulls deleted; also reset
@@ -506,12 +494,14 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve VPC Prefix by name, DB error: %w", nameErr)
 		}
 		if len(nameConflictVpcPrefixes) > 0 {
-			reportedVpcPrefix.Name = fmt.Sprintf("%s-recovered-%s", reportedVpcPrefix.Name, vpcPrefixID.String()[:8])
+			reportedVpcPrefix.Name = fmt.Sprintf("%s-recovered-%s", reportedVpcPrefix.Name, reportedVpcPrefix.ID.String()[:8])
 		}
 
+		// If the VPC Prefix was not soft-deleted, create a new VPC Prefix
+		// use the controller VPC Prefix ID and Status from the Site inventory to avoid creating a new VPC Prefix
 		readyMsg := "VPC Prefix was found on Site, Ready for use"
 		created, createErr := vpcPrefixDAO.Create(ctx, tx, cdbm.VpcPrefixCreateInput{
-			VpcPrefixID:  &vpcPrefixID,
+			VpcPrefixID:  &controllerVpcPrefixID,
 			Name:         reportedVpcPrefix.Name,
 			TenantOrg:    vpc.Org,
 			SiteID:       site.ID,
@@ -568,71 +558,28 @@ func getControllerVpcPrefixStatus(status *corev1.VpcPrefixStatus) (string, strin
 
 // deleteVpcPrefixFromDB is a helper function to delete VPC Prefix from DB
 func (mvp ManageVpcPrefix) deleteVpcPrefixFromDB(ctx context.Context, tx *cdb.Tx, vpcPrefix *cdbm.VpcPrefix, logger zerolog.Logger) error {
-	if vpcPrefix.IPBlockID != nil {
-		// Use the same tenant/IPBlock advisory lock key as REST create and inventory recovery
-		// so concurrent IPAM/FullGrant mutations serialize. Released on commit/rollback.
-		lockKey := fmt.Sprintf("%s-%s", vpcPrefix.TenantID, vpcPrefix.IPBlockID)
-		err := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(lockKey), false)
-		if err != nil {
-			logger.Error().Err(err).Msg("Failed to acquire advisory lock on IP Block")
-			return err
-		}
-		logger.Info().Msg("acquired advisory lock on IP Block for VPC Prefix")
-
-		// Reload by ID under the lock instead of trusting the optional relation.
-		// Include the tombstone so cleanup can still derive the IPAM namespace after
-		// the parent IPBlock has been soft-deleted.
-		ipBlocks, _, reloadErr := cdbm.NewIPBlockDAO(mvp.dbSession).GetAll(
-			ctx,
-			tx,
-			cdbm.IPBlockFilterInput{
-				IPBlockIDs:     []uuid.UUID{*vpcPrefix.IPBlockID},
-				IncludeDeleted: true,
-			},
-			cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)},
-			nil,
-		)
-		if reloadErr != nil {
-			logger.Error().Err(reloadErr).
-				Str("VPC Prefix ID", vpcPrefix.ID.String()).
-				Str("IP Block ID", vpcPrefix.IPBlockID.String()).
-				Msg("failed to reload IP Block under advisory lock for VPC Prefix delete")
-			return reloadErr
-		}
-		if len(ipBlocks) == 0 {
-			err = fmt.Errorf("unable to delete VPC Prefix %s: IP Block %s does not exist", vpcPrefix.ID, vpcPrefix.IPBlockID)
-			logger.Error().Err(err).
-				Str("VPC Prefix ID", vpcPrefix.ID.String()).
-				Str("IP Block ID", vpcPrefix.IPBlockID.String()).
-				Msg("failed to delete VPC Prefix from DB")
-			return err
-		}
-		freshIPBlock := &ipBlocks[0]
-
-		if freshIPBlock.Deleted != nil && freshIPBlock.FullGrant {
-			// A full grant has no child record in IPAM. The active-parent path clears
-			// FullGrant, but a deleted parent cannot be updated by the normal DAO and
-			// has no allocatable state left to restore.
-			logger.Info().Msg("skipped IPAM child cleanup for fully granted deleted IP Block")
-		} else {
-			ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
-			err = ipam.DeleteChildIpamEntryFromCidr(ctx, tx, mvp.dbSession, ipamStorage, freshIPBlock, vpcPrefix.Prefix)
-			if err != nil && !errors.Is(err, ipam.ErrPrefixDoesNotExistForIPBlock) {
-				logger.Error().Err(err).Msg("failed to delete ipam record for VPC Prefix")
-				return err
-			}
-			if errors.Is(err, ipam.ErrPrefixDoesNotExistForIPBlock) {
-				logger.Info().Msg("VPC Prefix IPAM entry was already absent")
-			} else {
-				logger.Info().Msg("deleted VPC Prefix IPAM entry")
-			}
-		}
+	// Acquire an advisory lock on the parent IP block ID on which there could be contention
+	// this lock is released when the transaction commits or rollsback
+	err := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(vpcPrefix.IPBlockID.String()), false)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to acquire advisory lock on IP Block")
+		return err
 	}
+	logger.Info().Msg("acquired advisory lock on IP Block for VPC Prefix")
+
+	// Delete IPAM entry for this subnet
+	ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
+	err = ipam.DeleteChildIpamEntryFromCidr(ctx, tx, mvp.dbSession, ipamStorage, vpcPrefix.IPBlock, vpcPrefix.Prefix)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to delete ipam record for Subnet")
+		return err
+	}
+	logger.Info().Msg("deleted VPC Prefix IPAM entry")
 
 	// Soft-delete VPC Prefix
 	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(mvp.dbSession)
 
-	err := vpcPrefixDAO.Delete(ctx, tx, vpcPrefix.ID)
+	err = vpcPrefixDAO.Delete(ctx, tx, vpcPrefix.ID)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to delete VPC Prefix from DB")
 		return err

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -318,7 +318,6 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		// fail every inventory cycle.
 		matches, _, reloadErr := vpcPrefixDAO.GetAll(ctx, tx, cdbm.VpcPrefixFilterInput{
 			VpcPrefixIDs:   []uuid.UUID{vpcPrefixID},
-			SiteIDs:        []uuid.UUID{site.ID},
 			IncludeDeleted: true,
 		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 		if reloadErr != nil {
@@ -327,6 +326,10 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 
 		if len(matches) > 0 {
 			existingVpcPrefix := &matches[0]
+			if existingVpcPrefix.SiteID != site.ID {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC Prefix ID already exists under a different Site for VPC Prefix %s", vpcPrefixID)
+				return nil, nil
+			}
 			if existingVpcPrefix.Deleted == nil {
 				return existingVpcPrefix, nil
 			}
@@ -469,7 +472,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		return created, nil
 	})
 	if err != nil {
-		logger.Warn().Err(err).Msg(err.Error())
+		logger.Warn().Err(err).Msg("failed to recover VPC Prefix from Site inventory")
 		return nil
 	}
 	return vpcPrefix
@@ -507,18 +510,29 @@ func (mvp ManageVpcPrefix) deleteVpcPrefixFromDB(ctx context.Context, tx *cdb.Tx
 		// IPBlockID is nullable on the model. When unset there is no parent block and no
 		// child CIDR to release in IPAM (inventory recovery always sets IpBlockID today).
 	case vpcPrefix.IPBlock != nil:
-		// Acquire an advisory lock on the parent IP block ID on which there could be contention
-		// this lock is released when the transaction commits or rollsback
-		err := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(vpcPrefix.IPBlockID.String()), false)
+		// Use the same tenant/IPBlock advisory lock key as REST create and inventory recovery
+		// so concurrent IPAM/FullGrant mutations serialize. Released on commit/rollback.
+		lockKey := fmt.Sprintf("%s-%s", vpcPrefix.TenantID, vpcPrefix.IPBlockID)
+		err := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(lockKey), false)
 		if err != nil {
 			logger.Error().Err(err).Msg("Failed to acquire advisory lock on IP Block")
 			return err
 		}
 		logger.Info().Msg("acquired advisory lock on IP Block for VPC Prefix")
 
+		// Refresh FullGrant under the lock; a concurrent create may have flipped it.
+		freshIPBlock, reloadErr := cdbm.NewIPBlockDAO(mvp.dbSession).GetByID(ctx, tx, *vpcPrefix.IPBlockID, nil)
+		if reloadErr != nil {
+			logger.Error().Err(reloadErr).
+				Str("VPC Prefix ID", vpcPrefix.ID.String()).
+				Str("IP Block ID", vpcPrefix.IPBlockID.String()).
+				Msg("failed to reload IP Block under advisory lock for VPC Prefix delete")
+			return reloadErr
+		}
+
 		// Delete IPAM entry for this VPC Prefix
 		ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
-		err = ipam.DeleteChildIpamEntryFromCidr(ctx, tx, mvp.dbSession, ipamStorage, vpcPrefix.IPBlock, vpcPrefix.Prefix)
+		err = ipam.DeleteChildIpamEntryFromCidr(ctx, tx, mvp.dbSession, ipamStorage, freshIPBlock, vpcPrefix.Prefix)
 		if err != nil {
 			logger.Error().Err(err).Msg("failed to delete ipam record for VPC Prefix")
 			return err
@@ -528,8 +542,11 @@ func (mvp ManageVpcPrefix) deleteVpcPrefixFromDB(ctx context.Context, tx *cdb.Tx
 		// IPBlockID is set but the relation was not loaded (or the parent IPBlock is
 		// soft-deleted). Skipping cleanup would soft-delete the prefix while leaking its
 		// child CIDR in IPAM.
-		err := fmt.Errorf("unable to delete VPC Prefix: IP Block relation is missing for IP Block ID %s", vpcPrefix.IPBlockID)
-		logger.Error().Err(err).Msg("failed to delete VPC Prefix from DB")
+		err := fmt.Errorf("unable to delete VPC Prefix %s: IP Block relation is missing for IP Block ID %s", vpcPrefix.ID, vpcPrefix.IPBlockID)
+		logger.Error().Err(err).
+			Str("VPC Prefix ID", vpcPrefix.ID.String()).
+			Str("IP Block ID", vpcPrefix.IPBlockID.String()).
+			Msg("failed to delete VPC Prefix from DB")
 		return err
 	}
 

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -281,16 +281,6 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 	reportedVpcPrefix.Prefix = canonicalPrefix
 	prefixLength := reportedPrefix.Bits()
 
-	// This is the gate for the IPAM claim below: a stale inventory snapshot can still
-	// report a just-deleted prefix as TERMINATING/TERMINATED, and recreating from that
-	// would resurrect a user delete. UpdateVpcPrefixesInDB checks the same thing first
-	// only to skip the transaction.
-	reportedStatus, _ := getControllerVpcPrefixStatus(controllerVpcPrefix.GetStatus())
-	if reportedStatus == cdbm.VpcPrefixStatusDeleting || reportedStatus == cdbm.VpcPrefixStatusDeleted {
-		logger.Warn().Msgf("unable to create VPC Prefix found on Site: Site reports status %s", reportedStatus)
-		return nil
-	}
-
 	if reportedVpcPrefix.VpcID == uuid.Nil {
 		logger.Warn().Msg("unable to create VPC Prefix found on Site: VPC Prefix on Site is reporting empty VPC ID")
 		return nil

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -273,12 +273,12 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 	// netip.ParsePrefix accepts host bits (e.g. 10.20.0.1/16). Reject those before any
 	// IPAM mutation; otherwise the equal-length full-grant path can persist FullGrant
 	// with no VpcPrefix when a later soft-skip commits the transaction.
-	canonicalPrefix := reportedPrefix.Masked().String()
-	if reportedPrefix.String() != canonicalPrefix {
-		logger.Warn().Msgf("unable to create VPC Prefix found on Site: Prefix CIDR %s is not in canonical masked form %s", reportedVpcPrefix.Prefix, canonicalPrefix)
+	maskedPrefixCIDR := reportedPrefix.Masked().String()
+	if reportedPrefix.String() != maskedPrefixCIDR {
+		logger.Warn().Msgf("unable to create VPC Prefix found on Site: Prefix CIDR %s is not in canonical masked form %s", reportedVpcPrefix.Prefix, maskedPrefixCIDR)
 		return nil
 	}
-	reportedVpcPrefix.Prefix = canonicalPrefix
+	reportedVpcPrefix.Prefix = maskedPrefixCIDR
 	prefixLength := reportedPrefix.Bits()
 
 	if reportedVpcPrefix.VpcID == uuid.Nil {
@@ -492,7 +492,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		return created, nil
 	})
 	if err != nil {
-		logger.Warn().Err(err).Msg("failed to recover VPC Prefix from Site inventory")
+		logger.Error().Err(err).Msg("failed to recover VPC Prefix from Site inventory")
 		return nil
 	}
 	return vpcPrefix

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -252,7 +252,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 
 	vpcPrefixID, err := uuid.Parse(controllerVpcPrefix.GetId().GetValue())
 	if err != nil {
-		logger.Warn().Msg(fmt.Sprintf("unable to create VPC Prefix found on Site: failed to parse VPC Prefix Controller ID, not a valid UUID %s", controllerVpcPrefix.GetId().GetValue()))
+		logger.Warn().Msgf("unable to create VPC Prefix found on Site: failed to parse VPC Prefix Controller ID, not a valid UUID %s", controllerVpcPrefix.GetId().GetValue())
 		return nil
 	}
 
@@ -265,9 +265,9 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		logger.Warn().Msg("unable to create VPC Prefix found on Site: VPC Prefix on Site is reporting empty Prefix")
 		return nil
 	}
-	reportedPrefix, prefixErr := netip.ParsePrefix(reportedVpcPrefix.Prefix)
-	if prefixErr != nil {
-		logger.Warn().Msg(fmt.Sprintf("unable to create VPC Prefix found on Site: failed to parse Prefix CIDR %s", reportedVpcPrefix.Prefix))
+	reportedPrefix, err := netip.ParsePrefix(reportedVpcPrefix.Prefix)
+	if err != nil {
+		logger.Warn().Msgf("unable to create VPC Prefix found on Site: failed to parse Prefix CIDR %s", reportedVpcPrefix.Prefix)
 		return nil
 	}
 	// netip.ParsePrefix accepts host bits (e.g. 10.20.0.1/16). Reject those before any
@@ -281,7 +281,10 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 	reportedVpcPrefix.Prefix = canonicalPrefix
 	prefixLength := reportedPrefix.Bits()
 
-	// Belt-and-braces with UpdateVpcPrefixesInDB: never create/undelete from a terminal Site status.
+	// This is the gate for the IPAM claim below: a stale inventory snapshot can still
+	// report a just-deleted prefix as TERMINATING/TERMINATED, and recreating from that
+	// would resurrect a user delete. UpdateVpcPrefixesInDB checks the same thing first
+	// only to skip the transaction.
 	reportedStatus, _ := getControllerVpcPrefixStatus(controllerVpcPrefix.GetStatus())
 	if reportedStatus == cdbm.VpcPrefixStatusDeleting || reportedStatus == cdbm.VpcPrefixStatusDeleted {
 		logger.Warn().Msgf("unable to create VPC Prefix found on Site: Site reports status %s", reportedStatus)
@@ -292,15 +295,16 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		logger.Warn().Msg("unable to create VPC Prefix found on Site: VPC Prefix on Site is reporting empty VPC ID")
 		return nil
 	}
-	vpcID := reportedVpcPrefix.VpcID
+	parentVpcID := reportedVpcPrefix.VpcID
 
 	vpcPrefix, err := cdb.WithTxResult(ctx, mvp.dbSession, func(tx *cdb.Tx) (*cdbm.VpcPrefix, error) {
 		vpcPrefixDAO := cdbm.NewVpcPrefixDAO(mvp.dbSession)
 		vpcDAO := cdbm.NewVpcDAO(mvp.dbSession)
+		sdDAO := cdbm.NewStatusDetailDAO(mvp.dbSession)
 
 		// Parent VPC must already exist in REST; inventory VpcId is the site-facing VPC ID.
 		vpcMatches, _, vpcErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
-			VpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID},
+			VpcIDs: []uuid.UUID{parentVpcID}, SiteIDs: []uuid.UUID{site.ID},
 		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 		if vpcErr != nil {
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve parent VPC by ID, DB error: %w", vpcErr)
@@ -308,7 +312,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		if len(vpcMatches) == 0 {
 			// Even if this happens, the VPC will be created based on the createOrUpdateVpcFromSite function in the vpc activity
 			// hence we are just returning nil and next inventory iteration VPC will be created in the vpc activity
-			logger.Warn().Msgf("unable to create VPC Prefix found on Site: no VPC was found for ID: %s", vpcID)
+			logger.Warn().Msgf("unable to create VPC Prefix found on Site: no VPC was found for ID: %s", parentVpcID)
 			return nil, nil
 		}
 		vpc := &vpcMatches[0]
@@ -324,8 +328,13 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve VPC Prefix by controller ID, DB error: %w", reloadErr)
 		}
 
+		// Non-nil from here on means this inventory entry is an undelete, not a create.
+		var existingVpcPrefix *cdbm.VpcPrefix
 		if len(matches) > 0 {
-			existingVpcPrefix := &matches[0]
+			existingVpcPrefix = &matches[0]
+		}
+
+		if existingVpcPrefix != nil {
 			if existingVpcPrefix.SiteID != site.ID {
 				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC Prefix ID already exists under a different Site for VPC Prefix %s", vpcPrefixID)
 				return nil, nil
@@ -334,7 +343,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 				return existingVpcPrefix, nil
 			}
 			if existingVpcPrefix.Org != vpc.Org {
-				logger.Warn().Msg(fmt.Sprintf("unable to create VPC Prefix found on Site: tenant organization differs in REST cache and Site record %s", vpc.Org))
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: tenant organization differs in REST cache and Site record %s", vpc.Org)
 				return nil, nil
 			}
 		}
@@ -352,19 +361,20 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 
 		var ipBlock *cdbm.IPBlock
 		for i := range ipBlocks {
+			candidateIPBlock := &ipBlocks[i]
 			// A fully granted IPBlock is entirely owned by an existing VPC Prefix, but the ipam DB
 			// reports it as empty and full-granting does not change its Status, so skip it here.
-			if ipBlocks[i].FullGrant {
+			if candidateIPBlock.FullGrant {
 				continue
 			}
-			candidateCIDR := ipam.GetCidrForIPBlock(ctx, ipBlocks[i].Prefix, ipBlocks[i].PrefixLength)
+			candidateCIDR := ipam.GetCidrForIPBlock(ctx, candidateIPBlock.Prefix, candidateIPBlock.PrefixLength)
 			candidatePrefix, parseErr := netip.ParsePrefix(candidateCIDR)
 			if parseErr != nil || candidatePrefix.Addr().BitLen() != reportedPrefix.Addr().BitLen() ||
 				candidatePrefix.Bits() > reportedPrefix.Bits() || !candidatePrefix.Contains(reportedPrefix.Addr()) {
 				continue
 			}
-			if ipBlock == nil || ipBlocks[i].PrefixLength > ipBlock.PrefixLength {
-				ipBlock = &ipBlocks[i]
+			if ipBlock == nil || candidateIPBlock.PrefixLength > ipBlock.PrefixLength {
+				ipBlock = candidateIPBlock
 			}
 		}
 		if ipBlock == nil {
@@ -372,19 +382,19 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			return nil, nil
 		}
 
-		if len(matches) > 0 && (matches[0].IPBlockID == nil || *matches[0].IPBlockID != ipBlock.ID) {
-			logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
-			return nil, nil
-		}
-		if len(matches) > 0 {
+		if existingVpcPrefix != nil {
 			// Clear restores the row as stored; do not acquire a Site CIDR that disagrees with
-			// the cached Prefix/VpcID or DB and IPAM will permanently diverge.
-			existingPrefix, existingPrefixErr := netip.ParsePrefix(matches[0].Prefix)
-			if existingPrefixErr != nil || existingPrefix.Masked().String() != reportedVpcPrefix.Prefix {
+			// the cached IPBlock/Prefix/VpcID or DB and IPAM will permanently diverge.
+			if existingVpcPrefix.IPBlockID == nil || *existingVpcPrefix.IPBlockID != ipBlock.ID {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
+				return nil, nil
+			}
+			existingPrefix, parseErr := netip.ParsePrefix(existingVpcPrefix.Prefix)
+			if parseErr != nil || existingPrefix.Masked().String() != reportedVpcPrefix.Prefix {
 				logger.Warn().Msgf("unable to create VPC Prefix found on Site: prefix differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
 				return nil, nil
 			}
-			if matches[0].VpcID != vpc.ID {
+			if existingVpcPrefix.VpcID != vpc.ID {
 				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
 				return nil, nil
 			}
@@ -392,7 +402,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 
 		// Claim the exact Site-reported CIDR in REST IPAM while holding the same
 		// tenant/IPBlock lock used by the normal REST create path.
-		lockErr := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(fmt.Sprintf("%s-%s", vpc.TenantID, ipBlock.ID)), false)
+		lockErr := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(fmt.Sprintf("%s-%s", vpc.TenantID.String(), ipBlock.ID.String())), false)
 		if lockErr != nil {
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to acquire advisory lock on IP Block, DB error: %w", lockErr)
 		}
@@ -407,16 +417,19 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			if childPrefix.Cidr != reportedVpcPrefix.Prefix {
 				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: allocated Prefix %s differs from Site record %s", childPrefix.Cidr, reportedVpcPrefix.Prefix)
 			}
-		} else if _, allocateErr := ipam.AcquireSpecificChildIpamEntryForIPBlock(ctx, tx, mvp.dbSession, ipamStorage, ipBlock, reportedVpcPrefix.Prefix); allocateErr != nil {
-			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create IPAM entry for VPC Prefix: %w", allocateErr)
+		} else {
+			_, allocateErr := ipam.AcquireSpecificChildIpamEntryForIPBlock(ctx, tx, mvp.dbSession, ipamStorage, ipBlock, reportedVpcPrefix.Prefix)
+			if allocateErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create IPAM entry for VPC Prefix: %w", allocateErr)
+			}
 		}
 
-		if len(matches) > 0 {
+		if existingVpcPrefix != nil {
 			// Soft-deleted rows almost always carry Status=Deleting (set by the REST
 			// delete path before soft-delete). Clear only nulls deleted; also reset
 			// Status from Site inventory here. UpdateVpcPrefixesInDB skips refresh when
 			// Status is Deleting and Site reports a non-terminal state (e.g. READY).
-			restored, clearErr := vpcPrefixDAO.Clear(ctx, tx, cdbm.VpcPrefixClearInput{VpcPrefixID: matches[0].ID, Deleted: true})
+			restored, clearErr := vpcPrefixDAO.Clear(ctx, tx, cdbm.VpcPrefixClearInput{VpcPrefixID: existingVpcPrefix.ID, Deleted: true})
 			if clearErr != nil {
 				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to clear soft-delete timestamp for VPC Prefix, DB error: %w", clearErr)
 			}
@@ -428,9 +441,10 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			if updateErr != nil {
 				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to update VPC Prefix status after undelete, DB error: %w", updateErr)
 			}
-			if _, statusErr := cdbm.NewStatusDetailDAO(mvp.dbSession).Create(ctx, tx, cdbm.StatusDetailCreateInput{
+			_, statusErr := sdDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
 				EntityID: updated.ID.String(), Status: status, Message: &statusMessage,
-			}); statusErr != nil {
+			})
+			if statusErr != nil {
 				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create Status Detail after undelete, DB error: %w", statusErr)
 			}
 			return updated, nil
@@ -464,9 +478,10 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		if createErr != nil {
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create VPC Prefix, DB error: %w", createErr)
 		}
-		if _, statusErr := cdbm.NewStatusDetailDAO(mvp.dbSession).Create(ctx, tx, cdbm.StatusDetailCreateInput{
+		_, statusErr := sdDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
 			EntityID: created.ID.String(), Status: cdbm.VpcPrefixStatusReady, Message: &readyMsg,
-		}); statusErr != nil {
+		})
+		if statusErr != nil {
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create Status Detail, DB error: %w", statusErr)
 		}
 		return created, nil

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -6,6 +6,7 @@ package vpcprefix
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/netip"
 	"time"
@@ -96,8 +97,14 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 			logger.Error().Msg("received VPC Prefix inventory entry with missing controller ID, skipping")
 			continue
 		}
-		controllerVpcPrefixIDStr := controllerVpcPrefix.GetId().GetValue()
-		slogger := logger.With().Str("VPC Prefix Controller ID", controllerVpcPrefixIDStr).Logger()
+		reportedVpcPrefixID := controllerVpcPrefix.GetId().GetValue()
+		slogger := logger.With().Str("VPC Prefix Controller ID", reportedVpcPrefixID).Logger()
+		controllerVpcPrefixID, parseErr := uuid.Parse(reportedVpcPrefixID)
+		if parseErr != nil {
+			slogger.Error().Err(parseErr).Msg("received VPC Prefix inventory entry with invalid controller ID, skipping")
+			continue
+		}
+		controllerVpcPrefixIDStr := controllerVpcPrefixID.String()
 
 		vpcPrefix := existingVpcPrefixIDMap[controllerVpcPrefixIDStr]
 
@@ -120,7 +127,7 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 
 			// Keep in-memory maps in sync so later inventory entries and missing-on-Site detection see this VPC Prefix.
 			existingVpcPrefixIDMap[vpcPrefix.ID.String()] = vpcPrefix
-			slogger.Info().Str("VPC Prefix ID", vpcPrefix.ID.String()).Msg("created or undeleted VPC Prefix from Site inventory")
+			logger.Info().Str("VPC Prefix ID", vpcPrefix.ID.String()).Msg("created or undeleted VPC Prefix from Site inventory")
 		}
 
 		reportedVpcPrefixIDMap[vpcPrefix.ID] = true
@@ -186,8 +193,8 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 
 		// If the VpcPrefix was already deleting or deleted, we can remove it from the DB.
 		if vpcPrefix.Status == cdbm.VpcPrefixStatusDeleting || vpcPrefix.Status == cdbm.VpcPrefixStatusDeleted {
-			// Retrieve Subnet with IPBlock
-			curVpcPrefix, serr := vpcPrefixDAO.GetByID(ctx, nil, vpcPrefix.ID, []string{cdbm.IPBlockRelationName})
+			// The delete helper reloads the IPBlock under its advisory lock.
+			curVpcPrefix, serr := vpcPrefixDAO.GetByID(ctx, nil, vpcPrefix.ID, nil)
 			if serr != nil {
 				slogger.Error().Err(serr).Msg("failed to get VPC Prefix from DB")
 				continue
@@ -234,6 +241,15 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 	}
 
 	return nil
+}
+
+func ipBlockContainsPrefix(ctx context.Context, ipBlock *cdbm.IPBlock, prefix netip.Prefix) bool {
+	ipBlockCIDR := ipam.GetCidrForIPBlock(ctx, ipBlock.Prefix, ipBlock.PrefixLength)
+	ipBlockPrefix, err := netip.ParsePrefix(ipBlockCIDR)
+	return err == nil &&
+		ipBlockPrefix.Addr().BitLen() == prefix.Addr().BitLen() &&
+		ipBlockPrefix.Bits() <= prefix.Bits() &&
+		ipBlockPrefix.Contains(prefix.Addr())
 }
 
 // createOrUpdateVpcPrefixFromSite creates a REST VPC Prefix from Site inventory, or undeletes
@@ -332,60 +348,78 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			if existingVpcPrefix.Deleted == nil {
 				return existingVpcPrefix, nil
 			}
+			if existingVpcPrefix.VpcID != vpc.ID {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
+				return nil, nil
+			}
 			if existingVpcPrefix.Org != vpc.Org {
 				logger.Warn().Msgf("unable to create VPC Prefix found on Site: tenant organization differs in REST cache and Site record %s", vpc.Org)
 				return nil, nil
 			}
-		}
-
-		// Site inventory does not report the REST IPBlock ID. Find the most specific
-		// tenant IPBlock that contains the reported prefix.
-		ipBlocks, _, ipBlockErr := cdbm.NewIPBlockDAO(mvp.dbSession).GetAll(ctx, tx, cdbm.IPBlockFilterInput{
-			SiteIDs:   []uuid.UUID{site.ID},
-			TenantIDs: []uuid.UUID{vpc.TenantID},
-			Statuses:  []string{cdbm.IPBlockStatusReady},
-		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
-		if ipBlockErr != nil {
-			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve IP Blocks, DB error: %w", ipBlockErr)
-		}
-
-		var ipBlock *cdbm.IPBlock
-		for i := range ipBlocks {
-			candidateIPBlock := &ipBlocks[i]
-			// A fully granted IPBlock is entirely owned by an existing VPC Prefix, but the ipam DB
-			// reports it as empty and full-granting does not change its Status, so skip it here.
-			if candidateIPBlock.FullGrant {
-				continue
-			}
-			candidateCIDR := ipam.GetCidrForIPBlock(ctx, candidateIPBlock.Prefix, candidateIPBlock.PrefixLength)
-			candidatePrefix, parseErr := netip.ParsePrefix(candidateCIDR)
-			if parseErr != nil || candidatePrefix.Addr().BitLen() != reportedPrefix.Addr().BitLen() ||
-				candidatePrefix.Bits() > reportedPrefix.Bits() || !candidatePrefix.Contains(reportedPrefix.Addr()) {
-				continue
-			}
-			if ipBlock == nil || candidateIPBlock.PrefixLength > ipBlock.PrefixLength {
-				ipBlock = candidateIPBlock
-			}
-		}
-		if ipBlock == nil {
-			logger.Warn().Msgf("unable to create VPC Prefix found on Site: no containing IP Block was found for Prefix: %s", reportedVpcPrefix.Prefix)
-			return nil, nil
-		}
-
-		if existingVpcPrefix != nil {
 			// Clear restores the row as stored; do not acquire a Site CIDR that disagrees with
-			// the cached IPBlock/Prefix/VpcID or DB and IPAM will permanently diverge.
-			if existingVpcPrefix.IPBlockID == nil || *existingVpcPrefix.IPBlockID != ipBlock.ID {
-				logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
-				return nil, nil
-			}
+			// the cached Prefix/VpcID or DB and IPAM will permanently diverge.
 			existingPrefix, parseErr := netip.ParsePrefix(existingVpcPrefix.Prefix)
 			if parseErr != nil || existingPrefix.Masked().String() != reportedVpcPrefix.Prefix {
 				logger.Warn().Msgf("unable to create VPC Prefix found on Site: prefix differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
 				return nil, nil
 			}
-			if existingVpcPrefix.VpcID != vpc.ID {
-				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
+		}
+
+		ipBlockDAO := cdbm.NewIPBlockDAO(mvp.dbSession)
+		var ipBlock *cdbm.IPBlock
+		if existingVpcPrefix != nil {
+			// Undelete must preserve the stored association. Re-selecting from all
+			// containing blocks could strand the row when a more-specific block appears.
+			if existingVpcPrefix.IPBlockID == nil {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: stored IP Block ID is missing for VPC Prefix %s", existingVpcPrefix.ID)
+				return nil, nil
+			}
+
+			ipBlock, reloadErr = ipBlockDAO.GetByID(ctx, tx, *existingVpcPrefix.IPBlockID, nil)
+			if reloadErr != nil {
+				if errors.Is(reloadErr, cdb.ErrDoesNotExist) {
+					logger.Warn().Msgf("unable to create VPC Prefix found on Site: stored IP Block %s was not found for VPC Prefix %s", existingVpcPrefix.IPBlockID, existingVpcPrefix.ID)
+					return nil, nil
+				}
+				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve stored IP Block, DB error: %w", reloadErr)
+			}
+			if ipBlock.SiteID != site.ID {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: stored IP Block belongs to a different Site for VPC Prefix %s", existingVpcPrefix.ID)
+				return nil, nil
+			}
+			if ipBlock.TenantID == nil || *ipBlock.TenantID != vpc.TenantID {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: stored IP Block belongs to a different Tenant for VPC Prefix %s", existingVpcPrefix.ID)
+				return nil, nil
+			}
+			if !ipBlockContainsPrefix(ctx, ipBlock, reportedPrefix) {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: stored IP Block does not contain Prefix %s for VPC Prefix %s", reportedPrefix, existingVpcPrefix.ID)
+				return nil, nil
+			}
+		} else {
+			// Site inventory does not report the REST IPBlock ID for a new VPC Prefix.
+			// Find the most specific Ready tenant IPBlock that contains its prefix.
+			ipBlocks, _, ipBlockErr := ipBlockDAO.GetAll(ctx, tx, cdbm.IPBlockFilterInput{
+				SiteIDs:   []uuid.UUID{site.ID},
+				TenantIDs: []uuid.UUID{vpc.TenantID},
+				Statuses:  []string{cdbm.IPBlockStatusReady},
+			}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+			if ipBlockErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve IP Blocks, DB error: %w", ipBlockErr)
+			}
+
+			for i := range ipBlocks {
+				candidateIPBlock := &ipBlocks[i]
+				// A fully granted IPBlock is entirely owned by an existing VPC Prefix,
+				// but the IPAM DB reports it as empty and its Status stays Ready.
+				if candidateIPBlock.FullGrant || !ipBlockContainsPrefix(ctx, candidateIPBlock, reportedPrefix) {
+					continue
+				}
+				if ipBlock == nil || candidateIPBlock.PrefixLength > ipBlock.PrefixLength {
+					ipBlock = candidateIPBlock
+				}
+			}
+			if ipBlock == nil {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: no containing IP Block was found for Prefix: %s", reportedPrefix)
 				return nil, nil
 			}
 		}
@@ -406,6 +440,15 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to reload IP Block under advisory lock, DB error: %w", reloadIPBlockErr)
 		}
 		ipBlock = freshIPBlock
+		if ipBlock.SiteID != site.ID || ipBlock.TenantID == nil || *ipBlock.TenantID != vpc.TenantID ||
+			!ipBlockContainsPrefix(ctx, ipBlock, reportedPrefix) {
+			logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block ownership or Prefix changed while recovering VPC Prefix %s", vpcPrefixID)
+			return nil, nil
+		}
+		if existingVpcPrefix == nil && ipBlock.Status != cdbm.IPBlockStatusReady {
+			logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block %s is no longer Ready", ipBlock.ID)
+			return nil, nil
+		}
 		if ipBlock.FullGrant {
 			logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block %s was fully granted concurrently", ipBlock.ID)
 			return nil, nil
@@ -478,7 +521,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			Prefix:       reportedVpcPrefix.Prefix,
 			PrefixLength: prefixLength,
 			Status:       cdbm.VpcPrefixStatusReady,
-			CreatedBy:    site.ID,
+			CreatedBy:    site.CreatedBy,
 		})
 		if createErr != nil {
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create VPC Prefix, DB error: %w", createErr)
@@ -525,11 +568,7 @@ func getControllerVpcPrefixStatus(status *corev1.VpcPrefixStatus) (string, strin
 
 // deleteVpcPrefixFromDB is a helper function to delete VPC Prefix from DB
 func (mvp ManageVpcPrefix) deleteVpcPrefixFromDB(ctx context.Context, tx *cdb.Tx, vpcPrefix *cdbm.VpcPrefix, logger zerolog.Logger) error {
-	switch {
-	case vpcPrefix.IPBlockID == nil:
-		// IPBlockID is nullable on the model. When unset there is no parent block and no
-		// child CIDR to release in IPAM (inventory recovery always sets IpBlockID today).
-	case vpcPrefix.IPBlock != nil:
+	if vpcPrefix.IPBlockID != nil {
 		// Use the same tenant/IPBlock advisory lock key as REST create and inventory recovery
 		// so concurrent IPAM/FullGrant mutations serialize. Released on commit/rollback.
 		lockKey := fmt.Sprintf("%s-%s", vpcPrefix.TenantID, vpcPrefix.IPBlockID)
@@ -540,8 +579,19 @@ func (mvp ManageVpcPrefix) deleteVpcPrefixFromDB(ctx context.Context, tx *cdb.Tx
 		}
 		logger.Info().Msg("acquired advisory lock on IP Block for VPC Prefix")
 
-		// Refresh FullGrant under the lock; a concurrent create may have flipped it.
-		freshIPBlock, reloadErr := cdbm.NewIPBlockDAO(mvp.dbSession).GetByID(ctx, tx, *vpcPrefix.IPBlockID, nil)
+		// Reload by ID under the lock instead of trusting the optional relation.
+		// Include the tombstone so cleanup can still derive the IPAM namespace after
+		// the parent IPBlock has been soft-deleted.
+		ipBlocks, _, reloadErr := cdbm.NewIPBlockDAO(mvp.dbSession).GetAll(
+			ctx,
+			tx,
+			cdbm.IPBlockFilterInput{
+				IPBlockIDs:     []uuid.UUID{*vpcPrefix.IPBlockID},
+				IncludeDeleted: true,
+			},
+			cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
 		if reloadErr != nil {
 			logger.Error().Err(reloadErr).
 				Str("VPC Prefix ID", vpcPrefix.ID.String()).
@@ -549,25 +599,34 @@ func (mvp ManageVpcPrefix) deleteVpcPrefixFromDB(ctx context.Context, tx *cdb.Tx
 				Msg("failed to reload IP Block under advisory lock for VPC Prefix delete")
 			return reloadErr
 		}
-
-		// Delete IPAM entry for this VPC Prefix
-		ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
-		err = ipam.DeleteChildIpamEntryFromCidr(ctx, tx, mvp.dbSession, ipamStorage, freshIPBlock, vpcPrefix.Prefix)
-		if err != nil {
-			logger.Error().Err(err).Msg("failed to delete ipam record for VPC Prefix")
+		if len(ipBlocks) == 0 {
+			err = fmt.Errorf("unable to delete VPC Prefix %s: IP Block %s does not exist", vpcPrefix.ID, vpcPrefix.IPBlockID)
+			logger.Error().Err(err).
+				Str("VPC Prefix ID", vpcPrefix.ID.String()).
+				Str("IP Block ID", vpcPrefix.IPBlockID.String()).
+				Msg("failed to delete VPC Prefix from DB")
 			return err
 		}
-		logger.Info().Msg("deleted VPC Prefix IPAM entry")
-	default:
-		// IPBlockID is set but the relation was not loaded (or the parent IPBlock is
-		// soft-deleted). Skipping cleanup would soft-delete the prefix while leaking its
-		// child CIDR in IPAM.
-		err := fmt.Errorf("unable to delete VPC Prefix %s: IP Block relation is missing for IP Block ID %s", vpcPrefix.ID, vpcPrefix.IPBlockID)
-		logger.Error().Err(err).
-			Str("VPC Prefix ID", vpcPrefix.ID.String()).
-			Str("IP Block ID", vpcPrefix.IPBlockID.String()).
-			Msg("failed to delete VPC Prefix from DB")
-		return err
+		freshIPBlock := &ipBlocks[0]
+
+		if freshIPBlock.Deleted != nil && freshIPBlock.FullGrant {
+			// A full grant has no child record in IPAM. The active-parent path clears
+			// FullGrant, but a deleted parent cannot be updated by the normal DAO and
+			// has no allocatable state left to restore.
+			logger.Info().Msg("skipped IPAM child cleanup for fully granted deleted IP Block")
+		} else {
+			ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
+			err = ipam.DeleteChildIpamEntryFromCidr(ctx, tx, mvp.dbSession, ipamStorage, freshIPBlock, vpcPrefix.Prefix)
+			if err != nil && !errors.Is(err, ipam.ErrPrefixDoesNotExistForIPBlock) {
+				logger.Error().Err(err).Msg("failed to delete ipam record for VPC Prefix")
+				return err
+			}
+			if errors.Is(err, ipam.ErrPrefixDoesNotExistForIPBlock) {
+				logger.Info().Msg("VPC Prefix IPAM entry was already absent")
+			} else {
+				logger.Info().Msg("deleted VPC Prefix IPAM entry")
+			}
+		}
 	}
 
 	// Soft-delete VPC Prefix

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -6,6 +6,8 @@ package vpcprefix
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/google/uuid"
@@ -90,12 +92,35 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 
 	// Iterate through VpcPrefix Inventory and update DB
 	for _, controllerVpcPrefix := range vpcPrefixInventory.VpcPrefixes {
-		slogger := logger.With().Str("VPC Prefix Controller ID", controllerVpcPrefix.Id.Value).Logger()
-
-		vpcPrefix := existingVpcPrefixIDMap[controllerVpcPrefix.Id.Value]
-		if vpcPrefix == nil {
-			logger.Warn().Str("Controller VPC Prefix ID", controllerVpcPrefix.Id.Value).Msg("VPC Prefix does not have a record in DB, possibly created directly on Site")
+		if controllerVpcPrefix == nil || controllerVpcPrefix.GetId().GetValue() == "" {
+			logger.Error().Msg("received VPC Prefix inventory entry with missing controller ID, skipping")
 			continue
+		}
+		controllerVpcPrefixIDStr := controllerVpcPrefix.GetId().GetValue()
+		slogger := logger.With().Str("VPC Prefix Controller ID", controllerVpcPrefixIDStr).Logger()
+
+		vpcPrefix := existingVpcPrefixIDMap[controllerVpcPrefixIDStr]
+
+		// No active REST row for this inventory VPC Prefix: create one or undelete a soft-deleted match,
+		// then fall through so the main inventory loop applies Site-reported status updates.
+		if vpcPrefix == nil {
+			// Inventory pushes are unordered Temporal workflows. A stale snapshot can still list a
+			// just-deleted prefix as TERMINATING/TERMINATED (or even READY). Never create/undelete
+			// from a terminal Site status — that re-claims IPAM and resurrects a user delete.
+			reportedStatus, _ := getControllerVpcPrefixStatus(controllerVpcPrefix.GetStatus())
+			if reportedStatus == cdbm.VpcPrefixStatusDeleting || reportedStatus == cdbm.VpcPrefixStatusDeleted {
+				slogger.Info().Msgf("skipping create or undelete of VPC Prefix from Site inventory: Site reports status %s", reportedStatus)
+				continue
+			}
+
+			vpcPrefix = mvp.createOrUpdateVpcPrefixFromSite(ctx, site, controllerVpcPrefix)
+			if vpcPrefix == nil {
+				continue
+			}
+
+			// Keep in-memory maps in sync so later inventory entries and missing-on-Site detection see this VPC Prefix.
+			existingVpcPrefixIDMap[vpcPrefix.ID.String()] = vpcPrefix
+			slogger.Info().Str("VPC Prefix ID", vpcPrefix.ID.String()).Msg("created or undeleted VPC Prefix from Site inventory")
 		}
 
 		reportedVpcPrefixIDMap[vpcPrefix.ID] = true
@@ -211,6 +236,245 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 	return nil
 }
 
+// createOrUpdateVpcPrefixFromSite creates a REST VPC Prefix from Site inventory, or undeletes
+// a matching soft-deleted row (and resets Status from Site inventory on undelete).
+// Returns nil when skipped or on failure.
+func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
+	ctx context.Context,
+	site *cdbm.Site,
+	controllerVpcPrefix *corev1.VpcPrefix,
+) *cdbm.VpcPrefix {
+	logger := log.With().
+		Str("Activity", "UpdateVpcPrefixesInDB").
+		Str("Site ID", site.ID.String()).
+		Str("VPC Prefix Controller ID", controllerVpcPrefix.GetId().GetValue()).
+		Logger()
+
+	vpcPrefixID, err := uuid.Parse(controllerVpcPrefix.GetId().GetValue())
+	if err != nil {
+		logger.Warn().Msg(fmt.Sprintf("unable to create VPC Prefix found on Site: failed to parse VPC Prefix Controller ID, not a valid UUID %s", controllerVpcPrefix.GetId().GetValue()))
+		return nil
+	}
+
+	reportedVpcPrefix := new(cdbm.VpcPrefix)
+	reportedVpcPrefix.FromProto(controllerVpcPrefix)
+	if reportedVpcPrefix.Name == "" {
+		reportedVpcPrefix.Name = fmt.Sprintf("recovered-%s", vpcPrefixID.String()[:8])
+	}
+	if reportedVpcPrefix.Prefix == "" {
+		logger.Warn().Msg("unable to create VPC Prefix found on Site: VPC Prefix on Site is reporting empty Prefix")
+		return nil
+	}
+	reportedPrefix, prefixErr := netip.ParsePrefix(reportedVpcPrefix.Prefix)
+	if prefixErr != nil {
+		logger.Warn().Msg(fmt.Sprintf("unable to create VPC Prefix found on Site: failed to parse Prefix CIDR %s", reportedVpcPrefix.Prefix))
+		return nil
+	}
+	// netip.ParsePrefix accepts host bits (e.g. 10.20.0.1/16). Reject those before any
+	// IPAM mutation; otherwise the equal-length full-grant path can persist FullGrant
+	// with no VpcPrefix when a later soft-skip commits the transaction.
+	canonicalPrefix := reportedPrefix.Masked().String()
+	if reportedPrefix.String() != canonicalPrefix {
+		logger.Warn().Msgf("unable to create VPC Prefix found on Site: Prefix CIDR %s is not in canonical masked form %s", reportedVpcPrefix.Prefix, canonicalPrefix)
+		return nil
+	}
+	reportedVpcPrefix.Prefix = canonicalPrefix
+	prefixLength := reportedPrefix.Bits()
+
+	// Belt-and-braces with UpdateVpcPrefixesInDB: never create/undelete from a terminal Site status.
+	reportedStatus, _ := getControllerVpcPrefixStatus(controllerVpcPrefix.GetStatus())
+	if reportedStatus == cdbm.VpcPrefixStatusDeleting || reportedStatus == cdbm.VpcPrefixStatusDeleted {
+		logger.Warn().Msgf("unable to create VPC Prefix found on Site: Site reports status %s", reportedStatus)
+		return nil
+	}
+
+	if reportedVpcPrefix.VpcID == uuid.Nil {
+		logger.Warn().Msg("unable to create VPC Prefix found on Site: VPC Prefix on Site is reporting empty VPC ID")
+		return nil
+	}
+	vpcID := reportedVpcPrefix.VpcID
+
+	vpcPrefix, err := cdb.WithTxResult(ctx, mvp.dbSession, func(tx *cdb.Tx) (*cdbm.VpcPrefix, error) {
+		vpcPrefixDAO := cdbm.NewVpcPrefixDAO(mvp.dbSession)
+		vpcDAO := cdbm.NewVpcDAO(mvp.dbSession)
+
+		// Parent VPC must already exist in REST; inventory VpcId is the site-facing VPC ID.
+		vpcMatches, _, vpcErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
+			VpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID},
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if vpcErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve parent VPC by ID, DB error: %w", vpcErr)
+		}
+		if len(vpcMatches) == 0 {
+			// Even if this happens, the VPC will be created based on the createOrUpdateVpcFromSite function in the vpc activity
+			// hence we are just returning nil and next inventory iteration VPC will be created in the vpc activity
+			logger.Warn().Msgf("unable to create VPC Prefix found on Site: no VPC was found for ID: %s", vpcID)
+			return nil, nil
+		}
+		vpc := &vpcMatches[0]
+
+		// Lookup by primary key globally (not scoped to site.ID). A same-UUID row under
+		// another site would otherwise be invisible here and Create would unique-constraint
+		// fail every inventory cycle.
+		matches, _, reloadErr := vpcPrefixDAO.GetAll(ctx, tx, cdbm.VpcPrefixFilterInput{
+			VpcPrefixIDs:   []uuid.UUID{vpcPrefixID},
+			SiteIDs:        []uuid.UUID{site.ID},
+			IncludeDeleted: true,
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if reloadErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve VPC Prefix by controller ID, DB error: %w", reloadErr)
+		}
+
+		if len(matches) > 0 {
+			existingVpcPrefix := &matches[0]
+			if existingVpcPrefix.Deleted == nil {
+				return existingVpcPrefix, nil
+			}
+			if existingVpcPrefix.Org != vpc.Org {
+				logger.Warn().Msg(fmt.Sprintf("unable to create VPC Prefix found on Site: tenant organization differs in REST cache and Site record %s", vpc.Org))
+				return nil, nil
+			}
+		}
+
+		// Site inventory does not report the REST IPBlock ID. Find the most specific
+		// tenant IPBlock that contains the reported prefix.
+		ipBlocks, _, ipBlockErr := cdbm.NewIPBlockDAO(mvp.dbSession).GetAll(ctx, tx, cdbm.IPBlockFilterInput{
+			SiteIDs:   []uuid.UUID{site.ID},
+			TenantIDs: []uuid.UUID{vpc.TenantID},
+			Statuses:  []string{cdbm.IPBlockStatusReady},
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if ipBlockErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve IP Blocks, DB error: %w", ipBlockErr)
+		}
+
+		var ipBlock *cdbm.IPBlock
+		for i := range ipBlocks {
+			// A fully granted IPBlock is entirely owned by an existing VPC Prefix, but the ipam DB
+			// reports it as empty and full-granting does not change its Status, so skip it here.
+			if ipBlocks[i].FullGrant {
+				continue
+			}
+			candidateCIDR := ipam.GetCidrForIPBlock(ctx, ipBlocks[i].Prefix, ipBlocks[i].PrefixLength)
+			candidatePrefix, parseErr := netip.ParsePrefix(candidateCIDR)
+			if parseErr != nil || candidatePrefix.Addr().BitLen() != reportedPrefix.Addr().BitLen() ||
+				candidatePrefix.Bits() > reportedPrefix.Bits() || !candidatePrefix.Contains(reportedPrefix.Addr()) {
+				continue
+			}
+			if ipBlock == nil || ipBlocks[i].PrefixLength > ipBlock.PrefixLength {
+				ipBlock = &ipBlocks[i]
+			}
+		}
+		if ipBlock == nil {
+			logger.Warn().Msgf("unable to create VPC Prefix found on Site: no containing IP Block was found for Prefix: %s", reportedVpcPrefix.Prefix)
+			return nil, nil
+		}
+
+		if len(matches) > 0 && (matches[0].IPBlockID == nil || *matches[0].IPBlockID != ipBlock.ID) {
+			logger.Warn().Msgf("unable to create VPC Prefix found on Site: IP Block differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
+			return nil, nil
+		}
+		if len(matches) > 0 {
+			// Clear restores the row as stored; do not acquire a Site CIDR that disagrees with
+			// the cached Prefix/VpcID or DB and IPAM will permanently diverge.
+			existingPrefix, existingPrefixErr := netip.ParsePrefix(matches[0].Prefix)
+			if existingPrefixErr != nil || existingPrefix.Masked().String() != reportedVpcPrefix.Prefix {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: prefix differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
+				return nil, nil
+			}
+			if matches[0].VpcID != vpc.ID {
+				logger.Warn().Msgf("unable to create VPC Prefix found on Site: VPC differs in REST cache and Site record for VPC Prefix %s", vpcPrefixID)
+				return nil, nil
+			}
+		}
+
+		// Claim the exact Site-reported CIDR in REST IPAM while holding the same
+		// tenant/IPBlock lock used by the normal REST create path.
+		lockErr := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(fmt.Sprintf("%s-%s", vpc.TenantID, ipBlock.ID)), false)
+		if lockErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to acquire advisory lock on IP Block, DB error: %w", lockErr)
+		}
+		ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
+		// Soft-skips after IPAM mutation must return a non-nil error so WithTxResult
+		// rolls back (e.g. FullGrant=true from CreateChildIpamEntryForIPBlock).
+		if ipBlock.PrefixLength == prefixLength {
+			childPrefix, allocateErr := ipam.CreateChildIpamEntryForIPBlock(ctx, tx, mvp.dbSession, ipamStorage, ipBlock, prefixLength)
+			if allocateErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create IPAM entry for VPC Prefix: %w", allocateErr)
+			}
+			if childPrefix.Cidr != reportedVpcPrefix.Prefix {
+				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: allocated Prefix %s differs from Site record %s", childPrefix.Cidr, reportedVpcPrefix.Prefix)
+			}
+		} else if _, allocateErr := ipam.AcquireSpecificChildIpamEntryForIPBlock(ctx, tx, mvp.dbSession, ipamStorage, ipBlock, reportedVpcPrefix.Prefix); allocateErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create IPAM entry for VPC Prefix: %w", allocateErr)
+		}
+
+		if len(matches) > 0 {
+			// Soft-deleted rows almost always carry Status=Deleting (set by the REST
+			// delete path before soft-delete). Clear only nulls deleted; also reset
+			// Status from Site inventory here. UpdateVpcPrefixesInDB skips refresh when
+			// Status is Deleting and Site reports a non-terminal state (e.g. READY).
+			restored, clearErr := vpcPrefixDAO.Clear(ctx, tx, cdbm.VpcPrefixClearInput{VpcPrefixID: matches[0].ID, Deleted: true})
+			if clearErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to clear soft-delete timestamp for VPC Prefix, DB error: %w", clearErr)
+			}
+			status, statusMessage := getControllerVpcPrefixStatus(controllerVpcPrefix.GetStatus())
+			updated, updateErr := vpcPrefixDAO.Update(ctx, tx, cdbm.VpcPrefixUpdateInput{
+				VpcPrefixID: restored.ID,
+				Status:      &status,
+			})
+			if updateErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to update VPC Prefix status after undelete, DB error: %w", updateErr)
+			}
+			if _, statusErr := cdbm.NewStatusDetailDAO(mvp.dbSession).Create(ctx, tx, cdbm.StatusDetailCreateInput{
+				EntityID: updated.ID.String(), Status: status, Message: &statusMessage,
+			}); statusErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create Status Detail after undelete, DB error: %w", statusErr)
+			}
+			return updated, nil
+		}
+
+		// If an active VPC Prefix already uses this name for the Tenant/Site, append a recovered suffix.
+		nameConflictVpcPrefixes, _, nameErr := vpcPrefixDAO.GetAll(ctx, tx, cdbm.VpcPrefixFilterInput{
+			Names: []string{reportedVpcPrefix.Name}, TenantIDs: []uuid.UUID{vpc.TenantID}, SiteIDs: []uuid.UUID{site.ID},
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if nameErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to retrieve VPC Prefix by name, DB error: %w", nameErr)
+		}
+		if len(nameConflictVpcPrefixes) > 0 {
+			reportedVpcPrefix.Name = fmt.Sprintf("%s-recovered-%s", reportedVpcPrefix.Name, vpcPrefixID.String()[:8])
+		}
+
+		readyMsg := "VPC Prefix was found on Site, Ready for use"
+		created, createErr := vpcPrefixDAO.Create(ctx, tx, cdbm.VpcPrefixCreateInput{
+			VpcPrefixID:  &vpcPrefixID,
+			Name:         reportedVpcPrefix.Name,
+			TenantOrg:    vpc.Org,
+			SiteID:       site.ID,
+			VpcID:        vpc.ID,
+			TenantID:     vpc.TenantID,
+			IpBlockID:    &ipBlock.ID,
+			Prefix:       reportedVpcPrefix.Prefix,
+			PrefixLength: prefixLength,
+			Status:       cdbm.VpcPrefixStatusReady,
+			CreatedBy:    site.ID,
+		})
+		if createErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create VPC Prefix, DB error: %w", createErr)
+		}
+		if _, statusErr := cdbm.NewStatusDetailDAO(mvp.dbSession).Create(ctx, tx, cdbm.StatusDetailCreateInput{
+			EntityID: created.ID.String(), Status: cdbm.VpcPrefixStatusReady, Message: &readyMsg,
+		}); statusErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create Status Detail, DB error: %w", statusErr)
+		}
+		return created, nil
+	})
+	if err != nil {
+		logger.Warn().Err(err).Msg(err.Error())
+		return nil
+	}
+	return vpcPrefix
+}
+
 // getControllerVpcPrefixStatus maps Controller VPC Prefix tenant state into REST status and status-detail text.
 func getControllerVpcPrefixStatus(status *corev1.VpcPrefixStatus) (string, string) {
 	// Older Controller builds did not report status; inventory presence meant ready.
@@ -238,28 +502,41 @@ func getControllerVpcPrefixStatus(status *corev1.VpcPrefixStatus) (string, strin
 
 // deleteVpcPrefixFromDB is a helper function to delete VPC Prefix from DB
 func (mvp ManageVpcPrefix) deleteVpcPrefixFromDB(ctx context.Context, tx *cdb.Tx, vpcPrefix *cdbm.VpcPrefix, logger zerolog.Logger) error {
-	// Acquire an advisory lock on the parent IP block ID on which there could be contention
-	// this lock is released when the transaction commits or rollsback
-	err := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(vpcPrefix.IPBlockID.String()), false)
-	if err != nil {
-		logger.Error().Err(err).Msg("Failed to acquire advisory lock on IP Block")
-		return err
-	}
-	logger.Info().Msg("acquired advisory lock on IP Block for VPC Prefix")
+	switch {
+	case vpcPrefix.IPBlockID == nil:
+		// IPBlockID is nullable on the model. When unset there is no parent block and no
+		// child CIDR to release in IPAM (inventory recovery always sets IpBlockID today).
+	case vpcPrefix.IPBlock != nil:
+		// Acquire an advisory lock on the parent IP block ID on which there could be contention
+		// this lock is released when the transaction commits or rollsback
+		err := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(vpcPrefix.IPBlockID.String()), false)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to acquire advisory lock on IP Block")
+			return err
+		}
+		logger.Info().Msg("acquired advisory lock on IP Block for VPC Prefix")
 
-	// Delete IPAM entry for this subnet
-	ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
-	err = ipam.DeleteChildIpamEntryFromCidr(ctx, tx, mvp.dbSession, ipamStorage, vpcPrefix.IPBlock, vpcPrefix.Prefix)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to delete ipam record for Subnet")
+		// Delete IPAM entry for this VPC Prefix
+		ipamStorage := ipam.NewIpamStorage(mvp.dbSession.DB, tx.GetBunTx())
+		err = ipam.DeleteChildIpamEntryFromCidr(ctx, tx, mvp.dbSession, ipamStorage, vpcPrefix.IPBlock, vpcPrefix.Prefix)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to delete ipam record for VPC Prefix")
+			return err
+		}
+		logger.Info().Msg("deleted VPC Prefix IPAM entry")
+	default:
+		// IPBlockID is set but the relation was not loaded (or the parent IPBlock is
+		// soft-deleted). Skipping cleanup would soft-delete the prefix while leaking its
+		// child CIDR in IPAM.
+		err := fmt.Errorf("unable to delete VPC Prefix: IP Block relation is missing for IP Block ID %s", vpcPrefix.IPBlockID)
+		logger.Error().Err(err).Msg("failed to delete VPC Prefix from DB")
 		return err
 	}
-	logger.Info().Msg("deleted VPC Prefix IPAM entry")
 
 	// Soft-delete VPC Prefix
 	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(mvp.dbSession)
 
-	err = vpcPrefixDAO.Delete(ctx, tx, vpcPrefix.ID)
+	err := vpcPrefixDAO.Delete(ctx, tx, vpcPrefix.ID)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to delete VPC Prefix from DB")
 		return err

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
@@ -854,7 +854,8 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 	})
 
 	t.Run("inventory restores soft-deleted VPC Prefix", func(t *testing.T) {
-		// Prefix may already be soft-deleted by the TERMINATING skip case; ensure that state.
+		// Depends on the preceding TERMINATING subtest leaving the row soft-deleted with
+		// Status=Deleting. Do not soft-delete here — that would hide failures in the prior case.
 		existing, _, err := vpcPrefixDAO.GetAll(
 			ctx,
 			nil,
@@ -864,20 +865,8 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 		)
 		require.NoError(t, err)
 		require.Len(t, existing, 1)
-		if existing[0].Deleted == nil {
-			_, err = vpcPrefixDAO.Update(ctx, nil, cdbm.VpcPrefixUpdateInput{
-				VpcPrefixID:     controllerVpcPrefixID,
-				Status:          cutil.GetPtr(cdbm.VpcPrefixStatusDeleting),
-				IsMissingOnSite: cutil.GetPtr(true),
-			})
-			require.NoError(t, err)
-			require.NoError(t, ipam.DeleteChildIpamEntryFromCidr(
-				ctx, nil, dbSession, ipamStorage, ipBlock, controllerVpcPrefix.Config.Prefix,
-			))
-			require.NoError(t, vpcPrefixDAO.Delete(ctx, nil, controllerVpcPrefixID))
-		} else {
-			assert.Equal(t, cdbm.VpcPrefixStatusDeleting, existing[0].Status)
-		}
+		require.NotNil(t, existing[0].Deleted, "expected the prefix to be soft-deleted by the preceding subtest")
+		require.Equal(t, cdbm.VpcPrefixStatusDeleting, existing[0].Status)
 
 		deleted, _, err := vpcPrefixDAO.GetAll(
 			ctx,

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
@@ -5,6 +5,7 @@ package vpcprefix
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"reflect"
 	"testing"
@@ -13,10 +14,12 @@ import (
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/ipam"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
+	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	cdbu "github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun/extra/bundebug"
@@ -184,14 +187,14 @@ func testVPCSiteBuildAllocation(t *testing.T, dbSession *cdb.Session, st *cdbm.S
 	return al
 }
 
-// testVPCBuildVPC Building VPCPrefix in DB
+// testVPCBuildVPC Building VPC in DB
 func testVPCBuildVPC(t *testing.T, dbSession *cdb.Session, name string, ip *cdbm.InfrastructureProvider, tn *cdbm.Tenant, st *cdbm.Site, ct *uuid.UUID, lb map[string]string, user *cdbm.User, status string) *cdbm.Vpc {
 	vpcDAO := cdbm.NewVpcDAO(dbSession)
 
 	input := cdbm.VpcCreateInput{
 		Name:                      name,
-		Description:               cutil.GetPtr("Test VPCPrefix"),
-		Org:                       st.Org,
+		Description:               cutil.GetPtr("Test VPC"),
+		Org:                       tn.Org,
 		InfrastructureProviderID:  ip.ID,
 		TenantID:                  tn.ID,
 		SiteID:                    st.ID,
@@ -235,7 +238,7 @@ func testVPCPrefixBuildIPBlock(t *testing.T, dbSession *cdb.Session, name string
 func testVPCBuildVPCPrefix(t *testing.T, dbSession *cdb.Session, name string, st *cdbm.Site, tenant *cdbm.Tenant, vpcID uuid.UUID, ipv4BlockID *uuid.UUID, prefix *string, prefixLength *int, status string, user *cdbm.User) *cdbm.VpcPrefix {
 	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(dbSession)
 
-	vpcprefix, err := vpcPrefixDAO.Create(context.Background(), nil, cdbm.VpcPrefixCreateInput{Name: name, TenantOrg: st.Org, SiteID: st.ID, VpcID: vpcID, TenantID: tenant.ID, IpBlockID: ipv4BlockID, Prefix: *prefix, PrefixLength: *prefixLength, Status: status, CreatedBy: user.ID})
+	vpcprefix, err := vpcPrefixDAO.Create(context.Background(), nil, cdbm.VpcPrefixCreateInput{Name: name, TenantOrg: tenant.Org, SiteID: st.ID, VpcID: vpcID, TenantID: tenant.ID, IpBlockID: ipv4BlockID, Prefix: *prefix, PrefixLength: *prefixLength, Status: status, CreatedBy: user.ID})
 	assert.Nil(t, err)
 
 	return vpcprefix
@@ -664,4 +667,853 @@ func TestNewManageVpcPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testVpcPrefixInitDB(t)
+	defer dbSession.Close()
+	testVPCPrefixSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testVPCBuildVPC(
+		t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser, cdbm.VpcStatusReady,
+	)
+	controllerVpcID := parentVpc.ID
+	ipBlock := testVPCPrefixBuildIPBlock(
+		t, dbSession, "test-vpc-prefix-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	manager := ManageVpcPrefix{dbSession: dbSession}
+	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(dbSession)
+	statusDetailDAO := cdbm.NewStatusDetailDAO(dbSession)
+
+	controllerVpcPrefixID := uuid.New()
+	controllerVpcPrefix := &corev1.VpcPrefix{
+		Id:    &corev1.VpcPrefixId{Value: controllerVpcPrefixID.String()},
+		VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+		Config: &corev1.VpcPrefixConfig{
+			Prefix: "10.20.30.0/24",
+		},
+		Metadata: &corev1.Metadata{
+			Name: "site-created-vpc-prefix",
+		},
+		Status: &corev1.VpcPrefixStatus{
+			TenantState: corev1.TenantState_READY,
+		},
+	}
+	inventory := &corev1.VpcPrefixInventory{
+		VpcPrefixes: []*corev1.VpcPrefix{controllerVpcPrefix},
+	}
+
+	if !t.Run("auto creates VPC Prefix from inventory", func(t *testing.T) {
+		err := manager.UpdateVpcPrefixesInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+
+		created, err := vpcPrefixDAO.GetByID(ctx, nil, controllerVpcPrefixID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, controllerVpcPrefixID, created.ID)
+		assert.Equal(t, parentVpc.ID, created.VpcID)
+		assert.Equal(t, tenant.ID, created.TenantID)
+		assert.Equal(t, tenantOrg, created.Org)
+		assert.Equal(t, site.ID, created.SiteID)
+		assert.Equal(t, site.ID, created.CreatedBy)
+		assert.Equal(t, cdbm.VpcPrefixStatusReady, created.Status)
+		assert.Equal(t, "site-created-vpc-prefix", created.Name)
+		assert.Equal(t, "10.20.30.0/24", created.Prefix)
+		assert.Equal(t, 24, created.PrefixLength)
+		require.NotNil(t, created.IPBlockID)
+		assert.Equal(t, ipBlock.ID, *created.IPBlockID)
+
+		ipamer := cipam.NewWithStorage(ipamStorage)
+		ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+			ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+		))
+		assert.NotNil(t, ipamer.PrefixFrom(ctx, controllerVpcPrefix.Config.Prefix))
+
+		statusDetails, _, statusErr := statusDetailDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{created.ID.String()}},
+			cdbp.PageInput{},
+		)
+		require.NoError(t, statusErr)
+		require.NotEmpty(t, statusDetails)
+		foundCreateMessage := false
+		for i := range statusDetails {
+			if statusDetails[i].Message != nil &&
+				*statusDetails[i].Message == "VPC Prefix was found on Site, Ready for use" {
+				foundCreateMessage = true
+				break
+			}
+		}
+		assert.True(t, foundCreateMessage)
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("inventory replay is idempotent", func(t *testing.T) {
+		err := manager.UpdateVpcPrefixesInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+		prefixes, count, err := vpcPrefixDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{controllerVpcPrefixID}},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, prefixes, 1)
+		assert.Equal(t, 1, count)
+	}) {
+		t.FailNow()
+	}
+
+	t.Run("inventory skips restore when Site reports TERMINATING", func(t *testing.T) {
+		_, err := vpcPrefixDAO.Update(ctx, nil, cdbm.VpcPrefixUpdateInput{
+			// Seed Deleting: that is the status the REST delete path leaves before soft-delete.
+			VpcPrefixID:     controllerVpcPrefixID,
+			Status:          cutil.GetPtr(cdbm.VpcPrefixStatusDeleting),
+			IsMissingOnSite: cutil.GetPtr(true),
+		})
+		require.NoError(t, err)
+		require.NoError(t, ipam.DeleteChildIpamEntryFromCidr(
+			ctx, nil, dbSession, ipamStorage, ipBlock, controllerVpcPrefix.Config.Prefix,
+		))
+		require.NoError(t, vpcPrefixDAO.Delete(ctx, nil, controllerVpcPrefixID))
+
+		deleted, _, err := vpcPrefixDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{controllerVpcPrefixID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deleted, 1)
+		require.NotNil(t, deleted[0].Deleted)
+		assert.Equal(t, cdbm.VpcPrefixStatusDeleting, deleted[0].Status)
+		deletedAt := *deleted[0].Deleted
+
+		terminatingInventory := &corev1.VpcPrefixInventory{
+			VpcPrefixes: []*corev1.VpcPrefix{
+				{
+					Id:    &corev1.VpcPrefixId{Value: controllerVpcPrefixID.String()},
+					VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+					Config: &corev1.VpcPrefixConfig{
+						Prefix: controllerVpcPrefix.Config.Prefix,
+					},
+					Metadata: &corev1.Metadata{
+						Name: "site-created-vpc-prefix",
+					},
+					Status: &corev1.VpcPrefixStatus{
+						TenantState: corev1.TenantState_TERMINATING,
+					},
+				},
+			},
+		}
+		err = manager.UpdateVpcPrefixesInDB(ctx, site.ID, terminatingInventory)
+		require.NoError(t, err)
+
+		stillDeleted, _, err := vpcPrefixDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{controllerVpcPrefixID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, stillDeleted, 1)
+		require.NotNil(t, stillDeleted[0].Deleted)
+		assert.Equal(t, deletedAt, *stillDeleted[0].Deleted)
+		assert.Equal(t, cdbm.VpcPrefixStatusDeleting, stillDeleted[0].Status)
+
+		_, err = vpcPrefixDAO.GetByID(ctx, nil, controllerVpcPrefixID, nil)
+		assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+		ipamer := cipam.NewWithStorage(ipamStorage)
+		ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+			ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+		))
+		assert.Nil(t, ipamer.PrefixFrom(ctx, controllerVpcPrefix.Config.Prefix))
+	})
+
+	t.Run("inventory restores soft-deleted VPC Prefix", func(t *testing.T) {
+		// Prefix may already be soft-deleted by the TERMINATING skip case; ensure that state.
+		existing, _, err := vpcPrefixDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{controllerVpcPrefixID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, existing, 1)
+		if existing[0].Deleted == nil {
+			_, err = vpcPrefixDAO.Update(ctx, nil, cdbm.VpcPrefixUpdateInput{
+				VpcPrefixID:     controllerVpcPrefixID,
+				Status:          cutil.GetPtr(cdbm.VpcPrefixStatusDeleting),
+				IsMissingOnSite: cutil.GetPtr(true),
+			})
+			require.NoError(t, err)
+			require.NoError(t, ipam.DeleteChildIpamEntryFromCidr(
+				ctx, nil, dbSession, ipamStorage, ipBlock, controllerVpcPrefix.Config.Prefix,
+			))
+			require.NoError(t, vpcPrefixDAO.Delete(ctx, nil, controllerVpcPrefixID))
+		} else {
+			assert.Equal(t, cdbm.VpcPrefixStatusDeleting, existing[0].Status)
+		}
+
+		deleted, _, err := vpcPrefixDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{controllerVpcPrefixID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deleted, 1)
+		require.NotNil(t, deleted[0].Deleted)
+		assert.Equal(t, cdbm.VpcPrefixStatusDeleting, deleted[0].Status)
+
+		err = manager.UpdateVpcPrefixesInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+
+		restored, err := vpcPrefixDAO.GetByID(ctx, nil, controllerVpcPrefixID, nil)
+		require.NoError(t, err)
+		assert.Nil(t, restored.Deleted)
+		assert.False(t, restored.IsMissingOnSite)
+		assert.Equal(t, cdbm.VpcPrefixStatusReady, restored.Status)
+		ipamer := cipam.NewWithStorage(ipamStorage)
+		ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+			ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+		))
+		assert.NotNil(t, ipamer.PrefixFrom(ctx, controllerVpcPrefix.Config.Prefix))
+
+		statusDetails, _, statusErr := statusDetailDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{restored.ID.String()}},
+			cdbp.PageInput{},
+		)
+		require.NoError(t, statusErr)
+		foundReadyMessage := false
+		for i := range statusDetails {
+			if statusDetails[i].Message != nil &&
+				*statusDetails[i].Message == "VPC Prefix is ready for use" {
+				foundReadyMessage = true
+				break
+			}
+		}
+		assert.True(t, foundReadyMessage)
+	})
+
+	t.Run("inventory skips restore when tenant organization differs", func(t *testing.T) {
+		require.NoError(t, ipam.DeleteChildIpamEntryFromCidr(
+			ctx, nil, dbSession, ipamStorage, ipBlock, controllerVpcPrefix.Config.Prefix,
+		))
+		require.NoError(t, vpcPrefixDAO.Delete(ctx, nil, controllerVpcPrefixID))
+		deleted, _, err := vpcPrefixDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{controllerVpcPrefixID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deleted, 1)
+		require.NotNil(t, deleted[0].Deleted)
+		deletedAt := *deleted[0].Deleted
+
+		_, err = dbSession.DB.NewUpdate().
+			Model((*cdbm.VpcPrefix)(nil)).
+			Set("org = ?", "other-tenant-org").
+			Where("id = ?", controllerVpcPrefixID).
+			WhereAllWithDeleted().
+			Exec(ctx)
+		require.NoError(t, err)
+
+		err = manager.UpdateVpcPrefixesInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+
+		stillDeleted, _, err := vpcPrefixDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{controllerVpcPrefixID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, stillDeleted, 1)
+		require.NotNil(t, stillDeleted[0].Deleted)
+		assert.Equal(t, deletedAt, *stillDeleted[0].Deleted)
+
+		_, err = vpcPrefixDAO.GetByID(ctx, nil, controllerVpcPrefixID, nil)
+		assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+	})
+}
+
+func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsIncompleteOwnership(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testVpcPrefixInitDB(t)
+	defer dbSession.Close()
+	testVPCPrefixSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	authorizedTenantOrg := "test-authorized-tenant"
+	authorizedTenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), authorizedTenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	authorizedTenant := testVPCBuildTenant(t, dbSession, "test-authorized-tenant", authorizedTenantOrg, authorizedTenantUser)
+
+	parentVpc := testVPCBuildVPC(
+		t, dbSession, "parent-vpc", provider, authorizedTenant, site, nil, nil, authorizedTenantUser, cdbm.VpcStatusReady,
+	)
+	controllerVpcID := parentVpc.ID
+	ipBlock := testVPCPrefixBuildIPBlock(
+		t, dbSession, "test-vpc-prefix-ip-block", site, provider, &authorizedTenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.0.0.0", 8,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, authorizedTenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+	ipamer := cipam.NewWithStorage(ipamStorage)
+	ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+		ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	))
+	_, err = ipamer.AcquireSpecificChildPrefix(ctx, "10.0.0.0/8", "10.5.0.0/24")
+	require.NoError(t, err)
+	existingPrefix := testVPCBuildVPCPrefix(
+		t, dbSession, "existing-name", site, authorizedTenant, parentVpc.ID, nil,
+		cutil.GetPtr("10.0.0.0/24"), cutil.GetPtr(24), cdbm.VpcPrefixStatusReady, authorizedTenantUser,
+	)
+
+	manager := ManageVpcPrefix{dbSession: dbSession}
+
+	tests := []struct {
+		name                string
+		controllerVpcPrefix *corev1.VpcPrefix
+		wantVpcPrefix       bool
+		wantName            string
+		wantNamePref        string
+	}{
+		{
+			name: "unknown parent VPC is rejected",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:    &corev1.VpcPrefixId{Value: uuid.NewString()},
+				VpcId: &corev1.VpcId{Value: uuid.NewString()},
+				Config: &corev1.VpcPrefixConfig{
+					Prefix: "10.1.0.0/24",
+				},
+				Metadata: &corev1.Metadata{Name: "unknown-vpc-prefix"},
+			},
+		},
+		{
+			name: "invalid controller VPC Prefix ID",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:    &corev1.VpcPrefixId{Value: "not-a-uuid"},
+				VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+				Config: &corev1.VpcPrefixConfig{
+					Prefix: "10.1.0.0/24",
+				},
+				Metadata: &corev1.Metadata{Name: "invalid-id-prefix"},
+			},
+		},
+		{
+			name: "empty prefix is rejected",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:       &corev1.VpcPrefixId{Value: uuid.NewString()},
+				VpcId:    &corev1.VpcId{Value: controllerVpcID.String()},
+				Config:   &corev1.VpcPrefixConfig{Prefix: ""},
+				Metadata: &corev1.Metadata{Name: "missing-prefix"},
+			},
+		},
+		{
+			name: "invalid prefix CIDR is rejected",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:       &corev1.VpcPrefixId{Value: uuid.NewString()},
+				VpcId:    &corev1.VpcId{Value: controllerVpcID.String()},
+				Config:   &corev1.VpcPrefixConfig{Prefix: "not-a-cidr"},
+				Metadata: &corev1.Metadata{Name: "bad-cidr-prefix"},
+			},
+		},
+		{
+			name: "empty VPC ID is rejected",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:       &corev1.VpcPrefixId{Value: uuid.NewString()},
+				Config:   &corev1.VpcPrefixConfig{Prefix: "10.1.0.0/24"},
+				Metadata: &corev1.Metadata{Name: "missing-vpc-id"},
+			},
+		},
+		{
+			name: "no containing IP Block is rejected",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:       &corev1.VpcPrefixId{Value: uuid.NewString()},
+				VpcId:    &corev1.VpcId{Value: controllerVpcID.String()},
+				Config:   &corev1.VpcPrefixConfig{Prefix: "192.168.1.0/24"},
+				Metadata: &corev1.Metadata{Name: "no-ip-block-prefix"},
+			},
+		},
+		{
+			name: "already allocated Site CIDR is rejected",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:       &corev1.VpcPrefixId{Value: uuid.NewString()},
+				VpcId:    &corev1.VpcId{Value: controllerVpcID.String()},
+				Config:   &corev1.VpcPrefixConfig{Prefix: "10.5.0.0/24"},
+				Metadata: &corev1.Metadata{Name: "allocated-prefix"},
+			},
+		},
+		{
+			name: "renames VPC Prefix when active name already exists",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:    &corev1.VpcPrefixId{Value: uuid.NewString()},
+				VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+				Config: &corev1.VpcPrefixConfig{
+					Prefix: "10.2.0.0/24",
+				},
+				Metadata: &corev1.Metadata{Name: existingPrefix.Name},
+			},
+			wantVpcPrefix: true,
+			wantNamePref:  existingPrefix.Name + "-recovered-",
+		},
+		{
+			name: "assigns recovered name when metadata name is empty",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:    &corev1.VpcPrefixId{Value: uuid.NewString()},
+				VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+				Config: &corev1.VpcPrefixConfig{
+					Prefix: "10.3.0.0/24",
+				},
+				Metadata: &corev1.Metadata{Name: ""},
+			},
+			wantVpcPrefix: true,
+			wantNamePref:  "recovered-",
+		},
+		{
+			name: "creates VPC Prefix using parent VPC REST ID as site VPC ID",
+			controllerVpcPrefix: &corev1.VpcPrefix{
+				Id:    &corev1.VpcPrefixId{Value: uuid.NewString()},
+				VpcId: &corev1.VpcId{Value: parentVpc.ID.String()},
+				Config: &corev1.VpcPrefixConfig{
+					Prefix: "10.4.0.0/24",
+				},
+				Metadata: &corev1.Metadata{Name: "rest-id-parent-vpc-prefix"},
+			},
+			wantVpcPrefix: true,
+			wantName:      "rest-id-parent-vpc-prefix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vpcPrefix := manager.createOrUpdateVpcPrefixFromSite(ctx, site, tt.controllerVpcPrefix)
+			if tt.wantVpcPrefix {
+				require.NotNil(t, vpcPrefix)
+				assert.Equal(t, cdbm.VpcPrefixStatusReady, vpcPrefix.Status)
+				assert.Equal(t, authorizedTenant.ID, vpcPrefix.TenantID)
+				assert.Equal(t, parentVpc.ID, vpcPrefix.VpcID)
+				require.NotNil(t, vpcPrefix.IPBlockID)
+				assert.Equal(t, ipBlock.ID, *vpcPrefix.IPBlockID)
+				assert.NotNil(t, ipamer.PrefixFrom(ctx, tt.controllerVpcPrefix.Config.Prefix))
+				if tt.wantName != "" {
+					assert.Equal(t, tt.wantName, vpcPrefix.Name)
+				}
+				if tt.wantNamePref != "" {
+					assert.True(t, len(vpcPrefix.Name) > len(tt.wantNamePref))
+					assert.Equal(t, tt.wantNamePref, vpcPrefix.Name[:len(tt.wantNamePref)])
+				}
+			} else {
+				assert.Nil(t, vpcPrefix)
+			}
+		})
+	}
+}
+
+func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_RejectsHostBitsEqualLengthCIDR(t *testing.T) {
+	// Regression: a non-canonical equal-length CIDR (host bits set) must not leave the
+	// parent IPBlock with FullGrant=true after a soft-skip commits the transaction.
+	ctx := context.Background()
+	dbSession := testVpcPrefixInitDB(t)
+	defer dbSession.Close()
+	testVPCPrefixSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testVPCBuildVPC(
+		t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser, cdbm.VpcStatusReady,
+	)
+	ipBlock := testVPCPrefixBuildIPBlock(
+		t, dbSession, "test-full-grant-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	hostBitsVpcPrefixID := uuid.New()
+	manager := ManageVpcPrefix{dbSession: dbSession}
+	created := manager.createOrUpdateVpcPrefixFromSite(ctx, site, &corev1.VpcPrefix{
+		Id:    &corev1.VpcPrefixId{Value: hostBitsVpcPrefixID.String()},
+		VpcId: &corev1.VpcId{Value: parentVpc.ID.String()},
+		Config: &corev1.VpcPrefixConfig{
+			// netip.ParsePrefix accepts this; Masked() form is 10.20.0.0/16.
+			Prefix: "10.20.0.1/16",
+		},
+		Metadata: &corev1.Metadata{Name: "host-bits-vpc-prefix"},
+		Status:   &corev1.VpcPrefixStatus{TenantState: corev1.TenantState_READY},
+	})
+	assert.Nil(t, created)
+
+	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(dbSession)
+	_, err = vpcPrefixDAO.GetByID(ctx, nil, hostBitsVpcPrefixID, nil)
+	assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+	ipBlockDAO := cdbm.NewIPBlockDAO(dbSession)
+	reloadedIPBlock, err := ipBlockDAO.GetByID(ctx, nil, ipBlock.ID, nil)
+	require.NoError(t, err)
+	assert.False(t, reloadedIPBlock.FullGrant)
+
+	// A normal REST-style full-grant create on the same IPBlock must still succeed.
+	childPrefix, err := ipam.CreateChildIpamEntryForIPBlock(
+		ctx, nil, dbSession, ipamStorage, reloadedIPBlock, reloadedIPBlock.PrefixLength,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "10.20.0.0/16", childPrefix.Cidr)
+	reloadedIPBlock, err = ipBlockDAO.GetByID(ctx, nil, ipBlock.ID, nil)
+	require.NoError(t, err)
+	assert.True(t, reloadedIPBlock.FullGrant)
+}
+
+func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsFullGrantIPBlock(t *testing.T) {
+	// Regression: FullGrant lives only in the REST DB, so the ipam library reports a fully
+	// granted IPBlock as empty. Recovery must not carve a child CIDR out of it.
+	ctx := context.Background()
+	dbSession := testVpcPrefixInitDB(t)
+	defer dbSession.Close()
+	testVPCPrefixSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testVPCBuildVPC(
+		t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser, cdbm.VpcStatusReady,
+	)
+	ipBlock := testVPCPrefixBuildIPBlock(
+		t, dbSession, "test-full-grant-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	// Full-grant the whole IPBlock the way the REST create path does.
+	_, err = ipam.CreateChildIpamEntryForIPBlock(
+		ctx, nil, dbSession, ipamStorage, ipBlock, ipBlock.PrefixLength,
+	)
+	require.NoError(t, err)
+	ipBlockDAO := cdbm.NewIPBlockDAO(dbSession)
+	fullGrantedIPBlock, err := ipBlockDAO.GetByID(ctx, nil, ipBlock.ID, nil)
+	require.NoError(t, err)
+	require.True(t, fullGrantedIPBlock.FullGrant)
+
+	childVpcPrefixID := uuid.New()
+	manager := ManageVpcPrefix{dbSession: dbSession}
+	created := manager.createOrUpdateVpcPrefixFromSite(ctx, site, &corev1.VpcPrefix{
+		Id:    &corev1.VpcPrefixId{Value: childVpcPrefixID.String()},
+		VpcId: &corev1.VpcId{Value: parentVpc.ID.String()},
+		Config: &corev1.VpcPrefixConfig{
+			Prefix: "10.20.30.0/24",
+		},
+		Metadata: &corev1.Metadata{Name: "full-grant-child-vpc-prefix"},
+		Status:   &corev1.VpcPrefixStatus{TenantState: corev1.TenantState_READY},
+	})
+	assert.Nil(t, created)
+
+	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(dbSession)
+	_, err = vpcPrefixDAO.GetByID(ctx, nil, childVpcPrefixID, nil)
+	assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+	ipamer := cipam.NewWithStorage(ipamStorage)
+	ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+		ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	))
+	assert.Nil(t, ipamer.PrefixFrom(ctx, "10.20.30.0/24"))
+
+	reloadedIPBlock, err := ipBlockDAO.GetByID(ctx, nil, ipBlock.ID, nil)
+	require.NoError(t, err)
+	assert.True(t, reloadedIPBlock.FullGrant)
+}
+
+func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsRestoreWhenPrefixDiffers(t *testing.T) {
+	// Soft-deleted row stores 10.20.30.0/24; Site reports the same controller UUID with a
+	// different CIDR in the same IPBlock. Undelete must not acquire the reported CIDR.
+	ctx := context.Background()
+	dbSession := testVpcPrefixInitDB(t)
+	defer dbSession.Close()
+	testVPCPrefixSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testVPCBuildVPC(
+		t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser, cdbm.VpcStatusReady,
+	)
+	ipBlock := testVPCPrefixBuildIPBlock(
+		t, dbSession, "test-prefix-mismatch-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	storedCIDR := "10.20.30.0/24"
+	reportedCIDR := "10.20.31.0/24"
+	vpcPrefixID := uuid.New()
+	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(dbSession)
+	_, err = vpcPrefixDAO.Create(ctx, nil, cdbm.VpcPrefixCreateInput{
+		VpcPrefixID:  &vpcPrefixID,
+		Name:         "stored-vpc-prefix",
+		TenantOrg:    tenant.Org,
+		SiteID:       site.ID,
+		VpcID:        parentVpc.ID,
+		TenantID:     tenant.ID,
+		IpBlockID:    &ipBlock.ID,
+		Prefix:       storedCIDR,
+		PrefixLength: 24,
+		Status:       cdbm.VpcPrefixStatusDeleting,
+		CreatedBy:    site.ID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, vpcPrefixDAO.Delete(ctx, nil, vpcPrefixID))
+
+	deleted, _, err := vpcPrefixDAO.GetAll(
+		ctx,
+		nil,
+		cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{vpcPrefixID}, IncludeDeleted: true},
+		cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, deleted, 1)
+	require.NotNil(t, deleted[0].Deleted)
+	deletedAt := *deleted[0].Deleted
+
+	manager := ManageVpcPrefix{dbSession: dbSession}
+	created := manager.createOrUpdateVpcPrefixFromSite(ctx, site, &corev1.VpcPrefix{
+		Id:    &corev1.VpcPrefixId{Value: vpcPrefixID.String()},
+		VpcId: &corev1.VpcId{Value: parentVpc.ID.String()},
+		Config: &corev1.VpcPrefixConfig{
+			Prefix: reportedCIDR,
+		},
+		Metadata: &corev1.Metadata{Name: "drifted-vpc-prefix"},
+		Status:   &corev1.VpcPrefixStatus{TenantState: corev1.TenantState_READY},
+	})
+	assert.Nil(t, created)
+
+	stillDeleted, _, err := vpcPrefixDAO.GetAll(
+		ctx,
+		nil,
+		cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{vpcPrefixID}, IncludeDeleted: true},
+		cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, stillDeleted, 1)
+	require.NotNil(t, stillDeleted[0].Deleted)
+	assert.Equal(t, deletedAt, *stillDeleted[0].Deleted)
+	assert.Equal(t, storedCIDR, stillDeleted[0].Prefix)
+
+	_, err = vpcPrefixDAO.GetByID(ctx, nil, vpcPrefixID, nil)
+	assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+	ipamer := cipam.NewWithStorage(ipamStorage)
+	ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+		ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	))
+	assert.Nil(t, ipamer.PrefixFrom(ctx, reportedCIDR))
+	assert.Nil(t, ipamer.PrefixFrom(ctx, storedCIDR))
+}
+
+func TestManageVpcPrefix_DeleteVpcPrefixFromDB_ErrorsWhenIPBlockRelationMissing(t *testing.T) {
+	// IPBlockID set but IPBlock relation nil must abort delete — silent skip would leak the CIDR.
+	ctx := context.Background()
+	dbSession := testVpcPrefixInitDB(t)
+	defer dbSession.Close()
+	testVPCPrefixSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testVPCBuildVPC(
+		t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser, cdbm.VpcStatusReady,
+	)
+	ipBlock := testVPCPrefixBuildIPBlock(
+		t, dbSession, "test-missing-relation-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	prefix := "10.20.30.0/24"
+	prefixLength := 24
+	vpcPrefix := testVPCBuildVPCPrefix(
+		t, dbSession, "missing-relation-vpc-prefix", site, tenant, parentVpc.ID, &ipBlock.ID,
+		&prefix, &prefixLength, cdbm.VpcPrefixStatusDeleting, tenantUser,
+	)
+	// Simulate a caller that omitted IPBlockRelationName (or a soft-deleted parent block).
+	vpcPrefix.IPBlock = nil
+	require.NotNil(t, vpcPrefix.IPBlockID)
+
+	manager := ManageVpcPrefix{dbSession: dbSession}
+	tx, err := cdb.BeginTx(ctx, dbSession, &sql.TxOptions{})
+	require.NoError(t, err)
+	err = manager.deleteVpcPrefixFromDB(ctx, tx, vpcPrefix, zerolog.Nop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IP Block relation is missing")
+	require.NoError(t, tx.Rollback())
+
+	stillActive, err := cdbm.NewVpcPrefixDAO(dbSession).GetByID(ctx, nil, vpcPrefix.ID, nil)
+	require.NoError(t, err)
+	assert.Nil(t, stillActive.Deleted)
+}
+
+func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsWhenIDExistsUnderDifferentSite(t *testing.T) {
+	// Same controller UUID under another site must skip cleanly — not unique-constraint-fail every cycle.
+	ctx := context.Background()
+	dbSession := testVpcPrefixInitDB(t)
+	defer dbSession.Close()
+	testVPCPrefixSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	siteA := testVPCBuildSite(t, dbSession, provider, "test-site-a", providerUser)
+	siteB := testVPCBuildSite(t, dbSession, provider, "test-site-b", providerUser)
+
+	vpcA := testVPCBuildVPC(t, dbSession, "vpc-a", provider, tenant, siteA, nil, nil, tenantUser, cdbm.VpcStatusReady)
+	vpcB := testVPCBuildVPC(t, dbSession, "vpc-b", provider, tenant, siteB, nil, nil, tenantUser, cdbm.VpcStatusReady)
+
+	ipBlockA := testVPCPrefixBuildIPBlock(
+		t, dbSession, "ip-block-a", siteA, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.10.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipBlockB := testVPCPrefixBuildIPBlock(
+		t, dbSession, "ip-block-b", siteB, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlockB.Prefix, ipBlockB.PrefixLength, ipBlockB.RoutingType,
+		ipBlockB.InfrastructureProviderID.String(), ipBlockB.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	sharedVpcPrefixID := uuid.New()
+	prefixA := "10.10.1.0/24"
+	prefixLengthA := 24
+	existing, err := cdbm.NewVpcPrefixDAO(dbSession).Create(ctx, nil, cdbm.VpcPrefixCreateInput{
+		VpcPrefixID:  &sharedVpcPrefixID,
+		Name:         "site-a-vpc-prefix",
+		TenantOrg:    tenant.Org,
+		SiteID:       siteA.ID,
+		VpcID:        vpcA.ID,
+		TenantID:     tenant.ID,
+		IpBlockID:    &ipBlockA.ID,
+		Prefix:       prefixA,
+		PrefixLength: prefixLengthA,
+		Status:       cdbm.VpcPrefixStatusReady,
+		CreatedBy:    tenantUser.ID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, sharedVpcPrefixID, existing.ID)
+	require.Equal(t, siteA.ID, existing.SiteID)
+
+	manager := ManageVpcPrefix{dbSession: dbSession}
+	created := manager.createOrUpdateVpcPrefixFromSite(ctx, siteB, &corev1.VpcPrefix{
+		Id:    &corev1.VpcPrefixId{Value: sharedVpcPrefixID.String()},
+		VpcId: &corev1.VpcId{Value: vpcB.ID.String()},
+		Config: &corev1.VpcPrefixConfig{
+			Prefix: "10.20.1.0/24",
+		},
+		Metadata: &corev1.Metadata{Name: "site-b-collision-vpc-prefix"},
+		Status:   &corev1.VpcPrefixStatus{TenantState: corev1.TenantState_READY},
+	})
+	assert.Nil(t, created)
+
+	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(dbSession)
+	stillOriginal, err := vpcPrefixDAO.GetByID(ctx, nil, sharedVpcPrefixID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, siteA.ID, stillOriginal.SiteID)
+	assert.Equal(t, prefixA, stillOriginal.Prefix)
+	assert.Equal(t, "site-a-vpc-prefix", stillOriginal.Name)
+	assert.Nil(t, stillOriginal.Deleted)
+
+	siteBPrefixes, _, err := vpcPrefixDAO.GetAll(ctx, nil, cdbm.VpcPrefixFilterInput{
+		SiteIDs: []uuid.UUID{siteB.ID},
+	}, cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, siteBPrefixes)
+
+	ipamer := cipam.NewWithStorage(ipamStorage)
+	ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+		ctx, ipBlockB.RoutingType, ipBlockB.InfrastructureProviderID.String(), ipBlockB.SiteID.String(),
+	))
+	assert.Nil(t, ipamer.PrefixFrom(ctx, "10.20.1.0/24"))
 }

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
@@ -4,10 +4,13 @@
 package vpcprefix
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
+	"net/netip"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +23,7 @@ import (
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun/extra/bundebug"
@@ -622,6 +626,19 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB(t *testing.T) {
 
 		})
 	}
+
+	regressionTests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{
+			name: "auto creates, replays, and restores VPC Prefixes",
+			run:  testManageVpcPrefixUpdateVpcPrefixesInDBAutoCreatesAndRestores,
+		},
+	}
+	for _, test := range regressionTests {
+		t.Run(test.name, test.run)
+	}
 }
 
 func TestNewManageVpcPrefix(t *testing.T) {
@@ -669,7 +686,7 @@ func TestNewManageVpcPrefix(t *testing.T) {
 	}
 }
 
-func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing.T) {
+func testManageVpcPrefixUpdateVpcPrefixesInDBAutoCreatesAndRestores(t *testing.T) {
 	ctx := context.Background()
 	dbSession := testVpcPrefixInitDB(t)
 	defer dbSession.Close()
@@ -703,7 +720,7 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(dbSession)
 	statusDetailDAO := cdbm.NewStatusDetailDAO(dbSession)
 
-	controllerVpcPrefixID := uuid.New()
+	controllerVpcPrefixID := uuid.MustParse("abcdef01-2345-4678-9abc-def012345678")
 	controllerVpcPrefix := &corev1.VpcPrefix{
 		Id:    &corev1.VpcPrefixId{Value: controllerVpcPrefixID.String()},
 		VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
@@ -722,8 +739,16 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 	}
 
 	if !t.Run("auto creates VPC Prefix from inventory", func(t *testing.T) {
+		var logOutput bytes.Buffer
+		originalLogger := log.Logger
+		log.Logger = zerolog.New(&logOutput)
+		defer func() {
+			log.Logger = originalLogger
+		}()
+
 		err := manager.UpdateVpcPrefixesInDB(ctx, site.ID, inventory)
 		require.NoError(t, err)
+		assert.Contains(t, logOutput.String(), "created or undeleted VPC Prefix from Site inventory")
 
 		created, err := vpcPrefixDAO.GetByID(ctx, nil, controllerVpcPrefixID, nil)
 		require.NoError(t, err)
@@ -732,7 +757,7 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 		assert.Equal(t, tenant.ID, created.TenantID)
 		assert.Equal(t, tenantOrg, created.Org)
 		assert.Equal(t, site.ID, created.SiteID)
-		assert.Equal(t, site.ID, created.CreatedBy)
+		assert.Equal(t, site.CreatedBy, created.CreatedBy)
 		assert.Equal(t, cdbm.VpcPrefixStatusReady, created.Status)
 		assert.Equal(t, "site-created-vpc-prefix", created.Name)
 		assert.Equal(t, "10.20.30.0/24", created.Prefix)
@@ -783,6 +808,37 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 	}) {
 		t.FailNow()
 	}
+
+	t.Run("uppercase inventory ID matches the active VPC Prefix without recovery logging", func(t *testing.T) {
+		canonicalID := controllerVpcPrefix.Id.Value
+		controllerVpcPrefix.Id.Value = strings.ToUpper(canonicalID)
+		require.NotEqual(t, canonicalID, controllerVpcPrefix.Id.Value)
+		defer func() {
+			controllerVpcPrefix.Id.Value = canonicalID
+		}()
+
+		var logOutput bytes.Buffer
+		originalLogger := log.Logger
+		log.Logger = zerolog.New(&logOutput)
+		defer func() {
+			log.Logger = originalLogger
+		}()
+
+		err := manager.UpdateVpcPrefixesInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+
+		prefixes, count, err := vpcPrefixDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcPrefixFilterInput{VpcPrefixIDs: []uuid.UUID{controllerVpcPrefixID}},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, prefixes, 1)
+		assert.Equal(t, 1, count)
+		assert.NotContains(t, logOutput.String(), "created or undeleted VPC Prefix from Site inventory")
+	})
 
 	t.Run("inventory skips restore when Site reports TERMINATING", func(t *testing.T) {
 		_, err := vpcPrefixDAO.Update(ctx, nil, cdbm.VpcPrefixUpdateInput{
@@ -854,6 +910,13 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 	})
 
 	t.Run("inventory restores soft-deleted VPC Prefix", func(t *testing.T) {
+		var logOutput bytes.Buffer
+		originalLogger := log.Logger
+		log.Logger = zerolog.New(&logOutput)
+		defer func() {
+			log.Logger = originalLogger
+		}()
+
 		// Depends on the preceding TERMINATING subtest leaving the row soft-deleted with
 		// Status=Deleting. Do not soft-delete here — that would hide failures in the prior case.
 		existing, _, err := vpcPrefixDAO.GetAll(
@@ -882,6 +945,7 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 
 		err = manager.UpdateVpcPrefixesInDB(ctx, site.ID, inventory)
 		require.NoError(t, err)
+		assert.Contains(t, logOutput.String(), "created or undeleted VPC Prefix from Site inventory")
 
 		restored, err := vpcPrefixDAO.GetByID(ctx, nil, controllerVpcPrefixID, nil)
 		require.NoError(t, err)
@@ -957,7 +1021,66 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB_AutoCreatesAndRestores(t *testing
 	})
 }
 
-func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsIncompleteOwnership(t *testing.T) {
+func TestIpBlockContainsPrefix(t *testing.T) {
+	tests := []struct {
+		name            string
+		ipBlockPrefix   string
+		ipBlockLength   int
+		reportedPrefix  string
+		expectedContain bool
+	}{
+		{
+			name:            "contains a narrower IPv4 prefix",
+			ipBlockPrefix:   "10.20.0.0",
+			ipBlockLength:   16,
+			reportedPrefix:  "10.20.30.0/24",
+			expectedContain: true,
+		},
+		{
+			name:            "rejects an IPv4 prefix outside the block",
+			ipBlockPrefix:   "10.20.0.0",
+			ipBlockLength:   16,
+			reportedPrefix:  "10.21.30.0/24",
+			expectedContain: false,
+		},
+		{
+			name:            "rejects a reported prefix wider than the block",
+			ipBlockPrefix:   "10.20.16.0",
+			ipBlockLength:   20,
+			reportedPrefix:  "10.20.0.0/16",
+			expectedContain: false,
+		},
+		{
+			name:            "rejects a different address family",
+			ipBlockPrefix:   "10.20.0.0",
+			ipBlockLength:   16,
+			reportedPrefix:  "2001:db8::/64",
+			expectedContain: false,
+		},
+		{
+			name:            "rejects an invalid IP Block prefix",
+			ipBlockPrefix:   "not-an-address",
+			ipBlockLength:   16,
+			reportedPrefix:  "10.20.30.0/24",
+			expectedContain: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reportedPrefix, err := netip.ParsePrefix(test.reportedPrefix)
+			require.NoError(t, err)
+
+			ipBlock := &cdbm.IPBlock{
+				Prefix:       test.ipBlockPrefix,
+				PrefixLength: test.ipBlockLength,
+			}
+			assert.Equal(t, test.expectedContain, ipBlockContainsPrefix(context.Background(), ipBlock, reportedPrefix))
+		})
+	}
+}
+
+func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite(t *testing.T) {
 	ctx := context.Background()
 	dbSession := testVpcPrefixInitDB(t)
 	defer dbSession.Close()
@@ -1137,9 +1260,143 @@ func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsIncompleteOwnershi
 			}
 		})
 	}
+
+	storedIPBlockTests := []struct {
+		name                    string
+		storedIPBlockStatus     string
+		createMoreSpecificBlock bool
+	}{
+		{
+			name:                    "undelete ignores a newer more-specific IP Block",
+			storedIPBlockStatus:     cdbm.IPBlockStatusReady,
+			createMoreSpecificBlock: true,
+		},
+		{
+			name:                "undelete uses a stored IP Block that is not Ready",
+			storedIPBlockStatus: cdbm.IPBlockStatusError,
+		},
+	}
+
+	for _, test := range storedIPBlockTests {
+		t.Run(test.name, func(t *testing.T) {
+			testCtx := context.Background()
+			testDBSession := testVpcPrefixInitDB(t)
+			defer testDBSession.Close()
+			testVPCPrefixSetupSchema(t, testDBSession)
+
+			testProviderOrg := "test-provider-org"
+			testProviderUser := testVPCBuildUser(t, testDBSession, uuid.NewString(), testProviderOrg, []string{"FORGE_PROVIDER_ADMIN"})
+			testProvider := testVPCSiteBuildInfrastructureProvider(t, testDBSession, "test-provider", testProviderOrg, testProviderUser)
+			testTenantOrg := "test-tenant-org"
+			testTenantUser := testVPCBuildUser(t, testDBSession, uuid.NewString(), testTenantOrg, []string{"FORGE_TENANT_ADMIN"})
+			testTenant := testVPCBuildTenant(t, testDBSession, "test-tenant", testTenantOrg, testTenantUser)
+			testSite := testVPCBuildSite(t, testDBSession, testProvider, "test-site", testProviderUser)
+			testParentVpc := testVPCBuildVPC(
+				t, testDBSession, "parent-vpc", testProvider, testTenant, testSite, nil, nil, testTenantUser, cdbm.VpcStatusReady,
+			)
+			storedIPBlock := testVPCPrefixBuildIPBlock(
+				t, testDBSession, "stored-ip-block", testSite, testProvider, &testTenant.ID,
+				cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+				cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, testTenantUser,
+			)
+
+			testIPAMStorage := ipam.NewIpamStorage(testDBSession.DB, nil)
+			_, err := ipam.CreateIpamEntryForIPBlock(
+				testCtx, testIPAMStorage, storedIPBlock.Prefix, storedIPBlock.PrefixLength,
+				storedIPBlock.RoutingType, storedIPBlock.InfrastructureProviderID.String(),
+				storedIPBlock.SiteID.String(),
+			)
+			require.NoError(t, err)
+
+			controllerVpcPrefixID := uuid.New()
+			testVpcPrefixDAO := cdbm.NewVpcPrefixDAO(testDBSession)
+			_, err = testVpcPrefixDAO.Create(testCtx, nil, cdbm.VpcPrefixCreateInput{
+				VpcPrefixID:  &controllerVpcPrefixID,
+				Name:         "stored-ip-block-prefix",
+				TenantOrg:    testTenant.Org,
+				SiteID:       testSite.ID,
+				VpcID:        testParentVpc.ID,
+				TenantID:     testTenant.ID,
+				IpBlockID:    &storedIPBlock.ID,
+				Prefix:       "10.20.30.0/24",
+				PrefixLength: 24,
+				Status:       cdbm.VpcPrefixStatusDeleting,
+				CreatedBy:    testTenantUser.ID,
+			})
+			require.NoError(t, err)
+			err = testVpcPrefixDAO.Delete(testCtx, nil, controllerVpcPrefixID)
+			require.NoError(t, err)
+
+			if test.storedIPBlockStatus != cdbm.IPBlockStatusReady {
+				_, err = cdbm.NewIPBlockDAO(testDBSession).Update(testCtx, nil, cdbm.IPBlockUpdateInput{
+					IPBlockID: storedIPBlock.ID,
+					Status:    &test.storedIPBlockStatus,
+				})
+				require.NoError(t, err)
+			}
+			if test.createMoreSpecificBlock {
+				testVPCPrefixBuildIPBlock(
+					t, testDBSession, "more-specific-ip-block", testSite, testProvider, &testTenant.ID,
+					cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.16.0", 20,
+					cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, testTenantUser,
+				)
+			}
+
+			controllerVpcPrefix := &corev1.VpcPrefix{
+				Id:    &corev1.VpcPrefixId{Value: controllerVpcPrefixID.String()},
+				VpcId: &corev1.VpcId{Value: testParentVpc.ID.String()},
+				Config: &corev1.VpcPrefixConfig{
+					Prefix: "10.20.30.0/24",
+				},
+				Metadata: &corev1.Metadata{Name: "stored-ip-block-prefix"},
+				Status: &corev1.VpcPrefixStatus{
+					TenantState: corev1.TenantState_READY,
+				},
+			}
+
+			testManager := ManageVpcPrefix{dbSession: testDBSession}
+			restored := testManager.createOrUpdateVpcPrefixFromSite(testCtx, testSite, controllerVpcPrefix)
+			require.NotNil(t, restored)
+			require.NotNil(t, restored.IPBlockID)
+			assert.Equal(t, storedIPBlock.ID, *restored.IPBlockID)
+
+			testIPAMer := cipam.NewWithStorage(testIPAMStorage)
+			testIPAMer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+				testCtx, storedIPBlock.RoutingType, storedIPBlock.InfrastructureProviderID.String(),
+				storedIPBlock.SiteID.String(),
+			))
+			assert.NotNil(t, testIPAMer.PrefixFrom(testCtx, controllerVpcPrefix.Config.Prefix))
+		})
+	}
+
+	regressionTests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{
+			name: "rejects host bits in an equal-length CIDR",
+			run:  testCreateOrUpdateVpcPrefixRejectsHostBitsEqualLengthCIDR,
+		},
+		{
+			name: "skips a fully granted IP Block",
+			run:  testCreateOrUpdateVpcPrefixSkipsFullGrantIPBlock,
+		},
+		{
+			name: "skips undelete when the stored Prefix differs",
+			run:  testCreateOrUpdateVpcPrefixSkipsRestoreWhenPrefixDiffers,
+		},
+		{
+			name: "skips a controller ID owned by another Site",
+			run:  testCreateOrUpdateVpcPrefixSkipsIDOwnedByDifferentSite,
+		},
+	}
+
+	for _, test := range regressionTests {
+		t.Run(test.name, test.run)
+	}
 }
 
-func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_RejectsHostBitsEqualLengthCIDR(t *testing.T) {
+func testCreateOrUpdateVpcPrefixRejectsHostBitsEqualLengthCIDR(t *testing.T) {
 	// Regression: a non-canonical equal-length CIDR (host bits set) must not leave the
 	// parent IPBlock with FullGrant=true after a soft-skip commits the transaction.
 	ctx := context.Background()
@@ -1204,7 +1461,7 @@ func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_RejectsHostBitsEqualLen
 	assert.True(t, reloadedIPBlock.FullGrant)
 }
 
-func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsFullGrantIPBlock(t *testing.T) {
+func testCreateOrUpdateVpcPrefixSkipsFullGrantIPBlock(t *testing.T) {
 	// Regression: FullGrant lives only in the REST DB, so the ipam library reports a fully
 	// granted IPBlock as empty. Recovery must not carve a child CIDR out of it.
 	ctx := context.Background()
@@ -1273,7 +1530,7 @@ func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsFullGrantIPBlock(t
 	assert.True(t, reloadedIPBlock.FullGrant)
 }
 
-func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsRestoreWhenPrefixDiffers(t *testing.T) {
+func testCreateOrUpdateVpcPrefixSkipsRestoreWhenPrefixDiffers(t *testing.T) {
 	// Soft-deleted row stores 10.20.30.0/24; Site reports the same controller UUID with a
 	// different CIDR in the same IPBlock. Undelete must not acquire the reported CIDR.
 	ctx := context.Background()
@@ -1319,7 +1576,7 @@ func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsRestoreWhenPrefixD
 		Prefix:       storedCIDR,
 		PrefixLength: 24,
 		Status:       cdbm.VpcPrefixStatusDeleting,
-		CreatedBy:    site.ID,
+		CreatedBy:    tenantUser.ID,
 	})
 	require.NoError(t, err)
 	require.NoError(t, vpcPrefixDAO.Delete(ctx, nil, vpcPrefixID))
@@ -1372,53 +1629,114 @@ func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsRestoreWhenPrefixD
 	assert.Nil(t, ipamer.PrefixFrom(ctx, storedCIDR))
 }
 
-func TestManageVpcPrefix_DeleteVpcPrefixFromDB_ErrorsWhenIPBlockRelationMissing(t *testing.T) {
-	// IPBlockID set but IPBlock relation nil must abort delete — silent skip would leak the CIDR.
-	ctx := context.Background()
-	dbSession := testVpcPrefixInitDB(t)
-	defer dbSession.Close()
-	testVPCPrefixSetupSchema(t, dbSession)
+func TestManageVpcPrefix_DeleteVpcPrefixFromDB(t *testing.T) {
+	tests := []struct {
+		name                string
+		softDeleteIPBlock   bool
+		fullGrant           bool
+		allocateChildPrefix bool
+	}{
+		{
+			name:                "reloads an active IP Block when the relation is absent",
+			allocateChildPrefix: true,
+		},
+		{
+			name:                "releases the CIDR through a soft-deleted IP Block",
+			softDeleteIPBlock:   true,
+			allocateChildPrefix: true,
+		},
+		{
+			name:              "accepts an already absent CIDR through a soft-deleted IP Block",
+			softDeleteIPBlock: true,
+		},
+		{
+			name:              "deletes through a fully granted soft-deleted IP Block",
+			softDeleteIPBlock: true,
+			fullGrant:         true,
+		},
+	}
 
-	providerOrg := "test-provider-org"
-	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
-	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
-	tenantOrg := "test-tenant-org"
-	tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
-	tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
-	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			dbSession := testVpcPrefixInitDB(t)
+			defer dbSession.Close()
+			testVPCPrefixSetupSchema(t, dbSession)
 
-	parentVpc := testVPCBuildVPC(
-		t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser, cdbm.VpcStatusReady,
-	)
-	ipBlock := testVPCPrefixBuildIPBlock(
-		t, dbSession, "test-missing-relation-ip-block", site, provider, &tenant.ID,
-		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
-		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
-	)
-	prefix := "10.20.30.0/24"
-	prefixLength := 24
-	vpcPrefix := testVPCBuildVPCPrefix(
-		t, dbSession, "missing-relation-vpc-prefix", site, tenant, parentVpc.ID, &ipBlock.ID,
-		&prefix, &prefixLength, cdbm.VpcPrefixStatusDeleting, tenantUser,
-	)
-	// Simulate a caller that omitted IPBlockRelationName (or a soft-deleted parent block).
-	vpcPrefix.IPBlock = nil
-	require.NotNil(t, vpcPrefix.IPBlockID)
+			providerOrg := "test-provider-org"
+			providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+			provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+			tenantOrg := "test-tenant-org"
+			tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+			tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+			site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+			parentVpc := testVPCBuildVPC(
+				t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser, cdbm.VpcStatusReady,
+			)
+			ipBlock := testVPCPrefixBuildIPBlock(
+				t, dbSession, "delete-ip-block", site, provider, &tenant.ID,
+				cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+				cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+			)
 
-	manager := ManageVpcPrefix{dbSession: dbSession}
-	tx, err := cdb.BeginTx(ctx, dbSession, &sql.TxOptions{})
-	require.NoError(t, err)
-	err = manager.deleteVpcPrefixFromDB(ctx, tx, vpcPrefix, zerolog.Nop())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "IP Block relation is missing")
-	require.NoError(t, tx.Rollback())
+			ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+			_, err := ipam.CreateIpamEntryForIPBlock(
+				ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+				ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+			)
+			require.NoError(t, err)
 
-	stillActive, err := cdbm.NewVpcPrefixDAO(dbSession).GetByID(ctx, nil, vpcPrefix.ID, nil)
-	require.NoError(t, err)
-	assert.Nil(t, stillActive.Deleted)
+			prefix := "10.20.30.0/24"
+			prefixLength := 24
+			if test.fullGrant {
+				prefix = "10.20.0.0/16"
+				prefixLength = 16
+				_, err = ipam.CreateChildIpamEntryForIPBlock(
+					ctx, nil, dbSession, ipamStorage, ipBlock, ipBlock.PrefixLength,
+				)
+				require.NoError(t, err)
+			} else if test.allocateChildPrefix {
+				_, err = ipam.AcquireSpecificChildIpamEntryForIPBlock(
+					ctx, nil, dbSession, ipamStorage, ipBlock, prefix,
+				)
+				require.NoError(t, err)
+			}
+
+			vpcPrefix := testVPCBuildVPCPrefix(
+				t, dbSession, "delete-vpc-prefix", site, tenant, parentVpc.ID, &ipBlock.ID,
+				&prefix, &prefixLength, cdbm.VpcPrefixStatusDeleting, tenantUser,
+			)
+			vpcPrefix.IPBlock = nil
+			require.NotNil(t, vpcPrefix.IPBlockID)
+
+			if test.softDeleteIPBlock {
+				err = cdbm.NewIPBlockDAO(dbSession).Delete(ctx, nil, ipBlock.ID)
+				require.NoError(t, err)
+			}
+
+			manager := ManageVpcPrefix{dbSession: dbSession}
+			tx, err := cdb.BeginTx(ctx, dbSession, &sql.TxOptions{})
+			require.NoError(t, err)
+			err = manager.deleteVpcPrefixFromDB(ctx, tx, vpcPrefix, zerolog.Nop())
+			require.NoError(t, err)
+			err = tx.Commit()
+			require.NoError(t, err)
+
+			_, err = cdbm.NewVpcPrefixDAO(dbSession).GetByID(ctx, nil, vpcPrefix.ID, nil)
+			assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+			if !test.fullGrant {
+				ipamer := cipam.NewWithStorage(ipamStorage)
+				ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+					ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+				))
+				assert.Nil(t, ipamer.PrefixFrom(ctx, prefix))
+			}
+		})
+	}
 }
 
-func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite_SkipsWhenIDExistsUnderDifferentSite(t *testing.T) {
+func testCreateOrUpdateVpcPrefixSkipsIDOwnedByDifferentSite(t *testing.T) {
 	// Same controller UUID under another site must skip cleanly — not unique-constraint-fail every cycle.
 	ctx := context.Background()
 	dbSession := testVpcPrefixInitDB(t)

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/netip"
 	"reflect"
 	"strings"
 	"testing"
@@ -92,6 +91,10 @@ func testVPCPrefixSetupSchema(t *testing.T, dbSession *cdb.Session) {
 	// create VPCPrefix table
 	err = dbSession.DB.ResetModel(context.Background(), (*cdbm.VpcPrefix)(nil))
 	assert.Nil(t, err)
+	// ensure the shared IPAM schema exists even when another package reset the test DB
+	ipamDB := cipam.NewBunStorage(dbSession.DB, nil)
+	err = ipamDB.ApplyDbSchema()
+	require.NoError(t, err)
 }
 
 // testVPCSiteBuildInfrastructureProvider Building Infra Provider in DB
@@ -809,7 +812,7 @@ func testManageVpcPrefixUpdateVpcPrefixesInDBAutoCreatesAndRestores(t *testing.T
 		t.FailNow()
 	}
 
-	t.Run("uppercase inventory ID matches the active VPC Prefix without recovery logging", func(t *testing.T) {
+	t.Run("uppercase inventory ID follows the recovery path", func(t *testing.T) {
 		canonicalID := controllerVpcPrefix.Id.Value
 		controllerVpcPrefix.Id.Value = strings.ToUpper(canonicalID)
 		require.NotEqual(t, canonicalID, controllerVpcPrefix.Id.Value)
@@ -837,7 +840,7 @@ func testManageVpcPrefixUpdateVpcPrefixesInDBAutoCreatesAndRestores(t *testing.T
 		require.NoError(t, err)
 		require.Len(t, prefixes, 1)
 		assert.Equal(t, 1, count)
-		assert.NotContains(t, logOutput.String(), "created or undeleted VPC Prefix from Site inventory")
+		assert.Contains(t, logOutput.String(), "created or undeleted VPC Prefix from Site inventory")
 	})
 
 	t.Run("inventory skips restore when Site reports TERMINATING", func(t *testing.T) {
@@ -1019,65 +1022,6 @@ func testManageVpcPrefixUpdateVpcPrefixesInDBAutoCreatesAndRestores(t *testing.T
 		_, err = vpcPrefixDAO.GetByID(ctx, nil, controllerVpcPrefixID, nil)
 		assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
 	})
-}
-
-func TestIpBlockContainsPrefix(t *testing.T) {
-	tests := []struct {
-		name            string
-		ipBlockPrefix   string
-		ipBlockLength   int
-		reportedPrefix  string
-		expectedContain bool
-	}{
-		{
-			name:            "contains a narrower IPv4 prefix",
-			ipBlockPrefix:   "10.20.0.0",
-			ipBlockLength:   16,
-			reportedPrefix:  "10.20.30.0/24",
-			expectedContain: true,
-		},
-		{
-			name:            "rejects an IPv4 prefix outside the block",
-			ipBlockPrefix:   "10.20.0.0",
-			ipBlockLength:   16,
-			reportedPrefix:  "10.21.30.0/24",
-			expectedContain: false,
-		},
-		{
-			name:            "rejects a reported prefix wider than the block",
-			ipBlockPrefix:   "10.20.16.0",
-			ipBlockLength:   20,
-			reportedPrefix:  "10.20.0.0/16",
-			expectedContain: false,
-		},
-		{
-			name:            "rejects a different address family",
-			ipBlockPrefix:   "10.20.0.0",
-			ipBlockLength:   16,
-			reportedPrefix:  "2001:db8::/64",
-			expectedContain: false,
-		},
-		{
-			name:            "rejects an invalid IP Block prefix",
-			ipBlockPrefix:   "not-an-address",
-			ipBlockLength:   16,
-			reportedPrefix:  "10.20.30.0/24",
-			expectedContain: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			reportedPrefix, err := netip.ParsePrefix(test.reportedPrefix)
-			require.NoError(t, err)
-
-			ipBlock := &cdbm.IPBlock{
-				Prefix:       test.ipBlockPrefix,
-				PrefixLength: test.ipBlockLength,
-			}
-			assert.Equal(t, test.expectedContain, ipBlockContainsPrefix(context.Background(), ipBlock, reportedPrefix))
-		})
-	}
 }
 
 func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite(t *testing.T) {
@@ -1265,14 +1209,16 @@ func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite(t *testing.T) {
 		name                    string
 		storedIPBlockStatus     string
 		createMoreSpecificBlock bool
+		expectedRestore         bool
 	}{
 		{
 			name:                    "undelete ignores a newer more-specific IP Block",
 			storedIPBlockStatus:     cdbm.IPBlockStatusReady,
 			createMoreSpecificBlock: true,
+			expectedRestore:         true,
 		},
 		{
-			name:                "undelete uses a stored IP Block that is not Ready",
+			name:                "undelete skips a stored IP Block that is not Ready",
 			storedIPBlockStatus: cdbm.IPBlockStatusError,
 		},
 	}
@@ -1356,6 +1302,23 @@ func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite(t *testing.T) {
 
 			testManager := ManageVpcPrefix{dbSession: testDBSession}
 			restored := testManager.createOrUpdateVpcPrefixFromSite(testCtx, testSite, controllerVpcPrefix)
+			if !test.expectedRestore {
+				assert.Nil(t, restored)
+				deleted, _, getErr := testVpcPrefixDAO.GetAll(
+					testCtx,
+					nil,
+					cdbm.VpcPrefixFilterInput{
+						VpcPrefixIDs:   []uuid.UUID{controllerVpcPrefixID},
+						IncludeDeleted: true,
+					},
+					cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+					nil,
+				)
+				require.NoError(t, getErr)
+				require.Len(t, deleted, 1)
+				assert.NotNil(t, deleted[0].Deleted)
+				return
+			}
 			require.NotNil(t, restored)
 			require.NotNil(t, restored.IPBlockID)
 			assert.Equal(t, storedIPBlock.ID, *restored.IPBlockID)
@@ -1631,28 +1594,17 @@ func testCreateOrUpdateVpcPrefixSkipsRestoreWhenPrefixDiffers(t *testing.T) {
 
 func TestManageVpcPrefix_DeleteVpcPrefixFromDB(t *testing.T) {
 	tests := []struct {
-		name                string
-		softDeleteIPBlock   bool
-		fullGrant           bool
-		allocateChildPrefix bool
+		name          string
+		clearRelation bool
+		expectedError bool
 	}{
 		{
-			name:                "reloads an active IP Block when the relation is absent",
-			allocateChildPrefix: true,
+			name: "deletes with a loaded IP Block relation",
 		},
 		{
-			name:                "releases the CIDR through a soft-deleted IP Block",
-			softDeleteIPBlock:   true,
-			allocateChildPrefix: true,
-		},
-		{
-			name:              "accepts an already absent CIDR through a soft-deleted IP Block",
-			softDeleteIPBlock: true,
-		},
-		{
-			name:              "deletes through a fully granted soft-deleted IP Block",
-			softDeleteIPBlock: true,
-			fullGrant:         true,
+			name:          "rejects a missing IP Block relation",
+			clearRelation: true,
+			expectedError: true,
 		},
 	}
 
@@ -1688,44 +1640,41 @@ func TestManageVpcPrefix_DeleteVpcPrefixFromDB(t *testing.T) {
 
 			prefix := "10.20.30.0/24"
 			prefixLength := 24
-			if test.fullGrant {
-				prefix = "10.20.0.0/16"
-				prefixLength = 16
-				_, err = ipam.CreateChildIpamEntryForIPBlock(
-					ctx, nil, dbSession, ipamStorage, ipBlock, ipBlock.PrefixLength,
-				)
-				require.NoError(t, err)
-			} else if test.allocateChildPrefix {
-				_, err = ipam.AcquireSpecificChildIpamEntryForIPBlock(
-					ctx, nil, dbSession, ipamStorage, ipBlock, prefix,
-				)
-				require.NoError(t, err)
-			}
+			_, err = ipam.AcquireSpecificChildIpamEntryForIPBlock(
+				ctx, nil, dbSession, ipamStorage, ipBlock, prefix,
+			)
+			require.NoError(t, err)
 
 			vpcPrefix := testVPCBuildVPCPrefix(
 				t, dbSession, "delete-vpc-prefix", site, tenant, parentVpc.ID, &ipBlock.ID,
 				&prefix, &prefixLength, cdbm.VpcPrefixStatusDeleting, tenantUser,
 			)
-			vpcPrefix.IPBlock = nil
+			vpcPrefix, err = cdbm.NewVpcPrefixDAO(dbSession).GetByID(
+				ctx, nil, vpcPrefix.ID, []string{cdbm.IPBlockRelationName},
+			)
+			require.NoError(t, err)
+			require.NotNil(t, vpcPrefix.IPBlock)
 			require.NotNil(t, vpcPrefix.IPBlockID)
 
-			if test.softDeleteIPBlock {
-				err = cdbm.NewIPBlockDAO(dbSession).Delete(ctx, nil, ipBlock.ID)
-				require.NoError(t, err)
+			if test.clearRelation {
+				vpcPrefix.IPBlock = nil
 			}
 
 			manager := ManageVpcPrefix{dbSession: dbSession}
 			tx, err := cdb.BeginTx(ctx, dbSession, &sql.TxOptions{})
 			require.NoError(t, err)
 			err = manager.deleteVpcPrefixFromDB(ctx, tx, vpcPrefix, zerolog.Nop())
-			require.NoError(t, err)
-			err = tx.Commit()
-			require.NoError(t, err)
+			assert.Equal(t, test.expectedError, err != nil)
+			if test.expectedError {
+				require.NoError(t, tx.Rollback())
+				stillActive, getErr := cdbm.NewVpcPrefixDAO(dbSession).GetByID(ctx, nil, vpcPrefix.ID, nil)
+				require.NoError(t, getErr)
+				assert.Nil(t, stillActive.Deleted)
+			} else {
+				require.NoError(t, tx.Commit())
+				_, getErr := cdbm.NewVpcPrefixDAO(dbSession).GetByID(ctx, nil, vpcPrefix.ID, nil)
+				assert.ErrorIs(t, getErr, cdb.ErrDoesNotExist)
 
-			_, err = cdbm.NewVpcPrefixDAO(dbSession).GetByID(ctx, nil, vpcPrefix.ID, nil)
-			assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
-
-			if !test.fullGrant {
 				ipamer := cipam.NewWithStorage(ipamStorage)
 				ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
 					ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),


### PR DESCRIPTION
## Description
Site inventory previously skipped VPC Prefixes that existed on Site but had no active REST database record, leaving Site and REST state inconsistent. This PR reconciles those VPC Prefixes using their controller ID

Soft-deleted VPC Prefixes are restored when reported by a newer inventory snapshot, while true orphans are auto-created after validating parent VPC ownership, a containing Ready tenant IPBlock, IPAM claim of the Site-reported CIDR, and name conflicts. Recovery writes are transactional and retry-safe.

Key behaviors:
- Resolve the most specific Ready tenant IPBlock that contains the reported prefix (skip FullGrant blocks).
- Claim the Site-reported CIDR via IPAM under the same tenant/IPBlock advisory lock as the REST create path.
- Skip create/undelete when Site reports TERMINATING/TERMINATED so stale inventory cannot resurrect a user delete.
- On undelete, clear soft-delete and refresh Status from Site inventory in the same transaction.
- Reject non-canonical (host-bits) CIDRs and Prefix/VpcID/IPBlock drift before mutating IPAM.

## Related issues
This PR is part of the issue (https://github.com/NVIDIA/infra-controller/issues/3436)

## Type of Change
- [x] **Add** - New feature or capability

## Testing
- [x] Unit tests added/updated

Tests executed:
go test ./workflow/pkg/activity/vpcprefix/ -count=1
go test ./db/pkg/db/model/ -run VpcPrefix -count=1

## Additional Notes
- VPC Prefix identity matching uses controller IDs, not names.
- Empty inventory names become recovered-<8hex>; name conflicts append -recovered-<8hex>.
- Adds VpcPrefixDAO.Clear / IncludeDeleted and AcquireSpecificChildIpamEntryForIPBlock for FullGrant-safe IPAM claims.
- No database schema migration is required.