### PR TITLE
feat(flow): rack-scale decommission workflow with proto mirror sync a…

### DIFF
--- a/rest-api/flow/internal/service/server_impl.go
+++ b/rest-api/flow/internal/service/server_impl.go
@@ -840,6 +840,12 @@ func (rs *FlowServerImpl) decommissionRackImpl(
 			"target_spec is required",
 		)
 	}
+	if targetSpec.GetComponents() != nil {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"decommission requires rack targets; component targets are not supported",
+		)
+	}
 
 	info := &operations.DecommissionTaskInfo{
 		RuleID: protobuf.UUIDStringFrom(req.GetRuleId()),

--- a/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity.go
@@ -217,14 +217,21 @@ func (a *Activities) DecommissionControl(
 
 // GetDecommissionStatusResult is the result of the GetDecommissionStatus activity.
 type GetDecommissionStatusResult struct {
-	// States maps each component ID to its current raw decommission state
+	// States maps each found component ID to its current raw decommission state
 	// string as returned by the component manager (e.g. "Decommissioning/...",
-	// "Decommissioned", "Failed/...").
+	// "Decommissioned", "Failed/..."). Only IDs that Core returned a record for
+	// are present here.
 	States map[string]string
+	// NotFound holds component IDs for which the reader could not return a
+	// usable state. This can mean the record is absent or that its state was
+	// omitted; it is not a terminal-success signal.
+	NotFound []string
 }
 
 // GetDecommissionStatus returns the decommission state for target components.
 // This activity is designed to be called repeatedly in a polling loop.
+// Component IDs with an empty state are returned in NotFound rather than as
+// empty strings in States, so the caller can reject the ambiguous result.
 func (a *Activities) GetDecommissionStatus(
 	ctx context.Context,
 	target common.Target,
@@ -234,12 +241,22 @@ func (a *Activities) GetDecommissionStatus(
 		return nil, err
 	}
 
-	states, err := reader.GetDecommissionStatus(ctx, target)
+	rawStates, err := reader.GetDecommissionStatus(ctx, target)
 	if err != nil {
 		return nil, err
 	}
 
-	return &GetDecommissionStatusResult{States: states}, nil
+	result := &GetDecommissionStatusResult{
+		States: make(map[string]string, len(rawStates)),
+	}
+	for id, state := range rawStates {
+		if state == "" {
+			result.NotFound = append(result.NotFound, id)
+		} else {
+			result.States[id] = state
+		}
+	}
+	return result, nil
 }
 
 // VerifyFirmwareConsistency checks that all target components report the

--- a/rest-api/flow/internal/task/executor/temporalworkflow/workflow/actions.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/workflow/actions.go
@@ -5,6 +5,7 @@ package workflow
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -647,10 +648,24 @@ func executeDecommissionControlAction(actx actionExecutionContext) error {
 	).Get(ctx, nil)
 }
 
+// maxConsecutiveFailureDuration is the time span over which consecutive
+// GetDecommissionStatus errors must occur before the wait loop aborts.
+// A time-based budget scales with the configured poll interval rather than
+// being coupled to a fixed attempt count: a Core outage that outlasts this
+// window is treated as unrecoverable and the workflow returns an error.
+const maxConsecutiveFailureDuration = 5 * time.Minute
+
 // executeWaitDecommissionedAction polls GetDecommissionStatus until all
-// components reach the "Decommissioned" terminal state. States that begin
-// with "Decommissioning/" are in-progress; any other non-terminal state is
-// treated as an error. Uses config.Timeout and config.PollInterval.
+// components reach terminal state. The terminal value is "Decommissioning/Decommissioned".
+// Ready and the managed-host maintenance
+// states are pending because Core records the request before its controller
+// transitions the host; states beginning with "Decommissioning/" are also in
+// progress. Any other non-terminal state is a hard failure.
+//
+// Consecutive GetDecommissionStatus errors are tracked by elapsed time; after
+// maxConsecutiveFailureDuration the loop aborts rather than spinning until the
+// deadline. The initial status call uses the same failure budget as subsequent
+// polls. Uses config.Timeout and config.PollInterval.
 func executeWaitDecommissionedAction(actx actionExecutionContext) error {
 	ctx := actx.workflowContext
 	target := actx.target
@@ -664,13 +679,35 @@ func executeWaitDecommissionedAction(actx actionExecutionContext) error {
 		pollInterval = 30 * time.Second
 	}
 
+	// Establish the deadline before any activity so initial status time is charged
+	// against config.Timeout and cannot extend the total action duration.
+	deadline := workflow.Now(ctx).Add(timeout)
+
 	log.Debug().
 		Dur("timeout", timeout).
 		Dur("poll_interval", pollInterval).
 		Str("target", target.String()).
 		Msg("Waiting for decommission to complete")
 
-	deadline := workflow.Now(ctx).Add(timeout)
+	// activityOpts returns options bounded by the remaining action time so no
+	// single activity can run past the configured deadline.
+	activityOpts := func() workflow.ActivityOptions {
+		remaining := deadline.Sub(workflow.Now(ctx))
+		bound := 30 * time.Second
+		if remaining < bound {
+			bound = remaining
+		}
+		return workflow.ActivityOptions{
+			ScheduleToCloseTimeout: bound,
+			StartToCloseTimeout:    bound,
+			RetryPolicy: &temporal.RetryPolicy{
+				MaximumAttempts: 1,
+			},
+		}
+	}
+
+	var firstFailureAt time.Time
+	firstPoll := true
 
 	for {
 		if workflow.Now(ctx).After(deadline) {
@@ -679,46 +716,117 @@ func executeWaitDecommissionedAction(actx actionExecutionContext) error {
 			)
 		}
 
-		if err := workflow.Sleep(ctx, pollInterval); err != nil {
-			return fmt.Errorf("workflow sleep interrupted: %w", err)
+		if firstPoll {
+			firstPoll = false
+		} else {
+			// Cap the sleep to the remaining deadline so a large PollInterval
+			// cannot push the actual timeout past the configured bound.
+			sleep := pollInterval
+			if remaining := deadline.Sub(workflow.Now(ctx)); sleep > remaining {
+				sleep = remaining
+			}
+			if err := workflow.Sleep(ctx, sleep); err != nil {
+				return fmt.Errorf("workflow sleep interrupted: %w", err)
+			}
+
+			// Recheck after sleep using >= so that a capped sleep that lands exactly
+			// on the deadline also terminates rather than firing one more activity.
+			if !workflow.Now(ctx).Before(deadline) {
+				return fmt.Errorf(
+					"timed out waiting for decommission to complete (timeout %v)", timeout,
+				)
+			}
 		}
 
+		// Use a short fire-once policy so a hung status call fails quickly
+		// and the poll loop's time-based failure budget controls retries.
+		statusCtx := workflow.WithActivityOptions(ctx, activityOpts())
 		var result activity.GetDecommissionStatusResult
 		err := workflow.ExecuteActivity(
-			ctx, activity.NameGetDecommissionStatus, target,
-		).Get(ctx, &result)
+			statusCtx, activity.NameGetDecommissionStatus, target,
+		).Get(statusCtx, &result)
 		if err != nil {
-			log.Warn().Err(err).Msg("Failed to get decommission status, will retry")
+			now := workflow.Now(ctx)
+			if firstFailureAt.IsZero() {
+				firstFailureAt = now
+			}
+			elapsed := now.Sub(firstFailureAt)
+			log.Warn().
+				Err(err).
+				Dur("consecutive_failure_duration", elapsed).
+				Dur("limit", maxConsecutiveFailureDuration).
+				Msg("Failed to get decommission status")
+			if elapsed >= maxConsecutiveFailureDuration {
+				return fmt.Errorf(
+					"aborting: GetDecommissionStatus has been failing for %v: %w",
+					elapsed, err,
+				)
+			}
 			continue
 		}
+		firstFailureAt = time.Time{} // reset on success
 
-		allDecommissioned := true
-		for componentID, state := range result.States {
-			if state == "Decommissioned" {
-				continue
-			}
-			if strings.HasPrefix(state, "Decommissioning/") {
-				allDecommissioned = false
-				log.Debug().
-					Str("component_id", componentID).
-					Str("state", state).
-					Msg("Component still decommissioning")
-				continue
-			}
-			// Any other state is unexpected/terminal-error
-			return fmt.Errorf(
-				"decommission failed for component %s: unexpected state %q",
-				componentID, state,
-			)
+		done, err := evaluateDecommissionResult(&result)
+		if err != nil {
+			return err
 		}
-
-		if allDecommissioned {
+		if done {
 			log.Info().
-				Int("count", len(result.States)).
+				Int("states_count", len(result.States)).
 				Msg("All components decommissioned")
 			return nil
 		}
 	}
+}
+
+// evaluateDecommissionResult inspects a GetDecommissionStatusResult and
+// returns (true, nil) when every component is terminal, (false, nil) when
+// polling should continue, and (false, err) on a hard failure state.
+// NotFound entries are ambiguous and fail closed rather than being inferred as
+// terminal success.
+//
+// All entries are inspected before returning so that a hard-failure state is
+// never masked by an in-progress state that happened to be iterated first
+// (Go map iteration is unordered).
+func evaluateDecommissionResult(result *activity.GetDecommissionStatusResult) (bool, error) {
+	if len(result.States) == 0 && len(result.NotFound) == 0 {
+		return false, errors.New("decommission status result is empty")
+	}
+	if len(result.NotFound) > 0 {
+		return false, fmt.Errorf(
+			"decommission status unavailable for component IDs: %v",
+			result.NotFound,
+		)
+	}
+
+	inProgress := false
+	for componentID, state := range result.States {
+		switch {
+		case state == "Decommissioned", state == "Decommissioning/Decommissioned":
+			// Terminal success — keep scanning.
+		case state == "Ready", strings.HasPrefix(state, "Maintenance("):
+			// Core commits decommission_requested before its asynchronous
+			// controller transitions the managed host out of Ready. A pending
+			// maintenance request takes precedence without clearing that flag.
+			log.Debug().
+				Str("component_id", componentID).
+				Str("state", state).
+				Msg("Component has an accepted decommission request that is pending")
+			inProgress = true
+		case strings.HasPrefix(state, "Decommissioning/"):
+			log.Debug().
+				Str("component_id", componentID).
+				Str("state", state).
+				Msg("Component still decommissioning")
+			inProgress = true
+		default:
+			return false, fmt.Errorf(
+				"decommission failed for component %s: reached unexpected state %q",
+				componentID, state,
+			)
+		}
+	}
+	return !inProgress, nil
 }
 
 // extractOverrideReadinessCheck reads the OverrideReadinessCheck flag from

--- a/rest-api/flow/internal/task/executor/temporalworkflow/workflow/decommission_test.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/workflow/decommission_test.go
@@ -1,0 +1,339 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	temporalworkflow "go.temporal.io/sdk/workflow"
+
+	activitypkg "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/executor/temporalworkflow/activity"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/executor/temporalworkflow/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operationrules"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+// runWaitDecommissionedWorkflow is a thin test shim that invokes
+// executeWaitDecommissionedAction inside a Temporal workflow environment.
+func runWaitDecommissionedWorkflow(
+	ctx temporalworkflow.Context,
+	target common.Target,
+	cfg operationrules.ActionConfig,
+) error {
+	return executeWaitDecommissionedAction(actionExecutionContext{
+		workflowContext: ctx,
+		config:          cfg,
+		target:          target,
+	})
+}
+
+// stubGetDecommissionStatus is the no-op stub registered with the test
+// environment; OnActivity overrides the actual return value per test.
+func stubGetDecommissionStatus(_ context.Context, _ common.Target) (*activitypkg.GetDecommissionStatusResult, error) {
+	return nil, nil
+}
+
+func registerDecommissionActivities(env *testsuite.TestWorkflowEnvironment) {
+	env.RegisterWorkflowWithOptions(runWaitDecommissionedWorkflow,
+		temporalworkflow.RegisterOptions{Name: "runWaitDecommissionedWorkflow"})
+	env.RegisterActivityWithOptions(stubGetDecommissionStatus,
+		activity.RegisterOptions{Name: activitypkg.NameGetDecommissionStatus})
+}
+
+func decommissionTestTarget() common.Target {
+	return common.Target{
+		Type:         devicetypes.ComponentTypeCompute,
+		ComponentIDs: []string{"comp-1", "comp-2"},
+	}
+}
+
+func shortDecommissionConfig() operationrules.ActionConfig {
+	return operationrules.ActionConfig{
+		Timeout:      10 * time.Second,
+		PollInterval: time.Second,
+	}
+}
+
+func TestEvaluateDecommissionResult_ManagedHostTerminalState(t *testing.T) {
+	result := &activitypkg.GetDecommissionStatusResult{
+		States: map[string]string{
+			"comp-1": "Decommissioning/Decommissioned",
+		},
+	}
+
+	done, err := evaluateDecommissionResult(result)
+
+	assert.NoError(t, err)
+	assert.True(t, done)
+}
+
+func TestEvaluateDecommissionResult_EmptyResultFails(t *testing.T) {
+	done, err := evaluateDecommissionResult(&activitypkg.GetDecommissionStatusResult{})
+
+	assert.ErrorContains(t, err, "status result is empty")
+	assert.False(t, done)
+}
+
+func TestEvaluateDecommissionResult_AcceptedPendingStates(t *testing.T) {
+	for _, state := range []string{
+		"Ready",
+		"Maintenance(PowerOn)",
+		"Maintenance(PowerOff)",
+		"Maintenance(Reset)",
+		"Maintenance(FutureOperation)",
+	} {
+		t.Run(state, func(t *testing.T) {
+			result := &activitypkg.GetDecommissionStatusResult{
+				States: map[string]string{"comp-1": state},
+			}
+
+			done, err := evaluateDecommissionResult(result)
+
+			assert.NoError(t, err)
+			assert.False(t, done)
+		})
+	}
+}
+
+func TestEvaluateDecommissionResult_UnexpectedStateFails(t *testing.T) {
+	result := &activitypkg.GetDecommissionStatusResult{
+		States: map[string]string{"comp-1": "Failed/maintenance failed"},
+	}
+
+	done, err := evaluateDecommissionResult(result)
+
+	assert.Error(t, err)
+	assert.False(t, done)
+}
+
+// TestWaitDecommissioned_AllNotFound verifies that a later ambiguous lookup
+// result cannot be inferred as successful decommissioning.
+func TestWaitDecommissioned_AllNotFound(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	registerDecommissionActivities(env)
+
+	// Initial status: all IDs found in Core, still in progress.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{
+				"comp-1": "Decommissioning/step1",
+				"comp-2": "Decommissioning/step1",
+			},
+		}, nil).Once()
+
+	// First poll: neither component has a usable status.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			NotFound: []string{"comp-1", "comp-2"},
+		}, nil).Once()
+
+	env.ExecuteWorkflow(runWaitDecommissionedWorkflow, decommissionTestTarget(), shortDecommissionConfig())
+
+	assert.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "comp-1")
+	assert.Contains(t, err.Error(), "comp-2")
+}
+
+// TestWaitDecommissioned_Mixed verifies that an explicit terminal state cannot
+// mask another component whose status is unavailable.
+func TestWaitDecommissioned_Mixed(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	registerDecommissionActivities(env)
+
+	// Initial status: both IDs known.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{
+				"comp-1": "Decommissioning/step1",
+				"comp-2": "Decommissioning/step1",
+			},
+		}, nil).Once()
+
+	// First poll: comp-1 reached Decommissioned; comp-2 has no usable status.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States:   map[string]string{"comp-1": "Decommissioned"},
+			NotFound: []string{"comp-2"},
+		}, nil).Once()
+
+	env.ExecuteWorkflow(runWaitDecommissionedWorkflow, decommissionTestTarget(), shortDecommissionConfig())
+
+	assert.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "comp-2")
+}
+
+// TestWaitDecommissioned_UnknownID verifies that a component with no usable
+// status causes an immediate error rather than polling until timeout.
+func TestWaitDecommissioned_UnknownID(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	registerDecommissionActivities(env)
+
+	// Initial status: comp-1 is not found — unknown or mistyped ID.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States:   map[string]string{"comp-2": "Decommissioning/step1"},
+			NotFound: []string{"comp-1"},
+		}, nil).Once()
+
+	env.ExecuteWorkflow(runWaitDecommissionedWorkflow, decommissionTestTarget(), shortDecommissionConfig())
+
+	assert.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "comp-1")
+}
+
+// TestWaitDecommissioned_InitialStatusErrorRecovers verifies that the initial
+// status call uses the same transient-failure budget as subsequent polls.
+func TestWaitDecommissioned_InitialStatusErrorRecovers(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	registerDecommissionActivities(env)
+
+	// The first lookup fails transiently after decommissioning has started.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(nil, errors.New("Core unreachable")).Once()
+	// A later lookup recovers and reports the actual managed-host terminal state.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{
+				"comp-1": "Decommissioning/Decommissioned",
+				"comp-2": "Decommissioning/Decommissioned",
+			},
+		}, nil).Once()
+
+	env.ExecuteWorkflow(runWaitDecommissionedWorkflow, decommissionTestTarget(), shortDecommissionConfig())
+
+	assert.True(t, env.IsWorkflowCompleted())
+	assert.NoError(t, env.GetWorkflowError())
+}
+
+// TestWaitDecommissioned_AcceptedRequestPending verifies that the status poll
+// tolerates Ready and prioritized maintenance while Core retains an accepted
+// decommission request, then observes the asynchronous controller transition.
+func TestWaitDecommissioned_AcceptedRequestPending(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	registerDecommissionActivities(env)
+
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{
+				"comp-1": "Ready",
+				"comp-2": "Ready",
+			},
+		}, nil).Once()
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{
+				"comp-1": "Maintenance(Reset)",
+				"comp-2": "Maintenance(Reset)",
+			},
+		}, nil).Once()
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{
+				"comp-1": "Ready",
+				"comp-2": "Ready",
+			},
+		}, nil).Once()
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{
+				"comp-1": "Decommissioning/SuppressingSiteExplorer",
+				"comp-2": "Decommissioning/SuppressingSiteExplorer",
+			},
+		}, nil).Once()
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{
+				"comp-1": "Decommissioning/Decommissioned",
+				"comp-2": "Decommissioning/Decommissioned",
+			},
+		}, nil).Once()
+
+	env.ExecuteWorkflow(runWaitDecommissionedWorkflow, decommissionTestTarget(), shortDecommissionConfig())
+
+	assert.True(t, env.IsWorkflowCompleted())
+	assert.NoError(t, env.GetWorkflowError())
+}
+
+// TestWaitDecommissioned_PollIntervalExceedsTimeout verifies that when
+// PollInterval is longer than the configured timeout the workflow still
+// respects the timeout bound: the sleep is capped to the remaining time and
+// the deadline is re-checked immediately after waking, so the workflow does
+// not fire a full extra activity round-trip past the deadline.
+func TestWaitDecommissioned_PollIntervalExceedsTimeout(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	registerDecommissionActivities(env)
+
+	cfg := operationrules.ActionConfig{
+		Timeout:      2 * time.Second,
+		PollInterval: 10 * time.Second, // much larger than timeout
+	}
+
+	// Initial status: all IDs known, still in progress.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{"comp-1": "Decommissioning/step1"},
+		}, nil).Once()
+
+	// The loop should time out before firing a second poll — if sleep is not
+	// capped, it would sleep for 10 s past the 2 s deadline and then call the
+	// activity again. We register a second response that would indicate
+	// success; if it is reached the test fails because the timeout was ignored.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(&activitypkg.GetDecommissionStatusResult{
+			States: map[string]string{"comp-1": "Decommissioned"},
+		}, nil)
+
+	env.ExecuteWorkflow(runWaitDecommissionedWorkflow, decommissionTestTarget(), cfg)
+
+	assert.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	assert.Error(t, err, "workflow must time out, not succeed via the post-deadline poll")
+	assert.Contains(t, err.Error(), "timed out")
+}
+
+// TestWaitDecommissioned_ActivityError verifies that repeated activity errors
+// abort the workflow after maxConsecutiveFailureDuration rather than spinning
+// until the four-hour deadline. Timeout is set above maxConsecutiveFailureDuration
+// (5 min) so the test actually exercises the failure-budget path rather than
+// the normal timeout.
+func TestWaitDecommissioned_ActivityError(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	registerDecommissionActivities(env)
+
+	cfg := operationrules.ActionConfig{
+		Timeout:      10 * time.Minute, // above maxConsecutiveFailureDuration (5 min)
+		PollInterval: time.Second,
+	}
+
+	// All status calls fail.
+	env.OnActivity(activitypkg.NameGetDecommissionStatus, mock.Anything, mock.Anything).
+		Return(nil, errors.New("Core unreachable"))
+
+	env.ExecuteWorkflow(runWaitDecommissionedWorkflow, decommissionTestTarget(), cfg)
+
+	assert.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "GetDecommissionStatus has been failing")
+}

