### PR TITLE
fix(ci): limit release workflow token permissions

### DIFF
--- a/.github/ci/check-release-permissions.sh
+++ b/.github/ci/check-release-permissions.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-release-permissions.sh [workflow-path]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+workflow_path="${1:-${repo_root}/.github/workflows/release.yaml}"
+
+# Approval does not touch the repository, and `fetch-new-version` only reads it.
+# Keep `release-new-version` as the only job that can write contents.
+bash "${script_dir}/check-ci-permissions.sh" \
+	--workflow-name "Carbide Release new version" \
+	--workflow-path "${workflow_path}" \
+	--workflow-permissions "contents=none" \
+	--job-permissions "fetch-new-version=contents=read" \
+	--job-permissions "release-new-version=contents=write"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,9 @@ jobs:
       - name: Check Image Scan token permissions
         run: bash .github/ci/check-image-scan-ci-permissions.sh
 
+      - name: Check Carbide Release new version token permissions
+        run: bash .github/ci/check-release-permissions.sh
+
       - name: Check Core CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh core
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ name: Carbide Release new version
 on:
   workflow_dispatch:
 
+permissions:
+  contents: none
+
 jobs:
   # ============================================================================
   # Release new version
@@ -36,6 +39,8 @@ jobs:
   # ============================================================================
   fetch-new-version:
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     needs:
       - release-new-version-approve
     outputs:
@@ -69,6 +74,8 @@ jobs:
   # ============================================================================
   release-new-version:
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: write
     needs:
       - fetch-new-version
     steps:


### PR DESCRIPTION
Before this change, `.github/workflows/release.yaml` left approval, version discovery, and tag publication to inherit the repository or event token default. The approval job does not need repository access, version discovery only needs to read the checkout, and the final release job is the one place that pushes a tag.

This defaults the workflow to `contents: none`, replaces that default with `contents: read` for `fetch-new-version`, and gives only `release-new-version` `contents: write`. GitHub enforces those declarations on each runtime token. The shell checker is the configuration guard: it parses the workflow during Core CI and requires this exact reviewed inventory, so a later YAML edit cannot silently broaden the next release run.

Primary callouts are:

- Expected green-run effect: Effectively none. Approval, version discovery, and tag publication behavior should stay the same, and Core CI gains one small shell policy check in the existing gate-detection job.
- What it really buys us: The approval job receives no repository authority, version discovery stays read-only, and only the exact release job that pushes the version tag can write repository contents.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4936.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- The shared permission checker passes all 60 fixtures.
- The release workflow check reports one job using exact `contents: none` and two jobs using their exact reviewed overrides.
- Bash syntax, ShellCheck 0.11.0, Actionlint 1.7.12, and `git diff --check` pass locally. Actionlint ignores only the workflow's existing custom-runner labels and deliberately disabled release steps.
- The full nightly format, Clippy, and refreshed Carbide-lints gates pass locally.

## Additional Notes

The pinned tag action still receives no explicit `github_token`; its existing fallback pushes through the credential persisted by `actions/checkout`. Supplying a separate token is deliberately outside this permission-boundary PR.

This workflow only accepts manual dispatches. The checker exercises the complete configuration locally and in Core CI, but this PR does not dispatch a release or create a tag; the next authorized manual release is the runtime acceptance.
