### PR TITLE
feat(dpf): gate DPUService rollout on carbide confirming the DPU is current

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -10,7 +10,7 @@ applicable.
 ## `NicoConfig` (top-level)
 
 | Field | Type | Default | Group | Description |
-|-------|------|---------|-------|-------------|
+| ------- | ------ | --------- | ------- | ------------- |
 | `listen` | `SocketAddr` | `[::]:1079` | `server` | Socket address for the gRPC API server. |
 | `listen_only` | `bool` | `false` | `server` | Run passively (no background services, RPC/web only). Used in dev mode. |
 | `metrics_endpoint` | `Option<SocketAddr>` | — | `integrations` | Socket address for the Prometheus `/metrics` HTTP server. |
@@ -268,7 +268,7 @@ identity. An exact SPIFFE service override can give a trusted internal service a
 different share without allowing it to exceed either global bound.
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `true` | Enable fair, bounded API admission. When `false`, admission is bypassed and the other fields in this section are not validated. |
 | `max_work_in_flight` | `usize` | `64` | Maximum business requests executing concurrently. When enabled, must be greater than zero and no greater than `tokio::sync::Semaphore::MAX_PERMITS`. |
 | `max_pending` | `usize` | `1024` | Maximum business requests waiting for execution. When enabled, must be greater than zero and no greater than `tokio::sync::Semaphore::MAX_PERMITS`. |
@@ -284,7 +284,7 @@ Every field is required for each service override; the nested structure has no
 field-level defaults.
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `max_work_in_flight` | `usize` | **required** | Maximum requests from this service that may execute concurrently. Must be greater than zero, no greater than the global `max_work_in_flight`, and representable as a `u32`. |
 | `max_pending` | `usize` | **required** | Hard bound on this service's pending requests. Must be greater than zero and no greater than the global `max_pending`. |
 | `pending_timeout` | `Duration` | **required** | Maximum time this service's pending request may wait for execution. Admission can reject earlier when its queue-delay estimate exceeds this value. Must be greater than zero. |
@@ -310,7 +310,7 @@ extracted identifier contains characters such as `/` or `.`.
 ### `TlsConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `root_cafile_path` | `String` | `""` | Root CA certificate for client validation. |
 | `identity_pemfile_path` | `String` | `""` | Server identity certificate PEM. |
 | `identity_keyfile_path` | `String` | `""` | Server identity private key. |
@@ -319,7 +319,7 @@ extracted identifier contains characters such as `/` or `.`.
 ### `AuthConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `permissive_mode` | `bool` | — | Enable permissive authorization (dev mode). |
 | `casbin_policy_file` | `Option<PathBuf>` | — | Path to Casbin CSV policy file. |
 | `cli_certs` | `Option<AllowedCertCriteria>` | — | Additional allowed cert criteria for nico-admin-cli. |
@@ -328,7 +328,7 @@ extracted identifier contains characters such as `/` or `.`.
 ### `IBFabricConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enables InfiniBand fabric management. |
 | `max_partition_per_tenant` | `i32` | `31` | Maximum IB partitions per tenant (1-31). |
 | `allow_insecure` | `bool` | `false` | Allow insecure fabric configs that skip tenant isolation. |
@@ -340,7 +340,7 @@ extracted identifier contains characters such as `/` or `.`.
 ### `NvLinkConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enables NvLink partitioning. |
 | `monitor_run_interval` | `Duration` | `60s` | NvLink monitor polling interval. |
 | `nmx_c_tls_ca_cert_path` | `Option<String>` | — | Extra CA bundle for verifying the NMX-C server over HTTPS. |
@@ -355,7 +355,7 @@ extracted identifier contains characters such as `/` or `.`.
 ### `NmxCCertificateRotationConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enables NMX-C server certificate expiry checks and rotation. |
 | `run_interval` | `Duration` | `1h` | Interval between checks of the certificate served by NMX-C. |
 | `rotate_before_expiry` | `Duration` | `1w` | Requests rotation when the served certificate expires within this duration. Must leave enough time for the replacement certificate to be issued first. |
@@ -367,7 +367,7 @@ extracted identifier contains characters such as `/` or `.`.
 ### `SiteExplorerConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `true` | Enables hardware discovery. |
 | `run_interval` | `Duration` | `120s` | Interval between exploration runs. |
 | `concurrent_explorations` | `u64` | `30` | Max nodes explored in parallel. |
@@ -394,7 +394,7 @@ Shared by all `*StateControllerConfig` structs (machine, network segment, VPC pr
 partition, DPA interface, rack, power shelf, switch, SPDM).
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `iteration_time` | `Duration` | `30s` | Target duration for one state controller iteration. |
 | `max_object_handling_time` | `Duration` | `3m` | Timeout for evaluating/advancing a single object's state. |
 | `max_concurrency` | `usize` | `10` | Max objects advanced in parallel. |
@@ -417,7 +417,7 @@ TOML section: `[observability]`.
 TOML section: `[observability.per_object_state_metrics]`.
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Registers per-object state metrics and starts the dedicated listener. When `object_types` is empty, registration and the listener are both skipped even if this is `true`. |
 | `listen_address` | `SocketAddr` | `[::]:9091` | Dual-stack address serving `/metrics`; the Helm chart derives it from `service.perObjectStateMetrics.port`. |
 | `object_types` | `Vec<PerObjectStateMetricObjectType>` | all supported types | Types to publish: `machine`, `switch`, `power_shelf`, `rack`, `network_segment`, `vpc_prefix`, `spdm_attestation`, and/or `ib_partition`. An empty list publishes no state series and skips the dedicated listener. |
@@ -427,14 +427,14 @@ TOML section: `[observability.per_object_state_metrics]`.
 Extends `StateControllerConfig` with:
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `dpu_wait_time` | `Duration` | `5m`    | Time before a DPU is considered definitively down. |
-| `power_down_wait` | `Duration` | `2m`    | Wait after power-down before powering on. |
-| `failure_retry_time` | `Duration` | `90m`   | Time before re-triggering reboot if machine hasn't called back. |
-| `dpu_up_threshold` | `Duration` | `5m`    | Max time without DPU health report before assuming it's down. |
-| `scout_reporting_timeout` | `Duration` | `5m`    | Duration without scout report before host is unhealthy. |
-| `waiting_for_measurements_timeout` | `Duration` | `4h`    | How long a host may remain in WaitingForMeasurements before being escalated to Failed. |
-| `uefi_boot_wait` | `Duration` | `5m`    | Wait time for UEFI boot completion after host reboot. |
+| ------- | ------ | --------- | ------------- |
+| `dpu_wait_time` | `Duration` | `5m` | Time before a DPU is considered definitively down. |
+| `power_down_wait` | `Duration` | `2m` | Wait after power-down before powering on. |
+| `failure_retry_time` | `Duration` | `90m` | Time before re-triggering reboot if machine hasn't called back. |
+| `dpu_up_threshold` | `Duration` | `5m` | Max time without DPU health report before assuming it's down. |
+| `scout_reporting_timeout` | `Duration` | `5m` | Duration without scout report before host is unhealthy. |
+| `waiting_for_measurements_timeout` | `Duration` | `4h` | How long a host may remain in WaitingForMeasurements before being escalated to Failed. |
+| `uefi_boot_wait` | `Duration` | `5m` | Wait time for UEFI boot completion after host reboot. |
 | `max_bios_config_retries` | `u32` | `3` | Shared retry budget for automated host boot-configuration convergence across BIOS recovery and boot-order verification. |
 | `polling_bios_setup_stuck_threshold` | `Duration` | `15m` | Time in PollingBiosSetup with `is_bios_setup == false` before recovery escalation. |
 | `boot_interface_observation_interval` | `Duration` | `10m` | Positive time between successful Redfish observations of an already-verified boot interface. |
@@ -473,7 +473,7 @@ Extends `StateControllerConfig` with:
 ### `FirmwareGlobal`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `autoupdate` | `bool` | `false` | Enable automatic host firmware updates. |
 | `host_enable_autoupdate` | `Vec<String>` | `[]` | Host models to force-enable autoupdate. |
 | `host_disable_autoupdate` | `Vec<String>` | `[]` | Host models to force-disable autoupdate. |
@@ -492,7 +492,7 @@ Extends `StateControllerConfig` with:
 ### `MachineUpdater`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `instance_autoreboot_period` | `Option<TimePeriod>` | — | UTC time window for automatic machine reboots. |
 | `max_concurrent_machine_updates_absolute` | `Option<i32>` | — | Hard cap on concurrent machine updates. |
 | `max_concurrent_machine_updates_percent` | `Option<i32>` | — | Percentage cap on concurrent updates (lesser of absolute/percent is used). |
@@ -500,7 +500,7 @@ Extends `StateControllerConfig` with:
 ### `PowerManagerOptions`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enable power management. |
 | `next_try_duration_on_success` | `Duration` | `5m` | Retry interval after successful power operation. |
 | `next_try_duration_on_failure` | `Duration` | `2m` | Retry interval after failed power operation. |
@@ -509,7 +509,7 @@ Extends `StateControllerConfig` with:
 ### `VmaasConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `allow_instance_vf` | `bool` | `true` | Global instance-VF admission switch for creation and network updates. `false` rejects every VF. With DPF intercept topology, `true` additionally requires every requested VF ID to be explicitly selected by that topology. Without DPF intercept topology, the historical boolean-only admission behavior is preserved. |
 | `hbn_reps` | `Option<String>` | — | Select which representors from the configured VF population HBN is expected to use during DPU provisioning. When omitted, HBN uses its default representor selection. |
 | `bridging` | `Option<HostRepresentorBridgingConfig>` | — | Provisioning-time topology for bridges inserted between host representors and HBN or DPF's `br-sfc`. Under DPF, a present `vmaas_config` makes this map the complete configurable PF/VF inventory and requires exactly one PF entry. |
@@ -524,7 +524,7 @@ Extends `StateControllerConfig` with:
 ### `HostInterceptBridging`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `bridge` | `String` | **required** | Bridge that sits between the host PF/VF representor and br-hbn or br-sfc. |
 | `patch_port` | `String` | **required** | Patch port on this bridge that connects it toward HBN or SFC. |
 | `skip_create` | `bool` | `false` | When true, the entry is omitted from provisioning-time bridge creation. |
@@ -545,7 +545,7 @@ Without configured DPF intercept topology, NICo deliberately preserves the estab
 ### `DpfInterfaceIdentity`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `controller_id` | `u8` | **required** | DPF controller number (`0..=255`) containing the selected PF or VF. |
 | `pf_id` | `u8` | **required** | PF identifier (`0..=255`) on the selected controller. |
 | `vf_id` | `Option<u8>` | — | VF identifier. Omission selects the PF. Under DPF intercept topology, presence selects that VMaaS VF and requires both `vf_id <= 15` and `vf_id < dpu_config.num_of_vfs`; pre-DPF provisioning ignores this typed field. |
@@ -553,7 +553,7 @@ Without configured DPF intercept topology, NICo deliberately preserves the estab
 ### `DpuConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `bootstrap_ca_source` | `BootstrapCaSource` | `legacy_download` | How non-DPF DPUs obtain the API trust anchor: `legacy_download`, `embedded`, or `mounted`. Omitting the field preserves the historical PXE download. The field is not sent to host Scout boots. Non-network modes do not fall back to downloading. |
 | `dpu_nic_firmware_initial_update_enabled` | `bool` | `false` | Enable DPU NIC firmware updates on initial discovery. |
 | `dpu_nic_firmware_reprovision_update_enabled` | `bool` | `true` | Enable DPU NIC firmware updates on reprovisioning. |
@@ -579,7 +579,7 @@ client-certificate authentication is not used.
 ### `NetworkSecurityGroupConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `max_network_security_group_size` | `u32` | `200` | Max expanded rules per NSG. |
 | `stateful_acls_enabled` | `bool` | `true` | Enable stateful ACLs (toggled on DPU via nvue). |
 | `policy_overrides` | `Vec<NetworkSecurityGroupRule>` | `[]` | NSG rules injected before user-defined rules. |
@@ -587,7 +587,7 @@ client-certificate authentication is not used.
 ### `FnnConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `admin_vpc` | `Option<AdminFnnConfig>` | — | FNN configuration for the admin network VPC. |
 | `common_internal_route_target` | `Option<RouteTargetConfig>` | — | Double-tag for internal tenant routes (consumed by the network infrastructure). |
 | `additional_route_target_imports` | `Vec<RouteTargetConfig>` | `[]` | Extra route targets imported on DPU VRFs. |
@@ -597,7 +597,7 @@ client-certificate authentication is not used.
 ### `FnnRoutingProfileConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `route_target_imports` | `Option<Vec<RouteTargetConfig>>` | — (effective `[]`) | Route targets imported into DPU VRFs for VPC routes. |
 | `route_targets_on_exports` | `Option<Vec<RouteTargetConfig>>` | — (effective `[]`) | Route targets added to routes exported by the DPU. |
 | `internal` | `Option<bool>` | — (effective `false`) | Whether the profile uses internal VNI allocation. This property cannot be overridden on a VPC. |
