### PR TITLE
feat(images): Allow narrowing image build architectures, grouped by functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,13 @@ bootstrap: ## Set up an Ubuntu/Debian build host: apt deps, rustup, submodules, 
 #   make images-core   NICo Core image (nico) only
 #   make images-rest   REST service images only
 #
-# Images are pushed as amd64/arm64 manifests at
-# $(IMAGE_REGISTRY)/<name>:$(IMAGE_TAG). Override IMAGE_REGISTRY and IMAGE_TAG to
-# publish under your own registry/tag (defaults match rest-api/). Override
-# NICO_ARCHES, BOOT_ARTIFACTS_ARCHES, and/or DPU_ARCHES (each "amd64 arm64" by
-# default) to restrict which architectures a given image group builds, e.g.:
+# Images are pushed as manifests at $(IMAGE_REGISTRY)/<name>:$(IMAGE_TAG)
+# containing whichever architectures NICO_ARCHES, BOOT_ARTIFACTS_ARCHES, and
+# DPU_ARCHES select for that image's group (each "amd64 arm64" by default, so
+# manifests are multi-arch unless you narrow them). Override IMAGE_REGISTRY and
+# IMAGE_TAG to publish under your own registry/tag (defaults match rest-api/).
+# Override NICO_ARCHES / BOOT_ARTIFACTS_ARCHES / DPU_ARCHES to restrict which
+# architectures a given image group builds, e.g.:
 #   make images-all NICO_ARCHES=amd64 DPU_ARCHES=arm64
 
 IMAGE_REGISTRY ?= localhost:5000

--- a/Makefile
+++ b/Makefile
@@ -140,12 +140,20 @@ images-all: ## Build every image (stack + machine validation + boot artifacts; n
 	$(MAKE) images-all-validate
 	$(MAKE) images images-machine-validation images-boot-artifacts images-bfb
 
+# Safe to call concurrently from multiple sibling targets (images-base,
+# images-rest, images-boot-artifacts, images-bfb each invoke this themselves).
 images-registry:
 	@if [ "$(IMAGE_REGISTRY)" = "localhost:5000" ] && ! curl -fsS http://localhost:5000/v2/ >/dev/null 2>&1; then \
-		if docker inspect $(LOCAL_REGISTRY_CONTAINER) >/dev/null 2>&1; then \
-			docker start $(LOCAL_REGISTRY_CONTAINER); \
-		else \
-			docker run -d --rm --name $(LOCAL_REGISTRY_CONTAINER) -p 5000:5000 registry:2; \
+		docker start $(LOCAL_REGISTRY_CONTAINER) >/dev/null 2>&1 || \
+			docker run -d --rm --name $(LOCAL_REGISTRY_CONTAINER) -p 5000:5000 registry:2 >/dev/null 2>&1 || true; \
+		ready=0; \
+		for i in 1 2 3 4 5 6 7 8 9 10; do \
+			if curl -fsS http://localhost:5000/v2/ >/dev/null 2>&1; then ready=1; break; fi; \
+			sleep 0.5; \
+		done; \
+		if [ "$$ready" != "1" ]; then \
+			echo "images-registry: local registry at localhost:5000 did not become ready after starting $(LOCAL_REGISTRY_CONTAINER)" >&2; \
+			exit 1; \
 		fi; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,10 @@ bootstrap: ## Set up an Ubuntu/Debian build host: apt deps, rustup, submodules, 
 #
 # Images are pushed as amd64/arm64 manifests at
 # $(IMAGE_REGISTRY)/<name>:$(IMAGE_TAG). Override IMAGE_REGISTRY and IMAGE_TAG to
-# publish under your own registry/tag (defaults match rest-api/).
+# publish under your own registry/tag (defaults match rest-api/). Override
+# NICO_ARCHES, BOOT_ARTIFACTS_ARCHES, and/or DPU_ARCHES (each "amd64 arm64" by
+# default) to restrict which architectures a given image group builds, e.g.:
+#   make images-all NICO_ARCHES=amd64 DPU_ARCHES=arm64
 
 IMAGE_REGISTRY ?= localhost:5000
 IMAGE_TAG ?= latest
@@ -94,19 +97,22 @@ CI_COMMIT_SHORT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo un
 LOCAL_REGISTRY_CONTAINER ?= nico-build-registry
 BOOT_ARTIFACTS_RUNTIME_IMAGE ?= docker.io/library/alpine:3.20.10@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
