### PR TITLE
Fix assigned SKU validation bypass

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -797,7 +797,7 @@ be propagated there by DPF.
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `false` | Enable BOM/SKU validation. |
 | `ignore_unassigned_machines` | `bool` | `false` | Let machines without a SKU bypass validation. |
-| `allow_allocation_on_validation_failure` | `bool` | `false` | Keep machines allocatable even when validation fails. |
+| `allow_allocation_on_validation_failure` | `bool` | `false` | Keep machines with an assigned SKU allocatable even when validation fails. |
 | `find_match_interval` | `Duration` | `5m` | Interval between SKU match attempts. |
 | `auto_generate_missing_sku` | `bool` | `false` | Auto-create missing SKUs from expected machines. |
 | `auto_generate_missing_sku_interval` | `Duration` | `5m` | Interval between auto-generate attempts. |

--- a/crates/api-core/src/handlers/sku.rs
+++ b/crates/api-core/src/handlers/sku.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use carbide_uuid::machine::MachineId;
+use health_report::HealthReport;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{BomValidating, ManagedHostState};
 use model::sku::Sku;
@@ -23,7 +24,7 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
-use crate::handlers::utils::convert_and_log_machine_id;
+use crate::handlers::utils::{StateHandlerWakeupFailed, WakeupTrigger, convert_and_log_machine_id};
 
 pub(crate) async fn create(
     api: &Api,
@@ -220,8 +221,15 @@ pub(crate) async fn remove_sku_association(
 
     let mut txn = api.txn_begin().await?;
 
-    let machine =
-        db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?;
+    let machine = db::machine::find_one(
+        &mut txn,
+        &machine_id,
+        MachineSearchConfig {
+            for_update: true,
+            ..MachineSearchConfig::default()
+        },
+    )
+    .await?;
 
     let machine = machine.ok_or(CarbideError::NotFoundError {
         kind: "machine",
@@ -243,9 +251,67 @@ pub(crate) async fn remove_sku_association(
             }
         }
     }
+    // The machine row lock serializes this check with allocation, which locks the
+    // same row before creating an instance.
+    let bom_validation_requires_sku = api.runtime_config.bom_validation.enabled
+        && !api.runtime_config.bom_validation.ignore_unassigned_machines
+        && !machine.is_dpu();
+    let sku_assignment_required_for_unallocated_host = bom_validation_requires_sku
+        && db::instance::find_id_by_machine_id(&mut txn, &machine_id)
+            .await?
+            .is_none();
+
+    // Forced removal is allowed in every lifecycle state, but it must leave
+    // the allocation-blocking alert behind until the controller can park the
+    // host or verify a replacement SKU.
+    let should_block_allocation_for_unassigned_sku =
+        machine.config.hw_sku.is_some() && sku_assignment_required_for_unallocated_host;
+    let should_wait_for_sku_assignment = should_block_allocation_for_unassigned_sku
+        && matches!(
+            machine.current_state(),
+            ManagedHostState::Ready | ManagedHostState::BomValidating { .. }
+        );
+    let waiting_for_sku_assignment_context = machine.current_state().bom_validation_context();
+
     db::machine::unassign_sku(&mut txn, &machine_id).await?;
 
+    if should_block_allocation_for_unassigned_sku {
+        db::machine::update_sku_validation_health_report(
+            &mut txn,
+            &machine_id,
+            &HealthReport::sku_unassigned(),
+        )
+        .await?;
+    }
+
+    // Keep an unassigned, unallocated host from being allocated between this
+    // request committing and the machine state controller's next iteration.
+    // Updating the state also advances its version, so a controller iteration
+    // that loaded the former SKU cannot commit a stale transition to Ready.
+    let waiting_for_sku_assignment =
+        should_wait_for_sku_assignment.then_some(ManagedHostState::BomValidating {
+            bom_validating_state: BomValidating::WaitingForSkuAssignment(
+                waiting_for_sku_assignment_context,
+            ),
+        });
+    if let Some(waiting_for_sku_assignment) = &waiting_for_sku_assignment {
+        db::machine::update_state(&mut txn, &machine_id, waiting_for_sku_assignment).await?;
+    }
+
     txn.commit().await?;
+
+    if waiting_for_sku_assignment.is_some()
+        && let Err(err) = api
+            .machine_state_handler_enqueuer
+            .enqueue_object(&machine_id)
+            .await
+    {
+        carbide_instrument::emit(StateHandlerWakeupFailed {
+            trigger: WakeupTrigger::SkuAssociationRemoved,
+            machine_id,
+            err: err.to_string(),
+        });
+    }
 
     Ok(Response::new(()))
 }

--- a/crates/api-core/src/handlers/utils.rs
+++ b/crates/api-core/src/handlers/utils.rs
@@ -109,6 +109,7 @@ pub(super) enum WakeupTrigger {
     ScoutFirmwareUpgradeStatus,
     DpuNetworkStatus,
     BootInterfaceIntent,
+    SkuAssociationRemoved,
 }
 
 /// A change was recorded but the machine's state handler could not be woken:
@@ -257,6 +258,7 @@ mod tests {
                 WakeupTrigger::ScoutFirmwareUpgradeStatus,
                 WakeupTrigger::DpuNetworkStatus,
                 WakeupTrigger::BootInterfaceIntent,
+                WakeupTrigger::SkuAssociationRemoved,
             ] {
                 carbide_instrument::emit(StateHandlerWakeupFailed {
                     trigger,
@@ -266,7 +268,7 @@ mod tests {
             }
         });
 
-        assert_eq!(logs.len(), 5);
+        assert_eq!(logs.len(), 6);
         for log in &logs {
             assert_eq!(log.level, tracing::Level::WARN);
             assert_eq!(log.message, "Failed to wake up state handler for machine");
@@ -290,6 +292,7 @@ mod tests {
             "scout_firmware_upgrade_status",
             "dpu_network_status",
             "boot_interface_intent",
+            "sku_association_removed",
         ] {
             assert_eq!(
                 metrics.counter_delta(

--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -273,12 +273,29 @@ pub(in crate::tests) mod tests {
         find_match_interval: Option<Duration>,
         auto_generate_missing_sku: bool,
     ) -> TestEnv {
+        create_test_env_for_bom_validation_with_ignore_unassigned_machines(
+            db_pool,
+            allow_allocation_on_validation_failure,
+            find_match_interval,
+            auto_generate_missing_sku,
+            false,
+        )
+        .await
+    }
+
+    async fn create_test_env_for_bom_validation_with_ignore_unassigned_machines(
+        db_pool: sqlx::PgPool,
+        allow_allocation_on_validation_failure: bool,
+        find_match_interval: Option<Duration>,
+        auto_generate_missing_sku: bool,
+        ignore_unassigned_machines: bool,
+    ) -> TestEnv {
         let mut overrides = TestEnvOverrides::default();
         let mut config = get_config();
         config.bom_validation.enabled = true;
         config.bom_validation.allow_allocation_on_validation_failure =
             allow_allocation_on_validation_failure;
-        config.bom_validation.ignore_unassigned_machines = false; // Deprecated, will be removed
+        config.bom_validation.ignore_unassigned_machines = ignore_unassigned_machines;
         config.bom_validation.auto_generate_missing_sku = auto_generate_missing_sku;
         config.bom_validation.auto_generate_missing_sku_interval = Duration::from_secs(2);
 
@@ -1482,6 +1499,46 @@ pub(in crate::tests) mod tests {
         // With prevent_allocation=true, should stay in SkuVerificationFailed
         assert!(matches!(
             machine.current_state(),
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::SkuVerificationFailed(_)
+            }
+        ));
+
+        Ok(())
+    }
+
+    /// An assigned SKU must still block allocation when only unassigned machines are ignored.
+    #[crate::sqlx_test]
+    async fn test_ignore_unassigned_machines_does_not_bypass_assigned_sku_verification(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        let env = create_test_env_for_bom_validation_with_ignore_unassigned_machines(
+            pool.clone(),
+            false,
+            None,
+            false,
+            true,
+        )
+        .await;
+
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        let mut txn = pool.begin().await?;
+        let current_sku = db::sku::generate_sku_from_machine(txn.as_mut(), &machine_id).await?;
+        db::sku::create(&mut txn, &current_sku).await?;
+        db::machine::assign_sku(&mut txn, &machine_id, &current_sku.id).await?;
+        let current_sku_id = current_sku.id;
+        assign_mismatched_sku(&mut txn, &machine_id, &current_sku_id).await?;
+        db::machine::update_sku_status_verify_request_time(&mut txn, &machine_id).await?;
+        txn.commit().await?;
+
+        handle_inventory_update(&pool, &env, &mh).await;
+        env.run_machine_state_controller_iteration().await;
+        env.run_machine_state_controller_iteration().await;
+
+        assert!(matches!(
+            get_machine_state(&pool, &mh).await,
             ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::SkuVerificationFailed(_)
             }

--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -21,6 +21,7 @@ pub(in crate::tests) mod tests {
     use db::sku::CURRENT_SKU_VERSION;
     use db::{self, DatabaseError, ObjectFilter, WithTransaction};
     use futures_util::FutureExt;
+    use health_report::{HealthProbeAlert, HealthReport};
     use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
     use model::machine::machine_search_config::MachineSearchConfig;
     use model::machine::{
@@ -39,6 +40,13 @@ pub(in crate::tests) mod tests {
         get_config,
     };
 
+    fn sku_unassigned_alert(report: Option<&HealthReport>) -> Option<&HealthProbeAlert> {
+        report?
+            .alerts
+            .iter()
+            .find(|alert| alert.is_sku_unassigned())
+    }
+
     // ================================================================================
     // SKU Test Suite Structure
     // ================================================================================
@@ -46,67 +54,44 @@ pub(in crate::tests) mod tests {
     // This test suite validates SKU (Stock Keeping Unit) validation behavior across
     // different configuration combinations and machine states.
     //
-    // Key configuration parameters (A×B matrix):
+    // Key configuration parameters (A×B×C matrix):
     //   A = allow_allocation_on_validation_failure (F=block on failure, T=allow allocation despite failures)
     //   B = auto_generate_missing_sku (F=manual, T=auto-generate)
+    //   C = ignore_unassigned_machines (F=wait for assignment, T=bypass unassigned machines)
     //
     // When allow_allocation_on_validation_failure=true, machines in failed states
-    // (SkuVerificationFailed, SkuMissing, WaitingForSkuAssignment) can transition
-    // back to Ready/MachineValidation instead of staying blocked.
+    // (SkuVerificationFailed, SkuMissing) can transition back to Ready/MachineValidation
+    // instead of staying blocked.
     //
     // ================================================================================
     //
     // SKU VALIDATION TESTS
     // ================================================================================
     //
-    // ┌────┬───┬───┬─────────────────────────────┬────────────────────────────┬──────────────────────────────────────────────────────────┐
-    // │ #  │ A │ B │ Scenario                    │ Expected Behavior          │ Test Name                                                │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │ 1. Machine Creation Scenarios                                                                                                    │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │1.1 │ F │ * │ Machine created, no SKU     │ Ready (fixture assigns SKU)│ test_machine_creation_succeeds_when_not_assigned         │
-    // │1.2 │ F │ * │ Same as 1.1, fixture off    │ Stuck in WaitingForSku     │ test_machine_creation_without_auto_sku                   │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │ 2. WaitingForSkuAssignment State                                                                                                 │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │2.1 │ F │ F │ WaitingForSkuAssignment     │ Stays in Waiting           │ test_stays_in_waiting_state_when_not_assigned            │
-    // │2.2 │ F │ F │ Waiting → Test assigns SKU  │ → UpdatingInventory        │ test_leave_waiting_when_assigned                         │
-    // │2.3 │ F │ F │ No SKU assigned             │ Stuck in Waiting           │ test_stuck_in_waiting_without_sku                        │
-    // │2.4 │ T │ F │ No SKU (skips Waiting)      │ Panic (never enters)       │ test_escapes_waiting_with_allow_allocation               │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │ 3. SkuMissing State                                                                                                              │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │3.1 │ F │ F │ SKU assigned but missing    │ Stays in SkuMissing        │ test_stays_in_missing_state_when_assigned_sku_is_missing │
-    // │3.2 │ F │ F │ SkuMissing → Remove SKU ID  │ → WaitingForSkuAssignment  │ test_proceeds_when_sku_missing                           │
-    // │3.3 │ F │ T │ SKU assigned but missing    │ Auto-gen → Ready           │ test_auto_generates_sku_when_missing                     │
-    // │3.4 │ T │ F │ SkuMissing state            │ Escapes → MachineValidation│ test_allow_allocation_escapes_from_sku_missing           │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │ 4. SKU Verification Success Scenarios                                                                                            │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │4.1 │ F │ * │ SKU assigned and matches    │ MachineValidation → Ready  │ test_discovery_moves_to_machine_validation_state         │
-    // │4.2 │ F │ * │ Ready → Manual re-verify    │ Skip MachineVal → Ready    │ test_manual_verify_skips_machine_validation              │
-    // │4.3 │ F │ * │ Ready → Manual verify (F→S) │ Skip MachineVal → Ready    │ test_manual_verify_to_failed_to_passed_skips_machine_... │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │ 5. SKU Verification Failure Scenarios                                                                                            │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │5.1 │ F │ * │ Re-verify mismatched SKU    │ → VerificationFailed       │ test_stays_in_failed_when_verification_fails             │
-    // │5.2 │ F │ * │ Replace SKU, no re-verify   │ Stays Ready (no validation)│ test_continues_to_ready_when_verification_fails          │
-    // │5.3 │ T │ * │ SkuVerificationFailed state │ Escapes → Ready            │ test_allow_allocation_escapes_from_sku_failed            │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │ 6. SKU Auto-Matching Scenarios                                                                                                   │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │6.1 │ F │ * │ Second machine, same HW     │ Auto-match existing → Ready│ test_auto_match_sku                                      │
-    // │6.2 │ F │ * │ SKU replacement triggers    │ Re-verify (to BomValidating)│ test_replace_triggers_verify                            │
-    // │6.3 │ F │ * │ Unassign + clear status     │ Immediate re-match → Ready │ test_auto_match_after_unassign                           │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │ 7. SKU Version Compatibility                                                                                                     │
-    // ├────┼───┼───┼─────────────────────────────┼────────────────────────────┼──────────────────────────────────────────────────────────┤
-    // │7.1 │ F │ * │ Different SKU schema vers   │ Version compatibility test │ test_match_all_sku_versions                              │
-    // └────┴───┴───┴─────────────────────────────┴────────────────────────────┴──────────────────────────────────────────────────────────┘
+    // Test index (`number [A/B/C]`: scenario → expected behavior):
+    // - Machine creation: 1.1 [F/*/*] create with no SKU → fixture assigns SKU;
+    //   1.2 [F/*/F] fixture assignment off → WaitingForSkuAssignment.
+    // - Waiting for assignment: 2.1 [F/F/F] remains waiting; 2.2 [F/F/F] manual
+    //   assignment → UpdatingInventory; 2.3 [F/F/F] no SKU remains waiting; 2.4
+    //   [T/F/F] no SKU remains waiting; 2.5 [F/F/T] no SKU → Ready; 2.6 [T/F/F]
+    //   Ready machine is unassigned → WaitingForSkuAssignment; 2.7 [T/F/T] no SKU → Ready.
+    // - Missing assigned SKU: 3.1 [F/F/*] remains SkuMissing; 3.2 [F/F/F] unassign
+    //   → WaitingForSkuAssignment; 3.3 [F/T/*] auto-generates a SKU → Ready; 3.4
+    //   [T/F/*] escapes → MachineValidation; 3.5 [F/F/T] remains SkuMissing.
+    // - Verification success: 4.1 [F/*/*] matched SKU → Ready; 4.2 [F/*/*] manual
+    //   re-verification → Ready; 4.3 [F/*/*] failed then passed verification → Ready.
+    // - Verification failure: 5.1 [F/*/*] mismatch → SkuVerificationFailed; 5.2
+    //   [F/*/*] replacement without re-verification → Ready; 5.3 [T/*/*] failure
+    //   escapes → Ready; 5.4 [F/F/T] assigned mismatch blocks, then unassignment
+    //   bypasses validation.
+    // - Auto-matching: 6.1 [F/*/*] matching second machine → Ready; 6.2 [F/*/*]
+    //   replacement → re-verification; 6.3 [F/*/*] unassign → re-match.
+    // - Version compatibility: 7.1 [F/*/*] validates all supported SKU versions.
     //
     // Legend:
     //   A = allow_allocation_on_validation_failure (F=false/block, T=true/allow, *=not relevant)
     //   B = auto_generate_missing_sku (F=false/manual, T=true/auto-gen, *=not relevant)
+    //   C = ignore_unassigned_machines (F=false/wait for assignment, T=true/bypass unassigned machines, *=not relevant)
     //
     // ================================================================================
 
@@ -354,19 +339,17 @@ pub(in crate::tests) mod tests {
         .ok_or_else(|| eyre::eyre!("machine not found: {}", machine_id))
     }
 
-    /// Helper: Clear the SKU status/timestamp on a machine to allow re-matching
-    /// Used in tests to reset the SKU matching state and test re-match behavior
-    pub(in crate::tests) async fn clear_sku_status(
+    /// Removes the automatic SKU-matching throttle from a machine's test status.
+    async fn clear_last_match_attempt(
         txn: &mut PgConnection,
         machine_id: &MachineId,
-    ) -> Result<(), DatabaseError> {
-        let query = "UPDATE machines SET hw_sku_status=null WHERE id=$1 RETURNING id";
-
-        let _: () = sqlx::query_as(query)
-            .bind(machine_id)
-            .fetch_one(txn)
-            .await
-            .map_err(|e| DatabaseError::new("clear sku last match attempt", e))?;
+    ) -> Result<(), sqlx::Error> {
+        let _: () = sqlx::query_as(
+            "UPDATE machines SET hw_sku_status=hw_sku_status - 'last_match_attempt' WHERE id=$1 RETURNING id",
+        )
+        .bind(machine_id)
+        .fetch_one(txn)
+        .await?;
 
         Ok(())
     }
@@ -713,6 +696,7 @@ pub(in crate::tests) mod tests {
         // when machine reaches that state, without calling assign_sku_if_needed
 
         let mh = create_managed_host_with_config(&env, managed_host_config).await;
+        let machine_id = mh.host().id;
 
         // Verify machine stays in WaitingForSkuAssignment (run state machine a few times to ensure it's stable)
         env.run_machine_state_controller_iteration().await;
@@ -727,6 +711,36 @@ pub(in crate::tests) mod tests {
                 bom_validating_state: BomValidating::WaitingForSkuAssignment(_)
             }
         ));
+        let initial_alert_since = sku_unassigned_alert(machine.sku_validation_health_report())
+            .and_then(|alert| alert.in_alert_since)
+            .expect("unassigned SKU alert has an in_alert_since timestamp");
+        txn.commit().await?;
+
+        // Remaining in this state must preserve the alert age without rewriting it.
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert_eq!(
+            sku_unassigned_alert(machine.sku_validation_health_report())
+                .and_then(|alert| alert.in_alert_since),
+            Some(initial_alert_since)
+        );
+        db::machine::update_sku_validation_health_report(
+            &mut txn,
+            &machine_id,
+            &HealthReport::empty(HealthReport::SKU_VALIDATION_SOURCE.to_string()),
+        )
+        .await?;
+        txn.commit().await?;
+
+        // An existing WaitingForSkuAssignment state repairs a missing alert on the next iteration.
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert!(sku_unassigned_alert(machine.sku_validation_health_report()).is_some());
+        txn.commit().await?;
 
         Ok(())
     }
@@ -774,6 +788,8 @@ pub(in crate::tests) mod tests {
                 bom_validating_state: BomValidating::UpdatingInventory(_)
             }
         ));
+        assert!(machine.sku_validation_health_report().is_none());
+        txn.commit().await?;
 
         Ok(())
     }
@@ -821,21 +837,18 @@ pub(in crate::tests) mod tests {
         Ok(())
     }
 
-    /// Test 2.4: Never enters WaitingForSkuAssignment with allow_allocation_on_validation_failure=true
+    /// Test 2.4: An unassigned SKU still waits when allocation on validation failure is enabled
     /// Conditions:
     /// - allow_allocation_on_validation_failure = true
     /// - auto_generate_missing_sku = false
     /// - auto_assign_sku_in_fixture = false
-    /// - expected_state = WaitingForSkuAssignment
-    /// Expected: fixture panics because machine never enters WaitingForSkuAssignment
-    /// (machine directly skips to MachineValidation, proving allow_allocation logic works)
+    /// Expected: machine enters WaitingForSkuAssignment because no SKU validation has failed
     #[crate::sqlx_test]
-    #[should_panic(expected = "Expected Machine state condition not hit after")]
-    async fn test_escapes_waiting_with_allow_allocation(pool: sqlx::PgPool) {
+    async fn test_allow_allocation_does_not_bypass_unassigned_sku(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
         let env = create_test_env_for_bom_validation(pool.clone(), true, None, false).await;
 
-        // Expect WaitingForSkuAssignment, but machine will never enter that state
-        // because allow_allocation=true makes it skip directly to MachineValidation
         let mut config =
             ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::WaitingForSkuAssignment(
@@ -847,9 +860,227 @@ pub(in crate::tests) mod tests {
             });
         config.auto_assign_sku_in_fixture = false;
 
-        // This will panic because machine never enters WaitingForSkuAssignment
-        // (it goes directly from MatchingSku to MachineValidation)
-        let _mh = create_managed_host_with_config(&env, config).await;
+        let mh = create_managed_host_with_config(&env, config).await;
+
+        assert!(matches!(
+            get_machine_state(&pool, &mh).await,
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::WaitingForSkuAssignment(_)
+            }
+        ));
+
+        Ok(())
+    }
+
+    /// Test 2.5: An unassigned SKU bypasses validation only when explicitly ignored
+    #[crate::sqlx_test]
+    async fn test_ignore_unassigned_machines_bypasses_sku_assignment(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        let env = create_test_env_for_bom_validation_with_ignore_unassigned_machines(
+            pool.clone(),
+            false,
+            None,
+            false,
+            true,
+        )
+        .await;
+
+        let mh = create_managed_host(&env).await;
+
+        assert!(matches!(
+            get_machine_state(&pool, &mh).await,
+            ManagedHostState::Ready
+        ));
+
+        let machine_id = mh.host().id;
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert!(
+            machine
+                .status
+                .hw_sku
+                .as_ref()
+                .is_some_and(|status| status.last_match_attempt.is_some())
+        );
+        // A host may carry this allocation block from a forced SKU removal
+        // before the site enables the explicit unassigned-machine bypass.
+        db::machine::update_sku_validation_health_report(
+            &mut txn,
+            &machine_id,
+            &HealthReport::sku_unassigned(),
+        )
+        .await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert!(machine.sku_validation_health_report().is_none());
+        clear_last_match_attempt(&mut txn, &machine_id).await?;
+        txn.commit().await?;
+
+        // A Ready machine with a SKU status but no previous match attempt must retry matching.
+        // This also proves the no-match timestamp is committed by the Ready-state bypass path.
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert!(machine.config.hw_sku.is_none());
+        assert!(
+            machine
+                .status
+                .hw_sku
+                .as_ref()
+                .is_some_and(|status| status.last_match_attempt.is_some())
+        );
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Disabling BOM validation clears an allocation block left by a prior strict policy.
+    #[crate::sqlx_test]
+    async fn test_disabled_bom_validation_clears_unassigned_sku_alert(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        let mut overrides = TestEnvOverrides::default();
+        let mut config = get_config();
+        config.bom_validation.enabled = false;
+        overrides.config = Some(config);
+        let env = create_test_env_with_overrides(pool.clone(), overrides).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        assert!(matches!(
+            get_machine_state(&pool, &mh).await,
+            ManagedHostState::Ready
+        ));
+
+        let mut txn = pool.begin().await?;
+        db::machine::update_sku_validation_health_report(
+            &mut txn,
+            &machine_id,
+            &HealthReport::sku_unassigned(),
+        )
+        .await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert!(machine.sku_validation_health_report().is_none());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Test 2.6: Ready machines without a matching SKU wait even when allocation failures are allowed.
+    #[crate::sqlx_test]
+    async fn test_allow_allocation_does_not_bypass_unassigned_ready_machine(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        let env = create_test_env_for_bom_validation(pool.clone(), true, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        let sku_id = machine
+            .config
+            .hw_sku
+            .clone()
+            .expect("fixture assigns a SKU");
+        db::machine::unassign_sku(&mut txn, &machine_id).await?;
+        db::sku::delete(&mut txn, &sku_id).await?;
+        clear_last_match_attempt(&mut txn, &machine_id).await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert!(matches!(
+            machine.current_state(),
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::WaitingForSkuAssignment(_)
+            }
+        ));
+        assert!(sku_unassigned_alert(machine.sku_validation_health_report()).is_some());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Test 2.7: Sites using both compatibility settings still bypass unassigned machines.
+    #[crate::sqlx_test]
+    async fn test_allow_allocation_and_ignore_unassigned_machines_bypass_sku_assignment(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        let env = create_test_env_for_bom_validation_with_ignore_unassigned_machines(
+            pool.clone(),
+            true,
+            None,
+            false,
+            true,
+        )
+        .await;
+
+        let mh = create_managed_host(&env).await;
+        assert!(matches!(
+            get_machine_state(&pool, &mh).await,
+            ManagedHostState::Ready
+        ));
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert!(machine.config.hw_sku.is_none());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Test 3.5: An assigned SKU remains blocked when only unassigned machines are ignored.
+    #[crate::sqlx_test]
+    async fn test_ignore_unassigned_machines_does_not_bypass_missing_sku(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        let env = create_test_env_for_bom_validation_with_ignore_unassigned_machines(
+            pool.clone(),
+            false,
+            None,
+            false,
+            true,
+        )
+        .await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        let mut txn = pool.begin().await?;
+        db::machine::assign_sku(&mut txn, &machine_id, "missing-sku").await?;
+        txn.commit().await?;
+
+        // The Ready-state path recognizes the assigned, missing SKU.
+        env.run_machine_state_controller_iteration().await;
+        assert!(matches!(
+            get_machine_state(&pool, &mh).await,
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::SkuMissing(_)
+            }
+        ));
+
+        // The SkuMissing-state path remains blocked as well.
+        env.run_machine_state_controller_iteration().await;
+        assert!(matches!(
+            get_machine_state(&pool, &mh).await,
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::SkuMissing(_)
+            }
+        ));
+
+        Ok(())
     }
 
     /// Test 3.1: SkuMissing State → stays in SkuMissing
@@ -1017,6 +1248,8 @@ pub(in crate::tests) mod tests {
                 bom_validating_state: BomValidating::WaitingForSkuAssignment(_)
             }
         ));
+        assert!(sku_unassigned_alert(machine.sku_validation_health_report()).is_some());
+        txn.commit().await?;
 
         Ok(())
     }
@@ -1503,13 +1736,144 @@ pub(in crate::tests) mod tests {
                 bom_validating_state: BomValidating::SkuVerificationFailed(_)
             }
         ));
+        assert!(machine.sku_validation_health_report().is_some());
+        txn.commit().await?;
+
+        let mut txn = pool.begin().await?;
+        db::machine::unassign_sku(&mut txn, &machine_id).await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(matches!(
+            machine.current_state(),
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::WaitingForSkuAssignment(_)
+            }
+        ));
+        assert!(sku_unassigned_alert(machine.sku_validation_health_report()).is_some());
+        txn.commit().await?;
 
         Ok(())
     }
 
-    /// An assigned SKU must still block allocation when only unassigned machines are ignored.
+    /// A maintenance request must not interrupt a failed SKU validation.
     #[crate::sqlx_test]
-    async fn test_ignore_unassigned_machines_does_not_bypass_assigned_sku_verification(
+    async fn test_maintenance_request_does_not_interrupt_sku_verification_failure(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use model::machine::MachineMaintenanceOperation;
+
+        let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        let current_sku_id = machine
+            .config
+            .hw_sku
+            .as_deref()
+            .expect("fixture assigns a SKU");
+        assign_mismatched_sku(&mut txn, &machine_id, current_sku_id).await?;
+        db::machine::update_sku_status_verify_request_time(&mut txn, &machine_id).await?;
+        txn.commit().await?;
+
+        handle_inventory_update(&pool, &env, &mh).await;
+        env.run_machine_state_controller_iteration_until_state_condition(
+            &machine_id,
+            3,
+            |machine| {
+                matches!(
+                    machine.current_state(),
+                    ManagedHostState::BomValidating {
+                        bom_validating_state: BomValidating::SkuVerificationFailed(_)
+                    }
+                )
+            },
+        )
+        .await;
+
+        let mut txn = pool.begin().await?;
+        db::machine::set_machine_maintenance_requested(
+            &mut txn,
+            machine_id,
+            "test",
+            MachineMaintenanceOperation::Reset,
+        )
+        .await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(matches!(
+            machine.current_state(),
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::SkuVerificationFailed(_)
+            }
+        ));
+        assert!(machine.sku_validation_health_report().is_some());
+        assert!(machine.machine_maintenance_requested.is_some());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// A maintenance request must not interrupt an in-flight SKU inventory update.
+    #[crate::sqlx_test]
+    async fn test_maintenance_request_does_not_interrupt_sku_inventory_update(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use model::machine::MachineMaintenanceOperation;
+
+        let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        let mut txn = pool.begin().await?;
+        // Re-enter UpdatingInventory after the fixture's discovery timestamp so
+        // this iteration remains in the in-flight state rather than immediately
+        // consuming the fresh inventory snapshot.
+        db::machine::update_state(
+            &mut txn,
+            &machine_id,
+            &ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::UpdatingInventory(
+                    BomValidatingContext::default(),
+                ),
+            },
+        )
+        .await?;
+        db::machine::set_machine_maintenance_requested(
+            &mut txn,
+            machine_id,
+            "test",
+            MachineMaintenanceOperation::Reset,
+        )
+        .await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(matches!(
+            machine.current_state(),
+            ManagedHostState::BomValidating { .. }
+        ));
+        assert!(machine.machine_maintenance_requested.is_some());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Test 5.4: An assigned SKU blocks allocation until the SKU is unassigned.
+    #[crate::sqlx_test]
+    async fn test_ignore_unassigned_machines_only_bypasses_after_sku_unassignment(
         pool: sqlx::PgPool,
     ) -> Result<(), eyre::Error> {
         let env = create_test_env_for_bom_validation_with_ignore_unassigned_machines(
@@ -1527,7 +1891,6 @@ pub(in crate::tests) mod tests {
         let mut txn = pool.begin().await?;
         let current_sku = db::sku::generate_sku_from_machine(txn.as_mut(), &machine_id).await?;
         db::sku::create(&mut txn, &current_sku).await?;
-        db::machine::assign_sku(&mut txn, &machine_id, &current_sku.id).await?;
         let current_sku_id = current_sku.id;
         assign_mismatched_sku(&mut txn, &machine_id, &current_sku_id).await?;
         db::machine::update_sku_status_verify_request_time(&mut txn, &machine_id).await?;
@@ -1543,6 +1906,352 @@ pub(in crate::tests) mod tests {
                 bom_validating_state: BomValidating::SkuVerificationFailed(_)
             }
         ));
+
+        let mut txn = pool.begin().await?;
+        db::machine::unassign_sku(&mut txn, &machine_id).await?;
+        db::sku::delete(&mut txn, &current_sku_id).await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration_until_state_matches(
+            &machine_id,
+            20,
+            ManagedHostState::Ready,
+        )
+        .await;
+
+        let mut txn = pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        assert!(machine.config.hw_sku.is_none());
+        assert!(machine.sku_validation_health_report().is_none());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Removing an SKU from a Ready machine atomically blocks allocation until an SKU is assigned.
+    #[crate::sqlx_test]
+    async fn test_remove_sku_association_waits_for_assignment_before_committing(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use rpc::forge::RemoveSkuRequest;
+        use rpc::forge::forge_server::Forge;
+
+        let env = create_test_env_for_bom_validation(pool.clone(), true, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        assert!(matches!(
+            get_machine_state(&pool, &mh).await,
+            ManagedHostState::Ready
+        ));
+
+        env.api
+            .remove_sku_association(tonic::Request::new(RemoveSkuRequest {
+                machine_id: Some(machine_id),
+                force: false,
+            }))
+            .await?;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(machine.config.hw_sku.is_none());
+        assert!(matches!(
+            machine.current_state(),
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::WaitingForSkuAssignment(_)
+            }
+        ));
+        assert!(sku_unassigned_alert(machine.sku_validation_health_report()).is_some());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// A forced SKU removal during maintenance retains the allocation block.
+    #[crate::sqlx_test]
+    async fn test_force_remove_sku_association_during_maintenance_blocks_allocation(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use model::machine::MachineMaintenanceOperation;
+        use rpc::forge::RemoveSkuRequest;
+        use rpc::forge::forge_server::Forge;
+
+        let env = create_test_env_for_bom_validation(pool.clone(), true, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        let mut txn = pool.begin().await?;
+        db::machine::set_machine_maintenance_requested(
+            &mut txn,
+            machine_id,
+            "test",
+            MachineMaintenanceOperation::Reset,
+        )
+        .await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration_until_state_condition(
+            &machine_id,
+            3,
+            |machine| {
+                matches!(
+                    machine.current_state(),
+                    ManagedHostState::Maintenance { .. }
+                )
+            },
+        )
+        .await;
+
+        env.api
+            .remove_sku_association(tonic::Request::new(RemoveSkuRequest {
+                machine_id: Some(machine_id),
+                force: true,
+            }))
+            .await?;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(machine.config.hw_sku.is_none());
+        assert!(matches!(
+            machine.current_state(),
+            ManagedHostState::Maintenance { .. }
+        ));
+        let state_version_before_noop = machine.current_version();
+        let alert_since_before_noop = sku_unassigned_alert(machine.sku_validation_health_report())
+            .and_then(|alert| alert.in_alert_since)
+            .expect("forced removal must block allocation");
+        txn.commit().await?;
+
+        // An already unassigned host is a no-op and remains accepted, even
+        // while maintenance is active.
+        env.api
+            .remove_sku_association(tonic::Request::new(RemoveSkuRequest {
+                machine_id: Some(machine_id),
+                force: true,
+            }))
+            .await?;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert_eq!(machine.current_version(), state_version_before_noop);
+        assert_eq!(
+            sku_unassigned_alert(machine.sku_validation_health_report())
+                .and_then(|alert| alert.in_alert_since),
+            Some(alert_since_before_noop)
+        );
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Forced removal remains available outside Maintenance for administrative recovery.
+    #[crate::sqlx_test]
+    async fn test_force_remove_sku_association_from_non_bom_state(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use rpc::forge::forge_server::Forge;
+        use rpc::forge::{RemoveSkuRequest, SkuMachinePair};
+
+        let env = create_test_env_for_bom_validation(pool.clone(), true, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+        let expected_state = ManagedHostState::HostInit {
+            machine_state: MachineState::Discovered {
+                skip_reboot_wait: true,
+            },
+        };
+
+        let mut txn = pool.begin().await?;
+        let sku_id = get_machine_by_id(&mut txn, &machine_id)
+            .await?
+            .config
+            .hw_sku
+            .expect("fixture assigns a SKU");
+        db::machine::update_state(&mut txn, &machine_id, &expected_state).await?;
+        txn.commit().await?;
+
+        env.api
+            .remove_sku_association(tonic::Request::new(RemoveSkuRequest {
+                machine_id: Some(machine_id),
+                force: true,
+            }))
+            .await?;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(machine.config.hw_sku.is_none());
+        assert_eq!(machine.current_state(), &expected_state);
+        assert!(sku_unassigned_alert(machine.sku_validation_health_report()).is_some());
+        txn.commit().await?;
+
+        // A forced replacement can happen before the host reaches Ready. The
+        // state version advances later, so the normal verify-request shortcut
+        // is no longer applicable; Ready must still clear the stale alert.
+        env.api
+            .assign_sku_to_machine(tonic::Request::new(SkuMachinePair {
+                sku_id,
+                machine_id: Some(machine_id),
+                force: true,
+            }))
+            .await?;
+        let mut txn = pool.begin().await?;
+        db::machine::update_state(&mut txn, &machine_id, &ManagedHostState::Ready).await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(machine.config.hw_sku.is_some());
+        assert!(machine.sku_validation_health_report().is_none());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Forced removal remains available to repair a host whose assigned SKU was deleted.
+    #[crate::sqlx_test]
+    async fn test_force_remove_sku_association_from_sku_missing_waits_for_assignment(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use rpc::forge::RemoveSkuRequest;
+        use rpc::forge::forge_server::Forge;
+
+        let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        let mut txn = pool.begin().await?;
+        db::machine::unassign_sku(&mut txn, &machine_id).await?;
+        db::machine::assign_sku(&mut txn, &machine_id, "deleted-sku").await?;
+        txn.commit().await?;
+
+        env.run_machine_state_controller_iteration_until_state_condition(
+            &machine_id,
+            3,
+            |machine| {
+                matches!(
+                    machine.current_state(),
+                    ManagedHostState::BomValidating {
+                        bom_validating_state: BomValidating::SkuMissing(_)
+                    }
+                )
+            },
+        )
+        .await;
+
+        let expected_context = BomValidatingContext {
+            machine_validation_context: Some(MachineValidationContext::Cleanup),
+            reboot_retry_count: Some(3),
+        };
+        let mut txn = pool.begin().await?;
+        db::machine::update_state(
+            &mut txn,
+            &machine_id,
+            &ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::SkuMissing(expected_context.clone()),
+            },
+        )
+        .await?;
+        let pre_removal_version = get_machine_by_id(&mut txn, &machine_id)
+            .await?
+            .current_version();
+        txn.commit().await?;
+
+        env.api
+            .remove_sku_association(tonic::Request::new(RemoveSkuRequest {
+                machine_id: Some(machine_id),
+                force: true,
+            }))
+            .await?;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(machine.config.hw_sku.is_none());
+        // The API moves every BomValidating substate to Waiting atomically. That
+        // version change makes a controller iteration that loaded the former SKU
+        // lose its compare-and-swap rather than transition this unassigned host.
+        assert!(matches!(
+            machine.current_state(),
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::WaitingForSkuAssignment(context)
+            } if context == &expected_context
+        ));
+        assert_ne!(machine.current_version(), pre_removal_version);
+        assert!(sku_unassigned_alert(machine.sku_validation_health_report()).is_some());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Removing an SKU from a DPU does not apply waiting state or SKU health.
+    #[crate::sqlx_test]
+    async fn test_remove_sku_association_from_dpu_does_not_add_waiting_state_or_alert(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use rpc::forge::RemoveSkuRequest;
+        use rpc::forge::forge_server::Forge;
+
+        let env = create_test_env_for_bom_validation(pool.clone(), true, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let dpu_id = mh.dpu().id;
+
+        let mut txn = pool.begin().await?;
+        assert!(matches!(
+            get_machine_by_id(&mut txn, &dpu_id).await?.current_state(),
+            ManagedHostState::Ready
+        ));
+        txn.commit().await?;
+
+        env.api
+            .remove_sku_association(tonic::Request::new(RemoveSkuRequest {
+                machine_id: Some(dpu_id),
+                force: false,
+            }))
+            .await?;
+
+        let mut txn = pool.begin().await?;
+        let dpu = get_machine_by_id(&mut txn, &dpu_id).await?;
+        assert!(dpu.config.hw_sku.is_none());
+        assert!(matches!(dpu.current_state(), ManagedHostState::Ready));
+        assert!(dpu.sku_validation_health_report().is_none());
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    /// Removing an SKU does not overwrite an in-progress instance allocation.
+    #[crate::sqlx_test]
+    async fn test_remove_sku_association_preserves_ready_state_with_pending_instance(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use rpc::forge::RemoveSkuRequest;
+        use rpc::forge::forge_server::Forge;
+
+        let env = create_test_env_for_bom_validation(pool.clone(), true, None, false).await;
+        let mh = create_managed_host(&env).await;
+        let machine_id = mh.host().id;
+
+        let mut txn = pool.begin().await?;
+        sqlx::query("INSERT INTO instances (machine_id) VALUES ($1)")
+            .bind(machine_id)
+            .execute(&mut *txn)
+            .await?;
+        txn.commit().await?;
+
+        env.api
+            .remove_sku_association(tonic::Request::new(RemoveSkuRequest {
+                machine_id: Some(machine_id),
+                force: false,
+            }))
+            .await?;
+
+        let mut txn = pool.begin().await?;
+        let machine = get_machine_by_id(&mut txn, &machine_id).await?;
+        assert!(machine.config.hw_sku.is_none());
+        assert!(matches!(machine.current_state(), ManagedHostState::Ready));
+        assert!(machine.sku_validation_health_report().is_none());
+        txn.commit().await?;
 
         Ok(())
     }
@@ -1788,16 +2497,13 @@ pub(in crate::tests) mod tests {
         Ok(())
     }
 
-    /// Test 6.3: Auto-matching SKU after unassign and status clear
+    /// Test 6.3: Auto-matching SKU after unassign
     /// Conditions:
     /// - allow_allocation_on_validation_failure = false (standard mode)
     /// - auto_generate_missing_sku = false
     /// - Machine reaches Ready with auto-matched SKU
-    /// - SKU is unassigned and hw_sku_status is cleared (simulating fresh start)
+    /// - SKU is unassigned after a verification request creates an SKU status without a match attempt
     /// Expected: Machine re-enters BOM validation flow and successfully re-matches the same SKU
-    /// Note: Status is cleared to bypass find_match_interval for immediate re-matching. The
-    ///       find_match_interval config throttles retry attempts when NO matching SKU is found,
-    ///       not when a matching SKU exists (which matches immediately).
     #[crate::sqlx_test]
     async fn test_auto_match_after_unassign(pool: sqlx::PgPool) -> Result<(), eyre::Error> {
         let env = create_test_env_for_bom_validation(
@@ -1854,8 +2560,9 @@ pub(in crate::tests) mod tests {
         assert_eq!(machine.config.hw_sku, Some(expected_sku.id.clone()));
         assert_eq!(machine.current_state(), &ManagedHostState::Ready);
 
-        clear_sku_status(&mut txn, &machine_id).await?;
-        // test that an unassigned can find and assign a machine.
+        db::machine::update_sku_status_verify_request_time(&mut txn, &machine_id).await?;
+        // Unassigning retains the status; a missing last_match_attempt means matching has never
+        // been attempted and must not suppress the first re-match.
         db::machine::unassign_sku(&mut txn, &machine_id).await?;
         txn.commit().await?;
 

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -163,6 +163,24 @@ pub async fn find_one(
         .pop())
 }
 
+/// Locks a machine row and reports whether it exists.
+///
+/// Callers that need synchronization but not a full machine snapshot should use
+/// this instead of `find_one` with `for_update`.
+pub async fn lock_machine(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+) -> Result<bool, DatabaseError> {
+    let query = "SELECT 1 FROM machines WHERE id = $1 FOR UPDATE";
+    let locked: Option<i32> = sqlx::query_scalar(query)
+        .bind(machine_id.to_string())
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(locked.is_some())
+}
+
 pub async fn find_existing_machine(
     txn: &mut PgConnection,
     macaddr: MacAddress,
@@ -255,6 +273,65 @@ pub async fn advance(
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::new("update machines state", e))?;
+
+    Ok(true)
+}
+
+/// Updates a machine controller state only when its current state version
+/// matches `expected_version`.
+///
+/// The state controller uses this compare-and-swap to avoid overwriting a
+/// state transition made by an API request after the controller loaded its
+/// snapshot. The associated DPUs are updated only after the host transition
+/// succeeds.
+pub async fn try_update_controller_state(
+    txn: &mut PgConnection,
+    host_id: &MachineId,
+    expected_version: ConfigVersion,
+    new_version: ConfigVersion,
+    state: &ManagedHostState,
+) -> Result<bool, DatabaseError> {
+    let query = "WITH updated AS (
+        UPDATE machines
+        SET controller_state_version = $1, controller_state = $2, controller_state_outcome = NULL
+        WHERE id = $3
+          AND controller_state_version = $4
+        RETURNING id
+    )
+    SELECT EXISTS (SELECT 1 FROM machines WHERE id = $3),
+           EXISTS (SELECT 1 FROM updated)";
+    let (exists, updated): (bool, bool) = sqlx::query_as(query)
+        .bind(new_version)
+        .bind(sqlx::types::Json(state))
+        .bind(host_id.to_string())
+        .bind(expected_version)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::new("try_update_controller_state", e))?;
+
+    if !exists {
+        return Err(DatabaseError::NotFoundError {
+            kind: "machine",
+            id: host_id.to_string(),
+        });
+    }
+
+    if !updated {
+        return Ok(false);
+    }
+
+    crate::state_history::persist(
+        txn,
+        crate::state_history::StateHistoryTableId::Machine,
+        host_id,
+        state,
+        new_version,
+    )
+    .await?;
+
+    for dpu in find_dpus_by_host_machine_id(txn, host_id).await? {
+        advance(&dpu, txn, state, Some(new_version)).await?;
+    }
 
     Ok(true)
 }
@@ -3298,6 +3375,109 @@ mod test {
             1.0
         );
 
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn try_update_controller_state_rejects_stale_version(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")?;
+        let mut txn = pool.begin().await?;
+        super::create(
+            txn.as_mut(),
+            None,
+            &machine_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+        let machine = super::find_one(txn.as_mut(), &machine_id, MachineSearchConfig::default())
+            .await?
+            .expect("created machine should still exist");
+        let initial_version = machine.current_version();
+        let transitioned_version = initial_version.increment();
+        let transitioned_state = ManagedHostState::Created;
+
+        assert!(
+            super::try_update_controller_state(
+                txn.as_mut(),
+                &machine_id,
+                initial_version,
+                transitioned_version,
+                &transitioned_state,
+            )
+            .await?
+        );
+
+        super::update_state(txn.as_mut(), &machine_id, &ManagedHostState::Ready).await?;
+
+        assert!(
+            !super::try_update_controller_state(
+                txn.as_mut(),
+                &machine_id,
+                transitioned_version,
+                transitioned_version,
+                &ManagedHostState::Created,
+            )
+            .await?,
+            "a stale controller snapshot must not overwrite a newer state"
+        );
+
+        let machine = super::find_one(txn.as_mut(), &machine_id, MachineSearchConfig::default())
+            .await?
+            .expect("created machine should still exist");
+        assert_eq!(machine.current_state(), &ManagedHostState::Ready);
+        assert_ne!(machine.current_version(), transitioned_version);
+
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn try_update_controller_state_reports_missing_machine(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")?;
+        let mut txn = pool.begin().await?;
+        super::create(
+            txn.as_mut(),
+            None,
+            &machine_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+        let machine = super::find_one(txn.as_mut(), &machine_id, MachineSearchConfig::default())
+            .await?
+            .expect("created machine should still exist");
+        sqlx::query("DELETE FROM machines WHERE id = $1")
+            .bind(machine_id)
+            .execute(txn.as_mut())
+            .await?;
+
+        let error = super::try_update_controller_state(
+            txn.as_mut(),
+            &machine_id,
+            machine.current_version(),
+            machine.current_version().increment(),
+            &ManagedHostState::Created,
+        )
+        .await
+        .expect_err("a deleted machine must not look like a version conflict");
+        assert!(matches!(
+            error,
+            crate::DatabaseError::NotFoundError {
+                kind: "machine",
+                ..
+            }
+        ));
+
+        txn.rollback().await?;
         Ok(())
     }
 

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -3075,6 +3075,33 @@ pub enum BomValidating {
     SkuMissing(BomValidatingContext),
 }
 
+impl BomValidating {
+    /// Returns the context carried through this BOM-validation substate.
+    pub fn context(&self) -> &BomValidatingContext {
+        match self {
+            Self::MatchingSku(context)
+            | Self::UpdatingInventory(context)
+            | Self::VerifyingSku(context)
+            | Self::SkuVerificationFailed(context)
+            | Self::WaitingForSkuAssignment(context)
+            | Self::SkuMissing(context) => context,
+        }
+    }
+}
+
+impl ManagedHostState {
+    /// Returns the context carried by BOM validation, or the default context
+    /// for states outside that flow.
+    pub fn bom_validation_context(&self) -> BomValidatingContext {
+        match self {
+            Self::BomValidating {
+                bom_validating_state,
+            } => bom_validating_state.context().clone(),
+            _ => BomValidatingContext::default(),
+        }
+    }
+}
+
 /// Represents the machine validation test filter
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct MachineValidationFilter {

--- a/crates/health-report/src/lib.rs
+++ b/crates/health-report/src/lib.rs
@@ -214,6 +214,17 @@ impl HealthReport {
         }
     }
 
+    /// Returns a health report that indicates that a machine needs a SKU assignment.
+    pub fn sku_unassigned() -> Self {
+        Self {
+            source: Self::SKU_VALIDATION_SOURCE.to_string(),
+            observed_at: Some(chrono::Utc::now()),
+            successes: vec![],
+            alerts: vec![HealthProbeAlert::sku_unassigned()],
+            triggered_by: None,
+        }
+    }
+
     /// Update the in_alert_since timestamps on all alerts in the reports
     /// by taking into account the timestaps in a previous report
     /// - If the alert has been reported in the previous report, the old timestamp
@@ -479,6 +490,22 @@ impl HealthProbeAlert {
         }
     }
 
+    pub fn sku_unassigned() -> Self {
+        Self {
+            id: HealthProbeId::sku_unassigned(),
+            target: None,
+            in_alert_since: Some(chrono::Utc::now()),
+            message: "No SKU is assigned. Assign a SKU to resume BOM validation.".to_string(),
+            tenant_message: None,
+            classifications: vec![HealthAlertClassification::prevent_allocations()],
+        }
+    }
+
+    /// Returns whether this alert represents a missing SKU assignment.
+    pub fn is_sku_unassigned(&self) -> bool {
+        self.id.is_sku_unassigned()
+    }
+
     pub fn ib_port_down(down_ports: Vec<String>, total_ports: usize) -> Self {
         let message = format!(
             "IB port(s) down: {} of {} ports are not active. Down GUIDs: {}",
@@ -594,6 +621,16 @@ impl HealthProbeId {
     /// The ID used by SKU validation alerts.
     pub fn sku_validation() -> Self {
         HealthProbeId("SkuValidation".to_string())
+    }
+
+    /// The ID used when a machine needs a SKU assignment.
+    pub fn sku_unassigned() -> Self {
+        HealthProbeId("SkuUnassigned".to_string())
+    }
+
+    /// Returns whether this ID represents a missing SKU assignment.
+    pub fn is_sku_unassigned(&self) -> bool {
+        self == &Self::sku_unassigned()
     }
 
     /// The ID is used to mark host under internal maintenance.
@@ -895,6 +932,14 @@ mod tests {
             serde_json::from_str::<HealthReport>(&serialized).unwrap(),
             report
         );
+    }
+
+    #[test]
+    fn test_sku_unassigned_alert_matches_its_constructor() {
+        let alert = HealthProbeAlert::sku_unassigned();
+        assert!(alert.is_sku_unassigned());
+        assert_eq!(alert.id, HealthProbeId::sku_unassigned());
+        assert_ne!(alert.id, HealthProbeId::sku_validation());
     }
 
     #[test]

--- a/crates/machine-controller/src/config/bom_validation.rs
+++ b/crates/machine-controller/src/config/bom_validation.rs
@@ -26,15 +26,15 @@ pub struct BomValidationConfig {
     #[serde(default)]
     pub enabled: bool,
 
-    /// Allow machines that do not have a SKU assigned to bypass SKU validation
-    /// When true, machines in WaitingForSkuAssignment state can proceed without a SKU
+    /// Allow machines without an assigned SKU to bypass SKU validation rather than wait for assignment.
+    /// This applies during initial validation and when processing unassigned Ready machines.
     #[serde(default)]
     pub ignore_unassigned_machines: bool,
 
     /// Allow machines to stay in Ready state and remain allocatable even when SKU validation fails
     /// When false (default): Standard mode - validation failures block allocation (machine enters failed state)
-    /// When true: Allow allocation mode - validation still occurs and health reports are recorded, but machines do not transition
-    /// into failed states (SkuVerificationFailed, SkuMissing, WaitingForSkuAssignment) and can proceed to Ready/MachineValidation
+    /// When true: Allow allocation mode - validation still occurs, but machines with an assigned SKU do not transition into failed
+    /// states (SkuVerificationFailed, SkuMissing); their SKU validation health reports are cleared before proceeding to Ready/MachineValidation
     #[serde(default)]
     pub allow_allocation_on_validation_failure: bool,
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1750,7 +1750,13 @@ impl MachineStateHandler {
             }
 
             ManagedHostState::Maintenance { .. } => {
-                maintenance::handle_maintenance(host_machine_id, mh_snapshot, ctx).await
+                maintenance::handle_maintenance(
+                    host_machine_id,
+                    mh_snapshot,
+                    &self.host_handler.host_handler_params,
+                    ctx,
+                )
+                .await
             }
 
             // ManagedHostState::Measuring is introduced into the flow when

--- a/crates/machine-controller/src/handler/maintenance.rs
+++ b/crates/machine-controller/src/handler/maintenance.rs
@@ -24,23 +24,28 @@ use carbide_uuid::machine::MachineId;
 use chrono::Utc;
 use component_manager::compute_tray_manager::{ComputeTrayEndpoint, ComputeTrayResult};
 use db::machine as db_machine;
+use health_report::HealthReport;
 use mac_address::MacAddress;
 use model::component_manager::PowerAction;
 use model::machine::{
-    FailureCause, FailureDetails, FailureSource, Machine, MachineMaintenanceOperation,
-    ManagedHostState, ManagedHostStateSnapshot, StateMachineArea,
+    BomValidating, BomValidatingContext, FailureCause, FailureDetails, FailureSource, Machine,
+    MachineMaintenanceOperation, ManagedHostState, ManagedHostStateSnapshot, StateMachineArea,
 };
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
 
+use crate::config::BomValidationConfig;
 use crate::context::MachineStateHandlerContextObjects;
+use crate::handler::HostHandlerParams;
+use crate::handler::sku::{clear_sku_validation_report, has_only_sku_unassigned_alert};
 
 /// Handles the Maintenance state for a host, dispatching on the requested
 /// operation (`PowerOn` / `PowerOff` / `Reset`).
 pub(super) async fn handle_maintenance(
     host_machine_id: &MachineId,
     mh_snapshot: &ManagedHostStateSnapshot,
+    host_handler_params: &HostHandlerParams,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let operation = match &mh_snapshot.managed_state {
@@ -50,24 +55,28 @@ pub(super) async fn handle_maintenance(
 
     match operation {
         MachineMaintenanceOperation::PowerOn => {
-            handle_power_on(host_machine_id, mh_snapshot, ctx).await
+            handle_power_on(host_machine_id, mh_snapshot, host_handler_params, ctx).await
         }
         MachineMaintenanceOperation::PowerOff => {
-            handle_power_off(host_machine_id, mh_snapshot, ctx).await
+            handle_power_off(host_machine_id, mh_snapshot, host_handler_params, ctx).await
         }
-        MachineMaintenanceOperation::Reset => handle_reset(host_machine_id, mh_snapshot, ctx).await,
+        MachineMaintenanceOperation::Reset => {
+            handle_reset(host_machine_id, mh_snapshot, host_handler_params, ctx).await
+        }
     }
 }
 
 async fn handle_power_on(
     host_machine_id: &MachineId,
     mh_snapshot: &ManagedHostStateSnapshot,
+    host_handler_params: &HostHandlerParams,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     tracing::info!(machine_id = %host_machine_id, "Machine maintenance: PowerOn");
     invoke_power_operation(
         host_machine_id,
         mh_snapshot,
+        host_handler_params,
         ctx,
         PowerAction::On,
         "PowerOn",
@@ -78,12 +87,14 @@ async fn handle_power_on(
 async fn handle_power_off(
     host_machine_id: &MachineId,
     mh_snapshot: &ManagedHostStateSnapshot,
+    host_handler_params: &HostHandlerParams,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     tracing::info!(machine_id = %host_machine_id, "Machine maintenance: PowerOff");
     invoke_power_operation(
         host_machine_id,
         mh_snapshot,
+        host_handler_params,
         ctx,
         PowerAction::ForceOff,
         "PowerOff",
@@ -94,12 +105,14 @@ async fn handle_power_off(
 async fn handle_reset(
     host_machine_id: &MachineId,
     mh_snapshot: &ManagedHostStateSnapshot,
+    host_handler_params: &HostHandlerParams,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     tracing::info!(machine_id = %host_machine_id, "Machine maintenance: Reset");
     invoke_power_operation(
         host_machine_id,
         mh_snapshot,
+        host_handler_params,
         ctx,
         PowerAction::ForceRestart,
         "Reset",
@@ -111,6 +124,7 @@ async fn handle_reset(
 async fn invoke_power_operation(
     host_machine_id: &MachineId,
     mh_snapshot: &ManagedHostStateSnapshot,
+    host_handler_params: &HostHandlerParams,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     action: PowerAction,
     operation_label: &'static str,
@@ -163,11 +177,27 @@ async fn invoke_power_operation(
                     machine_id = %host_machine_id,
                     operation = operation_label,
                     backend = component_manager.compute_tray.name(),
-                    "Machine power control succeeded; returning host to Ready"
+                    "Machine power control succeeded"
                 );
                 let mut txn = ctx.services.db_pool.begin().await?;
                 db_machine::clear_machine_maintenance_requested(&mut txn, *host_machine_id).await?;
-                return Ok(StateHandlerOutcome::transition(ManagedHostState::Ready).with_txn(txn));
+                let next_state = post_maintenance_state(
+                    mh_snapshot.host_snapshot.config.hw_sku.is_some(),
+                    mh_snapshot.instance.is_some(),
+                    super::pending_ready_boot_config_state(&mh_snapshot.host_snapshot).is_some(),
+                    &host_handler_params.bom_validation,
+                );
+                if matches!(&next_state, ManagedHostState::BomValidating { .. }) {
+                    db_machine::update_sku_validation_health_report(
+                        &mut txn,
+                        host_machine_id,
+                        &HealthReport::sku_unassigned(),
+                    )
+                    .await?;
+                } else if has_only_sku_unassigned_alert(mh_snapshot) {
+                    clear_sku_validation_report(&mut txn, mh_snapshot).await?;
+                }
+                return Ok(StateHandlerOutcome::transition(next_state).with_txn(txn));
             }
 
             let summary = result
@@ -206,6 +236,35 @@ async fn invoke_power_operation(
             )
             .await
         }
+    }
+}
+
+/// Returns the state after an on-demand maintenance operation completes.
+///
+/// A strict unassigned-SKU policy must not return an unassigned host directly
+/// to `Ready`, because that opens an allocation window before the Ready handler
+/// can re-enter BOM validation. A pending boot-interface change is already an
+/// allocation barrier, so it instead returns to `Ready` to resume that
+/// reconciliation before BOM validation.
+fn post_maintenance_state(
+    has_assigned_sku: bool,
+    has_instance: bool,
+    has_pending_boot_interface_config: bool,
+    bom_validation: &BomValidationConfig,
+) -> ManagedHostState {
+    if bom_validation.enabled
+        && !bom_validation.ignore_unassigned_machines
+        && !has_assigned_sku
+        && !has_instance
+        && !has_pending_boot_interface_config
+    {
+        ManagedHostState::BomValidating {
+            bom_validating_state: BomValidating::WaitingForSkuAssignment(
+                BomValidatingContext::default(),
+            ),
+        }
+    } else {
+        ManagedHostState::Ready
     }
 }
 
@@ -294,4 +353,43 @@ pub(super) fn maintenance_transition_if_requested(
     Some(StateHandlerOutcome::transition(
         ManagedHostState::maintenance_for_operation(req.operation),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn post_maintenance_state_requires_sku_assignment_when_strict() {
+        let mut bom_validation = BomValidationConfig {
+            enabled: true,
+            ..BomValidationConfig::default()
+        };
+
+        assert!(matches!(
+            post_maintenance_state(false, false, false, &bom_validation),
+            ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::WaitingForSkuAssignment(_),
+            }
+        ));
+
+        assert_eq!(
+            post_maintenance_state(true, false, false, &bom_validation),
+            ManagedHostState::Ready
+        );
+        assert_eq!(
+            post_maintenance_state(false, true, false, &bom_validation),
+            ManagedHostState::Ready
+        );
+        assert_eq!(
+            post_maintenance_state(false, false, true, &bom_validation),
+            ManagedHostState::Ready
+        );
+
+        bom_validation.ignore_unassigned_machines = true;
+        assert_eq!(
+            post_maintenance_state(false, false, false, &bom_validation),
+            ManagedHostState::Ready
+        );
+    }
 }

--- a/crates/machine-controller/src/handler/sku.rs
+++ b/crates/machine-controller/src/handler/sku.rs
@@ -16,7 +16,7 @@
  */
 
 use chrono::Utc;
-use health_report::HealthReport;
+use health_report::{HealthProbeAlert, HealthReport};
 use model::machine::{
     BomValidating, BomValidatingContext, MachineState, MachineValidatingState, ManagedHostState,
     ManagedHostStateSnapshot, ValidationState,
@@ -32,28 +32,7 @@ use crate::handler::{
     HostHandlerParams, discovered_after_state_transition, trigger_reboot_if_needed,
 };
 
-fn get_bom_validation_context(state: &ManagedHostState) -> BomValidatingContext {
-    if let ManagedHostState::BomValidating {
-        bom_validating_state,
-    } = state
-    {
-        match bom_validating_state {
-            BomValidating::MatchingSku(bom_validating_context)
-            | BomValidating::UpdatingInventory(bom_validating_context)
-            | BomValidating::VerifyingSku(bom_validating_context)
-            | BomValidating::SkuVerificationFailed(bom_validating_context)
-            | BomValidating::WaitingForSkuAssignment(bom_validating_context)
-            | BomValidating::SkuMissing(bom_validating_context) => bom_validating_context.clone(),
-        }
-    } else {
-        BomValidatingContext {
-            machine_validation_context: None,
-            reboot_retry_count: None,
-        }
-    }
-}
-
-async fn clear_sku_validation_report(
+pub(super) async fn clear_sku_validation_report(
     txn: &mut PgConnection,
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<(), StateHandlerError> {
@@ -67,19 +46,32 @@ async fn clear_sku_validation_report(
     .await?)
 }
 
+pub(super) fn has_only_sku_unassigned_alert(mh_snapshot: &ManagedHostStateSnapshot) -> bool {
+    mh_snapshot
+        .host_snapshot
+        .sku_validation_health_report()
+        .is_some_and(|report| {
+            !report.alerts.is_empty()
+                && report
+                    .alerts
+                    .iter()
+                    .all(HealthProbeAlert::is_sku_unassigned)
+        })
+}
+
 async fn match_sku_for_machine(
     txn: &mut PgConnection,
     host_handler_params: &HostHandlerParams,
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<Option<model::sku::Sku>, StateHandlerError> {
     let sku_status = mh_snapshot.host_snapshot.status.hw_sku.as_ref();
-    if sku_status.is_none()
-        || sku_status.is_some_and(|ss| {
-            ss.last_match_attempt.is_some_and(|t| {
-                t < (Utc::now() - host_handler_params.bom_validation.find_match_interval)
-            })
+    // A verification request creates SKU status but not a matching-attempt timestamp. When the
+    // SKU is later unassigned, that machine still needs an initial automatic match attempt.
+    if sku_status.is_none_or(|status| {
+        status.last_match_attempt.is_none_or(|attempt| {
+            attempt < (Utc::now() - host_handler_params.bom_validation.find_match_interval)
         })
-    {
+    }) {
         let machine_sku =
             db::sku::generate_sku_from_machine(&mut *txn, &mh_snapshot.host_snapshot.id).await?;
         let matching_sku = db::sku::find_matching(txn, &machine_sku).await?;
@@ -188,19 +180,22 @@ async fn generate_missing_sku_for_machine(
     true
 }
 
-/// Determine whether validation failures should allow allocation for any machine.
+/// Determine whether validation failures for a machine with an assigned SKU allow allocation.
 fn should_allow_allocation_on_validation_failure(host_handler_params: &HostHandlerParams) -> bool {
     host_handler_params
         .bom_validation
         .allow_allocation_on_validation_failure
 }
 
-/// Determine whether a machine without an assigned SKU may bypass BOM validation.
-fn should_allow_allocation_without_assigned_sku(host_handler_params: &HostHandlerParams) -> bool {
+/// Determine whether this unassigned machine may bypass BOM validation.
+fn should_ignore_unassigned_machine(
+    host_handler_params: &HostHandlerParams,
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> bool {
     host_handler_params
         .bom_validation
         .ignore_unassigned_machines
-        || should_allow_allocation_on_validation_failure(host_handler_params)
+        && mh_snapshot.host_snapshot.config.hw_sku.is_none()
 }
 
 pub(crate) async fn handle_bom_validation_requested(
@@ -210,12 +205,31 @@ pub(crate) async fn handle_bom_validation_requested(
 ) -> Result<Option<StateHandlerOutcome<ManagedHostState>>, StateHandlerError> {
     if !host_handler_params.bom_validation.enabled {
         tracing::debug!("BOM validation disabled");
+        if has_only_sku_unassigned_alert(mh_snapshot) {
+            let mut txn = services.db_pool.begin().await?;
+            clear_sku_validation_report(&mut txn, mh_snapshot).await?;
+            txn.commit().await?;
+        }
         return Ok(None);
     }
 
     let mut txn = services.db_pool.begin().await?;
     // Case 1: Machine has no SKU assigned
     if mh_snapshot.host_snapshot.config.hw_sku.is_none() {
+        // Serialize this decision with instance allocation. If allocation won
+        // after the controller took its snapshot, leave the host alone; the
+        // next iteration sees the instance and moves it into its assignment
+        // flow. If this transaction wins the lock, allocation re-checks the
+        // state after the BOM transition commits.
+        if !db::machine::lock_machine(txn.as_mut(), &mh_snapshot.host_snapshot.id).await?
+            || db::instance::find_id_by_machine_id(&mut txn, &mh_snapshot.host_snapshot.id)
+                .await?
+                .is_some()
+        {
+            txn.rollback().await?;
+            return Ok(Some(StateHandlerOutcome::do_nothing()));
+        }
+
         // Always try to find a matching SKU for machine regardless of configs
         if let Some(sku) = match_sku_for_machine(&mut txn, host_handler_params, mh_snapshot).await?
         {
@@ -237,15 +251,28 @@ pub(crate) async fn handle_bom_validation_requested(
                 "Cannot find a matching SKU for machine"
             );
 
-            if should_allow_allocation_without_assigned_sku(host_handler_params) {
+            if should_ignore_unassigned_machine(host_handler_params, mh_snapshot) {
                 // Case 1.2.1: Allow allocation despite no SKU match
                 tracing::info!(
                     machine_id=%mh_snapshot.host_snapshot.id,
                     "No SKU is assigned and unassigned-machine bypass is enabled, staying in Ready state"
                 );
+                // A forced SKU removal can leave this alert behind while the host is
+                // in a non-BOM state. The explicit bypass makes that allocation
+                // block inapplicable, but preserve any other validation alert.
+                if has_only_sku_unassigned_alert(mh_snapshot) {
+                    clear_sku_validation_report(&mut txn, mh_snapshot).await?;
+                }
+                txn.commit().await?;
                 return Ok(None);
             } else {
                 // Case 1.2.2: Block allocation, wait for SKU assignment
+                if should_allow_allocation_on_validation_failure(host_handler_params) {
+                    tracing::warn!(
+                        machine_id=%mh_snapshot.host_snapshot.id,
+                        "Machine has no assigned SKU; allow_allocation_on_validation_failure only applies after assigned-SKU validation failures, waiting for SKU assignment"
+                    );
+                }
                 return advance_to_waiting_for_sku_assignment(
                     txn,
                     mh_snapshot,
@@ -292,6 +319,7 @@ pub(crate) async fn handle_bom_validation_requested(
                 sku_id=%sku_id,
                 "Assigned SKU does not exist, but allow_allocation_on_validation_failure is true, staying in Ready state"
             );
+            txn.commit().await?;
             return Ok(None);
         } else {
             // Case 2.2.2: Block allocation, transition to SkuMissing state
@@ -300,7 +328,16 @@ pub(crate) async fn handle_bom_validation_requested(
     }
 
     // Case 2.3: SKU exists and no verification requested
-    // Stay in current state, no action needed
+    // A forced removal can record an unassigned-SKU allocation block while a
+    // non-BOM state is active. Once a replacement SKU is assigned and reaches
+    // this path, clear only that stale block; any other validation alert still
+    // requires its normal recovery flow.
+    if has_only_sku_unassigned_alert(mh_snapshot) {
+        clear_sku_validation_report(&mut txn, mh_snapshot).await?;
+    }
+
+    // Stay in current state, no further action needed.
+    txn.commit().await?;
     Ok(None)
 }
 
@@ -308,8 +345,10 @@ async fn advance_to_sku_missing(
     mut txn: PgTransaction<'static>,
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let bom_validation_context =
-        get_bom_validation_context(mh_snapshot.host_snapshot.current_state());
+    let bom_validation_context = mh_snapshot
+        .host_snapshot
+        .current_state()
+        .bom_validation_context();
     let health_report = HealthReport::sku_missing(
         mh_snapshot
             .host_snapshot
@@ -338,8 +377,10 @@ async fn advance_to_updating_inventory(
     mut txn: PgTransaction<'static>,
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let bom_validation_context =
-        get_bom_validation_context(mh_snapshot.host_snapshot.current_state());
+    let bom_validation_context = mh_snapshot
+        .host_snapshot
+        .current_state()
+        .bom_validation_context();
 
     db::machine_topology::set_topology_update_needed(&mut txn, &mh_snapshot.host_snapshot.id, true)
         .await?;
@@ -353,13 +394,11 @@ async fn advance_to_updating_inventory(
 }
 
 async fn advance_to_waiting_for_sku_assignment(
-    txn: PgTransaction<'static>,
+    mut txn: PgTransaction<'static>,
     mh_snapshot: &ManagedHostStateSnapshot,
     host_handler_params: &HostHandlerParams,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    if should_allow_allocation_without_assigned_sku(host_handler_params)
-        && mh_snapshot.host_snapshot.config.hw_sku.is_none()
-    {
+    if should_ignore_unassigned_machine(host_handler_params, mh_snapshot) {
         skip_bom_validation_and_advance(
             txn,
             host_handler_params,
@@ -368,8 +407,17 @@ async fn advance_to_waiting_for_sku_assignment(
         )
         .await
     } else {
-        let bom_validation_context =
-            get_bom_validation_context(mh_snapshot.host_snapshot.current_state());
+        let bom_validation_context = mh_snapshot
+            .host_snapshot
+            .current_state()
+            .bom_validation_context();
+        let health_report = HealthReport::sku_unassigned();
+        db::machine::update_sku_validation_health_report(
+            &mut txn,
+            &mh_snapshot.host_snapshot.id,
+            &health_report,
+        )
+        .await?;
 
         Ok(
             StateHandlerOutcome::transition(ManagedHostState::BomValidating {
@@ -387,7 +435,10 @@ async fn advance_to_machine_validating(
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     // transitioning to machine validating with a None context is a bug.
-    let context = get_bom_validation_context(mh_snapshot.host_snapshot.current_state());
+    let context = mh_snapshot
+        .host_snapshot
+        .current_state()
+        .bom_validation_context();
 
     let Some(context) = context.machine_validation_context else {
         tracing::info!("SKU verification complete; Skipping machine validation");
@@ -416,8 +467,9 @@ async fn advance_to_machine_validating(
     )
 }
 
-/// Skip BOM validation and proceed to machine validation (or Ready if machine validation is disabled)
-/// Used when BOM validation is disabled or when allow_allocation_on_validation_failure is enabled
+/// Skip BOM validation and proceed to machine validation (or Ready if machine validation is disabled).
+///
+/// Used when BOM validation is disabled or when a configured bypass applies.
 async fn skip_bom_validation_and_advance(
     txn: PgTransaction<'static>,
     host_handler_params: &HostHandlerParams,
@@ -601,18 +653,12 @@ pub(crate) async fn handle_bom_validation_state(
                     )
                 }
             }
-            BomValidating::SkuVerificationFailed(bom_validating_context) => {
+            BomValidating::SkuVerificationFailed(_) => {
                 // If SKU was unassigned, transition to waiting for SKU assignment
                 let txn = ctx.services.db_pool.begin().await?;
                 if mh_snapshot.host_snapshot.config.hw_sku.is_none() {
-                    Ok(
-                        StateHandlerOutcome::transition(ManagedHostState::BomValidating {
-                            bom_validating_state: BomValidating::WaitingForSkuAssignment(
-                                bom_validating_context.clone(),
-                            ),
-                        })
-                        .with_txn(txn),
-                    )
+                    advance_to_waiting_for_sku_assignment(txn, mh_snapshot, host_handler_params)
+                        .await
                 } else if mh_snapshot
                     .host_snapshot
                     .status
@@ -647,8 +693,9 @@ pub(crate) async fn handle_bom_validation_state(
                         .await?
                         .is_some()
                 {
+                    clear_sku_validation_report(&mut txn, mh_snapshot).await?;
                     advance_to_updating_inventory(txn, mh_snapshot).await
-                } else if should_allow_allocation_without_assigned_sku(host_handler_params) {
+                } else if should_ignore_unassigned_machine(host_handler_params, mh_snapshot) {
                     // Allow machine to proceed without SKU assignment
                     skip_bom_validation_and_advance(
                         txn,
@@ -658,7 +705,25 @@ pub(crate) async fn handle_bom_validation_state(
                     )
                     .await
                 } else {
-                    // Stay in waiting state until SKU is assigned
+                    // Repair a missing alert once without rewriting it on every controller
+                    // iteration.
+                    if !mh_snapshot
+                        .host_snapshot
+                        .sku_validation_health_report()
+                        .is_some_and(|report| {
+                            report
+                                .alerts
+                                .iter()
+                                .any(HealthProbeAlert::is_sku_unassigned)
+                        })
+                    {
+                        db::machine::update_sku_validation_health_report(
+                            &mut txn,
+                            &mh_snapshot.host_snapshot.id,
+                            &HealthReport::sku_unassigned(),
+                        )
+                        .await?;
+                    }
                     Ok(StateHandlerOutcome::do_nothing().with_txn(txn))
                 }
             }
@@ -701,13 +766,21 @@ pub(crate) async fn handle_bom_validation_state(
                         .await
                 };
 
-                // Clear health report for internal transitions within BomValidating
-                // External transitions are handled by the generic cleanup below
+                // Clear the missing-SKU report for internal transitions except when the machine
+                // remains blocked waiting for an assignment; that transition replaces it with an
+                // explicit unassigned-SKU report.
                 if let Ok(StateHandlerOutcome::Transition {
-                    next_state: ManagedHostState::BomValidating { .. },
+                    next_state:
+                        ManagedHostState::BomValidating {
+                            bom_validating_state,
+                        },
                     txn: Some(txn),
                     ..
                 }) = &mut outcome
+                    && !matches!(
+                        bom_validating_state,
+                        BomValidating::WaitingForSkuAssignment(_)
+                    )
                 {
                     clear_sku_validation_report(txn, mh_snapshot).await?;
                 }

--- a/crates/machine-controller/src/handler/sku.rs
+++ b/crates/machine-controller/src/handler/sku.rs
@@ -188,16 +188,19 @@ async fn generate_missing_sku_for_machine(
     true
 }
 
-/// Helper function to determine if machine should be allowed to allocate even when validation fails
-/// This is useful to avoid blocking allocation when SKU validation issues occur
+/// Determine whether validation failures should allow allocation for any machine.
 fn should_allow_allocation_on_validation_failure(host_handler_params: &HostHandlerParams) -> bool {
-    // TODO:tmp solution to consider ignore_unassigned_machines for compatibale with some running sites
+    host_handler_params
+        .bom_validation
+        .allow_allocation_on_validation_failure
+}
+
+/// Determine whether a machine without an assigned SKU may bypass BOM validation.
+fn should_allow_allocation_without_assigned_sku(host_handler_params: &HostHandlerParams) -> bool {
     host_handler_params
         .bom_validation
         .ignore_unassigned_machines
-        || host_handler_params
-            .bom_validation
-            .allow_allocation_on_validation_failure
+        || should_allow_allocation_on_validation_failure(host_handler_params)
 }
 
 pub(crate) async fn handle_bom_validation_requested(
@@ -234,11 +237,11 @@ pub(crate) async fn handle_bom_validation_requested(
                 "Cannot find a matching SKU for machine"
             );
 
-            if should_allow_allocation_on_validation_failure(host_handler_params) {
+            if should_allow_allocation_without_assigned_sku(host_handler_params) {
                 // Case 1.2.1: Allow allocation despite no SKU match
                 tracing::info!(
                     machine_id=%mh_snapshot.host_snapshot.id,
-                    "allow_allocation_on_validation_failure is true, staying in Ready state"
+                    "No SKU is assigned and unassigned-machine bypass is enabled, staying in Ready state"
                 );
                 return Ok(None);
             } else {
@@ -354,14 +357,14 @@ async fn advance_to_waiting_for_sku_assignment(
     mh_snapshot: &ManagedHostStateSnapshot,
     host_handler_params: &HostHandlerParams,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    if should_allow_allocation_on_validation_failure(host_handler_params)
+    if should_allow_allocation_without_assigned_sku(host_handler_params)
         && mh_snapshot.host_snapshot.config.hw_sku.is_none()
     {
         skip_bom_validation_and_advance(
             txn,
             host_handler_params,
             mh_snapshot,
-            "allow_allocation_when_sku_unassigned",
+            "unassigned_sku_bypass",
         )
         .await
     } else {
@@ -645,13 +648,13 @@ pub(crate) async fn handle_bom_validation_state(
                         .is_some()
                 {
                     advance_to_updating_inventory(txn, mh_snapshot).await
-                } else if should_allow_allocation_on_validation_failure(host_handler_params) {
+                } else if should_allow_allocation_without_assigned_sku(host_handler_params) {
                     // Allow machine to proceed without SKU assignment
                     skip_bom_validation_and_advance(
                         txn,
                         host_handler_params,
                         mh_snapshot,
-                        "allow_allocation_on_validation_failure",
+                        "unassigned_sku_bypass",
                     )
                     .await
                 } else {

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -130,17 +130,23 @@ impl StateControllerIO for MachineStateControllerIO {
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        _old_version: ConfigVersion,
-        _new_version: ConfigVersion,
+        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        db::machine::update_state(txn, object_id, new_state).await?;
-        Ok(true)
+        db::machine::try_update_controller_state(
+            txn,
+            object_id,
+            old_version,
+            new_version,
+            new_state,
+        )
+        .await
     }
 
     /// State history for machines (including DPUs) is persisted internally by
-    /// `db::machine::advance()` inside `update_state`, so this is actually a
-    /// no-op for now.
+    /// `db::machine::try_update_controller_state()` after its compare-and-swap
+    /// succeeds, so this is actually a no-op for now.
     // TODO(chet): Pull this in as well.
     async fn persist_state_history(
         &self,

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1572,7 +1572,7 @@ message RuntimeConfig {
 
   // BOM Validation Configuration
   bool bom_validation_enabled = 35;
-  bool bom_validation_ignore_unassigned_machines = 36; // TODO: Remove after all consumers updated
+  bool bom_validation_ignore_unassigned_machines = 36;
 
   repeated string dpu_nic_firmware_update_versions=37;
 

--- a/crates/state-controller/src/controller/processor.rs
+++ b/crates/state-controller/src/controller/processor.rs
@@ -714,8 +714,8 @@ async fn process_object<IO: StateControllerIO>(
         let mut next_state_entered_at = None;
         let mut next_state_sla = None;
         if let Ok(StateHandlerOutcome::Transition {
-                      next_state: next, ..
-                  }) = &handler_outcome
+            next_state: next, ..
+        }) = &handler_outcome
         {
             next_state = Some(next.clone());
 

--- a/deploy/files/nico-api/nico-api-site-config.toml
+++ b/deploy/files/nico-api/nico-api-site-config.toml
@@ -61,6 +61,8 @@ enabled = true
 
 [bom_validation]
 enabled = true
+# This bypass does not cover assigned-SKU failures; set
+# allow_allocation_on_validation_failure = true to allocate despite those failures.
 ignore_unassigned_machines = true
 
 [pools.lo-ip]

--- a/docs/architecture/health/health_probe_ids.md
+++ b/docs/architecture/health/health_probe_ids.md
@@ -22,6 +22,11 @@ all specified tests on the host.
 An alert with this ID is placed on a host in case the SKU validation workflow failed.
 The alert will make the host un-allocatable by tenants.
 
+### `SkuUnassigned`
+
+An alert with this ID is placed on a host when SKU validation requires a SKU assignment and none is configured.
+The alert will make the host un-allocatable by tenants until NICo finds a matching SKU or an operator assigns one.
+
 ## Repair workflow integrations related health probe identifiers
 
 ### `TenantReportedIssue`
@@ -60,6 +65,7 @@ Indicates that an already-ingested Managed Host's BMC MAC is no longer listed in
 Indicates that a BMC sensor reported a warning/critical/failure condition.
 
 Details:
+
 - `target` is set to the BMC sensor ID (for example, a fan/temperature/power sensor name).
 - The alert `message` contains the entity type, reading, unit, and threshold ranges used for evaluation.
 - Classifications are documented in [Health alert classifications](health_alert_classifications.md), including `Hardware`, `SensorWarning`, `SensorCritical`, and `SensorFailure`.
@@ -126,7 +132,7 @@ Indicates that an expected service on the DPU is not runnning
 ### `PostConfigCheckWait`
 
 The alert is placed on a host for a few seconds after a configuration change by dpu-agent in order to allow the configuration changes to "settle" before doing the health assessment.
-That avoids the host to move between states even though the new configuration might be  problematic.
+That avoids the host to move between states even though the new configuration might be problematic.
 
 ### `RestrictedMode`
 
@@ -146,6 +152,7 @@ Indicates that the dpu-agent disk utilization on the DPU is above a critical thr
 
 The alert indicates that no health report was received, where health report
 was expected. It is different from `HeartbeatTimeout` in the following sense
+
 - `HeartbeatTimeout` alerts can be emitted if data is available, but stale.
   `MissingReport` is only emitted if data has never been received.
 - `MissingReport` is mainly used on the NICo client side. It has no impact on

--- a/docs/architecture/health_aggregation.md
+++ b/docs/architecture/health_aggregation.md
@@ -1,11 +1,10 @@
 # Health Checks and Health Aggregation
 
-[summary]: #summary
-
 NVIDIA Infra Controller (NICo) integrates a variety of tools to continuously assess and report the health of any host under its management. It also allows site operators to configure and extend the set of health checks via runtime configurations and extension APIs.
 
 The health information that is obtained by these tools is rolled up within NICo Core into an "aggregated host health".
 The aggregated host health information is used for multiple purposes:
+
 1. For NICo internal decision making - e.g. "is this host usable as a bare metal instance by a tenant" and "is the host allowed to transition between 2 states".
 2. The aggregated host health information is made available to NICo API users. Site administrators can use the information to assess host health and external fleet health automation systems can use it to trigger remediation workflows.
 3. A filtered subset of the aggregated health status is made available to tenants in order to inform them whether their host is subject to known problems and whether they should release it.
@@ -13,6 +12,7 @@ The aggregated host health information is used for multiple purposes:
 ## Health check types
 
 Health checks roughly fall into 3 categories:
+
 1. Out of band health checks: These continuous health checks are able to continuously assess the health of a host - independent of whether the host is used as a bare metal instance or not. Within this category, NICo provides the following types of health checks
     1. [BMC health metric based health monitoring](#bmc-health-monitoring)
     2. [BMC inventory based health monitoring](#bmc-inventory-monitoring)
@@ -193,6 +193,7 @@ For failed health checks, the `HealthProbeAlert` can carry an optional set of `c
 The core idea here is that not all types of alerts have the same significance, and that different alerts will require a different response by NICo and site administrators: E.g. a BGP peering failure with a BGP peering issue on just one of the 2 redundant links will not render a host automatically unusable, while a fully unreachable DPU implies that the host can't be used.
 
 Health alert classifications decouple the NICo logic from the actual alert IDs. E.g. NICo logic does not have to encode an exhaustive check over all possible health probe IDs:
+
 ```rust
 if alert.id == "BgpPeeringFailure" || alert.id === BmcUnreachable || lots_of_other_conditions {
     host_is_fit_for_instance_creation = false;
@@ -200,6 +201,7 @@ if alert.id == "BgpPeeringFailure" || alert.id === BmcUnreachable || lots_of_oth
 ```
 
 Instead of this, it can just scan whether any of the health alerts in the aggregate host health carries a certain condition:
+
 ```rust
 if alert.classifications.contains("PreventAllocations") {
   host_is_fit_for_instance_creation = false;
@@ -216,6 +218,7 @@ The set of classifications that are currently interpreted by NICo is described i
 
 NICo will schedule the execution of validation tests via the `scout` tool on the actual host at various points
 in the lifecycle of a managed host:
+
 1. When the host is ingested into NICo
 2. After an instance is released by tenant and got cleaned up
 3. On demand while the host is not assigned to any tenant
@@ -236,6 +239,7 @@ SKU validation is a feature in NICo which validates that a host contains all the
 The SKU is the definition of hardware components within the host. And the SKU validation workflow compares it to the set of hardware components that have been detected via NICo hardware discovery workflows - which utilize inband data as well as out of band data.
 
 SKU validation can thereby e.g. detect
+
 - whether a host has the right type of CPU installed
 - whether a host has the right amount of memory installed
 - whether a host has the right type and amount of GPUS installed
@@ -244,7 +248,8 @@ SKU validation can thereby e.g. detect
 SKU validation runs at the same points in the host lifecycle as machine validation tests, and can also be run on-demand while the host is not assigned to any tenant.
 
 If SKU validation fails, a Health Alert with ID `SkuValidation` will be placed on the host
-to make the host un-allocatable by tenants.
+to make the host un-allocatable by tenants. When SKU validation requires a SKU assignment,
+an alert with ID `SkuUnassigned` is placed on the host until NICo finds a matching SKU or an operator assigns one.
 
 Details can be found in the [SKU Validation guide](../provisioning/sku-validation.md).
 
@@ -255,6 +260,7 @@ Details can be found in the [SKU Validation guide](../provisioning/sku-validatio
 The [`nico-hw-health`](https://github.com/NVIDIA/infra-controller/blob/main/crates/health) service periodically queries all Host and DPU BMCs in the system for health information. It emits the captured health datapoints as metrics on a metrics endpoint that can be scraped by a standard telemetry system (prometheus/otel).
 
 Health metrics fetched from BMCs include:
+
 - Fan speeds
 - Temperatures
 - Power supply utilization, outputs and voltages
@@ -289,12 +295,14 @@ The publishing sinks expose that inventory context using the conventions of the 
 The Site Explorer process within NICo Core periodically queries all Host and DPU BMCs in order to record certain BMC properties (e.g. components within a host and firmware versions).
 
 In certain conditions the scraping process will place a health alert on the host:
+
 - If the host BMC is not reachable
 - If any of the host properties indicates the host is not fit for instance creation.
 
 ### dpu-agent based health monitoring
 
 [`dpu-agent`](https://github.com/NVIDIA/infra-controller/blob/main/crates/agent) collects health information directly on the DPU and sends a health-**rollup** towards `nico-core`. The agent monitors a variety of health conditions, including
+
 - whether BGP sessions are established to peers according to the current configuration of the DPU
 - whether all required services on the DPU are running
 - whether the DPU is configured in restricted mode
@@ -326,6 +334,7 @@ This allows you to integrate health information from multiple external systems a
 If a ManagedHost's health is overridden, the remaining behavior is exactly the same
 as if the overridden Health report would have been directly derived from monitoring
 hardware health:
+
 - The host will be allocatable depending on whether any `PreventAllocations` classification is present in the aggregate host health
 - State transitions behave as if NICo integrated monitoring would have detected
   the same health status:

--- a/docs/architecture/state_machines/managedhost.md
+++ b/docs/architecture/state_machines/managedhost.md
@@ -343,25 +343,30 @@ stateDiagram-v2
     Ready --> bv_requested
 
     bv_requested --> BV_UpdatingInventory : Possible SKU match
-    bv_requested --> BV_WaitingForSkuAssignment : SKU unassigned
+    bv_requested --> BV_WaitingForSkuAssignment : SKU unassigned AND !ignore unassigned machines
+    bv_requested --> Ready : SKU unassigned AND ignore unassigned machines
     bv_requested --> BV_SkuMissing : SKU not found
 
     BV_MatchingSku --> BV_VerifyingSku : SKU present
-    BV_MatchingSku --> BV_WaitingForSkuAssignment : SKU not present AND !matched
+    BV_MatchingSku --> BV_WaitingForSkuAssignment : SKU not present AND !matched AND !ignore unassigned machines
+    BV_MatchingSku --> bv_validation_enabled : SKU not present AND !matched AND ignore unassigned machines
     BV_UpdatingInventory --> BV_UpdatingInventory : Wait discovery
     BV_UpdatingInventory --> BV_MatchingSku : SKU not present
     BV_UpdatingInventory --> BV_VerifyingSku : SKU present
     BV_VerifyingSku --> BV_MatchingSku : SKU present
     BV_VerifyingSku --> BV_SkuMissing : SKU not found
     BV_VerifyingSku --> BV_SkuVerificationFailed : SKU diff is not empty
-    BV_SkuVerificationFailed --> BV_WaitingForSkuAssignment : SKU not present
+    BV_SkuVerificationFailed --> BV_WaitingForSkuAssignment : SKU not present AND !ignore unassigned machines
+    BV_SkuVerificationFailed --> bv_validation_enabled : SKU not present AND ignore unassigned machines
     BV_SkuVerificationFailed --> BV_UpdatingInventory : Update timeout
     BV_SkuVerificationFailed --> BV_SkuVerificationFailed : Wait update timeout
     BV_WaitingForSkuAssignment --> BV_UpdatingInventory : SKU present OR matched
-    BV_WaitingForSkuAssignment --> BV_WaitingForSkuAssignment : wait assignment
+    BV_WaitingForSkuAssignment --> BV_WaitingForSkuAssignment : wait assignment AND !ignore unassigned machines
+    BV_WaitingForSkuAssignment --> bv_validation_enabled : ignore unassigned machines
     BV_SkuMissing --> BV_UpdatingInventory : SKU present and found
     BV_SkuMissing --> BV_SkuMissing : SKU present and not found
-    BV_SkuMissing --> BV_WaitingForSkuAssignment : SKU not present
+    BV_SkuMissing --> BV_WaitingForSkuAssignment : SKU not present AND !ignore unassigned machines
+    BV_SkuMissing --> bv_validation_enabled : SKU not present AND ignore unassigned machines
 
     BV_WaitingForSkuAssignment --> bv_validation_enabled : BOM validation disabled
     BV_MatchingSku --> bv_validation_enabled : BOM validation disabled OR (SKU Present and matched)
@@ -370,6 +375,14 @@ stateDiagram-v2
     bv_validation_enabled --> Validation_V_RebootHost : validation enabled
     bv_validation_enabled --> HostInit_HI_Discovered : validation disabled
 ```
+
+Maintenance does not interrupt an in-progress BOM validation. Under the strict
+SKU policy, successful maintenance returns an unallocated host without an
+assigned SKU to
+`WaitingForSkuAssignment`, never directly to `Ready`. An already allocated host
+instead returns to `Ready`, so the normal assigned-host flow resumes. A host
+with pending boot-interface reconciliation also returns to `Ready`: that work
+already prevents allocation and must resume before SKU validation.
 
 ## Machine Validation State Details (ValidationState)
 
@@ -555,7 +568,6 @@ stateDiagram-v2
     A_Failed --> A_HPC_SBO_SetBootOrder : BiosSetupFailed AND is_bios_setup ok
 ```
 
-
 ## Host Reprovision State Details (HostReprovisionState)
 
 Shows the host firmware reprovision process:
@@ -673,7 +685,6 @@ stateDiagram-v2
     DR_RebootHost --> Assigned_A_Ready : if entered from Assigned AND host reprovision not requested
 ```
 
-
 ## WaitingForCleanup State Details
 
 ```mermaid
@@ -757,7 +768,6 @@ stateDiagram-v2
 ```
 
 ## Failed State
-
 
 ```mermaid
 stateDiagram-v2

--- a/docs/provisioning/sku-validation.md
+++ b/docs/provisioning/sku-validation.md
@@ -15,10 +15,9 @@ SKUs can be downloaded for modification or use with other sites.
 Machines that are assigned a SKU are automatically validated during ingestion based on their discovery information.
 Hardware validation occurs during initial ingestion and after an instance is released and new discovery information is received.
 
-New machines are automatically checked against existing SKUs and if a match is found, the machine passes
-SKU validation and continues with the normal ingestion process.  If no match is found the machine waits until
-a matching SKU is available or until the machine is made compatible with an existing SKU, if SKU validation is enabled
-in the site (`ignore_unassigned_machines` configuration option).
+New machines are automatically checked against existing SKUs and, if a match is found, pass SKU validation and continue
+with the normal ingestion process. If no match is found, a machine waits for a matching or manually assigned SKU unless
+the site enables `ignore_unassigned_machines`, in which case it bypasses SKU validation until a SKU is assigned.
 
 ## Behavior
 
@@ -38,16 +37,21 @@ An admin can also assign or remove a SKU on an individual host manually, either 
 `nico-admin-cli sku unassign` commands or from the machine detail page of the [NICo Debug WebUI](../operations/debug_webui.md).
 
 ### BOM Validation States
-Verifying a SKU against a machine goes through several steps to acquire updated machine inventory and perform the validation.  Depending on the inventory of the machine and the SKU configuration, the state machine needs to handle several situations.  The bom validation process is broken down into the following sub-states:
+
+Verifying a SKU against a machine goes through several steps to acquire updated machine inventory and perform the validation. Depending on the inventory of the machine and the SKU configuration, the state machine needs to handle several situations. The bom validation process is broken down into the following sub-states:
+
 - `MatchingSku` - The state machine will attempt to find an existing SKU that matches the machine inventory.
-- `UpdatingInventory` - NICo is requesting that scout re-inventory the machine.  This ensures that other operations are using a recent version of the machine inventory
+- `UpdatingInventory` - NICo is requesting that scout re-inventory the machine. This ensures that other operations are using a recent version of the machine inventory
 - `VerifyingSku` - NICo is comparing the machine inventory against the SKU
-- `SkuVerificationFailed` - The machine did not match the SKU.  Manual intervention is required.  The `sku verify` command may be used to retry the verification
-- `WaitingForSkuAssignment` - The machine does not have a SKU assigned and the configuration requires one.
-- `SkuMissing` - The machine has a SKU assigned, but the SKU does not exist.  This happens when a SKU is specified in the expected machines, but was not created.  If configured, NICo will attempt to generate a SKU
+- `SkuVerificationFailed` - The machine did not match the SKU. Manual intervention is required. The `sku verify` command may be used to retry the verification
+- `WaitingForSkuAssignment` - The machine does not have a SKU assigned and the configuration requires one. NICo adds an
+  unassigned-SKU health alert that prevents allocations until NICo automatically finds a matching SKU or an operator
+  assigns one.
+- `SkuMissing` - The machine has a SKU assigned, but the SKU does not exist. This happens when a SKU is specified in the expected machines, but was not created. If configured, NICo will attempt to generate a SKU
 
 ### Versions
-NICo maintains a version of the SKU schema used when a SKU is created.  This ensures that the same comparison is used during the lifetime of a SKU and ensures that the behavior of BOM validation does not change between NICo versions.  When new components are added, or new data sources are used during validation, existing SKUs will not be updated with the change and continue to behave as they did in previous NICo versions.  In order to use the new version, a new SKU must be created.
+
+NICo maintains a version of the SKU schema used when a SKU is created. This ensures that the same comparison is used during the lifetime of a SKU and ensures that the behavior of BOM validation does not change between NICo versions. When new components are added, or new data sources are used during validation, existing SKUs will not be updated with the change and continue to behave as they did in previous NICo versions. In order to use the new version, a new SKU must be created.
 
 ### Configuration
 
@@ -64,33 +68,55 @@ auto_generate_missing_sku = false,
 auto_generate_missing_sku_interval = "300s"
 ```
 
- - `enabled` - Enables or disables the entire bom validation process.  When disabled, machines
+- `enabled` - Enables or disables the entire bom validation process. When disabled, machines
   will skip bom validation and proceed as if all validation has passed.
- - `allow_allocation_on_validation_failure` - When true, machines are allowed to stay in Ready state and remain allocatable
-  even when SKU validation fails. Validation still occurs but only logs are recorded - health reports are cleared instead
-  of recording validation failures. Machines do not transition into failed states (SkuVerificationFailed, SkuMissing,
-  WaitingForSkuAssignment). When false (default), standard mode applies where validation failures are recorded in health
-  reports and machines enter failed states and become unallocatable until fixed. This is useful for avoiding machine
-  allocation blockage due to SKU validation issues when you only need logging without health report alerts.
- - `ignore_unassigned_machines` - When true and BOM validation encounters a machine that does not have an associated SKU,
+- `allow_allocation_on_validation_failure` - When true, machines with an assigned SKU are allowed to stay in Ready state
+  and remain allocatable even when SKU validation fails. Validation still occurs but only logs are recorded - health reports
+  are cleared instead of recording validation failures. Machines do not transition into failed states
+  (SkuVerificationFailed, SkuMissing). This does not bypass SKU assignment: a machine without an assigned SKU remains in
+  WaitingForSkuAssignment unless `ignore_unassigned_machines` is true. When false (default), standard mode applies where
+  validation failures are recorded in health reports and machines enter failed states and become unallocatable until fixed.
+  This is useful for avoiding machine allocation blockage due to SKU validation issues when you only need logging without
+  health report alerts. Before enabling this setting without `ignore_unassigned_machines`, assign SKUs to every machine
+  that must remain allocatable.
+- `ignore_unassigned_machines` - When true and BOM validation encounters a machine that does not have an associated SKU,
   it will proceed as if all validation has passed. Only machines with an associated SKU will be validated. This allows
   existing sites to be upgraded and BOM Validation enabled as SKUs are added to the system without impacting site operation.
   Machines that do not have an assigned SKU will still be usable and assignable.
- - `find_match_interval` - determines how often NICo will attempt to find a matching SKU for a machine.  NICo will only
-  attempt to find a SKU when the machine is in the `Ready` state.
- - `auto_generate_missing_sku` - enable or disable generation of a SKU from a machine.  This only applies to a machine with a SKU
+- `find_match_interval` - determines how often NICo will attempt to find a matching SKU for an unassigned machine. NICo
+  attempts matching during initial validation (`MatchingSku`) and when an unassigned machine is processed in `Ready` or
+  `WaitingForSkuAssignment`. A machine without a previous matching attempt is tried immediately, including when its SKU
+  status was created by a verification request before the SKU was unassigned. After no match is found, NICo records the
+  attempt and waits for this interval before trying again; this also applies when `ignore_unassigned_machines` keeps the
+  machine in `Ready`.
+- `auto_generate_missing_sku` - enable or disable generation of a SKU from a machine. This only applies to a machine with a SKU
   specified in the expected machine configuration and in the `SkuMissing` state.
- - `auto_generate_missing_sku_interval` - determines how often NICo will attempt to generate a sku from the machine data.
+- `auto_generate_missing_sku_interval` - determines how often NICo will attempt to generate a sku from the machine data.
+
+### Upgrade impact
+
+Sites that set `allow_allocation_on_validation_failure = true` while leaving `ignore_unassigned_machines = false` must assign
+an SKU to every machine that must remain allocatable. To continue allowing machines without an assigned SKU, set
+`ignore_unassigned_machines = true` as well.
+
+For sites that set `ignore_unassigned_machines = true`, an unsuccessful SKU match is now recorded. When a matching SKU is
+created later, automatic matching resumes after `find_match_interval` (five minutes by default) rather than on the next
+controller iteration.
+
+For sites that set `ignore_unassigned_machines = true` while leaving `allow_allocation_on_validation_failure = false`,
+assigned-SKU validation behavior is unchanged: a missing or mismatched assigned SKU blocks allocation as `SkuMissing` or
+`SkuVerificationFailed`. `ignore_unassigned_machines` only bypasses machines that have no SKU. To keep assigned machines
+allocatable despite those failures, set `allow_allocation_on_validation_failure = true`.
 
 ### Hardware Validated
 
 Machines will (currently) have the following hardware validated against the SKU:
 
- - Chassis (motherboard): Vendor and model matched
- - CPU: Model and count matched
- - GPUs: Model, memory capacity, and count matched
- - Memory: Type, capacity, and count matched
- - Storage: Model and count matched
+- Chassis (motherboard): Vendor and model matched
+- CPU: Model and count matched
+- GPUs: Model, memory capacity, and count matched
+- Memory: Type, capacity, and count matched
+- Storage: Model and count matched
 
 ## Design Information
 
@@ -104,20 +130,20 @@ By convention, SKU names (defined per site) are in the following format:
 
 Where:
 
- - `<vendor>` is the first word of the "chassis" "vendor" field, e.g. `dell` or `lenovo`
- - `<model>` is the unique ending to the "chassis" "model" field, e.g. `r750` or `sr670v2`
- - `<node_type>` is one of the following types of node that are deployed in NICo:
-    - `gpu`
-    - `cpu`
-    - `storage`
-    - `controller` (site controller node, if applicable)
- - `<idx>` arbitrary index starting at 1 to define different configurations, if required, generally 1
+- `<vendor>` is the first word of the "chassis" "vendor" field, e.g. `dell` or `lenovo`
+- `<model>` is the unique ending to the "chassis" "model" field, e.g. `r750` or `sr670v2`
+- `<node_type>` is one of the following types of node that are deployed in NICo:
+  - `gpu`
+  - `cpu`
+  - `storage`
+  - `controller` (site controller node, if applicable)
+- `<idx>` arbitrary index starting at 1 to define different configurations, if required, generally 1
 
 Some example SKU names:
 
- - `lenovo.sr670v2.gpu.1`
- - `dell.r750.gpu.1`
- - `dell.r750.storage.1`
+- `lenovo.sr670v2.gpu.1`
+- `dell.r750.gpu.1`
+- `dell.r750.storage.1`
 
 ## Managing SKU Validation
 
@@ -129,12 +155,14 @@ by visiting the admin page for a site and clicking "SKUs" from the left-side nav
 ### Viewing SKU information
 
 There are 2 commands for showing information related to SKUs:
-- `sku show` lists SKUs or shows information related to an existing SKU.
-- `sku generate` shows what a SKU would look like for a machine.  The generate command does not create the SKU or assign the SKU to the machine.
 
-Both commands honor the JSON format flag `-f json` to change the output to JSON.  JSON is used by other commands.
+- `sku show` lists SKUs or shows information related to an existing SKU.
+- `sku generate` shows what a SKU would look like for a machine. The generate command does not create the SKU or assign the SKU to the machine.
+
+Both commands honor the JSON format flag `-f json` to change the output to JSON. JSON is used by other commands.
 
 The `sku show` command can be used to list all SKUs, or show the details of a single SKU:
+
 ```sh
 nico-admin-cli sku show [<sku id>]
 
@@ -273,7 +301,8 @@ nico-admin-cli sku unassign <machineid>
 ```
 
 ### Replacing an existing SKU
-If a SKU has a set of components that do not work for a set of machines (either due to bugs, or NICo software updates) updating machines by unassigning and assigning a SKU would be challenging.  Replacing the components of a SKU can be done with the `sku replace` command.  This will force all machines to go through verification when no instance is allocated to the machine (all machines are verified when an instance is released).
+
+If a SKU has a set of components that do not work for a set of machines (either due to bugs, or NICo software updates) updating machines by unassigning and assigning a SKU would be challenging. Replacing the components of a SKU can be done with the `sku replace` command. This will force all machines to go through verification when no instance is allocated to the machine (all machines are verified when an instance is released).
 
 ```sh
 nico-admin-cli sku replace <filename> [--id <sku_name>]
@@ -291,9 +320,10 @@ nico-admin-cli sku delete <sku_name>
 ```
 
 #### Upgrading a SKU to the current version example
-When a new version of NICo is released that changes how SKUs behave, existing SKUs maintain their previous behavior.  In order to use the new version of the SKU, a manual "upgrade" process is required using the `sku replace` command.
 
-The existing SKU is below.  Note that the "Storage Devices" section includes a device with a model of "NO_MODEL" and there is no TPM.  The extra storage device is created by the raid card and may not always exist and should not have been included in the SKU.
+When a new version of NICo is released that changes how SKUs behave, existing SKUs maintain their previous behavior. In order to use the new version of the SKU, a manual "upgrade" process is required using the `sku replace` command.
+
+The existing SKU is below. Note that the "Storage Devices" section includes a device with a model of "NO_MODEL" and there is no TPM. The extra storage device is created by the raid card and may not always exist and should not have been included in the SKU.
 
 ```sh
 nico-admin-cli sku show XE9680
@@ -337,7 +367,7 @@ Storage Devices:
           +----------------------------------+-------+
 ```
 
-Using the `sku generate` command, we can see what the updated SKU looks like for the same machine.  This is the same machine that generated the older SKU in a previous release.  Note that the "NO_MODEL" device is gone, the RAID controller is now shown as `Dell BOSS-N1` and the version of the TPM is shown.
+Using the `sku generate` command, we can see what the updated SKU looks like for the same machine. This is the same machine that generated the older SKU in a previous release. Note that the "NO_MODEL" device is gone, the RAID controller is now shown as `Dell BOSS-N1` and the version of the TPM is shown.
 
 ``` sh
 nico-admin-cli sku generate fm100hti7olik00gefc9qlma831n6q49d1odkksp86q639cugt5afjnm4s0
@@ -384,13 +414,15 @@ Storage Devices:
 
 ```
 
-Create a new SKU file using the generate command again, but create a json file.  Note that the same ID needs to be specified as the existing SKU in order for the replace command to find the old SKU.
+Create a new SKU file using the generate command again, but create a json file. Note that the same ID needs to be specified as the existing SKU in order for the replace command to find the old SKU.
+
 ```sh
 nico-admin-cli -f json -o /tmp/xe9680.json sku g fm100hti7olik00gefc9qlma831n6q49d1odkksp86q639cugt5afjnm4s0 --id XE9680
 
 ```
 
 Then replace the old SKU
+
 ```sh
 nico-admin-cli sku replace /tmp/xe9680.json
 +--------+---------------------------------------+------------------+-----------------------------+
@@ -402,6 +434,7 @@ nico-admin-cli sku replace /tmp/xe9680.json
 ```
 
 The `show sku` command now shows the updated components (and version)
+
 ```sh
 nico-admin-cli sku show XE9680
 ID                  : XE9680
@@ -445,7 +478,6 @@ Storage Devices:
           | Dell Ent NVMe FIPS CM6 RI 3.84TB | 8     |
           +----------------------------------+-------+
 ```
-
 
 ### Finding assigned machines for a SKU
 

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -149,6 +149,8 @@ nico-api:
 
       [bom_validation]
       enabled = true
+      # This bypass does not cover assigned-SKU failures; set
+      # allow_allocation_on_validation_failure = true to allocate despite those failures.
       ignore_unassigned_machines = true
 
       # -----------------------------------------------------------------------

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -8716,7 +8716,7 @@ type RuntimeConfig struct {
 	VpcIsolationBehavior     string   `protobuf:"bytes,34,opt,name=vpc_isolation_behavior,json=vpcIsolationBehavior,proto3" json:"vpc_isolation_behavior,omitempty"`
 	// BOM Validation Configuration
 	BomValidationEnabled                            bool     `protobuf:"varint,35,opt,name=bom_validation_enabled,json=bomValidationEnabled,proto3" json:"bom_validation_enabled,omitempty"`
-	BomValidationIgnoreUnassignedMachines           bool     `protobuf:"varint,36,opt,name=bom_validation_ignore_unassigned_machines,json=bomValidationIgnoreUnassignedMachines,proto3" json:"bom_validation_ignore_unassigned_machines,omitempty"` // TODO: Remove after all consumers updated
+	BomValidationIgnoreUnassignedMachines           bool     `protobuf:"varint,36,opt,name=bom_validation_ignore_unassigned_machines,json=bomValidationIgnoreUnassignedMachines,proto3" json:"bom_validation_ignore_unassigned_machines,omitempty"`
 	DpuNicFirmwareUpdateVersions                    []string `protobuf:"bytes,37,rep,name=dpu_nic_firmware_update_versions,json=dpuNicFirmwareUpdateVersions,proto3" json:"dpu_nic_firmware_update_versions,omitempty"`
 	DpaEnabled                                      bool     `protobuf:"varint,38,opt,name=dpa_enabled,json=dpaEnabled,proto3" json:"dpa_enabled,omitempty"`
 	MqttEndpoint                                    string   `protobuf:"bytes,39,opt,name=mqtt_endpoint,json=mqttEndpoint,proto3" json:"mqtt_endpoint,omitempty"`

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -1544,7 +1544,7 @@ message RuntimeConfig {
 
   // BOM Validation Configuration
   bool bom_validation_enabled = 35;
-  bool bom_validation_ignore_unassigned_machines = 36; // TODO: Remove after all consumers updated
+  bool bom_validation_ignore_unassigned_machines = 36;
 
   repeated string dpu_nic_firmware_update_versions=37;
 


### PR DESCRIPTION
Ensure that the legacy unassigned-machine compatibility setting does not allow machines with an assigned SKU to bypass BOM validation failures. This preserves the setting's intended scope while keeping the explicit allocation-on-validation-failure override available for all validation failures.

## Related issues


## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The new regression test explicitly assigns a SKU before simulating a mismatch, so it exercises the assigned-SKU validation path even when unassigned machines are ignored.