### PR TITLE
docs: add NICo upgrade guide

### DIFF
--- a/docs/development/release_and_qa_process.md
+++ b/docs/development/release_and_qa_process.md
@@ -6,8 +6,8 @@ This page describes how the NVIDIA Infra Controller (NICo) project is branched, 
 
 - Use the latest final `vX.Y.Z` tag for production-style deployments.
 - `main`, `-pr`, and `-rc` builds are for prerelease testing.
-- Every month, `main` branches to `releases/vX.Y`; after one month of QA, that branch becomes the final `vX.Y.0` release.
-- Patch releases stay on the same `releases/vX.Y` branch and ship only when fixes warrant them.
+- Every month, `main` branches to `release/vX.Y`; after one month of QA, that branch becomes the final `vX.Y.0` release.
+- Patch releases stay on the same `release/vX.Y` branch and ship only when fixes warrant them.
 - NICo keeps three minor releases visible: Current, Maintenance, and EOL. Upgrades are supported from EOL to Maintenance or Current, from Maintenance to Current, and to newer patches within the same minor version. Anything older than EOL has no supported upgrade path.
 - Guaranteed public APIs stay backward-compatible within a major version. Breaking removals require a future major release and at least one full three-month roadmap window of notice.
 
@@ -26,7 +26,7 @@ NICo uses just two long-lived branch types — `main` and per-minor-version rele
 | Branch | Purpose | Stability |
 | ------ | ------- | --------- |
 | `main` | Ongoing development | No stability guarantee |
-| `releases/vX.Y` | Stabilization and release of `vX.Y.*` | Improves over QA window, becomes stable after a non-`-rc` tag is cut |
+| `release/vX.Y` | Stabilization and release of `vX.Y.*` | Improves over QA window, becomes stable after a non-`-rc` tag is cut |
 
 ### Main Branch — Ongoing Development
 
@@ -36,7 +36,7 @@ Use `main` if you want early access to in-progress features and you accept that 
 
 ### Release Branches
 
-When development for a minor version is feature-complete, a new long-lived release branch (for example, `releases/v2.1`) is cut from `main`. This single branch holds the entire life of that minor version:
+When development for a minor version is feature-complete, a new long-lived release branch (for example, `release/v2.1`) is cut from `main`. This single branch holds the entire life of that minor version:
 
 - **During the one-month QA window**, the branch carries `vX.Y.Z-rcN` tags as fixes land — these are *release candidates*, not final releases.
 - **After QA signs off**, a final `vX.Y.0` tag is cut on the same branch.
