### PR TITLE
[release/v2.1] Add patch verb to carbide-api DPF secrets RBAC (#4485)

### DIFF
--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -468,7 +468,7 @@ rules:
     verbs: ["get", "patch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create"]
+    verbs: ["get", "create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -546,7 +546,7 @@ rules:
     verbs: ["get", "patch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create"]
+    verbs: ["get", "create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/charts/nico-api/templates/dpf-rbac.yaml
+++ b/helm/charts/nico-api/templates/dpf-rbac.yaml
@@ -54,7 +54,7 @@ rules:
     verbs: ["get", "patch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create"]
+    verbs: ["get", "create", "patch"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Backport of #4485 (`45b30307a`) to `release/v2.1`. Clean cherry-pick, no conflicts.

**Why 2.1 needs this:** v2.1.0-rc.4 installs with DPF enabled fail at nico-api startup:

```
Error: failed to initialize DPF SDK: kubernetes client error: ApiError: secrets "bmc-shared-password" is forbidden:
User "system:serviceaccount:nico-system:nico-api" cannot patch resource "secrets" ... in the namespace "dpf-operator-system": Forbidden (403)
```

#4167 (which IS in release/v2.1) switched the `bmc-shared-password` write to **server-side apply** (`Patch::Apply` in `crates/dpf/src/repository/kube.rs`), which always uses the Kubernetes PATCH verb — even on first creation. The `nico-api-dpf` Role on the branch still only grants `get, create`, so the SDK 403s before the secret ever exists. #4485 added the missing `patch` verb on main but was never backported; installs from main succeed while 2.1-RC.4 fails. This went unnoticed until RC4 because an earlier deploy-blocking bug masked it.

Observed on deployed site (helm-prereqs `setup.sh`, DPF enabled by default, v2.1.0-rc.4).

## Related issues

Backport of #4485; runtime requirement introduced by #4167.

## Type of Change

- [x] **Bug fix** - Non-breaking change which fixes an issue

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Covered by existing checks — one-line RBAC verb addition (plus the same snippet in docs and setup-machine-a-tron.sh); identical change has been running on main since Aug 4. Verified the live failure matches: `kubectl get role nico-api-dpf -n dpf-operator-system` shows `verbs: ["get", "create"]` on rc.4.