### PR TITLE
fix(ci): limit Core reusable workflow token permissions

### DIFF
--- a/.github/ci/check-build-boot-artifacts-permissions.sh
+++ b/.github/ci/check-build-boot-artifacts-permissions.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-build-boot-artifacts-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/build-boot-artifacts.yml}"
+
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Build Artifacts (Boot & Ephemeral Images)" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=read"

--- a/.github/ci/check-docker-build-permissions.sh
+++ b/.github/ci/check-docker-build-permissions.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-docker-build-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/docker-build.yml}"
+
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Build Container with Buildx" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=read"

--- a/.github/ci/check-notify-build-status-permissions.sh
+++ b/.github/ci/check-notify-build-status-permissions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-notify-build-status-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/notify-build-status.yml}"
+
+# Slack uses its own bot token; this reusable workflow does not need repository access.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Notify Build Status" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=none"

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -64,6 +64,9 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,15 @@ jobs:
       - name: Check Image Scan token permissions
         run: bash .github/ci/check-image-scan-ci-permissions.sh
 
+      - name: Check Build Artifacts (Boot & Ephemeral Images) token permissions
+        run: bash .github/ci/check-build-boot-artifacts-permissions.sh
+
+      - name: Check Build Container with Buildx token permissions
+        run: bash .github/ci/check-docker-build-permissions.sh
+
+      - name: Check Notify Build Status token permissions
+        run: bash .github/ci/check-notify-build-status-permissions.sh
+
       - name: Check Core CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh core
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -123,6 +123,8 @@ on:
         description: 'All tags applied during the build'
         value: ${{ jobs.build.outputs.tags }}
 
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/notify-build-status.yml
+++ b/.github/workflows/notify-build-status.yml
@@ -55,6 +55,10 @@ on:
         description: 'Slack Bot OAuth Token'
         required: true
 
+# Slack notification uses its own bot token, so this workflow does not need repository access.
+permissions:
+  contents: none
+
 jobs:
   notify:
     runs-on: linux-amd64-cpu4


### PR DESCRIPTION
GitHub already applies the caller's token ceiling at runtime, but these three reusable Core workflows did not declare their own permission contracts. That meant an eligible future caller could silently give them more authority than the current Core workflow does.

This keeps the boot-artifact and container-build paths at `contents: read`, gives Slack notification `contents: none`, and records all three contracts in the shared permission checker. Build, cache, artifact, and registry behavior stays the same; Slack continues using its own bot token.

Primary callouts are:

- Expected green-run effect: Effectively none. Build, cache, artifact, registry, and Slack behavior should stay the same, and Core CI gains three small shell policy checks in the existing gate-detection job.
- What it really buys us: The heavily reused build paths can never receive more than read-only repository access, and the external Slack notification path receives no repository authority at all.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4934.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- The shared permission checker passes all 60 fixtures.
- The three workflow-specific checks each report one job using its exact reviewed workflow default.
- Bash syntax, ShellCheck 0.11.0, Actionlint 1.7.12, and `git diff --check` pass locally.
- The full nightly format, Clippy, and refreshed Carbide-lints gates pass locally.
- Independent Codex, Claude, and CodeRabbit reviews found no remaining issue.

## Additional Notes

Core pull request CI exercises every boot-artifact and container-build caller. Build-status notification deliberately skips pull request refs, so its first runtime confirmation will be the next eligible post-merge `main`, release-branch, or tag run.

Caller permissions, build and notification job graphs, registry and Slack credentials, pinned actions, caches, and artifact behavior are unchanged.
