### PR TITLE
fix(dpf-sim): survive fleet-scale caches at 4,500 hosts (203 restarts to zero)

### DIFF
--- a/dev/k8s/dpf-sim-controller/cmd/main.go
+++ b/dev/k8s/dpf-sim-controller/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -44,6 +45,10 @@ func main() {
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "health probe endpoint")
 	flag.StringVar(&dpfNamespace, "dpf-namespace", "dpf-operator-system",
 		"namespace where NICo creates DPF CRs (must match site config)")
+	var cacheSyncTimeout time.Duration
+	flag.DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 15*time.Minute,
+		"how long to wait for the initial informer cache sync; the 2m default is\n"+
+			"too short once the namespace holds thousands of DPU/DPUDevice CRs")
 	flag.DurationVar(&phaseDwell, "phase-dwell", 3*time.Second,
 		"time each dwell-gated DPU phase lingers before advancing")
 	var reconcileConcurrency int
@@ -61,6 +66,7 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Raise with --cache-sync-timeout when simulating very large fleets.
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog := ctrl.Log.WithName("setup")
 
@@ -76,6 +82,16 @@ func main() {
 			DefaultNamespaces: map[string]cache.Config{dpfNamespace: {}},
 		},
 		// Simulator is single-instance dev tooling; no leader election.
+		//
+		// Fleet-scale caches need far longer than the 2-minute default to do
+		// their initial LIST: at 4,500 hosts the DPF namespace holds ~9,000
+		// DPUs and ~9,000 DPUDevices, the sync times out, and the manager
+		// exits before reconciling anything ("failed to wait for dpudevice
+		// caches to sync"). The pod then crash-loops and every machine sits
+		// at dpfstate=waitingforready forever.
+		Controller: config.Controller{
+			CacheSyncTimeout: cacheSyncTimeout,
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/dev/k8s/dpf-sim-controller/cmd/main.go
+++ b/dev/k8s/dpf-sim-controller/cmd/main.go
@@ -66,6 +66,16 @@ func main() {
 		os.Exit(2)
 	}
 
+	// controller-runtime only honors a manager-level CacheSyncTimeout that is
+	// positive; zero or negative silently falls back to the per-controller
+	// 2-minute default -- the very value this flag exists to raise past. Fail
+	// loudly instead of letting "0 = no timeout" intuition reintroduce the
+	// fleet-scale crash-loop.
+	if cacheSyncTimeout <= 0 {
+		fmt.Fprintf(os.Stderr, "invalid --cache-sync-timeout %v: must be > 0\n", cacheSyncTimeout)
+		os.Exit(2)
+	}
+
 	// Raise with --cache-sync-timeout when simulating very large fleets.
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog := ctrl.Log.WithName("setup")

--- a/dev/k8s/dpf-sim-controller/config/manager/manager.yaml
+++ b/dev/k8s/dpf-sim-controller/config/manager/manager.yaml
@@ -49,8 +49,8 @@ spec:
               port: 8081
           resources:
             requests:
-              cpu: 50m
-              memory: 64Mi
+              cpu: 500m
+              memory: 1Gi
             limits:
-              cpu: 200m
-              memory: 128Mi
+              cpu: "2"
+              memory: 4Gi


### PR DESCRIPTION
At 4,500 simulated hosts the DPF namespace holds ~9,000 DPUs and ~9,000 DPUDevices. The dpf-sim controller-runtime cache cannot complete its initial LIST within the 2-minute default `CacheSyncTimeout`, so the manager exits with `failed to wait for dpudevice caches to sync` before reconciling anything, and the pod crash-loops indefinitely.

**Measured before/after:** 203 restarts with ~2,100 machines parked at `dpfstate=waitingforready` → 0 restarts, cache syncs and the fleet drains normally.

The fix adds a `--cache-sync-timeout` flag (default 15m) and raises the manager's resources from 200m/128Mi — sized for a handful of DPUs — to 2 CPU / 4Gi.

Note: this PR was originally scoped to also release the discovery admission permit at the transaction boundary, but that exact change already landed on main via #4873 (`drop(admin_admission)` immediately after the commit in `discover_machine`), so only the dpf-sim fix remains.
