### PR TITLE
feat(machine-a-tron): Simulate BlueField system interfaces

### DIFF
--- a/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use bmc_explorer::nv_generate_exploration_report;
-use bmc_mock::{DpuSettings, test_support};
+use bmc_mock::{DpuSettings, DpuSystemEthernetInterface, test_support};
 use model::site_explorer::{BlueFieldOperatingMode, EndpointType};
 use tokio::test;
 
@@ -50,21 +50,24 @@ async fn explore_bluefield3_baseline() {
 
 #[test]
 async fn explore_bluefield3_ignores_invalid_system_interface_mac() {
-    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
-    h.state.injection.put(vec![bmc_mock::injection::Rule {
-        id: "invalid_system_interface_mac".into(),
-        selector: bmc_mock::injection::Selector::Path {
-            method: Some("GET".into()),
-            glob: "/redfish/v1/Systems/Bluefield/EthernetInterfaces/oob_net0".into(),
-        },
-        action: bmc_mock::injection::Action::JsonMerge(serde_json::json!({
-            "Id": "eth0",
-            "InterfaceEnabled": true,
-            "LinkStatus": "LinkDown",
-            "MACAddress": "00:00:11:e7:fe:80:00:00:00:00:00:00:02:00:00:03:00:18:00:01",
-        })),
-        remaining: None,
-    }]);
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings {
+        system_ethernet_interfaces: vec![
+            DpuSystemEthernetInterface {
+                id: "eth0".into(),
+                mac_address: "00:00:11:e7:fe:80:00:00:00:00:00:00:02:00:00:03:00:18:00:01".into(),
+                interface_enabled: true,
+                link_status: "LinkDown".into(),
+            },
+            DpuSystemEthernetInterface {
+                id: "eth1".into(),
+                mac_address: "02:00:00:00:00:04".into(),
+                interface_enabled: false,
+                link_status: "NoLink".into(),
+            },
+        ],
+        ..Default::default()
+    })
+    .await;
 
     let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
@@ -80,8 +83,17 @@ async fn explore_bluefield3_ignores_invalid_system_interface_mac() {
         .iter()
         .find(|interface| interface.id.as_deref() == Some("oob_net0"))
         .expect("OOB interface must be preserved");
+    let eth1 = system
+        .ethernet_interfaces
+        .iter()
+        .find(|interface| interface.id.as_deref() == Some("eth1"))
+        .expect("interfaces must be independently configurable");
 
     assert_eq!(eth0.mac_address, None);
+    assert_eq!(eth0.interface_enabled, Some(true));
+    assert_eq!(eth0.link_status.as_deref(), Some("LinkDown"));
+    assert_eq!(eth1.interface_enabled, Some(false));
+    assert_eq!(eth1.link_status.as_deref(), Some("NoLink"));
     assert!(oob.mac_address.is_some(), "valid OOB MAC must be preserved");
     assert!(system.base_mac.is_some(), "DPU base MAC must be preserved");
     assert!(

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 use mac_address::MacAddress;
 use serde_json::json;
 
-use crate::{BootOptionKind, Callbacks, LogService, LogServices, hw, redfish};
+use crate::{
+    BootOptionKind, Callbacks, DpuSystemEthernetInterface, LogService, LogServices, hw, redfish,
+};
 
 pub(crate) struct Bluefield3<'a> {
     pub(crate) product_serial_number: Cow<'a, str>,
@@ -30,6 +32,7 @@ pub(crate) struct Bluefield3<'a> {
     pub(crate) oob_mac_address: Option<MacAddress>,
     pub(crate) mode: Mode,
     pub(crate) firmware_versions: FirmwareVersions,
+    pub(crate) system_ethernet_interfaces: &'a [DpuSystemEthernetInterface],
 }
 
 pub(crate) enum Mode {
@@ -122,7 +125,7 @@ impl Bluefield3<'_> {
         } else {
             "DpuMode"
         };
-        let eth_interfaces =
+        let mut eth_interfaces =
             self.oob_mac_address
                 .iter()
                 .map(|mac| {
@@ -133,7 +136,17 @@ impl Bluefield3<'_> {
                     .description("1G DPU OOB network interface")
                     .build()
                 })
-                .collect();
+                .collect::<Vec<_>>();
+        eth_interfaces.extend(self.system_ethernet_interfaces.iter().map(|interface| {
+            redfish::ethernet_interface::builder(&redfish::ethernet_interface::system_resource(
+                "Bluefield",
+                &interface.id,
+            ))
+            .raw_mac_address(&interface.mac_address)
+            .interface_enabled(interface.interface_enabled)
+            .link_status(&interface.link_status)
+            .build()
+        }));
         let boot_options = [
             boot_opt_builder("Boot0040", BootOptionKind::Disk)
                 .display_name("ubuntu0")

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -47,8 +47,8 @@ pub use carbide_axum_utils::injection;
 pub use combined_server::{CombinedServer, ListenerOrAddress};
 pub use hw::rack::{RackElevation, RackUnit};
 pub use machine_info::{
-    DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostFirmwareVersions, HostMachineInfo,
-    MachineInfo,
+    DpuFirmwareVersions, DpuMachineInfo, DpuSettings, DpuSystemEthernetInterface,
+    HostFirmwareVersions, HostMachineInfo, MachineInfo,
 };
 pub use mock_machine_router::{
     BmcCommand, MachineRouterOptions, SetSystemPowerError, SetSystemPowerResult, machine_router,

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -119,6 +119,16 @@ pub struct DpuSettings {
     pub firmware_versions: DpuFirmwareVersions,
     #[serde(default = "default_true")]
     pub exposes_oob_eth: bool,
+    #[serde(default)]
+    pub system_ethernet_interfaces: Vec<DpuSystemEthernetInterface>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct DpuSystemEthernetInterface {
+    pub id: String,
+    pub mac_address: String,
+    pub interface_enabled: bool,
+    pub link_status: String,
 }
 
 fn default_true() -> bool {
@@ -136,6 +146,7 @@ impl Default for DpuSettings {
             nic_mode: false,
             firmware_versions: Default::default(),
             exposes_oob_eth: true,
+            system_ethernet_interfaces: Vec::new(),
         }
     }
 }
@@ -193,6 +204,7 @@ impl DpuMachineInfo {
                 erot: settings.firmware_versions.cec.clone().unwrap_or_default(),
                 dpu_nic: settings.firmware_versions.nic.clone().unwrap_or_default(),
             },
+            system_ethernet_interfaces: &settings.system_ethernet_interfaces,
         }
     }
 

--- a/crates/bmc-mock/src/redfish/ethernet_interface.rs
+++ b/crates/bmc-mock/src/redfish/ethernet_interface.rs
@@ -103,8 +103,16 @@ impl EthernetInterfaceBuilder {
         self.add_str_field("MACAddress", &addr.to_string())
     }
 
+    pub(crate) fn raw_mac_address(self, addr: &str) -> Self {
+        self.add_str_field("MACAddress", addr)
+    }
+
     pub(crate) fn interface_enabled(self, v: bool) -> Self {
         self.apply_patch(json!({ "InterfaceEnabled": v }))
+    }
+
+    pub(crate) fn link_status(self, v: &str) -> Self {
+        self.add_str_field("LinkStatus", v)
     }
 
     pub(crate) fn description(self, v: &str) -> Self {

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -22,7 +22,8 @@ use std::time::Duration;
 
 use bmc_mock::mac_address_pool::MacAddressPool;
 use bmc_mock::{
-    DpuMachineInfo, DpuSettings, HardwareType, HostFirmwareVersions, RackInfo, RackType,
+    DpuMachineInfo, DpuSettings, DpuSystemEthernetInterface, HardwareType, HostFirmwareVersions,
+    RackInfo, RackType,
 };
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::rack::{RackId, RackProfileId};
@@ -129,6 +130,9 @@ pub struct MachineConfig {
     #[serde(default)]
     pub dpu_firmware_versions: Option<DpuFirmwareVersions>,
 
+    #[serde(default)]
+    pub dpu_system_ethernet_interfaces: Vec<DpuSystemEthernetInterface>,
+
     /// Initial host BMC / UEFI firmware versions to report in FirmwareInventory.
     /// carbide will detect that these are older than the desired versions and
     /// trigger an upgrade.  After the simulated power-cycle bmc-mock applies
@@ -187,6 +191,8 @@ pub struct WiwynnGb200RackConfig {
     #[serde(default)]
     pub dpu_firmware_versions: Option<DpuFirmwareVersions>,
     #[serde(default)]
+    pub dpu_system_ethernet_interfaces: Vec<DpuSystemEthernetInterface>,
+    #[serde(default)]
     pub dpu_agent_version: Option<String>,
 }
 
@@ -216,6 +222,7 @@ impl WiwynnGb200RackConfig {
             network_virtualization_type: self.network_virtualization_type.clone(),
             dpus_in_nic_mode: self.dpus_in_nic_mode,
             dpu_firmware_versions: self.dpu_firmware_versions.clone(),
+            dpu_system_ethernet_interfaces: self.dpu_system_ethernet_interfaces.clone(),
             host_firmware_versions: None,
             dpu_agent_version: self.dpu_agent_version.clone(),
         }
@@ -261,6 +268,8 @@ pub struct LenovoGb300RackConfig {
     #[serde(default)]
     pub dpu_firmware_versions: Option<DpuFirmwareVersions>,
     #[serde(default)]
+    pub dpu_system_ethernet_interfaces: Vec<DpuSystemEthernetInterface>,
+    #[serde(default)]
     pub dpu_agent_version: Option<String>,
 }
 
@@ -290,6 +299,7 @@ impl LenovoGb300RackConfig {
             network_virtualization_type: self.network_virtualization_type.clone(),
             dpus_in_nic_mode: self.dpus_in_nic_mode,
             dpu_firmware_versions: self.dpu_firmware_versions.clone(),
+            dpu_system_ethernet_interfaces: self.dpu_system_ethernet_interfaces.clone(),
             host_firmware_versions: None,
             dpu_agent_version: self.dpu_agent_version.clone(),
         }
@@ -951,6 +961,10 @@ run_interval_working = "100ms"
 run_interval_idle = "1s"
 network_status_run_interval = "5s"
 scout_run_interval = "5s"
+dpu_system_ethernet_interfaces = [
+  { id = "eth0", mac_address = "00:00:11:e7:fe:80:00:00:00:00:00:00:02:00:00:03:00:18:00:01", interface_enabled = true, link_status = "LinkDown" },
+  { id = "eth1", mac_address = "02:00:00:00:00:04", interface_enabled = false, link_status = "NoLink" },
+]
     "#,
         )
         .expect("Could not parse config")
@@ -970,6 +984,7 @@ scout_run_interval = "5s"
             network_virtualization_type: machine.network_virtualization_type.clone(),
             dpus_in_nic_mode: machine.dpus_in_nic_mode,
             dpu_firmware_versions: machine.dpu_firmware_versions.clone(),
+            dpu_system_ethernet_interfaces: machine.dpu_system_ethernet_interfaces.clone(),
             dpu_agent_version: machine.dpu_agent_version.clone(),
         }
     }
@@ -988,6 +1003,7 @@ scout_run_interval = "5s"
             network_virtualization_type: machine.network_virtualization_type.clone(),
             dpus_in_nic_mode: machine.dpus_in_nic_mode,
             dpu_firmware_versions: machine.dpu_firmware_versions.clone(),
+            dpu_system_ethernet_interfaces: machine.dpu_system_ethernet_interfaces.clone(),
             dpu_agent_version: machine.dpu_agent_version.clone(),
         }
     }
