### PR TITLE
feat(flow): add data encryption key

### DIFF
--- a/helm/charts/nico-flow/templates/data-encryption-secret.yaml
+++ b/helm/charts/nico-flow/templates/data-encryption-secret.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- $encryptionKey := .Values.dataEncryption.key.value }}
+{{- if not $encryptionKey }}
+  {{- $existingSecret := lookup "v1" "Secret" (include "nico-flow.namespace" .) "flow-data-encryption-key" }}
+  {{- $existingKey := dig "data" "flow-data-encryption-key" "" $existingSecret }}
+  {{- if $existingKey }}
+    {{- $encryptionKey = $existingKey | b64dec }}
+  {{- else }}
+    {{- $encryptionKey = randBytes 32 }}
+  {{- end }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flow-data-encryption-key
+  namespace: {{ include "nico-flow.namespace" . }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "nico-flow.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  flow-data-encryption-key: {{ $encryptionKey | quote }}

--- a/helm/charts/nico-flow/templates/data-encryption-secret.yaml
+++ b/helm/charts/nico-flow/templates/data-encryption-secret.yaml
@@ -1,16 +1,28 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- $encryptionKey := .Values.dataEncryption.key.value }}
-{{- if not $encryptionKey }}
-  {{- $existingSecret := lookup "v1" "Secret" (include "nico-flow.namespace" .) "flow-data-encryption-key" }}
-  {{- $existingKey := dig "data" "flow-data-encryption-key" "" $existingSecret }}
-  {{- if $existingKey }}
-    {{- $encryptionKey = $existingKey | b64dec }}
-  {{- else }}
-    {{- $encryptionKey = randBytes 32 }}
-  {{- end }}
+{{- $configuredKey := trim .Values.dataEncryption.key.value }}
+{{- $externalSecret := trim .Values.dataEncryption.key.existingSecret }}
+{{- if and $externalSecret $configuredKey }}
+  {{- fail "dataEncryption.key.existingSecret and dataEncryption.key.value are mutually exclusive" }}
 {{- end }}
