### PR TITLE
fix(ci): reject unexpected aggregate skips

### DIFF
--- a/.github/ci/check_ci_gate.py
+++ b/.github/ci/check_ci_gate.py
@@ -4,18 +4,19 @@
 
 """Keep every CI job accounted for by its final required check.
 
-GitHub Actions makes `needs` a static list: it waits for the jobs named there,
-but adding a new top-level job does not update a final gate or warn us that the
-job was omitted. The `inventory` command reads the small part of the workflow
-used by the selected gate policy and requires every job to be gated or
-explicitly exempted. It also protects the gate's `if: always()` condition so a
-failed dependency cannot skip the required check.
+GitHub gives a final job the result of each job in its `needs` list, but a
+skipped job does not fail a required check. GitHub also does not tell the final
+job whether that skip was expected.
 
-The `results` command evaluates `${{ toJson(needs) }}` from `NEEDS_JSON`.
-`success` and `skipped` pass because conditional jobs legitimately omit work.
-Every gated top-level job is listed independently, so an upstream failure stays
-visible even when it makes downstream jobs skip. Any other or malformed result
-fails closed.
+This script checks both parts of that contract:
+
+* `inventory` makes sure every top-level job feeds the final gate or has a
+  reviewed exemption.
+* `results` makes sure every job succeeded, unless the workflow already
+  recorded a reason for that job to skip.
+
+Missing jobs, missing decisions, failures, cancellations, and unexpected skips
+all fail the final gate.
 """
 
 from __future__ import annotations
@@ -30,15 +31,18 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-
-# We only need the root job IDs plus the selected gate's `if` and `needs`
-# fields. Keep this grammar deliberately narrow and reject unfamiliar
-# formatting: silently skipping a line could let a job escape the required
-# check.
+# This is intentionally not a general YAML parser. We only accept the workflow
+# layout needed to find root jobs, `gate_job.if`, and `gate_job.needs`. If that
+# layout changes, failing here is safer than silently missing a job and letting
+# the required check approve it.
 JOB_KEY = re.compile(r"^  (?P<job>[A-Za-z_][A-Za-z0-9_-]*):(?:\s*#.*)?$")
 NEEDS_ITEM = re.compile(r"^      - (?P<job>[A-Za-z_][A-Za-z0-9_-]*)(?:\s*#.*)?$")
 GATE_IF = re.compile(r"^    if:\s*(?P<condition>.*)$")
-PASSING_RESULTS = frozenset({"success", "skipped"})
+PR_REF_PREFIX = "refs/heads/pull-request/"
+UPSTREAM_REPOSITORY = "NVIDIA/infra-controller"
+
+
+# Workflow inventory
 
 
 class WorkflowFormatError(ValueError):
@@ -46,20 +50,15 @@ class WorkflowFormatError(ValueError):
 
 
 @dataclass(frozen=True)
-class GatePolicy:
-    """Name one final gate and every job intentionally outside it.
-
-    `display_name` identifies the lane in human-readable output. `gate_job`
-    is the top-level job that branch protection requires. Each exemption maps
-    a job ID to the reviewed reason it cannot or should not gate that lane.
-    """
+class WorkflowGate:
+    """Describe the final required job in one workflow."""
 
     display_name: str
     gate_job: str
     exemptions: Mapping[str, str]
 
 
