### PR TITLE
chore: bump libredfish to v0.46.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6886,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.6#8b0fc4384f82df962b085e6602bc78d348b2300c"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.7#97be4e1722e94a77d4278522d7664be5ba381d92"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.6" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.7" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.1" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
This PR bumps libredfish to `v0.46.7` which brings in the following change:

- fix(lenovo): restore hard disk during boot order remediation by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/125

## Related issues

- https://github.com/NVIDIA/infra-controller/issues/4830
- https://github.com/NVIDIA/infra-controller/issues/4701

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
