### PR TITLE
fix(admin-ui): maintain existing filters in grouped host drilldown

### DIFF
--- a/crates/api-web/src/managed_host.rs
+++ b/crates/api-web/src/managed_host.rs
@@ -74,7 +74,7 @@ struct GroupedHosts {
 struct HostGroup {
     num_in_group: usize,
     group_fields: Vec<String>,
-    filter: String,
+    query: String,
 }
 
 #[derive(PartialEq, Eq)]
@@ -564,7 +564,20 @@ pub(super) async fn show_html(
 
     hosts.sort_unstable();
 
-    let grouped_hosts = group_hosts(&hosts, &group_by);
+    let active_filters = ActiveFilters {
+        health_alerts: &active_health_alerts_filter,
+        maintenance: &active_maintenance_filter,
+        vendor: &active_vendor_filter,
+        model: &active_model_filter,
+        state: &active_state_filter,
+        gpu: &active_gpu_filter,
+        ib: &active_ib_filter,
+        mem: active_mem_filter,
+        time_in_state_above_sla: &active_time_in_state_above_sla_filter,
+        group_by: &group_by_param,
+    };
+
+    let grouped_hosts = group_hosts(&hosts, &group_by, &active_filters);
 
     // Paginate the filtered result set (only for individual view, not grouped).
     let (info, hosts) = if grouped_hosts.is_some() {
@@ -630,19 +643,7 @@ pub(super) async fn show_html(
         || active_ib_filter != "all"
         || active_mem_filter != -1;
 
-    let extra_query_params = ActiveFilters {
-        health_alerts: &active_health_alerts_filter,
-        maintenance: &active_maintenance_filter,
-        vendor: &active_vendor_filter,
-        model: &active_model_filter,
-        state: &active_state_filter,
-        gpu: &active_gpu_filter,
-        ib: &active_ib_filter,
-        mem: active_mem_filter,
-        time_in_state_above_sla: &active_time_in_state_above_sla_filter,
-        group_by: &group_by_param,
-    }
-    .to_query_params();
+    let extra_query_params = active_filters.to_query_params();
 
     let has_dpf_warning = hosts
         .iter()
@@ -675,7 +676,11 @@ pub(super) async fn show_html(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-fn group_hosts(hosts: &[ManagedHostRowDisplay], group_by: &[GroupingKey]) -> Option<GroupedHosts> {
+fn group_hosts(
+    hosts: &[ManagedHostRowDisplay],
+    group_by: &[GroupingKey],
+    active_filters: &ActiveFilters<'_>,
+) -> Option<GroupedHosts> {
     if group_by.is_empty() || hosts.is_empty() {
         return None;
     }
@@ -692,11 +697,11 @@ fn group_hosts(hosts: &[ManagedHostRowDisplay], group_by: &[GroupingKey]) -> Opt
     let mut groups = Vec::new();
     for (k, num) in count {
         let fields: Vec<String> = k.as_str().split(',').map(|s| s.to_string()).collect();
-        let filter = filter_expr(group_by, &fields);
+        let query = active_filters.to_drilldown_query_params(group_by, &fields);
         groups.push(HostGroup {
             num_in_group: num,
             group_fields: fields,
-            filter,
+            query,
         });
         total += num;
     }
@@ -708,16 +713,6 @@ fn group_hosts(hosts: &[ManagedHostRowDisplay], group_by: &[GroupingKey]) -> Opt
         groups,
         total,
     })
-}
-
-// keys: health,host_memory,num_gpus,num_ib_ifs,state
-// OUT: state-filter=all&gpu-filter=all&ib-filter=all&mem-filter=all
-fn filter_expr(keys: &[GroupingKey], values: &[String]) -> String {
-    keys.iter()
-        .zip(values.iter())
-        .map(|(k, v)| format!("{}={}", k.filter_name(), v.to_lowercase()))
-        .collect::<Vec<_>>()
-        .join("&")
 }
 
 pub(super) async fn show_all_json(state: AxumState<Arc<Api>>) -> Response {
@@ -785,42 +780,75 @@ struct ActiveFilters<'a> {
 }
 
 impl ActiveFilters<'_> {
-    fn to_query_params(&self) -> String {
-        let mut parts = Vec::new();
+    fn query_pairs(&self, include_group_by: bool) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::new();
         if self.health_alerts != "all" {
-            parts.push(format!("&health-alerts-filter={}", self.health_alerts));
+            pairs.push(("health-alerts-filter", self.health_alerts.to_string()));
         }
         if self.maintenance != "all" {
-            parts.push(format!("&maintenance-filter={}", self.maintenance));
+            pairs.push(("maintenance-filter", self.maintenance.to_string()));
         }
         if self.vendor != "all" {
-            parts.push(format!("&vendor-filter={}", self.vendor));
+            pairs.push(("vendor-filter", self.vendor.to_string()));
         }
         if self.model != "all" {
-            parts.push(format!("&model-filter={}", self.model));
+            pairs.push(("model-filter", self.model.to_string()));
         }
         if self.state != "all" {
-            parts.push(format!("&state-filter={}", self.state));
+            pairs.push(("state-filter", self.state.to_string()));
         }
         if self.gpu != "all" {
-            parts.push(format!("&gpu-filter={}", self.gpu));
+            pairs.push(("gpu-filter", self.gpu.to_string()));
         }
         if self.ib != "all" {
-            parts.push(format!("&ib-filter={}", self.ib));
+            pairs.push(("ib-filter", self.ib.to_string()));
         }
         if self.mem != -1 {
-            parts.push(format!("&mem-filter={}", self.mem));
+            pairs.push(("mem-filter", self.mem.to_string()));
         }
         if self.time_in_state_above_sla != "all" {
-            parts.push(format!(
-                "&time-in-state-above-sla-filter={}",
-                self.time_in_state_above_sla
+            pairs.push((
+                "time-in-state-above-sla-filter",
+                self.time_in_state_above_sla.to_string(),
             ));
         }
-        if self.group_by != "none" {
-            parts.push(format!("&group-by={}", self.group_by));
+        if include_group_by && self.group_by != "none" {
+            pairs.push(("group-by", self.group_by.to_string()));
         }
-        parts.join("")
+        pairs
+    }
+
+    fn encode_query_pair((key, value): (&str, String)) -> String {
+        format!("{key}={}", urlencoding::encode(&value))
+    }
+
+    fn to_query_params(&self) -> String {
+        self.query_pairs(true)
+            .into_iter()
+            .map(Self::encode_query_pair)
+            .map(|part| format!("&{part}"))
+            .join("")
+    }
+
+    fn to_drilldown_query_params(
+        &self,
+        grouping_keys: &[GroupingKey],
+        group_values: &[String],
+    ) -> String {
+        let grouped_filter_names: HashSet<_> =
+            grouping_keys.iter().map(GroupingKey::filter_name).collect();
+
+        self.query_pairs(false)
+            .into_iter()
+            .filter(|(key, _)| !grouped_filter_names.contains(key))
+            .chain(
+                grouping_keys
+                    .iter()
+                    .zip(group_values)
+                    .map(|(key, value)| (key.filter_name(), value.to_lowercase())),
+            )
+            .map(Self::encode_query_pair)
+            .join("&")
     }
 }
 
@@ -872,8 +900,43 @@ mod tests {
     use itertools::Itertools;
     use model::machine::LoadSnapshotOptions;
 
-    use super::ManagedHostRowDisplay;
+    use super::{ActiveFilters, GroupingKey, ManagedHostRowDisplay};
     use crate::tests::env::TestEnv;
+
+    fn active_filters_with_model(model: &str) -> ActiveFilters<'_> {
+        ActiveFilters {
+            health_alerts: "all",
+            maintenance: "all",
+            vendor: "all",
+            model,
+            state: "all",
+            gpu: "all",
+            ib: "all",
+            mem: -1,
+            time_in_state_above_sla: "all",
+            group_by: "none",
+        }
+    }
+
+    #[test]
+    fn test_active_filters_to_query_params_encodes_space() {
+        let active_filters = active_filters_with_model("poweredge r750");
+
+        assert_eq!(
+            active_filters.to_query_params(),
+            "&model-filter=poweredge%20r750"
+        );
+    }
+
+    #[test]
+    fn test_active_filters_to_drilldown_query_params_encodes_ampersand() {
+        let active_filters = active_filters_with_model("r&d");
+
+        assert_eq!(
+            active_filters.to_drilldown_query_params(&[GroupingKey::State], &["Ready".to_string()]),
+            "model-filter=r%26d&state-filter=ready"
+        );
+    }
 
     // Test the ManagedHostRowDisplay as a proxy for testing that the HTML has what we want in
     // managed_host::show_html (parsing the HTML string is prohibitive)

--- a/crates/api-web/src/tests/managed_host.rs
+++ b/crates/api-web/src/tests/managed_host.rs
@@ -673,3 +673,42 @@ async fn test_managed_host_empty_health_alert_filter_is_unfiltered(pool: sqlx::P
     assert!(body_str.contains("All Managed Hosts (1)"));
     assert!(body_str.contains(&mh.host.id.to_string()));
 }
+
+#[crate::sqlx_test]
+async fn test_managed_host_group_drilldown_preserves_other_filters(pool: sqlx::PgPool) {
+    let env = TestEnv::new(pool).await;
+    _ = env.create_ready_managed_host(1).await;
+
+    let app = make_test_app(&env.test_harness);
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri(
+                    "/admin/managed-host?health-alerts-filter=healthy&state-filter=ready&time-in-state-above-sla-filter=false&group-by=state&current_page=7&limit=25",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body_str = std::str::from_utf8(&body_bytes).expect("Invalid UTF-8 in body");
+
+    let drilldown_link = r#"href="/admin/managed-host?health-alerts-filter=healthy&#38;time-in-state-above-sla-filter=false&#38;state-filter=ready""#;
+    assert!(
+        body_str.contains(drilldown_link),
+        "expected grouped-host drilldown link to preserve active filters: {body_str}"
+    );
+    assert_eq!(
+        body_str.matches("state-filter=ready").count(),
+        1,
+        "group filter must replace, not duplicate, the active state filter"
+    );
+}

--- a/crates/api-web/templates/managed_host_grouped_table.html
+++ b/crates/api-web/templates/managed_host_grouped_table.html
@@ -12,7 +12,7 @@
 		{% for group in grouped_hosts.as_ref().unwrap().groups %}
 		<tr>
 			<td>
-				<a style="display: block" href="/admin/managed-host?{{ group.filter }}"> + </a>
+				<a style="display: block" href="/admin/managed-host?{{ group.query }}"> + </a>
 			</td>
 			{% for value in group.group_fields %}
 				<td>{{ value }}</td>


### PR DESCRIPTION
Previously, if you looked at the managed hosts page, applied one or more filters, and then grouped the results (by state, by host type, etc), clicking the link to expand the list of hosts within any particular group would clear the filters other than those associated with the group by value, thereby showing an overly broad list of managed hosts. This PR addresses that problem, instead preserving the filter values that existed outside of the grouping.

## Related issues
Internal issue

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Written with help from ChatGPT

