### PR TITLE
fix(ci): limit PR description token permissions

### DIFF
--- a/.github/ci/check-pr-description-permissions.sh
+++ b/.github/ci/check-pr-description-permissions.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-pr-description-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/pr-description.yml}"
+
+# `GET /pulls/{number}` accepts either pull-request or contents read access.
+# The base template already requires `contents: read`, so that one scope covers
+# both reads. Only this job publishes the status used by branch protection.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Pull Request Description" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=read" \
+	--job-permissions "validate=contents=read,statuses=write"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,9 @@ jobs:
       - name: Check Core CI token permissions
         run: bash .github/ci/check-core-ci-permissions.sh
 
+      - name: Check Pull Request Description token permissions
+        run: bash .github/ci/check-pr-description-permissions.sh
+
       - name: Check Stale PRs token permissions
         run: bash .github/ci/check-stale-ci-permissions.sh
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -14,8 +14,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  statuses: write
 
 concurrency:
   group: pr-description-${{ github.event.pull_request.number }}
@@ -26,6 +24,9 @@ jobs:
     name: Validate pull request description
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Publish pr-description status
         env:


### PR DESCRIPTION
GitHub already applies the permissions declared in `Pull Request Description` at runtime, but CI did not record the workflow's approved token contract. The validator reads the pull request and base template, then publishes the `pr-description` status on the pull request head.

This keeps `contents: read` as the workflow default, gives `validate` the complete `contents: read` and `statuses: write` inventory it needs, and enrolls that exact contract in the shared permission checker. GitHub accepts `contents: read` for both reads, so the redundant `pull-requests: read` scope goes away.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4929.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- The workflow-specific policy reports one reviewed job override with the exact expected inventory.
- All 60 shared permission-checker fixtures pass.
- Bash syntax, ShellCheck 0.11.0, Actionlint 1.7.12, and `git diff --check` pass locally.
- Hosted Core gate detection checked the exact PR head and reported `Checked 1 Pull Request Description job: 0 use the workflow default and 1 use reviewed job permissions.`

## Additional Notes

`pull_request_target` loads its workflow from the default branch, so the next natural event after merge will verify the reduced runtime token and successful `pr-description` status publication.

[GitHub documents `GET /pulls/{number}` as accepting either `Pull requests: read` or `Contents: read`](https://docs.github.com/en/rest/pulls/pulls?apiVersion=latest#get-a-pull-request).
