### PR TITLE
backport(v2.0): Ingestion fixes

### DIFF
--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -886,11 +886,7 @@ impl EndpointExplorationReport {
             .and_then(|value| value.model.as_ref())
             .unwrap_or(&"".to_string())
             .to_string();
-        match model.to_lowercase() {
-            value if value.contains("bluefield 2") => Some(DpuModel::BlueField2),
-            value if value.contains("bluefield 3") => Some(DpuModel::BlueField3),
-            _ => Some(DpuModel::Unknown),
-        }
+        Some(DpuModel::from(model))
     }
 
     pub fn create_temporary_dmi_data(
@@ -2313,6 +2309,37 @@ mod tests {
     use crate::firmware::FirmwareComponent;
     use crate::machine::machine_id::from_hardware_info;
 
+    #[test]
+    fn identify_dpu_recognizes_bluefield_model_variants() {
+        value_scenarios!(
+            run = |(system_id, model)| {
+                let report = EndpointExplorationReport {
+                    systems: vec![ComputerSystem {
+                        id: system_id.to_string(),
+                        ..Default::default()
+                    }],
+                    chassis: vec![Chassis {
+                        id: "Card1".to_string(),
+                        model: Some(model.to_string()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                };
+                let identified = report.identify_dpu();
+                if let Some(dpu_model) = &identified {
+                    assert_eq!(report.model(), Some(dpu_model.to_string()));
+                }
+                identified
+            };
+            "BlueField model identification" {
+                ("Bluefield", "NVIDIA BlueField 2 DPU") => Some(DpuModel::BlueField2),
+                ("Bluefield", "NVIDIA BlueField 3 DPU") => Some(DpuModel::BlueField3),
+                ("Bluefield", "BlueField-3 DPU") => Some(DpuModel::BlueField3),
+                ("Bluefield", "unrecognized DPU") => Some(DpuModel::Unknown),
+                ("System", "BlueField-3 DPU") => None,
+            }
+        );
+    }
     fn create_test_firmware(firmware_type: FirmwareComponentType, regex_pattern: &str) -> Firmware {
         let mut components = HashMap::new();
         components.insert(

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -3845,9 +3845,11 @@ mod tests {
         assert_eq!(oob, "5c:25:73:9e:ac:ea".parse().unwrap());
     }
 
+    const BF3_MODEL_VARIANTS: [&str; 2] = ["NVIDIA BlueField 3 DPU", "BlueField-3 DPU"];
+
     // Minimal BlueField-3 report with a single manager eth0 interface carrying
     // `eth0_mac`. Classifies as BF3 (system id "Bluefield" + Card1 BF3 chassis).
-    fn bf3_report_with_eth0(eth0_mac: &str) -> EndpointExplorationReport {
+    fn bf3_report_with_eth0(model: &str, eth0_mac: &str) -> EndpointExplorationReport {
         use model::site_explorer::{Chassis, ComputerSystem, EthernetInterface, Manager};
         EndpointExplorationReport {
             systems: vec![ComputerSystem {
@@ -3856,7 +3858,7 @@ mod tests {
             }],
             chassis: vec![Chassis {
                 id: "Card1".to_string(),
-                model: Some("NVIDIA BlueField 3 DPU".to_string()),
+                model: Some(model.to_string()),
                 ..Default::default()
             }],
             managers: vec![Manager {
@@ -3873,17 +3875,34 @@ mod tests {
 
     #[test]
     fn bmc_eth0_offset_skips_locally_administered_mac() {
-        // Transient pre-sync MAC (locally-administered bit set) must not derive
-        // a base MAC, even though the platform classifies and an eth0 exists.
-        let transient = bf3_report_with_eth0("9a:72:d5:07:ae:7e");
-        assert_eq!(bmc_eth0_to_base_mac_offset(&transient), Some(0x25));
-        assert!(derive_base_mac_from_bmc_eth0(&transient).is_none());
-
-        // Sanity: the same report with the real (globally-unique) eth0 derives.
-        let synced = bf3_report_with_eth0("5c:25:73:9e:ac:eb");
-        assert_eq!(
-            derive_base_mac_from_bmc_eth0(&synced),
-            Some("5c:25:73:9e:ac:c6".parse().unwrap())
+        check_values(
+            [
+                Check {
+                    scenario: "space-separated BF3 model with pre-sync eth0",
+                    input: (BF3_MODEL_VARIANTS[0], "9a:72:d5:07:ae:7e"),
+                    expect: None,
+                },
+                Check {
+                    scenario: "hyphenated BF3 model with pre-sync eth0",
+                    input: (BF3_MODEL_VARIANTS[1], "9a:72:d5:07:ae:7e"),
+                    expect: None,
+                },
+                Check {
+                    scenario: "space-separated BF3 model with synced eth0",
+                    input: (BF3_MODEL_VARIANTS[0], "5c:25:73:9e:ac:eb"),
+                    expect: Some("5c:25:73:9e:ac:c6".parse().unwrap()),
+                },
+                Check {
+                    scenario: "hyphenated BF3 model with synced eth0",
+                    input: (BF3_MODEL_VARIANTS[1], "5c:25:73:9e:ac:eb"),
+                    expect: Some("5c:25:73:9e:ac:c6".parse().unwrap()),
+                },
+            ],
+            |(model, eth0_mac)| {
+                let report = bf3_report_with_eth0(model, eth0_mac);
+                assert_eq!(bmc_eth0_to_base_mac_offset(&report), Some(0x25));
+                derive_base_mac_from_bmc_eth0(&report)
+            },
         );
     }
 
@@ -4125,6 +4144,12 @@ mod tests {
             ep
         };
 
+        let bf3_with_empty_sys_image = |model| {
+            let mut ep = explored_endpoint(bf3_report_with_eth0(model, "5c:25:73:9e:ac:eb"));
+            ep.report.service = with_sys_image("").report.service;
+            ep
+        };
+
         // Drop the firmware-inventory entry whose `id` matches `inventory_id`.
         let without_inventory = |inventory_id: &str| {
             let mut ep = endpoint();
@@ -4151,6 +4176,16 @@ mod tests {
                     scenario: "legacy sys-image MAC, sanitized",
                     input: endpoint(),
                     expect: Yields("B8:3F:D2:90:95:F4".parse().unwrap()),
+                },
+                Case {
+                    scenario: "space-separated BF3 model falls back to BMC eth0",
+                    input: bf3_with_empty_sys_image(BF3_MODEL_VARIANTS[0]),
+                    expect: Yields("5c:25:73:9e:ac:c6".parse().unwrap()),
+                },
+                Case {
+                    scenario: "hyphenated BF3 model falls back to BMC eth0",
+                    input: bf3_with_empty_sys_image(BF3_MODEL_VARIANTS[1]),
+                    expect: Yields("5c:25:73:9e:ac:c6".parse().unwrap()),
                 },
                 Case {
                     scenario: "legacy sys-image MAC fails sanitization",

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -3810,7 +3810,7 @@ fn health_reports_equal_ignoring_observed_at(
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use config_version::ConfigVersion;
     use model::site_explorer::PreingestionState;
 

--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }}
               if [ -x /opt/nico/nico-hw-health ]; then
                 exec /opt/nico/nico-hw-health
               else

--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              ulimit -Sn {{ .Values.fileDescriptorLimit | int }}
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
               if [ -x /opt/nico/nico-hw-health ]; then
                 exec /opt/nico/nico-hw-health
               else

--- a/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
@@ -1,0 +1,16 @@
+suite: hardware-health file descriptor limit
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: uses the default soft limit
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 65536'
+  - it: allows an override
+    set:
+      fileDescriptorLimit: 32768
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 32768'

--- a/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
@@ -6,11 +6,11 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 65536'
+          pattern: 'ulimit -Sn 65536 \|\| exit 1'
   - it: allows an override
     set:
       fileDescriptorLimit: 32768
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 32768'
+          pattern: 'ulimit -Sn 32768 \|\| exit 1'

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -27,6 +27,7 @@ namespaceOverride: ""
 
 replicas: 1
 
+## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
 fileDescriptorLimit: 65536
 
 service:

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -27,6 +27,8 @@ namespaceOverride: ""
 
 replicas: 1
 
+fileDescriptorLimit: 65536
+
 service:
   port: 9009
 

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              ulimit -Sn {{ .Values.fileDescriptorLimit | int }}
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
               if [ -x /opt/nico/ssh-console ]; then
                 exec /opt/nico/ssh-console run -c /etc/nico/ssh-console/config.toml
               else

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }}
               if [ -x /opt/nico/ssh-console ]; then
                 exec /opt/nico/ssh-console run -c /etc/nico/ssh-console/config.toml
               else

--- a/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
@@ -1,0 +1,16 @@
+suite: ssh-console file descriptor limit
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: uses the default soft limit
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 65536'
+  - it: allows an override
+    set:
+      fileDescriptorLimit: 32768
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 32768'

--- a/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
@@ -6,11 +6,11 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 65536'
+          pattern: 'ulimit -Sn 65536 \|\| exit 1'
   - it: allows an override
     set:
       fileDescriptorLimit: 32768
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 32768'
+          pattern: 'ulimit -Sn 32768 \|\| exit 1'

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -29,6 +29,7 @@ replicas: 1
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-ssh-console-rs.name" . }}-config-files'
 
+## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
 fileDescriptorLimit: 65536
 
 imagePullSecrets: []

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -29,6 +29,8 @@ replicas: 1
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-ssh-console-rs.name" . }}-config-files'
 
+fileDescriptorLimit: 65536
+
 imagePullSecrets: []
 
 service:


### PR DESCRIPTION
Backports #4960 (file-descriptor limits) and #4829 (hyphenated BlueField-3 PF0 fallback) to `release/v2.0`.

Includes the v2.0 Site Explorer test-helper import required for the BF3 fallback coverage.

Validated together in developer bundle.