### PR TITLE
Fix rms rack firmware completion

### DIFF
--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -8236,13 +8236,18 @@ impl StateHandler for InstanceStateHandler {
                         .host_reprovision_requested
                         .is_some()
                     {
+                        let reprovision_state = if is_rack_level_reprovisioning(mh_snapshot) {
+                            HostReprovisionState::WaitingForRackFirmwareUpgrade
+                        } else {
+                            HostReprovisionState::CheckingFirmwareV2 {
+                                firmware_type: None,
+                                firmware_number: None,
+                            }
+                        };
                         Ok(StateHandlerOutcome::transition(
                             ManagedHostState::Assigned {
                                 instance_state: InstanceState::HostReprovision {
-                                    reprovision_state: HostReprovisionState::CheckingFirmwareV2 {
-                                        firmware_type: None,
-                                        firmware_number: None,
-                                    },
+                                    reprovision_state,
                                 },
                             },
                         ))
@@ -9432,6 +9437,25 @@ impl HostUpgradeState {
                     machine_id: *machine_id,
                     clear_reset: true,
                 });
+        }
+
+        if is_rack_level_reprovisioning(state)
+            && matches!(
+                host_reprovision_state,
+                HostReprovisionState::CheckingFirmware
+                    | HostReprovisionState::CheckingFirmwareRepeat
+                    | HostReprovisionState::CheckingFirmwareV2 { .. }
+                    | HostReprovisionState::CheckingFirmwareRepeatV2 { .. }
+            )
+        {
+            tracing::info!(
+                %machine_id,
+                "Rack-level firmware upgrade bypassing legacy host firmware checks"
+            );
+            return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
+                HostReprovisionState::WaitingForRackFirmwareUpgrade,
+                retry_count,
+            )));
         }
 
         match host_reprovision_state {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -9376,7 +9376,7 @@ impl HostUpgradeState {
 
         // Treat Ready (but flagged to do updates) the same as HostReprovisionState/CheckingFirmware
         let original_state = &state.managed_state.clone();
-        let (mut host_reprovision_state, retry_count) = match &state.managed_state {
+        let (mut host_reprovision_state, mut retry_count) = match &state.managed_state {
             ManagedHostState::HostReprovision {
                 reprovision_state,
                 retry_count,
@@ -9421,6 +9421,7 @@ impl HostUpgradeState {
             })
         {
             tracing::info!(%machine_id, "Host firmware upgrade reset requested, returning to CheckingFirmwareRepeat");
+            retry_count = 0;
             host_reprovision_state = &HostReprovisionState::CheckingFirmwareRepeatV2 {
                 firmware_type: None,
                 firmware_number: None,

--- a/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
+++ b/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
@@ -193,7 +193,7 @@ async fn advances_on_completion(pool: PgPool) {
 }
 
 #[sqlx_test]
-async fn assigned_host_returns_to_assigned_ready_on_completion(
+async fn assigned_host_bypasses_legacy_check_and_returns_ready_on_completion(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut env = Env::builder(pool).build().await;
@@ -204,7 +204,10 @@ async fn assigned_host_returns_to_assigned_ready_on_completion(
         &host,
         ManagedHostState::Assigned {
             instance_state: InstanceState::HostReprovision {
-                reprovision_state: HostReprovisionState::WaitingForRackFirmwareUpgrade,
+                reprovision_state: HostReprovisionState::CheckingFirmwareV2 {
+                    firmware_type: None,
+                    firmware_number: None,
+                },
             },
         },
         RackFirmwareUpgradeState::Completed,
@@ -212,6 +215,19 @@ async fn assigned_host_returns_to_assigned_ready_on_completion(
         Some(chrono::Duration::zero()),
     )
     .await;
+
+    env.run_single_iteration().await;
+
+    let machine = host.host.machine().await;
+    assert!(matches!(
+        machine.current_state(),
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::HostReprovision {
+                reprovision_state: HostReprovisionState::WaitingForRackFirmwareUpgrade,
+            },
+        }
+    ));
+    assert!(machine.host_reprovision_requested.is_some());
 
     env.run_single_iteration().await;
 

--- a/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
+++ b/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
@@ -193,6 +193,51 @@ async fn advances_on_completion(pool: PgPool) {
 }
 
 #[sqlx_test]
+async fn rack_reset_clears_host_reprovision_retry_count(pool: PgPool) {
+    let mut env = Env::builder(pool).build().await;
+    let host = managed_host(&env.test_harness).await;
+    prepare_rack_upgrade(
+        &env.test_harness,
+        &host,
+        ManagedHostState::HostReprovision {
+            reprovision_state: HostReprovisionState::CheckingFirmwareV2 {
+                firmware_type: None,
+                firmware_number: None,
+            },
+            retry_count: 3,
+        },
+        RackFirmwareUpgradeState::InProgress,
+        chrono::Duration::zero(),
+        None,
+    )
+    .await;
+
+    let mut txn = env.test_harness.db_txn().await;
+    db::host_machine_update::reset_host_reprovisioning_request(txn.as_mut(), &host.host.id, false)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_single_iteration().await;
+
+    let machine = host.host.machine().await;
+    assert!(matches!(
+        machine.current_state(),
+        ManagedHostState::HostReprovision {
+            reprovision_state: HostReprovisionState::WaitingForRackFirmwareUpgrade,
+            retry_count: 0,
+        }
+    ));
+    assert_eq!(
+        machine
+            .host_reprovision_requested
+            .as_ref()
+            .and_then(|request| request.request_reset),
+        Some(false)
+    );
+}
+
+#[sqlx_test]
 async fn assigned_host_bypasses_legacy_check_and_returns_ready_on_completion(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
After an RMS-managed rack firmware update completed, NICO could enter the legacy firmware path and attempt a redundant update based on known_firmware.
This change ensures rack-initiated updates bypass legacy firmware checks and return the host to Ready or Assigned/Ready after RMS completes.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/2016

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