+{{- if not $externalSecret }}
+{{- $existingSecret := lookup "v1" "Secret" (include "nico-flow.namespace" .) "flow-data-encryption-key" }}
+{{- $existingKeyData := dig "data" "flow-data-encryption-key" "" $existingSecret }}
+{{- $existingKey := "" }}
+{{- if $existingKeyData }}
+  {{- $existingKey = trim ($existingKeyData | b64dec) }}
+{{- end }}
+{{- if and $configuredKey (not (regexMatch "^[A-Za-z0-9+/]{43}=$" $configuredKey)) }}
+  {{- fail "dataEncryption.key.value must be a base64 encoding of exactly 32 bytes" }}
+{{- end }}
+{{- if and $existingKey (not (regexMatch "^[A-Za-z0-9+/]{43}=$" $existingKey)) }}
+  {{- fail "existing flow-data-encryption-key must be a base64 encoding of exactly 32 bytes" }}
+{{- end }}
+{{- if and $configuredKey $existingKey (ne $configuredKey $existingKey) }}
+  {{- fail "dataEncryption.key.value does not match the existing flow-data-encryption-key; use an explicit rotation workflow to change keys" }}
+{{- end }}
+{{- $encryptionKey := coalesce $configuredKey $existingKey (randBytes 32) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,3 +35,4 @@ metadata:
 type: Opaque
 stringData:
   flow-data-encryption-key: {{ $encryptionKey | quote }}
+{{- end }}

--- a/helm/charts/nico-flow/templates/deployment.yaml
+++ b/helm/charts/nico-flow/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: {{ .Values.temporal.enableTls | quote }}
             - name: TEMPORAL_SERVER_NAME
               value: {{ .Values.temporal.serverName | quote }}
+            - name: FLOW_DATA_ENCRYPTION_KEY_PATH
+              value: /var/run/secrets/flow-data-encryption/encryption-key
             - name: PSM_API_URL
               value: {{ printf "psm.%s.svc.cluster.local:%d" (include "nico-flow.namespace" .) (int .Values.ports.psm) | quote }}
             - name: NSM_API_URL
@@ -95,6 +97,9 @@ spec:
             {{- end }}
             - name: temporal-client-certs
               mountPath: {{ .Values.temporal.certPath }}
+              readOnly: true
+            - name: data-encryption-key
+              mountPath: /var/run/secrets/flow-data-encryption
               readOnly: true
         ## -------------------------------------------------------------
         ## psm — power-shelf manager (gRPC 50052)
@@ -210,6 +215,12 @@ spec:
         - name: temporal-client-certs
           secret:
             secretName: {{ .Values.temporalCert.secretName }}
+        - name: data-encryption-key
+          secret:
+            secretName: flow-data-encryption-key
+            items:
+              - key: flow-data-encryption-key
+                path: encryption-key
         - name: psm-firmware
           {{- toYaml .Values.firmware.psm.volume | nindent 10 }}
         - name: nsm-scratch

--- a/helm/charts/nico-flow/templates/deployment.yaml
+++ b/helm/charts/nico-flow/templates/deployment.yaml
@@ -217,7 +217,7 @@ spec:
             secretName: {{ .Values.temporalCert.secretName }}
         - name: data-encryption-key
           secret:
-            secretName: flow-data-encryption-key
+            secretName: {{ default "flow-data-encryption-key" (trim .Values.dataEncryption.key.existingSecret) | quote }}
             items:
               - key: flow-data-encryption-key
                 path: encryption-key

--- a/helm/charts/nico-flow/tests/data_encryption_deployment_test.yaml
+++ b/helm/charts/nico-flow/tests/data_encryption_deployment_test.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: Flow data encryption key mount
+templates:
+  - deployment.yaml
+tests:
+  - it: mounts the key read-only in the Flow container only
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FLOW_DATA_ENCRYPTION_KEY_PATH
+            value: /var/run/secrets/flow-data-encryption/encryption-key
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data-encryption-key
+            mountPath: /var/run/secrets/flow-data-encryption
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: data-encryption-key
+      - notContains:
+          path: spec.template.spec.containers[2].volumeMounts
+          content:
+            name: data-encryption-key
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data-encryption-key
+            secret:
+              secretName: flow-data-encryption-key
+              items:
+                - key: flow-data-encryption-key
+                  path: encryption-key

--- a/helm/charts/nico-flow/tests/data_encryption_deployment_test.yaml
+++ b/helm/charts/nico-flow/tests/data_encryption_deployment_test.yaml
@@ -35,3 +35,17 @@ tests:
               items:
                 - key: flow-data-encryption-key
                   path: encryption-key
+
+  - it: mounts an externally managed Secret
+    set:
+      dataEncryption.key.existingSecret: externally-managed-flow-key
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data-encryption-key
+            secret:
+              secretName: externally-managed-flow-key
+              items:
+                - key: flow-data-encryption-key
+                  path: encryption-key

--- a/helm/charts/nico-flow/tests/data_encryption_secret_test.yaml
+++ b/helm/charts/nico-flow/tests/data_encryption_secret_test.yaml
@@ -19,11 +19,33 @@ tests:
 
   - it: uses an explicitly configured key
     set:
-      dataEncryption.key.value: configured-key
+      dataEncryption.key.value: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
     asserts:
       - equal:
           path: stringData.flow-data-encryption-key
-          value: configured-key
+          value: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+
+  - it: rejects an invalid explicitly configured key
+    set:
+      dataEncryption.key.value: weak-key
+    asserts:
+      - failedTemplate:
+          errorMessage: dataEncryption.key.value must be a base64 encoding of exactly 32 bytes
+
+  - it: leaves an externally managed key out of the rendered manifests
+    set:
+      dataEncryption.key.existingSecret: externally-managed-flow-key
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rejects mutually exclusive key sources
+    set:
+      dataEncryption.key.existingSecret: externally-managed-flow-key
+      dataEncryption.key.value: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+    asserts:
+      - failedTemplate:
+          errorMessage: dataEncryption.key.existingSecret and dataEncryption.key.value are mutually exclusive
 
   - it: reuses the existing key on upgrade
     release:
@@ -43,11 +65,36 @@ tests:
             name: flow-data-encryption-key
             namespace: flow
           data:
-            flow-data-encryption-key: ZXhpc3Rpbmcta2V5
+            flow-data-encryption-key: TURFeU16UTFOamM0T1dGaVkyUmxaakF4TWpNME5UWTNPRGxoWW1Oa1pXWT0=
     asserts:
       - equal:
           path: stringData.flow-data-encryption-key
-          value: existing-key
+          value: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+
+  - it: rejects a configured key that differs from the existing key
+    release:
+      namespace: flow
+      upgrade: true
+    set:
+      dataEncryption.key.value: YWJjZGVmMDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODk=
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: flow-data-encryption-key
+            namespace: flow
+          data:
+            flow-data-encryption-key: TURFeU16UTFOamM0T1dGaVkyUmxaakF4TWpNME5UWTNPRGxoWW1Oa1pXWT0=
+    asserts:
+      - failedTemplate:
+          errorMessage: dataEncryption.key.value does not match the existing flow-data-encryption-key; use an explicit rotation workflow to change keys
 
   - it: generates a key when upgrading a release that does not have one
     release:

--- a/helm/charts/nico-flow/tests/data_encryption_secret_test.yaml
+++ b/helm/charts/nico-flow/tests/data_encryption_secret_test.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: Flow data encryption key
+templates:
+  - data-encryption-secret.yaml
+tests:
+  - it: generates the key from 32 random bytes on first install
+    asserts:
+      - equal:
+          path: metadata.name
+          value: flow-data-encryption-key
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - matchRegex:
+          path: stringData.flow-data-encryption-key
+          pattern: ^[A-Za-z0-9+/]{43}=$
+
+  - it: uses an explicitly configured key
+    set:
+      dataEncryption.key.value: configured-key
+    asserts:
+      - equal:
+          path: stringData.flow-data-encryption-key
+          value: configured-key
+
+  - it: reuses the existing key on upgrade
+    release:
+      namespace: flow
+      upgrade: true
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: flow-data-encryption-key
+            namespace: flow
+          data:
+            flow-data-encryption-key: ZXhpc3Rpbmcta2V5
+    asserts:
+      - equal:
+          path: stringData.flow-data-encryption-key
+          value: existing-key
+
+  - it: generates a key when upgrading a release that does not have one
+    release:
+      namespace: flow
+      upgrade: true
+    asserts:
+      - matchRegex:
+          path: stringData.flow-data-encryption-key
+          pattern: ^[A-Za-z0-9+/]{43}=$

--- a/helm/charts/nico-flow/values.yaml
+++ b/helm/charts/nico-flow/values.yaml
@@ -167,6 +167,18 @@ temporal:
   serverName: interservice.server.temporal.local
   certPath: /var/run/secrets/temporal-client-certs
 
+## Encryption key used to keep sensitive Flow data out of plaintext database
+## records and Temporal payload history. When value is empty (the default), the
+## chart reuses the existing flow-data-encryption-key
+## Secret. If the Secret does not exist, the chart generates a key, including
+## when upgrading a release installed before this setting was introduced. An
+## explicit value takes precedence. Helm retains the Secret when the release is
+## uninstalled. Changing the value is not a supported rotation mechanism:
+## data encrypted with the previous key becomes unreadable.
+dataEncryption:
+  key:
+    value: ""
+
 ## Vault for PSM/NSM dynamic secrets.
 vault:
   address: https://vault.vault.svc.cluster.local:8200

--- a/helm/charts/nico-flow/values.yaml
+++ b/helm/charts/nico-flow/values.yaml
@@ -168,15 +168,19 @@ temporal:
   certPath: /var/run/secrets/temporal-client-certs
 
 ## Encryption key used to keep sensitive Flow data out of plaintext database
-## records and Temporal payload history. When value is empty (the default), the
-## chart reuses the existing flow-data-encryption-key
-## Secret. If the Secret does not exist, the chart generates a key, including
-## when upgrading a release installed before this setting was introduced. An
-## explicit value takes precedence. Helm retains the Secret when the release is
-## uninstalled. Changing the value is not a supported rotation mechanism:
-## data encrypted with the previous key becomes unreadable.
+## records and Temporal payload history. By default, the chart reuses the
+## existing flow-data-encryption-key Secret or generates a key from 32 random
+## bytes if the Secret does not exist. Helm retains a chart-managed Secret when
+## the release is uninstalled. GitOps deployments that render charts without
+## cluster access must provision a Secret separately and set existingSecret to
+## its name so each render is deterministic. The Secret must contain a
+## flow-data-encryption-key entry whose value is a base64 encoding of exactly 32
+## random bytes. value accepts the same format and is mutually exclusive with
+## existingSecret. A configured value must match a chart-managed Secret that
+## already exists. Key rotation is not supported.
 dataEncryption:
   key:
+    existingSecret: ""
     value: ""
 
 ## Vault for PSM/NSM dynamic secrets.

--- a/rest-api/flow/internal/secret/cipher.go
+++ b/rest-api/flow/internal/secret/cipher.go
@@ -9,7 +9,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -22,15 +22,22 @@ type Cipher struct {
 	aead cipher.AEAD
 }
 
-// NewCipher derives an AES-256 key from key and constructs a Cipher.
+// NewCipher decodes a base64-encoded 256-bit key and constructs a Cipher.
 func NewCipher(key string) (*Cipher, error) {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return nil, errors.New("data encryption key is empty")
 	}
 
-	digest := sha256.Sum256([]byte(key))
-	block, err := aes.NewCipher(digest[:])
+	keyBytes, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return nil, fmt.Errorf("data encryption key must be base64 encoded: %w", err)
+	}
+	if len(keyBytes) != 32 {
+		return nil, errors.New("data encryption key must decode to exactly 32 bytes")
+	}
+
+	block, err := aes.NewCipher(keyBytes)
 	if err != nil {
 		return nil, fmt.Errorf("create data encryption cipher: %w", err)
 	}
@@ -54,26 +61,38 @@ func NewCipherFromFile(path string) (*Cipher, error) {
 	return NewCipher(string(data))
 }
 
-// Encrypt returns nonce-prefixed AES-GCM ciphertext.
-func (c *Cipher) Encrypt(plaintext []byte) ([]byte, error) {
+// Encrypt returns nonce-prefixed AES-GCM ciphertext bound to additionalData.
+// Callers must use stable, record-specific data and limit each key to
+// substantially fewer than 2^32 encryptions to keep random-nonce collision risk
+// negligible.
+func (c *Cipher) Encrypt(plaintext, additionalData []byte) ([]byte, error) {
+	if len(additionalData) == 0 {
+		return nil, errors.New("additional authenticated data is empty")
+	}
+
 	nonce := make([]byte, c.aead.NonceSize())
 	_, err := io.ReadFull(rand.Reader, nonce)
 	if err != nil {
 		return nil, fmt.Errorf("generate data encryption nonce: %w", err)
 	}
 
-	return c.aead.Seal(nonce, nonce, plaintext, nil), nil
+	return c.aead.Seal(nonce, nonce, plaintext, additionalData), nil
 }
 
-// Decrypt opens nonce-prefixed AES-GCM ciphertext.
-func (c *Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
+// Decrypt opens nonce-prefixed AES-GCM ciphertext using the same additionalData
+// supplied during encryption.
+func (c *Cipher) Decrypt(ciphertext, additionalData []byte) ([]byte, error) {
+	if len(additionalData) == 0 {
+		return nil, errors.New("additional authenticated data is empty")
+	}
+
 	nonceSize := c.aead.NonceSize()
 	if len(ciphertext) < nonceSize {
 		return nil, errors.New("encrypted data is too short")
 	}
 
 	nonce := ciphertext[:nonceSize]
-	plaintext, err := c.aead.Open(nil, nonce, ciphertext[nonceSize:], nil)
+	plaintext, err := c.aead.Open(nil, nonce, ciphertext[nonceSize:], additionalData)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt data: %w", err)
 	}

--- a/rest-api/flow/internal/secret/cipher.go
+++ b/rest-api/flow/internal/secret/cipher.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package secret encrypts sensitive Flow data before it is persisted or sent
+// through Temporal.
+package secret
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Cipher encrypts and decrypts sensitive data using AES-GCM.
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+// NewCipher derives an AES-256 key from key and constructs a Cipher.
+func NewCipher(key string) (*Cipher, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, errors.New("data encryption key is empty")
+	}
+
+	digest := sha256.Sum256([]byte(key))
+	block, err := aes.NewCipher(digest[:])
+	if err != nil {
+		return nil, fmt.Errorf("create data encryption cipher: %w", err)
+	}
+
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create data encryption GCM: %w", err)
+	}
+
+	return &Cipher{aead: aead}, nil
+}
+
+// NewCipherFromFile reads and trims the key at path before constructing a
+// Cipher. Kubernetes Secret volume files may include a trailing newline.
+func NewCipherFromFile(path string) (*Cipher, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read data encryption key %q: %w", path, err)
+	}
+
+	return NewCipher(string(data))
+}
+
+// Encrypt returns nonce-prefixed AES-GCM ciphertext.
+func (c *Cipher) Encrypt(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	_, err := io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return nil, fmt.Errorf("generate data encryption nonce: %w", err)
+	}
+
+	return c.aead.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Decrypt opens nonce-prefixed AES-GCM ciphertext.
+func (c *Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
+	nonceSize := c.aead.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, errors.New("encrypted data is too short")
+	}
+
+	nonce := ciphertext[:nonceSize]
+	plaintext, err := c.aead.Open(nil, nonce, ciphertext[nonceSize:], nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt data: %w", err)
+	}
+
+	return plaintext, nil
+}

