### PR TITLE
chore: Select DPF deployment type of Bf4Generic or Bf4Astra based on …

### DIFF
--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -47,7 +47,7 @@ fn default_mock(deployment_type: DpuDeploymentType) -> MockDpfOperations {
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
     mock.expect_deployment_type_for_dpu()
-        .returning(move |_| Ok(deployment_type));
+        .returning(move |__, _| Ok(deployment_type));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock
 }

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -80,7 +80,7 @@ fn provisioning_mock_with_dpu_count(
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| Ok(DpuDeploymentType::Bf3));
+        .returning(|_, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_snapshot_host()
         .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));
@@ -363,7 +363,7 @@ fn capturing_mock(
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| Ok(DpuDeploymentType::Bf3));
+        .returning(|__, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_snapshot_host()
         .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));

--- a/crates/api-core/src/tests/dpf/stale_labels.rs
+++ b/crates/api-core/src/tests/dpf/stale_labels.rs
@@ -49,7 +49,7 @@ fn provisioning_mock_with_labels_valid(labels_valid: Arc<AtomicBool>) -> MockDpf
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| Ok(DpuDeploymentType::Bf3));
+        .returning(|_, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels()
         .returning(move |_, _| Ok(labels_valid.load(Ordering::SeqCst)));
     mock

--- a/crates/api-core/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api-core/src/tests/dpf/waiting_for_ready.rs
@@ -59,7 +59,7 @@ fn expect_provisioning(mock: &mut MockDpfOperations) {
     mock.expect_register_dpu_device().returning(|_| Ok(()));
     mock.expect_register_dpu_node().returning(|_| Ok(()));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| Ok(DpuDeploymentType::Bf3));
+        .returning(move |__, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
 }
 
@@ -529,7 +529,7 @@ async fn test_waiting_for_ready_idempotent_reboot(pool: sqlx::PgPool) {
 async fn test_reboot_persists_on_intent_before_power_command(pool: sqlx::PgPool) {
     let mut mock = MockDpfOperations::new();
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| Ok(DpuDeploymentType::Bf3));
+        .returning(|_, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(mock);
     let env = create_test_env_with_overrides(

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -1100,7 +1100,7 @@ async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| Ok(DpuDeploymentType::Bf3));
+        .returning(|__, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(carbide_dpf::DpuPhase::Ready));

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -45,7 +45,7 @@ use super::instance::status::network::InstanceNetworkStatusObservation;
 use super::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
 use super::metadata::Metadata;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
-use crate::dpa_interface::DpaInterface;
+use crate::dpa_interface::{DpaInterface, DpaInterfaceType};
 use crate::errors::{ModelError, ModelResult};
 use crate::expected_machine::ExpectedMachineData;
 use crate::firmware::FirmwareComponentType;
@@ -437,6 +437,12 @@ impl ManagedHostStateSnapshot {
     /// different interface than `boot_interface_mac`.
     pub fn boot_interface(&self) -> Option<MachineBootInterface> {
         pick_boot_interface_pair(&self.host_snapshot.status.interfaces)
+    }
+
+    pub fn has_astra_nics(&self) -> bool {
+        self.dpa_interface_snapshots
+            .iter()
+            .any(|nic| matches!(nic.interface_type, DpaInterfaceType::Astra))
     }
 
     /// Returns `true` if override report is hw_health, `false` otherwise.

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -94,7 +94,11 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// Returns `Err` when the part number is absent or does not match any known
     /// generation, so unrecognized hardware never silently routes to a wrong
     /// deployment.
-    fn deployment_type_for_dpu(&self, dpu: &Machine) -> Result<DpuDeploymentType, DpfError>;
+    fn deployment_type_for_dpu(
+        &self,
+        dpu: &Machine,
+        astra_nics: bool,
+    ) -> Result<DpuDeploymentType, DpfError>;
 
     /// Check that a DPUNode's labels match the current expected labels.
     /// Returns `false` when the node exists but has stale labels.
@@ -540,7 +544,11 @@ impl DpfOperations for DpfSdkOps {
         self.sdk.reboot_complete(node_name).await
     }
 
-    fn deployment_type_for_dpu(&self, dpu: &Machine) -> Result<DpuDeploymentType, DpfError> {
+    fn deployment_type_for_dpu(
+        &self,
+        dpu: &Machine,
+        astra_nics: bool,
+    ) -> Result<DpuDeploymentType, DpfError> {
         let product_name = dpu
             .status
             .hardware_info
@@ -558,7 +566,11 @@ impl DpfOperations for DpfSdkOps {
 
         // Only a BF3 or BF4 DPU can reach here.
         let deployment_type = if is_bf4_dmi_product(product_name) {
-            DpuDeploymentType::Bf4Generic
+            if astra_nics {
+                DpuDeploymentType::Bf4Astra
+            } else {
+                DpuDeploymentType::Bf4Generic
+            }
         } else {
             DpuDeploymentType::Bf3
         };

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -190,6 +190,8 @@ async fn create_and_register_dpudevices_and_dpunode(
             missing: "primary_dpu",
         })?;
 
+    let astra_nics = state.has_astra_nics();
+
     for dpu in &state.dpu_snapshots {
         let serial_number = dpu
             .status
@@ -228,7 +230,7 @@ async fn create_and_register_dpudevices_and_dpunode(
             missing: "primary_dpu_snapshot",
         })?;
     let deployment_type = dpf_sdk
-        .deployment_type_for_dpu(primary_dpu)
+        .deployment_type_for_dpu(primary_dpu, astra_nics)
         .map_err(dpf_error)?;
 
     let device_ids: Vec<String> = state
@@ -596,8 +598,11 @@ pub(super) async fn handle_dpf_state(
     power_down_wait: chrono::Duration,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
+
+    let astra_nics = state.has_astra_nics();
+
     let deployment_type = dpf_sdk
-        .deployment_type_for_dpu(dpu_snapshot)
+        .deployment_type_for_dpu(dpu_snapshot, astra_nics)
         .map_err(dpf_error)?;
     if !dpf_sdk
         .verify_node_labels(&node_name, deployment_type)


### PR DESCRIPTION
…whether host machine has Astra NICs or not.

When determining DPF deployment type, if the host machine
has Astra NICs, choose Bf4Astra instead of Bf4Generic.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This is the same set of changes as https://github.com/NVIDIA/infra-controller/pull/4871 which was approved by Ashok and Ken. That PR got messed up after a rebase.

Closes https://github.com/NVIDIA/infra-controller/issues/5496
