### PR TITLE
feat(flow): sync NVLink domain topology from Core

### DIFF
--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -444,10 +444,9 @@ func (c *grpcClient) FindSwitchNvosIPs(ctx context.Context, switchIds []string) 
 // deleted switches by default; the details response must include every
 // requested switch so callers can safely reconcile omitted memberships.
 func (c *grpcClient) GetObservedNVLinkDomainMemberships(ctx context.Context) ([]NVLinkDomainMembership, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.grpcTimeout)
-	defer cancel()
-
-	idsResponse, err := c.gclient.FindSwitchIds(ctx, &corev1.SwitchSearchFilter{})
+	idsCtx, idsCancel := context.WithTimeout(ctx, c.grpcTimeout)
+	idsResponse, err := c.gclient.FindSwitchIds(idsCtx, &corev1.SwitchSearchFilter{})
+	idsCancel()
 	if err != nil {
 		return nil, fmt.Errorf("FindSwitchIds for NVLink domain topology: %w", err)
 	}
@@ -457,7 +456,9 @@ func (c *grpcClient) GetObservedNVLinkDomainMemberships(ctx context.Context) ([]
 		return []NVLinkDomainMembership{}, nil
 	}
 
-	detailsResponse, err := c.gclient.FindSwitchesByIds(ctx, &corev1.SwitchesByIdsRequest{
+	detailsCtx, detailsCancel := context.WithTimeout(ctx, c.grpcTimeout)
+	defer detailsCancel()
+	detailsResponse, err := c.gclient.FindSwitchesByIds(detailsCtx, &corev1.SwitchesByIdsRequest{
 		SwitchIds: switchIDs,
 	})
 	if err != nil {

--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -439,6 +439,76 @@ func (c *grpcClient) FindSwitchNvosIPs(ctx context.Context, switchIds []string) 
 	return result, nil
 }
 
+// GetObservedNVLinkDomainMemberships returns valid rack/domain observations
+// from a complete snapshot of Core's active switches. FindSwitchIds excludes
+// deleted switches by default; the details response must include every
+// requested switch so callers can safely reconcile omitted memberships.
+func (c *grpcClient) GetObservedNVLinkDomainMemberships(ctx context.Context) ([]NVLinkDomainMembership, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.grpcTimeout)
+	defer cancel()
+
+	idsResponse, err := c.gclient.FindSwitchIds(ctx, &corev1.SwitchSearchFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("FindSwitchIds for NVLink domain topology: %w", err)
+	}
+
+	switchIDs := idsResponse.GetIds()
+	if len(switchIDs) == 0 {
+		return []NVLinkDomainMembership{}, nil
+	}
+
+	detailsResponse, err := c.gclient.FindSwitchesByIds(ctx, &corev1.SwitchesByIdsRequest{
+		SwitchIds: switchIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("FindSwitchesByIds for NVLink domain topology: %w", err)
+	}
+
+	return nvLinkDomainMembershipsFromSwitches(switchIDs, detailsResponse.GetSwitches())
+}
+
+func nvLinkDomainMembershipsFromSwitches(
+	switchIDs []*corev1.SwitchId,
+	switches []*corev1.Switch,
+) ([]NVLinkDomainMembership, error) {
+	requested := make(map[string]struct{}, len(switchIDs))
+	for _, id := range switchIDs {
+		value := id.GetId()
+		if value != "" {
+			requested[value] = struct{}{}
+		}
+	}
+
+	seen := make(map[string]struct{}, len(switches))
+	memberships := make([]NVLinkDomainMembership, 0, len(switches))
+	for _, sw := range switches {
+		switchID := sw.GetId().GetId()
+		if switchID == "" {
+			continue
+		}
+		seen[switchID] = struct{}{}
+
+		domainID := sw.GetNvlinkDomainUuid().GetValue()
+		rackID := sw.GetRackId().GetId()
+		if domainID == "" || rackID == "" {
+			continue
+		}
+		memberships = append(memberships, NVLinkDomainMembership{
+			DomainID: domainID,
+			RackID:   rackID,
+		})
+	}
+
+	for switchID := range requested {
+		_, ok := seen[switchID]
+		if !ok {
+			return nil, fmt.Errorf("FindSwitchesByIds omitted active switch %s", switchID)
+		}
+	}
+
+	return memberships, nil
+}
+
 // FindPowerShelfRackIDs returns the rack assignment of each given power shelf.
 func (c *grpcClient) FindPowerShelfRackIDs(ctx context.Context, shelfIds []string) (map[string]string, error) {
 	if len(shelfIds) == 0 {
@@ -1252,6 +1322,10 @@ func (c *grpcClient) SetPowerShelfControllerState(shelfID, state string) {
 }
 
 func (c *grpcClient) SetRackHostMachineIDs(rackID string, machineIDs []string) {
+	panic("Not a unit test")
+}
+
+func (c *grpcClient) SetObservedNVLinkDomainMemberships(memberships []NVLinkDomainMembership) {
 	panic("Not a unit test")
 }
 

--- a/rest-api/flow/internal/nicoapi/grpc_domain_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_domain_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nicoapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
+)
+
+func TestNVLinkDomainMembershipsFromSwitches(t *testing.T) {
+	domainID := "20000000-0000-0000-0000-000000000001"
+	switchWithDomain := func(switchID, rackID string) *corev1.Switch {
+		return &corev1.Switch{
+			Id:               &corev1.SwitchId{Id: switchID},
+			RackId:           &corev1.RackId{Id: rackID},
+			NvlinkDomainUuid: &corev1.NVLinkDomainId{Value: domainID},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		requested []*corev1.SwitchId
+		switches  []*corev1.Switch
+		want      []NVLinkDomainMembership
+		wantErr   string
+	}{
+		{
+			name:      "returns duplicate rack observations",
+			requested: []*corev1.SwitchId{{Id: "switch-a"}, {Id: "switch-b"}},
+			switches: []*corev1.Switch{
+				switchWithDomain("switch-a", "rack-a"),
+				switchWithDomain("switch-b", "rack-a"),
+			},
+			want: []NVLinkDomainMembership{
+				{DomainID: domainID, RackID: "rack-a"},
+				{DomainID: domainID, RackID: "rack-a"},
+			},
+		},
+		{
+			name:      "skips switch without domain observation",
+			requested: []*corev1.SwitchId{{Id: "switch-a"}},
+			switches: []*corev1.Switch{
+				{Id: &corev1.SwitchId{Id: "switch-a"}, RackId: &corev1.RackId{Id: "rack-a"}},
+			},
+			want: []NVLinkDomainMembership{},
+		},
+		{
+			name:      "skips switch without rack assignment",
+			requested: []*corev1.SwitchId{{Id: "switch-a"}},
+			switches: []*corev1.Switch{
+				{Id: &corev1.SwitchId{Id: "switch-a"}, NvlinkDomainUuid: &corev1.NVLinkDomainId{Value: domainID}},
+			},
+			want: []NVLinkDomainMembership{},
+		},
+		{
+			name:      "rejects partial details response",
+			requested: []*corev1.SwitchId{{Id: "switch-a"}, {Id: "switch-b"}},
+			switches:  []*corev1.Switch{switchWithDomain("switch-a", "rack-a")},
+			wantErr:   "omitted active switch switch-b",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := nvLinkDomainMembershipsFromSwitches(test.requested, test.switches)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/rest-api/flow/internal/nicoapi/grpc_domain_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_domain_test.go
@@ -4,13 +4,64 @@
 package nicoapi
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
+
+type deadlineTrackingForgeClient struct {
+	corev1.ForgeClient
+	deadlines []time.Time
+}
+
+func (c *deadlineTrackingForgeClient) recordDeadline(ctx context.Context) {
+	deadline, ok := ctx.Deadline()
+	if ok {
+		c.deadlines = append(c.deadlines, deadline)
+	}
+}
+
+func (c *deadlineTrackingForgeClient) FindSwitchIds(
+	ctx context.Context,
+	_ *corev1.SwitchSearchFilter,
+	_ ...grpc.CallOption,
+) (*corev1.SwitchIdList, error) {
+	c.recordDeadline(ctx)
+	time.Sleep(10 * time.Millisecond)
+	return &corev1.SwitchIdList{Ids: []*corev1.SwitchId{{Id: "switch-a"}}}, nil
+}
+
+func (c *deadlineTrackingForgeClient) FindSwitchesByIds(
+	ctx context.Context,
+	_ *corev1.SwitchesByIdsRequest,
+	_ ...grpc.CallOption,
+) (*corev1.SwitchList, error) {
+	c.recordDeadline(ctx)
+	return &corev1.SwitchList{Switches: []*corev1.Switch{
+		{
+			Id:               &corev1.SwitchId{Id: "switch-a"},
+			RackId:           &corev1.RackId{Id: "rack-a"},
+			NvlinkDomainUuid: &corev1.NVLinkDomainId{Value: "20000000-0000-0000-0000-000000000001"},
+		},
+	}}, nil
+}
+
+func TestGetObservedNVLinkDomainMembershipsUsesPerRPCTimeouts(t *testing.T) {
+	forgeClient := &deadlineTrackingForgeClient{}
+	client := &grpcClient{gclient: forgeClient, grpcTimeout: time.Minute}
+
+	memberships, err := client.GetObservedNVLinkDomainMemberships(context.Background())
+	require.NoError(t, err)
+	require.Len(t, memberships, 1)
+	require.Len(t, forgeClient.deadlines, 2)
+	assert.Greater(t, forgeClient.deadlines[1].Sub(forgeClient.deadlines[0]), 5*time.Millisecond)
+}
 
 func TestNVLinkDomainMembershipsFromSwitches(t *testing.T) {
 	domainID := "20000000-0000-0000-0000-000000000001"

--- a/rest-api/flow/internal/nicoapi/mock.go
+++ b/rest-api/flow/internal/nicoapi/mock.go
@@ -28,6 +28,7 @@ type mockClient struct {
 	powerShelfRackIDs          map[string]string // power shelf ID → rack ID
 	switchControllerStates     map[string]string // switch ID → raw core controller_state
 	switchNvosIPs              map[string]string // switch ID → resolved NVOS host IP
+	nvLinkDomainMemberships    []NVLinkDomainMembership
 	powerShelfControllerStates map[string]string // shelf ID → raw core controller_state
 	hostMachinesByRackID       map[string][]string
 	// Detail tables for the GetAllExpected*Details RPCs (Flow's mirror sync).
@@ -260,6 +261,19 @@ func (c *mockClient) FindSwitchNvosIPs(_ context.Context, switchIds []string) (m
 		}
 	}
 	return out, nil
+}
+
+func (c *mockClient) GetObservedNVLinkDomainMemberships(_ context.Context) ([]NVLinkDomainMembership, error) {
+	out := make([]NVLinkDomainMembership, len(c.nvLinkDomainMemberships))
+	copy(out, c.nvLinkDomainMemberships)
+	return out, nil
+}
+
+// SetObservedNVLinkDomainMemberships replaces the Core domain observations
+// returned by the mock client.
+func (c *mockClient) SetObservedNVLinkDomainMemberships(memberships []NVLinkDomainMembership) {
+	c.nvLinkDomainMemberships = make([]NVLinkDomainMembership, len(memberships))
+	copy(c.nvLinkDomainMemberships, memberships)
 }
 
 func (c *mockClient) FindPowerShelfControllerStates(_ context.Context, shelfIds []string) (map[string]string, error) {

--- a/rest-api/flow/internal/nicoapi/mod.go
+++ b/rest-api/flow/internal/nicoapi/mod.go
@@ -62,6 +62,12 @@ type Client interface {
 	// endpoint are omitted from the result.
 	FindSwitchNvosIPs(ctx context.Context, switchIds []string) (map[string]string, error)
 
+	// GetObservedNVLinkDomainMemberships returns valid rack/domain observations
+	// from a complete snapshot of Core's active switch inventory. Switches without
+	// a valid observation are omitted, so callers may clear omitted rack
+	// memberships after a successful read.
+	GetObservedNVLinkDomainMemberships(ctx context.Context) ([]NVLinkDomainMembership, error)
+
 	// FindPowerShelfControllerStates is the power-shelf equivalent of
 	// FindSwitchControllerStates.
 	FindPowerShelfControllerStates(ctx context.Context, shelfIds []string) (map[string]string, error)
@@ -254,6 +260,7 @@ type Client interface {
 	SetPowerShelfRackID(shelfID, rackID string)
 	SetSwitchControllerState(switchID, state string)
 	SetSwitchNvosIP(switchID, ip string)
+	SetObservedNVLinkDomainMemberships(memberships []NVLinkDomainMembership)
 	SetPowerShelfControllerState(shelfID, state string)
 	SetRackHostMachineIDs(rackID string, machineIDs []string)
 	AddExpectedRackDetail(detail ExpectedRackDetail)

--- a/rest-api/flow/internal/nicoapi/model.go
+++ b/rest-api/flow/internal/nicoapi/model.go
@@ -386,6 +386,15 @@ type ExpectedRackDetail struct {
 	Labels        map[string]string
 }
 
+// NVLinkDomainMembership is one valid rack-scoped NVLink domain observation
+// from Core's actual switch inventory. Core stores the last valid observation
+// on every active switch in a rack, so a snapshot may contain duplicate rows
+// for the same domain and rack.
+type NVLinkDomainMembership struct {
+	DomainID string
+	RackID   string
+}
+
 // ExpectedMachineDetail is the canonical expected-machine representation
 // returned by GetAllExpectedMachines. ExpectedMachineID is the Core-side UUID
 // for the expected_machines row (distinct from the runtime machine_id assigned

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
@@ -17,18 +17,19 @@ import (
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
 
-// runActualSync runs every per-type actual-vs-expected drift detector,
-// concatenates their drifts, and logs a per-type "received from Core"
-// summary. Each type-specific function handles its own errors internally
-// and falls back to nil drifts; one type's RPC failure doesn't suppress the
-// others.
+// runActualSync runs every per-type actual-vs-expected drift detector, projects
+// observed NVLink domain topology, concatenates the component drifts, and logs
+// a per-type inventory summary. Each type-specific function handles its own
+// errors internally and falls back to nil drifts; one type's RPC failure
+// doesn't suppress the others.
 //
 // allRPCOK is true only when every type's drift-affecting RPCs succeeded. The
 // drift table is a full-table replace with no per-type discriminator, so the
 // caller must not overwrite it from a partial view: if any type's RPC failed,
 // the previously persisted drifts are kept rather than being wiped. The
-// returned drifts are not yet persisted — runInventoryOne owns the
-// table-replacement transaction.
+// observed-domain projection is best effort and does not affect allRPCOK
+// because it does not contribute component drifts. The returned drifts are not
+// yet persisted — runInventoryOne owns the table-replacement transaction.
 func runActualSync(
 	ctx context.Context,
 	pool *cdb.Session,
@@ -43,6 +44,10 @@ func runActualSync(
 	switchesReceived, nvSwitchDrifts, switchOK := syncNVSwitchesNICo(ctx, pool, nicoClient)
 	drifts = append(drifts, nvSwitchDrifts...)
 	allRPCOK = allRPCOK && switchOK
+
+	// Domain membership is observed topology rather than expected inventory.
+	// Project it after switch sync so this cycle's switch links are available.
+	syncObservedNVLinkDomainTopology(ctx, pool, nicoClient)
 
 	powershelvesReceived, powershelfDrifts, powershelfOK := syncPowershelvesNICo(ctx, pool, nicoClient)
 	drifts = append(drifts, powershelfDrifts...)

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_domain.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_domain.go
@@ -1,0 +1,339 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventorysync
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/uptrace/bun"
+
+	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+)
+
+// domainMirrorResult summarizes one committed actual domain-topology reconciliation.
+type domainMirrorResult struct {
+	pulled              int
+	domainsInserted     int
+	domainsResurrected  int
+	domainsSoftDeleted  int
+	membershipsAssigned int
+	membershipsCleared  int
+}
+
+type clearedDomainMembership struct {
+	rackExternalID string
+	rackID         uuid.UUID
+	domainID       uuid.UUID
+}
+
+type domainTopologySnapshot struct {
+	domainByRack map[uuid.UUID]uuid.UUID
+	domainIDs    map[uuid.UUID]struct{}
+}
+
+func (r domainMirrorResult) log() {
+	log.Info().
+		Str("resource", "nvlink_domains").
+		Int("pulled", r.pulled).
+		Int("domains_inserted", r.domainsInserted).
+		Int("domains_resurrected", r.domainsResurrected).
+		Int("domains_soft_deleted", r.domainsSoftDeleted).
+		Int("memberships_assigned", r.membershipsAssigned).
+		Int("memberships_cleared", r.membershipsCleared).
+		Msg("Actual-inventory sync: NVLink domains")
+}
+
+func pullObservedNVLinkDomainMemberships(
+	ctx context.Context,
+	nicoClient nicoapi.Client,
+) (rows []nicoapi.NVLinkDomainMembership, rpcOK bool) {
+	rows, err := nicoClient.GetObservedNVLinkDomainMemberships(ctx)
+	if err != nil {
+		log.Error().Err(err).
+			Msg("Actual-inventory sync: pulling observed NVLink domain memberships failed; preserving existing topology")
+		return nil, false
+	}
+	return rows, true
+}
+
+func syncObservedNVLinkDomainTopology(
+	ctx context.Context,
+	pool *cdb.Session,
+	nicoClient nicoapi.Client,
+) {
+	memberships, membershipsOK := pullObservedNVLinkDomainMemberships(ctx, nicoClient)
+	if !membershipsOK {
+		return
+	}
+
+	rackIDByExternalID, err := loadRackIDByExternalID(ctx, pool.DB)
+	if err != nil {
+		log.Error().Err(err).
+			Msg("Actual-inventory sync: loading rack external_id map failed; preserving existing NVLink domain topology")
+		return
+	}
+
+	result, err := mirrorObservedNVLinkDomainMemberships(ctx, pool, memberships, rackIDByExternalID)
+	if err != nil {
+		log.Error().Err(err).
+			Msg("Actual-inventory sync: NVLink domain reconciliation failed; preserving existing topology")
+		return
+	}
+	result.log()
+}
+
+// mirrorObservedNVLinkDomainMemberships reconciles a complete observed
+// domain-topology snapshot into Flow. rackIDByExternalID translates inventory
+// rack IDs into Flow rack UUIDs.
+//
+// A rack omitted from a successful snapshot has no observed domain membership
+// and is cleared. Domain rows and rack memberships are committed together. A
+// displaced domain is soft-deleted only when no active rack references it;
+// unrelated unreferenced domains are preserved because Flow supports manual
+// domain creation.
+func mirrorObservedNVLinkDomainMemberships(
+	ctx context.Context,
+	pool *cdb.Session,
+	memberships []nicoapi.NVLinkDomainMembership,
+	rackIDByExternalID map[string]uuid.UUID,
+) (domainMirrorResult, error) {
+	result := domainMirrorResult{pulled: len(memberships)}
+	snapshot, err := buildDomainTopologySnapshot(memberships, rackIDByExternalID)
+	if err != nil {
+		return result, err
+	}
+
+	rackExternalIDByID := make(map[uuid.UUID]string, len(rackIDByExternalID))
+	for externalID, rackID := range rackIDByExternalID {
+		rackExternalIDByID[rackID] = externalID
+	}
+	clearedMemberships := make([]clearedDomainMembership, 0)
+
+	err = pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		var existingDomains []model.NVLDomain
+		err := tx.NewSelect().
+			Model(&existingDomains).
+			WhereAllWithDeleted().
+			Scan(ctx)
+		if err != nil {
+			return fmt.Errorf("load existing NVLink domains: %w", err)
+		}
+
+		existingByID := make(map[uuid.UUID]*model.NVLDomain, len(existingDomains))
+		for i := range existingDomains {
+			existingByID[existingDomains[i].ID] = &existingDomains[i]
+		}
+
+		rackIDs := sortedUUIDValues(rackIDByExternalID)
+		currentDomainByRack := make(map[uuid.UUID]uuid.UUID, len(rackIDs))
+		if len(rackIDs) > 0 {
+			var currentRacks []model.Rack
+			err = tx.NewSelect().
+				Model(&currentRacks).
+				Column("id", "nvldomain_id").
+				Where("id IN (?)", bun.In(rackIDs)).
+				Scan(ctx)
+			if err != nil {
+				return fmt.Errorf("load current rack NVLink domain memberships: %w", err)
+			}
+			for i := range currentRacks {
+				currentDomainByRack[currentRacks[i].ID] = currentRacks[i].NVLDomainID
+			}
+		}
+
+		domainIDs := sortedUUIDKeys(snapshot.domainIDs)
+		for _, domainID := range domainIDs {
+			existing, found := existingByID[domainID]
+			if !found {
+				domain := model.NVLDomain{ID: domainID, Name: domainID.String()}
+				_, err = tx.NewInsert().Model(&domain).Exec(ctx)
+				if err != nil {
+					return fmt.Errorf("insert NVLink domain %s: %w", domainID, err)
+				}
+				result.domainsInserted++
+				continue
+			}
+
+			if existing.DeletedAt == nil {
+				continue
+			}
+
+			_, err = tx.NewUpdate().
+				Model(existing).
+				Set("deleted_at = NULL").
+				WhereAllWithDeleted().
+				Where("id = ?", domainID).
+				Exec(ctx)
+			if err != nil {
+				return fmt.Errorf("restore NVLink domain %s: %w", domainID, err)
+			}
+			if existing.DeletedAt != nil {
+				result.domainsResurrected++
+			}
+		}
+
+		now := time.Now()
+		displacedDomainIDs := make(map[uuid.UUID]struct{})
+		for _, rackID := range rackIDs {
+			domainID, assigned := snapshot.domainByRack[rackID]
+			currentDomainID := currentDomainByRack[rackID]
+			if currentDomainID != uuid.Nil && (!assigned || currentDomainID != domainID) {
+				displacedDomainIDs[currentDomainID] = struct{}{}
+			}
+			query := tx.NewUpdate().
+				Model((*model.Rack)(nil)).
+				Set("updated_at = ?", now).
+				Where("id = ?", rackID)
+			if assigned {
+				query = query.
+					Set("nvldomain_id = ?", domainID).
+					Where("nvldomain_id IS DISTINCT FROM ?", domainID)
+			} else {
+				query = query.
+					Set("nvldomain_id = NULL").
+					Where("nvldomain_id IS NOT NULL")
+			}
+
+			updateResult, updateErr := query.Exec(ctx)
+			if updateErr != nil {
+				return fmt.Errorf("reconcile NVLink domain for rack %s: %w", rackID, updateErr)
+			}
+			changed, rowsErr := updateResult.RowsAffected()
+			if rowsErr != nil {
+				return fmt.Errorf("count NVLink domain changes for rack %s: %w", rackID, rowsErr)
+			}
+			if changed == 0 {
+				continue
+			}
+			if assigned {
+				result.membershipsAssigned += int(changed)
+			} else {
+				result.membershipsCleared += int(changed)
+				clearedMemberships = append(clearedMemberships, clearedDomainMembership{
+					rackExternalID: rackExternalIDByID[rackID],
+					rackID:         rackID,
+					domainID:       currentDomainID,
+				})
+			}
+		}
+
+		var referencedDomainIDs []uuid.UUID
+		err = tx.NewSelect().
+			Model((*model.Rack)(nil)).
+			Column("nvldomain_id").
+			Where("nvldomain_id IS NOT NULL").
+			Group("nvldomain_id").
+			Scan(ctx, &referencedDomainIDs)
+		if err != nil {
+			return fmt.Errorf("load active rack NVLink domain references: %w", err)
+		}
+		referencedDomainIDSet := make(map[uuid.UUID]struct{}, len(referencedDomainIDs))
+		for _, domainID := range referencedDomainIDs {
+			referencedDomainIDSet[domainID] = struct{}{}
+		}
+
+		for i := range existingDomains {
+			existing := &existingDomains[i]
+			if existing.DeletedAt != nil {
+				continue
+			}
+			_, displaced := displacedDomainIDs[existing.ID]
+			if !displaced {
+				continue
+			}
+			_, referenced := referencedDomainIDSet[existing.ID]
+			if referenced {
+				continue
+			}
+
+			deleteResult, deleteErr := tx.NewDelete().
+				Model(existing).
+				Where("id = ?", existing.ID).
+				Exec(ctx)
+			if deleteErr != nil {
+				return fmt.Errorf("soft-delete stale NVLink domain %s: %w", existing.ID, deleteErr)
+			}
+			changed, rowsErr := deleteResult.RowsAffected()
+			if rowsErr != nil {
+				return fmt.Errorf("count stale NVLink domain deletes for %s: %w", existing.ID, rowsErr)
+			}
+			result.domainsSoftDeleted += int(changed)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return domainMirrorResult{pulled: len(memberships)}, err
+	}
+	for _, cleared := range clearedMemberships {
+		log.Info().
+			Str("rack_external_id", cleared.rackExternalID).
+			Stringer("rack_id", cleared.rackID).
+			Stringer("previous_domain_id", cleared.domainID).
+			Msg("Actual-inventory sync: cleared rack NVLink domain membership because the observed snapshot contained no valid membership")
+	}
+
+	return result, nil
+}
+
+func buildDomainTopologySnapshot(
+	memberships []nicoapi.NVLinkDomainMembership,
+	rackIDByExternalID map[string]uuid.UUID,
+) (domainTopologySnapshot, error) {
+	domainByRack := make(map[uuid.UUID]uuid.UUID)
+	domainIDs := make(map[uuid.UUID]struct{})
+
+	for _, membership := range memberships {
+		domainID, err := uuid.Parse(membership.DomainID)
+		if err != nil || domainID == uuid.Nil {
+			return domainTopologySnapshot{}, fmt.Errorf("invalid observed NVLink domain ID %q", membership.DomainID)
+		}
+
+		rackID, ok := rackIDByExternalID[membership.RackID]
+		if !ok {
+			return domainTopologySnapshot{}, fmt.Errorf(
+				"observed NVLink domain %s references rack %q absent from Flow rack inventory",
+				domainID, membership.RackID,
+			)
+		}
+
+		currentDomainID, exists := domainByRack[rackID]
+		if exists && currentDomainID != domainID {
+			return domainTopologySnapshot{}, fmt.Errorf(
+				"rack %q has conflicting observed NVLink domains %s and %s",
+				membership.RackID, currentDomainID, domainID,
+			)
+		}
+
+		domainByRack[rackID] = domainID
+		domainIDs[domainID] = struct{}{}
+	}
+
+	return domainTopologySnapshot{domainByRack: domainByRack, domainIDs: domainIDs}, nil
+}
+
+func sortedUUIDKeys(values map[uuid.UUID]struct{}) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i].String() < ids[j].String() })
+	return ids
+}
+
+func sortedUUIDValues(values map[string]uuid.UUID) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(values))
+	for _, id := range values {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i].String() < ids[j].String() })
+	return ids
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_domain.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_domain.go
@@ -98,7 +98,8 @@ func syncObservedNVLinkDomainTopology(
 // and is cleared. Domain rows and rack memberships are committed together. A
 // displaced domain is soft-deleted only when no active rack references it;
 // unrelated unreferenced domains are preserved because Flow supports manual
-// domain creation.
+// domain creation. Observations for racks absent from active Flow inventory are
+// skipped with a warning without invalidating observations for known racks.
 func mirrorObservedNVLinkDomainMemberships(
 	ctx context.Context,
 	pool *cdb.Session,
@@ -166,18 +167,21 @@ func mirrorObservedNVLinkDomainMemberships(
 				continue
 			}
 
-			_, err = tx.NewUpdate().
+			updateResult, updateErr := tx.NewUpdate().
 				Model(existing).
 				Set("deleted_at = NULL").
 				WhereAllWithDeleted().
 				Where("id = ?", domainID).
+				Where("deleted_at IS NOT NULL").
 				Exec(ctx)
-			if err != nil {
-				return fmt.Errorf("restore NVLink domain %s: %w", domainID, err)
+			if updateErr != nil {
+				return fmt.Errorf("restore NVLink domain %s: %w", domainID, updateErr)
 			}
-			if existing.DeletedAt != nil {
-				result.domainsResurrected++
+			changed, rowsErr := updateResult.RowsAffected()
+			if rowsErr != nil {
+				return fmt.Errorf("count restored NVLink domains for %s: %w", domainID, rowsErr)
 			}
+			result.domainsResurrected += int(changed)
 		}
 
 		now := time.Now()
@@ -290,6 +294,8 @@ func buildDomainTopologySnapshot(
 ) (domainTopologySnapshot, error) {
 	domainByRack := make(map[uuid.UUID]uuid.UUID)
 	domainIDs := make(map[uuid.UUID]struct{})
+	unknownRackIDs := make(map[string]struct{})
+	skippedUnknownMemberships := 0
 
 	for _, membership := range memberships {
 		domainID, err := uuid.Parse(membership.DomainID)
@@ -299,10 +305,9 @@ func buildDomainTopologySnapshot(
 
 		rackID, ok := rackIDByExternalID[membership.RackID]
 		if !ok {
-			return domainTopologySnapshot{}, fmt.Errorf(
-				"observed NVLink domain %s references rack %q absent from Flow rack inventory",
-				domainID, membership.RackID,
-			)
+			unknownRackIDs[membership.RackID] = struct{}{}
+			skippedUnknownMemberships++
+			continue
 		}
 
 		currentDomainID, exists := domainByRack[rackID]
@@ -315,6 +320,18 @@ func buildDomainTopologySnapshot(
 
 		domainByRack[rackID] = domainID
 		domainIDs[domainID] = struct{}{}
+	}
+
+	if skippedUnknownMemberships > 0 {
+		unknownRacks := make([]string, 0, len(unknownRackIDs))
+		for rackID := range unknownRackIDs {
+			unknownRacks = append(unknownRacks, rackID)
+		}
+		sort.Strings(unknownRacks)
+		log.Warn().
+			Int("skipped_memberships", skippedUnknownMemberships).
+			Strs("rack_external_ids", unknownRacks).
+			Msg("Actual-inventory sync: skipped observed NVLink domain memberships for racks absent from Flow rack inventory")
 	}
 
 	return domainTopologySnapshot{domainByRack: domainByRack, domainIDs: domainIDs}, nil

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_domain_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_domain_test.go
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventorysync
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+)
+
+type failDomainMembershipClient struct {
+	nicoapi.Client
+}
+
+func (c *failDomainMembershipClient) GetObservedNVLinkDomainMemberships(_ context.Context) ([]nicoapi.NVLinkDomainMembership, error) {
+	return nil, errors.New("domain snapshot unavailable")
+}
+
+func TestBuildDomainTopologySnapshot(t *testing.T) {
+	rackA := uuid.MustParse("10000000-0000-0000-0000-000000000001")
+	rackB := uuid.MustParse("10000000-0000-0000-0000-000000000002")
+	domainA := "20000000-0000-0000-0000-000000000001"
+	domainB := "20000000-0000-0000-0000-000000000002"
+	rackIDs := map[string]uuid.UUID{"rack-a": rackA, "rack-b": rackB}
+
+	tests := []struct {
+		name            string
+		memberships     []nicoapi.NVLinkDomainMembership
+		wantRackCount   int
+		wantDomainCount int
+		wantErr         string
+	}{
+		{
+			name: "deduplicates switch observations",
+			memberships: []nicoapi.NVLinkDomainMembership{
+				{DomainID: domainA, RackID: "rack-a"},
+				{DomainID: domainA, RackID: "rack-a"},
+				{DomainID: domainA, RackID: "rack-b"},
+			},
+			wantRackCount:   2,
+			wantDomainCount: 1,
+		},
+		{
+			name: "accepts no valid observations",
+		},
+		{
+			name: "rejects invalid domain UUID",
+			memberships: []nicoapi.NVLinkDomainMembership{
+				{DomainID: "not-a-uuid", RackID: "rack-a"},
+			},
+			wantErr: "invalid observed NVLink domain ID",
+		},
+		{
+			name: "rejects unknown rack",
+			memberships: []nicoapi.NVLinkDomainMembership{
+				{DomainID: domainA, RackID: "unknown"},
+			},
+			wantErr: "absent from Flow rack inventory",
+		},
+		{
+			name: "rejects conflicting rack memberships",
+			memberships: []nicoapi.NVLinkDomainMembership{
+				{DomainID: domainA, RackID: "rack-a"},
+				{DomainID: domainB, RackID: "rack-a"},
+			},
+			wantErr: "conflicting observed NVLink domains",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot, err := buildDomainTopologySnapshot(test.memberships, rackIDs)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, snapshot.domainByRack, test.wantRackCount)
+			assert.Len(t, snapshot.domainIDs, test.wantDomainCount)
+		})
+	}
+}
+
+func TestPullObservedNVLinkDomainMembershipsPreservesTopologyOnFailure(t *testing.T) {
+	client := &failDomainMembershipClient{Client: nicoapi.NewMockClient()}
+	memberships, ok := pullObservedNVLinkDomainMemberships(context.Background(), client)
+	assert.False(t, ok)
+	assert.Nil(t, memberships)
+}
+
+func TestMirrorObservedNVLinkDomainMembershipsLifecycle(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	rackA := model.Rack{Name: "domain-rack-a", ExternalID: strPtr("rack-a")}
+	rackB := model.Rack{Name: "domain-rack-b", ExternalID: strPtr("rack-b")}
+	require.NoError(t, rackA.Create(ctx, pool.DB))
+	require.NoError(t, rackB.Create(ctx, pool.DB))
+	rackIDs := map[string]uuid.UUID{"rack-a": rackA.ID, "rack-b": rackB.ID}
+	domainA := uuid.MustParse("20000000-0000-0000-0000-000000000001")
+	domainB := uuid.MustParse("20000000-0000-0000-0000-000000000002")
+
+	initial := []nicoapi.NVLinkDomainMembership{
+		{DomainID: domainA.String(), RackID: "rack-a"},
+		{DomainID: domainA.String(), RackID: "rack-a"},
+		{DomainID: domainA.String(), RackID: "rack-b"},
+	}
+	result, err := mirrorObservedNVLinkDomainMemberships(ctx, pool, initial, rackIDs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.domainsInserted)
+	assert.Equal(t, 2, result.membershipsAssigned)
+
+	result, err = mirrorObservedNVLinkDomainMemberships(ctx, pool, initial, rackIDs)
+	require.NoError(t, err)
+	assert.Equal(t, domainMirrorResult{pulled: len(initial)}, result)
+
+	moved := []nicoapi.NVLinkDomainMembership{
+		{DomainID: domainA.String(), RackID: "rack-a"},
+		{DomainID: domainB.String(), RackID: "rack-b"},
+	}
+	result, err = mirrorObservedNVLinkDomainMemberships(ctx, pool, moved, rackIDs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.domainsInserted)
+	assert.Equal(t, 1, result.membershipsAssigned)
+	orphanDomain := model.NVLDomain{
+		ID:   uuid.MustParse("20000000-0000-0000-0000-000000000003"),
+		Name: "manually-created-domain",
+	}
+	require.NoError(t, orphanDomain.Create(ctx, pool.DB))
+
+	var logOutput bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&logOutput)
+	result, err = mirrorObservedNVLinkDomainMemberships(ctx, pool, nil, rackIDs)
+	log.Logger = originalLogger
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.membershipsCleared)
+	assert.Equal(t, 2, result.domainsSoftDeleted)
+	assert.Contains(t, logOutput.String(), "cleared rack NVLink domain membership because the observed snapshot contained no valid membership")
+	assert.Contains(t, logOutput.String(), `"rack_external_id":"rack-a"`)
+	assert.Contains(t, logOutput.String(), `"previous_domain_id":"`+domainA.String()+`"`)
+	var rackAAfterEmpty model.Rack
+	err = pool.DB.NewSelect().Model(&rackAAfterEmpty).Where("id = ?", rackA.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uuid.Nil, rackAAfterEmpty.NVLDomainID)
+	var rackBAfterEmpty model.Rack
+	err = pool.DB.NewSelect().Model(&rackBAfterEmpty).Where("id = ?", rackB.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uuid.Nil, rackBAfterEmpty.NVLDomainID)
+	_, err = pool.DB.NewUpdate().
+		Model((*model.NVLDomain)(nil)).
+		Set("name = ?", "friendly-domain-b").
+		WhereAllWithDeleted().
+		Where("id = ?", domainB).
+		Exec(ctx)
+	require.NoError(t, err)
+	_, err = pool.DB.NewDelete().
+		Model(&model.NVLDomain{ID: domainB}).
+		Where("id = ?", domainB).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	resurrected := []nicoapi.NVLinkDomainMembership{
+		{DomainID: domainB.String(), RackID: "rack-b"},
+	}
+	result, err = mirrorObservedNVLinkDomainMemberships(ctx, pool, resurrected, rackIDs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.domainsResurrected)
+	assert.Equal(t, 1, result.membershipsAssigned)
+
+	converged := []nicoapi.NVLinkDomainMembership{
+		{DomainID: domainB.String(), RackID: "rack-a"},
+		{DomainID: domainB.String(), RackID: "rack-b"},
+	}
+	result, err = mirrorObservedNVLinkDomainMemberships(ctx, pool, converged, rackIDs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.membershipsAssigned)
+	assert.Equal(t, 0, result.domainsSoftDeleted)
+
+	var gotRackA model.Rack
+	err = pool.DB.NewSelect().Model(&gotRackA).Where("id = ?", rackA.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, domainB, gotRackA.NVLDomainID)
+	var gotRackB model.Rack
+	err = pool.DB.NewSelect().Model(&gotRackB).Where("id = ?", rackB.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, domainB, gotRackB.NVLDomainID)
+	var gotDomainB model.NVLDomain
+	err = pool.DB.NewSelect().Model(&gotDomainB).Where("id = ?", domainB).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "friendly-domain-b", gotDomainB.Name)
+	var gotOrphanDomain model.NVLDomain
+	err = pool.DB.NewSelect().Model(&gotOrphanDomain).Where("id = ?", orphanDomain.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, orphanDomain.Name, gotOrphanDomain.Name)
+	var gotDomainA model.NVLDomain
+	err = pool.DB.NewSelect().
+		Model(&gotDomainA).
+		WhereAllWithDeleted().
+		Where("id = ?", domainA).
+		Scan(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, gotDomainA.DeletedAt)
+}
+
+func TestMirrorObservedNVLinkDomainMembershipsRollsBackAllWrites(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	oldDomain := model.NVLDomain{
+		ID:   uuid.MustParse("30000000-0000-0000-0000-000000000001"),
+		Name: "old-domain",
+	}
+	require.NoError(t, oldDomain.Create(ctx, pool.DB))
+	targetDomainID := uuid.MustParse("30000000-0000-0000-0000-000000000002")
+	nameConflict := model.NVLDomain{
+		ID:   uuid.MustParse("30000000-0000-0000-0000-000000000003"),
+		Name: targetDomainID.String(),
+	}
+	require.NoError(t, nameConflict.Create(ctx, pool.DB))
+	rack := model.Rack{
+		Name:        "rollback-rack",
+		ExternalID:  strPtr("rack-a"),
+		NVLDomainID: oldDomain.ID,
+	}
+	require.NoError(t, rack.Create(ctx, pool.DB))
+
+	memberships := []nicoapi.NVLinkDomainMembership{
+		{DomainID: targetDomainID.String(), RackID: "rack-a"},
+	}
+	result, err := mirrorObservedNVLinkDomainMemberships(
+		ctx,
+		pool,
+		memberships,
+		map[string]uuid.UUID{"rack-a": rack.ID},
+	)
+	require.Error(t, err)
+	assert.Equal(t, domainMirrorResult{pulled: 1}, result)
+
+	var gotRack model.Rack
+	err = pool.DB.NewSelect().Model(&gotRack).Where("id = ?", rack.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, oldDomain.ID, gotRack.NVLDomainID)
+	var activeDomains []model.NVLDomain
+	err = pool.DB.NewSelect().Model(&activeDomains).Order("id").Scan(ctx)
+	require.NoError(t, err)
+	assert.Len(t, activeDomains, 2)
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_domain_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_domain_test.go
@@ -62,11 +62,19 @@ func TestBuildDomainTopologySnapshot(t *testing.T) {
 			wantErr: "invalid observed NVLink domain ID",
 		},
 		{
-			name: "rejects unknown rack",
+			name: "skips unknown rack",
 			memberships: []nicoapi.NVLinkDomainMembership{
 				{DomainID: domainA, RackID: "unknown"},
 			},
-			wantErr: "absent from Flow rack inventory",
+		},
+		{
+			name: "keeps known membership when another rack is unknown",
+			memberships: []nicoapi.NVLinkDomainMembership{
+				{DomainID: domainA, RackID: "rack-a"},
+				{DomainID: domainB, RackID: "unknown"},
+			},
+			wantRackCount:   1,
+			wantDomainCount: 1,
 		},
 		{
 			name: "rejects conflicting rack memberships",

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory.go
@@ -3,7 +3,8 @@
 
 // Package inventorysync reconciles Flow's rack / component / BMC / drift
 // tables against Core every cycle: syncExpectedFromCore mirrors Core's
-// expected inventory, runActualSync detects drift against Core's runtime view.
+// expected inventory, while runActualSync detects drift and projects observed
+// topology.
 //
 // TODO: this job writes the DB directly via bun model.* and pool.RunInTx,
 // bypassing the service -> inventorymanager -> store layering the rest of Flow
@@ -36,9 +37,9 @@ import (
 //     expected_mirror*.go). Gated by expectedSyncEnabled; when false the
 //     step is skipped entirely and Flow's existing ingestion path is the
 //     sole writer to rack / component.
-//  2. runActualSync reconciles each component type against Core's runtime
-//     view and returns one combined drift set (the "actual" half — see
-//     actual_sync*.go).
+//  2. runActualSync reconciles actual component state, projects valid NVLink
+//     domain observations, and returns one combined drift set (the "actual"
+//     half — see actual_sync*.go).
 //  3. The drift set replaces the whole component_drift table atomically so
 //     stale rows from previous runs can't linger. The replace is skipped
 //     when any actual-sync RPC failed: component_drift is a full-table


### PR DESCRIPTION
Inside Core, NVLink Manager records the last valid NMX-C domain UUID as actual/discovered state on every active switch in a rack. Flow currently has no projection of those observations, so its `nvldomain` rows and `rack.nvldomain_id` memberships do not follow Core's runtime topology.

This change runs domain reconciliation in the actual-inventory half of the inventory sync, after actual switch reconciliation. It reads all active Core switches, verifies that the switch-detail response is complete, deduplicates rack-scoped observations, creates or restores observed Flow domain rows, and reconciles rack memberships in one transaction. Because Core retains the last valid UUID across transient NMX-C failures and partial RPC responses are rejected, a rack omitted from a successful complete snapshot is treated as having no actual domain membership and its Flow membership is cleared. Each committed clear logs the Core rack ID, Flow rack UUID, and previous domain UUID. Observations for racks not yet present in Flow are logged and skipped without blocking reconciliation for known racks. A displaced domain is soft-deleted only if no active rack still references it; unrelated manually created domains are preserved.

## Related issues

Relates to #2080

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
 
## Additional Notes
 