### PR TITLE
feat(flow): identify mirrored rows by external_id and host BMC MAC

### DIFF
--- a/rest-api/flow/internal/db/migrations/20260813000000_nullable_chassis_labels.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260813000000_nullable_chassis_labels.down.sql
@@ -2,9 +2,31 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- The empty string is how a missing label was represented while these columns
--- were NOT NULL, so it is the inverse of the model's nullzero mapping. Rows
--- that collide on a unique constraint once collapsed to it must be resolved by
--- hand before this migration can complete.
+-- were NOT NULL, so it is the inverse of the model's nullzero mapping. It is
+-- not distinct the way NULL is, so rows that collapse onto the same pair
+-- cannot coexist under the restored constraint. Refuse the downgrade rather
+-- than invent labels to tell them apart.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM component
+        GROUP BY coalesce(manufacturer, ''), coalesce(serial_number, '')
+        HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'component rows share a (manufacturer, serial_number) pair once NULL collapses to the empty string'
+            USING HINT = 'Give the affected rows distinct labels, or remove them, before downgrading.';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM rack
+        GROUP BY coalesce(manufacturer, ''), coalesce(serial_number, '')
+        HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'rack rows share a (manufacturer, serial_number) pair once NULL collapses to the empty string'
+            USING HINT = 'Give the affected rows distinct labels, or remove them, before downgrading.';
+    END IF;
+END $$;
+
 UPDATE component SET manufacturer = '' WHERE manufacturer IS NULL;
 UPDATE component SET serial_number = '' WHERE serial_number IS NULL;
 

--- a/rest-api/flow/internal/db/migrations/20260813000000_nullable_chassis_labels.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260813000000_nullable_chassis_labels.down.sql
@@ -1,0 +1,20 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- The empty string is how a missing label was represented while these columns
+-- were NOT NULL, so it is the inverse of the model's nullzero mapping. Rows
+-- that collide on a unique constraint once collapsed to it must be resolved by
+-- hand before this migration can complete.
+UPDATE component SET manufacturer = '' WHERE manufacturer IS NULL;
+UPDATE component SET serial_number = '' WHERE serial_number IS NULL;
+
+ALTER TABLE component
+    ALTER COLUMN manufacturer SET NOT NULL,
+    ALTER COLUMN serial_number SET NOT NULL;
+
+UPDATE rack SET manufacturer = '' WHERE manufacturer IS NULL;
+UPDATE rack SET serial_number = '' WHERE serial_number IS NULL;
+
+ALTER TABLE rack
+    ALTER COLUMN manufacturer SET NOT NULL,
+    ALTER COLUMN serial_number SET NOT NULL;

--- a/rest-api/flow/internal/db/migrations/20260813000000_nullable_chassis_labels.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260813000000_nullable_chassis_labels.up.sql
@@ -1,0 +1,15 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Chassis manufacturer and serial number become descriptive metadata: a
+-- mirrored rack is identified by external_id and a mirrored component by its
+-- host BMC MAC address. Both (manufacturer, serial_number) unique constraints
+-- stay in place, and NULLs are distinct in Postgres, so a row missing either
+-- half occupies no slot in them.
+ALTER TABLE component
+    ALTER COLUMN manufacturer DROP NOT NULL,
+    ALTER COLUMN serial_number DROP NOT NULL;
+
+ALTER TABLE rack
+    ALTER COLUMN manufacturer DROP NOT NULL,
+    ALTER COLUMN serial_number DROP NOT NULL;

--- a/rest-api/flow/internal/db/model/component.go
+++ b/rest-api/flow/internal/db/model/component.go
@@ -22,12 +22,16 @@ import (
 type Component struct {
 	bun.BaseModel `bun:"table:component,alias:c"`
 
-	ID              uuid.UUID      `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	Name            string         `bun:"name"`
-	Type            string         `bun:"type,type:varchar(16),default:'Compute'"`
-	Manufacturer    string         `bun:"manufacturer,notnull,unique:component_manufacturer_serial_idx"`
+	ID   uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	Name string    `bun:"name"`
+	Type string    `bun:"type,type:varchar(16),default:'Compute'"`
+	// Manufacturer and SerialNumber are descriptive labels, not identity: a
+	// mirrored component is identified by its host BMC's MAC address. nullzero
+	// maps the empty string to SQL NULL, so a component missing either half
+	// occupies no slot in component_manufacturer_serial_idx.
+	Manufacturer    string         `bun:"manufacturer,nullzero,unique:component_manufacturer_serial_idx"`
 	Model           string         `bun:"model"`
-	SerialNumber    string         `bun:"serial_number,notnull,notnull,unique:component_manufacturer_serial_idx"`
+	SerialNumber    string         `bun:"serial_number,nullzero,unique:component_manufacturer_serial_idx"`
 	Description     map[string]any `bun:"description,type:jsonb,json_use_number"`
 	FirmwareVersion string         `bun:"firmware_version,nullzero"`
 	// RackID is uuid.Nil when the component has been ingested but is not yet
@@ -55,6 +59,9 @@ func (cd *Component) Create(ctx context.Context, idb bun.IDB) error {
 	return err
 }
 
+// Get looks the component up by ID, or by (manufacturer, serial_number) when no
+// ID is set. Both label columns are nullable, so a component stored without one
+// of them is only reachable by the first form.
 func (cd *Component) Get(
 	ctx context.Context,
 	idb bun.IDB,

--- a/rest-api/flow/internal/db/model/rack.go
+++ b/rest-api/flow/internal/db/model/rack.go
@@ -24,10 +24,14 @@ var defaultRackPagination = dbquery.Pagination{
 type Rack struct {
 	bun.BaseModel `bun:"table:rack,alias:r"`
 
-	ID           uuid.UUID      `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	Name         string         `bun:"name,notnull,unique:rack_name_idx"`
-	Manufacturer string         `bun:"manufacturer,notnull,unique:rack_manufacturer_serial_idx"`
-	SerialNumber string         `bun:"serial_number,notnull,unique:rack_manufacturer_serial_idx"`
+	ID   uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	Name string    `bun:"name,notnull,unique:rack_name_idx"`
+	// Manufacturer and SerialNumber are descriptive chassis labels, not
+	// identity: a mirrored rack is identified by ExternalID. nullzero maps the
+	// empty string to SQL NULL, so a rack missing either half occupies no slot
+	// in rack_manufacturer_serial_idx.
+	Manufacturer string         `bun:"manufacturer,nullzero,unique:rack_manufacturer_serial_idx"`
+	SerialNumber string         `bun:"serial_number,nullzero,unique:rack_manufacturer_serial_idx"`
 	Description  map[string]any `bun:"description,type:jsonb,json_use_number"`
 	Location     map[string]any `bun:"location,type:jsonb"`
 	NVLDomainID  uuid.UUID      `bun:"nvldomain_id,type:uuid"`
@@ -73,6 +77,9 @@ func (rd *Rack) Create(ctx context.Context, idb bun.IDB) error {
 	return err
 }
 
+// Get looks the rack up by ID, or by (manufacturer, serial_number) when no ID
+// is set. Both chassis columns are nullable, so a rack stored without one of
+// them is only reachable by the first form.
 func (rd *Rack) Get(
 	ctx context.Context,
 	idb bun.IDB,

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror.go
@@ -139,12 +139,21 @@ func loadRackIDByExternalID(ctx context.Context, idb bun.IDB) (map[string]uuid.U
 	return out, nil
 }
 
-// rackNaturalKey joins manufacturer and serial number with a NUL byte. NUL
-// can't appear inside either component, so this is collision-free without
-// having to escape. Used by both the rack and component mirrors to key
-// "is this row already known" maps off the shared (manufacturer, serial)
-// pair, so it lives here next to the orchestrator rather than in either
-// type-specific file.
-func rackNaturalKey(manufacturer, serialNumber string) string {
+// naturalKey joins manufacturer and serial number with a NUL byte, which can't
+// appear inside either half, so the result is collision-free without escaping.
+// Both mirrors key their "is this row already known" maps off it, so it lives
+// here next to the orchestrator rather than in either type-specific file.
+func naturalKey(manufacturer, serialNumber string) string {
 	return manufacturer + "\x00" + serialNumber
+}
+
+// naturalKeyOrEmpty returns the empty string unless both halves are populated.
+// A half-populated pair identifies nothing: every row missing the same half
+// shares one key, so a map built on it hands an arbitrary one of them back.
+// Callers skip such rows and match them by their real identity instead.
+func naturalKeyOrEmpty(manufacturer, serialNumber string) string {
+	if manufacturer == "" || serialNumber == "" {
+		return ""
+	}
+	return naturalKey(manufacturer, serialNumber)
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
@@ -16,6 +16,7 @@ import (
 	"github.com/uptrace/bun"
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/utils"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -231,10 +232,12 @@ func pullExpectedPowerShelves(ctx context.Context, c nicoapi.Client) (rows []nic
 }
 
 // mirrorExpectedComponents reconciles Flow's component table for a single
-// component type against the supplied normalised specs. Matching key is
-// (manufacturer, serial_number), the same unique key Flow's ingestion path
-// already enforces; resurrect behaviour is symmetrical to the rack mirror so
-// transient Core absence doesn't cause UUID churn.
+// component type against the supplied normalised specs. A component is
+// identified by its host BMC's MAC address, which bmc.mac_address makes unique
+// across the table; (manufacturer, serial_number) is a fallback for rows no MAC
+// can reach and is otherwise descriptive metadata. Resurrect behaviour is
+// symmetrical to the rack mirror so transient Core absence doesn't cause UUID
+// churn.
 //
 // rackIDByExtID resolves a Core rack_id string (e.g. "a12") to the Flow rack
 // UUID. A spec whose RackExternalID can't be resolved is mirrored with a NULL
@@ -267,10 +270,16 @@ func mirrorExpectedComponents(
 		return result
 	}
 
-	flowBySerial := make(map[string]*model.Component, len(existing))
+	flowByHostMAC := make(map[string]*model.Component, len(existing))
+	flowByNaturalKey := make(map[string]*model.Component, len(existing))
 	for i := range existing {
 		c := &existing[i]
-		flowBySerial[rackNaturalKey(c.Manufacturer, c.SerialNumber)] = c
+		for _, mac := range hostBMCMACs(c) {
+			flowByHostMAC[mac] = c
+		}
+		if key := naturalKeyOrEmpty(c.Manufacturer, c.SerialNumber); key != "" {
+			flowByNaturalKey[key] = c
+		}
 	}
 
 	type plan struct {
@@ -282,25 +291,26 @@ func mirrorExpectedComponents(
 	}
 	var p plan
 
-	// seenKeys: every (manufacturer, serial) Core is still reporting this
-	// cycle, recorded BEFORE any validity / dedup skip. The delete phase
-	// treats a row whose key is absent from this set as "Core dropped it".
-	// plannedKeys: keys we've already queued an insert/update for, used to
-	// drop Core duplicates before they hit the (manufacturer, serial)
-	// unique index and roll back the whole type's transaction.
-	seenKeys := make(map[string]struct{}, len(specs))
-	plannedKeys := make(map[string]struct{}, len(specs))
+	// seenMACs / seenNaturalKeys: every host BMC MAC and every complete
+	// (manufacturer, serial) pair Core is still reporting this cycle, recorded
+	// BEFORE any validity / dedup skip so a partially-populated Core row reads
+	// as a blip rather than an absence and can't drive a soft-delete.
+	// plannedMACs / plannedNaturalKeys: values already queued this cycle, so
+	// two Core specs can't collide on bmc's primary key or on
+	// component_manufacturer_serial_idx.
+	seenMACs := make(map[string]struct{}, len(specs))
+	seenNaturalKeys := make(map[string]struct{}, len(specs))
+	plannedMACs := make(map[string]struct{}, len(specs))
+	plannedNaturalKeys := make(map[string]struct{}, len(specs))
 
 	for _, s := range specs {
-		// Record the natural key as "still reported by Core" as early as
-		// possible. The key needs only (manufacturer, serial); a missing
-		// BMC MAC is a partial-row blip, not an absence, so it must not
-		// let the delete phase soft-delete a row Core is still listing.
-		keyDerivable := s.Manufacturer != "" && s.SerialNumber != ""
-		var key string
-		if keyDerivable {
-			key = rackNaturalKey(s.Manufacturer, s.SerialNumber)
-			seenKeys[key] = struct{}{}
+		mac := utils.NormalizeMAC(s.BMC.MACAddress)
+		if mac != "" {
+			seenMACs[mac] = struct{}{}
+		}
+		naturalKey := naturalKeyOrEmpty(s.Manufacturer, s.SerialNumber)
+		if naturalKey != "" {
+			seenNaturalKeys[naturalKey] = struct{}{}
 		}
 
 		if !specValid(s) {
@@ -308,24 +318,42 @@ func mirrorExpectedComponents(
 				Str("type", componentType).
 				Str("serial", s.SerialNumber).
 				Str("manufacturer", s.Manufacturer).
-				Str("bmc_mac", s.BMC.MACAddress).
-				Msg("Expected-inventory mirror: skipping Core expected component missing required identity (manufacturer / serial / BMC MAC); row preserved if its key is still reported")
+				Msg("Expected-inventory mirror: skipping Core expected component with no BMC MAC address; Flow has no identity to mirror it under")
 			result.skippedNoIDOrKey++
 			continue
 		}
 
-		// specValid guarantees manufacturer and serial are set, so key is
-		// populated here. Drop Core duplicates: planning the same key twice
-		// would queue two INSERTs that collide on the unique index.
-		if _, planned := plannedKeys[key]; planned {
+		// One MAC on two Core specs is a Core-side fault: bmc.mac_address is
+		// that table's primary key, so the second spec has nowhere to land.
+		if _, planned := plannedMACs[mac]; planned {
 			log.Warn().
 				Str("type", componentType).
-				Str("manufacturer", s.Manufacturer).
 				Str("serial", s.SerialNumber).
-				Msg("Expected-inventory mirror: Core returned duplicate spec for this component; skipping the later occurrence to avoid a unique-constraint abort (Cloud REST is producing duplicates)")
+				Str("bmc_mac", s.BMC.MACAddress).
+				Msg("Expected-inventory mirror: Core reported this BMC MAC address on more than one expected component; skipping the later occurrence")
 			continue
 		}
-		plannedKeys[key] = struct{}{}
+		plannedMACs[mac] = struct{}{}
+
+		// Two components can't both store the same pair —
+		// component_manufacturer_serial_idx would abort the type's
+		// transaction. Drop the labels off the loser rather than the
+		// component: the MAC is its identity and the labels are metadata.
+		if naturalKey != "" {
+			if _, planned := plannedNaturalKeys[naturalKey]; planned {
+				log.Warn().
+					Str("type", componentType).
+					Str("manufacturer", s.Manufacturer).
+					Str("serial", s.SerialNumber).
+					Str("bmc_mac", s.BMC.MACAddress).
+					Msg("Expected-inventory mirror: Core reported this manufacturer and serial number on more than one expected component; mirroring the later one without them")
+				s.Manufacturer = ""
+				s.SerialNumber = ""
+				naturalKey = ""
+			} else {
+				plannedNaturalKeys[naturalKey] = struct{}{}
+			}
+		}
 
 		rackID, ok := resolveRackID(s, rackIDByExtID)
 		if !ok {
@@ -347,7 +375,17 @@ func mirrorExpectedComponents(
 
 		desired := componentFromSpec(s, rackID)
 
-		if cur, ok := flowBySerial[key]; ok {
+		// Match on the host BMC MAC first. The natural key is a fallback for
+		// rows the MAC can't reach: those the AddComponent gRPC created with
+		// no BMC at all, and those whose BMC board was swapped so Core now
+		// reports a MAC Flow has never seen. Either way the match adopts the
+		// existing UUID and planBMCReconciliation repoints the BMC row.
+		cur := flowByHostMAC[mac]
+		if cur == nil && naturalKey != "" {
+			cur = flowByNaturalKey[naturalKey]
+		}
+
+		if cur != nil {
 			candidate := *cur
 			needUpdate := false
 			if candidate.DeletedAt != nil {
@@ -361,6 +399,7 @@ func mirrorExpectedComponents(
 					Msg("Expected-inventory mirror: resurrecting soft-deleted component")
 			}
 
+			clearComponentLabelsIfSlotTaken(&desired, flowByNaturalKey, candidate.ID, componentType)
 			diffs := diffComponentFields(&candidate, &desired, s)
 			if len(diffs) > 0 {
 				applyComponentChanges(&candidate, &desired, s)
@@ -376,6 +415,7 @@ func mirrorExpectedComponents(
 			continue
 		}
 
+		clearComponentLabelsIfSlotTaken(&desired, flowByNaturalKey, uuid.Nil, componentType)
 		p.toInsert = append(p.toInsert, desired)
 		p.toInsertBMCs = append(p.toInsertBMCs, model.BMC{
 			MacAddress: s.BMC.MACAddress,
@@ -394,7 +434,21 @@ func mirrorExpectedComponents(
 		if c.DeletedAt != nil {
 			continue
 		}
-		if _, seen := seenKeys[rackNaturalKey(c.Manufacturer, c.SerialNumber)]; seen {
+		macs := hostBMCMACs(c)
+		key := naturalKeyOrEmpty(c.Manufacturer, c.SerialNumber)
+		if len(macs) == 0 && key == "" {
+			// Nothing on this row can be compared with what Core reported, so
+			// "Core dropped it" is indistinguishable from "Flow cannot
+			// recognise it". Left in place, with a warn so the operator can
+			// repair the row.
+			result.legacyExempt++
+			log.Warn().
+				Str("type", componentType).
+				Str("component_id", c.ID.String()).
+				Msg("Expected-inventory mirror: Flow component has neither a host BMC nor a manufacturer/serial pair; it cannot be matched against Core and is left in place")
+			continue
+		}
+		if stillReportedByCore(macs, key, seenMACs, seenNaturalKeys) {
 			continue
 		}
 		p.toDelete = append(p.toDelete, *c)
@@ -438,7 +492,8 @@ func mirrorExpectedComponents(
 			p.toUpdate[i].UpdatedAt = now
 			if _, err := tx.NewUpdate().
 				Model(&p.toUpdate[i]).
-				Column("name", "model", "slot_id", "tray_index", "host_id", "rack_id", "deleted_at", "updated_at").
+				Column("name", "model", "manufacturer", "serial_number", "slot_id",
+					"tray_index", "host_id", "rack_id", "deleted_at", "updated_at").
 				WhereAllWithDeleted().
 				Where("id = ?", p.toUpdate[i].ID).
 				Exec(ctx); err != nil {
@@ -492,11 +547,77 @@ func mirrorExpectedComponents(
 	return result
 }
 
-// specValid rejects rows missing fields the mirror needs to construct a row
-// that both inserts cleanly (Component.Manufacturer / SerialNumber are
-// NOT NULL and form a unique index) and reconciles BMC (MAC is BMC PK).
+// specValid rejects a Core row carrying no BMC MAC address. The MAC is the
+// mirrored component's identity, so without one the row could not be matched
+// again on any later cycle. Manufacturer and serial number are descriptive
+// metadata and may be absent.
 func specValid(s expectedComponentSpec) bool {
-	return s.Manufacturer != "" && s.SerialNumber != "" && s.BMC.MACAddress != ""
+	return s.BMC.MACAddress != ""
+}
+
+// hostBMCMACs returns the normalised MAC of every type='Host' BMC on the
+// component. bmc.mac_address is that table's primary key, so a MAC belongs to
+// exactly one component and each of these identifies this row uniquely. A
+// component carrying several host BMCs is an ingestion fault that
+// planBMCReconciliation reduces to one; until it does, accepting any of them
+// keeps the component reachable.
+func hostBMCMACs(c *model.Component) []string {
+	hostType := devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)
+	var macs []string
+	for i := range c.BMCs {
+		if c.BMCs[i].Type != hostType || c.BMCs[i].MacAddress == "" {
+			continue
+		}
+		macs = append(macs, utils.NormalizeMAC(c.BMCs[i].MacAddress))
+	}
+	return macs
+}
+
+// stillReportedByCore reports whether what Core sent this cycle covers the
+// component, by any of its host BMC MACs or by its complete chassis pair.
+// Either alone is enough: a BMC board swap changes the MAC while the pair
+// holds, and a relabelled chassis changes the pair while the MAC holds.
+func stillReportedByCore(macs []string, naturalKey string, seenMACs, seenNaturalKeys map[string]struct{}) bool {
+	for _, mac := range macs {
+		if _, ok := seenMACs[mac]; ok {
+			return true
+		}
+	}
+	if naturalKey == "" {
+		return false
+	}
+	_, ok := seenNaturalKeys[naturalKey]
+	return ok
+}
+
+// clearComponentLabelsIfSlotTaken blanks desired's manufacturer and serial
+// number when a Flow component other than selfID already holds that complete
+// pair. selfID is uuid.Nil for an INSERT. component_manufacturer_serial_idx
+// covers soft-deleted rows too, so writing an occupied pair would abort the
+// whole type's transaction; the component is still mirrored under its host BMC
+// MAC, just without the labels.
+func clearComponentLabelsIfSlotTaken(
+	desired *model.Component,
+	flowByNaturalKey map[string]*model.Component,
+	selfID uuid.UUID,
+	componentType string,
+) {
+	key := naturalKeyOrEmpty(desired.Manufacturer, desired.SerialNumber)
+	if key == "" {
+		return
+	}
+	owner, ok := flowByNaturalKey[key]
+	if !ok || owner.ID == selfID {
+		return
+	}
+	log.Warn().
+		Str("type", componentType).
+		Str("manufacturer", desired.Manufacturer).
+		Str("serial", desired.SerialNumber).
+		Str("held_by_component_id", owner.ID.String()).
+		Msg("Expected-inventory mirror: another Flow component already holds this manufacturer and serial number; mirroring this component without them")
+	desired.Manufacturer = ""
+	desired.SerialNumber = ""
 }
 
 // resolveRackID translates Core's rack_id string into the Flow Rack.ID
@@ -542,16 +663,25 @@ func componentFromSpec(s expectedComponentSpec, rackID uuid.UUID) model.Componen
 }
 
 // applyComponentChanges copies mirror-managed fields from desired into
-// existing. Identity (Manufacturer/SerialNumber/Type), runtime (ComponentID,
-// PowerState, FirmwareVersion), lifecycle (Status, IngestedAt) and audit
-// (CreatedAt, UpdatedAt) are intentionally not touched. Fields named in
-// spec.preserveFields are also skipped — those are the columns whose Core
-// labels were malformed and so should keep Flow's existing value rather
-// than be overwritten with the parseLabelInt fallback zero.
+// existing. Type, runtime (ComponentID, PowerState, FirmwareVersion), lifecycle
+// (Status, IngestedAt) and audit (CreatedAt, UpdatedAt) are intentionally not
+// touched. Fields named in spec.preserveFields are also skipped — those are the
+// columns whose Core labels were malformed and so should keep Flow's existing
+// value rather than be overwritten with the parseLabelInt fallback zero.
+//
+// Manufacturer and serial number are only filled in when Flow's copy is empty:
+// Core dropping a label it used to send is a data gap, not an instruction to
+// erase what Flow already recorded.
 func applyComponentChanges(existing, desired *model.Component, spec expectedComponentSpec) {
 	existing.Name = desired.Name
 	existing.Model = desired.Model
 	existing.RackID = desired.RackID
+	if existing.Manufacturer == "" {
+		existing.Manufacturer = desired.Manufacturer
+	}
+	if existing.SerialNumber == "" {
+		existing.SerialNumber = desired.SerialNumber
+	}
 	if !spec.preserveFields["slot_id"] {
 		existing.SlotID = desired.SlotID
 	}
@@ -578,6 +708,12 @@ func diffComponentFields(existing, desired *model.Component, spec expectedCompon
 	}
 	if existing.Model != desired.Model {
 		diffs = append(diffs, fieldChange{"model", existing.Model, desired.Model})
+	}
+	if existing.Manufacturer == "" && desired.Manufacturer != "" {
+		diffs = append(diffs, fieldChange{"manufacturer", existing.Manufacturer, desired.Manufacturer})
+	}
+	if existing.SerialNumber == "" && desired.SerialNumber != "" {
+		diffs = append(diffs, fieldChange{"serial_number", existing.SerialNumber, desired.SerialNumber})
 	}
 	if !spec.preserveFields["slot_id"] && existing.SlotID != desired.SlotID {
 		diffs = append(diffs, fieldChange{"slot_id", strconv.Itoa(existing.SlotID), strconv.Itoa(desired.SlotID)})

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component_test.go
@@ -121,17 +121,115 @@ func TestSpecValid(t *testing.T) {
 	}
 	assert.True(t, specValid(base), "complete spec should be valid")
 
-	for name, mutate := range map[string]func(*expectedComponentSpec){
-		"missing manufacturer": func(s *expectedComponentSpec) { s.Manufacturer = "" },
-		"missing serial":       func(s *expectedComponentSpec) { s.SerialNumber = "" },
-		"missing bmc mac":      func(s *expectedComponentSpec) { s.BMC.MACAddress = "" },
+	for name, tc := range map[string]struct {
+		mutate func(*expectedComponentSpec)
+		want   bool
+	}{
+		"missing manufacturer": {mutate: func(s *expectedComponentSpec) { s.Manufacturer = "" }, want: true},
+		"missing serial":       {mutate: func(s *expectedComponentSpec) { s.SerialNumber = "" }, want: true},
+		"missing both labels": {mutate: func(s *expectedComponentSpec) {
+			s.Manufacturer = ""
+			s.SerialNumber = ""
+		}, want: true},
+		"missing bmc mac": {mutate: func(s *expectedComponentSpec) { s.BMC.MACAddress = "" }, want: false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			s := base
-			mutate(&s)
-			assert.False(t, specValid(s))
+			tc.mutate(&s)
+			assert.Equal(t, tc.want, specValid(s))
 		})
 	}
+}
+
+func TestHostBMCMACs(t *testing.T) {
+	hostType := devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)
+
+	t.Run("returns the normalised MAC of every host BMC", func(t *testing.T) {
+		c := &model.Component{BMCs: []model.BMC{
+			{MacAddress: "AA:BB:CC:DD:EE:FF", Type: hostType},
+			{MacAddress: "aa:bb:cc:dd:ee:01", Type: hostType},
+		}}
+		assert.Equal(t, []string{"aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:01"}, hostBMCMACs(c))
+	})
+
+	t.Run("non-host BMCs are ignored", func(t *testing.T) {
+		c := &model.Component{BMCs: []model.BMC{
+			{MacAddress: "aa:bb:cc:dd:ee:ff", Type: devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU)},
+		}}
+		assert.Empty(t, hostBMCMACs(c))
+	})
+
+	t.Run("a component with no BMC at all yields nothing", func(t *testing.T) {
+		assert.Empty(t, hostBMCMACs(&model.Component{}))
+	})
+}
+
+func TestStillReportedByCore(t *testing.T) {
+	seenMACs := map[string]struct{}{"aa:bb:cc:dd:ee:ff": {}}
+	seenNaturalKeys := map[string]struct{}{naturalKey("Foxconn", "SN-1"): {}}
+
+	tests := []struct {
+		name       string
+		macs       []string
+		naturalKey string
+		want       bool
+	}{
+		{name: "MAC still reported", macs: []string{"aa:bb:cc:dd:ee:ff"}, want: true},
+		{
+			name:       "BMC board swapped, chassis pair still reported",
+			macs:       []string{"aa:bb:cc:dd:ee:02"},
+			naturalKey: naturalKey("Foxconn", "SN-1"),
+			want:       true,
+		},
+		{
+			name:       "chassis relabelled, MAC still reported",
+			macs:       []string{"aa:bb:cc:dd:ee:ff"},
+			naturalKey: naturalKey("Wistron", "SN-9"),
+			want:       true,
+		},
+		{name: "neither is reported", macs: []string{"aa:bb:cc:dd:ee:02"}, naturalKey: naturalKey("Wistron", "SN-9")},
+		{name: "no MAC and no pair", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stillReportedByCore(tc.macs, tc.naturalKey, seenMACs, seenNaturalKeys))
+		})
+	}
+}
+
+func TestClearComponentLabelsIfSlotTaken(t *testing.T) {
+	owner := &model.Component{ID: uuid.New(), Manufacturer: "Foxconn", SerialNumber: "SN-1"}
+	flowByNaturalKey := map[string]*model.Component{
+		naturalKey("Foxconn", "SN-1"): owner,
+	}
+
+	t.Run("labels held by another component are dropped", func(t *testing.T) {
+		desired := model.Component{Manufacturer: "Foxconn", SerialNumber: "SN-1"}
+		clearComponentLabelsIfSlotTaken(&desired, flowByNaturalKey, uuid.New(), "Compute")
+		assert.Empty(t, desired.Manufacturer)
+		assert.Empty(t, desired.SerialNumber)
+	})
+
+	t.Run("the component already holding the pair keeps it", func(t *testing.T) {
+		desired := model.Component{Manufacturer: "Foxconn", SerialNumber: "SN-1"}
+		clearComponentLabelsIfSlotTaken(&desired, flowByNaturalKey, owner.ID, "Compute")
+		assert.Equal(t, "Foxconn", desired.Manufacturer)
+		assert.Equal(t, "SN-1", desired.SerialNumber)
+	})
+
+	t.Run("an unclaimed pair is kept", func(t *testing.T) {
+		desired := model.Component{Manufacturer: "Wistron", SerialNumber: "SN-9"}
+		clearComponentLabelsIfSlotTaken(&desired, flowByNaturalKey, uuid.Nil, "Compute")
+		assert.Equal(t, "Wistron", desired.Manufacturer)
+		assert.Equal(t, "SN-9", desired.SerialNumber)
+	})
+
+	t.Run("a half-populated pair occupies no slot and is left alone", func(t *testing.T) {
+		desired := model.Component{SerialNumber: "SN-1"}
+		clearComponentLabelsIfSlotTaken(&desired, flowByNaturalKey, uuid.Nil, "Compute")
+		assert.Equal(t, "SN-1", desired.SerialNumber)
+	})
 }
 
 func TestResolveRackID(t *testing.T) {

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -131,28 +131,80 @@ func TestMirrorRacks_RenameKeepsRow(t *testing.T) {
 	assert.Equal(t, "new", *got.ExternalID, "external_id must be updated to Core's new rack_id")
 }
 
-// #3: a Core row that's present but malformed (missing chassis labels) must
-// not cause the matching Flow rack to be soft-deleted.
-func TestMirrorRacks_MalformedPresentNotDeleted(t *testing.T) {
+// #3: a Core row missing a chassis label is mirrored, not skipped, and the
+// existing Flow rack survives with its own label intact.
+func TestMirrorRacks_MissingChassisLabelStillMirrored(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
-	r := model.Rack{Name: "malformed", Manufacturer: "Mfg", SerialNumber: "MF-1", ExternalID: strPtr("a12")}
+	r := model.Rack{Name: "labelled", Manufacturer: "Mfg", SerialNumber: "MF-1", ExternalID: strPtr("a12")}
 	require.NoError(t, r.Create(ctx, pool.DB))
 
-	malformed := nicoapi.ExpectedRackDetail{
+	unlabelled := nicoapi.ExpectedRackDetail{
 		RackID: "a12",
 		Name:   "still-here",
 		Labels: map[string]string{labelChassisSerialNumber: "MF-1"}, // manufacturer missing
 	}
-	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{malformed})
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{unlabelled})
 
 	got, err := (&model.Rack{ID: r.ID}).GetIncludingDeleted(ctx, pool.DB)
 	require.NoError(t, err)
-	assert.Nil(t, got.DeletedAt, "rack still listed by Core (even malformed) must survive")
+	assert.Nil(t, got.DeletedAt, "rack still listed by Core must survive")
+	assert.Equal(t, "still-here", got.Name, "the row must be updated, proving Core's row was not skipped")
+	assert.Equal(t, "Mfg", got.Manufacturer, "Core omitting a label must not erase Flow's copy")
 }
 
-// #4: duplicate Core racks for the same chassis must not abort the whole
-// transaction on the (manufacturer, serial) unique index.
+// A Core rack carrying no chassis labels at all is mirrored under its rack_id.
+// This is the case that used to be skipped outright.
+func TestMirrorRacks_NoChassisLabelsStillMirrored(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		{RackID: "klamath-1", Name: "klamath-1"},
+	})
+
+	var got model.Rack
+	require.NoError(t, pool.DB.NewSelect().Model(&got).Where("external_id = ?", "klamath-1").Scan(ctx))
+	assert.Empty(t, got.Manufacturer)
+	assert.Empty(t, got.SerialNumber)
+}
+
+// Several Core racks with no chassis labels must all be mirrored: the labels
+// land as NULL, which is distinct in Postgres, so they don't collapse onto one
+// slot in rack_manufacturer_serial_idx.
+func TestMirrorRacks_UnlabelledRacksDoNotCollapse(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		{RackID: "klamath-1", Name: "klamath-1", Labels: map[string]string{labelChassisManufacturer: "NVIDIA"}},
+		{RackID: "klamath-2", Name: "klamath-2", Labels: map[string]string{labelChassisManufacturer: "NVIDIA"}},
+		{RackID: "klamath-3", Name: "klamath-3", Labels: map[string]string{labelChassisManufacturer: "NVIDIA"}},
+		{RackID: "klamath-4", Name: "klamath-4", Labels: map[string]string{labelChassisManufacturer: "NVIDIA"}},
+	})
+
+	n, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Where("manufacturer = ?", "NVIDIA").Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n, "every serial-less rack must be mirrored, not deduplicated onto one chassis key")
+}
+
+// A rack stored without chassis labels picks them up once Core starts sending
+// them.
+func TestMirrorRacks_ChassisLabelsBackfilled(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	r := model.Rack{Name: "backfill", ExternalID: strPtr("a12")}
+	require.NoError(t, r.Create(ctx, pool.DB))
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{coreRack("a12", "Mfg", "BF-1")})
+
+	got, err := (&model.Rack{ID: r.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Equal(t, "Mfg", got.Manufacturer)
+	assert.Equal(t, "BF-1", got.SerialNumber)
+}
+
+// #4: two Core racks reporting the same chassis must not abort the cycle on
+// rack_manufacturer_serial_idx. Both racks are mirrored; only the first keeps
+// the contested labels.
 func TestMirrorRacks_DuplicateChassisNoAbort(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
@@ -161,9 +213,13 @@ func TestMirrorRacks_DuplicateChassisNoAbort(t *testing.T) {
 		coreRack("b34", "Mfg", "DUP-1"),
 	})
 
-	n, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Where("serial_number = ?", "DUP-1").Count(ctx)
+	total, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Count(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 1, n, "exactly one rack inserted; the duplicate is dropped, not a constraint abort")
+	assert.Equal(t, 2, total, "both racks must be mirrored under their own rack_id")
+
+	withSerial, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Where("serial_number = ?", "DUP-1").Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, withSerial, "only one rack may hold the contested chassis pair")
 }
 
 // #8: an empty Core description must not wipe operator-set rack metadata.
@@ -362,9 +418,10 @@ func TestRunInventoryOne_DriftTablePreservedOnRPCFailure(t *testing.T) {
 	assert.Equal(t, 1, n, "drift table must not be wiped when an actual-sync RPC failed")
 }
 
-// #4: duplicate component specs must not abort the transaction on the
-// (manufacturer, serial) unique index.
-func TestMirrorComponents_DuplicateSpecNoAbort(t *testing.T) {
+// #4: two specs reporting the same manufacturer and serial must not abort the
+// transaction on component_manufacturer_serial_idx. Both are mirrored under
+// their own BMC MAC; only the first keeps the contested labels.
+func TestMirrorComponents_DuplicateSerialNoAbort(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
 	specs := []expectedComponentSpec{
@@ -373,7 +430,119 @@ func TestMirrorComponents_DuplicateSpecNoAbort(t *testing.T) {
 	}
 	mirrorExpectedComponents(ctx, pool, compType(), specs, map[string]uuid.UUID{})
 
-	n, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("serial_number = ?", "C-DUP").Count(ctx)
+	total, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Count(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 1, n, "exactly one component inserted; the duplicate spec is dropped")
+	assert.Equal(t, 2, total, "both components must be mirrored under their own BMC MAC")
+
+	withSerial, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Where("serial_number = ?", "C-DUP").Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, withSerial, "only one component may hold the contested manufacturer and serial")
+}
+
+// Core reporting the same BMC MAC on two specs is a Core-side fault:
+// bmc.mac_address is a primary key, so the later spec is dropped.
+func TestMirrorComponents_DuplicateMACSkipsLaterSpec(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	specs := []expectedComponentSpec{
+		computeSpec("Mfg", "C-MAC-1", "aa:bb:cc:dd:ee:31"),
+		computeSpec("Mfg", "C-MAC-2", "aa:bb:cc:dd:ee:31"),
+	}
+	mirrorExpectedComponents(ctx, pool, compType(), specs, map[string]uuid.UUID{})
+
+	total, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "only the first spec on a MAC may be mirrored")
+}
+
+// A spec carrying only a BMC MAC is mirrored; manufacturer and serial land as
+// NULL rather than blocking the row.
+func TestMirrorComponents_NoLabelsStillMirrored(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	mirrorExpectedComponents(ctx, pool, compType(),
+		[]expectedComponentSpec{computeSpec("", "", "aa:bb:cc:dd:ee:41")},
+		map[string]uuid.UUID{})
+
+	var bmc model.BMC
+	require.NoError(t, pool.DB.NewSelect().Model(&bmc).Where("mac_address = ?", "aa:bb:cc:dd:ee:41").Scan(ctx))
+
+	got, err := (&model.Component{ID: bmc.ComponentID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Empty(t, got.Manufacturer)
+	assert.Empty(t, got.SerialNumber)
+}
+
+// Relabelling a chassis in Core must not fork the component: the host BMC MAC
+// is its identity, so the existing row is updated in place.
+func TestMirrorComponents_MatchByMACSurvivesRelabel(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	const mac = "aa:bb:cc:dd:ee:51"
+	c := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-OLD"}
+	require.NoError(t, c.Create(ctx, pool.DB))
+	hostBMC := model.BMC{
+		MacAddress:  mac,
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		ComponentID: c.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&hostBMC).Exec(ctx)
+	require.NoError(t, err)
+
+	mirrorExpectedComponents(ctx, pool, compType(),
+		[]expectedComponentSpec{computeSpec("Mfg", "C-NEW", mac)},
+		map[string]uuid.UUID{})
+
+	total, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "the MAC match must update in place, not insert a second component")
+
+	got, err := (&model.Component{ID: c.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt)
+	assert.Equal(t, "C-OLD", got.SerialNumber, "a populated serial is not overwritten by Core's new one")
+}
+
+// Swapping a BMC board changes the MAC Core reports. The natural key adopts the
+// existing row and the BMC is repointed, so the component keeps its UUID.
+func TestMirrorComponents_BMCBoardSwapAdoptsByNaturalKey(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	c := model.Component{Type: compType(), Manufacturer: "Mfg", SerialNumber: "C-SWAP"}
+	require.NoError(t, c.Create(ctx, pool.DB))
+	oldBMC := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:61",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		ComponentID: c.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&oldBMC).Exec(ctx)
+	require.NoError(t, err)
+
+	mirrorExpectedComponents(ctx, pool, compType(),
+		[]expectedComponentSpec{computeSpec("Mfg", "C-SWAP", "aa:bb:cc:dd:ee:62")},
+		map[string]uuid.UUID{})
+
+	total, err := pool.DB.NewSelect().Model((*model.Component)(nil)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "the natural key must adopt the existing row, not insert a second component")
+
+	got, err := (&model.Component{ID: c.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	require.Len(t, got.BMCs, 1)
+	assert.Equal(t, "aa:bb:cc:dd:ee:62", got.BMCs[0].MacAddress, "the host BMC must be repointed to Core's new MAC")
+}
+
+// A Flow component with neither a host BMC nor a complete chassis pair can't be
+// compared with what Core reported, so the delete phase leaves it alone.
+func TestMirrorComponents_UnmatchableRowExemptFromDelete(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	c := model.Component{Type: compType(), Name: "orphan"}
+	require.NoError(t, c.Create(ctx, pool.DB))
+
+	mirrorExpectedComponents(ctx, pool, compType(), nil, map[string]uuid.UUID{})
+
+	got, err := (&model.Component{ID: c.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt, "a component the mirror cannot match must not be soft-deleted")
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -64,6 +64,14 @@ func coreRack(rackID, mfr, serial string) nicoapi.ExpectedRackDetail {
 	}
 }
 
+// coreRackNamed is coreRack with an explicit name, for cases that contend on
+// the chassis pair and so must not also contend on rack_name_idx.
+func coreRackNamed(rackID, name, mfr, serial string) nicoapi.ExpectedRackDetail {
+	r := coreRack(rackID, mfr, serial)
+	r.Name = name
+	return r
+}
+
 func computeSpec(mfr, serial, mac string) expectedComponentSpec {
 	return expectedComponentSpec{
 		Type:         devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
@@ -212,8 +220,8 @@ func TestMirrorRacks_AdoptionDoesNotStealAnIdentifiedRack(t *testing.T) {
 
 	// Both racks claim the same chassis; a12 already holds the Flow row.
 	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
-		coreRack("b34", "Mfg", "ST-1"),
-		coreRack("a12", "Mfg", "ST-1"),
+		coreRackNamed("b34", "rack-b34", "Mfg", "ST-1"),
+		coreRackNamed("a12", "rack-a12", "Mfg", "ST-1"),
 	})
 
 	got, err := (&model.Rack{ID: owner.ID}).GetIncludingDeleted(ctx, pool.DB)
@@ -235,8 +243,8 @@ func TestMirrorRacks_DuplicateChassisNoAbort(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
 	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
-		coreRack("a12", "Mfg", "DUP-1"),
-		coreRack("b34", "Mfg", "DUP-1"),
+		coreRackNamed("a12", "rack-a12", "Mfg", "DUP-1"),
+		coreRackNamed("b34", "rack-b34", "Mfg", "DUP-1"),
 	})
 
 	total, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Count(ctx)
@@ -246,6 +254,25 @@ func TestMirrorRacks_DuplicateChassisNoAbort(t *testing.T) {
 	withSerial, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Where("serial_number = ?", "DUP-1").Count(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 1, withSerial, "only one rack may hold the contested chassis pair")
+}
+
+// Two Core racks resolving to the same name must not abort the cycle on
+// rack_name_idx: the second write is skipped and the first still lands.
+func TestMirrorRacks_DuplicateNameNoAbort(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		coreRackNamed("a12", "same-name", "Mfg", "NM-1"),
+		coreRackNamed("b34", "same-name", "Mfg", "NM-2"),
+	})
+
+	total, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "the first rack must land; the second is skipped, not left to abort the cycle")
+
+	var got model.Rack
+	require.NoError(t, pool.DB.NewSelect().Model(&got).Where("name = ?", "same-name").Scan(ctx))
+	assert.Equal(t, "NM-1", got.SerialNumber)
 }
 
 // #8: an empty Core description must not wipe operator-set rack metadata.

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -194,6 +194,27 @@ func TestMirrorRacks_UnlabelledRacksDoNotCollapse(t *testing.T) {
 	assert.Equal(t, 4, n, "every serial-less rack must be mirrored, not deduplicated onto one chassis key")
 }
 
+// A rack the mirror has never reached is adopted by its chassis pair: Core's
+// rack_id is written onto the existing row rather than inserted as a new one.
+func TestMirrorRacks_LegacyRackAdoptedByNaturalKey(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	legacy := model.Rack{Name: "legacy", Manufacturer: "Mfg", SerialNumber: "LG-1"}
+	require.NoError(t, legacy.Create(ctx, pool.DB))
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{coreRack("a12", "Mfg", "LG-1")})
+
+	total, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "adoption must reuse the existing row, not insert a second rack")
+
+	got, err := (&model.Rack{ID: legacy.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt)
+	require.NotNil(t, got.ExternalID)
+	assert.Equal(t, "a12", *got.ExternalID)
+}
+
 // A rack stored without chassis labels picks them up once Core starts sending
 // them.
 func TestMirrorRacks_ChassisLabelsBackfilled(t *testing.T) {

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -202,6 +202,32 @@ func TestMirrorRacks_ChassisLabelsBackfilled(t *testing.T) {
 	assert.Equal(t, "BF-1", got.SerialNumber)
 }
 
+// A Core rack whose chassis pair matches an already-identified Flow rack must
+// not take that rack's row while Core still reports the rack_id on it.
+func TestMirrorRacks_AdoptionDoesNotStealAnIdentifiedRack(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	owner := model.Rack{Name: "owner", Manufacturer: "Mfg", SerialNumber: "ST-1", ExternalID: strPtr("a12")}
+	require.NoError(t, owner.Create(ctx, pool.DB))
+
+	// Both racks claim the same chassis; a12 already holds the Flow row.
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		coreRack("b34", "Mfg", "ST-1"),
+		coreRack("a12", "Mfg", "ST-1"),
+	})
+
+	got, err := (&model.Rack{ID: owner.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt)
+	require.NotNil(t, got.ExternalID)
+	assert.Equal(t, "a12", *got.ExternalID, "the row must stay with the rack_id already on it")
+	assert.Equal(t, "ST-1", got.SerialNumber, "the owner keeps the contested chassis pair")
+
+	var intruder model.Rack
+	require.NoError(t, pool.DB.NewSelect().Model(&intruder).Where("external_id = ?", "b34").Scan(ctx))
+	assert.Empty(t, intruder.SerialNumber, "the second rack is mirrored without the contested pair")
+}
+
 // #4: two Core racks reporting the same chassis must not abort the cycle on
 // rack_manufacturer_serial_idx. Both racks are mirrored; only the first keeps
 // the contested labels.

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
@@ -152,13 +152,18 @@ func mirrorExpectedRacks(
 	// start. See nameUnavailable.
 	plannedNames := make(map[string]struct{}, len(coreRacks))
 
-	// coreExtIDs is every rack_id in this response. Precomputed because the
-	// adoption guard has to ask about rack_ids the loop below has not reached
-	// yet, whereas seenExtID only fills in as it goes.
+	// coreExtIDs / coreNaturalKeys: every rack_id and every complete chassis
+	// pair in this response. Both are precomputed because the guards reading
+	// them ask about Core rows the loops below have not reached yet, whereas
+	// seenExtID only fills in as it goes.
 	coreExtIDs := make(map[string]struct{}, len(coreRacks))
+	coreNaturalKeys := make(map[string]struct{}, len(coreRacks))
 	for _, cr := range coreRacks {
 		if cr.RackID != "" {
 			coreExtIDs[cr.RackID] = struct{}{}
+		}
+		if key := naturalKeyOrEmpty(cr.Labels[labelChassisManufacturer], cr.Labels[labelChassisSerialNumber]); key != "" {
+			coreNaturalKeys[key] = struct{}{}
 		}
 	}
 
@@ -309,8 +314,9 @@ func mirrorExpectedRacks(
 		// External_id is NULL — never adopted. Only legacy-warn if the
 		// (manufacturer, serial) doesn't appear in Core's set either,
 		// otherwise it'll be picked up by the adoption path above and a
-		// "future GC" warn would be misleading.
-		if _, adoptable := adoptableFromCore(r, coreRacks); !adoptable {
+		// "future GC" warn would be misleading. A rack with an incomplete pair
+		// keys to the empty string, which is never in the set.
+		if _, adoptable := coreNaturalKeys[naturalKeyOrEmpty(r.Manufacturer, r.SerialNumber)]; !adoptable {
 			result.legacyExempt++
 			log.Warn().
 				Str("rack_name", r.Name).
@@ -443,25 +449,6 @@ func getAllRacksIncludingDeleted(ctx context.Context, idb bun.IDB) ([]model.Rack
 		return nil, err
 	}
 	return racks, nil
-}
-
-// adoptableFromCore returns the Core rack_id whose chassis pair matches this
-// Flow rack's, meaning the adoption path will reach it. Used to suppress the
-// "legacy not in Core" warn for rows that get picked up on this same cycle. A
-// rack with an incomplete pair is never adoptable, since naturalKeyOrEmpty
-// keeps it out of the adoption index.
-func adoptableFromCore(r *model.Rack, coreRacks []nicoapi.ExpectedRackDetail) (string, bool) {
-	want := naturalKeyOrEmpty(r.Manufacturer, r.SerialNumber)
-	if want == "" {
-		return "", false
-	}
-	for _, cr := range coreRacks {
-		key := naturalKeyOrEmpty(cr.Labels[labelChassisManufacturer], cr.Labels[labelChassisSerialNumber])
-		if key == want {
-			return cr.RackID, true
-		}
-	}
-	return "", false
 }
 
 // buildRackFromCore translates one Core ExpectedRackDetail into the Flow Rack

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
@@ -148,6 +148,16 @@ func mirrorExpectedRacks(
 	touchedIDs := make(map[uuid.UUID]struct{}, len(coreRacks))
 	plannedNaturalKeys := make(map[string]struct{}, len(coreRacks))
 
+	// coreExtIDs is every rack_id in this response. Precomputed because the
+	// adoption guard has to ask about rack_ids the loop below has not reached
+	// yet, whereas seenExtID only fills in as it goes.
+	coreExtIDs := make(map[string]struct{}, len(coreRacks))
+	for _, cr := range coreRacks {
+		if cr.RackID != "" {
+			coreExtIDs[cr.RackID] = struct{}{}
+		}
+	}
+
 	for _, cr := range coreRacks {
 		// Record the rack_id as "still reported" before any skip below.
 		if cr.RackID != "" {
@@ -223,7 +233,7 @@ func mirrorExpectedRacks(
 		// external_id, so a row passes through here at most once. A match
 		// that's also soft-deleted gets resurrected at the same time — see
 		// the function-level comment for why this matters.
-		if existing, ok := flowByNaturalKey[naturalKey]; ok {
+		if existing, ok := flowByNaturalKey[naturalKey]; ok && adoptableByNaturalKey(existing, coreExtIDs) {
 			candidate := *existing
 			candidate.ExternalID = built.ExternalID
 			if candidate.DeletedAt != nil {
@@ -555,6 +565,22 @@ func rackUpdatedFromCore(existing, fromCore *model.Rack) *model.Rack {
 		return nil
 	}
 	return &patched
+}
+
+// adoptableByNaturalKey reports whether a natural-key match may take over the
+// Flow row and write Core's rack_id onto it. A row carrying no external_id has
+// never been claimed, so it is always adoptable. A row that carries one may only
+// be re-pointed once Core has stopped reporting that rack_id, which is how a
+// rack re-registered under a new rack_id keeps its UUID. While both rack_ids are
+// live the row belongs to the one already named on it: taking it would leave the
+// other Core rack with no row of its own and make the two trade this one on
+// every cycle.
+func adoptableByNaturalKey(r *model.Rack, coreExtIDs map[string]struct{}) bool {
+	if r.ExternalID == nil || *r.ExternalID == "" {
+		return true
+	}
+	_, stillReported := coreExtIDs[*r.ExternalID]
+	return !stillReported
 }
 
 // clearChassisLabelsIfSlotTaken blanks built's chassis labels when a Flow rack

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
@@ -57,18 +57,20 @@ func pullExpectedRacks(
 // expected_racks view. The algorithm is, in order:
 //
 //  1. Index every Flow rack — including soft-deleted ones — by external_id
-//     (mirror-owned) and by (manufacturer, serial_number) (the natural key
-//     shared with Core). Including soft-deleted rows is what makes
-//     resurrection work: a rack that briefly disappeared from Core and came
-//     back keeps its UUID, and a re-insert would otherwise collide on the
-//     (manufacturer, serial_number) unique index that the soft-deleted row
+//     (the mirrored rack's identity) and by (manufacturer, serial_number).
+//     Only rows carrying both halves enter the second index; a half-populated
+//     pair identifies nothing and would let unrelated racks match each other.
+//     Including soft-deleted rows is what makes resurrection work: a rack that
+//     briefly disappeared from Core and came back keeps its UUID, and a
+//     re-insert would otherwise collide on the unique constraint the tombstone
 //     still occupies.
 //
-//  2. For each Core row, find the matching Flow row preferring external_id
-//     and falling back to (manufacturer, serial_number) to adopt rows that
-//     predate the mirror. New rows are inserted. A matched row that's
-//     currently soft-deleted is resurrected by clearing deleted_at;
-//     mirror-managed fields are updated alongside on real deltas.
+//  2. For each Core row, find the matching Flow row by external_id, falling
+//     back to (manufacturer, serial_number) to adopt rows the mirror has never
+//     reached. New rows are inserted. A matched row that's currently
+//     soft-deleted is resurrected by clearing deleted_at; mirror-managed
+//     fields are updated alongside on real deltas. A Core rack carrying no
+//     rack_id is skipped, there being no identity to store it under.
 //
 //  3. Live Flow rows whose external_id is set but no longer appear in Core
 //     are soft-deleted (including the case where Core returned zero racks —
@@ -94,13 +96,15 @@ func mirrorExpectedRacks(
 	}
 
 	flowByExtID := make(map[string]*model.Rack, len(flowRacks))
-	flowBySerial := make(map[string]*model.Rack, len(flowRacks))
+	flowByNaturalKey := make(map[string]*model.Rack, len(flowRacks))
 	for i := range flowRacks {
 		r := &flowRacks[i]
 		if r.ExternalID != nil && *r.ExternalID != "" {
 			flowByExtID[*r.ExternalID] = r
 		}
-		flowBySerial[rackNaturalKey(r.Manufacturer, r.SerialNumber)] = r
+		if key := naturalKeyOrEmpty(r.Manufacturer, r.SerialNumber); key != "" {
+			flowByNaturalKey[key] = r
+		}
 	}
 
 	type plan struct {
@@ -137,12 +141,12 @@ func mirrorExpectedRacks(
 	// touchedIDs: Flow rack UUIDs the match path adopted / updated this
 	// cycle; the delete phase skips them so a rack_id rename (update to the
 	// new external_id) isn't immediately undone by a soft-delete keyed off
-	// the stale in-memory external_id. plannedSerial: natural keys already
-	// queued, to drop Core duplicates before they collide on the
-	// (manufacturer, serial) unique index.
+	// the stale in-memory external_id. plannedNaturalKeys: complete natural
+	// keys already queued, to drop Core duplicates before they collide on the
+	// (manufacturer, serial) unique constraint.
 	seenExtID := make(map[string]struct{}, len(coreRacks))
 	touchedIDs := make(map[uuid.UUID]struct{}, len(coreRacks))
-	plannedSerial := make(map[string]struct{}, len(coreRacks))
+	plannedNaturalKeys := make(map[string]struct{}, len(coreRacks))
 
 	for _, cr := range coreRacks {
 		// Record the rack_id as "still reported" before any skip below.
@@ -152,45 +156,38 @@ func mirrorExpectedRacks(
 
 		built, ok := buildRackFromCore(cr)
 		if !ok {
-			// Required fields (manufacturer / serial) missing in Core's labels;
-			// inserting would violate NOT NULL or the (manufacturer, serial)
-			// unique constraint. Skip the write, but the rack_id is already in
-			// seenExtID so we don't soft-delete an existing Flow rack over a
-			// transient label gap.
 			log.Warn().
-				Str("rack_id", cr.RackID).
+				Str("rack_profile_id", cr.RackProfileID).
 				Str("name", cr.Name).
-				Msg("Expected-inventory mirror: skipping Core expected rack missing chassis manufacturer or serial-number labels; existing Flow rack preserved")
+				Msg("Expected-inventory mirror: skipping Core expected rack with no rack_id; Flow has no identity to mirror it under")
 			result.skippedNoIDOrKey++
 			continue
 		}
 
-		if cr.RackID == "" {
-			log.Warn().
-				Str("rack_profile_id", cr.RackProfileID).
-				Str("name", cr.Name).
-				Str("manufacturer", built.Manufacturer).
-				Str("serial", built.SerialNumber).
-				Msg("Expected-inventory mirror: Core expected rack has no rack_id; rack will be mirrored but components can't reference it")
+		// Two racks can't both store the same chassis pair —
+		// rack_manufacturer_serial_idx would abort the cycle. Drop the labels
+		// off the loser rather than the rack: external_id is its identity and
+		// the labels are metadata. An incomplete pair is stored as NULL and
+		// collides with nothing, so it needs no such check.
+		naturalKey := naturalKeyOrEmpty(built.Manufacturer, built.SerialNumber)
+		if naturalKey != "" {
+			_, planned := plannedNaturalKeys[naturalKey]
+			if planned {
+				log.Warn().
+					Str("rack_id", cr.RackID).
+					Str("manufacturer", built.Manufacturer).
+					Str("serial", built.SerialNumber).
+					Msg("Expected-inventory mirror: Core reported this chassis on more than one expected rack; mirroring the later rack without chassis labels")
+				built.Manufacturer = ""
+				built.SerialNumber = ""
+				naturalKey = ""
+			} else {
+				plannedNaturalKeys[naturalKey] = struct{}{}
+			}
 		}
-
-		// Drop Core duplicates: planning the same chassis twice would queue a
-		// second INSERT that collides on the (manufacturer, serial) unique
-		// index and roll back the whole rack mirror.
-		natKey := rackNaturalKey(built.Manufacturer, built.SerialNumber)
-		if _, planned := plannedSerial[natKey]; planned {
-			log.Warn().
-				Str("rack_id", cr.RackID).
-				Str("manufacturer", built.Manufacturer).
-				Str("serial", built.SerialNumber).
-				Msg("Expected-inventory mirror: Core returned duplicate expected racks for the same chassis; skipping the later occurrence")
-			continue
-		}
-		plannedSerial[natKey] = struct{}{}
 
 		// Prefer external_id match (already adopted on a previous cycle).
-		// Empty rack_ids never hit flowByExtID by construction.
-		if existing, ok := flowByExtID[cr.RackID]; ok && cr.RackID != "" {
+		if existing, ok := flowByExtID[cr.RackID]; ok {
 			candidate := *existing
 			needUpdate := false
 			if candidate.DeletedAt != nil {
@@ -198,6 +195,7 @@ func mirrorExpectedRacks(
 				needUpdate = true
 				result.resurrected++
 			}
+			clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, existing.ID, cr.RackID)
 			if patched := rackUpdatedFromCore(&candidate, &built); patched != nil {
 				candidate = *patched
 				needUpdate = true
@@ -219,17 +217,20 @@ func mirrorExpectedRacks(
 			continue
 		}
 
-		// Fall back to natural key (legacy ingestion-gRPC rows the mirror has
-		// never adopted; adopt by writing external_id alongside any deltas).
-		// A serial match that's also soft-deleted gets resurrected at the
-		// same time — see the function-level comment for why this matters.
-		if existing, ok := flowBySerial[natKey]; ok {
+		// Fall back to the natural key to adopt rows the mirror has never
+		// reached: those created before external_id existed, and those the
+		// CreateExpectedRack gRPC creates without one. Adoption writes
+		// external_id, so a row passes through here at most once. A match
+		// that's also soft-deleted gets resurrected at the same time — see
+		// the function-level comment for why this matters.
+		if existing, ok := flowByNaturalKey[naturalKey]; ok {
 			candidate := *existing
 			candidate.ExternalID = built.ExternalID
 			if candidate.DeletedAt != nil {
 				candidate.DeletedAt = nil
 				result.resurrected++
 			}
+			clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, existing.ID, cr.RackID)
 			if patched := rackUpdatedFromCore(&candidate, &built); patched != nil {
 				candidate = *patched
 			}
@@ -259,6 +260,7 @@ func mirrorExpectedRacks(
 			continue
 		}
 
+		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.Nil, cr.RackID)
 		p.toInsert = append(p.toInsert, built)
 	}
 
@@ -291,7 +293,7 @@ func mirrorExpectedRacks(
 		// (manufacturer, serial) doesn't appear in Core's set either,
 		// otherwise it'll be picked up by the adoption path above and a
 		// "future GC" warn would be misleading.
-		if _, adoptable := flowBySerialInCore(r, coreRacks); !adoptable {
+		if _, adoptable := adoptableFromCore(r, coreRacks); !adoptable {
 			result.legacyExempt++
 			log.Warn().
 				Str("rack_name", r.Name).
@@ -327,7 +329,8 @@ func mirrorExpectedRacks(
 			p.toUpdate[i].UpdatedAt = now
 			if _, err := tx.NewUpdate().
 				Model(&p.toUpdate[i]).
-				Column("name", "description", "location", "external_id", "deleted_at", "updated_at").
+				Column("name", "manufacturer", "serial_number", "description",
+					"location", "external_id", "deleted_at", "updated_at").
 				WhereAllWithDeleted().
 				Where("id = ?", p.toUpdate[i].ID).
 				Exec(ctx); err != nil {
@@ -410,19 +413,19 @@ func getAllRacksIncludingDeleted(ctx context.Context, idb bun.IDB) ([]model.Rack
 	return racks, nil
 }
 
-// flowBySerialInCore is a small helper: it scans Core's racks and returns
-// whether any of them shares this Flow rack's (manufacturer, serial_number).
-// Used to suppress the "legacy not in Core" warn for rows that the adoption
-// path will pick up on this same cycle.
-func flowBySerialInCore(r *model.Rack, coreRacks []nicoapi.ExpectedRackDetail) (string, bool) {
-	want := rackNaturalKey(r.Manufacturer, r.SerialNumber)
+// adoptableFromCore returns the Core rack_id whose chassis pair matches this
+// Flow rack's, meaning the adoption path will reach it. Used to suppress the
+// "legacy not in Core" warn for rows that get picked up on this same cycle. A
+// rack with an incomplete pair is never adoptable, since naturalKeyOrEmpty
+// keeps it out of the adoption index.
+func adoptableFromCore(r *model.Rack, coreRacks []nicoapi.ExpectedRackDetail) (string, bool) {
+	want := naturalKeyOrEmpty(r.Manufacturer, r.SerialNumber)
+	if want == "" {
+		return "", false
+	}
 	for _, cr := range coreRacks {
-		manufacturer := cr.Labels[labelChassisManufacturer]
-		serial := cr.Labels[labelChassisSerialNumber]
-		if manufacturer == "" || serial == "" {
-			continue
-		}
-		if rackNaturalKey(manufacturer, serial) == want {
+		key := naturalKeyOrEmpty(cr.Labels[labelChassisManufacturer], cr.Labels[labelChassisSerialNumber])
+		if key == want {
 			return cr.RackID, true
 		}
 	}
@@ -430,42 +433,33 @@ func flowBySerialInCore(r *model.Rack, coreRacks []nicoapi.ExpectedRackDetail) (
 }
 
 // buildRackFromCore translates one Core ExpectedRackDetail into the Flow Rack
-// shape the mirror will insert. Returns false if the Core row is missing
-// fields that Flow's rack table requires (manufacturer / serial_number are
-// NOT NULL and form a unique key).
+// shape the mirror will insert. Returns false when Core supplied no rack_id:
+// external_id is the mirrored rack's identity, so without one the row could
+// not be matched again on any later cycle. Core's expected_racks keys on
+// rack_id, so this is a Core-side data fault rather than an expected input.
+//
+// The chassis labels are copied through as-is, empty included. They are
+// descriptive metadata here, not identity, and the caller vets them against
+// rack_manufacturer_serial_idx before writing.
 func buildRackFromCore(cr nicoapi.ExpectedRackDetail) (model.Rack, bool) {
-	manufacturer := cr.Labels[labelChassisManufacturer]
-	serial := cr.Labels[labelChassisSerialNumber]
-	if manufacturer == "" || serial == "" {
+	if cr.RackID == "" {
 		return model.Rack{}, false
 	}
 
 	name := cr.Name
 	if name == "" {
-		// Flow's rack.name is NOT NULL with a unique index. Fall back to
-		// Core's stable rack_id first (operator-meaningful), then to
-		// manufacturer-serial so the row is still insertable when Core has
-		// neither. Operators can always rename later via the existing rack
-		// PATCH path.
-		switch {
-		case cr.RackID != "":
-			name = cr.RackID
-		default:
-			name = manufacturer + "-" + serial
-		}
+		// Flow's rack.name is NOT NULL with a unique index. Core's rack_id is
+		// operator-meaningful and unique, so it stands in until someone
+		// renames the rack through the PATCH path.
+		name = cr.RackID
 	}
 
+	extID := cr.RackID
 	r := model.Rack{
 		Name:         name,
-		Manufacturer: manufacturer,
-		SerialNumber: serial,
-	}
-	// Leave ExternalID NULL when Core has no rack_id. Storing an empty
-	// string would still hit the partial unique index (which excludes NULL
-	// but not the empty string), so two such racks would collide.
-	if cr.RackID != "" {
-		extID := cr.RackID
-		r.ExternalID = &extID
+		Manufacturer: cr.Labels[labelChassisManufacturer],
+		SerialNumber: cr.Labels[labelChassisSerialNumber],
+		ExternalID:   &extID,
 	}
 
 	if desc := rackDescriptionFromLabels(cr.Labels, cr.Description); len(desc) > 0 {
@@ -513,10 +507,13 @@ func rackLocationFromLabels(labels map[string]string) map[string]any {
 }
 
 // rackUpdatedFromCore returns a copy of `existing` with mirror-managed fields
-// overwritten from `fromCore`. It deliberately does not touch identity
-// (manufacturer / serial_number), lifecycle (status / ingested_at), or fields
-// the mirror has no opinion on (nvldomain_id is out of scope for this PR; the
-// runtime sync owns it).
+// overwritten from `fromCore`. Lifecycle (status / ingested_at) and
+// nvldomain_id belong to other paths and are left alone.
+//
+// A chassis label is filled in only when Flow's copy is empty: Core dropping a
+// label it used to send is a data gap, not an instruction to erase what Flow
+// already recorded. The caller has already blanked any pair that would collide
+// on rack_manufacturer_serial_idx.
 //
 // Returns nil when no patchable field changed so the caller can skip a no-op
 // UPDATE.
@@ -545,9 +542,46 @@ func rackUpdatedFromCore(existing, fromCore *model.Rack) *model.Rack {
 		patched.ExternalID = fromCore.ExternalID
 		changed = true
 	}
+	if existing.Manufacturer == "" && fromCore.Manufacturer != "" {
+		patched.Manufacturer = fromCore.Manufacturer
+		changed = true
+	}
+	if existing.SerialNumber == "" && fromCore.SerialNumber != "" {
+		patched.SerialNumber = fromCore.SerialNumber
+		changed = true
+	}
 
 	if !changed {
 		return nil
 	}
 	return &patched
+}
+
+// clearChassisLabelsIfSlotTaken blanks built's chassis labels when a Flow rack
+// other than selfID already holds that complete pair. selfID is uuid.Nil for an
+// INSERT. rack_manufacturer_serial_idx covers soft-deleted rows too, so writing
+// an occupied pair would abort the whole cycle; the rack is still mirrored under
+// its external_id, just without the labels.
+func clearChassisLabelsIfSlotTaken(
+	built *model.Rack,
+	flowByNaturalKey map[string]*model.Rack,
+	selfID uuid.UUID,
+	rackID string,
+) {
+	key := naturalKeyOrEmpty(built.Manufacturer, built.SerialNumber)
+	if key == "" {
+		return
+	}
+	owner, ok := flowByNaturalKey[key]
+	if !ok || owner.ID == selfID {
+		return
+	}
+	log.Warn().
+		Str("rack_id", rackID).
+		Str("manufacturer", built.Manufacturer).
+		Str("serial", built.SerialNumber).
+		Str("held_by_rack", owner.Name).
+		Msg("Expected-inventory mirror: another Flow rack already holds this chassis manufacturer and serial number; mirroring this rack without chassis labels")
+	built.Manufacturer = ""
+	built.SerialNumber = ""
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
@@ -147,6 +147,10 @@ func mirrorExpectedRacks(
 	seenExtID := make(map[string]struct{}, len(coreRacks))
 	touchedIDs := make(map[uuid.UUID]struct{}, len(coreRacks))
 	plannedNaturalKeys := make(map[string]struct{}, len(coreRacks))
+	// plannedNames: names claimed by a write already queued this cycle, which
+	// liveByName cannot know about since it is built from the state at cycle
+	// start. See nameUnavailable.
+	plannedNames := make(map[string]struct{}, len(coreRacks))
 
 	// coreExtIDs is every rack_id in this response. Precomputed because the
 	// adoption guard has to ask about rack_ids the loop below has not reached
@@ -210,7 +214,7 @@ func mirrorExpectedRacks(
 				candidate = *patched
 				needUpdate = true
 			}
-			if needUpdate && nameTakenByOtherLiveRack(liveByName, candidate.Name, existing.ID) {
+			if needUpdate && nameUnavailable(liveByName, plannedNames, candidate.Name, existing.ID) {
 				log.Warn().
 					Str("rack_id", cr.RackID).
 					Str("name", candidate.Name).
@@ -221,6 +225,7 @@ func mirrorExpectedRacks(
 				continue
 			}
 			if needUpdate {
+				plannedNames[candidate.Name] = struct{}{}
 				p.toUpdate = append(p.toUpdate, candidate)
 			}
 			touchedIDs[existing.ID] = struct{}{}
@@ -244,7 +249,7 @@ func mirrorExpectedRacks(
 			if patched := rackUpdatedFromCore(&candidate, &built); patched != nil {
 				candidate = *patched
 			}
-			if nameTakenByOtherLiveRack(liveByName, candidate.Name, existing.ID) {
+			if nameUnavailable(liveByName, plannedNames, candidate.Name, existing.ID) {
 				log.Warn().
 					Str("rack_id", cr.RackID).
 					Str("name", candidate.Name).
@@ -254,13 +259,14 @@ func mirrorExpectedRacks(
 				touchedIDs[existing.ID] = struct{}{}
 				continue
 			}
+			plannedNames[candidate.Name] = struct{}{}
 			p.toUpdate = append(p.toUpdate, candidate)
 			touchedIDs[existing.ID] = struct{}{}
 			result.adopted++
 			continue
 		}
 
-		if nameTakenByOtherLiveRack(liveByName, built.Name, uuid.Nil) {
+		if nameUnavailable(liveByName, plannedNames, built.Name, uuid.Nil) {
 			log.Warn().
 				Str("rack_id", cr.RackID).
 				Str("name", built.Name).
@@ -271,6 +277,7 @@ func mirrorExpectedRacks(
 		}
 
 		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.Nil, cr.RackID)
+		plannedNames[built.Name] = struct{}{}
 		p.toInsert = append(p.toInsert, built)
 	}
 
@@ -371,9 +378,24 @@ func mirrorExpectedRacks(
 	return result
 }
 
-// nameTakenByOtherLiveRack reports whether a live (non-deleted) Flow rack
-// other than selfID already holds name. selfID is uuid.Nil for an INSERT.
-func nameTakenByOtherLiveRack(liveByName map[string]uuid.UUID, name string, selfID uuid.UUID) bool {
+// nameUnavailable reports whether writing name would collide on rack_name_idx:
+// either a live Flow rack other than selfID already holds it, or a write queued
+// earlier in this cycle has claimed it. selfID is uuid.Nil for an INSERT.
+//
+// The index is a full unique constraint and every write lands in one
+// transaction, so a collision rolls back the entire cycle rather than the one
+// offending write. That is why queued claims count: two Core racks can resolve
+// to the same name, and the second must be skipped rather than left to abort
+// everything.
+func nameUnavailable(
+	liveByName map[string]uuid.UUID,
+	plannedNames map[string]struct{},
+	name string,
+	selfID uuid.UUID,
+) bool {
+	if _, planned := plannedNames[name]; planned {
+		return true
+	}
 	id, ok := liveByName[name]
 	return ok && id != selfID
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
@@ -16,12 +16,37 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 )
 
-func TestRackNaturalKeyIsCollisionFree(t *testing.T) {
+func TestNaturalKeyIsCollisionFree(t *testing.T) {
 	// The classic concatenation bug: "ab"+"cd" and "abc"+"d" collide if you
 	// don't separate with a forbidden byte.
-	a := rackNaturalKey("ab", "cd")
-	b := rackNaturalKey("abc", "d")
+	a := naturalKey("ab", "cd")
+	b := naturalKey("abc", "d")
 	assert.NotEqual(t, a, b, "manufacturer/serial collisions must be impossible")
+}
+
+func TestNaturalKeyOrEmpty(t *testing.T) {
+	tests := []struct {
+		name         string
+		manufacturer string
+		serialNumber string
+		wantEmpty    bool
+	}{
+		{name: "both halves populated", manufacturer: "Foxconn", serialNumber: "SN-1"},
+		{name: "no manufacturer", serialNumber: "SN-1", wantEmpty: true},
+		{name: "no serial", manufacturer: "Foxconn", wantEmpty: true},
+		{name: "neither", wantEmpty: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := naturalKeyOrEmpty(tc.manufacturer, tc.serialNumber)
+			if tc.wantEmpty {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Equal(t, naturalKey(tc.manufacturer, tc.serialNumber), got)
+		})
+	}
 }
 
 func TestBuildRackFromCore(t *testing.T) {
@@ -75,24 +100,47 @@ func TestBuildRackFromCore(t *testing.T) {
 			},
 		},
 		{
-			name: "missing manufacturer is unusable",
+			name: "missing manufacturer is mirrored without it",
 			in: nicoapi.ExpectedRackDetail{
 				RackID: "c01",
 				Labels: map[string]string{
 					labelChassisSerialNumber: "SN-C01",
 				},
 			},
-			wantOK: false,
+			wantOK: true,
+			assertRow: func(t *testing.T, r model.Rack) {
+				assert.Empty(t, r.Manufacturer)
+				assert.Equal(t, "SN-C01", r.SerialNumber)
+				require.NotNil(t, r.ExternalID)
+				assert.Equal(t, "c01", *r.ExternalID)
+			},
 		},
 		{
-			name: "missing serial is unusable",
+			name: "missing serial is mirrored without it",
 			in: nicoapi.ExpectedRackDetail{
 				RackID: "c02",
 				Labels: map[string]string{
 					labelChassisManufacturer: "Foxconn",
 				},
 			},
-			wantOK: false,
+			wantOK: true,
+			assertRow: func(t *testing.T, r model.Rack) {
+				assert.Equal(t, "Foxconn", r.Manufacturer)
+				assert.Empty(t, r.SerialNumber)
+			},
+		},
+		{
+			name: "no chassis labels at all is still mirrored under rack_id",
+			in: nicoapi.ExpectedRackDetail{
+				RackID: "c03",
+				Name:   "klamath-1",
+			},
+			wantOK: true,
+			assertRow: func(t *testing.T, r model.Rack) {
+				assert.Empty(t, r.Manufacturer)
+				assert.Empty(t, r.SerialNumber)
+				assert.Equal(t, "klamath-1", r.Name)
+			},
 		},
 		{
 			name: "no description/location labels leaves jsonb columns nil",
@@ -111,7 +159,7 @@ func TestBuildRackFromCore(t *testing.T) {
 			},
 		},
 		{
-			name: "missing rack_id yields nil ExternalID (NULL in DB) so partial unique index stays clean",
+			name: "missing rack_id is unusable: nothing to identify the rack by",
 			in: nicoapi.ExpectedRackDetail{
 				Name: "noext",
 				Labels: map[string]string{
@@ -119,25 +167,7 @@ func TestBuildRackFromCore(t *testing.T) {
 					labelChassisSerialNumber: "SN-E01",
 				},
 			},
-			wantOK: true,
-			assertRow: func(t *testing.T, r model.Rack) {
-				assert.Nil(t, r.ExternalID)
-				assert.Equal(t, "noext", r.Name)
-			},
-		},
-		{
-			name: "missing both rack_id and name falls back to manufacturer-serial",
-			in: nicoapi.ExpectedRackDetail{
-				Labels: map[string]string{
-					labelChassisManufacturer: "Foxconn",
-					labelChassisSerialNumber: "SN-F01",
-				},
-			},
-			wantOK: true,
-			assertRow: func(t *testing.T, r model.Rack) {
-				assert.Equal(t, "Foxconn-SN-F01", r.Name)
-				assert.Nil(t, r.ExternalID)
-			},
+			wantOK: false,
 		},
 	}
 
@@ -216,9 +246,36 @@ func TestRackUpdatedFromCore(t *testing.T) {
 		fromCore.Name = ""
 		assert.Nil(t, rackUpdatedFromCore(existing, &fromCore))
 	})
+
+	t.Run("chassis labels are backfilled once Core starts sending them", func(t *testing.T) {
+		existing := base()
+		existing.Manufacturer = ""
+		existing.SerialNumber = ""
+		fromCore := *base()
+		got := rackUpdatedFromCore(existing, &fromCore)
+		require.NotNil(t, got)
+		assert.Equal(t, "Foxconn", got.Manufacturer)
+		assert.Equal(t, "SN-1", got.SerialNumber)
+	})
+
+	t.Run("Core dropping a chassis label does not erase Flow's copy", func(t *testing.T) {
+		existing := base()
+		fromCore := *base()
+		fromCore.Manufacturer = ""
+		fromCore.SerialNumber = ""
+		assert.Nil(t, rackUpdatedFromCore(existing, &fromCore))
+	})
+
+	t.Run("a populated chassis label is not overwritten with a different one", func(t *testing.T) {
+		existing := base()
+		fromCore := *base()
+		fromCore.Manufacturer = "Wistron"
+		fromCore.SerialNumber = "SN-2"
+		assert.Nil(t, rackUpdatedFromCore(existing, &fromCore))
+	})
 }
 
-func TestFlowBySerialInCore(t *testing.T) {
+func TestAdoptableFromCore(t *testing.T) {
 	core := []nicoapi.ExpectedRackDetail{
 		{
 			RackID: "a12",
@@ -230,7 +287,6 @@ func TestFlowBySerialInCore(t *testing.T) {
 		{
 			RackID: "b07",
 			Labels: map[string]string{
-				// Missing manufacturer; should not match anything.
 				labelChassisSerialNumber: "SN-B07",
 			},
 		},
@@ -238,20 +294,26 @@ func TestFlowBySerialInCore(t *testing.T) {
 
 	t.Run("matches by (manufacturer, serial)", func(t *testing.T) {
 		flow := &model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-A12"}
-		ext, ok := flowBySerialInCore(flow, core)
+		ext, ok := adoptableFromCore(flow, core)
 		assert.True(t, ok)
 		assert.Equal(t, "a12", ext)
 	})
 
 	t.Run("no match returns false", func(t *testing.T) {
 		flow := &model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-ZZ"}
-		_, ok := flowBySerialInCore(flow, core)
+		_, ok := adoptableFromCore(flow, core)
 		assert.False(t, ok)
 	})
 
-	t.Run("core row without manufacturer is ignored", func(t *testing.T) {
+	t.Run("core row with a half-populated pair is not adoptable", func(t *testing.T) {
 		flow := &model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-B07"}
-		_, ok := flowBySerialInCore(flow, core)
+		_, ok := adoptableFromCore(flow, core)
+		assert.False(t, ok)
+	})
+
+	t.Run("flow row with a half-populated pair is not adoptable", func(t *testing.T) {
+		flow := &model.Rack{SerialNumber: "SN-B07"}
+		_, ok := adoptableFromCore(flow, core)
 		assert.False(t, ok)
 	})
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
@@ -275,6 +275,28 @@ func TestRackUpdatedFromCore(t *testing.T) {
 	})
 }
 
+func TestAdoptableByNaturalKey(t *testing.T) {
+	coreExtIDs := map[string]struct{}{"live": {}}
+
+	tests := []struct {
+		name       string
+		externalID *string
+		want       bool
+	}{
+		{name: "no external_id has never been claimed", want: true},
+		{name: "empty external_id has never been claimed", externalID: strPtr(""), want: true},
+		{name: "external_id Core no longer reports may be re-pointed", externalID: strPtr("retired"), want: true},
+		{name: "external_id Core still reports owns the row", externalID: strPtr("live")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &model.Rack{ExternalID: tc.externalID}
+			assert.Equal(t, tc.want, adoptableByNaturalKey(r, coreExtIDs))
+		})
+	}
+}
+
 func TestAdoptableFromCore(t *testing.T) {
 	core := []nicoapi.ExpectedRackDetail{
 		{

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
@@ -365,49 +365,6 @@ func TestAdoptableByNaturalKey(t *testing.T) {
 	}
 }
 
-func TestAdoptableFromCore(t *testing.T) {
-	core := []nicoapi.ExpectedRackDetail{
-		{
-			RackID: "a12",
-			Labels: map[string]string{
-				labelChassisManufacturer: "Foxconn",
-				labelChassisSerialNumber: "SN-A12",
-			},
-		},
-		{
-			RackID: "b07",
-			Labels: map[string]string{
-				labelChassisSerialNumber: "SN-B07",
-			},
-		},
-	}
-
-	t.Run("matches by (manufacturer, serial)", func(t *testing.T) {
-		flow := &model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-A12"}
-		ext, ok := adoptableFromCore(flow, core)
-		assert.True(t, ok)
-		assert.Equal(t, "a12", ext)
-	})
-
-	t.Run("no match returns false", func(t *testing.T) {
-		flow := &model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-ZZ"}
-		_, ok := adoptableFromCore(flow, core)
-		assert.False(t, ok)
-	})
-
-	t.Run("core row with a half-populated pair is not adoptable", func(t *testing.T) {
-		flow := &model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-B07"}
-		_, ok := adoptableFromCore(flow, core)
-		assert.False(t, ok)
-	})
-
-	t.Run("flow row with a half-populated pair is not adoptable", func(t *testing.T) {
-		flow := &model.Rack{SerialNumber: "SN-B07"}
-		_, ok := adoptableFromCore(flow, core)
-		assert.False(t, ok)
-	})
-}
-
 // errExpectedRacksClient is a tiny test wrapper around the production mock
 // that overrides GetAllExpectedRackDetails to inject either an RPC error or a
 // custom row set. It satisfies the same nicoapi.Client interface so it slots

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
@@ -275,6 +275,74 @@ func TestRackUpdatedFromCore(t *testing.T) {
 	})
 }
 
+func TestNameUnavailable(t *testing.T) {
+	holder := uuid.New()
+	liveByName := map[string]uuid.UUID{"held": holder}
+
+	tests := []struct {
+		name         string
+		plannedNames map[string]struct{}
+		rackName     string
+		selfID       uuid.UUID
+		want         bool
+	}{
+		{name: "free name", rackName: "free", selfID: uuid.Nil},
+		{name: "name held by another live rack", rackName: "held", selfID: uuid.New(), want: true},
+		{name: "name held by the rack being updated", rackName: "held", selfID: holder},
+		{
+			name:         "name claimed by a write queued earlier this cycle",
+			plannedNames: map[string]struct{}{"free": {}},
+			rackName:     "free",
+			selfID:       uuid.Nil,
+			want:         true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			planned := tc.plannedNames
+			if planned == nil {
+				planned = map[string]struct{}{}
+			}
+			assert.Equal(t, tc.want, nameUnavailable(liveByName, planned, tc.rackName, tc.selfID))
+		})
+	}
+}
+
+func TestClearChassisLabelsIfSlotTaken(t *testing.T) {
+	owner := &model.Rack{ID: uuid.New(), Name: "owner", Manufacturer: "Foxconn", SerialNumber: "SN-1"}
+	flowByNaturalKey := map[string]*model.Rack{
+		naturalKey("Foxconn", "SN-1"): owner,
+	}
+
+	t.Run("labels held by another rack are dropped", func(t *testing.T) {
+		built := model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-1"}
+		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.New(), "b34")
+		assert.Empty(t, built.Manufacturer)
+		assert.Empty(t, built.SerialNumber)
+	})
+
+	t.Run("the rack already holding the pair keeps it", func(t *testing.T) {
+		built := model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-1"}
+		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, owner.ID, "a12")
+		assert.Equal(t, "Foxconn", built.Manufacturer)
+		assert.Equal(t, "SN-1", built.SerialNumber)
+	})
+
+	t.Run("an unclaimed pair is kept", func(t *testing.T) {
+		built := model.Rack{Manufacturer: "Wistron", SerialNumber: "SN-9"}
+		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.Nil, "c01")
+		assert.Equal(t, "Wistron", built.Manufacturer)
+		assert.Equal(t, "SN-9", built.SerialNumber)
+	})
+
+	t.Run("a half-populated pair occupies no slot and is left alone", func(t *testing.T) {
+		built := model.Rack{SerialNumber: "SN-1"}
+		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.Nil, "c02")
+		assert.Equal(t, "SN-1", built.SerialNumber)
+	})
+}
+
 func TestAdoptableByNaturalKey(t *testing.T) {
 	coreExtIDs := map[string]struct{}{"live": {}}
 


### PR DESCRIPTION
Core does not label every rack or component with a chassis manufacturer and serial number, but Flow used `(manufacturer, serial_number)` as the row identity for both tables: the expected-inventory mirror matched Core rows to Flow rows on that pair, and both tables carry a unique constraint on it. Rows Core had not labelled were skipped outright, and several rows sharing one incomplete pair collapsed onto a single key — a site with four racks labelled `manufacturer=NVIDIA` and no serial could only ever mirror one of them. This PR separates row identity from the chassis labels so those rows mirror normally.
- A mirrored rack is now identified by `external_id` (Core's `rack_id`, which is the primary key of Core's `expected_racks` table) and a mirrored component by its host BMC's MAC address (`bmc.mac_address` is that table's primary key, so a MAC belongs to exactly one component). `buildRackFromCore` requires only `rack_id`; `specValid` requires only a BMC MAC.
- All four `manufacturer` / `serial_number` columns become nullable. Both `(manufacturer, serial_number)` unique constraints stay in place: NULLs are distinct in Postgres, so a row missing either half occupies no slot in them and `GetComponentInfoBySerial`'s uniqueness contract is unchanged.
- The chassis pair stays as a fallback for rows the primary identifier cannot reach — racks created before `external_id` existed or through the `CreateExpectedRack` gRPC, which still does not populate it, and components whose BMC board was swapped so Core reports a MAC Flow has never seen. Only rows carrying both halves enter the fallback index, since a half-populated pair identifies nothing. Otherwise the labels are descriptive metadata, filled in when Core starts supplying one and never erased when Core drops one. Where two rows contend for one pair, the loser is mirrored without the labels rather than dropped.
- A Flow component with neither a host BMC nor a complete chassis pair cannot be compared against what Core reported, so the delete phase now leaves it in place with a warn rather than soft-deleting it. The `AddComponent` gRPC creates components with no BMC at all, so such rows exist today.
- Fixes a pre-existing bug in rack adoption: two Core racks sharing a chassis pair both fell through to the natural-key fallback, so the second overwrote the `external_id` of the row the first already owned. The two then traded that row on every cycle and one of them never got a row of its own. Adoption now only re-points a row whose `external_id` Core has stopped reporting, which still lets a rack re-registered under a new `rack_id` keep its UUID.


## Related issues
#4966

## Type of Change 
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes 
- [ ] **This PR contains breaking changes**

## Testing 
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes 

