### PR TITLE
fix(auth): allow anonymous callers to GetJWKS and GetOpenIDConfiguration

### DIFF
--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -1102,6 +1102,17 @@ mod rbac_rule_tests {
     }
 
     #[test]
+    fn anonymous_rules_allow_certless_callers() {
+        // Certless callers must be allowed when a rule lists Anonymous among other principals.
+        for method in ["GetJWKS", "GetOpenIDConfiguration"] {
+            assert!(
+                InternalRBACRules::allowed_from_static(method, &[]),
+                "{method}"
+            );
+        }
+    }
+
+    #[test]
     fn rbac_rule_tests() -> Result<(), eyre::Report> {
         assert!(InternalRBACRules::allowed_from_static(
             "Version",

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -943,8 +943,8 @@ impl InternalRBACRules {
     pub(super) fn allowed(&self, msg: &str, user_principals: &[crate::auth::Principal]) -> bool {
         if let Some(perm_info) = self.perms.get(msg) {
             if user_principals.is_empty() {
-                // No proper cert presented, but we will allow stuff that allows just Anonymous
-                return perm_info.principals.as_slice() == [Principal::Anonymous];
+                // No proper cert presented, but we allow any rule that lists Anonymous.
+                return perm_info.principals.contains(&Principal::Anonymous);
             }
             user_principals.iter().any(|user_principal| {
                 perm_info


### PR DESCRIPTION
## Related issues
nvbug 6504386

## Description
Two public Core gRPC calls, `GetJWKS` and `GetOpenIDConfiguration`, were wrongly returning 403 to callers with no client certificate, even though they're supposed to allow anonymous access. 

Root cause: in `InternalRBACRules::allowed`, the "no client certificate" branch allowed a request only when the rule's principal set was *exactly* `[Anonymous]`. The affected rules are `[Anonymous, Agent, ForgeAdminCLI, SiteAgent]`, so the exact-match check failed and certless callers were denied. The fix changes that check from exact equality to membership, so any rule that *lists* `Anonymous` allows certless callers, while rules without `Anonymous` still reject them.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Ran Core locally with permission checks turned on and called the two RPCs with no client certificate:
- Before the fix: both returned 403.
- After the fix: both worked (no 403).

## Additional Notes
One-line change in `InternalRBACRules::allowed`: check whether the rule *contains* Anonymous instead of checking that the rule *equals* exactly `[Anonymous]`.