### PR TITLE
fix(instrument): stabilize concurrent log capture

### DIFF
--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -92,6 +92,7 @@ impl CapturedLog {
 /// events at every level. Internal diagnostics whose target starts with
 /// `opentelemetry` are excluded.
 pub fn capture_logs(f: impl FnOnce()) -> Vec<CapturedLog> {
+    keep_callsites_enabled();
     let captured = Arc::new(Mutex::new(Vec::new()));
     let layer = CaptureLayer {
         captured: captured.clone(),
@@ -114,6 +115,7 @@ pub async fn capture_logs_async<F>(future: F) -> (F::Output, Vec<CapturedLog>)
 where
     F: Future,
 {
+    keep_callsites_enabled();
     let captured = Arc::new(Mutex::new(Vec::new()));
     let layer = CaptureLayer {
         captured: captured.clone(),
@@ -122,6 +124,17 @@ where
     let output = future.with_subscriber(subscriber).await;
     let logs = captured.lock().unwrap_or_else(|p| p.into_inner());
     (output, logs.clone())
+}
+
+/// Keeps tracing's process-wide callsite cache interested at every level.
+///
+/// A test harness may run capture and non-capture tests concurrently. Without
+/// a persistent interested dispatch, registering or dropping their temporary
+/// dispatches can rebuild the global callsite cache while another capture is
+/// active and briefly disable records that its subscriber accepts.
+fn keep_callsites_enabled() {
+    static DISPATCH: OnceLock<tracing::Dispatch> = OnceLock::new();
+    DISPATCH.get_or_init(|| tracing::Dispatch::new(tracing_subscriber::registry()));
 }
 
 struct CaptureLayer {


### PR DESCRIPTION
## What changed

Keep a persistent, always-interested tracing dispatch alive whenever the test log-capture helpers are used. Both synchronous and asynchronous capture paths initialize it before installing their temporary capture subscriber.

## Why

Parallel tests can register and drop temporary tracing dispatches while other tests emit records. Those changes rebuild tracing's process-wide callsite interest cache and can briefly mark INFO or DEBUG callsites disabled, causing `capture_logs` and `capture_logs_async` to miss records nondeterministically.

This surfaced in `carbide-dhcp-server` as intermittent failures in `process_packet_logs_and_counts_the_decoded_request` and `packet_events_count_per_label_and_log_at_their_operational_level`.

Before: failure in a range of 1 to 30 iterations.
After: no failure in 5000 iterations.

## Impact

Test log capture remains deterministic when capture and non-capture tests execute concurrently. Production instrumentation is unchanged because the helper is available only with test support.

## Validation

- Reproduced the unfixed workspace artifact failing after 204 runs and again after 30 runs.
- Ran the fixed package-mode DHCP test binary 5,000 times successfully on Linux.
- Ran the fixed workspace-mode DHCP test binary 5,000 times successfully on Linux.
- `cargo test -p carbide-instrument`
- `cargo clippy -p carbide-instrument --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`