### PR TITLE
feat(api-db): key BMC suppressions by source

### DIFF
--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -25,7 +25,7 @@ use common::api_fixtures::TestEnv;
 use db::{self, ObjectColumnFilter};
 use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
-use model::bmc_suppression::{BmcSuppressionSubsystem, NewBmcSuppression};
+use model::bmc_suppression::{BmcSuppressionSource, BmcSuppressionSubsystem, NewBmcSuppression};
 use model::hardware_info::HardwareInfo;
 use model::machine::ManagedHostStateSnapshot;
 use model::machine_boot_interface::MachineBootInterfaceTarget;
@@ -861,6 +861,7 @@ async fn test_manual_refreshes_reject_site_explorer_suppressed_bmc(
         &NewBmcSuppression {
             bmc_mac_address: bmc_interface.mac_address,
             reason: "manual refresh rejection test".to_string(),
+            source: BmcSuppressionSource::Decommissioning,
             subsystem: BmcSuppressionSubsystem::SiteExplorer,
         },
     )

--- a/crates/api-db/migrations/20260813171609_bmc_suppression_source.sql
+++ b/crates/api-db/migrations/20260813171609_bmc_suppression_source.sql
@@ -1,0 +1,15 @@
+-- Give each suppression requester its own row so independent workflows can
+-- suppress and clear without racing on a shared (mac, subsystem) key.
+-- A subsystem treats a MAC as suppressed while any source still has a row.
+ALTER TABLE bmc_suppressions
+    ADD COLUMN source TEXT NOT NULL DEFAULT 'decommissioning'
+        CHECK (source IN ('decommissioning'));
+
+ALTER TABLE bmc_suppressions
+    ALTER COLUMN source DROP DEFAULT;
+
+ALTER TABLE bmc_suppressions
+    DROP CONSTRAINT bmc_suppressions_pkey;
+
+ALTER TABLE bmc_suppressions
+    ADD PRIMARY KEY (bmc_mac_address, subsystem, source);

--- a/crates/api-db/src/bmc_suppression.rs
+++ b/crates/api-db/src/bmc_suppression.rs
@@ -16,15 +16,21 @@
  */
 
 //! Per-subsystem suppression requests for BMC MAC addresses.
+//!
+//! Writers key rows by `(bmc_mac_address, subsystem, source)`. Consumers that
+//! only care whether a subsystem should skip a MAC query by subsystem alone so
+//! any active source keeps the MAC suppressed.
 
 use mac_address::MacAddress;
-use model::bmc_suppression::{BmcSuppression, BmcSuppressionSubsystem, NewBmcSuppression};
+use model::bmc_suppression::{
+    BmcSuppression, BmcSuppressionSource, BmcSuppressionSubsystem, NewBmcSuppression,
+};
 use sqlx::PgConnection;
 
 use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
-/// Inserts or updates a suppression request.
+/// Inserts or updates a suppression request for one source.
 ///
 /// Repeated requests preserve the original request and acknowledgement
 /// timestamps so retries do not restart an acknowledged handoff.
@@ -35,13 +41,15 @@ pub async fn upsert(
     const QUERY: &str = "INSERT INTO bmc_suppressions (
         bmc_mac_address,
         subsystem,
+        source,
         reason
-    ) VALUES ($1, $2, $3)
-    ON CONFLICT (bmc_mac_address, subsystem) DO UPDATE SET
+    ) VALUES ($1, $2, $3, $4)
+    ON CONFLICT (bmc_mac_address, subsystem, source) DO UPDATE SET
         reason = EXCLUDED.reason
     RETURNING
         bmc_mac_address,
         subsystem,
+        source,
         reason,
         requested_at,
         acknowledged_at";
