### PR TITLE
feat(rest-api): Add replayable Temporal workflow/activity logger

### DIFF
--- a/rest-api/common/pkg/log/temporal.go
+++ b/rest-api/common/pkg/log/temporal.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package log builds the loggers this service hands to the Temporal SDK and the
+// loggers workflow and activity code should use, so every Temporal log line
+// lands in the same zerolog stream, with the same fields and writers, as the
+// rest of the service.
+package log
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
+	"go.temporal.io/sdk/activity"
+	temporallog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/workflow"
+	zlogadapter "logur.dev/adapter/zerolog"
+	"logur.dev/logur"
+)
+
+// Field names shared by the workflow and activity loggers. `Workflow` and
+// `Activity` keep the names the hand-rolled loggers already emitted so existing
+// log queries keep working, while the values now come from the Temporal SDK
+// rather than a literal that can drift from the registered name.
+const (
+	fieldWorkflow   = "Workflow"
+	fieldActivity   = "Activity"
+	fieldWorkflowID = "WorkflowID"
+	fieldRunID      = "RunID"
+	fieldActivityID = "ActivityID"
+	fieldAttempt    = "Attempt"
+)
+
+// TemporalClientLogger returns the logger to pass as `client.Options.Logger`.
+// The worker copies it out of the client, so it backs the SDK's own lines plus
+// everything reached through `workflow.GetLogger` and `activity.GetLogger`.
+//
+// zerolog.Logger is a value, so the returned logger is a snapshot of the global
+// logger. Call this only after the process has finished configuring that logger,
+// otherwise Temporal logs miss writers added later, such as the Sentry writer.
+func TemporalClientLogger() temporallog.Logger {
+	return logur.LoggerToKV(zlogadapter.New(zlog.Logger))
+}
+
+// TemporalWorkflowLogger returns the global logger tagged with the identity of
+// the running workflow. During history replay it returns a disabled logger, so
+// a replayed workflow does not re-emit the lines its first execution already
+// logged.
+//
+// Only logging and metrics may depend on the replay flag. A workflow must never
+// branch on it for anything that changes the sequence of commands it produces.
+func TemporalWorkflowLogger(ctx workflow.Context) zerolog.Logger {
+	if workflow.IsReplaying(ctx) {
+		return zerolog.Nop()
+	}
+
+	info := workflow.GetInfo(ctx)
+
+	return zlog.With().
+		Str(fieldWorkflow, info.WorkflowType.Name).
+		Str(fieldWorkflowID, info.WorkflowExecution.ID).
+		Str(fieldRunID, info.WorkflowExecution.RunID).
+		Logger()
+}
+
+// TemporalActivityLogger returns the global logger tagged with the identity of
+// the running activity and of the workflow run that scheduled it. Outside an
+// activity context, which is how unit tests invoke activity methods, it returns
+// the global logger untagged instead of panicking in `activity.GetInfo`.
+func TemporalActivityLogger(ctx context.Context) zerolog.Logger {
+	if !activity.IsActivity(ctx) {
+		return zlog.Logger
+	}
+
+	info := activity.GetInfo(ctx)
+
+	return zlog.With().
+		Str(fieldActivity, info.ActivityType.Name).
+		Str(fieldActivityID, info.ActivityID).
+		Str(fieldWorkflowID, info.WorkflowExecution.ID).
+		Str(fieldRunID, info.WorkflowExecution.RunID).
+		Int32(fieldAttempt, info.Attempt).
+		Logger()
+}