+# Architectures to build, per image group. Each defaults to both so the
+# published tags stay multi-arch unless you deliberately narrow them, e.g.:
+#   make images-all NICO_ARCHES=amd64 DPU_ARCHES=arm64
+NICO_ARCHES ?= amd64 arm64
+BOOT_ARTIFACTS_ARCHES ?= amd64 arm64
+DPU_ARCHES ?= amd64 arm64
+
+# $(call check-arches,$(SOME_ARCHES),SOME_ARCHES) aborts the build with a clear
+# error if SOME_ARCHES contains anything other than amd64/arm64.
+check-arches = $(if $(filter-out amd64 arm64,$(1)),$(error $(2) must be a subset of "amd64 arm64", got: $(1)))
+
 # Intermediate base containers the Core and machine-validation images build FROM.
 CORE_BUILD_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)-amd64
 CORE_BUILD_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)-arm64
 CORE_RUNTIME_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-runtime-container:$(IMAGE_TAG)-amd64
 CORE_RUNTIME_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-runtime-container:$(IMAGE_TAG)-arm64
-CORE_IMAGE_AMD64 := $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)-amd64
-CORE_IMAGE_ARM64 := $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)-arm64
-MACHINE_VALIDATION_IMAGE_AMD64 := $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-amd64
-MACHINE_VALIDATION_IMAGE_ARM64 := $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-arm64
-BOOT_ARTIFACTS_X86_IMAGE_AMD64 := $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG)-amd64
-BOOT_ARTIFACTS_X86_IMAGE_ARM64 := $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG)-arm64
-BOOT_ARTIFACTS_BFB_IMAGE_AMD64 := $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG)-amd64
-BOOT_ARTIFACTS_BFB_IMAGE_ARM64 := $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG)-arm64
 
 .PHONY: images images-all images-registry images-base images-core images-rest \
         images-machine-validation images-boot-artifacts images-bfb
@@ -128,69 +134,90 @@ images-registry:
 		fi; \
 	fi
 
-images-base: images-registry ## Build and push the amd64 + arm64 Core base containers
-	docker buildx build --platform linux/amd64 --push --file dev/docker/Dockerfile.build-container-x86_64 -t $(CORE_BUILD_CONTAINER_AMD64) .
-	docker buildx build --platform linux/arm64 --push --file dev/docker/Dockerfile.build-container-aarch64 -t $(CORE_BUILD_CONTAINER_ARM64) .
-	docker buildx build --platform linux/amd64 --push --file dev/docker/Dockerfile.runtime-container-x86_64 -t $(CORE_RUNTIME_CONTAINER_AMD64) .
-	docker buildx build --platform linux/arm64 --push --file dev/docker/Dockerfile.runtime-container-aarch64 -t $(CORE_RUNTIME_CONTAINER_ARM64) .
+images-base: images-registry ## Build and push the Core base containers (NICO_ARCHES="amd64 arm64")
+	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
+	@set -e; \
+	for arch in $(NICO_ARCHES); do \
+		case $$arch in \
+			amd64) build_file=dev/docker/Dockerfile.build-container-x86_64; build_tag=$(CORE_BUILD_CONTAINER_AMD64); \
+			       runtime_file=dev/docker/Dockerfile.runtime-container-x86_64; runtime_tag=$(CORE_RUNTIME_CONTAINER_AMD64) ;; \
+			arm64) build_file=dev/docker/Dockerfile.build-container-aarch64; build_tag=$(CORE_BUILD_CONTAINER_ARM64); \
+			       runtime_file=dev/docker/Dockerfile.runtime-container-aarch64; runtime_tag=$(CORE_RUNTIME_CONTAINER_ARM64) ;; \
+		esac; \
+		docker buildx build --platform linux/$$arch --push --file $$build_file -t $$build_tag . ; \
+		docker buildx build --platform linux/$$arch --push --file $$runtime_file -t $$runtime_tag . ; \
+	done
 
-images-core: images-base ## Build the NICo Core image (nico)
-	docker buildx build --platform linux/amd64 --push \
-		--build-arg CONTAINER_BUILD_X86_64=$(CORE_BUILD_CONTAINER_AMD64) \
-		--build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
-		--build-arg VERSION=$(VERSION) \
-		--build-arg CI_COMMIT_SHORT_SHA=$(CI_COMMIT_SHORT_SHA) \
-		--file dev/docker/Dockerfile.release-container-sa-x86_64 \
-		-t $(CORE_IMAGE_AMD64) .
-	docker buildx build --platform linux/arm64 --push \
-		--build-arg CONTAINER_BUILD_AARCH64=$(CORE_BUILD_CONTAINER_ARM64) \
-		--build-arg CONTAINER_RUNTIME_AARCH64=$(CORE_RUNTIME_CONTAINER_ARM64) \
-		--build-arg VERSION=$(VERSION) \
-		--build-arg CI_COMMIT_SHORT_SHA=$(CI_COMMIT_SHORT_SHA) \
-		--file dev/docker/Dockerfile.release-container-aarch64 \
-		-t $(CORE_IMAGE_ARM64) .
-	docker buildx imagetools create -t $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG) \
-		$(CORE_IMAGE_AMD64) $(CORE_IMAGE_ARM64)
+images-core: images-base ## Build the NICo Core image (nico) (NICO_ARCHES="amd64 arm64")
+	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
+	@set -e; \
+	tags=""; \
+	for arch in $(NICO_ARCHES); do \
+		case $$arch in \
+			amd64) file=dev/docker/Dockerfile.release-container-sa-x86_64; \
+			       buildarg="--build-arg CONTAINER_BUILD_X86_64=$(CORE_BUILD_CONTAINER_AMD64) --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64)" ;; \
+			arm64) file=dev/docker/Dockerfile.release-container-aarch64; \
+			       buildarg="--build-arg CONTAINER_BUILD_AARCH64=$(CORE_BUILD_CONTAINER_ARM64) --build-arg CONTAINER_RUNTIME_AARCH64=$(CORE_RUNTIME_CONTAINER_ARM64)" ;; \
+		esac; \
+		tag=$(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)-$$arch; \
+		docker buildx build --platform linux/$$arch --push $$buildarg \
+			--build-arg VERSION=$(VERSION) \
+			--build-arg CI_COMMIT_SHORT_SHA=$(CI_COMMIT_SHORT_SHA) \
+			--file $$file -t $$tag . ; \
+		tags="$$tags $$tag"; \
+	done; \
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG) $$tags
 
