### PR TITLE
patch(v2.1): discover host NICs in partial Redfish inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,6 +3075,7 @@ version = "0.0.1"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "axum",
  "bmc-explorer",
  "bmc-mock",
  "bmc-vendor",

--- a/crates/api-db/src/predicted_machine_interface.rs
+++ b/crates/api-db/src/predicted_machine_interface.rs
@@ -74,6 +74,40 @@ pub async fn set_boot_interface_id(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Reconciles the selected primary state on a pending prediction.
+pub async fn set_primary_interface(
+    id: uuid::Uuid,
+    primary_interface: bool,
+    txn: &mut PgConnection,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE predicted_machine_interfaces SET primary_interface = $1 WHERE id = $2";
+    sqlx::query(query)
+        .bind(primary_interface)
+        .bind(id)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Clears the primary flag from every pending prediction except the selected
+/// MAC, keeping boot selection unambiguous when a refreshed report adds or
+/// changes the primary candidate.
+pub async fn demote_other_primary_interfaces_for_machine(
+    machine_id: &carbide_uuid::machine::MachineId,
+    primary_mac_address: MacAddress,
+    txn: &mut PgConnection,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE predicted_machine_interfaces SET primary_interface=false WHERE machine_id=$1 AND mac_address!=$2 AND primary_interface=true";
+    sqlx::query(query)
+        .bind(machine_id)
+        .bind(primary_mac_address)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 pub async fn delete(
     value: &PredictedMachineInterface,
     txn: &mut PgConnection,

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1639,8 +1639,8 @@ pub struct NetworkAdapter {
     /// adapter.
     ///
     /// These remain attached to the adapter that reported them so callers can
-    /// use them as supplemental inventory when `ComputerSystem.EthernetInterfaces`
-    /// does not expose usable MAC addresses.
+    /// apply their own interface-selection policy without fabricating
+    /// `ComputerSystem.EthernetInterfaces` inventory.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub port_mac_addresses: Vec<MacAddress>,
 }

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -172,9 +172,14 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
 
     let hw_type = hw_type(&root, &explored_system, &explored_chassis);
     let linked_chassis_ids = explored_system.linked_chassis_ids();
+    let has_system_mac_address = explored_system.has_usable_ethernet_mac_address();
     if should_use_network_adapter_port_fallback(
         hw_type,
-        explored_system.has_usable_ethernet_mac_address(),
+        has_system_mac_address,
+        &linked_chassis_ids,
+    ) || should_fetch_supplemental_network_adapter_ports(
+        hw_type,
+        has_system_mac_address,
         &linked_chassis_ids,
     ) {
         explored_chassis
@@ -329,6 +334,15 @@ fn should_use_network_adapter_port_fallback(
     linked_chassis_ids: &[nv_redfish::core::ODataId],
 ) -> bool {
     hw_type == Some(hw::HwType::Lenovo) && !has_system_mac_address && !linked_chassis_ids.is_empty()
+}
+
+/// Whether linked adapter Ports can supplement a Lenovo XCC's System inventory.
+fn should_fetch_supplemental_network_adapter_ports(
+    hw_type: Option<hw::HwType>,
+    has_system_mac_address: bool,
+    linked_chassis_ids: &[nv_redfish::core::ODataId],
+) -> bool {
+    hw_type == Some(hw::HwType::Lenovo) && has_system_mac_address && !linked_chassis_ids.is_empty()
 }
 
 /// Builds an exploration report for a Delta power shelf.
@@ -1178,7 +1192,10 @@ mod tests {
     use nv_redfish::core::ODataId;
 
     use super::hw::HwType;
-    use super::{Product, is_bf4_product, should_use_network_adapter_port_fallback};
+    use super::{
+        Product, is_bf4_product, should_fetch_supplemental_network_adapter_ports,
+        should_use_network_adapter_port_fallback,
+    };
 
     #[test]
     fn is_bf4_product_matches_bf4_service_root_products() {
@@ -1216,6 +1233,38 @@ mod tests {
             }
             "Lenovo XCC without a linked chassis" {
                 (Some(HwType::Lenovo), false, false) => false,
+            }
+        );
+    }
+
+    #[test]
+    fn lenovo_network_adapter_port_fetch_supplements_partial_inventory() {
+        value_scenarios!(run = |(hw_type, has_system_mac_address, has_linked_chassis)| {
+            let linked_chassis_ids = has_linked_chassis
+                .then(|| ODataId::from("/redfish/v1/Chassis/Self".to_string()))
+                .into_iter()
+                .collect::<Vec<_>>();
+
+            should_fetch_supplemental_network_adapter_ports(
+                hw_type,
+                has_system_mac_address,
+                &linked_chassis_ids,
+            )
+        };
+            "Lenovo XCC without a System MAC" {
+                (Some(HwType::Lenovo), false, true) => false,
+            }
+            "Lenovo XCC with a System MAC supplements its inventory" {
+                (Some(HwType::Lenovo), true, true) => true,
+            }
+            "non-Lenovo host" {
+                (Some(HwType::Ami), true, true) => false,
+            }
+            "Lenovo AMI host" {
+                (Some(HwType::LenovoAmi), true, true) => false,
+            }
+            "Lenovo XCC without a linked chassis" {
+                (Some(HwType::Lenovo), true, false) => false,
             }
         );
     }

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -38,6 +38,7 @@ mod machine_info;
 mod middleware_router;
 mod mock_machine_router;
 mod redfish;
+mod tar_router;
 pub mod test_support;
 pub mod tls;
 

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -17,6 +17,8 @@
 
 use std::sync::{Arc, Mutex};
 
+use axum::routing::get;
+use axum::{Json, Router};
 use axum_http_client::AxumRouterHttpClient;
 use mac_address::MacAddress;
 use nv_redfish::bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
@@ -320,6 +322,124 @@ pub async fn generic_ami_bmc() -> TestBmcHandle {
         MachineRouterOptions::default(),
     ))
     .await
+}
+
+/// Builds a router from the recorded Lenovo ThinkSystem SR670 Redfish tree.
+pub fn lenovo_thinksystem_sr670_router() -> Router {
+    let archive_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("lenovo_thinksystem_sr670.tar.gz");
+    crate::tar_router::tar_router(crate::tar_router::TarGzOption::Disk(&archive_path), None)
+        .expect("Lenovo ThinkSystem SR670 archive must be readable")
+}
+
+/// Builds the recorded Lenovo XCC router with five usable System interfaces
+/// and the ConnectX-7 MAC reported only through its linked adapter Port.
+pub fn lenovo_xcc_router_with_partial_system_network_inventory() -> Router {
+    const SYSTEM_INTERFACES: &str = "/redfish/v1/Systems/1/EthernetInterfaces";
+    const ADAPTERS: &str = "/redfish/v1/Chassis/1/NetworkAdapters";
+    const ADAPTER: &str = "/redfish/v1/Chassis/1/NetworkAdapters/slot-15";
+    const PORTS: &str = "/redfish/v1/Chassis/1/NetworkAdapters/slot-15/Ports";
+    const PORT: &str = "/redfish/v1/Chassis/1/NetworkAdapters/slot-15/Ports/2";
+
+    let interfaces = [
+        ("ToManager", "0a:8f:c3:a5:8a:41"),
+        ("NIC1", "00:62:0b:4c:28:a8"),
+        ("NIC2", "00:62:0b:4c:28:a9"),
+        ("NIC3", "00:62:0b:4c:28:aa"),
+        ("NIC4", "00:62:0b:4c:28:ab"),
+    ];
+    let interface_members = interfaces
+        .iter()
+        .map(|(id, _)| serde_json::json!({ "@odata.id": format!("{SYSTEM_INTERFACES}/{id}") }))
+        .collect::<Vec<_>>();
+    let mut router = Router::new().route(
+        SYSTEM_INTERFACES,
+        get(move || {
+            let interface_members = interface_members.clone();
+            async move {
+                Json(serde_json::json!({
+                    "@odata.id": SYSTEM_INTERFACES,
+                    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+                    "Name": "Ethernet Interface Collection",
+                    "Members": interface_members,
+                }))
+            }
+        }),
+    );
+    for (id, mac_address) in interfaces {
+        let path = format!("{SYSTEM_INTERFACES}/{id}");
+        let interface_odata_id = path.clone();
+        router = router.route(
+            &path,
+            get(move || {
+                let interface_odata_id = interface_odata_id.clone();
+                async move {
+                    Json(serde_json::json!({
+                        "@odata.id": interface_odata_id,
+                        "@odata.type": "#EthernetInterface.v1_12_0.EthernetInterface",
+                        "Id": id,
+                        "Name": id,
+                        "InterfaceEnabled": true,
+                        "MACAddress": mac_address,
+                        "Status": { "State": "Enabled" },
+                    }))
+                }
+            }),
+        );
+    }
+
+    router
+        .route(
+            ADAPTERS,
+            get(|| async {
+                Json(serde_json::json!({
+                    "@odata.id": ADAPTERS,
+                    "@odata.type": "#NetworkAdapterCollection.NetworkAdapterCollection",
+                    "Name": "Network Adapter Collection",
+                    "Members": [{ "@odata.id": ADAPTER }],
+                }))
+            }),
+        )
+        .route(
+            ADAPTER,
+            get(|| async {
+                Json(serde_json::json!({
+                    "@odata.id": ADAPTER,
+                    "@odata.type": "#NetworkAdapter.v1_7_0.NetworkAdapter",
+                    "Id": "slot-15",
+                    "Name": "ConnectX-7",
+                    "Manufacturer": "NVIDIA",
+                    "Model": "ConnectX-7",
+                    "Ports": { "@odata.id": PORTS },
+                }))
+            }),
+        )
+        .route(
+            PORTS,
+            get(|| async {
+                Json(serde_json::json!({
+                    "@odata.id": PORTS,
+                    "@odata.type": "#PortCollection.PortCollection",
+                    "Name": "Port Collection",
+                    "Members": [{ "@odata.id": PORT }],
+                }))
+            }),
+        )
+        .route(
+            PORT,
+            get(|| async {
+                Json(serde_json::json!({
+                    "@odata.id": PORT,
+                    "@odata.type": "#Port.v1_6_0.Port",
+                    "Id": "2",
+                    "Name": "Port 2",
+                    "Oem": {
+                        "Lenovo": { "PhysicalPortMacAddress": "94:6d:ae:53:cb:9b" },
+                    },
+                }))
+            }),
+        )
+        .fallback_service(lenovo_thinksystem_sr670_router())
 }
 
 const TEST_ADAPTERS: &str = "/redfish/v1/Chassis/Self/NetworkAdapters";

--- a/crates/site-explorer/Cargo.toml
+++ b/crates/site-explorer/Cargo.toml
@@ -61,6 +61,7 @@ thiserror = { workspace = true }
 version-compare = { workspace = true }
 
 [dev-dependencies]
+axum = { workspace = true }
 bmc-explorer = { path = "../bmc-explorer", features = ["test-support"] }
 bmc-mock = { path = "../bmc-mock" }
 opentelemetry-prometheus = { workspace = true }

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -1763,6 +1763,7 @@ mod tests {
     use std::net::TcpListener;
 
     use arc_swap::ArcSwap;
+    use axum::Router;
     use bmc_mock::{CombinedServer, ListenerOrAddress};
     use carbide_instrument::Outcome;
     use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
@@ -1790,20 +1791,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn default_nvredfish_mode_does_not_apply_lenovo_fallback_to_generic_ami() {
-        let (router, _state) = bmc_mock::test_support::
-            generic_ami_router_with_network_adapter_port_and_disabled_system_mac(
-                serde_json::json!({
-                "@odata.id": "/redfish/v1/Chassis/Self/NetworkAdapters/1/Ports/1",
-                "@odata.type": "#Port.v1_6_0.Port",
-                "Id": "1",
-                "Name": "Port 1",
-                "Oem": {
-                    "Lenovo": { "PhysicalPortMacAddress": "946DAE53CB9B" }
-                }
-                }),
-            );
+    async fn explore_router_in_default_mode(router: Router) -> EndpointExplorationReport {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let bmc_ip_address = listener.local_addr().unwrap();
         let _server = CombinedServer::run_router(
@@ -1826,7 +1814,7 @@ mod tests {
             None,
         );
 
-        let report = explorer
+        explorer
             .generate_exploration_report(
                 bmc_ip_address,
                 Credentials::new("root", "password"),
@@ -1834,7 +1822,24 @@ mod tests {
                 None,
             )
             .await
-            .unwrap();
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn default_nvredfish_mode_does_not_apply_lenovo_fallback_to_generic_ami() {
+        let (router, _state) = bmc_mock::test_support::
+            generic_ami_router_with_network_adapter_port_and_disabled_system_mac(
+                serde_json::json!({
+                "@odata.id": "/redfish/v1/Chassis/Self/NetworkAdapters/1/Ports/1",
+                "@odata.type": "#Port.v1_6_0.Port",
+                "Id": "1",
+                "Name": "Port 1",
+                "Oem": {
+                    "Lenovo": { "PhysicalPortMacAddress": "946DAE53CB9B" }
+                }
+                }),
+            );
+        let report = explore_router_in_default_mode(router).await;
 
         assert!(report.all_mac_addresses().is_empty());
         assert!(
@@ -1850,6 +1855,41 @@ mod tests {
                     interface.id.as_deref() == Some("disabled") && interface.mac_address.is_none()
                 })
         );
+    }
+
+    #[tokio::test]
+    async fn default_nvredfish_mode_discovers_lenovo_port_mac_with_partial_system_inventory() {
+        let report = explore_router_in_default_mode(
+            bmc_mock::test_support::lenovo_xcc_router_with_partial_system_network_inventory(),
+        )
+        .await;
+        let port_mac_address = "94:6d:ae:53:cb:9b".parse().unwrap();
+        let adapter = report
+            .chassis
+            .iter()
+            .flat_map(|chassis| &chassis.network_adapters)
+            .find(|adapter| adapter.id == "slot-15")
+            .expect("ConnectX-7 adapter must be explored");
+
+        assert_eq!(adapter.port_mac_addresses, vec![port_mac_address]);
+        assert_eq!(report.systems[0].ethernet_interfaces.len(), 5);
+        assert!(
+            report.systems[0]
+                .ethernet_interfaces
+                .iter()
+                .all(|interface| {
+                    interface.interface_enabled == Some(true) && interface.mac_address.is_some()
+                }),
+            "the System interface inventory must remain usable",
+        );
+        assert!(
+            report.systems[0]
+                .ethernet_interfaces
+                .iter()
+                .all(|interface| interface.mac_address != Some(port_mac_address)),
+            "adapter Port inventory must not be synthesized into the System interface collection",
+        );
+        assert_eq!(report.find_interface_id_for_mac(port_mac_address), None);
     }
 
     #[test]

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -23,7 +23,7 @@ use carbide_secrets::credentials::{
 };
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::machine::{MachineId, MachineType};
-use db::{ObjectColumnFilter, Transaction};
+use db::Transaction;
 use itertools::Itertools;
 use librms::RmsApi;
 use librms::protos::rack_manager as rms;
@@ -233,14 +233,20 @@ impl MachineCreator {
         // Zero-dpu case: If the explored host had no DPUs, we can create the machine now
         if managed_host.explored_host.dpus.is_empty() {
             if let Some(machine_id) = self
-                .create_zero_dpu_machine(&mut txn, &managed_host, report, machine_data)
+                .create_zero_dpu_machine(
+                    &mut txn,
+                    &managed_host,
+                    report,
+                    expected_machine.bmc_mac_address,
+                    machine_data,
+                )
                 .await?
             {
                 managed_host.machine_id = Some(machine_id);
             } else {
-                // An existing-object path may have initialized or enriched the
-                // desired boot target. Keep that restart-safe write even though
-                // there is no new machine to count this iteration.
+                // An existing predicted host may have gained interfaces and a
+                // desired boot target. Keep those restart-safe writes even
+                // though there is no new machine to count this iteration.
                 txn.commit().await?;
                 return Ok(false);
             }
@@ -485,6 +491,7 @@ impl MachineCreator {
         txn: &mut PgConnection,
         managed_host: &ManagedHost<'_>,
         report: &mut EndpointExplorationReport,
+        bmc_mac_address: MacAddress,
         machine_data: Option<&ExpectedMachineData>,
     ) -> SiteExplorerResult<Option<MachineId>> {
         // If there's already a machine with the same MAC address as this endpoint, return false. We
@@ -503,31 +510,121 @@ impl MachineCreator {
                     .map(|id| (*mac, id.to_string()))
             })
             .collect();
+        let endpoint_machine_id =
+            db::machine_topology::find_machine_id_by_bmc_mac(&mut *txn, bmc_mac_address).await?;
+
+        let mut existing_predicted_host_machine_id = None;
         for mac_address in &mac_addresses {
             if let Some(machine) = db::machine::find_by_mac_address(txn, mac_address).await? {
-                if matches!(
-                    machine.id.machine_type(),
-                    MachineType::Host | MachineType::PredictedHost
-                ) {
-                    reconcile_desired_boot_interface(txn, &machine.id).await?;
+                match machine.id.machine_type() {
+                    MachineType::Host => {
+                        // ExpectedMachine is ingestion policy, not a way to
+                        // rewrite interfaces on an already managed host.
+                        reconcile_desired_boot_interface(txn, &machine.id).await?;
+                        return Ok(None);
+                    }
+                    MachineType::PredictedHost => {
+                        if endpoint_machine_id != Some(machine.id) {
+                            tracing::warn!(
+                                %mac_address,
+                                predicted_machine_id = %machine.id,
+                                ?endpoint_machine_id,
+                                %bmc_mac_address,
+                                "Could not confirm that the predicted interface belongs to the explored BMC; skipping refresh",
+                            );
+                            return Ok(None);
+                        }
+                        existing_predicted_host_machine_id = Some(machine.id);
+                    }
+                    _ => {
+                        // Preserve the existing collision behavior for a MAC
+                        // already owned by a non-host machine.
+                        return Ok(None);
+                    }
                 }
-                return Ok(None);
+                continue;
             }
 
-            // If we already minted this machine and it hasn't DHCP'd yet, there will be an
-            // predicted_machine_interface with this MAC address. If so, also skip.
-            let predictions = db::predicted_machine_interface::find_by(
+            // If we already minted this machine and it hasn't DHCP'd yet, a
+            // prediction identifies the host that this refreshed report needs
+            // to reconcile.
+            if let Some(prediction) =
+                db::predicted_machine_interface::find_by_mac_address(&mut *txn, *mac_address)
+                    .await?
+            {
+                match prediction.machine_id.machine_type() {
+                    MachineType::Host => {
+                        reconcile_desired_boot_interface(txn, &prediction.machine_id).await?;
+                        return Ok(None);
+                    }
+                    MachineType::PredictedHost => {
+                        if endpoint_machine_id != Some(prediction.machine_id) {
+                            tracing::warn!(
+                                %mac_address,
+                                predicted_machine_id = %prediction.machine_id,
+                                ?endpoint_machine_id,
+                                %bmc_mac_address,
+                                "Could not confirm that the predicted interface belongs to the explored BMC; skipping refresh",
+                            );
+                            return Ok(None);
+                        }
+                        existing_predicted_host_machine_id = Some(prediction.machine_id);
+                    }
+                    _ => return Ok(None),
+                }
+            }
+        }
+
+        // A declared primary remains authoritative while the host is awaiting
+        // its first lease. Without one, retained boot metadata is only a
+        // fallback when the predicted host has no primary row or prediction;
+        // an unrelated retained interface must not replace a settled primary
+        // during an ordinary refresh.
+        let declared_primary = machine_data.and_then(|data| data.declared_primary_mac());
+        let has_existing_primary = if declared_primary.is_none()
+            && let Some(machine_id) = existing_predicted_host_machine_id
+        {
+            db::machine_interface::machine_has_primary_interface(&machine_id, &mut *txn).await?
+                || db::predicted_machine_interface::find_by_machine_id(&mut *txn, &machine_id)
+                    .await?
+                    .iter()
+                    .any(|prediction| prediction.primary_interface)
+        } else {
+            false
+        };
+        let primary_mac = match declared_primary {
+            Some(declared) => Some(declared),
+            None if !has_existing_primary => {
+                let mut recovered = None;
+                for mac_address in &mac_addresses {
+                    if db::retained_boot_interface::find_by_mac(
+                        &mut *txn,
+                        *mac_address,
+                        self.config.retained_boot_interface_window,
+                    )
+                    .await?
+                    .is_some()
+                    {
+                        recovered = Some(*mac_address);
+                        break;
+                    }
+                }
+                recovered
+            }
+            None => None,
+        };
+
+        if let Some(machine_id) = existing_predicted_host_machine_id {
+            Self::reconcile_zero_dpu_host_interfaces(
                 txn,
-                ObjectColumnFilter::One(
-                    db::predicted_machine_interface::MacAddressColumn,
-                    mac_address,
-                ),
+                &machine_id,
+                &mac_addresses,
+                &report_boot_interface_ids,
+                primary_mac,
             )
             .await?;
-            if let Some(prediction) = predictions.first() {
-                reconcile_desired_boot_interface(txn, &prediction.machine_id).await?;
-                return Ok(None);
-            }
+            reconcile_desired_boot_interface(txn, &machine_id).await?;
+            return Ok(None);
         }
 
         let machine_id = match managed_host.machine_id.as_ref() {
@@ -573,63 +670,93 @@ impl MachineCreator {
         self.create_machine_from_explored_managed_host(txn, managed_host, machine_id, machine_data)
             .await?;
 
-        // Settle this host's single boot interface as we take ownership: the
-        // declared `ExpectedInterface.primary` (if any) is the host's primary, and
-        // every other NIC is non-primary. Routing both the already-leased rows and
-        // the freshly-minted predictions through the same declaration makes the
-        // choice authoritative regardless of DHCP arrival order, and keeps exactly
-        // one primary per machine -- so adopting several NICs that leased before
-        // ingestion never trips the `one_primary_interface_per_machine` index.
-        // The host's primary (boot) interface is a declared `ExpectedInterface.primary`
-        // when set, otherwise the boot interface preserved across `--delete-interfaces`
-        // in `retained_boot_interfaces`. The retained fallback lets a host with no
-        // declared primary -- a DPU flipped to NIC mode is the common case -- re-ingest
-        // with a settled boot interface, so the controller has a boot target to
-        // provision from instead of parking with no primary at all.
-        let declared_primary = machine_data.and_then(|data| data.declared_primary_mac());
-        let primary_mac = match declared_primary {
-            Some(declared) => Some(declared),
-            None => {
-                let mut recovered = None;
-                for mac_address in &mac_addresses {
-                    if db::retained_boot_interface::find_by_mac(
-                        &mut *txn,
-                        *mac_address,
-                        self.config.retained_boot_interface_window,
-                    )
-                    .await?
-                    .is_some()
-                    {
-                        recovered = Some(*mac_address);
-                        break;
-                    }
-                }
-                recovered
-            }
-        };
+        Self::reconcile_zero_dpu_host_interfaces(
+            txn,
+            machine_id,
+            &mac_addresses,
+            &report_boot_interface_ids,
+            primary_mac,
+        )
+        .await?;
 
-        // Create and attach a non-DPU machine_interface to the host for every MAC address we see in
-        // the exploration report
-        for mac_address in mac_addresses {
-            let is_primary = primary_mac == Some(mac_address);
+        Ok(Some(*machine_id))
+    }
+
+    /// Reconciles every discovered Host candidate with a zero-DPU host.
+    ///
+    /// This runs for both a newly minted host and a refreshed report for an
+    /// existing predicted host. That second path matters when the BMC learns a
+    /// declared NIC through supplemental adapter-Port inventory after it has
+    /// already reported other System interfaces.
+    async fn reconcile_zero_dpu_host_interfaces(
+        txn: &mut PgConnection,
+        machine_id: &MachineId,
+        mac_addresses: &[MacAddress],
+        report_boot_interface_ids: &[(MacAddress, String)],
+        primary_mac: Option<MacAddress>,
+    ) -> SiteExplorerResult<()> {
+        // If the selected primary has already DHCP'd, settle the host's real
+        // rows before adopting it so the partial unique index never sees two
+        // primary interfaces at once. A pending prediction does not require
+        // demoting the currently leased primary; DHCP promotion handles that
+        // transition when the selected NIC actually arrives.
+        let selected_primary = primary_mac.filter(|mac| mac_addresses.contains(mac));
+        let selected_primary_has_real_row = if let Some(primary_mac) = selected_primary
+            && let Some(primary_interface) =
+                db::machine_interface::find_by_mac_address(&mut *txn, primary_mac)
+                    .await?
+                    .into_iter()
+                    .min_by_key(|interface| interface.interface_type == InterfaceType::Bmc)
+            && primary_interface.interface_type != InterfaceType::Bmc
+            && primary_interface
+                .machine_id
+                .is_none_or(|existing_machine_id| existing_machine_id == *machine_id)
+        {
+            if primary_interface.machine_id.is_none() || !primary_interface.primary_interface {
+                db::machine_interface::demote_primary_interfaces_for_machine(machine_id, txn)
+                    .await?;
+            }
+            true
+        } else {
+            false
+        };
+        if let Some(primary_mac) = selected_primary {
+            db::predicted_machine_interface::demote_other_primary_interfaces_for_machine(
+                machine_id,
+                primary_mac,
+                txn,
+            )
+            .await?;
+        }
+
+        // Route already-leased rows and pending predictions through the same
+        // declaration so a refresh can add inventory without minting another
+        // host or depending on DHCP arrival order.
+        for mac_address in mac_addresses.iter().copied() {
+            let is_primary = selected_primary == Some(mac_address);
             if let Some(machine_interface) =
                 db::machine_interface::find_by_mac_address(&mut *txn, mac_address)
                     .await?
                     .into_iter()
-                    .next()
+                    .min_by_key(|interface| interface.interface_type == InterfaceType::Bmc)
             {
                 // There's already a machine_interface with this MAC...
                 if let Some(existing_machine_id) = machine_interface.machine_id {
                     // Same machine_id means the preallocated BMC interface row we
                     // just attached via update_machine_topology(), not a contradiction.
                     if existing_machine_id == *machine_id {
-                        // Reconcile its primary flag like the anonymous path
-                        // below, so a stale primary does not collide when the
-                        // real primary NIC is adopted. A BMC interface is never
-                        // primary, even when it shares the host NIC MAC.
+                        // Preserve a settled primary when no declaration (or
+                        // retained fallback) selects a replacement. Likewise,
+                        // a primary that exists only as a prediction takes over
+                        // at DHCP promotion, not while it is still pending.
+                        // Once the selected primary is an owned row, reconcile
+                        // every owned row to the machine-wide choice.
                         let want_primary =
                             is_primary && machine_interface.interface_type != InterfaceType::Bmc;
-                        if machine_interface.primary_interface != want_primary {
+                        if (selected_primary_has_real_row
+                            || machine_interface.interface_type == InterfaceType::Bmc)
+                            && machine_interface.primary_interface != want_primary
+                        {
                             db::machine_interface::set_primary_interface(
                                 &machine_interface.id,
                                 want_primary,
@@ -671,6 +798,50 @@ impl MachineCreator {
                     )
                     .await?;
                 }
+                continue;
+            }
+
+            let boot_interface_id = report_boot_interface_ids
+                .iter()
+                .find(|(mac, _)| *mac == mac_address)
+                .map(|(_, id)| id.clone());
+
+            if let Some(prediction) =
+                db::predicted_machine_interface::find_by_mac_address(&mut *txn, mac_address).await?
+            {
+                if prediction.machine_id != *machine_id {
+                    tracing::error!(
+                        %mac_address,
+                        %machine_id,
+                        existing_machine_id = %prediction.machine_id,
+                        "BUG! Found existing predicted_machine_interface with this MAC address, we should not have gotten here!",
+                    );
+                    return Err(SiteExplorerError::AlreadyFoundError {
+                        kind: "PredictedMachineInterface",
+                        id: mac_address.to_string(),
+                    });
+                }
+                // An absent declaration is not an instruction to clear a
+                // retained or previously settled prediction. A real primary
+                // selection is authoritative across every pending candidate.
+                if is_primary && !prediction.primary_interface {
+                    db::predicted_machine_interface::set_primary_interface(
+                        prediction.id,
+                        true,
+                        txn,
+                    )
+                    .await?;
+                }
+                if let Some(boot_interface_id) = boot_interface_id.as_deref()
+                    && prediction.boot_interface_id.as_deref() != Some(boot_interface_id)
+                {
+                    db::predicted_machine_interface::set_boot_interface_id(
+                        txn,
+                        mac_address,
+                        boot_interface_id,
+                    )
+                    .await?;
+                }
             } else {
                 // Give the predicted interface its boot interface id when
                 // the live report resolves one, so the promoted row starts
@@ -680,10 +851,6 @@ impl MachineCreator {
                 // check. The retained pair instead lands on the row at
                 // creation (see `create_with_type`), where the window is
                 // checked at DHCP time.
-                let boot_interface_id = report_boot_interface_ids
-                    .iter()
-                    .find(|(mac, _)| *mac == mac_address)
-                    .map(|(_, id)| id.clone());
                 db::predicted_machine_interface::create(
                     NewPredictedMachineInterface {
                         machine_id,
@@ -698,7 +865,7 @@ impl MachineCreator {
             }
         }
 
-        Ok(Some(*machine_id))
+        Ok(())
     }
 
     /// Owns a declared integrated (non-DPU) host NIC as a managed-DPU host's
@@ -1369,36 +1536,85 @@ fn resolve_interface_id(
 /// `host_mac_addresses_for_predicted_machine` finds the Host interfaces used to
 /// mint `predicted_machine_interface` rows for a zero-DPU host.
 ///
-/// Redfish-reported System EthernetInterfaces remain authoritative. When the
-/// BMC omits that inventory, only Host-role ExpectedMachine declarations are a
-/// valid fallback; treating DPU OS or DPU BMC declarations as Host interfaces
-/// would attach those endpoints to the wrong machine.
+/// System EthernetInterfaces remain Host candidates. Adapter Ports are broader
+/// chassis inventory, so when at least one usable System interface exists we
+/// include only discovered Port MACs that ExpectedMachine also declares as
+/// Host interfaces. When no usable System MAC exists, discovered Ports preserve
+/// the existing hardware fallback alongside any System MACs. ExpectedMachine
+/// supplies MACs by itself only when Redfish reports neither collection.
 fn host_mac_addresses_for_predicted_machine(
     report: &EndpointExplorationReport,
     machine_data: Option<&ExpectedMachineData>,
 ) -> Vec<MacAddress> {
-    let from_redfish = report.all_mac_addresses();
-    match from_redfish.as_slice() {
-        [_, ..] => from_redfish,
-        [] => machine_data
-            .filter(|_| !(report.is_dpu() || report.is_switch() || report.is_power_shelf()))
-            .map(|data| {
-                data.interfaces
-                    .iter()
-                    .filter(|interface| interface.role.is_host())
-                    .map(|interface| interface.mac_address)
-                    .dedup()
-                    .collect::<Vec<_>>()
-            })
-            .none_if_empty()
-            .inspect(|host_mac_addresses| {
-                tracing::info!(
-                    host_nic_count = host_mac_addresses.len(),
-                    "System EthernetInterfaces missing from Redfish; using ExpectedMachine.interfaces for predicted machine interfaces"
-                );
-            })
-            .unwrap_or_default(),
+    let system_mac_addresses = report
+        .systems
+        .iter()
+        .flat_map(|system| &system.ethernet_interfaces)
+        .filter_map(|interface| interface.mac_address)
+        .unique()
+        .collect::<Vec<_>>();
+    let has_usable_system_mac_address = report
+        .systems
+        .iter()
+        .flat_map(|system| &system.ethernet_interfaces)
+        .any(|interface| {
+            interface.interface_enabled != Some(false) && interface.mac_address.is_some()
+        });
+    let port_mac_addresses = report
+        .chassis
+        .iter()
+        .flat_map(|chassis| &chassis.network_adapters)
+        .flat_map(|adapter| adapter.port_mac_addresses.iter().copied())
+        .unique()
+        .collect::<Vec<_>>();
+    let is_host_report = !(report.is_dpu() || report.is_switch() || report.is_power_shelf());
+
+    if has_usable_system_mac_address {
+        let declared_host_mac_addresses = machine_data
+            .into_iter()
+            .flat_map(|data| &data.interfaces)
+            .filter(|interface| interface.role.is_host())
+            .map(|interface| interface.mac_address)
+            .collect::<Vec<_>>();
+
+        return system_mac_addresses
+            .into_iter()
+            .chain(port_mac_addresses.into_iter().filter(|mac_address| {
+                is_host_report && declared_host_mac_addresses.contains(mac_address)
+            }))
+            .unique()
+            .collect();
     }
+
+    if !port_mac_addresses.is_empty() && is_host_report {
+        return system_mac_addresses
+            .into_iter()
+            .chain(port_mac_addresses)
+            .unique()
+            .collect();
+    }
+    if !system_mac_addresses.is_empty() {
+        return system_mac_addresses;
+    }
+
+    machine_data
+        .filter(|_| is_host_report)
+        .map(|data| {
+            data.interfaces
+                .iter()
+                .filter(|interface| interface.role.is_host())
+                .map(|interface| interface.mac_address)
+                .unique()
+                .collect::<Vec<_>>()
+        })
+        .none_if_empty()
+        .inspect(|host_mac_addresses| {
+            tracing::info!(
+                host_nic_count = host_mac_addresses.len(),
+                "Redfish host MAC inventory missing; using ExpectedMachine.interfaces for predicted machine interfaces"
+            );
+        })
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -1407,12 +1623,13 @@ mod tests {
 
     use carbide_test_support::{Check, check_values};
     use model::expected_machine::{ExpectedInterface, ExpectedInterfaceRole};
-    use model::site_explorer::{Chassis, ComputerSystem, EthernetInterface};
+    use model::site_explorer::{Chassis, ComputerSystem, EthernetInterface, NetworkAdapter};
 
     use super::*;
 
-    /// Redfish inventory stays authoritative, and the zero-DPU fallback uses
-    /// only Host declarations from a host ExpectedMachine.
+    /// Redfish inventory stays authoritative, ExpectedMachine narrows
+    /// supplemental Ports, and the zero-DPU fallback uses only Host
+    /// declarations from a host ExpectedMachine.
     #[test]
     fn host_mac_addresses_for_predicted_machine_cases() {
         let host_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
@@ -1420,6 +1637,15 @@ mod tests {
         let dpu_bmc_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x03]);
         let host_bmc_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x04]);
         let redfish_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x05]);
+        let declared_port_mac = MacAddress::new([0x94, 0x6d, 0xae, 0x53, 0xcb, 0x9b]);
+        let unrelated_port_mac = MacAddress::new([0x94, 0x6d, 0xae, 0x53, 0xcb, 0x9a]);
+        let system_macs = [
+            MacAddress::new([0x0a, 0x8f, 0xc3, 0xa5, 0x8a, 0x41]),
+            MacAddress::new([0x00, 0x62, 0x0b, 0x4c, 0x28, 0xa8]),
+            MacAddress::new([0x00, 0x62, 0x0b, 0x4c, 0x28, 0xa9]),
+            MacAddress::new([0x00, 0x62, 0x0b, 0x4c, 0x28, 0xaa]),
+            MacAddress::new([0x00, 0x62, 0x0b, 0x4c, 0x28, 0xab]),
+        ];
         let interface = |mac_address, role| ExpectedInterface {
             mac_address,
             role,
@@ -1437,9 +1663,25 @@ mod tests {
                 interface(host_bmc_mac, ExpectedInterfaceRole::HostBmc),
             ])
         };
+        let report_with_ports = |port_mac_addresses| EndpointExplorationReport {
+            chassis: vec![Chassis {
+                network_adapters: vec![NetworkAdapter {
+                    id: "slot-15".to_string(),
+                    port_mac_addresses,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
         let excluded_report = |chassis_id: &str| EndpointExplorationReport {
             chassis: vec![Chassis {
                 id: chassis_id.to_string(),
+                network_adapters: vec![NetworkAdapter {
+                    id: "slot-15".to_string(),
+                    port_mac_addresses: vec![declared_port_mac],
+                    ..Default::default()
+                }],
                 ..Default::default()
             }],
             ..Default::default()
@@ -1463,6 +1705,86 @@ mod tests {
                         Some(all_roles()),
                     ),
                     expect: vec![redfish_mac],
+                },
+                Check {
+                    scenario: "declared discovered Port supplements partial System inventory",
+                    input: (
+                        EndpointExplorationReport {
+                            systems: vec![ComputerSystem {
+                                ethernet_interfaces: system_macs
+                                    .into_iter()
+                                    .map(|mac_address| EthernetInterface {
+                                        mac_address: Some(mac_address),
+                                        ..Default::default()
+                                    })
+                                    .collect(),
+                                ..Default::default()
+                            }],
+                            chassis: report_with_ports(vec![
+                                declared_port_mac,
+                                unrelated_port_mac,
+                                dpu_os_mac,
+                                system_macs[0],
+                            ])
+                            .chassis,
+                            ..Default::default()
+                        },
+                        Some(machine_data(vec![
+                            ExpectedInterface {
+                                primary: Some(true),
+                                ..interface(declared_port_mac, ExpectedInterfaceRole::Host)
+                            },
+                            interface(system_macs[0], ExpectedInterfaceRole::Host),
+                            interface(dpu_os_mac, ExpectedInterfaceRole::DpuOs),
+                        ])),
+                    ),
+                    expect: system_macs.into_iter().chain([declared_port_mac]).collect(),
+                },
+                Check {
+                    scenario: "undeclared Ports do not supplement usable System inventory",
+                    input: (
+                        EndpointExplorationReport {
+                            systems: vec![ComputerSystem {
+                                ethernet_interfaces: vec![EthernetInterface {
+                                    mac_address: Some(redfish_mac),
+                                    ..Default::default()
+                                }],
+                                ..Default::default()
+                            }],
+                            chassis: report_with_ports(vec![declared_port_mac]).chassis,
+                            ..Default::default()
+                        },
+                        None,
+                    ),
+                    expect: vec![redfish_mac],
+                },
+                Check {
+                    scenario: "disabled System interfaces do not suppress the adapter-Port fallback",
+                    input: (
+                        EndpointExplorationReport {
+                            systems: vec![ComputerSystem {
+                                ethernet_interfaces: vec![EthernetInterface {
+                                    mac_address: Some(redfish_mac),
+                                    interface_enabled: Some(false),
+                                    ..Default::default()
+                                }],
+                                ..Default::default()
+                            }],
+                            chassis: report_with_ports(vec![declared_port_mac, unrelated_port_mac])
+                                .chassis,
+                            ..Default::default()
+                        },
+                        None,
+                    ),
+                    expect: vec![redfish_mac, declared_port_mac, unrelated_port_mac],
+                },
+                Check {
+                    scenario: "adapter Ports remain the hardware fallback without System inventory",
+                    input: (
+                        report_with_ports(vec![declared_port_mac, unrelated_port_mac]),
+                        None,
+                    ),
+                    expect: vec![declared_port_mac, unrelated_port_mac],
                 },
                 Check {
                     scenario: "Host declarations provide the zero-DPU fallback",
@@ -1492,18 +1814,30 @@ mod tests {
                         EndpointExplorationReport {
                             systems: vec![ComputerSystem {
                                 id: "Bluefield".to_string(),
+                                ethernet_interfaces: vec![EthernetInterface {
+                                    mac_address: Some(redfish_mac),
+                                    ..Default::default()
+                                }],
                                 ..Default::default()
                             }],
                             chassis: vec![Chassis {
                                 id: "Card1".to_string(),
                                 model: Some("BlueField 3 DPU".to_string()),
+                                network_adapters: vec![NetworkAdapter {
+                                    id: "slot-15".to_string(),
+                                    port_mac_addresses: vec![declared_port_mac],
+                                    ..Default::default()
+                                }],
                                 ..Default::default()
                             }],
                             ..Default::default()
                         },
-                        Some(all_roles()),
+                        Some(machine_data(vec![interface(
+                            declared_port_mac,
+                            ExpectedInterfaceRole::Host,
+                        )])),
                     ),
-                    expect: vec![],
+                    expect: vec![redfish_mac],
                 },
                 Check {
                     scenario: "switch reports do not use Host declarations",

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -283,9 +283,10 @@ impl RedfishClient {
 
         let service_root = client.get_service_root().await.map_err(map_redfish_error)?;
         let redfish_vendor = service_root.vendor();
-        // Lenovo XCC is currently the platform where we have verified this
-        // fallback. Keep that policy here so the inventory path stays generic.
-        let supports_adapter_port_mac_fallback = redfish_vendor == Some(RedfishVendor::Lenovo);
+        // Lenovo XCC is the platform where we have verified that adapter Ports
+        // belong to the linked host chassis. Keep that policy here so the
+        // inventory path stays generic.
+        let supports_adapter_port_mac_inventory = redfish_vendor == Some(RedfishVendor::Lenovo);
         let vendor = redfish_vendor.map(bmc_vendor);
 
         let manager = fetch_manager(client.as_ref())
@@ -299,9 +300,8 @@ impl RedfishClient {
         } = fetch_system(client.as_ref()).await?;
 
         let fetch_network_adapter_ports = should_fetch_network_adapter_ports(
-            supports_adapter_port_mac_fallback,
+            supports_adapter_port_mac_inventory,
             is_host,
-            &system.ethernet_interfaces,
             &linked_chassis_ids,
         );
         // TODO (spyda): once we test the BMC reset logic, we can enhance our logic here
@@ -1126,17 +1126,11 @@ struct FetchedChassis {
 }
 
 fn should_fetch_network_adapter_ports(
-    supports_adapter_port_mac_fallback: bool,
+    supports_adapter_port_mac_inventory: bool,
     is_host: bool,
-    system_interfaces: &[EthernetInterface],
     linked_chassis_ids: &[String],
 ) -> bool {
-    supports_adapter_port_mac_fallback
-        && is_host
-        && !linked_chassis_ids.is_empty()
-        && !system_interfaces.iter().any(|interface| {
-            interface.interface_enabled != Some(false) && interface.mac_address.is_some()
-        })
+    supports_adapter_port_mac_inventory && is_host && !linked_chassis_ids.is_empty()
 }
 
 async fn fetch_network_adapter_port_mac_addresses(
@@ -1705,7 +1699,6 @@ mod tests {
     use libredfish::model::service_root::RedfishVendor;
     use mac_address::MacAddress;
     use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
-    use model::site_explorer::EthernetInterface;
 
     use super::{
         BootInterfaceTarget, EndpointExplorationError, MachineSetupStatus, RedfishClient,
@@ -1724,7 +1717,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn detected_lenovo_host_keeps_network_adapter_port_mac_on_its_adapter() {
+    async fn detected_lenovo_host_collects_linked_network_adapter_port_mac() {
         let mac_address = MacAddress::new([0x94, 0x6d, 0xae, 0x53, 0xcb, 0x9b]);
         let sim = Arc::new(RedfishSim::default());
         sim.set_service_root_vendor(Some("Lenovo".to_string()));
@@ -1792,70 +1785,39 @@ mod tests {
     }
 
     #[test]
-    fn network_adapter_port_fallback_gate_cases() {
+    fn network_adapter_port_inventory_gate_cases() {
         #[derive(Clone)]
         struct Input {
-            supports_adapter_port_mac_fallback: bool,
+            supports_adapter_port_mac_inventory: bool,
             is_host: bool,
-            system_interfaces: Vec<EthernetInterface>,
             linked_chassis_ids: Vec<String>,
         }
-
-        let interface = |interface_enabled, mac_address| EthernetInterface {
-            interface_enabled,
-            mac_address,
-            ..Default::default()
-        };
-        let mac_address = MacAddress::new([0x94, 0x6d, 0xae, 0x53, 0xcb, 0x9b]);
 
         check_values(
             [
                 Check {
-                    scenario: "eligible host without a System MAC uses linked adapter ports",
+                    scenario: "eligible host uses linked adapter ports",
                     input: Input {
-                        supports_adapter_port_mac_fallback: true,
+                        supports_adapter_port_mac_inventory: true,
                         is_host: true,
-                        system_interfaces: vec![interface(None, None)],
                         linked_chassis_ids: vec!["Card1".to_string()],
                     },
                     expect: true,
                 },
                 Check {
-                    scenario: "host with a System MAC skips adapter ports",
+                    scenario: "non-host skips adapter ports",
                     input: Input {
-                        supports_adapter_port_mac_fallback: true,
-                        is_host: true,
-                        system_interfaces: vec![interface(None, Some(mac_address))],
-                        linked_chassis_ids: vec!["Card1".to_string()],
-                    },
-                    expect: false,
-                },
-                Check {
-                    scenario: "host with a disabled System interface uses adapter ports",
-                    input: Input {
-                        supports_adapter_port_mac_fallback: true,
-                        is_host: true,
-                        system_interfaces: vec![interface(Some(false), Some(mac_address))],
-                        linked_chassis_ids: vec!["Card1".to_string()],
-                    },
-                    expect: true,
-                },
-                Check {
-                    scenario: "non-host without a System MAC skips adapter ports",
-                    input: Input {
-                        supports_adapter_port_mac_fallback: true,
+                        supports_adapter_port_mac_inventory: true,
                         is_host: false,
-                        system_interfaces: vec![],
                         linked_chassis_ids: vec!["Card1".to_string()],
                     },
                     expect: false,
                 },
                 Check {
-                    scenario: "platform without adapter-port fallback skips adapter ports",
+                    scenario: "platform without adapter-port inventory skips adapter ports",
                     input: Input {
-                        supports_adapter_port_mac_fallback: false,
+                        supports_adapter_port_mac_inventory: false,
                         is_host: true,
-                        system_interfaces: vec![],
                         linked_chassis_ids: vec!["Card1".to_string()],
                     },
                     expect: false,
@@ -1863,9 +1825,8 @@ mod tests {
                 Check {
                     scenario: "eligible host without chassis links skips adapter ports",
                     input: Input {
-                        supports_adapter_port_mac_fallback: true,
+                        supports_adapter_port_mac_inventory: true,
                         is_host: true,
-                        system_interfaces: vec![],
                         linked_chassis_ids: vec![],
                     },
                     expect: false,
@@ -1873,9 +1834,8 @@ mod tests {
             ],
             |input| {
                 should_fetch_network_adapter_ports(
-                    input.supports_adapter_port_mac_fallback,
+                    input.supports_adapter_port_mac_inventory,
                     input.is_host,
-                    &input.system_interfaces,
                     &input.linked_chassis_ids,
                 )
             },

--- a/crates/site-explorer/tests/integration/zero_dpu.rs
+++ b/crates/site-explorer/tests/integration/zero_dpu.rs
@@ -28,7 +28,7 @@ use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
 use mac_address::MacAddress;
 use model::expected_machine::{
-    ExpectedInterface, ExpectedMachine, ExpectedMachineData, HostDpuPolicy,
+    ExpectedInterface, ExpectedInterfaceRole, ExpectedMachine, ExpectedMachineData, HostDpuPolicy,
 };
 use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
 use model::test_support::ManagedHostConfig;
@@ -394,8 +394,10 @@ async fn test_zero_dpu_recovers_primary_from_retained_boot_interface(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = init(pool).await;
-    let mock_host = zero_dpu_host();
+    let mut mock_host = zero_dpu_host();
     let inband_mac = *mock_host.non_dpu_macs.first().unwrap();
+    let other_retained_mac = MacAddress::from_str("d4:04:e6:84:20:02")?;
+    mock_host.non_dpu_macs.push(other_retained_mac);
     register_zero_dpu_expected_machine(&env, &mock_host).await?;
 
     // The host's boot interface was retained by a prior `--delete-interfaces`,
@@ -449,6 +451,49 @@ async fn test_zero_dpu_recovers_primary_from_retained_boot_interface(
         predicted.primary_interface,
         "a zero-DPU host with no declared primary should recover its primary from \
          retained_boot_interfaces, so the controller has a boot target",
+    );
+    txn.rollback().await?;
+
+    // Promotion consumes the primary NIC's retention record. Record retained
+    // metadata for the other NIC before the next exploration: every deleted
+    // interface can leave one of these records, so its presence alone must not
+    // replace a settled primary.
+    env.api()
+        .discover_dhcp(
+            rpc::forge::DhcpDiscovery::builder(inband_mac, env.host_inband_segment.relay_address)
+                .vendor_string("Bluefield")
+                .tonic_request(),
+        )
+        .await?;
+    let mut txn = env.pool.begin().await?;
+    db::retained_boot_interface::upsert(txn.as_mut(), other_retained_mac, "NIC.Embedded.2-1-1")
+        .await?;
+    txn.commit().await?;
+    env.site_explorer.run_single_iteration().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let promoted = db::machine_interface::find_by_mac_address(txn.as_mut(), inband_mac)
+        .await?
+        .into_iter()
+        .next()
+        .expect("the retained-primary prediction should promote on DHCP");
+    assert!(
+        promoted.primary_interface,
+        "an exploration refresh must preserve the settled primary after retention is consumed",
+    );
+    assert!(
+        db::retained_boot_interface::find_by_mac(txn.as_mut(), inband_mac, None)
+            .await?
+            .is_none(),
+        "promotion should consume the retained fallback before the refresh",
+    );
+    let other_prediction =
+        db::predicted_machine_interface::find_by_mac_address(txn.as_mut(), other_retained_mac)
+            .await?
+            .expect("the other reported NIC should remain a pending prediction");
+    assert!(
+        !other_prediction.primary_interface,
+        "retained metadata for another NIC must not replace the settled primary",
     );
     txn.rollback().await?;
 
@@ -703,6 +748,158 @@ async fn test_exploration_refreshes_pending_predicted_boot_interface_id(
             interface_id: "NIC.Embedded.1-1-1".to_string(),
         }),
     );
+
+    Ok(())
+}
+
+/// A BMC may report onboard System interfaces first and learn the declared
+/// boot NIC later through supplemental adapter-Port inventory. The refresh
+/// must add that hardware-discovered NIC to the existing predicted host and
+/// make it the MAC-only boot target without requiring another force-delete.
+#[sqlx_test]
+async fn test_exploration_refresh_adds_declared_adapter_port_to_predicted_host(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = init(pool).await;
+    let system_macs = vec![
+        MacAddress::from_str("0a:8f:c3:a5:8a:41")?,
+        MacAddress::from_str("00:62:0b:4c:28:a8")?,
+        MacAddress::from_str("00:62:0b:4c:28:a9")?,
+        MacAddress::from_str("00:62:0b:4c:28:aa")?,
+        MacAddress::from_str("00:62:0b:4c:28:ab")?,
+    ];
+    let declared_port_mac = MacAddress::from_str("94:6d:ae:53:cb:9b")?;
+    let unrelated_port_mac = MacAddress::from_str("94:6d:ae:53:cb:9a")?;
+    let mock_host = ManagedHostConfig {
+        dpus: vec![],
+        non_dpu_macs: system_macs.clone(),
+        ..ManagedHostConfig::default()
+    };
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: mock_host.bmc_mac_address,
+            data: ExpectedMachineData {
+                serial_number: mock_host.serial.clone(),
+                dpu_policy: HostDpuPolicy::Ignore,
+                interfaces: vec![ExpectedInterface {
+                    mac_address: declared_port_mac,
+                    role: ExpectedInterfaceRole::Host,
+                    primary: Some(true),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    let host_bmc_response = env
+        .api()
+        .discover_dhcp(
+            rpc::forge::DhcpDiscovery::builder(
+                mock_host.bmc_mac_address,
+                env.underlay_segment.relay_address,
+            )
+            .vendor_string("SomeVendor")
+            .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let host_bmc_ip = host_bmc_response.address.parse()?;
+
+    // The first report has the exact partial-inventory shape from QA: five
+    // usable System MACs, but not the declared ConnectX-7 MAC.
+    env.site_explorer
+        .insert_endpoint_result(host_bmc_ip, Ok(mock_host.clone().into()));
+    env.site_explorer.run_single_iteration().await?;
+    let mut txn = env.pool.begin().await?;
+    db::explored_endpoints::set_preingestion_complete(host_bmc_ip, &mut txn).await?;
+    txn.commit().await?;
+    env.site_explorer.run_single_iteration().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let initial_prediction =
+        db::predicted_machine_interface::find_by_mac_address(txn.as_mut(), system_macs[0])
+            .await?
+            .expect("partial System inventory should mint the predicted host");
+    let machine_id = initial_prediction.machine_id;
+    let predictions =
+        db::predicted_machine_interface::find_by_machine_id(txn.as_mut(), &machine_id).await?;
+    assert_eq!(predictions.len(), system_macs.len());
+    assert!(
+        predictions
+            .iter()
+            .all(|prediction| !prediction.primary_interface)
+    );
+    assert!(
+        db::machine_desired_boot_interface::get(txn.as_mut(), &machine_id)
+            .await?
+            .is_none(),
+        "several non-primary System candidates do not identify a boot NIC",
+    );
+    // Leave one old prediction flagged primary, then omit it from the next
+    // report. Selecting the declared Port must clear stale primary intent
+    // across the whole predicted host, not only the refreshed candidates.
+    db::predicted_machine_interface::set_primary_interface(
+        initial_prediction.id,
+        true,
+        txn.as_mut(),
+    )
+    .await?;
+    txn.commit().await?;
+
+    // The refreshed report adds the declared MAC only to adapter-Port
+    // inventory. An unrelated Port proves ExpectedMachine is selection policy
+    // over discovered hardware, not a reason to ingest every chassis MAC.
+    let mut refreshed_report: model::site_explorer::EndpointExplorationReport =
+        mock_host.clone().into();
+    refreshed_report.systems[0]
+        .ethernet_interfaces
+        .retain(|interface| interface.mac_address != Some(system_macs[0]));
+    refreshed_report.chassis[0].network_adapters[0].port_mac_addresses =
+        vec![declared_port_mac, unrelated_port_mac];
+    env.site_explorer
+        .insert_endpoint_result(host_bmc_ip, Ok(refreshed_report));
+    env.site_explorer.run_single_iteration().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let predictions =
+        db::predicted_machine_interface::find_by_machine_id(txn.as_mut(), &machine_id).await?;
+    assert_eq!(predictions.len(), system_macs.len() + 1);
+    let declared_prediction = predictions
+        .iter()
+        .find(|prediction| prediction.mac_address == declared_port_mac)
+        .expect("the refreshed report should add the declared Port MAC");
+    assert!(declared_prediction.primary_interface);
+    assert!(
+        predictions.iter().all(|prediction| {
+            prediction.mac_address == declared_port_mac || !prediction.primary_interface
+        }),
+        "the declared Port must be the only primary prediction, including stale inventory",
+    );
+    assert!(
+        declared_prediction.boot_interface_id.is_none(),
+        "adapter Port inventory does not supply a System boot-interface id",
+    );
+    assert!(
+        predictions
+            .iter()
+            .all(|prediction| prediction.mac_address != unrelated_port_mac),
+        "an undeclared supplemental Port must not become a Host prediction",
+    );
+    let desired = db::machine_desired_boot_interface::get(txn.as_mut(), &machine_id)
+        .await?
+        .expect("the declared Port prediction should settle the boot target");
+    assert_eq!(
+        desired.value,
+        MachineBootInterfaceTarget::MacOnly(declared_port_mac),
+    );
+    txn.rollback().await?;
 
     Ok(())
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR cherry-picks commit 1badba5325663cd80825d7e48c9875b7059319c0 (#4968) into `release/v2.1`.

Lenovo XCC can report usable onboard `ComputerSystem.EthernetInterfaces` while exposing an installed ConnectX NIC only through a linked chassis `NetworkAdapter.Port`. The adapter-Port fetch treated any System MAC as proof that inventory was complete, so the declared NoDpu boot NIC never reached `predicted_machine_interfaces`.

So, this keeps the verified Lenovo + `ComputerSystem.Links.Chassis` boundary, but collects adapter Ports as supplemental inventory even when System interfaces exist. Site Explorer still uses System interfaces as Host candidates; it adds a Port MAC alongside them only when that MAC was actually reported by hardware and `ExpectedMachine` declares it as a Host interface. It does not synthesize `EthernetInterfaces`, treat the declaration as an override, or use a Port ID as a boot-interface ID.

A refreshed report can now add that MAC to an existing predicted host, keep its boot target MAC-only, and leave already-managed hosts alone. Retained boot metadata is consulted only when a predicted host has no primary, so an unrelated stale record cannot replace a settled primary.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4952

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`cargo test -p bmc-explorer -p carbide-site-explorer --lib` and the `zero_dpu` integration tests pass on the branch.

## Additional Notes

**One conflict, in `crates/bmc-explorer/src/lib.rs`.** It was the test module's `use super::{...}` list: the incoming side also imports `should_fetch_bf4_chassis_except_irot_nic`, which #4968 does not add and this branch does not have -- it comes from the BlueField-4 IRoT chassis work on `main`. Resolved to this branch's existing names plus #4968's new `should_fetch_supplemental_network_adapter_ports`; nothing else references the BF4 helper here. The rest of the pick applied cleanly.

**Prerequisite is already on this branch.** #4968 builds on the adapter-Port fetch from #4534, which landed here in #4832, so `fetch_network_adapter_ports` is present and this is a true follow-on rather than a partial backport.

`crates/site-explorer` picks up an `axum` dev dependency; it resolves against this branch's existing workspace pin (`0.8.4`), so no `Cargo.toml` workspace change was needed.