@@ -615,7 +615,7 @@ override are combined, properties still unset use the effective defaults above.
 ### `VpcDefinition`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `organization_id` | `Option<String>` | — | Tenant organization that owns the seeded VPC. |
 | `network_virtualization_type` | `VpcVirtualizationType` | **required** | Data plane used by the VPC. |
 | `routing_profile_type` | `Option<String>` | — | Named FNN routing profile recorded on the seeded VPC. |
@@ -631,7 +631,7 @@ override are combined, properties still unset use the effective defaults above.
 ### `DpaConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enable Cluster Interconnect Network. |
 | `mqtt_endpoint` | `String` | `"mqtt.nico"` | MQTT broker host for DPA. |
 | `mqtt_broker_port` | `u16` | `1884` | MQTT broker port. |
@@ -644,7 +644,7 @@ override are combined, properties still unset use the effective defaults above.
 ### `DsxExchangeEventBusConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enable the DSX Exchange Event Bus for managed-host state publishing, BMS metadata subscription, and BMS rack/isolation/heartbeat publishing. |
 | `mqtt_endpoint` | `String` | `"mqtt.nico"` | MQTT broker host. |
 | `mqtt_broker_port` | `u16` | `1884` | MQTT broker port. |
@@ -662,7 +662,7 @@ In addition to publishing on every state change, NICo can re-publish current
 events, so consumers handle them identically.
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `true` | Enable periodic republishing (on by default whenever the DSX Exchange Event Bus is enabled). Change-driven publishing is unaffected by this setting. |
 | `interval` | `Duration` | `5m` | How often a republish sweep runs, clamped to 1 second through 1 hour. |
 | `scope` | `RepublishScope` | `all` | Which managed hosts to publish each sweep (see [RepublishScope](#republishscope)). |
@@ -679,10 +679,11 @@ events, so consumers handle them identically.
 ### `DpfConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enable DPF Kubernetes deployment. |
 | `deployment_scoped_service_interfaces` | `bool` | `false` | Opt the complete DPF namespace into deployment-scoped `-bf3`, `-bf4`, and `-astra` DPUServiceInterfaces. Each resource selects Nodes in the remote DPU cluster through DPF's propagated `svc.dpu.nvidia.com/owned-by-dpudeployment=<namespace>_<deployment_name>` ownership label; management-cluster DPUNode deployment labels are not used for this selector. Enabling or disabling is a planned migration: stop NICo, remove old-mode NICo ServiceInterfaces in both transition directions, perform DPU re-ingestion, and restart. NICo neither detects nor deletes old-mode resources; skipping cleanup can leave competing interface generations active. Astra requires this setting. |
 | `pf_total_sf_reserved` | `u32` | `30` | SF capacity reserved beyond the NICo-managed HBN, DHCP, and FMDS endpoints when an intercept-bridging inventory is configured. NICo sets `PF_TOTAL_SF` to the effective inventory's endpoint count plus this value for BF3 and generic BF4. Without configured intercept bridging, this value is the complete `PF_TOTAL_SF`, preserving the legacy default of `30`; BF4 Astra retains its fixed flavor and ignores this setting. Changing this value changes the BF3/generic-BF4 flavor. Every intercept-inventory change requires controlled ServiceInterface cleanup and DPU re-ingestion, even when the serialized flavor and its hash remain unchanged. Operators must select a value compatible with their platform's SF and BAR capacity. With configured intercept bridging, startup rejects configurations whose managed endpoint count plus reserve exceeds `u32::MAX`. |
+| `dpu_service_sync_enabled` | `bool` | `true` | Whether NICo rolls a changed DPUService out on its own, by releasing the DPF maintenance hold on hosts whose DPUs already match their DPUDeployment. Selects *who* opens the gate, never whether one exists: DPF is always configured to park a changed DPUService behind a hold, so no service update reaches a DPU unchecked. Setting `false` does not resume unchecked rollout — the held DPUs wait for an operator to release them deliberately. Hosts still awaiting reprovisioning, and hosts carrying a live tenant instance, keep their hold either way. |
 | `dpu_agent_bootstrap_ca` | `DpfDpuAgentBootstrapCa` | `legacy_download` | Bootstrap trust for the containerized DPU agent. Supports `legacy_download` and `mounted`, as described in the following examples. |
 | `services` | `Box<DpfMandatoryServicesConfig>` | built-in mandatory-service defaults | Helm chart, image, pull-secret, and `extra_helm_values` settings for the six mandatory DPF services. |
 | `docker_image_pull_secret` | `Option<String>` | — | Override for the Kubernetes `imagePullSecrets` entry used to pull mandatory-service images (applied to every mandatory service except `dts` and `doca_hbn`, which take a pull secret only from their per-service config). |
@@ -745,7 +746,7 @@ be propagated there by DPF.
 ### `RmsConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `api_url` | `Option<String>` | — | RMS API URL for rack-level firmware upgrades and power sequencing. |
 | `root_ca_path` | `Option<String>` | — | Path to the root CA certificate for TLS verification. |
 | `client_cert` | `Option<String>` | — | Path to the client certificate PEM for mTLS. |
@@ -763,7 +764,7 @@ be propagated there by DPF.
 ### `MachineIdentityConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Master switch for machine identity APIs (opt-in; set `true` with `current_encryption_key_id` and credentials). |
 | `algorithm` | `String` | `"ES256"` | Signing algorithm for per-org keys. |
 | `token_ttl_min_sec` | `u32` | `60` | Minimum token TTL in seconds. |
@@ -784,7 +785,7 @@ be propagated there by DPF.
 ### `MachineValidationConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enable machine validation tests. |
 | `test_selection_mode` | `MachineValidationTestSelectionMode` | `Default` | `Default`, `EnableAll`, or `DisableAll`. |
 | `run_interval` | `Duration` | `60s` | Validation check interval. |
@@ -794,7 +795,7 @@ be propagated there by DPF.
 ### `BomValidationConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Enable BOM/SKU validation. |
 | `ignore_unassigned_machines` | `bool` | `false` | Let machines without a SKU bypass validation. |
 | `allow_allocation_on_validation_failure` | `bool` | `false` | Keep machines allocatable even when validation fails. |
@@ -812,7 +813,7 @@ be propagated there by DPF.
 ### `MqttOAuth2Config`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `token_url` | `String` | **required** | OAuth2 token endpoint URL. |
 | `scopes` | `Vec<String>` | `[]` | OAuth2 scopes to request. |
 | `http_timeout` | `Duration` | `30s` | Token endpoint HTTP timeout. |
@@ -821,7 +822,7 @@ be propagated there by DPF.
 ### `TracingConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `false` | Whether to enable OTLP tracing. |
 | `allow_runtime_changes` | `bool` | `true` | Whether tracing may be enabled/disabled at runtime (`nico-admin-cli set tracing-enabled`). |
 | `otlp_endpoint` | `Option<String>` | — | The endpoint traces are sent to. The `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env var takes precedence when set. |
@@ -836,7 +837,7 @@ be propagated there by DPF.
 ### `SecretsConfig`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `kms` | `KmsConfig` | **required** | KMS backend configuration (see [KmsConfig](#kmsconfig)). |
 | `routing` | `HashMap<String, String>` | **required** | Maps path prefixes to the `kek_id` that encrypts new writes under them, longest prefix winning. A `/` catch-all entry is required. Reads never consult routing — every stored row records the KEK that wrote it. |
 | `backends` | `Vec<CredentialBackend>` | `[vault]` | The credential backend read order, highest priority first (first match wins). The local-override readers (env, file) are always tried ahead of these when enabled. |
@@ -861,7 +862,7 @@ be propagated there by DPF.
 ### `DedicatedVaultSettings`
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| ------- | ------ | --------- | ------------- |
 | `address` | `String` | **required, non-empty** | Vault address, e.g. `https://vault-certs.example:8200`. |
 | `pki_mount_location` | `String` | **required, non-empty** | PKI secrets-engine mount path on the target Vault. |
 | `pki_role_name` | `String` | **required, non-empty** | PKI role used to sign leaf certificates. |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1081,6 +1081,7 @@ impl CarbideConfig {
 
             dpa_enabled: self.is_dpa_enabled(),
             dpf_enabled: self.dpf.enabled,
+            dpu_service_sync_enabled: self.dpf.dpu_service_sync_enabled,
             spdm_enabled: self.spdm.enabled,
             bmc_rotation_enabled: self.bmc_rotation_enabled,
             uefi_rotation_enabled: self.uefi_rotation_enabled,
@@ -1527,6 +1528,22 @@ pub struct DpfConfig {
     /// Without intercept bridging, this remains the complete legacy `PF_TOTAL_SF` value.
     #[serde(default = "default_dpf_pf_total_sf_reserved")]
     pub pf_total_sf_reserved: u32,
+    /// Whether carbide rolls a changed DPUService out on its own, by releasing
+    /// the DPF maintenance hold for hosts it has confirmed are already running
+    /// the software their DPUDeployment declares.
+    ///
+    /// This selects *who* opens the gate, never whether one exists. DPF is
+    /// always configured to park a changed DPUService behind a maintenance hold
+    /// (`upgradePolicy.applyNodeEffect`), so no service update ever reaches a DPU
+    /// without something having checked its side effects first.
+    ///
+    /// On by default. Setting it to false does not resume unchecked rollout: it
+    /// means the held DPUs wait for an operator to release them deliberately,
+    /// rather than for carbide to do it on the host's next idle sweep. Hosts
+    /// still awaiting reprovisioning, and hosts carrying a live tenant instance,
+    /// keep their hold either way.
+    #[serde(default = "default_to_true")]
+    pub dpu_service_sync_enabled: bool,
     /// Optional override for the Kubernetes `imagePullSecrets` entry used to pull the
     /// docker images of the mandatory services. When set, it is applied to every
     /// mandatory service except `dts` and `doca_hbn`, which take a pull secret only
@@ -1556,6 +1573,7 @@ impl Default for DpfConfig {
             enabled: false,
             deployment_scoped_service_interfaces: false,
             pf_total_sf_reserved: default_dpf_pf_total_sf_reserved(),
+            dpu_service_sync_enabled: default_to_true(),
             docker_image_pull_secret: None,
             dpu_agent_bootstrap_ca: DpfDpuAgentBootstrapCa::default(),
             services: Box::default(),

--- a/crates/api-core/src/tests/dpf/dpu_service_sync.rs
+++ b/crates/api-core/src/tests/dpf/dpu_service_sync.rs
@@ -1,0 +1,391 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Releasing the DPF maintenance hold so a changed DPUService rolls out.
+//!
+//! DPF parks a DPU in `NodeEffect` when its services change, and carbide opens
+//! that gate only for a DPU already running the software its DPUDeployment
+//! declares. These cover the four outcomes: released, deferred because the DPU
+//! is outdated, deferred because the release itself failed, and not attempted
+//! at all because nothing is pending.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase};
+use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
+use carbide_uuid::machine::MachineId;
+use model::machine::{DpfState, DpuInitState, DpuInitStates, ManagedHostState};
+use model::machine_pending_action::MachinePendingActionKind::DpuServiceSync;
+use tokio::time::timeout;
+
+use super::dpf_config;
+use crate::tests::common::api_fixtures::test_managed_host::TestManagedHost;
+use crate::tests::common::api_fixtures::{
+    TestEnv, TestEnvOverrides, create_managed_host_with_dpf, create_test_env_with_overrides,
+    get_config,
+};
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Counters for the two calls this handler is responsible for, so a test can
+/// assert what happened *after* provisioning rather than in total.
+#[derive(Default)]
+struct Calls {
+    outdated_checks: AtomicUsize,
+    hold_releases: AtomicUsize,
+}
+
+/// `outdated` drives what `is_dpu_outdated` reports; `release_fails` makes the
+/// hold release return an error so the marker's survival can be checked.
+fn mock(
+    calls: Arc<Calls>,
+    outdated: Arc<AtomicBool>,
+    release_fails: Arc<AtomicBool>,
+) -> MockDpfOperations {
+    let mut mock = MockDpfOperations::new();
+    mock.expect_register_dpu_device().returning(|_| Ok(()));
+    mock.expect_register_dpu_node().returning(|_| Ok(()));
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
+
+    let outdated_calls = calls.clone();
+    mock.expect_is_dpu_outdated().returning(move |_| {
+        outdated_calls
+            .outdated_checks
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(outdated.load(Ordering::SeqCst))
+    });
+
+    mock.expect_release_maintenance_hold().returning(move |_| {
+        calls.hold_releases.fetch_add(1, Ordering::SeqCst);
+        if release_fails.load(Ordering::SeqCst) {
+            Err(DpfError::InvalidState("release refused".to_string()))
+        } else {
+            Ok(())
+        }
+    });
+    mock
+}
+
+struct Fixture {
+    env: TestEnv,
+    mh: TestManagedHost,
+    calls: Arc<Calls>,
+    pool: sqlx::PgPool,
+}
+
+/// Provisions a DPF host and returns it sitting in `Ready`, with the call
+/// counters zeroed so only post-provisioning activity is measured.
+async fn provisioned(
+    pool: sqlx::PgPool,
+    outdated: Arc<AtomicBool>,
+    release_fails: Arc<AtomicBool>,
+) -> Fixture {
+    provisioned_with_sync(pool, outdated, release_fails, true).await
+}
+
+async fn provisioned_with_sync(
+    pool: sqlx::PgPool,
+    outdated: Arc<AtomicBool>,
+    release_fails: Arc<AtomicBool>,
+    sync_enabled: bool,
+) -> Fixture {
+    let calls = Arc::new(Calls::default());
+    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(mock(calls.clone(), outdated, release_fails));
+
+    let mut config = get_config();
+    config.dpf = dpf_config();
+    config.dpf.dpu_service_sync_enabled = sync_enabled;
+
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(dpf_sdk),
+    )
+    .await;
+
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during initial provisioning");
+
+    calls.outdated_checks.store(0, Ordering::SeqCst);
+    calls.hold_releases.store(0, Ordering::SeqCst);
+
+    Fixture {
+        env,
+        mh,
+        calls,
+        pool,
+    }
+}
+
+async fn request_sync(pool: &sqlx::PgPool, host_id: &MachineId) {
+    let mut conn = pool.acquire().await.unwrap();
+    db::machine_pending_action::request(&mut conn, host_id, DpuServiceSync)
+        .await
+        .expect("recorded pending action");
+}
+
+async fn is_outstanding(pool: &sqlx::PgPool, host_id: &MachineId) -> bool {
+    db::machine_pending_action::is_outstanding(pool, host_id, DpuServiceSync)
+        .await
+        .expect("read pending action")
+}
+
+/// Puts one DPU back into the DPF `WaitingForReady` substate so the provisioning
+/// handler runs again without replaying the whole operator workflow.
+async fn reset_host_to_waiting_for_ready(
+    pool: &sqlx::PgPool,
+    host_id: &MachineId,
+    dpu_id: &MachineId,
+) {
+    let state = ManagedHostState::DPUInit {
+        dpu_states: DpuInitStates {
+            states: HashMap::from([(
+                *dpu_id,
+                DpuInitState::DpfStates {
+                    state: DpfState::WaitingForReady { phase_detail: None },
+                },
+            )]),
+        },
+    };
+    let version = format!("V999-T{}", chrono::Utc::now().timestamp_micros());
+
+    sqlx::query(
+        "UPDATE machines SET \
+            controller_state = $1, \
+            controller_state_version = $2, \
+            controller_state_outcome = NULL, \
+            health_reports = '{\"merges\": {}, \"replace\": null}'::jsonb \
+         WHERE id = $3",
+    )
+    .bind(sqlx::types::Json(serde_json::to_value(&state).unwrap()))
+    .bind(&version)
+    .bind(host_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// A host whose DPUs all match their deployment gets its hold released, and the
+/// pending action is recorded as completed.
+#[crate::sqlx_test]
+async fn hold_is_released_when_every_dpu_is_current(pool: sqlx::PgPool) {
+    let fixture = provisioned(
+        pool,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+    request_sync(&fixture.pool, &fixture.mh.id).await;
+
+    timeout(
+        TEST_TIMEOUT,
+        fixture.env.run_machine_state_controller_iteration(),
+    )
+    .await
+    .expect("timed out during state controller iteration");
+
+    assert_eq!(
+        fixture.calls.hold_releases.load(Ordering::SeqCst),
+        1,
+        "an up-to-date host should have its maintenance hold released"
+    );
+    assert!(
+        !is_outstanding(&fixture.pool, &fixture.mh.id).await,
+        "a successful release must complete the pending action"
+    );
+}
+
+/// A DPU still awaiting reprovisioning keeps its hold, and the pending action
+/// stays outstanding so a later sweep can retry once the DPU is current.
+#[crate::sqlx_test]
+async fn hold_is_kept_while_a_dpu_is_outdated(pool: sqlx::PgPool) {
+    let fixture = provisioned(
+        pool,
+        Arc::new(AtomicBool::new(true)),
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+    request_sync(&fixture.pool, &fixture.mh.id).await;
+
+    timeout(
+        TEST_TIMEOUT,
+        fixture.env.run_machine_state_controller_iteration(),
+    )
+    .await
+    .expect("timed out during state controller iteration");
+
+    assert!(
+        fixture.calls.outdated_checks.load(Ordering::SeqCst) > 0,
+        "the handler should have evaluated the host's DPUs"
+    );
+    assert_eq!(
+        fixture.calls.hold_releases.load(Ordering::SeqCst),
+        0,
+        "an outdated DPU must keep its hold; reprovisioning owns it"
+    );
+    assert!(
+        is_outstanding(&fixture.pool, &fixture.mh.id).await,
+        "deferring must not consume the pending action"
+    );
+}
+
+/// A release that fails leaves the pending action outstanding. Completing it
+/// here would strand the host: a DPU already in `NodeEffect` does not re-enter
+/// it, so the watcher never re-fires and the signal would be lost.
+#[crate::sqlx_test]
+async fn a_failed_release_leaves_the_action_outstanding(pool: sqlx::PgPool) {
+    // Provisioning releases its own hold on the way to Ready, so the failure is
+    // armed only once the host has arrived there.
+    let release_fails = Arc::new(AtomicBool::new(false));
+    let fixture = provisioned(
+        pool,
+        Arc::new(AtomicBool::new(false)),
+        release_fails.clone(),
+    )
+    .await;
+    release_fails.store(true, Ordering::SeqCst);
+    request_sync(&fixture.pool, &fixture.mh.id).await;
+
+    timeout(
+        TEST_TIMEOUT,
+        fixture.env.run_machine_state_controller_iteration(),
+    )
+    .await
+    .expect("timed out during state controller iteration");
+
+    assert_eq!(
+        fixture.calls.hold_releases.load(Ordering::SeqCst),
+        1,
+        "the release should have been attempted"
+    );
+    assert!(
+        is_outstanding(&fixture.pool, &fixture.mh.id).await,
+        "a failed release must not complete the pending action"
+    );
+}
+
+/// Provisioning releases the node's hold itself, which satisfies whatever the
+/// pending action was asking for. It retires the action there so the host does
+/// not arrive in `Ready` carrying a marker for work already done.
+///
+/// The watcher cannot make this distinction on its own: it fires on the
+/// `NodeEffect` phase, which says a DPU is parked but not why, so a provisioning
+/// pass records a marker exactly as a DPUService change does.
+#[crate::sqlx_test]
+async fn provisioning_retires_the_pending_action_when_it_releases_the_hold(pool: sqlx::PgPool) {
+    let fixture = provisioned(
+        pool,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+    request_sync(&fixture.pool, &fixture.mh.id).await;
+    reset_host_to_waiting_for_ready(&fixture.pool, &fixture.mh.id, &fixture.mh.dpu_ids[0]).await;
+
+    timeout(
+        TEST_TIMEOUT,
+        fixture.env.run_machine_state_controller_iteration(),
+    )
+    .await
+    .expect("timed out during state controller iteration");
+
+    assert!(
+        !is_outstanding(&fixture.pool, &fixture.mh.id).await,
+        "the provisioning release must retire the pending action"
+    );
+    assert_eq!(
+        fixture.calls.outdated_checks.load(Ordering::SeqCst),
+        0,
+        "provisioning retires the action without consulting Kubernetes about DPU currency"
+    );
+}
+
+/// With the site switch off, carbide never opens the gate itself. The hold and
+/// the pending action both survive, because the rollout is then an operator's to
+/// drive rather than something to abandon.
+#[crate::sqlx_test]
+async fn the_site_switch_stops_carbide_releasing_the_hold(pool: sqlx::PgPool) {
+    let fixture = provisioned_with_sync(
+        pool,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        false,
+    )
+    .await;
+    request_sync(&fixture.pool, &fixture.mh.id).await;
+
+    timeout(
+        TEST_TIMEOUT,
+        fixture.env.run_machine_state_controller_iteration(),
+    )
+    .await
+    .expect("timed out during state controller iteration");
+
+    assert_eq!(
+        fixture.calls.outdated_checks.load(Ordering::SeqCst),
+        0,
+        "a disabled site should not even inspect its DPUs"
+    );
+    assert_eq!(
+        fixture.calls.hold_releases.load(Ordering::SeqCst),
+        0,
+        "a disabled site must not release the hold"
+    );
+    assert!(
+        is_outstanding(&fixture.pool, &fixture.mh.id).await,
+        "the pending action must survive so an operator can still act on it"
+    );
+}
+
+/// Without a pending action the handler makes no Kubernetes calls at all. This
+/// is what keeps ordinary Ready sweeps off the API server, so it is the load
+/// property worth pinning down rather than an incidental detail.
+#[crate::sqlx_test]
+async fn nothing_is_checked_without_a_pending_action(pool: sqlx::PgPool) {
+    let fixture = provisioned(
+        pool,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await;
+
+    timeout(
+        TEST_TIMEOUT,
+        fixture.env.run_machine_state_controller_iteration(),
+    )
+    .await
+    .expect("timed out during state controller iteration");
+
+    assert_eq!(
+        fixture.calls.outdated_checks.load(Ordering::SeqCst),
+        0,
+        "no marker means no DPU should be inspected"
+    );
+    assert_eq!(
+        fixture.calls.hold_releases.load(Ordering::SeqCst),
+        0,
+        "no marker means no hold should be released"
+    );
+}

--- a/crates/api-core/src/tests/dpf/mod.rs
+++ b/crates/api-core/src/tests/dpf/mod.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+mod dpu_service_sync;
 mod happy_path;
 mod reprovisioning;
 mod stale_labels;

--- a/crates/api-db/migrations/20260810150847_machine_pending_actions.sql
+++ b/crates/api-db/migrations/20260810150847_machine_pending_actions.sql
@@ -1,0 +1,72 @@
+-- Durable record that an external system is waiting on carbide to act for a
+-- machine, plus a short history of the actions already completed.
+--
+-- The state controller's work queue cannot carry this signal. It stores only an
+-- object id and coalesces duplicate enqueues, so a handler waking up cannot tell
+-- why it woke: a targeted wakeup and a periodic sweep are indistinguishable, and
+-- the targeted one is silently dropped when the sweep queued the machine first.
+-- Without a durable marker, every reconcile pass would have to re-derive the
+-- answer from Kubernetes for every machine, every time.
+--
+-- An outstanding action is a row with a NULL `completed_at`; the consumer stamps
+-- that column only once the work has actually succeeded. A machine that is not
+-- currently eligible therefore keeps its outstanding row until it becomes
+-- eligible, and completing the work leaves a record behind rather than erasing
+-- the fact that it ran.
+CREATE TYPE machine_pending_action_kind AS ENUM (
+    'dpu_service_sync'
+);
+
+CREATE TABLE machine_pending_actions (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    machine_id varchar(64) NOT NULL
+        REFERENCES machines(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    kind machine_pending_action_kind NOT NULL,
+    requested_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    completed_at timestamptz
+);
+
+-- At most one outstanding request per machine and kind, so re-requesting an
+-- action that is still owed updates that row instead of queueing a duplicate.
+-- Completed rows are exempt, which is what lets them accumulate as history.
+CREATE UNIQUE INDEX machine_pending_actions_outstanding_idx
+    ON machine_pending_actions (machine_id, kind)
+    WHERE completed_at IS NULL;
+
+CREATE INDEX machine_pending_actions_machine_id_idx
+    ON machine_pending_actions (machine_id);
+
+CREATE FUNCTION machine_pending_actions_keep_limit() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    -- Writers for one machine share this lock so two completions cannot both
+    -- trim from the same 20-row window.
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended(NEW.machine_id, TG_RELID::bigint)
+    );
+    -- Only completed rows are trimmed. An outstanding row is the signal that
+    -- work is still owed, and nothing re-creates it once dropped, so it must
+    -- never be evicted by history retention.
+    DELETE FROM machine_pending_actions
+    WHERE machine_id = NEW.machine_id
+      AND completed_at IS NOT NULL
+      AND id NOT IN (
+          SELECT id
+          FROM machine_pending_actions
+          WHERE machine_id = NEW.machine_id
+            AND completed_at IS NOT NULL
+          ORDER BY id DESC
+          LIMIT 20
+      );
+    RETURN NULL;
+END;
+$$;
+
+-- Completion is the only transition that grows the history, so an insert (which
+-- always starts outstanding) cannot overflow the window.
+CREATE TRIGGER t_machine_pending_actions_keep_limit
+    AFTER UPDATE OF completed_at ON machine_pending_actions
+    FOR EACH ROW
+    WHEN (OLD.completed_at IS NULL AND NEW.completed_at IS NOT NULL)
+    EXECUTE FUNCTION machine_pending_actions_keep_limit();

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -58,6 +58,7 @@ pub mod machine_boot_override;
 pub mod machine_desired_boot_interface;
 pub mod machine_interface;
 pub mod machine_interface_address;
+pub mod machine_pending_action;
 pub mod machine_topology;
 pub mod machine_validation;
 pub mod machine_validation_config;

--- a/crates/api-db/src/machine_pending_action.rs
+++ b/crates/api-db/src/machine_pending_action.rs
@@ -1,0 +1,314 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Durable markers for work carbide still owes an external system per machine,
+//! and a bounded history of the work already done.
+
+use carbide_uuid::machine::MachineId;
+use model::machine_pending_action::{MachinePendingAction, MachinePendingActionKind};
+use sqlx::PgConnection;
+
+use crate::db_read::DbReader;
+use crate::{DatabaseError, DatabaseResult};
+
+/// Records that `kind` is owed for `machine_id`, returning the outstanding row.
+///
+/// Re-requesting an action that is already outstanding is a no-op write that
+/// preserves the original `requested_at`, so the returned timestamp is how long
+/// the machine has been waiting. Requesting one that was previously completed
+/// starts a new row, leaving the earlier completion in the history.
+pub async fn request(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+    kind: MachinePendingActionKind,
+) -> DatabaseResult<MachinePendingAction> {
+    // The conflict target is the partial unique index over outstanding rows, so
+    // only an unfinished request collides. `kind` already equals `EXCLUDED.kind`
+    // there; assigning it is the way to make this a `DO UPDATE` -- which returns
+    // the existing row -- without changing any column.
+    const QUERY: &str = "INSERT INTO machine_pending_actions (
+        machine_id,
+        kind
+    ) VALUES ($1, $2)
+    ON CONFLICT (machine_id, kind) WHERE completed_at IS NULL DO UPDATE SET
+        kind = EXCLUDED.kind
+    RETURNING machine_id, kind, requested_at, completed_at";
+
+    sqlx::query_as(QUERY)
+        .bind(machine_id)
+        .bind(kind)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+/// Returns whether `kind` is still owed for `machine_id`.
+pub async fn is_outstanding(
+    db: impl DbReader<'_>,
+    machine_id: &MachineId,
+    kind: MachinePendingActionKind,
+) -> DatabaseResult<bool> {
+    const QUERY: &str = "SELECT EXISTS(
+        SELECT 1
+        FROM machine_pending_actions
+        WHERE machine_id = $1 AND kind = $2 AND completed_at IS NULL
+    )";
+
+    sqlx::query_scalar(QUERY)
+        .bind(machine_id)
+        .bind(kind)
+        .fetch_one(db)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+/// Marks an outstanding action as done, which callers must do only once the work
+/// has actually succeeded.
+///
+/// Returns `true` when an outstanding row was completed. Completing work that
+/// was skipped rather than finished drops the signal: nothing re-requests it
+/// until the external system independently re-triggers, which it may never do.
+pub async fn complete(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+    kind: MachinePendingActionKind,
+) -> DatabaseResult<bool> {
+    const QUERY: &str = "UPDATE machine_pending_actions
+        SET completed_at = statement_timestamp()
+        WHERE machine_id = $1 AND kind = $2 AND completed_at IS NULL";
+
+    sqlx::query(QUERY)
+        .bind(machine_id)
+        .bind(kind)
+        .execute(txn)
+        .await
+        .map(|result| result.rows_affected() > 0)
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+/// Returns a machine's actions, newest first.
+///
+/// Any outstanding action sorts first, followed by the retained completions.
+/// History is capped per machine by the database, so this is bounded.
+pub async fn find_all_for_machine(
+    db: impl DbReader<'_>,
+    machine_id: &MachineId,
+) -> DatabaseResult<Vec<MachinePendingAction>> {
+    const QUERY: &str = "SELECT
+        machine_id,
+        kind,
+        requested_at,
+        completed_at
+    FROM machine_pending_actions
+    WHERE machine_id = $1
+    ORDER BY id DESC";
+
+    sqlx::query_as(QUERY)
+        .bind(machine_id)
+        .fetch_all(db)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
+    use model::machine_pending_action::MachinePendingActionKind;
+    use sqlx::{PgConnection, PgPool};
+
+    use super::{complete, find_all_for_machine, is_outstanding, request};
+
+    const DPU_SERVICE_SYNC: MachinePendingActionKind = MachinePendingActionKind::DpuServiceSync;
+
+    fn machine_id(marker: u8) -> MachineId {
+        let mut hardware_id = [0u8; 32];
+        hardware_id[0] = marker;
+        MachineId::new(
+            MachineIdSource::ProductBoardChassisSerial,
+            hardware_id,
+            MachineType::Host,
+        )
+    }
+
+    async fn seed_machine(
+        txn: &mut PgConnection,
+        machine_id: &MachineId,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"INSERT INTO machines (id, dpf)
+               VALUES ($1, '{"enabled": false, "used_for_ingestion": false}'::jsonb)"#,
+        )
+        .bind(machine_id)
+        .execute(txn)
+        .await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn requests_are_scoped_to_one_machine(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let requested = machine_id(1);
+        let untouched = machine_id(2);
+        seed_machine(txn.as_mut(), &requested).await?;
+        seed_machine(txn.as_mut(), &untouched).await?;
+
+        assert!(!is_outstanding(txn.as_mut(), &requested, DPU_SERVICE_SYNC).await?);
+
+        let action = request(txn.as_mut(), &requested, DPU_SERVICE_SYNC).await?;
+        assert_eq!(action.machine_id, requested);
+        assert_eq!(action.kind, DPU_SERVICE_SYNC);
+        assert!(action.is_outstanding());
+
+        assert!(is_outstanding(txn.as_mut(), &requested, DPU_SERVICE_SYNC).await?);
+        assert!(!is_outstanding(txn.as_mut(), &untouched, DPU_SERVICE_SYNC).await?);
+        assert!(
+            find_all_for_machine(txn.as_mut(), &untouched)
+                .await?
+                .is_empty()
+        );
+
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn re_requesting_outstanding_work_preserves_the_original_request_time(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let machine_id = machine_id(1);
+        seed_machine(txn.as_mut(), &machine_id).await?;
+
+        let first = request(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?;
+        let repeated = request(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?;
+        assert_eq!(
+            repeated, first,
+            "a re-request must not restart the pending clock or queue a duplicate"
+        );
+        assert_eq!(
+            find_all_for_machine(txn.as_mut(), &machine_id).await?.len(),
+            1
+        );
+
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn completing_retains_the_record_and_reopens_the_slot(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let machine_id = machine_id(1);
+        seed_machine(txn.as_mut(), &machine_id).await?;
+
+        assert!(
+            !complete(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?,
+            "completing work that was never requested must not invent a record"
+        );
+
+        let requested = request(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?;
+        assert!(complete(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?);
+        assert!(!is_outstanding(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?);
+        assert!(
+            !complete(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?,
+            "completion is not repeatable"
+        );
+
+        let history = find_all_for_machine(txn.as_mut(), &machine_id).await?;
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].requested_at, requested.requested_at);
+        assert!(history[0].completed_at.is_some());
+
+        // A later request is a new wait, and does not disturb the completed row.
+        let second = request(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?;
+        assert!(second.is_outstanding());
+        let history = find_all_for_machine(txn.as_mut(), &machine_id).await?;
+        assert_eq!(history.len(), 2);
+        assert!(history[0].is_outstanding(), "newest first");
+        assert!(history[1].completed_at.is_some());
+
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn history_is_capped_per_machine_without_evicting_outstanding_work(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let busy = machine_id(1);
+        let quiet = machine_id(2);
+        seed_machine(txn.as_mut(), &busy).await?;
+        seed_machine(txn.as_mut(), &quiet).await?;
+
+        let quiet_first = request(txn.as_mut(), &quiet, DPU_SERVICE_SYNC).await?;
+        assert!(complete(txn.as_mut(), &quiet, DPU_SERVICE_SYNC).await?);
+
+        for _ in 0..25 {
+            request(txn.as_mut(), &busy, DPU_SERVICE_SYNC).await?;
+            assert!(complete(txn.as_mut(), &busy, DPU_SERVICE_SYNC).await?);
+        }
+        // Outstanding again, on top of an already-full history.
+        let outstanding = request(txn.as_mut(), &busy, DPU_SERVICE_SYNC).await?;
+
+        let history = find_all_for_machine(txn.as_mut(), &busy).await?;
+        assert_eq!(history.len(), 21, "20 completions plus the outstanding row");
+        assert_eq!(
+            history
+                .iter()
+                .filter(|action| action.is_outstanding())
+                .count(),
+            1
+        );
+        assert_eq!(history[0].requested_at, outstanding.requested_at);
+        assert!(
+            is_outstanding(txn.as_mut(), &busy, DPU_SERVICE_SYNC).await?,
+            "retention must never evict the outstanding marker"
+        );
+
+        // Trimming one machine's history leaves another machine's alone.
+        let quiet_history = find_all_for_machine(txn.as_mut(), &quiet).await?;
+        assert_eq!(quiet_history.len(), 1);
+        assert_eq!(quiet_history[0].requested_at, quiet_first.requested_at);
+
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn deleting_the_machine_clears_its_actions(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let machine_id = machine_id(1);
+        seed_machine(txn.as_mut(), &machine_id).await?;
+        request(txn.as_mut(), &machine_id, DPU_SERVICE_SYNC).await?;
+
+        // The FK cascades, which is why `cleanup_machine_by_id` needs no entry
+        // for this table.
+        sqlx::query("DELETE FROM machines WHERE id = $1")
+            .bind(machine_id)
+            .execute(txn.as_mut())
+            .await?;
+        assert!(
+            find_all_for_machine(txn.as_mut(), &machine_id)
+                .await?
+                .is_empty()
+        );
+
+        Ok(())
+    }
+}

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -68,6 +68,7 @@ pub mod machine_boot_interface;
 pub mod machine_boot_override;
 pub mod machine_interface;
 pub mod machine_interface_address;
+pub mod machine_pending_action;
 pub mod machine_update_module;
 pub mod machine_validation;
 pub mod metadata;

--- a/crates/api-model/src/machine_pending_action.rs
+++ b/crates/api-model/src/machine_pending_action.rs
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::machine::MachineId;
+use chrono::{DateTime, Utc};
+
+/// Work carbide still owes an external system for one machine.
+///
+/// Mirrors the `machine_pending_action_kind` Postgres enum
+/// (`20260810150847_machine_pending_actions.sql`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "machine_pending_action_kind", rename_all = "snake_case")]
+pub enum MachinePendingActionKind {
+    /// DPF has staged a DPUService update and parked the DPU in the NodeEffect
+    /// phase, waiting for carbide to release the maintenance hold.
+    DpuServiceSync,
+}
+
+/// One requested action for one machine, outstanding or already completed.
+///
+/// There is no payload beyond the timing: a `None` `completed_at` means the work
+/// is still owed. `requested_at` is the first time the action was requested and
+/// survives re-requests, so it measures how long the machine waited rather than
+/// when the request was last observed.
+#[derive(Clone, Debug, Eq, PartialEq, sqlx::FromRow)]
+pub struct MachinePendingAction {
+    pub machine_id: MachineId,
+    pub kind: MachinePendingActionKind,
+    pub requested_at: DateTime<Utc>,
+    /// When the work succeeded, or `None` while it is still owed.
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+impl MachinePendingAction {
+    /// Whether this action is still owed.
+    pub fn is_outstanding(&self) -> bool {
+        self.completed_at.is_none()
+    }
+}

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -824,8 +824,13 @@ pub fn build_service_configuration(
             deployment_service_name: svc.name.clone(),
             interfaces: interfaces.none_if_empty(),
             service_configuration,
+            // Treat a service update as disruptive so DPF creates a new revision
+            // and parks the DPU in the NodeEffect phase instead of restarting
+            // services underneath whatever is running. That phase is the gate
+            // carbide opens once it has confirmed the DPU is not still awaiting
+            // reprovisioning -- see the DPU service sync handler.
             upgrade_policy: DpuServiceConfigurationUpgradePolicy {
-                apply_node_effect: Some(false),
+                apply_node_effect: Some(true),
             },
         },
     }
@@ -951,8 +956,10 @@ pub fn build_deployment(
     } else {
         Some(DpuDeploymentServiceChains {
             switches: all_switches,
+            // Disruptive for the same reason as the per-service policy above: a
+            // service-chain change must wait for carbide to release the hold.
             upgrade_policy: DpuDeploymentServiceChainsUpgradePolicy {
-                apply_node_effect: Some(false),
+                apply_node_effect: Some(true),
             },
         })
     };
@@ -2111,7 +2118,32 @@ impl<R: DpuDeploymentRepository + DpuRepository, L> DpfSdk<R, L> {
 /// exercised directly, without standing up repository mocks for a namespace
 /// scan.
 fn dpu_mismatch(namespace: &str, dpu: &DPU, deployment: &DPUDeployment) -> Option<DpuMismatch> {
-    let cr_name = dpu.metadata.name.clone()?;
+    match dpu_comparison(namespace, dpu, deployment) {
+        DpuComparison::Mismatch(mismatch) => Some(mismatch),
+        DpuComparison::Match | DpuComparison::Inconclusive => None,
+    }
+}
+
+/// The outcome of comparing one DPU against the DPUDeployment that owns it.
+///
+/// The third case is the point of this type: `Match` and `Inconclusive` are both
+/// "no drift to report", but only one of them means the DPU is current. Callers
+/// whose safe answer is to skip may treat them alike; callers that act on
+/// "current" must not. Keeping them distinct in the return value is what stops a
+/// future early return from silently reading as `Match`.
+enum DpuComparison {
+    /// The DPU matches everything its deployment declares.
+    Match,
+    /// The DPU differs from its deployment and needs reprovisioning.
+    Mismatch(DpuMismatch),
+    /// The pair could not be compared, so nothing is known either way.
+    Inconclusive,
+}
+
+fn dpu_comparison(namespace: &str, dpu: &DPU, deployment: &DPUDeployment) -> DpuComparison {
+    let Some(cr_name) = dpu.metadata.name.clone() else {
+        return DpuComparison::Inconclusive;
+    };
     let expected_flavor = deployment.spec.dpus.flavor.clone().unwrap_or_default();
     let flavor_matches = dpu.spec.dpu_flavor == expected_flavor;
 
@@ -2148,14 +2180,14 @@ fn dpu_mismatch(namespace: &str, dpu: &DPU, deployment: &DPUDeployment) -> Optio
                 dpu_name = %cr_name,
                 "Owning DPUDeployment sets neither or both of bfb and blueFieldSoftware; skipping"
             );
-            return None;
+            return DpuComparison::Inconclusive;
         }
     };
 
     if source_matches && flavor_matches {
-        return None;
+        return DpuComparison::Match;
     }
-    Some(DpuMismatch {
+    DpuComparison::Mismatch(DpuMismatch {
         dpu_cr_name: cr_name,
         dpu_labels: dpu.metadata.labels.clone().unwrap_or_default(),
         target_source,
@@ -2454,6 +2486,93 @@ impl<R: DpuServiceTemplateRepository, L> DpfSdk<R, L> {
 }
 
 impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, L> DpfSdk<R, L> {
+    /// Fetch a DPU CR together with the DPUDeployment that owns it, resolved
+    /// through the `svc.dpu.nvidia.com/owned-by-dpudeployment` label.
+    ///
+    /// Returns the deployment's name alongside it, since callers report it in
+    /// errors and log lines.
+    async fn dpu_with_owning_deployment(
+        &self,
+        dpu_name: &str,
+    ) -> Result<(DPU, String, DPUDeployment), DpfError> {
+        let dpu = DpuRepository::get(&*self.repo, dpu_name, &self.namespace)
+            .await?
+            .ok_or_else(|| DpfError::InvalidState(format!("DPU CR not found: {dpu_name}")))?;
+
+        let owner_label = dpu
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|l| l.get(DPU_OWNED_BY_DEPLOYMENT_LABEL))
+            .ok_or_else(|| {
+                DpfError::InvalidState(format!(
+                    "DPU {dpu_name} is missing {DPU_OWNED_BY_DEPLOYMENT_LABEL} label"
+                ))
+            })?;
+
+        let deployment_name = owner_label
+            .strip_prefix(&format!("{}_", self.namespace))
+            .unwrap_or(owner_label.as_str())
+            .to_string();
+
+        let deployment =
+            DpuDeploymentRepository::get(&*self.repo, &deployment_name, &self.namespace)
+                .await?
+                .ok_or_else(|| {
+                    DpfError::InvalidState(format!(
+                        "DPUDeployment {deployment_name} not found for DPU {dpu_name}"
+                    ))
+                })?;
+
+        Ok((dpu, deployment_name, deployment))
+    }
+
+    /// Whether one DPU's installed BFB, BlueFieldSoftware, or flavor differs
+    /// from what its owning DPUDeployment declares.
+    ///
+    /// This answers "is a reprovision still coming for this DPU", which gates
+    /// work that must not land on an OS about to be replaced.
+    ///
+    /// Note the deliberate asymmetry with [`Self::find_outdated_dpus_dpf`],
+    /// which skips a DPU it cannot evaluate so a malformed deployment never
+    /// triggers a fleet-wide reprovision. Here an unevaluable DPU reports
+    /// `true`: the caller's safe action is to do nothing, so "unknown" must not
+    /// be reported as "up to date".
+    pub async fn is_dpu_outdated(&self, dpu_name: &str) -> Result<bool, DpfError> {
+        let (dpu, deployment_name, deployment) = self.dpu_with_owning_deployment(dpu_name).await?;
+
+        if !dpu_deployment_is_ready(&deployment) {
+            tracing::info!(
+                dpu_name,
+                deployment = %deployment_name,
+                "DPU's owning DPUDeployment is not ready; treating the DPU as outdated"
+            );
+            return Ok(true);
+        }
+
+        match dpu_comparison(&self.namespace, &dpu, &deployment) {
+            DpuComparison::Match => Ok(false),
+            DpuComparison::Mismatch(mismatch) => {
+                tracing::info!(
+                    dpu_name,
+                    deployment = %deployment_name,
+                    target_source = %mismatch.target_source,
+                    "DPU does not match its owning DPUDeployment"
+                );
+                Ok(true)
+            }
+            DpuComparison::Inconclusive => {
+                tracing::warn!(
+                    dpu_name,
+                    deployment = %deployment_name,
+                    "DPU could not be compared against its owning DPUDeployment; \
+                     treating it as outdated"
+                );
+                Ok(true)
+            }
+        }
+    }
+
     /// Resolve the installed service versions for a DPU by looking up its owning
     /// DPUDeployment (via the `svc.dpu.nvidia.com/owned-by-dpudeployment` label on the DPU CR)
     /// and reading each service's DPUServiceTemplate.
@@ -2473,33 +2592,7 @@ impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, 
         &self,
         dpu_name: &str,
     ) -> Result<Vec<DpuServiceVersion>, DpfError> {
-        let dpu = DpuRepository::get(&*self.repo, dpu_name, &self.namespace)
-            .await?
-            .ok_or_else(|| DpfError::InvalidState(format!("DPU CR not found: {dpu_name}")))?;
-
-        let owner_label = dpu
-            .metadata
-            .labels
-            .as_ref()
-            .and_then(|l| l.get(DPU_OWNED_BY_DEPLOYMENT_LABEL))
-            .ok_or_else(|| {
-                DpfError::InvalidState(format!(
-                    "DPU {dpu_name} is missing {DPU_OWNED_BY_DEPLOYMENT_LABEL} label"
-                ))
-            })?;
-
-        let deployment_name = owner_label
-            .strip_prefix(&format!("{}_", self.namespace))
-            .unwrap_or(owner_label.as_str());
-
-        let deployment =
-            DpuDeploymentRepository::get(&*self.repo, deployment_name, &self.namespace)
-                .await?
-                .ok_or_else(|| {
-                    DpfError::InvalidState(format!(
-                        "DPUDeployment {deployment_name} not found for DPU {dpu_name}"
-                    ))
-                })?;
+        let (_dpu, deployment_name, deployment) = self.dpu_with_owning_deployment(dpu_name).await?;
 
         let mut versions = Vec::new();
         for (service_name, service) in &deployment.spec.services {

--- a/crates/dpf/src/test/mod.rs
+++ b/crates/dpf/src/test/mod.rs
@@ -21,6 +21,7 @@ mod sdk_device_registration;
 mod sdk_initialization;
 mod sdk_join_set;
 mod sdk_maintenance_hold;
+mod sdk_outdated_dpu;
 mod sdk_provisioning_flow;
 mod sdk_reboot_annotation;
 mod watcher_combined;

--- a/crates/dpf/src/test/sdk_outdated_dpu.rs
+++ b/crates/dpf/src/test/sdk_outdated_dpu.rs
@@ -166,9 +166,15 @@ impl DpuServiceTemplateRepository for OutdatedDpuMock {
 
 /// A DPU owned by [`DEPLOYMENT`], built through serde so the literal names only
 /// the fields these tests care about.
-fn dpu(bfb: Option<&str>, installed_bfb_file: Option<&str>, flavor: &str) -> DPU {
+fn dpu(
+    bfb: Option<&str>,
+    blue_field_software: Option<&str>,
+    installed_bfb_file: Option<&str>,
+    flavor: &str,
+) -> DPU {
     let spec = serde_json::json!({
         "bfb": bfb,
+        "blueFieldSoftware": blue_field_software,
         "dpuDeviceName": "device-001",
         "dpuFlavor": flavor,
         "dpuNodeName": "node-host-001",
@@ -243,32 +249,55 @@ async fn is_outdated(mock: OutdatedDpuMock) -> Result<bool, DpfError> {
         .await
 }
 
+/// Both provisioning sources, matching and drifted. A DPUDeployment declares
+/// either a BFB or a BlueFieldSoftware CR, and the two are compared differently:
+/// a BFB against the image actually installed, BlueFieldSoftware against the CR
+/// name the DPU was created with.
 #[tokio::test]
-async fn a_dpu_matching_its_deployment_is_current() {
-    let mock = OutdatedDpuMock::with(
-        dpu(
-            Some("bf-bundle-abc"),
-            Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
-            FLAVOR,
+async fn a_dpu_is_current_only_while_it_matches_its_declared_provisioning_source() {
+    let cases: [(&str, DPU, DPUDeployment, bool); 4] = [
+        (
+            "BFB matches the installed image",
+            dpu(
+                Some("bf-bundle-abc"),
+                None,
+                Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+                FLAVOR,
+            ),
+            deployment(Some("bf-bundle-abc"), None, true),
+            false,
         ),
-        deployment(Some("bf-bundle-abc"), None, true),
-    );
-
-    assert!(!is_outdated(mock).await.expect("evaluated"));
-}
-
-#[tokio::test]
-async fn a_dpu_running_an_older_image_is_outdated() {
-    let mock = OutdatedDpuMock::with(
-        dpu(
-            Some("bf-bundle-old"),
-            Some("/bfb/test-namespace-bf-bundle-old.bfb"),
-            FLAVOR,
+        (
+            "BFB moved on from the installed image",
+            dpu(
+                Some("bf-bundle-old"),
+                None,
+                Some("/bfb/test-namespace-bf-bundle-old.bfb"),
+                FLAVOR,
+            ),
+            deployment(Some("bf-bundle-new"), None, true),
+            true,
         ),
-        deployment(Some("bf-bundle-new"), None, true),
-    );
+        (
+            "BlueFieldSoftware matches the DPU's spec",
+            dpu(None, Some("bf-software-abc"), None, FLAVOR),
+            deployment(None, Some("bf-software-abc"), true),
+            false,
+        ),
+        (
+            "BlueFieldSoftware moved on from the DPU's spec",
+            dpu(None, Some("bf-software-old"), None, FLAVOR),
+            deployment(None, Some("bf-software-new"), true),
+            true,
+        ),
+    ];
 
-    assert!(is_outdated(mock).await.expect("evaluated"));
+    for (name, dpu, deployment, expected_outdated) in cases {
+        let outdated = is_outdated(OutdatedDpuMock::with(dpu, deployment))
+            .await
+            .unwrap_or_else(|error| panic!("{name}: evaluation failed: {error}"));
+        assert_eq!(outdated, expected_outdated, "{name}");
+    }
 }
 
 #[tokio::test]
@@ -276,6 +305,7 @@ async fn a_dpu_whose_flavor_drifted_is_outdated() {
     let mock = OutdatedDpuMock::with(
         dpu(
             Some("bf-bundle-abc"),
+            None,
             Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
             "some-other-flavor",
         ),
@@ -293,6 +323,7 @@ async fn an_unready_deployment_leaves_the_dpu_outdated() {
     let mock = OutdatedDpuMock::with(
         dpu(
             Some("bf-bundle-abc"),
+            None,
             Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
             FLAVOR,
         ),
@@ -309,7 +340,7 @@ async fn a_deployment_declaring_no_provisioning_source_leaves_the_dpu_outdated()
     // inconclusive. `find_outdated_dpus_dpf` skips this case; here it must not
     // read as "up to date".
     let mock = OutdatedDpuMock::with(
-        dpu(Some("bf-bundle-abc"), None, FLAVOR),
+        dpu(Some("bf-bundle-abc"), None, None, FLAVOR),
         deployment(None, None, true),
     );
 
@@ -319,7 +350,7 @@ async fn a_deployment_declaring_no_provisioning_source_leaves_the_dpu_outdated()
 #[tokio::test]
 async fn a_deployment_declaring_both_provisioning_sources_leaves_the_dpu_outdated() {
     let mock = OutdatedDpuMock::with(
-        dpu(Some("bf-bundle-abc"), None, FLAVOR),
+        dpu(Some("bf-bundle-abc"), None, None, FLAVOR),
         deployment(Some("bf-bundle-abc"), Some("bf-software-abc"), true),
     );
 
@@ -340,6 +371,7 @@ async fn a_missing_dpu_is_an_error_rather_than_a_verdict() {
 async fn a_dpu_without_an_owner_label_is_an_error() {
     let mut orphan = dpu(
         Some("bf-bundle-abc"),
+        None,
         Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
         FLAVOR,
     );

--- a/crates/dpf/src/test/sdk_outdated_dpu.rs
+++ b/crates/dpf/src/test/sdk_outdated_dpu.rs
@@ -1,0 +1,350 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! `DpfSdk::is_dpu_outdated`, the single-DPU staleness check that gates work
+//! which must not land on a DPU still awaiting reprovisioning.
+//!
+//! Every path that cannot produce a confident "this DPU is current" must report
+//! `true`, because the caller's safe action is to do nothing.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use kube::core::ObjectMeta;
+
+use crate::crds::dpudeployments_generated::DPUDeployment;
+use crate::crds::dpus_generated::DPU;
+use crate::crds::dpuservicetemplates_generated::DPUServiceTemplate;
+use crate::error::DpfError;
+use crate::repository::{
+    DpuDeploymentRepository, DpuRepository, DpuServiceTemplateRepository, K8sConfigRepository,
+};
+use crate::sdk::DpfSdkBuilder;
+
+const TEST_NS: &str = "test-namespace";
+const DEPLOYMENT: &str = "test-deployment";
+const FLAVOR: &str = "test-flavor";
+const DPU_NAME: &str = "node-host-001-device-001";
+const OWNED_BY_LABEL: &str = "svc.dpu.nvidia.com/owned-by-dpudeployment";
+
+#[derive(Default, Clone)]
+struct OutdatedDpuMock {
+    dpus: Arc<DashMap<String, DPU>>,
+    deployments: Arc<DashMap<String, DPUDeployment>>,
+}
+
+impl OutdatedDpuMock {
+    fn with(dpu: DPU, deployment: DPUDeployment) -> Self {
+        let mock = Self::default();
+        mock.dpus.insert(DPU_NAME.to_string(), dpu);
+        mock.deployments.insert(DEPLOYMENT.to_string(), deployment);
+        mock
+    }
+}
+
+#[async_trait]
+impl DpuRepository for OutdatedDpuMock {
+    async fn get(&self, name: &str, _ns: &str) -> Result<Option<DPU>, DpfError> {
+        Ok(self.dpus.get(name).map(|dpu| dpu.clone()))
+    }
+    async fn list(&self, _ns: &str, _selector: Option<&str>) -> Result<Vec<DPU>, DpfError> {
+        Ok(self.dpus.iter().map(|e| e.value().clone()).collect())
+    }
+    async fn patch_status(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _patch: serde_json::Value,
+    ) -> Result<(), DpfError> {
+        Ok(())
+    }
+    async fn delete(&self, _name: &str, _ns: &str) -> Result<(), DpfError> {
+        Ok(())
+    }
+    fn watch<F, Fut>(
+        &self,
+        _ns: &str,
+        _selector: Option<&str>,
+        _handler: F,
+    ) -> impl Future<Output = ()> + Send + 'static
+    where
+        F: Fn(Arc<DPU>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(), DpfError>> + Send + 'static,
+    {
+        futures::future::pending()
+    }
+}
+
+#[async_trait]
+impl DpuDeploymentRepository for OutdatedDpuMock {
+    async fn get(&self, name: &str, _ns: &str) -> Result<Option<DPUDeployment>, DpfError> {
+        Ok(self.deployments.get(name).map(|d| d.clone()))
+    }
+    async fn list(&self, _ns: &str) -> Result<Vec<DPUDeployment>, DpfError> {
+        Ok(self.deployments.iter().map(|e| e.value().clone()).collect())
+    }
+    async fn apply(&self, d: &DPUDeployment) -> Result<DPUDeployment, DpfError> {
+        Ok(d.clone())
+    }
+    async fn patch(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _patch: serde_json::Value,
+    ) -> Result<(), DpfError> {
+        Ok(())
+    }
+    async fn delete(&self, _name: &str, _ns: &str) -> Result<(), DpfError> {
+        Ok(())
+    }
+}
+
+/// Required by `build_without_resources`; nothing here reads config or secrets.
+#[async_trait]
+impl K8sConfigRepository for OutdatedDpuMock {
+    async fn get_configmap(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<Option<BTreeMap<String, String>>, DpfError> {
+        Ok(None)
+    }
+    async fn apply_configmap(
+        &self,
+        _: &str,
+        _: &str,
+        _: BTreeMap<String, String>,
+    ) -> Result<(), DpfError> {
+        Ok(())
+    }
+    async fn get_secret(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
+        Ok(None)
+    }
+    async fn apply_secret(
+        &self,
+        _: &str,
+        _: &str,
+        _: BTreeMap<String, Vec<u8>>,
+    ) -> Result<(), DpfError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DpuServiceTemplateRepository for OutdatedDpuMock {
+    async fn get(&self, _name: &str, _ns: &str) -> Result<Option<DPUServiceTemplate>, DpfError> {
+        Ok(None)
+    }
+    async fn list(&self, _ns: &str) -> Result<Vec<DPUServiceTemplate>, DpfError> {
+        Ok(vec![])
+    }
+    async fn apply(&self, t: &DPUServiceTemplate) -> Result<DPUServiceTemplate, DpfError> {
+        Ok(t.clone())
+    }
+}
+
+/// A DPU owned by [`DEPLOYMENT`], built through serde so the literal names only
+/// the fields these tests care about.
+fn dpu(bfb: Option<&str>, installed_bfb_file: Option<&str>, flavor: &str) -> DPU {
+    let spec = serde_json::json!({
+        "bfb": bfb,
+        "dpuDeviceName": "device-001",
+        "dpuFlavor": flavor,
+        "dpuNodeName": "node-host-001",
+        "nodeEffect": {},
+        "serialNumber": "SN123",
+    });
+    let status = serde_json::json!({
+        "phase": "Ready",
+        "bfbFile": installed_bfb_file,
+    });
+
+    DPU {
+        metadata: ObjectMeta {
+            name: Some(DPU_NAME.to_string()),
+            namespace: Some(TEST_NS.to_string()),
+            labels: Some(BTreeMap::from([(
+                OWNED_BY_LABEL.to_string(),
+                format!("{TEST_NS}_{DEPLOYMENT}"),
+            )])),
+            ..Default::default()
+        },
+        spec: serde_json::from_value(spec).expect("valid DpuSpec"),
+        status: Some(serde_json::from_value(status).expect("valid DpuStatus")),
+    }
+}
+
+/// `ready` controls whether `DPUSetsReconciled` is `True` at the current
+/// generation, which is what [`dpu_deployment_is_ready`] requires.
+fn deployment(bfb: Option<&str>, blue_field_software: Option<&str>, ready: bool) -> DPUDeployment {
+    let spec = serde_json::json!({
+        "dpus": {
+            "bfb": bfb,
+            "blueFieldSoftware": blue_field_software,
+            "flavor": FLAVOR,
+            "dpuSetStrategy": { "type": "OnDelete" },
+            "nodeEffect": {},
+        },
+        "services": {},
+        "serviceChains": {
+            "switches": [],
+            "upgradePolicy": { "applyNodeEffect": true },
+        },
+    });
+    let status = serde_json::json!({
+        "conditions": [{
+            "type": "DPUSetsReconciled",
+            "status": if ready { "True" } else { "False" },
+            "observedGeneration": 1,
+            "lastTransitionTime": "2026-01-01T00:00:00Z",
+            "reason": "Test",
+        }],
+    });
+
+    DPUDeployment {
+        metadata: ObjectMeta {
+            name: Some(DEPLOYMENT.to_string()),
+            namespace: Some(TEST_NS.to_string()),
+            generation: Some(1),
+            ..Default::default()
+        },
+        spec: serde_json::from_value(spec).expect("valid DpuDeploymentSpec"),
+        status: Some(serde_json::from_value(status).expect("valid DpuDeploymentStatus")),
+    }
+}
+
+async fn is_outdated(mock: OutdatedDpuMock) -> Result<bool, DpfError> {
+    DpfSdkBuilder::new(mock, TEST_NS, String::new())
+        .build_without_resources()
+        .await
+        .expect("sdk")
+        .is_dpu_outdated(DPU_NAME)
+        .await
+}
+
+#[tokio::test]
+async fn a_dpu_matching_its_deployment_is_current() {
+    let mock = OutdatedDpuMock::with(
+        dpu(
+            Some("bf-bundle-abc"),
+            Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            FLAVOR,
+        ),
+        deployment(Some("bf-bundle-abc"), None, true),
+    );
+
+    assert!(!is_outdated(mock).await.expect("evaluated"));
+}
+
+#[tokio::test]
+async fn a_dpu_running_an_older_image_is_outdated() {
+    let mock = OutdatedDpuMock::with(
+        dpu(
+            Some("bf-bundle-old"),
+            Some("/bfb/test-namespace-bf-bundle-old.bfb"),
+            FLAVOR,
+        ),
+        deployment(Some("bf-bundle-new"), None, true),
+    );
+
+    assert!(is_outdated(mock).await.expect("evaluated"));
+}
+
+#[tokio::test]
+async fn a_dpu_whose_flavor_drifted_is_outdated() {
+    let mock = OutdatedDpuMock::with(
+        dpu(
+            Some("bf-bundle-abc"),
+            Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            "some-other-flavor",
+        ),
+        deployment(Some("bf-bundle-abc"), None, true),
+    );
+
+    assert!(is_outdated(mock).await.expect("evaluated"));
+}
+
+#[tokio::test]
+async fn an_unready_deployment_leaves_the_dpu_outdated() {
+    // Matches on every field, so only the deployment's readiness decides. An
+    // unready deployment is still settling and its declared state is not yet
+    // authoritative.
+    let mock = OutdatedDpuMock::with(
+        dpu(
+            Some("bf-bundle-abc"),
+            Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            FLAVOR,
+        ),
+        deployment(Some("bf-bundle-abc"), None, false),
+    );
+
+    assert!(is_outdated(mock).await.expect("evaluated"));
+}
+
+#[tokio::test]
+async fn a_deployment_declaring_no_provisioning_source_leaves_the_dpu_outdated() {
+    // Neither bfb nor blueFieldSoftware violates the DPU CRD's
+    // `has(self.bfb) != has(self.blueFieldSoftware)` rule, so the comparison is
+    // inconclusive. `find_outdated_dpus_dpf` skips this case; here it must not
+    // read as "up to date".
+    let mock = OutdatedDpuMock::with(
+        dpu(Some("bf-bundle-abc"), None, FLAVOR),
+        deployment(None, None, true),
+    );
+
+    assert!(is_outdated(mock).await.expect("evaluated"));
+}
+
+#[tokio::test]
+async fn a_deployment_declaring_both_provisioning_sources_leaves_the_dpu_outdated() {
+    let mock = OutdatedDpuMock::with(
+        dpu(Some("bf-bundle-abc"), None, FLAVOR),
+        deployment(Some("bf-bundle-abc"), Some("bf-software-abc"), true),
+    );
+
+    assert!(is_outdated(mock).await.expect("evaluated"));
+}
+
+#[tokio::test]
+async fn a_missing_dpu_is_an_error_rather_than_a_verdict() {
+    // Nothing seeded. Reporting `false` here would release a hold for a DPU
+    // that cannot be inspected; reporting `true` would silently stall. The
+    // caller needs to tell this apart from a real answer.
+    let mock = OutdatedDpuMock::default();
+
+    assert!(is_outdated(mock).await.is_err());
+}
+
+#[tokio::test]
+async fn a_dpu_without_an_owner_label_is_an_error() {
+    let mut orphan = dpu(
+        Some("bf-bundle-abc"),
+        Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+        FLAVOR,
+    );
+    orphan.metadata.labels = None;
+    let mock = OutdatedDpuMock::with(orphan, deployment(Some("bf-bundle-abc"), None, true));
+
+    assert!(is_outdated(mock).await.is_err());
+}

--- a/crates/machine-controller/src/config/mod.rs
+++ b/crates/machine-controller/src/config/mod.rs
@@ -45,6 +45,10 @@ pub struct MachineStateHandlerSiteConfig {
 
     pub dpa_enabled: bool,
     pub dpf_enabled: bool,
+    /// Site-wide enable for releasing the DPF maintenance hold so a changed
+    /// DPUService rolls out. When `false`, a host that DPF has parked in the
+    /// NodeEffect phase keeps its hold and its pending marker.
+    pub dpu_service_sync_enabled: bool,
     pub spdm_enabled: bool,
 
     /// Site-wide kill-switch for the passive BMC credential rotation guard. When
@@ -76,6 +80,7 @@ impl MachineStateHandlerSiteConfig {
             oem_manager_profiles: HashMap::new(),
             dpa_enabled: true,
             dpf_enabled: false,
+            dpu_service_sync_enabled: true,
             spdm_enabled: false,
             bmc_rotation_enabled: false,
             uefi_rotation_enabled: false,

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -30,6 +30,7 @@ use carbide_dpf::{
 use carbide_uuid::machine::MachineId;
 use model::dpu_machine_update::OutdatedDpfDpu;
 use model::machine::{Machine, ManagedHostStateSnapshot};
+use model::machine_pending_action::{MachinePendingAction, MachinePendingActionKind};
 use sqlx::PgPool;
 use state_controller::controller::Enqueuer;
 use tokio::task::JoinSet;
@@ -132,6 +133,13 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// from carbide config — see [`DpfSdk::find_outdated_dpus_dpf`] for
     /// details.
     async fn find_outdated_dpus_dpf(&self) -> Result<Vec<OutdatedDpfDpu>, DpfError>;
+
+    /// Whether one DPU still differs from its owning DPUDeployment, i.e. a
+    /// reprovision is still coming for it.
+    ///
+    /// Reports `true` for a DPU it cannot evaluate, so callers gated on "this
+    /// DPU is already up to date" fail closed.
+    async fn is_dpu_outdated(&self, dpu_name: &str) -> Result<bool, DpfError>;
 }
 
 /// Check whether the DPUNode and DPUDevice CRs are missing for the given host.
@@ -376,7 +384,7 @@ impl DpfSdkOps {
                             host_bmc_ip_address = %event.host_bmc_ip,
                             "DPF reboot required"
                         );
-                        enqueue_host(&db_pool, &event.node_name, "reboot").await
+                        enqueue_host(&db_pool, &event.node_name, "reboot", None).await
                     }
                 }
             })
@@ -391,7 +399,7 @@ impl DpfSdkOps {
                             node = %event.node_name,
                             "DPF DPU ready"
                         );
-                        enqueue_host(&db_pool, &event.node_name, "ready").await
+                        enqueue_host(&db_pool, &event.node_name, "ready", None).await
                     }
                 }
             })
@@ -404,7 +412,16 @@ impl DpfSdkOps {
                             node = %event.node_name,
                             "DPF maintenance needed (NodeEffect phase)"
                         );
-                        enqueue_host(&db_pool, &event.node_name, "maintenance").await
+                        // A DPUService change is one of the things that drives a
+                        // DPU here, and rolling it out needs carbide to release
+                        // the hold once the DPU is confirmed up to date.
+                        enqueue_host(
+                            &db_pool,
+                            &event.node_name,
+                            "maintenance",
+                            Some(MachinePendingActionKind::DpuServiceSync),
+                        )
+                        .await
                     }
                 }
             })
@@ -418,7 +435,7 @@ impl DpfSdkOps {
                             node = %event.node_name,
                             "DPF DPU entered error phase"
                         );
-                        enqueue_host(&db_pool, &event.node_name, "error").await
+                        enqueue_host(&db_pool, &event.node_name, "error", None).await
                     }
                 }
             })
@@ -432,10 +449,38 @@ impl DpfSdkOps {
     }
 }
 
+/// Records that a host owes `kind`, returning the stored action.
+async fn record_pending_action(
+    db_pool: &PgPool,
+    host_machine_id: &MachineId,
+    kind: MachinePendingActionKind,
+) -> Result<MachinePendingAction, DpfError> {
+    let mut conn = db_pool.acquire().await.map_err(|e| {
+        DpfError::InvalidState(format!("Failed to acquire database connection: {e}"))
+    })?;
+    db::machine_pending_action::request(&mut conn, host_machine_id, kind)
+        .await
+        .map_err(|e| {
+            DpfError::InvalidState(format!(
+                "DB error recording pending action for machine {host_machine_id}: {e}"
+            ))
+        })
+}
+
 /// Look up a host by DPUNode CR name and enqueue it for state handling.
 /// CR name format: `node-{dpf_id}`, where `dpf_id` is the host's BMC MAC
 /// address with colons replaced by hyphens.
-async fn enqueue_host(db_pool: &PgPool, node_name: &str, reason: &str) -> Result<(), DpfError> {
+///
+/// `pending_action` records durable work the host owes before it is enqueued.
+/// The queue itself cannot carry that signal: it stores only an object id and
+/// coalesces duplicates, so this enqueue is indistinguishable from the periodic
+/// sweep's and is dropped outright if the sweep queued the host first.
+async fn enqueue_host(
+    db_pool: &PgPool,
+    node_name: &str,
+    reason: &str,
+    pending_action: Option<MachinePendingActionKind>,
+) -> Result<(), DpfError> {
     let bmc_mac_id = node_id_from_dpu_node_cr_name(node_name);
     let bmc_mac: mac_address::MacAddress = bmc_mac_id
         .replace('-', ":")
@@ -458,32 +503,39 @@ async fn enqueue_host(db_pool: &PgPool, node_name: &str, reason: &str) -> Result
         return Ok(());
     };
 
-    let host = {
-        let mut conn = db_pool.acquire().await.map_err(|e| {
-            DpfError::InvalidState(format!("Failed to acquire database connection: {e}"))
-        })?;
-        db::machine::find_one(
-            &mut *conn,
-            &host_machine_id,
-            model::machine::machine_search_config::MachineSearchConfig::default(),
-        )
-        .await
-        .map_err(|e| DpfError::InvalidState(format!("DB error looking up host: {e}")))?
-    };
-
-    let Some(host) = host else {
-        tracing::warn!(node = %node_name, reason, "Could not find host for DPF node");
-        return Ok(());
-    };
+    // Written before the enqueue so a processor cannot reach the host's handler
+    // while the marker is still missing.
+    //
+    // A failure here must not suppress the enqueue. This callback's wake-up is
+    // what the DPF provisioning handler relies on to release a node's hold, and
+    // that is older and more important than the marker; losing it would stall
+    // provisioning until the periodic sweep noticed. The marker is recoverable
+    // on its own -- the watcher fires again while the DPU stays in NodeEffect.
+    if let Some(kind) = pending_action {
+        match record_pending_action(db_pool, &host_machine_id, kind).await {
+            Ok(action) => tracing::info!(
+                node = %node_name,
+                machine_id = %host_machine_id,
+                requested_at = %action.requested_at,
+                "Recorded pending DPF action for host"
+            ),
+            Err(error) => tracing::warn!(
+                node = %node_name,
+                machine_id = %host_machine_id,
+                %error,
+                "Could not record pending DPF action; enqueueing the host regardless"
+            ),
+        }
+    }
 
     Enqueuer::<MachineStateControllerIO>::new(db_pool.clone())
-        .enqueue_object(&host.id)
+        .enqueue_object(&host_machine_id)
         .await
         .map_err(|e| {
-            DpfError::InvalidState(format!("Failed to enqueue machine {}: {e}", host.id))
+            DpfError::InvalidState(format!("Failed to enqueue machine {host_machine_id}: {e}"))
         })?;
 
-    tracing::info!(node = %node_name, machine_id = %host.id, reason, "Enqueued host for DPF state handling");
+    tracing::info!(node = %node_name, machine_id = %host_machine_id, reason, "Enqueued host for DPF state handling");
     Ok(())
 }
 
@@ -583,6 +635,10 @@ impl DpfOperations for DpfSdkOps {
 
     async fn snapshot_host(&self, node_name: &str) -> Result<HostDpfSnapshot, DpfError> {
         self.sdk.snapshot_host(node_name).await
+    }
+
+    async fn is_dpu_outdated(&self, dpu_name: &str) -> Result<bool, DpfError> {
+        self.sdk.is_dpu_outdated(dpu_name).await
     }
 
     async fn list_service_template_versions(

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -506,27 +506,34 @@ async fn enqueue_host(
     // Written before the enqueue so a processor cannot reach the host's handler
     // while the marker is still missing.
     //
-    // A failure here must not suppress the enqueue. This callback's wake-up is
+    // A failure here must not suppress the enqueue: this callback's wake-up is
     // what the DPF provisioning handler relies on to release a node's hold, and
-    // that is older and more important than the marker; losing it would stall
-    // provisioning until the periodic sweep noticed. The marker is recoverable
-    // on its own -- the watcher fires again while the DPU stays in NodeEffect.
-    if let Some(kind) = pending_action {
-        match record_pending_action(db_pool, &host_machine_id, kind).await {
-            Ok(action) => tracing::info!(
-                node = %node_name,
-                machine_id = %host_machine_id,
-                requested_at = %action.requested_at,
-                "Recorded pending DPF action for host"
-            ),
-            Err(error) => tracing::warn!(
-                node = %node_name,
-                machine_id = %host_machine_id,
-                %error,
-                "Could not record pending DPF action; enqueueing the host regardless"
-            ),
-        }
-    }
+    // that is older and more important than the marker. The error is carried
+    // past the enqueue and returned instead, so the watcher retries this event
+    // (~30s) rather than leaving the marker to the next hourly resync.
+    let marker_error = match pending_action {
+        Some(kind) => match record_pending_action(db_pool, &host_machine_id, kind).await {
+            Ok(action) => {
+                tracing::info!(
+                    node = %node_name,
+                    machine_id = %host_machine_id,
+                    requested_at = %action.requested_at,
+                    "Recorded pending DPF action for host"
+                );
+                None
+            }
+            Err(error) => {
+                tracing::warn!(
+                    node = %node_name,
+                    machine_id = %host_machine_id,
+                    %error,
+                    "Could not record pending DPF action; enqueueing the host before retrying"
+                );
+                Some(error)
+            }
+        },
+        None => None,
+    };
 
     Enqueuer::<MachineStateControllerIO>::new(db_pool.clone())
         .enqueue_object(&host_machine_id)
@@ -536,7 +543,11 @@ async fn enqueue_host(
         })?;
 
     tracing::info!(node = %node_name, machine_id = %host_machine_id, reason, "Enqueued host for DPF state handling");
-    Ok(())
+
+    match marker_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
 }
 
 impl std::fmt::Debug for DpfSdkOps {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -121,6 +121,7 @@ pub mod attestation;
 mod bios_config;
 mod boot_interface_observation;
 mod dpf;
+mod dpu_action_handler;
 mod dpu_uefi_rotation;
 mod firmware_artifact;
 mod helpers;
@@ -1119,6 +1120,15 @@ impl MachineStateHandler {
                         ManagedHostState::RotatingDpuUefi { dpu_machine_id },
                     ));
                 }
+
+                // Releasing a DPF maintenance hold restarts DPU services, so it
+                // belongs with the idle-only work above rather than ahead of it.
+                dpu_action_handler::handle_pending_dpu_actions(
+                    self.dpu_handler.dpf_sdk.as_deref(),
+                    ctx,
+                    mh_snapshot,
+                )
+                .await?;
 
                 // Periodic BMC observation is deliberately Ready's final work,
                 // so it cannot preempt lifecycle or operator-requested actions.

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -465,6 +465,26 @@ async fn handle_dpf_waiting_for_ready(
         .await
         .map_err(dpf_error)?;
 
+    // The watcher records a pending service sync for any DPU it sees in the
+    // NodeEffect phase, because the phase does not say why the DPU is parked --
+    // a provisioning pass produces one just as a DPUService change does. This
+    // release satisfies whichever it was, so retire the marker here rather than
+    // leave the Ready handler to rediscover it and call Kubernetes for work that
+    // has already happened.
+    //
+    // Bookkeeping only: a failure here costs a redundant check later, so it must
+    // not fail provisioning.
+    if let Err(error) =
+        super::dpu_action_handler::complete_pending_sync(ctx, &state.host_snapshot).await
+    {
+        tracing::warn!(
+            machine_id = %state.host_snapshot.id,
+            node = %node_name,
+            %error,
+            "Could not retire the host's pending DPU service sync after releasing its hold"
+        );
+    }
+
     if dpf_sdk
         .is_reboot_required(&node_name)
         .await

--- a/crates/machine-controller/src/handler/dpu_action_handler.rs
+++ b/crates/machine-controller/src/handler/dpu_action_handler.rs
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Releases the DPF maintenance hold for hosts whose DPUs are already running
+//! the software their DPUDeployment declares.
+//!
+//! A DPUService change (helm chart or image version) drives every affected DPU
+//! into the NodeEffect phase, where DPF waits for permission to disrupt it.
+//! Granting that permission is only correct for a DPU that is otherwise up to
+//! date: one still awaiting reprovisioning is about to have its OS replaced, and
+//! the new services may not run on the OS currently installed.
+//!
+//! Scope: this decides *when* a declared service version reaches a DPU, not
+//! *whether* that version belongs there. It asks only whether the DPU matches
+//! its DPUDeployment, so a deployment that pairs a service version with an
+//! incompatible BFB is rolled out faithfully. Keeping those versions coherent is
+//! the operator's responsibility, deliberately -- a compatibility check here
+//! would also reject the test builds that qualifying a new service depends on.
+//!
+//! Runs from the `Ready` arm only. `Ready` is not the only state where releasing
+//! a hold would be safe -- `HostInit` has provisioned DPUs and no tenant either
+//! -- but keeping the automatic path narrow means it can never collide with the
+//! DPF states where NICo itself drives DPU operations.
+//!
+//! The accepted cost is that a host which never reaches `Ready` never receives a
+//! service update. That matters most when the update *is* the fix: a DPUService
+//! version that breaks host provisioning strands hosts in `HostInit`, and they
+//! cannot be repaired by the automatic path. Recovering those is an explicit
+//! operator action rather than something this handler infers.
+
+use carbide_dpf::sdk::{dpu_cr_name, dpu_node_cr_name};
+use model::machine::{Machine, ManagedHostState, ManagedHostStateSnapshot};
+use model::machine_pending_action::MachinePendingActionKind::DpuServiceSync;
+use state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+use crate::context::MachineStateHandlerContextObjects;
+use crate::dpf::DpfOperations;
+
+/// Performs the DPU-side work a host owes, recorded as a pending action while
+/// the host was busy elsewhere.
+///
+/// Only [`DpuServiceSync`] exists today: release the maintenance hold once every
+/// one of the host's DPUs matches its owning DPUDeployment.
+///
+/// Always reports [`StateHandlerOutcome::do_nothing`]: this is background work
+/// that must never preempt a lifecycle or operator-requested transition, and it
+/// drives no state change of its own. Failures are logged rather than returned
+/// for the same reason — the pending marker survives, so the next sweep retries.
+pub(super) async fn handle_pending_dpu_actions(
+    dpf_sdk: Option<&dyn DpfOperations>,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let host = &mh_snapshot.host_snapshot;
+
+    if !ctx.services.site_config.dpu_service_sync_enabled || !host.config.dpf.used_for_ingestion {
+        return Ok(StateHandlerOutcome::do_nothing());
+    }
+
+    // `used_for_ingestion` does not guarantee the SDK was configured.
+    let Some(dpf_sdk) = dpf_sdk else {
+        return Ok(StateHandlerOutcome::do_nothing());
+    };
+
+    // The marker is what keeps ordinary Ready sweeps off the Kubernetes API:
+    // without one, DPF is not waiting on this host and there is nothing to do.
+    //
+    // A database failure here is logged like every other failure in this
+    // function rather than returned. Propagating would abort the rest of Ready's
+    // work for the sake of a background task, and the marker survives either way.
+    match pending_sync_is_outstanding(ctx, host).await {
+        Ok(true) => {}
+        Ok(false) => return Ok(StateHandlerOutcome::do_nothing()),
+        Err(error) => {
+            tracing::warn!(
+                machine_id = %host.id,
+                %error,
+                "Could not read the host's pending DPU actions"
+            );
+            return Ok(StateHandlerOutcome::do_nothing());
+        }
+    }
+
+    let Some(node_id) = host.dpf_id() else {
+        tracing::warn!(
+            machine_id = %host.id,
+            "Host has no BMC MAC, so its DPF node cannot be identified"
+        );
+        return Ok(StateHandlerOutcome::do_nothing());
+    };
+    let node_name = dpu_node_cr_name(&node_id);
+
+    // "Every DPU is current" is only a reason to release the hold when there is
+    // at least one DPU to have checked. An empty snapshot means the host's DPUs
+    // could not be resolved, not that they are all up to date, and releasing on
+    // it would grant DPF permission having verified nothing.
+    if mh_snapshot.dpu_snapshots.is_empty() {
+        tracing::warn!(
+            machine_id = %host.id,
+            "Host has no DPU snapshots, so its DPUs cannot be checked for currency"
+        );
+        return Ok(StateHandlerOutcome::do_nothing());
+    }
+
+    // The hold is per node, so every DPU on the host must be up to date before
+    // it is safe to lift. A DPU that is still outdated keeps its reprovision,
+    // and this host keeps its marker for a later sweep to retry.
+    for dpu_snapshot in &mh_snapshot.dpu_snapshots {
+        let Some(device_id) = dpu_snapshot.dpf_id() else {
+            tracing::warn!(
+                machine_id = %host.id,
+                dpu_machine_id = %dpu_snapshot.id,
+                "DPU has no BMC MAC, so its DPU CR cannot be identified"
+            );
+            return Ok(StateHandlerOutcome::do_nothing());
+        };
+
+        match dpf_sdk
+            .is_dpu_outdated(&dpu_cr_name(&device_id, &node_id))
+            .await
+        {
+            Ok(false) => {}
+            Ok(true) => {
+                tracing::info!(
+                    machine_id = %host.id,
+                    dpu_machine_id = %dpu_snapshot.id,
+                    "Holding the DPF maintenance hold: DPU still awaits reprovisioning"
+                );
+                return Ok(StateHandlerOutcome::do_nothing());
+            }
+            Err(error) => {
+                tracing::warn!(
+                    machine_id = %host.id,
+                    dpu_machine_id = %dpu_snapshot.id,
+                    %error,
+                    "Could not determine whether the DPU is up to date"
+                );
+                return Ok(StateHandlerOutcome::do_nothing());
+            }
+        }
+    }
+
+    if let Err(error) = dpf_sdk.release_maintenance_hold(&node_name).await {
+        tracing::warn!(
+            machine_id = %host.id,
+            node = %node_name,
+            %error,
+            "Failed to release the DPF maintenance hold for DPU service sync"
+        );
+        return Ok(StateHandlerOutcome::do_nothing());
+    }
+
+    // Only now, after a release that actually succeeded. A DPU already sitting
+    // in NodeEffect does not re-enter it, so the watcher will not re-fire; a
+    // marker cleared on any other path is a signal lost until a watcher relist.
+    //
+    // Failing to record the completion is the safe direction: the marker stays
+    // outstanding and the next sweep releases an already-released hold, which is
+    // a no-op.
+    if let Err(error) = complete_pending_sync(ctx, host).await {
+        tracing::warn!(
+            machine_id = %host.id,
+            %error,
+            "Released the hold but could not record the action as completed"
+        );
+        return Ok(StateHandlerOutcome::do_nothing());
+    }
+
+    tracing::info!(
+        machine_id = %host.id,
+        node = %node_name,
+        dpu_count = mh_snapshot.dpu_snapshots.len(),
+        "Released the DPF maintenance hold so DPU services can roll out"
+    );
+    Ok(StateHandlerOutcome::do_nothing())
+}
+
+async fn pending_sync_is_outstanding(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    host: &Machine,
+) -> Result<bool, StateHandlerError> {
+    let mut conn = ctx.services.db_pool.acquire().await?;
+    Ok(db::machine_pending_action::is_outstanding(&mut *conn, &host.id, DpuServiceSync).await?)
+}
+
+/// Marks this host's pending DPU service sync as done.
+///
+/// Callable from the DPF provisioning handler as well: releasing a node's hold
+/// there satisfies any sync recorded for it, and the watcher cannot tell the two
+/// causes apart when it writes the marker.
+pub(super) async fn complete_pending_sync(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    host: &Machine,
+) -> Result<bool, StateHandlerError> {
+    let mut conn = ctx.services.db_pool.acquire().await?;
+    Ok(db::machine_pending_action::complete(&mut conn, &host.id, DpuServiceSync).await?)
+}

--- a/crates/machine-controller/src/handler/dpu_action_handler.rs
+++ b/crates/machine-controller/src/handler/dpu_action_handler.rs
@@ -156,6 +156,36 @@ pub(super) async fn handle_pending_dpu_actions(
         }
     }
 
+    // The tenant check that let this host through ran against the snapshot the
+    // iteration opened with, and the DPU checks since have cost a Kubernetes
+    // round trip each. Allocation commits under a row lock this handler does not
+    // hold, so an instance can appear in that window.
+    //
+    // The transitions elsewhere in `Ready` do not need this: they only propose a
+    // new state and lose harmlessly to the optimistic-concurrency version check.
+    // Releasing a hold is an external action that cannot be taken back, so it
+    // re-reads instead. That narrows the window to this query plus the patch
+    // rather than closing it; the marker survives, so a host that slips through
+    // is caught on the sweep after its instance is gone.
+    match host_has_instance(ctx, host).await {
+        Ok(false) => {}
+        Ok(true) => {
+            tracing::info!(
+                machine_id = %host.id,
+                "Host was assigned while its DPUs were being checked; keeping the hold"
+            );
+            return Ok(StateHandlerOutcome::do_nothing());
+        }
+        Err(error) => {
+            tracing::warn!(
+                machine_id = %host.id,
+                %error,
+                "Could not confirm the host is still unassigned; keeping the hold"
+            );
+            return Ok(StateHandlerOutcome::do_nothing());
+        }
+    }
+
     if let Err(error) = dpf_sdk.release_maintenance_hold(&node_name).await {
         tracing::warn!(
             machine_id = %host.id,
@@ -189,6 +219,18 @@ pub(super) async fn handle_pending_dpu_actions(
         "Released the DPF maintenance hold so DPU services can roll out"
     );
     Ok(StateHandlerOutcome::do_nothing())
+}
+
+/// Whether an instance is currently assigned to this host, read fresh rather
+/// than from the iteration's snapshot.
+async fn host_has_instance(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    host: &Machine,
+) -> Result<bool, StateHandlerError> {
+    let mut conn = ctx.services.db_pool.acquire().await?;
+    Ok(db::instance::find_id_by_machine_id(&mut conn, &host.id)
+        .await?
+        .is_some())
 }
 
 async fn pending_sync_is_outstanding(


### PR DESCRIPTION
A DPUService change — a new helm chart or docker image version for a service
running on the DPU — used to reach every DPU as soon as it was declared. DPF was
configured to treat those updates as non-disruptive, so nothing could intervene
between declaring a version and it landing.

That is wrong for a DPU that is still waiting to be reprovisioned. Its OS is
about to be replaced, and the services paired with the new OS are not
necessarily the services the current one can run. Concretely: a BFB update
brings a matching HBN version with it, and installing that HBN on a DPU still
running the older BFB breaks the DPU. Reprovisioning is deliberately paced and
tenant-aware, so a DPU can sit on the old BFB for days while the new services
are already being pushed at it.

This makes the update disruptive instead, which parks the affected DPU in the
NodeEffect phase behind a DPF maintenance hold, and gives carbide the job of
releasing that hold — but only for DPUs it has confirmed are already running the
software their DPUDeployment declares. A DPU still awaiting reprovisioning keeps
its hold and receives the new services after it has been reprovisioned, not
before. A host carrying a tenant instance is never touched.

The hold is not a drain: a held DPU keeps serving traffic while it waits, so
nothing is disrupted by waiting.

**What this decides, and what it does not.** This governs *when* a declared
service version reaches a DPU. It does not judge *whether* that version belongs
there — it asks only whether a DPU matches its own DPUDeployment, so a
deployment pairing a service version with an incompatible BFB is rolled out
faithfully. Keeping those coherent stays with whoever writes the config,
deliberately: a compatibility check here would also reject the test builds that
qualifying a new service version depends on.

## Related issues

Closes #4877.

Follow-ups already known, to be tracked on that issue rather than fixed here:

- The hold release acts on the snapshot taken at the start of the iteration, so
  an instance allocated during the handler's Kubernetes calls is disrupted
  anyway. Re-reading the instance immediately before releasing would narrow it.
- A release that finds no maintenance object reports success, so a request
  recorded before DPF created that object can be retired without the hold
  actually being lifted.
- The watcher fires on every update while a DPU is parked, so after a request is
  retired the next update records a fresh one, repeating the check-and-release
  cycle and filling the retained history with duplicates from a single rollout.
- Nothing bounds a request whose DPU can never be evaluated, so it retries
  indefinitely with only a log line.

## Type of Change

- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality

## Breaking Changes

- [ ] **This PR contains breaking changes**

Not breaking, but **this ships on and changes behaviour without any operator
action**. On upgrade, existing DPUServiceConfiguration and DPUDeployment objects
are re-applied as disruptive, so DPUs enter NodeEffect and carbide begins
releasing holds for idle, up-to-date hosts. Sites wanting to schedule that
themselves should set `dpf.dpu_service_sync_enabled = false` before upgrading.

That setting selects *who* opens the gate, never whether one exists. With it
off, held DPUs wait for an operator rather than for carbide — a DPUService
change never reaches a DPU unchecked either way. **The operator-facing command
to release a hold does not exist yet**, so a site that disables this today has
no supported way to complete a rollout. That command, and the ability to recover
a host stuck outside `Ready` (a bad DPUService version can strand hosts in
`HostInit`, where they cannot receive the fix), are the required follow-up.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated

New coverage: the single-DPU staleness check across all four verdicts including
both fail-closed paths; hold released when every DPU is current; hold kept and
the request preserved while a DPU is outdated; a failed release leaving the
request outstanding; no Kubernetes calls at all without a pending request; the
site switch stopping carbide from releasing while keeping the request for an
operator; and provisioning retiring the request it satisfied.

Verified against a live database: 31 DPF integration tests, 120 DPF unit tests,
5 pending-action database tests. Clippy and `format-nightly` clean.

## Additional Notes

Worth confirming with the DPF team before this reaches a fleet: whether
releasing the hold rolls the new services out without reprovisioning. That was
confirmed while these updates were still configured as non-disruptive, and this
PR changes that configuration.

Reviewing by commit should read more easily than the combined diff — the durable
record, the DPF-side gate, the watcher recording the request, and the release
decision are separate steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