-images-rest: images-registry ## Build the REST service images (api, workflow, site-manager, site-agent, db, cert-manager, flow, psm, nsm)
-	$(MAKE) -C rest-api docker-build IMAGE_REGISTRY=$(IMAGE_REGISTRY) IMAGE_TAG=$(IMAGE_TAG)
+images-rest: images-registry ## Build the REST service images (api, workflow, site-manager, site-agent, db, cert-manager, flow, psm, nsm) (NICO_ARCHES="amd64 arm64")
+	$(MAKE) -C rest-api docker-build IMAGE_REGISTRY=$(IMAGE_REGISTRY) IMAGE_TAG=$(IMAGE_TAG) DOCKER_ARCHES="$(NICO_ARCHES)"
 
-images-machine-validation: images-base ## Build the machine-validation runner + config images
+images-machine-validation: images-base ## Build the machine-validation runner + config images (NICO_ARCHES="amd64 arm64")
+	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
 	docker buildx build --platform linux/amd64 --load --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
 		-t machine-validation-runner:$(IMAGE_TAG) \
 		--file dev/docker/Dockerfile.machine-validation-runner .
 	mkdir -p crates/machine-validation/images
 	docker save --output crates/machine-validation/images/machine-validation-runner.tar machine-validation-runner:$(IMAGE_TAG)
-	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
-		-t $(MACHINE_VALIDATION_IMAGE_AMD64) \
-		--file dev/docker/Dockerfile.machine-validation-config .
-	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_AARCH64=$(CORE_RUNTIME_CONTAINER_ARM64) \
-		-t $(MACHINE_VALIDATION_IMAGE_ARM64) \
-		--file dev/docker/Dockerfile.machine-validation-config-aarch64 .
-	docker buildx imagetools create -t $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG) \
-		$(MACHINE_VALIDATION_IMAGE_AMD64) $(MACHINE_VALIDATION_IMAGE_ARM64)
+	@set -e; \
+	tags=""; \
+	for arch in $(NICO_ARCHES); do \
+		case $$arch in \
+			amd64) file=dev/docker/Dockerfile.machine-validation-config; \
+			       buildarg="--build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64)" ;; \
+			arm64) file=dev/docker/Dockerfile.machine-validation-config-aarch64; \
+			       buildarg="--build-arg CONTAINER_RUNTIME_AARCH64=$(CORE_RUNTIME_CONTAINER_ARM64)" ;; \
+		esac; \
+		tag=$(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-$$arch; \
+		docker buildx build --platform linux/$$arch --push $$buildarg -t $$tag --file $$file . ; \
+		tags="$$tags $$tag"; \
+	done; \
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG) $$tags
 
-images-boot-artifacts: images-registry ## Build the x86 boot-artifact image (requires mkosi + rust toolchain on the host)
+images-boot-artifacts: images-registry ## Build the x86 boot-artifact image (BOOT_ARTIFACTS_ARCHES="amd64 arm64"; requires mkosi + rust toolchain on the host)
+	$(call check-arches,$(BOOT_ARTIFACTS_ARCHES),BOOT_ARTIFACTS_ARCHES)
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-x86-host-sa
-	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_X86_64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
-		-t $(BOOT_ARTIFACTS_X86_IMAGE_AMD64) \
-		--file dev/docker/Dockerfile.release-artifacts-x86_64 .
-	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_X86_64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
-		-t $(BOOT_ARTIFACTS_X86_IMAGE_ARM64) \
-		--file dev/docker/Dockerfile.release-artifacts-x86_64 .
-	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG) \
-		$(BOOT_ARTIFACTS_X86_IMAGE_AMD64) $(BOOT_ARTIFACTS_X86_IMAGE_ARM64)
+	@set -e; \
+	tags=""; \
+	for arch in $(BOOT_ARTIFACTS_ARCHES); do \
+		tag=$(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG)-$$arch; \
+		docker buildx build --platform linux/$$arch --push --build-arg CONTAINER_RUNTIME_X86_64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
+			-t $$tag --file dev/docker/Dockerfile.release-artifacts-x86_64 . ; \
+		tags="$$tags $$tag"; \
+	done; \
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG) $$tags
 