--- a/rest-api/common/pkg/log/temporal_test.go
+++ b/rest-api/common/pkg/log/temporal_test.go
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	temporallog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+// captureGlobalLogger points the global zerolog logger at a buffer for the
+// duration of the test, matching how the services configure it: a timestamp on
+// every line.
+func captureGlobalLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	previous := zlog.Logger
+	zlog.Logger = zerolog.New(buf).With().Timestamp().Logger()
+	t.Cleanup(func() { zlog.Logger = previous })
+
+	return buf
+}
+
+// findLine returns the fields of the first captured line with the given message.
+// The buffer also holds the Temporal SDK's own lines, so tests match on their
+// own message rather than assuming a line position.
+func findLine(t *testing.T, buf *bytes.Buffer, msg string) map[string]any {
+	t.Helper()
+
+	decoder := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	for decoder.More() {
+		fields := map[string]any{}
+		require.NoError(t, decoder.Decode(&fields))
+
+		if fields[zerolog.MessageFieldName] == msg {
+			return fields
+		}
+	}
+
+	t.Fatalf("no log line with message %q in:\n%s", msg, buf.String())
+	return nil
+}
+
+func TestTemporalClientLogger(t *testing.T) {
+	tests := []struct {
+		name    string
+		emit    func(logger temporallog.Logger)
+		message string
+		want    map[string]any
+	}{
+		{
+			name:    "AddsTimestampFromGlobalLogger",
+			emit:    func(l temporallog.Logger) { l.Info("plain line") },
+			message: "plain line",
+		},
+		{
+			name:    "MapsKeyvalsToFields",
+			emit:    func(l temporallog.Logger) { l.Info("tagged line", "SiteID", "site-1") },
+			message: "tagged line",
+			want:    map[string]any{"SiteID": "site-1"},
+		},
+		{
+			name:    "ToleratesOddKeyvals",
+			emit:    func(l temporallog.Logger) { l.Info("odd line", "SiteID") },
+			message: "odd line",
+			want:    map[string]any{"SiteID": nil},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := captureGlobalLogger(t)
+
+			tt.emit(TemporalClientLogger())
+
+			fields := findLine(t, buf, tt.message)
+			assert.Contains(t, fields, zerolog.TimestampFieldName,
+				"Temporal logs must carry the same timestamp as the rest of the service")
+			for key, value := range tt.want {
+				assert.Equal(t, value, fields[key])
+			}
+		})
+	}
+}
+
+func TestTemporalWorkflowLogger(t *testing.T) {
+	tests := []struct {
+		name       string
+		wf         func(ctx workflow.Context) error
+		message    string
+		wantFields map[string]any
+	}{
+		{
+			name: "TagsWorkflowIdentity",
+			wf: func(ctx workflow.Context) error {
+				logger := TemporalWorkflowLogger(ctx)
+				logger.Info().Msg("identity line")
+				return nil
+			},
+			message: "identity line",
+		},
+		{
+			name: "PreservesCallerFields",
+			wf: func(ctx workflow.Context) error {
+				logger := TemporalWorkflowLogger(ctx).With().Str("SiteID", "site-1").Logger()
+				logger.Info().Msg("caller line")
+				return nil
+			},
+			message:    "caller line",
+			wantFields: map[string]any{"SiteID": "site-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := captureGlobalLogger(t)
+
+			suite := &testsuite.WorkflowTestSuite{}
+			suite.SetLogger(TemporalClientLogger())
+			env := suite.NewTestWorkflowEnvironment()
+			env.RegisterWorkflowWithOptions(tt.wf, workflow.RegisterOptions{Name: "TestWorkflow"})
+			env.ExecuteWorkflow("TestWorkflow")
+
+			require.True(t, env.IsWorkflowCompleted())
+			require.NoError(t, env.GetWorkflowError())
+
+			fields := findLine(t, buf, tt.message)
+			assert.Equal(t, "TestWorkflow", fields[fieldWorkflow])
+			assert.NotEmpty(t, fields[fieldWorkflowID])
+			assert.NotEmpty(t, fields[fieldRunID])
+			for key, value := range tt.wantFields {
+				assert.Equal(t, value, fields[key])
+			}
+		})
+	}
+}
+
+func TestTemporalActivityLogger(t *testing.T) {
+	tests := []struct {
+		name        string
+		inActivity  bool
+		message     string
+		wantTagged  bool
+		wantFields  map[string]any
+		wantMissing []string
+	}{
+		{
+			name:       "TagsActivityIdentity",
+			inActivity: true,
+			message:    "activity line",
+			wantTagged: true,
+			wantFields: map[string]any{fieldActivity: "TestActivity", fieldAttempt: float64(1)},
+		},
+		{
+			// Activity methods are unit tested by calling them directly, where
+			// activity.GetInfo would panic.
+			name:        "UntaggedOutsideActivityContext",
+			inActivity:  false,
+			message:     "direct call line",
+			wantMissing: []string{fieldActivity, fieldActivityID, fieldAttempt},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := captureGlobalLogger(t)
+			message := tt.message
+
+			act := func(ctx context.Context) error {
+				logger := TemporalActivityLogger(ctx)
+				logger.Info().Msg(message)
+				return nil
+			}
+
+			if tt.inActivity {
+				suite := &testsuite.WorkflowTestSuite{}
+				suite.SetLogger(TemporalClientLogger())
+				env := suite.NewTestActivityEnvironment()
+				env.RegisterActivityWithOptions(act, activity.RegisterOptions{Name: "TestActivity"})
+
+				_, err := env.ExecuteActivity("TestActivity")
+				require.NoError(t, err)
+			} else {
+				require.NoError(t, act(context.Background()))
+			}
+
+			fields := findLine(t, buf, tt.message)
+			for key, value := range tt.wantFields {
+				assert.Equal(t, value, fields[key])
+			}
+			for _, key := range tt.wantMissing {
+				assert.NotContains(t, fields, key)
+			}
+			if tt.wantTagged {
+				assert.NotEmpty(t, fields[fieldWorkflowID])
+				assert.NotEmpty(t, fields[fieldRunID])
+			}
+		})
+	}
+}

--- a/rest-api/workflow/cmd/workflow/main.go
+++ b/rest-api/workflow/cmd/workflow/main.go
@@ -14,8 +14,6 @@ import (
 	sentryZerolog "github.com/getsentry/sentry-go/zerolog"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	zlogadapter "logur.dev/adapter/zerolog"
-	"logur.dev/logur"
 
 	tsdkClient "go.temporal.io/sdk/client"
 	tsdkConverter "go.temporal.io/sdk/converter"
@@ -29,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	clog "github.com/NVIDIA/infra-controller/rest-api/common/pkg/log"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/internal/config"
@@ -179,7 +178,10 @@ func main() {
 		}
 	}
 
-	tLogger := logur.LoggerToKV(zlogadapter.New(zerolog.New(os.Stderr)))
+	// Must stay below the Sentry setup above. The logger is a snapshot of the
+	// global zerolog logger, so building it any earlier leaves the Sentry writer
+	// off every workflow and activity log line.
+	tLogger := clog.TemporalClientLogger()
 	var tc tsdkClient.Client
 
 	tcfg, err := cfg.GetTemporalConfig()


### PR DESCRIPTION
Currently we're using a basic zerolog logger for all Temporal workflow and activities which doesn't support Temporal replay and manually attaches workflow/activity information to logger that can be error prone. This PR adds a common module for fetching these loggers.

## Type of Change
- [x] **Change** - Changes in existing functionality

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated