### PR TITLE
feat(helm): add optional nvswitch mTLS certs

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -74,6 +74,61 @@ Top-level `global:` values are automatically passed to all subcharts.
 | `global.spiffe.trustDomain` | SPIFFE trust domain for mTLS | `nico.local` |
 | `global.labels` | Common labels applied to all resources | See `values.yaml` |
 
+### NVSwitch mTLS Certificates
+
+`nico-api.nvSwitchTls` can ask cert-manager to issue NICo's dedicated NMX-C
+client identity and, optionally, the NVSwitch server identity. Both leaves
+use the existing `nvSwitchTls.issuerRef`, which defaults to
+`vault-nico-issuer`. NMX-C/NVUE must trust the CA behind that issuer when NICo
+connects, and NICo uses the CA returned in its client Secret to verify the
+server certificate presented by the switch.
+
+The profiles are deliberately fixed to the capabilities each peer needs:
+
+- `nicoClient` uses `digital signature` and `client auth`. Its Secret is
+  mounted read-only in the nico-api container as `tls.crt`, `tls.key`, and
+  `ca.crt`.
+- `switchServer` uses `digital signature`, `server auth`, and `client auth`.
+  Its Secret is created in the NICo namespace but is never mounted into
+  nico-api. A switch installer or operator must copy the certificate, private
+  key, and CA to NMX-C/NVUE and bind them there.
+
+Both profiles are off by default. Enable `switchServer` only when this Helm
+release should own the server artifact. Configure `dnsNames` or `ipAddresses`,
+as appropriate, with a SAN that exactly matches `nmx_c_tls_authority` in the
+NICo site configuration.
+
+```yaml
+nico-api:
+  nvSwitchTls:
+    issuerRef:
+      kind: ClusterIssuer
+      name: vault-nico-issuer
+      group: cert-manager.io
+    nicoClient:
+      enabled: true
+      uris:
+        - spiffe://switch.local/nico-system/sa/nico-nmxc
+    switchServer:
+      enabled: true
+      dnsNames:
+        - nmxc.example.internal
+
+  siteConfig:
+    enabled: true
+    nicoApiSiteConfig: |
+      [nvlink_config]
+      enabled = true
+      nmx_c_tls_ca_cert_path = "/var/run/secrets/nvswitch-client/ca.crt"
+      nmx_c_tls_client_cert_path = "/var/run/secrets/nvswitch-client/tls.crt"
+      nmx_c_tls_client_key_path = "/var/run/secrets/nvswitch-client/tls.key"
+      nmx_c_tls_authority = "nmxc.example.internal"
+```
+
+The configured issuer and any cert-manager approver policy must allow both
+requested URI/DNS identities, durations, key profile, and usages. Creating the
+Kubernetes Secret does not install or bind the server identity on a switch.
+
 ### Grafana Dashboards
 
 The chart packages three dashboards built from NICo's exported Prometheus
@@ -308,6 +363,7 @@ names, SPIFFE identities, and trust domains are already `nico`-prefixed.
 > **Cutting over to nico naming on an existing site:** if you want to fully migrate an
 > existing site from `carbide`/`forge` naming to `nico` naming rather than preserving the
 > old names in-place, the safe procedure is:
+>
 > 1. Back up the PostgreSQL database (`pg_dump`).
 > 2. Uninstall the current release (`helm uninstall nico -n forge-system`).
 > 3. Re-install from scratch with the new defaults and your target namespace

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -237,6 +237,11 @@ spec:
             - name: spiffe
               mountPath: "/var/run/secrets/spiffe.io"
               readOnly: true
+            {{- if .Values.nvSwitchTls.nicoClient.enabled }}
+            - name: nvswitch-nico-client
+              mountPath: {{ .Values.nvSwitchTls.nicoClient.mountPath }}
+              readOnly: true
+            {{- end }}
             - name: nico-roots
               mountPath: "/var/run/secrets/forge-roots"
               readOnly: true