--- a/rest-api/flow/internal/secret/cipher_test.go
+++ b/rest-api/flow/internal/secret/cipher_test.go
@@ -4,6 +4,7 @@
 package secret
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,22 +12,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testKey      = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+	otherTestKey = "YWJjZGVmMDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODk="
+)
+
 func TestNewCipher(t *testing.T) {
 	tests := []struct {
-		name    string
-		key     string
-		wantErr string
+		name        string
+		key         string
+		wantErrPart string
 	}{
-		{name: "valid key", key: "test-key"},
-		{name: "empty key", wantErr: "data encryption key is empty"},
-		{name: "whitespace key", key: " \n", wantErr: "data encryption key is empty"},
+		{name: "valid key", key: testKey},
+		{name: "empty key", wantErrPart: "data encryption key is empty"},
+		{name: "whitespace key", key: " \n", wantErrPart: "data encryption key is empty"},
+		{name: "invalid base64", key: "not-base64", wantErrPart: "data encryption key must be base64 encoded"},
+		{name: "short decoded key", key: base64.StdEncoding.EncodeToString([]byte("short")), wantErrPart: "data encryption key must decode to exactly 32 bytes"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cipher, err := NewCipher(tt.key)
-			if tt.wantErr != "" {
-				require.EqualError(t, err, tt.wantErr)
+			if tt.wantErrPart != "" {
+				require.ErrorContains(t, err, tt.wantErrPart)
 				require.Nil(t, cipher)
 				return
 			}
@@ -40,7 +48,7 @@ func TestNewCipher(t *testing.T) {
 func TestNewCipherFromFile(t *testing.T) {
 	dir := t.TempDir()
 	validPath := filepath.Join(dir, "valid-key")
-	require.NoError(t, os.WriteFile(validPath, []byte("test-key\n"), 0o600))
+	require.NoError(t, os.WriteFile(validPath, []byte(testKey+"\n"), 0o600))
 	emptyPath := filepath.Join(dir, "empty-key")
 	require.NoError(t, os.WriteFile(emptyPath, []byte(" \n"), 0o600))
 
@@ -69,45 +77,57 @@ func TestNewCipherFromFile(t *testing.T) {
 	}
 }
 
-func TestCipher_EncryptDecrypt(t *testing.T) {
+func TestCipher_Encrypt(t *testing.T) {
 	plaintext := []byte("download-credential")
-	cipher, err := NewCipher("test-key")
+	additionalData := []byte("firmware-auth:task-123")
+	cipher, err := NewCipher(testKey)
 	require.NoError(t, err)
 
-	first, err := cipher.Encrypt(plaintext)
+	first, err := cipher.Encrypt(plaintext, additionalData)
 	require.NoError(t, err)
-	second, err := cipher.Encrypt(plaintext)
+	second, err := cipher.Encrypt(plaintext, additionalData)
 	require.NoError(t, err)
 	require.NotEqual(t, first, second)
 	require.NotContains(t, string(first), string(plaintext))
 
-	decrypted, err := cipher.Decrypt(first)
+	decrypted, err := cipher.Decrypt(first, additionalData)
 	require.NoError(t, err)
 	require.Equal(t, plaintext, decrypted)
+
+	ciphertext, err := cipher.Encrypt(plaintext, nil)
+	require.EqualError(t, err, "additional authenticated data is empty")
+	require.Nil(t, ciphertext)
 }
 
 func TestCipher_Decrypt(t *testing.T) {
-	cipher, err := NewCipher("test-key")
+	additionalData := []byte("firmware-auth:task-123")
+	cipher, err := NewCipher(testKey)
 	require.NoError(t, err)
-	otherCipher, err := NewCipher("other-key")
+	otherCipher, err := NewCipher(otherTestKey)
 	require.NoError(t, err)
 
-	ciphertext, err := cipher.Encrypt([]byte("download-credential"))
+	ciphertext, err := cipher.Encrypt([]byte("download-credential"), additionalData)
 	require.NoError(t, err)
+	tamperedCiphertext := append([]byte(nil), ciphertext...)
+	tamperedCiphertext[len(tamperedCiphertext)-1] ^= 1
 
 	tests := []struct {
-		name       string
-		cipher     *Cipher
-		ciphertext []byte
-		wantErr    string
+		name           string
+		cipher         *Cipher
+		ciphertext     []byte
+		additionalData []byte
+		wantErr        string
 	}{
-		{name: "wrong key", cipher: otherCipher, ciphertext: ciphertext, wantErr: "decrypt data"},
-		{name: "short ciphertext", cipher: cipher, ciphertext: []byte("short"), wantErr: "encrypted data is too short"},
+		{name: "wrong key", cipher: otherCipher, ciphertext: ciphertext, additionalData: additionalData, wantErr: "decrypt data"},
+		{name: "wrong additional data", cipher: cipher, ciphertext: ciphertext, additionalData: []byte("firmware-auth:task-456"), wantErr: "decrypt data"},
+		{name: "empty additional data", cipher: cipher, ciphertext: ciphertext, wantErr: "additional authenticated data is empty"},
+		{name: "short ciphertext", cipher: cipher, ciphertext: []byte("short"), additionalData: additionalData, wantErr: "encrypted data is too short"},
+		{name: "tampered ciphertext", cipher: cipher, ciphertext: tamperedCiphertext, additionalData: additionalData, wantErr: "decrypt data"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plaintext, err := tt.cipher.Decrypt(tt.ciphertext)
+			plaintext, err := tt.cipher.Decrypt(tt.ciphertext, tt.additionalData)
 			require.ErrorContains(t, err, tt.wantErr)
 			require.Nil(t, plaintext)
 		})

--- a/rest-api/flow/internal/secret/cipher_test.go
+++ b/rest-api/flow/internal/secret/cipher_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCipher(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr string
+	}{
+		{name: "valid key", key: "test-key"},
+		{name: "empty key", wantErr: "data encryption key is empty"},
+		{name: "whitespace key", key: " \n", wantErr: "data encryption key is empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cipher, err := NewCipher(tt.key)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				require.Nil(t, cipher)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cipher)
+		})
+	}
+}
+
+func TestNewCipherFromFile(t *testing.T) {
+	dir := t.TempDir()
+	validPath := filepath.Join(dir, "valid-key")
+	require.NoError(t, os.WriteFile(validPath, []byte("test-key\n"), 0o600))
+	emptyPath := filepath.Join(dir, "empty-key")
+	require.NoError(t, os.WriteFile(emptyPath, []byte(" \n"), 0o600))
+
+	tests := []struct {
+		name        string
+		path        string
+		wantErrPart string
+	}{
+		{name: "valid key", path: validPath},
+		{name: "missing file", path: filepath.Join(dir, "missing-key"), wantErrPart: "read data encryption key"},
+		{name: "empty file", path: emptyPath, wantErrPart: "data encryption key is empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cipher, err := NewCipherFromFile(tt.path)
+			if tt.wantErrPart != "" {
+				require.ErrorContains(t, err, tt.wantErrPart)
+				require.Nil(t, cipher)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cipher)
+		})
+	}
+}
+
+func TestCipher_EncryptDecrypt(t *testing.T) {
+	plaintext := []byte("download-credential")
+	cipher, err := NewCipher("test-key")
+	require.NoError(t, err)
+
+	first, err := cipher.Encrypt(plaintext)
+	require.NoError(t, err)
+	second, err := cipher.Encrypt(plaintext)
+	require.NoError(t, err)
+	require.NotEqual(t, first, second)
+	require.NotContains(t, string(first), string(plaintext))
+
+	decrypted, err := cipher.Decrypt(first)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decrypted)
+}
+
+func TestCipher_Decrypt(t *testing.T) {
+	cipher, err := NewCipher("test-key")
+	require.NoError(t, err)
+	otherCipher, err := NewCipher("other-key")
+	require.NoError(t, err)
+
+	ciphertext, err := cipher.Encrypt([]byte("download-credential"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		cipher     *Cipher
+		ciphertext []byte
+		wantErr    string
+	}{
+		{name: "wrong key", cipher: otherCipher, ciphertext: ciphertext, wantErr: "decrypt data"},
+		{name: "short ciphertext", cipher: cipher, ciphertext: []byte("short"), wantErr: "encrypted data is too short"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plaintext, err := tt.cipher.Decrypt(tt.ciphertext)
+			require.ErrorContains(t, err, tt.wantErr)
+			require.Nil(t, plaintext)
+		})
+	}
+}


### PR DESCRIPTION
Add Flow-side data encryption infrastructure whose first consumer will be firmware download authentication data for #4392.

- Create a dedicated `flow-data-encryption-key` Kubernetes Secret.
- Reuse the existing key when present.
- Generate a key on first install or when upgrading an existing Flow release that predates the Secret.
- Mount the key read-only in the Flow container only.
- Add a general Flow AES-256-GCM helper with a random nonce for encrypting and decrypting sensitive data.
- Document that key rotation is not supported by this initial implementation.

This PR only introduces the encryption infrastructure. Wiring authentication data through Flow tasks and Temporal workflows is tracked by https://github.com/NVIDIA/infra-controller/issues/4392.

## Related issues

#4392 step 1

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `go test -race ./flow/internal/secret`
- `go vet ./flow/internal/secret`
- `helm lint ./helm/charts/nico-flow`
- Helm rendering for first install, existing-release upgrade without a key, and upgrade with an explicitly configured key

## Additional Notes

Existing Flow releases do not need to pre-create the Secret. Their first upgrade with this chart bootstraps the key automatically. Helm retains the key Secret when the Flow release is uninstalled so a subsequent reinstall can reuse it.
