### PR TITLE
feat(machine-a-tron): derive CBC topology from rack placement

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1377,6 +1377,7 @@ where
             "config".to_string(),
             Arc::new(MachineConfig {
                 rack_id: None,
+                rack_placement: None,
                 hw_type,
                 host_count,
                 dpu_per_host_count,

--- a/crates/bmc-mock/src/hw/dgx_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/dgx_gb300_nvl.rs
@@ -38,7 +38,7 @@ pub(crate) struct DgxGB300Nvl<'a> {
     pub(crate) bmc_mac_address_usb0: MacAddress,
     pub(crate) hgx_bmc_mac_address_usb0: MacAddress,
     pub(crate) hgx_serial_number: Cow<'a, str>,
-    pub(crate) topology: hw::nvidia_gbx00::Topology,
+    pub(crate) topology: Option<hw::nvidia_gbx00::Topology>,
     pub(crate) cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
     pub(crate) gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
     pub(crate) io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
@@ -226,7 +226,9 @@ impl DgxGB300Nvl<'_> {
         };
         redfish::chassis::ChassisConfig {
             chassis: (0..=3)
-                .map(|n| hw::nvidia_gbx00::cbc_chassis(format!("CBC_{n}").into(), &self.topology))
+                .map(|n| {
+                    hw::nvidia_gbx00::cbc_chassis(format!("CBC_{n}").into(), self.topology.as_ref())
+                })
                 .chain(std::iter::once(redfish::chassis::SingleChassisConfig {
                     id: "Chassis_0".into(),
                     chassis_type: "RackMount".into(),

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -33,7 +33,7 @@ pub(crate) struct LenovoGB300Nvl<'a> {
     pub(crate) bmc_mac_address_usb0: MacAddress,
     pub(crate) hgx_bmc_mac_address_usb0: MacAddress,
     pub(crate) hgx_serial_number: Cow<'a, str>,
-    pub(crate) topology: hw::nvidia_gbx00::Topology,
+    pub(crate) topology: Option<hw::nvidia_gbx00::Topology>,
     pub(crate) cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
     pub(crate) gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
     pub(crate) io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
@@ -233,7 +233,9 @@ impl LenovoGB300Nvl<'_> {
         };
         redfish::chassis::ChassisConfig {
             chassis: (0..=3)
-                .map(|n| hw::nvidia_gbx00::cbc_chassis(format!("CBC_{n}").into(), &self.topology))
+                .map(|n| {
+                    hw::nvidia_gbx00::cbc_chassis(format!("CBC_{n}").into(), self.topology.as_ref())
+                })
                 .chain(std::iter::once(redfish::chassis::SingleChassisConfig {
                     id: "Chassis_0".into(),
                     chassis_type: "RackMount".into(),

--- a/crates/bmc-mock/src/hw/nvidia_gbx00.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gbx00.rs
@@ -21,7 +21,10 @@ use std::borrow::Cow;
 
 use serde_json::json;
 
-use crate::redfish;
+use crate::{RackPlacement, redfish};
+
+const CBC_CHASSIS_PHYSICAL_SLOT_OFFSET: u32 = 10;
+const CBC_REVISION_ID: u32 = 2;
 
 pub(crate) struct Topology {
     pub(crate) chassis_physical_slot_number: u32,
@@ -30,10 +33,22 @@ pub(crate) struct Topology {
     pub(crate) topology_id: u32,
 }
 
+impl Topology {
+    pub(crate) fn from_rack_placement(placement: RackPlacement) -> Option<Self> {
+        let compute_tray_index = u32::from(placement.compute_tray_index()?);
+        Some(Self {
+            chassis_physical_slot_number: compute_tray_index + CBC_CHASSIS_PHYSICAL_SLOT_OFFSET,
+            compute_tray_index,
+            revision_id: CBC_REVISION_ID,
+            topology_id: placement.topology_id(),
+        })
+    }
+}
+
 // CBC chassis definition.
 pub(super) fn cbc_chassis(
     chassis_id: Cow<'static, str>,
-    topology: &Topology,
+    topology: Option<&Topology>,
 ) -> redfish::chassis::SingleChassisConfig {
     redfish::chassis::SingleChassisConfig {
         id: chassis_id,
@@ -43,15 +58,94 @@ pub(super) fn cbc_chassis(
         model: Some("18x1RU CBL Cartridge".into()),
         serial_number: Some("1821220000000".into()),
         pcie_devices: Some(vec![]),
-        oem: Some(json!({
-            "Nvidia": {
-                "@odata.type": "#NvidiaChassis.v1_4_0.NvidiaCBCChassis",
-                "ChassisPhysicalSlotNumber": topology.chassis_physical_slot_number,
-                "ComputeTrayIndex": topology.compute_tray_index,
-                "RevisionId": topology.revision_id,
-                "TopologyId": topology.topology_id,
-            }
-        })),
+        oem: topology.map(|topology| {
+            json!({
+                "Nvidia": {
+                    "@odata.type": "#NvidiaChassis.v1_4_0.NvidiaCBCChassis",
+                    "ChassisPhysicalSlotNumber": topology.chassis_physical_slot_number,
+                    "ComputeTrayIndex": topology.compute_tray_index,
+                    "RevisionId": topology.revision_id,
+                    "TopologyId": topology.topology_id,
+                }
+            })
+        }),
         ..redfish::chassis::SingleChassisConfig::defaults()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+    use crate::{RackInfo, RackType};
+
+    #[derive(Debug)]
+    struct Input {
+        rack_type: RackType,
+        position: u8,
+    }
+
+    #[test]
+    fn cbc_values_follow_rack_placement() {
+        check_values(
+            [
+                Check {
+                    scenario: "first lower compute tray",
+                    input: Input {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        position: 11,
+                    },
+                    expect: Some((10, 0, 2, 128)),
+                },
+                Check {
+                    scenario: "last lower compute tray",
+                    input: Input {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        position: 18,
+                    },
+                    expect: Some((17, 7, 2, 128)),
+                },
+                Check {
+                    scenario: "first upper compute tray",
+                    input: Input {
+                        rack_type: RackType::LenovoGb300Nvl72,
+                        position: 28,
+                    },
+                    expect: Some((18, 8, 2, 128)),
+                },
+                Check {
+                    scenario: "last upper compute tray",
+                    input: Input {
+                        rack_type: RackType::LenovoGb300Nvl72,
+                        position: 37,
+                    },
+                    expect: Some((27, 17, 2, 128)),
+                },
+                Check {
+                    scenario: "non-compute rack member",
+                    input: Input {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        position: 19,
+                    },
+                    expect: None,
+                },
+            ],
+            |input| {
+                let placement = RackInfo {
+                    rack_type: input.rack_type,
+                }
+                .placement(input.position);
+                let topology = Topology::from_rack_placement(placement);
+                let chassis = cbc_chassis("CBC_0".into(), topology.as_ref());
+                let nvidia = chassis.oem?.get("Nvidia")?.clone();
+                Some((
+                    nvidia.get("ChassisPhysicalSlotNumber")?.as_u64()?,
+                    nvidia.get("ComputeTrayIndex")?.as_u64()?,
+                    nvidia.get("RevisionId")?.as_u64()?,
+                    nvidia.get("TopologyId")?.as_u64()?,
+                ))
+            },
+        );
     }
 }

--- a/crates/bmc-mock/src/hw/rack.rs
+++ b/crates/bmc-mock/src/hw/rack.rs
@@ -17,6 +17,46 @@
 
 use crate::HardwareType;
 
+const FIRST_COMPUTE_RANGE_START: u8 = 11;
+const FIRST_COMPUTE_RANGE_END: u8 = 18;
+const SECOND_COMPUTE_RANGE_START: u8 = 28;
+const SECOND_COMPUTE_RANGE_END: u8 = 37;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RackPlacement {
+    position: u8,
+    topology_id: u32,
+}
+
+impl RackPlacement {
+    pub(crate) fn new(position: u8, topology_id: u32) -> Self {
+        Self {
+            position,
+            topology_id,
+        }
+    }
+
+    pub fn position(self) -> u8 {
+        self.position
+    }
+
+    pub fn topology_id(self) -> u32 {
+        self.topology_id
+    }
+
+    pub(crate) fn compute_tray_index(self) -> Option<u8> {
+        match self.position {
+            FIRST_COMPUTE_RANGE_START..=FIRST_COMPUTE_RANGE_END => {
+                Some(self.position - FIRST_COMPUTE_RANGE_START)
+            }
+            SECOND_COMPUTE_RANGE_START..=SECOND_COMPUTE_RANGE_END => {
+                Some(self.position - SECOND_COMPUTE_RANGE_START + 8)
+            }
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RackUnit {
     pub position: u8,

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -39,7 +39,7 @@ pub(crate) struct SupermicroGB300Nvl<'a> {
     pub(crate) bmc_mac_address_usb0: MacAddress,
     pub(crate) hgx_bmc_mac_address_usb0: MacAddress,
     pub(crate) hgx_serial_number: Cow<'a, str>,
-    pub(crate) topology: hw::nvidia_gbx00::Topology,
+    pub(crate) topology: Option<hw::nvidia_gbx00::Topology>,
     pub(crate) cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
     pub(crate) gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
     pub(crate) io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
@@ -252,7 +252,9 @@ impl SupermicroGB300Nvl<'_> {
         };
         redfish::chassis::ChassisConfig {
             chassis: (0..=3)
-                .map(|n| hw::nvidia_gbx00::cbc_chassis(format!("CBC_{n}").into(), &self.topology))
+                .map(|n| {
+                    hw::nvidia_gbx00::cbc_chassis(format!("CBC_{n}").into(), self.topology.as_ref())
+                })
                 .chain(std::iter::once(redfish::chassis::SingleChassisConfig {
                     id: "Chassis_0".into(),
                     // SMC GB300 scrape: Chassis_0 is a Shelf with PDB part number AOM-PDB-B3.

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -28,7 +28,7 @@ pub(crate) struct WiwynnGB200Nvl<'a> {
     pub(crate) compute_board: [hw::nvidia_gb200::BiancaBoard<'a>; 2],
     pub(crate) dpu1: hw::bluefield3::Bluefield3<'a>,
     pub(crate) dpu2: hw::bluefield3::Bluefield3<'a>,
-    pub(crate) topology: hw::nvidia_gbx00::Topology,
+    pub(crate) topology: Option<hw::nvidia_gbx00::Topology>,
     pub(crate) io_board: [hw::nvidia_gb200::IoBoard<'a>; 2],
 }
 
@@ -217,7 +217,7 @@ impl WiwynnGB200Nvl<'_> {
                 ..redfish::chassis::SingleChassisConfig::defaults()
             }))
             .chain((0..4).map(|index| {
-                hw::nvidia_gbx00::cbc_chassis(format!("CBC_{index}").into(), &self.topology)
+                hw::nvidia_gbx00::cbc_chassis(format!("CBC_{index}").into(), self.topology.as_ref())
             }))
             .chain(
                 [(0, "HGX_CPU_0"), (1, "HGX_CPU_1")]

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -46,7 +46,7 @@ pub use bmc_state::{BmcEvent, BmcState};
 pub use carbide_axum_utils::authority_router::authority_router as combined_router;
 pub use carbide_axum_utils::injection;
 pub use combined_server::{CombinedServer, ListenerOrAddress};
-pub use hw::rack::{RackElevation, RackUnit};
+pub use hw::rack::{RackElevation, RackPlacement, RackUnit};
 pub use machine_info::{
     DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostFirmwareVersions, HostMachineInfo,
     MachineInfo,

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -23,7 +23,9 @@ use serde::{Deserialize, Serialize};
 use crate::infiniband::Guid;
 use crate::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use crate::redfish::update_service::UpdateServiceConfig;
-use crate::{DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HardwareType, hw, redfish};
+use crate::{
+    DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HardwareType, RackPlacement, hw, redfish,
+};
 
 /// Represents static information we know ahead of time about a host or DPU (independent of any
 /// state we get from carbide like IP addresses or machine ID's.) Intended to be immutable and
@@ -37,6 +39,7 @@ pub enum MachineInfo {
 #[derive(Debug, Clone)]
 pub struct HostMachineInfo {
     pub hw_type: HardwareType,
+    pub rack_placement: Option<RackPlacement>,
     pub bmc_mac_address: MacAddress,
     pub serial: String,
     pub dpus: Vec<DpuMachineInfo>,
@@ -330,6 +333,7 @@ impl HostMachineInfo {
             .map(|mac| format!("MT{}", mac.to_string().replace(':', "")));
         Self {
             hw_type,
+            rack_placement: None,
             bmc_mac_address,
             serial: bmc_mac_address.to_string().replace(':', ""),
             non_dpu_mac_address: if dpus.is_empty()
@@ -702,12 +706,9 @@ impl HostMachineInfo {
                     serial_number: "MT0000000002".into(),
                 },
             ],
-            topology: hw::nvidia_gbx00::Topology {
-                chassis_physical_slot_number: 24,
-                compute_tray_index: 14,
-                revision_id: 2,
-                topology_id: 128,
-            },
+            topology: self
+                .rack_placement
+                .and_then(hw::nvidia_gbx00::Topology::from_rack_placement),
         }
     }
 
@@ -744,12 +745,9 @@ impl HostMachineInfo {
             bmc_mac_address_usb0: next_mac(),
             hgx_bmc_mac_address_usb0: next_mac(),
             hgx_serial_number: superchip_a_sn.into(),
-            topology: hw::nvidia_gbx00::Topology {
-                chassis_physical_slot_number: 25,
-                compute_tray_index: 15,
-                revision_id: 2,
-                topology_id: 128,
-            },
+            topology: self
+                .rack_placement
+                .and_then(hw::nvidia_gbx00::Topology::from_rack_placement),
             cpu: boards.cpu,
             gpu: boards.gpu,
             io_board: boards.io_board,
@@ -787,12 +785,9 @@ impl HostMachineInfo {
             bmc_mac_address_usb0: next_mac(),
             hgx_bmc_mac_address_usb0: next_mac(),
             hgx_serial_number: superchip_a_sn.into(),
-            topology: hw::nvidia_gbx00::Topology {
-                chassis_physical_slot_number: 25,
-                compute_tray_index: 15,
-                revision_id: 2,
-                topology_id: 128,
-            },
+            topology: self
+                .rack_placement
+                .and_then(hw::nvidia_gbx00::Topology::from_rack_placement),
             cpu: boards.cpu,
             gpu: boards.gpu,
             io_board: boards.io_board,
@@ -830,12 +825,9 @@ impl HostMachineInfo {
             bmc_mac_address_usb0: next_mac(),
             hgx_bmc_mac_address_usb0: next_mac(),
             hgx_serial_number: "012345678901234567890123".into(),
-            topology: hw::nvidia_gbx00::Topology {
-                chassis_physical_slot_number: 25,
-                compute_tray_index: 15,
-                revision_id: 2,
-                topology_id: 128,
-            },
+            topology: self
+                .rack_placement
+                .and_then(hw::nvidia_gbx00::Topology::from_rack_placement),
             cpu: [
                 hw::nvidia_gb300::NvidiaGB300Cpu {
                     serial_number: cpu0_sn.into(),

--- a/crates/bmc-mock/src/rack_info.rs
+++ b/crates/bmc-mock/src/rack_info.rs
@@ -15,10 +15,17 @@
  * limitations under the License.
  */
 
-use crate::RackType;
+use std::collections::BTreeSet;
+
 use crate::hw::lenovo_gb300_nvl72_rack::LenovoGB300Nvl72Rack;
-use crate::hw::rack::RackElevation;
+use crate::hw::rack::{RackElevation, RackPlacement};
 use crate::hw::wiwynn_gb200_nvl72_rack::WiwynnGB200Nvl72Rack;
+use crate::{HardwareType, RackType};
+
+const NVL72_TOPOLOGY_ID: u32 = 128;
+const RACK_POSITION_MIN: u8 = 1;
+const RACK_POSITION_MAX: u8 = 48;
+const COMPUTE_TRAY_COUNT: usize = 18;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RackInfo {
@@ -26,11 +33,17 @@ pub struct RackInfo {
 }
 
 impl RackInfo {
-    pub fn rack_elevation(&self) -> RackElevation {
-        match self.rack_type {
+    pub fn rack_elevation(&self) -> eyre::Result<RackElevation> {
+        let elevation = match self.rack_type {
             RackType::WiwynnGb200Nvl72 => self.wiwynn_gb200_nvl72_rack().rack_elevation(),
             RackType::LenovoGb300Nvl72 => self.lenovo_gb300_nvl72_rack().rack_elevation(),
-        }
+        };
+        self.validate_elevation(&elevation)?;
+        Ok(elevation)
+    }
+
+    pub fn placement(&self, position: u8) -> RackPlacement {
+        RackPlacement::new(position, self.topology_id())
     }
 
     fn wiwynn_gb200_nvl72_rack(&self) -> WiwynnGB200Nvl72Rack {
@@ -39,5 +52,240 @@ impl RackInfo {
 
     fn lenovo_gb300_nvl72_rack(&self) -> LenovoGB300Nvl72Rack {
         LenovoGB300Nvl72Rack
+    }
+
+    fn topology_id(&self) -> u32 {
+        match self.rack_type {
+            RackType::WiwynnGb200Nvl72 | RackType::LenovoGb300Nvl72 => NVL72_TOPOLOGY_ID,
+        }
+    }
+
+    fn compute_tray_hardware_type(&self) -> HardwareType {
+        match self.rack_type {
+            RackType::WiwynnGb200Nvl72 => HardwareType::WiwynnGB200Nvl,
+            RackType::LenovoGb300Nvl72 => HardwareType::LenovoGB300Nvl,
+        }
+    }
+
+    fn validate_elevation(&self, elevation: &RackElevation) -> eyre::Result<()> {
+        let mut occupied_positions = BTreeSet::new();
+        for unit in &elevation.units {
+            eyre::ensure!(
+                (RACK_POSITION_MIN..=RACK_POSITION_MAX).contains(&unit.position),
+                "{} rack design position {} must be between {} and {}",
+                self.rack_type,
+                unit.position,
+                RACK_POSITION_MIN,
+                RACK_POSITION_MAX
+            );
+            eyre::ensure!(
+                occupied_positions.insert(unit.position),
+                "{} rack design position {} is occupied more than once",
+                self.rack_type,
+                unit.position
+            );
+        }
+
+        let expected_compute_type = self.compute_tray_hardware_type();
+        let mut cbc_index_counts = [0_u8; COMPUTE_TRAY_COUNT];
+        for unit in &elevation.units {
+            if is_gbx00_compute_tray(unit.hardware_type)
+                && unit.hardware_type != expected_compute_type
+            {
+                eyre::bail!(
+                    "{} rack design position {} uses {}, expected {}",
+                    self.rack_type,
+                    unit.position,
+                    unit.hardware_type,
+                    expected_compute_type
+                );
+            }
+            if unit.hardware_type != expected_compute_type {
+                continue;
+            }
+
+            let placement = self.placement(unit.position);
+            let compute_tray_index = placement.compute_tray_index().ok_or_else(|| {
+                eyre::eyre!(
+                    "{} compute tray at rack position {} cannot be mapped to a CBC index; compute trays must occupy positions 11 through 18 or 28 through 37",
+                    self.rack_type,
+                    unit.position
+                )
+            })?;
+            cbc_index_counts[usize::from(compute_tray_index)] += 1;
+        }
+
+        for (compute_tray_index, machine_count) in cbc_index_counts.into_iter().enumerate() {
+            eyre::ensure!(
+                machine_count == 1,
+                "{} rack design CBC compute tray index {} must resolve to exactly one machine, found {}",
+                self.rack_type,
+                compute_tray_index,
+                machine_count
+            );
+        }
+
+        Ok(())
+    }
+}
+
+fn is_gbx00_compute_tray(hardware_type: HardwareType) -> bool {
+    matches!(
+        hardware_type,
+        HardwareType::WiwynnGB200Nvl
+            | HardwareType::LenovoGB300Nvl
+            | HardwareType::NvidiaDgxGb300
+            | HardwareType::SupermicroGb300Nvl
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
+    use super::*;
+
+    #[derive(Clone, Copy, Debug)]
+    enum Mutation {
+        None,
+        OutOfRangePosition,
+        DuplicatePosition,
+        InvalidComputePosition,
+        MissingComputeTray,
+        WrongComputeHardware,
+    }
+
+    #[derive(Debug)]
+    struct ValidationInput {
+        rack_type: RackType,
+        mutation: Mutation,
+    }
+
+    fn unvalidated_elevation(rack_info: RackInfo) -> RackElevation {
+        match rack_info.rack_type {
+            RackType::WiwynnGb200Nvl72 => rack_info.wiwynn_gb200_nvl72_rack().rack_elevation(),
+            RackType::LenovoGb300Nvl72 => rack_info.lenovo_gb300_nvl72_rack().rack_elevation(),
+        }
+    }
+
+    #[test]
+    fn rack_placement_validation() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid WIWYNN GB200 rack",
+                    input: ValidationInput {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        mutation: Mutation::None,
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "valid Lenovo GB300 rack",
+                    input: ValidationInput {
+                        rack_type: RackType::LenovoGb300Nvl72,
+                        mutation: Mutation::None,
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "rack position outside the 48-position design",
+                    input: ValidationInput {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        mutation: Mutation::OutOfRangePosition,
+                    },
+                    expect: FailsWith(
+                        "WIWYNN GB200 NVL72 rack design position 0 must be between 1 and 48"
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "duplicate occupied position",
+                    input: ValidationInput {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        mutation: Mutation::DuplicatePosition,
+                    },
+                    expect: FailsWith(
+                        "WIWYNN GB200 NVL72 rack design position 6 is occupied more than once"
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "compute tray outside CBC ranges",
+                    input: ValidationInput {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        mutation: Mutation::InvalidComputePosition,
+                    },
+                    expect: FailsWith(
+                        "WIWYNN GB200 NVL72 compute tray at rack position 10 cannot be mapped to a CBC index; compute trays must occupy positions 11 through 18 or 28 through 37"
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "CBC index without a machine",
+                    input: ValidationInput {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        mutation: Mutation::MissingComputeTray,
+                    },
+                    expect: FailsWith(
+                        "WIWYNN GB200 NVL72 rack design CBC compute tray index 17 must resolve to exactly one machine, found 0"
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "compute hardware from the wrong design",
+                    input: ValidationInput {
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        mutation: Mutation::WrongComputeHardware,
+                    },
+                    expect: FailsWith(
+                        "WIWYNN GB200 NVL72 rack design position 11 uses Lenovo GB300 NVL, expected WIWYNN GB200 NVL"
+                            .to_string(),
+                    ),
+                },
+            ],
+            |input| {
+                let rack_info = RackInfo {
+                    rack_type: input.rack_type,
+                };
+                let mut elevation = unvalidated_elevation(rack_info);
+                match input.mutation {
+                    Mutation::None => {}
+                    Mutation::OutOfRangePosition => elevation.units[0].position = 0,
+                    Mutation::DuplicatePosition => {
+                        elevation.units[1].position = elevation.units[0].position;
+                    }
+                    Mutation::InvalidComputePosition => {
+                        elevation
+                            .units
+                            .iter_mut()
+                            .find(|unit| unit.position == 11)
+                            .unwrap()
+                            .position = 10;
+                    }
+                    Mutation::MissingComputeTray => {
+                        elevation
+                            .units
+                            .iter_mut()
+                            .find(|unit| unit.position == 37)
+                            .unwrap()
+                            .hardware_type = HardwareType::NvidiaSwitchNd5200Ld;
+                    }
+                    Mutation::WrongComputeHardware => {
+                        elevation
+                            .units
+                            .iter_mut()
+                            .find(|unit| unit.position == 11)
+                            .unwrap()
+                            .hardware_type = HardwareType::LenovoGB300Nvl;
+                    }
+                }
+
+                rack_info
+                    .validate_elevation(&elevation)
+                    .map_err(|error| error.to_string())
+            },
+        );
     }
 }

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -22,12 +22,14 @@ use std::time::Duration;
 
 use bmc_mock::mac_address_pool::MacAddressPool;
 use bmc_mock::{
-    DpuMachineInfo, DpuSettings, HardwareType, HostFirmwareVersions, RackInfo, RackType,
+    DpuMachineInfo, DpuSettings, HardwareType, HostFirmwareVersions, RackInfo, RackPlacement,
+    RackType,
 };
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use clap::Parser;
 use duration_str::deserialize_duration;
+use eyre::Context;
 use mac_address::MacAddress;
 use rpc::forge::DesiredFirmwareVersionEntry;
 use rpc::forge_tls_client::ForgeClientConfig;
@@ -75,6 +77,8 @@ pub struct MachineATronArgs {
 pub struct MachineConfig {
     #[serde(default)]
     pub rack_id: Option<RackId>,
+    #[serde(skip)]
+    pub rack_placement: Option<RackPlacement>,
     #[serde(default = "default_hardware_type")]
     pub hw_type: HardwareType,
     pub host_count: u32,
@@ -195,11 +199,13 @@ impl WiwynnGb200RackConfig {
     fn component_machine_config(
         &self,
         rack_id: RackId,
+        rack_placement: RackPlacement,
         hw_type: HardwareType,
         dpu_per_host_count: u32,
     ) -> MachineConfig {
         MachineConfig {
             rack_id: Some(rack_id),
+            rack_placement: Some(rack_placement),
             hw_type,
             host_count: 1,
             vpc_count: 0,
@@ -269,11 +275,13 @@ impl LenovoGb300RackConfig {
     fn component_machine_config(
         &self,
         rack_id: RackId,
+        rack_placement: RackPlacement,
         hw_type: HardwareType,
         dpu_per_host_count: u32,
     ) -> MachineConfig {
         MachineConfig {
             rack_id: Some(rack_id),
+            rack_placement: Some(rack_placement),
             hw_type,
             host_count: 1,
             vpc_count: 0,
@@ -329,16 +337,23 @@ impl RackModelConfig {
     fn component_machine_config(
         &self,
         rack_id: RackId,
+        rack_placement: RackPlacement,
         hardware_type: HardwareType,
         dpu_per_host_count: u32,
     ) -> MachineConfig {
         match self {
-            Self::WiwynnGb200Nvl72 { simulation } => {
-                simulation.component_machine_config(rack_id, hardware_type, dpu_per_host_count)
-            }
-            Self::LenovoGb300Nvl72 { simulation } => {
-                simulation.component_machine_config(rack_id, hardware_type, dpu_per_host_count)
-            }
+            Self::WiwynnGb200Nvl72 { simulation } => simulation.component_machine_config(
+                rack_id,
+                rack_placement,
+                hardware_type,
+                dpu_per_host_count,
+            ),
+            Self::LenovoGb300Nvl72 { simulation } => simulation.component_machine_config(
+                rack_id,
+                rack_placement,
+                hardware_type,
+                dpu_per_host_count,
+            ),
         }
     }
 }
@@ -600,11 +615,15 @@ impl MachineATronConfig {
 
         for (rack_id, rack) in configured_racks {
             let rack_type = rack.model.rack_type();
-            let elevation = RackInfo { rack_type }.rack_elevation();
+            let rack_info = RackInfo { rack_type };
+            let elevation = rack_info.rack_elevation().wrap_err_with(|| {
+                format!("rack {rack_id} uses an invalid {rack_type} rack design")
+            })?;
             let rack_key = encoded_rack_key(&rack_id);
             let mut members = Vec::with_capacity(elevation.units.len());
 
             for unit in elevation.units {
+                let placement = rack_info.placement(unit.position);
                 let machine_config_section = format!("rack-{rack_key}--unit-{:02}", unit.position);
                 let dpu_per_host_count = unit
                     .hardware_type
@@ -617,6 +636,7 @@ impl MachineATronConfig {
                             machine_config_section.clone(),
                             Arc::new(rack.model.component_machine_config(
                                 rack_id.clone(),
+                                placement,
                                 unit.hardware_type,
                                 dpu_per_host_count,
                             )),
@@ -625,7 +645,7 @@ impl MachineATronConfig {
                     "rack {rack_id} generated duplicate device identity {machine_config_section}"
                 );
                 members.push(RackMemberRegistration {
-                    position: unit.position,
+                    placement,
                     hardware_type: unit.hardware_type,
                     machine_config_section,
                 });
@@ -1163,11 +1183,19 @@ scout_run_interval = "5s"
                         eyre::ensure!(
                             rack.members
                                 .iter()
-                                .map(|member| member.position)
+                                .map(|member| member.placement.position())
                                 .collect::<BTreeSet<_>>()
                                 .len()
                                 == expected.member_count
                         );
+                        for member in &rack.members {
+                            let machine = first
+                                .machines
+                                .get(&member.machine_config_section)
+                                .expect("rack member must reference a generated machine");
+                            eyre::ensure!(machine.rack_id.as_ref() == Some(&rack.rack_id));
+                            eyre::ensure!(machine.rack_placement == Some(member.placement));
+                        }
                     }
 
                     for machine in first.machines.values() {

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -315,7 +315,7 @@ mod tests {
     use axum::http::{Method, Request, StatusCode};
     use axum::routing::get;
     use bmc_mock::ipmi_sim::IpmiEndpoint;
-    use bmc_mock::{HardwareType, RackType};
+    use bmc_mock::{HardwareType, RackInfo, RackType};
     use carbide_uuid::rack::{RackId, RackProfileId};
     use tower::ServiceExt;
     use uuid::Uuid;
@@ -347,7 +347,10 @@ mod tests {
             rack_type: RackType::WiwynnGb200Nvl72,
             version: 1,
             members: vec![RackMemberRegistration {
-                position: 11,
+                placement: RackInfo {
+                    rack_type: RackType::WiwynnGb200Nvl72,
+                }
+                .placement(11),
                 hardware_type: HardwareType::WiwynnGB200Nvl,
                 machine_config_section: machine_config_section.to_string(),
             }],

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -153,6 +153,7 @@ impl HostMachine {
             .collect::<Vec<_>>();
         let mut host_info = HostMachineInfo {
             hw_type: persisted_device.hw_type,
+            rack_placement: config.rack_placement,
             bmc_mac_address: persisted_device.bmc_mac_address,
             serial: persisted_device.serial.clone(),
             dpus: persisted_device
@@ -259,6 +260,7 @@ impl HostMachine {
             mac_pool,
             hw_pool_config,
         );
+        host_info.rack_placement = config.rack_placement;
         host_info.initial_host_firmware = config.host_firmware_versions.clone();
         host_info.desired_host_firmware = desired_host_firmware(config.hw_type, &app_context);
         let dpus = dpu_machines
@@ -643,6 +645,7 @@ impl MachineHandle {
             mat_id: Uuid::new_v4(),
             host_info: HostMachineInfo {
                 hw_type: Default::default(),
+                rack_placement: None,
                 bmc_mac_address: mac,
                 serial: "test-host".to_string(),
                 dpus: Vec::new(),

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -593,6 +593,7 @@ mod tests {
     fn host_info(dpu_host_macs: &[MacAddress], non_dpu_mac: Option<MacAddress>) -> HostMachineInfo {
         HostMachineInfo {
             hw_type: HardwareType::WiwynnGB200Nvl,
+            rack_placement: None,
             bmc_mac_address: mac("02:00:00:00:00:f0"),
             serial: "test-host".to_string(),
             dpus: dpu_host_macs

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -130,7 +130,10 @@ impl PowerShelfActor {
         Self {
             mat_id: Uuid::new_v4(),
             machine_config_section,
-            host_info: HostMachineInfo::new(config.hw_type, Vec::new(), mac_pool, hw_mac_addr_pool),
+            host_info: HostMachineInfo {
+                rack_placement: config.rack_placement,
+                ..HostMachineInfo::new(config.hw_type, Vec::new(), mac_pool, hw_mac_addr_pool)
+            },
             app_context,
             config,
             live_state: Arc::new(RwLock::new(PowerShelfLiveState::new(&fsm))),
@@ -153,6 +156,7 @@ impl PowerShelfActor {
     ) -> Self {
         let host_info = HostMachineInfo {
             hw_type: persisted.hw_type,
+            rack_placement: config.rack_placement,
             bmc_mac_address: persisted.bmc_mac_address,
             serial: persisted.serial.clone(),
             dpus: Vec::new(),

--- a/crates/machine-a-tron/src/rack.rs
+++ b/crates/machine-a-tron/src/rack.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use bmc_mock::{HardwareType, RackType};
+use bmc_mock::{HardwareType, RackPlacement, RackType};
 use carbide_uuid::rack::{RackId, RackProfileId};
 use serde::Serialize;
 
@@ -23,7 +23,7 @@ use crate::status::DeviceStatus;
 
 #[derive(Clone, Debug)]
 pub(crate) struct RackMemberRegistration {
-    pub position: u8,
+    pub placement: RackPlacement,
     pub hardware_type: HardwareType,
     pub machine_config_section: String,
 }
@@ -39,7 +39,7 @@ pub(crate) struct RackRegistration {
 
 #[derive(Clone, Debug)]
 pub(crate) struct RackMemberRef {
-    pub position: u8,
+    pub placement: RackPlacement,
     pub device_index: usize,
 }
 

--- a/crates/machine-a-tron/src/simulator_registry.rs
+++ b/crates/machine-a-tron/src/simulator_registry.rs
@@ -104,12 +104,12 @@ impl SimulatorRegistry {
                             eyre::eyre!(
                                 "rack {} unit {} ({}) has no simulator",
                                 registration.rack_id,
-                                member.position,
+                                member.placement.position(),
                                 member.hardware_type
                             )
                         })?;
                     Ok(RackMemberRef {
-                        position: member.position,
+                        placement: member.placement,
                         device_index,
                     })
                 })
@@ -191,7 +191,7 @@ impl SimulatorRegistry {
                 .members
                 .iter()
                 .map(|member| RackMemberStatus {
-                    position: member.position,
+                    position: member.placement.position(),
                     device: self.inner.devices[member.device_index].status(status_config),
                 })
                 .collect(),

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -132,7 +132,10 @@ impl SwitchActor {
         Self {
             mat_id: Uuid::new_v4(),
             machine_config_section,
-            host_info: HostMachineInfo::new(config.hw_type, Vec::new(), mac_pool, hw_mac_addr_pool),
+            host_info: HostMachineInfo {
+                rack_placement: config.rack_placement,
+                ..HostMachineInfo::new(config.hw_type, Vec::new(), mac_pool, hw_mac_addr_pool)
+            },
             app_context,
             config,
             live_state: Arc::new(RwLock::new(SwitchLiveState::new(&fsm))),
@@ -155,6 +158,7 @@ impl SwitchActor {
     ) -> Self {
         let host_info = HostMachineInfo {
             hw_type: persisted.hw_type,
+            rack_placement: config.rack_placement,
             bmc_mac_address: persisted.bmc_mac_address,
             serial: persisted.serial.clone(),
             dpus: Vec::new(),


### PR DESCRIPTION
Generates CBC data from canonical MAT rack placement instead of static values. Rack layouts are validated so every CBC index maps to exactly one machine.


## Related issues

Closes #4281

## Type of Change

- [x] **Add** - New feature or capability

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Additional Notes

Validated all 18 GB200 compute trays through Tilt and Redfish.