### PR TITLE
feat(machine-a-tron): Simulate Lenovo adapter Ports

### DIFF
--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -354,7 +354,9 @@ fn should_fetch_supplemental_network_adapter_ports(
     has_system_mac_address: bool,
     linked_chassis_ids: &[nv_redfish::core::ODataId],
 ) -> bool {
-    hw_type == Some(hw::HwType::Lenovo) && has_system_mac_address && !linked_chassis_ids.is_empty()
+    matches!(hw_type, Some(hw::HwType::Lenovo | hw::HwType::LenovoGb300))
+        && has_system_mac_address
+        && !linked_chassis_ids.is_empty()
 }
 
 /// Builds an exploration report for a Delta power shelf.
@@ -1281,6 +1283,9 @@ mod tests {
             }
             "Lenovo XCC with a System MAC supplements its inventory" {
                 (Some(HwType::Lenovo), true, true) => true,
+            }
+            "Lenovo GB300 with a System MAC supplements its inventory" {
+                (Some(HwType::LenovoGb300), true, true) => true,
             }
             "non-Lenovo host" {
                 (Some(HwType::Ami), true, true) => false,

--- a/crates/bmc-explorer/tests/integration/lenovo_gb300_explore.rs
+++ b/crates/bmc-explorer/tests/integration/lenovo_gb300_explore.rs
@@ -50,6 +50,22 @@ async fn explore_lenovo_gb300() {
     assert!(!report.systems.is_empty(), "systems must be present");
     assert!(!report.chassis.is_empty(), "chassis must be present");
 
+    let system_mac = report.systems[0].ethernet_interfaces[0]
+        .mac_address
+        .expect("Lenovo system interface must report a MAC address");
+    let port_mac_addresses = report
+        .chassis
+        .iter()
+        .flat_map(|chassis| &chassis.network_adapters)
+        .flat_map(|adapter| &adapter.port_mac_addresses)
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(port_mac_addresses.len(), 1);
+    let supplemental_mac = port_mac_addresses[0];
+    assert_ne!(supplemental_mac, system_mac);
+    assert!(report.all_mac_addresses().contains(&supplemental_mac));
+    assert_eq!(report.find_interface_id_for_mac(supplemental_mac), None);
+
     let lockdown = report
         .lockdown_status
         .expect("GB300 lockdown status must be populated");

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -153,7 +153,7 @@ impl LenovoGB300Nvl<'_> {
                     &format!("EthernetInterface{index}"),
                 ))
                 .mac_address(nic.mac_address)
-                .interface_enabled(false)
+                .interface_enabled(true)
                 .build()
             })
             .collect();

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -241,6 +241,7 @@ impl LenovoGB300Nvl<'_> {
                     part_number: Some("SC57C26750".into()),
                     model: Some(" ".into()),
                     serial_number: Some(self.chassis_0_serial_number.to_string().into()),
+                    network_adapters: Some(vec![self.host_network_adapter()]),
                     sensors: Some(redfish::sensor::generate_chassis_sensors(
                         "Chassis_0",
                         redfish::sensor::Layout {
@@ -274,6 +275,26 @@ impl LenovoGB300Nvl<'_> {
                 )))
                 .collect(),
         }
+    }
+
+    fn host_network_adapter(&self) -> redfish::network_adapter::NetworkAdapter {
+        const CHASSIS_ID: &str = "Chassis_0";
+        const ADAPTER_ID: &str = "slot-16";
+        let port = redfish::network_adapter::port_builder(
+            &redfish::network_adapter::port_resource(CHASSIS_ID, ADAPTER_ID, "1"),
+        )
+        .lenovo_physical_mac_address(self.dpu.host_nic().mac_address)
+        .build();
+        redfish::network_adapter::builder_from_nic(
+            &redfish::network_adapter::chassis_resource(CHASSIS_ID, ADAPTER_ID),
+            &self.dpu.host_nic(),
+        )
+        .ports(
+            &redfish::network_adapter::port_collection(CHASSIS_ID, ADAPTER_ID),
+            vec![port],
+        )
+        .status(redfish::resource::Status::Ok)
+        .build()
     }
 
     pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {

--- a/crates/bmc-mock/src/redfish/chassis.rs
+++ b/crates/bmc-mock/src/redfish/chassis.rs
@@ -56,6 +56,7 @@ pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const CHASSIS_ID: &str = "{chassis_id}";
     const NET_ADAPTER_ID: &str = "{network_adapter_id}";
     const NET_FUNC_ID: &str = "{function_id}";
+    const PORT_ID: &str = "{port_id}";
     const PCIE_DEVICE_ID: &str = "{pcie_device_id}";
     const SENSOR_ID: &str = "{sensor_id}";
     const POWER_SUPPLY_ID: &str = "{power_supply_id}";
@@ -83,6 +84,14 @@ pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
             )
             .odata_id,
             get(get_chassis_network_adapters_network_device_function),