-images-bfb: images-registry ## Build the aarch64 DPU BFB boot-artifact image (cross-arch; requires mkosi + aarch64 toolchain)
+images-bfb: images-registry ## Build the aarch64 DPU BFB boot-artifact image (DPU_ARCHES="amd64 arm64"; cross-arch; requires mkosi + aarch64 toolchain)
+	$(call check-arches,$(DPU_ARCHES),DPU_ARCHES)
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-bfb-sa
-	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_AARCH64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
-		-t $(BOOT_ARTIFACTS_BFB_IMAGE_AMD64) \
-		--file dev/docker/Dockerfile.release-artifacts-aarch64 .
-	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_AARCH64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
-		-t $(BOOT_ARTIFACTS_BFB_IMAGE_ARM64) \
-		--file dev/docker/Dockerfile.release-artifacts-aarch64 .
-	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG) \
-		$(BOOT_ARTIFACTS_BFB_IMAGE_AMD64) $(BOOT_ARTIFACTS_BFB_IMAGE_ARM64)
+	@set -e; \
+	tags=""; \
+	for arch in $(DPU_ARCHES); do \
+		tag=$(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG)-$$arch; \
+		docker buildx build --platform linux/$$arch --push --build-arg CONTAINER_RUNTIME_AARCH64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
+			-t $$tag --file dev/docker/Dockerfile.release-artifacts-aarch64 . ; \
+		tags="$$tags $$tag"; \
+	done; \
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG) $$tags
 
 # =============================================================================
 # Rest (delegate to rest-api/Makefile)

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ DPU_ARCHES ?= amd64 arm64
 
 # $(call check-arches,$(SOME_ARCHES),SOME_ARCHES) aborts the build with a clear
 # error if SOME_ARCHES contains anything other than amd64/arm64.
-check-arches = $(if $(filter-out amd64 arm64,$(1)),$(error $(2) must be a subset of "amd64 arm64", got: $(1)))
+check-arches = $(if $(strip $(1)),,$(error $(2) must not be empty))$(if $(filter-out amd64 arm64,$(1)),$(error $(2) must be a subset of "amd64 arm64", got: $(1)))
 
 # $(call require-amd64,$(SOME_ARCHES),error-message) aborts the build if amd64 is
 # missing from SOME_ARCHES.

--- a/Makefile
+++ b/Makefile
@@ -104,13 +104,9 @@ NICO_ARCHES ?= amd64 arm64
 BOOT_ARTIFACTS_ARCHES ?= amd64 arm64
 DPU_ARCHES ?= amd64 arm64
 
-# $(call check-arches,$(SOME_ARCHES),SOME_ARCHES) aborts the build with a clear
-# error if SOME_ARCHES contains anything other than amd64/arm64.
 check-arches = $(if $(strip $(1)),,$(error $(2) must not be empty))$(if $(filter-out amd64 arm64,$(1)),$(error $(2) must be a subset of "amd64 arm64", got: $(1)))
 
-# $(call require-amd64,$(SOME_ARCHES),error-message) aborts the build if amd64 is
-# missing from SOME_ARCHES.
-require-amd64 = $(if $(filter amd64,$(1)),,$(error $(2)))
+require-nico-amd64 = $(if $(filter amd64,$(NICO_ARCHES)),,$(error NICO_ARCHES must include amd64: the machine-validation-runner intermediate image is always built for amd64 and depends on the amd64 Core runtime base container that images-base only pushes when amd64 is requested; got: $(NICO_ARCHES)))
 
 # Intermediate base containers the Core and machine-validation images build FROM.
 CORE_BUILD_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)-amd64
@@ -118,16 +114,25 @@ CORE_BUILD_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)
 CORE_RUNTIME_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-runtime-container:$(IMAGE_TAG)-amd64
 CORE_RUNTIME_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-runtime-container:$(IMAGE_TAG)-arm64
 
-.PHONY: images images-all images-registry images-base images-core images-rest \
-        images-machine-validation images-boot-artifacts images-bfb
+.PHONY: images images-all images-validate images-all-validate images-registry \
+        images-base images-core images-rest images-machine-validation \
+        images-boot-artifacts images-bfb
 
