### PR TITLE
fix(sdk): tolerate additive response fields

### DIFF
--- a/rest-api/openapi/templates/go/model_simple.mustache
+++ b/rest-api/openapi/templates/go/model_simple.mustache
@@ -548,7 +548,6 @@ func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 	var{{{classname}}} := _{{{classname}}}{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&var{{{classname}}})
 
 	if err != nil {
@@ -570,4 +569,3 @@ func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 {{/isArray}}
 {{/vendorExtensions.x-go-generate-unmarshal-json}}
 {{>nullable_model}}
-

--- a/rest-api/sdk/standard/dpu_machine_test.go
+++ b/rest-api/sdk/standard/dpu_machine_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package standard
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDpuMachineUnmarshalJSON(t *testing.T) {
+	// "observed_at" is an additive server field absent from OpenAPI.
+	const response = `{
+		"id": "dpu-1",
+		"infrastructureProviderId": "provider-1",
+		"siteId": "site-1",
+		"hostMachineId": "host-1",
+		"dmiData": {"productSerial": "dpu-serial-1"},
+		"health": {
+			"observedAt": "2026-01-01T00:00:00Z",
+			"observed_at": "2026-01-01T00:00:00Z"
+		},
+		"state": "Ready",
+		"dpuNetworkConfig": {
+			"asn": 64512,
+			"vniDevice": "dpu-vni",
+			"managedHostConfigVersion": "v1",
+			"useAdminNetwork": true,
+			"remoteId": "remote-1",
+			"vpcIsolationBehavior": "Strict",
+			"statefulAclsEnabled": true,
+			"enableDhcp": true,
+			"isPrimaryDpu": true,
+			"datacenterAsn": 64513
+		}
+	}`
+
+	t.Run("allows additive fields", func(t *testing.T) {
+		var machine DpuMachine
+		require.NoError(t, json.Unmarshal([]byte(response), &machine))
+		require.Equal(t, "dpu-1", machine.Id)
+		require.Equal(t, "dpu-serial-1", machine.DmiData.GetProductSerial())
+		require.Equal(t, "2026-01-01T00:00:00Z", machine.Health.GetObservedAt())
+		require.Equal(t, "Ready", machine.State)
+		require.Equal(t, int32(64512), machine.DpuNetworkConfig.Asn)
+		require.Equal(t, "dpu-vni", machine.DpuNetworkConfig.VniDevice)
+	})
+
+	t.Run("requires schema fields", func(t *testing.T) {
+		withoutState := strings.Replace(response, "\t\t\"state\": \"Ready\",\n", "", 1)
+
+		var machine DpuMachine
+		require.Error(t, json.Unmarshal([]byte(withoutState), &machine))
+	})
+}

--- a/rest-api/sdk/standard/model_action_config.go
+++ b/rest-api/sdk/standard/model_action_config.go
@@ -222,7 +222,6 @@ func (o *ActionConfig) UnmarshalJSON(data []byte) (err error) {
 	varActionConfig := _ActionConfig{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varActionConfig)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_advance_task_run_request.go
+++ b/rest-api/sdk/standard/model_advance_task_run_request.go
@@ -148,7 +148,6 @@ func (o *AdvanceTaskRunRequest) UnmarshalJSON(data []byte) (err error) {
 	varAdvanceTaskRunRequest := _AdvanceTaskRunRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAdvanceTaskRunRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_allocation_constraint_create_request.go
+++ b/rest-api/sdk/standard/model_allocation_constraint_create_request.go
@@ -198,7 +198,6 @@ func (o *AllocationConstraintCreateRequest) UnmarshalJSON(data []byte) (err erro
 	varAllocationConstraintCreateRequest := _AllocationConstraintCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAllocationConstraintCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_allocation_constraint_update_request.go
+++ b/rest-api/sdk/standard/model_allocation_constraint_update_request.go
@@ -111,7 +111,6 @@ func (o *AllocationConstraintUpdateRequest) UnmarshalJSON(data []byte) (err erro
 	varAllocationConstraintUpdateRequest := _AllocationConstraintUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAllocationConstraintUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_allocation_create_request.go
+++ b/rest-api/sdk/standard/model_allocation_create_request.go
@@ -254,7 +254,6 @@ func (o *AllocationCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varAllocationCreateRequest := _AllocationCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAllocationCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_batch_bring_up_rack_request.go
+++ b/rest-api/sdk/standard/model_batch_bring_up_rack_request.go
@@ -263,7 +263,6 @@ func (o *BatchBringUpRackRequest) UnmarshalJSON(data []byte) (err error) {
 	varBatchBringUpRackRequest := _BatchBringUpRackRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBatchBringUpRackRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_batch_instance_create_request.go
+++ b/rest-api/sdk/standard/model_batch_instance_create_request.go
@@ -878,7 +878,6 @@ func (o *BatchInstanceCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varBatchInstanceCreateRequest := _BatchInstanceCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBatchInstanceCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_batch_rack_firmware_update_request.go
+++ b/rest-api/sdk/standard/model_batch_rack_firmware_update_request.go
@@ -274,7 +274,6 @@ func (o *BatchRackFirmwareUpdateRequest) UnmarshalJSON(data []byte) (err error) 
 	varBatchRackFirmwareUpdateRequest := _BatchRackFirmwareUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBatchRackFirmwareUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_batch_tray_firmware_update_request.go
+++ b/rest-api/sdk/standard/model_batch_tray_firmware_update_request.go
@@ -311,7 +311,6 @@ func (o *BatchTrayFirmwareUpdateRequest) UnmarshalJSON(data []byte) (err error) 
 	varBatchTrayFirmwareUpdateRequest := _BatchTrayFirmwareUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBatchTrayFirmwareUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_batch_update_rack_power_state_request.go
+++ b/rest-api/sdk/standard/model_batch_update_rack_power_state_request.go
@@ -255,7 +255,6 @@ func (o *BatchUpdateRackPowerStateRequest) UnmarshalJSON(data []byte) (err error
 	varBatchUpdateRackPowerStateRequest := _BatchUpdateRackPowerStateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBatchUpdateRackPowerStateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_batch_update_tray_power_state_request.go
+++ b/rest-api/sdk/standard/model_batch_update_tray_power_state_request.go
@@ -255,7 +255,6 @@ func (o *BatchUpdateTrayPowerStateRequest) UnmarshalJSON(data []byte) (err error
 	varBatchUpdateTrayPowerStateRequest := _BatchUpdateTrayPowerStateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBatchUpdateTrayPowerStateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_bmc_credential.go
+++ b/rest-api/sdk/standard/model_bmc_credential.go
@@ -214,7 +214,6 @@ func (o *BMCCredential) UnmarshalJSON(data []byte) (err error) {
 	varBMCCredential := _BMCCredential{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBMCCredential)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_bmc_credential_request.go
+++ b/rest-api/sdk/standard/model_bmc_credential_request.go
@@ -243,7 +243,6 @@ func (o *BMCCredentialRequest) UnmarshalJSON(data []byte) (err error) {
 	varBMCCredentialRequest := _BMCCredentialRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBMCCredentialRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_bring_up_rack_request.go
+++ b/rest-api/sdk/standard/model_bring_up_rack_request.go
@@ -226,7 +226,6 @@ func (o *BringUpRackRequest) UnmarshalJSON(data []byte) (err error) {
 	varBringUpRackRequest := _BringUpRackRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBringUpRackRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_cancel_task_request.go
+++ b/rest-api/sdk/standard/model_cancel_task_request.go
@@ -111,7 +111,6 @@ func (o *CancelTaskRequest) UnmarshalJSON(data []byte) (err error) {
 	varCancelTaskRequest := _CancelTaskRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCancelTaskRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_cancel_task_run_request.go
+++ b/rest-api/sdk/standard/model_cancel_task_run_request.go
@@ -148,7 +148,6 @@ func (o *CancelTaskRunRequest) UnmarshalJSON(data []byte) (err error) {
 	varCancelTaskRunRequest := _CancelTaskRunRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCancelTaskRunRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_create_rule_request.go
+++ b/rest-api/sdk/standard/model_create_rule_request.go
@@ -263,7 +263,6 @@ func (o *CreateRuleRequest) UnmarshalJSON(data []byte) (err error) {
 	varCreateRuleRequest := _CreateRuleRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCreateRuleRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_create_task_run_request.go
+++ b/rest-api/sdk/standard/model_create_task_run_request.go
@@ -270,7 +270,6 @@ func (o *CreateTaskRunRequest) UnmarshalJSON(data []byte) (err error) {
 	varCreateTaskRunRequest := _CreateTaskRunRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCreateTaskRunRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_credential_rotation_request.go
+++ b/rest-api/sdk/standard/model_credential_rotation_request.go
@@ -214,7 +214,6 @@ func (o *CredentialRotationRequest) UnmarshalJSON(data []byte) (err error) {
 	varCredentialRotationRequest := _CredentialRotationRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCredentialRotationRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_credential_rotation_result.go
+++ b/rest-api/sdk/standard/model_credential_rotation_result.go
@@ -189,7 +189,6 @@ func (o *CredentialRotationResult) UnmarshalJSON(data []byte) (err error) {
 	varCredentialRotationResult := _CredentialRotationResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCredentialRotationResult)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_credential_rotation_status.go
+++ b/rest-api/sdk/standard/model_credential_rotation_status.go
@@ -350,7 +350,6 @@ func (o *CredentialRotationStatus) UnmarshalJSON(data []byte) (err error) {
 	varCredentialRotationStatus := _CredentialRotationStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCredentialRotationStatus)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_device_credential_rotation_status.go
+++ b/rest-api/sdk/standard/model_device_credential_rotation_status.go
@@ -439,7 +439,6 @@ func (o *DeviceCredentialRotationStatus) UnmarshalJSON(data []byte) (err error) 
 	varDeviceCredentialRotationStatus := _DeviceCredentialRotationStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDeviceCredentialRotationStatus)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_dpu_extension_service_create_request.go
+++ b/rest-api/sdk/standard/model_dpu_extension_service_create_request.go
@@ -320,7 +320,6 @@ func (o *DpuExtensionServiceCreateRequest) UnmarshalJSON(data []byte) (err error
 	varDpuExtensionServiceCreateRequest := _DpuExtensionServiceCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDpuExtensionServiceCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_dpu_extension_service_observability_logging.go
+++ b/rest-api/sdk/standard/model_dpu_extension_service_observability_logging.go
@@ -111,7 +111,6 @@ func (o *DpuExtensionServiceObservabilityLogging) UnmarshalJSON(data []byte) (er
 	varDpuExtensionServiceObservabilityLogging := _DpuExtensionServiceObservabilityLogging{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDpuExtensionServiceObservabilityLogging)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_dpu_extension_service_observability_prometheus.go
+++ b/rest-api/sdk/standard/model_dpu_extension_service_observability_prometheus.go
@@ -140,7 +140,6 @@ func (o *DpuExtensionServiceObservabilityPrometheus) UnmarshalJSON(data []byte) 
 	varDpuExtensionServiceObservabilityPrometheus := _DpuExtensionServiceObservabilityPrometheus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDpuExtensionServiceObservabilityPrometheus)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_dpu_interface_config.go
+++ b/rest-api/sdk/standard/model_dpu_interface_config.go
@@ -760,7 +760,6 @@ func (o *DpuInterfaceConfig) UnmarshalJSON(data []byte) (err error) {
 	varDpuInterfaceConfig := _DpuInterfaceConfig{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDpuInterfaceConfig)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_dpu_machine.go
+++ b/rest-api/sdk/standard/model_dpu_machine.go
@@ -601,7 +601,6 @@ func (o *DpuMachine) UnmarshalJSON(data []byte) (err error) {
 	varDpuMachine := _DpuMachine{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDpuMachine)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_dpu_network_config.go
+++ b/rest-api/sdk/standard/model_dpu_network_config.go
@@ -1185,7 +1185,6 @@ func (o *DpuNetworkConfig) UnmarshalJSON(data []byte) (err error) {
 	varDpuNetworkConfig := _DpuNetworkConfig{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDpuNetworkConfig)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_dpu_reprovision_request.go
+++ b/rest-api/sdk/standard/model_dpu_reprovision_request.go
@@ -193,7 +193,6 @@ func (o *DpuReprovisionRequest) UnmarshalJSON(data []byte) (err error) {
 	varDpuReprovisionRequest := _DpuReprovisionRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDpuReprovisionRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_endpoint_exploration_report.go
+++ b/rest-api/sdk/standard/model_endpoint_exploration_report.go
@@ -628,7 +628,6 @@ func (o *EndpointExplorationReport) UnmarshalJSON(data []byte) (err error) {
 	varEndpointExplorationReport := _EndpointExplorationReport{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varEndpointExplorationReport)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_expected_machine_create_request.go
+++ b/rest-api/sdk/standard/model_expected_machine_create_request.go
@@ -905,7 +905,6 @@ func (o *ExpectedMachineCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varExpectedMachineCreateRequest := _ExpectedMachineCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExpectedMachineCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_expected_power_shelf_create_request.go
+++ b/rest-api/sdk/standard/model_expected_power_shelf_create_request.go
@@ -734,7 +734,6 @@ func (o *ExpectedPowerShelfCreateRequest) UnmarshalJSON(data []byte) (err error)
 	varExpectedPowerShelfCreateRequest := _ExpectedPowerShelfCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExpectedPowerShelfCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_expected_rack_create_request.go
+++ b/rest-api/sdk/standard/model_expected_rack_create_request.go
@@ -302,7 +302,6 @@ func (o *ExpectedRackCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varExpectedRackCreateRequest := _ExpectedRackCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExpectedRackCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_expected_rack_list.go
+++ b/rest-api/sdk/standard/model_expected_rack_list.go
@@ -140,7 +140,6 @@ func (o *ExpectedRackList) UnmarshalJSON(data []byte) (err error) {
 	varExpectedRackList := _ExpectedRackList{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExpectedRackList)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_expected_switch_create_request.go
+++ b/rest-api/sdk/standard/model_expected_switch_create_request.go
@@ -867,7 +867,6 @@ func (o *ExpectedSwitchCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varExpectedSwitchCreateRequest := _ExpectedSwitchCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExpectedSwitchCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_boot_option.go
+++ b/rest-api/sdk/standard/model_explored_boot_option.go
@@ -232,7 +232,6 @@ func (o *ExploredBootOption) UnmarshalJSON(data []byte) (err error) {
 	varExploredBootOption := _ExploredBootOption{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredBootOption)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_chassis.go
+++ b/rest-api/sdk/standard/model_explored_chassis.go
@@ -334,7 +334,6 @@ func (o *ExploredChassis) UnmarshalJSON(data []byte) (err error) {
 	varExploredChassis := _ExploredChassis{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredChassis)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_computer_system.go
+++ b/rest-api/sdk/standard/model_explored_computer_system.go
@@ -423,7 +423,6 @@ func (o *ExploredComputerSystem) UnmarshalJSON(data []byte) (err error) {
 	varExploredComputerSystem := _ExploredComputerSystem{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredComputerSystem)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_endpoint.go
+++ b/rest-api/sdk/standard/model_explored_endpoint.go
@@ -379,7 +379,6 @@ func (o *ExploredEndpoint) UnmarshalJSON(data []byte) (err error) {
 	varExploredEndpoint := _ExploredEndpoint{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredEndpoint)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_inventory.go
+++ b/rest-api/sdk/standard/model_explored_inventory.go
@@ -251,7 +251,6 @@ func (o *ExploredInventory) UnmarshalJSON(data []byte) (err error) {
 	varExploredInventory := _ExploredInventory{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredInventory)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_lockdown_status.go
+++ b/rest-api/sdk/standard/model_explored_lockdown_status.go
@@ -138,7 +138,6 @@ func (o *ExploredLockdownStatus) UnmarshalJSON(data []byte) (err error) {
 	varExploredLockdownStatus := _ExploredLockdownStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredLockdownStatus)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_machine_boot_interface_pair.go
+++ b/rest-api/sdk/standard/model_explored_machine_boot_interface_pair.go
@@ -138,7 +138,6 @@ func (o *ExploredMachineBootInterfacePair) UnmarshalJSON(data []byte) (err error
 	varExploredMachineBootInterfacePair := _ExploredMachineBootInterfacePair{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredMachineBootInterfacePair)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_machine_setup_diff.go
+++ b/rest-api/sdk/standard/model_explored_machine_setup_diff.go
@@ -166,7 +166,6 @@ func (o *ExploredMachineSetupDiff) UnmarshalJSON(data []byte) (err error) {
 	varExploredMachineSetupDiff := _ExploredMachineSetupDiff{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredMachineSetupDiff)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_machine_setup_status.go
+++ b/rest-api/sdk/standard/model_explored_machine_setup_status.go
@@ -182,7 +182,6 @@ func (o *ExploredMachineSetupStatus) UnmarshalJSON(data []byte) (err error) {
 	varExploredMachineSetupStatus := _ExploredMachineSetupStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredMachineSetupStatus)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_manager.go
+++ b/rest-api/sdk/standard/model_explored_manager.go
@@ -146,7 +146,6 @@ func (o *ExploredManager) UnmarshalJSON(data []byte) (err error) {
 	varExploredManager := _ExploredManager{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredManager)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_network_adapter.go
+++ b/rest-api/sdk/standard/model_explored_network_adapter.go
@@ -298,7 +298,6 @@ func (o *ExploredNetworkAdapter) UnmarshalJSON(data []byte) (err error) {
 	varExploredNetworkAdapter := _ExploredNetworkAdapter{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredNetworkAdapter)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_secure_boot_status.go
+++ b/rest-api/sdk/standard/model_explored_secure_boot_status.go
@@ -110,7 +110,6 @@ func (o *ExploredSecureBootStatus) UnmarshalJSON(data []byte) (err error) {
 	varExploredSecureBootStatus := _ExploredSecureBootStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredSecureBootStatus)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_service.go
+++ b/rest-api/sdk/standard/model_explored_service.go
@@ -146,7 +146,6 @@ func (o *ExploredService) UnmarshalJSON(data []byte) (err error) {
 	varExploredService := _ExploredService{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredService)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_explored_system_status.go
+++ b/rest-api/sdk/standard/model_explored_system_status.go
@@ -204,7 +204,6 @@ func (o *ExploredSystemStatus) UnmarshalJSON(data []byte) (err error) {
 	varExploredSystemStatus := _ExploredSystemStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varExploredSystemStatus)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_firmware_update_request.go
+++ b/rest-api/sdk/standard/model_firmware_update_request.go
@@ -274,7 +274,6 @@ func (o *FirmwareUpdateRequest) UnmarshalJSON(data []byte) (err error) {
 	varFirmwareUpdateRequest := _FirmwareUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varFirmwareUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_host_firmware_artifact.go
+++ b/rest-api/sdk/standard/model_host_firmware_artifact.go
@@ -148,7 +148,6 @@ func (o *HostFirmwareArtifact) UnmarshalJSON(data []byte) (err error) {
 	varHostFirmwareArtifact := _HostFirmwareArtifact{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varHostFirmwareArtifact)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_host_firmware_component.go
+++ b/rest-api/sdk/standard/model_host_firmware_component.go
@@ -213,7 +213,6 @@ func (o *HostFirmwareComponent) UnmarshalJSON(data []byte) (err error) {
 	varHostFirmwareComponent := _HostFirmwareComponent{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varHostFirmwareComponent)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_host_firmware_component_config.go
+++ b/rest-api/sdk/standard/model_host_firmware_component_config.go
@@ -176,7 +176,6 @@ func (o *HostFirmwareComponentConfig) UnmarshalJSON(data []byte) (err error) {
 	varHostFirmwareComponentConfig := _HostFirmwareComponentConfig{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varHostFirmwareComponentConfig)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_host_firmware_config.go
+++ b/rest-api/sdk/standard/model_host_firmware_config.go
@@ -286,7 +286,6 @@ func (o *HostFirmwareConfig) UnmarshalJSON(data []byte) (err error) {
 	varHostFirmwareConfig := _HostFirmwareConfig{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varHostFirmwareConfig)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_host_firmware_config_create_or_update_request.go
+++ b/rest-api/sdk/standard/model_host_firmware_config_create_or_update_request.go
@@ -272,7 +272,6 @@ func (o *HostFirmwareConfigCreateOrUpdateRequest) UnmarshalJSON(data []byte) (er
 	varHostFirmwareConfigCreateOrUpdateRequest := _HostFirmwareConfigCreateOrUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varHostFirmwareConfigCreateOrUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_host_firmware_config_delete_request.go
+++ b/rest-api/sdk/standard/model_host_firmware_config_delete_request.go
@@ -169,7 +169,6 @@ func (o *HostFirmwareConfigDeleteRequest) UnmarshalJSON(data []byte) (err error)
 	varHostFirmwareConfigDeleteRequest := _HostFirmwareConfigDeleteRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varHostFirmwareConfigDeleteRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_host_firmware_version_config.go
+++ b/rest-api/sdk/standard/model_host_firmware_version_config.go
@@ -337,7 +337,6 @@ func (o *HostFirmwareVersionConfig) UnmarshalJSON(data []byte) (err error) {
 	varHostFirmwareVersionConfig := _HostFirmwareVersionConfig{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varHostFirmwareVersionConfig)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_infini_band_partition_create_request.go
+++ b/rest-api/sdk/standard/model_infini_band_partition_create_request.go
@@ -225,7 +225,6 @@ func (o *InfiniBandPartitionCreateRequest) UnmarshalJSON(data []byte) (err error
 	varInfiniBandPartitionCreateRequest := _InfiniBandPartitionCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varInfiniBandPartitionCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_infini_band_partition_update_request.go
+++ b/rest-api/sdk/standard/model_infini_band_partition_update_request.go
@@ -196,7 +196,6 @@ func (o *InfiniBandPartitionUpdateRequest) UnmarshalJSON(data []byte) (err error
 	varInfiniBandPartitionUpdateRequest := _InfiniBandPartitionUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varInfiniBandPartitionUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_instance_create_request.go
+++ b/rest-api/sdk/standard/model_instance_create_request.go
@@ -912,7 +912,6 @@ func (o *InstanceCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varInstanceCreateRequest := _InstanceCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varInstanceCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_instance_type_create_request.go
+++ b/rest-api/sdk/standard/model_instance_type_create_request.go
@@ -310,7 +310,6 @@ func (o *InstanceTypeCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varInstanceTypeCreateRequest := _InstanceTypeCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varInstanceTypeCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_interface_network_security_group_config.go
+++ b/rest-api/sdk/standard/model_interface_network_security_group_config.go
@@ -206,7 +206,6 @@ func (o *InterfaceNetworkSecurityGroupConfig) UnmarshalJSON(data []byte) (err er
 	varInterfaceNetworkSecurityGroupConfig := _InterfaceNetworkSecurityGroupConfig{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varInterfaceNetworkSecurityGroupConfig)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_ip_block_create_request.go
+++ b/rest-api/sdk/standard/model_ip_block_create_request.go
@@ -304,7 +304,6 @@ func (o *IpBlockCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varIpBlockCreateRequest := _IpBlockCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varIpBlockCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_ipxe_template.go
+++ b/rest-api/sdk/standard/model_ipxe_template.go
@@ -358,7 +358,6 @@ func (o *IpxeTemplate) UnmarshalJSON(data []byte) (err error) {
 	varIpxeTemplate := _IpxeTemplate{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varIpxeTemplate)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_health_issue.go
+++ b/rest-api/sdk/standard/model_machine_health_issue.go
@@ -173,7 +173,6 @@ func (o *MachineHealthIssue) UnmarshalJSON(data []byte) (err error) {
 	varMachineHealthIssue := _MachineHealthIssue{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineHealthIssue)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_health_probe_alert.go
+++ b/rest-api/sdk/standard/model_machine_health_probe_alert.go
@@ -322,7 +322,6 @@ func (o *MachineHealthProbeAlert) UnmarshalJSON(data []byte) (err error) {
 	varMachineHealthProbeAlert := _MachineHealthProbeAlert{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineHealthProbeAlert)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_health_probe_success.go
+++ b/rest-api/sdk/standard/model_machine_health_probe_success.go
@@ -159,7 +159,6 @@ func (o *MachineHealthProbeSuccess) UnmarshalJSON(data []byte) (err error) {
 	varMachineHealthProbeSuccess := _MachineHealthProbeSuccess{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineHealthProbeSuccess)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_health_report_entry.go
+++ b/rest-api/sdk/standard/model_machine_health_report_entry.go
@@ -289,7 +289,6 @@ func (o *MachineHealthReportEntry) UnmarshalJSON(data []byte) (err error) {
 	varMachineHealthReportEntry := _MachineHealthReportEntry{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineHealthReportEntry)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_health_report_entry_request.go
+++ b/rest-api/sdk/standard/model_machine_health_report_entry_request.go
@@ -214,7 +214,6 @@ func (o *MachineHealthReportEntryRequest) UnmarshalJSON(data []byte) (err error)
 	varMachineHealthReportEntryRequest := _MachineHealthReportEntryRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineHealthReportEntryRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_instance_type_create_request.go
+++ b/rest-api/sdk/standard/model_machine_instance_type_create_request.go
@@ -111,7 +111,6 @@ func (o *MachineInstanceTypeCreateRequest) UnmarshalJSON(data []byte) (err error
 	varMachineInstanceTypeCreateRequest := _MachineInstanceTypeCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineInstanceTypeCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_lifecycle_state.go
+++ b/rest-api/sdk/standard/model_machine_lifecycle_state.go
@@ -218,7 +218,6 @@ func (o *MachineLifecycleState) UnmarshalJSON(data []byte) (err error) {
 	varMachineLifecycleState := _MachineLifecycleState{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineLifecycleState)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_online_repair.go
+++ b/rest-api/sdk/standard/model_machine_online_repair.go
@@ -185,7 +185,6 @@ func (o *MachineOnlineRepair) UnmarshalJSON(data []byte) (err error) {
 	varMachineOnlineRepair := _MachineOnlineRepair{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineOnlineRepair)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_online_repair_acknowledgments.go
+++ b/rest-api/sdk/standard/model_machine_online_repair_acknowledgments.go
@@ -169,7 +169,6 @@ func (o *MachineOnlineRepairAcknowledgments) UnmarshalJSON(data []byte) (err err
 	varMachineOnlineRepairAcknowledgments := _MachineOnlineRepairAcknowledgments{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineOnlineRepairAcknowledgments)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_online_repair_policy.go
+++ b/rest-api/sdk/standard/model_machine_online_repair_policy.go
@@ -111,7 +111,6 @@ func (o *MachineOnlineRepairPolicy) UnmarshalJSON(data []byte) (err error) {
 	varMachineOnlineRepairPolicy := _MachineOnlineRepairPolicy{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineOnlineRepairPolicy)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_power_control_request.go
+++ b/rest-api/sdk/standard/model_machine_power_control_request.go
@@ -148,7 +148,6 @@ func (o *MachinePowerControlRequest) UnmarshalJSON(data []byte) (err error) {
 	varMachinePowerControlRequest := _MachinePowerControlRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachinePowerControlRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_validation_result.go
+++ b/rest-api/sdk/standard/model_machine_validation_result.go
@@ -431,7 +431,6 @@ func (o *MachineValidationResult) UnmarshalJSON(data []byte) (err error) {
 	varMachineValidationResult := _MachineValidationResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineValidationResult)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_validation_run.go
+++ b/rest-api/sdk/standard/model_machine_validation_run.go
@@ -316,7 +316,6 @@ func (o *MachineValidationRun) UnmarshalJSON(data []byte) (err error) {
 	varMachineValidationRun := _MachineValidationRun{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineValidationRun)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_machine_validation_status.go
+++ b/rest-api/sdk/standard/model_machine_validation_status.go
@@ -169,7 +169,6 @@ func (o *MachineValidationStatus) UnmarshalJSON(data []byte) (err error) {
 	varMachineValidationStatus := _MachineValidationStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMachineValidationStatus)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_managed_host_network_config.go
+++ b/rest-api/sdk/standard/model_managed_host_network_config.go
@@ -147,7 +147,6 @@ func (o *ManagedHostNetworkConfig) UnmarshalJSON(data []byte) (err error) {
 	varManagedHostNetworkConfig := _ManagedHostNetworkConfig{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varManagedHostNetworkConfig)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_managed_host_quarantine_state.go
+++ b/rest-api/sdk/standard/model_managed_host_quarantine_state.go
@@ -159,7 +159,6 @@ func (o *ManagedHostQuarantineState) UnmarshalJSON(data []byte) (err error) {
 	varManagedHostQuarantineState := _ManagedHostQuarantineState{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varManagedHostQuarantineState)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_measured_boot_trusted_machine.go
+++ b/rest-api/sdk/standard/model_measured_boot_trusted_machine.go
@@ -259,7 +259,6 @@ func (o *MeasuredBootTrustedMachine) UnmarshalJSON(data []byte) (err error) {
 	varMeasuredBootTrustedMachine := _MeasuredBootTrustedMachine{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMeasuredBootTrustedMachine)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_measured_boot_trusted_machine_create_request.go
+++ b/rest-api/sdk/standard/model_measured_boot_trusted_machine_create_request.go
@@ -243,7 +243,6 @@ func (o *MeasuredBootTrustedMachineCreateRequest) UnmarshalJSON(data []byte) (er
 	varMeasuredBootTrustedMachineCreateRequest := _MeasuredBootTrustedMachineCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMeasuredBootTrustedMachineCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_measured_boot_trusted_profile.go
+++ b/rest-api/sdk/standard/model_measured_boot_trusted_profile.go
@@ -259,7 +259,6 @@ func (o *MeasuredBootTrustedProfile) UnmarshalJSON(data []byte) (err error) {
 	varMeasuredBootTrustedProfile := _MeasuredBootTrustedProfile{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMeasuredBootTrustedProfile)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_measured_boot_trusted_profile_create_request.go
+++ b/rest-api/sdk/standard/model_measured_boot_trusted_profile_create_request.go
@@ -243,7 +243,6 @@ func (o *MeasuredBootTrustedProfileCreateRequest) UnmarshalJSON(data []byte) (er
 	varMeasuredBootTrustedProfileCreateRequest := _MeasuredBootTrustedProfileCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMeasuredBootTrustedProfileCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_message_response.go
+++ b/rest-api/sdk/standard/model_message_response.go
@@ -111,7 +111,6 @@ func (o *MessageResponse) UnmarshalJSON(data []byte) (err error) {
 	varMessageResponse := _MessageResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMessageResponse)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_network_security_group_create_request.go
+++ b/rest-api/sdk/standard/model_network_security_group_create_request.go
@@ -336,7 +336,6 @@ func (o *NetworkSecurityGroupCreateRequest) UnmarshalJSON(data []byte) (err erro
 	varNetworkSecurityGroupCreateRequest := _NetworkSecurityGroupCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNetworkSecurityGroupCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_network_security_group_rule.go
+++ b/rest-api/sdk/standard/model_network_security_group_rule.go
@@ -408,7 +408,6 @@ func (o *NetworkSecurityGroupRule) UnmarshalJSON(data []byte) (err error) {
 	varNetworkSecurityGroupRule := _NetworkSecurityGroupRule{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNetworkSecurityGroupRule)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_nv_link_logical_partition_create_request.go
+++ b/rest-api/sdk/standard/model_nv_link_logical_partition_create_request.go
@@ -188,7 +188,6 @@ func (o *NVLinkLogicalPartitionCreateRequest) UnmarshalJSON(data []byte) (err er
 	varNVLinkLogicalPartitionCreateRequest := _NVLinkLogicalPartitionCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNVLinkLogicalPartitionCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_operating_system_create_request.go
+++ b/rest-api/sdk/standard/model_operating_system_create_request.go
@@ -984,7 +984,6 @@ func (o *OperatingSystemCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varOperatingSystemCreateRequest := _OperatingSystemCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varOperatingSystemCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_operating_system_ipxe_artifact.go
+++ b/rest-api/sdk/standard/model_operating_system_ipxe_artifact.go
@@ -321,7 +321,6 @@ func (o *OperatingSystemIpxeArtifact) UnmarshalJSON(data []byte) (err error) {
 	varOperatingSystemIpxeArtifact := _OperatingSystemIpxeArtifact{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varOperatingSystemIpxeArtifact)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_operating_system_ipxe_parameter.go
+++ b/rest-api/sdk/standard/model_operating_system_ipxe_parameter.go
@@ -140,7 +140,6 @@ func (o *OperatingSystemIpxeParameter) UnmarshalJSON(data []byte) (err error) {
 	varOperatingSystemIpxeParameter := _OperatingSystemIpxeParameter{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varOperatingSystemIpxeParameter)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_operation_rule.go
+++ b/rest-api/sdk/standard/model_operation_rule.go
@@ -351,7 +351,6 @@ func (o *OperationRule) UnmarshalJSON(data []byte) (err error) {
 	varOperationRule := _OperationRule{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varOperationRule)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_operator_error_schema.go
+++ b/rest-api/sdk/standard/model_operator_error_schema.go
@@ -188,7 +188,6 @@ func (o *OperatorErrorSchema) UnmarshalJSON(data []byte) (err error) {
 	varOperatorErrorSchema := _OperatorErrorSchema{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varOperatorErrorSchema)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_retry_policy.go
+++ b/rest-api/sdk/standard/model_retry_policy.go
@@ -206,7 +206,6 @@ func (o *RetryPolicy) UnmarshalJSON(data []byte) (err error) {
 	varRetryPolicy := _RetryPolicy{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRetryPolicy)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_rule_definition.go
+++ b/rest-api/sdk/standard/model_rule_definition.go
@@ -148,7 +148,6 @@ func (o *RuleDefinition) UnmarshalJSON(data []byte) (err error) {
 	varRuleDefinition := _RuleDefinition{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRuleDefinition)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_sequence_step.go
+++ b/rest-api/sdk/standard/model_sequence_step.go
@@ -389,7 +389,6 @@ func (o *SequenceStep) UnmarshalJSON(data []byte) (err error) {
 	varSequenceStep := _SequenceStep{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSequenceStep)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_site_create_request.go
+++ b/rest-api/sdk/standard/model_site_create_request.go
@@ -281,7 +281,6 @@ func (o *SiteCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varSiteCreateRequest := _SiteCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSiteCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_site_explorer_endpoint_action.go
+++ b/rest-api/sdk/standard/model_site_explorer_endpoint_action.go
@@ -198,7 +198,6 @@ func (o *SiteExplorerEndpointAction) UnmarshalJSON(data []byte) (err error) {
 	varSiteExplorerEndpointAction := _SiteExplorerEndpointAction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSiteExplorerEndpointAction)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_site_explorer_endpoint_action_request.go
+++ b/rest-api/sdk/standard/model_site_explorer_endpoint_action_request.go
@@ -206,7 +206,6 @@ func (o *SiteExplorerEndpointActionRequest) UnmarshalJSON(data []byte) (err erro
 	varSiteExplorerEndpointActionRequest := _SiteExplorerEndpointActionRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSiteExplorerEndpointActionRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_sku_create_request.go
+++ b/rest-api/sdk/standard/model_sku_create_request.go
@@ -253,7 +253,6 @@ func (o *SkuCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varSkuCreateRequest := _SkuCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSkuCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_ssh_key_create_request.go
+++ b/rest-api/sdk/standard/model_ssh_key_create_request.go
@@ -188,7 +188,6 @@ func (o *SshKeyCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varSshKeyCreateRequest := _SshKeyCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSshKeyCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_ssh_key_group_create_request.go
+++ b/rest-api/sdk/standard/model_ssh_key_group_create_request.go
@@ -233,7 +233,6 @@ func (o *SshKeyGroupCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varSshKeyGroupCreateRequest := _SshKeyGroupCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSshKeyGroupCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_ssh_key_group_update_request.go
+++ b/rest-api/sdk/standard/model_ssh_key_group_update_request.go
@@ -281,7 +281,6 @@ func (o *SshKeyGroupUpdateRequest) UnmarshalJSON(data []byte) (err error) {
 	varSshKeyGroupUpdateRequest := _SshKeyGroupUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSshKeyGroupUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_subnet_create_request.go
+++ b/rest-api/sdk/standard/model_subnet_create_request.go
@@ -313,7 +313,6 @@ func (o *SubnetCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varSubnetCreateRequest := _SubnetCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSubnetCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_subnet_update_request.go
+++ b/rest-api/sdk/standard/model_subnet_update_request.go
@@ -159,7 +159,6 @@ func (o *SubnetUpdateRequest) UnmarshalJSON(data []byte) (err error) {
 	varSubnetUpdateRequest := _SubnetUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSubnetUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_report_v1.go
+++ b/rest-api/sdk/standard/model_task_report_v1.go
@@ -176,7 +176,6 @@ func (o *TaskReportV1) UnmarshalJSON(data []byte) (err error) {
 	varTaskReportV1 := _TaskReportV1{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskReportV1)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_report_v1_stage.go
+++ b/rest-api/sdk/standard/model_task_report_v1_stage.go
@@ -279,7 +279,6 @@ func (o *TaskReportV1Stage) UnmarshalJSON(data []byte) (err error) {
 	varTaskReportV1Stage := _TaskReportV1Stage{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskReportV1Stage)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_report_v1_step.go
+++ b/rest-api/sdk/standard/model_task_report_v1_step.go
@@ -362,7 +362,6 @@ func (o *TaskReportV1Step) UnmarshalJSON(data []byte) (err error) {
 	varTaskReportV1Step := _TaskReportV1Step{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskReportV1Step)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run.go
+++ b/rest-api/sdk/standard/model_task_run.go
@@ -559,7 +559,6 @@ func (o *TaskRun) UnmarshalJSON(data []byte) (err error) {
 	varTaskRun := _TaskRun{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRun)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_count_phases.go
+++ b/rest-api/sdk/standard/model_task_run_count_phases.go
@@ -111,7 +111,6 @@ func (o *TaskRunCountPhases) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunCountPhases := _TaskRunCountPhases{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunCountPhases)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_equal_phases.go
+++ b/rest-api/sdk/standard/model_task_run_equal_phases.go
@@ -111,7 +111,6 @@ func (o *TaskRunEqualPhases) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunEqualPhases := _TaskRunEqualPhases{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunEqualPhases)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_failure_count_gate.go
+++ b/rest-api/sdk/standard/model_task_run_failure_count_gate.go
@@ -152,7 +152,6 @@ func (o *TaskRunFailureCountGate) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunFailureCountGate := _TaskRunFailureCountGate{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunFailureCountGate)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_failure_rate_gate.go
+++ b/rest-api/sdk/standard/model_task_run_failure_rate_gate.go
@@ -152,7 +152,6 @@ func (o *TaskRunFailureRateGate) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunFailureRateGate := _TaskRunFailureRateGate{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunFailureRateGate)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_firmware_operation.go
+++ b/rest-api/sdk/standard/model_task_run_firmware_operation.go
@@ -237,7 +237,6 @@ func (o *TaskRunFirmwareOperation) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunFirmwareOperation := _TaskRunFirmwareOperation{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunFirmwareOperation)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_operation.go
+++ b/rest-api/sdk/standard/model_task_run_operation.go
@@ -147,7 +147,6 @@ func (o *TaskRunOperation) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunOperation := _TaskRunOperation{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunOperation)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_options.go
+++ b/rest-api/sdk/standard/model_task_run_options.go
@@ -255,7 +255,6 @@ func (o *TaskRunOptions) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunOptions := _TaskRunOptions{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunOptions)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_outcome_counts.go
+++ b/rest-api/sdk/standard/model_task_run_outcome_counts.go
@@ -198,7 +198,6 @@ func (o *TaskRunOutcomeCounts) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunOutcomeCounts := _TaskRunOutcomeCounts{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunOutcomeCounts)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_percentage_phases.go
+++ b/rest-api/sdk/standard/model_task_run_percentage_phases.go
@@ -111,7 +111,6 @@ func (o *TaskRunPercentagePhases) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunPercentagePhases := _TaskRunPercentagePhases{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunPercentagePhases)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_percentage_selector.go
+++ b/rest-api/sdk/standard/model_task_run_percentage_selector.go
@@ -148,7 +148,6 @@ func (o *TaskRunPercentageSelector) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunPercentageSelector := _TaskRunPercentageSelector{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunPercentageSelector)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_phase_stats.go
+++ b/rest-api/sdk/standard/model_task_run_phase_stats.go
@@ -168,7 +168,6 @@ func (o *TaskRunPhaseStats) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunPhaseStats := _TaskRunPhaseStats{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunPhaseStats)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_site_request.go
+++ b/rest-api/sdk/standard/model_task_run_site_request.go
@@ -111,7 +111,6 @@ func (o *TaskRunSiteRequest) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunSiteRequest := _TaskRunSiteRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunSiteRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_stats.go
+++ b/rest-api/sdk/standard/model_task_run_stats.go
@@ -138,7 +138,6 @@ func (o *TaskRunStats) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunStats := _TaskRunStats{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunStats)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_task_run_target.go
+++ b/rest-api/sdk/standard/model_task_run_target.go
@@ -400,7 +400,6 @@ func (o *TaskRunTarget) UnmarshalJSON(data []byte) (err error) {
 	varTaskRunTarget := _TaskRunTarget{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTaskRunTarget)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_tenant_account_create_request.go
+++ b/rest-api/sdk/standard/model_tenant_account_create_request.go
@@ -152,7 +152,6 @@ func (o *TenantAccountCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varTenantAccountCreateRequest := _TenantAccountCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenantAccountCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_tenant_account_site_capability.go
+++ b/rest-api/sdk/standard/model_tenant_account_site_capability.go
@@ -148,7 +148,6 @@ func (o *TenantAccountSiteCapability) UnmarshalJSON(data []byte) (err error) {
 	varTenantAccountSiteCapability := _TenantAccountSiteCapability{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenantAccountSiteCapability)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_tenant_identity_basic_client_secret_request.go
+++ b/rest-api/sdk/standard/model_tenant_identity_basic_client_secret_request.go
@@ -140,7 +140,6 @@ func (o *TenantIdentityBasicClientSecretRequest) UnmarshalJSON(data []byte) (err
 	varTenantIdentityBasicClientSecretRequest := _TenantIdentityBasicClientSecretRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenantIdentityBasicClientSecretRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_tenant_identity_config_create_or_update_request_with_key_rotation.go
+++ b/rest-api/sdk/standard/model_tenant_identity_config_create_or_update_request_with_key_rotation.go
@@ -342,7 +342,6 @@ func (o *TenantIdentityConfigCreateOrUpdateRequestWithKeyRotation) UnmarshalJSON
 	varTenantIdentityConfigCreateOrUpdateRequestWithKeyRotation := _TenantIdentityConfigCreateOrUpdateRequestWithKeyRotation{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenantIdentityConfigCreateOrUpdateRequestWithKeyRotation)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_tenant_identity_config_create_or_update_request_without_key_rotation.go
+++ b/rest-api/sdk/standard/model_tenant_identity_config_create_or_update_request_without_key_rotation.go
@@ -325,7 +325,6 @@ func (o *TenantIdentityConfigCreateOrUpdateRequestWithoutKeyRotation) UnmarshalJ
 	varTenantIdentityConfigCreateOrUpdateRequestWithoutKeyRotation := _TenantIdentityConfigCreateOrUpdateRequestWithoutKeyRotation{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenantIdentityConfigCreateOrUpdateRequestWithoutKeyRotation)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_tenant_identity_jwks.go
+++ b/rest-api/sdk/standard/model_tenant_identity_jwks.go
@@ -111,7 +111,6 @@ func (o *TenantIdentityJWKS) UnmarshalJSON(data []byte) (err error) {
 	varTenantIdentityJWKS := _TenantIdentityJWKS{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenantIdentityJWKS)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_tenant_identity_signing_key.go
+++ b/rest-api/sdk/standard/model_tenant_identity_signing_key.go
@@ -218,7 +218,6 @@ func (o *TenantIdentitySigningKey) UnmarshalJSON(data []byte) (err error) {
 	varTenantIdentitySigningKey := _TenantIdentitySigningKey{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenantIdentitySigningKey)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_tenant_identity_token_delegation_create_or_update_request.go
+++ b/rest-api/sdk/standard/model_tenant_identity_token_delegation_create_or_update_request.go
@@ -177,7 +177,6 @@ func (o *TenantIdentityTokenDelegationCreateOrUpdateRequest) UnmarshalJSON(data 
 	varTenantIdentityTokenDelegationCreateOrUpdateRequest := _TenantIdentityTokenDelegationCreateOrUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenantIdentityTokenDelegationCreateOrUpdateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_uefi_credential.go
+++ b/rest-api/sdk/standard/model_uefi_credential.go
@@ -140,7 +140,6 @@ func (o *UEFICredential) UnmarshalJSON(data []byte) (err error) {
 	varUEFICredential := _UEFICredential{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varUEFICredential)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_uefi_credential_request.go
+++ b/rest-api/sdk/standard/model_uefi_credential_request.go
@@ -169,7 +169,6 @@ func (o *UEFICredentialRequest) UnmarshalJSON(data []byte) (err error) {
 	varUEFICredentialRequest := _UEFICredentialRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varUEFICredentialRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_update_power_state_request.go
+++ b/rest-api/sdk/standard/model_update_power_state_request.go
@@ -218,7 +218,6 @@ func (o *UpdatePowerStateRequest) UnmarshalJSON(data []byte) (err error) {
 	varUpdatePowerStateRequest := _UpdatePowerStateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varUpdatePowerStateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_update_rule_request.go
+++ b/rest-api/sdk/standard/model_update_rule_request.go
@@ -221,7 +221,6 @@ func (o *UpdateRuleRequest) UnmarshalJSON(data []byte) (err error) {
 	varUpdateRuleRequest := _UpdateRuleRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varUpdateRuleRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_vpc_create_request.go
+++ b/rest-api/sdk/standard/model_vpc_create_request.go
@@ -550,7 +550,6 @@ func (o *VpcCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varVpcCreateRequest := _VpcCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varVpcCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_vpc_effective_routing_profile.go
+++ b/rest-api/sdk/standard/model_vpc_effective_routing_profile.go
@@ -336,7 +336,6 @@ func (o *VpcEffectiveRoutingProfile) UnmarshalJSON(data []byte) (err error) {
 	varVpcEffectiveRoutingProfile := _VpcEffectiveRoutingProfile{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varVpcEffectiveRoutingProfile)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_vpc_peering_create_request.go
+++ b/rest-api/sdk/standard/model_vpc_peering_create_request.go
@@ -169,7 +169,6 @@ func (o *VpcPeeringCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varVpcPeeringCreateRequest := _VpcPeeringCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varVpcPeeringCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_vpc_prefix_create_request.go
+++ b/rest-api/sdk/standard/model_vpc_prefix_create_request.go
@@ -198,7 +198,6 @@ func (o *VpcPrefixCreateRequest) UnmarshalJSON(data []byte) (err error) {
 	varVpcPrefixCreateRequest := _VpcPrefixCreateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varVpcPrefixCreateRequest)
 
 	if err != nil {

--- a/rest-api/sdk/standard/model_vpc_prefix_update_request.go
+++ b/rest-api/sdk/standard/model_vpc_prefix_update_request.go
@@ -111,7 +111,6 @@ func (o *VpcPrefixUpdateRequest) UnmarshalJSON(data []byte) (err error) {
 	varVpcPrefixUpdateRequest := _VpcPrefixUpdateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varVpcPrefixUpdateRequest)
 
 	if err != nil {


### PR DESCRIPTION
## Fix

The generated standard Go SDK rejected response fields not described by the OpenAPI schema. It now uses normal JSON decoding, which preserves required-field validation while tolerating additive response fields. This allows for existing Go SDK users to continue to use older versions when NICo is updated.

## Validation

- `make generate-sdk`
- `go test ./...` from `rest-api/sdk/standard`