### PR TITLE
feat(dev): add observability stack to tilt

### DIFF
--- a/dev/deployment/tilt/README.md
+++ b/dev/deployment/tilt/README.md
@@ -50,6 +50,64 @@ Tilt forwards these endpoints:
 | Keycloak | `http://localhost:18082` |
 | MCP | `http://localhost:18080/mcp` |
 | Temporal UI | `http://localhost:18233` |
+| Grafana | `http://localhost:13000` |
+| Prometheus | `http://localhost:19090` |
+
+## Pod logs
+
+Grafana Alloy collects stdout and stderr from every pod through the Kubernetes
+API and sends the logs to the local Loki instance. Grafana has Loki provisioned
+as its default data source and permits anonymous access because its Tilt
+port-forward listens only on localhost.
+
+Open **Explore** in Grafana and use a LogQL selector such as:
+
+```text
+{cluster="local-carbide"}
+```
+
+Narrow the results with the `namespace`, `workload`, `pod`, `container`, or
+`app` labels. For example, machine-a-tron logs can be selected with:
+
+```text
+{namespace="nico-system", app="nico-machine-a-tron"}
+```
+
+Loki stores logs on a 2 GiB persistent volume and retains them for 24 hours.
+The volume survives pod restarts but is removed with the local Kind cluster.
+
+## Pod metrics
+
+Prometheus discovers ServiceMonitor and PodMonitor resources across the local
+cluster. It also automatically scrapes every Kubernetes Service labeled
+`app.kubernetes.io/metrics` whose service name ends in `-metrics` or whose port
+is named `metrics`. This collects NICo service metrics without redeploying the
+manual application resources. Grafana provisions Prometheus as a data source
+alongside Loki.
+
+Open **Explore** in Grafana, select the Prometheus data source, and start with:
+
+```promql
+up{namespace="nico-system"}
+```
+
+Prometheus stores metrics on a 2 GiB persistent volume and retains them for 24
+hours. Its UI at `http://localhost:19090` also shows discovered endpoints under
+**Status > Targets**.
+
+## Dashboards
+
+Tilt provisions the checked-in **NICo Core Health**, **NICo / Site Overview**,
+**NICo / Site Explorer**, **NICo / Object Lifecycle**, and **NICo / API
+Performance** dashboards into the **NICo** Grafana folder. The Tilt-local Site
+Explorer dashboard adapts the canonical Forge dashboard panels to the current
+`carbide_*` metric names. Grafana's dashboard sidecar watches their labeled
+ConfigMap, so changes to the dashboard JSON files are loaded without a manual
+import or Grafana restart.
+
+The Prometheus chart also publishes its standard Kubernetes dashboards for the
+same sidecar to load. These cover cluster, namespace, workload, pod, node,
+kubelet, API server, and persistent-volume metrics.
 
 All Tilt settings are in [`values.yaml`](values.yaml). NICo Core values are at
 the document root, while the `tilt` section contains the prerequisite and REST
@@ -71,9 +129,10 @@ rebuilds.
 ## Optional profiles
 
 The `tilt.profiles` switches in [`values.yaml`](values.yaml) control REST, MCP,
-and DSX Exchange. REST brings Temporal and Keycloak, MCP automatically brings
-REST, and DSX Exchange brings NATS. The committed defaults enable REST and MCP
-and disable DSX Exchange.
+DSX Exchange, and observability. REST brings Temporal and Keycloak, MCP
+automatically brings REST, and DSX Exchange brings NATS. Observability manages
+Loki, Alloy, Prometheus, Grafana, and the NICo metrics monitors as one unit. All
+optional profiles are disabled by default.
 
 Changes to `values.yaml` reload the running Tilt session. For temporary
 overrides, use `tilt args`. Start only Core with:
@@ -92,6 +151,12 @@ Add DSX Exchange with:
 
 ```bash
 tilt args -- --dsx-exchange=true
+```
+
+Enable the complete observability stack with:
+
+```bash
+tilt args -- --observability=true
 ```
 
 Return to the values-file defaults with:

--- a/dev/deployment/tilt/Tiltfile
+++ b/dev/deployment/tilt/Tiltfile
@@ -23,14 +23,17 @@ profiles = tilt_values['profiles']
 config.define_bool('rest')
 config.define_bool('mcp')
 config.define_bool('dsx-exchange')