-images: images-core images-rest ## Build the deployable service stack (NICo Core + REST images)
+images-validate:
+	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
+
+images-all-validate: images-validate
+	$(call check-arches,$(BOOT_ARTIFACTS_ARCHES),BOOT_ARTIFACTS_ARCHES)
+	$(call check-arches,$(DPU_ARCHES),DPU_ARCHES)
+	$(require-nico-amd64)
+
+images: images-validate images-core images-rest ## Build the deployable service stack (NICo Core + REST images)
 	@echo ""
 	@echo "Deployable multi-arch images pushed under $(IMAGE_REGISTRY) (tag: $(IMAGE_TAG)):"
 	@echo "  $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)   (NICo Core)"
 	@echo "  $(IMAGE_REGISTRY)/nico-rest-*:$(IMAGE_TAG)       (REST services)"
 
-images-all: images images-machine-validation images-boot-artifacts images-bfb ## Build every image (stack + machine validation + boot artifacts; needs an mkosi build host)
+images-all: images-all-validate images images-machine-validation images-boot-artifacts images-bfb ## Build every image (stack + machine validation + boot artifacts; needs an mkosi build host)
 
 images-registry:
 	@if [ "$(IMAGE_REGISTRY)" = "localhost:5000" ] && ! curl -fsS http://localhost:5000/v2/ >/dev/null 2>&1; then \
@@ -178,7 +183,7 @@ images-rest: images-registry ## Build the REST service images (api, workflow, si
 
 images-machine-validation: images-base ## Build the machine-validation runner + config images (NICO_ARCHES="amd64 arm64"; must include amd64)
 	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
-	$(call require-amd64,$(NICO_ARCHES),NICO_ARCHES must include amd64: the machine-validation-runner intermediate image is always built for amd64 and depends on the amd64 Core runtime base container that images-base only pushes when amd64 is requested; got: $(NICO_ARCHES))
+	$(require-nico-amd64)
 	docker buildx build --platform linux/amd64 --load --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
 		-t machine-validation-runner:$(IMAGE_TAG) \
 		--file dev/docker/Dockerfile.machine-validation-runner .

--- a/Makefile
+++ b/Makefile
@@ -126,13 +126,19 @@ images-all-validate: images-validate
 	$(call check-arches,$(DPU_ARCHES),DPU_ARCHES)
 	$(require-nico-amd64)
 
-images: images-validate images-core images-rest ## Build the deployable service stack (NICo Core + REST images)
+images: ## Build the deployable service stack (NICo Core + REST images)
+	# Ensure validation runs before building even with parallel builds.
+	$(MAKE) images-validate
+	$(MAKE) images-core images-rest
 	@echo ""
 	@echo "Deployable multi-arch images pushed under $(IMAGE_REGISTRY) (tag: $(IMAGE_TAG)):"
 	@echo "  $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)   (NICo Core)"
 	@echo "  $(IMAGE_REGISTRY)/nico-rest-*:$(IMAGE_TAG)       (REST services)"
 
-images-all: images-all-validate images images-machine-validation images-boot-artifacts images-bfb ## Build every image (stack + machine validation + boot artifacts; needs an mkosi build host)
+images-all: ## Build every image (stack + machine validation + boot artifacts; needs an mkosi build host)
+	# Ensure validation runs before building even with parallel builds.
+	$(MAKE) images-all-validate
+	$(MAKE) images images-machine-validation images-boot-artifacts images-bfb
 
 images-registry:
 	@if [ "$(IMAGE_REGISTRY)" = "localhost:5000" ] && ! curl -fsS http://localhost:5000/v2/ >/dev/null 2>&1; then \
@@ -143,8 +149,9 @@ images-registry:
 		fi; \
 	fi
 
-images-base: images-registry ## Build and push the Core base containers (NICO_ARCHES="amd64 arm64")
+images-base: ## Build and push the Core base containers (NICO_ARCHES="amd64 arm64")
 	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
+	$(MAKE) images-registry
 	@set -e; \
 	for arch in $(NICO_ARCHES); do \
 		case $$arch in \
@@ -157,8 +164,9 @@ images-base: images-registry ## Build and push the Core base containers (NICO_AR
 		docker buildx build --platform linux/$$arch --push --file $$runtime_file -t $$runtime_tag . ; \
 	done
 
-images-core: images-base ## Build the NICo Core image (nico) (NICO_ARCHES="amd64 arm64")
+images-core: ## Build the NICo Core image (nico) (NICO_ARCHES="amd64 arm64")
 	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
+	$(MAKE) images-base
 	@set -e; \
 	tags=""; \
 	for arch in $(NICO_ARCHES); do \
@@ -177,13 +185,15 @@ images-core: images-base ## Build the NICo Core image (nico) (NICO_ARCHES="amd64
 	done; \
 	docker buildx imagetools create -t $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG) $$tags
 