--- a/rest-api/proto/flow/gen/v1/roundtrip_test.go
+++ b/rest-api/proto/flow/gen/v1/roundtrip_test.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package flow_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	flow "github.com/NVIDIA/infra-controller/rest-api/proto/flow/gen/v1"
+)
+
+// TestDecommissionRackRequest_MarshalRoundTrip verifies that a populated
+// DecommissionRackRequest can be marshaled to protobuf bytes and unmarshaled
+// back without data loss or a panic (the manually-patched version used a
+// wrong msgTypes slot that caused a SIGSEGV during marshal).
+func TestDecommissionRackRequest_MarshalRoundTrip(t *testing.T) {
+	original := &flow.DecommissionRackRequest{
+		TargetSpec: &flow.OperationTargetSpec{
+			Targets: &flow.OperationTargetSpec_Racks{
+				Racks: &flow.RackTargets{
+					Targets: []*flow.RackTarget{
+						{Identifier: &flow.RackTarget_Id{Id: &flow.UUID{Id: "rack-uuid-1234"}}},
+					},
+				},
+			},
+		},
+		Description: "test decommission",
+		QueueOptions: &flow.QueueOptions{
+			ConflictStrategy: flow.ConflictStrategy_CONFLICT_STRATEGY_REJECT,
+		},
+		RuleId: &flow.UUID{Id: "rule-uuid-5678"},
+	}
+
+	b, err := proto.Marshal(original)
+	require.NoError(t, err, "marshal must not error or panic")
+	require.NotEmpty(t, b, "marshal must produce non-empty bytes for a populated message")
+
+	roundTripped := &flow.DecommissionRackRequest{}
+	require.NoError(t, proto.Unmarshal(b, roundTripped))
+
+	assert.True(t, proto.Equal(original, roundTripped), "round-tripped message must equal the original")
+	assert.Equal(t, "rack-uuid-1234", roundTripped.GetTargetSpec().GetRacks().GetTargets()[0].GetId().GetId())
+	assert.Equal(t, "test decommission", roundTripped.GetDescription())
+	assert.Equal(t, flow.ConflictStrategy_CONFLICT_STRATEGY_REJECT, roundTripped.GetQueueOptions().GetConflictStrategy())
+	assert.Equal(t, "rule-uuid-5678", roundTripped.GetRuleId().GetId())
+}


