### PR TITLE
feat(health): support extended proto for NMX-C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,6 +2103,7 @@ dependencies = [
  "opentelemetry-proto",
  "prometheus",
  "prost",
+ "prost-reflect",
  "prost-types",
  "rand 0.10.1",
  "rcgen",
@@ -9058,8 +9059,11 @@ version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
 dependencies = [
+ "base64",
  "prost",
  "prost-types",
+ "serde",
+ "serde-value",
 ]
 
 [[package]]

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -77,6 +77,7 @@ tokio = { workspace = true }
 tonic = { workspace = true, features = ["tls-native-roots"] }
 tonic-prost = { workspace = true }
 prost = { workspace = true }
+prost-reflect = { workspace = true, features = ["serde"] }
 prost-types = { workspace = true }
 nv-redfish = { workspace = true, features = [
   "bmc-http",

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -371,6 +371,46 @@ initial_backoff = "1s"
 # Maximum reconnect delay after repeated connect or stream failures.
 max_backoff = "30s"
 
+# Optional. Omit this table to use the generated NMX-C collector.
+#
+# The override replaces the generated NMX-C collector with descriptor-driven
+# request encoding and response decoding. Responses are emitted as generic logs
+# and are not mapped to generated NMX-C events. Every OTLP target includes
+# canonical protobuf JSON regardless of include_diagnostics. These payloads may
+# be large.
+#
+# Enabling the override requires at least one [[sinks.otlp.targets]] entry. The
+# descriptor and request are loaded at startup; changes require a carbide-health
+# restart.
+#
+# [collectors.nmxc.schema_override]
+#
+# Required when the schema_override table is enabled. No default.
+# Path to a complete binary FileDescriptorSet containing the configured methods
+# and all imported descriptors. Relative paths use the process working directory.
+# descriptor_set_path = "/etc/carbide-health/nmx_c.desc"
+#
+# Optional. Default: "/nmx_c.NMX_Controller/Hello".
+# Fully qualified gRPC path in /package.Service/Method form. The method must
+# exist in the descriptor and use a unary request and response.
+# hello_rpc_path = "/nmx_c.NMX_Controller/Hello"
+#
+# Optional. Default: "/nmx_c.NMX_Controller/Subscribe".
+# Fully qualified gRPC path in /package.Service/Method form. The method must
+# exist in the descriptor, accept one request, and stream responses.
+# subscribe_rpc_path = "/nmx_c.NMX_Controller/Subscribe"
+#
+# Optional. Default: 4194304 (4 MiB). Valid range: 1-67108864.
+# Maximum encoded size accepted for one Subscribe response, in bytes.
+# max_frame_size_bytes = 4194304
+#
+# Optional. Default: empty.
+# Additional SubscribeRequest fields, using names and values accepted by the
+# supplied descriptor's protobuf JSON mapping. gateway_id, notify_on_self_change,
+# and heart_beat_rate are set by [collectors.nmxc] and cannot be repeated here.
+# [collectors.nmxc.schema_override.subscribe_fields]
+# additionalBooleanField = true
+
 [collectors.nmxt]
 scrape_interval = "1m"
 request_timeout = "30s"

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -401,7 +401,7 @@ max_backoff = "30s"
 # subscribe_rpc_path = "/nmx_c.NMX_Controller/Subscribe"
 #
 # Optional. Default: 4194304 (4 MiB). Valid range: 1-67108864.
-# Maximum encoded size accepted for one Subscribe response, in bytes.
+# Maximum encoded size accepted for one Hello or Subscribe response, in bytes.
 # max_frame_size_bytes = 4194304
 #
 # Optional. Default: empty.

--- a/crates/health/src/collectors/mod.rs
+++ b/crates/health/src/collectors/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod inventory;
 mod leak_detector;
 mod logs;
 mod nmxc;
+mod nmxc_schema_override;
 mod nmxt;
 mod nvue;
 #[cfg(test)]
@@ -44,6 +45,9 @@ pub use logs::{
     SseLogCollector, SseLogCollectorConfig,
 };
 pub use nmxc::{NmxcCollector, NmxcCollectorConfig};
+pub(crate) use nmxc_schema_override::{
+    NmxcSchemaOverride, NmxcSchemaOverrideCollector, NmxcSchemaOverrideCollectorConfig,
+};
 pub(crate) use nmxt::NMXT_PORT;
 pub use nmxt::{NmxtCollector, NmxtCollectorConfig};
 pub(crate) use nvue::gnmi::subscriber::spawn_gnmi_collector;

--- a/crates/health/src/collectors/nmxc.rs
+++ b/crates/health/src/collectors/nmxc.rs
@@ -235,20 +235,20 @@ fn hello_request(gateway_id: &str) -> ClientHello {
 }
 
 /// Builds the switch-host gRPC endpoint URL, including IPv6 bracket formatting.
-fn nmxc_endpoint_url(host: &str, port: u16, tls_enabled: bool) -> String {
+pub(super) fn nmxc_endpoint_url(host: &str, port: u16, tls_enabled: bool) -> String {
     let scheme = if tls_enabled { "https" } else { "http" };
     format!("{scheme}://{host}:{port}")
 }
 
-/// Creates a tonic NMX-C client with transport settings scoped to the collector.
+/// Creates a tonic NMX-C channel with transport settings scoped to the collector.
 ///
 /// When an mTLS profile is configured, certificate files are read while
 /// building the channel, so reconnects pick up rotated material.
-async fn nmxc_client(
+pub(super) async fn nmxc_channel(
     endpoint_url: &str,
     connect_timeout: Duration,
     tls_config: Option<&MtlsProfileConfig>,
-) -> Result<NmxcClient, HealthError> {
+) -> Result<Channel, HealthError> {
     let mut endpoint = Endpoint::from_shared(endpoint_url.to_string())
         .map_err(|error| nmxc_transport_error(endpoint_url, "parse endpoint", error))?
         .connect_timeout(connect_timeout)
@@ -266,12 +266,20 @@ async fn nmxc_client(
             .map_err(|error| nmxc_transport_error(endpoint_url, "configure TLS", error))?;
     }
 
-    let channel = endpoint
+    endpoint
         .connect()
         .await
-        .map_err(|error| nmxc_transport_error(endpoint_url, "connect", error))?;
+        .map_err(|error| nmxc_transport_error(endpoint_url, "connect", error))
+}
 
-    Ok(NmxControllerClient::new(channel))
+async fn nmxc_client(
+    endpoint_url: &str,
+    connect_timeout: Duration,
+    tls_config: Option<&MtlsProfileConfig>,
+) -> Result<NmxcClient, HealthError> {
+    nmxc_channel(endpoint_url, connect_timeout, tls_config)
+        .await
+        .map(NmxControllerClient::new)
 }
 
 /// Converts tonic transport failures into collector status errors with endpoint context.
@@ -286,7 +294,7 @@ fn nmxc_transport_error(
 }
 
 /// Creates a deadline-exceeded status for bounded NMX-C RPC phases.
-fn nmxc_timeout_error(operation: &str, timeout: Duration) -> HealthError {
+pub(super) fn nmxc_timeout_error(operation: &str, timeout: Duration) -> HealthError {
     HealthError::NmxcStatus(tonic::Status::deadline_exceeded(format!(
         "NMX-C {operation} timed out after {timeout:?}"
     )))
@@ -615,7 +623,7 @@ fn domain_state_info_to_events(info: &DomainStateInfo) -> Vec<Result<CollectorEv
 }
 
 /// Builds a sink log event with the supplied severity, body, and attributes.
-fn log_record(
+pub(super) fn log_record(
     severity: LogSeverity,
     body: impl Into<String>,
     attributes: Vec<(Cow<'static, str>, String)>,

--- a/crates/health/src/collectors/nmxc_schema_override.rs
+++ b/crates/health/src/collectors/nmxc_schema_override.rs
@@ -288,12 +288,11 @@ impl<B: Bmc + 'static> StreamingCollector<B> for NmxcSchemaOverrideCollector {
             .await?;
 
         let first = receive_initial_subscribe_item(&mut stream, self.rpc_timeout).await?;
-        let initial = initial_schema_override_frame_to_events(first, &self.schema_override);
+        let initial = initial_schema_override_frame_to_event(first, &self.schema_override);
         let schema_override = self.schema_override.clone();
 
         let remaining = stream
-            .map(move |item| schema_override_frame_to_events(item, &schema_override))
-            .flat_map(futures::stream::iter)
+            .map(move |item| schema_override_frame_to_event(item, &schema_override))
             .boxed();
 
         Ok(finalize_connection(initial, remaining))
@@ -320,102 +319,113 @@ async fn receive_initial_subscribe_item(
 }
 
 fn finalize_connection(
-    initial: Vec<Result<CollectorEvent, HealthError>>,
+    initial: Result<CollectorEvent, (CollectorEvent, HealthError)>,
     remaining: super::runtime::EventStream<'static>,
 ) -> StreamingConnectResult<'static> {
-    let mut events = Vec::new();
-
-    for event in initial {
-        match event {
-            Ok(event) => events.push(event),
-            Err(error) => return StreamingConnectResult::Failed { events, error },
+    let event = match initial {
+        Ok(event) => event,
+        Err((event, error)) => {
+            return StreamingConnectResult::Failed {
+                events: vec![event],
+                error,
+            };
         }
-    }
+    };
 
     StreamingConnectResult::Connected(
-        futures::stream::iter(events.into_iter().map(Ok))
+        futures::stream::once(async { Ok(event) })
             .chain(remaining)
             .boxed(),
     )
 }
 
-fn initial_schema_override_frame_to_events(
+fn initial_schema_override_frame_to_event(
     raw: Bytes,
     schema_override: &NmxcSchemaOverride,
-) -> Vec<Result<CollectorEvent, HealthError>> {
+) -> Result<CollectorEvent, (CollectorEvent, HealthError)> {
     let decoded = match schema_override.decode_notification(&raw) {
         Ok(decoded) => decoded,
         Err(error) => {
-            return schema_override_failure_events(HealthError::NmxcStatus(
-                tonic::Status::internal(format!("NMX-C notification decode failed: {error}")),
-            ));
+            let error = HealthError::NmxcStatus(tonic::Status::internal(format!(
+                "NMX-C notification decode failed: {error}"
+            )));
+
+            return Err((schema_override_failure_log(&error), error));
         }
     };
 
     let Some(selected) = decoded.field.as_ref() else {
-        return initial_schema_override_failure_events(
+        return Err(initial_schema_override_failure(
             decoded,
             schema_override,
             HealthError::NmxcStatus(tonic::Status::failed_precondition(
                 "NMX-C subscribe acknowledgement missing notification payload",
             )),
-        );
+        ));
     };
 
     if selected.number() != 1 {
         let selected_name = selected.name().to_string();
 
-        return initial_schema_override_failure_events(
+        return Err(initial_schema_override_failure(
             decoded,
             schema_override,
             HealthError::NmxcStatus(tonic::Status::failed_precondition(format!(
                 "NMX-C subscribe expected subscription acknowledgement field 1, received {}",
                 selected_name
             ))),
-        );
+        ));
     }
 
     let acknowledgement = decoded.message.get_field(selected);
 
     let Value::Message(acknowledgement) = acknowledgement.as_ref() else {
-        return initial_schema_override_failure_events(
+        return Err(initial_schema_override_failure(
             decoded,
             schema_override,
             HealthError::NmxcStatus(tonic::Status::failed_precondition(
                 "NMX-C subscribe acknowledgement payload is not a message",
             )),
-        );
+        ));
     };
 
     if let Err(error) = check_dynamic_response_success(acknowledgement, "Subscribe") {
-        return initial_schema_override_failure_events(decoded, schema_override, error);
+        return Err(initial_schema_override_failure(
+            decoded,
+            schema_override,
+            error,
+        ));
     }
 
-    vec![Ok(schema_override_notification_to_log(
+    Ok(schema_override_notification_to_log(
         &decoded,
         schema_override,
         LogSeverity::Info,
-    ))]
+    ))
 }
 
-fn schema_override_frame_to_events(
+fn schema_override_frame_to_event(
     item: Result<Bytes, tonic::Status>,
     schema_override: &NmxcSchemaOverride,
-) -> Vec<Result<CollectorEvent, HealthError>> {
-    let raw = match item {
-        Ok(raw) => raw,
-        Err(status) => return vec![Err(HealthError::NmxcStatus(status))],
-    };
+) -> Result<CollectorEvent, HealthError> {
+    let raw = item.map_err(HealthError::NmxcStatus)?;
 
     match schema_override.decode_notification(&raw) {
-        Ok(decoded) => vec![Ok(schema_override_notification_to_log(
+        Ok(decoded) => Ok(schema_override_notification_to_log(
             &decoded,
             schema_override,
             LogSeverity::Info,
-        ))],
-        Err(error) => schema_override_failure_events(HealthError::NmxcStatus(
-            tonic::Status::internal(format!("NMX-C notification decode failed: {error}")),
         )),
+        Err(error) => {
+            let error = HealthError::NmxcStatus(tonic::Status::internal(format!(
+                "NMX-C notification decode failed: {error}"
+            )));
+
+            // Tonic has already separated this payload from the following
+            // gRPC messages, so a dynamic decode failure does not corrupt the
+            // stream. Report the dropped notification and keep reading.
+            Ok(schema_override_failure_log(&error))
+        }
     }
 }
 
@@ -456,34 +466,28 @@ fn schema_override_notification_to_log(
     )
 }
 
-fn initial_schema_override_failure_events(
+fn initial_schema_override_failure(
     decoded: DecodedNotification,
     schema_override: &NmxcSchemaOverride,
     error: HealthError,
-) -> Vec<Result<CollectorEvent, HealthError>> {
-    vec![
-        Ok(schema_override_notification_to_log(
-            &decoded,
-            schema_override,
-            LogSeverity::Error,
-        )),
-        Err(error),
-    ]
+) -> (CollectorEvent, HealthError) {
+    (
+        schema_override_notification_to_log(&decoded, schema_override, LogSeverity::Error),
+        error,
+    )
 }
 
-fn schema_override_failure_events(error: HealthError) -> Vec<Result<CollectorEvent, HealthError>> {
+fn schema_override_failure_log(error: &HealthError) -> CollectorEvent {
     let message = error.to_string();
 
-    let log = log_record(
+    log_record(
         LogSeverity::Error,
         message.clone(),
         vec![
             ("notification".into(), "unrecognized".to_string()),
             ("body".into(), message),
         ],
-    );
-
-    vec![Ok(log), Err(error)]
+    )
 }
 
 /// Descriptor-derived information extracted from one Subscribe response frame.
@@ -1204,11 +1208,13 @@ mod tests {
         ];
 
         for (name, frame) in cases {
-            let events = initial_schema_override_frame_to_events(frame, &schema_override);
+            let Err((event, _error)) =
+                initial_schema_override_frame_to_event(frame, &schema_override)
+            else {
+                panic!("{name} should fail after emitting its decoded response");
+            };
 
-            assert_eq!(events.len(), 2, "{name}");
-
-            let Ok(CollectorEvent::Log(record)) = &events[0] else {
+            let CollectorEvent::Log(record) = event else {
                 panic!("{name} should emit its decoded response first");
             };
 
@@ -1223,9 +1229,39 @@ mod tests {
                 key.as_ref() == "protobuf.message_type"
                     && value == schema_override.response.full_name()
             }));
-
-            assert!(events[1].is_err(), "{name}");
         }
+    }
+
+    #[test]
+    fn malformed_frames_fail_initial_connection_but_not_connected_stream() {
+        let schema_override = load_schema_override(
+            &override_descriptor_set(),
+            serde_json::json!({ "testOption": true }),
+        )
+        .expect("schema override should load");
+
+        let malformed = Bytes::from_static(&[0x0f]);
+
+        let Err((event, _error)) =
+            initial_schema_override_frame_to_event(malformed.clone(), &schema_override)
+        else {
+            panic!("malformed initial acknowledgement should fail the stream");
+        };
+
+        let CollectorEvent::Log(record) = event else {
+            panic!("malformed initial acknowledgement should emit an error log");
+        };
+
+        assert_eq!(record.severity, LogSeverity::Error);
+
+        let connected = schema_override_frame_to_event(Ok(malformed), &schema_override)
+            .expect("connected stream decode failure should become a log");
+
+        let CollectorEvent::Log(record) = connected else {
+            panic!("connected stream decode failure should emit a log");
+        };
+
+        assert_eq!(record.severity, LogSeverity::Error);
     }
 
     #[test]

--- a/crates/health/src/collectors/nmxc_schema_override.rs
+++ b/crates/health/src/collectors/nmxc_schema_override.rs
@@ -1,0 +1,1295 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Descriptor-driven replacement for the generated NMX-C collector.
+//!
+//! The descriptor is validated at startup, supplies both RPC request and
+//! response types, and decodes every Subscribe frame to canonical protobuf
+//! JSON. The generated NMX-C event mapping is not used in this mode.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::{Buf, Bytes};
+use futures::StreamExt;
+use http::uri::PathAndQuery;
+use nv_redfish::core::Bmc;
+use prost_reflect::{
+    DescriptorPool, DynamicMessage, FieldDescriptor, Kind, MessageDescriptor, MethodDescriptor,
+    OneofDescriptor, ReflectMessage, Value,
+};
+use serde::de::IntoDeserializer;
+use tonic::codec::{BufferSettings, Codec, DecodeBuf, Decoder};
+use tonic::transport::Channel;
+use tonic::{Status, Streaming};
+use tonic_prost::ProstEncoder;
+
+use super::nmxc::{log_record, nmxc_channel, nmxc_endpoint_url, nmxc_timeout_error};
+use super::runtime::{StreamingCollector, StreamingConnectResult};
+use crate::HealthError;
+use crate::config::{
+    MtlsProfileConfig, NmxcCollectorConfig as NmxcCollectorOptions, NmxcSchemaOverrideConfig,
+};
+use crate::endpoint::BmcEndpoint;
+use crate::sink::{CollectorEvent, LogSeverity};
+
+const NMX_C_CURRENT_MAJOR_VERSION: &str = "PROTO_MSG_MAJOR_VERSION";
+const NMX_C_CURRENT_MINOR_VERSION: &str = "PROTO_MSG_MINOR_VERSION";
+const NMX_C_SUCCESS_RETURN_CODE: &str = "NMX_ST_SUCCESS";
+
+/// Validated descriptor state and immutable requests for one NMX-C schema override.
+///
+/// Loading verifies the Hello and Subscribe method shapes, the base NMX-C
+/// request fields, response status fields, and the initial acknowledgement.
+/// Runtime frames are decoded exclusively through this descriptor.
+#[derive(Clone, Debug)]
+pub(crate) struct NmxcSchemaOverride {
+    hello_request: DynamicMessage,
+    hello_response: MessageDescriptor,
+    subscribe_request: DynamicMessage,
+    response: MessageDescriptor,
+    notification: OneofDescriptor,
+    hello_rpc_path: PathAndQuery,
+    subscribe_rpc_path: PathAndQuery,
+    max_frame_size_bytes: usize,
+}
+
+impl NmxcSchemaOverride {
+    /// Loads and validates the descriptor set and builds immutable request templates.
+    pub(crate) fn load(
+        schema_override: &NmxcSchemaOverrideConfig,
+        nmxc: &NmxcCollectorOptions,
+    ) -> Result<Self, NmxcSchemaOverrideError> {
+        let descriptor_bytes =
+            fs::read(&schema_override.descriptor_set_path).map_err(|source| {
+                NmxcSchemaOverrideError::ReadDescriptor {
+                    path: schema_override.descriptor_set_path.clone(),
+                    source,
+                }
+            })?;
+
+        let pool = DescriptorPool::decode(descriptor_bytes.as_slice())?;
+
+        let (hello, hello_rpc_path) = resolve_method(&pool, &schema_override.hello_rpc_path)?;
+
+        if hello.is_client_streaming() || hello.is_server_streaming() {
+            return Err(invalid_descriptor(format!(
+                "{} must be unary",
+                schema_override.hello_rpc_path
+            )));
+        }
+
+        let (subscribe, subscribe_rpc_path) =
+            resolve_method(&pool, &schema_override.subscribe_rpc_path)?;
+
+        if subscribe.is_client_streaming() || !subscribe.is_server_streaming() {
+            return Err(invalid_descriptor(format!(
+                "{} must accept one request and stream responses",
+                schema_override.subscribe_rpc_path
+            )));
+        }
+
+        let hello_request = build_hello_request(hello.input(), &nmxc.gateway_id)?;
+        let hello_response = hello.output();
+
+        validate_response_header(hello_response.clone())?;
+
+        let subscribe_request =
+            build_subscribe_request(subscribe.input(), &schema_override.subscribe_fields, nmxc)?;
+
+        let response = subscribe.output();
+
+        let acknowledgement = response.get_field(1).ok_or_else(|| {
+            invalid_descriptor(format!(
+                "{} must define subscription acknowledgement field 1",
+                response.full_name()
+            ))
+        })?;
+
+        let notification = acknowledgement.containing_oneof().ok_or_else(|| {
+            invalid_descriptor(format!(
+                "{}.{} must belong to a notification oneof",
+                response.full_name(),
+                acknowledgement.name()
+            ))
+        })?;
+
+        let Kind::Message(acknowledgement) = acknowledgement.kind() else {
+            return Err(invalid_descriptor(format!(
+                "{}.{} must be a message",
+                response.full_name(),
+                acknowledgement.name()
+            )));
+        };
+
+        validate_response_header(acknowledgement)?;
+
+        Ok(Self {
+            hello_request,
+            hello_response,
+            subscribe_request,
+            response,
+            notification,
+            hello_rpc_path,
+            subscribe_rpc_path,
+            max_frame_size_bytes: schema_override.max_frame_size_bytes,
+        })
+    }
+
+    /// Decodes a response frame and serializes its canonical protobuf JSON form.
+    fn decode_notification(
+        &self,
+        raw: &Bytes,
+    ) -> Result<DecodedNotification, NmxcSchemaOverrideError> {
+        let message = DynamicMessage::decode(self.response.clone(), raw.clone())
+            .map_err(NmxcSchemaOverrideError::DecodeNotification)?;
+
+        let field = self
+            .notification
+            .fields()
+            .find(|field| message.has_field(field));
+
+        let json = serde_json::to_string(&message)
+            .map_err(NmxcSchemaOverrideError::SerializeNotification)?;
+
+        Ok(DecodedNotification {
+            message,
+            field,
+            json,
+        })
+    }
+
+    /// Completes the descriptor-defined Hello and starts the Subscribe stream.
+    pub(crate) async fn open_stream(
+        &self,
+        channel: Channel,
+        rpc_timeout: Duration,
+    ) -> Result<Streaming<Bytes>, HealthError> {
+        let mut grpc = tonic::client::Grpc::new(channel.clone());
+
+        let hello = tokio::time::timeout(rpc_timeout, async {
+            grpc.ready().await.map_err(service_not_ready)?;
+
+            grpc.unary(
+                tonic::Request::new(self.hello_request.clone()),
+                self.hello_rpc_path.clone(),
+                DynamicRpcCodec,
+            )
+            .await
+        })
+        .await
+        .map_err(|_| nmxc_timeout_error("Hello", rpc_timeout))?
+        .map_err(HealthError::NmxcStatus)?
+        .into_inner();
+
+        let hello =
+            DynamicMessage::decode(self.hello_response.clone(), hello).map_err(|error| {
+                HealthError::NmxcStatus(tonic::Status::internal(format!(
+                    "NMX-C Hello response decode failed: {error}"
+                )))
+            })?;
+
+        check_dynamic_response_success(&hello, "Hello")?;
+
+        let mut grpc =
+            tonic::client::Grpc::new(channel).max_decoding_message_size(self.max_frame_size_bytes);
+
+        let response = tokio::time::timeout(rpc_timeout, async {
+            grpc.ready().await.map_err(service_not_ready)?;
+
+            grpc.server_streaming(
+                tonic::Request::new(self.subscribe_request.clone()),
+                self.subscribe_rpc_path.clone(),
+                DynamicRpcCodec,
+            )
+            .await
+        })
+        .await
+        .map_err(|_| nmxc_timeout_error("Subscribe", rpc_timeout))?
+        .map_err(HealthError::NmxcStatus)?;
+
+        Ok(response.into_inner())
+    }
+}
+
+/// Runtime configuration for the descriptor-driven NMX-C collector.
+pub(crate) struct NmxcSchemaOverrideCollectorConfig {
+    pub(crate) nmxc_config: NmxcCollectorOptions,
+    pub(crate) tls_config: Option<MtlsProfileConfig>,
+    pub(crate) schema_override: Arc<NmxcSchemaOverride>,
+}
+
+/// NMX-C collector whose protobuf contract is supplied at service startup.
+pub(crate) struct NmxcSchemaOverrideCollector {
+    endpoint_url: String,
+    connect_timeout: Duration,
+    rpc_timeout: Duration,
+    tls_config: Option<MtlsProfileConfig>,
+    schema_override: Arc<NmxcSchemaOverride>,
+}
+
+#[async_trait]
+impl<B: Bmc + 'static> StreamingCollector<B> for NmxcSchemaOverrideCollector {
+    type Config = NmxcSchemaOverrideCollectorConfig;
+
+    fn new_runner(
+        _bmc: Arc<B>,
+        endpoint: Arc<BmcEndpoint>,
+        config: Self::Config,
+    ) -> Result<Self, HealthError> {
+        let connect_timeout = config.nmxc_config.connect_timeout();
+        let rpc_timeout = config.nmxc_config.rpc_timeout();
+        let switch_connect_host = endpoint.switch_connect_host_for_uri();
+
+        let endpoint_url = nmxc_endpoint_url(
+            switch_connect_host.as_ref(),
+            config.nmxc_config.grpc_port,
+            config.tls_config.is_some(),
+        );
+
+        Ok(Self {
+            endpoint_url,
+            connect_timeout,
+            rpc_timeout,
+            tls_config: config.tls_config,
+            schema_override: config.schema_override,
+        })
+    }
+
+    async fn connect(&mut self) -> Result<StreamingConnectResult<'_>, HealthError> {
+        let channel = nmxc_channel(
+            &self.endpoint_url,
+            self.connect_timeout,
+            self.tls_config.as_ref(),
+        )
+        .await?;
+
+        let mut stream = self
+            .schema_override
+            .open_stream(channel, self.rpc_timeout)
+            .await?;
+
+        let first = receive_initial_subscribe_item(&mut stream, self.rpc_timeout).await?;
+        let initial = initial_schema_override_frame_to_events(first, &self.schema_override);
+        let schema_override = self.schema_override.clone();
+
+        let remaining = stream
+            .map(move |item| schema_override_frame_to_events(item, &schema_override))
+            .flat_map(futures::stream::iter)
+            .boxed();
+
+        Ok(finalize_connection(initial, remaining))
+    }
+
+    fn collector_type(&self) -> &'static str {
+        "nmxc"
+    }
+}
+
+async fn receive_initial_subscribe_item(
+    stream: &mut Streaming<Bytes>,
+    rpc_timeout: Duration,
+) -> Result<Bytes, HealthError> {
+    tokio::time::timeout(rpc_timeout, stream.message())
+        .await
+        .map_err(|_| nmxc_timeout_error("initial Subscribe response", rpc_timeout))?
+        .map_err(HealthError::NmxcStatus)?
+        .ok_or_else(|| {
+            HealthError::NmxcStatus(tonic::Status::unavailable(
+                "NMX-C Subscribe stream closed before its acknowledgement",
+            ))
+        })
+}
+
+fn finalize_connection(
+    initial: Vec<Result<CollectorEvent, HealthError>>,
+    remaining: super::runtime::EventStream<'static>,
+) -> StreamingConnectResult<'static> {
+    let mut events = Vec::new();
+
+    for event in initial {
+        match event {
+            Ok(event) => events.push(event),
+            Err(error) => return StreamingConnectResult::Failed { events, error },
+        }
+    }
+
+    StreamingConnectResult::Connected(
+        futures::stream::iter(events.into_iter().map(Ok))
+            .chain(remaining)
+            .boxed(),
+    )
+}
+
+fn initial_schema_override_frame_to_events(
+    raw: Bytes,
+    schema_override: &NmxcSchemaOverride,
+) -> Vec<Result<CollectorEvent, HealthError>> {
+    let decoded = match schema_override.decode_notification(&raw) {
+        Ok(decoded) => decoded,
+        Err(error) => {
+            return schema_override_failure_events(HealthError::NmxcStatus(
+                tonic::Status::internal(format!("NMX-C notification decode failed: {error}")),
+            ));
+        }
+    };
+
+    let Some(selected) = decoded.field.as_ref() else {
+        return initial_schema_override_failure_events(
+            decoded,
+            schema_override,
+            HealthError::NmxcStatus(tonic::Status::failed_precondition(
+                "NMX-C subscribe acknowledgement missing notification payload",
+            )),
+        );
+    };
+
+    if selected.number() != 1 {
+        let selected_name = selected.name().to_string();
+
+        return initial_schema_override_failure_events(
+            decoded,
+            schema_override,
+            HealthError::NmxcStatus(tonic::Status::failed_precondition(format!(
+                "NMX-C subscribe expected subscription acknowledgement field 1, received {}",
+                selected_name
+            ))),
+        );
+    }
+
+    let acknowledgement = decoded.message.get_field(selected);
+
+    let Value::Message(acknowledgement) = acknowledgement.as_ref() else {
+        return initial_schema_override_failure_events(
+            decoded,
+            schema_override,
+            HealthError::NmxcStatus(tonic::Status::failed_precondition(
+                "NMX-C subscribe acknowledgement payload is not a message",
+            )),
+        );
+    };
+
+    if let Err(error) = check_dynamic_response_success(acknowledgement, "Subscribe") {
+        return initial_schema_override_failure_events(decoded, schema_override, error);
+    }
+
+    vec![Ok(schema_override_notification_to_log(
+        &decoded,
+        schema_override,
+        LogSeverity::Info,
+    ))]
+}
+
+fn schema_override_frame_to_events(
+    item: Result<Bytes, tonic::Status>,
+    schema_override: &NmxcSchemaOverride,
+) -> Vec<Result<CollectorEvent, HealthError>> {
+    let raw = match item {
+        Ok(raw) => raw,
+        Err(status) => return vec![Err(HealthError::NmxcStatus(status))],
+    };
+
+    match schema_override.decode_notification(&raw) {
+        Ok(decoded) => vec![Ok(schema_override_notification_to_log(
+            &decoded,
+            schema_override,
+            LogSeverity::Info,
+        ))],
+        Err(error) => schema_override_failure_events(HealthError::NmxcStatus(
+            tonic::Status::internal(format!("NMX-C notification decode failed: {error}")),
+        )),
+    }
+}
+
+fn schema_override_notification_to_log(
+    decoded: &DecodedNotification,
+    schema_override: &NmxcSchemaOverride,
+    severity: LogSeverity,
+) -> CollectorEvent {
+    let notification = decoded
+        .field
+        .as_ref()
+        .map_or("unrecognized", FieldDescriptor::name);
+
+    let message_args = serde_json::json!([notification]).to_string();
+
+    let body = format!("NMX-C schema-override notification received: {notification}");
+
+    log_record(
+        severity,
+        body.clone(),
+        vec![
+            ("notification".into(), notification.to_string()),
+            ("body".into(), body),
+            (
+                "message_id".into(),
+                "CarbideHealth.1.0.NmxcSchemaOverrideNotification".to_string(),
+            ),
+            ("message_args".into(), message_args),
+            (
+                "protobuf.message_type".into(),
+                schema_override.response.full_name().to_string(),
+            ),
+            (
+                crate::sink::LogRecord::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE.into(),
+                decoded.json.clone(),
+            ),
+        ],
+    )
+}
+
+fn initial_schema_override_failure_events(
+    decoded: DecodedNotification,
+    schema_override: &NmxcSchemaOverride,
+    error: HealthError,
+) -> Vec<Result<CollectorEvent, HealthError>> {
+    vec![
+        Ok(schema_override_notification_to_log(
+            &decoded,
+            schema_override,
+            LogSeverity::Error,
+        )),
+        Err(error),
+    ]
+}
+
+fn schema_override_failure_events(error: HealthError) -> Vec<Result<CollectorEvent, HealthError>> {
+    let message = error.to_string();
+
+    let log = log_record(
+        LogSeverity::Error,
+        message.clone(),
+        vec![
+            ("notification".into(), "unrecognized".to_string()),
+            ("body".into(), message),
+        ],
+    );
+
+    vec![Ok(log), Err(error)]
+}
+
+/// Descriptor-derived information extracted from one Subscribe response frame.
+struct DecodedNotification {
+    message: DynamicMessage,
+    field: Option<FieldDescriptor>,
+    json: String,
+}
+
+fn service_not_ready(error: tonic::transport::Error) -> tonic::Status {
+    tonic::Status::unknown(format!("service was not ready: {error}"))
+}
+
+fn check_dynamic_response_success(
+    message: &DynamicMessage,
+    operation: &str,
+) -> Result<(), HealthError> {
+    let Some(header_field) = message.descriptor().get_field(1) else {
+        return Err(dynamic_response_error(
+            operation,
+            "response is missing server header field 1",
+        ));
+    };
+
+    if !message.has_field(&header_field) {
+        return Err(dynamic_response_error(
+            operation,
+            "response omitted its server header",
+        ));
+    }
+
+    let header = message.get_field(&header_field);
+
+    let Value::Message(header) = header.as_ref() else {
+        return Err(dynamic_response_error(
+            operation,
+            "server header field is not a message",
+        ));
+    };
+
+    let Some(return_code_field) = header.descriptor().get_field(4) else {
+        return Err(dynamic_response_error(
+            operation,
+            "server header is missing return code field 4",
+        ));
+    };
+
+    let Kind::Enum(return_codes) = return_code_field.kind() else {
+        return Err(dynamic_response_error(
+            operation,
+            "server return code field is not an enum",
+        ));
+    };
+
+    let Some(success) = return_codes.get_value_by_name(NMX_C_SUCCESS_RETURN_CODE) else {
+        return Err(dynamic_response_error(
+            operation,
+            "server return code enum has no success value",
+        ));
+    };
+
+    let return_code = header.get_field(&return_code_field);
+
+    let Value::EnumNumber(actual) = return_code.as_ref() else {
+        return Err(dynamic_response_error(
+            operation,
+            "server return code is not an enum value",
+        ));
+    };
+
+    if *actual != success.number() {
+        let value = return_codes
+            .get_value(*actual)
+            .map_or_else(|| actual.to_string(), |value| value.name().to_string());
+
+        return Err(dynamic_response_error(
+            operation,
+            format!("server returned {value}"),
+        ));
+    }
+
+    Ok(())
+}
+
+fn dynamic_response_error(operation: &str, message: impl std::fmt::Display) -> HealthError {
+    HealthError::NmxcStatus(tonic::Status::failed_precondition(format!(
+        "NMX-C {operation} {message}"
+    )))
+}
+
+fn resolve_method(
+    pool: &DescriptorPool,
+    path: &str,
+) -> Result<(MethodDescriptor, PathAndQuery), NmxcSchemaOverrideError> {
+    let path_and_query = PathAndQuery::try_from(path.to_string())
+        .map_err(|error| invalid_descriptor(format!("invalid gRPC path {path:?}: {error}")))?;
+
+    let Some((service_name, method_name)) = path.strip_prefix('/').and_then(|v| v.split_once('/'))
+    else {
+        return Err(invalid_descriptor(format!(
+            "gRPC path {path:?} must have the form /package.Service/Method"
+        )));
+    };
+
+    if service_name.is_empty() || method_name.is_empty() || method_name.contains('/') {
+        return Err(invalid_descriptor(format!(
+            "gRPC path {path:?} must have the form /package.Service/Method"
+        )));
+    }
+
+    let service = pool
+        .get_service_by_name(service_name)
+        .ok_or_else(|| invalid_descriptor(format!("missing service {service_name}")))?;
+
+    let method = service
+        .methods()
+        .find(|method| method.name() == method_name)
+        .ok_or_else(|| {
+            invalid_descriptor(format!("missing method {service_name}.{method_name}"))
+        })?;
+
+    Ok((method, path_and_query))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum NmxcSchemaOverrideError {
+    #[error("failed to read NMX-C descriptor set {path}")]
+    ReadDescriptor {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to decode NMX-C descriptor set")]
+    DecodeDescriptor(#[from] prost_reflect::DescriptorError),
+
+    #[error("invalid NMX-C descriptor set: {0}")]
+    InvalidDescriptor(String),
+
+    #[error("invalid [collectors.nmxc.schema_override].subscribe_fields")]
+    InvalidSubscribeRequest(#[source] serde_json::Error),
+
+    #[error("failed to decode an NMX-C schema-override notification")]
+    DecodeNotification(#[source] prost::DecodeError),
+
+    #[error("failed to serialize an NMX-C schema-override notification")]
+    SerializeNotification(#[source] serde_json::Error),
+}
+
+fn invalid_descriptor(message: String) -> NmxcSchemaOverrideError {
+    NmxcSchemaOverrideError::InvalidDescriptor(message)
+}
+
+fn build_hello_request(
+    descriptor: MessageDescriptor,
+    gateway_id: &str,
+) -> Result<DynamicMessage, NmxcSchemaOverrideError> {
+    let mut request = DynamicMessage::new(descriptor);
+
+    set_field(
+        &mut request,
+        1,
+        Kind::String,
+        Value::String(gateway_id.to_string()),
+    )?;
+
+    // Fields 1-3 are the base NMX-C Hello contract. The supplied descriptor
+    // may extend the schema but must preserve these request semantics.
+    set_current_enum(&mut request, 2, NMX_C_CURRENT_MAJOR_VERSION)?;
+
+    set_current_enum(&mut request, 3, NMX_C_CURRENT_MINOR_VERSION)?;
+
+    Ok(request)
+}
+
+fn build_subscribe_request(
+    descriptor: MessageDescriptor,
+    configured: &serde_json::Map<String, serde_json::Value>,
+    nmxc: &NmxcCollectorOptions,
+) -> Result<DynamicMessage, NmxcSchemaOverrideError> {
+    for field in descriptor.fields().filter(|field| field.number() <= 3) {
+        if configured.contains_key(field.name()) || configured.contains_key(field.json_name()) {
+            return Err(invalid_descriptor(format!(
+                "subscribe request field {} is owned by [collectors.nmxc] and must not be repeated in schema override config",
+                field.json_name()
+            )));
+        }
+    }
+
+    let configured = serde_json::Value::Object(configured.clone());
+
+    let mut request = DynamicMessage::deserialize(descriptor, configured.into_deserializer())
+        .map_err(NmxcSchemaOverrideError::InvalidSubscribeRequest)?;
+
+    set_field(
+        &mut request,
+        1,
+        Kind::String,
+        Value::String(nmxc.gateway_id.clone()),
+    )?;
+
+    set_field(
+        &mut request,
+        2,
+        Kind::Bool,
+        Value::Bool(nmxc.notify_on_self_change),
+    )?;
+
+    set_field(
+        &mut request,
+        3,
+        Kind::Uint32,
+        Value::U32(nmxc.heartbeat_rate),
+    )?;
+
+    Ok(request)
+}
+
+fn validate_response_header(descriptor: MessageDescriptor) -> Result<(), NmxcSchemaOverrideError> {
+    let Some(header) = descriptor.get_field(1) else {
+        return Err(invalid_descriptor(format!(
+            "{} must define server header field 1",
+            descriptor.full_name()
+        )));
+    };
+
+    let Kind::Message(header_message) = header.kind() else {
+        return Err(invalid_descriptor(format!(
+            "{}.{} must be a message",
+            descriptor.full_name(),
+            header.name()
+        )));
+    };
+
+    let Some(return_code) = header_message.get_field(4) else {
+        return Err(invalid_descriptor(format!(
+            "{} must define return code field 4",
+            header_message.full_name()
+        )));
+    };
+
+    let Kind::Enum(return_codes) = return_code.kind() else {
+        return Err(invalid_descriptor(format!(
+            "{}.{} must be an enum",
+            header_message.full_name(),
+            return_code.name()
+        )));
+    };
+
+    if return_codes
+        .get_value_by_name(NMX_C_SUCCESS_RETURN_CODE)
+        .is_none()
+    {
+        return Err(invalid_descriptor(format!(
+            "{} must define {NMX_C_SUCCESS_RETURN_CODE}",
+            return_codes.full_name()
+        )));
+    }
+
+    Ok(())
+}
+
+fn set_current_enum(
+    message: &mut DynamicMessage,
+    number: u32,
+    current_value: &str,
+) -> Result<(), NmxcSchemaOverrideError> {
+    let field = message.descriptor().get_field(number).ok_or_else(|| {
+        invalid_descriptor(format!(
+            "{} is missing field {number}",
+            message.descriptor().full_name()
+        ))
+    })?;
+
+    let Kind::Enum(enumeration) = field.kind() else {
+        return Err(invalid_descriptor(format!(
+            "{}.{} must be an enum",
+            message.descriptor().full_name(),
+            field.name()
+        )));
+    };
+
+    let value = enumeration
+        .get_value_by_name(current_value)
+        .ok_or_else(|| {
+            invalid_descriptor(format!(
+                "{} is missing enum value {current_value}",
+                enumeration.full_name()
+            ))
+        })?;
+
+    message
+        .try_set_field(&field, Value::EnumNumber(value.number()))
+        .map_err(|error| invalid_descriptor(error.to_string()))
+}
+
+fn set_field(
+    message: &mut DynamicMessage,
+    number: u32,
+    expected_kind: Kind,
+    value: Value,
+) -> Result<(), NmxcSchemaOverrideError> {
+    let field = message.descriptor().get_field(number).ok_or_else(|| {
+        invalid_descriptor(format!(
+            "{} is missing field {number}",
+            message.descriptor().full_name()
+        ))
+    })?;
+
+    if field.kind() != expected_kind {
+        return Err(invalid_descriptor(format!(
+            "{}.{} has incompatible type {:?}",
+            message.descriptor().full_name(),
+            field.name(),
+            field.kind()
+        )));
+    }
+
+    message
+        .try_set_field(&field, value)
+        .map_err(|error| invalid_descriptor(error.to_string()))
+}
+
+/// Yields each NMX-C `Subscribe` response frame undecoded.
+#[derive(Default)]
+struct RawFrameDecoder;
+
+impl Decoder for RawFrameDecoder {
+    type Item = Bytes;
+    type Error = Status;
+
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Bytes>, Status> {
+        let len = src.remaining();
+        Ok(Some(src.copy_to_bytes(len)))
+    }
+}
+
+/// Encodes a dynamic Subscribe request and leaves response frames undecoded.
+struct DynamicRpcCodec;
+
+impl Codec for DynamicRpcCodec {
+    type Encode = DynamicMessage;
+    type Decode = Bytes;
+    type Encoder = ProstEncoder<DynamicMessage>;
+    type Decoder = RawFrameDecoder;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        ProstEncoder::new(BufferSettings::default())
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        RawFrameDecoder
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prost::Message;
+    use prost_types::field_descriptor_proto::{Label, Type};
+    use prost_types::{EnumValueDescriptorProto, FieldDescriptorProto, FileDescriptorSet};
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn override_descriptor_set() -> FileDescriptorSet {
+        let mut descriptor_set = FileDescriptorSet::decode(rpc::REFLECTION_API_SERVICE_DESCRIPTOR)
+            .expect("repository descriptor set should decode");
+
+        let nmx_c = descriptor_set
+            .file
+            .iter_mut()
+            .find(|file| file.name.as_deref() == Some("nmx_c.proto"))
+            .expect("repository descriptor set should contain nmx_c.proto");
+
+        let minor = nmx_c
+            .enum_type
+            .iter_mut()
+            .find(|enumeration| enumeration.name.as_deref() == Some("ProtoMsgMinorVersion"))
+            .expect("nmx_c.proto should contain its minor version enum");
+
+        minor
+            .value
+            .iter_mut()
+            .find(|value| value.name.as_deref() == Some(NMX_C_CURRENT_MINOR_VERSION))
+            .expect("minor version enum should contain its current value")
+            .name = Some("PROTO_MSG_MINOR_VERSION_REPLACED".to_string());
+
+        minor.value.push(EnumValueDescriptorProto {
+            name: Some(NMX_C_CURRENT_MINOR_VERSION.to_string()),
+            number: Some(99),
+            ..Default::default()
+        });
+
+        let subscribe = nmx_c
+            .message_type
+            .iter_mut()
+            .find(|message| message.name.as_deref() == Some("SubscribeRequest"))
+            .expect("nmx_c.proto should contain SubscribeRequest");
+
+        subscribe.field.push(FieldDescriptorProto {
+            name: Some("test_option".to_string()),
+            json_name: Some("testOption".to_string()),
+            number: Some(4),
+            label: Some(Label::Optional as i32),
+            r#type: Some(Type::Bool as i32),
+            ..Default::default()
+        });
+
+        let notification = nmx_c
+            .message_type
+            .iter_mut()
+            .find(|message| message.name.as_deref() == Some("ServerNotification"))
+            .expect("nmx_c.proto should contain ServerNotification");
+
+        notification.field.push(FieldDescriptorProto {
+            name: Some("test_notification".to_string()),
+            json_name: Some("testNotification".to_string()),
+            number: Some(12),
+            label: Some(Label::Optional as i32),
+            r#type: Some(Type::Message as i32),
+            type_name: Some(".nmx_c.SubscriptionResponse".to_string()),
+            oneof_index: Some(0),
+            ..Default::default()
+        });
+
+        descriptor_set
+    }
+
+    fn load_schema_override(
+        descriptor_set: &FileDescriptorSet,
+        subscribe_fields: serde_json::Value,
+    ) -> Result<NmxcSchemaOverride, NmxcSchemaOverrideError> {
+        let descriptor_file = NamedTempFile::new().expect("descriptor temp file should open");
+
+        fs::write(descriptor_file.path(), descriptor_set.encode_to_vec())
+            .expect("descriptor temp file should be writable");
+
+        NmxcSchemaOverride::load(
+            &NmxcSchemaOverrideConfig {
+                descriptor_set_path: descriptor_file.path().to_path_buf(),
+                hello_rpc_path: "/nmx_c.NMX_Controller/Hello".to_string(),
+                subscribe_rpc_path: "/nmx_c.NMX_Controller/Subscribe".to_string(),
+                max_frame_size_bytes: 4 * 1024 * 1024,
+                subscribe_fields: subscribe_fields
+                    .as_object()
+                    .expect("test SubscribeRequest should be an object")
+                    .clone(),
+            },
+            &NmxcCollectorOptions {
+                gateway_id: "test-gateway".to_string(),
+                notify_on_self_change: true,
+                heartbeat_rate: 17,
+                ..Default::default()
+            },
+        )
+    }
+
+    fn dynamic_response(descriptor: MessageDescriptor, return_code: &str) -> DynamicMessage {
+        let mut response = DynamicMessage::new(descriptor);
+
+        let header_field = response
+            .descriptor()
+            .get_field(1)
+            .expect("test Hello response should contain its server header");
+
+        let Kind::Message(header_descriptor) = header_field.kind() else {
+            panic!("test server header should be a message");
+        };
+
+        let mut header = DynamicMessage::new(header_descriptor);
+
+        let return_code_field = header
+            .descriptor()
+            .get_field(4)
+            .expect("test server header should contain its return code");
+
+        let Kind::Enum(return_codes) = return_code_field.kind() else {
+            panic!("test return code should be an enum");
+        };
+
+        let return_code = return_codes
+            .get_value_by_name(return_code)
+            .expect("test return code should exist");
+
+        header
+            .try_set_field(&return_code_field, Value::EnumNumber(return_code.number()))
+            .expect("test return code should be assignable");
+
+        response
+            .try_set_field(&header_field, Value::Message(header))
+            .expect("test server header should be assignable");
+
+        response
+    }
+
+    fn notification_frame(
+        schema_override: &NmxcSchemaOverride,
+        field_number: Option<u32>,
+        return_code: &str,
+    ) -> Bytes {
+        let mut response = DynamicMessage::new(schema_override.response.clone());
+
+        if let Some(field_number) = field_number {
+            let field = response
+                .descriptor()
+                .get_field(field_number)
+                .expect("test notification field should exist");
+
+            let Kind::Message(payload) = field.kind() else {
+                panic!("test notification payload should be a message");
+            };
+
+            let payload = if field_number == 1 {
+                dynamic_response(payload, return_code)
+            } else {
+                DynamicMessage::new(payload)
+            };
+
+            response
+                .try_set_field(&field, Value::Message(payload))
+                .expect("test notification payload should be assignable");
+        }
+
+        response.encode_to_vec().into()
+    }
+
+    #[test]
+    fn schema_override_builds_versioned_hello_and_configured_subscribe_requests() {
+        let schema_override = load_schema_override(
+            &override_descriptor_set(),
+            serde_json::json!({ "testOption": true }),
+        )
+        .expect("schema override should load");
+
+        let hello = &schema_override.hello_request;
+        let subscribe = &schema_override.subscribe_request;
+
+        assert_eq!(
+            hello.get_field_by_number(1).as_deref(),
+            Some(&Value::String("test-gateway".to_string()))
+        );
+
+        assert_eq!(
+            hello.get_field_by_number(3).as_deref(),
+            Some(&Value::EnumNumber(99))
+        );
+
+        assert_eq!(
+            subscribe.get_field_by_number(2).as_deref(),
+            Some(&Value::Bool(true))
+        );
+
+        assert_eq!(
+            subscribe.get_field_by_number(3).as_deref(),
+            Some(&Value::U32(17))
+        );
+
+        assert_eq!(
+            subscribe.get_field_by_number(4).as_deref(),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn dynamic_hello_validation_uses_the_configured_descriptor() {
+        let schema_override = load_schema_override(
+            &override_descriptor_set(),
+            serde_json::json!({ "testOption": true }),
+        )
+        .expect("schema override should load");
+
+        assert!(
+            check_dynamic_response_success(
+                &dynamic_response(
+                    schema_override.hello_response.clone(),
+                    NMX_C_SUCCESS_RETURN_CODE,
+                ),
+                "Hello",
+            )
+            .is_ok()
+        );
+
+        let error = check_dynamic_response_success(
+            &dynamic_response(schema_override.hello_response, "NMX_ST_BADPARAM"),
+            "Hello",
+        )
+        .expect_err("failed Hello response should be rejected");
+
+        assert!(error.to_string().contains("NMX_ST_BADPARAM"));
+    }
+
+    #[test]
+    fn schema_override_uses_configured_rpc_paths() {
+        let mut descriptor_set = override_descriptor_set();
+
+        let nmx_c = descriptor_set
+            .file
+            .iter_mut()
+            .find(|file| file.name.as_deref() == Some("nmx_c.proto"))
+            .expect("descriptor should contain nmx_c.proto");
+
+        let service = nmx_c
+            .service
+            .first_mut()
+            .expect("descriptor should contain the NMX-C service");
+
+        service.name = Some("CustomController".to_string());
+        service
+            .method
+            .iter_mut()
+            .find(|method| method.name.as_deref() == Some("Hello"))
+            .expect("service should contain Hello")
+            .name = Some("Open".to_string());
+
+        service
+            .method
+            .iter_mut()
+            .find(|method| method.name.as_deref() == Some("Subscribe"))
+            .expect("service should contain Subscribe")
+            .name = Some("Watch".to_string());
+
+        let descriptor_file = NamedTempFile::new().expect("descriptor temp file should open");
+        fs::write(descriptor_file.path(), descriptor_set.encode_to_vec())
+            .expect("descriptor temp file should be writable");
+
+        let schema_override = NmxcSchemaOverride::load(
+            &NmxcSchemaOverrideConfig {
+                descriptor_set_path: descriptor_file.path().to_path_buf(),
+                hello_rpc_path: "/nmx_c.CustomController/Open".to_string(),
+                subscribe_rpc_path: "/nmx_c.CustomController/Watch".to_string(),
+                max_frame_size_bytes: 8 * 1024 * 1024,
+                subscribe_fields: serde_json::json!({ "testOption": true })
+                    .as_object()
+                    .expect("test SubscribeRequest should be an object")
+                    .clone(),
+            },
+            &NmxcCollectorOptions::default(),
+        )
+        .expect("configured runtime methods should load");
+
+        assert_eq!(
+            schema_override.hello_rpc_path.as_str(),
+            "/nmx_c.CustomController/Open"
+        );
+
+        assert_eq!(
+            schema_override.subscribe_rpc_path.as_str(),
+            "/nmx_c.CustomController/Watch"
+        );
+
+        assert_eq!(schema_override.max_frame_size_bytes, 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn schema_override_decodes_configured_notification() {
+        let schema_override = load_schema_override(
+            &override_descriptor_set(),
+            serde_json::json!({ "testOption": true }),
+        )
+        .expect("schema override should load");
+
+        let field = schema_override
+            .response
+            .get_field(12)
+            .expect("extended response should contain the added notification field");
+
+        let Kind::Message(payload_descriptor) = field.kind() else {
+            panic!("extended notification should be a message");
+        };
+
+        let mut response = DynamicMessage::new(schema_override.response.clone());
+
+        response
+            .try_set_field(
+                &field,
+                Value::Message(DynamicMessage::new(payload_descriptor)),
+            )
+            .expect("extended notification should accept its payload");
+
+        let decoded = schema_override
+            .decode_notification(&response.encode_to_vec().into())
+            .expect("runtime response should decode");
+
+        let selected = decoded
+            .field
+            .expect("runtime response should select its oneof field");
+
+        assert_eq!(selected.number(), 12);
+        assert_eq!(selected.name(), "test_notification");
+
+        let decoded_json: serde_json::Value =
+            serde_json::from_str(&decoded.json).expect("decoded notification should be JSON");
+
+        assert_eq!(decoded_json["testNotification"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn invalid_initial_responses_preserve_decoded_payload_before_failure() {
+        let schema_override = load_schema_override(
+            &override_descriptor_set(),
+            serde_json::json!({ "testOption": true }),
+        )
+        .expect("schema override should load");
+
+        let cases = [
+            (
+                "rejected acknowledgement",
+                notification_frame(&schema_override, Some(1), "NMX_ST_BADPARAM"),
+            ),
+            (
+                "unexpected notification",
+                notification_frame(&schema_override, Some(12), NMX_C_SUCCESS_RETURN_CODE),
+            ),
+            (
+                "missing notification",
+                notification_frame(&schema_override, None, NMX_C_SUCCESS_RETURN_CODE),
+            ),
+        ];
+
+        for (name, frame) in cases {
+            let events = initial_schema_override_frame_to_events(frame, &schema_override);
+
+            assert_eq!(events.len(), 2, "{name}");
+
+            let Ok(CollectorEvent::Log(record)) = &events[0] else {
+                panic!("{name} should emit its decoded response first");
+            };
+
+            assert_eq!(record.severity, LogSeverity::Error, "{name}");
+
+            assert!(record.attributes.iter().any(|(key, value)| {
+                key.as_ref() == crate::sink::LogRecord::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE
+                    && serde_json::from_str::<serde_json::Value>(value).is_ok()
+            }));
+
+            assert!(record.attributes.iter().any(|(key, value)| {
+                key.as_ref() == "protobuf.message_type"
+                    && value == schema_override.response.full_name()
+            }));
+
+            assert!(events[1].is_err(), "{name}");
+        }
+    }
+
+    #[test]
+    fn schema_override_rejects_invalid_subscribe_acknowledgement_at_startup() {
+        let mut descriptor_set = override_descriptor_set();
+
+        let nmx_c = descriptor_set
+            .file
+            .iter_mut()
+            .find(|file| file.name.as_deref() == Some("nmx_c.proto"))
+            .expect("descriptor should contain nmx_c.proto");
+
+        let acknowledgement = nmx_c
+            .message_type
+            .iter_mut()
+            .find(|message| message.name.as_deref() == Some("SubscriptionResponse"))
+            .expect("descriptor should contain the acknowledgement message");
+
+        acknowledgement
+            .field
+            .retain(|field| field.number != Some(1));
+
+        let error = load_schema_override(&descriptor_set, serde_json::json!({}))
+            .expect_err("invalid acknowledgement should fail at startup");
+
+        assert!(error.to_string().contains("server header field 1"));
+    }
+
+    #[test]
+    fn schema_override_rejects_values_owned_by_nmxc_config() {
+        let error = load_schema_override(
+            &override_descriptor_set(),
+            serde_json::json!({ "gatewayId": "duplicate" }),
+        )
+        .expect_err("runtime-owned field should be rejected");
+
+        assert!(error.to_string().contains("owned by [collectors.nmxc]"));
+    }
+
+    #[test]
+    fn schema_override_rejects_incompatible_subscribe_field_types() {
+        let mut descriptor_set = override_descriptor_set();
+
+        let nmx_c = descriptor_set
+            .file
+            .iter_mut()
+            .find(|file| file.name.as_deref() == Some("nmx_c.proto"))
+            .expect("descriptor should contain nmx_c.proto");
+
+        let subscribe = nmx_c
+            .message_type
+            .iter_mut()
+            .find(|message| message.name.as_deref() == Some("SubscribeRequest"))
+            .expect("descriptor should contain SubscribeRequest");
+
+        subscribe
+            .field
+            .iter_mut()
+            .find(|field| field.number == Some(3))
+            .expect("SubscribeRequest should contain field 3")
+            .r#type = Some(Type::String as i32);
+
+        let error = load_schema_override(&descriptor_set, serde_json::json!({}))
+            .expect_err("incompatible runtime field should be rejected");
+
+        assert!(error.to_string().contains("incompatible type"));
+    }
+}

--- a/crates/health/src/collectors/nmxc_schema_override.rs
+++ b/crates/health/src/collectors/nmxc_schema_override.rs
@@ -182,7 +182,8 @@ impl NmxcSchemaOverride {
         channel: Channel,
         rpc_timeout: Duration,
     ) -> Result<Streaming<Bytes>, HealthError> {
-        let mut grpc = tonic::client::Grpc::new(channel.clone());
+        let mut grpc = tonic::client::Grpc::new(channel.clone())
+            .max_decoding_message_size(self.max_frame_size_bytes);
 
         let hello = tokio::time::timeout(rpc_timeout, async {
             grpc.ready().await.map_err(service_not_ready)?;

--- a/crates/health/src/collectors/nmxc_schema_override.rs
+++ b/crates/health/src/collectors/nmxc_schema_override.rs
@@ -203,7 +203,7 @@ impl NmxcSchemaOverride {
         let hello =
             DynamicMessage::decode(self.hello_response.clone(), hello).map_err(|error| {
                 HealthError::NmxcStatus(tonic::Status::internal(format!(
-                    "NMX-C Hello response decode failed: {error}"
+                    "NMX-C hello response decode failed: {error}"
                 )))
             })?;
 
@@ -314,7 +314,7 @@ async fn receive_initial_subscribe_item(
         .map_err(HealthError::NmxcStatus)?
         .ok_or_else(|| {
             HealthError::NmxcStatus(tonic::Status::unavailable(
-                "NMX-C Subscribe stream closed before its acknowledgement",
+                "NMX-C subscribe stream closed before its acknowledgement",
             ))
         })
 }

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1529,7 +1529,7 @@ pub struct NmxcSchemaOverrideConfig {
     #[serde(default = "default_nmxc_subscribe_rpc_path")]
     pub subscribe_rpc_path: String,
 
-    /// Optional maximum encoded size accepted for one Subscribe response frame.
+    /// Optional maximum encoded size accepted for one Hello or Subscribe response.
     ///
     /// Defaults to 4 MiB when omitted. Valid values are 1 byte through 64 MiB.
     #[serde(default = "default_nmxc_max_frame_size_bytes")]

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -549,13 +549,13 @@ pub struct OtlpTargetConfig {
     )]
     pub flush_interval: std::time::Duration,
 
-    /// Export Redfish diagnostic payload fields to this target.
+    /// Export collector diagnostic payload fields to this target.
     ///
     /// Disabled by default because payload bodies are opaque and may be large or
     /// sensitive. If no diagnostic-capable sink enables diagnostics, collectors
     /// do not attach diagnostic fields. OTLP exports parent logs normally and
-    /// keeps diagnostics as latest-wins per endpoint while the drain is backed
-    /// up.
+    /// uses the parent event identity for queue replacement while backed up.
+    /// This setting does not control descriptor-decoded NMX-C payloads.
     #[serde(default)]
     pub include_diagnostics: bool,
 
@@ -1492,6 +1492,64 @@ impl Default for NmxtCollectorConfig {
 
 const DEFAULT_NMX_C_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_NMX_C_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_NMX_C_MAX_FRAME_SIZE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_NMX_C_FRAME_SIZE_BYTES: usize = 64 * 1024 * 1024;
+
+fn default_nmxc_hello_rpc_path() -> String {
+    "/nmx_c.NMX_Controller/Hello".to_string()
+}
+
+fn default_nmxc_subscribe_rpc_path() -> String {
+    "/nmx_c.NMX_Controller/Subscribe".to_string()
+}
+
+/// Descriptor-driven replacement configuration for the generated NMX-C collector.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NmxcSchemaOverrideConfig {
+    /// Required path to a complete binary protobuf `FileDescriptorSet`.
+    ///
+    /// The set must contain the configured methods and all imported descriptors.
+    /// Relative paths are resolved from the service process working directory.
+    /// This field has no default.
+    pub descriptor_set_path: PathBuf,
+
+    /// Optional fully qualified gRPC path for the NMX-C Hello method.
+    ///
+    /// The path must use `/package.Service/Method` form and identify a unary
+    /// method in the descriptor. Defaults to `/nmx_c.NMX_Controller/Hello`.
+    #[serde(default = "default_nmxc_hello_rpc_path")]
+    pub hello_rpc_path: String,
+
+    /// Optional fully qualified gRPC path for the NMX-C Subscribe method.
+    ///
+    /// The path must use `/package.Service/Method` form and identify a method
+    /// that accepts one request and streams responses. Defaults to
+    /// `/nmx_c.NMX_Controller/Subscribe`.
+    #[serde(default = "default_nmxc_subscribe_rpc_path")]
+    pub subscribe_rpc_path: String,
+
+    /// Optional maximum encoded size accepted for one Subscribe response frame.
+    ///
+    /// Defaults to 4 MiB when omitted. Valid values are 1 byte through 64 MiB.
+    #[serde(default = "default_nmxc_max_frame_size_bytes")]
+    pub max_frame_size_bytes: usize,
+
+    /// Optional additional `SubscribeRequest` fields.
+    ///
+    /// Keys and values follow the supplied descriptor's protobuf JSON mapping.
+    /// The map is empty when omitted. Values are validated when the descriptor
+    /// and request are loaded at startup.
+    ///
+    /// `gateway_id`, `notify_on_self_change`, and `heart_beat_rate` remain owned
+    /// by `[collectors.nmxc]` and must not be repeated here.
+    #[serde(default)]
+    pub subscribe_fields: serde_json::Map<String, serde_json::Value>,
+}
+
+const fn default_nmxc_max_frame_size_bytes() -> usize {
+    DEFAULT_NMX_C_MAX_FRAME_SIZE_BYTES
+}
 
 /// Configuration for streaming NMX-C controller notifications from switch hosts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1524,6 +1582,15 @@ pub struct NmxcCollectorConfig {
     /// Maximum retry backoff after repeated streaming connection failures.
     #[serde(with = "humantime_serde")]
     pub max_backoff: Duration,
+
+    /// Optional descriptor-driven replacement for the generated NMX-C collector.
+    ///
+    /// Omission uses the generated collector. The descriptor and request are
+    /// loaded at service startup, so changes require a restart. Responses are
+    /// emitted as generic logs and are not projected through the generated
+    /// NMX-C event mapping. Every OTLP target includes canonical protobuf JSON,
+    /// independently of its diagnostic payload setting.
+    pub schema_override: Option<NmxcSchemaOverrideConfig>,
 }
 
 impl Default for NmxcCollectorConfig {
@@ -1537,6 +1604,7 @@ impl Default for NmxcCollectorConfig {
             rpc_timeout: None,
             initial_backoff: Duration::from_secs(1),
             max_backoff: Duration::from_secs(30),
+            schema_override: None,
         }
     }
 }
@@ -1590,6 +1658,28 @@ impl NmxcCollectorConfig {
                 "[collectors.nmxc].max_backoff must be greater than or equal to initial_backoff"
                     .to_string(),
             );
+        }
+
+        if let Some(schema_override) = &self.schema_override {
+            if schema_override.descriptor_set_path.as_os_str().is_empty() {
+                return Err(
+                    "[collectors.nmxc.schema_override].descriptor_set_path must not be empty"
+                        .to_string(),
+                );
+            }
+
+            if schema_override.max_frame_size_bytes == 0 {
+                return Err(
+                    "[collectors.nmxc.schema_override].max_frame_size_bytes must be greater than 0"
+                        .to_string(),
+                );
+            }
+
+            if schema_override.max_frame_size_bytes > MAX_NMX_C_FRAME_SIZE_BYTES {
+                return Err(format!(
+                    "[collectors.nmxc.schema_override].max_frame_size_bytes must not exceed {MAX_NMX_C_FRAME_SIZE_BYTES}"
+                ));
+            }
         }
 
         Ok(())
@@ -1986,6 +2076,12 @@ impl Config {
 
         if let Configurable::Enabled(nmxc) = &self.collectors.nmxc {
             nmxc.validate()?;
+
+            if nmxc.schema_override.is_some() && !self.sinks.otlp.is_enabled() {
+                return Err(
+                    "collectors.nmxc.schema_override requires at least one OTLP target".to_string(),
+                );
+            }
         }
 
         if let Configurable::Enabled(reachability) = &self.collectors.reachability {
@@ -3422,6 +3518,7 @@ skip_empty_reports = false
         assert_eq!(defaults.rpc_timeout(), Duration::from_secs(10));
         assert_eq!(defaults.initial_backoff, Duration::from_secs(1));
         assert_eq!(defaults.max_backoff, Duration::from_secs(30));
+        assert!(defaults.schema_override.is_none());
     }
 
     #[test]
@@ -3442,6 +3539,12 @@ connect_timeout = "3s"
 rpc_timeout = "4s"
 initial_backoff = "2s"
 max_backoff = "20s"
+
+[collectors.nmxc.schema_override]
+descriptor_set_path = "/etc/carbide-health/nmx_c.desc"
+
+[collectors.nmxc.schema_override.subscribe_fields]
+testOption = true
 "#;
 
         let config: Config = Figment::new()
@@ -3461,6 +3564,36 @@ max_backoff = "20s"
             assert_eq!(nmxc.rpc_timeout(), Duration::from_secs(4));
             assert_eq!(nmxc.initial_backoff, Duration::from_secs(2));
             assert_eq!(nmxc.max_backoff, Duration::from_secs(20));
+
+            let schema_override = nmxc
+                .schema_override
+                .as_ref()
+                .expect("schema override config should parse");
+
+            assert_eq!(
+                schema_override.descriptor_set_path,
+                PathBuf::from("/etc/carbide-health/nmx_c.desc")
+            );
+
+            assert_eq!(
+                schema_override.hello_rpc_path,
+                "/nmx_c.NMX_Controller/Hello"
+            );
+
+            assert_eq!(
+                schema_override.subscribe_rpc_path,
+                "/nmx_c.NMX_Controller/Subscribe"
+            );
+
+            assert_eq!(
+                schema_override.max_frame_size_bytes,
+                DEFAULT_NMX_C_MAX_FRAME_SIZE_BYTES
+            );
+
+            assert_eq!(
+                schema_override.subscribe_fields["testOption"],
+                serde_json::Value::Bool(true)
+            );
         } else {
             panic!("nmxc config should be enabled");
         }
@@ -3471,6 +3604,17 @@ max_backoff = "20s"
         scenarios!(run = |config: NmxcCollectorConfig| config.validate();
             "valid configuration" {
                 NmxcCollectorConfig::default() => Yields(()),
+
+                NmxcCollectorConfig {
+                    schema_override: Some(NmxcSchemaOverrideConfig {
+                        descriptor_set_path: PathBuf::from("nmx_c.desc"),
+                        hello_rpc_path: default_nmxc_hello_rpc_path(),
+                        subscribe_rpc_path: default_nmxc_subscribe_rpc_path(),
+                        max_frame_size_bytes: MAX_NMX_C_FRAME_SIZE_BYTES,
+                        subscribe_fields: Default::default(),
+                    }),
+                    ..NmxcCollectorConfig::default()
+                } => Yields(()),
             }
 
             "connection settings" {
@@ -3532,7 +3676,79 @@ max_backoff = "20s"
                         .to_string()
                 ),
             }
+
+            "schema override settings" {
+                NmxcCollectorConfig {
+                    schema_override: Some(NmxcSchemaOverrideConfig {
+                        descriptor_set_path: PathBuf::new(),
+                        hello_rpc_path: default_nmxc_hello_rpc_path(),
+                        subscribe_rpc_path: default_nmxc_subscribe_rpc_path(),
+                        max_frame_size_bytes: DEFAULT_NMX_C_MAX_FRAME_SIZE_BYTES,
+                        subscribe_fields: Default::default(),
+                    }),
+                    ..NmxcCollectorConfig::default()
+                } => FailsWith(
+                    "[collectors.nmxc.schema_override].descriptor_set_path must not be empty"
+                        .to_string()
+                ),
+
+                NmxcCollectorConfig {
+                    schema_override: Some(NmxcSchemaOverrideConfig {
+                        descriptor_set_path: PathBuf::from("nmx_c.desc"),
+                        hello_rpc_path: default_nmxc_hello_rpc_path(),
+                        subscribe_rpc_path: default_nmxc_subscribe_rpc_path(),
+                        max_frame_size_bytes: 0,
+                        subscribe_fields: Default::default(),
+                    }),
+                    ..NmxcCollectorConfig::default()
+                } => FailsWith(
+                    "[collectors.nmxc.schema_override].max_frame_size_bytes must be greater than 0"
+                        .to_string()
+                ),
+
+                NmxcCollectorConfig {
+                    schema_override: Some(NmxcSchemaOverrideConfig {
+                        descriptor_set_path: PathBuf::from("nmx_c.desc"),
+                        hello_rpc_path: default_nmxc_hello_rpc_path(),
+                        subscribe_rpc_path: default_nmxc_subscribe_rpc_path(),
+                        max_frame_size_bytes: MAX_NMX_C_FRAME_SIZE_BYTES + 1,
+                        subscribe_fields: Default::default(),
+                    }),
+                    ..NmxcCollectorConfig::default()
+                } => FailsWith(
+                    format!(
+                        "[collectors.nmxc.schema_override].max_frame_size_bytes must not exceed {MAX_NMX_C_FRAME_SIZE_BYTES}"
+                    )
+                ),
+            }
         );
+    }
+
+    #[test]
+    fn nmxc_schema_override_accepts_otlp_target_without_diagnostics() {
+        let mut config = Config::default();
+
+        config.collectors.nmxc = Configurable::Enabled(NmxcCollectorConfig {
+            schema_override: Some(NmxcSchemaOverrideConfig {
+                descriptor_set_path: PathBuf::from("nmx_c.desc"),
+                hello_rpc_path: default_nmxc_hello_rpc_path(),
+                subscribe_rpc_path: default_nmxc_subscribe_rpc_path(),
+                max_frame_size_bytes: DEFAULT_NMX_C_MAX_FRAME_SIZE_BYTES,
+                subscribe_fields: Default::default(),
+            }),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            config.validate(),
+            Err("collectors.nmxc.schema_override requires at least one OTLP target".to_string())
+        );
+
+        config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
+            targets: vec![otlp_target("http://localhost:4317")],
+        });
+
+        assert_eq!(config.validate(), Ok(()));
     }
 
     #[test]

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -29,7 +29,7 @@ use super::reachability::ReachabilitySpec;
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
 use crate::bmc::BmcClient;
-use crate::collectors::{Collector, LogDowngradeRegistry, SharedInventory};
+use crate::collectors::{Collector, LogDowngradeRegistry, NmxcSchemaOverride, SharedInventory};
 use crate::config::{
     Config, Configurable, DiscoveryConfig, FirmwareCollectorConfig as FirmwareCollectorOptions,
     GpuInventoryConfig, LeakDetectorCollectorConfig as LeakDetectorCollectorOptions,
@@ -274,6 +274,7 @@ pub struct DiscoveryLoopContext {
     pub(crate) leak_detector_config: Configurable<LeakDetectorCollectorOptions>,
     pub(crate) nmxt_config: Configurable<NmxtCollectorOptions>,
     pub(crate) nmxc_config: Configurable<NmxcCollectorOptions>,
+    pub(crate) nmxc_schema_override: Option<Arc<NmxcSchemaOverride>>,
     pub(crate) nvue_config: Configurable<NvueCollectorOptions>,
     pub(crate) tls_config: Option<MtlsProfileConfig>,
     pub(crate) tls_http_client_provider: Option<MtlsHttpClientProvider>,
@@ -300,7 +301,8 @@ impl DiscoveryLoopContext {
         metrics_manager: Arc<MetricsManager>,
         config: Arc<Config>,
     ) -> Result<Self, HealthError> {
-        Self::new_with_tls_config(limiter, metrics_manager, config, None)
+        let nmxc_schema_override = load_nmxc_schema_override(&config)?;
+        Self::new_with_tls_config(limiter, metrics_manager, config, None, nmxc_schema_override)
     }
 
     pub(crate) fn new_with_tls_config(
@@ -308,6 +310,7 @@ impl DiscoveryLoopContext {
         metrics_manager: Arc<MetricsManager>,
         config: Arc<Config>,
         tls_config: Option<MtlsProfileConfig>,
+        nmxc_schema_override: Option<Arc<NmxcSchemaOverride>>,
     ) -> Result<Self, HealthError> {
         let registry = metrics_manager.global_registry();
 
@@ -365,6 +368,7 @@ impl DiscoveryLoopContext {
             leak_detector_config: config.collectors.leak_detector.clone(),
             nmxt_config: config.collectors.nmxt.clone(),
             nmxc_config: config.collectors.nmxc.clone(),
+            nmxc_schema_override,
             nvue_config: config.collectors.nvue.clone(),
             tls_config,
             tls_http_client_provider,
@@ -384,6 +388,23 @@ impl DiscoveryLoopContext {
             logs_include_diagnostics: config.sinks.includes_log_diagnostics(),
         })
     }
+}
+
+pub(crate) fn load_nmxc_schema_override(
+    config: &Config,
+) -> Result<Option<Arc<NmxcSchemaOverride>>, HealthError> {
+    let Some(nmxc) = config.collectors.nmxc.as_option() else {
+        return Ok(None);
+    };
+
+    let Some(schema_override) = &nmxc.schema_override else {
+        return Ok(None);
+    };
+
+    NmxcSchemaOverride::load(schema_override, nmxc)
+        .map(Arc::new)
+        .map(Some)
+        .map_err(|error| HealthError::NmxcSchemaOverride(Box::new(error)))
 }
 
 /// Returns the cadence at which periodic HTTP switch collectors reload mTLS material.

--- a/crates/health/src/discovery/mod.rs
+++ b/crates/health/src/discovery/mod.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use carbide_utils::managed_loop::{self, LoopManager};
 pub use context::DiscoveryLoopContext;
+pub(crate) use context::load_nmxc_schema_override;
 pub use iteration::run_discovery_iteration;
 
 use crate::HealthError;

--- a/crates/health/src/discovery/reachability.rs
+++ b/crates/health/src/discovery/reachability.rs
@@ -455,6 +455,7 @@ mod tests {
             ),
             Arc::new(config),
             None,
+            None,
         )
         .expect("discovery context should start");
 

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -27,13 +27,17 @@ use crate::collectors::{
     EntityDiscoveryCollector, EntityDiscoveryCollectorConfig, FailureKind, FirmwareCollector,
     FirmwareCollectorConfig, GpuInventoryCollector, GpuInventoryCollectorConfig,
     LeakDetectorCollector, LeakDetectorCollectorConfig, LogsCollector, LogsCollectorConfig,
-    MetricsCollector, MetricsCollectorConfig, NmxcCollector, NmxcCollectorConfig, NmxtCollector,
+    MetricsCollector, MetricsCollectorConfig, NmxcCollector, NmxcCollectorConfig,
+    NmxcSchemaOverrideCollector, NmxcSchemaOverrideCollectorConfig, NmxtCollector,
     NmxtCollectorConfig, NvueRestCollector, NvueRestCollectorConfig, SensorCollector,
     SensorCollectorConfig, SseLogCollector, SseLogCollectorConfig, StreamingCollectorStartContext,
     TelemetryCollector, TelemetryCollectorConfig, spawn_gnmi_collector,
 };
-use crate::config::{Configurable, LogCollectionMode, PeriodicLogConfig};
+use crate::config::{
+    Configurable, LogCollectionMode, NmxcCollectorConfig as NmxcCollectorOptions, PeriodicLogConfig,
+};
 use crate::endpoint::{BmcEndpoint, EndpointMetadata, SwitchEndpointRole};
+use crate::metrics::CollectorRegistry;
 use crate::sink::DataSink;
 
 fn logs_state_file_path(template: &str, endpoint_id: &str) -> PathBuf {
@@ -615,6 +619,50 @@ fn spawn_generic_redfish_collectors(
     Ok(())
 }
 
+fn start_nmxc_collector(
+    ctx: &DiscoveryLoopContext,
+    endpoint: &Arc<BmcEndpoint>,
+    bmc: &Arc<BmcClient>,
+    config: &NmxcCollectorOptions,
+    data_sink: Arc<dyn DataSink>,
+    collector_registry: Arc<CollectorRegistry>,
+) -> Result<Collector, HealthError> {
+    let start_context = StreamingCollectorStartContext {
+        backoff_config: BackoffConfig {
+            initial: config.initial_backoff,
+            max: config.max_backoff,
+        },
+        collector_registry,
+    };
+
+    if let Some(schema_override) = &ctx.nmxc_schema_override {
+        Collector::start_streaming::<NmxcSchemaOverrideCollector, _>(
+            endpoint.clone(),
+            bmc.clone(),
+            NmxcSchemaOverrideCollectorConfig {
+                nmxc_config: config.clone(),
+                tls_config: ctx.tls_config.clone(),
+                schema_override: schema_override.clone(),
+            },
+            data_sink,
+            start_context,
+            |_| true,
+        )
+    } else {
+        Collector::start_streaming::<NmxcCollector, _>(
+            endpoint.clone(),
+            bmc.clone(),
+            NmxcCollectorConfig {
+                nmxc_config: config.clone(),
+                tls_config: ctx.tls_config.clone(),
+            },
+            data_sink,
+            start_context,
+            |_| true,
+        )
+    }
+}
+
 fn spawn_switch_host_collectors(
     ctx: &mut DiscoveryLoopContext,
     endpoint: &Arc<BmcEndpoint>,
@@ -683,22 +731,13 @@ fn spawn_switch_host_collectors(
                     .create_collector_registry(format!("nmxc_collector_{key}"), metrics_prefix)?,
             );
 
-            match Collector::start_streaming::<NmxcCollector, _>(
-                endpoint_arc.clone(),
-                bmc.clone(),
-                NmxcCollectorConfig {
-                    nmxc_config: nmxc_cfg.clone(),
-                    tls_config: ctx.tls_config.clone(),
-                },
+            match start_nmxc_collector(
+                ctx,
+                &endpoint_arc,
+                &bmc,
+                nmxc_cfg,
                 data_sink,
-                StreamingCollectorStartContext {
-                    backoff_config: BackoffConfig {
-                        initial: nmxc_cfg.initial_backoff,
-                        max: nmxc_cfg.max_backoff,
-                    },
-                    collector_registry,
-                },
-                |_| true,
+                collector_registry,
             ) {
                 Ok(handle) => {
                     ctx.collectors

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -108,6 +108,10 @@ pub enum HealthError {
     #[error("NMX-C RPC failed: {0}")]
     NmxcStatus(tonic::Status),
 
+    /// Descriptor-driven NMX-C configuration is invalid.
+    #[error("NMX-C schema override configuration failed: {0}")]
+    NmxcSchemaOverride(#[source] Box<dyn std::error::Error + Send + Sync>),
+
     /// Client TLS material could not be read, validated, or applied.
     #[error("TLS profile error: {0}")]
     Tls(#[source] Box<dyn std::error::Error + Send + Sync>),
@@ -362,6 +366,7 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
     }
 
     let tls_config = config.tls.switch.clone();
+    let nmxc_schema_override = discovery::load_nmxc_schema_override(&config)?;
 
     let metrics_endpoint = config.metrics_addr()?;
     let metrics_manager = Arc::new(MetricsManager::new(&config.metrics.prefix)?);
@@ -446,6 +451,7 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
             metrics_manager.clone(),
             config.clone(),
             tls_config,
+            nmxc_schema_override,
         )?;
 
         let interval = config.endpoint_discovery_interval;

--- a/crates/health/src/sink/event_mapper.rs
+++ b/crates/health/src/sink/event_mapper.rs
@@ -19,6 +19,8 @@ use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
+use super::LogRecord;
+
 #[cfg(not(feature = "bench-hooks"))]
 pub(crate) trait RedfishEventMapper: Send + Sync {
     fn queue_key(&self, bmc_id: &str, attributes: &[(Cow<'static, str>, String)]) -> String;
@@ -59,6 +61,15 @@ impl OpenBmcEventMapper {
 
 impl RedfishEventMapper for OpenBmcEventMapper {
     fn queue_key(&self, bmc_id: &str, attributes: &[(Cow<'static, str>, String)]) -> String {
+        // The decoded protobuf represents the complete notification. Its hash
+        // keeps distinct notifications separate while retaining latest-wins
+        // replacement for exact duplicates.
+        if let Some(payload) =
+            Self::find_attr(attributes, LogRecord::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE)
+        {
+            return format!("{bmc_id}|protobuf|{}", Self::hash_string(payload));
+        }
+
         let message_id = Self::find_attr(attributes, "message_id").unwrap_or("");
 
         if message_id.is_empty() {

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -285,6 +285,8 @@ pub struct LogRecord {
 }
 
 impl LogRecord {
+    pub(crate) const DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE: &'static str = "protobuf.decoded_payload";
+
     /// Converts the collector-internal log record into the record a sink emits.
     ///
     /// Diagnostic payloads stay in a separate carrier until this boundary so
@@ -342,6 +344,29 @@ impl LogRecord {
             severity: self.severity,
             attributes,
             diagnostic_record: None,
+        })
+    }
+
+    /// Removes decoded protobuf JSON while preserving all other log content.
+    pub(crate) fn without_decoded_protobuf_payload(&self) -> Cow<'_, Self> {
+        if !self
+            .attributes
+            .iter()
+            .any(|(key, _)| key.as_ref() == Self::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE)
+        {
+            return Cow::Borrowed(self);
+        }
+
+        Cow::Owned(Self {
+            body: self.body.clone(),
+            severity: self.severity,
+            attributes: self
+                .attributes
+                .iter()
+                .filter(|(key, _)| key.as_ref() != Self::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE)
+                .cloned()
+                .collect(),
+            diagnostic_record: self.diagnostic_record.clone(),
         })
     }
 }

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -65,6 +65,7 @@ impl DataSink for LogFileSink {
         // collector-only diagnostic carrier into the emitted body and
         // attributes before JSONL serialization.
         let record = record.emitted_log_record(self.include_diagnostics);
+        let record = record.without_decoded_protobuf_payload();
         let json_record = JsonLogRecord::from_log_record(context, record.as_ref());
 
         let line = match serde_json::to_string(&json_record) {
@@ -376,6 +377,41 @@ mod tests {
         assert_eq!(parsed["body"], "something happened");
         assert_eq!(parsed["severity"], "INFO");
         assert_eq!(parsed["endpoint"], "aa:bb:cc:dd:ee:ff");
+    }
+
+    #[test]
+    fn test_excludes_decoded_protobuf_from_jsonl() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let config = LogFileSinkConfig {
+            include_diagnostics: true,
+            output_dir: dir.path().to_string_lossy().into_owned(),
+            max_file_size: 1024 * 1024,
+            max_backups: 2,
+        };
+
+        let sink = LogFileSink::new(&config).expect("sink");
+
+        let event = CollectorEvent::Log(
+            LogRecord {
+                body: "protobuf event".to_string(),
+                severity: LogSeverity::Info,
+                attributes: vec![(
+                    Cow::Borrowed(LogRecord::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE),
+                    "decoded-payload-marker".to_string(),
+                )],
+                diagnostic_record: None,
+            }
+            .into(),
+        );
+
+        sink.handle_event(&test_context(), &event);
+
+        let contents =
+            fs::read_to_string(dir.path().join("health_logs.jsonl")).expect("read JSONL output");
+
+        assert!(!contents.contains("decoded-payload-marker"));
+        assert!(!contents.contains(LogRecord::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE));
     }
 
     /// Verifies log files embed diagnostics in the parent log body when enabled.

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -167,13 +167,13 @@ impl OtlpSink {
 
     /// Enqueues the emitted log record using the parent event identity.
     fn enqueue_log_event(&self, context: &EventContext, record: &LogRecord) {
+        let record = record.emitted_log_record(self.include_diagnostics);
+
         let key = self
             .mapper
             .queue_key(&context.endpoint_key, &record.attributes);
-        let record = record
-            .emitted_log_record(self.include_diagnostics)
-            .into_owned();
-        let event = CollectorEvent::Log(Box::new(record));
+
+        let event = CollectorEvent::Log(Box::new(record.into_owned()));
 
         if self.queue.save_latest(key, (context.clone(), event)) {
             self.replaced_total.inc();
@@ -331,6 +331,36 @@ mod tests {
                 "42".to_string(),
             )],
         }
+    }
+
+    fn decoded_protobuf_event(test_value: &str) -> CollectorEvent {
+        CollectorEvent::Log(Box::new(LogRecord {
+            body: "Extended protobuf notification received".to_string(),
+            severity: LogSeverity::Info,
+            attributes: vec![
+                (
+                    Cow::Borrowed("notification"),
+                    "extended_notification".to_string(),
+                ),
+                (
+                    Cow::Borrowed("message_id"),
+                    "Example.1.0.ExtendedNotification".to_string(),
+                ),
+                (
+                    Cow::Borrowed("message_args"),
+                    r#"["extended_notification"]"#.to_string(),
+                ),
+                (
+                    Cow::Borrowed(LogRecord::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE),
+                    serde_json::json!({ "testField": test_value }).to_string(),
+                ),
+                (
+                    Cow::Borrowed("protobuf.message_type"),
+                    "example.Notification".to_string(),
+                ),
+            ],
+            diagnostic_record: None,
+        }))
     }
 
     fn metric_event() -> CollectorEvent {
@@ -680,6 +710,67 @@ mod tests {
                 .iter()
                 .any(|(key, _)| key.as_ref() == "redfish.parent.log_entry_id")
         );
+    }
+
+    #[test]
+    fn decoded_protobuf_is_projected_for_all_otlp_targets() {
+        let enabled = OtlpSink::new_for_bench_with_diagnostics(Arc::new(OpenBmcEventMapper), true);
+        let context = test_context();
+
+        enabled.handle_event(&context, &decoded_protobuf_event("first"));
+        enabled.handle_event(&context, &decoded_protobuf_event("second"));
+        enabled.handle_event(&context, &decoded_protobuf_event("second"));
+
+        let mut records = Vec::new();
+
+        while let Some((_key, (_context, CollectorEvent::Log(record)))) = enabled.queue.pop() {
+            records.push(record);
+        }
+
+        assert_eq!(records.len(), 2, "distinct notifications remain queued");
+        assert_eq!(enabled.replaced_total.get() as u64, 1);
+
+        assert!(records.iter().all(|record| {
+            record.attributes.iter().any(|(key, value)| {
+                key.as_ref() == "protobuf.decoded_payload" && value.contains("testField")
+            })
+        }));
+
+        assert!(records.iter().any(|record| {
+            record
+                .attributes
+                .iter()
+                .any(|(_, value)| value.contains("first"))
+        }));
+
+        assert!(records.iter().any(|record| {
+            record
+                .attributes
+                .iter()
+                .any(|(_, value)| value.contains("second"))
+        }));
+
+        let diagnostics_disabled =
+            OtlpSink::new_for_bench_with_diagnostics(Arc::new(OpenBmcEventMapper), false);
+
+        diagnostics_disabled.handle_event(&context, &decoded_protobuf_event("first"));
+        diagnostics_disabled.handle_event(&context, &decoded_protobuf_event("second"));
+
+        let mut diagnostics_disabled_records = Vec::new();
+
+        while let Some((_key, (_context, CollectorEvent::Log(record)))) =
+            diagnostics_disabled.queue.pop()
+        {
+            diagnostics_disabled_records.push(record);
+        }
+
+        assert_eq!(diagnostics_disabled_records.len(), 2);
+
+        assert!(diagnostics_disabled_records.iter().all(|record| {
+            record.attributes.iter().any(|(key, value)| {
+                key.as_ref() == "protobuf.decoded_payload" && value.contains("testField")
+            })
+        }));
     }
 
     #[test]

--- a/crates/health/src/sink/tracing.rs
+++ b/crates/health/src/sink/tracing.rs
@@ -95,6 +95,7 @@ impl DataSink for TracingSink {
             }
             CollectorEvent::Log(record) => {
                 let record = record.emitted_log_record(self.include_diagnostics);
+                let record = record.without_decoded_protobuf_payload();
 
                 tracing::info!(
                     endpoint = %context.endpoint_key(),
@@ -155,20 +156,24 @@ mod tests {
     use crate::sink::{LogRecord, LogSeverity};
 
     #[test]
-    fn log_events_preserve_attributes_without_diagnostics() {
+    fn decoded_protobuf_payload_is_not_emitted_by_tracing_sink() {
         let sink = TracingSink::new(&TracingSinkConfig {
-            include_diagnostics: false,
+            include_diagnostics: true,
         });
 
         let endpoint = test_endpoint(mac("00:11:22:33:44:55"));
-        let context = EventContext::from_endpoint(&endpoint, "nvue_rest");
+        let context = EventContext::from_endpoint(&endpoint, "test_collector");
 
         let event = CollectorEvent::Log(Box::new(LogRecord {
-            body: "nvue_rest: collected system reboot reason".to_string(),
+            body: "Test notification".to_string(),
             severity: LogSeverity::Info,
             attributes: vec![
                 (Cow::Borrowed("gentime"), "2026-07-05 12:34:56".to_string()),
                 (Cow::Borrowed("user"), "admin".to_string()),
+                (
+                    Cow::Borrowed(LogRecord::DECODED_PROTOBUF_PAYLOAD_ATTRIBUTE),
+                    serde_json::json!({ "testField": {} }).to_string(),
+                ),
             ],
             diagnostic_record: None,
         }));


### PR DESCRIPTION
Add an optional descriptor-driven NMX-C schema override that lets `health` use a user-supplied protobuf schema for Hello and Subscribe operations. When enabled, responses are dynamically decoded and emitted as endpoint-correlated logs, with canonical protobuf JSON available to OTLP targets. The existing generated NMX-C collector remains the default when no override is configured.

## Related issues

Resolves #5043

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

### Manual Testing

Method:

- Configured a complete descriptor set and a OTLP receiver.
- Ran `health` against two NMX-C endpoints.

Coverage:

- Two endpoints running different deployed NMX-C versions that are compatible with the descriptor's schema.
- One descriptor override used for both endpoints.
- Approximately 17 minutes of passive collection.

Results:

- Both endpoints completed the descriptor-defined Hello and Subscribe flow.
- The OTLP receiver captured 511 decoded records with endpoint correlation metadata.
- No service errors or reconnects occurred during the capture.

Selected output:

```text
Body: NMX-C schema-override notification received: subscriptionResponse
notification: subscriptionResponse
message_id: CarbideHealth.1.0.NmxcSchemaOverrideNotification
protobuf.message_type: nmx_c.ServerNotification
protobuf.decoded_payload: {"subscriptionResponse":{"serverHeader":{"appVer":"<version>","returnCode":"NMX_ST_SUCCESS"}}}
```

## Additional Notes

For now, one schema override applies to all NMX-C endpoints subscribed by a `health` instance. The supplied descriptor must be compatible with every target endpoint.