+        )
+        .route(
+            &redfish::network_adapter::port_collection(CHASSIS_ID, NET_ADAPTER_ID).odata_id,
+            get(get_chassis_network_adapter_ports),
+        )
+        .route(
+            &redfish::network_adapter::port_resource(CHASSIS_ID, NET_ADAPTER_ID, PORT_ID).odata_id,
+            get(get_chassis_network_adapter_port),
         )
         .route(
             &redfish::pcie_device::chassis_collection(CHASSIS_ID).odata_id,
@@ -406,6 +415,47 @@ async fn get_chassis_network_adapters_network_device_function(
         .and_then(|chassis_state| chassis_state.find_network_adapter(&network_adapter_id))
         .and_then(|network_adapter| network_adapter.find_function(&function_id))
         .map(|function| function.to_json().into_ok_response())
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_chassis_network_adapter_ports(
+    State(state): State<BmcState>,
+    Path((chassis_id, network_adapter_id)): Path<(String, String)>,
+) -> Response {
+    state
+        .chassis_state
+        .find(&chassis_id)
+        .and_then(|chassis_state| chassis_state.find_network_adapter(&network_adapter_id))
+        .map(|network_adapter| {
+            let members = network_adapter
+                .ports
+                .iter()
+                .map(|port| {
+                    redfish::network_adapter::port_resource(
+                        &chassis_id,
+                        &network_adapter_id,
+                        &port.id,
+                    )
+                    .entity_ref()
+                })
+                .collect::<Vec<_>>();
+            redfish::network_adapter::port_collection(&chassis_id, &network_adapter_id)
+                .with_members(&members)
+                .into_ok_response()
+        })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_chassis_network_adapter_port(
+    State(state): State<BmcState>,
+    Path((chassis_id, network_adapter_id, port_id)): Path<(String, String, String)>,
+) -> Response {
+    state
+        .chassis_state
+        .find(&chassis_id)
+        .and_then(|chassis_state| chassis_state.find_network_adapter(&network_adapter_id))
+        .and_then(|network_adapter| network_adapter.find_port(&port_id))
+        .map(|port| port.to_json().into_ok_response())
         .unwrap_or_else(http::not_found)
 }
 

--- a/crates/bmc-mock/src/redfish/network_adapter.rs
+++ b/crates/bmc-mock/src/redfish/network_adapter.rs
@@ -36,6 +36,30 @@ pub(crate) fn chassis_resource(chassis_id: &str, adapter_id: &str) -> redfish::R
     }
 }
 
+pub(crate) fn port_resource(
+    chassis_id: &str,
+    adapter_id: &str,
+    port_id: &str,
+) -> redfish::Resource<'static> {
+    let odata_id =
+        format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters/{adapter_id}/Ports/{port_id}");
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#Port.v1_6_0.Port"),
+        id: Cow::Owned(port_id.into()),
+        name: Cow::Borrowed("Port"),
+    }
+}
+
+pub(crate) fn port_collection(chassis_id: &str, adapter_id: &str) -> redfish::Collection<'static> {
+    let odata_id = format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters/{adapter_id}/Ports");
+    redfish::Collection {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#PortCollection.PortCollection"),
+        name: Cow::Borrowed("Port Collection"),
+    }
+}
+
 pub(super) fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters");
     redfish::Collection {
@@ -49,6 +73,7 @@ pub(crate) struct NetworkAdapter {
     pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
     pub(crate) functions: Vec<redfish::network_device_function::NetworkDeviceFunction>,
+    pub(crate) ports: Vec<Port>,
 }
 
 impl NetworkAdapter {
@@ -61,6 +86,61 @@ impl NetworkAdapter {
     ) -> Option<&redfish::network_device_function::NetworkDeviceFunction> {
         self.functions.iter().find(|f| f.id.as_ref() == function_id)
     }
+
+    pub(crate) fn find_port(&self, port_id: &str) -> Option<&Port> {
+        self.ports.iter().find(|port| port.id.as_ref() == port_id)
+    }
+}
+
+pub(crate) struct Port {
+    pub(crate) id: Cow<'static, str>,
+    value: serde_json::Value,
+}
+
+impl Port {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
+        self.value.clone()
+    }
+}
+
+pub(crate) fn port_builder(resource: &redfish::Resource) -> PortBuilder {
+    PortBuilder {
+        id: Cow::Owned(resource.id.to_string()),
+        value: resource.json_patch(),
+    }
+}
+
+pub(crate) struct PortBuilder {
+    id: Cow<'static, str>,
+    value: serde_json::Value,
+}
+
+impl Builder for PortBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            id: self.id,
+            value: self.value.patch(patch),
+        }
+    }
+}
+
+impl PortBuilder {
+    pub(crate) fn lenovo_physical_mac_address(self, mac_address: mac_address::MacAddress) -> Self {
+        self.apply_patch(json!({
+            "Oem": {
+                "Lenovo": {
+                    "PhysicalPortMacAddress": mac_address,
+                }
+            }
+        }))
+    }
+
+    pub(crate) fn build(self) -> Port {
+        Port {
+            id: self.id,
+            value: self.value,
+        }
+    }
 }
 
 /// Get builder of the network adapter.
