### PR TITLE
fix(dev): disable RMS for devspace/tilt local development

### DIFF
--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -15,6 +15,12 @@ nico-api:
       memory: "1Gi"
   webAuth:
     mode: "none"
+  # DevSpace does not deploy rack-manager. Do not render RMS-backed services
+  # into nico-api's configuration when their backend is absent.
+  componentManager:
+    enabled: false
+  rms:
+    enabled: false
   siteConfig:
     enabled: true
     nicoApiSiteConfig: |

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -30,6 +30,10 @@ nico-api:
       value: "1"
   webAuth:
     mode: none
+  componentManager:
+    enabled: false
+  rms:
+    enabled: false
   siteConfig:
     enabled: true
     nicoApiSiteConfig: |


### PR DESCRIPTION
Today neigther tilt nor devspace deploy RMS. Machine also doesn't have RMS simulation. This causes additional errors / delays in machine creation. 

## Related issues

Related to #5074 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
