### PR TITLE
feat(nvlink-manager): use chassis serial fallback mapping

### DIFF
--- a/crates/nvlink-manager/src/switch_cert_monitor.rs
+++ b/crates/nvlink-manager/src/switch_cert_monitor.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, io};
@@ -32,6 +32,9 @@ use component_manager::component_manager::{
 };
 use db::db_read::PgPoolReader;
 use db::work_lock_manager::WorkLockManagerHandle;
+use model::machine::LoadSnapshotOptions;
+use model::machine::machine_search_config::MachineSearchConfig;
+use model::nmxc::NvlinkNmxcEndpoint;
 use model::rack::{MaintenanceActivity, MaintenanceScope};
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::Meter;
@@ -47,7 +50,7 @@ use x509_parser::prelude::{FromDer, X509Certificate};
 
 use crate::config::NvLinkConfig;
 use crate::errors::{NvLinkManagerError, NvLinkManagerResult};
-use crate::nmx_c_endpoint;
+use crate::{managed_host_chassis_serial, nmx_c_endpoint};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct CertificateInfo {
@@ -55,11 +58,77 @@ struct CertificateInfo {
     not_after_timestamp: i64,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SwitchCertificateMonitorTargetSource {
+    ReadyControlPlane { switch_id: SwitchId },
+    LegacyChassisMapping { chassis_serials: Vec<String> },
+}
+
+impl SwitchCertificateMonitorTargetSource {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::ReadyControlPlane { .. } => "ready_control_plane_switch",
+            Self::LegacyChassisMapping { .. } => "legacy_chassis_mapping",
+        }
+    }
+
+    fn switch_id(&self) -> Option<&SwitchId> {
+        match self {
+            Self::ReadyControlPlane { switch_id } => Some(switch_id),
+            Self::LegacyChassisMapping { .. } => None,
+        }
+    }
+
+    fn chassis_serials(&self) -> &[String] {
+        match self {
+            Self::ReadyControlPlane { .. } => &[],
+            Self::LegacyChassisMapping { chassis_serials } => chassis_serials,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct SwitchCertificateMonitorTarget {
-    switch_id: SwitchId,
-    rack_id: RackId,
+    rack_id: Option<RackId>,
     endpoint_url: String,
+    source: SwitchCertificateMonitorTargetSource,
+}
+
+/// Adds alert-only targets from the legacy chassis mapping, while keeping
+/// ready control-plane switch discovery authoritative.
+fn merge_switch_certificate_monitor_targets(
+    primary_targets: Vec<SwitchCertificateMonitorTarget>,
+    legacy_endpoints: Vec<NvlinkNmxcEndpoint>,
+) -> Vec<SwitchCertificateMonitorTarget> {
+    let claimed_endpoints = primary_targets
+        .iter()
+        .map(|target| target.endpoint_url.clone())
+        .collect::<HashSet<_>>();
+    let mut targets = primary_targets;
+    targets.reserve(legacy_endpoints.len());
+
+    let mut chassis_serials_by_endpoint: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for row in legacy_endpoints {
+        let endpoint_url = row.endpoint.trim().to_string();
+        if claimed_endpoints.contains(&endpoint_url) {
+            continue;
+        }
+        chassis_serials_by_endpoint
+            .entry(endpoint_url)
+            .or_default()
+            .insert(row.chassis_serial);
+    }
+
+    targets.extend(chassis_serials_by_endpoint.into_iter().map(
+        |(endpoint_url, chassis_serials)| SwitchCertificateMonitorTarget {
+            rack_id: None,
+            endpoint_url,
+            source: SwitchCertificateMonitorTargetSource::LegacyChassisMapping {
+                chassis_serials: chassis_serials.into_iter().collect(),
+            },
+        },
+    ));
+    targets
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -599,7 +668,18 @@ impl SwitchCertificateMonitor {
         let targets = self.load_switch_certificate_monitor_targets().await?;
 
         for target in targets {
-            let rack_id_label = target.rack_id.to_string();
+            let rack_id_label = target
+                .rack_id
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "unassociated".to_string());
+            let switch_id_label = target
+                .source
+                .switch_id()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "unavailable".to_string());
+            let target_source = target.source.name();
+            let chassis_serials = target.source.chassis_serials().join(",");
 
             let observed_cert = tokio::select! {
                 _ = cancel_token.cancelled() => {
@@ -621,9 +701,11 @@ impl SwitchCertificateMonitor {
 
                     if rotation_required {
                         tracing::warn!(
-                            switch_id = %target.switch_id,
+                            switch_id = %switch_id_label,
                             rack_id = %rack_id_label,
                             endpoint = %target.endpoint_url,
+                            target_source,
+                            chassis_serials,
                             observed_fingerprint = %observed_cert.fingerprint_sha256,
                             observed_not_after = observed_cert.not_after_timestamp,
                             rotate_before_expiry_seconds = self
@@ -636,9 +718,11 @@ impl SwitchCertificateMonitor {
                     }
 
                     tracing::debug!(
-                        switch_id = %target.switch_id,
+                        switch_id = %switch_id_label,
                         rack_id = %rack_id_label,
                         endpoint = %target.endpoint_url,
+                        target_source,
+                        chassis_serials,
                         observed_not_after = observed_cert.not_after_timestamp,
                         observed_fingerprint = %observed_cert.fingerprint_sha256,
                         rotation_required,
@@ -648,9 +732,11 @@ impl SwitchCertificateMonitor {
                 }
                 Ok(CertificateProbeOutcome::Expired) => {
                     tracing::warn!(
-                        switch_id = %target.switch_id,
+                        switch_id = %switch_id_label,
                         rack_id = %rack_id_label,
                         endpoint = %target.endpoint_url,
+                        target_source,
+                        chassis_serials,
                         "NMX-C server certificate is expired"
                     );
                     (
@@ -667,9 +753,11 @@ impl SwitchCertificateMonitor {
                 }
                 Err(error) => {
                     tracing::warn!(
-                        switch_id = %target.switch_id,
+                        switch_id = %switch_id_label,
                         rack_id = %rack_id_label,
                         endpoint = %target.endpoint_url,
+                        target_source,
+                        chassis_serials,
                         error = %error,
                         "Failed to probe NMX-C server certificate"
                     );
@@ -700,9 +788,11 @@ impl SwitchCertificateMonitor {
                     }
                     Err(error) => {
                         tracing::warn!(
-                            switch_id = %target.switch_id,
+                            switch_id = %switch_id_label,
                             rack_id = %rack_id_label,
                             endpoint = %target.endpoint_url,
+                            target_source,
+                            chassis_serials,
                             error = %error,
                             "Failed to request NMX-C cluster configuration via rack state machine"
                         );
@@ -735,18 +825,92 @@ impl SwitchCertificateMonitor {
                 .await
                 .map_err(NvLinkManagerError::from)?;
 
-        Ok(endpoint_rows
+        let primary_targets = endpoint_rows
             .into_iter()
             .map(|row| SwitchCertificateMonitorTarget {
-                switch_id: row.switch_id,
-                rack_id: row.rack_id,
+                rack_id: Some(row.rack_id),
                 endpoint_url: nmx_c_endpoint::nmx_c_endpoint_url_from_nvos_ip(
                     &row.nvos_ip,
                     None,
                     &self.config,
                 ),
+                source: SwitchCertificateMonitorTargetSource::ReadyControlPlane {
+                    switch_id: row.switch_id,
+                },
             })
-            .collect())
+            .collect::<Vec<_>>();
+
+        let primary_rack_ids = primary_targets
+            .iter()
+            .filter_map(|target| target.rack_id.clone())
+            .collect::<HashSet<_>>();
+        let legacy_endpoints_result = async {
+            let machine_ids = db::machine::find_machine_ids(
+                &mut db_reader,
+                MachineSearchConfig {
+                    mnnvl_only: true,
+                    include_predicted_host: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(NvLinkManagerError::from)?;
+            let snapshots = db::managed_host::load_by_machine_ids(
+                &mut db_reader,
+                &machine_ids,
+                LoadSnapshotOptions {
+                    include_instance_data: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(NvLinkManagerError::from)?;
+
+            // Do not consult the legacy mapping for a chassis that already belongs to a rack
+            // with an authoritative ready control-plane endpoint. This avoids probing a stale
+            // legacy URL alongside its replacement.
+            let mut chassis_serials = BTreeSet::new();
+            let mut chassis_serials_with_primary_targets = HashSet::new();
+            for snapshot in snapshots.values() {
+                let Some(chassis_serial) = managed_host_chassis_serial(snapshot) else {
+                    continue;
+                };
+                chassis_serials.insert(chassis_serial.clone());
+                if snapshot
+                    .host_snapshot
+                    .rack_id
+                    .as_ref()
+                    .is_some_and(|rack_id| primary_rack_ids.contains(rack_id))
+                {
+                    chassis_serials_with_primary_targets.insert(chassis_serial);
+                }
+            }
+            chassis_serials.retain(|serial| !chassis_serials_with_primary_targets.contains(serial));
+
+            let chassis_serial_refs = chassis_serials
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+            db::nvlink_nmxc_endpoints::find_by_chassis_serials(&mut db_reader, &chassis_serial_refs)
+                .await
+                .map_err(NvLinkManagerError::from)
+        }
+        .await;
+
+        match legacy_endpoints_result {
+            Ok(legacy_endpoints) => Ok(merge_switch_certificate_monitor_targets(
+                primary_targets,
+                legacy_endpoints,
+            )),
+            Err(error) if !primary_targets.is_empty() => {
+                tracing::warn!(
+                    error = %error,
+                    "Failed to load legacy chassis-mapped NMX-C certificate monitor targets; continuing with ready control-plane switches"
+                );
+                Ok(primary_targets)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     async fn request_nmx_cluster_configuration_with_rack_state_controller(
@@ -754,6 +918,21 @@ impl SwitchCertificateMonitor {
         target: &SwitchCertificateMonitorTarget,
         cancel_token: &CancellationToken,
     ) -> Result<SwitchCertApplyStatus, String> {
+        let Some(rack_id) = target.rack_id.as_ref() else {
+            tracing::warn!(
+                endpoint = %target.endpoint_url,
+                target_source = target.source.name(),
+                chassis_serials = target.source.chassis_serials().join(","),
+                "NMX-C certificate rotation is required, but this legacy chassis-mapped endpoint has no actionable rack; automatic rotation is unavailable"
+            );
+            return Ok(SwitchCertApplyStatus::Skipped);
+        };
+        let switch_id_label = target
+            .source
+            .switch_id()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "unavailable".to_string());
+
         if self.component_manager.is_none() {
             return Err(
                 "component manager is not configured; cannot request NMX-C cluster configuration"
@@ -774,7 +953,7 @@ impl SwitchCertificateMonitor {
             }
             outcome = request_rack_maintenance_via_state_controller(
                 &self.db_pool,
-                &target.rack_id,
+                rack_id,
                 scope,
                 RackMaintenanceEligibility::RequireReady,
                 None,
@@ -788,8 +967,8 @@ impl SwitchCertificateMonitor {
         match outcome {
             RackMaintenanceRequestOutcome::Scheduled => {
                 tracing::info!(
-                    switch_id = %target.switch_id,
-                    rack_id = %target.rack_id,
+                    switch_id = %switch_id_label,
+                    rack_id = %rack_id,
                     endpoint = %target.endpoint_url,
                     "Requested full-rack NMX-C cluster configuration via component manager"
                 );
@@ -797,8 +976,8 @@ impl SwitchCertificateMonitor {
             }
             RackMaintenanceRequestOutcome::AlreadyPending => {
                 tracing::debug!(
-                    switch_id = %target.switch_id,
-                    rack_id = %target.rack_id,
+                    switch_id = %switch_id_label,
+                    rack_id = %rack_id,
                     endpoint = %target.endpoint_url,
                     "Full-rack NMX-C cluster configuration is already pending"
                 );
@@ -806,8 +985,8 @@ impl SwitchCertificateMonitor {
             }
             RackMaintenanceRequestOutcome::Busy => {
                 tracing::info!(
-                    switch_id = %target.switch_id,
-                    rack_id = %target.rack_id,
+                    switch_id = %switch_id_label,
+                    rack_id = %rack_id,
                     endpoint = %target.endpoint_url,
                     "Deferring NMX-C certificate rotation because different rack maintenance is pending"
                 );
@@ -815,8 +994,8 @@ impl SwitchCertificateMonitor {
             }
             RackMaintenanceRequestOutcome::Deferred { state } => {
                 tracing::info!(
-                    switch_id = %target.switch_id,
-                    rack_id = %target.rack_id,
+                    switch_id = %switch_id_label,
+                    rack_id = %rack_id,
                     endpoint = %target.endpoint_url,
                     ?state,
                     "Deferring NMX-C certificate rotation until the rack is ready"
@@ -1104,6 +1283,67 @@ mod tests {
     use rustls_pki_types::UnixTime;
 
     use super::*;
+
+    fn ready_control_plane_target(
+        rack_id: &str,
+        endpoint_url: &str,
+    ) -> SwitchCertificateMonitorTarget {
+        SwitchCertificateMonitorTarget {
+            rack_id: Some(RackId::new(rack_id)),
+            endpoint_url: endpoint_url.to_string(),
+            source: SwitchCertificateMonitorTargetSource::ReadyControlPlane {
+                switch_id: SwitchId::from(uuid::Uuid::new_v4()),
+            },
+        }
+    }
+
+    fn legacy_endpoint(chassis_serial: &str, endpoint: &str) -> NvlinkNmxcEndpoint {
+        NvlinkNmxcEndpoint {
+            chassis_serial: chassis_serial.to_string(),
+            endpoint: endpoint.to_string(),
+        }
+    }
+
+    #[test]
+    fn legacy_chassis_endpoints_are_added_as_alert_only_targets() {
+        let targets = merge_switch_certificate_monitor_targets(
+            vec![],
+            vec![
+                legacy_endpoint("chassis-b", "https://10.0.0.2:9370"),
+                legacy_endpoint("chassis-a", "https://10.0.0.2:9370"),
+                legacy_endpoint("chassis-c", "https://10.0.0.3:9370"),
+            ],
+        );
+
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].rack_id, None);
+        assert_eq!(targets[0].endpoint_url, "https://10.0.0.2:9370");
+        assert_eq!(
+            targets[0].source,
+            SwitchCertificateMonitorTargetSource::LegacyChassisMapping {
+                chassis_serials: vec!["chassis-a".to_string(), "chassis-b".to_string()],
+            }
+        );
+        assert_eq!(targets[1].rack_id, None);
+        assert_eq!(targets[1].endpoint_url, "https://10.0.0.3:9370");
+    }
+
+    #[test]
+    fn ready_control_plane_endpoint_wins_over_legacy_mapping() {
+        let primary = ready_control_plane_target("rack-a", "https://10.0.0.2:9370");
+        let targets = merge_switch_certificate_monitor_targets(
+            vec![primary.clone()],
+            vec![
+                legacy_endpoint("chassis-a", "https://10.0.0.2:9370"),
+                legacy_endpoint("chassis-b", "https://10.0.0.3:9370"),
+            ],
+        );
+
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0], primary);
+        assert_eq!(targets[1].endpoint_url, "https://10.0.0.3:9370");
+        assert_eq!(targets[1].rack_id, None);
+    }
 
     #[test]
     fn probe_classifies_only_expired_certificate_tls_errors_for_rotation() {


### PR DESCRIPTION
..when getting the NMX-C endpoint if the primary switch IP isn't available from the DB. When this is the case, the cert-monitor will not trigger rack maintenance to rotate the cert (since there is no switch management service to execute the maitenance), it will just emit metrics.

## Description

In some deployments, NICo will not ingest racks/switches, which means it isn't possible for the nvlink-manager's cert monitor to:
- get a rack's primary switch IP from the DB.
- trigger rack maintenance to rotate the switch certificate.
NICo should still monitor NVSwitch certs in these deployments, so add a fallback method to get the NMX-C endpoint via the chassis serial mapping (in the same way the partition monitor does), so that we can emit metrics when certs are near expiry.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

