### PR TITLE
docs: add SitePrefix admin CLI reference

### DIFF
--- a/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-create.md
+++ b/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-create.md
@@ -1,0 +1,71 @@
+# `nico-admin-cli site-prefix create`
+
+_[Network commands](../../network.md) › [site-prefix](./site-prefix.md) › **create**_
+
+## NAME
+
+nico-admin-cli-site-prefix-create - Create a tenant-managed,
+datacenter-only SitePrefix in Provisioning
+
+## SYNOPSIS
+
+**nico-admin-cli site-prefix create** \<**--tenant-organization-id**\>
+\<**--prefix**\> \<**--name**\> \[**--description**\] \[**--label**\]
+\[**--site-prefix-id**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Create a tenant-managed, datacenter-only SitePrefix in Provisioning
+
+## OPTIONS
+
+**--tenant-organization-id** *\<TENANT_ORGANIZATION_ID\>*  
+Tenant organization that will own the SitePrefix
+
+**--prefix** *\<CIDR\>*  
+Canonical RFC1918 IPv4 prefix with a length from /8 through /31
+
+**--name** *\<NAME\>*  
+SitePrefix name
+
+**--description** *\<DESCRIPTION\>*  
+SitePrefix description
+
+**--label** *\<KEY\[:VALUE\]\>*  
+Metadata label; repeat this option to add more than one
+
+**--site-prefix-id** *\<SITE_PREFIX_ID\>*  
+Use this SitePrefix ID instead of generating one locally
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> -   primary-id: Sort by the primary id
+>
+> -   state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli site-prefix create --tenant-organization-id fds34511233a --prefix 10.0.0.0/16 --name tenant-private-space
+nico-admin-cli site-prefix create --tenant-organization-id fds34511233a --prefix 192.168.0.0/20 --name lab-space --description "Private lab address space" --label environment:lab --label team:networking
+nico-admin-cli site-prefix create --tenant-organization-id fds34511233a --site-prefix-id 12345678-1234-5678-90ab-cdef01234567 --prefix 172.16.0.0/16 --name tenant-private-space
+```
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-delete.md
+++ b/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-delete.md
@@ -1,0 +1,60 @@
+# `nico-admin-cli site-prefix delete`
+
+_[Network commands](../../network.md) › [site-prefix](./site-prefix.md) › **delete**_
+
+## NAME
+
+nico-admin-cli-site-prefix-delete - Record retirement intent and return
+the retained Deleting SitePrefix
+
+## SYNOPSIS
+
+**nico-admin-cli site-prefix delete** \<**--tenant-organization-id**\>
+\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+\<*SITE_PREFIX_ID*\>
+
+## DESCRIPTION
+
+Record retirement intent and return the retained Deleting SitePrefix
+
+This is not a force-delete path. The CIDR and quota slot remain in use
+until child resources and the dataplane have drained.
+
+## OPTIONS
+
+**--tenant-organization-id** *\<TENANT_ORGANIZATION_ID\>*  
+Owning tenant organization; Core rejects a different tenant
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> -   primary-id: Sort by the primary id
+>
+> -   state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*SITE_PREFIX_ID*\>  
+SitePrefix to move into the Deleting state
+
+## Examples
+
+```sh
+nico-admin-cli site-prefix delete 12345678-1234-5678-90ab-cdef01234567 --tenant-organization-id fds34511233a
+nico-admin-cli site-prefix retire 12345678-1234-5678-90ab-cdef01234567 --tenant-organization-id fds34511233a
+```
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-show.md
+++ b/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-show.md
@@ -1,0 +1,103 @@
+# `nico-admin-cli site-prefix show`
+
+_[Network commands](../../network.md) › [site-prefix](./site-prefix.md) › **show**_
+
+## NAME
+
+nico-admin-cli-site-prefix-show - List SitePrefixes or show one by ID
+
+## SYNOPSIS
+
+**nico-admin-cli site-prefix show** \[**--tenant-organization-id**\]
+\[**--authority**\] \[**--routing-scope**\] \[**--lifecycle-state**\]
+\[**--prefix**\] \[**--contains**\] \[**--contained-by**\]
+\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+\[*SITE_PREFIX_ID*\]
+
+## DESCRIPTION
+
+List SitePrefixes or show one by ID
+
+## OPTIONS
+
+**--tenant-organization-id** *\<TENANT_ORGANIZATION_ID\>*  
+Return tenant-managed SitePrefixes owned by this tenant
+
+**--authority** *\<AUTHORITY\>*  
+Filter by management authority  
+
+  
+*Possible values:*
+
+> -   operator-managed
+>
+> -   tenant-managed
+
+**--routing-scope** *\<ROUTING_SCOPE\>*  
+Filter by routing scope  
+
+  
+*Possible values:*
+
+> -   datacenter-only
+
+**--lifecycle-state** *\<LIFECYCLE_STATE\>*  
+Filter by lifecycle state  
+
+  
+*Possible values:*
+
+> -   provisioning
+>
+> -   ready
+>
+> -   deleting
+>
+> -   error
+
+**--prefix** *\<CIDR\>*  
+Return every SitePrefix with this exact CIDR
+
+**--contains** *\<CIDR\>*  
+Return SitePrefixes that contain this prefix
+
+**--contained-by** *\<CIDR\>*  
+Return SitePrefixes contained by this prefix
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> -   primary-id: Sort by the primary id
+>
+> -   state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\[*SITE_PREFIX_ID*\]  
+SitePrefix ID to show; omit to search inventory
+
+## Examples
+
+```sh
+nico-admin-cli site-prefix show
+nico-admin-cli site-prefix show 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli site-prefix show --tenant-organization-id fds34511233a --authority tenant-managed
+nico-admin-cli site-prefix show --prefix 10.0.0.0/16
+nico-admin-cli site-prefix show --prefix 10.0.0.0/16 --tenant-organization-id fds34511233a
+nico-admin-cli site-prefix show --contains 10.0.8.0/24 --lifecycle-state ready
+```
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-state-history.md
+++ b/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-state-history.md
@@ -1,0 +1,53 @@
+# `nico-admin-cli site-prefix state-history`
+
+_[Network commands](../../network.md) › [site-prefix](./site-prefix.md) › **state-history**_
+
+## NAME
+
+nico-admin-cli-site-prefix-state-history - Show all lifecycle state
+history for a SitePrefix, or an empty collection
+
+## SYNOPSIS
+
+**nico-admin-cli site-prefix state-history** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*SITE_PREFIX_ID*\>
+
+## DESCRIPTION
+
+Show all lifecycle state history for a SitePrefix, or an empty
+collection
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> -   primary-id: Sort by the primary id
+>
+> -   state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*SITE_PREFIX_ID*\>  
+SitePrefix history to show
+
+## Examples
+
+```sh
+nico-admin-cli site-prefix state-history 12345678-1234-5678-90ab-cdef01234567
+```
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-update.md
+++ b/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix-update.md
@@ -1,0 +1,74 @@
+# `nico-admin-cli site-prefix update`
+
+_[Network commands](../../network.md) › [site-prefix](./site-prefix.md) › **update**_
+
+## NAME
+
+nico-admin-cli-site-prefix-update - Replace the complete metadata
+document on a tenant-managed SitePrefix
+
+## SYNOPSIS
+
+**nico-admin-cli site-prefix update** \<**--tenant-organization-id**\>
+\<**--name**\> \[**--description**\] \[**--label**\]
+\[**--if-version-match**\] \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\] \<*SITE_PREFIX_ID*\>
+
+## DESCRIPTION
+
+Replace the complete metadata document on a tenant-managed SitePrefix
+
+Tenant ownership, CIDR, authority, and routing scope are immutable.
+
+## OPTIONS
+
+**--tenant-organization-id** *\<TENANT_ORGANIZATION_ID\>*  
+Owning tenant organization; Core rejects a different tenant
+
+**--name** *\<NAME\>*  
+Replacement SitePrefix name
+
+**--description** *\<DESCRIPTION\>*  
+Replacement description; omit this option to clear the description
+
+**--label** *\<KEY\[:VALUE\]\>*  
+Replacement metadata label; repeat for more than one and omit all labels
+to clear them
+
+**--if-version-match** *\<VERSION\>*  
+Update only when the stored SitePrefix has this
+V\<number\>-T\<Unix-epoch-microseconds\> version
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> -   primary-id: Sort by the primary id
+>
+> -   state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*SITE_PREFIX_ID*\>  
+SitePrefix to update
+
+## Examples
+
+```sh
+nico-admin-cli site-prefix update 12345678-1234-5678-90ab-cdef01234567 --tenant-organization-id fds34511233a --name production-space --description "Production private address space" --label environment:production
+nico-admin-cli site-prefix update 12345678-1234-5678-90ab-cdef01234567 --tenant-organization-id fds34511233a --name production-space --if-version-match V4-T1750000000000000
+```
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix.md
+++ b/docs/manuals/nico-admin-cli/commands/site-prefix/site-prefix.md
@@ -1,0 +1,61 @@
+# `nico-admin-cli site-prefix`
+
+_[Network commands](../../network.md) › **site-prefix**_
+
+## NAME
+
+nico-admin-cli-site-prefix - SitePrefix management
+
+## SYNOPSIS
+
+**nico-admin-cli site-prefix** \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+SitePrefix management
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> -   primary-id: Sort by the primary id
+>
+> -   state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli site-prefix show
+nico-admin-cli site-prefix show 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli site-prefix create --tenant-organization-id fds34511233a --prefix 10.0.0.0/16 --name tenant-private-space
+nico-admin-cli site-prefix delete 12345678-1234-5678-90ab-cdef01234567 --tenant-organization-id fds34511233a
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`show`](./site-prefix-show.md) | List SitePrefixes or show one by ID |
+| [`create`](./site-prefix-create.md) | Create a tenant-managed, datacenter-only SitePrefix in Provisioning |
+| [`update`](./site-prefix-update.md) | Replace the complete metadata document on a tenant-managed SitePrefix |
+| [`delete`](./site-prefix-delete.md) | Record retirement intent and return the retained Deleting SitePrefix |
+| [`state-history`](./site-prefix-state-history.md) | Show all lifecycle state history for a SitePrefix, or an empty collection |
+
+---
+
+**See also:** [Network commands](../../network.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/network.md
+++ b/docs/manuals/nico-admin-cli/network.md
@@ -16,6 +16,7 @@ For global flags and setup, see [the overview](./README.md) and [`setup.md`](./s
 | [`nvl-domain`](./commands/nvl-domain/nvl-domain.md) | NVLink domain related handling. |
 | [`resource-pool`](./commands/resource-pool/resource-pool.md) | Resource pool handling. |
 | [`route-server`](./commands/route-server/route-server.md) | Route server handling. |
+| [`site-prefix`](./commands/site-prefix/site-prefix.md) | SitePrefix management. |
 | [`spx-partition`](./commands/spx-partition/spx-partition.md) | SPX Partition related handling. |
 | [`vpc`](./commands/vpc/vpc.md) | VPC related handling. |
 | [`vpc-peering`](./commands/vpc-peering/vpc-peering.md) | VPC peering handling. |


### PR DESCRIPTION
The `site-prefix` command family is already available in `nico-admin-cli`, but
its generated reference pages were kept out of the implementation PR so the
operator-facing contract could be reviewed separately.

This adds the six generated SitePrefix command pages and the Network command
index entry. The pages come directly from the merged Clap tree and cover
listing and filtering, creation, complete metadata replacement, retirement,
and lifecycle history.

## Related issues

Closes https://github.com/NVIDIA/infra-controller/issues/4921

Part of https://github.com/NVIDIA/infra-controller/issues/4226

Generated from the command family added in https://github.com/NVIDIA/infra-controller/pull/4745

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)