@@ -54,14 +54,14 @@ NICo uses [semantic versioning](https://semver.org/) of the form `vX.Y.Z`:
 
 The following tag forms appear in the repository:
 
-- **`vX.Y.0`** — A minor release. Published as a GitHub release from `releases/vX.Y`.
-- **`vX.Y.Z`** (where `Z > 0`) — A patch release on top of `vX.Y.0`. Also published as a GitHub release from `releases/vX.Y`.
-- **`vX.Y.Z-rcN`** (for example, `v2.1.0-rc1` or `v2.1.5-rc3`) — A release candidate. Applied to commits on `releases/vX.Y` during the QA window for whichever release is being prepared (initial `.0` or a later patch).
+- **`vX.Y.0`** — A minor release. Published as a GitHub release from `release/vX.Y`.
+- **`vX.Y.Z`** (where `Z > 0`) — A patch release on top of `vX.Y.0`. Also published as a GitHub release from `release/vX.Y`.
+- **`vX.Y.Z-rcN`** (for example, `v2.1.0-rc1` or `v2.1.5-rc3`) — A release candidate. Applied to commits on `release/vX.Y` during the QA window for whichever release is being prepared (initial `.0` or a later patch).
 
-  All four elements — major, minor, patch, and RC number — are always present. Patch releases live on the same `releases/vX.Y` branch and are distinguished only by the tag. So the first release candidate for `v2.1.5` is tagged `v2.1.5-rc1` on `releases/v2.1`, and the final tag (after QA signs off) is `v2.1.5`.
+  All four elements — major, minor, patch, and RC number — are always present. Patch releases live on the same `release/vX.Y` branch and are distinguished only by the tag. So the first release candidate for `v2.1.5` is tagged `v2.1.5-rc1` on `release/v2.1`, and the final tag (after QA signs off) is `v2.1.5`.
 - **`vX.Y.Z-pr`** (always with `Z = 0`, for example, `v2.2.0-pr`) — Applied to `main` immediately after a release branch is cut, to indicate that `main` is now the **prerelease** for the next minor version.
 
-  All three numeric elements are present for consistency with `-rcN` tags. For example, the day `releases/v2.1` is cut, `main` is tagged `v2.2.0-pr`, signaling that `main` is now pre-v2.2.0.
+  All three numeric elements are present for consistency with `-rcN` tags. For example, the day `release/v2.1` is cut, `main` is tagged `v2.2.0-pr`, signaling that `main` is now pre-v2.2.0.
 
 ## Release Cadence
 
@@ -84,32 +84,32 @@ The roadmap is refreshed at least once per month, typically after the monthly br
 
 Every month:
 
-1. **Code complete** (last day of each month): a new release branch (for example, `releases/v2.1`) is cut from `main`.
+1. **Code complete** (last day of each month): a new release branch (for example, `release/v2.1`) is cut from `main`.
 1. Immediately after the cut, `main` is tagged with `vX.(Y+1).0-pr` to mark the start of the next prerelease cycle on `main`.
-1. The release branch is **stabilized and QA tested for one month**. During this window, release-candidate tags (for example, `v2.1.0-rc1`, `v2.1.0-rc2`, …) are applied to commits on the branch as QA cycles through them.
-1. **Final minor release** (last day of the following month): when QA signs off, a `vX.Y.0` tag is cut on the same `releases/vX.Y` branch and published as a GitHub release.
+1. The release branch is **stabilized and QA tested for one month**. During this window, release-candidate tags (for example, `v2.1.0-rc1`, `v2.1.0-rc2`, and so on) are applied to commits on the branch as QA cycles through them.
+1. **Final minor release** (last day of the following month): when QA signs off, a `vX.Y.0` tag is cut on the same `release/vX.Y` branch and published as a GitHub release.
 
 In short: minor releases ship one month after code complete.
 
 ### Patch Releases (X.Y.Z)
 
-Patch releases happen on the `releases/vX.Y` branch after the corresponding `vX.Y.0` has shipped. They are cut **as needed** — primarily for critical bug fixes (data loss, security, production-blocking regressions) or significant issues that cannot wait for the next minor release. There is no fixed patch cadence; patches ship when the fixes warrant them.
+Patch releases happen on the `release/vX.Y` branch after the corresponding `vX.Y.0` has shipped. They are cut **as needed** — primarily for critical bug fixes (data loss, security, production-blocking regressions) or significant issues that cannot wait for the next minor release. There is no fixed patch cadence; patches ship when the fixes warrant them.
 
 Patch releases go through their own QA window, scoped to the changes being shipped. The mechanics are the same as for a minor release but use a patch-versioned RC tag:
 
-1. Candidate commits are tagged on `releases/vX.Y` as `vX.Y.Z-rcN` (for example, `v2.1.5-rc1`, `v2.1.5-rc2`).
+1. Candidate commits are tagged on `release/vX.Y` as `vX.Y.Z-rcN` (for example, `v2.1.5-rc1`, `v2.1.5-rc2`).
 1. QA executes the relevant test plans against the RC tag.
 1. After QA signs off, the final `vX.Y.Z` tag is cut on the same branch.
 
-Note that **patch releases do not get their own branch.** All `v2.1.*` work lives on `releases/v2.1`; only the tags distinguish a patch RC from the final patch release. Each final patch release is published on GitHub with a `vX.Y.Z` tag.
+Note that **patch releases do not get their own branch.** All `v2.1.*` work lives on `release/v2.1`; only the tags distinguish a patch RC from the final patch release. Each final patch release is published on GitHub with a `vX.Y.Z` tag.
 
 ## Which Version Should I Use?
 
 | Goal | What to run |
 | ---- | ----------- |
 | Early access to in-progress features | Latest `main` |
-| Slightly more stable, willing to help shake out bugs | Latest `vX.Y.Z-rcN` tag on `releases/vX.Y` |
-| Most stable, production-style use | Latest non-`-rc`, non-`-pr` tag on `releases/vX.Y` |
+| Slightly more stable, willing to help shake out bugs | Latest `vX.Y.Z-rcN` tag on `release/vX.Y` |
+| Most stable, production-style use | Latest non-`-rc`, non-`-pr` tag on `release/vX.Y` |
 
 Bugs found on a tagged release (`vX.Y.Z` with no `-rc` or `-pr` suffix) are treated with the highest priority and are tracked as **QA test escapes** — defects that slipped past the QA window and require a follow-up fix, typically in the next patch release.
 
@@ -300,7 +300,7 @@ If you build automation that depends on any of the unguaranteed items above, exp
 A few terms used on this page that are not always obvious:
 
 - **Code complete** — the point in the cycle at which feature work for a minor version stops and stabilization begins. On this date, the release branch is cut from `main`.
-- **Release candidate (rc)** — a tagged build on a `releases/vX.Y` branch that is a candidate for release, pending QA sign-off. Identified by the `-rcN` suffix on the tag (for example, `v2.1.0-rc1`, `v2.1.5-rc2`). Note: `-rc` is a tag suffix only; there is no `releases/...-rc` branch.
+- **Release candidate (rc)** — a tagged build on a `release/vX.Y` branch that is a candidate for release, pending QA sign-off. Identified by the `-rcN` suffix on the tag (for example, `v2.1.0-rc1`, `v2.1.5-rc2`). Note: `-rc` is a tag suffix only; there is no `release/...-rc` branch.
 - **Prerelease (pr)** — a build of `main` that is on its way to becoming the next minor release. Identified by the `-pr` suffix on a tag (for example, `v2.2.0-pr`).
 - **QA sign-off** — the formal acknowledgment from QA that a release candidate has passed its test plan and can be promoted to a final release.
 - **QA test escape** — a defect discovered in a tagged, signed-off release that was not caught during the QA window. These are treated as high-priority and typically fixed in a subsequent patch release.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -662,9 +662,9 @@ kubectl logs -n nico-system -l app.kubernetes.io/name=nico-api --tail=50 \
 
 ## Upgrading
 
-To upgrade an existing NICo installation to a new release, re-run `setup.sh` with the new image tags after checking out the target release. `setup.sh` is idempotent — each phase upgrades its component in place while preserving Vault state, PostgreSQL data, MetalLB site config, and the site UUID.
+To upgrade an existing NICo installation to a new release, check out the target release, and re-run `setup.sh` with the new image tags. `setup.sh` is idempotent: each phase upgrades its component in-place while preserving Vault state, PostgreSQL data, MetalLB site config, and the site UUID.
 
-Refer to the [Upgrading NICo](../manuals/upgrade.md) guide for the pre-upgrade checklist, version-specific notes (including the 2.0→2.1 MetalLB CRD ownership migration), and rollback considerations.
+Refer to the [Upgrading NICo](../manuals/upgrade.md) guide for the pre-upgrade checklist, version-specific notes (including the 2.0-to-2.1 MetalLB CRD ownership migration), and rollback considerations.
 
 ## Teardown
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -660,6 +660,12 @@ kubectl logs -n nico-system -l app.kubernetes.io/name=nico-api --tail=50 \
     | grep -i "site explorer\|bmc\|discovery"
 ```
 
+## Upgrading
+
+To upgrade an existing NICo installation to a new release, re-run `setup.sh` with the new image tags after checking out the target release. `setup.sh` is idempotent — each phase upgrades its component in place while preserving Vault state, PostgreSQL data, MetalLB site config, and the site UUID.
+
+Refer to the [Upgrading NICo](../manuals/upgrade.md) guide for the pre-upgrade checklist, version-specific notes (including the 2.0→2.1 MetalLB CRD ownership migration), and rollback considerations.
+
 ## Teardown
 
 To perform teardown, run the following command:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -62,6 +62,9 @@ navigation:
               slug: dpf-setup
             - page: Day 0 Machine Identity
               path: getting-started/installation-options/day0-machine-identity.md
+            - page: Upgrading NICo
+              path: manuals/upgrade.md
+              slug: upgrading-nico
           slug: installation-options
 
     - section: Architecture

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -62,9 +62,6 @@ navigation:
               slug: dpf-setup
             - page: Day 0 Machine Identity
               path: getting-started/installation-options/day0-machine-identity.md
-            - page: Upgrading NICo
-              path: manuals/upgrade.md
-              slug: upgrading-nico
           slug: installation-options
 
     - section: Architecture
@@ -158,6 +155,9 @@ navigation:
 
     - section: Operations (Day 2)
       contents:
+        - page: Upgrading NICo
+          path: manuals/upgrade.md
+          slug: upgrading-nico
         - section: DPU Management
           contents:
             - page: DPU Lifecycle Management

--- a/docs/manuals/upgrade.md
+++ b/docs/manuals/upgrade.md
@@ -10,7 +10,7 @@ Every installation phase is designed to be safe to re-run:
 
 | Phase | Behavior on re-run |
 | ----- | ------------------ |
-| **1 — local-path-provisioner** | Manifests are `kubectl apply`'d — idempotent. StorageClasses are upserted. |
+| **1 — local-path-provisioner** | Manifests are `kubectl apply`'d — idempotent. The StorageClass is **deleted and re-created** on every run (its `provisioner` field is immutable). Existing PVs and PVCs are unaffected, but new PVC provisioning fails during that brief window. |
 | **1b — postgres-operator** | `helmfile sync` issues `helm upgrade --install` — upgrades the release in place. Existing `PostgreSQL` CRs (including `nico-pg-cluster`) are untouched. |
 | **1c — MetalLB** | CRDs are applied server-side with `--force-conflicts`. Any helm-owned CRDs from a prior install have their ownership labels stripped before sync, preventing deletion. `helmfile sync` upgrades the release. Existing `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instances are preserved and re-applied (idempotent `kubectl apply`). Refer to [MetalLB CRD ownership](#20--21-metallb-crd-ownership-migration). |
 | **2 — cert-manager** | `helmfile sync` upgrades the release. Existing `ClusterIssuer`, `Certificate`, and `CertificateRequest` objects are untouched. The Vault TLS bootstrap certs are re-applied server-side; existing certs that are still valid are not reissued. |
@@ -20,6 +20,7 @@ Every installation phase is designed to be safe to re-run:
 | **5 — external-secrets + nico-prereqs** | `helmfile sync` upgrades both releases. Existing `ClusterSecretStore` and `ExternalSecret` objects are reconciled to their new definitions. The ESO controller re-syncs all secrets on the next poll cycle. |
 | **5b — DPF** | DPF components are upgraded via their helm charts. The `DPFOperatorConfig`, `DPUCluster`, and `DPUService` objects are preserved. Refer to [DPF version update](#20--21-dpf-version-update). |
 | **6 — NICo Core** | `helm upgrade --install nico` rolls out the new Core image tag. The PostgreSQL database schema is migrated by the pre-upgrade Job (uses the `imagepullsecret` Secret, which is upserted). NICo state (host records, machine state, firmware inventory) lives in PostgreSQL and is preserved. |
+| **6b — DPF enablement** | On DPF-enabled sites only: refreshes the BMC-root credential, then runs a **second** `helm upgrade` of Core with the `[dpf]` block enabled and restarts `nico-api`. Core therefore rolls out twice on a DPF site. |
 | **7a–7g — NICo REST** | REST components are upgraded via `helm upgrade --install`. The `nico_rest` PostgreSQL database is migrated in-place by the REST migration Job. Temporal workflow state is preserved. The Keycloak realm and client credentials are preserved. |
 | **7h — NICo Flow** | Flow, PSM, and NSM are upgraded in place. |
 | **7i — NICo REST site-agent** | The site-agent StatefulSet is upgraded. The site UUID (stored in the `site-registration` Secret) and REST site record are preserved. |
@@ -27,11 +28,12 @@ Every installation phase is designed to be safe to re-run:
 ### What is preserved across upgrades
 
 - **Vault cluster**: init state, unseal keys, PKI chain, AppRole credentials, all secrets. Vault is never re-initialized on an upgrade run.
-- **PostgreSQL data**: all NICo Core and NICo REST database state, including host records, machine state, site config, Keycloak realm data, and Temporal workflow history.
+- **PostgreSQL data**: all NICo Core and NICo REST database state, including host records, machine state, and site config in `nico-pg-cluster`. Keycloak realm data and Temporal workflow history live in a **separate** plain `postgres` StatefulSet in the same namespace (created in phase 7c) and are also preserved.
 - **MetalLB site config**: `IPAddressPool`, `BGPPeer`, `BGPAdvertisement`, and `L2Advertisement` instances. These are re-applied on every run so any manual changes outside `setup.sh` are reconciled back to the values in `values/metallb-config.yaml`.
 - **SSH host key**: the cluster SSH identity is preserved so BMC consoles do not require known-host updates.
 - **Site UUID**: the REST site identity and site-agent registration are preserved.
-- **Certificates**: all cert-manager-managed certificates remain valid until their natural expiry; they are not reissued on upgrade.
+- **Certificates**: all cert-manager-managed certificates remain valid until their natural expiry; they are not reissued on upgrade unless the new release changes a Certificate spec.
+- **Site UUID caveat**: the `site-registration` Secret is deleted and re-created if `NICO_SITE_UUID` differs from the registered one — keep it unset (or identical to the initial install) on upgrades.
 
 ### What changes during an upgrade
 
@@ -49,7 +51,7 @@ Complete every item before running `setup.sh`. Missing any of these can cause th
 
 ### Back up Vault unseal keys
 
-Vault unseal keys are stored in the `vault-cluster-keys` Secret in the `vault` namespace. If this Secret is lost and all Vault pods restart simultaneously, the cluster is unrecoverable without a Vault snapshot.
+Vault unseal keys are stored in the `vault-cluster-keys` Secret in the `vault` namespace. If this Secret is lost and all Vault pods restart simultaneously, the Vault data is unrecoverable — a Raft snapshot does **not** substitute for the unseal keys, because snapshots are encrypted with the same keyring the keys protect.
 
 ```bash
 # Verify the backup Secret exists
@@ -64,8 +66,27 @@ kubectl get secret vault-cluster-keys -n vault -o json > vault-cluster-keys-back
 ```
 
 <Warning>
-This file contains the plaintext Vault unseal keys. Store it in a secure, offline location and delete the local copy after storing.
+This file contains the plaintext Vault unseal keys **and the Vault root token**. Anyone holding it has full control of Vault. Store it in a secure, offline location and delete the local copy after storing.
 </Warning>
+
+### Back up the databases
+
+Take the backup **before** the upgrade — once the new version's migrations run, the prior image tags alone are no longer a working rollback. There are **two** PostgreSQL instances in the `postgres` namespace, and both need a dump:
+
+```bash
+umask 077
+# nico-pg-cluster: nico_system_nico, nico_rest, and (with Flow) flow/psm/nsm
+kubectl exec -n postgres \
+    "$(kubectl get pods -n postgres -l application=spilo,spilo-role=master -o jsonpath='{.items[0].metadata.name}')" \
+    -- su postgres -c "pg_dumpall" > nico_pg_pre_upgrade.sql
+
+# plain `postgres` StatefulSet: temporal, temporal_visibility, keycloak
+kubectl exec -n postgres postgres-0 -- pg_dumpall -U postgres > nico_rest_pg_pre_upgrade.sql
+```
+
+<Note>
+These are **logical** dumps, not PVC snapshots. Restoring means recreating the databases from SQL — expect downtime proportional to database size — and in-flight Temporal workflows at dump time cannot be replayed. If your storage class supports volume snapshots, snapshot the PostgreSQL and Vault PVCs as well for a faster, more complete restore point.
+</Note>
 
 ### Check cluster health before upgrading
 
@@ -83,10 +104,11 @@ kubectl get pods -n dpf-operator-system   # if DPF is enabled — phase 5b upgra
 
 All pods should be `Running` or `Completed`. Check for pods stuck in `CrashLoopBackOff`, `Pending`, or `Error`.
 
-Capture the current LoadBalancer VIP assignments as a baseline — the post-upgrade verification diffs against this:
+Capture the current LoadBalancer VIP assignments as a baseline — the post-upgrade verification diffs against this. The command records only stable fields (namespace, name, VIP) across **all** namespaces, so cosmetic changes such as `AGE` or port ordering cannot show up as false diffs:
 
 ```bash
-kubectl get svc -n nico-system -o wide | grep LoadBalancer > pre-upgrade-vips.txt
+kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.metadata.namespace}{"/"}{.metadata.name}{" "}{.status.loadBalancer.ingress[0].ip}{"\n"}{end}' \
+    > pre-upgrade-vips.txt
 ```
 
 Verify that Vault is fully unsealed — a sealed Vault blocks the upgrade at phase 4:
@@ -99,7 +121,7 @@ Both should show `Initialized true` and `Sealed false`.
 
 ### Pull the new release
 
-Update your local checkout to the target release branch or tag:
+Update your local checkout to the target release branch or tag. The commands below assume an `upstream` remote pointing at the main repository; add it once with `git remote add upstream https://github.com/NVIDIA/infra-controller.git` (or substitute `origin` if you cloned the main repository directly):
 
 ```bash
 git fetch upstream
@@ -136,6 +158,15 @@ export NICO_REST_IMAGE_TAG=v2.1.0                      # new REST tag
 
 If you are upgrading DPF as part of this release, the DPF version is read from `NICO_DPF_VERSION` (defaulting to the value baked into `setup.sh`). You do not normally need to set this explicitly unless your site uses a pinned version.
 
+DPF is enabled by default, and on DPF sites two more variables are **required** — preflight raises hard errors when they are unset:
+
+```bash
+export NICO_DPF_DPU_INTERFACE=<DPU high-speed interface, e.g. ens1f0np0>
+export NICO_DPF_DPU_CLUSTER_VIP=<VIP for the DPU cluster control plane>
+```
+
+Set them to the same values used at initial install (they are not persisted by `setup.sh`).
+
 ### Run the pre-flight check
 
 ```bash
@@ -145,16 +176,24 @@ source ./preflight.sh
 
 Fix all errors before proceeding. Warnings about `NICO_DPF_BMC_ROOT_PASSWORD` being unset are safe to ignore on an upgrade (the credential is already stored in Vault from the initial install).
 
+<Warning>
+`setup.sh -y` does **not** stop on preflight errors — with `-y` set, hard errors are printed and the run continues ("Things may fail"). The preflight gate is only enforced interactively, so genuinely resolve every error here rather than relying on the script to stop you.
+</Warning>
+
 </Steps>
 
 ## Running the upgrade
 
-With the checklist complete, run `setup.sh` exactly as you would for a fresh install:
+With the checklist complete — including the [version-specific notes](#version-specific-upgrade-notes) for your upgrade path, which describe behavior that happens *during* the run — run `setup.sh` exactly as you would for a fresh install:
 
 ```bash
 cd helm-prereqs/
 ./setup.sh -y
 ```
+
+<Warning>
+If a phase fails, `setup.sh` prints `SETUP FAILED` and offers: `Run clean.sh to revert the cluster now? [y/N]`. **Always answer `N` on an upgrade.** `clean.sh` is a full teardown — it deletes the Vault key Secrets (`vault-cluster-keys`, `vaultroottoken`), the `postgres`, `nico-rest`, `temporal`, and `flow` namespaces, and flips local-path PVs to `Delete` so their host directories are reclaimed. Accepting it destroys the very data the upgrade preserves. Diagnose the failed phase and re-run `setup.sh` instead.
+</Warning>
 
 `setup.sh` processes all phases in order. Phases that find their components already at the correct state complete quickly. Phases that detect a version delta or config change apply the update.
 
@@ -165,7 +204,7 @@ cd helm-prereqs/
 | `--skip-core` | Skip Phase 6 only. Prerequisites and the REST stack still upgrade; NICo Core is left on its current image. Useful when the Core image did not change. |
 | `--skip-rest` | Skip Phase 7 only. Prerequisites and NICo Core still upgrade; the REST stack is left untouched. |
 | `--skip-flow` | Skip the Flow upgrade (Phase 7h). |
-| `--skip-dpf` | Skip DPF upgrade. Use only if DPF is not enabled at this site. |
+| `--skip-dpf` | Use **only** if DPF is not enabled at this site. This is not a pure skip: it clears `INSTALL_DPF`, which drops phases 5b and 6b *and* redeploys NICo Core with the `[dpf]` block disabled — on a DPF-enabled site that is a config change, not a skip. |
 | `--core-values <file>` | Use a per-site NICo Core values file (same as initial install). |
 | `--metallb-config <path>` | Use a site-specific MetalLB manifest or kustomize dir (same as initial install). |
 
@@ -178,6 +217,7 @@ cd helm-prereqs/
 | Phase 5 (ESO + nico-prereqs) | 1–3 min |
 | Phase 5b (DPF) | 3–10 min (depends on DPF version delta) |
 | Phase 6 (NICo Core) | 3–8 min (includes DB migration Job) |
+| Phase 6b (DPF enablement — DPF sites only) | 2–5 min (second Core rollout + nico-api restart) |
 | Phases 7a–7i (NICo REST + site-agent) | 5–15 min (Temporal and DB migrations are the slowest steps) |
 
 Total: typically **15–45 minutes** for a full upgrade with DPF.
@@ -203,14 +243,14 @@ kubectl get deployment -n nico-system nico-api \
     -o jsonpath='{.spec.template.spec.containers[0].image}'
 ```
 
-Verify every LoadBalancer service kept its VIP — an upgrade must not reassign them. Diff against the baseline captured in the pre-upgrade checklist:
+Verify every LoadBalancer service in the cluster kept its VIP — an upgrade must not reassign them. Diff against the baseline captured in the pre-upgrade checklist (same stable namespace/name/VIP fields):
 
 ```bash
-kubectl get svc -n nico-system -o wide | grep LoadBalancer | diff pre-upgrade-vips.txt - \
-    && echo "VIPs unchanged"
+kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.metadata.namespace}{"/"}{.metadata.name}{" "}{.status.loadBalancer.ingress[0].ip}{"\n"}{end}' \
+    | diff pre-upgrade-vips.txt - && echo "VIPs unchanged"
 ```
 
-Any diff output or `<pending>` entry means MetalLB reassigned or stopped advertising a VIP — check the MetalLB CRDs and site config objects (see the 2.0→2.1 note below) and the pins in `values/nico-core.yaml`.
+Any diff output or a missing address means MetalLB reassigned or stopped advertising a VIP — check the MetalLB CRDs and site config objects (see the 2.0→2.1 note below) and the pins in `values/nico-core.yaml`.
 
 Verify PostgreSQL has an elected leader and the cluster is running:
 
@@ -277,6 +317,10 @@ NICo 2.1 requires `startupProbe` to be explicitly configured in the machine-a-tr
 
 ## Rollback
 
+<Warning>
+Downgrades are **not a supported version move** — the [release and QA process](../development/release_and_qa_process.md) tests forward upgrades only, and the supported recovery for a bad release is a forward-fix in the next patch. Treat the procedure below as disaster recovery for a failed upgrade, not as a routine operation.
+</Warning>
+
 `setup.sh` does not have a built-in rollback mechanism. Rollback consists of:
 
 1. Checking out the prior release branch or tag.
@@ -284,26 +328,15 @@ NICo 2.1 requires `startupProbe` to be explicitly configured in the machine-a-tr
 
 For NICo Core and REST, the Helm release is rolled back in place, and the database migration Jobs for the prior version run on startup. NICo's database migrations are designed to be forward-compatible; rolling back does not guarantee schema compatibility if the new version added non-nullable columns — which is why a pre-upgrade database backup is essential.
 
-The `nico-pg-cluster` hosts several databases: `nico_system_nico` (NICo Core), `nico_rest` (NICo REST), and — when Flow is enabled — `flow`, `psm`, and `nsm`. A rollback backup must cover all of them; use `pg_dumpall`, which also captures roles and grants:
+The database dumps from the [pre-upgrade checklist](#back-up-the-databases) are the rollback foundation: `nico-pg-cluster` holds `nico_system_nico` (NICo Core), `nico_rest` (NICo REST), and — when Flow is enabled — `flow`, `psm`, and `nsm`, while the plain `postgres` StatefulSet holds `temporal`, `temporal_visibility`, and `keycloak`. Restoring means replaying the SQL against a clean instance (`psql -f <dump>.sql`).
 
-```bash
-umask 077
-kubectl exec -n postgres \
-    "$(kubectl get pods -n postgres -l application=spilo,spilo-role=master -o jsonpath='{.items[0].metadata.name}')" \
-    -- su postgres -c "pg_dumpall" > nico_pg_pre_upgrade.sql
-```
-
-<Note>
-This is a **logical** dump, not a PVC snapshot. Restoring it means recreating the databases from SQL (`psql -f nico_pg_pre_upgrade.sql` against a clean cluster) — expect downtime proportional to database size. It also does not capture Vault storage or Temporal workflow history; in-flight workflows at the time of the dump cannot be replayed from it. If your storage class supports volume snapshots, snapshot the PostgreSQL and Vault PVCs as well for a faster, more complete restore point.
-</Note>
-
-Because of these limitations, re-running `setup.sh` with the prior image tags alone is **not** a complete rollback if the new version's migrations already ran — restore the database dump first, then deploy the prior version.
+Re-running `setup.sh` with the prior image tags alone is **not** a complete rollback if the new version's migrations already ran — restore the database dumps first, then deploy the prior version.
 
 For DPF, rolling back to a prior DPF version is not supported by NVIDIA. If DPF fails to upgrade, reach out to NVIDIA support rather than attempting a downgrade.
 
 ## Using setup.sh for individual component upgrades
 
-You can narrow an upgrade to particular components with the `--skip-*` flags. Each one skips exactly the phase it names — **none of them skip the prerequisite stack**, and there is no `--skip-prereqs`:
+You can narrow an upgrade to particular components with the `--skip-*` flags. `--skip-core`, `--skip-rest`, and `--skip-flow` skip exactly the phase they name — **none of them skip the prerequisite stack**, and there is no `--skip-prereqs`. (`--skip-dpf` is the exception: refer to its caveat in the flag table above. `--skip-core` also suppresses the `imagepullsecret` upsert that the Core migration Job uses.)
 
 ```bash
 # Prerequisites + NICo Core; leave the REST stack untouched (skips Phase 7)
@@ -318,14 +351,15 @@ You can narrow an upgrade to particular components with the `--skip-*` flags. Ea
 
 The prerequisite phases therefore run on every invocation. That is by design and is cheap: each one is idempotent, and a phase whose inputs have not changed reconciles to the same state and exits quickly.
 
-For a single-helm-chart upgrade (e.g., rotating the NICo Core image tag without going through the full script):
+For a single-helm-chart upgrade (e.g., rotating the NICo Core image tag without going through the full script), run from the **repository root**, matching what `setup.sh` itself executes:
 
 ```bash
-helm upgrade nico ../helm \
+helm upgrade --install nico ./helm \
     -n nico-system \
     -f helm-prereqs/values/nico-core.yaml \
-    --set global.image.tag="${NICO_CORE_IMAGE_TAG}" \
-    --timeout 300s --wait
+    --set-string global.image.repository="${NICO_IMAGE_REGISTRY}/nvmetal-carbide" \
+    --set-string global.image.tag="${NICO_CORE_IMAGE_TAG}" \
+    --timeout 600s --wait
 ```
 
-This skips the MetalLB CRD handling, DPF management, and other prereq phases — only do this when you are certain those components do not need updating.
+This skips the MetalLB CRD handling, DPF management, the `imagepullsecret` upsert the migration Job depends on, and the other prereq phases — only do this when you are certain those components do not need updating. **Do not use this on a DPF-enabled site**: there, Core deploys in two phases with different values (`--set nico-api.dpf.rbacCreate=true` plus the `[dpf]`-enabled block), which is why `setup.sh` refuses to print a standalone command on the DPF path — use `./setup.sh -y --skip-rest` instead.

--- a/docs/manuals/upgrade.md
+++ b/docs/manuals/upgrade.md
@@ -2,23 +2,23 @@
 
 `setup.sh` is designed to be **idempotent**: running it against an existing NICo installation upgrades each component in place. The same script and values files used for initial installation are the mechanism for upgrades — there is no separate upgrade script.
 
-This page documents how each component behaves when `setup.sh` is re-run against a live cluster, what to prepare before upgrading, and version-specific considerations for the 2.0→2.1 path.
+This page documents how each component behaves when you re-run `setup.sh` against a live cluster, what to prepare before upgrading, and version-specific considerations for the 2.0-to-2.1 upgrade path.
 
 ## How setup.sh handles upgrades
 
-Every installation phase is designed to be safe to re-run:
+Every installation phase is safe to re-run:
 
 | Phase | Behavior on re-run |
 | ----- | ------------------ |
-| **1 — local-path-provisioner** | Manifests are `kubectl apply`'d — idempotent. The StorageClass is **deleted and re-created** on every run (its `provisioner` field is immutable). Existing PVs and PVCs are unaffected, but new PVC provisioning fails during that brief window. |
+| **1 — local-path-provisioner** | Manifests applied using `kubectl apply` are idempotent. The StorageClass is **deleted and re-created** on every run (its `provisioner` field is immutable). Existing PVs and PVCs are unaffected, but new PVC provisioning fails during that brief window. |
 | **1b — postgres-operator** | `helmfile sync` issues `helm upgrade --install` — upgrades the release in place. Existing `PostgreSQL` CRs (including `nico-pg-cluster`) are untouched. |
-| **1c — MetalLB** | CRDs are applied server-side with `--force-conflicts`. Any helm-owned CRDs from a prior install have their ownership labels stripped before sync, preventing deletion. `helmfile sync` upgrades the release. Existing `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instances are preserved and re-applied (idempotent `kubectl apply`). Refer to [MetalLB CRD ownership](#20--21-metallb-crd-ownership-migration). |
+| **1c — MetalLB** | CRDs are applied server-side with `--force-conflicts`. Any Helm-owned CRDs from a prior install have their ownership labels stripped before sync, preventing deletion. `helmfile sync` upgrades the release. Existing `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instances are preserved and re-applied (idempotent `kubectl apply`). Refer to [MetalLB CRD ownership](#20--21-metallb-crd-ownership-migration). |
 | **2 — cert-manager** | `helmfile sync` upgrades the release. Existing `ClusterIssuer`, `Certificate`, and `CertificateRequest` objects are untouched. The Vault TLS bootstrap certs are re-applied server-side; existing certs that are still valid are not reissued. |
 | **3 — Vault** | `helmfile sync` upgrades the release. The StatefulSet rolling-update leaves Vault pods running. |
 | **4 — Vault unseal** | `unseal_vault.sh` checks whether Vault is already initialized. If it is, it skips `vault operator init` and only unseals any pods that were restarted and became sealed again. The Vault cluster keys (`vault-cluster-keys` Secret) and root token (`vaultroottoken`) are preserved. |
 | **4 (SSH host key)** | `bootstrap_ssh_host_key.sh` detects an existing SSH host key Secret and skips re-generation. The cluster's SSH identity is preserved across upgrades. |
 | **5 — external-secrets + nico-prereqs** | `helmfile sync` upgrades both releases. Existing `ClusterSecretStore` and `ExternalSecret` objects are reconciled to their new definitions. The ESO controller re-syncs all secrets on the next poll cycle. |
-| **5b — DPF** | DPF components are upgraded via their helm charts. The `DPFOperatorConfig`, `DPUCluster`, and `DPUService` objects are preserved. Refer to [DPF version update](#20--21-dpf-version-update). |
+| **5b — DPF** | DPF components are upgraded via their Helm charts. The `DPFOperatorConfig`, `DPUCluster`, and `DPUService` objects are preserved. Refer to [DPF version update](#20--21-dpf-version-update). |
 | **6 — NICo Core** | `helm upgrade --install nico` rolls out the new Core image tag. The PostgreSQL database schema is migrated by the pre-upgrade Job (uses the `imagepullsecret` Secret, which is upserted). NICo state (host records, machine state, firmware inventory) lives in PostgreSQL and is preserved. |
 | **6b — DPF enablement** | On DPF-enabled sites only: refreshes the BMC-root credential, then runs a **second** `helm upgrade` of Core with the `[dpf]` block enabled and restarts `nico-api`. Core therefore rolls out twice on a DPF site. |
 | **7a–7g — NICo REST** | REST components are upgraded via `helm upgrade --install`. The `nico_rest` PostgreSQL database is migrated in-place by the REST migration Job. Temporal workflow state is preserved. The Keycloak realm and client credentials are preserved. |
@@ -36,9 +36,9 @@ Every installation phase is designed to be safe to re-run:
 
 ### What changes during an upgrade
 
-- All helm release images are updated to the new tags set in `NICO_CORE_IMAGE_TAG`, `NICO_REST_IMAGE_TAG`, etc.
+- All Helm release images are updated to the new tags set in `NICO_CORE_IMAGE_TAG`, `NICO_REST_IMAGE_TAG`, etc.
 - CRD schemas are updated to their new versions via server-side apply.
-- ConfigMaps and Secrets produced by helm are updated to reflect new chart values.
+- ConfigMaps and Secrets produced by Helm are updated to reflect new chart values.
 - The NICo Core and REST database schemas are migrated forward by their respective pre-upgrade Jobs.
 - DPF operator and DPUService images are updated to the new `NICO_DPF_VERSION`.
 
@@ -134,7 +134,7 @@ Review the release changelog for breaking changes:
 
 ### Review values file changes
 
-Check whether new release added required values fields or changed defaults:
+Check whether the new release added required values fields or changed any default values. If so, update your site values files to include any new required fields before running `setup.sh`.
 
 ```bash
 git diff upstream/release/v2.0..upstream/release/v2.1 -- helm-prereqs/values.yaml \
@@ -142,8 +142,6 @@ git diff upstream/release/v2.0..upstream/release/v2.1 -- helm-prereqs/values.yam
     helm-prereqs/values/nico-rest.yaml \
     helm-prereqs/values/metallb-config.yaml
 ```
-
-Update your site values files to include any new required fields before running `setup.sh`.
 
 ### Update image tags
 
@@ -279,13 +277,13 @@ cd helm-prereqs/
 
 ### 2.0 → 2.1: MetalLB CRD ownership migration
 
-**Impact:** This upgrade path requires special handling that `setup.sh` performs automatically. If you skip MetalLB's phase in your upgrade (e.g., by removing it from the helmfile run), your site config objects (`IPAddressPool`, `BGPPeer`, `BGPAdvertisement`) will be deleted.
+**Impact:** This upgrade path requires special handling that `setup.sh` performs automatically. If you skip MetalLB's phase in your upgrade (for example, by removing it from the helmfile run), your site config objects (`IPAddressPool`, `BGPPeer`, `BGPAdvertisement`) will be deleted.
 
-**Root cause:** In NICo 2.0, MetalLB was deployed with `crds.enabled: true` (the helm chart default), which places all seven MetalLB CRDs inside the helm release manifest. In NICo 2.1, `crds.enabled: false` is set explicitly so that the MetalLB cert rotator can take SSA field ownership of the CRD `caBundle` without conflicting with helm on every re-sync. When helm sees `crds.enabled` change from `true` to `false`, it removes the CRDs from its manifest — and Kubernetes garbage-collects every `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instance stored as CRD resources, permanently deleting your site config.
+**Root cause:** In NICo 2.0, MetalLB was deployed with `crds.enabled: true` (the Helm chart default), which places all seven MetalLB CRDs inside the Helm release manifest. In NICo 2.1, `crds.enabled: false` is set explicitly so that the MetalLB cert rotator can take SSA field ownership of the CRD `caBundle` without conflicting with Helm on every re-sync. When Helm sees `crds.enabled` change from `true` to `false`, it removes the CRDs from its manifest — and Kubernetes garbage-collects every `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instance stored as CRD resources, permanently deleting your site config.
 
-**How setup.sh handles this:** Before running `helmfile sync` for MetalLB, `setup.sh` strips the `app.kubernetes.io/managed-by: Helm` label and the `meta.helm.sh/release-name` / `meta.helm.sh/release-namespace` annotations from any existing MetalLB CRDs. With the labels removed, helm does not consider the CRDs part of its managed set and does not delete them during the sync. CRDs are then applied directly (server-side, `--force-conflicts`) before and after the helmfile sync.
+**How setup.sh handles this:** Before running `helmfile sync` for MetalLB, `setup.sh` strips the `app.kubernetes.io/managed-by: Helm` label and the `meta.helm.sh/release-name` / `meta.helm.sh/release-namespace` annotations from any existing MetalLB CRDs. With the labels removed, Helm does not consider the CRDs part of its managed set and does not delete them during the sync. CRDs are then applied directly (server-side, `--force-conflicts`) before and after the helmfile sync.
 
-**If you are upgrading manually** (not via `setup.sh`), you must strip helm ownership from all MetalLB CRDs before running `helmfile sync` or `helm upgrade`:
+**If you are upgrading manually** (not via `setup.sh`), you must strip Helm ownership from all MetalLB CRDs before running `helmfile sync` or `helm upgrade`:
 
 ```bash
 for crd in $(kubectl get crd -o name | grep '\.metallb\.io$'); do
@@ -317,19 +315,19 @@ NICo 2.1 requires `startupProbe` to be explicitly configured in the machine-a-tr
 ## Rollback
 
 <Warning>
-Downgrades are **not a supported version move** — the [release and QA process](../development/release_and_qa_process.md) tests forward upgrades only, and the supported recovery for a bad release is a forward-fix in the next patch. Treat the procedure below as disaster recovery for a failed upgrade, not as a routine operation.
+Downgrades are **not a supported version move**. The [release and QA process](../development/release_and_qa_process.md) tests forward upgrades only, and the supported recovery for a bad release is a forward-fix in the next patch. Treat the following procedure as disaster recovery for a failed upgrade, not as a routine operation.
 </Warning>
 
 `setup.sh` does not have a built-in rollback mechanism. Rollback consists of:
 
 1. Checking out the prior release branch or tag.
-2. Re-running `setup.sh` with the prior image tags.
+1. Re-running `setup.sh` with the prior image tags.
 
-For NICo Core and REST, the Helm release is rolled back in place, and the database migration Jobs for the prior version run on startup. NICo's database migrations are designed to be forward-compatible; rolling back does not guarantee schema compatibility if the new version added non-nullable columns — which is why a pre-upgrade database backup is essential.
+For NICo Core and REST, the Helm release is rolled back in-place, and the database migration Jobs for the prior version run on startup. NICo's database migrations are designed to be forward-compatible; rolling back does not guarantee schema compatibility if the new version added non-nullable columns. This is why a pre-upgrade database backup is essential.
 
 The database dumps from the [pre-upgrade checklist](#back-up-the-databases) are the rollback foundation: `nico-pg-cluster` holds `nico_system_nico` (NICo Core), `nico_rest` (NICo REST), and — when Flow is enabled — `flow`, `psm`, and `nsm`, while the plain `postgres` StatefulSet holds `temporal`, `temporal_visibility`, and `keycloak`. Restoring means replaying the SQL against a clean instance (`psql -f <dump>.sql`).
 
-Re-running `setup.sh` with the prior image tags alone is **not** a complete rollback if the new version's migrations already ran — restore the database dumps first, then deploy the prior version.
+Re-running `setup.sh` with the prior image tags alone is **not** a complete rollback if the new version's migrations already ran. Restore the database dumps first, then deploy the prior version.
 
 For DPF, rolling back to a prior DPF version is not supported by NVIDIA. If DPF fails to upgrade, reach out to NVIDIA support rather than attempting a downgrade.
 
@@ -350,7 +348,7 @@ You can narrow an upgrade to particular components with the `--skip-*` flags. `-
 
 The prerequisite phases therefore run on every invocation. That is by design and is cheap: each one is idempotent, and a phase whose inputs have not changed reconciles to the same state and exits quickly.
 
-For a single-helm-chart upgrade (e.g., rotating the NICo Core image tag without going through the full script), run from the **repository root**, matching what `setup.sh` itself executes:
+For a single-Helm-chart upgrade (such as rotating the NICo Core image tag without going through the full script), run from the **repository root**, matching what `setup.sh` itself executes:
 
 ```bash
 helm upgrade --install nico ./helm \
@@ -361,4 +359,8 @@ helm upgrade --install nico ./helm \
     --timeout 600s --wait
 ```
 
-This skips the MetalLB CRD handling, DPF management, the `imagepullsecret` upsert the migration Job depends on, and the other prereq phases — only do this when you are certain those components do not need updating. **Do not use this on a DPF-enabled site**: there, Core deploys in two phases with different values (`--set nico-api.dpf.rbacCreate=true` plus the `[dpf]`-enabled block), which is why `setup.sh` refuses to print a standalone command on the DPF path — use `./setup.sh -y --skip-rest` instead.
+<Warning>
+This skips the MetalLB CRD handling, DPF management, the `imagepullsecret` upsert the migration Job depends on, and the other prereq phases. Only do this when you are certain those components do not need updating.
+
+**Do not use this on a DPF-enabled site**. Core deploys in two phases with different values (`--set nico-api.dpf.rbacCreate=true` plus the `[dpf]`-enabled block), which is why `setup.sh` refuses to print a standalone command on the DPF path. Use `./setup.sh -y --skip-rest` instead.
+</Warning>

--- a/docs/manuals/upgrade.md
+++ b/docs/manuals/upgrade.md
@@ -57,6 +57,7 @@ kubectl get secret vault-cluster-keys -n vault -o jsonpath='{.metadata.name}'
 Export and store it offline:
 
 ```bash
+umask 077   # keep the backup readable only by you
 kubectl get secret vault-cluster-keys -n vault -o json > vault-cluster-keys-backup.json
 ```
 
@@ -75,6 +76,7 @@ kubectl get pods -n temporal
 kubectl get pods -n vault
 kubectl get pods -n postgres
 kubectl get pods -n metallb-system
+kubectl get pods -n dpf-operator-system   # if DPF is enabled — phase 5b upgrades it
 ```
 
 All pods should be `Running` or `Completed`. Check for pods stuck in `CrashLoopBackOff`, `Pending`, or `Error`.
@@ -105,7 +107,7 @@ Review the release changelog for breaking changes:
 Check whether new release added required values fields or changed defaults:
 
 ```bash
-git diff release/v2.0..release/v2.1 -- helm-prereqs/values.yaml \
+git diff upstream/release/v2.0..upstream/release/v2.1 -- helm-prereqs/values.yaml \
     helm-prereqs/values/nico-core.yaml \
     helm-prereqs/values/nico-rest.yaml \
     helm-prereqs/values/metallb-config.yaml
@@ -118,9 +120,9 @@ Update your site values files to include any new required fields before running 
 Set the new image tags for the target release:
 
 ```bash
-export NICO_IMAGE_REGISTRY=<your-registry>
-export NICO_CORE_IMAGE_TAG=<new-core-tag>     # e.g. v2.1.0
-export NICO_REST_IMAGE_TAG=<new-rest-tag>     # e.g. v2.1.0
+export NICO_IMAGE_REGISTRY=registry.example.com/nico   # your registry
+export NICO_CORE_IMAGE_TAG=v2.1.0                      # new Core tag
+export NICO_REST_IMAGE_TAG=v2.1.0                      # new REST tag
 ```
 
 If you are upgrading DPF as part of this release, the DPF version is read from `NICO_DPF_VERSION` (defaulting to the value baked into `setup.sh`). You do not normally need to set this explicitly unless your site uses a pinned version.
@@ -167,7 +169,7 @@ cd helm-prereqs/
 | Phase 6 (NICo Core) | 3–8 min (includes DB migration Job) |
 | Phases 7a–7i (NICo REST + site-agent) | 5–15 min (Temporal and DB migrations are the slowest steps) |
 
-Total: typically **15–40 minutes** for a full upgrade with DPF.
+Total: typically **15–45 minutes** for a full upgrade with DPF.
 
 ## Post-upgrade verification
 
@@ -190,7 +192,32 @@ kubectl get deployment -n nico-system nico-api \
     -o jsonpath='{.spec.template.spec.containers[0].image}'
 ```
 
-Run the included health check:
+Verify every LoadBalancer service kept its VIP — an upgrade must not reassign them:
+
+```bash
+kubectl get svc -n nico-system -o wide | grep LoadBalancer
+```
+
+Every service should show the same external IP it had before the upgrade (the VIPs pinned in `values/nico-core.yaml`). Any `<pending>` entry means MetalLB is not advertising — check the MetalLB CRDs and site config objects (see the 2.0→2.1 note below).
+
+Verify PostgreSQL has an elected leader and the cluster is running:
+
+```bash
+kubectl get postgresql -n postgres nico-pg-cluster -o jsonpath='{.status.PostgresClusterStatus}'
+kubectl get pods -n postgres -l application=spilo,spilo-role=master
+```
+
+The first command should print `Running`; the second should show exactly one master pod in `Running` state.
+
+Verify NICo Core is serving — hit the same HTTP health port the liveness probe uses (1080, exposed via the metrics Service):
+
+```bash
+kubectl run -i --rm --restart=Never --image=curlimages/curl upgrade-check \
+  -n nico-system --quiet -- \
+  -sf http://nico-api-metrics.nico-system.svc.cluster.local:1080/ >/dev/null && echo "nico-api healthy"
+```
+
+Then run the included health check, which covers the full stack (Vault, cert-manager, ESO, MetalLB, `.forge` DNS records):
 
 ```bash
 cd helm-prereqs/
@@ -243,13 +270,22 @@ NICo 2.1 requires `startupProbe` to be explicitly configured in the machine-a-tr
 1. Checking out the prior release branch or tag.
 2. Re-running `setup.sh` with the prior image tags.
 
-For NICo Core and REST, the Helm release is rolled back in place, and the database migration Jobs for the prior version run on startup. NICo's database migrations are designed to be forward-compatible; rolling back does not guarantee schema compatibility if the new version added non-nullable columns. For production sites, snapshot the PostgreSQL PVCs before upgrading:
+For NICo Core and REST, the Helm release is rolled back in place, and the database migration Jobs for the prior version run on startup. NICo's database migrations are designed to be forward-compatible; rolling back does not guarantee schema compatibility if the new version added non-nullable columns — which is why a pre-upgrade database backup is essential.
+
+The `nico-pg-cluster` hosts several databases: `nico_system_nico` (NICo Core), `nico_rest` (NICo REST), and — when Flow is enabled — `flow`, `psm`, and `nsm`. A rollback backup must cover all of them; use `pg_dumpall`, which also captures roles and grants:
 
 ```bash
+umask 077
 kubectl exec -n postgres \
     "$(kubectl get pods -n postgres -l application=spilo,spilo-role=master -o jsonpath='{.items[0].metadata.name}')" \
-    -- su postgres -c "pg_dump nico_rest" > nico_rest_pre_upgrade.sql
+    -- su postgres -c "pg_dumpall" > nico_pg_pre_upgrade.sql
 ```
+
+<Note>
+This is a **logical** dump, not a PVC snapshot. Restoring it means recreating the databases from SQL (`psql -f nico_pg_pre_upgrade.sql` against a clean cluster) — expect downtime proportional to database size. It also does not capture Vault storage or Temporal workflow history; in-flight workflows at the time of the dump cannot be replayed from it. If your storage class supports volume snapshots, snapshot the PostgreSQL and Vault PVCs as well for a faster, more complete restore point.
+</Note>
+
+Because of these limitations, re-running `setup.sh` with the prior image tags alone is **not** a complete rollback if the new version's migrations already ran — restore the database dump first, then deploy the prior version.
 
 For DPF, rolling back to a prior DPF version is not supported by NVIDIA. If DPF fails to upgrade, reach out to NVIDIA support rather than attempting a downgrade.
 

--- a/docs/manuals/upgrade.md
+++ b/docs/manuals/upgrade.md
@@ -157,8 +157,8 @@ cd helm-prereqs/
 
 | Flag | When to use |
 |------|------------|
-| `--skip-core` | Upgrade only the prerequisite stack (MetalLB, Vault, etc.) without rolling NICo Core. Useful when the prerequisite stack changed but the Core image did not. |
-| `--skip-rest` | Upgrade only NICo Core and prerequisites, skipping the REST stack. |
+| `--skip-core` | Skip Phase 6 only. Prerequisites and the REST stack still upgrade; NICo Core is left on its current image. Useful when the Core image did not change. |
+| `--skip-rest` | Skip Phase 7 only. Prerequisites and NICo Core still upgrade; the REST stack is left untouched. |
 | `--skip-flow` | Skip the Flow upgrade (Phase 7h). |
 | `--skip-dpf` | Skip DPF upgrade. Use only if DPF is not enabled at this site. |
 | `--core-values <file>` | Use a per-site NICo Core values file (same as initial install). |
@@ -298,17 +298,20 @@ For DPF, rolling back to a prior DPF version is not supported by NVIDIA. If DPF 
 
 ## Using setup.sh for individual component upgrades
 
-You can re-run only specific phases without going through the full upgrade sequence. The simplest way is to use the `--skip-*` flags:
+You can narrow an upgrade to particular components with the `--skip-*` flags. Each one skips exactly the phase it names — **none of them skip the prerequisite stack**, and there is no `--skip-prereqs`:
 
 ```bash
-# Upgrade only NICo Core image (skip all prereqs and REST)
+# Prerequisites + NICo Core; leave the REST stack untouched (skips Phase 7)
 ./setup.sh -y --skip-rest
 
-# Upgrade only NICo REST (skip Core and prereqs)
-# Setup.sh does not have --skip-prereqs; re-running the full script is safe
-# because all prereq phases are idempotent and fast when nothing changes.
+# Prerequisites + NICo REST; leave Core untouched (skips Phase 6)
 ./setup.sh -y --skip-core
+
+# Prerequisites only, fully non-interactive
+./setup.sh -y --skip-core --skip-rest
 ```
+
+The prerequisite phases therefore run on every invocation. That is by design and is cheap: each one is idempotent, and a phase whose inputs have not changed reconciles to the same state and exits quickly.
 
 For a single-helm-chart upgrade (e.g., rotating the NICo Core image tag without going through the full script):
 

--- a/docs/manuals/upgrade.md
+++ b/docs/manuals/upgrade.md
@@ -31,9 +31,8 @@ Every installation phase is designed to be safe to re-run:
 - **PostgreSQL data**: all NICo Core and NICo REST database state, including host records, machine state, and site config in `nico-pg-cluster`. Keycloak realm data and Temporal workflow history live in a **separate** plain `postgres` StatefulSet in the same namespace (created in phase 7c) and are also preserved.
 - **MetalLB site config**: `IPAddressPool`, `BGPPeer`, `BGPAdvertisement`, and `L2Advertisement` instances. These are re-applied on every run so any manual changes outside `setup.sh` are reconciled back to the values in `values/metallb-config.yaml`.
 - **SSH host key**: the cluster SSH identity is preserved so BMC consoles do not require known-host updates.
-- **Site UUID**: the REST site identity and site-agent registration are preserved.
+- **Site UUID**: the REST site identity and site-agent registration are preserved — as long as `NICO_SITE_UUID` is unset or identical to the initial install; a different value deletes and re-creates the `site-registration` Secret.
 - **Certificates**: all cert-manager-managed certificates remain valid until their natural expiry; they are not reissued on upgrade unless the new release changes a Certificate spec.
-- **Site UUID caveat**: the `site-registration` Secret is deleted and re-created if `NICO_SITE_UUID` differs from the registered one — keep it unset (or identical to the initial install) on upgrades.
 
 ### What changes during an upgrade
 

--- a/docs/manuals/upgrade.md
+++ b/docs/manuals/upgrade.md
@@ -1,0 +1,280 @@
+# Upgrading NICo
+
+`setup.sh` is designed to be **idempotent**: running it against an existing NICo installation upgrades each component in place. The same script and values files used for initial installation are the mechanism for upgrades — there is no separate upgrade script.
+
+This page documents how each component behaves when `setup.sh` is re-run against a live cluster, what to prepare before upgrading, and version-specific considerations for the 2.0→2.1 path.
+
+## How setup.sh handles upgrades
+
+Every installation phase is designed to be safe to re-run:
+
+| Phase | Behavior on re-run |
+|-------|-------------------|
+| **1 — local-path-provisioner** | Manifests are `kubectl apply`'d — idempotent. StorageClasses are upserted. |
+| **1b — postgres-operator** | `helmfile sync` issues `helm upgrade --install` — upgrades the release in place. Existing `PostgreSQL` CRs (including `nico-pg-cluster`) are untouched. |
+| **1c — MetalLB** | CRDs are applied server-side with `--force-conflicts`. Any helm-owned CRDs from a prior install have their ownership labels stripped before sync, preventing deletion. `helmfile sync` upgrades the release. Existing `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instances are preserved and re-applied (idempotent `kubectl apply`). See [MetalLB CRD ownership](#metallb-crd-ownership-2021-upgrade-path). |
+| **2 — cert-manager** | `helmfile sync` upgrades the release. Existing `ClusterIssuer`, `Certificate`, and `CertificateRequest` objects are untouched. The Vault TLS bootstrap certs are re-applied server-side; existing certs that are still valid are not reissued. |
+| **3 — Vault** | `helmfile sync` upgrades the release. The StatefulSet rolling-update leaves Vault pods running. |
+| **4 — Vault unseal** | `unseal_vault.sh` checks whether Vault is already initialized. If it is, it skips `vault operator init` and only unseals any pods that were restarted and became sealed again. The Vault cluster keys (`vault-cluster-keys` Secret) and root token (`vaultroottoken`) are preserved. |
+| **4 (SSH host key)** | `bootstrap_ssh_host_key.sh` detects an existing SSH host key Secret and skips re-generation. The cluster's SSH identity is preserved across upgrades. |
+| **5 — external-secrets + nico-prereqs** | `helmfile sync` upgrades both releases. Existing `ClusterSecretStore` and `ExternalSecret` objects are reconciled to their new definitions. The ESO controller re-syncs all secrets on the next poll cycle. |
+| **5b — DPF** | DPF components are upgraded via their helm charts. The `DPFOperatorConfig`, `DPUCluster`, and `DPUService` objects are preserved. See [DPF upgrade considerations](#dpf-upgrade-considerations). |
+| **6 — NICo Core** | `helm upgrade --install nico` rolls out the new Core image tag. The PostgreSQL database schema is migrated by the pre-upgrade Job (uses the `imagepullsecret` Secret, which is upserted). NICo state (host records, machine state, firmware inventory) lives in PostgreSQL and is preserved. |
+| **7a–7g — NICo REST** | REST components are upgraded via `helm upgrade --install`. The `nico_rest` PostgreSQL database is migrated in-place by the REST migration Job. Temporal workflow state is preserved. The Keycloak realm and client credentials are preserved. |
+| **7h — NICo Flow** | Flow, PSM, and NSM are upgraded in place. |
+| **7i — NICo REST site-agent** | The site-agent StatefulSet is upgraded. The site UUID (stored in the `site-registration` Secret) and REST site record are preserved. |
+
+### What is preserved across upgrades
+
+- **Vault cluster**: init state, unseal keys, PKI chain, AppRole credentials, all secrets. Vault is never re-initialized on an upgrade run.
+- **PostgreSQL data**: all NICo Core and NICo REST database state, including host records, machine state, site config, Keycloak realm data, and Temporal workflow history.
+- **MetalLB site config**: `IPAddressPool`, `BGPPeer`, `BGPAdvertisement`, and `L2Advertisement` instances. These are re-applied on every run so any manual changes outside `setup.sh` are reconciled back to the values in `values/metallb-config.yaml`.
+- **SSH host key**: the cluster SSH identity is preserved so BMC consoles do not require known-host updates.
+- **Site UUID**: the REST site identity and site-agent registration are preserved.
+- **Certificates**: all cert-manager-managed certificates remain valid until their natural expiry; they are not reissued on upgrade.
+
+### What changes during an upgrade
+
+- All helm release images are updated to the new tags set in `NICO_CORE_IMAGE_TAG`, `NICO_REST_IMAGE_TAG`, etc.
+- CRD schemas are updated to their new versions via server-side apply.
+- ConfigMaps and Secrets produced by helm are updated to reflect new chart values.
+- The NICo Core and REST database schemas are migrated forward by their respective pre-upgrade Jobs.
+- DPF operator and DPUService images are updated to the new `NICO_DPF_VERSION`.
+
+## Pre-upgrade checklist
+
+Complete every item before running `setup.sh`. Missing any of these can cause the upgrade to fail or leave the cluster in a partially upgraded state.
+
+### 1. Back up Vault unseal keys
+
+Vault unseal keys are stored in the `vault-cluster-keys` Secret in the `vault` namespace. If this Secret is lost and all Vault pods restart simultaneously, the cluster is unrecoverable without a Vault snapshot.
+
+```bash
+# Verify the backup Secret exists
+kubectl get secret vault-cluster-keys -n vault -o jsonpath='{.metadata.name}'
+```
+
+Export and store it offline:
+
+```bash
+kubectl get secret vault-cluster-keys -n vault -o json > vault-cluster-keys-backup.json
+```
+
+<Warning>
+This file contains the plaintext Vault unseal keys. Store it in a secure, offline location and delete the local copy after storing.
+</Warning>
+
+### 2. Check cluster health before upgrading
+
+Do not upgrade a cluster that already has degraded components. Resolve any existing issues first.
+
+```bash
+kubectl get pods -n nico-system
+kubectl get pods -n nico-rest
+kubectl get pods -n temporal
+kubectl get pods -n vault
+kubectl get pods -n postgres
+kubectl get pods -n metallb-system
+```
+
+All pods should be `Running` or `Completed`. Check for pods stuck in `CrashLoopBackOff`, `Pending`, or `Error`.
+
+Verify that Vault is fully unsealed — a sealed Vault blocks the upgrade at phase 4:
+
+```bash
+kubectl exec -n vault vault-0 -c vault -- vault status -tls-skip-verify | grep -E "Sealed|Initialized"
+```
+
+Both should show `Initialized true` and `Sealed false`.
+
+### 3. Pull the new release
+
+Update your local checkout to the target release branch or tag:
+
+```bash
+git fetch upstream
+git checkout upstream/release/v2.1   # or the specific release tag
+```
+
+Review the release changelog for breaking changes:
+- `fern/changelog/` — user-facing changelog entries
+- `helm-prereqs/` diff from the prior release — any new required values fields or removed flags
+
+### 4. Review values file changes
+
+Check whether new release added required values fields or changed defaults:
+
+```bash
+git diff release/v2.0..release/v2.1 -- helm-prereqs/values.yaml \
+    helm-prereqs/values/nico-core.yaml \
+    helm-prereqs/values/nico-rest.yaml \
+    helm-prereqs/values/metallb-config.yaml
+```
+
+Update your site values files to include any new required fields before running `setup.sh`.
+
+### 5. Update image tags
+
+Set the new image tags for the target release:
+
+```bash
+export NICO_IMAGE_REGISTRY=<your-registry>
+export NICO_CORE_IMAGE_TAG=<new-core-tag>     # e.g. v2.1.0
+export NICO_REST_IMAGE_TAG=<new-rest-tag>     # e.g. v2.1.0
+```
+
+If you are upgrading DPF as part of this release, the DPF version is read from `NICO_DPF_VERSION` (defaulting to the value baked into `setup.sh`). You do not normally need to set this explicitly unless your site uses a pinned version.
+
+### 6. Run the pre-flight check
+
+```bash
+cd helm-prereqs/
+source ./preflight.sh
+```
+
+Fix all errors before proceeding. Warnings about `NICO_DPF_BMC_ROOT_PASSWORD` being unset are safe to ignore on an upgrade (the credential is already stored in Vault from the initial install).
+
+## Running the upgrade
+
+With the checklist complete, run `setup.sh` exactly as you would for a fresh install:
+
+```bash
+cd helm-prereqs/
+./setup.sh -y
+```
+
+`setup.sh` processes all phases in order. Phases that find their components already at the correct state complete quickly. Phases that detect a version delta or config change apply the update.
+
+### Upgrade-specific flags
+
+| Flag | When to use |
+|------|------------|
+| `--skip-core` | Upgrade only the prerequisite stack (MetalLB, Vault, etc.) without rolling NICo Core. Useful when the prerequisite stack changed but the Core image did not. |
+| `--skip-rest` | Upgrade only NICo Core and prerequisites, skipping the REST stack. |
+| `--skip-flow` | Skip the Flow upgrade (Phase 7h). |
+| `--skip-dpf` | Skip DPF upgrade. Use only if DPF is not enabled at this site. |
+| `--core-values <file>` | Use a per-site NICo Core values file (same as initial install). |
+| `--metallb-config <path>` | Use a site-specific MetalLB manifest or kustomize dir (same as initial install). |
+
+### Estimated upgrade time
+
+| Phase | Typical duration |
+|-------|-----------------|
+| Phases 1–1c (storage, postgres-operator, MetalLB) | 2–5 min |
+| Phases 2–4 (cert-manager, Vault, unseal) | 1–3 min (Vault is already initialized; only rolling update time) |
+| Phase 5 (ESO + nico-prereqs) | 1–3 min |
+| Phase 5b (DPF) | 3–10 min (depends on DPF version delta) |
+| Phase 6 (NICo Core) | 3–8 min (includes DB migration Job) |
+| Phases 7a–7i (NICo REST + site-agent) | 5–15 min (Temporal and DB migrations are the slowest steps) |
+
+Total: typically **15–40 minutes** for a full upgrade with DPF.
+
+## Post-upgrade verification
+
+Run the same checks as after initial installation:
+
+```bash
+kubectl get pods -n nico-system
+kubectl get pods -n nico-rest
+kubectl get pods -n temporal
+kubectl get pods -n vault
+kubectl get pods -n postgres
+kubectl get pods -n metallb-system
+kubectl get pods -n dpf-operator-system   # if DPF enabled
+```
+
+Verify the deployed image versions match the target tags:
+
+```bash
+kubectl get deployment -n nico-system nico-api \
+    -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+Run the included health check:
+
+```bash
+cd helm-prereqs/
+./health-check.sh
+```
+
+## Version-specific upgrade notes
+
+### 2.0 → 2.1: MetalLB CRD ownership migration
+
+**Impact:** This upgrade path requires special handling that `setup.sh` performs automatically. If you skip MetalLB's phase in your upgrade (e.g., by removing it from the helmfile run), your site config objects (`IPAddressPool`, `BGPPeer`, `BGPAdvertisement`) will be deleted.
+
+**Root cause:** In NICo 2.0, MetalLB was deployed with `crds.enabled: true` (the helm chart default), which places all seven MetalLB CRDs inside the helm release manifest. In NICo 2.1, `crds.enabled: false` is set explicitly so that the MetalLB cert rotator can take SSA field ownership of the CRD `caBundle` without conflicting with helm on every re-sync. When helm sees `crds.enabled` change from `true` to `false`, it removes the CRDs from its manifest — and Kubernetes garbage-collects every `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instance stored as CRD resources, permanently deleting your site config.
+
+**How setup.sh handles this:** Before running `helmfile sync` for MetalLB, `setup.sh` strips the `app.kubernetes.io/managed-by: Helm` label and the `meta.helm.sh/release-name` / `meta.helm.sh/release-namespace` annotations from any existing MetalLB CRDs. With the labels removed, helm does not consider the CRDs part of its managed set and does not delete them during the sync. CRDs are then applied directly (server-side, `--force-conflicts`) before and after the helmfile sync.
+
+**If you are upgrading manually** (not via `setup.sh`), you must strip helm ownership from all MetalLB CRDs before running `helmfile sync` or `helm upgrade`:
+
+```bash
+for crd in $(kubectl get crd -o name | grep '\.metallb\.io$'); do
+    kubectl annotate "${crd}" meta.helm.sh/release-name- meta.helm.sh/release-namespace- --overwrite
+    kubectl label  "${crd}" app.kubernetes.io/managed-by- --overwrite
+done
+```
+
+Then apply the CRDs directly before sync:
+
+```bash
+METALLB_VERSION="0.14.5"   # match the version in helmfile.yaml
+helm template metallb metallb/metallb --version "${METALLB_VERSION}" \
+    -n metallb-system --include-crds \
+    | awk '/^---[[:space:]]*$/ { if (doc ~ /kind: CustomResourceDefinition/) printf "%s---\n", doc; doc = ""; next } { doc = doc $0 "\n" } END { if (doc ~ /kind: CustomResourceDefinition/) printf "%s", doc }' \
+    | kubectl apply --server-side --force-conflicts -f -
+```
+
+### 2.0 → 2.1: DPF version update
+
+The default `NICO_DPF_VERSION` in `setup.sh` is updated with each NICo minor release to the tested DOCA Platform Framework version. On a 2.0→2.1 upgrade, DPF is upgraded from its 2.0 version to the 2.1 version automatically as part of phase 5b.
+
+DPF manages DPU provisioning state in `DPUCluster`, `DPUService`, and `DPF` CRs, all of which persist across the upgrade. In-flight DPU provisioning workflows may pause while the DPF operator restarts; they resume automatically when the new operator pod comes up.
+
+### 2.0 → 2.1: NICo Core startupProbe
+
+NICo 2.1 requires `startupProbe` to be explicitly configured in the machine-a-tron deployment (issue #4298). The chart now validates this at render time and fails with a clear error if `startupProbe` is absent. The default values provide a suitable probe scaled to ~2,300 hosts; for larger sites, refer to `helm-prereqs/values/machine-a-tron-scale.yaml` for recommended parameters scaled to 13,500 hosts.
+
+## Rollback
+
+`setup.sh` does not have a built-in rollback mechanism. Rollback consists of:
+
+1. Checking out the prior release branch or tag.
+2. Re-running `setup.sh` with the prior image tags.
+
+For NICo Core and REST, the Helm release is rolled back in place, and the database migration Jobs for the prior version run on startup. NICo's database migrations are designed to be forward-compatible; rolling back does not guarantee schema compatibility if the new version added non-nullable columns. For production sites, snapshot the PostgreSQL PVCs before upgrading:
+
+```bash
+kubectl exec -n postgres \
+    "$(kubectl get pods -n postgres -l application=spilo,spilo-role=master -o jsonpath='{.items[0].metadata.name}')" \
+    -- su postgres -c "pg_dump nico_rest" > nico_rest_pre_upgrade.sql
+```
+
+For DPF, rolling back to a prior DPF version is not supported by NVIDIA. If DPF fails to upgrade, reach out to NVIDIA support rather than attempting a downgrade.
+
+## Using setup.sh for individual component upgrades
+
+You can re-run only specific phases without going through the full upgrade sequence. The simplest way is to use the `--skip-*` flags:
+
+```bash
+# Upgrade only NICo Core image (skip all prereqs and REST)
+./setup.sh -y --skip-rest
+
+# Upgrade only NICo REST (skip Core and prereqs)
+# Setup.sh does not have --skip-prereqs; re-running the full script is safe
+# because all prereq phases are idempotent and fast when nothing changes.
+./setup.sh -y --skip-core
+```
+
+For a single-helm-chart upgrade (e.g., rotating the NICo Core image tag without going through the full script):
+
+```bash
+helm upgrade nico ../helm \
+    -n nico-system \
+    -f helm-prereqs/values/nico-core.yaml \
+    --set global.image.tag="${NICO_CORE_IMAGE_TAG}" \
+    --timeout 300s --wait
+```
+
+This skips the MetalLB CRD handling, DPF management, and other prereq phases — only do this when you are certain those components do not need updating.

--- a/docs/manuals/upgrade.md
+++ b/docs/manuals/upgrade.md
@@ -1,4 +1,4 @@
-# Upgrading NICo
+# Upgrading NICo <Badge intent="info">v2.1</Badge> <Badge intent="launch" minimal>New</Badge>
 
 `setup.sh` is designed to be **idempotent**: running it against an existing NICo installation upgrades each component in place. The same script and values files used for initial installation are the mechanism for upgrades — there is no separate upgrade script.
 
@@ -9,16 +9,16 @@ This page documents how each component behaves when `setup.sh` is re-run against
 Every installation phase is designed to be safe to re-run:
 
 | Phase | Behavior on re-run |
-|-------|-------------------|
+| ----- | ------------------ |
 | **1 — local-path-provisioner** | Manifests are `kubectl apply`'d — idempotent. StorageClasses are upserted. |
 | **1b — postgres-operator** | `helmfile sync` issues `helm upgrade --install` — upgrades the release in place. Existing `PostgreSQL` CRs (including `nico-pg-cluster`) are untouched. |
-| **1c — MetalLB** | CRDs are applied server-side with `--force-conflicts`. Any helm-owned CRDs from a prior install have their ownership labels stripped before sync, preventing deletion. `helmfile sync` upgrades the release. Existing `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instances are preserved and re-applied (idempotent `kubectl apply`). See [MetalLB CRD ownership](#metallb-crd-ownership-2021-upgrade-path). |
+| **1c — MetalLB** | CRDs are applied server-side with `--force-conflicts`. Any helm-owned CRDs from a prior install have their ownership labels stripped before sync, preventing deletion. `helmfile sync` upgrades the release. Existing `IPAddressPool`, `BGPPeer`, and `BGPAdvertisement` instances are preserved and re-applied (idempotent `kubectl apply`). Refer to [MetalLB CRD ownership](#20--21-metallb-crd-ownership-migration). |
 | **2 — cert-manager** | `helmfile sync` upgrades the release. Existing `ClusterIssuer`, `Certificate`, and `CertificateRequest` objects are untouched. The Vault TLS bootstrap certs are re-applied server-side; existing certs that are still valid are not reissued. |
 | **3 — Vault** | `helmfile sync` upgrades the release. The StatefulSet rolling-update leaves Vault pods running. |
 | **4 — Vault unseal** | `unseal_vault.sh` checks whether Vault is already initialized. If it is, it skips `vault operator init` and only unseals any pods that were restarted and became sealed again. The Vault cluster keys (`vault-cluster-keys` Secret) and root token (`vaultroottoken`) are preserved. |
 | **4 (SSH host key)** | `bootstrap_ssh_host_key.sh` detects an existing SSH host key Secret and skips re-generation. The cluster's SSH identity is preserved across upgrades. |
 | **5 — external-secrets + nico-prereqs** | `helmfile sync` upgrades both releases. Existing `ClusterSecretStore` and `ExternalSecret` objects are reconciled to their new definitions. The ESO controller re-syncs all secrets on the next poll cycle. |
-| **5b — DPF** | DPF components are upgraded via their helm charts. The `DPFOperatorConfig`, `DPUCluster`, and `DPUService` objects are preserved. See [DPF upgrade considerations](#dpf-upgrade-considerations). |
+| **5b — DPF** | DPF components are upgraded via their helm charts. The `DPFOperatorConfig`, `DPUCluster`, and `DPUService` objects are preserved. Refer to [DPF version update](#20--21-dpf-version-update). |
 | **6 — NICo Core** | `helm upgrade --install nico` rolls out the new Core image tag. The PostgreSQL database schema is migrated by the pre-upgrade Job (uses the `imagepullsecret` Secret, which is upserted). NICo state (host records, machine state, firmware inventory) lives in PostgreSQL and is preserved. |
 | **7a–7g — NICo REST** | REST components are upgraded via `helm upgrade --install`. The `nico_rest` PostgreSQL database is migrated in-place by the REST migration Job. Temporal workflow state is preserved. The Keycloak realm and client credentials are preserved. |
 | **7h — NICo Flow** | Flow, PSM, and NSM are upgraded in place. |
@@ -45,7 +45,9 @@ Every installation phase is designed to be safe to re-run:
 
 Complete every item before running `setup.sh`. Missing any of these can cause the upgrade to fail or leave the cluster in a partially upgraded state.
 
-### 1. Back up Vault unseal keys
+<Steps toc={true}>
+
+### Back up Vault unseal keys
 
 Vault unseal keys are stored in the `vault-cluster-keys` Secret in the `vault` namespace. If this Secret is lost and all Vault pods restart simultaneously, the cluster is unrecoverable without a Vault snapshot.
 
@@ -65,7 +67,7 @@ kubectl get secret vault-cluster-keys -n vault -o json > vault-cluster-keys-back
 This file contains the plaintext Vault unseal keys. Store it in a secure, offline location and delete the local copy after storing.
 </Warning>
 
-### 2. Check cluster health before upgrading
+### Check cluster health before upgrading
 
 Do not upgrade a cluster that already has degraded components. Resolve any existing issues first.
 
@@ -95,7 +97,7 @@ kubectl exec -n vault vault-0 -c vault -- vault status -tls-skip-verify | grep -
 
 Both should show `Initialized true` and `Sealed false`.
 
-### 3. Pull the new release
+### Pull the new release
 
 Update your local checkout to the target release branch or tag:
 
@@ -105,10 +107,11 @@ git checkout upstream/release/v2.1   # or the specific release tag
 ```
 
 Review the release changelog for breaking changes:
+
 - `fern/changelog/` — user-facing changelog entries
 - `helm-prereqs/` diff from the prior release — any new required values fields or removed flags
 
-### 4. Review values file changes
+### Review values file changes
 
 Check whether new release added required values fields or changed defaults:
 
@@ -121,7 +124,7 @@ git diff upstream/release/v2.0..upstream/release/v2.1 -- helm-prereqs/values.yam
 
 Update your site values files to include any new required fields before running `setup.sh`.
 
-### 5. Update image tags
+### Update image tags
 
 Set the new image tags for the target release:
 
@@ -133,7 +136,7 @@ export NICO_REST_IMAGE_TAG=v2.1.0                      # new REST tag
 
 If you are upgrading DPF as part of this release, the DPF version is read from `NICO_DPF_VERSION` (defaulting to the value baked into `setup.sh`). You do not normally need to set this explicitly unless your site uses a pinned version.
 
-### 6. Run the pre-flight check
+### Run the pre-flight check
 
 ```bash
 cd helm-prereqs/
@@ -141,6 +144,8 @@ source ./preflight.sh
 ```
 
 Fix all errors before proceeding. Warnings about `NICO_DPF_BMC_ROOT_PASSWORD` being unset are safe to ignore on an upgrade (the credential is already stored in Vault from the initial install).
+
+</Steps>
 
 ## Running the upgrade
 
@@ -156,7 +161,7 @@ cd helm-prereqs/
 ### Upgrade-specific flags
 
 | Flag | When to use |
-|------|------------|
+| ---- | ----------- |
 | `--skip-core` | Skip Phase 6 only. Prerequisites and the REST stack still upgrade; NICo Core is left on its current image. Useful when the Core image did not change. |
 | `--skip-rest` | Skip Phase 7 only. Prerequisites and NICo Core still upgrade; the REST stack is left untouched. |
 | `--skip-flow` | Skip the Flow upgrade (Phase 7h). |
@@ -167,7 +172,7 @@ cd helm-prereqs/
 ### Estimated upgrade time
 
 | Phase | Typical duration |
-|-------|-----------------|
+| ----- | ---------------- |
 | Phases 1–1c (storage, postgres-operator, MetalLB) | 2–5 min |
 | Phases 2–4 (cert-manager, Vault, unseal) | 1–3 min (Vault is already initialized; only rolling update time) |
 | Phase 5 (ESO + nico-prereqs) | 1–3 min |

--- a/docs/manuals/upgrade.md
+++ b/docs/manuals/upgrade.md
@@ -81,6 +81,12 @@ kubectl get pods -n dpf-operator-system   # if DPF is enabled — phase 5b upgra
 
 All pods should be `Running` or `Completed`. Check for pods stuck in `CrashLoopBackOff`, `Pending`, or `Error`.
 
+Capture the current LoadBalancer VIP assignments as a baseline — the post-upgrade verification diffs against this:
+
+```bash
+kubectl get svc -n nico-system -o wide | grep LoadBalancer > pre-upgrade-vips.txt
+```
+
 Verify that Vault is fully unsealed — a sealed Vault blocks the upgrade at phase 4:
 
 ```bash
@@ -192,13 +198,14 @@ kubectl get deployment -n nico-system nico-api \
     -o jsonpath='{.spec.template.spec.containers[0].image}'
 ```
 
-Verify every LoadBalancer service kept its VIP — an upgrade must not reassign them:
+Verify every LoadBalancer service kept its VIP — an upgrade must not reassign them. Diff against the baseline captured in the pre-upgrade checklist:
 
 ```bash
-kubectl get svc -n nico-system -o wide | grep LoadBalancer
+kubectl get svc -n nico-system -o wide | grep LoadBalancer | diff pre-upgrade-vips.txt - \
+    && echo "VIPs unchanged"
 ```
 
-Every service should show the same external IP it had before the upgrade (the VIPs pinned in `values/nico-core.yaml`). Any `<pending>` entry means MetalLB is not advertising — check the MetalLB CRDs and site config objects (see the 2.0→2.1 note below).
+Any diff output or `<pending>` entry means MetalLB reassigned or stopped advertising a VIP — check the MetalLB CRDs and site config objects (see the 2.0→2.1 note below) and the pins in `values/nico-core.yaml`.
 
 Verify PostgreSQL has an elected leader and the cluster is running:
 

--- a/docs/overview/lifecycle.md
+++ b/docs/overview/lifecycle.md
@@ -109,7 +109,7 @@ firmware inventory.
 
 Upgrading NICo itself is also a Day 2 operation. Re-running `setup.sh` from a
 newer release upgrades each component in place while preserving Vault state,
-PostgreSQL data, and the site configuration. See the
+PostgreSQL data, and the site configuration. Refer to the
 [Upgrading NICo](../manuals/upgrade.md) guide for the pre-upgrade checklist,
 version-specific migration notes, and rollback procedure.
 

--- a/docs/overview/lifecycle.md
+++ b/docs/overview/lifecycle.md
@@ -105,6 +105,14 @@ updates occur entirely out of band without disrupting active tenants. NICo
 applies updates against the site baseline and tracks them in the per-machine
 firmware inventory.
 
+### Platform Upgrades
+
+Upgrading NICo itself is also a Day 2 operation. Re-running `setup.sh` from a
+newer release upgrades each component in place while preserving Vault state,
+PostgreSQL data, and the site configuration. See the
+[Upgrading NICo](../manuals/upgrade.md) guide for the pre-upgrade checklist,
+version-specific migration notes, and rollback procedure.
+
 ### Tenant Transitions (Sanitization)
 
 When a tenant releases a host, NICo performs a full cleanup sequence before the

--- a/fern/changelog/overview.mdx
+++ b/fern/changelog/overview.mdx
@@ -1,5 +1,5 @@
 Release history for NVIDIA Infra Controller, including new capabilities, compatibility information, upgrade requirements, and fixes.
 
 <Tip title="">
-Refer to the [Release and QA Process](../../docs/development/release_and_qa_process.md) page for more information on how new releases are created and tested.
+Refer to the [Release and QA Process](../../docs/development/release_and_qa_process.md) page for more information on how new releases are created and tested. To move an existing installation to a new release, follow the [Upgrading NICo](../../docs/manuals/upgrade.md) guide.
 </Tip>

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -36,7 +36,7 @@ For complete step-by-step deployment instructions, see the **[Quick Start Guide]
 
 For manual phase-by-phase installation (re-running individual phases, debugging failures), see the **[Reference Installation](https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/reference-installation)** guide.
 
-To upgrade an existing NICo installation to a new release using `setup.sh`, see the **[Upgrading NICo](https://docs.nvidia.com/infra-controller/documentation/operations-day-2/upgrading-nico)** guide. `setup.sh` is idempotent and handles upgrades in place — the same script and values files used for initial installation are the upgrade mechanism.
+To upgrade an existing NICo installation to a new release using `setup.sh`, refer to the **[Upgrading NICo](https://docs.nvidia.com/infra-controller/documentation/operations-day-2/upgrading-nico)** guide. `setup.sh` is idempotent and handles upgrades in place — the same script and values files used for initial installation are the upgrade mechanism.
 
 For the optional site-local monitoring stack (metrics + logs + traces: Prometheus, Grafana, Loki, Tempo, OTEL), see **[observability/README.md](observability/README.md)**.
 

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -36,7 +36,7 @@ For complete step-by-step deployment instructions, see the **[Quick Start Guide]
 
 For manual phase-by-phase installation (re-running individual phases, debugging failures), see the **[Reference Installation](https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/reference-installation)** guide.
 
-To upgrade an existing NICo installation to a new release using `setup.sh`, see the **[Upgrading NICo](https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/upgrading-nico)** guide. `setup.sh` is idempotent and handles upgrades in place — the same script and values files used for initial installation are the upgrade mechanism.
+To upgrade an existing NICo installation to a new release using `setup.sh`, see the **[Upgrading NICo](https://docs.nvidia.com/infra-controller/documentation/operations-day-2/upgrading-nico)** guide. `setup.sh` is idempotent and handles upgrades in place — the same script and values files used for initial installation are the upgrade mechanism.
 
 For the optional site-local monitoring stack (metrics + logs + traces: Prometheus, Grafana, Loki, Tempo, OTEL), see **[observability/README.md](observability/README.md)**.
 

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -36,6 +36,8 @@ For complete step-by-step deployment instructions, see the **[Quick Start Guide]
 
 For manual phase-by-phase installation (re-running individual phases, debugging failures), see the **[Reference Installation](https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/reference-installation)** guide.
 
+To upgrade an existing NICo installation to a new release using `setup.sh`, see the **[Upgrading NICo](https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/upgrading-nico)** guide. `setup.sh` is idempotent and handles upgrades in place — the same script and values files used for initial installation are the upgrade mechanism.
+
 For the optional site-local monitoring stack (metrics + logs + traces: Prometheus, Grafana, Loki, Tempo, OTEL), see **[observability/README.md](observability/README.md)**.
 
 ## Directory structure


### PR DESCRIPTION
## Summary

- Adds `docs/manuals/upgrade.md` — a comprehensive guide for upgrading an existing NICo installation using `setup.sh`
- Documents per-phase idempotent behavior on re-run, what is preserved vs. what changes, pre-upgrade checklist, timing estimates, and post-upgrade verification
- Includes detailed 2.0→2.1 version-specific notes covering the MetalLB CRD ownership migration (fix from #4997), DPF version update, and startupProbe requirement (#4298)
- Covers rollback procedure with PostgreSQL snapshot command and per-component upgrade recipes
- Wired into `docs/index.yml` under Getting Started > Installation Options and cross-linked from `helm-prereqs/README.md` and the Quick Start Guide

Validated on dev6: the 2.0→2.1 MetalLB upgrade path described in the doc matches what was tested and confirmed working with #4997.

Closes #5012

## Test plan

- [ ] Docs render correctly in the Fern doc site (check index.yml wiring)
- [ ] All relative links resolve (`../manuals/upgrade.md` from quick-start.md)
- [ ] Version-specific MetalLB notes match the behavior of `setup.sh` post-#4997