### PR TITLE
fix: ignore irot UUID for BF4

### DIFF
--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -42,6 +42,7 @@ use model::site_explorer::{
 };
 use nv_redfish::assembly::Model as AssemblyModel;
 use nv_redfish::computer_system::BootOption;
+use nv_redfish::core::ODataId;
 use nv_redfish::oem::ami::config_bmc::{
     LockdownBiosSettingsChangeState, LockdownBiosUpgradeDowngradeState,
     LockoutBiosVariableWriteMode, LockoutHostControlState,
@@ -78,6 +79,12 @@ pub fn is_bf4_product(product: Option<Product<&str>>) -> bool {
     product == Some(Product::new("B4240V")) || product == Some(Product::new("BlueField-4"))
 }
 
+/// BlueField-4 BMC firmware reports a non-UUID value (`STATIC:1026:0:MCTP_EID:101`)
+/// in the `UUID` of the IRoT NIC chassis. skip it for now. TODO: remove this once we have a fix.
+fn should_fetch_bf4_chassis_except_irot_nic(odata_id: &ODataId) -> bool {
+    odata_id.last_segment() != Some("BlueField_IRoT_NIC_0")
+}
+
 /// Builds the chassis exploration config shared by [`nv_generate_exploration_report`]
 /// and the [`detect_hw_type`] accessor, so detection cannot drift between them.
 fn build_chassis_explore_config<B: Bmc>(root: &ServiceRoot<B>) -> chassis::Config {
@@ -106,9 +113,14 @@ fn build_chassis_explore_config<B: Bmc>(root: &ServiceRoot<B>) -> chassis::Confi
         // with ERoT chassis. It stucks sometimes until next request
         // of BlueField_ERoT. Because carbide doesn't need
         // BlueField_ERoT we just skip it.
-        lazy_fetch: (root.vendor() == Some(Vendor::new("Nvidia"))
-            && root.product() == Some(Product::new("BlueField-3 DPU")))
-        .then_some(|odata_id| odata_id.last_segment() != Some("Bluefield_ERoT")),
+        // BlueField-4: skip IRoT NIC (invalid STATIC UUID breaks parsing).
+        lazy_fetch: if is_nvidia_vendor && is_bf4_product(root.product()) {
+            Some(should_fetch_bf4_chassis_except_irot_nic)
+        } else {
+            (root.vendor() == Some(Vendor::new("Nvidia"))
+                && root.product() == Some(Product::new("BlueField-3 DPU")))
+            .then_some(|odata_id| odata_id.last_segment() != Some("Bluefield_ERoT"))
+        },
     }
 }
 
@@ -1178,7 +1190,10 @@ mod tests {
     use nv_redfish::core::ODataId;
 
     use super::hw::HwType;
-    use super::{Product, is_bf4_product, should_use_network_adapter_port_fallback};
+    use super::{
+        Product, is_bf4_product, should_fetch_bf4_chassis_except_irot_nic,
+        should_use_network_adapter_port_fallback,
+    };
 
     #[test]
     fn is_bf4_product_matches_bf4_service_root_products() {
@@ -1186,6 +1201,19 @@ mod tests {
         assert!(is_bf4_product(Some(Product::new("BlueField-4"))));
         assert!(!is_bf4_product(Some(Product::new("BlueField-3 DPU"))));
         assert!(!is_bf4_product(None));
+    }
+
+    #[test]
+    fn bf4_chassis_fetch_excludes_irot_nic() {
+        assert!(!should_fetch_bf4_chassis_except_irot_nic(&ODataId::from(
+            "/redfish/v1/Chassis/BlueField_IRoT_NIC_0".to_string()
+        )));
+        assert!(should_fetch_bf4_chassis_except_irot_nic(&ODataId::from(
+            "/redfish/v1/Chassis/BlueField_ERoT_BMC_0".to_string()
+        )));
+        assert!(should_fetch_bf4_chassis_except_irot_nic(&ODataId::from(
+            "/redfish/v1/Chassis/BlueField_0".to_string()
+        )));
     }
 
     #[test]

--- a/crates/bmc-explorer/tests/integration/bluefield4_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield4_explore.rs
@@ -18,6 +18,7 @@ use bmc_explorer::nv_generate_exploration_report;
 use bmc_mock::{DpuMachineInfo, DpuSettings, HardwareType, MachineInfo, test_support};
 use mac_address::MacAddress;
 use model::site_explorer::EndpointType;
+use serde_json::json;
 use tokio::test;
 
 use crate::common;
@@ -62,8 +63,11 @@ async fn explore_bluefield4_and_generate_machine_id_from_system_serial() {
             "BlueField_BMC_0",
             "BlueField_ERoT_BMC_0",
             "BlueField_ERoT_CPU_0",
-            "BlueField_IRoT_NIC_0",
         ]
+    );
+    assert!(
+        !chassis_ids.contains(&"BlueField_IRoT_NIC_0"),
+        "BlueField_IRoT_NIC_0 should be skipped; NICo does not need it and some firmware returns a non-UUID STATIC value"
     );
     let bmc_chassis_serial = report
         .chassis
@@ -129,4 +133,42 @@ async fn explore_b4240v_and_generate_machine_id() {
         .expect("B4240V report should have enough collected data for machine ID")
         .expect("B4240V report should generate a DPU machine ID");
     assert!(machine_id.machine_type().is_dpu());
+}
+
+#[test]
+async fn explore_bluefield4_succeeds_when_irot_nic_has_invalid_uuid() {
+    let h = test_support::dell_poweredge_r760_bluefield4_bmc(DpuMachineInfo {
+        hw_type: HardwareType::DellPowerEdgeR760Bf4,
+        bmc_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x04, 0x11]),
+        host_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x04, 0x12]),
+        oob_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x04, 0x13]),
+        serial: "MT2610604VN6".to_string(),
+        settings: DpuSettings::default(),
+    })
+    .await;
+
+    // Field BMCs have returned UUID = "STATIC:1026:0:MCTP_EID:101" on this
+    // chassis. nv-redfish rejects that while parsing the member; skipping the
+    // fetch keeps exploration healthy.
+    h.state.injection.put(vec![bmc_mock::injection::Rule {
+        id: "irot_invalid_uuid".into(),
+        selector: bmc_mock::injection::Selector::Path {
+            method: Some("GET".into()),
+            glob: "/redfish/v1/Chassis/BlueField_IRoT_NIC_0".into(),
+        },
+        action: bmc_mock::injection::Action::JsonMerge(json!({
+            "UUID": "STATIC:1026:0:MCTP_EID:101"
+        })),
+        remaining: Some(100),
+    }]);
+
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .expect("exploration must succeed even when IRoT NIC reports a non-UUID STATIC value");
+
+    let chassis_ids: Vec<&str> = report.chassis.iter().map(|c| c.id.as_str()).collect();
+    assert!(
+        !chassis_ids.contains(&"BlueField_IRoT_NIC_0"),
+        "BlueField_IRoT_NIC_0 should be skipped, got: {chassis_ids:?}"
+    );
 }


### PR DESCRIPTION

Description: Some BF4 BMCs return a non-UUID STATIC:... value in the IRoT NIC chassis UUID, which fails nv-redfish parsing and aborts exploration. This is a bug that will be fixed in future release. For now, skip fetching that chassis on BF4 (NICo does not need it for inventory/pairing). Remove this code patch whenever NIC UUID issue got fixed. 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Intern

## Testing
- [ x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
`/redfish/v1/Chassis/BlueField_IRoT_NIC_0
  UUID = "STATIC:1026:0:MCTP_EID:101"`
