### PR TITLE
fix(ci): keep Core lint on the pull request revision

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1605,11 +1605,6 @@ jobs:
           "make sync-protobuf (from the repository root)"
 
   lint-police:
-    # Merge validation uses the PR API to resolve `.base.ref`, then fetches
-    # that branch before creating the local merge result. It never edits the PR.
-    permissions:
-      contents: read
-      pull-requests: read
     needs:
       - prepare
       - build-container-x86_64
@@ -1621,39 +1616,20 @@ jobs:
         username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
         password: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
     steps:
+      # The PR mirror's `github.sha` is the submitted head commit. Keep lint on
+      # the same revision as the other PR checks and builds. Validation of the
+      # exact queued revision is tracked at:
+      # https://github.com/NVIDIA/infra-controller/issues/4587
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.sha }}
           persist-credentials: false
 
-      - name: Build pull request merge result
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -o pipefail
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          PR_NUMBER="${GITHUB_REF_NAME##pull-request/}"
-          if ! TARGET="$(
-            curl -sf \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
-              | jq -r '.base.ref'
-          )"; then
-            echo "Could not query the base ref for PR ${PR_NUMBER}." >&2
-            echo "Confirm the lint-police job still declares 'pull-requests: read'." >&2
-            exit 1
-          fi
-          if [[ -z "${TARGET}" || "${TARGET}" == "null" ]]; then
-            echo "Could not resolve the base ref for PR ${PR_NUMBER}." >&2
-            exit 1
-          fi
-          git fetch --no-tags origin "${TARGET}:refs/remotes/origin/${TARGET}"
-          git -c user.name="CI merge validation" \
-            -c user.email=ci@example.invalid \
-            merge --no-commit --no-ff "origin/${TARGET}"
+      # Checkout scopes its safe-directory entry to a temporary HOME. The
+      # remaining steps run as root against the runner-owned bind mount.
+      - name: Trust the workspace in this container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Validate Cargo metadata
         run: cargo metadata --locked --no-deps --format-version 1 >/dev/null


### PR DESCRIPTION
Most Core and REST jobs already test the immutable pull request commit in `github.sha`, but `lint-police` was the exception: it fetched the target branch and created a private local merge before linting. That meant one Core aggregate could combine lint from a different source tree than its tests and builds.

This keeps `lint-police` on the submitted revision, matching the rest of the PR run. It also removes the API lookup, fetch, local merge, and `pull-requests: read` permission that existed only for that alternate tree.

Primary callouts are:
- **Expected green-run effect:** Effectively none, beyond removing a small setup step from `lint-police`.
- **What it really buys us:** Every check and build in an ordinary PR run starts from the same submitted commit, so a green aggregate describes one source tree.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4577.

Part of #4572.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

This PR intentionally does not create an integration commit or try to keep itself continuously rebased while unrelated changes land on `main`. GitHub's later `merge_group` event owns validation of the exact revision queued for merge.

Closes #4577
