### PR TITLE
fix(rest-api): Reuse unchanged instance interfaces

### DIFF
--- a/rest-api/api/pkg/api/handler/instance.go
+++ b/rest-api/api/pkg/api/handler/instance.go
@@ -3488,76 +3488,6 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 			}
 			newdbIfcs = []cdbm.Interface{}
 		case len(apiRequest.Interfaces) > 0:
-			keyForInterface := func(ifc cdbm.Interface) cdbm.EthernetInterfaceKey {
-				vpcID := uuid.Nil
-				if ifc.VpcID != nil {
-					vpcID = *ifc.VpcID
-				} else if ifc.VpcPrefix != nil {
-					vpcID = ifc.VpcPrefix.VpcID
-				} else if ifc.Subnet != nil {
-					vpcID = ifc.Subnet.VpcID
-				}
-
-				key := cdbm.EthernetInterfaceKey{
-					SubnetID:                uuid.Nil,
-					VpcPrefixID:             uuid.Nil,
-					VpcID:                   vpcID,
-					VpcIPFamilyMode:         "",
-					HasVpcIPFamilyMode:      false,
-					VirtualFunctionID:       0,
-					HasVirtualFunctionID:    false,
-					Device:                  "",
-					HasDevice:               false,
-					DeviceInstance:          0,
-					HasDeviceInstance:       false,
-					IsPhysical:              ifc.IsPhysical,
-					RequestedIPAddress:      "",
-					HasRequestedIPAddress:   false,
-					InlineRoutingProfile:    "",
-					HasInlineRoutingProfile: false,
-				}
-
-				if ifc.SubnetID != nil {
-					key.SubnetID = *ifc.SubnetID
-				}
-
-				if ifc.VpcPrefixID != nil {
-					key.VpcPrefixID = *ifc.VpcPrefixID
-				}
-
-				if ifc.VpcIPFamilyMode != nil {
-					key.VpcIPFamilyMode = *ifc.VpcIPFamilyMode
-					key.HasVpcIPFamilyMode = true
-				}
-
-				if ifc.VirtualFunctionID != nil {
-					key.VirtualFunctionID = *ifc.VirtualFunctionID
-					key.HasVirtualFunctionID = true
-				}
-
-				if ifc.Device != nil {
-					key.Device = *ifc.Device
-					key.HasDevice = true
-				}
-
-				if ifc.DeviceInstance != nil {
-					key.DeviceInstance = *ifc.DeviceInstance
-					key.HasDeviceInstance = true
-				}
-
-				if ifc.RequestedIpAddress != nil {
-					key.RequestedIPAddress = *ifc.RequestedIpAddress
-					key.HasRequestedIPAddress = true
-				}
-
-				if ifc.InlineRoutingProfile != nil {
-					key.InlineRoutingProfile = strings.Join(ifc.InlineRoutingProfile.AllowedAnycastPrefixes, "\x00")
-					key.HasInlineRoutingProfile = true
-				}
-
-				return key
-			}
-
 			existingIfcMap := make(map[cdbm.EthernetInterfaceKey][]cdbm.Interface)
 
 			for existingIfcIndex := range existingIfcs {
@@ -3565,13 +3495,13 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 					continue
 				}
 