+config.define_bool('observability')
 options = config.parse()
 enable_mcp = options.get('mcp', profiles['mcp'])
 enable_rest = options.get('rest', profiles['rest']) or enable_mcp
 enable_dsx_exchange = options.get('dsx-exchange', profiles['dsxExchange'])
+enable_observability = options.get('observability', profiles['observability'])
 local_config = tilt_values['localConfig']
 core_namespace = local_config['coreNamespace']
 rest_namespace = local_config['restNamespace']
 temporal_namespace = local_config['temporalNamespace']
+observability_namespace = local_config['observabilityNamespace']
 
 def merged(first, second):
     result = {}
@@ -46,7 +49,8 @@ def component_values(global_values, values):
 def helm_json_flags(values, prefix=''):
     flags = []
     for key, value in values.items():
-        path = '%s.%s' % (prefix, key) if prefix else key
+        escaped_key = key.replace('\\', '\\\\').replace('.', '\\.')
+        path = '%s.%s' % (prefix, escaped_key) if prefix else escaped_key
         if type(value) == 'dict' and len(value):
             flags.extend(helm_json_flags(value, path))
         else:
@@ -126,7 +130,10 @@ def prerequisite(
         version,
         values,
         repo,
-        resource_deps=[]):
+        resource_deps=[],
+        port_forwards=[],
+        links=[],
+        labels=['infrastructure']):
     helm_resource(
         name=name,
         chart=chart,
@@ -134,8 +141,10 @@ def prerequisite(
         namespace=namespace,
         deps=[values_file],
         resource_deps=[repo] + resource_deps,
-        labels=['infrastructure'],
+        labels=labels,
         pod_readiness='wait',
+        port_forwards=port_forwards,
+        links=links,
         flags=[
             '--version=%s' % version,
             '--create-namespace',
@@ -175,6 +184,24 @@ helm_repo(
     'https://helm.releases.hashicorp.com',
     resource_name='repo-hashicorp',
     labels=['infrastructure'],
+)
+helm_repo(
+    'grafana-community',
+    'https://grafana-community.github.io/helm-charts',
+    resource_name='repo-grafana-community',
+    labels=['observability'],
+)
+helm_repo(
+    'grafana',
+    'https://grafana.github.io/helm-charts',
+    resource_name='repo-grafana',
+    labels=['observability'],
+)
+helm_repo(
+    'prometheus-community',
+    'https://prometheus-community.github.io/helm-charts',
+    resource_name='repo-prometheus-community',
+    labels=['observability'],
 )
 
 prerequisite(
@@ -231,6 +258,19 @@ namespace_objects = [
     },
 ]
 
+observability_namespace_object = {
+    'apiVersion': 'v1',
+    'kind': 'Namespace',
+    'metadata': object_metadata(observability_namespace),
+}
+k8s_yaml(encode_yaml(observability_namespace_object))
+k8s_resource(
+    new_name='nico-observability-namespace',
+    objects=[object_selector(observability_namespace_object)],
+    labels=['observability'],
+    pod_readiness='ignore',
+)
+
 for obj in namespace_objects:
     k8s_yaml(encode_yaml(obj))
 
@@ -239,6 +279,109 @@ k8s_resource(
     objects=[object_selector(obj) for obj in namespace_objects],
     labels=['infrastructure'],
     pod_readiness='ignore',
+)
+
+observability_values = tilt_values['observability']
+grafana_dashboard_object = {
+    'apiVersion': 'v1',
+    'kind': 'ConfigMap',
+    'metadata': merged(
+        object_metadata('grafana-dashboards-nico', observability_namespace),
+        {
+            'labels': {'grafana_dashboard': '1'},
+            'annotations': {'grafana_folder': 'NICo'},
+        },
+    ),
+    'data': {
+        'nico-api-performance.json': str(read_file(os.path.join(
+            repo_root,
+            'helm/observability/dashboards/nico-api-performance.json',
+        ))),
+        'nico-lifecycle.json': str(read_file(os.path.join(
+            repo_root,
+            'helm/observability/dashboards/nico-lifecycle.json',
+        ))),
+        'nico-overview.json': str(read_file(os.path.join(
+            repo_root,
+            'helm/observability/dashboards/nico-overview.json',
+        ))),
+        'nico-site-explorer.json': str(read_file(os.path.join(
+            repo_root,
+            'dev/deployment/tilt/dashboards/nico-site-explorer.json',
+        ))),
+        'nico-core-health.json': str(read_file(os.path.join(
+            repo_root,
+            'helm-prereqs/observability/dashboards/nico-core-health.json',
+        ))),
+    },
+}
+k8s_yaml(encode_yaml(grafana_dashboard_object))
+k8s_resource(
+    new_name='grafana-dashboards',
+    objects=[object_selector(grafana_dashboard_object)],
+    resource_deps=['nico-observability-namespace'],
+    labels=['observability'],
+    pod_readiness='ignore',
+)
+prerequisite(
+    name='prometheus',
+    chart='prometheus-community/kube-prometheus-stack',
+    release_name='prometheus',
+    namespace=observability_namespace,
+    version='59.1.0',
+    values=observability_values['prometheus'],
+    repo='repo-prometheus-community',
+    resource_deps=['nico-observability-namespace'],
+    port_forwards=[port_forward(19090, 9090)],
+    links=[link('http://localhost:19090', 'Prometheus')],
+    labels=['observability'],
+)
+prerequisite(
+    name='loki',
+    chart='grafana-community/loki',
+    release_name='loki',
+    namespace=observability_namespace,
+    version='18.8.1',
+    values=observability_values['loki'],
+    repo='repo-grafana-community',
+    resource_deps=['nico-observability-namespace'],
+    labels=['observability'],
+)
+prerequisite(
+    name='alloy',
+    chart='grafana/alloy',
+    release_name='alloy',
+    namespace=observability_namespace,
+    version='1.11.1',
+    values=observability_values['alloy'],
+    repo='repo-grafana',
+    resource_deps=['nico-observability-namespace', 'loki'],
+    labels=['observability'],
+)
+helm_resource(
+    name='grafana',
+    chart='grafana-community/grafana',
+    release_name='grafana',
+    namespace=observability_namespace,
+    deps=[values_file],
+    resource_deps=[
+        'repo-grafana-community',
+        'nico-observability-namespace',
+        'grafana-dashboards',
+        'loki',
+        'prometheus',
+    ],
+    labels=['observability'],
+    pod_readiness='wait',
+    port_forwards=[port_forward(13000, 3000)],
+    links=[link('http://localhost:13000', 'Grafana')],
+    flags=[
+        '--version=12.10.4',
+        '--create-namespace',
+    ] + helm_json_flags(observability_values['grafana']) + [
+        '--wait',
+        '--timeout=5m',
+    ],
 )
 
 local_objects = [
@@ -621,6 +764,15 @@ docker_build(
     ),
 )
 docker_build(
+    'nico-devspace-core-artifacts',
+    repo_root,
+    dockerfile=os.path.join(
+        devspace_dir,
+        'Dockerfile.core-artifacts',
+    ),
+    ignore=['dev/deployment/tilt'],
+)
+docker_build(
     'nico-api',
     repo_root,
     dockerfile=os.path.join(devspace_dir, 'Dockerfile.api'),
@@ -904,6 +1056,18 @@ enabled_resources = [
     'nico-bmc-proxy',
     'nico-machine-a-tron',
 ]
+if enable_observability:
+    enabled_resources.extend([
+        'repo-grafana-community',
+        'repo-grafana',
+        'repo-prometheus-community',
+        'nico-observability-namespace',
+        'grafana-dashboards',
+        'prometheus',
+        'loki',
+        'alloy',
+        'grafana',
+    ])
 if enable_rest:
     enabled_resources.extend([
         'nico-local-namespaces',

--- a/dev/deployment/tilt/dashboards/nico-site-explorer.json
+++ b/dev/deployment/tilt/dashboards/nico-site-explorer.json
@@ -1,0 +1,812 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 176,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(carbide_endpoint_explorations_count{})",
+          "hide": false,
+          "legendFormat": "Endpoint exploration attempts",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Average Endpoint Explorations Attempted",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red"
+              },
+              {
+                "color": "dark-yellow",
+                "value": 0.3
+              },
+              {
+                "color": "dark-green",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 175,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(carbide_endpoint_exploration_success_count{})/sum(carbide_endpoint_explorations_count{})",
+          "hide": false,
+          "legendFormat": "Endpoint exploration attempts",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Average Endpoint Exploration Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": " The time it takes to explore a single endpoint",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 111,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(increase(carbide_endpoint_exploration_duration_milliseconds_sum{}[2m])) / sum(increase(carbide_endpoint_exploration_duration_milliseconds_count{}[2m])) ",
+          "legendFormat": "Endpoint exploration time",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Endpoint Exploration Time",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "If an endpoint could not be explored successfully, this graph shows the failure",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by(failure) (carbide_endpoint_exploration_failures_count{})",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoint Exploration Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The time it takes to execute a site-explorer run and various steps inside it",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 4
+      },
+      "id": 162,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(carbide_site_explorer_iteration_latency_milliseconds_sum{}[2m])) / sum(increase(carbide_site_explorer_iteration_latency_milliseconds_count{}[2m])) ",
+          "legendFormat": "Total Iteration Time",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(carbide_site_explorer_create_machines_latency_milliseconds_sum{}[2m])) / sum(increase(carbide_site_explorer_create_machines_latency_milliseconds_count{}[2m])) ",
+          "hide": false,
+          "legendFormat": "Create Machines Time",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Site Explorer Iteration Times",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The amount of ManagedHosts that were fully identified during the last endpoint exploration. Identified means Hosts and DPUs have been mapped",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 7,
+        "y": 4
+      },
+      "id": 202,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(carbide_site_exploration_identified_managed_hosts_count{})",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "Identified ManagedHosts",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Identified Managed Hosts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The total number of machines that were expected to be part of the site but could not be identified by site-explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 7,
+        "y": 7
+      },
+      "id": 201,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(carbide_endpoint_exploration_expected_machines_missing_overall_count{})",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "Missing Machines",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Missing Expected Machines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The amount of endpoints which has been explored in total (not just in the last site-explorer iteration).\n- Expected means the endpoint was defined in expected-machines\n- Unexpected means the endpoint was not defined in expected-machines\n- na means the endpoint is a DPU and expected-machines is not applicable to it",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 0,
+        "y": 11
+      },
+      "id": 120,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by(expectation) (carbide_endpoint_exploration_machines_explored_overall_count{})",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Explored Endpoints by Expectation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The amount of ManagedHosts that were created in initial state in site exploration runs",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 7,
+        "y": 11
+      },
+      "id": 132,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(carbide_site_explorer_created_machines_count{})",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "Created ManagedHosts",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Managed Hosts Created",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "nico",
+    "site-explorer"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "NICo / Site Explorer",
+  "uid": "nico-site-explorer",
+  "version": 1,
+  "weekStart": ""
+}

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -199,10 +199,11 @@ nico-machine-a-tron:
           adminDhcpRelayAddress: 192.168.176.1
 
 tilt:
-  profiles: # Toggle REST, MCP, and DSX Exchange; required dependencies follow automatically.
+  profiles: # Toggle optional stacks; required dependencies follow automatically.
     rest: false
     mcp: false
     dsxExchange: false
+    observability: false
 
   certManager:
     crds:
@@ -321,6 +322,272 @@ tilt:
             vault kv put secrets/machines/all_dpus/site_default/uefi-metadata-items/auth - >/dev/null
           printf '%s' '{"UsernamePassword":{"username":"root","password":"vault-password"}}' | \
             vault kv put secrets/machines/all_hosts/site_default/uefi-metadata-items/auth - >/dev/null
+
+  observability:
+    prometheus:
+      fullnameOverride: prometheus-stack
+      crds:
+        enabled: true
+      defaultRules:
+        create: false
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+        forceDeployDashboards: true
+      kubeControllerManager:
+        enabled: false
+      kubeEtcd:
+        enabled: false
+      kubeScheduler:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          retention: 24h
+          scrapeInterval: 30s
+          evaluationInterval: 30s
+          serviceMonitorSelectorNilUsesHelmValues: false
+          podMonitorSelectorNilUsesHelmValues: false
+          probeSelectorNilUsesHelmValues: false
+          ruleSelectorNilUsesHelmValues: false
+          additionalScrapeConfigs:
+            - job_name: nico-services
+              kubernetes_sd_configs:
+                - role: endpoints
+              relabel_configs:
+                - action: keep
+                  source_labels:
+                    - __meta_kubernetes_service_label_app_kubernetes_io_metrics
+                  regex: .+
+                - action: keep
+                  source_labels:
+                    - __meta_kubernetes_service_name
+                    - __meta_kubernetes_endpoint_port_name
+                  separator: ";"
+                  regex: (.+-metrics;.+)|(.+;metrics)
+                - source_labels:
+                    - __meta_kubernetes_service_label_app_kubernetes_io_metrics
+                  target_label: job
+                - source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - source_labels:
+                    - __meta_kubernetes_service_name
+                  target_label: service
+                - source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+                - source_labels:
+                    - __meta_kubernetes_pod_container_name
+                  target_label: container
+                - replacement: local-carbide
+                  target_label: cluster
+          walCompression: true
+          storageSpec:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 2Gi
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      prometheusOperator:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+    loki:
+      deploymentMode: Monolithic
+      loki:
+        auth_enabled: false
+        commonConfig:
+          path_prefix: /var/loki
+          replication_factor: 1
+        schemaConfig:
+          configs:
+            - from: "2024-04-01"
+              store: tsdb
+              object_store: filesystem
+              schema: v13
+              index:
+                prefix: index_
+                period: 24h
+        storage:
+          type: filesystem
+        limits_config:
+          retention_period: 24h
+        compactor:
+          retention_enabled: true
+          delete_request_store: filesystem
+      singleBinary:
+        replicas: 1
+        podDisruptionBudget:
+          enabled: false
+        persistence:
+          enabled: true
+          size: 2Gi
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 1Gi
+      read:
+        replicas: 0
+      write:
+        replicas: 0
+      backend:
+        replicas: 0
+      podDisruptionBudget:
+        enabled: false
+      gateway:
+        enabled: true
+        resources:
+          requests:
+            cpu: 20m
+            memory: 32Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+      chunksCache:
+        enabled: false
+      resultsCache:
+        enabled: false
+      lokiCanary:
+        enabled: false
+      test:
+        enabled: false
+
+    alloy:
+      crds:
+        create: false
+      alloy:
+        enableReporting: false
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        configMap:
+          content: |
+            logging {
+              level  = "info"
+              format = "logfmt"
+            }
+
+            discovery.kubernetes "pods" {
+              role = "pod"
+            }
+
+            discovery.relabel "pod_logs" {
+              targets = discovery.kubernetes.pods.targets
+
+              rule {
+                source_labels = ["__meta_kubernetes_namespace"]
+                target_label  = "namespace"
+              }
+              rule {
+                source_labels = ["__meta_kubernetes_pod_name"]
+                target_label  = "pod"
+              }
+              rule {
+                source_labels = ["__meta_kubernetes_pod_container_name"]
+                target_label  = "container"
+              }
+              rule {
+                source_labels = ["__meta_kubernetes_pod_controller_name"]
+                target_label  = "workload"
+              }
+              rule {
+                source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+                target_label  = "app"
+              }
+              rule {
+                replacement  = "local-carbide"
+                target_label = "cluster"
+              }
+            }
+
+            loki.source.kubernetes "pods" {
+              targets    = discovery.relabel.pod_logs.output
+              forward_to = [loki.write.local.receiver]
+            }
+
+            loki.write "local" {
+              endpoint {
+                url = "http://loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
+              }
+            }
+      controller:
+        type: deployment
+        replicas: 1
+
+    grafana:
+      testFramework:
+        enabled: false
+      persistence:
+        enabled: false
+      grafana.ini:
+        analytics:
+          check_for_updates: false
+          reporting_enabled: false
+        auth:
+          disable_login_form: true
+        auth.anonymous:
+          enabled: true
+          org_role: Admin
+      datasources:
+        datasources.yaml:
+          apiVersion: 1
+          datasources:
+            - name: Prometheus
+              uid: prometheus
+              type: prometheus
+              access: proxy
+              url: http://prometheus-stack-prometheus.observability.svc.cluster.local:9090
+              isDefault: false
+              editable: false
+              jsonData:
+                httpMethod: POST
+                timeInterval: 30s
+            - name: Loki
+              uid: loki
+              type: loki
+              access: proxy
+              url: http://loki-gateway.observability.svc.cluster.local
+              isDefault: true
+              editable: false
+      sidecar:
+        dashboards:
+          enabled: true
+          label: grafana_dashboard
+          labelValue: "1"
+          searchNamespace: observability
+          folderAnnotation: grafana_folder
+          skipReload: true
+          provider:
+            foldersFromFilesStructure: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
 
   temporal:
     server:
@@ -460,6 +727,7 @@ tilt:
     coreNamespace: nico-system
     restNamespace: nico-rest
     temporalNamespace: temporal
+    observabilityNamespace: observability
     vault:
       service: http://nico-vault.nico-system.svc.cluster.local:8200
       mount: secrets


### PR DESCRIPTION
Today Tiltfile doesn't provide any observability stack.
This PR adds Grafana / Prometheus / Loki / Alloy stack to local development.

## Related issues

N/A

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