-images-rest: images-registry ## Build the REST service images (api, workflow, site-manager, site-agent, db, cert-manager, flow, psm, nsm) (NICO_ARCHES="amd64 arm64")
+images-rest: ## Build the REST service images (api, workflow, site-manager, site-agent, db, cert-manager, flow, psm, nsm) (NICO_ARCHES="amd64 arm64")
 	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
+	$(MAKE) images-registry
 	$(MAKE) -C rest-api docker-build IMAGE_REGISTRY=$(IMAGE_REGISTRY) IMAGE_TAG=$(IMAGE_TAG) DOCKER_ARCHES="$(NICO_ARCHES)"
 
-images-machine-validation: images-base ## Build the machine-validation runner + config images (NICO_ARCHES="amd64 arm64"; must include amd64)
+images-machine-validation: ## Build the machine-validation runner + config images (NICO_ARCHES="amd64 arm64"; must include amd64)
 	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
 	$(require-nico-amd64)
+	$(MAKE) images-base
 	docker buildx build --platform linux/amd64 --load --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
 		-t machine-validation-runner:$(IMAGE_TAG) \
 		--file dev/docker/Dockerfile.machine-validation-runner .
@@ -204,8 +214,9 @@ images-machine-validation: images-base ## Build the machine-validation runner + 
 	done; \
 	docker buildx imagetools create -t $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG) $$tags
 
-images-boot-artifacts: images-registry ## Build the x86 boot-artifact image (BOOT_ARTIFACTS_ARCHES="amd64 arm64"; requires mkosi + rust toolchain on the host)
+images-boot-artifacts: ## Build the x86 boot-artifact image (BOOT_ARTIFACTS_ARCHES="amd64 arm64"; requires mkosi + rust toolchain on the host)
 	$(call check-arches,$(BOOT_ARTIFACTS_ARCHES),BOOT_ARTIFACTS_ARCHES)
+	$(MAKE) images-registry
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-x86-host-sa
 	@set -e; \
 	tags=""; \
@@ -217,8 +228,9 @@ images-boot-artifacts: images-registry ## Build the x86 boot-artifact image (BOO
 	done; \
 	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG) $$tags
 
-images-bfb: images-registry ## Build the aarch64 DPU BFB boot-artifact image (DPU_ARCHES="amd64 arm64"; cross-arch; requires mkosi + aarch64 toolchain)
+images-bfb: ## Build the aarch64 DPU BFB boot-artifact image (DPU_ARCHES="amd64 arm64"; cross-arch; requires mkosi + aarch64 toolchain)
 	$(call check-arches,$(DPU_ARCHES),DPU_ARCHES)
+	$(MAKE) images-registry
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-bfb-sa
 	@set -e; \
 	tags=""; \

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ images-core: images-base ## Build the NICo Core image (nico) (NICO_ARCHES="amd64
 	docker buildx imagetools create -t $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG) $$tags
 
 images-rest: images-registry ## Build the REST service images (api, workflow, site-manager, site-agent, db, cert-manager, flow, psm, nsm) (NICO_ARCHES="amd64 arm64")
+	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
 	$(MAKE) -C rest-api docker-build IMAGE_REGISTRY=$(IMAGE_REGISTRY) IMAGE_TAG=$(IMAGE_TAG) DOCKER_ARCHES="$(NICO_ARCHES)"
 
 images-machine-validation: images-base ## Build the machine-validation runner + config images (NICO_ARCHES="amd64 arm64"; must include amd64)

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ DPU_ARCHES ?= amd64 arm64
 # error if SOME_ARCHES contains anything other than amd64/arm64.
 check-arches = $(if $(filter-out amd64 arm64,$(1)),$(error $(2) must be a subset of "amd64 arm64", got: $(1)))
 
+# $(call require-amd64,$(SOME_ARCHES),error-message) aborts the build if amd64 is
+# missing from SOME_ARCHES.
+require-amd64 = $(if $(filter amd64,$(1)),,$(error $(2)))
+
 # Intermediate base containers the Core and machine-validation images build FROM.
 CORE_BUILD_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)-amd64
 CORE_BUILD_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)-arm64
@@ -171,8 +175,9 @@ images-core: images-base ## Build the NICo Core image (nico) (NICO_ARCHES="amd64
 images-rest: images-registry ## Build the REST service images (api, workflow, site-manager, site-agent, db, cert-manager, flow, psm, nsm) (NICO_ARCHES="amd64 arm64")
 	$(MAKE) -C rest-api docker-build IMAGE_REGISTRY=$(IMAGE_REGISTRY) IMAGE_TAG=$(IMAGE_TAG) DOCKER_ARCHES="$(NICO_ARCHES)"
 
-images-machine-validation: images-base ## Build the machine-validation runner + config images (NICO_ARCHES="amd64 arm64")
+images-machine-validation: images-base ## Build the machine-validation runner + config images (NICO_ARCHES="amd64 arm64"; must include amd64)
 	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
