### PR TITLE
fix(machine-controller): close rack firmware test transaction

### DIFF
--- a/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
+++ b/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
@@ -193,7 +193,9 @@ async fn advances_on_completion(pool: PgPool) {
 }
 
 #[sqlx_test]
-async fn assigned_host_returns_to_assigned_ready_on_completion(pool: PgPool) {
+async fn assigned_host_returns_to_assigned_ready_on_completion(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut env = Env::builder(pool).build().await;
     let host = managed_host(&env.test_harness).await;
     let instance_id = create_instance(&env.test_harness, &host).await;
@@ -223,10 +225,12 @@ async fn assigned_host_returns_to_assigned_ready_on_completion(pool: PgPool) {
     assert!(machine.host_reprovision_requested.is_none());
 
     let mut txn = env.test_harness.db_txn().await;
-    let attached_instance = db::instance::find_id_by_machine_id(txn.as_mut(), &host.host.id)
-        .await
-        .unwrap();
+    let attached_instance =
+        db::instance::find_id_by_machine_id(txn.as_mut(), &host.host.id).await?;
     assert_eq!(attached_instance, Some(instance_id));
+    txn.rollback().await?;
+
+    Ok(())
 }
 
 #[sqlx_test]


### PR DESCRIPTION
The assigned-host rack firmware test only reads through its final transaction, but drops it without closing it. That makes the `txn_without_commit` lint stop any branch that rebuilds the integration target.

This rolls the transaction back after the attachment assertion. Production rack firmware behavior is unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5041

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The focused integration test, workspace Clippy, and custom Carbide lints pass. Local CodeRabbit, Claude, and Codex reviews found no actionable issues. Hosted CodeRabbit then suggested propagating the final SQLx errors instead of unwrapping them; that follow-up is included in the current head.

Closes #5041