@@ -1029,6 +1045,24 @@ scout_run_interval = "5s"
     #[test]
     fn test_serialize_config() {
         let cfg = rack_config();
+        assert_eq!(
+            cfg.machines["config"].dpu_system_ethernet_interfaces,
+            vec![
+                DpuSystemEthernetInterface {
+                    id: "eth0".into(),
+                    mac_address: "00:00:11:e7:fe:80:00:00:00:00:00:00:02:00:00:03:00:18:00:01"
+                        .into(),
+                    interface_enabled: true,
+                    link_status: "LinkDown".into(),
+                },
+                DpuSystemEthernetInterface {
+                    id: "eth1".into(),
+                    mac_address: "02:00:00:00:00:04".into(),
+                    interface_enabled: false,
+                    link_status: "NoLink".into(),
+                },
+            ]
+        );
         cfg.validate().expect("Could not validate config");
         let serialized = toml::to_string(&cfg).expect("Could not serialize config");
         let round_tripped = toml::from_str::<MachineATronConfig>(&serialized)

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -139,6 +139,7 @@ impl DpuMachine {
             DpuSettings {
                 nic_mode: config.dpus_in_nic_mode,
                 firmware_versions: firmware_versions.into(),
+                system_ethernet_interfaces: config.dpu_system_ethernet_interfaces.clone(),
                 ..Default::default()
             },
         );


### PR DESCRIPTION
Machine-a-Tron can now configure independent BlueField system Ethernet interfaces, including raw malformed MAC values, as the first composable Redfish inventory capability in #4982. The existing OOB interface remains unchanged.

## Related issues
Related to #4982

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
The configured interfaces were exercised through the live Redfish endpoint in DevSpace.
