### PR TITLE
fix(health): fix omission of `exclude_services` not applying default value

### DIFF
--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1332,7 +1332,7 @@ pub struct PeriodicLogConfig {
     /// `["Journal"]` to suppress the bmcweb HTTP-access log, which is
     /// high-volume and self-referential. Set to `[]` to collect from every
     /// discovered LogService.
-    #[serde(default)]
+    #[serde(default = "default_excluded_log_services")]
     pub exclude_services: Vec<String>,
 
     /// When true, on the first encounter of a LogService with no saved state,
@@ -1350,10 +1350,14 @@ impl Default for PeriodicLogConfig {
             logs_collection_interval: Duration::from_secs(300),
             state_refresh_interval: Duration::from_secs(1800),
             logs_state_file: "/tmp/logs_collector_{machine_id}.json".to_string(),
-            exclude_services: vec!["Journal".to_string()],
+            exclude_services: default_excluded_log_services(),
             skip_initial_history: false,
         }
     }
+}
+
+fn default_excluded_log_services() -> Vec<String> {
+    vec!["Journal".to_string()]
 }
 
 /// downgrade thresholds and periodic fallback for `collectors.logs.mode = "auto"`.
@@ -2218,10 +2222,7 @@ mod tests {
     }
 
     fn parsed_periodic_defaults() -> PeriodicLogConfig {
-        PeriodicLogConfig {
-            exclude_services: vec![],
-            ..PeriodicLogConfig::default()
-        }
+        PeriodicLogConfig::default()
     }
 
     #[test]
@@ -4567,6 +4568,75 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
                     "[collectors.logs.sse].max_backoff must be greater than or equal to initial_backoff"
                         .to_string()
                 ),
+            }
+        );
+    }
+
+    #[test]
+    fn excluded_log_services_config_surface() {
+        scenarios!(run = |toml| {
+            Figment::new()
+                .merge(Serialized::defaults(Config::default()))
+                .merge(Toml::string(toml))
+                .extract::<Config>()
+                .map_err(|_| ())
+                .and_then(|config| {
+                    config.validate().map_err(|_| ())?;
+                    let logs = config.collectors.logs.as_option().ok_or(())?;
+
+                    Ok(match logs.mode {
+                        LogCollectionMode::Auto => {
+                            logs.auto_periodic_or_default().exclude_services
+                        }
+                        LogCollectionMode::Periodic => {
+                            logs.periodic_or_default().exclude_services
+                        }
+                        LogCollectionMode::Sse => Vec::new(),
+                    })
+                })
+        };
+            "periodic mode" {
+                r#"
+[collectors.logs]
+mode = "periodic"
+[collectors.logs.periodic]
+"# => Yields(vec!["Journal".to_string()]),
+
+                r#"
+[collectors.logs]
+mode = "periodic"
+[collectors.logs.periodic]
+exclude_services = ["Journal", "Dump"]
+"# => Yields(vec!["Journal".to_string(), "Dump".to_string()]),
+
+                r#"
+[collectors.logs]
+mode = "periodic"
+[collectors.logs.periodic]
+exclude_services = []
+"# => Yields(vec![]),
+            }
+
+            "auto fallback" {
+                r#"
+[collectors.logs]
+mode = "auto"
+[collectors.logs.auto]
+"# => Yields(vec!["Journal".to_string()]),
+
+                r#"
+[collectors.logs]
+mode = "auto"
+[collectors.logs.auto]
+exclude_services = ["Journal", "Dump"]
+"# => Yields(vec!["Journal".to_string(), "Dump".to_string()]),
+
+                r#"
+[collectors.logs]
+mode = "auto"
+[collectors.logs.auto]
+exclude_services = []
+"# => Yields(vec![]),
             }
         );
     }

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -40,6 +40,22 @@ fn logs_state_file_path(template: &str, endpoint_id: &str) -> PathBuf {
     PathBuf::from(template.replace("{machine_id}", endpoint_id))
 }
 
+fn build_periodic_logs_collector_config(
+    config: &PeriodicLogConfig,
+    state_file_path: PathBuf,
+    data_sink: Option<Arc<dyn DataSink>>,
+    include_diagnostics: bool,
+) -> LogsCollectorConfig {
+    LogsCollectorConfig {
+        state_file_path,
+        service_refresh_interval: config.state_refresh_interval,
+        data_sink,
+        include_diagnostics,
+        exclude_services: config.exclude_services.clone(),
+        skip_initial_history: config.skip_initial_history,
+    }
+}
+
 /// Returns whether an endpoint is eligible for direct NMX-C Subscribe collection.
 pub(super) fn switch_supports_nmxc_subscription(endpoint: &BmcEndpoint) -> bool {
     endpoint.switch_data().is_some_and(|switch| {
@@ -370,18 +386,17 @@ fn spawn_generic_redfish_collectors(
          -> Option<Result<Collector, HealthError>> {
             let endpoint_id = endpoint.log_identity().into_owned();
             let state_file_path = logs_state_file_path(&pcfg.logs_state_file, &endpoint_id);
+            let collector_config = build_periodic_logs_collector_config(
+                &pcfg,
+                state_file_path,
+                data_sink,
+                ctx.logs_include_diagnostics,
+            );
 
             Some(Collector::start::<LogsCollector<BmcClient>>(
                 endpoint_arc.clone(),
                 bmc.clone(),
-                LogsCollectorConfig {
-                    state_file_path,
-                    service_refresh_interval: pcfg.state_refresh_interval,
-                    data_sink,
-                    include_diagnostics: ctx.logs_include_diagnostics,
-                    exclude_services: pcfg.exclude_services.clone(),
-                    skip_initial_history: pcfg.skip_initial_history,
-                },
+                collector_config,
                 CollectorStartContext {
                     limiter: ctx.limiter.clone(),
                     iteration_interval: pcfg.logs_collection_interval,
@@ -818,6 +833,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::str::FromStr;
 
+    use carbide_test_support::{Check, check_values};
     use mac_address::MacAddress;
 
     use super::*;
@@ -952,6 +968,36 @@ mod tests {
     fn test_logs_state_file_path_replaces_endpoint_id() {
         let path = logs_state_file_path("/tmp/logs_{machine_id}.json", "endpoint-42");
         assert_eq!(path, PathBuf::from("/tmp/logs_endpoint-42.json"));
+    }
+
+    #[test]
+    fn periodic_logs_runtime_config_preserves_excluded_services() {
+        check_values(
+            [
+                Check {
+                    scenario: "custom exclusions",
+                    input: vec!["Journal".to_string(), "Dump".to_string()],
+                    expect: vec!["Journal".to_string(), "Dump".to_string()],
+                },
+                Check {
+                    scenario: "explicit empty exclusions",
+                    input: vec![],
+                    expect: vec![],
+                },
+            ],
+            |exclude_services| {
+                build_periodic_logs_collector_config(
+                    &PeriodicLogConfig {
+                        exclude_services,
+                        ..PeriodicLogConfig::default()
+                    },
+                    PathBuf::from("/tmp/logs_endpoint-42.json"),
+                    None,
+                    false,
+                )
+                .exclude_services
+            },
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description
Addresses a bug from #3349 where the default was not being applied if the log collection config excluded the `exclude_services` property. 

## Related issues
#3344 

## Type of Change
- [x] **Fix** - Bug fixes

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed