### PR TITLE
fix: point hardware-health at a hostname the nico-api cert covers

### DIFF
--- a/crates/dsx-exchange-consumer/example/config.example.toml
+++ b/crates/dsx-exchange-consumer/example/config.example.toml
@@ -30,7 +30,7 @@ value_state_ttl = "1h"
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
-api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
+api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
 
 # ==============================================================================
 # Metrics

--- a/crates/dsx-exchange-consumer/src/config.rs
+++ b/crates/dsx-exchange-consumer/src/config.rs
@@ -175,7 +175,7 @@ impl Default for CarbideApiConnectionConfig {
             root_ca: "/var/run/secrets/spiffe.io/ca.crt".to_string(),
             client_cert: "/var/run/secrets/spiffe.io/tls.crt".to_string(),
             client_key: "/var/run/secrets/spiffe.io/tls.key".to_string(),
-            api_url: Url::parse("https://carbide-api.forge-system.svc.cluster.local:1079")
+            api_url: Url::parse("https://nico-api.nico-system.svc.cluster.local:1079")
                 .expect("valid default URL"),
         }
     }
@@ -267,5 +267,18 @@ mod tests {
         assert_eq!(config.mqtt.endpoint, "mqtt.forge");
         assert_eq!(config.mqtt.port, 1884);
         assert_eq!(config.metrics.endpoint, "0.0.0.0:9009");
+    }
+
+    #[test]
+    fn test_carbide_api_default_url_uses_current_hostname() {
+        let config = CarbideApiConnectionConfig::default();
+        assert!(
+            config
+                .api_url
+                .as_str()
+                .starts_with("https://nico-api.nico-system.svc.cluster.local:1079"),
+            "unexpected default api_url: {}",
+            config.api_url,
+        );
     }
 }

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -32,7 +32,7 @@ endpoint_discovery_interval = "5m"
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
-api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
+api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
 
 [[endpoint_sources.static_bmc_endpoints]]
 ip = "10.0.0.1"
@@ -156,7 +156,7 @@ include_alert_details = false
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
-api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
+api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
 workers = 8
 skip_empty_reports = true
 
@@ -164,7 +164,7 @@ skip_empty_reports = true
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
-api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
+api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
 workers = 2
 skip_empty_reports = true
 
@@ -172,7 +172,7 @@ skip_empty_reports = true
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
-api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
+api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
 workers = 2
 skip_empty_reports = true
 
@@ -180,7 +180,7 @@ skip_empty_reports = true
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
-api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
+api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
 workers = 2
 skip_empty_reports = true
 

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -706,7 +706,7 @@ impl Default for CarbideApiConnectionConfig {
             root_ca: "/var/run/secrets/spiffe.io/ca.crt".to_string(),
             client_cert: "/var/run/secrets/spiffe.io/tls.crt".to_string(),
             client_key: "/var/run/secrets/spiffe.io/tls.key".to_string(),
-            api_url: Url::parse("https://carbide-api.forge-system.svc.cluster.local:1079").unwrap(),
+            api_url: Url::parse("https://carbide-api.nico-system.svc.cluster.local:1079").unwrap(),
         }
     }
 }
@@ -2243,7 +2243,7 @@ mod tests {
                 carbide_api
                     .api_url
                     .as_str()
-                    .starts_with("https://carbide-api.forge-system.svc.cluster.local:1079"),
+                    .starts_with("https://nico-api.nico-system.svc.cluster.local:1079"),
             );
         } else {
             panic!("carbide api empty for sources")

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -706,7 +706,7 @@ impl Default for CarbideApiConnectionConfig {
             root_ca: "/var/run/secrets/spiffe.io/ca.crt".to_string(),
             client_cert: "/var/run/secrets/spiffe.io/tls.crt".to_string(),
             client_key: "/var/run/secrets/spiffe.io/tls.key".to_string(),
-            api_url: Url::parse("https://carbide-api.nico-system.svc.cluster.local:1079").unwrap(),
+            api_url: Url::parse("https://nico-api.nico-system.svc.cluster.local:1079").unwrap(),
         }
     }
 }

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -52,10 +52,13 @@ namespaceOverride: ""
 ## expansion (which would otherwise try `carbide-api.forge-system.svc.
 ## cluster.local.<pod-search-domain>` first and get NXDOMAIN).
 legacyAlias:
-  # On by default to match the chart's cert SAN posture (the `nico-api`
-  # Certificate already includes `carbide-api.forge-system.svc.cluster.local`
-  # as a SAN). Flip to false on all-modern fleets where no client uses the
-  # legacy hostname.
+  # On by default so DNS resolution of the legacy hostname keeps working
+  # for existing pre-rename clients. Note this only covers name
+  # resolution -- the `nico-api` Certificate's SAN list does not include
+  # `carbide-api.forge-system.svc.cluster.local`, so any client actually
+  # dialing that hostname over TLS still fails certificate verification.
+  # Flip to false on all-modern fleets where no client uses the legacy
+  # hostname.
   enabled: true
   aliases:
     - name: carbide-api


### PR DESCRIPTION
## Summary
- Use the canonical nico-api hostname covered by its TLS certificate
- Update health and DSX exchange consumer defaults
- Update the example configuration and legacy alias documentation
Closes #3589.
Supersedes #3596 because its external fork branch could not be updated.
Original implementation by @RajMandaliya.
## Test plan
- cargo test -p carbide-health test_parse_example_config
- cargo test -p carbide-dsx-exchange-consumer
- cargo build -p carbide-health