-CORE_POLICY = GatePolicy(
+CORE_GATE = WorkflowGate(
     display_name="Core CI",
     gate_job="core-ci-pass",
     exemptions={
@@ -75,21 +74,21 @@ CORE_POLICY = GatePolicy(
     },
 )
 
-REST_POLICY = GatePolicy(
+REST_GATE = WorkflowGate(
     display_name="REST CI",
     gate_job="rest-ci-pass",
     exemptions={"rest-ci-pass": "A job cannot depend on itself."},
 )
 
-POLICIES: Mapping[str, GatePolicy] = {
-    "core": CORE_POLICY,
-    "rest": REST_POLICY,
+WORKFLOW_GATES: Mapping[str, WorkflowGate] = {
+    "core": CORE_GATE,
+    "rest": REST_GATE,
 }
 
 
 @dataclass(frozen=True)
 class WorkflowInventory:
-    """The gate policy extracted from one workflow.
+    """The top-level jobs and final gate dependencies in one workflow.
 
     `jobs` keeps every top-level job ID in declaration order. `gate_needs`
     keeps the gate's direct dependencies in their written order, including
@@ -153,7 +152,11 @@ def _parse_gate(
     positions: Mapping[str, int],
     gate_job: str,
 ) -> list[str]:
-    """Protect the gate condition and read its complete block-style `needs` list."""
+    """Read the final gate and require the form this checker can protect.
+
+    `if: always()` is part of the contract. Without it, an upstream failure
+    skips the final check before it can report which dependency failed.
+    """
 
     gate_start = positions.get(gate_job)
     if gate_start is None:
@@ -275,29 +278,171 @@ def _inventory_errors(
     return errors
 
 
-def inventory_errors(workflow_text: str, policy: GatePolicy) -> list[str]:
+def inventory_errors(workflow_text: str, gate: WorkflowGate) -> list[str]:
     """Parse the workflow and explain every invalid gate classification."""
 
     try:
-        inventory = parse_workflow(workflow_text, policy.gate_job)
+        inventory = parse_workflow(workflow_text, gate.gate_job)
     except WorkflowFormatError as error:
         return [str(error)]
 
-    return _inventory_errors(inventory, policy.exemptions)
+    return _inventory_errors(inventory, gate.exemptions)
 
 
-def result_errors(needs_context: Mapping[str, object]) -> list[str]:
-    """Return an error for every non-passing result in `needs_context`.
+# Recorded run decisions
 
-    The accepted status values are `success` and `skipped`. An empty context,
-    malformed job entry, or any other status fails closed.
-    """
 
-    if not needs_context:
+class GateInputError(ValueError):
+    """The workflow did not explain which jobs were allowed to skip."""
+
+
+# Most Core jobs run whenever `run_core_ci` is true. The jobs below have an
+# additional `if` condition controlled by one of `prepare`'s outputs. Keeping
+# only these exceptions here means we do not need a second list of all Core
+# jobs.
+CORE_JOBS_BY_PREPARE_OUTPUT: Mapping[str, frozenset[str]] = {
+    "build_container_x86_64_run": frozenset({"build-container-x86_64"}),
+    "build_container_aarch64_run": frozenset({"build-container-aarch64"}),
+    "runtime_container_x86_64_run": frozenset({"build-runtime-container-x86_64"}),
+    "runtime_container_aarch64_run": frozenset({"build-runtime-container-aarch64"}),
+    "build_artifacts_container_x86_64_run": frozenset(
+        {"build-artifacts-container-x86_64"}
+    ),
+    "build_artifacts_container_aarch64_run": frozenset(
+        {"build-artifacts-container-aarch64"}
+    ),
+    "publish_images": frozenset(
+        {
+            "merge-manifests-nvmetal-carbide",
+            "merge-manifests-forge-cli",
+            "merge-manifests-machine-validation",
+            "build-push-helm-chart",
+            "build-push-helm-prereqs-chart",
+            "build-push-bluefield-helm-charts",
+            "promote-to-be-scanned-image",
+        }
+    ),
+    "source_files_changed": frozenset(
+        {"build-machine-a-tron", "build-mat-k8s-controller", "lint-police"}
+    ),
+    "proto_files_changed": frozenset({"proto-police"}),
+    "core_rpc_proto_files_changed": frozenset({"check-rest-core-proto-sync"}),
+}
+
+CORE_PR_ONLY_JOBS = frozenset({"lint-police", "migration-police", "proto-police"})
+CORE_UPSTREAM_ONLY_JOB = "promote-to-be-scanned-image"
+
+
+def _read_boolean_output(
+    job: str, details: Mapping[str, object], output_name: str
+) -> bool:
+    """Read one `true` or `false` output from a completed job."""
+
+    outputs = details.get("outputs")
+    if not isinstance(outputs, Mapping):
+        raise GateInputError(f"`{job}` did not provide a job outputs object")
+    value = outputs.get(output_name)
+    if not isinstance(value, str) or value not in {"true", "false"}:
+        raise GateInputError(
+            f"`{job}` output `{output_name}` must be 'true' or 'false', "
+            f"found {value!r}"
+        )
+    return value == "true"
+
+
+def _is_pull_request_run(environment: Mapping[str, str]) -> bool:
+    """Return whether `GITHUB_REF` names a pull request mirror branch."""
+
+    ref = environment.get("GITHUB_REF")
+    if not ref:
+        raise GateInputError("`GITHUB_REF` is not set")
+    return ref.startswith(PR_REF_PREFIX)
+
+
+def _workflow_should_run(job_results: Mapping[str, object], output_name: str) -> bool:
+    """Read `run_core_ci` or `run_rest_ci` from the `changes` job."""
+
+    changes = job_results.get("changes")
+    if not isinstance(changes, Mapping):
+        raise GateInputError("`changes` did not provide a job result object")
+    if changes.get("result") != "success":
+        raise GateInputError("`changes` was unexpectedly skipped")
+    return _read_boolean_output("changes", changes, output_name)
+
+
+def _core_jobs_allowed_to_skip(
+    job_results: Mapping[str, object], environment: Mapping[str, str]
+) -> set[str]:
+    """Return the Core jobs that did not need to run."""
+
+    should_run = _workflow_should_run(job_results, "run_core_ci")
+    is_pull_request = _is_pull_request_run(environment)
+    if not should_run:
+        if not is_pull_request:
+            raise GateInputError(
+                "`changes.run_core_ci` was false outside a pull request"
+            )
+        # A REST-only PR skips Core, but `migration-police` still runs for the
+        # pull request as a whole.
+        return set(job_results) - {"changes", "migration-police"}
+
+    prepare = job_results.get("prepare")
+    if not isinstance(prepare, Mapping) or prepare.get("result") != "success":
+        raise GateInputError("`prepare` was unexpectedly skipped")
+
+    allowed: set[str] = set()
+    # Use the decisions that `prepare` already made. Re-running path filters or
+    # release logic here could disagree with the jobs we are checking.
+    for output_name, jobs in CORE_JOBS_BY_PREPARE_OUTPUT.items():
+        if not _read_boolean_output("prepare", prepare, output_name):
+            allowed.update(jobs)
+
+    if not is_pull_request:
+        allowed.update(CORE_PR_ONLY_JOBS)
+
+    repository = environment.get("GITHUB_REPOSITORY")
+    if not repository:
+        raise GateInputError("`GITHUB_REPOSITORY` is not set")
+    if repository != UPSTREAM_REPOSITORY:
+        allowed.add(CORE_UPSTREAM_ONLY_JOB)
+    return allowed
+
+
+def _rest_jobs_allowed_to_skip(
+    job_results: Mapping[str, object], environment: Mapping[str, str]
+) -> set[str]:
+    """Return the REST jobs that did not need to run."""
+
+    should_run = _workflow_should_run(job_results, "run_rest_ci")
+    is_pull_request = _is_pull_request_run(environment)
+    if not should_run:
+        if not is_pull_request:
+            raise GateInputError(
+                "`changes.run_rest_ci` was false outside a pull request"
+            )
+        return set(job_results) - {"changes"}
+
+    # Both reusable build callers are direct gate dependencies, but the ref
+    # selects exactly one of them for a given run.
+    if is_pull_request:
+        return {"build-and-push"}
+    return {"build-and-push-pr"}
+
+
+def result_errors(
+    job_results: Mapping[str, object],
+    workflow_name: str,
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return every reason the Core or REST final gate must fail."""
+
+    if not job_results:
         return ["the gate received no job results"]
 
+    skipped_jobs: set[str] = set()
     errors: list[str] = []
-    for job, details in sorted(needs_context.items()):
+    for job, details in sorted(job_results.items()):
         if not isinstance(details, Mapping):
             errors.append(f"`{job}` did not provide a job result object")
             continue
@@ -307,10 +452,42 @@ def result_errors(needs_context: Mapping[str, object]) -> list[str]:
             errors.append(f"`{job}` failed")
         elif result == "cancelled":
             errors.append(f"`{job}` was cancelled")
-        elif result not in PASSING_RESULTS:
+        elif result == "skipped":
+            skipped_jobs.add(job)
+        elif result == "success":
+            continue
+        else:
             errors.append(f"`{job}` returned unsupported result {result!r}")
+    if errors:
+        # Once a dependency is unhealthy, its downstream skips need no second
+        # explanation: the final check is already guaranteed to fail.
+        return errors
 
-    return errors
+    github_environment = os.environ if environment is None else environment
+    try:
+        if workflow_name == "core":
+            allowed_skips = _core_jobs_allowed_to_skip(
+                job_results, github_environment
+            )
+        elif workflow_name == "rest":
+            allowed_skips = _rest_jobs_allowed_to_skip(
+                job_results, github_environment
+            )
+        else:
+            return [f"unknown workflow {workflow_name!r}"]
+    except GateInputError as error:
+        return [str(error)]
+
+    # An optional job that ran anyway has already succeeded, so only unexpected
+    # skips can still make this run fail.
+    return [
+        f"`{job}` was unexpectedly skipped; if this is intentional, update the "
+        "skip rules in `.github/ci/check_ci_gate.py`"
+        for job in sorted(skipped_jobs - allowed_skips)
+    ]
+
+
+# Command-line entry points
 
 
 def _print_annotations(errors: list[str]) -> None:
@@ -320,7 +497,7 @@ def _print_annotations(errors: list[str]) -> None:
         print(f"::error::{error}")
 
 
-def _check_inventory(workflow_path: Path, policy: GatePolicy) -> int:
+def _check_inventory(workflow_path: Path, gate: WorkflowGate) -> int:
     """Check one workflow file and report inventory errors as annotations.
 
     Returns zero only when the file is readable, uses the supported layout,
@@ -334,25 +511,25 @@ def _check_inventory(workflow_path: Path, policy: GatePolicy) -> int:
         return 1
 
     try:
-        inventory = parse_workflow(workflow_text, policy.gate_job)
+        inventory = parse_workflow(workflow_text, gate.gate_job)
     except WorkflowFormatError as error:
         _print_annotations([str(error)])
         return 1
 
-    errors = _inventory_errors(inventory, policy.exemptions)
+    errors = _inventory_errors(inventory, gate.exemptions)
     if errors:
         _print_annotations(errors)
         return 1
 
     print(
-        f"{policy.display_name} gate accounts for {len(inventory.jobs)} "
+        f"{gate.display_name} gate accounts for {len(inventory.jobs)} "
         f"top-level jobs ({len(inventory.gate_needs)} gated, "
-        f"{len(policy.exemptions)} exempt)."
+        f"{len(gate.exemptions)} exempt)."
     )
     return 0
 
 
-def _check_results() -> int:
+def _check_results(workflow_name: str) -> int:
     """Check `NEEDS_JSON` and report invalid job results as annotations.
 
     Each dependency is printed for the Actions log. Returns zero only when the
@@ -365,24 +542,27 @@ def _check_results() -> int:
         return 1
 
     try:
-        needs_context = json.loads(needs_json)
+        job_results = json.loads(needs_json)
     except json.JSONDecodeError as error:
         _print_annotations([f"`NEEDS_JSON` is not valid JSON: {error}"])
         return 1
-    if not isinstance(needs_context, Mapping):
+    if not isinstance(job_results, Mapping):
         _print_annotations(["`NEEDS_JSON` must contain a JSON object"])
         return 1
 
-    for job, details in sorted(needs_context.items()):
+    for job, details in sorted(job_results.items()):
         result = details.get("result") if isinstance(details, Mapping) else None
         print(f"{job}: {result}")
 
-    errors = result_errors(needs_context)
+    errors = result_errors(job_results, workflow_name)
     if errors:
         _print_annotations(errors)
         return 1
 
-    print("All required jobs succeeded or were intentionally skipped.")
+    print(
+        f"All {WORKFLOW_GATES[workflow_name].display_name} jobs succeeded or skipped "
+        "for a recorded reason."
+    )
     return 0
 
 
@@ -398,13 +578,24 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "inventory", help="verify that every top-level job is gated or exempt"
     )
     inventory.add_argument(
-        "--policy",
-        choices=tuple(POLICIES),
+        "--workflow",
+        dest="workflow_name",
+        choices=tuple(WORKFLOW_GATES),
         required=True,
-        help="select the workflow's reviewed gate policy",
+        help="choose the Core or REST workflow",
     )
-    inventory.add_argument("workflow", type=Path)
-    commands.add_parser("results", help="evaluate the job results in `NEEDS_JSON`")
+    inventory.add_argument("workflow_file", type=Path)
+
+    results = commands.add_parser(
+        "results", help="evaluate the job results in `NEEDS_JSON`"
+    )
+    results.add_argument(
+        "--workflow",
+        dest="workflow_name",
+        choices=tuple(WORKFLOW_GATES),
+        required=True,
+        help="choose the Core or REST workflow",
+    )
     return parser.parse_args(argv)
 
 
@@ -413,8 +604,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = _parse_args(argv)
     if args.command == "inventory":
-        return _check_inventory(args.workflow, POLICIES[args.policy])
-    return _check_results()
+        return _check_inventory(
+            args.workflow_file, WORKFLOW_GATES[args.workflow_name]
+        )
+    return _check_results(args.workflow_name)
 
 
 if __name__ == "__main__":

--- a/.github/ci/test_check_ci_gate.py
+++ b/.github/ci/test_check_ci_gate.py
@@ -7,9 +7,13 @@
 from __future__ import annotations
 
 import contextlib
+import copy
+import functools
 import io
+import itertools
+import json
 import os
-import tempfile
+import re
 import textwrap
 import unittest
 from dataclasses import replace
@@ -17,13 +21,30 @@ from pathlib import Path
 from unittest import mock
 
 from check_ci_gate import (
-    CORE_POLICY,
-    REST_POLICY,
+    CORE_GATE,
+    CORE_JOBS_BY_PREPARE_OUTPUT,
+    CORE_PR_ONLY_JOBS,
+    CORE_UPSTREAM_ONLY_JOB,
+    GateInputError,
+    JOB_KEY,
+    WORKFLOW_GATES,
+    _core_jobs_allowed_to_skip,
     inventory_errors,
     main,
+    parse_workflow,
     result_errors,
 )
 
+
+CI_DIR = Path(__file__).resolve().parent
+ROOT = CI_DIR.parents[1]
+WORKFLOWS = {
+    "core": ROOT / ".github/workflows/ci.yaml",
+    "rest": ROOT / ".github/workflows/rest-ci.yml",
+}
+PREPARE_OUTPUT_REFERENCE = re.compile(
+    r"needs\.prepare\.outputs\.(?P<output>[A-Za-z_][A-Za-z0-9_]*)"
+)
 
 COMPLETE_WORKFLOW = textwrap.dedent(
     """\
@@ -49,69 +70,165 @@ COMPLETE_WORKFLOW = textwrap.dedent(
     """
 )
 
-REST_WORKFLOW = textwrap.dedent(
-    """\
-    name: REST fixture
 
-    jobs:
-      changes:
-        runs-on: ubuntu-latest
-      prepare:
-        runs-on: ubuntu-latest
-      lint-and-test:
-        runs-on: ubuntu-latest
-      build-binaries:
-        runs-on: ubuntu-latest
-      security-secret-scan:
-        runs-on: ubuntu-latest
-      build-and-push:
-        runs-on: ubuntu-latest
-      build-and-push-pr:
-        runs-on: ubuntu-latest
-      helm:
-        runs-on: ubuntu-latest
-      rest-ci-pass:
-        runs-on: ubuntu-latest
-        if: always()
-        needs:
-          - changes
-          - prepare
-          - lint-and-test
-          - build-binaries
-          - security-secret-scan
-          - build-and-push
-          - build-and-push-pr
-          - helm
-        steps:
-          - run: true
-    """
-)
+@functools.cache
+def _read_workflow(workflow_name: str) -> str:
+    """Read the checked-in Core or REST workflow."""
+
+    return WORKFLOWS[workflow_name].read_text(encoding="utf-8")
+
+
+@functools.cache
+def _read_gate_dependencies(workflow_name: str) -> tuple[str, ...]:
+    """Return the jobs listed in the final gate's `needs` block."""
+
+    gate = WORKFLOW_GATES[workflow_name]
+    inventory = parse_workflow(_read_workflow(workflow_name), gate.gate_job)
+    return inventory.gate_needs
+
+
+def _read_job_yaml(workflow_name: str, job: str) -> str:
+    """Return the YAML block for one job in the checked-in workflow."""
+
+    lines = _read_workflow(workflow_name).splitlines()
+    header = f"  {job}:"
+    start = next(
+        (index for index, line in enumerate(lines) if line == header), None
+    )
+    if start is None:
+        raise AssertionError(
+            f"{workflow_name} workflow does not declare job {job!r}"
+        )
+
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if JOB_KEY.fullmatch(line):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def _read_job_condition(workflow_name: str, job: str) -> str:
+    """Return one job's top-level `if` condition, including folded lines."""
+
+    lines = _read_job_yaml(workflow_name, job).splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith("    if:"):
+            continue
+        condition = [line.partition("if:")[2].strip()]
+        for continuation in lines[index + 1 :]:
+            if continuation.strip() and not continuation.startswith("      "):
+                break
+            condition.append(continuation.strip())
+        return " ".join(part for part in condition if part)
+    return ""
+
+
+def _build_result_context(
+    workflow_name: str,
+    *,
+    run_ci: bool = True,
+    pull_request: bool = True,
+    skipped_jobs: set[str] | frozenset[str] = frozenset(),
+    upstream: bool = True,
+) -> tuple[dict[str, object], dict[str, str]]:
+    """Build the job results and GitHub variables for one test run."""
+
+    job_results: dict[str, object] = {
+        job: {
+            "result": "skipped" if job in skipped_jobs else "success",
+            "outputs": {},
+        }
+        for job in _read_gate_dependencies(workflow_name)
+    }
+    run_output = "run_core_ci" if workflow_name == "core" else "run_rest_ci"
+    job_results["changes"]["outputs"] = {run_output: str(run_ci).lower()}
+    if workflow_name == "core":
+        job_results["prepare"]["outputs"] = dict.fromkeys(
+            CORE_JOBS_BY_PREPARE_OUTPUT, "true"
+        )
+    environment = {
+        "GITHUB_REF": (
+            "refs/heads/pull-request/123" if pull_request else "refs/heads/main"
+        ),
+        "GITHUB_REPOSITORY": (
+            "NVIDIA/infra-controller" if upstream else "example/fork"
+        ),
+    }
+    return job_results, environment
 
 
 class InventoryTests(unittest.TestCase):
     """Verify that every workflow job has exactly one gate classification."""
+
+    def test_checked_in_workflows_match_gate_configuration(self) -> None:
+        for workflow_name, gate in WORKFLOW_GATES.items():
+            with self.subTest(workflow_name):
+                workflow = _read_workflow(workflow_name)
+                self.assertEqual(inventory_errors(workflow, gate), [])
+
+        # The Core table and the checked-in job conditions must reference each
+        # other in both directions. This makes a newly conditional job fail in
+        # `changes`, instead of surprising the final required check later.
+        expected_output_by_job: dict[str, str] = {}
+        for output_name, jobs in CORE_JOBS_BY_PREPARE_OUTPUT.items():
+            for job in jobs:
+                self.assertNotIn(job, expected_output_by_job)
+                expected_output_by_job[job] = output_name
+
+        actual_output_by_job: dict[str, str] = {}
+        pull_request_jobs: set[str] = set()
+        upstream_only_jobs: set[str] = set()
+        for job in _read_gate_dependencies("core"):
+            condition = _read_job_condition("core", job)
+            outputs = {
+                match.group("output")
+                for match in PREPARE_OUTPUT_REFERENCE.finditer(condition)
+            }
+            self.assertLessEqual(len(outputs), 1, job)
+            if outputs:
+                actual_output_by_job[job] = outputs.pop()
+            if "pull-request/" in condition:
+                pull_request_jobs.add(job)
+            if "github.repository ==" in condition:
+                upstream_only_jobs.add(job)
+
+        self.assertEqual(actual_output_by_job, expected_output_by_job)
+        self.assertEqual(pull_request_jobs, set(CORE_PR_ONLY_JOBS))
+        self.assertEqual(
+            upstream_only_jobs,
+            {CORE_UPSTREAM_ONLY_JOB},
+        )
+        self.assertIn(
+            "!startsWith(github.ref, 'refs/heads/pull-request/')",
+            _read_job_yaml("rest", "build-and-push"),
+        )
+        self.assertIn(
+            "startsWith(github.ref, 'refs/heads/pull-request/')",
+            _read_job_yaml("rest", "build-and-push-pr"),
+        )
 
     def test_inventory_classification(self) -> None:
         cases = (
             {
                 "name": "complete inventory",
                 "workflow": COMPLETE_WORKFLOW,
-                "policy": CORE_POLICY,
+                "gate": CORE_GATE,
                 "expected": [],
             },
             {
                 "name": "missing gate dependency",
                 "workflow": COMPLETE_WORKFLOW.replace("      - build\n", ""),
-                "policy": CORE_POLICY,
+                "gate": CORE_GATE,
                 "expected": ["top-level jobs are not gated or exempt: build"],
             },
             {
                 "name": "unknown exemption",
                 "workflow": COMPLETE_WORKFLOW,
-                "policy": replace(
-                    CORE_POLICY,
+                "gate": replace(
+                    CORE_GATE,
                     exemptions={
-                        **CORE_POLICY.exemptions,
+                        **CORE_GATE.exemptions,
                         "retired-job": "No longer used.",
                     },
                 ),
@@ -122,7 +239,7 @@ class InventoryTests(unittest.TestCase):
                 "workflow": COMPLETE_WORKFLOW.replace(
                     "      - build\n", "      - build\n      - retired-job\n"
                 ),
-                "policy": CORE_POLICY,
+                "gate": CORE_GATE,
                 "expected": [
                     "gate dependencies are not top-level jobs: retired-job"
                 ],
@@ -130,10 +247,10 @@ class InventoryTests(unittest.TestCase):
             {
                 "name": "duplicate classification",
                 "workflow": COMPLETE_WORKFLOW,
-                "policy": replace(
-                    CORE_POLICY,
+                "gate": replace(
+                    CORE_GATE,
                     exemptions={
-                        **CORE_POLICY.exemptions,
+                        **CORE_GATE.exemptions,
                         "build": "Fixture duplicate.",
                     },
                 ),
@@ -144,15 +261,15 @@ class InventoryTests(unittest.TestCase):
                 "workflow": COMPLETE_WORKFLOW.replace(
                     "      - build\n", "      - build\n      - build\n"
                 ),
-                "policy": CORE_POLICY,
+                "gate": CORE_GATE,
                 "expected": ["gate dependencies are listed more than once: build"],
             },
             {
                 "name": "empty exemption reason",
                 "workflow": COMPLETE_WORKFLOW,
-                "policy": replace(
-                    CORE_POLICY,
-                    exemptions={**CORE_POLICY.exemptions, "build-summary": ""},
+                "gate": replace(
+                    CORE_GATE,
+                    exemptions={**CORE_GATE.exemptions, "build-summary": ""},
                 ),
                 "expected": ["exemptions need a reason: build-summary"],
             },
@@ -161,36 +278,7 @@ class InventoryTests(unittest.TestCase):
         for case in cases:
             with self.subTest(case["name"]):
                 self.assertEqual(
-                    inventory_errors(case["workflow"], case["policy"]),
-                    case["expected"],
-                )
-
-    def test_lane_policies(self) -> None:
-        cases = (
-            {
-                "name": "REST policy",
-                "workflow": REST_WORKFLOW,
-                "policy": REST_POLICY,
-                "expected": [],
-            },
-            {
-                "name": "missing REST dependency",
-                "workflow": REST_WORKFLOW.replace("      - helm\n", ""),
-                "policy": REST_POLICY,
-                "expected": ["top-level jobs are not gated or exempt: helm"],
-            },
-            {
-                "name": "wrong policy",
-                "workflow": REST_WORKFLOW,
-                "policy": CORE_POLICY,
-                "expected": ["the workflow does not define `core-ci-pass`"],
-            },
-        )
-
-        for case in cases:
-            with self.subTest(case["name"]):
-                self.assertEqual(
-                    inventory_errors(case["workflow"], case["policy"]),
+                    inventory_errors(case["workflow"], case["gate"]),
                     case["expected"],
                 )
 
@@ -285,59 +373,46 @@ class InventoryTests(unittest.TestCase):
         for case in cases:
             with self.subTest(case["name"]):
                 self.assertEqual(
-                    inventory_errors(case["workflow"], CORE_POLICY),
+                    inventory_errors(case["workflow"], CORE_GATE),
                     [case["expected"]],
                 )
 
 
 class CommandTests(unittest.TestCase):
-    """Verify policy selection and workflow-file handling at the CLI boundary."""
+    """Verify workflow selection and file handling at the CLI boundary."""
 
-    def test_inventory_command_accepts_each_policy(self) -> None:
+    def test_inventory_command_accepts_each_workflow(self) -> None:
         cases = (
-            {
-                "name": "Core policy",
-                "policy": "core",
-                "workflow": COMPLETE_WORKFLOW,
-                "expected": "Core CI gate accounts for 5",
-            },
-            {
-                "name": "REST policy",
-                "policy": "rest",
-                "workflow": REST_WORKFLOW,
-                "expected": "REST CI gate accounts for 9",
-            },
+            ("core", "Core CI gate accounts for"),
+            ("rest", "REST CI gate accounts for"),
         )
 
-        for case in cases:
-            with self.subTest(case["name"]):
-                with tempfile.TemporaryDirectory() as directory:
-                    workflow_path = Path(directory) / "workflow.yml"
-                    workflow_path.write_text(case["workflow"], encoding="utf-8")
-                    output = io.StringIO()
-                    with contextlib.redirect_stdout(output):
-                        return_code = main(
-                            [
-                                "inventory",
-                                "--policy",
-                                case["policy"],
-                                str(workflow_path),
-                            ]
-                        )
+        for workflow_name, expected in cases:
+            with self.subTest(workflow_name):
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    return_code = main(
+                        [
+                            "inventory",
+                            "--workflow",
+                            workflow_name,
+                            str(WORKFLOWS[workflow_name]),
+                        ]
+                    )
 
                 self.assertEqual(return_code, 0)
-                self.assertIn(case["expected"], output.getvalue())
+                self.assertIn(expected, output.getvalue())
 
-    def test_inventory_command_rejects_unknown_policy(self) -> None:
+    def test_inventory_command_rejects_unknown_workflow(self) -> None:
         with contextlib.redirect_stderr(io.StringIO()):
             with self.assertRaisesRegex(SystemExit, "2"):
-                main(["inventory", "--policy", "unknown", "workflow.yml"])
+                main(["inventory", "--workflow", "unknown", "workflow.yml"])
 
     def test_inventory_command_rejects_unreadable_workflow(self) -> None:
         output = io.StringIO()
         with contextlib.redirect_stdout(output):
             return_code = main(
-                ["inventory", "--policy", "core", "/missing/workflow.yml"]
+                ["inventory", "--workflow", "core", "/missing/workflow.yml"]
             )
 
         self.assertEqual(return_code, 1)
@@ -345,115 +420,304 @@ class CommandTests(unittest.TestCase):
 
 
 class ResultTests(unittest.TestCase):
-    """Verify the final gate's success, skip, and fail-closed result policy."""
+    """Verify expected skips and every fail-closed result boundary."""
 
-    def test_gate_result_policy(self) -> None:
-        cases = (
-            {
-                "name": "success",
-                "result": "success",
-                "expected": [],
-            },
-            {
-                "name": "intentional skip",
-                "result": "skipped",
-                "expected": [],
-            },
-            {
-                "name": "failure",
-                "result": "failure",
-                "expected": ["`fixture-job` failed"],
-            },
-            {
-                "name": "cancellation",
-                "result": "cancelled",
-                "expected": ["`fixture-job` was cancelled"],
-            },
+    def _assert_results_pass(
+        self,
+        workflow_name: str,
+        *,
+        run_ci: bool = True,
+        pull_request: bool = True,
+        skipped_jobs: set[str] | frozenset[str] = frozenset(),
+        upstream: bool = True,
+    ) -> None:
+        job_results, environment = _build_result_context(
+            workflow_name,
+            run_ci=run_ci,
+            pull_request=pull_request,
+            skipped_jobs=skipped_jobs,
+            upstream=upstream,
+        )
+        self.assertEqual(
+            result_errors(job_results, workflow_name, environment=environment), []
         )
 
-        for case in cases:
-            with self.subTest(case["name"]):
-                needs_context = {"fixture-job": {"result": case["result"]}}
-                self.assertEqual(result_errors(needs_context), case["expected"])
+    def test_healthy_core_results(self) -> None:
+        core_jobs = set(_read_gate_dependencies("core"))
+        self._assert_results_pass("core")
+        self._assert_results_pass(
+            "core",
+            run_ci=False,
+            skipped_jobs=core_jobs - {"changes", "migration-police"},
+        )
+        self._assert_results_pass(
+            "core", pull_request=False, skipped_jobs=set(CORE_PR_ONLY_JOBS)
+        )
+        self._assert_results_pass(
+            "core", upstream=False, skipped_jobs={CORE_UPSTREAM_ONLY_JOB}
+        )
+        # A job that was allowed to skip may still run successfully.
+        self._assert_results_pass("core", upstream=False)
 
-    def test_non_mapping_job_result_is_rejected(self) -> None:
+    def test_every_rest_decision_combination(self) -> None:
+        rest_jobs = set(_read_gate_dependencies("rest"))
+        for run_ci, pull_request in itertools.product((False, True), repeat=2):
+            if not run_ci and not pull_request:
+                job_results, environment = _build_result_context(
+                    "rest", run_ci=False, pull_request=False
+                )
+                self.assertIn(
+                    "`changes.run_rest_ci` was false outside a pull request",
+                    result_errors(job_results, "rest", environment=environment),
+                )
+            elif not run_ci:
+                self._assert_results_pass(
+                    "rest", run_ci=False, skipped_jobs=rest_jobs - {"changes"}
+                )
+            else:
+                self._assert_results_pass(
+                    "rest",
+                    pull_request=pull_request,
+                    skipped_jobs={
+                        "build-and-push" if pull_request else "build-and-push-pr"
+                    },
+                )
+
+    def test_migration_police_still_runs_when_core_does_not(self) -> None:
+        job_results, environment = _build_result_context(
+            "core",
+            run_ci=False,
+            skipped_jobs=set(_read_gate_dependencies("core")) - {"changes"},
+        )
+        self.assertIn(
+            "`migration-police` was unexpectedly skipped",
+            result_errors(job_results, "core", environment=environment)[0],
+        )
+
+    def test_every_core_decision_combination(self) -> None:
+        """Cover every boolean input to the Core skip decision in one table."""
+
+        output_names = tuple(CORE_JOBS_BY_PREPARE_OUTPUT)
+        core_jobs = set(_read_gate_dependencies("core"))
+        prepare_combinations = tuple(
+            itertools.product((False, True), repeat=len(output_names))
+        )
+
+        for run_ci, pull_request, upstream in itertools.product(
+            (False, True), repeat=3
+        ):
+            for prepare_values in prepare_combinations:
+                prepare_decisions = dict(
+                    zip(output_names, prepare_values, strict=True)
+                )
+                job_results, environment = _build_result_context(
+                    "core",
+                    run_ci=run_ci,
+                    pull_request=pull_request,
+                    upstream=upstream,
+                )
+                job_results["prepare"]["outputs"].update(
+                    {
+                        name: str(value).lower()
+                        for name, value in prepare_decisions.items()
+                    }
+                )
+                if not run_ci and not pull_request:
+                    with self.assertRaisesRegex(
+                        GateInputError,
+                        "`changes.run_core_ci` was false outside a pull request",
+                    ):
+                        _core_jobs_allowed_to_skip(job_results, environment)
+                    continue
+
+                if not run_ci:
+                    expected = core_jobs - {"changes", "migration-police"}
+                else:
+                    expected = set()
+                    for output_name, value in prepare_decisions.items():
+                        if not value:
+                            expected.update(
+                                CORE_JOBS_BY_PREPARE_OUTPUT[output_name]
+                            )
+                    if not pull_request:
+                        expected.update(CORE_PR_ONLY_JOBS)
+                    if not upstream:
+                        expected.add(CORE_UPSTREAM_ONLY_JOB)
+
+                self.assertEqual(
+                    _core_jobs_allowed_to_skip(job_results, environment),
+                    expected,
+                    (run_ci, pull_request, upstream, prepare_decisions),
+                )
+
+    def test_every_gated_job_rejects_an_unexpected_skip(self) -> None:
+        core_results, core_environment = _build_result_context("core")
+        for job in _read_gate_dependencies("core"):
+            with self.subTest(workflow="core", job=job):
+                mutated = copy.deepcopy(core_results)
+                mutated[job]["result"] = "skipped"
+                self.assertIn(
+                    f"`{job}` was unexpectedly skipped",
+                    result_errors(
+                        mutated, "core", environment=core_environment
+                    )[0],
+                )
+
+        for job in _read_gate_dependencies("rest"):
+            # Use the ref that requires this job. The other Docker job is the
+            # one expected skip in the starting result set.
+            pull_request = job != "build-and-push"
+            rest_results, rest_environment = _build_result_context(
+                "rest",
+                pull_request=pull_request,
+                skipped_jobs={
+                    "build-and-push" if pull_request else "build-and-push-pr"
+                },
+            )
+            with self.subTest(workflow="rest", job=job):
+                rest_results[job]["result"] = "skipped"
+                self.assertIn(
+                    f"`{job}` was unexpectedly skipped",
+                    result_errors(
+                        rest_results, "rest", environment=rest_environment
+                    )[0],
+                )
+
+    def test_bad_terminal_and_malformed_results(self) -> None:
+        cases = (
+            ("failure", "failure", "failed"),
+            ("cancellation", "cancelled", "was cancelled"),
+            ("unknown", "waiting", "unsupported result 'waiting'"),
+        )
+        for name, result, expected in cases:
+            with self.subTest(name):
+                job_results = {"fixture-job": {"result": result}}
+                errors = result_errors(job_results, "rest", environment={})
+                self.assertIn(expected, errors[0])
+
+        self.assertIn(
+            "did not provide a job result object",
+            result_errors({"fixture-job": "success"}, "rest", environment={})[0],
+        )
+
+    def test_malformed_and_missing_boolean_outputs_fail_closed(self) -> None:
+        for job, output_name in (
+            ("changes", "run_core_ci"),
+            ("prepare", "publish_images"),
+        ):
+            for value in ("yes", None):
+                with self.subTest(output=output_name, value=value):
+                    job_results, environment = _build_result_context("core")
+                    outputs = job_results[job]["outputs"]
+                    if value is None:
+                        outputs.pop(output_name)
+                    else:
+                        outputs[output_name] = value
+                    errors = result_errors(
+                        job_results, "core", environment=environment
+                    )
+                    self.assertIn(output_name, errors[0])
+
+    def test_missing_github_variables_fail_closed(self) -> None:
+        core_results, environment = _build_result_context("core")
+        for variable, expected in (
+            ("GITHUB_REF", "`GITHUB_REF` is not set"),
+            ("GITHUB_REPOSITORY", "`GITHUB_REPOSITORY` is not set"),
+        ):
+            with self.subTest(variable=variable):
+                incomplete_environment = environment | {variable: ""}
+                self.assertEqual(
+                    result_errors(
+                        core_results,
+                        "core",
+                        environment=incomplete_environment,
+                    ),
+                    [expected],
+                )
+
+    def test_workflow_cannot_be_disabled_outside_a_pull_request(self) -> None:
+        job_results, environment = _build_result_context(
+            "core", run_ci=False, pull_request=False
+        )
+        errors = result_errors(job_results, "core", environment=environment)
+        self.assertIn(
+            "`changes.run_core_ci` was false outside a pull request", errors
+        )
+
+    def test_missing_workflow_decisions_fail_closed(self) -> None:
+        job_results, environment = _build_result_context("core")
+        job_results["prepare"]["result"] = "skipped"
+        self.assertIn(
+            "`prepare` was unexpectedly skipped",
+            result_errors(job_results, "core", environment=environment)[0],
+        )
+
+        job_results, environment = _build_result_context("core")
+        job_results["changes"].pop("outputs")
+        self.assertIn(
+            "did not provide a job outputs object",
+            result_errors(job_results, "core", environment=environment)[0],
+        )
+
+    def test_unknown_workflow_fails_closed(self) -> None:
+        core_results, environment = _build_result_context("core")
         self.assertEqual(
-            result_errors({"fixture-job": "success"}),
-            ["`fixture-job` did not provide a job result object"],
+            result_errors(core_results, "retired", environment=environment),
+            ["unknown workflow 'retired'"],
+        )
+
+    def test_workflow_only_regression(self) -> None:
+        # #4324 was possible because a workflow-only change skipped
+        # `lint-police` and `core-ci-pass` accepted that skip. The source
+        # filter selects lint; this assertion makes sure the final gate rejects
+        # the old result.
+        job_results, environment = _build_result_context("core")
+        job_results["lint-police"]["result"] = "skipped"
+        self.assertIn(
+            "`lint-police` was unexpectedly skipped",
+            result_errors(job_results, "core", environment=environment)[0],
         )
 
     def test_result_command_accepts_healthy_context(self) -> None:
-        needs_json = (
-            '{"successful-job":{"result":"success"},'
-            '"skipped-job":{"result":"skipped"}}'
+        job_results, environment = _build_result_context(
+            "rest", pull_request=False, skipped_jobs={"build-and-push-pr"}
         )
+        process_environment = {
+            **environment,
+            "NEEDS_JSON": json.dumps(job_results),
+        }
         output = io.StringIO()
-        with mock.patch.dict(os.environ, {"NEEDS_JSON": needs_json}):
-            with contextlib.redirect_stdout(output):
-                return_code = main(["results"])
+        with mock.patch.dict(
+            os.environ, process_environment, clear=True
+        ), contextlib.redirect_stdout(output):
+            return_code = main(["results", "--workflow", "rest"])
 
         self.assertEqual(return_code, 0)
-        self.assertNotIn("::error::", output.getvalue())
-        self.assertIn(
-            "All required jobs succeeded or were intentionally skipped.",
-            output.getvalue(),
-        )
+        self.assertIn("All REST CI jobs succeeded or skipped", output.getvalue())
 
     def test_result_command_rejects_invalid_context(self) -> None:
         cases = (
-            {
-                "name": "malformed JSON",
-                "needs_json": "{",
-                "expected": "::error::`NEEDS_JSON` is not valid JSON:",
-            },
-            {
-                "name": "empty context",
-                "needs_json": "{}",
-                "expected": "::error::the gate received no job results",
-            },
-            {
-                "name": "non-mapping JSON",
-                "needs_json": "[]",
-                "expected": "::error::`NEEDS_JSON` must contain a JSON object",
-            },
-            {
-                "name": "unsupported result",
-                "needs_json": '{"fixture-job":{"result":"waiting"}}',
-                "expected": (
-                    "::error::`fixture-job` returned unsupported result 'waiting'"
-                ),
-            },
-            {
-                "name": "missing result",
-                "needs_json": '{"fixture-job":{}}',
-                "expected": (
-                    "::error::`fixture-job` returned unsupported result None"
-                ),
-            },
-            {
-                "name": "null result",
-                "needs_json": '{"fixture-job":{"result":null}}',
-                "expected": (
-                    "::error::`fixture-job` returned unsupported result None"
-                ),
-            },
+            ("malformed", "{", "is not valid JSON"),
+            ("empty", "{}", "received no job results"),
+            ("non-mapping", "[]", "must contain a JSON object"),
         )
-
-        for case in cases:
-            with self.subTest(case["name"]):
+        for name, needs_json, expected in cases:
+            with self.subTest(name):
                 output = io.StringIO()
-                with mock.patch.dict(os.environ, {"NEEDS_JSON": case["needs_json"]}):
-                    with contextlib.redirect_stdout(output):
-                        return_code = main(["results"])
+                with mock.patch.dict(
+                    os.environ, {"NEEDS_JSON": needs_json}, clear=True
+                ), contextlib.redirect_stdout(output):
+                    return_code = main(["results", "--workflow", "rest"])
 
                 self.assertEqual(return_code, 1)
-                self.assertIn(case["expected"], output.getvalue())
+                self.assertIn(expected, output.getvalue())
 
     def test_result_command_rejects_missing_context(self) -> None:
         output = io.StringIO()
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with contextlib.redirect_stdout(output):
-                return_code = main(["results"])
+        with mock.patch.dict(
+            os.environ, {}, clear=True
+        ), contextlib.redirect_stdout(output):
+            return_code = main(["results", "--workflow", "core"])
 
         self.assertEqual(return_code, 1)
         self.assertIn("::error::`NEEDS_JSON` is not set", output.getvalue())

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
         run: bash .github/ci/test-resolve-secret-scan-range.sh
 
       - name: Check Core CI final-gate inventory
-        run: python3 -B .github/ci/check_ci_gate.py inventory --policy core .github/workflows/ci.yaml
+        run: python3 -B .github/ci/check_ci_gate.py inventory --workflow core .github/workflows/ci.yaml
 
       - name: Detect non-rest changes
         id: non-rest-changes
@@ -2220,14 +2220,17 @@ jobs:
   # ============================================================================
   # FINAL CORE CI GATE
   # ============================================================================
-  # Passes only when every required job reports `success` or `skipped`.
-  # `skipped` counts as pass — that's how rest-only PRs unblock when the
-  # `changes` gate intentionally skips the core pipeline.
-  # Any other result, plus missing or malformed data, fails closed.
+  # This is the final required Core check. A skip passes only when `changes`,
+  # `prepare`, the current ref, or the repository says that job did not need to
+  # run. Failures, cancellations, malformed decisions, and other skips fail.
+  # A workflow-only change selects `lint-police` through `source_files`, and
+  # this gate rejects that job disappearing (#4324).
   # Every job that can determine Core CI health is listed so an upstream
   # failure cannot be hidden when its downstream jobs become `skipped`.
   # Reporting-only jobs are explicitly exempted, and the checker in `changes`
   # rejects every job that is neither gated nor exempted.
+  # When a gated Core job gains another condition, register its allowed skip in
+  # `.github/ci/check_ci_gate.py`. Tests cover the existing selectors.
   # The checker also protects `if: always()` so a failed dependency cannot skip
   # this required check.
   # Branch protection should require only this gate and `rest-ci-pass`.
@@ -2315,4 +2318,4 @@ jobs:
       - name: Decide pass/fail
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
-        run: python3 -B .github/ci/check_ci_gate.py results
+        run: python3 -B .github/ci/check_ci_gate.py results --workflow core

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check REST CI final-gate inventory
-        run: python3 -B .github/ci/check_ci_gate.py inventory --policy rest .github/workflows/rest-ci.yml
+        run: python3 -B .github/ci/check_ci_gate.py inventory --workflow rest .github/workflows/rest-ci.yml
 
       - name: Check REST CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh rest
@@ -240,17 +240,16 @@ jobs:
   # ============================================================================
   # AGGREGATOR — single required check for branch protection
   # ============================================================================
-  # Passes only when every required job reports `success` or `skipped`.
-  # `skipped` counts as pass — that's how core-only PRs unblock when the
-  # `changes` gate intentionally skips the REST pipeline, and it is also what
-  # lets `build-and-push` and `build-and-push-pr` both sit in needs when
-  # exactly one of the two ever runs.
-  # Any other result, plus missing or malformed data, fails closed.
+  # This is the final required REST check. A skip passes only when `changes`
+  # says REST does not need to run, or when the ref chooses the other Docker
+  # job. Failures, cancellations, malformed decisions, and other skips fail.
   # Every job that can determine REST CI health is listed so an upstream
   # failure cannot be hidden when its downstream jobs become `skipped`.
   # The checker in `changes` rejects every job that is neither gated nor
   # exempted and protects `if: always()` so a failed dependency cannot skip
   # this required check.
+  # When a gated REST job gains another condition, update its allowed skip in
+  # `.github/ci/check_ci_gate.py`. The current Docker ref split has direct tests.
   rest-ci-pass:
     name: rest-ci-pass
     runs-on: linux-amd64-cpu4
@@ -275,4 +274,4 @@ jobs:
       - name: Decide pass/fail
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
-        run: python3 -B .github/ci/check_ci_gate.py results
+        run: python3 -B .github/ci/check_ci_gate.py results --workflow rest


### PR DESCRIPTION
> [!NOTE]
> While this PR seems large at first glance, just FYI that it contains:
>
> - +466/-202 lines of test changes.
>
> Don't let it scare you!

## Summary

`core-ci-pass` and `rest-ci-pass` are the final required checks for their workflows. They already rejected failed and cancelled dependencies, but they accepted every skipped job—even when the workflow had selected that job to run.

This change makes those checks mean what their names imply: selected work must finish successfully. The checker uses decisions the workflows already make to allow expected skips and rejects any unexplained skip. It adds no jobs or external service, and the required check names do not change.

Issue #4324 exposed this false-green path when a workflow change selected `lint-police` but the job disappeared behind a green final check.

## Related issues

- This supports [issue #4586](https://github.com/NVIDIA/infra-controller/issues/4586).
- #4324 is the regression that demonstrated the false-green behavior.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Validated locally at signed commit `e8435f9a932adaf725c9269dd765030537870d48`: 21 checker tests, both workflow inventories, both concurrency suites, Actionlint, formatting, Clippy, Carbide lints, and `git diff --check` passed. Exact-head hosted Core and REST validation is pending.

<details>
<summary>Independent review ledger</summary>

- CodeRabbit CLI: 0 received / 0 adopted / 0 declined in both full passes.
- Claude full-diff review: 9 received / 6 adopted / 3 declined after repository verification. The declined suggestions would duplicate the existing Python-version floor, add workflow metadata indirection, or weaken the intentional selector regression checks.
- Common-nits review: 1 received / 1 adopted / 0 declined.
- Fresh self-review: 2 received / 2 adopted / 0 declined.

</details>
