### PR TITLE
fix(ci): limit GitHub Pages token permissions

### DIFF
--- a/.github/ci/check-docs-pages-permissions.sh
+++ b/.github/ci/check-docs-pages-permissions.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-docs-pages-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/docs.yml}"
+
+# Building reads the Pages site configuration. Only deployment publishes the
+# artifact and requests the OIDC token used by GitHub Pages.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "GitHub Pages" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "pages=read" \
+	--job-permissions "deploy=id-token=write,pages=write"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,9 @@ jobs:
       - name: Check Image Scan token permissions
         run: bash .github/ci/check-image-scan-ci-permissions.sh
 
+      - name: Check GitHub Pages token permissions
+        run: bash .github/ci/check-docs-pages-permissions.sh
+
       - name: Check Core CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh core
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,11 +8,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-# Sets permissions for GitHub Pages deployment
+# The build only reads Pages configuration; deployment owns the write token.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  pages: read
 
 # Allow only one concurrent deployment
 concurrency:
@@ -55,6 +53,9 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
GitHub already applies the permissions declared in `Publish Github Pages Documentation` at runtime, but the workflow currently gives both jobs `contents: read`, `pages: write`, and access to request an OIDC token. The build job only creates and uploads the redirect artifact and reads the existing Pages configuration; only the deploy job publishes it.

This keeps `pages: read` as the workflow default, gives `deploy` the complete `pages: write` and `id-token: write` contract it needs, and enrolls that exact split in the shared permission checker. This narrows runtime authority without changing what the Pages workflow builds or deploys.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4926.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- The Pages policy check reports one workflow-default job and one reviewed job override.
- All 60 shared permission-checker fixtures pass.
- Bash syntax, ShellCheck 0.11.0, Actionlint 1.7.12, the full formatting, Clippy, and Carbide-lints gates, and `git diff --check` pass locally.
- Hosted Core gate detection reported `Checked 2 GitHub Pages jobs: 1 use the workflow default and 1 use reviewed job permissions.`

## Additional Notes

The production deployment was not manually dispatched; the next natural `main` run after merge will provide the deployment observation.

The redirect content, Pages actions, deployment environment, concurrency, and job layout are unchanged.