@@ -267,6 +272,11 @@ spec:
         - name: spiffe
           secret:
             secretName: {{ include "nico-api.name" . }}-certificate
+        {{- if .Values.nvSwitchTls.nicoClient.enabled }}
+        - name: nvswitch-nico-client
+          secret:
+            secretName: {{ .Values.nvSwitchTls.nicoClient.secretName }}
+        {{- end }}
         - name: nico-roots
           secret:
             secretName: nico-roots

--- a/helm/charts/nico-api/templates/nvswitch-nico-client-certificate.yaml
+++ b/helm/charts/nico-api/templates/nvswitch-nico-client-certificate.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.nvSwitchTls.nicoClient.enabled }}
+{{- $certificate := .Values.nvSwitchTls.nicoClient }}
+{{- $issuer := .Values.nvSwitchTls.issuerRef }}
+{{- if eq (len (default (list) $certificate.uris)) 0 }}
+{{- fail "nico-api: nvSwitchTls.nicoClient.uris must contain at least one URI SAN" }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $certificate.name }}
+  namespace: {{ include "nico-api.namespace" . }}
+  labels:
+    {{- include "nico-api.labels" . | nindent 4 }}
+spec:
+  secretName: {{ $certificate.secretName }}
+  duration: {{ $certificate.duration }}
+  renewBefore: {{ $certificate.renewBefore }}
+  isCA: false
+  usages:
+    - digital signature
+    - client auth
+  uris:
+    {{- toYaml $certificate.uris | nindent 4 }}
+  privateKey:
+    algorithm: {{ $certificate.privateKey.algorithm }}
+    size: {{ $certificate.privateKey.size }}
+    rotationPolicy: {{ $certificate.privateKey.rotationPolicy }}
+  issuerRef:
+    kind: {{ $issuer.kind }}
+    name: {{ $issuer.name }}
+    group: {{ $issuer.group }}
+{{- end }}

--- a/helm/charts/nico-api/templates/nvswitch-server-certificate.yaml
+++ b/helm/charts/nico-api/templates/nvswitch-server-certificate.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.nvSwitchTls.switchServer.enabled }}
+{{- $certificate := .Values.nvSwitchTls.switchServer }}
+{{- $issuer := .Values.nvSwitchTls.issuerRef }}
+{{- if and (eq (len (default (list) $certificate.dnsNames)) 0) (eq (len (default (list) $certificate.ipAddresses)) 0) }}
+{{- fail "nico-api: nvSwitchTls.switchServer must contain at least one dnsNames or ipAddresses SAN matching nmx_c_tls_authority" }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $certificate.name }}
+  namespace: {{ include "nico-api.namespace" . }}
+  labels:
+    {{- include "nico-api.labels" . | nindent 4 }}
+spec:
+  secretName: {{ $certificate.secretName }}
+  duration: {{ $certificate.duration }}
+  renewBefore: {{ $certificate.renewBefore }}
+  isCA: false
+  usages:
+    - digital signature
+    - server auth
+    - client auth
+  {{- with $certificate.dnsNames }}
+  dnsNames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $certificate.ipAddresses }}
+  ipAddresses:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $certificate.uris }}
+  uris:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  privateKey:
+    algorithm: {{ $certificate.privateKey.algorithm }}
+    size: {{ $certificate.privateKey.size }}
+    rotationPolicy: {{ $certificate.privateKey.rotationPolicy }}
+  issuerRef:
+    kind: {{ $issuer.kind }}
+    name: {{ $issuer.name }}
+    group: {{ $issuer.group }}
+{{- end }}

