### PR TITLE
fix(ci): limit Fern preview comment permissions

### DIFF
--- a/.github/ci/check-fern-docs-preview-comment-permissions.sh
+++ b/.github/ci/check-fern-docs-preview-comment-permissions.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-fern-docs-preview-comment-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/fern-docs-preview-comment.yml}"
+
+# The preview block replaces the workflow default, so it repeats Actions read
+# access alongside the pull request write used to publish the preview comment.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Preview Fern Docs: Comment" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "actions=read" \
+	--job-permissions "preview=actions=read,pull-requests=write"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: "Check Preview Fern Docs: Build token permissions"
         run: bash .github/ci/check-fern-docs-preview-build-permissions.sh
 
+      - name: "Check Preview Fern Docs: Comment token permissions"
+        run: bash .github/ci/check-fern-docs-preview-comment-permissions.sh
+
       - name: Check Publish Fern Docs token permissions
         run: bash .github/ci/check-publish-fern-docs-permissions.sh
 

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -31,7 +31,6 @@ on:
     types: [completed]
 
 permissions:
-  pull-requests: write
   actions: read
 
 jobs:
@@ -60,6 +59,9 @@ jobs:
     needs: artifact-present
     runs-on: ubuntu-latest
     if: needs.artifact-present.outputs.exists == 'true'
+    permissions:
+      actions: read
+      pull-requests: write
     steps:
       - name: Download fern sources and metadata
         uses: actions/download-artifact@v4


### PR DESCRIPTION
GitHub already applies this workflow's declared permissions at runtime, but both Fern preview-comment jobs currently receive `pull-requests: write`. Only `preview` posts or updates the pull request comment; `artifact-present` only checks the completed build for an artifact.

So, this keeps `actions: read` as the workflow default, gives only `preview` the complete `actions: read` and `pull-requests: write` contract, and records that exact split in our CI permission policy. Fern behavior stays the same, while a future permission change now has to be explicit and reviewed.

Primary callouts are:

- **Expected green-run effect:** Effectively none. Fern previews and comments should behave the same, and Core CI gains one small shell policy check in its existing gate job.
- **What it really buys us:** The artifact check cannot write to pull requests, and CI fails if either job's permission set broadens without an explicit policy update and review.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4917.

Part of #4572.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Passed locally:

- All 60 shared token-permission fixtures and the exact Fern preview-comment policy.
- Bash syntax and ShellCheck 0.11.0.
- Actionlint 1.7.12, excluding only the repository's known custom-runner-label diagnostic.
- Nightly formatting, full Clippy, custom Carbide lints, and `git diff --check`.
- Independent review found no actionable issue.

## Additional Notes

The `preview` job repeats `actions: read` because a job-level permission block replaces the workflow default; it does not extend it. The companion Fern build flow, `DOCS_FERN_TOKEN`, shared policy engine, and job layout are unchanged.