+	$(call require-amd64,$(NICO_ARCHES),NICO_ARCHES must include amd64: the machine-validation-runner intermediate image is always built for amd64 and depends on the amd64 Core runtime base container that images-base only pushes when amd64 is requested; got: $(NICO_ARCHES))
 	docker buildx build --platform linux/amd64 --load --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
 		-t machine-validation-runner:$(IMAGE_TAG) \
 		--file dev/docker/Dockerfile.machine-validation-runner .

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -76,6 +76,13 @@ make images-all NICO_ARCHES=amd64 DPU_ARCHES=arm64
 A single-architecture build still produces a valid tag at `$(IMAGE_TAG)` (the multi-arch
 manifest just has one entry). Values other than `amd64`/`arm64` fail fast with an error.
 
+`images-machine-validation` additionally requires `NICO_ARCHES` to include `amd64`:
+the `machine-validation-runner` intermediate image it embeds is always built for
+`amd64` regardless of which architectures you're publishing, and it depends on the
+amd64 Core runtime base container that `images-base` only pushes when `amd64` is
+requested. `NICO_ARCHES=arm64` alone fails fast with an error; use
+`NICO_ARCHES="amd64 arm64"` (the default) or `NICO_ARCHES=amd64`.
+
 Each architecture is built separately before the bare tag is assembled. This matches CI
 and is required for the REST Dockerfiles: a single combined Buildx invocation would reuse
 one builder stage and could copy an amd64 binary into the arm64 image. Building the

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -95,10 +95,11 @@ need to build or debug a single image.
 
 ### Verifying the build
 
-After `make images-all` completes with the default `*_ARCHES` values, verify that all 14
-deployable image tags contain both platforms. (If you narrowed `NICO_ARCHES`,
-`BOOT_ARTIFACTS_ARCHES`, or `DPU_ARCHES` to a single architecture, the corresponding
-images will only report that one platform — adjust the expected value below to match.)
+After `make images-all` completes, verify that each of the 14 deployable image tags
+contains the platforms you actually built. Set `NICO_ARCHES`, `BOOT_ARTIFACTS_ARCHES`,
+and `DPU_ARCHES` below to whatever you passed to `make` (they default to `amd64 arm64`,
+matching the Makefile); the script derives each image's expected platform list from its
+group automatically, so a narrowed selection doesn't produce false failures.
 
 ```bash
 images=(
@@ -107,12 +108,29 @@ images=(
   nico-psm nico-nsm nico-mcp machine-validation
   boot-artifacts-x86_64 boot-artifacts-aarch64
 )
+
+# Mirrors the Makefile defaults; set these to whatever you passed to `make`.
+NICO_ARCHES="${NICO_ARCHES:-amd64 arm64}"
+BOOT_ARTIFACTS_ARCHES="${BOOT_ARTIFACTS_ARCHES:-amd64 arm64}"
+DPU_ARCHES="${DPU_ARCHES:-amd64 arm64}"
+
+expected_platforms_for() {
+  local arches
+  case "$1" in
+    boot-artifacts-x86_64) arches="${BOOT_ARTIFACTS_ARCHES}" ;;
+    boot-artifacts-aarch64) arches="${DPU_ARCHES}" ;;
+    *) arches="${NICO_ARCHES}" ;;
+  esac
+  echo "${arches}" | tr ' ' '\n' | sed 's#^#linux/#' | sort | paste -sd, -
+}
+
 for image in "${images[@]}"; do
+  expected="$(expected_platforms_for "${image}")"
   platforms="$(docker buildx imagetools inspect --raw \
     "${IMAGE_REGISTRY}/${image}:${IMAGE_TAG}" | \
     jq -r '[.manifests[].platform | select(.os == "linux") | "\(.os)/\(.architecture)"] | unique | sort | join(",")')"
-  if [ "${platforms}" != "linux/amd64,linux/arm64" ]; then
-    printf 'FAIL %s: %s\n' "${image}" "${platforms}" >&2
+  if [ "${platforms}" != "${expected}" ]; then
+    printf 'FAIL %s: got %s, want %s\n' "${image}" "${platforms}" "${expected}" >&2
     exit 1
   fi
   printf 'PASS %s: %s\n' "${image}" "${platforms}"

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -61,7 +61,7 @@ under your own registry; authenticate Docker to that registry before running the
 make images IMAGE_REGISTRY=my-registry.example.com/nico IMAGE_TAG=v1.0.0
 ```
 
