### PR TITLE
fix(ci): limit artifact promotion token permissions

### DIFF
--- a/.github/ci/check-promotion-permissions.sh
+++ b/.github/ci/check-promotion-permissions.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-promotion-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/promotion.yaml}"
+
+# Image and Helm publication authenticate with the NVCR and NGC credentials,
+# so the workflow token only needs repository read access.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Carbide Artifacts Promotion" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=read"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,9 @@ jobs:
       - name: Check Stale PRs token permissions
         run: bash .github/ci/check-stale-ci-permissions.sh
 
+      - name: Check Artifacts Promotion token permissions
+        run: bash .github/ci/check-promotion-permissions.sh
+
       - name: Check Fern docs (check) token permissions
         run: bash .github/ci/check-fern-docs-ci-permissions.sh
 

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -24,6 +24,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   # ============================================================================
   # PREPARE - Validate source images exist


### PR DESCRIPTION
GitHub already applies the permissions declared in `Carbide Artifacts Promotion` at runtime, but this workflow did not declare its own token ceiling. That left its starting authority tied to the repository default instead of a contract reviewers could see in the workflow.

This gives the workflow an exact `contents: read` default and enrolls that contract in the shared permission checker. The repository checkouts keep the read access they need, while image and Helm publication continue using the existing NVCR and NGC credentials.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4931.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- The workflow-specific policy reports all six promotion jobs using the exact read-only default.
- All 60 shared permission-checker fixtures pass.
- Bash syntax, ShellCheck 0.11.0, Actionlint 1.7.12, `git diff --check`, the full Clippy gate, and Carbide-lints pass locally.

## Additional Notes

We did not dispatch a production promotion just to test token metadata. The next authorized promotion is the runtime acceptance boundary for the reduced token.

The production environment gate, NVCR and NGC credentials, artifact inputs, pinned actions, and promotion job graph are unchanged.
