### PR TITLE
refactor(agent): read family-neutral interface addresses

### DIFF
--- a/crates/admin-cli/src/dpu/network/cmd.rs
+++ b/crates/admin-cli/src/dpu/network/cmd.rs
@@ -50,6 +50,8 @@ fn deny_prefix(config: &ManagedHostNetworkConfigResponse) -> String {
     deny_prefixes.join("\n")
 }
 
+// This diagnostic view preserves the compatibility fields exposed to older agents.
+#[allow(deprecated)]
 async fn show_dpu_network_config(
     api_client: &ApiClient,
     output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -334,6 +334,8 @@ fn parse_managed_host_loopback_ips(
 
 /// Update the NVUE network config. Returns Ok(true) if the configuration changed, and
 /// Ok(false) if not.
+// The fetcher projects `addresses` into these compatibility fields before rendering.
+#[allow(deprecated)]
 pub(super) async fn update_nvue(
     vpc_virtualization_type: VpcVirtualizationType,
     update_flavor: NvueUpdateFlavor<'_>,
@@ -1106,6 +1108,8 @@ pub(super) async fn update_dhcp(
 }
 
 /// Interfaces to report back to server
+// The fetcher projects `addresses` into these compatibility fields before status reporting.
+#[allow(deprecated)]
 pub(super) async fn interfaces(
     network_config: &rpc::ManagedHostNetworkConfigResponse,
     factory_mac_address: MacAddress,
@@ -1229,6 +1233,8 @@ pub(super) async fn interfaces(
     Ok(interfaces)
 }
 
+// The fetcher projects `addresses` into the compatibility IPv4 field before health checks.
+#[allow(deprecated)]
 pub(super) fn tenant_peers(network_config: &rpc::ManagedHostNetworkConfigResponse) -> Vec<&str> {
     network_config
         .tenant_interfaces
@@ -2483,6 +2489,8 @@ mod tests {
         Ok(())
     }
 
+    // Builds the deprecated compatibility shape consumed by these renderer tests.
+    #[allow(deprecated)]
     fn netconf(
         virtualization_type: VpcVirtualizationType,
         interface_prefix_length: u8,
@@ -3225,7 +3233,9 @@ mod tests {
         }
     }
 
+    // Exercises the DHCP renderer's deprecated compatibility input.
     #[test]
+    #[allow(deprecated)]
     fn test_with_tenant_dhcp_server() -> Result<(), Box<dyn std::error::Error>> {
         // The config we received from API server
         // Admin won't be used

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -896,6 +896,8 @@ impl MainLoop {
 
                 let instance_data = self.periodic_config_reader.meta_data_conf_reader();
 
+                // The fetcher projects `addresses` into the compatibility prefix before use.
+                #[allow(deprecated)]
                 let proposed_routes: Vec<_> = conf
                     .tenant_interfaces
                     .iter()

--- a/crates/agent/src/periodic_config_fetcher.rs
+++ b/crates/agent/src/periodic_config_fetcher.rs
@@ -276,7 +276,92 @@ async fn fetch(
 ) -> Result<rpc::ManagedHostNetworkConfigResponse, eyre::Report> {
     let mut client = create_forge_client(forge_api, client_config).await?;
 
-    get_periodic_dpu_config(&mut client, dpu_machine_id).await
+    let mut response = get_periodic_dpu_config(&mut client, dpu_machine_id).await?;
+    normalize_network_config_addresses(&mut response)?;
+    Ok(response)
+}
+
+/// Projects the family-neutral address list into the compatibility fields used by the agent.
+fn normalize_network_config_addresses(
+    response: &mut rpc::ManagedHostNetworkConfigResponse,
+) -> Result<(), eyre::Report> {
+    if let Some(interface) = &mut response.admin_interface {
+        normalize_interface_addresses(interface).wrap_err_with(|| {
+            format!(
+                "invalid admin interface address configuration for VLAN {}",
+                interface.vlan_id
+            )
+        })?;
+    }
+
+    for (index, interface) in response.tenant_interfaces.iter_mut().enumerate() {
+        normalize_interface_addresses(interface).wrap_err_with(|| {
+            format!(
+                "invalid tenant interface address configuration at index {index} for VLAN {}",
+                interface.vlan_id
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Preserves a legacy payload, or makes a populated `addresses` list authoritative.
+#[allow(deprecated)]
+fn normalize_interface_addresses(
+    interface: &mut rpc::FlatInterfaceConfig,
+) -> Result<(), eyre::Report> {
+    if interface.addresses.is_empty() {
+        return Ok(());
+    }
+
+    let mut ipv4 = None;
+    let mut ipv6 = None;
+    for address in &interface.addresses {
+        let family = rpc::AddressFamily::try_from(address.address_family)
+            .wrap_err_with(|| format!("unknown address family value {}", address.address_family))?;
+        let slot = match family {
+            rpc::AddressFamily::V4 => &mut ipv4,
+            rpc::AddressFamily::V6 => &mut ipv6,
+            rpc::AddressFamily::Unspecified => {
+                return Err(eyre::eyre!("address family must be V4 or V6"));
+            }
+        };
+
+        if slot.replace(address.clone()).is_some() {
+            return Err(eyre::eyre!("duplicate {family:?} address configuration"));
+        }
+    }
+
+    let ipv4 = ipv4.ok_or_else(|| {
+        eyre::eyre!(
+            "IPv4 address configuration is required; IPv6-only agent support is tracked by https://github.com/NVIDIA/infra-controller/issues/2402"
+        )
+    })?;
+
+    interface.gateway.clone_from(&ipv4.gateway);
+    interface.ip.clone_from(&ipv4.ip);
+    interface
+        .interface_prefix
+        .clone_from(&ipv4.interface_prefix);
+    interface.prefix.clone_from(&ipv4.prefix);
+    interface.svi_ip.clone_from(&ipv4.svi_ip);
+    let prefixless_legacy_ipv6 = interface
+        .ipv6_interface_config
+        .clone()
+        .filter(|config| config.interface_prefix.is_empty());
+    interface.ipv6_interface_config = ipv6
+        .as_ref()
+        .map(|address| rpc::FlatInterfaceIpv6Config {
+            ip: address.ip.clone(),
+            interface_prefix: address.interface_prefix.clone(),
+            svi_ip: address.svi_ip.clone(),
+        })
+        // Core omits an incomplete legacy IPv6 entry from `addresses`. Preserve that sidecar
+        // until every persisted interface has an IPv6 interface prefix.
+        .or(prefixless_legacy_ipv6);
+
+    Ok(())
 }
 
 /// Picks the lowest address in each family across physical interfaces because HostInband status
@@ -442,6 +527,188 @@ mod tests {
     use carbide_test_support::scenarios;
 
     use super::*;
+
+    // Builds the deprecated compatibility shape used by older Core versions.
+    #[allow(deprecated)]
+    fn legacy_interface(addresses: Vec<rpc::InterfaceAddressConfig>) -> rpc::FlatInterfaceConfig {
+        rpc::FlatInterfaceConfig {
+            vlan_id: 100,
+            gateway: "198.51.100.1/24".to_string(),
+            ip: "198.51.100.10".to_string(),
+            interface_prefix: "198.51.100.10/32".to_string(),
+            prefix: "198.51.100.0/24".to_string(),
+            svi_ip: Some("198.51.100.2/24".to_string()),
+            ipv6_interface_config: Some(rpc::FlatInterfaceIpv6Config {
+                ip: "2001:db8:ffff::10".to_string(),
+                interface_prefix: "2001:db8:ffff::10/128".to_string(),
+                svi_ip: Some("2001:db8:ffff::2/64".to_string()),
+            }),
+            addresses,
+            ..Default::default()
+        }
+    }
+
+    fn ipv4_address() -> rpc::InterfaceAddressConfig {
+        rpc::InterfaceAddressConfig {
+            address_family: rpc::AddressFamily::V4.into(),
+            gateway: "192.0.2.1/24".to_string(),
+            ip: "192.0.2.10".to_string(),
+            interface_prefix: "192.0.2.10/32".to_string(),
+            prefix: "192.0.2.0/24".to_string(),
+            svi_ip: Some("192.0.2.2/24".to_string()),
+        }
+    }
+
+    fn ipv6_address() -> rpc::InterfaceAddressConfig {
+        rpc::InterfaceAddressConfig {
+            address_family: rpc::AddressFamily::V6.into(),
+            gateway: "2001:db8::/127".to_string(),
+            ip: "2001:db8::1".to_string(),
+            interface_prefix: "2001:db8::/127".to_string(),
+            prefix: "2001:db8::/64".to_string(),
+            svi_ip: Some("2001:db8::2/64".to_string()),
+        }
+    }
+
+    fn normalized_interface(
+        mut interface: rpc::FlatInterfaceConfig,
+    ) -> Result<rpc::FlatInterfaceConfig, ()> {
+        normalize_interface_addresses(&mut interface)
+            .map(|()| interface)
+            .map_err(drop)
+    }
+
+    // Describes the compatibility projection consumed by the current agent.
+    #[allow(deprecated)]
+    fn expected_ipv4_interface() -> rpc::FlatInterfaceConfig {
+        rpc::FlatInterfaceConfig {
+            vlan_id: 100,
+            gateway: "192.0.2.1/24".to_string(),
+            ip: "192.0.2.10".to_string(),
+            interface_prefix: "192.0.2.10/32".to_string(),
+            prefix: "192.0.2.0/24".to_string(),
+            svi_ip: Some("192.0.2.2/24".to_string()),
+            ipv6_interface_config: None,
+            addresses: vec![ipv4_address()],
+            ..Default::default()
+        }
+    }
+
+    // Exercises authoritative clearing of the deprecated optional SVI field.
+    #[test]
+    #[allow(deprecated)]
+    fn family_neutral_addresses_replace_or_fall_back_to_legacy_fields() {
+        let legacy = legacy_interface(vec![]);
+        let mut dual_stack = expected_ipv4_interface();
+        dual_stack.ipv6_interface_config = Some(rpc::FlatInterfaceIpv6Config {
+            ip: "2001:db8::1".to_string(),
+            interface_prefix: "2001:db8::/127".to_string(),
+            svi_ip: Some("2001:db8::2/64".to_string()),
+        });
+        dual_stack.addresses = vec![ipv6_address(), ipv4_address()];
+
+        let mut ipv4_without_svi = ipv4_address();
+        ipv4_without_svi.svi_ip = None;
+        let mut expected_ipv4_without_svi = expected_ipv4_interface();
+        expected_ipv4_without_svi.svi_ip = None;
+        expected_ipv4_without_svi.addresses = vec![ipv4_without_svi.clone()];
+
+        let mut ipv6_without_svi = ipv6_address();
+        ipv6_without_svi.svi_ip = None;
+        let mut dual_stack_without_ipv6_svi = expected_ipv4_interface();
+        dual_stack_without_ipv6_svi.ipv6_interface_config = Some(rpc::FlatInterfaceIpv6Config {
+            ip: "2001:db8::1".to_string(),
+            interface_prefix: "2001:db8::/127".to_string(),
+            svi_ip: None,
+        });
+        dual_stack_without_ipv6_svi.addresses = vec![ipv4_address(), ipv6_without_svi.clone()];
+
+        let prefixless_ipv6 = rpc::FlatInterfaceIpv6Config {
+            ip: "2001:db8::1".to_string(),
+            interface_prefix: String::new(),
+            svi_ip: Some("2001:db8::2/64".to_string()),
+        };
+        let mut legacy_with_prefixless_ipv6 = legacy_interface(vec![ipv4_address()]);
+        legacy_with_prefixless_ipv6.ipv6_interface_config = Some(prefixless_ipv6.clone());
+        let mut expected_with_prefixless_ipv6 = expected_ipv4_interface();
+        expected_with_prefixless_ipv6.ipv6_interface_config = Some(prefixless_ipv6);
+
+        scenarios!(run = normalized_interface;
+            "empty list falls back to legacy fields" {
+                legacy.clone() => Yields(legacy),
+            }
+            "IPv4 list overrides legacy fields and clears stale IPv6" {
+                legacy_interface(vec![ipv4_address()]) => Yields(expected_ipv4_interface()),
+            }
+            "reversed dual-stack list is selected by family without reordering" {
+                legacy_interface(vec![ipv6_address(), ipv4_address()]) => Yields(dual_stack),
+            }
+            "absent V4 SVI clears the legacy value" {
+                legacy_interface(vec![ipv4_without_svi]) => Yields(expected_ipv4_without_svi),
+            }
+            "absent V6 SVI clears the legacy sidecar value" {
+                legacy_interface(vec![ipv4_address(), ipv6_without_svi]) => Yields(dual_stack_without_ipv6_svi),
+            }
+            "prefixless legacy V6 sidecar survives its omitted address entry" {
+                legacy_with_prefixless_ipv6 => Yields(expected_with_prefixless_ipv6),
+            }
+        );
+    }
+
+    #[test]
+    fn family_neutral_addresses_reject_invalid_family_sets() {
+        let mut unspecified = ipv4_address();
+        unspecified.address_family = rpc::AddressFamily::Unspecified.into();
+        let mut unknown = ipv4_address();
+        unknown.address_family = 99;
+
+        scenarios!(run = normalized_interface;
+            "V4 is required during the compatibility phase" {
+                legacy_interface(vec![ipv6_address()]) => Fails,
+            }
+            "explicit family is required" {
+                legacy_interface(vec![unspecified]) => Fails,
+            }
+            "unknown family is rejected" {
+                legacy_interface(vec![unknown]) => Fails,
+            }
+            "duplicate V4 is rejected" {
+                legacy_interface(vec![ipv4_address(), ipv4_address()]) => Fails,
+            }
+            "duplicate V6 is rejected" {
+                legacy_interface(vec![ipv4_address(), ipv6_address(), ipv6_address()]) => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn network_config_normalizes_admin_and_every_tenant_interface() {
+        let mut response = rpc::ManagedHostNetworkConfigResponse {
+            admin_interface: Some(legacy_interface(vec![ipv4_address()])),
+            tenant_interfaces: vec![
+                legacy_interface(vec![ipv4_address()]),
+                legacy_interface(vec![ipv6_address(), ipv4_address()]),
+            ],
+            ..Default::default()
+        };
+
+        normalize_network_config_addresses(&mut response).unwrap();
+
+        assert_eq!(response.admin_interface.unwrap(), expected_ipv4_interface());
+        assert_eq!(response.tenant_interfaces[0], expected_ipv4_interface());
+        assert_eq!(
+            response.tenant_interfaces[1].addresses,
+            vec![ipv6_address(), ipv4_address()]
+        );
+        assert_eq!(
+            response.tenant_interfaces[1].ipv6_interface_config,
+            Some(rpc::FlatInterfaceIpv6Config {
+                ip: "2001:db8::1".to_string(),
+                interface_prefix: "2001:db8::/127".to_string(),
+                svi_ip: Some("2001:db8::2/64".to_string()),
+            })
+        );
+    }
 
     #[test]
     fn public_address_selection_is_family_specific_and_stable() {

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -435,6 +435,8 @@ async fn handle_version() -> impl IntoResponse {
     common::respond(resp)
 }
 
+// This mock omits `addresses` to exercise the rolling-upgrade fallback for older Core versions.
+#[allow(deprecated)]
 async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl IntoResponse {
     {
         state

--- a/crates/agent/src/tests/main_loop.rs
+++ b/crates/agent/src/tests/main_loop.rs
@@ -96,6 +96,9 @@ fn comparison_security_group_rule(
 
 /// Builds an interface that exercises every nested collection normalized
 /// by the fingerprint.
+///
+/// The deprecated scalar fields remain populated because Core dual-writes them for older agents.
+#[allow(deprecated)]
 fn comparison_interface(id: &str, vlan_id: u32, vni: u32) -> rpc::FlatInterfaceConfig {
     rpc::FlatInterfaceConfig {
         function_type: rpc::InterfaceFunctionType::Physical.into(),

--- a/crates/api-core/src/ethernet_virtualization.rs
+++ b/crates/api-core/src/ethernet_virtualization.rs
@@ -292,6 +292,7 @@ impl<'a> PrefixPair<'a> {
 }
 
 /// Mirrors the legacy family-specific fields into the staged address list.
+#[allow(deprecated)]
 fn interface_address_configs(
     config: &rpc::FlatInterfaceConfig,
     ipv6_segment_prefix: Option<&str>,
@@ -322,6 +323,8 @@ fn interface_address_configs(
     addresses
 }
 
+// This writer keeps the deprecated fields populated for older agents during the rollout.
+#[allow(deprecated)]
 pub(crate) async fn admin_network(
     txn: &mut PgConnection,
     snapshot: &ManagedHostStateSnapshot,
@@ -545,6 +548,8 @@ pub(crate) async fn admin_network(
 }
 
 #[allow(clippy::too_many_arguments)]
+// This writer keeps the deprecated fields populated for older agents during the rollout.
+#[allow(deprecated)]
 pub(crate) async fn tenant_network(
     txn: &mut PgConnection,
     instance_id: InstanceId,
@@ -855,6 +860,7 @@ mod test {
 
     use super::*;
 
+    #[allow(deprecated)]
     fn legacy_interface_config(
         ipv6_interface_config: Option<rpc::FlatInterfaceIpv6Config>,
     ) -> rpc::FlatInterfaceConfig {

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -2197,6 +2197,8 @@ pub(in crate::tests) async fn network_configured_with_health(
 
 /// Fake an iteration of forge-dpu-agent requesting network config, applying it, and reporting back.
 /// When reporting back, the health and extension services statuses reported by the DPU can be overrridden
+// This fixture reports the compatibility fields populated for older agents.
+#[allow(deprecated)]
 pub(in crate::tests) async fn network_configured_with_health_and_ext_services(
     env: &TestEnv,
     dpu_machine_id: &MachineId,

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -1836,6 +1836,8 @@ async fn test_can_not_create_instance_for_dpu(_: PgPoolOptions, options: PgConne
 }
 
 #[crate::sqlx_test]
+// This test verifies parity between `addresses` and the compatibility fields.
+#[allow(deprecated)]
 async fn test_instance_address_creation(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
     let env = create_test_env(pool).await;

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -905,6 +905,8 @@ async fn test_host_bmc_identity_wins_expected_interface_mac_lookup(
 }
 
 #[crate::sqlx_test]
+// This test exercises DHCP through the compatibility fields sent to older agents.
+#[allow(deprecated)]
 async fn test_machine_dhcp_with_api_for_instance_physical_virtual(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api-core/src/tests/machine_network.rs
+++ b/crates/api-core/src/tests/machine_network.rs
@@ -156,6 +156,8 @@ async fn test_clear_use_admin_network_changed_keeps_newer_version_flag(pool: sql
 }
 
 #[crate::sqlx_test]
+// This test verifies parity between `addresses` and the compatibility fields.
+#[allow(deprecated)]
 async fn test_managed_host_network_config(pool: sqlx::PgPool) {
     // The default fixture omits `lo-ip-v6`, which must preserve the existing IPv4-only response.
     let env = api_fixtures::create_test_env(pool).await;
@@ -1088,6 +1090,8 @@ async fn test_managed_host_network_config_errors_when_sitewide_bgp_password_miss
 }
 
 #[crate::sqlx_test]
+// This test compares compatibility fields across DPUs.
+#[allow(deprecated)]
 async fn test_managed_host_network_config_multi_dpu(pool: sqlx::PgPool) {
     let env = api_fixtures::create_test_env(pool).await;
 
@@ -1293,6 +1297,8 @@ prefix = "2001:db8:2390::/126"
 }
 
 #[crate::sqlx_test]
+// This test verifies the compatibility admin address chosen for older agents.
+#[allow(deprecated)]
 async fn test_managed_host_network_config_uses_non_dpu_primary_admin_interface(pool: sqlx::PgPool) {
     let env = api_fixtures::create_test_env(pool).await;
 
@@ -1671,6 +1677,8 @@ async fn test_managed_host_network_config_with_extension_services(pool: sqlx::Pg
 }
 
 #[crate::sqlx_test]
+// This test reports health with the compatibility interface fields.
+#[allow(deprecated)]
 async fn test_dpu_health_is_required(pool: sqlx::PgPool) {
     let env = api_fixtures::create_test_env(pool).await;
     let (_host_machine_id, dpu_machine_id) = create_managed_host(&env).await.into();

--- a/crates/machine-a-tron/src/dhcp_wrapper.rs
+++ b/crates/machine-a-tron/src/dhcp_wrapper.rs
@@ -309,6 +309,8 @@ impl DpuDhcpRelayServer {
 }
 
 // Synthesize a DHCP response given the provided ManagedHostNetworkConfigResponse
+// Machine-a-tron receives the compatibility fields from the agent-facing response.
+#[allow(deprecated)]
 fn synthesize_dhcp_response_for_host(
     managed_host_config: &ManagedHostNetworkConfigResponse,
 ) -> DhcpRelayResult<DhcpResponseInfo> {

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -1092,6 +1092,8 @@ impl MachineStateMachine {
         Ok(machine_discovery_result)
     }
 
+    // Machine-a-tron receives the compatibility fields from the agent-facing response.
+    #[allow(deprecated)]
     async fn send_network_status_observation(
         &self,
         machine_id: MachineId,

--- a/crates/rpc-utils/src/dhcp.rs
+++ b/crates/rpc-utils/src/dhcp.rs
@@ -209,6 +209,8 @@ impl HostConfig {
     }
 }
 
+// This conversion continues to consume the compatibility fields during the address-list rollout.
+#[allow(deprecated)]
 impl TryFrom<::rpc::forge::FlatInterfaceConfig> for InterfaceInfo {
     type Error = DhcpDataError;
     fn try_from(value: ::rpc::forge::FlatInterfaceConfig) -> Result<Self, Self::Error> {
@@ -370,6 +372,8 @@ mod tests {
         HOST_INTERFACE_ID.parse().unwrap()
     }
 
+    // Builds the deprecated compatibility shape consumed by this conversion.
+    #[allow(deprecated)]
     fn interface_config(
         function_type: InterfaceFunctionType,
         vlan_id: u32,

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4931,16 +4931,19 @@ message FlatInterfaceConfig {
   // isn't going to overflow once it gets to HBN.
   uint32 vni = 3;
 
-  // in CIDR notation
-  string gateway = 4;
-  // host admin ip for admin network, host ip for tenant
-  string ip = 5;
+  // Deprecated: use addresses.
+  // In CIDR notation.
+  string gateway = 4 [deprecated = true];
+  // Deprecated: use addresses.
+  // Host admin IP for admin network, host IP for tenant.
+  string ip = 5 [deprecated = true];
+  // Deprecated: use addresses.
   // The interface-specific prefix allocation (which may be a /32 for
   // just the host IP, or a larger allocation, like a /30, for FNN). The
   // `ip` as configured above will be contained within the `interface_prefix`
   // provided here, and the `interface_prefix` will be contained within
   // the `prefix` below (field 8).
-  string interface_prefix = 11;
+  string interface_prefix = 11 [deprecated = true];
   // If the interface is defined as a virtual function (associated
   // `function_type == InterfaceFunctionType::VIRTUAL_FUNCTION`,
   // then this value is set and specifies the virtual function ID that is configured
@@ -4950,6 +4953,7 @@ message FlatInterfaceConfig {
   // the prefix from the network segment this interface is attached to (which
   // could be independently derived from the `gateway` field).
   repeated string vpc_prefixes = 7;
+  // Deprecated: use addresses.
   // Prefix for the network segment this interface lives in,
   // which is what is referred to as a subnet in the UI. This
   // is not to be confused with the instance_prefix, which is
@@ -4961,7 +4965,7 @@ message FlatInterfaceConfig {
   // ultimately do want a DPU-specific prefix allocation to be its
   // own prefix entry in the `network_prefixes` table (or something
   // similar).
-  string prefix = 8;
+  string prefix = 8 [deprecated = true];
   // FQDN
   string fqdn = 9;
   // boot_url
@@ -4974,12 +4978,13 @@ message FlatInterfaceConfig {
   // unique per VPC.
   uint32 vpc_vni = 12;
 
+  // Deprecated: use addresses.
   // svi_ip (also known as the gateway IP), is the local DPU-hosted
   // gateway to be used by an instance in an FNN-L3 configuration (as
   // in the host actually sets this IP as its gateway). This is the 3rd
   // IP allocated from the /30, where the /30 is broken into two /31s,
   // and the SVI IP is the first IP in the second /31.
-  optional string svi_ip = 13;
+  optional string svi_ip = 13 [deprecated = true];
 
   // tenant_vrf_loopback_ip is an administrative IP assigned from
   // the FNN L3 allocated /30 DPU prefix. The tenant is not expected

--- a/crates/test-harness/src/machine_dpu.rs
+++ b/crates/test-harness/src/machine_dpu.rs
@@ -95,6 +95,8 @@ impl TestMachine for TestDpuMachine {
 
 impl TestMachinePrivate for TestDpuMachine {}
 
+// This harness models the compatibility fields consumed by older agents.
+#[allow(deprecated)]
 async fn record_dpu_network_status(api: &Api, dpu_machine_id: MachineId) {
     let network_config = api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {

--- a/rest-api/api/pkg/api/model/dpumachine.go
+++ b/rest-api/api/pkg/api/model/dpumachine.go
@@ -253,9 +253,9 @@ func (afic *APIFlatInterfaceConfig) FromProto(protoConfig *corev1.FlatInterfaceC
 	afic.FunctionType = protoConfig.FunctionType.String()
 	afic.VlanID = int(protoConfig.VlanId)
 	afic.Vni = int(protoConfig.Vni)
-	afic.Gateway = protoConfig.Gateway
-	afic.IP = protoConfig.Ip
-	afic.InterfacePrefix = protoConfig.InterfacePrefix
+	afic.Gateway = protoConfig.Gateway                 //nolint:staticcheck // Preserve the scalar REST compatibility field.
+	afic.IP = protoConfig.Ip                           //nolint:staticcheck // Preserve the scalar REST compatibility field.
+	afic.InterfacePrefix = protoConfig.InterfacePrefix //nolint:staticcheck // Preserve the scalar REST compatibility field.
 
 	if protoConfig.VirtualFunctionId != nil {
 		virtualFunctionID := int(*protoConfig.VirtualFunctionId)
@@ -263,12 +263,12 @@ func (afic *APIFlatInterfaceConfig) FromProto(protoConfig *corev1.FlatInterfaceC
 	}
 
 	afic.VpcPrefixes = protoConfig.VpcPrefixes
-	afic.Prefix = protoConfig.Prefix
+	afic.Prefix = protoConfig.Prefix //nolint:staticcheck // Preserve the scalar REST compatibility field.
 	afic.Fqdn = protoConfig.Fqdn
 
 	afic.BootURL = protoConfig.Booturl
 	afic.VpcVni = int(protoConfig.VpcVni)
-	afic.SviIP = protoConfig.SviIp
+	afic.SviIP = protoConfig.SviIp //nolint:staticcheck // Preserve the scalar REST compatibility field.
 	afic.TenantVrfLoopbackIP = protoConfig.TenantVrfLoopbackIp
 	afic.IsL2Segment = protoConfig.IsL2Segment
 	afic.VpcPeerPrefixes = protoConfig.VpcPeerPrefixes

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -26494,15 +26494,24 @@ type FlatInterfaceConfig struct {
 	// probably be checking somewhere that the VNI we're passing down
 	// isn't going to overflow once it gets to HBN.
 	Vni uint32 `protobuf:"varint,3,opt,name=vni,proto3" json:"vni,omitempty"`
-	// in CIDR notation
+	// Deprecated: use addresses.
+	// In CIDR notation.
+	//
+	// Deprecated: Marked as deprecated in nico_nico.proto.
 	Gateway string `protobuf:"bytes,4,opt,name=gateway,proto3" json:"gateway,omitempty"`
-	// host admin ip for admin network, host ip for tenant
+	// Deprecated: use addresses.
+	// Host admin IP for admin network, host IP for tenant.
+	//
+	// Deprecated: Marked as deprecated in nico_nico.proto.
 	Ip string `protobuf:"bytes,5,opt,name=ip,proto3" json:"ip,omitempty"`
+	// Deprecated: use addresses.
 	// The interface-specific prefix allocation (which may be a /32 for
 	// just the host IP, or a larger allocation, like a /30, for FNN). The
 	// `ip` as configured above will be contained within the `interface_prefix`
 	// provided here, and the `interface_prefix` will be contained within
 	// the `prefix` below (field 8).
+	//
+	// Deprecated: Marked as deprecated in nico_nico.proto.
 	InterfacePrefix string `protobuf:"bytes,11,opt,name=interface_prefix,json=interfacePrefix,proto3" json:"interface_prefix,omitempty"`
 	// If the interface is defined as a virtual function (associated
 	// `function_type == InterfaceFunctionType::VIRTUAL_FUNCTION`,
@@ -26513,6 +26522,7 @@ type FlatInterfaceConfig struct {
 	// the prefix from the network segment this interface is attached to (which
 	// could be independently derived from the `gateway` field).
 	VpcPrefixes []string `protobuf:"bytes,7,rep,name=vpc_prefixes,json=vpcPrefixes,proto3" json:"vpc_prefixes,omitempty"`
+	// Deprecated: use addresses.
 	// Prefix for the network segment this interface lives in,
 	// which is what is referred to as a subnet in the UI. This
 	// is not to be confused with the instance_prefix, which is
@@ -26524,6 +26534,8 @@ type FlatInterfaceConfig struct {
 	// ultimately do want a DPU-specific prefix allocation to be its
 	// own prefix entry in the `network_prefixes` table (or something
 	// similar).
+	//
+	// Deprecated: Marked as deprecated in nico_nico.proto.
 	Prefix string `protobuf:"bytes,8,opt,name=prefix,proto3" json:"prefix,omitempty"`
 	// FQDN
 	Fqdn string `protobuf:"bytes,9,opt,name=fqdn,proto3" json:"fqdn,omitempty"`
@@ -26535,11 +26547,14 @@ type FlatInterfaceConfig struct {
 	// pool), and is done in such a way that each VNI is globally
 	// unique per VPC.
 	VpcVni uint32 `protobuf:"varint,12,opt,name=vpc_vni,json=vpcVni,proto3" json:"vpc_vni,omitempty"`
+	// Deprecated: use addresses.
 	// svi_ip (also known as the gateway IP), is the local DPU-hosted
 	// gateway to be used by an instance in an FNN-L3 configuration (as
 	// in the host actually sets this IP as its gateway). This is the 3rd
 	// IP allocated from the /30, where the /30 is broken into two /31s,
 	// and the SVI IP is the first IP in the second /31.
+	//
+	// Deprecated: Marked as deprecated in nico_nico.proto.
 	SviIp *string `protobuf:"bytes,13,opt,name=svi_ip,json=sviIp,proto3,oneof" json:"svi_ip,omitempty"`
 	// tenant_vrf_loopback_ip is an administrative IP assigned from
 	// the FNN L3 allocated /30 DPU prefix. The tenant is not expected
@@ -26631,6 +26646,7 @@ func (x *FlatInterfaceConfig) GetVni() uint32 {
 	return 0
 }
 
+// Deprecated: Marked as deprecated in nico_nico.proto.
 func (x *FlatInterfaceConfig) GetGateway() string {
 	if x != nil {
 		return x.Gateway
@@ -26638,6 +26654,7 @@ func (x *FlatInterfaceConfig) GetGateway() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in nico_nico.proto.
 func (x *FlatInterfaceConfig) GetIp() string {
 	if x != nil {
 		return x.Ip
@@ -26645,6 +26662,7 @@ func (x *FlatInterfaceConfig) GetIp() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in nico_nico.proto.
 func (x *FlatInterfaceConfig) GetInterfacePrefix() string {
 	if x != nil {
 		return x.InterfacePrefix
@@ -26666,6 +26684,7 @@ func (x *FlatInterfaceConfig) GetVpcPrefixes() []string {
 	return nil
 }
 
+// Deprecated: Marked as deprecated in nico_nico.proto.
 func (x *FlatInterfaceConfig) GetPrefix() string {
 	if x != nil {
 		return x.Prefix
@@ -26694,6 +26713,7 @@ func (x *FlatInterfaceConfig) GetVpcVni() uint32 {
 	return 0
 }
 
+// Deprecated: Marked as deprecated in nico_nico.proto.
 func (x *FlatInterfaceConfig) GetSviIp() string {
 	if x != nil && x.SviIp != nil {
 		return *x.SviIp
@@ -65435,23 +65455,23 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x10quarantine_state\x18\x02 \x01(\v2!.forge.ManagedHostQuarantineStateH\x00R\x0fquarantineState\x88\x01\x01\x12)\n" +
 	"\x0eloopback_ip_v6\x18\x03 \x01(\tH\x01R\floopbackIpV6\x88\x01\x01B\x13\n" +
 	"\x11_quarantine_stateB\x11\n" +
-	"\x0f_loopback_ip_v6\"\xae\n" +
+	"\x0f_loopback_ip_v6\"\xc2\n" +
 	"\n" +
 	"\x13FlatInterfaceConfig\x12A\n" +
 	"\rfunction_type\x18\x01 \x01(\x0e2\x1c.forge.InterfaceFunctionTypeR\ffunctionType\x12\x17\n" +
 	"\avlan_id\x18\x02 \x01(\rR\x06vlanId\x12\x10\n" +
-	"\x03vni\x18\x03 \x01(\rR\x03vni\x12\x18\n" +
-	"\agateway\x18\x04 \x01(\tR\agateway\x12\x0e\n" +
-	"\x02ip\x18\x05 \x01(\tR\x02ip\x12)\n" +
-	"\x10interface_prefix\x18\v \x01(\tR\x0finterfacePrefix\x123\n" +
+	"\x03vni\x18\x03 \x01(\rR\x03vni\x12\x1c\n" +
+	"\agateway\x18\x04 \x01(\tB\x02\x18\x01R\agateway\x12\x12\n" +
+	"\x02ip\x18\x05 \x01(\tB\x02\x18\x01R\x02ip\x12-\n" +
+	"\x10interface_prefix\x18\v \x01(\tB\x02\x18\x01R\x0finterfacePrefix\x123\n" +
 	"\x13virtual_function_id\x18\x06 \x01(\rH\x00R\x11virtualFunctionId\x88\x01\x01\x12!\n" +
-	"\fvpc_prefixes\x18\a \x03(\tR\vvpcPrefixes\x12\x16\n" +
-	"\x06prefix\x18\b \x01(\tR\x06prefix\x12\x12\n" +
+	"\fvpc_prefixes\x18\a \x03(\tR\vvpcPrefixes\x12\x1a\n" +
+	"\x06prefix\x18\b \x01(\tB\x02\x18\x01R\x06prefix\x12\x12\n" +
 	"\x04fqdn\x18\t \x01(\tR\x04fqdn\x12\x1d\n" +
 	"\abooturl\x18\n" +
 	" \x01(\tH\x01R\abooturl\x88\x01\x01\x12\x17\n" +
-	"\avpc_vni\x18\f \x01(\rR\x06vpcVni\x12\x1a\n" +
-	"\x06svi_ip\x18\r \x01(\tH\x02R\x05sviIp\x88\x01\x01\x128\n" +
+	"\avpc_vni\x18\f \x01(\rR\x06vpcVni\x12\x1e\n" +
+	"\x06svi_ip\x18\r \x01(\tB\x02\x18\x01H\x02R\x05sviIp\x88\x01\x01\x128\n" +
 	"\x16tenant_vrf_loopback_ip\x18\x0e \x01(\tH\x03R\x13tenantVrfLoopbackIp\x88\x01\x01\x12\"\n" +
 	"\ris_l2_segment\x18\x0f \x01(\bR\visL2Segment\x12*\n" +
 	"\x11vpc_peer_prefixes\x18\x10 \x03(\tR\x0fvpcPeerPrefixes\x12\"\n" +

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -4752,16 +4752,19 @@ message FlatInterfaceConfig {
   // isn't going to overflow once it gets to HBN.
   uint32 vni = 3;
 
-  // in CIDR notation
-  string gateway = 4;
-  // host admin ip for admin network, host ip for tenant
-  string ip = 5;
+  // Deprecated: use addresses.
+  // In CIDR notation.
+  string gateway = 4 [deprecated = true];
+  // Deprecated: use addresses.
+  // Host admin IP for admin network, host IP for tenant.
+  string ip = 5 [deprecated = true];
+  // Deprecated: use addresses.
   // The interface-specific prefix allocation (which may be a /32 for
   // just the host IP, or a larger allocation, like a /30, for FNN). The
   // `ip` as configured above will be contained within the `interface_prefix`
   // provided here, and the `interface_prefix` will be contained within
   // the `prefix` below (field 8).
-  string interface_prefix = 11;
+  string interface_prefix = 11 [deprecated = true];
   // If the interface is defined as a virtual function (associated
   // `function_type == InterfaceFunctionType::VIRTUAL_FUNCTION`,
   // then this value is set and specifies the virtual function ID that is configured
@@ -4771,6 +4774,7 @@ message FlatInterfaceConfig {
   // the prefix from the network segment this interface is attached to (which
   // could be independently derived from the `gateway` field).
   repeated string vpc_prefixes = 7;
+  // Deprecated: use addresses.
   // Prefix for the network segment this interface lives in,
   // which is what is referred to as a subnet in the UI. This
   // is not to be confused with the instance_prefix, which is
@@ -4782,7 +4786,7 @@ message FlatInterfaceConfig {
   // ultimately do want a DPU-specific prefix allocation to be its
   // own prefix entry in the `network_prefixes` table (or something
   // similar).
-  string prefix = 8;
+  string prefix = 8 [deprecated = true];
   // FQDN
   string fqdn = 9;
   // boot_url
@@ -4795,12 +4799,13 @@ message FlatInterfaceConfig {
   // unique per VPC.
   uint32 vpc_vni = 12;
 
+  // Deprecated: use addresses.
   // svi_ip (also known as the gateway IP), is the local DPU-hosted
   // gateway to be used by an instance in an FNN-L3 configuration (as
   // in the host actually sets this IP as its gateway). This is the 3rd
   // IP allocated from the /30, where the /30 is broken into two /31s,
   // and the SVI IP is the first IP in the second /31.
-  optional string svi_ip = 13;
+  optional string svi_ip = 13 [deprecated = true];
 
   // tenant_vrf_loopback_ip is an administrative IP assigned from
   // the FNN L3 allocated /30 DPU prefix. The tenant is not expected


### PR DESCRIPTION
Core now sends each DPU interface's family-neutral `addresses` list, but the agent still consumed the IPv4 scalar fields and IPv6 sidecar. That left the new contract without a reader and kept downstream IPv6 work coupled to the legacy shape.

This PR switches the agent at one boundary: fetched network configuration is normalized before it enters the cache, so every existing renderer and DHCP consumer receives the same compatibility shape as before.

- An empty `addresses` list remains the rolling-upgrade fallback for older Core versions.
- A populated list is authoritative, selected by address family rather than position, and rejects missing IPv4, duplicate families, and invalid family values before replacing the last good configuration.
- Prefixless legacy IPv6 sidecars are preserved for interfaces stored before interface prefixes were introduced.
- The five IPv4-shaped scalar protobuf fields are formally deprecated while Core continues dual-writing them for older agents.

Tests added!

## Related issues

Closes #2395

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

This does not enable IPv6-only networking; that support boundary remains tracked by https://github.com/NVIDIA/infra-controller/issues/2402.