### PR DESCRIPTION
This is a re-issue of #5003 to restart the CI pipeline, incorporating all follow-up review feedback from that PR.

Adds rack-scale decommission support to the Flow service: a new `DecommissionRack` RPC and the workflow machinery to drive it. The RPC is guarded as `Unimplemented` until the switch and power-shelf decommission Core RPCs are merged (`DecommissionMachine` is already implemented); the guard can be lifted in a single-line follow-up once they land.

**Proto mirror sync (`rest-api/proto/flow/`)**
- Regenerated `gen/v1/` via `make flow-proto` (replaces the manual patch from #5003, which used the wrong `msgTypes` slot and caused a SIGSEGV on marshal)
- Added `DecommissionRack` RPC and `DecommissionRackRequest` to the source proto and mirror

**Poll loop (`executeWaitDecommissionedAction`)**
- Terminal state is `"Decommissioning/Decommissioned"`, so Core retains the managed-host record and transitions it rather than removing it
- `Ready` and `Maintenance(...)` states are treated as in-progress because Core records the decommission request before the machine controller begins the transition; arbitrary unknown and failure states fail the workflow immediately
- `NotFound` results fail closed at every poll, so record absence is ambiguous (unknown ID vs. transient lookup gap) and cannot be inferred as success
- Activity options bounded by remaining action time so neither the status call nor the sleep can extend the total action duration past `config.Timeout`
- Sleep capped to remaining deadline with a post-sleep `>=` recheck, preventing a large `PollInterval` from overshooting the configured bound
- Time-based consecutive-failure budget (`maxConsecutiveFailureDuration = 5 min`) replaces the previous count-based approach
- All state entries scanned before returning from `evaluateDecommissionResult` so a hard-failure state cannot be masked by an in-progress entry visited first (Go map iteration is unordered)

**Activity result type**
- `GetDecommissionStatusResult` carries `States` (components Core returned a record for) and `NotFound` (absent components) separately

**Known follow-ups (non-blocking while the endpoint is gated)**
- Core decommission control should become idempotent before the guard is removed: a repeated request for a host already in `Decommissioning/*` or `Decommissioning/Decommissioned` should succeed as a no-op rather than return `FailedPrecondition`; the follow-up should also cover state divergence where Flow can fail or time out while Core retains `decommission_requested`
- The consecutive-failure sleep should eventually be capped by the remaining failure budget; with `PollInterval > 5m` enforcement can currently be delayed until the next poll (non-blocking: default poll interval is 30 seconds and the endpoint is gated)

## Related issues
#5003, #4408

## Type of Change
- [x] **Add** - New feature or capability

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated

## Additional Notes                                                                              
`DecommissionRack` is kept behind an `Unimplemented` guard, and no decommission tasks can be created in production until the remaining Core RPCs are merged.