--- a/helm/charts/nico-api/tests/nvswitch_nico_client_certificate_test.yaml
+++ b/helm/charts/nico-api/tests/nvswitch_nico_client_certificate_test.yaml
@@ -1,0 +1,50 @@
+suite: NVSwitch NICo client certificate generation
+templates:
+  - nvswitch-nico-client-certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: is absent by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the NMX-C client identity when enabled
+    set:
+      nvSwitchTls:
+        nicoClient:
+          enabled: true
+          uris:
+            - spiffe://switch.local/nico-system/sa/nico-nmxc
+    asserts:
+      - equal:
+          path: spec.secretName
+          value: nvswitch-nico-client-certificate
+      - equal:
+          path: spec.usages
+          value:
+            - digital signature
+            - client auth
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://switch.local/nico-system/sa/nico-nmxc
+      - equal:
+          path: spec.privateKey
+          value:
+            algorithm: ECDSA
+            size: 384
+            rotationPolicy: Always
+      - equal:
+          path: spec.issuerRef
+          value:
+            kind: ClusterIssuer
+            name: vault-nico-issuer
+            group: cert-manager.io
+
+  - it: rejects a missing client URI SAN
+    set:
+      nvSwitchTls.nicoClient.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "nico-api: nvSwitchTls.nicoClient.uris must contain at least one URI SAN"

--- a/helm/charts/nico-api/tests/nvswitch_server_certificate_test.yaml
+++ b/helm/charts/nico-api/tests/nvswitch_server_certificate_test.yaml
@@ -1,0 +1,57 @@
+suite: NVSwitch server certificate generation
+templates:
+  - nvswitch-server-certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: is absent by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the server identity with DNS and IP SANs
+    set:
+      nvSwitchTls:
+        switchServer:
+          enabled: true
+          dnsNames:
+            - nvswitch.nico.local
+          ipAddresses:
+            - 192.0.2.10
+    asserts:
+      - equal:
+          path: spec.secretName
+          value: nvswitch-server-certificate
+      - equal:
+          path: spec.usages
+          value:
+            - digital signature
+            - server auth
+            - client auth
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nvswitch.nico.local
+      - equal:
+          path: spec.ipAddresses
+          value:
+            - 192.0.2.10
+      - equal:
+          path: spec.privateKey
+          value:
+            algorithm: ECDSA
+            size: 384
+            rotationPolicy: Always
+      - equal:
+          path: spec.issuerRef
+          value:
+            kind: ClusterIssuer
+            name: vault-nico-issuer
+            group: cert-manager.io
+
+  - it: rejects a missing DNS or IP SAN
+    set:
+      nvSwitchTls.switchServer.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "nico-api: nvSwitchTls.switchServer must contain at least one dnsNames or ipAddresses SAN matching nmx_c_tls_authority"

--- a/helm/charts/nico-api/tests/nvswitch_tls_deployment_test.yaml
+++ b/helm/charts/nico-api/tests/nvswitch_tls_deployment_test.yaml
@@ -1,0 +1,45 @@
+suite: NVSwitch TLS deployment integration
+templates:
+  - deployment.yaml
+tests:
+  - it: mounts the NICo client Secret read-only
+    set:
+      nvSwitchTls:
+        nicoClient:
+          enabled: true
+          secretName: nico-nmxc-client-tls
+          mountPath: /var/run/secrets/nmxc-client
+          uris:
+            - spiffe://switch.local/nico-system/sa/nico-nmxc
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nvswitch-nico-client
+            mountPath: /var/run/secrets/nmxc-client
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nvswitch-nico-client
+            secret:
+              secretName: nico-nmxc-client-tls
+
+  - it: never mounts the generated switch server Secret
+    set:
+      nvSwitchTls:
+        switchServer:
+          enabled: true
+          secretName: generated-switch-server-tls
+          dnsNames:
+            - nvswitch.nico.local
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nvswitch-server
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            secret:
+              secretName: generated-switch-server-tls

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -187,6 +187,52 @@ certificate:
   # Dev/sim only: IP SANs for direct-IP TLS (e.g. API VIP). Leave empty in production.
   ipAddresses: []
 