-By default every image group is built for both `amd64` and `arm64`. Each group has its
+By default, every image group is built for both `amd64` and `arm64`. Each group has its
 own override variable if you only need one architecture:
 
 - `NICO_ARCHES` — the NICo control-plane images (`images-base`, `images-core`,

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -61,6 +61,21 @@ under your own registry; authenticate Docker to that registry before running the
 make images IMAGE_REGISTRY=my-registry.example.com/nico IMAGE_TAG=v1.0.0
 ```
 
+By default every image group is built for both `amd64` and `arm64`. Each group has its
+own override variable if you only need one architecture:
+
+- `NICO_ARCHES` — the NICo control-plane images (`images-base`, `images-core`,
+  `images-rest`, `images-machine-validation`)
+- `BOOT_ARTIFACTS_ARCHES` — the x86 boot-artifact image (`images-boot-artifacts`)
+- `DPU_ARCHES` — the DPU BFB boot-artifact image (`images-bfb`)
+
+```sh
+make images-all NICO_ARCHES=amd64 DPU_ARCHES=arm64
+```
+
+A single-architecture build still produces a valid tag at `$(IMAGE_TAG)` (the multi-arch
+manifest just has one entry). Values other than `amd64`/`arm64` fail fast with an error.
+
 Each architecture is built separately before the bare tag is assembled. This matches CI
 and is required for the REST Dockerfiles: a single combined Buildx invocation would reuse
 one builder stage and could copy an amd64 binary into the arm64 image. Building the
@@ -73,8 +88,10 @@ need to build or debug a single image.
 
 ### Verifying the build
 
-After `make images-all` completes, verify that all 14 deployable image tags contain both
-platforms:
+After `make images-all` completes with the default `*_ARCHES` values, verify that all 14
+deployable image tags contain both platforms. (If you narrowed `NICO_ARCHES`,
+`BOOT_ARTIFACTS_ARCHES`, or `DPU_ARCHES` to a single architecture, the corresponding
+images will only report that one platform — adjust the expected value below to match.)
 
 ```bash
 images=(

--- a/rest-api/Makefile
+++ b/rest-api/Makefile
@@ -24,8 +24,7 @@ BUILD_DIR := build/binaries
 IMAGE_REGISTRY := localhost:5000
 IMAGE_TAG := latest
 DOCKERFILE_DIR := docker/production
-# Architectures to build; override to restrict to one, e.g. DOCKER_ARCHES=amd64.
-DOCKER_ARCHES ?= amd64 arm64
+DOCKER_ARCHES := amd64 arm64
 LOCAL_REGISTRY_CONTAINER := nico-build-registry
 REST_IMAGES := nico-rest-api nico-rest-workflow nico-rest-site-manager \
 	nico-rest-site-agent nico-rest-db nico-rest-cert-manager nico-flow \

--- a/rest-api/Makefile
+++ b/rest-api/Makefile
@@ -24,7 +24,8 @@ BUILD_DIR := build/binaries
 IMAGE_REGISTRY := localhost:5000
 IMAGE_TAG := latest
 DOCKERFILE_DIR := docker/production
-DOCKER_ARCHES := amd64 arm64
+# Architectures to build; override to restrict to one, e.g. DOCKER_ARCHES=amd64.
+DOCKER_ARCHES ?= amd64 arm64
 LOCAL_REGISTRY_CONTAINER := nico-build-registry
 REST_IMAGES := nico-rest-api nico-rest-workflow nico-rest-site-manager \
 	nico-rest-site-agent nico-rest-db nico-rest-cert-manager nico-flow \
@@ -297,15 +298,16 @@ docker-build:
 	fi
 	@set -e; \
 	for image in $(REST_IMAGES); do \
+		tags=""; \
 		for arch in $(DOCKER_ARCHES); do \
+			tag=$(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG)-$$arch; \
 			docker buildx build --platform linux/$$arch --push \
 				--build-arg TARGETOS=linux --build-arg TARGETARCH=$$arch \
-				-t $(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG)-$$arch \
+				-t $$tag \
 				-f $(DOCKERFILE_DIR)/Dockerfile.$$image .; \
+			tags="$$tags $$tag"; \
 		done; \
-		docker buildx imagetools create -t $(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG) \
-			$(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG)-amd64 \
-			$(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG)-arm64; \
+		docker buildx imagetools create -t $(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG) $$tags; \
 	done
 
 core-proto:


### PR DESCRIPTION
This PR introduces the ability to select which architectures the images are built for, grouped into 3 parts:

- `NICO_ARCHES` for the NICo components
- `BOOT_ARTIFACTS_ARCHES` for the boot-artifacts
- `DPU_ARCHES` for images-bfb

The motivation for this is to reduce build times and resources utilisation by only building the images we actually want to deploy.

The default behaviour remains unchanged: images for both amd64 and arm64 will be built if no arches are specified.

## Related issues
This PR solves https://github.com/NVIDIA/infra-controller/issues/4767

## Type of Change
- [x] **Add** - New feature or capability

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

## Additional Notes

If possible we would like this fix back-ported to 2.1, thus solving the issue we have at the moment.
