### PR TITLE
feat(web): make admin ui logs link configurable for different logging backends

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -117,6 +117,7 @@ applicable.
 | `initial_objects_file` | `Option<PathBuf>` | — | `server` | Path to the `initial_objects.toml` file for seeding the database. |
 | `enable_admin_ui` | `bool` | `true` | `server` | Whether to serve the admin web UI (the HTML pages under `/admin`). Set to `false` to run only the gRPC API; the gRPC service is unaffected either way. |
 | `web_ui_sidebar_tools` | `Vec<ToolLink>` | `[]` | `server` | External tool links surfaced in the admin web UI's "Tools" sidebar. Each entry's `name` must be unique; the section is hidden when the list is empty. |
+| `web_ui_logs_link_template` | `String` | `""` | `server` | URL template for the "Logs" link on machine and endpoint detail pages. The placeholder `{search}` is replaced with the machine ID or BMC IP. When empty, the link is hidden. |
 | `log_history` | `LogHistoryConfig` | *(default)* | `integrations` | In-memory log history for the admin web live log viewer at `/admin/logs` (see [LogHistoryConfig](#loghistoryconfig)). |
 | `tracing` | `TracingConfig` | *(default)* | `integrations` | OTLP trace export settings (see [TracingConfig](#tracingconfig)). |
 | `secrets` | `Option<SecretsConfig>` | — | `security` | Secrets backend configuration. When present, the credential reader chain and write target are operator-configured (see [SecretsConfig](#secretsconfig)). |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -803,6 +803,12 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub web_ui_sidebar_tools: Vec<ToolLink>,
 
+    /// URL template for the "Logs" link on machine and endpoint detail
+    /// pages. The placeholder `{search}` is replaced with the machine ID
+    /// or BMC IP. When empty, the Logs link is hidden.
+    #[serde(default)]
+    pub web_ui_logs_link_template: String,
+
     /// In-memory log history for the admin web live log viewer
     /// (`/admin/logs`): how much recent log data to keep for
     /// replay-on-connect and scrollback, and how many lines to send

--- a/crates/api-core/src/cfg/load.rs
+++ b/crates/api-core/src/cfg/load.rs
@@ -167,6 +167,10 @@ pub fn parse_carbide_config(
     // Publish the site name the same way, for the admin-UI sidebar header.
     crate::init_site_name(config.sitename.clone());
 
+    // Publish the logs link URL template for the "Logs" link on machine and
+    // endpoint detail pages.
+    crate::init_logs_link_template(config.web_ui_logs_link_template.clone());
+
     // Publish the deployment-wide host naming policy so the DB layer can read it
     // wherever an interface is [re]named (same way we do it w/ `init_tools` above).
     db::host_naming::configure(config.host_naming_strategy);

--- a/crates/api-core/src/lib.rs
+++ b/crates/api-core/src/lib.rs
@@ -143,3 +143,23 @@ pub(crate) fn init_site_name(site_name: Option<String>) {
 pub fn configured_site_name() -> Option<&'static str> {
     SITE_NAME.get().and_then(|name| name.as_deref())
 }
+
+/// Process-global URL template for the "Logs" link on machine and endpoint
+/// detail pages
+static LOGS_LINK_TEMPLATE: OnceLock<String> = OnceLock::new();
+
+/// Initialize the global logs link template. Call once during startup before
+/// serving any web requests. Subsequent calls are ignored.
+pub(crate) fn init_logs_link_template(template: String) {
+    let _ = LOGS_LINK_TEMPLATE.set(template);
+}
+
+/// The configured URL template for the "Logs" link on machine and endpoint
+/// detail pages. The placeholder `{search}` should be replaced with the
+/// machine ID or BMC IP by the caller.
+///
+/// Empty when not configured or when [`init_logs_link_template`] has not been
+/// called (e.g. unit tests).
+pub fn configured_logs_link_template() -> &'static str {
+    LOGS_LINK_TEMPLATE.get().map(String::as_str).unwrap_or("")
+}

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -143,6 +143,7 @@ pub fn get() -> CarbideConfig {
         default_tenant_routing_profile_type: "EXTERNAL".to_string(),
         enable_admin_ui: true,
         web_ui_sidebar_tools: vec![],
+        web_ui_logs_link_template: String::new(),
         log_history: Default::default(),
         observability: Default::default(),
         bgp_leaf_session_password: None,

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -72,6 +72,13 @@ trait Base {
     fn site_name() -> &'static str {
         carbide_api_core::configured_site_name().unwrap_or("local")
     }
+
+    /// URL template for the "Logs" link on machine and endpoint detail pages.
+    /// The placeholder `{search}` is replaced with the machine ID or BMC IP
+    /// by JavaScript. Empty when not configured.
+    fn logs_link_template() -> &'static str {
+        carbide_api_core::configured_logs_link_template()
+    }
 }
 
 /// Reusable template for rendering metadata (name, description, labels, version)

--- a/crates/api-web/templates/base.html
+++ b/crates/api-web/templates/base.html
@@ -259,7 +259,7 @@
 			// Build logs URL for a given search term (machine ID or BMC IP).
 			// Returns the URL with {search} replaced, or null if not configured.
 			function buildLogsUrl(searchTerm) {
-				const template = "{{ Self::logs_link_template() }}";
+				const template = {{ Self::logs_link_template()|json|safe }};
 				if (!template) return null;
 				return template.replace('{search}', encodeURIComponent(searchTerm));
 			}

--- a/crates/api-web/templates/base.html
+++ b/crates/api-web/templates/base.html
@@ -245,15 +245,6 @@
 				});
 			}
 
-
-			// Extract site name from URL (e.g., "dev3" from "api-dev3.frg.nvidia.com")
-			// If URL doesn't match the pattern, returns defaultSiteName (defaults to "dev3")
-			function getSiteName(defaultSiteName = "dev3") {
-				const url = window.location.href;
-				const match = url.match(/https?:\/\/api-([^.]+)\.frg\.nvidia\.com/);
-				return match ? match[1] : defaultSiteName;
-			}
-
 			function create_el(type, attributes, htmlAttributes) {
 				const el = document.createElement(type);
 				Object.assign(el, attributes);
@@ -265,31 +256,12 @@
 				return el;
 			}
 
-			// Build Grafana logs URL for a given search term (machine ID or BMC IP)
-			function buildGrafanaLogsUrl(searchTerm) {
-				const siteName = getSiteName();
-				const grafanaBaseUrl = 'https://grafana-' + siteName + '.frg.nvidia.com';
-				const query = '{k8s_container_name="carbide-api"} |= `' + searchTerm + '` != `SPAN`';
-				const panesJson = {
-					"KLl": {
-						"datasource": "P8E80F9AEF21F6940",
-						"queries": [{
-							"refId": "A",
-							"expr": query,
-							"queryType": "range",
-							"datasource": {
-								"type": "loki",
-								"uid": "P8E80F9AEF21F6940"
-							},
-							"editorMode": "builder"
-						}],
-						"range": {
-							"from": "now-6h",
-							"to": "now"
-						}
-					}
-				};
-				return grafanaBaseUrl + '/explore?panes=' + encodeURIComponent(JSON.stringify(panesJson)) + '&schemaVersion=1&orgId=1';
+			// Build logs URL for a given search term (machine ID or BMC IP).
+			// Returns the URL with {search} replaced, or null if not configured.
+			function buildLogsUrl(searchTerm) {
+				const template = "{{ Self::logs_link_template() }}";
+				if (!template) return null;
+				return template.replace('{search}', encodeURIComponent(searchTerm));
 			}
 
 			// "Show" pages have a JSON link, fill in its target

--- a/crates/api-web/templates/explored_endpoint_detail.html
+++ b/crates/api-web/templates/explored_endpoint_detail.html
@@ -7,7 +7,9 @@
     {% if !has_machine %}
     <a id="delete-link" href="#" onclick="if(confirm('Are you sure you want to delete this endpoint?')) { document.getElementById('delete-form').submit(); } return false;">Delete</a>
     {% endif %}
+    {% if !Self::logs_link_template().is_empty() %}
     <a id="logs-link" href="" target="_blank">Logs</a>
+    {% endif %}
     <a id="json-link" href="">JSON</a>
     <a id="refresh-endpoint" href="#" title="Explore this endpoint's report immediately. If you stay on this page, you will see the status message and spinner until the exploration finishes." aria-label="Explore endpoint report">
         <span>Explore</span>
@@ -507,8 +509,12 @@
 <script>
 
 document.addEventListener('DOMContentLoaded', function() {
-	const bmcIp = "{{ endpoint.address }}";
-	document.getElementById('logs-link').href = buildGrafanaLogsUrl(bmcIp);
+	// Set up Logs link (if configured)
+	const logsLink = document.getElementById('logs-link');
+	if (logsLink) {
+		const bmcIp = "{{ endpoint.address }}";
+		logsLink.href = buildLogsUrl(bmcIp);
+	}
 
 	var refreshToast = sessionStorage.getItem('refreshToast');
 	if (refreshToast) {

--- a/crates/api-web/templates/explored_endpoint_detail.html
+++ b/crates/api-web/templates/explored_endpoint_detail.html
@@ -509,10 +509,11 @@
 <script>
 
 document.addEventListener('DOMContentLoaded', function() {
+	const bmcIp = "{{ endpoint.address }}";
+
 	// Set up Logs link (if configured)
 	const logsLink = document.getElementById('logs-link');
 	if (logsLink) {
-		const bmcIp = "{{ endpoint.address }}";
 		logsLink.href = buildLogsUrl(bmcIp);
 	}
 

--- a/crates/api-web/templates/machine_detail.html
+++ b/crates/api-web/templates/machine_detail.html
@@ -4,7 +4,9 @@
 
 {% block content %}
 <div id="json">
+	{% if !Self::logs_link_template().is_empty() %}
 	<a id="logs-link" href="" target="_blank">Logs</a>
+	{% endif %}
 	<a id="json-link" href="">JSON</a>
 </div>
 <h1>{{ machine_type }} {{ id }}</h1>
@@ -633,9 +635,12 @@ Missing BMC Data
 		let quarantine_form = document.getElementById("quarantine_action");
 		quarantine_form.addEventListener("submit", are_you_sure_quarantine);
 
-		// Set up Logs link
-		const machineId = "{{ id }}";
-		document.getElementById('logs-link').href = buildGrafanaLogsUrl(machineId);
+		// Set up Logs link (if configured)
+		const logsLink = document.getElementById('logs-link');
+		if (logsLink) {
+			const machineId = "{{ id }}";
+			logsLink.href = buildLogsUrl(machineId);
+		}
 	});
 </script>
 

--- a/crates/api-web/templates/machine_detail.html
+++ b/crates/api-web/templates/machine_detail.html
@@ -630,10 +630,15 @@ Missing BMC Data
 	}
 
 	document.addEventListener("DOMContentLoaded", function(event){
-		let maintenance_form = document.getElementById("maintenance_action");
-		maintenance_form.addEventListener("submit", are_you_sure_maintenance);
-		let quarantine_form = document.getElementById("quarantine_action");
-		quarantine_form.addEventListener("submit", are_you_sure_quarantine);
+		// Set up maintenance/quarantine form handlers (Host machines only)
+		const maintenance_form = document.getElementById("maintenance_action");
+		if (maintenance_form) {
+			maintenance_form.addEventListener("submit", are_you_sure_maintenance);
+		}
+		const quarantine_form = document.getElementById("quarantine_action");
+		if (quarantine_form) {
+			quarantine_form.addEventListener("submit", are_you_sure_quarantine);
+		}
 
 		// Set up Logs link (if configured)
 		const logsLink = document.getElementById('logs-link');

--- a/deploy/files/nico-api/nico-api-site-config.toml
+++ b/deploy/files/nico-api/nico-api-site-config.toml
@@ -53,6 +53,16 @@ deny_prefixes = [
 # display_name = "Argo CD"
 # url = "https://argocd-ENVIORNMENT_NAME.example.com"
 
+# URL template for the "Logs" link on machine and endpoint detail pages.
+# The placeholder {search} is replaced with the machine ID or BMC IP.
+# Omit or leave empty to hide the Logs link.
+#
+# Example for Grafana Loki:
+# web_ui_logs_link_template = "https://grafana.example.com/explore?panes={\"a\":{\"datasource\":\"loki\",\"queries\":[{\"expr\":\"{k8s_container_name=\\\"nico-api\\\"} |= `{search}`\",\"queryType\":\"range\"}],\"range\":{\"from\":\"now-6h\",\"to\":\"now\"}}}&schemaVersion=1&orgId=1"
+#
+# Example for VictoriaLogs:
+# web_ui_logs_link_template = "https://victorialogs.example.com/select/logsql/query?query={_container_name=\"nico-api\"} AND {search}&time=6h"
+
 [site_explorer]
 run_interval = "30s"
 


### PR DESCRIPTION
The admin web UI's "Logs" link on machine and endpoint detail pages was hardcoded to Grafana Loki setup, making it non-functional for OSS users and customers who use different logging backends (VictoriaLogs, Datadog, Splunk, etc.).

This PR makes the Logs link configurable via a new `web_ui_logs_link_template` setting. Operators provide a URL template with a `{search}` placeholder that gets replaced with the machine ID or BMC IP. When not configured, the link is hidden.

Also fixes a JavaScript error on DPU machine pages where the maintenance/quarantine forms don't exist, which was preventing the Logs link from being set up

## Related issues
- Closes #4954

## Type of Change
- [x] **Add** - New feature or capability
- [x] **Fix** - Bug fixes

## Breaking Changes
- [x] **This PR contains breaking changes**
The "Logs" link on machine and endpoint detail pages is no longer shown by default. Operators must configure `web_ui_logs_link_template` in site config to enable it

## Testing
- [x] Manual testing performed
Verified on local deployment:
- Host machine page: Logs link works
- DPU machine page: Logs link works
- BMC/Endpoint page: Logs link works
- Without config: Logs link hidden

## Additional Notes
**Example site config:**
```toml
nico-api-site-config.toml:
----
attestation_enabled = false
dpu_ipmi_tool_impl = "test"
initial_domain_name = "local.nico"
initial_dpu_agent_upgrade_policy = "off"
max_database_connections = 64

# URL template for "Logs" link on machine/endpoint detail pages.
# {search} is replaced with machine ID or BMC IP. Omit to hide link.
web_ui_logs_link_template = "https://grafana.example.com/explore?{search}"

[pools.lo-ip]
...
```