@@ -49,36 +57,40 @@ pub async fn upsert(
     sqlx::query_as(QUERY)
         .bind(input.bmc_mac_address)
         .bind(input.subsystem)
+        .bind(input.source)
         .bind(&input.reason)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
-/// Returns an active suppression request, if one exists.
+/// Returns an active suppression request for one source, if one exists.
 pub async fn find(
     db: impl DbReader<'_>,
     bmc_mac_address: MacAddress,
     subsystem: BmcSuppressionSubsystem,
+    source: BmcSuppressionSource,
 ) -> DatabaseResult<Option<BmcSuppression>> {
     const QUERY: &str = "SELECT
         bmc_mac_address,
         subsystem,
+        source,
         reason,
         requested_at,
         acknowledged_at
     FROM bmc_suppressions
-    WHERE bmc_mac_address = $1 AND subsystem = $2";
+    WHERE bmc_mac_address = $1 AND subsystem = $2 AND source = $3";
 
     sqlx::query_as(QUERY)
         .bind(bmc_mac_address)
         .bind(subsystem)
+        .bind(source)
         .fetch_optional(db)
         .await
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
-/// Returns every BMC suppression for `subsystem`.
+/// Returns every BMC suppression for `subsystem`, across all sources.
 pub async fn find_all_by_subsystem(
     db: impl DbReader<'_>,
     subsystem: BmcSuppressionSubsystem,
@@ -86,12 +98,13 @@ pub async fn find_all_by_subsystem(
     const QUERY: &str = "SELECT
         bmc_mac_address,
         subsystem,
+        source,
         reason,
         requested_at,
         acknowledged_at
     FROM bmc_suppressions
     WHERE subsystem = $1
-    ORDER BY bmc_mac_address";
+    ORDER BY bmc_mac_address, source";
 
     sqlx::query_as(QUERY)
         .bind(subsystem)
@@ -102,18 +115,23 @@ pub async fn find_all_by_subsystem(
 
 /// Acknowledges pending suppression requests for the selected BMC MAC addresses.
 ///
-/// Returns the BMC MAC addresses acknowledged by this call.
+/// Acknowledgements are not source-scoped: every matching subsystem row is
+/// marked so each requester observes the handoff. Returns the distinct BMC MAC
+/// addresses that had at least one previously unacknowledged row.
 pub async fn acknowledge_unacknowledged(
     txn: &mut PgConnection,
     bmc_mac_addresses: &[MacAddress],
     subsystem: BmcSuppressionSubsystem,
 ) -> DatabaseResult<Vec<MacAddress>> {
-    const QUERY: &str = "UPDATE bmc_suppressions
+    const QUERY: &str = "WITH updated AS (
+        UPDATE bmc_suppressions
         SET acknowledged_at = statement_timestamp()
         WHERE bmc_mac_address = ANY($1)
             AND subsystem = $2
             AND acknowledged_at IS NULL
-        RETURNING bmc_mac_address";
+        RETURNING bmc_mac_address
+    )
+    SELECT DISTINCT bmc_mac_address FROM updated";
 
     sqlx::query_scalar(QUERY)
         .bind(bmc_mac_addresses)
@@ -123,7 +141,7 @@ pub async fn acknowledge_unacknowledged(
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
-/// Returns whether a BMC MAC is suppressed for `subsystem`.
+/// Returns whether a BMC MAC is suppressed for `subsystem` by any source.
 pub async fn is_suppressed(
     db: impl DbReader<'_>,
     bmc_mac_address: MacAddress,
@@ -143,11 +161,12 @@ pub async fn is_suppressed(
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
-/// Records that `subsystem` has observed and applied a suppression request.
+/// Records that `subsystem` has observed and applied suppression requests.
 ///
-/// The lookup and timestamp write are atomic. The return value is `true` when
-/// suppression is active and `false` when no matching request exists. Repeated
-/// acknowledgements preserve the first timestamp.
+/// Acknowledgements are not source-scoped: every matching subsystem row is
+/// marked. The lookup and timestamp write are atomic. The return value is
+/// `true` when at least one suppression is active and `false` when no matching
+/// request exists. Repeated acknowledgements preserve the first timestamp.
 pub async fn acknowledge(
     txn: &mut PgConnection,
     bmc_mac_address: MacAddress,
@@ -166,40 +185,45 @@ pub async fn acknowledge(
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
-/// Deletes one subsystem's suppression request for a BMC MAC.
+/// Deletes one source's suppression request for a BMC MAC and subsystem.
 ///
-/// Returns `true` when a row was removed.
+/// Returns `true` when a row was removed. Other sources' rows are left intact
+/// so the subsystem stays suppressed until every requester clears.
 pub async fn delete(
     txn: &mut PgConnection,
     bmc_mac_address: MacAddress,
     subsystem: BmcSuppressionSubsystem,
+    source: BmcSuppressionSource,
 ) -> DatabaseResult<bool> {
     const QUERY: &str = "DELETE FROM bmc_suppressions
-        WHERE bmc_mac_address = $1 AND subsystem = $2";
+        WHERE bmc_mac_address = $1 AND subsystem = $2 AND source = $3";
 
     sqlx::query(QUERY)
         .bind(bmc_mac_address)
         .bind(subsystem)
+        .bind(source)
         .execute(txn)
         .await
         .map(|result| result.rows_affected() > 0)
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
-/// Deletes a subsystem's suppression requests for a set of BMC MACs.
+/// Deletes one source's suppression requests for a set of BMC MACs.
 ///
 /// Returns the number of rows removed.
 pub async fn delete_many(
     txn: &mut PgConnection,
     bmc_mac_addresses: &[MacAddress],
     subsystem: BmcSuppressionSubsystem,
+    source: BmcSuppressionSource,
 ) -> DatabaseResult<u64> {
     const QUERY: &str = "DELETE FROM bmc_suppressions
-        WHERE bmc_mac_address = ANY($1) AND subsystem = $2";
+        WHERE bmc_mac_address = ANY($1) AND subsystem = $2 AND source = $3";
 
     sqlx::query(QUERY)
         .bind(bmc_mac_addresses)
         .bind(subsystem)
+        .bind(source)
         .execute(txn)
         .await
         .map(|result| result.rows_affected())
@@ -209,7 +233,9 @@ pub async fn delete_many(
 #[cfg(test)]
 mod tests {
     use mac_address::MacAddress;
-    use model::bmc_suppression::{BmcSuppressionSubsystem, NewBmcSuppression};
+    use model::bmc_suppression::{
+        BmcSuppressionSource, BmcSuppressionSubsystem, NewBmcSuppression,
+    };
 
     use super::{
         acknowledge, acknowledge_unacknowledged, delete, delete_many, find, find_all_by_subsystem,
@@ -218,6 +244,7 @@ mod tests {
 
     const SITE_EXPLORER: BmcSuppressionSubsystem = BmcSuppressionSubsystem::SiteExplorer;
     const DHCP: BmcSuppressionSubsystem = BmcSuppressionSubsystem::Dhcp;
+    const DECOMMISSIONING: BmcSuppressionSource = BmcSuppressionSource::Decommissioning;
 
     fn mac(last: u8) -> MacAddress {
         MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, last])
@@ -231,6 +258,7 @@ mod tests {
         NewBmcSuppression {
             bmc_mac_address: mac(last),
             subsystem,
+            source: DECOMMISSIONING,
             reason: reason.to_string(),
         }
     }
@@ -301,7 +329,7 @@ mod tests {
                     .unwrap()
             );
             assert!(
-                find(txn.as_mut(), mac(last), other_subsystem)
+                find(txn.as_mut(), mac(last), other_subsystem, DECOMMISSIONING)
                     .await
                     .unwrap()
                     .is_none()
@@ -312,7 +340,7 @@ mod tests {
                     .unwrap()
             );
             assert!(
-                find(txn.as_mut(), mac(last), subsystem)
+                find(txn.as_mut(), mac(last), subsystem, DECOMMISSIONING)
                     .await
                     .unwrap()
                     .unwrap()
@@ -342,7 +370,7 @@ mod tests {
         assert!(acknowledged.contains(&mac(1)));
         assert!(acknowledged.contains(&mac(3)));
         assert!(
-            find(txn.as_mut(), mac(1), SITE_EXPLORER)
+            find(txn.as_mut(), mac(1), SITE_EXPLORER, DECOMMISSIONING)
                 .await
                 .unwrap()
                 .unwrap()
@@ -350,7 +378,7 @@ mod tests {
                 .is_some()
         );
         assert!(
-            find(txn.as_mut(), mac(2), DHCP)
+            find(txn.as_mut(), mac(2), DHCP, DECOMMISSIONING)
                 .await
                 .unwrap()
                 .unwrap()
@@ -380,7 +408,7 @@ mod tests {
                 .await
                 .unwrap()
         );
-        let initial = find(txn.as_mut(), mac(1), SITE_EXPLORER)
+        let initial = find(txn.as_mut(), mac(1), SITE_EXPLORER, DECOMMISSIONING)
             .await
             .unwrap()
             .unwrap();
@@ -390,7 +418,7 @@ mod tests {
                 .await
                 .unwrap()
         );
-        let repeated = find(txn.as_mut(), mac(1), SITE_EXPLORER)
+        let repeated = find(txn.as_mut(), mac(1), SITE_EXPLORER, DECOMMISSIONING)
             .await
             .unwrap()
             .unwrap();
@@ -405,7 +433,11 @@ mod tests {
         assert_eq!(retried.requested_at, initial.requested_at);
         assert_eq!(retried.acknowledged_at, initial.acknowledged_at);
 
-        assert!(delete(txn.as_mut(), mac(1), SITE_EXPLORER).await.unwrap());
+        assert!(
+            delete(txn.as_mut(), mac(1), SITE_EXPLORER, DECOMMISSIONING)
+                .await
+                .unwrap()
+        );
         let recreated = upsert(
             txn.as_mut(),
             &upsert_input(1, SITE_EXPLORER, "new decommissioning request"),
@@ -416,7 +448,7 @@ mod tests {
     }
 
     #[crate::sqlx_test]
-    async fn delete_helpers_are_scoped_to_subsystem(pool: sqlx::PgPool) {
+    async fn delete_helpers_are_scoped_to_subsystem_and_source(pool: sqlx::PgPool) {
         let mut txn = pool.begin().await.unwrap();
 
         for last in 1..=3 {
@@ -430,22 +462,45 @@ mod tests {
             }
         }
 
-        assert!(delete(txn.as_mut(), mac(1), SITE_EXPLORER).await.unwrap());
-        assert!(!delete(txn.as_mut(), mac(1), SITE_EXPLORER).await.unwrap());
-        assert!(find(txn.as_mut(), mac(1), DHCP).await.unwrap().is_some());
+        assert!(
+            delete(txn.as_mut(), mac(1), SITE_EXPLORER, DECOMMISSIONING)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !delete(txn.as_mut(), mac(1), SITE_EXPLORER, DECOMMISSIONING)
+                .await
+                .unwrap()
+        );
+        assert!(
+            find(txn.as_mut(), mac(1), DHCP, DECOMMISSIONING)
+                .await
+                .unwrap()
+                .is_some()
+        );
 
         assert_eq!(
-            delete_many(txn.as_mut(), &[mac(2), mac(3), mac(4)], SITE_EXPLORER)
-                .await
-                .unwrap(),
+            delete_many(
+                txn.as_mut(),
+                &[mac(2), mac(3), mac(4)],
+                SITE_EXPLORER,
+                DECOMMISSIONING
+            )
+            .await
+            .unwrap(),
             2
         );
         assert!(
-            find(txn.as_mut(), mac(2), SITE_EXPLORER)
+            find(txn.as_mut(), mac(2), SITE_EXPLORER, DECOMMISSIONING)
                 .await
                 .unwrap()
                 .is_none()
         );
-        assert!(find(txn.as_mut(), mac(2), DHCP).await.unwrap().is_some());
+        assert!(
+            find(txn.as_mut(), mac(2), DHCP, DECOMMISSIONING)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/crates/api-model/src/bmc_suppression.rs
+++ b/crates/api-model/src/bmc_suppression.rs
@@ -26,20 +26,34 @@ pub enum BmcSuppressionSubsystem {
     Dhcp,
 }
 
-/// An active suppression request for one BMC MAC address and subsystem.
+/// Code path that requested a BMC MAC suppression.
+///
+/// Each source owns its own `(bmc_mac_address, subsystem, source)` row so
+/// independent workflows can suppress and clear without fighting over a shared
+/// row. A subsystem treats a MAC as suppressed while any source still has a
+/// matching row.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+pub enum BmcSuppressionSource {
+    Decommissioning,
+}
+
+/// An active suppression request for one BMC MAC address, subsystem, and source.
 #[derive(Clone, Debug, Eq, PartialEq, sqlx::FromRow)]
 pub struct BmcSuppression {
     pub bmc_mac_address: MacAddress,
     pub subsystem: BmcSuppressionSubsystem,
+    pub source: BmcSuppressionSource,
     pub reason: String,
     pub requested_at: DateTime<Utc>,
     pub acknowledged_at: Option<DateTime<Utc>>,
 }
 
-/// A new suppression request for one BMC MAC address and subsystem.
+/// A new suppression request for one BMC MAC address, subsystem, and source.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NewBmcSuppression {
     pub bmc_mac_address: MacAddress,
     pub subsystem: BmcSuppressionSubsystem,
+    pub source: BmcSuppressionSource,
     pub reason: String,
 }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -2078,15 +2078,20 @@ impl SiteExplorer {
             .map(|suppression| suppression.bmc_mac_address)
             .collect();
 
-        let mut guards = Vec::new();
-        let mut acknowledgements = Vec::new();
-        for suppression in suppressions
+        // Multiple sources may suppress the same MAC. Acknowledge once per MAC so
+        // endpoint claims are not contended across duplicate suppression rows.
+        let pending_macs: HashSet<MacAddress> = suppressions
             .iter()
             .filter(|suppression| suppression.acknowledged_at.is_none())
-        {
+            .map(|suppression| suppression.bmc_mac_address)
+            .collect();
+
+        let mut guards = Vec::new();
+        let mut acknowledgements = Vec::new();
+        for bmc_mac_address in pending_macs {
             let bmc_ips = db::machine_interface::lookup_bmc_ip_by_mac_address(
                 &self.database_connection,
-                suppression.bmc_mac_address,
+                bmc_mac_address,
             )
             .await?;
             let mut suppression_guards = Vec::new();
@@ -2101,7 +2106,7 @@ impl SiteExplorer {
             }
             if all_endpoints_available {
                 guards.extend(suppression_guards);
-                acknowledgements.push(suppression.bmc_mac_address);
+                acknowledgements.push(bmc_mac_address);
             }
         }
 

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -33,7 +33,7 @@ use db::ObjectFilter;
 use db::sku::CURRENT_SKU_VERSION;
 use itertools::Itertools;
 use mac_address::MacAddress;
-use model::bmc_suppression::{BmcSuppressionSubsystem, NewBmcSuppression};
+use model::bmc_suppression::{BmcSuppressionSource, BmcSuppressionSubsystem, NewBmcSuppression};
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{LoadSnapshotOptions, Machine};
@@ -167,6 +167,7 @@ fn suppression_input(
     NewBmcSuppression {
         bmc_mac_address,
         reason: "site explorer suppression test".to_string(),
+        source: BmcSuppressionSource::Decommissioning,
         subsystem,
     }
 }
@@ -275,6 +276,7 @@ async fn test_periodic_suppression_skips_every_candidate_class(
                 txn.as_mut(),
                 machine.mac,
                 BmcSuppressionSubsystem::SiteExplorer,
+                BmcSuppressionSource::Decommissioning,
             )
             .await?
             .unwrap()
@@ -282,10 +284,14 @@ async fn test_periodic_suppression_skips_every_candidate_class(
             .is_some()
         );
     }
-    let dhcp_only_suppression =
-        db::bmc_suppression::find(txn.as_mut(), machines[3].mac, BmcSuppressionSubsystem::Dhcp)
-            .await?
-            .unwrap();
+    let dhcp_only_suppression = db::bmc_suppression::find(
+        txn.as_mut(),
+        machines[3].mac,
+        BmcSuppressionSubsystem::Dhcp,
+        BmcSuppressionSource::Decommissioning,
+    )
+    .await?
+    .unwrap();
     assert!(dhcp_only_suppression.acknowledged_at.is_none());
     txn.commit().await?;
 
@@ -486,6 +492,7 @@ async fn test_suppressed_unexplored_endpoint_does_not_consume_budget_and_resumes
         txn.as_mut(),
         machines[0].mac,
         BmcSuppressionSubsystem::SiteExplorer,
+        BmcSuppressionSource::Decommissioning,
     )
     .await?;
     txn.commit().await?;
@@ -557,6 +564,7 @@ async fn test_suppression_is_acknowledged_before_precondition_failure(
             txn.as_mut(),
             suppressed_mac,
             BmcSuppressionSubsystem::SiteExplorer,
+            BmcSuppressionSource::Decommissioning,
         )
         .await?
         .unwrap()
@@ -605,6 +613,7 @@ async fn test_suppression_acknowledgement_waits_for_in_flight_exploration(
         &env.pool,
         machine.mac,
         BmcSuppressionSubsystem::SiteExplorer,
+        BmcSuppressionSource::Decommissioning,
     )
     .await?
     .unwrap();
@@ -620,6 +629,7 @@ async fn test_suppression_acknowledgement_waits_for_in_flight_exploration(
         &env.pool,
         machine.mac,
         BmcSuppressionSubsystem::SiteExplorer,
+        BmcSuppressionSource::Decommissioning,
     )
     .await?
     .unwrap();


### PR DESCRIPTION
Add a source column to the bmc_suppressions primary key so independent requesters can own their own rows without clearing each other early.

## Related issues
Implements #4951 

Both of these will use the suppression feature
#1969 - decommissioning
#4897 - credential rotation

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