+## Optional NVSwitch control-plane certificates. Both leaves use the
+## same existing issuer, which defaults to the vault-nico-issuer deployed by
+## the standard NICo prerequisites. Both profiles are disabled by default.
+nvSwitchTls:
+  issuerRef:
+    kind: ClusterIssuer
+    name: vault-nico-issuer
+    group: cert-manager.io
+
+  ## Dedicated NICo client identity for direct mTLS connections to NMX-C.
+  ## When enabled, the generated Secret is mounted read-only at mountPath.
+  nicoClient:
+    enabled: false
+    name: nvswitch-nico-client-certificate
+    secretName: nvswitch-nico-client-certificate
+    mountPath: /var/run/secrets/nvswitch-client
+    duration: 720h0m0s
+    renewBefore: 360h0m0s
+    ## At least one URI SAN is required when enabled. Any cert-manager approver
+    ## policy must allow the exact identity.
+    uris: []
+    privateKey:
+      algorithm: ECDSA
+      size: 384
+      rotationPolicy: Always
+
+  ## Server identity installed on NVUE/NMX-C by the site's switch installer.
+  ## This chart only creates the Secret; it deliberately does not mount it into
+  ## nico-api. Enable it only when this release should own the server artifact.
+  switchServer:
+    enabled: false
+    name: nvswitch-server-certificate
+    secretName: nvswitch-server-certificate
+    duration: 720h0m0s
+    renewBefore: 360h0m0s
+    ## Configure the SAN type that matches nmx_c_tls_authority. At least one
+    ## DNS name or IP address is required when this certificate is enabled.
+    dnsNames: []
+    ipAddresses: []
+    ## Optional identity metadata, subject to the issuer/approver policy.
+    uris: []
+    privateKey:
+      algorithm: ECDSA
+      size: 384
+      rotationPolicy: Always
+
 migrationJob:
   sslMode: require
 

--- a/helm/examples/values-full.yaml
+++ b/helm/examples/values-full.yaml
@@ -76,6 +76,46 @@ nico-api:
     RUST_BACKTRACE: "full"
     RUST_LIB_BACKTRACE: "0"
 
+  ## Optional NVSwitch TLS leaves issued by one existing issuer. The standard
+  ## NICo prerequisites provide vault-nico-issuer. Both leaves are off by
+  ## default. Enable switchServer only when this release should own that
+  ## artifact; an external installer or operator must install its Secret on
+  ## the switches.
+  nvSwitchTls:
+    issuerRef:
+      kind: ClusterIssuer
+      name: vault-nico-issuer
+      group: cert-manager.io
+    nicoClient:
+      enabled: false
+      name: nvswitch-nico-client-certificate
+      secretName: nvswitch-nico-client-certificate
+      mountPath: /var/run/secrets/nvswitch-client
+      duration: 720h0m0s
+      renewBefore: 360h0m0s
+      uris:
+        - spiffe://switch.local/nico-system/sa/nico-nmxc
+      privateKey:
+        algorithm: ECDSA
+        size: 384
+        rotationPolicy: Always
+    switchServer:
+      enabled: false
+      name: nvswitch-server-certificate
+      secretName: nvswitch-server-certificate
+      duration: 720h0m0s
+      renewBefore: 360h0m0s
+      ## Use dnsNames or ipAddresses to exactly match
+      ## nvlink_config.nmx_c_tls_authority.
+      dnsNames:
+        - nmxc.example.internal
+      ipAddresses: []
+      uris: []
+      privateKey:
+        algorithm: ECDSA
+        size: 384
+        rotationPolicy: Always
+
   ## WebUI authentication defaults to Basic with a generated password Secret.
   ## Select OAuth2 here; provider-specific settings remain in extraEnv.
   webAuth:


### PR DESCRIPTION
Optionally generate NICo client and switch server certs using vault-nico-issuer. The server cert must be copied to the switch (along with the CA that signed the client cert) and bound to NMX-C.

## Description
NICo nvlink-manager connects directly to NMX-C using mTLS, so it needs a client cert that the switch trusts. NMX-C also needs a server cert trusted by NICo, which the NICo nvswitch-cert-monitor will expect for cert rotation.

Add optional cert-manager Certificate resources for the NICo client and NVSwitch server identities. Both certificates use the existing vault-nico-issuer so they share the established site trust root.

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

