### PR TITLE
fix(helm-prereqs): make Patroni synchronous mode values-driven

### DIFF
--- a/helm-prereqs/templates/postgresql.yaml
+++ b/helm-prereqs/templates/postgresql.yaml
@@ -72,8 +72,12 @@ spec:
     nsm: nsm.nico
     {{- end }}
   patroni:
-    synchronous_mode: true
-    synchronous_mode_strict: true
+    # Templated (no `| default`): Go templates treat an explicit `false` as empty,
+    # so a default here would silently re-enable sync mode. Default lives in values.yaml.
+    # Single-instance clusters must set synchronousMode=false or Patroni strict sync
+    # blocks all writes (including the operator's own CREATE DATABASE).
+    synchronous_mode: {{ .Values.postgresql.synchronousMode }}
+    synchronous_mode_strict: {{ .Values.postgresql.synchronousMode }}
     synchronous_node_count: 1
   postgresql:
     version: "15"

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -187,6 +187,10 @@ flow:
 postgresql:
   enabled: true
   instances: 3
+  ## Patroni synchronous replication. Set false for single-instance clusters
+  ## (for development or simulation) — strict sync mode with no replicas
+  ## blocks all writes.
+  synchronousMode: true
   volumeSize: "10Gi"
   storageClass: "local-path-persistent"
   ## DB_HOST in nico-system-nico-database-config ConfigMap.


### PR DESCRIPTION
Hardcoded synchronous_mode_strict deadlocks single-instance postgres clusters: with no standby to acknowledge commits, all writes block -- including the operator's own CREATE DATABASE, so the chart's databases are never created. Expose it as postgresql.synchronousMode (default true, production behavior unchanged).

The default lives in values.yaml rather than '| default true' in the template: Go templates treat an explicit false as empty, which would silently coerce it back to true.

Fixes #5095


## Related issues
 ## Type of Change
 
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
 
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

 

