### PR TITLE
fix: bump libredfish to v0.44.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6306,7 +6306,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.3#02f9c19148f4aa4c6b7c9e5efe8f40361c9a3167"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.3.1#797f4c0c4970c64f6c8c70d1650b0cb24262f089"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.3" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.3.1" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.12-rc3" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
This PR bumps libredfish to `v0.44.3.1` which brings in the following change to NICo `v0.10`:

- fix(lenovo): restore hard disk during boot order remediation by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/125

## Related issues
- https://github.com/NVIDIA/infra-controller/issues/4830
- https://github.com/NVIDIA/infra-controller/issues/4701

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