-				key := keyForInterface(existingIfcs[existingIfcIndex])
+				key := existingIfcs[existingIfcIndex].EthernetKey()
 				existingIfcMap[key] = append(existingIfcMap[key], existingIfcs[existingIfcIndex])
 			}
 
 			reusedIfcIDs := make(map[uuid.UUID]struct{})
 			for _, dbifc := range dbInterfaces {
-				key := keyForInterface(dbifc)
+				key := dbifc.EthernetKey()
 
 				existingIfcsForKey := existingIfcMap[key]
 				if len(existingIfcsForKey) > 0 {
@@ -3627,20 +3557,11 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 				if existingIfcs[existingIfcIndex].Status != cdbm.InterfaceStatusDeleting {
 					existingIfcs[existingIfcIndex].Status = cdbm.InterfaceStatusDeleting
 
+					// Deleting rows retain their associations and allocated addresses until Site cleanup releases them.
 					_, err := ifcDAO.Update(ctx, tx, cdbm.InterfaceUpdateInput{
-						InterfaceID:          existingIfcs[existingIfcIndex].ID,
-						InstanceID:           nil,
-						SubnetID:             nil,
-						VpcPrefixID:          nil,
-						Device:               nil,
-						DeviceInstance:       nil,
-						VirtualFunctionID:    nil,
-						RequestedIpAddress:   nil,
-						InlineRoutingProfile: nil,
-						MacAddress:           nil,
-						IpAddresses:          nil,
-						Status:               cutil.GetPtr(cdbm.InterfaceStatusDeleting),
-					})
+						InterfaceID: existingIfcs[existingIfcIndex].ID,
+						Status:      cutil.GetPtr(cdbm.InterfaceStatusDeleting),
+					}) //nolint:exhaustruct // Only the lifecycle status changes; associations remain held.
 					if err != nil {
 						logger.Error().Err(err).Msg("failed to update Interface record in DB")
 

--- a/rest-api/api/pkg/api/handler/instance.go
+++ b/rest-api/api/pkg/api/handler/instance.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -3489,38 +3488,31 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 			}
 			newdbIfcs = []cdbm.Interface{}
 		case len(apiRequest.Interfaces) > 0:
-			reusedIfcIDs := make(map[uuid.UUID]struct{})
-			for _, dbifc := range dbInterfaces {
-				var reusedIfc *cdbm.Interface
-				for existingIfcIndex := range existingIfcs {
-					existingIfc := &existingIfcs[existingIfcIndex]
-					if existingIfc.Status == cdbm.InterfaceStatusDeleting {
-						continue
-					}
-
-					if _, reused := reusedIfcIDs[existingIfc.ID]; reused {
-						continue
-					}
-
-					networkMatches := reflect.DeepEqual(existingIfc.SubnetID, dbifc.SubnetID) &&
-						reflect.DeepEqual(existingIfc.VpcID, dbifc.VpcID) &&
-						reflect.DeepEqual(existingIfc.VpcIPFamilyMode, dbifc.VpcIPFamilyMode) &&
-						(dbifc.VpcID != nil || reflect.DeepEqual(existingIfc.VpcPrefixID, dbifc.VpcPrefixID))
-					if networkMatches &&
-						existingIfc.IsPhysical == dbifc.IsPhysical &&
-						reflect.DeepEqual(existingIfc.Device, dbifc.Device) &&
-						reflect.DeepEqual(existingIfc.DeviceInstance, dbifc.DeviceInstance) &&
-						reflect.DeepEqual(existingIfc.VirtualFunctionID, dbifc.VirtualFunctionID) &&
-						reflect.DeepEqual(existingIfc.RequestedIpAddress, dbifc.RequestedIpAddress) &&
-						reflect.DeepEqual(existingIfc.InlineRoutingProfile, dbifc.InlineRoutingProfile) {
-						reusedIfc = existingIfc
-						break
-					}
+			existingIfcMap := make(map[cdbm.EthernetInterfaceKey][]cdbm.Interface)
+			for existingIfcIndex := range existingIfcs {
+				if existingIfcs[existingIfcIndex].Status == cdbm.InterfaceStatusDeleting {
+					continue
 				}
 
-				if reusedIfc != nil {
+				key := existingIfcs[existingIfcIndex].EthernetKey()
+				existingIfcMap[key] = append(existingIfcMap[key], existingIfcs[existingIfcIndex])
+			}
+
+			reusedIfcIDs := make(map[uuid.UUID]struct{})
+			for _, dbifc := range dbInterfaces {
+				key := dbifc.EthernetKey()
+				existingIfcsForKey := existingIfcMap[key]
+
+				if len(existingIfcsForKey) > 0 {
+					reusedIfc := existingIfcsForKey[0]
+					if len(existingIfcsForKey) == 1 {
+						delete(existingIfcMap, key)
+					} else {
+						existingIfcMap[key] = existingIfcsForKey[1:]
+					}
+
 					reusedIfcIDs[reusedIfc.ID] = struct{}{}
-					newdbIfcs = append(newdbIfcs, *reusedIfc)
+					newdbIfcs = append(newdbIfcs, reusedIfc)
 					continue
 				}
 

--- a/rest-api/api/pkg/api/handler/instance.go
+++ b/rest-api/api/pkg/api/handler/instance.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -3488,33 +3489,38 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 			}
 			newdbIfcs = []cdbm.Interface{}
 		case len(apiRequest.Interfaces) > 0:
-			existingIfcMap := make(map[cdbm.EthernetInterfaceKey][]cdbm.Interface)
-
-			for existingIfcIndex := range existingIfcs {
-				if existingIfcs[existingIfcIndex].Status == cdbm.InterfaceStatusDeleting {
-					continue
-				}
-
-				key := existingIfcs[existingIfcIndex].EthernetKey()
-				existingIfcMap[key] = append(existingIfcMap[key], existingIfcs[existingIfcIndex])
-			}
-
 			reusedIfcIDs := make(map[uuid.UUID]struct{})
 			for _, dbifc := range dbInterfaces {
-				key := dbifc.EthernetKey()
-
-				existingIfcsForKey := existingIfcMap[key]
-				if len(existingIfcsForKey) > 0 {
-					reusedIfc := existingIfcsForKey[0]
-					if len(existingIfcsForKey) == 1 {
-						delete(existingIfcMap, key)
-					} else {
-						existingIfcMap[key] = existingIfcsForKey[1:]
+				var reusedIfc *cdbm.Interface
+				for existingIfcIndex := range existingIfcs {
+					existingIfc := &existingIfcs[existingIfcIndex]
+					if existingIfc.Status == cdbm.InterfaceStatusDeleting {
+						continue
 					}
 
-					reusedIfcIDs[reusedIfc.ID] = struct{}{}
-					newdbIfcs = append(newdbIfcs, reusedIfc)
+					if _, reused := reusedIfcIDs[existingIfc.ID]; reused {
+						continue
+					}
 
+					networkMatches := reflect.DeepEqual(existingIfc.SubnetID, dbifc.SubnetID) &&
+						reflect.DeepEqual(existingIfc.VpcID, dbifc.VpcID) &&
+						reflect.DeepEqual(existingIfc.VpcIPFamilyMode, dbifc.VpcIPFamilyMode) &&
+						(dbifc.VpcID != nil || reflect.DeepEqual(existingIfc.VpcPrefixID, dbifc.VpcPrefixID))
+					if networkMatches &&
+						existingIfc.IsPhysical == dbifc.IsPhysical &&
+						reflect.DeepEqual(existingIfc.Device, dbifc.Device) &&
+						reflect.DeepEqual(existingIfc.DeviceInstance, dbifc.DeviceInstance) &&
+						reflect.DeepEqual(existingIfc.VirtualFunctionID, dbifc.VirtualFunctionID) &&
+						reflect.DeepEqual(existingIfc.RequestedIpAddress, dbifc.RequestedIpAddress) &&
+						reflect.DeepEqual(existingIfc.InlineRoutingProfile, dbifc.InlineRoutingProfile) {
+						reusedIfc = existingIfc
+						break
+					}
+				}
+
+				if reusedIfc != nil {
+					reusedIfcIDs[reusedIfc.ID] = struct{}{}
+					newdbIfcs = append(newdbIfcs, *reusedIfc)
 					continue
 				}
 
@@ -3561,7 +3567,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 					_, err := ifcDAO.Update(ctx, tx, cdbm.InterfaceUpdateInput{
 						InterfaceID: existingIfcs[existingIfcIndex].ID,
 						Status:      cutil.GetPtr(cdbm.InterfaceStatusDeleting),
-					}) //nolint:exhaustruct // Only the lifecycle status changes; associations remain held.
+					})
 					if err != nil {
 						logger.Error().Err(err).Msg("failed to update Interface record in DB")
 

--- a/rest-api/api/pkg/api/handler/instance.go
+++ b/rest-api/api/pkg/api/handler/instance.go
@@ -2581,8 +2581,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 	// Collect all Subnet and VPC Prefix IDs for batch query
 	subnetIDs := []uuid.UUID{}
 	vpcPrefixIDs := []uuid.UUID{}
-	subnetIfcMap := map[uuid.UUID]int{}
-	vpcPrefixIfcMap := map[uuid.UUID]int{}
+	subnetIfcMap := map[uuid.UUID]uint64{}
+	vpcPrefixIfcMap := map[uuid.UUID]uint64{}
 
 	for _, ifc := range apiRequest.Interfaces {
 		if ifc.SubnetID != nil {
@@ -2638,8 +2638,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, interfaceVpcErr.Code, interfaceVpcErr.Message, interfaceVpcErr.Data)
 	}
 
-	existingSubnetIfcMap := map[uuid.UUID]int{}
-	existingVpcPrefixIfcMap := map[uuid.UUID]int{}
+	existingSubnetIfcMap := map[uuid.UUID]uint64{}
+	existingVpcPrefixIfcMap := map[uuid.UUID]uint64{}
 	if len(apiRequest.Interfaces) > 0 {
 		ifcDAO := cdbm.NewInterfaceDAO(uih.dbSession)
 		existingIfcsForCapacity, _, err := ifcDAO.GetAll(ctx, nil, cdbm.InterfaceFilterInput{InstanceIDs: []uuid.UUID{instance.ID}}, cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)}, nil)
@@ -2649,6 +2649,10 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		}
 		for i := range existingIfcsForCapacity {
 			eifc := &existingIfcsForCapacity[i]
+			if eifc.Status == cdbm.InterfaceStatusDeleting {
+				continue
+			}
+
 			if eifc.SubnetID != nil {
 				existingSubnetIfcMap[*eifc.SubnetID]++
 			}
@@ -2742,9 +2746,13 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 			}
 
 			// Check if Subnet is exhausted
-			incomingInterfaceIPs := subnetIfcMap[subnetID] - existingSubnetIfcMap[subnetID]
+			incomingInterfaceIPs := uint64(0)
+			if subnetIfcMap[subnetID] > existingSubnetIfcMap[subnetID] {
+				incomingInterfaceIPs = subnetIfcMap[subnetID] - existingSubnetIfcMap[subnetID]
+			}
+
 			subnetUsage := subnetUsageMap[subnetID]
-			if subnetUsage != nil && subnetUsage.AvailableIPs > 0 && subnetUsage.AcquiredIPs+uint64(incomingInterfaceIPs) > subnetUsage.AvailableIPs {
+			if incomingInterfaceIPs > 0 && subnetUsage != nil && subnetUsage.AvailableIPs > 0 && subnetUsage.AcquiredIPs+incomingInterfaceIPs > subnetUsage.AvailableIPs {
 				msg := fmt.Sprintf(
 					"Subnet %v does not have enough IP addresses: %d of %d IP addresses remain available, but the %d additional interface(s) in this request require %d IP address(es)",
 					subnetID, subnetUsage.AvailableIPs-subnetUsage.AcquiredIPs, subnetUsage.AvailableIPs, incomingInterfaceIPs, incomingInterfaceIPs,
@@ -2826,9 +2834,13 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 			}
 
 			// Check if VPC Prefix is exhausted
-			incomingInterfaceIPs := max(vpcPrefixIfcMap[vpcPrefixID]-existingVpcPrefixIfcMap[vpcPrefixID], 0)
+			incomingInterfaceIPs := uint64(0)
+			if vpcPrefixIfcMap[vpcPrefixID] > existingVpcPrefixIfcMap[vpcPrefixID] {
+				incomingInterfaceIPs = vpcPrefixIfcMap[vpcPrefixID] - existingVpcPrefixIfcMap[vpcPrefixID]
+			}
+
 			vpUsage := vpcPrefixUsageMap[vpcPrefixID]
-			if vpUsage != nil && vpUsage.AvailableIPs > 0 && vpUsage.AcquiredIPs+uint64(incomingInterfaceIPs)*2 > vpUsage.AvailableIPs {
+			if incomingInterfaceIPs > 0 && vpUsage != nil && vpUsage.AvailableIPs > 0 && vpUsage.AcquiredIPs+incomingInterfaceIPs*2 > vpUsage.AvailableIPs {
 				msg := fmt.Sprintf(
 					"VPC Prefix %v does not have enough IP addresses: %d of %d IP addresses remain available, but the %d additional interface(s) in this request require %d IP addresses",
 					vpcPrefixID, vpUsage.AvailableIPs-vpUsage.AcquiredIPs, vpUsage.AvailableIPs, incomingInterfaceIPs, incomingInterfaceIPs*2,
@@ -3460,8 +3472,8 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 		//     return an empty list. Reads after this should reflect the
 		//     auto contract (no explicit interfaces) rather than the
 		//     stale rows that pre-dated the mode switch.
-		//   - Explicit interfaces in the request: create the new rows
-		//     and mark the previous rows as Deleting (existing behavior).
+		//   - Explicit interfaces in the request: reuse matching rows,
+		//     create new rows, and mark only removed rows as Deleting.
 		//   - Neither (no interface change, not switching to auto):
 		//     carry the existing rows forward.
 		switch {
@@ -3476,7 +3488,106 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 			}
 			newdbIfcs = []cdbm.Interface{}
 		case len(apiRequest.Interfaces) > 0:
+			keyForInterface := func(ifc cdbm.Interface) cdbm.EthernetInterfaceKey {
+				vpcID := uuid.Nil
+				if ifc.VpcID != nil {
+					vpcID = *ifc.VpcID
+				} else if ifc.VpcPrefix != nil {
+					vpcID = ifc.VpcPrefix.VpcID
+				} else if ifc.Subnet != nil {
+					vpcID = ifc.Subnet.VpcID
+				}
+
+				key := cdbm.EthernetInterfaceKey{
+					SubnetID:                uuid.Nil,
+					VpcPrefixID:             uuid.Nil,
+					VpcID:                   vpcID,
+					VpcIPFamilyMode:         "",
+					HasVpcIPFamilyMode:      false,
+					VirtualFunctionID:       0,
+					HasVirtualFunctionID:    false,
+					Device:                  "",
+					HasDevice:               false,
+					DeviceInstance:          0,
+					HasDeviceInstance:       false,
+					IsPhysical:              ifc.IsPhysical,
+					RequestedIPAddress:      "",
+					HasRequestedIPAddress:   false,
+					InlineRoutingProfile:    "",
+					HasInlineRoutingProfile: false,
+				}
+
+				if ifc.SubnetID != nil {
+					key.SubnetID = *ifc.SubnetID
+				}
+
+				if ifc.VpcPrefixID != nil {
+					key.VpcPrefixID = *ifc.VpcPrefixID
+				}
+
+				if ifc.VpcIPFamilyMode != nil {
+					key.VpcIPFamilyMode = *ifc.VpcIPFamilyMode
+					key.HasVpcIPFamilyMode = true
+				}
+
+				if ifc.VirtualFunctionID != nil {
+					key.VirtualFunctionID = *ifc.VirtualFunctionID
+					key.HasVirtualFunctionID = true
+				}
+
+				if ifc.Device != nil {
+					key.Device = *ifc.Device
+					key.HasDevice = true
+				}
+
+				if ifc.DeviceInstance != nil {
+					key.DeviceInstance = *ifc.DeviceInstance
+					key.HasDeviceInstance = true
+				}
+
+				if ifc.RequestedIpAddress != nil {
+					key.RequestedIPAddress = *ifc.RequestedIpAddress
+					key.HasRequestedIPAddress = true
+				}
+
+				if ifc.InlineRoutingProfile != nil {
+					key.InlineRoutingProfile = strings.Join(ifc.InlineRoutingProfile.AllowedAnycastPrefixes, "\x00")
+					key.HasInlineRoutingProfile = true
+				}
+
+				return key
+			}
+
+			existingIfcMap := make(map[cdbm.EthernetInterfaceKey][]cdbm.Interface)
+
+			for existingIfcIndex := range existingIfcs {
+				if existingIfcs[existingIfcIndex].Status == cdbm.InterfaceStatusDeleting {
+					continue
+				}
+
+				key := keyForInterface(existingIfcs[existingIfcIndex])
+				existingIfcMap[key] = append(existingIfcMap[key], existingIfcs[existingIfcIndex])
+			}
+
+			reusedIfcIDs := make(map[uuid.UUID]struct{})
 			for _, dbifc := range dbInterfaces {
+				key := keyForInterface(dbifc)
+
+				existingIfcsForKey := existingIfcMap[key]
+				if len(existingIfcsForKey) > 0 {
+					reusedIfc := existingIfcsForKey[0]
+					if len(existingIfcsForKey) == 1 {
+						delete(existingIfcMap, key)
+					} else {
+						existingIfcMap[key] = existingIfcsForKey[1:]
+					}
+
+					reusedIfcIDs[reusedIfc.ID] = struct{}{}
+					newdbIfcs = append(newdbIfcs, reusedIfc)
+
+					continue
+				}
+
 				input := cdbm.InterfaceCreateInput{
 					InstanceID:           instance.ID,
 					SubnetID:             dbifc.SubnetID,
@@ -3502,19 +3613,45 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 				ifc := *newDbifc
 				ifc.Vpc = dbifc.Vpc
 				ifc.VpcPrefix = dbifc.VpcPrefix // We created the interface in the DB based on the values in dbifc, so we can populate this as well.
+				ifc.Subnet = dbifc.Subnet
 				// Add the new Interface to the list of new Interfaces
 				newdbIfcs = append(newdbIfcs, ifc)
 			}
 
-			// Update status of existing Interfaces to Deleting
-			for i := range existingIfcs {
-				existingIfcs[i].Status = cdbm.InterfaceStatusDeleting
-				_, err := ifcDAO.Update(ctx, tx, cdbm.InterfaceUpdateInput{InterfaceID: existingIfcs[i].ID, Status: cutil.GetPtr(cdbm.InterfaceStatusDeleting)})
-				if err != nil {
-					logger.Error().Err(err).Msg("failed to update Interface record in DB")
-					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Interface for Instance, DB error", nil)
+			unmatchedIfcs := make([]cdbm.Interface, 0, len(existingIfcs)-len(reusedIfcIDs))
+			for existingIfcIndex := range existingIfcs {
+				if _, reused := reusedIfcIDs[existingIfcs[existingIfcIndex].ID]; reused {
+					continue
 				}
+
+				if existingIfcs[existingIfcIndex].Status != cdbm.InterfaceStatusDeleting {
+					existingIfcs[existingIfcIndex].Status = cdbm.InterfaceStatusDeleting
+
+					_, err := ifcDAO.Update(ctx, tx, cdbm.InterfaceUpdateInput{
+						InterfaceID:          existingIfcs[existingIfcIndex].ID,
+						InstanceID:           nil,
+						SubnetID:             nil,
+						VpcPrefixID:          nil,
+						Device:               nil,
+						DeviceInstance:       nil,
+						VirtualFunctionID:    nil,
+						RequestedIpAddress:   nil,
+						InlineRoutingProfile: nil,
+						MacAddress:           nil,
+						IpAddresses:          nil,
+						Status:               cutil.GetPtr(cdbm.InterfaceStatusDeleting),
+					})
+					if err != nil {
+						logger.Error().Err(err).Msg("failed to update Interface record in DB")
+
+						return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Interface for Instance, DB error", nil)
+					}
+				}
+
+				unmatchedIfcs = append(unmatchedIfcs, existingIfcs[existingIfcIndex])
 			}
+
+			existingIfcs = unmatchedIfcs
 		default:
 			newdbIfcs = existingIfcs
 		}

--- a/rest-api/api/pkg/api/handler/instance.go
+++ b/rest-api/api/pkg/api/handler/instance.go
@@ -3490,19 +3490,19 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 			}
 			newdbIfcs = []cdbm.Interface{}
 		case len(apiRequest.Interfaces) > 0:
-			existingIfcMap := make(map[cdbm.EthernetInterfaceKey][]cdbm.Interface)
+			existingIfcMap := make(map[string][]cdbm.Interface, len(existingIfcs))
 			for existingIfcIndex := range existingIfcs {
 				if existingIfcs[existingIfcIndex].Status == cdbm.InterfaceStatusDeleting {
 					continue
 				}
 
-				key := existingIfcs[existingIfcIndex].EthernetKey()
+				key := existingIfcs[existingIfcIndex].EthernetInterfaceKey()
 				existingIfcMap[key] = append(existingIfcMap[key], existingIfcs[existingIfcIndex])
 			}
 
-			reusedIfcIDs := make(map[uuid.UUID]struct{})
+			reusedIfcIDs := make(map[uuid.UUID]bool)
 			for _, dbifc := range dbInterfaces {
-				key := dbifc.EthernetKey()
+				key := dbifc.EthernetInterfaceKey()
 				existingIfcsForKey := existingIfcMap[key]
 
 				if len(existingIfcsForKey) > 0 {
@@ -3513,7 +3513,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 						existingIfcMap[key] = existingIfcsForKey[1:]
 					}
 
-					reusedIfcIDs[reusedIfc.ID] = struct{}{}
+					reusedIfcIDs[reusedIfc.ID] = true
 					newdbIfcs = append(newdbIfcs, reusedIfc)
 					continue
 				}
@@ -3550,7 +3550,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 
 			unmatchedIfcs := make([]cdbm.Interface, 0, len(existingIfcs)-len(reusedIfcIDs))
 			for existingIfcIndex := range existingIfcs {
-				if _, reused := reusedIfcIDs[existingIfcs[existingIfcIndex].ID]; reused {
+				if reusedIfcIDs[existingIfcs[existingIfcIndex].ID] {
 					continue
 				}
 

--- a/rest-api/api/pkg/api/handler/instance.go
+++ b/rest-api/api/pkg/api/handler/instance.go
@@ -710,6 +710,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 
 			dbInterfaces = append(dbInterfaces, cdbm.Interface{
 				SubnetID:           &subnetID,
+				Subnet:             subnet,
 				IsPhysical:         ifc.IsPhysical,
 				RequestedIpAddress: nil, // RequestedIpAddress requires a VPC prefix, and model validation enforces this.
 				Status:             cdbm.InterfaceStatusPending,
@@ -2763,6 +2764,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 
 			dbInterfaces = append(dbInterfaces, cdbm.Interface{
 				SubnetID:           &subnetID,
+				Subnet:             subnet,
 				IsPhysical:         ifc.IsPhysical,
 				RequestedIpAddress: nil, // RequestedIpAddress requires a VPC prefix, and model validation enforces this.
 				Status:             cdbm.InterfaceStatusPending,

--- a/rest-api/api/pkg/api/handler/instance_test.go
+++ b/rest-api/api/pkg/api/handler/instance_test.go
@@ -560,6 +560,15 @@ func testUpdateInterfaceWithIPs(t *testing.T, dbSession *cdb.Session, ifc *cdbm.
 	return ifc
 }
 
+type ethernetReconciliationExpectation struct {
+	rowCount        int
+	readyIDs        []uuid.UUID
+	deletingIDs     []uuid.UUID
+	pendingCount    int
+	uniqueIPAddress *string
+	usagePrefix     *cdbm.VpcPrefix
+}
+
 func testUpdateMachineToUnhealthy(t *testing.T, dbSession *cdb.Session, m *cdbm.Machine) *cdbm.Machine {
 	m.Status = cdbm.MachineStatusError
 	_, err := dbSession.DB.NewUpdate().Where("id = ?", m.ID).Model(m).Exec(context.Background())
@@ -4402,6 +4411,24 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	// Add Network DPU capability to Instance Type
 	common.TestBuildMachineCapability(t, dbSession, nil, &ist4.ID, cdbm.MachineCapabilityTypeNetwork, "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller", nil, nil, cutil.GetPtr("Mellanox Technologies"), cutil.GetPtr(2), cutil.GetPtr(cdbm.MachineCapabilityDeviceTypeDPU), nil)
 
+	issue4908Device := cutil.GetPtr("MT42822 BlueField-2 integrated ConnectX-6 Dx network controller")
+	issue4908DeviceInstance := cutil.GetPtr(0)
+	issue4908VFID := cutil.GetPtr(1)
+
+	issue4908AddVFMachine := testInstanceBuildMachine(t, dbSession, ip.ID, st3.ID, cutil.GetPtr(false), nil)
+	assert.NotNil(t, testInstanceBuildMachineInstanceType(t, dbSession, issue4908AddVFMachine, ist4))
+	issue4908AddVFInstance := testInstanceBuildInstance(t, dbSession, "issue-4908-add-vf", tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cutil.GetPtr(issue4908AddVFMachine.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	issue4908AddVFPF := testInstanceBuildInterface(t, dbSession, issue4908AddVFInstance.ID, nil, &vpcPrefix1.ID, issue4908Device, issue4908DeviceInstance, nil, true, cdbm.InterfaceStatusReady, tnu1)
+	testUpdateInterfaceWithIPs(t, dbSession, issue4908AddVFPF, []string{"192.168.0.1"})
+
+	issue4908RemoveMachine := testInstanceBuildMachine(t, dbSession, ip.ID, st3.ID, cutil.GetPtr(false), nil)
+	assert.NotNil(t, testInstanceBuildMachineInstanceType(t, dbSession, issue4908RemoveMachine, ist4))
+	issue4908RemoveInstance := testInstanceBuildInstance(t, dbSession, "issue-4908-remove-vf", tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cutil.GetPtr(issue4908RemoveMachine.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	issue4908RemovePF := testInstanceBuildInterface(t, dbSession, issue4908RemoveInstance.ID, nil, &vpcPrefix1.ID, issue4908Device, issue4908DeviceInstance, nil, true, cdbm.InterfaceStatusReady, tnu1)
+	testUpdateInterfaceWithIPs(t, dbSession, issue4908RemovePF, []string{"192.168.0.3"})
+	issue4908RemoveVF := testInstanceBuildInterface(t, dbSession, issue4908RemoveInstance.ID, nil, &vpcPrefixSite3Secondary.ID, issue4908Device, issue4908DeviceInstance, issue4908VFID, false, cdbm.InterfaceStatusReady, tnu1)
+	testUpdateInterfaceWithIPs(t, dbSession, issue4908RemoveVF, []string{"192.174.0.1"})
+
 	inst13 := testInstanceBuildInstance(t, dbSession, "test-instance-nvlink-update", tn1.ID, ip.ID, st3.ID, &ist4.ID, vpc4.ID, cutil.GetPtr(mc5.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
 
 	// Add NVLink GPU capability to Machine
@@ -4761,7 +4788,8 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 		// When true with nvlinkInterfacesToDelete, still assert those rows are Deleting but skip Pending-row count/order checks.
 		nvLinkSkipPendingDBAssertions bool
 		// Optional hook after building the echo context and before Handle (e.g. adjust DB timestamps for time-sensitive branches).
-		beforeHandle func(t *testing.T)
+		beforeHandle           func(t *testing.T)
+		ethernetReconciliation *ethernetReconciliationExpectation
 	}
 
 	tests := []struct {
@@ -6159,6 +6187,105 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 			verifyChildSpanner:          true,
 		},
 		{
+			name: "test UpdateInstance adding VF reuses unchanged PF issue 4908",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{ //nolint:exhaustruct // This case leaves unrelated response assertions unset.
+				reqData: &model.APIInstanceUpdateRequest{ //nolint:exhaustruct // The request changes only Ethernet fields.
+					Name:       cutil.GetPtr("Issue 4908 Add VF"),
+					IpxeScript: os2.IpxeScript,
+					SecondaryVpcIDs: []string{
+						vpc4Site3Secondary.ID.String(),
+					},
+					Interfaces: []model.APIInterfaceCreateOrUpdateRequest{
+						{
+							SubnetID:             nil,
+							VpcPrefixID:          cutil.GetPtr(vpcPrefix1.ID.String()),
+							IPAddress:            nil,
+							InlineRoutingProfile: nil,
+							Device:               issue4908Device,
+							DeviceInstance:       issue4908DeviceInstance,
+							VirtualFunctionID:    nil,
+							IsPhysical:           true,
+						},
+						{
+							SubnetID:             nil,
+							VpcPrefixID:          cutil.GetPtr(vpcPrefixSite3Secondary.ID.String()),
+							IPAddress:            nil,
+							InlineRoutingProfile: nil,
+							Device:               issue4908Device,
+							DeviceInstance:       issue4908DeviceInstance,
+							VirtualFunctionID:    issue4908VFID,
+							IsPhysical:           false,
+						},
+					},
+				},
+				reqOrg:                tnOrg1,
+				reqUser:               tnu1,
+				reqInstance:           issue4908AddVFInstance.ID.String(),
+				cleanInstanceToStatus: issue4908AddVFInstance.Status,
+				respCode:              http.StatusOK,
+				ethernetReconciliation: &ethernetReconciliationExpectation{
+					rowCount:        2,
+					readyIDs:        []uuid.UUID{issue4908AddVFPF.ID},
+					deletingIDs:     []uuid.UUID{},
+					pendingCount:    1,
+					uniqueIPAddress: cutil.GetPtr("192.168.0.1"),
+					usagePrefix:     vpcPrefix1,
+				},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
+		{
+			name: "test UpdateInstance marks only omitted Ethernet interface deleting issue 4908",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{ //nolint:exhaustruct // This case leaves unrelated response assertions unset.
+				reqData: &model.APIInstanceUpdateRequest{ //nolint:exhaustruct // The request changes only Ethernet fields.
+					Name:       cutil.GetPtr("Issue 4908 Remove VF"),
+					IpxeScript: os2.IpxeScript,
+					Interfaces: []model.APIInterfaceCreateOrUpdateRequest{
+						{
+							SubnetID:             nil,
+							VpcPrefixID:          cutil.GetPtr(vpcPrefix1.ID.String()),
+							IPAddress:            nil,
+							InlineRoutingProfile: nil,
+							Device:               issue4908Device,
+							DeviceInstance:       issue4908DeviceInstance,
+							VirtualFunctionID:    nil,
+							IsPhysical:           true,
+						},
+					},
+				},
+				reqOrg:                tnOrg1,
+				reqUser:               tnu1,
+				reqInstance:           issue4908RemoveInstance.ID.String(),
+				cleanInstanceToStatus: issue4908RemoveInstance.Status,
+				respCode:              http.StatusOK,
+				ethernetReconciliation: &ethernetReconciliationExpectation{
+					rowCount:        2,
+					readyIDs:        []uuid.UUID{issue4908RemovePF.ID},
+					deletingIDs:     []uuid.UUID{issue4908RemoveVF.ID},
+					pendingCount:    0,
+					uniqueIPAddress: nil,
+					usagePrefix:     nil,
+				},
+			},
+			wantErr:                     false,
+			verifySiteControllerRequest: true,
+			verifyChildSpanner:          true,
+		},
+		{
 			name: "test Instance update API endpoint success with interface update",
 			fields: fields{
 				dbSession: dbSession,
@@ -7251,6 +7378,75 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				assert.ElementsMatch(t, tt.args.reqData.SecondaryVpcIDs, rst.SecondaryVpcIDs)
 			}
 
+			if expected := tt.args.ethernetReconciliation; expected != nil {
+				reconciledIfcs, _, reconciliationErr := ifcDAO.GetAll(
+					ctx,
+					nil,
+					cdbm.InterfaceFilterInput{
+						InstanceIDs:    []uuid.UUID{reqIns.ID},
+						SubnetID:       nil,
+						VpcPrefixID:    nil,
+						Device:         nil,
+						DeviceInstance: nil,
+						IsPhysical:     nil,
+						Statuses:       nil,
+						IPAddresses:    nil,
+					},
+					cdbp.PageInput{Offset: nil, Limit: cutil.GetPtr(cdbp.TotalLimit), OrderBy: nil},
+					nil,
+				)
+				require.NoError(t, reconciliationErr)
+				assert.Len(t, reconciledIfcs, expected.rowCount)
+				assert.Len(t, rst.Interfaces, expected.rowCount)
+
+				pendingCount := 0
+				deletingCount := 0
+				rowsWithExpectedIP := 0
+
+				for _, ifc := range reconciledIfcs {
+					switch ifc.Status {
+					case cdbm.InterfaceStatusPending:
+						pendingCount++
+					case cdbm.InterfaceStatusDeleting:
+						deletingCount++
+					}
+
+					for _, ipAddress := range ifc.IPAddresses {
+						if expected.uniqueIPAddress != nil && ipAddress == *expected.uniqueIPAddress {
+							rowsWithExpectedIP++
+						}
+					}
+				}
+
+				assert.Equal(t, expected.pendingCount, pendingCount)
+				assert.Equal(t, len(expected.deletingIDs), deletingCount)
+
+				if expected.uniqueIPAddress != nil {
+					assert.Equal(t, 1, rowsWithExpectedIP)
+				}
+
+				for _, interfaceID := range expected.readyIDs {
+					ifc, getErr := ifcDAO.GetByID(ctx, nil, interfaceID, nil)
+					require.NoError(t, getErr)
+					assert.Equal(t, cdbm.InterfaceStatusReady, ifc.Status)
+				}
+
+				for _, interfaceID := range expected.deletingIDs {
+					ifc, getErr := ifcDAO.GetByID(ctx, nil, interfaceID, nil)
+					require.NoError(t, getErr)
+					assert.Equal(t, cdbm.InterfaceStatusDeleting, ifc.Status)
+				}
+
+				if expected.usagePrefix != nil {
+					usageByID, usageErr := cdbm.NewVpcPrefixDAO(tt.fields.dbSession).GetPrefixUsage(ctx, nil, expected.usagePrefix)
+					require.NoError(t, usageErr)
+
+					usage := usageByID[expected.usagePrefix.ID]
+					require.NotNil(t, usage)
+					assert.LessOrEqual(t, usage.AcquiredIPs+uint64(2), usage.AvailableIPs)
+				}
+			}
+
 			if tt.args.expectedNetworkSecurityGroupInherited != nil {
 				assert.Equal(t, *tt.args.expectedNetworkSecurityGroupInherited, rst.NetworkSecurityGroupInherited)
 			}
@@ -7370,7 +7566,21 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 					if tt.args.respNoOfInterfaces != nil {
 						reqInsIfcs, _, _ = ifcDAO.GetAll(ec.Request().Context(), nil, cdbm.InterfaceFilterInput{InstanceIDs: []uuid.UUID{reqIns.ID}, Statuses: []string{cdbm.InterfaceStatusPending}}, cdbp.PageInput{OrderBy: &cdbp.OrderBy{Field: cdbm.InterfaceOrderByCreated, Order: cdbp.OrderAscending}}, nil)
 					} else {
-						reqInsIfcs, _, _ = ifcDAO.GetAll(ec.Request().Context(), nil, cdbm.InterfaceFilterInput{InstanceIDs: []uuid.UUID{reqIns.ID}}, cdbp.PageInput{OrderBy: &cdbp.OrderBy{Field: cdbm.InterfaceOrderByCreated, Order: cdbp.OrderAscending}}, nil)
+						reqInsIfcs, _, _ = ifcDAO.GetAll(ec.Request().Context(), nil, cdbm.InterfaceFilterInput{
+							InstanceIDs:    []uuid.UUID{reqIns.ID},
+							SubnetID:       nil,
+							VpcPrefixID:    nil,
+							Device:         nil,
+							DeviceInstance: nil,
+							IsPhysical:     nil,
+							Statuses: []string{
+								cdbm.InterfaceStatusPending,
+								cdbm.InterfaceStatusProvisioning,
+								cdbm.InterfaceStatusReady,
+								cdbm.InterfaceStatusError,
+							},
+							IPAddresses: nil,
+						}, cdbp.PageInput{Offset: nil, Limit: nil, OrderBy: &cdbp.OrderBy{Field: cdbm.InterfaceOrderByCreated, Order: cdbp.OrderAscending}}, nil)
 					}
 
 					assert.Equal(t, len(reqInsIfcs), len(siteReq.Config.Network.Interfaces))
@@ -7421,7 +7631,7 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 
 						// Check if VirtualFunctionId is present
 						if reqInsIfcs[i].VirtualFunctionID != nil {
-							assert.Equal(t, siteIfc.VirtualFunctionId, reqInsIfcs[i].VirtualFunctionID)
+							assert.Equal(t, uint32(*reqInsIfcs[i].VirtualFunctionID), siteIfc.GetVirtualFunctionId())
 						}
 
 						if reqInsIfcs[i].RequestedIpAddress != nil {

--- a/rest-api/db/pkg/db/model/interface.go
+++ b/rest-api/db/pkg/db/model/interface.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net/netip"
-	"strings"
 	"time"
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
@@ -132,97 +131,6 @@ type Interface struct {
 	Updated              time.Time                      `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted              *time.Time                     `bun:"deleted,soft_delete"`
 	CreatedBy            uuid.UUID                      `bun:"type:uuid,notnull"`
-}
-
-// EthernetInterfaceKey identifies an Ethernet interface configuration for update reconciliation.
-type EthernetInterfaceKey struct {
-	SubnetID                uuid.UUID
-	VpcPrefixID             uuid.UUID
-	VpcID                   uuid.UUID
-	VpcIPFamilyMode         InterfaceVpcIPFamilyMode
-	HasVpcIPFamilyMode      bool
-	VirtualFunctionID       int
-	HasVirtualFunctionID    bool
-	Device                  string
-	HasDevice               bool
-	DeviceInstance          int
-	HasDeviceInstance       bool
-	IsPhysical              bool
-	RequestedIPAddress      string
-	HasRequestedIPAddress   bool
-	InlineRoutingProfile    string
-	HasInlineRoutingProfile bool
-}
-
-// EthernetKey returns the comparable fields that identify an Interface during update reconciliation.
-func (ifc Interface) EthernetKey() EthernetInterfaceKey {
-	vpcID := uuid.Nil
-	if ifc.VpcID != nil {
-		vpcID = *ifc.VpcID
-	} else if ifc.VpcPrefix != nil {
-		vpcID = ifc.VpcPrefix.VpcID
-	} else if ifc.Subnet != nil {
-		vpcID = ifc.Subnet.VpcID
-	}
-
-	key := EthernetInterfaceKey{
-		SubnetID:                uuid.Nil,
-		VpcPrefixID:             uuid.Nil,
-		VpcID:                   vpcID,
-		VpcIPFamilyMode:         "",
-		HasVpcIPFamilyMode:      false,
-		VirtualFunctionID:       0,
-		HasVirtualFunctionID:    false,
-		Device:                  "",
-		HasDevice:               false,
-		DeviceInstance:          0,
-		HasDeviceInstance:       false,
-		IsPhysical:              ifc.IsPhysical,
-		RequestedIPAddress:      "",
-		HasRequestedIPAddress:   false,
-		InlineRoutingProfile:    "",
-		HasInlineRoutingProfile: false,
-	}
-
-	if ifc.SubnetID != nil {
-		key.SubnetID = *ifc.SubnetID
-	}
-
-	if ifc.VpcPrefixID != nil {
-		key.VpcPrefixID = *ifc.VpcPrefixID
-	}
-
-	if ifc.VpcIPFamilyMode != nil {
-		key.VpcIPFamilyMode = *ifc.VpcIPFamilyMode
-		key.HasVpcIPFamilyMode = true
-	}
-
-	if ifc.VirtualFunctionID != nil {
-		key.VirtualFunctionID = *ifc.VirtualFunctionID
-		key.HasVirtualFunctionID = true
-	}
-
-	if ifc.Device != nil {
-		key.Device = *ifc.Device
-		key.HasDevice = true
-	}
-
-	if ifc.DeviceInstance != nil {
-		key.DeviceInstance = *ifc.DeviceInstance
-		key.HasDeviceInstance = true
-	}
-
-	if ifc.RequestedIpAddress != nil {
-		key.RequestedIPAddress = *ifc.RequestedIpAddress
-		key.HasRequestedIPAddress = true
-	}
-
-	if ifc.InlineRoutingProfile != nil {
-		key.InlineRoutingProfile = strings.Join(ifc.InlineRoutingProfile.AllowedAnycastPrefixes, "\x00")
-		key.HasInlineRoutingProfile = true
-	}
-
-	return key
 }
 
 // InterfaceCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/interface.go
+++ b/rest-api/db/pkg/db/model/interface.go
@@ -135,11 +135,8 @@ type Interface struct {
 	CreatedBy            uuid.UUID                      `bun:"type:uuid,notnull"`
 }
 
-// EthernetInterfaceKey identifies an Ethernet interface configuration for update reconciliation.
-type EthernetInterfaceKey string
-
-// EthernetKey returns a stable string key for the Interface fields controlled by an update request.
-func (ifc Interface) EthernetKey() EthernetInterfaceKey {
+// EthernetInterfaceKey returns a stable string key for the Interface fields controlled by an update request.
+func (ifc Interface) EthernetInterfaceKey() string {
 	values := url.Values{}
 	if ifc.SubnetID != nil {
 		values.Set("subnet_id", ifc.SubnetID.String())
@@ -174,7 +171,7 @@ func (ifc Interface) EthernetKey() EthernetInterfaceKey {
 		values["inline_routing_prefix"] = append([]string(nil), ifc.InlineRoutingProfile.AllowedAnycastPrefixes...)
 	}
 
-	return EthernetInterfaceKey(values.Encode())
+	return values.Encode()
 }
 
 // InterfaceCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/interface.go
+++ b/rest-api/db/pkg/db/model/interface.go
@@ -132,6 +132,26 @@ type Interface struct {
 	CreatedBy            uuid.UUID                      `bun:"type:uuid,notnull"`
 }
 
+// EthernetInterfaceKey identifies an Ethernet interface configuration for update reconciliation.
+type EthernetInterfaceKey struct {
+	SubnetID                uuid.UUID
+	VpcPrefixID             uuid.UUID
+	VpcID                   uuid.UUID
+	VpcIPFamilyMode         InterfaceVpcIPFamilyMode
+	HasVpcIPFamilyMode      bool
+	VirtualFunctionID       int
+	HasVirtualFunctionID    bool
+	Device                  string
+	HasDevice               bool
+	DeviceInstance          int
+	HasDeviceInstance       bool
+	IsPhysical              bool
+	RequestedIPAddress      string
+	HasRequestedIPAddress   bool
+	InlineRoutingProfile    string
+	HasInlineRoutingProfile bool
+}
+
 // InterfaceCreateInput input parameters for Create method
 type InterfaceCreateInput struct {
 	InstanceID           uuid.UUID

--- a/rest-api/db/pkg/db/model/interface.go
+++ b/rest-api/db/pkg/db/model/interface.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/netip"
+	"strings"
 	"time"
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
@@ -150,6 +152,77 @@ type EthernetInterfaceKey struct {
 	HasRequestedIPAddress   bool
 	InlineRoutingProfile    string
 	HasInlineRoutingProfile bool
+}
+
+// EthernetKey returns the comparable fields that identify an Interface during update reconciliation.
+func (ifc Interface) EthernetKey() EthernetInterfaceKey {
+	vpcID := uuid.Nil
+	if ifc.VpcID != nil {
+		vpcID = *ifc.VpcID
+	} else if ifc.VpcPrefix != nil {
+		vpcID = ifc.VpcPrefix.VpcID
+	} else if ifc.Subnet != nil {
+		vpcID = ifc.Subnet.VpcID
+	}
+
+	key := EthernetInterfaceKey{
+		SubnetID:                uuid.Nil,
+		VpcPrefixID:             uuid.Nil,
+		VpcID:                   vpcID,
+		VpcIPFamilyMode:         "",
+		HasVpcIPFamilyMode:      false,
+		VirtualFunctionID:       0,
+		HasVirtualFunctionID:    false,
+		Device:                  "",
+		HasDevice:               false,
+		DeviceInstance:          0,
+		HasDeviceInstance:       false,
+		IsPhysical:              ifc.IsPhysical,
+		RequestedIPAddress:      "",
+		HasRequestedIPAddress:   false,
+		InlineRoutingProfile:    "",
+		HasInlineRoutingProfile: false,
+	}
+
+	if ifc.SubnetID != nil {
+		key.SubnetID = *ifc.SubnetID
+	}
+
+	if ifc.VpcPrefixID != nil {
+		key.VpcPrefixID = *ifc.VpcPrefixID
+	}
+
+	if ifc.VpcIPFamilyMode != nil {
+		key.VpcIPFamilyMode = *ifc.VpcIPFamilyMode
+		key.HasVpcIPFamilyMode = true
+	}
+
+	if ifc.VirtualFunctionID != nil {
+		key.VirtualFunctionID = *ifc.VirtualFunctionID
+		key.HasVirtualFunctionID = true
+	}
+
+	if ifc.Device != nil {
+		key.Device = *ifc.Device
+		key.HasDevice = true
+	}
+
+	if ifc.DeviceInstance != nil {
+		key.DeviceInstance = *ifc.DeviceInstance
+		key.HasDeviceInstance = true
+	}
+
+	if ifc.RequestedIpAddress != nil {
+		key.RequestedIPAddress = *ifc.RequestedIpAddress
+		key.HasRequestedIPAddress = true
+	}
+
+	if ifc.InlineRoutingProfile != nil {
+		key.InlineRoutingProfile = strings.Join(ifc.InlineRoutingProfile.AllowedAnycastPrefixes, "\x00")
+		key.HasInlineRoutingProfile = true
+	}
+
+	return key
 }
 
 // InterfaceCreateInput input parameters for Create method
@@ -538,6 +611,13 @@ func (ifcd InterfaceSQLDAO) Update(ctx context.Context, tx *db.Tx, input Interfa
 		}
 	}
 	if input.IpAddresses != nil {
+		for _, ipAddress := range input.IpAddresses {
+			_, parseErr := netip.ParseAddr(ipAddress)
+			if parseErr != nil {
+				return nil, fmt.Errorf("invalid Interface IP address %q: %w", ipAddress, parseErr)
+			}
+		}
+
 		is.IPAddresses = input.IpAddresses
 		updatedFields = append(updatedFields, "ip_addresses")
 

--- a/rest-api/db/pkg/db/model/interface.go
+++ b/rest-api/db/pkg/db/model/interface.go
@@ -8,6 +8,8 @@ import (
 	"database/sql"
 	"fmt"
 	"net/netip"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
@@ -131,6 +133,48 @@ type Interface struct {
 	Updated              time.Time                      `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted              *time.Time                     `bun:"deleted,soft_delete"`
 	CreatedBy            uuid.UUID                      `bun:"type:uuid,notnull"`
+}
+
+// EthernetInterfaceKey identifies an Ethernet interface configuration for update reconciliation.
+type EthernetInterfaceKey string
+
+// EthernetKey returns a stable string key for the Interface fields controlled by an update request.
+func (ifc Interface) EthernetKey() EthernetInterfaceKey {
+	values := url.Values{}
+	if ifc.SubnetID != nil {
+		values.Set("subnet_id", ifc.SubnetID.String())
+	}
+
+	if ifc.VpcID != nil {
+		values.Set("vpc_id", ifc.VpcID.String())
+		if ifc.VpcIPFamilyMode != nil {
+			values.Set("vpc_ip_family_mode", string(*ifc.VpcIPFamilyMode))
+		}
+	} else if ifc.VpcPrefixID != nil {
+		// A Core-selected VPC interface may also have a resolved prefix. Its
+		// desired identity remains the VPC selector, not that resolved result.
+		values.Set("vpc_prefix_id", ifc.VpcPrefixID.String())
+	}
+
+	values.Set("is_physical", strconv.FormatBool(ifc.IsPhysical))
+	if ifc.VirtualFunctionID != nil {
+		values.Set("virtual_function_id", strconv.Itoa(*ifc.VirtualFunctionID))
+	}
+	if ifc.Device != nil {
+		values.Set("device", *ifc.Device)
+	}
+	if ifc.DeviceInstance != nil {
+		values.Set("device_instance", strconv.Itoa(*ifc.DeviceInstance))
+	}
+	if ifc.RequestedIpAddress != nil {
+		values.Set("requested_ip_address", *ifc.RequestedIpAddress)
+	}
+	if ifc.InlineRoutingProfile != nil {
+		values.Set("has_inline_routing_profile", "true")
+		values["inline_routing_prefix"] = append([]string(nil), ifc.InlineRoutingProfile.AllowedAnycastPrefixes...)
+	}
+
+	return EthernetInterfaceKey(values.Encode())
 }
 
 // InterfaceCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/interface_test.go
+++ b/rest-api/db/pkg/db/model/interface_test.go
@@ -1344,7 +1344,7 @@ func TestInterfaceSQLDAO_Update(t *testing.T) {
 
 	vfID := 10
 	macAddress := "21-41-A7-A6-40-76"
-	ipAddresses := []string{"192.0.2.3", "2001:db8:abcd:0018"}
+	ipAddresses := []string{"192.0.2.3", "2001:db8:abcd::18"}
 	routingProfile := &InterfaceInlineRoutingProfile{
 		AllowedAnycastPrefixes: []string{"192.0.2.0/24", "2001:db8::/64"},
 	}
@@ -1485,6 +1485,18 @@ func TestInterfaceSQLDAO_Update(t *testing.T) {
 			id:          uuid.New(),
 			paramStatus: cutil.GetPtr(InterfaceStatusProvisioning),
 			expectError: true,
+		},
+		{
+			desc:             "failed with malformed IP address",
+			id:               ifc1.ID,
+			paramIPAddresses: []string{"not-an-ip"},
+			expectError:      true,
+		},
+		{
+			desc:             "failed with CIDR-form IP address",
+			id:               ifc1.ID,
+			paramIPAddresses: []string{"192.0.2.1/31"},
+			expectError:      true,
 		},
 	}
 	for _, tc := range tests {

--- a/rest-api/db/pkg/db/model/interface_test.go
+++ b/rest-api/db/pkg/db/model/interface_test.go
@@ -112,6 +112,42 @@ func TestInterfaceInlineRoutingProfile_ToProtoFromProto(t *testing.T) {
 	assert.Equal(t, []string{"198.51.100.0/24", "2001:db8:1::/64"}, fromProto.AllowedAnycastPrefixes)
 }
 
+func TestInterface_EthernetKey(t *testing.T) {
+	vpcID := uuid.New()
+	familyMode := InterfaceVpcIPFamilyModeIPv4Only
+	deviceInstance := 0
+
+	var base Interface
+	base.VpcID = &vpcID
+	base.VpcIPFamilyMode = &familyMode
+	base.Device = cutil.GetPtr("device")
+	base.DeviceInstance = &deviceInstance
+	base.IsPhysical = true
+
+	sameVpcID := vpcID
+	sameFamilyMode := familyMode
+	sameDeviceInstance := deviceInstance
+	same := base
+	same.VpcID = &sameVpcID
+	same.VpcIPFamilyMode = &sameFamilyMode
+	same.Device = cutil.GetPtr("device")
+	same.DeviceInstance = &sameDeviceInstance
+	same.VpcPrefixID = cutil.GetPtr(uuid.New())
+	assert.Equal(t, base.EthernetKey(), same.EthernetKey(), "resolved prefixes must not change VPC-selector identity")
+
+	missingDeviceInstance := base
+	missingDeviceInstance.DeviceInstance = nil
+	assert.NotEqual(t, base.EthernetKey(), missingDeviceInstance.EthernetKey())
+
+	emptyProfile := base
+	emptyProfile.InlineRoutingProfile = &InterfaceInlineRoutingProfile{}
+	assert.NotEqual(t, base.EthernetKey(), emptyProfile.EthernetKey())
+
+	differentVpc := base
+	differentVpc.VpcID = cutil.GetPtr(uuid.New())
+	assert.NotEqual(t, base.EthernetKey(), differentVpc.EthernetKey())
+}
+
 func TestInterfaceSQLDAO_Create(t *testing.T) {
 	ctx := context.Background()
 	dbSession := testInstanceInitDB(t)

--- a/rest-api/db/pkg/db/model/interface_test.go
+++ b/rest-api/db/pkg/db/model/interface_test.go
@@ -146,6 +146,15 @@ func TestInterface_EthernetKey(t *testing.T) {
 	differentVpc := base
 	differentVpc.VpcID = cutil.GetPtr(uuid.New())
 	assert.NotEqual(t, base.EthernetKey(), differentVpc.EthernetKey())
+
+	virtualFunction := base
+	virtualFunction.IsPhysical = false
+	virtualFunction.VirtualFunctionID = cutil.GetPtr(1)
+	assert.NotEqual(t, base.EthernetKey(), virtualFunction.EthernetKey(), "a virtual function must not match a physical function")
+
+	otherVirtualFunction := virtualFunction
+	otherVirtualFunction.VirtualFunctionID = cutil.GetPtr(2)
+	assert.NotEqual(t, virtualFunction.EthernetKey(), otherVirtualFunction.EthernetKey())
 }
 
 func TestInterfaceSQLDAO_Create(t *testing.T) {

--- a/rest-api/db/pkg/db/model/interface_test.go
+++ b/rest-api/db/pkg/db/model/interface_test.go
@@ -133,28 +133,28 @@ func TestInterface_EthernetKey(t *testing.T) {
 	same.Device = cutil.GetPtr("device")
 	same.DeviceInstance = &sameDeviceInstance
 	same.VpcPrefixID = cutil.GetPtr(uuid.New())
-	assert.Equal(t, base.EthernetKey(), same.EthernetKey(), "resolved prefixes must not change VPC-selector identity")
+	assert.Equal(t, base.EthernetInterfaceKey(), same.EthernetInterfaceKey(), "resolved prefixes must not change VPC-selector identity")
 
 	missingDeviceInstance := base
 	missingDeviceInstance.DeviceInstance = nil
-	assert.NotEqual(t, base.EthernetKey(), missingDeviceInstance.EthernetKey())
+	assert.NotEqual(t, base.EthernetInterfaceKey(), missingDeviceInstance.EthernetInterfaceKey())
 
 	emptyProfile := base
 	emptyProfile.InlineRoutingProfile = &InterfaceInlineRoutingProfile{}
-	assert.NotEqual(t, base.EthernetKey(), emptyProfile.EthernetKey())
+	assert.NotEqual(t, base.EthernetInterfaceKey(), emptyProfile.EthernetInterfaceKey())
 
 	differentVpc := base
 	differentVpc.VpcID = cutil.GetPtr(uuid.New())
-	assert.NotEqual(t, base.EthernetKey(), differentVpc.EthernetKey())
+	assert.NotEqual(t, base.EthernetInterfaceKey(), differentVpc.EthernetInterfaceKey())
 
 	virtualFunction := base
 	virtualFunction.IsPhysical = false
 	virtualFunction.VirtualFunctionID = cutil.GetPtr(1)
-	assert.NotEqual(t, base.EthernetKey(), virtualFunction.EthernetKey(), "a virtual function must not match a physical function")
+	assert.NotEqual(t, base.EthernetInterfaceKey(), virtualFunction.EthernetInterfaceKey(), "a virtual function must not match a physical function")
 
 	otherVirtualFunction := virtualFunction
 	otherVirtualFunction.VirtualFunctionID = cutil.GetPtr(2)
-	assert.NotEqual(t, virtualFunction.EthernetKey(), otherVirtualFunction.EthernetKey())
+	assert.NotEqual(t, virtualFunction.EthernetInterfaceKey(), otherVirtualFunction.EthernetInterfaceKey())
 }
 
 func TestInterfaceSQLDAO_Create(t *testing.T) {

--- a/rest-api/db/pkg/db/model/vpcprefix.go
+++ b/rest-api/db/pkg/db/model/vpcprefix.go
@@ -580,7 +580,7 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 
 		_, acquireErr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, prefix)
 		if acquireErr != nil {
-			continue
+			return nil, fmt.Errorf("failed to acquire Interface prefix %q from %q: %w", prefix, validatedCidr, acquireErr)
 		}
 
 		acquiredPrefixes[prefix] = struct{}{}

--- a/rest-api/db/pkg/db/model/vpcprefix.go
+++ b/rest-api/db/pkg/db/model/vpcprefix.go
@@ -41,6 +41,9 @@ const (
 
 	// VpcPrefixOrderByDefault default field to be used for ordering when none specified
 	VpcPrefixOrderByDefault = "created"
+
+	vpcPrefixInterfaceBits          = 31
+	vpcPrefixIPsPerInterface uint64 = 2
 )
 
 var (
@@ -540,7 +543,8 @@ func (vpsd VpcPrefixSQLDAO) Delete(ctx context.Context, tx *db.Tx, id uuid.UUID)
 	return nil
 }
 
-func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCount int64, ips []string) (*cipam.Usage, error) {
+//nolint:cyclop,funlen // Sequential guards intentionally keep address handling inline.
+func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWithoutIPs uint64, ips []string) (*cipam.Usage, error) {
 	ipamer := cipam.New(ctx)
 	ipamPrefix, err := ipamer.NewPrefix(ctx, cidr)
 	if err != nil {
@@ -555,25 +559,31 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCount int
 
 	acquiredPrefixes := make(map[string]struct{})
 	for _, ipStr := range ips {
-		netIpAddr, ierr := netip.ParseAddr(strings.TrimSpace(ipStr))
-		if ierr != nil || !netIpAddr.Is4() {
+		ipAddress, parseErr := netip.ParseAddr(strings.TrimSpace(ipStr))
+		if parseErr != nil || !ipAddress.Is4() {
 			continue
 		}
-		if !netIpPrefix.Contains(netIpAddr) {
+
+		if !netIpPrefix.Contains(ipAddress) {
 			continue
 		}
-		contained31Prefix, perr := netIpAddr.Prefix(31)
-		if perr != nil {
+
+		containedPrefix, prefixErr := ipAddress.Prefix(vpcPrefixInterfaceBits)
+		if prefixErr != nil {
 			continue
 		}
-		k := contained31Prefix.Masked().String()
-		if _, dup := acquiredPrefixes[k]; dup {
+
+		prefix := containedPrefix.Masked().String()
+		if _, dup := acquiredPrefixes[prefix]; dup {
 			continue
 		}
-		if _, ierr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, k); ierr != nil {
+
+		_, acquireErr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, prefix)
+		if acquireErr != nil {
 			continue
 		}
-		acquiredPrefixes[k] = struct{}{}
+
+		acquiredPrefixes[prefix] = struct{}{}
 	}
 
 	ipamPrefix = ipamer.PrefixFrom(ctx, validatedCidr)
@@ -583,7 +593,8 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCount int
 
 	usage := ipamPrefix.Usage()
 
-	acquiredIPs := uint64(ifcCount) * 2
+	acquiredIPs := uint64(len(acquiredPrefixes))*vpcPrefixIPsPerInterface +
+		ifcCountWithoutIPs*vpcPrefixIPsPerInterface
 	if acquiredIPs > usage.AvailableIPs {
 		acquiredIPs = usage.AvailableIPs
 	}
@@ -622,10 +633,10 @@ func (vpsd VpcPrefixSQLDAO) GetPrefixUsage(ctx context.Context, tx *db.Tx, vpcPr
 
 	idb := db.GetIDB(tx, vpsd.dbSession)
 
-	ifcCounts := make(map[uuid.UUID]int64, len(vpcPrefixIDs))
+	ifcCountsWithoutIPs := make(map[uuid.UUID]uint64, len(vpcPrefixIDs))
 	ifcIPs := make(map[uuid.UUID][]string, len(vpcPrefixIDs))
 	for _, id := range vpcPrefixIDs {
-		ifcCounts[id] = 0
+		ifcCountsWithoutIPs[id] = 0
 		ifcIPs[id] = nil
 	}
 
@@ -644,15 +655,18 @@ func (vpsd VpcPrefixSQLDAO) GetPrefixUsage(ctx context.Context, tx *db.Tx, vpcPr
 		return nil, err
 	}
 	for _, r := range rows {
-		ifcCounts[r.VpcPrefixID]++
-		if len(r.IPAddresses) > 0 {
-			ifcIPs[r.VpcPrefixID] = append(ifcIPs[r.VpcPrefixID], r.IPAddresses...)
+		if len(r.IPAddresses) == 0 {
+			ifcCountsWithoutIPs[r.VpcPrefixID]++
+
+			continue
 		}
+
+		ifcIPs[r.VpcPrefixID] = append(ifcIPs[r.VpcPrefixID], r.IPAddresses...)
 	}
 
 	usageByID := make(map[uuid.UUID]*cipam.Usage, len(vpcPrefixIDs))
 	for _, vpcPrefixID := range vpcPrefixIDs {
-		usage, uerr := vpcPrefixUsageFromInterfaces(ctx, vpcPrefixCIDRs[vpcPrefixID], ifcCounts[vpcPrefixID], ifcIPs[vpcPrefixID])
+		usage, uerr := vpcPrefixUsageFromInterfaces(ctx, vpcPrefixCIDRs[vpcPrefixID], ifcCountsWithoutIPs[vpcPrefixID], ifcIPs[vpcPrefixID])
 		if uerr != nil {
 			return nil, uerr
 		}

--- a/rest-api/db/pkg/db/model/vpcprefix.go
+++ b/rest-api/db/pkg/db/model/vpcprefix.go
@@ -557,7 +557,6 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 		return nil, err
 	}
 
-	acquiresChildPrefixes := netIpPrefix.Bits() < vpcPrefixInterfaceBits
 	acquiredPrefixes := make(map[string]struct{})
 	for _, ipStr := range ips {
 		ipAddress, parseErr := netip.ParseAddr(strings.TrimSpace(ipStr))
@@ -579,11 +578,9 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 			continue
 		}
 
-		if acquiresChildPrefixes {
-			_, acquireErr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, prefix)
-			if acquireErr != nil {
-				return nil, fmt.Errorf("failed to acquire Interface prefix %q from %q: %w", prefix, validatedCidr, acquireErr)
-			}
+		_, acquireErr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, prefix)
+		if acquireErr != nil {
+			return nil, fmt.Errorf("failed to acquire Interface prefix %q from %q: %w", prefix, validatedCidr, acquireErr)
 		}
 
 		acquiredPrefixes[prefix] = struct{}{}
@@ -596,11 +593,6 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 
 	usage := ipamPrefix.Usage()
 
-	acquiredPrefixCount := usage.AcquiredPrefixes
-	if !acquiresChildPrefixes {
-		acquiredPrefixCount = uint64(len(acquiredPrefixes))
-	}
-
 	acquiredIPs := uint64(len(acquiredPrefixes))*vpcPrefixIPsPerInterface +
 		ifcCountWithoutIPs*vpcPrefixIPsPerInterface
 	if acquiredIPs > usage.AvailableIPs {
@@ -612,7 +604,7 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 		AcquiredIPs:               acquiredIPs,
 		AvailableSmallestPrefixes: usage.AvailableSmallestPrefixes,
 		AvailablePrefixes:         usage.AvailablePrefixes,
-		AcquiredPrefixes:          acquiredPrefixCount,
+		AcquiredPrefixes:          usage.AcquiredPrefixes,
 	}, nil
 }
 

--- a/rest-api/db/pkg/db/model/vpcprefix.go
+++ b/rest-api/db/pkg/db/model/vpcprefix.go
@@ -552,11 +552,15 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 	}
 
 	validatedCidr := ipamPrefix.Cidr
-	netIpPrefix, err := netip.ParsePrefix(validatedCidr)
+	validIpPrefixFromCidr, err := netip.ParsePrefix(validatedCidr)
 	if err != nil {
 		return nil, err
 	}
 
+	// A /31 VpcPrefix is itself the single Interface slot, and IPAM refuses a child
+	// the same length as its parent. Every other length still goes through IPAM so
+	// that genuinely impossible allocations keep surfacing as errors.
+	acquiresChildPrefixes := validIpPrefixFromCidr.Bits() != vpcPrefixInterfaceBits
 	acquiredPrefixes := make(map[string]struct{})
 	for _, ipStr := range ips {
 		ipAddress, parseErr := netip.ParseAddr(strings.TrimSpace(ipStr))
@@ -564,7 +568,7 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 			continue
 		}
 
-		if !netIpPrefix.Contains(ipAddress) {
+		if !validIpPrefixFromCidr.Contains(ipAddress) {
 			continue
 		}
 
@@ -578,9 +582,11 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 			continue
 		}
 
-		_, acquireErr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, prefix)
-		if acquireErr != nil {
-			return nil, fmt.Errorf("failed to acquire Interface prefix %q from %q: %w", prefix, validatedCidr, acquireErr)
+		if acquiresChildPrefixes {
+			_, acquireErr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, prefix)
+			if acquireErr != nil {
+				return nil, fmt.Errorf("failed to acquire Interface prefix %q from %q: %w", prefix, validatedCidr, acquireErr)
+			}
 		}
 
 		acquiredPrefixes[prefix] = struct{}{}
@@ -593,6 +599,13 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 
 	usage := ipamPrefix.Usage()
 
+	// A /31 acquires no children, so IPAM reports zero for it. The locally tracked
+	// set is what consumed capacity there, and it must agree with AcquiredIPs below.
+	acquiredPrefixCount := usage.AcquiredPrefixes
+	if !acquiresChildPrefixes {
+		acquiredPrefixCount = uint64(len(acquiredPrefixes))
+	}
+
 	acquiredIPs := uint64(len(acquiredPrefixes))*vpcPrefixIPsPerInterface +
 		ifcCountWithoutIPs*vpcPrefixIPsPerInterface
 	if acquiredIPs > usage.AvailableIPs {
@@ -604,7 +617,7 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 		AcquiredIPs:               acquiredIPs,
 		AvailableSmallestPrefixes: usage.AvailableSmallestPrefixes,
 		AvailablePrefixes:         usage.AvailablePrefixes,
-		AcquiredPrefixes:          usage.AcquiredPrefixes,
+		AcquiredPrefixes:          acquiredPrefixCount,
 	}, nil
 }
 

--- a/rest-api/db/pkg/db/model/vpcprefix.go
+++ b/rest-api/db/pkg/db/model/vpcprefix.go
@@ -557,6 +557,7 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 		return nil, err
 	}
 
+	acquiresChildPrefixes := netIpPrefix.Bits() < vpcPrefixInterfaceBits
 	acquiredPrefixes := make(map[string]struct{})
 	for _, ipStr := range ips {
 		ipAddress, parseErr := netip.ParseAddr(strings.TrimSpace(ipStr))
@@ -578,9 +579,11 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 			continue
 		}
 
-		_, acquireErr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, prefix)
-		if acquireErr != nil {
-			return nil, fmt.Errorf("failed to acquire Interface prefix %q from %q: %w", prefix, validatedCidr, acquireErr)
+		if acquiresChildPrefixes {
+			_, acquireErr := ipamer.AcquireSpecificChildPrefix(ctx, validatedCidr, prefix)
+			if acquireErr != nil {
+				return nil, fmt.Errorf("failed to acquire Interface prefix %q from %q: %w", prefix, validatedCidr, acquireErr)
+			}
 		}
 
 		acquiredPrefixes[prefix] = struct{}{}
@@ -593,6 +596,11 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 
 	usage := ipamPrefix.Usage()
 
+	acquiredPrefixCount := usage.AcquiredPrefixes
+	if !acquiresChildPrefixes {
+		acquiredPrefixCount = uint64(len(acquiredPrefixes))
+	}
+
 	acquiredIPs := uint64(len(acquiredPrefixes))*vpcPrefixIPsPerInterface +
 		ifcCountWithoutIPs*vpcPrefixIPsPerInterface
 	if acquiredIPs > usage.AvailableIPs {
@@ -604,7 +612,7 @@ func vpcPrefixUsageFromInterfaces(ctx context.Context, cidr string, ifcCountWith
 		AcquiredIPs:               acquiredIPs,
 		AvailableSmallestPrefixes: usage.AvailableSmallestPrefixes,
 		AvailablePrefixes:         usage.AvailablePrefixes,
-		AcquiredPrefixes:          usage.AcquiredPrefixes,
+		AcquiredPrefixes:          acquiredPrefixCount,
 	}, nil
 }
 

--- a/rest-api/db/pkg/db/model/vpcprefix_test.go
+++ b/rest-api/db/pkg/db/model/vpcprefix_test.go
@@ -6,7 +6,6 @@ package model
 import (
 	"context"
 	"fmt"
-	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -983,16 +982,6 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			expectedAcquiredPrefixes:          2,
 		},
 		{
-			name:                              "/31 prefix with assigned IP is fully consumed",
-			cidr:                              "10.0.0.0/31",
-			ifcCountWithoutIPs:                0,
-			ips:                               []string{"10.0.0.1"},
-			expectedAvailableIPs:              2,
-			expectedAcquiredIPs:               2,
-			expectedAvailableSmallestPrefixes: 0,
-			expectedAcquiredPrefixes:          1,
-		},
-		{
 			name:                              "non-empty invalid or inapplicable addresses are not pending reservations",
 			cidr:                              "10.0.0.0/28",
 			ifcCountWithoutIPs:                0,
@@ -1017,6 +1006,14 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			assert.Equal(t, testCase.expectedAcquiredPrefixes, usage.AcquiredPrefixes)
 		})
 	}
+
+	t.Run("unexpected child prefix acquisition error is propagated", func(t *testing.T) {
+		t.Parallel()
+
+		usage, err := vpcPrefixUsageFromInterfaces(context.Background(), "10.0.0.1/32", 0, []string{"10.0.0.1"})
+		require.Error(t, err)
+		assert.Nil(t, usage)
+	})
 }
 
 //nolint:funlen,paralleltest // Cases and fixtures stay inline; model tests share a PostgreSQL schema.
@@ -1028,7 +1025,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 
 	tests := []struct {
 		name                       string
-		cidr                       string
 		interfaces                 []interfaceFixture
 		expectedAvailableIPs       uint64
 		expectedAcquiredIPs        uint64
@@ -1039,7 +1035,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 	}{
 		{
 			name: "stale deleting rows do not exhaust prefix issue 4908",
-			cidr: "10.0.0.0/28",
 			// Deleting rows still hold capacity; duplicate /31 addresses are de-duplicated by prefix.
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
@@ -1062,7 +1057,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		},
 		{
 			name: "deleting interface with a distinct IP still consumes capacity",
-			cidr: "10.0.0.0/28",
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
 				{status: InterfaceStatusDeleting, ipAddress: cutil.GetPtr("10.0.0.3")},
@@ -1076,7 +1070,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		},
 		{
 			name: "pending interfaces without IPs reserve one /31 each",
-			cidr: "10.0.0.0/28",
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusPending, ipAddress: nil},
 				{status: InterfaceStatusPending, ipAddress: nil},
@@ -1091,7 +1084,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		},
 		{
 			name: "mixed duplicate and pending interfaces reserve unique /31s",
-			cidr: "10.0.0.0/28",
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.3")},
@@ -1108,7 +1100,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		},
 		{
 			name: "usage clamps when acquired and pending interfaces exceed capacity",
-			cidr: "10.0.0.0/28",
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.3")},
@@ -1123,19 +1114,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			expectedAvailableIPs:       16,
 			expectedAcquiredIPs:        16,
 			expectedAcquiredPrefixes:   8,
-			expectedAvailableSmallest:  0,
-			expectedFreeInterfaceSlots: 0,
-			expectedAdmissionAllowed:   false,
-		},
-		{
-			name: "supported /31 prefix with assigned IP is fully consumed",
-			cidr: "10.0.0.0/31",
-			interfaces: []interfaceFixture{
-				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
-			},
-			expectedAvailableIPs:       2,
-			expectedAcquiredIPs:        2,
-			expectedAcquiredPrefixes:   1,
 			expectedAvailableSmallest:  0,
 			expectedFreeInterfaceSlots: 0,
 			expectedAdmissionAllowed:   false,
@@ -1163,9 +1141,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			_, err := dbSession.DB.NewUpdate().Model(instance).Column("status").Where("id = ?", instance.ID).Exec(context.Background())
 			require.NoError(t, err)
 
-			parsedPrefix, parseErr := netip.ParsePrefix(testCase.cidr)
-			require.NoError(t, parseErr)
-
 			vpcPrefix, err := NewVpcPrefixDAO(dbSession).Create(context.Background(), nil, VpcPrefixCreateInput{
 				VpcPrefixID:  nil,
 				Name:         "issue-4908-prefix",
@@ -1174,8 +1149,8 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 				VpcID:        vpc.ID,
 				TenantID:     tenant.ID,
 				IpBlockID:    nil,
-				Prefix:       testCase.cidr,
-				PrefixLength: parsedPrefix.Bits(),
+				Prefix:       "10.0.0.0/28",
+				PrefixLength: 28,
 				Status:       VpcPrefixStatusReady,
 				CreatedBy:    user.ID,
 			})

--- a/rest-api/db/pkg/db/model/vpcprefix_test.go
+++ b/rest-api/db/pkg/db/model/vpcprefix_test.go
@@ -936,7 +936,6 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 		cidr                              string
 		ifcCountWithoutIPs                uint64
 		ips                               []string
-		expectError                       bool
 		expectedAvailableIPs              uint64
 		expectedAcquiredIPs               uint64
 		expectedAvailableSmallestPrefixes uint64
@@ -993,27 +992,36 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			expectedAcquiredPrefixes:          0,
 		},
 		{
-			// A /31 is the smallest prefix length the API accepts, but IPAM cannot carve a
-			// /31 child out of a /31 parent, so an assigned address makes usage fail.
-			name:               "/31 prefix with one assigned IP returns a child prefix error",
-			cidr:               "10.0.0.0/31",
-			ifcCountWithoutIPs: 0,
-			ips:                []string{"10.0.0.1"},
-			expectError:        true,
+			// A /31 is the smallest prefix length the API accepts and cannot yield a /31
+			// child, so usage must still be reported rather than failing the request.
+			name:                              "/31 prefix with one assigned IP does not error",
+			cidr:                              "10.0.0.0/31",
+			ifcCountWithoutIPs:                0,
+			ips:                               []string{"10.0.0.1"},
+			expectedAvailableIPs:              2,
+			expectedAcquiredIPs:               2,
+			expectedAvailableSmallestPrefixes: 0,
+			expectedAcquiredPrefixes:          1,
 		},
 		{
-			name:               "/31 prefix with both addresses of the same /31 returns a child prefix error",
-			cidr:               "10.0.0.0/31",
-			ifcCountWithoutIPs: 0,
-			ips:                []string{"10.0.0.0", "10.0.0.1"},
-			expectError:        true,
+			name:                              "/31 prefix with both addresses of the same /31 counts once",
+			cidr:                              "10.0.0.0/31",
+			ifcCountWithoutIPs:                0,
+			ips:                               []string{"10.0.0.0", "10.0.0.1"},
+			expectedAvailableIPs:              2,
+			expectedAcquiredIPs:               2,
+			expectedAvailableSmallestPrefixes: 0,
+			expectedAcquiredPrefixes:          1,
 		},
 		{
-			name:               "/31 prefix with duplicate Ready and Deleting IP returns a child prefix error",
-			cidr:               "10.0.0.0/31",
-			ifcCountWithoutIPs: 0,
-			ips:                []string{"10.0.0.1", "10.0.0.1"},
-			expectError:        true,
+			name:                              "/31 prefix with duplicate Ready and Deleting IP counts once",
+			cidr:                              "10.0.0.0/31",
+			ifcCountWithoutIPs:                0,
+			ips:                               []string{"10.0.0.1", "10.0.0.1"},
+			expectedAvailableIPs:              2,
+			expectedAcquiredIPs:               2,
+			expectedAvailableSmallestPrefixes: 0,
+			expectedAcquiredPrefixes:          1,
 		},
 		{
 			name:                              "/31 prefix without interfaces is fully available",
@@ -1052,13 +1060,6 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			t.Parallel()
 
 			usage, err := vpcPrefixUsageFromInterfaces(context.Background(), testCase.cidr, testCase.ifcCountWithoutIPs, testCase.ips)
-			if testCase.expectError {
-				require.Error(t, err)
-				assert.Nil(t, usage)
-
-				return
-			}
-
 			require.NoError(t, err)
 			require.NotNil(t, usage)
 			assert.Equal(t, testCase.expectedAvailableIPs, usage.AvailableIPs)
@@ -1091,7 +1092,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		name                       string
 		prefixLength               int
 		interfaces                 []interfaceFixture
-		expectError                bool
 		expectedAvailableIPs       uint64
 		expectedAcquiredIPs        uint64
 		expectedAcquiredPrefixes   uint64
@@ -1185,14 +1185,19 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			expectedAdmissionAllowed:   false,
 		},
 		{
-			// A /31 is the smallest VpcPrefix the API accepts, so this reaches the DAO,
-			// but IPAM cannot carve a /31 child out of it once an address is assigned.
-			name:         "/31 prefix with one Ready interface returns a child prefix error issue 4908 follow-up",
+			// A /31 is the smallest VpcPrefix the API accepts and holds exactly one
+			// Interface, so a single Ready row consumes it without erroring.
+			name:         "/31 prefix with one Ready interface is fully acquired issue 4908 follow-up",
 			prefixLength: 31,
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
 			},
-			expectError: true,
+			expectedAvailableIPs:       2,
+			expectedAcquiredIPs:        2,
+			expectedAcquiredPrefixes:   1,
+			expectedAvailableSmallest:  0,
+			expectedFreeInterfaceSlots: 0,
+			expectedAdmissionAllowed:   false,
 		},
 		{
 			name:                       "/31 prefix without interfaces admits one interface",
@@ -1258,13 +1263,6 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			}
 
 			usageByID, err := NewVpcPrefixDAO(dbSession).GetPrefixUsage(context.Background(), nil, vpcPrefix)
-			if testCase.expectError {
-				require.Error(t, err)
-				assert.Nil(t, usageByID)
-
-				return
-			}
-
 			require.NoError(t, err)
 
 			usage := usageByID[vpcPrefix.ID]

--- a/rest-api/db/pkg/db/model/vpcprefix_test.go
+++ b/rest-api/db/pkg/db/model/vpcprefix_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -982,6 +983,16 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			expectedAcquiredPrefixes:          2,
 		},
 		{
+			name:                              "/31 prefix with assigned IP is fully consumed",
+			cidr:                              "10.0.0.0/31",
+			ifcCountWithoutIPs:                0,
+			ips:                               []string{"10.0.0.1"},
+			expectedAvailableIPs:              2,
+			expectedAcquiredIPs:               2,
+			expectedAvailableSmallestPrefixes: 0,
+			expectedAcquiredPrefixes:          1,
+		},
+		{
 			name:                              "non-empty invalid or inapplicable addresses are not pending reservations",
 			cidr:                              "10.0.0.0/28",
 			ifcCountWithoutIPs:                0,
@@ -1006,14 +1017,6 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			assert.Equal(t, testCase.expectedAcquiredPrefixes, usage.AcquiredPrefixes)
 		})
 	}
-
-	t.Run("unexpected child prefix acquisition error is propagated", func(t *testing.T) {
-		t.Parallel()
-
-		usage, err := vpcPrefixUsageFromInterfaces(context.Background(), "10.0.0.1/32", 0, []string{"10.0.0.1"})
-		require.Error(t, err)
-		assert.Nil(t, usage)
-	})
 }
 
 //nolint:funlen,paralleltest // Cases and fixtures stay inline; model tests share a PostgreSQL schema.
@@ -1025,6 +1028,7 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 
 	tests := []struct {
 		name                       string
+		cidr                       string
 		interfaces                 []interfaceFixture
 		expectedAvailableIPs       uint64
 		expectedAcquiredIPs        uint64
@@ -1035,6 +1039,7 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 	}{
 		{
 			name: "stale deleting rows do not exhaust prefix issue 4908",
+			cidr: "10.0.0.0/28",
 			// Deleting rows still hold capacity; duplicate /31 addresses are de-duplicated by prefix.
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
@@ -1057,6 +1062,7 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		},
 		{
 			name: "deleting interface with a distinct IP still consumes capacity",
+			cidr: "10.0.0.0/28",
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
 				{status: InterfaceStatusDeleting, ipAddress: cutil.GetPtr("10.0.0.3")},
@@ -1070,6 +1076,7 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		},
 		{
 			name: "pending interfaces without IPs reserve one /31 each",
+			cidr: "10.0.0.0/28",
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusPending, ipAddress: nil},
 				{status: InterfaceStatusPending, ipAddress: nil},
@@ -1084,6 +1091,7 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		},
 		{
 			name: "mixed duplicate and pending interfaces reserve unique /31s",
+			cidr: "10.0.0.0/28",
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.3")},
@@ -1100,6 +1108,7 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		},
 		{
 			name: "usage clamps when acquired and pending interfaces exceed capacity",
+			cidr: "10.0.0.0/28",
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.3")},
@@ -1114,6 +1123,19 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			expectedAvailableIPs:       16,
 			expectedAcquiredIPs:        16,
 			expectedAcquiredPrefixes:   8,
+			expectedAvailableSmallest:  0,
+			expectedFreeInterfaceSlots: 0,
+			expectedAdmissionAllowed:   false,
+		},
+		{
+			name: "supported /31 prefix with assigned IP is fully consumed",
+			cidr: "10.0.0.0/31",
+			interfaces: []interfaceFixture{
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
+			},
+			expectedAvailableIPs:       2,
+			expectedAcquiredIPs:        2,
+			expectedAcquiredPrefixes:   1,
 			expectedAvailableSmallest:  0,
 			expectedFreeInterfaceSlots: 0,
 			expectedAdmissionAllowed:   false,
@@ -1141,6 +1163,9 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			_, err := dbSession.DB.NewUpdate().Model(instance).Column("status").Where("id = ?", instance.ID).Exec(context.Background())
 			require.NoError(t, err)
 
+			parsedPrefix, parseErr := netip.ParsePrefix(testCase.cidr)
+			require.NoError(t, parseErr)
+
 			vpcPrefix, err := NewVpcPrefixDAO(dbSession).Create(context.Background(), nil, VpcPrefixCreateInput{
 				VpcPrefixID:  nil,
 				Name:         "issue-4908-prefix",
@@ -1149,8 +1174,8 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 				VpcID:        vpc.ID,
 				TenantID:     tenant.ID,
 				IpBlockID:    nil,
-				Prefix:       "10.0.0.0/28",
-				PrefixLength: 28,
+				Prefix:       testCase.cidr,
+				PrefixLength: parsedPrefix.Bits(),
 				Status:       VpcPrefixStatusReady,
 				CreatedBy:    user.ID,
 			})

--- a/rest-api/db/pkg/db/model/vpcprefix_test.go
+++ b/rest-api/db/pkg/db/model/vpcprefix_test.go
@@ -926,3 +926,236 @@ func testVpcPrefixSQLDAO_Delete(t *testing.T) {
 		})
 	}
 }
+
+//nolint:funlen // Cases stay inline so each usage invariant is visible at the call site.
+func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                              string
+		cidr                              string
+		ifcCountWithoutIPs                uint64
+		ips                               []string
+		expectedAvailableIPs              uint64
+		expectedAcquiredIPs               uint64
+		expectedAvailableSmallestPrefixes uint64
+		expectedAcquiredPrefixes          uint64
+	}{
+		{
+			name:                              "pending interfaces reserve one /31 each",
+			cidr:                              "10.0.0.0/28",
+			ifcCountWithoutIPs:                3,
+			ips:                               nil,
+			expectedAvailableIPs:              16,
+			expectedAcquiredIPs:               6,
+			expectedAvailableSmallestPrefixes: 4,
+			expectedAcquiredPrefixes:          0,
+		},
+		{
+			name:                              "duplicate acquired prefix and pending interfaces are counted once each",
+			cidr:                              "10.0.0.0/28",
+			ifcCountWithoutIPs:                2,
+			ips:                               []string{"10.0.0.1", "10.0.0.3", "10.0.0.1"},
+			expectedAvailableIPs:              16,
+			expectedAcquiredIPs:               8,
+			expectedAvailableSmallestPrefixes: 3,
+			expectedAcquiredPrefixes:          2,
+		},
+		{
+			name:                              "prefix without interfaces is fully available",
+			cidr:                              "10.0.0.0/28",
+			ifcCountWithoutIPs:                0,
+			ips:                               nil,
+			expectedAvailableIPs:              16,
+			expectedAcquiredIPs:               0,
+			expectedAvailableSmallestPrefixes: 4,
+			expectedAcquiredPrefixes:          0,
+		},
+		{
+			name:                              "acquired IPs clamp to prefix capacity",
+			cidr:                              "10.0.0.0/30",
+			ifcCountWithoutIPs:                1,
+			ips:                               []string{"10.0.0.1", "10.0.0.3"},
+			expectedAvailableIPs:              4,
+			expectedAcquiredIPs:               4,
+			expectedAvailableSmallestPrefixes: 0,
+			expectedAcquiredPrefixes:          2,
+		},
+		{
+			name:                              "non-empty invalid or inapplicable addresses are not pending reservations",
+			cidr:                              "10.0.0.0/28",
+			ifcCountWithoutIPs:                0,
+			ips:                               []string{"invalid", "2001:db8::1", "192.0.2.1"},
+			expectedAvailableIPs:              16,
+			expectedAcquiredIPs:               0,
+			expectedAvailableSmallestPrefixes: 4,
+			expectedAcquiredPrefixes:          0,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			usage, err := vpcPrefixUsageFromInterfaces(context.Background(), testCase.cidr, testCase.ifcCountWithoutIPs, testCase.ips)
+			require.NoError(t, err)
+			require.NotNil(t, usage)
+			assert.Equal(t, testCase.expectedAvailableIPs, usage.AvailableIPs)
+			assert.Equal(t, testCase.expectedAcquiredIPs, usage.AcquiredIPs)
+			assert.Equal(t, testCase.expectedAvailableSmallestPrefixes, usage.AvailableSmallestPrefixes)
+			assert.Equal(t, testCase.expectedAcquiredPrefixes, usage.AcquiredPrefixes)
+		})
+	}
+}
+
+//nolint:funlen,paralleltest // Cases and fixtures stay inline; model tests share a PostgreSQL schema.
+func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
+	type interfaceFixture struct {
+		status    string
+		ipAddress *string
+	}
+
+	tests := []struct {
+		name                       string
+		interfaces                 []interfaceFixture
+		expectedAvailableIPs       uint64
+		expectedAcquiredIPs        uint64
+		expectedAcquiredPrefixes   uint64
+		expectedAvailableSmallest  uint64
+		expectedFreeInterfaceSlots uint64
+		expectedAdmissionAllowed   bool
+	}{
+		{
+			name: "stale deleting rows do not exhaust prefix issue 4908",
+			interfaces: []interfaceFixture{
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.3")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.5")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.7")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.9")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.13")},
+				{status: InterfaceStatusDeleting, ipAddress: cutil.GetPtr("10.0.0.1")},
+				{status: InterfaceStatusDeleting, ipAddress: cutil.GetPtr("10.0.0.3")},
+				{status: InterfaceStatusDeleting, ipAddress: cutil.GetPtr("10.0.0.9")},
+				{status: InterfaceStatusDeleting, ipAddress: cutil.GetPtr("10.0.0.13")},
+			},
+			expectedAvailableIPs:       16,
+			expectedAcquiredIPs:        12,
+			expectedAcquiredPrefixes:   6,
+			expectedAvailableSmallest:  0,
+			expectedFreeInterfaceSlots: 2,
+			expectedAdmissionAllowed:   true,
+		},
+		{
+			name: "pending interfaces without IPs reserve one /31 each",
+			interfaces: []interfaceFixture{
+				{status: InterfaceStatusPending, ipAddress: nil},
+				{status: InterfaceStatusPending, ipAddress: nil},
+				{status: InterfaceStatusPending, ipAddress: nil},
+			},
+			expectedAvailableIPs:       16,
+			expectedAcquiredIPs:        6,
+			expectedAcquiredPrefixes:   0,
+			expectedAvailableSmallest:  4,
+			expectedFreeInterfaceSlots: 5,
+			expectedAdmissionAllowed:   true,
+		},
+		{
+			name: "mixed duplicate and pending interfaces reserve unique /31s",
+			interfaces: []interfaceFixture{
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.3")},
+				{status: InterfaceStatusDeleting, ipAddress: cutil.GetPtr("10.0.0.1")},
+				{status: InterfaceStatusPending, ipAddress: nil},
+				{status: InterfaceStatusPending, ipAddress: nil},
+			},
+			expectedAvailableIPs:       16,
+			expectedAcquiredIPs:        8,
+			expectedAcquiredPrefixes:   2,
+			expectedAvailableSmallest:  3,
+			expectedFreeInterfaceSlots: 4,
+			expectedAdmissionAllowed:   true,
+		},
+		{
+			name: "usage clamps when acquired and pending interfaces exceed capacity",
+			interfaces: []interfaceFixture{
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.3")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.5")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.7")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.9")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.11")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.13")},
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.15")},
+				{status: InterfaceStatusPending, ipAddress: nil},
+			},
+			expectedAvailableIPs:       16,
+			expectedAcquiredIPs:        16,
+			expectedAcquiredPrefixes:   8,
+			expectedAvailableSmallest:  0,
+			expectedFreeInterfaceSlots: 0,
+			expectedAdmissionAllowed:   false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			dbSession := testVpcPrefixInitDB(t)
+			t.Cleanup(func() {
+				dbSession.Close()
+			})
+			testInterfaceSetupSchema(t, dbSession)
+
+			infrastructureProvider := testInstanceBuildInfrastructureProvider(t, dbSession, "issue-4908-provider")
+			site := testInstanceBuildSite(t, dbSession, infrastructureProvider, "issue-4908-site")
+			tenant := testInstanceBuildTenant(t, dbSession, "issue-4908-tenant")
+			vpc := testInstanceBuildVpc(t, dbSession, infrastructureProvider, site, tenant, "issue-4908-vpc")
+			user := testInstanceBuildUser(t, dbSession, "issue-4908-user")
+			instanceType := testInstanceBuildInstanceType(t, dbSession, infrastructureProvider, "issue-4908-instance-type")
+			machine := testMachineBuildMachine(t, dbSession, infrastructureProvider.ID, site.ID, &instanceType.ID, cutil.GetPtr("issue-4908-machine-type"))
+			operatingSystem := testInstanceBuildOperatingSystem(t, dbSession, "issue-4908-os")
+			instance := TestBuildInstance(t, dbSession, "issue-4908-instance", tenant, infrastructureProvider, site, instanceType, vpc, machine, operatingSystem)
+			instance.Status = InstanceStatusConfiguring
+			_, err := dbSession.DB.NewUpdate().Model(instance).Column("status").Where("id = ?", instance.ID).Exec(context.Background())
+			require.NoError(t, err)
+
+			vpcPrefix, err := NewVpcPrefixDAO(dbSession).Create(context.Background(), nil, VpcPrefixCreateInput{
+				VpcPrefixID:  nil,
+				Name:         "issue-4908-prefix",
+				TenantOrg:    tenant.Org,
+				SiteID:       site.ID,
+				VpcID:        vpc.ID,
+				TenantID:     tenant.ID,
+				IpBlockID:    nil,
+				Prefix:       "10.0.0.0/28",
+				PrefixLength: 28,
+				Status:       VpcPrefixStatusReady,
+				CreatedBy:    user.ID,
+			})
+			require.NoError(t, err)
+
+			for _, interfaceFixture := range testCase.interfaces {
+				ifc := TestBuildInterface(t, dbSession, instance, nil, &vpcPrefix.ID, true, interfaceFixture.status)
+				if interfaceFixture.ipAddress != nil {
+					ifc.IPAddresses = []string{*interfaceFixture.ipAddress}
+					_, err = dbSession.DB.NewUpdate().Model(ifc).Column("ip_addresses").Where("id = ?", ifc.ID).Exec(context.Background())
+					require.NoError(t, err)
+				}
+			}
+
+			usageByID, err := NewVpcPrefixDAO(dbSession).GetPrefixUsage(context.Background(), nil, vpcPrefix)
+			require.NoError(t, err)
+
+			usage := usageByID[vpcPrefix.ID]
+			require.NotNil(t, usage)
+			assert.Equal(t, testCase.expectedAvailableIPs, usage.AvailableIPs)
+			assert.Equal(t, testCase.expectedAcquiredIPs, usage.AcquiredIPs)
+			assert.Equal(t, testCase.expectedAcquiredPrefixes, usage.AcquiredPrefixes)
+			assert.Equal(t, testCase.expectedAvailableSmallest, usage.AvailableSmallestPrefixes)
+			assert.Equal(t, testCase.expectedFreeInterfaceSlots, (usage.AvailableIPs-usage.AcquiredIPs)/vpcPrefixIPsPerInterface)
+
+			admissionAllowed := usage.AcquiredIPs+vpcPrefixIPsPerInterface <= usage.AvailableIPs
+			assert.Equal(t, testCase.expectedAdmissionAllowed, admissionAllowed)
+		})
+	}
+}

--- a/rest-api/db/pkg/db/model/vpcprefix_test.go
+++ b/rest-api/db/pkg/db/model/vpcprefix_test.go
@@ -936,6 +936,7 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 		cidr                              string
 		ifcCountWithoutIPs                uint64
 		ips                               []string
+		expectError                       bool
 		expectedAvailableIPs              uint64
 		expectedAcquiredIPs               uint64
 		expectedAvailableSmallestPrefixes uint64
@@ -991,6 +992,59 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			expectedAvailableSmallestPrefixes: 4,
 			expectedAcquiredPrefixes:          0,
 		},
+		{
+			// A /31 is the smallest prefix length the API accepts, but IPAM cannot carve a
+			// /31 child out of a /31 parent, so an assigned address makes usage fail.
+			name:               "/31 prefix with one assigned IP returns a child prefix error",
+			cidr:               "10.0.0.0/31",
+			ifcCountWithoutIPs: 0,
+			ips:                []string{"10.0.0.1"},
+			expectError:        true,
+		},
+		{
+			name:               "/31 prefix with both addresses of the same /31 returns a child prefix error",
+			cidr:               "10.0.0.0/31",
+			ifcCountWithoutIPs: 0,
+			ips:                []string{"10.0.0.0", "10.0.0.1"},
+			expectError:        true,
+		},
+		{
+			name:               "/31 prefix with duplicate Ready and Deleting IP returns a child prefix error",
+			cidr:               "10.0.0.0/31",
+			ifcCountWithoutIPs: 0,
+			ips:                []string{"10.0.0.1", "10.0.0.1"},
+			expectError:        true,
+		},
+		{
+			name:                              "/31 prefix without interfaces is fully available",
+			cidr:                              "10.0.0.0/31",
+			ifcCountWithoutIPs:                0,
+			ips:                               nil,
+			expectedAvailableIPs:              2,
+			expectedAcquiredIPs:               0,
+			expectedAvailableSmallestPrefixes: 0,
+			expectedAcquiredPrefixes:          0,
+		},
+		{
+			name:                              "/31 prefix with one pending interface reserves the prefix",
+			cidr:                              "10.0.0.0/31",
+			ifcCountWithoutIPs:                1,
+			ips:                               nil,
+			expectedAvailableIPs:              2,
+			expectedAcquiredIPs:               2,
+			expectedAvailableSmallestPrefixes: 0,
+			expectedAcquiredPrefixes:          0,
+		},
+		{
+			name:                              "/31 prefix ignores out-of-range IP",
+			cidr:                              "10.0.0.0/31",
+			ifcCountWithoutIPs:                0,
+			ips:                               []string{"192.0.2.1"},
+			expectedAvailableIPs:              2,
+			expectedAcquiredIPs:               0,
+			expectedAvailableSmallestPrefixes: 0,
+			expectedAcquiredPrefixes:          0,
+		},
 	}
 
 	for _, testCase := range tests {
@@ -998,6 +1052,13 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			t.Parallel()
 
 			usage, err := vpcPrefixUsageFromInterfaces(context.Background(), testCase.cidr, testCase.ifcCountWithoutIPs, testCase.ips)
+			if testCase.expectError {
+				require.Error(t, err)
+				assert.Nil(t, usage)
+
+				return
+			}
+
 			require.NoError(t, err)
 			require.NotNil(t, usage)
 			assert.Equal(t, testCase.expectedAvailableIPs, usage.AvailableIPs)
@@ -1023,9 +1084,14 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 		ipAddress *string
 	}
 
+	// prefixLength selects the VpcPrefix size under test; zero means the default /28.
+	const defaultPrefixLength = 28
+
 	tests := []struct {
 		name                       string
+		prefixLength               int
 		interfaces                 []interfaceFixture
+		expectError                bool
 		expectedAvailableIPs       uint64
 		expectedAcquiredIPs        uint64
 		expectedAcquiredPrefixes   uint64
@@ -1118,6 +1184,27 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			expectedFreeInterfaceSlots: 0,
 			expectedAdmissionAllowed:   false,
 		},
+		{
+			// A /31 is the smallest VpcPrefix the API accepts, so this reaches the DAO,
+			// but IPAM cannot carve a /31 child out of it once an address is assigned.
+			name:         "/31 prefix with one Ready interface returns a child prefix error issue 4908 follow-up",
+			prefixLength: 31,
+			interfaces: []interfaceFixture{
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
+			},
+			expectError: true,
+		},
+		{
+			name:                       "/31 prefix without interfaces admits one interface",
+			prefixLength:               31,
+			interfaces:                 nil,
+			expectedAvailableIPs:       2,
+			expectedAcquiredIPs:        0,
+			expectedAcquiredPrefixes:   0,
+			expectedAvailableSmallest:  0,
+			expectedFreeInterfaceSlots: 1,
+			expectedAdmissionAllowed:   true,
+		},
 	}
 
 	for _, testCase := range tests {
@@ -1141,6 +1228,11 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			_, err := dbSession.DB.NewUpdate().Model(instance).Column("status").Where("id = ?", instance.ID).Exec(context.Background())
 			require.NoError(t, err)
 
+			prefixLength := testCase.prefixLength
+			if prefixLength == 0 {
+				prefixLength = defaultPrefixLength
+			}
+
 			vpcPrefix, err := NewVpcPrefixDAO(dbSession).Create(context.Background(), nil, VpcPrefixCreateInput{
 				VpcPrefixID:  nil,
 				Name:         "issue-4908-prefix",
@@ -1149,8 +1241,8 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 				VpcID:        vpc.ID,
 				TenantID:     tenant.ID,
 				IpBlockID:    nil,
-				Prefix:       "10.0.0.0/28",
-				PrefixLength: 28,
+				Prefix:       fmt.Sprintf("10.0.0.0/%d", prefixLength),
+				PrefixLength: prefixLength,
 				Status:       VpcPrefixStatusReady,
 				CreatedBy:    user.ID,
 			})
@@ -1166,6 +1258,13 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			}
 
 			usageByID, err := NewVpcPrefixDAO(dbSession).GetPrefixUsage(context.Background(), nil, vpcPrefix)
+			if testCase.expectError {
+				require.Error(t, err)
+				assert.Nil(t, usageByID)
+
+				return
+			}
+
 			require.NoError(t, err)
 
 			usage := usageByID[vpcPrefix.ID]

--- a/rest-api/db/pkg/db/model/vpcprefix_test.go
+++ b/rest-api/db/pkg/db/model/vpcprefix_test.go
@@ -985,7 +985,7 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			name:                              "non-empty invalid or inapplicable addresses are not pending reservations",
 			cidr:                              "10.0.0.0/28",
 			ifcCountWithoutIPs:                0,
-			ips:                               []string{"invalid", "2001:db8::1", "192.0.2.1"},
+			ips:                               []string{"invalid", "10.0.0.1/31", "2001:db8::1", "192.0.2.1"},
 			expectedAvailableIPs:              16,
 			expectedAcquiredIPs:               0,
 			expectedAvailableSmallestPrefixes: 4,
@@ -1006,6 +1006,14 @@ func TestVpcPrefixUsageFromInterfaces(t *testing.T) {
 			assert.Equal(t, testCase.expectedAcquiredPrefixes, usage.AcquiredPrefixes)
 		})
 	}
+
+	t.Run("unexpected child prefix acquisition error is propagated", func(t *testing.T) {
+		t.Parallel()
+
+		usage, err := vpcPrefixUsageFromInterfaces(context.Background(), "10.0.0.1/32", 0, []string{"10.0.0.1"})
+		require.Error(t, err)
+		assert.Nil(t, usage)
+	})
 }
 
 //nolint:funlen,paralleltest // Cases and fixtures stay inline; model tests share a PostgreSQL schema.
@@ -1027,6 +1035,7 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 	}{
 		{
 			name: "stale deleting rows do not exhaust prefix issue 4908",
+			// Deleting rows still hold capacity; duplicate /31 addresses are de-duplicated by prefix.
 			interfaces: []interfaceFixture{
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
 				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.3")},
@@ -1044,6 +1053,19 @@ func TestVpcPrefixSQLDAO_GetPrefixUsage(t *testing.T) {
 			expectedAcquiredPrefixes:   6,
 			expectedAvailableSmallest:  0,
 			expectedFreeInterfaceSlots: 2,
+			expectedAdmissionAllowed:   true,
+		},
+		{
+			name: "deleting interface with a distinct IP still consumes capacity",
+			interfaces: []interfaceFixture{
+				{status: InterfaceStatusReady, ipAddress: cutil.GetPtr("10.0.0.1")},
+				{status: InterfaceStatusDeleting, ipAddress: cutil.GetPtr("10.0.0.3")},
+			},
+			expectedAvailableIPs:       16,
+			expectedAcquiredIPs:        4,
+			expectedAcquiredPrefixes:   2,
+			expectedAvailableSmallest:  3,
+			expectedFreeInterfaceSlots: 6,
 			expectedAdmissionAllowed:   true,
 		},
 		{


### PR DESCRIPTION
## Description 

Problem
`UpdateInstance` previously created replacement rows for unchanged physical
interfaces and marked the original rows as `Deleting`. Because both rows
remained non-deleted and held the same IP, VPC prefix usage counted the
allocation twice and could incorrectly report the prefix as exhausted.

Summary
- Reconcile Ethernet interfaces during `UpdateInstance` instead of replacing every row.
- Reuse matching interfaces in request order and mark only omitted interfaces as `Deleting`.
- Ignore `Deleting` rows when calculating existing demand for capacity admission.
- Calculate VPC prefix usage from unique acquired `/31` prefixes plus interfaces awaiting IP allocation.
- Preserve the existing `/30` meaning of `availableSmallestPrefixes`.

Result
Adding a VF no longer replaces an unchanged PF. Stale Ready/Deleting rows
holding the same IP are counted as one `/31`, while pending interfaces without
an assigned IP continue to reserve capacity.

## Related issues
Fixes #4908] [#4908](https://github.com/NVIDIA/infra-controller/issues/4908)

## Type of Change
- [x] **Fix** - Bug fixes


## Testing
- [x] Unit tests added/updated

Steps:- 
-  Reproduced the original regression before the fix (`AcquiredIPs == 16`).
-  Verified six unique `/31` allocations report `AcquiredIPs == 12`.
-  Verified adding a VF preserves the original PF row and creates no duplicate.
-  Verified omitted interfaces transition to `Deleting`.
-  Verified pending, mixed, invalid-IP, zero-interface, and clamp cases.
-  Ran the REST DB test suite.
-  Ran the Instance handler test suite.
-  Ran formatting and changed-code lint checks.
