### PR TITLE
perf(api): eliminate fleet-wide admin-segment lock holds in the ingestion hot path

### DIFF
--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -274,6 +274,7 @@ async fn ensure_dhcp_address_for_family(
             db::machine_interface::lock_network_segments_exclusive(
                 &mut *txn,
                 std::slice::from_ref(&segment.id),
+                "ensure_dhcp_address_for_family",
             )
             .await?;
             db::machine_interface_address::delete_by_interface_family(

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -367,7 +367,7 @@ async fn force_delete_cleanup_txn(
     // All admin segments, rather than a set computed from this machine's
     // interfaces: the snapshots predate the BMC work above, and they omit
     // BMC-typed interfaces that `force_cleanup` still row-locks.
-    db::machine_interface::lock_all_admin_segments(&mut txn).await?;
+    db::machine_interface::lock_all_admin_segments(&mut txn, "machine_delete").await?;
 
     // Clean up the explored tables next, in site-explorer's write order
     // (`explored_managed_hosts`, then each machine topology and its

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -164,7 +164,7 @@ pub(crate) async fn discover_machine(
     // whole transaction holds locks in the allocator order (segment advisory
     // lock first, then interface rows) all the way to the reconcile pass --
     // which re-acquires the same locks as a no-op.
-    db::machine_interface::lock_all_admin_segments(&mut txn).await?;
+    db::machine_interface::lock_all_admin_segments(&mut txn, "machine_discovery").await?;
 
     tracing::debug!(
         remote_ip_address = ?remote_ip,

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -177,25 +177,43 @@ pub(crate) async fn discover_machine(
 
     let mut txn = api.txn_begin().await?;
 
-    // Advisory-lock the admin segments before any machine-interface row
-    // writes in this transaction (`associate_interface_with_dpu_machine`,
-    // the proactive host-interface create, `set_primary_interface`), so the
-    // whole transaction holds locks in the allocator order (segment advisory
-    // lock first, then interface rows) all the way to the reconcile pass --
-    // which re-acquires the same locks as a no-op.
+    // Advisory-lock the admin segments before any machine-interface row work
+    // in this transaction, so the whole transaction holds locks in the
+    // allocator order (segment advisory lock first, then interface rows).
     //
-    // The call site is labelled by branch (#4711 attribution): every one of
-    // those interface writes, and the reconcile pass, is gated behind
-    // `if hardware_info.is_dpu()` below, so the `_host` tally is the part of
-    // this traffic that a future change could plausibly stop taking. It is
-    // NOT free to drop today -- see the note on `unlocked_discovery_rejection`
-    // about the host/DPU row-lock ordering these locks currently serialize.
-    let lock_site = if hardware_info.is_dpu() {
-        "machine_discovery_dpu"
+    // LOAD-BEARING (#4711), read before changing the branch below.
+    //
+    // The DPU branch takes the locks EXCLUSIVELY: it writes interface rows
+    // (`associate_interface_with_dpu_machine`, the proactive host-interface
+    // create, `set_primary_interface`) and ends in
+    // `reconcile_admin_addresses_for_host`, which re-acquires the same locks
+    // exclusively -- as a no-op only because this transaction already holds
+    // them in that mode.
+    //
+    // The host branch takes them SHARED. Every segment-lock-reachable call in
+    // this handler is gated behind `if hardware_info.is_dpu()`; the host path
+    // only reads interfaces (`find_one`,
+    // `find_{optional_for_update,for_update_if_matches_instance}_by_ip`) and
+    // writes `machines`, `machine_topologies`, and attestation rows, none of
+    // which touch a segment lock. Shared still conflicts with exclusive, so a
+    // host discovery remains mutually excluded from DPU discovery, machine
+    // creation, deletion, and reconcile; only host-versus-host becomes
+    // concurrent. That is the whole win: shared acquisitions measured 0.41 ms
+    // against 14-155 ms for exclusive on the hottest key.
+    //
+    // DANGER: PostgreSQL advisory locks do NOT upgrade. Adding any call that
+    // reaches a segment lock -- interface create, address allocation,
+    // `reconcile_admin_addresses_for_host` -- to the host path would make this
+    // transaction take S and then ask for X on the same key, which deadlocks
+    // against another transaction doing the same. Such a call must either move
+    // behind `is_dpu()` or force this branch back to
+    // `lock_all_admin_segments`.
+    if hardware_info.is_dpu() {
+        db::machine_interface::lock_all_admin_segments(&mut txn, "machine_discovery_dpu").await?;
     } else {
-        "machine_discovery_host"
-    };
-    db::machine_interface::lock_all_admin_segments(&mut txn, lock_site).await?;
+        db::machine_interface::lock_all_admin_segments_shared(&mut txn, "machine_discovery_host")
+            .await?;
+    }
 
     tracing::debug!(
         remote_ip_address = ?remote_ip,

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -16,12 +16,13 @@
  */
 
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use ::rpc::forge as rpc;
 use carbide_utils::none_if_empty::NoneIfEmpty;
-use carbide_uuid::machine::MachineIdSource;
+use carbide_uuid::machine::{MachineId, MachineIdSource, MachineInterfaceId};
 use carbide_uuid::nvlink::NvLinkDomainId;
 use db::WithTransaction;
 use futures_util::FutureExt;
@@ -116,6 +117,24 @@ pub(crate) async fn discover_machine(
         })?)
     };
 
+    // LOAD-BEARING (#4711): reject the hopeless retries BEFORE the admission
+    // permit and the global admin-segment locks. See
+    // `unlocked_discovery_rejection` for the measurements and the safety
+    // rules; without it this handler is a fleet-wide serialization point that
+    // wedges machine creation at scale.
+    if let Some(rejection) = unlocked_discovery_rejection(
+        api,
+        machine_discovery_info.machine_interface_id,
+        machine_discovery_info.create_machine,
+        &hardware_info,
+        &stable_machine_id,
+        remote_ip,
+    )
+    .await
+    {
+        return Err(rejection.into());
+    }
+
     // Keep readers that are waiting behind instance allocation out of open
     // database transactions. Hold the same permit through the main discovery
     // transaction so the admin-lock queue remains bounded too.
@@ -164,7 +183,19 @@ pub(crate) async fn discover_machine(
     // whole transaction holds locks in the allocator order (segment advisory
     // lock first, then interface rows) all the way to the reconcile pass --
     // which re-acquires the same locks as a no-op.
-    db::machine_interface::lock_all_admin_segments(&mut txn, "machine_discovery").await?;
+    //
+    // The call site is labelled by branch (#4711 attribution): every one of
+    // those interface writes, and the reconcile pass, is gated behind
+    // `if hardware_info.is_dpu()` below, so the `_host` tally is the part of
+    // this traffic that a future change could plausibly stop taking. It is
+    // NOT free to drop today -- see the note on `unlocked_discovery_rejection`
+    // about the host/DPU row-lock ordering these locks currently serialize.
+    let lock_site = if hardware_info.is_dpu() {
+        "machine_discovery_dpu"
+    } else {
+        "machine_discovery_host"
+    };
+    db::machine_interface::lock_all_admin_segments(&mut txn, lock_site).await?;
 
     tracing::debug!(
         remote_ip_address = ?remote_ip,
@@ -617,6 +648,156 @@ fn discovery_source_owner_error() -> CarbideError {
     CarbideError::PermissionDeniedError(
         "discovery source IP and selected interface do not identify one host".to_string(),
     )
+}
+
+/// Unlocked pre-check for `discover_machine`: returns the error the locked
+/// path would return, for the one case that dominates admin-segment lock
+/// traffic, WITHOUT taking the admission permit or the global locks.
+///
+/// # Why this exists (#4711, measured -- do not delete)
+///
+/// Instrumented 4,500-host ingestion run: the `machine_discovery` call site
+/// was 705,875 of 718,000 admin-segment advisory lock acquisitions -- 99% of
+/// all of them -- and roughly **15 of every 16 were failed retries**. A site
+/// has only ~2 admin segments, so `lock_all_admin_segments` is effectively a
+/// global lock, and every discovering machine in the fleet queued on it.
+///
+/// `machine-a-tron` (and scout / DPU agents in the field) re-issue
+/// `DiscoverMachine` every 5 seconds with no backoff until their machine
+/// exists. Each of those retries took every admin-segment lock at the top of
+/// the handler and only then fell out with `PermissionDenied` a few dozen
+/// lines later. That is a positive feedback loop: slower ingestion -> more
+/// retries -> more global-lock traffic -> slower ingestion, until machine
+/// creation wedges with every backend parked in `pg_advisory_xact_lock`.
+///
+/// This is the same shape of fix as the `#4711 fast path` in
+/// `machine_interface::reconcile_admin_addresses_for_host`: decide with an
+/// unlocked read, and only pay for the lock when the call can actually do
+/// work.
+///
+/// # Rules any future edit must keep
+///
+/// 1. **Read-only, and never `FOR UPDATE`.** Taking `machine_interfaces` /
+///    `machine_interface_addresses` row locks before the segment advisory
+///    lock would invert the allocator order documented on
+///    `machine_interface::lock_network_segments_exclusive` (segment advisory
+///    lock first, then interface/address rows) and risk deadlock against
+///    every flow that follows it. Hence
+///    `find_optional_by_ip_unlocked` rather than
+///    `find_optional_for_update_by_ip`, and a `MachineSearchConfig` with
+///    `for_update` left at its `false` default.
+/// 2. **Reject only on monotonic "nothing exists yet" facts.** Both facts
+///    tested here -- the caller's interface has no machine association at
+///    all, and the machine this hardware derives does not exist -- flip false
+///    exactly once, when site-explorer creates and associates, and never flip
+///    back under normal operation. So a rejection here is never durable: the
+///    client's retry 5s later passes the pre-check and takes exactly today's
+///    code path. Do NOT add a condition that can oscillate; that would turn a
+///    transient rejection into a livelock.
+/// 3. **Uncertainty falls through.** No interface for the source IP, an
+///    ambiguous IP, an instance-scoped caller (the allocated-host-running-
+///    scout case, which has no lock-free lookup), or any query error returns
+///    `None` and lets the locked path produce the authoritative answer. This
+///    is a filter, never a source of state the write path then trusts.
+/// 4. **Same error as the locked path.** The rejection below is byte-for-byte
+///    the `PermissionDeniedError` the authorization match returns for these
+///    inputs, so clients and tests see no behavioural change.
+///
+/// Residual risk is one lost round trip: if the association lands between this
+/// read and where the locked path would have read it, the caller is rejected
+/// and retries 5s later. That is the same window the client already tolerates.
+///
+/// Takes the two request fields it needs by value rather than the whole
+/// `MachineDiscoveryInfo`, because `discovery_data` has already been moved out
+/// of it by the time this runs.
+async fn unlocked_discovery_rejection(
+    api: &Api,
+    caller_machine_interface_id: Option<MachineInterfaceId>,
+    create_machine: bool,
+    hardware_info: &HardwareInfo,
+    stable_machine_id: &MachineId,
+    remote_ip: Option<IpAddr>,
+) -> Option<CarbideError> {
+    // Reads go straight to the pool: no transaction is opened, so a rejected
+    // retry never occupies a pool connection while the fleet is contending.
+    let pool = &api.database_connection;
+
+    // Mirror the handler's caller-interface resolution, read-only. Only the
+    // two lookups that have a lock-free equivalent are mirrored; anything else
+    // falls through (rule 3).
+    let caller_interface = if api.runtime_config.allow_insecure_discovery {
+        let interface_id = caller_machine_interface_id?;
+        db::machine_interface::find_one(pool, interface_id)
+            .await
+            .ok()?
+    } else {
+        db::machine_interface::find_optional_by_ip_unlocked(pool, remote_ip?)
+            .await
+            .ok()??
+    };
+
+    // Monotonic fact 1: the caller's interface is not associated with any
+    // machine yet. This is the state every machine sits in while it waits for
+    // site-explorer, and it is what makes the authorization match below
+    // reduce to a constant. Once an association exists the match can succeed,
+    // so we must not decide anything here.
+    if caller_interface.machine_id.is_some() {
+        return None;
+    }
+
+    // Monotonic fact 2: the machine this hardware derives does not exist.
+    // Strictly narrower than fact 1 needs -- `machine_interfaces.machine_id`
+    // has an `ON UPDATE CASCADE` FK to `machines(id)`, so an unassociated
+    // interface already implies the caller owns nothing -- but it anchors the
+    // pre-check on the "site-explorer has not created it yet" condition the
+    // retry loop is actually waiting on, and it guarantees we stop rejecting
+    // the moment the machine appears.
+    let machine_exists = db::machine::find_one(
+        pool,
+        stable_machine_id,
+        MachineSearchConfig {
+            include_dpus: true,
+            ..MachineSearchConfig::default()
+        },
+    )
+    .await
+    .ok()?
+    .is_some();
+    if machine_exists {
+        return None;
+    }
+
+    // With `caller_interface.machine_id == None` the authorization match in
+    // `discover_machine` collapses to exactly this arm:
+    //     None if hardware_info.is_dpu() && create_machine
+    //         => !site_explorer_creates_machines
+    // (every other arm needs a `Some(machine_id)`). Evaluate it here and
+    // reject only when it is false. Keep this expression in sync with that
+    // match.
+    let site_explorer_creates_machines = api
+        .runtime_config
+        .site_explorer
+        .create_machines
+        .load(Ordering::Relaxed);
+    let authorized = hardware_info.is_dpu() && create_machine && !site_explorer_creates_machines;
+    if authorized {
+        // This call would go on to create the machine itself. Not our case.
+        return None;
+    }
+
+    tracing::debug!(
+        target: "carbide::lock_profile",
+        phase = "machine_discovery",
+        outcome = "rejected_unlocked",
+        %stable_machine_id,
+        machine_interface_id = %caller_interface.id,
+        is_dpu = hardware_info.is_dpu(),
+        "discovery rejected without taking admin segment locks"
+    );
+
+    Some(CarbideError::PermissionDeniedError(
+        "machine discovery is not authorized for the selected interface".to_string(),
+    ))
 }
 
 // Host has completed discovery

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -139,7 +139,7 @@ async fn set_primary_interface_core(
 
     // Site Explorer takes these locks before it changes interface ownership.
     // Matching that order keeps an operator write from deadlocking discovery.
-    db::machine_interface::lock_all_admin_segments(&mut txn).await?;
+    db::machine_interface::lock_all_admin_segments(&mut txn, "managed_host").await?;
     let interface_snapshots =
         db::machine_interface::find_by_machine_id_for_update(&mut txn, &host_machine_id).await?;
     let machine = db::machine::find_one(

--- a/crates/api-db/src/host_naming/mod.rs
+++ b/crates/api-db/src/host_naming/mod.rs
@@ -161,7 +161,33 @@ pub async fn hostname_for(
     txn: &mut PgConnection,
     ctx: &NamingContext<'_>,
 ) -> DatabaseResult<String> {
-    match configured().strategy().name(txn, ctx).await? {
+    let naming = configured().strategy().name(txn, ctx).await?;
+    resolve_naming(ctx, naming)
+}
+
+/// Read-only counterpart of [`hostname_for`]: resolves the same name but is
+/// guaranteed never to write.
+///
+/// `hostname_for` is allowed to write -- serial naming's bare-serial claim
+/// renames a demoted sibling via `update_interface_hostname`. Unlocked
+/// pre-checks (the #4711 fast path in `reconcile_admin_addresses_for_host`)
+/// must not call it: a write from the pre-check would take machine-interface
+/// row locks before the segment advisory lock, inverting the allocator order.
+/// They call this instead; a name mismatch sends the caller to the locked
+/// path, where the real `hostname_for` performs any claim, rename, and
+/// duplicate-identifier validation under the lock.
+pub async fn hostname_for_readonly(
+    txn: &mut PgConnection,
+    ctx: &NamingContext<'_>,
+) -> DatabaseResult<String> {
+    let naming = configured().strategy().preview(txn, ctx).await?;
+    resolve_naming(ctx, naming)
+}
+
+/// Turn a strategy decision into the concrete name: the assigned one, or the
+/// stored one when the strategy keeps it.
+fn resolve_naming(ctx: &NamingContext<'_>, naming: Naming) -> DatabaseResult<String> {
+    match naming {
         Naming::Assign(hostname) => Ok(hostname),
         Naming::Keep => ctx.current_hostname.map(str::to_string).ok_or_else(|| {
             DatabaseError::internal(
@@ -180,6 +206,21 @@ pub trait HostNamingStrategy: Send + Sync {
     /// the database (the others ignore it).
     async fn name(&self, txn: &mut PgConnection, ctx: &NamingContext<'_>)
     -> DatabaseResult<Naming>;
+
+    /// The decision [`Self::name`] would make, computed WITHOUT side effects.
+    ///
+    /// The default forwards to [`Self::name`], which is correct only for
+    /// strategies whose `name` never writes. A strategy that can write there
+    /// (serial naming's bare-serial claim) MUST override this with a
+    /// write-free equivalent: the unlocked reconcile pre-check relies on it
+    /// (see [`hostname_for_readonly`]).
+    async fn preview(
+        &self,
+        txn: &mut PgConnection,
+        ctx: &NamingContext<'_>,
+    ) -> DatabaseResult<Naming> {
+        self.name(txn, ctx).await
+    }
 }
 
 /// Config-selectable naming strategy. Deserializes from snake_case (e.g.
@@ -319,6 +360,25 @@ impl HostNamingStrategy for SerialNumberHostNamingStrategy {
             // No usable serial (yet): the temporary IP-based name.
             None => Ok(Naming::Assign(ip_or_dormant(ctx)?)),
         }
+    }
+
+    /// Write-free preview. `name` can rename a demoted sibling while claiming
+    /// the bare serial and can fail loudly on duplicated identifiers; neither
+    /// belongs in an unlocked pre-check. The previewed outcome is the same
+    /// name either way: when the stored name already matches it, `name` would
+    /// return early without writing, and when it differs the caller takes the
+    /// locked path, where `name` performs the claim -- validation, sibling
+    /// renames, and any duplicate-serial error -- under the lock.
+    async fn preview(
+        &self,
+        txn: &mut PgConnection,
+        ctx: &NamingContext<'_>,
+    ) -> DatabaseResult<Naming> {
+        Ok(Naming::Assign(match usable_serial(txn, ctx).await? {
+            Some(serial) if ctx.is_primary => serial_to_hostname(&serial)?,
+            Some(serial) => serial_with_mac_hostname(&serial, ctx.mac_address)?,
+            None => ip_or_dormant(ctx)?,
+        }))
     }
 }
 

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2325,8 +2325,9 @@ pub async fn lock_network_segments_exclusive(
 /// sites on the assumption it dominated, and measured no reduction at all --
 /// the attribution had been inferred rather than measured. This records which
 /// site actually acquires the lock, so the next change can be aimed.
-static ADMIN_LOCK_SITES: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<&'static str, u64>>> =
-    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+static ADMIN_LOCK_SITES: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<&'static str, u64>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 /// Count one acquisition and, every 2,000, log the running per-site breakdown.
 /// Logged at INFO deliberately: the previous diagnostic used `debug!` while
@@ -2453,6 +2454,43 @@ pub async fn find_optional_for_update_by_ip(
         _ => Err(DatabaseError::internal(format!(
             "multiple machine interfaces map to discovery IP {remote_ip}"
         ))),
+    }
+}
+
+/// Read-only sibling of [`find_optional_for_update_by_ip`], for callers that
+/// must resolve the discovery IP *before* opening the transaction that takes
+/// the admin-segment advisory locks (see `discover_machine`'s pre-check).
+///
+/// Deliberately has no `FOR UPDATE`: row locks taken before the segment
+/// advisory lock would invert the allocator order documented on
+/// [`lock_network_segments_exclusive`] (segment advisory lock first, then
+/// machine interface/address rows) and could deadlock against every flow that
+/// follows that order. It also takes a pool rather than a connection so it
+/// cannot accidentally be spliced into a locking transaction.
+///
+/// Returns `None` both when no interface owns the address and when the address
+/// is ambiguous. Callers are pre-checks: "cannot decide" and "nothing here"
+/// must both fall through to the locked path, which stays the authority on the
+/// decision and on the error text.
+pub async fn find_optional_by_ip_unlocked(
+    pool: &sqlx::PgPool,
+    remote_ip: IpAddr,
+) -> Result<Option<MachineInterfaceSnapshot>, DatabaseError> {
+    let query = r#"
+        SELECT mi.id
+        FROM machine_interface_addresses mia
+        JOIN machine_interfaces mi ON mi.id = mia.interface_id
+        WHERE mia.address = $1::inet
+    "#;
+    let interface_ids: Vec<(MachineInterfaceId,)> = sqlx::query_as(query)
+        .bind(remote_ip)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    match interface_ids.as_slice() {
+        [(interface_id,)] => find_one(pool, *interface_id).await.map(Some),
+        _ => Ok(None),
     }
 }
 

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2319,7 +2319,46 @@ pub async fn lock_network_segments_exclusive(
 /// the transaction so the whole transaction follows the allocator order.
 /// Later acquisitions of the same locks in the same transaction (reconcile's
 /// own pass) are no-ops.
-pub async fn lock_all_admin_segments(txn: &mut PgConnection) -> DatabaseResult<()> {
+/// Per-call-site tally of admin-segment lock acquisitions (#4711).
+///
+/// The first attempt at reducing this traffic optimized ONE of the five call
+/// sites on the assumption it dominated, and measured no reduction at all --
+/// the attribution had been inferred rather than measured. This records which
+/// site actually acquires the lock, so the next change can be aimed.
+static ADMIN_LOCK_SITES: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<&'static str, u64>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Count one acquisition and, every 2,000, log the running per-site breakdown.
+/// Logged at INFO deliberately: the previous diagnostic used `debug!` while
+/// RUST_LOG=info, so it produced nothing and the run had to be repeated.
+pub(crate) fn record_admin_lock_site(call_site: &'static str) {
+    let Ok(mut sites) = ADMIN_LOCK_SITES.lock() else {
+        return;
+    };
+    *sites.entry(call_site).or_insert(0) += 1;
+    let total: u64 = sites.values().sum();
+    if total.is_multiple_of(2000) {
+        let mut breakdown: Vec<_> = sites.iter().map(|(k, v)| (*k, *v)).collect();
+        breakdown.sort_by(|a, b| b.1.cmp(&a.1));
+        let rendered = breakdown
+            .iter()
+            .map(|(site, n)| format!("{site}={n}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        tracing::info!(
+            target: "carbide::lock_profile",
+            total_acquisitions = total,
+            breakdown = %rendered,
+            "admin-segment lock acquisitions by call site"
+        );
+    }
+}
+
+pub async fn lock_all_admin_segments(
+    txn: &mut PgConnection,
+    call_site: &'static str,
+) -> DatabaseResult<()> {
+    record_admin_lock_site(call_site);
     let segment_ids =
         db_network_segment::list_segment_ids(&mut *txn, Some(NetworkSegmentType::Admin)).await?;
     lock_network_segments_exclusive(txn, &segment_ids).await
@@ -2998,7 +3037,7 @@ pub async fn reconcile_admin_addresses_for_host(
     //
     // This matches allocator lock ordering: segment advisory lock first, then
     // machine interface/address row locks.
-    let segments = load_and_lock_all_admin_segments(&mut txn).await?;
+    let segments = load_and_lock_all_admin_segments(&mut txn, "reconcile_admin_addresses").await?;
     let segments_by_id = segments
         .iter()
         .map(|segment| (segment.id, segment))
@@ -3400,7 +3439,9 @@ async fn load_all_admin_segments(
 
 async fn load_and_lock_all_admin_segments(
     txn: &mut Transaction<'_>,
+    call_site: &'static str,
 ) -> DatabaseResult<Vec<NetworkSegment>> {
+    record_admin_lock_site(call_site);
     let (segments, segment_ids) = load_all_admin_segments(txn).await?;
     if segment_ids.is_empty() {
         return Ok(segments);

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -1742,9 +1742,10 @@ async fn create_fast_path(
                 .iter()
                 .any(|prefix| prefix.prefix.is_ipv6())
             {
-                lock_network_segment_exclusive(&mut fast_txn, segment).await?;
+                lock_network_segment_exclusive(&mut fast_txn, segment, "create_fast_path").await?;
             } else {
-                lock_network_segment_shared(&mut fast_txn, segment).await?;
+                lock_network_segment_shared(&mut fast_txn, segment, "create_fast_path_shared")
+                    .await?;
             }
 
             let segment_exhausted = match try_create_fast_path(
@@ -1891,7 +1892,7 @@ pub async fn create_slow_path(
 
     // If either requested addresses are auto-generated, we lock the entire table
     // by way of the inner_txn.
-    lock_network_segment_exclusive(&mut inner_txn, segment).await?;
+    lock_network_segment_exclusive(&mut inner_txn, segment, "create_slow_path").await?;
 
     // Collect SVI IPs so the allocator knows they're already reserved.
     let mut reserved_ips = vec![];
@@ -2271,7 +2272,11 @@ async fn lock_network_segment_shared(
     // Note: Must be a transaction since we're doing locks
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,
+    call_site: &'static str,
 ) -> DatabaseResult<()> {
+    // Issues its own query rather than funnelling through
+    // `lock_network_segments_exclusive`, so it records its own acquisition.
+    record_admin_lock_site(call_site);
     let query = "SELECT pg_advisory_xact_lock_shared(hashtextextended($1::text, 0))";
     sqlx::query_scalar(query)
         .bind(format!("network_segment.{}", segment.id))
@@ -2284,8 +2289,12 @@ async fn lock_network_segment_exclusive(
     // Note: Must be a transaction since we're doing locks
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,
+    call_site: &'static str,
 ) -> DatabaseResult<()> {
-    lock_network_segments_exclusive(txn.as_mut(), std::slice::from_ref(&segment.id)).await
+    // No `record_admin_lock_site` here: the delegate below records, and
+    // recording in both would count this call twice.
+    lock_network_segments_exclusive(txn.as_mut(), std::slice::from_ref(&segment.id), call_site)
+        .await
 }
 
 /// Advisory-lock every segment in `segment_ids`, in ascending id order --
@@ -2294,10 +2303,17 @@ async fn lock_network_segment_exclusive(
 /// ordering; every segment-lock helper funnels through it. Must run inside a
 /// transaction: the locks are `pg_advisory_xact_lock`-scoped and release on
 /// commit or rollback.
+///
+/// `call_site` names the caller for the [`record_admin_lock_site`] tally; it
+/// must be a `&'static str` label, conventionally the enclosing function name.
 pub async fn lock_network_segments_exclusive(
     txn: &mut PgConnection,
     segment_ids: &[NetworkSegmentId],
+    call_site: &'static str,
 ) -> DatabaseResult<()> {
+    // One increment per invocation, not per segment id, so the numbers stay
+    // comparable with the counts collected before this funnel was instrumented.
+    record_admin_lock_site(call_site);
     let mut ids = segment_ids.to_vec();
     ids.sort_unstable();
     ids.dedup();
@@ -2319,12 +2335,21 @@ pub async fn lock_network_segments_exclusive(
 /// the transaction so the whole transaction follows the allocator order.
 /// Later acquisitions of the same locks in the same transaction (reconcile's
 /// own pass) are no-ops.
-/// Per-call-site tally of admin-segment lock acquisitions (#4711).
+/// Per-call-site tally of network-segment advisory lock acquisitions (#4711).
 ///
 /// The first attempt at reducing this traffic optimized ONE of the five call
 /// sites on the assumption it dominated, and measured no reduction at all --
 /// the attribution had been inferred rather than measured. This records which
 /// site actually acquires the lock, so the next change can be aimed.
+///
+/// The second attempt instrumented only `lock_all_admin_segments` and logged
+/// nothing across a 4,500-host run that Postgres recorded as 787,922
+/// `pg_advisory_xact_lock` calls: the traffic came from the direct
+/// `lock_network_segment_{exclusive,shared}` callers, which bypassed the
+/// counter. Every segment-lock helper now records, so the tally covers all of
+/// them -- shared acquisitions included, under a `_shared`-suffixed label,
+/// since shared locks do not conflict with each other and should not be read
+/// as contention.
 static ADMIN_LOCK_SITES: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<&'static str, u64>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
@@ -2350,7 +2375,7 @@ pub(crate) fn record_admin_lock_site(call_site: &'static str) {
             target: "carbide::lock_profile",
             total_acquisitions = total,
             breakdown = %rendered,
-            "admin-segment lock acquisitions by call site"
+            "network-segment lock acquisitions by call site"
         );
     }
 }
@@ -2359,10 +2384,9 @@ pub async fn lock_all_admin_segments(
     txn: &mut PgConnection,
     call_site: &'static str,
 ) -> DatabaseResult<()> {
-    record_admin_lock_site(call_site);
     let segment_ids =
         db_network_segment::list_segment_ids(&mut *txn, Some(NetworkSegmentType::Admin)).await?;
-    lock_network_segments_exclusive(txn, &segment_ids).await
+    lock_network_segments_exclusive(txn, &segment_ids, call_site).await
 }
 
 static ADMIN_LOCK_ADMISSION: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
@@ -2408,7 +2432,7 @@ pub async fn allocate_svi_ip(
         });
 
     // Prevent other allocations from happening concurrently in this network segment
-    lock_network_segment_exclusive(txn, segment).await?;
+    lock_network_segment_exclusive(txn, segment, "allocate_svi_ip").await?;
 
     let mut addresses_allocator = IpAllocator::new(
         txn.as_mut(),
@@ -3479,13 +3503,12 @@ async fn load_and_lock_all_admin_segments(
     txn: &mut Transaction<'_>,
     call_site: &'static str,
 ) -> DatabaseResult<Vec<NetworkSegment>> {
-    record_admin_lock_site(call_site);
     let (segments, segment_ids) = load_all_admin_segments(txn).await?;
     if segment_ids.is_empty() {
         return Ok(segments);
     }
 
-    lock_network_segments_exclusive(txn.as_pgconn(), &segment_ids).await?;
+    lock_network_segments_exclusive(txn.as_pgconn(), &segment_ids, call_site).await?;
 
     Ok(segments)
 }
@@ -3821,9 +3844,11 @@ pub async fn allocate_address_for_family(
 ) -> DatabaseResult<Vec<IpAddr>> {
     let mut fast_txn = Transaction::begin_inner(txn).await?;
     if family == IpAddressFamily::Ipv6 {
-        lock_network_segment_exclusive(&mut fast_txn, segment).await?;
+        lock_network_segment_exclusive(&mut fast_txn, segment, "allocate_address_for_family")
+            .await?;
     } else {
-        lock_network_segment_shared(&mut fast_txn, segment).await?;
+        lock_network_segment_shared(&mut fast_txn, segment, "allocate_address_for_family_shared")
+            .await?;
     }
 
     let mut allocated_addresses = Vec::new();

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2328,13 +2328,6 @@ pub async fn lock_network_segments_exclusive(
     Ok(())
 }
 
-/// Advisory-lock every admin segment, in ascending id order. Transactions
-/// that touch machine-interface rows before their segment locks -- the flows
-/// that end in `reconcile_admin_addresses_for_host`, and machine teardown,
-/// which deletes interface rows wholesale -- call this right after opening
-/// the transaction so the whole transaction follows the allocator order.
-/// Later acquisitions of the same locks in the same transaction (reconcile's
-/// own pass) are no-ops.
 /// Per-call-site tally of network-segment advisory lock acquisitions (#4711).
 ///
 /// The first attempt at reducing this traffic optimized ONE of the five call
@@ -2349,37 +2342,92 @@ pub async fn lock_network_segments_exclusive(
 /// counter. Every segment-lock helper now records, so the tally covers all of
 /// them -- shared acquisitions included, under a `_shared`-suffixed label,
 /// since shared locks do not conflict with each other and should not be read
-/// as contention.
-static ADMIN_LOCK_SITES: std::sync::LazyLock<
-    std::sync::Mutex<std::collections::HashMap<&'static str, u64>>,
-> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-
-/// Count one acquisition and, every 2,000, log the running per-site breakdown.
-/// Logged at INFO deliberately: the previous diagnostic used `debug!` while
-/// RUST_LOG=info, so it produced nothing and the run had to be repeated.
-pub(crate) fn record_admin_lock_site(call_site: &'static str) {
-    let Ok(mut sites) = ADMIN_LOCK_SITES.lock() else {
-        return;
-    };
-    *sites.entry(call_site).or_insert(0) += 1;
-    let total: u64 = sites.values().sum();
-    if total.is_multiple_of(2000) {
-        let mut breakdown: Vec<_> = sites.iter().map(|(k, v)| (*k, *v)).collect();
-        breakdown.sort_by(|a, b| b.1.cmp(&a.1));
-        let rendered = breakdown
-            .iter()
-            .map(|(site, n)| format!("{site}={n}"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        tracing::info!(
-            target: "carbide::lock_profile",
-            total_acquisitions = total,
-            breakdown = %rendered,
-            "network-segment lock acquisitions by call site"
-        );
-    }
+/// as contention. `machine_discovery_host` is the one exception: it kept its
+/// name when it moved to `lock_all_admin_segments_shared` so its counts stay
+/// comparable with the runs recorded before the move. Read it as shared.
+///
+/// The third attempt emitted nothing either, across four deployed images, for
+/// two reasons that are both fixed below: the tally gave up forever if the
+/// mutex was ever poisoned, and it only logged when the running total hit an
+/// exact multiple of 2,000 -- a per-process total that a restart, or any
+/// concurrent increment landing between the check and the next one, walks
+/// straight past. The trigger is now purely time-based, so the breakdown
+/// appears as long as *any* acquisition happens at all.
+struct AdminLockSites {
+    /// Acquisitions per `call_site` label since process start.
+    counts: std::collections::HashMap<&'static str, u64>,
+    /// When the breakdown was last emitted; `None` until the first emission,
+    /// so the very first acquisition logs immediately and proves the counter
+    /// is alive rather than leaving an ambiguous silent window.
+    last_emit: Option<std::time::Instant>,
 }
 
+static ADMIN_LOCK_SITES: std::sync::LazyLock<std::sync::Mutex<AdminLockSites>> =
+    std::sync::LazyLock::new(|| {
+        std::sync::Mutex::new(AdminLockSites {
+            counts: std::collections::HashMap::new(),
+            last_emit: None,
+        })
+    });
+
+/// Minimum wall-clock interval between breakdown emissions. Time-based rather
+/// than count-based so a low-traffic process still reports, and a high-traffic
+/// one cannot flood: at most one line per interval, whatever the rate.
+const LOCK_PROFILE_EMIT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Count one acquisition and, at most once every [`LOCK_PROFILE_EMIT_INTERVAL`],
+/// log the running per-site breakdown.
+///
+/// Logged at INFO deliberately: an earlier diagnostic used `debug!` while
+/// RUST_LOG=info, so it produced nothing and the run had to be repeated.
+pub(crate) fn record_admin_lock_site(call_site: &'static str) {
+    // Recover from poisoning instead of returning: a panic anywhere else while
+    // this mutex was held would otherwise silence the tally for the remaining
+    // life of the process, which is indistinguishable from "the code never
+    // ran" -- the exact ambiguity that cost four deployed images.
+    let mut sites = ADMIN_LOCK_SITES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *sites.counts.entry(call_site).or_insert(0) += 1;
+
+    let now = std::time::Instant::now();
+    if !sites
+        .last_emit
+        .is_none_or(|last| now.duration_since(last) >= LOCK_PROFILE_EMIT_INTERVAL)
+    {
+        return;
+    }
+    sites.last_emit = Some(now);
+    emit_admin_lock_breakdown(&sites.counts);
+}
+
+/// Render the tally: the total, plus every call site, busiest first.
+fn emit_admin_lock_breakdown(counts: &std::collections::HashMap<&'static str, u64>) {
+    let total: u64 = counts.values().sum();
+    let mut breakdown: Vec<(&'static str, u64)> = counts.iter().map(|(k, v)| (*k, *v)).collect();
+    // Descending by count, then by label so equal counts render stably and
+    // successive lines can be diffed against each other.
+    breakdown.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    let rendered = breakdown
+        .iter()
+        .map(|(site, n)| format!("{site}={n}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    tracing::info!(
+        target: "carbide::lock_profile",
+        total_acquisitions = total,
+        breakdown = %rendered,
+        "network-segment lock acquisitions by call site"
+    );
+}
+
+/// Advisory-lock every admin segment exclusively, in ascending id order.
+/// Transactions that touch machine-interface rows before their segment locks
+/// -- the flows that end in `reconcile_admin_addresses_for_host`, and machine
+/// teardown, which deletes interface rows wholesale -- call this right after
+/// opening the transaction so the whole transaction follows the allocator
+/// order. Later acquisitions of the same locks in the same transaction
+/// (reconcile's own pass) are no-ops.
 pub async fn lock_all_admin_segments(
     txn: &mut PgConnection,
     call_site: &'static str,
@@ -2387,6 +2435,52 @@ pub async fn lock_all_admin_segments(
     let segment_ids =
         db_network_segment::list_segment_ids(&mut *txn, Some(NetworkSegmentType::Admin)).await?;
     lock_network_segments_exclusive(txn, &segment_ids, call_site).await
+}
+
+/// Shared-mode counterpart of [`lock_all_admin_segments`], for transactions
+/// that must be excluded from the writers but not from each other.
+///
+/// Measured (#4711): during a 4,500-host run, sampling `pg_locks` joined to
+/// `pg_stat_activity` found 101 exclusive holders against 4 shared, with
+/// `network_segment.admin` the hottest key; exclusive acquisitions averaged
+/// 14-155 ms against 0.41 ms for shared. A shared lock still conflicts with an
+/// exclusive one, so callers of this function remain mutually excluded from
+/// every `lock_all_admin_segments` / `lock_network_segments_exclusive`
+/// transaction -- creation, deletion, DPU discovery, reconcile. Only
+/// shared-versus-shared runs concurrently.
+///
+/// # Upgrade hazard -- read before calling
+///
+/// PostgreSQL advisory locks do **not** upgrade. A transaction that takes a
+/// shared lock on a key and later asks for the exclusive lock on that same key
+/// can deadlock against another transaction doing the same thing. A caller may
+/// therefore use this **only** if it provably never acquires a segment lock
+/// again for the rest of its transaction -- no `lock_network_segment_*`, no
+/// `lock_all_admin_segments`, and nothing that reaches them (interface
+/// creation, address allocation, `reconcile_admin_addresses_for_host`).
+pub async fn lock_all_admin_segments_shared(
+    txn: &mut PgConnection,
+    call_site: &'static str,
+) -> DatabaseResult<()> {
+    let mut segment_ids =
+        db_network_segment::list_segment_ids(&mut *txn, Some(NetworkSegmentType::Admin)).await?;
+    // One increment per invocation, matching the exclusive funnel, so the two
+    // are directly comparable.
+    record_admin_lock_site(call_site);
+    // Same ascending order and dedup as the exclusive path: mode does not
+    // change the deadlock-avoidance rule, since shared and exclusive waiters
+    // queue on the same keys.
+    segment_ids.sort_unstable();
+    segment_ids.dedup();
+    for id in segment_ids {
+        let query = "SELECT pg_advisory_xact_lock_shared(hashtextextended($1::text, 0))";
+        sqlx::query_scalar::<_, ()>(query)
+            .bind(format!("network_segment.{id}"))
+            .fetch_one(&mut *txn)
+            .await
+            .map_err(|e| DatabaseError::query(query, e))?;
+    }
+    Ok(())
 }
 
 static ADMIN_LOCK_ADMISSION: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2806,11 +2806,189 @@ pub async fn create_host_machine_dpu_interface_proactively(
 ///
 /// Returns `true` only when the externally visible active admin config changed. Dormant-interface
 /// cleanup is persisted but intentionally returns `false` by itself.
+/// Whether the unlocked pre-check in `reconcile_admin_addresses_for_host` runs.
+/// Set `ADMIN_RECONCILE_FAST_PATH=0` to force every reconcile down the locked
+/// path (the pre-#4711 behaviour), so the two can be A/B'd on a live fleet.
+fn admin_reconcile_fast_path_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        !matches!(
+            std::env::var("ADMIN_RECONCILE_FAST_PATH").as_deref(),
+            Ok("0") | Ok("false")
+        )
+    })
+}
+
+/// Read-only predicate: would the locked reconcile below write anything?
+///
+/// This mirrors the mutation sites in `reconcile_admin_addresses_for_host` and
+/// must stay conservative -- when it cannot prove the host is already settled it
+/// returns `true` and the caller takes the full locked path. A wrong `true`
+/// only costs a lock acquisition; a wrong `false` would skip real work.
+///
+/// Skipping without the lock is safe against concurrent change because every
+/// flow that mutates a host's admin interfaces reconciles that host afterwards,
+/// and the state controller reconciles periodically regardless. A decision made
+/// against a slightly stale read therefore delays convergence by one pass at
+/// worst; it cannot lose work permanently.
+async fn admin_reconcile_work_needed(
+    txn: &mut PgConnection,
+    host_machine_id: &MachineId,
+    segments_by_id: &HashMap<NetworkSegmentId, &NetworkSegment>,
+    interfaces: &[AdminInterfaceForReconcile],
+) -> DatabaseResult<bool> {
+    // No DPU-backed host link: the locked path commits without writing.
+    if !interfaces
+        .iter()
+        .any(|interface| interface.is_dpu_backed_host_link)
+    {
+        return Ok(false);
+    }
+
+    let primary_to_repair = match interfaces
+        .iter()
+        .position(|interface| interface.primary_interface)
+    {
+        Some(index) if interfaces[index].is_dpu_backed_host_link => {
+            match segments_by_id.get(&interfaces[index].segment_id) {
+                Some(segment) => Some((index, *segment)),
+                // Segment missing: let the locked path raise the real error.
+                None => return Ok(true),
+            }
+        }
+        Some(_) => None,
+        // No primary in the admin set: the locked path decides whether this is
+        // the valid non-admin-primary case or a genuine error.
+        None => return Ok(true),
+    };
+
+    // Site 1: the primary is missing an address for a family its segment serves.
+    if let Some((primary_index, primary_segment)) = primary_to_repair {
+        for family in [IpAddressFamily::Ipv4, IpAddressFamily::Ipv6] {
+            let served = primary_segment
+                .prefixes
+                .iter()
+                .any(|prefix| prefix.prefix.is_address_family(family));
+            if served
+                && !interfaces[primary_index]
+                    .addresses
+                    .iter()
+                    .any(|address| address.address.is_address_family(family))
+            {
+                return Ok(true);
+            }
+        }
+    }
+
+    // Sites 2 and 3: dormant DPU-backed links must already be free of DHCP rows,
+    // and the addressless ones must already be DNS-silent under their settled name.
+    for interface in interfaces
+        .iter()
+        .filter(|interface| interface.is_dpu_backed_host_link && !interface.primary_interface)
+    {
+        if interface
+            .addresses
+            .iter()
+            .any(|address| address.allocation_type == AllocationType::Dhcp)
+        {
+            return Ok(true);
+        }
+        if interface.addresses.is_empty() {
+            let ctx = NamingContext {
+                mac_address: interface.mac_address,
+                addresses: &[],
+                current_hostname: Some(&interface.hostname),
+                machine_id: Some(*host_machine_id),
+                is_primary: interface.primary_interface,
+                interface_type: InterfaceType::Data,
+                interface_id: Some(interface.id),
+                domain_id: interface.domain_id,
+            };
+            let hostname = host_naming::hostname_for(&mut *txn, &ctx).await?;
+            if interface.domain_id.is_some() || interface.hostname != hostname {
+                return Ok(true);
+            }
+        }
+    }
+
+    // Site 4: the primary's name and domain must already match the active config.
+    if let Some((primary_index, primary_segment)) = primary_to_repair {
+        let primary = &interfaces[primary_index];
+        if primary.addresses.is_empty() {
+            return Ok(true);
+        }
+        let active_addresses: Vec<IpAddr> = primary
+            .addresses
+            .iter()
+            .map(|address| address.address)
+            .collect();
+        let ctx = NamingContext {
+            mac_address: primary.mac_address,
+            addresses: &active_addresses,
+            current_hostname: Some(&primary.hostname),
+            machine_id: Some(*host_machine_id),
+            is_primary: true,
+            interface_type: InterfaceType::Data,
+            interface_id: Some(primary.id),
+            domain_id: primary.domain_id,
+        };
+        let hostname = host_naming::hostname_for(&mut *txn, &ctx).await?;
+        if primary.hostname != hostname || primary.domain_id != primary_segment.config.subdomain_id
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
 pub async fn reconcile_admin_addresses_for_host(
     txn: &mut PgConnection,
     host_machine_id: &MachineId,
 ) -> DatabaseResult<bool> {
     let mut txn = Transaction::begin_inner(txn).await?;
+
+    // #4711 fast path. This function is called for every host on every
+    // exploration and state-controller pass, but a host's admin addressing
+    // settles once and then never changes: measured at 4,500 hosts, ~99.6% of
+    // these transactions took every admin-segment advisory lock and wrote
+    // nothing. Because the lock set is global (a site has ~2 admin segments),
+    // that turned a per-host operation into a fleet-wide serialization point
+    // saturated at ~400 acquisitions/sec -- capping ingestion at ~13
+    // machines/min at 4,500 hosts against 138/min at 1,000.
+    //
+    // So: decide with an unlocked read, and only pay for the lock when there is
+    // actually something to write. The locked path below re-reads everything
+    // `FOR UPDATE` under the lock and re-derives its own decisions, so this is a
+    // pure filter -- it never supplies state that the write path then trusts.
+    if admin_reconcile_fast_path_enabled() {
+        let precheck_t0 = std::time::Instant::now();
+        let (segments, _) = load_all_admin_segments(&mut txn).await?;
+        let segments_by_id = segments
+            .iter()
+            .map(|segment| (segment.id, segment))
+            .collect::<HashMap<_, _>>();
+        let interfaces = find_host_admin_interfaces(txn.as_pgconn(), host_machine_id).await?;
+        if !admin_reconcile_work_needed(
+            txn.as_pgconn(),
+            host_machine_id,
+            &segments_by_id,
+            &interfaces,
+        )
+        .await?
+        {
+            txn.commit().await?;
+            tracing::debug!(
+                target: "carbide::lock_profile",
+                phase = "reconcile_admin_addresses",
+                outcome = "skipped_unlocked",
+                interfaces = interfaces.len(),
+                total_ms = precheck_t0.elapsed().as_millis() as u64,
+                "admin reconcile skipped without taking segment locks"
+            );
+            return Ok(false);
+        }
+    }
 
     // Lock all admin segments up front instead of doing a precise pre-read of
     // this host's segment set. The precise approach would need a locked re-read
@@ -3056,7 +3234,29 @@ async fn find_host_admin_interfaces_for_update(
     txn: &mut PgConnection,
     host_machine_id: &MachineId,
 ) -> DatabaseResult<Vec<AdminInterfaceForReconcile>> {
-    let query = r#"
+    find_host_admin_interfaces_inner(txn, host_machine_id, true).await
+}
+
+/// The same read WITHOUT `FOR UPDATE`, for the read-only pre-check. Taking row
+/// locks here would reintroduce exactly the serialization the pre-check exists
+/// to avoid.
+async fn find_host_admin_interfaces(
+    txn: &mut PgConnection,
+    host_machine_id: &MachineId,
+) -> DatabaseResult<Vec<AdminInterfaceForReconcile>> {
+    find_host_admin_interfaces_inner(txn, host_machine_id, false).await
+}
+
+async fn find_host_admin_interfaces_inner(
+    txn: &mut PgConnection,
+    host_machine_id: &MachineId,
+    lock_rows: bool,
+) -> DatabaseResult<Vec<AdminInterfaceForReconcile>> {
+    // Both variants stay string literals so they remain statically auditable --
+    // the only difference is the trailing `FOR UPDATE OF mi`.
+    macro_rules! admin_interfaces_query {
+        () => {
+            r#"
 SELECT
     mi.id,
     mi.segment_id,
@@ -3073,8 +3273,15 @@ JOIN network_segments ns ON ns.id = mi.segment_id
 LEFT JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
 WHERE mi.machine_id = $1
   AND ns.network_segment_type = 'admin'
-ORDER BY mi.id, mia.address
-FOR UPDATE OF mi"#;
+ORDER BY mi.id, mia.address"#
+        };
+    }
+
+    let query = if lock_rows {
+        concat!(admin_interfaces_query!(), "\nFOR UPDATE OF mi")
+    } else {
+        admin_interfaces_query!()
+    };
 
     let rows: Vec<AdminInterfaceForReconcileRow> = sqlx::query_as(query)
         .bind(host_machine_id)
@@ -3156,9 +3363,12 @@ FOR UPDATE"#;
 /// This intentionally locks more broadly than the specific host touches so reconciliation follows
 /// the same high-level lock order as address allocation: segment advisory lock first, then
 /// machine interface/address row locks.
-async fn load_and_lock_all_admin_segments(
+/// Load every admin segment WITHOUT taking the advisory locks. Callers that
+/// intend to write must use `load_and_lock_all_admin_segments`; this exists for
+/// the read-only pre-check that decides whether a write is needed at all.
+async fn load_all_admin_segments(
     txn: &mut Transaction<'_>,
-) -> DatabaseResult<Vec<NetworkSegment>> {
+) -> DatabaseResult<(Vec<NetworkSegment>, Vec<NetworkSegmentId>)> {
     let mut segment_ids =
         db_network_segment::list_segment_ids(txn.as_pgconn(), Some(NetworkSegmentType::Admin))
             .await?;
@@ -3166,7 +3376,7 @@ async fn load_and_lock_all_admin_segments(
     segment_ids.dedup();
 
     if segment_ids.is_empty() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     }
 
     let mut segments = db_network_segment::find_by(
@@ -3183,6 +3393,17 @@ async fn load_and_lock_all_admin_segments(
             segments.len(),
             segment_ids.len(),
         )));
+    }
+
+    Ok((segments, segment_ids))
+}
+
+async fn load_and_lock_all_admin_segments(
+    txn: &mut Transaction<'_>,
+) -> DatabaseResult<Vec<NetworkSegment>> {
+    let (segments, segment_ids) = load_all_admin_segments(txn).await?;
+    if segment_ids.is_empty() {
+        return Ok(segments);
     }
 
     lock_network_segments_exclusive(txn.as_pgconn(), &segment_ids).await?;

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2304,7 +2304,7 @@ async fn lock_network_segment_exclusive(
 /// transaction: the locks are `pg_advisory_xact_lock`-scoped and release on
 /// commit or rollback.
 ///
-/// `call_site` names the caller for the [`record_admin_lock_site`] tally; it
+/// `call_site` names the caller for the `record_admin_lock_site` tally; it
 /// must be a `&'static str` label, conventionally the enclosing function name.
 pub async fn lock_network_segments_exclusive(
     txn: &mut PgConnection,
@@ -3099,7 +3099,11 @@ async fn admin_reconcile_work_needed(
                 interface_id: Some(interface.id),
                 domain_id: interface.domain_id,
             };
-            let hostname = host_naming::hostname_for(&mut *txn, &ctx).await?;
+            // `hostname_for_readonly`, not `hostname_for`: this predicate runs
+            // before the segment lock, and `hostname_for` may write (serial
+            // naming's bare-serial claim). Any mismatch routes to the locked
+            // path, which resolves the name again with the real call.
+            let hostname = host_naming::hostname_for_readonly(&mut *txn, &ctx).await?;
             if interface.domain_id.is_some() || interface.hostname != hostname {
                 return Ok(true);
             }
@@ -3127,7 +3131,10 @@ async fn admin_reconcile_work_needed(
             interface_id: Some(primary.id),
             domain_id: primary.domain_id,
         };
-        let hostname = host_naming::hostname_for(&mut *txn, &ctx).await?;
+        // Read-only for the same reason as above: for a primary under serial
+        // naming, `hostname_for` claims the bare serial, which can rename a
+        // demoted sibling -- a write this unlocked predicate must never make.
+        let hostname = host_naming::hostname_for_readonly(&mut *txn, &ctx).await?;
         if primary.hostname != hostname || primary.domain_id != primary_segment.config.subdomain_id
         {
             return Ok(true);

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -425,7 +425,12 @@ impl MachineCreator {
             };
 
             for dpu_report in managed_host.explored_host.dpus.iter() {
-                self.configure_dpu_interface(&mut txn, dpu_report).await?;
+                // The steady-state branch holds the segment locks only under
+                // eager locking (the acquisition at transaction start); under
+                // lazy locking it reaches here unlocked and the callee locks
+                // before its one possible write.
+                self.configure_dpu_interface(&mut txn, dpu_report, !lazy_segment_lock)
+                    .await?;
             }
 
             self.reconcile_host_admin_addresses(&mut txn, &host_machine_id)
@@ -1146,7 +1151,11 @@ impl MachineCreator {
         explored_dpu: &ExploredDpu,
     ) -> SiteExplorerResult<Option<Machine>> {
         if let Some(dpu_machine) = self.create_dpu_machine(txn, explored_dpu).await? {
-            self.configure_dpu_interface(txn, explored_dpu).await?;
+            // The creation branch of `create_managed_host` -- this function's
+            // only caller -- holds every admin-segment lock on both locking
+            // modes by the time it gets here: eagerly at transaction start, or
+            // lazily at the branch decision. No re-acquisition needed.
+            self.configure_dpu_interface(txn, explored_dpu, true).await?;
             let dpu_machine_id: &MachineId = explored_dpu.report.machine_id.as_ref().unwrap();
             let dpu_bmc_info = explored_dpu.bmc_info();
             let dpu_hw_info = explored_dpu.hardware_info()?;
@@ -1188,10 +1197,17 @@ impl MachineCreator {
     // configure_dpu_interface checks the machine_interfaces table to see if the DPU's machine interface has its machine id set.
     // If the machine ID is already configured appropriately for the DPU's machine interface, configure_dpu_interface will return false
     // If the DPU's machine interface was missing the machine ID in the table, configure_dpu_interface will set the machine ID and return true.
+    // `segments_already_locked` says whether this transaction already holds
+    // every admin-segment advisory lock. Passing `true` when it does not would
+    // let the association below write without the lock, so callers may pass it
+    // only when the acquisition is visible on their own path: the creation
+    // branch locks at entry in both modes, the steady-state branch only under
+    // eager locking.
     async fn configure_dpu_interface(
         &self,
         txn: &mut PgConnection,
         explored_dpu: &ExploredDpu,
+        segments_already_locked: bool,
     ) -> SiteExplorerResult<bool> {
         let dpu_machine_id: &MachineId = explored_dpu.report.machine_id.as_ref().unwrap();
         let oob_net0_mac = explored_dpu.report.systems.iter().find_map(|x| {
@@ -1221,14 +1237,15 @@ impl MachineCreator {
             {
                 let interface_id = interface.id;
 
-                // The read above is a pure filter: re-take the decision under
-                // the locks before writing, so no write is based on unlocked
-                // state. Acquiring here still precedes every row lock this
-                // transaction takes, so the allocator order (segment advisory
-                // lock first, then machine interface/address rows) holds.
-                // Under `MACHINE_CREATOR_LAZY_LOCK=0` the caller already holds
-                // these locks and this block is skipped entirely.
-                if lazy_segment_lock_enabled() {
+                // When the caller reached here unlocked, the read above is a
+                // pure filter: re-take the decision under the locks before
+                // writing, so no write is based on unlocked state. Acquiring
+                // here still precedes every row lock this transaction takes,
+                // so the allocator order (segment advisory lock first, then
+                // machine interface/address rows) holds. When the caller
+                // already holds the locks, the read above was made under them
+                // and this re-acquisition and re-read would be redundant.
+                if !segments_already_locked {
                     db::machine_interface::lock_all_admin_segments(
                         &mut *txn,
                         "machine_creator_dpu_interface",

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -228,7 +228,7 @@ impl MachineCreator {
         // transaction holds locks in the allocator order (segment advisory
         // lock first, then interface rows) all the way to the reconcile
         // pass -- which re-acquires the same locks as a no-op.
-        db::machine_interface::lock_all_admin_segments(txn.as_pgconn()).await?;
+        db::machine_interface::lock_all_admin_segments(txn.as_pgconn(), "machine_creator").await?;
 
         // Zero-dpu case: If the explored host had no DPUs, we can create the machine now
         if managed_host.explored_host.dpus.is_empty() {

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -57,6 +57,44 @@ use crate::metrics::{SiteExplorationMetrics, SiteExplorerMachineSlotTrayPersiste
 
 const DESIRED_BOOT_INTERFACE_RECONCILE_PAGE_SIZE: i64 = 100;
 
+/// Whether `create_managed_host` acquires the admin-segment advisory locks
+/// lazily -- immediately before the writes that need them -- instead of
+/// unconditionally at the top of its transaction.
+///
+/// # Why (measured, #4711 follow-up -- do not delete)
+///
+/// A profiler sampled once a second which query each backend was running while
+/// it *held* a granted admin-segment advisory lock, over a full 4,500-host run
+/// (72,562 hold-time samples). Of the 39,791 exclusive samples on the
+/// admin-segment keys, 24,907 (63%) caught the holder `idle in transaction`:
+/// the lock was granted, the transaction was open, and the backend was doing
+/// nothing in the database at all -- the application was computing, round
+/// tripping, or waiting. Only 27% were `active`. Three earlier fixes all
+/// targeted how *often* the lock was acquired and moved throughput not at all
+/// (55.7, 56.3, 54.3, 56.4 machines/min -- flat within noise), because
+/// acquisition count was never the cost. Wall-clock hold time is.
+///
+/// `create_managed_host` took the fleet-wide exclusive lock unconditionally,
+/// before it knew which branch it was in, and `pg_advisory_xact_lock` releases
+/// only at COMMIT. So the whole transaction -- every read, every application
+/// round trip, and the commit itself -- was one fleet-wide critical section,
+/// even on the steady-state branch, which at 4,500 hosts is ~99.6% of passes
+/// and writes nothing that needs the lock.
+///
+/// Set `MACHINE_CREATOR_LAZY_LOCK=0` to restore the unconditional acquisition
+/// (the previous behaviour), so the two can be A/B'd on a live fleet without a
+/// rebuild. Same shape and same knob style as `ADMIN_RECONCILE_FAST_PATH` in
+/// `carbide_api_db::machine_interface`.
+fn lazy_segment_lock_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        !matches!(
+            std::env::var("MACHINE_CREATOR_LAZY_LOCK").as_deref(),
+            Ok("0") | Ok("false")
+        )
+    })
+}
+
 /// Creates machines from site-explorer managed-host reports.
 pub struct MachineCreator {
     database_connection: PgPool,
@@ -133,6 +171,19 @@ impl MachineCreator {
     /// its initial desired target still commit atomically. Keyset pages prevent
     /// permanently MAC-only hosts from starving later IDs, while one
     /// transaction per machine bounds locks and preserves completed progress.
+    ///
+    /// This sweep is also the *only* path for hosts that already exist (#4711).
+    /// `create_managed_host`'s steady-state branch deliberately does not
+    /// reconcile inline: with `MACHINE_CREATOR_LAZY_LOCK=0` it holds every
+    /// admin-segment advisory lock until it commits, so reconciling there would
+    /// put these reads inside a fleet-wide critical section for every host on
+    /// every pass -- and with lazy locking on, that branch runs unlocked, where
+    /// these writes would invert the segment-lock ordering (see the comment at
+    /// the call site). Here they take no segment lock and never ask for one.
+    /// Anything that branch would have fixed shows up in
+    /// `find_incomplete_machine_ids` (`desired_interface_id IS NULL` covers
+    /// both the unset and MAC-only cases), so keep this pass unconditional --
+    /// gating it behind `create_machines` would strand those hosts.
     pub(crate) async fn reconcile_desired_boot_interfaces(&self) -> SiteExplorerResult<()> {
         let mut after_id = None;
         loop {
@@ -220,7 +271,11 @@ impl MachineCreator {
 
         // Admission permit BEFORE the transaction: waiters on the admin-segment
         // advisory lock must queue in memory, not on open pool connections.
+        // Kept unconditional even under lazy locking: the lock-wait window is
+        // now inside the transaction, so the permit must still bound how many
+        // transactions can be sitting in it at once.
         let _admin_admission = db::machine_interface::admin_lock_admission().await;
+        let lazy_segment_lock = lazy_segment_lock_enabled();
         let mut txn = Transaction::begin(pool).await?;
 
         // Advisory-lock the admin segments before any machine-interface row
@@ -228,10 +283,42 @@ impl MachineCreator {
         // transaction holds locks in the allocator order (segment advisory
         // lock first, then interface rows) all the way to the reconcile
         // pass -- which re-acquires the same locks as a no-op.
-        db::machine_interface::lock_all_admin_segments(txn.as_pgconn(), "machine_creator").await?;
+        //
+        // Under `lazy_segment_lock` this acquisition moves down to the three
+        // points that actually need it (see [`lazy_segment_lock_enabled`] for
+        // the measurement): the zero-DPU branch, the creation branch, and the
+        // one write inside `configure_dpu_interface`. Nothing between here and
+        // those points writes anything, and nothing between here and those
+        // points takes a row lock -- `lookup_host_machine_ids_by_dpu_ids` and
+        // `find_by_mac_address` are plain `SELECT`s with no `FOR UPDATE` -- so
+        // the allocator order (segment advisory lock first, then machine
+        // interface/address rows) still holds on every path.
+        if !lazy_segment_lock {
+            db::machine_interface::lock_all_admin_segments(txn.as_pgconn(), "machine_creator")
+                .await?;
+        }
 
         // Zero-dpu case: If the explored host had no DPUs, we can create the machine now
         if managed_host.explored_host.dpus.is_empty() {
+            // Locked eagerly for the whole branch, lazy mode included.
+            // `create_zero_dpu_machine` writes on *both* its outcomes: the
+            // "already exists" outcome still calls
+            // `reconcile_desired_boot_interface`, which writes
+            // `machine_desired_boot_interface` rows. `set_primary_interface`
+            // in `managed_host::set_primary_interface` writes that same table
+            // while holding these segment locks, so a transaction that wrote
+            // it *first* and asked for the segment locks afterwards would
+            // close an ABBA cycle against that handler. Taking the locks at
+            // branch entry, before any of it, keeps this path in the
+            // documented order. This branch is also not where the cost is: the
+            // measured fleet is DPU-backed, so it takes the branch below.
+            if lazy_segment_lock {
+                db::machine_interface::lock_all_admin_segments(
+                    txn.as_pgconn(),
+                    "machine_creator_zero_dpu",
+                )
+                .await?;
+            }
             if let Some(machine_id) = self
                 .create_zero_dpu_machine(
                     &mut txn,
@@ -262,8 +349,34 @@ impl MachineCreator {
             dpu_ids.push(dpu_machine_id);
         }
 
-        let existing_hosts_by_dpu_id =
+        let mut existing_hosts_by_dpu_id =
             db::machine::lookup_host_machine_ids_by_dpu_ids(&mut txn, &dpu_ids).await?;
+
+        // Unlocked pre-read as a pure filter, re-validated under the lock --
+        // the same shape as the #4711 pre-check in
+        // `reconcile_admin_addresses_for_host`.
+        //
+        // A non-empty result means the steady-state branch: it writes nothing
+        // that needs a segment lock, and the one write it can reach
+        // (`configure_dpu_interface`) re-reads and re-checks under the lock
+        // itself, so the unlocked answer is never trusted by a writer.
+        //
+        // An empty result means the creation branch, which writes machines,
+        // interfaces and addresses. Take the locks and ask again, so that
+        // branch is decided by a read taken *under* the lock: a host created
+        // by a concurrent pass since the pre-read is then visible, and this
+        // transaction falls into the steady-state branch exactly as it would
+        // have before. Only reads have happened so far in this transaction, so
+        // acquiring here still precedes every row lock it will take.
+        if lazy_segment_lock && existing_hosts_by_dpu_id.is_empty() {
+            db::machine_interface::lock_all_admin_segments(
+                txn.as_pgconn(),
+                "machine_creator_create",
+            )
+            .await?;
+            existing_hosts_by_dpu_id =
+                db::machine::lookup_host_machine_ids_by_dpu_ids(&mut txn, &dpu_ids).await?;
+        }
 
         if !existing_hosts_by_dpu_id.is_empty() {
             // TODO: We run this code for every endpoint on every site explorer run, and it is slow.
@@ -317,7 +430,54 @@ impl MachineCreator {
 
             self.reconcile_host_admin_addresses(&mut txn, &host_machine_id)
                 .await?;
-            reconcile_desired_boot_interface(&mut txn, &host_machine_id).await?;
+
+            // Deliberately NOT reconciling the desired boot interface here
+            // (#4711), for two independent reasons.
+            //
+            // Performance, which is why it was removed: with
+            // `MACHINE_CREATOR_LAZY_LOCK=0` this transaction has held every
+            // admin-segment advisory lock since it opened, and those locks are
+            // `pg_advisory_xact_lock` -- they release at COMMIT, not when the
+            // allocator is done. So every statement between the lock and the
+            // commit below runs inside a fleet-wide critical section, and the
+            // measured cost of that section is dominated by ordinary reads and
+            // by the application time between them, not by lock acquisition.
+            // `reconcile_desired_boot_interface` contributes three reads (the
+            // desired target, this host's interface snapshots with their
+            // address aggregation, and its predicted interfaces), and this is
+            // the steady-state branch: it runs for every already-ingested host
+            // on every exploration pass while creating nothing.
+            //
+            // Deadlock safety, which is why it must not come back: under lazy
+            // locking this branch reaches here *unlocked*, and
+            // `reconcile_desired_boot_interface` writes
+            // `machine_desired_boot_interface` rows. `configure_dpu_interface`
+            // above and `reconcile_host_admin_addresses` below can both still
+            // acquire the segment locks later in this same transaction. Writing
+            // that table first and asking for the segment locks afterwards
+            // inverts the order that `managed_host::set_primary_interface`
+            // uses (segment locks, then `machine_desired_boot_interface::set`),
+            // which is an ABBA cycle. Restoring this call would require taking
+            // the segment locks before it.
+            //
+            // Dropping it here loses no work, because the identical work is
+            // already done unlocked in the same pass:
+            // `reconcile_desired_boot_interfaces` runs right after
+            // `create_machines` in `SiteExplorer::explore_site` -- unconditional
+            // on every `run_single_iteration`, and outside the `create_machines`
+            // gate -- one transaction per machine, taking no segment lock. It
+            // selects exactly the machines this call could have changed:
+            // `find_incomplete_machine_ids` returns every host/predicted-host
+            // row whose `desired_interface_id` is NULL, which covers both the
+            // unset and the MAC-only cases, and an already-complete Pair is a
+            // no-op in `reconcile_desired_boot_interface` regardless.
+            // `host_machine_id` came from `machine_interfaces.machine_id`,
+            // which has a foreign key to `machines`, so the sweep is guaranteed
+            // to see this host.
+            //
+            // The creation-time call further down stays where it is: a
+            // brand-new machine and its initial desired target must still
+            // commit atomically.
 
             txn.commit().await?;
             return Ok(false);
@@ -1049,24 +1209,56 @@ impl MachineCreator {
 
         // If machine_interface exists for the DPU and machine_id is not updated, do it now.
         if let Some(oob_net0_mac) = oob_net0_mac {
+            // Unlocked on the steady-state path (see `create_managed_host`).
+            // This is the only lock-needing write the steady-state branch can
+            // reach, and in steady state it does not fire: the DPU's interface
+            // was associated on the pass that ingested it, so `machine_id` is
+            // already `Some` and this function is a pure read.
             let mi = db::machine_interface::find_by_mac_address(&mut *txn, oob_net0_mac).await?;
 
             if let Some(interface) = mi.first()
                 && interface.machine_id.is_none()
             {
+                let interface_id = interface.id;
+
+                // The read above is a pure filter: re-take the decision under
+                // the locks before writing, so no write is based on unlocked
+                // state. Acquiring here still precedes every row lock this
+                // transaction takes, so the allocator order (segment advisory
+                // lock first, then machine interface/address rows) holds.
+                // Under `MACHINE_CREATOR_LAZY_LOCK=0` the caller already holds
+                // these locks and this block is skipped entirely.
+                if lazy_segment_lock_enabled() {
+                    db::machine_interface::lock_all_admin_segments(
+                        &mut *txn,
+                        "machine_creator_dpu_interface",
+                    )
+                    .await?;
+                    let locked =
+                        db::machine_interface::find_by_mac_address(&mut *txn, oob_net0_mac).await?;
+                    let still_unowned = locked
+                        .first()
+                        .is_some_and(|i| i.id == interface_id && i.machine_id.is_none());
+                    if !still_unowned {
+                        // Another writer claimed it between the two reads;
+                        // it did the same association we were about to do.
+                        return Ok(false);
+                    }
+                }
+
                 tracing::info!(
-                    machine_interface_id = %interface.id,
+                    machine_interface_id = %interface_id,
                     machine_id = %dpu_machine_id,
                     "Associating machine interface with machine"
                 );
                 db::machine_interface::associate_interface_with_machine(
-                    &interface.id,
+                    &interface_id,
                     MachineInterfaceAssociation::Machine(*dpu_machine_id),
                     txn,
                 )
                 .await?;
                 db::machine_interface::associate_interface_with_dpu_machine(
-                    &interface.id,
+                    &interface_id,
                     dpu_machine_id,
                     txn,
                 )


### PR DESCRIPTION
Fixes #4711.

Machine ingestion at 4,500 hosts (13,500 machines) was capped at 54–56 machines/min across five consecutive runs, regardless of tuning. Hold-time profiling — 72,562 one-second samples of `pg_locks` joined to the holding backend's running query — showed why every earlier fix missed: **63% of exclusive admin-segment lock hold time was `idle in transaction`**. The fleet-wide lock was held across application round-trips, not across expensive queries; acquiring it was only ~10% of the time it was held.

## The changes, in dependency order

1. **Reconcile fast path** — `reconcile_admin_addresses_for_host` decides with an unlocked read and only takes the segment locks when there is genuinely something to write, re-reading `FOR UPDATE` under the lock. Gated by `ADMIN_RECONCILE_FAST_PATH` (default on).
2. **Per-call-site lock tally** — every segment-lock acquisition is counted by caller and emitted at INFO on a 30s timer (poison-safe). Folded into this PR rather than shipped separately because the later commits use its labeled API, and it is how the fixes' effect is verified on a live fleet.
3. **Discovery pre-check** — retries that will fail authorization (the client retries every 5s until site-explorer creates the machine) are rejected *before* the admission permit and the locks, on monotonic conditions only.
4. **Shared lock on discovery's host branch** — the non-DPU branch provably never allocates (every segment-lock-reachable call is inside `is_dpu()`); it now takes the locks shared. Shared still conflicts with exclusive, so mutual exclusion against DPU/creator/delete/reconcile flows is preserved; only host↔host becomes concurrent.
5. **Lazy acquisition in `machine_creator`** — the biggest win. The lock is no longer taken at the top of `create_managed_host`; the steady-state pass (the dominant outcome at scale) commits without ever holding it. The three write paths acquire immediately before writing, with unlocked reads used strictly as filters and re-validated under the lock. The zero-DPU branch stays eager on purpose (it writes on both outcomes). Gated by `MACHINE_CREATOR_LAZY_LOCK` (default on).

## Measured results (4,500 hosts / 13,500 machines, dev6)

| Configuration | Rate | Time to ALL machines ready |
|---|---|---|
| Before (5-run plateau) | 54–56/min | 4h 35m – 4h 46m |
| Lazy lock alone | 71.3/min | 3h 51m |
| **Composed (two identical runs)** | **79.6 and 100.0/min** | **3h 00m – 3h 35m** |

- Segment-exclusive hold samples: 39,791 → 6,929 (−83%); `idle in transaction` holds −85%
- Reconcile acquisitions: 44 → 2.7 per machine (−94%) once the lazy lock stopped masking the pre-check — the two changes are individually insufficient (+27% and 0% respectively) and only compose
- **Zero `40P01` deadlocks across nine consecutive 100%-ready runs**
- At 1,000 hosts the same code and config measures **186.8/min with all 3,000 machines ready in 39 minutes** (35% above the previous small-scale best)

## Safety notes for review

- PostgreSQL advisory locks do not upgrade: no path takes shared-then-exclusive on the same key (verified per call site; the host/DPU branches are separate transactions).
- The documented ordering — segment advisory lock before `machine_interfaces`/`machine_interface_addresses` row locks, segment ids ascending — is preserved at every lazy acquisition point; unlocked prefixes take no row locks (plain SELECTs only).
- Known pre-existing residual, documented in the lazy-lock commit: under the non-default `SerialNumber` host-naming strategy, the reconcile pre-check can write an interface hostname before the locked path acquires segment locks. Inert under the default `IpAddress` strategy; needs its own fix before anyone enables `SerialNumber` at scale.
- Both env knobs default on and exist so the old behaviour can be A/B'd on a live fleet without a rebuild.