@@ -69,6 +149,7 @@ pub(crate) fn builder(resource: &redfish::Resource) -> NetworkAdapterBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
         functions: Vec::new(),
+        ports: Vec::new(),
     }
 }
 
@@ -88,6 +169,7 @@ pub(crate) struct NetworkAdapterBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
     functions: Vec<redfish::network_device_function::NetworkDeviceFunction>,
+    ports: Vec<Port>,
 }
 
 impl Builder for NetworkAdapterBuilder {
@@ -96,6 +178,7 @@ impl Builder for NetworkAdapterBuilder {
             value: self.value.patch(patch),
             id: self.id,
             functions: self.functions,
+            ports: self.ports,
         }
     }
 }
@@ -131,6 +214,12 @@ impl NetworkAdapterBuilder {
         v
     }
 
+    pub(crate) fn ports(self, collection: &redfish::Collection<'_>, ports: Vec<Port>) -> Self {
+        let mut value = self.apply_patch(collection.nav_property("Ports"));
+        value.ports = ports;
+        value
+    }
+
     pub(crate) fn status(self, status: redfish::resource::Status) -> Self {
         self.apply_patch(json!({
             "Status": status.into_json()
@@ -142,6 +231,7 @@ impl NetworkAdapterBuilder {
             id: self.id,
             value: self.value,
             functions: self.functions,
+            ports: self.ports,
         }
     }
 }

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -642,6 +642,7 @@ mod test {
         let interfaces = get_json(&router, "/redfish/v1/Systems/System_0/EthernetInterfaces").await;
         let interface_path = interfaces["Members"][0]["@odata.id"].as_str().unwrap();
         let interface = get_json(&router, interface_path).await;
+        assert_eq!(interface["InterfaceEnabled"], true);
         assert_ne!(interface["MACAddress"], expected_host_mac);
 
         let chassis = get_json(&router, "/redfish/v1/Chassis/Chassis_0").await;

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -608,6 +608,58 @@ mod test {
     use crate::test_support::axum_http_client::Error;
     use crate::test_support::host_info;
 
+    async fn get_json(router: &Router, path: &str) -> serde_json::Value {
+        let response = router
+            .clone()
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "GET {path}");
+        serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn lenovo_profile_exposes_declared_host_mac_only_through_adapter_port() {
+        let machine = host_info(HardwareType::LenovoGB300Nvl);
+        let expected_host_mac = match &machine {
+            MachineInfo::Host(host) => host.system_mac_address().unwrap().to_string(),
+            MachineInfo::Dpu(_) => unreachable!("Lenovo GB300 must be a host"),
+        };
+        let router = machine_router(
+            &machine,
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions::default(),
+        )
+        .0;
+
+        let interfaces = get_json(&router, "/redfish/v1/Systems/System_0/EthernetInterfaces").await;
+        let interface_path = interfaces["Members"][0]["@odata.id"].as_str().unwrap();
+        let interface = get_json(&router, interface_path).await;
+        assert_ne!(interface["MACAddress"], expected_host_mac);
+
+        let chassis = get_json(&router, "/redfish/v1/Chassis/Chassis_0").await;
+        let adapters_path = chassis["NetworkAdapters"]["@odata.id"].as_str().unwrap();
+        let adapters = get_json(&router, adapters_path).await;
+        let adapter_path = adapters["Members"][0]["@odata.id"].as_str().unwrap();
+        let adapter = get_json(&router, adapter_path).await;
+        let ports_path = adapter["Ports"]["@odata.id"].as_str().unwrap();
+        let ports = get_json(&router, ports_path).await;
+        let port_path = ports["Members"][0]["@odata.id"].as_str().unwrap();
+        let port = get_json(&router, port_path).await;
+
+        assert_eq!(
+            port["Oem"]["Lenovo"]["PhysicalPortMacAddress"],
+            expected_host_mac
+        );
+    }
+
     #[tokio::test]
     async fn caller_provided_injection_store_is_active() {
         let injection = Arc::new(InjectionStore::new());


### PR DESCRIPTION
Machine-a-Tron's Lenovo GB300 profile cannot reproduce the partial NIC inventory from #4982 because it exposes an onboard System interface but no chassis adapter Ports. This adds a deterministic Port-only host NIC MAC and makes Lenovo GB300 exploration collect it without treating the Port ID as a firmware interface ID.

## Related issues

Resolves #4982

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Manual testing used the repository's legacy full-stack DevSpace deployment because this revision has no `full` profile. A one-host Lenovo profile exposed an enabled System interface and a distinct chassis adapter Port MAC through the live Redfish service. The focused tests and clippy checks passed. The full `bmc-mock` test package completed 68 tests, but its real `ipmitool` test could not start because the local `ipmitool` binary was unavailable.
