### PR TITLE
fix(helm): configure file descriptor limits

### DIFF
--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }}
               if [ -x /opt/nico/nico-hw-health ]; then
                 exec /opt/nico/nico-hw-health
               else

--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              ulimit -Sn {{ .Values.fileDescriptorLimit | int }}
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
               if [ -x /opt/nico/nico-hw-health ]; then
                 exec /opt/nico/nico-hw-health
               else

--- a/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
@@ -1,0 +1,16 @@
+suite: hardware-health file descriptor limit
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: uses the default soft limit
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 65536'
+  - it: allows an override
+    set:
+      fileDescriptorLimit: 32768
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 32768'

--- a/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
@@ -6,11 +6,11 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 65536'
+          pattern: 'ulimit -Sn 65536 \|\| exit 1'
   - it: allows an override
     set:
       fileDescriptorLimit: 32768
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 32768'
+          pattern: 'ulimit -Sn 32768 \|\| exit 1'

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -27,6 +27,7 @@ namespaceOverride: ""
 
 replicas: 1
 
+## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
 fileDescriptorLimit: 65536
 
 service:

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -27,6 +27,8 @@ namespaceOverride: ""
 
 replicas: 1
 
+fileDescriptorLimit: 65536
+
 service:
   port: 9009
 

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              ulimit -Sn {{ .Values.fileDescriptorLimit | int }}
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
               if [ -x /opt/nico/ssh-console ]; then
                 exec /opt/nico/ssh-console run -c /etc/nico/ssh-console/config.toml
               else

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }}
               if [ -x /opt/nico/ssh-console ]; then
                 exec /opt/nico/ssh-console run -c /etc/nico/ssh-console/config.toml
               else

--- a/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
@@ -1,0 +1,16 @@
+suite: ssh-console file descriptor limit
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: uses the default soft limit
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 65536'
+  - it: allows an override
+    set:
+      fileDescriptorLimit: 32768
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 32768'

--- a/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
@@ -6,11 +6,11 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 65536'
+          pattern: 'ulimit -Sn 65536 \|\| exit 1'
   - it: allows an override
     set:
       fileDescriptorLimit: 32768
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 32768'
+          pattern: 'ulimit -Sn 32768 \|\| exit 1'

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -29,6 +29,7 @@ replicas: 1
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-ssh-console-rs.name" . }}-config-files'
 
+## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
 fileDescriptorLimit: 65536
 
 imagePullSecrets: []

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -29,6 +29,8 @@ replicas: 1
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-ssh-console-rs.name" . }}-config-files'
 
+fileDescriptorLimit: 65536
+
 imagePullSecrets: []
 
 service:


### PR DESCRIPTION
Fixes #4955.

Set a configurable 65536 soft file-descriptor limit for hardware health and SSH console, which otherwise inherit a 1024 limit during high-concurrency ingestion.