### PR TITLE
fix(api-core): restore DPF service sync test compilation

### DIFF
--- a/crates/api-core/src/tests/dpf/dpu_service_sync.rs
+++ b/crates/api-core/src/tests/dpf/dpu_service_sync.rs
@@ -66,7 +66,7 @@ fn mock(
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| Ok(DpuDeploymentType::Bf3));
+        .returning(|_, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
 
     let outdated_calls = calls.clone();


### PR DESCRIPTION
`DpfOperations::deployment_type_for_dpu` now accepts the Astra NIC flag, but the shared DPU service sync mock was still using the old one-argument callback.

So this accepts the second mock argument while preserving the existing `DpuDeploymentType::Bf3` response. The API Core test target compiles again, and all six DPU service sync tests pass.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4959

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

```bash
cargo test -p carbide-api-core --lib --no-run dpu_service_sync
cargo test -p carbide-api-core --lib tests::dpf::dpu_service_sync -- --nocapture
cargo make format-nightly
cargo make clippy
cargo carbide-lints --all-targets --all-features
```

## Additional Notes

This only updates the test mock callback signature; production behavior is unchanged.
