### PR TITLE
fix(devspace): trust Vault admin CA and build nico-mcp only with dsx-exchange profile

### DIFF
--- a/dev/deployment/devspace/README.md
+++ b/dev/deployment/devspace/README.md
@@ -29,6 +29,7 @@ By default this script assumes an empty cluster and will idempotently:
 - deploy a simple PostgreSQL instance
 - deploy a simple Vault dev server
 - configure Vault mounts and a local PKI role
+- add the Vault PKI public CA to the generated Core admin-client trust bundle
 - create a separate REST database in the local PostgreSQL instance
 - deploy Temporal and create its `cloud` and `site` namespaces
 - deploy the local Keycloak realm
@@ -64,8 +65,21 @@ LOCAL_DEV_VAULT_TOKEN=... \
 LOCAL_DEV_VAULT_KV_MOUNT=secrets \
 LOCAL_DEV_VAULT_PKI_MOUNT=certs \
 LOCAL_DEV_VAULT_AUTH_MODE=root-token \
+LOCAL_DEV_VAULT_ADMIN_CA_FILE=/path/to/vault-pki-ca.pem \
 dev/deployment/devspace/bootstrap-prereqs.sh
 ```
+
+`LOCAL_DEV_VAULT_ADMIN_CA_FILE` is optional when
+`LOCAL_DEV_INSTALL_VAULT=0`. When set, it must name a readable regular file
+containing only one or more valid X.509 certificates as bare PEM `CERTIFICATE`
+blocks and whitespace. The public certificates are copied to
+`nico-api.siteConfig.adminRootCertPem` in `values.generated.yaml`; private keys
+and PEM metadata are rejected. When omitted for an external Vault, the
+generated values do not set `adminRootCertPem`.
+
+When the bootstrap script manages the local Vault, it reads the public CA
+directly from `LOCAL_DEV_VAULT_PKI_MOUNT`. Setting
+`LOCAL_DEV_VAULT_ADMIN_CA_FILE` overrides that CA.
 
 ```bash
 LOCAL_DEV_INSTALL_CERT_MANAGER=0 \
@@ -80,8 +94,11 @@ dev/deployment/devspace/bootstrap-prereqs.sh
 Important:
 
 - The script writes the generated Helm values file from these settings.
+- The generated values trust the configured Vault PKI CA for authenticated
+  Core admin-client operations when the bootstrap script manages local Vault
+  or `LOCAL_DEV_VAULT_ADMIN_CA_FILE` is set.
 - For local Vault, the app uses root-token auth by setting `automountServiceAccountToken: false`.
-- For external Vault, either keep `VAULT_AUTH_MODE=root-token` or supply your own compatible auth setup.
+- For external Vault, either keep `LOCAL_DEV_VAULT_AUTH_MODE=root-token` or supply your own compatible auth setup.
 - `LOCAL_DEV_INSTALL_TEMPORAL=0` and `LOCAL_DEV_INSTALL_KEYCLOAK=0` skip those managed services.
 - `LOCAL_DEV_INSTALL_REST_PREREQS=0` preserves the Core-only bootstrap behavior.
 - A full-stack deployment expects PostgreSQL at `postgres.postgres.svc.cluster.local` and requires the `nico_rest`, `keycloak`, `temporal`, and `temporal_visibility` databases and roles when the local PostgreSQL installation is skipped. A nondefault PostgreSQL host is supported only by the Core-only path.

--- a/dev/deployment/devspace/bootstrap-prereqs.sh
+++ b/dev/deployment/devspace/bootstrap-prereqs.sh
@@ -52,6 +52,8 @@ VAULT_KV_MOUNT="${LOCAL_DEV_VAULT_KV_MOUNT:-secrets}"
 VAULT_PKI_MOUNT="${LOCAL_DEV_VAULT_PKI_MOUNT:-certs}"
 VAULT_PKI_ROLE_NAME="${LOCAL_DEV_VAULT_PKI_ROLE_NAME:-nico-cluster}"
 VAULT_AUTH_MODE="${LOCAL_DEV_VAULT_AUTH_MODE:-root-token}"
+VAULT_ADMIN_CA_FILE="${LOCAL_DEV_VAULT_ADMIN_CA_FILE:-}"
+ADMIN_ROOT_CERT_PEM=""
 
 CERT_ISSUER_KIND="${LOCAL_DEV_CERT_ISSUER_KIND:-Issuer}"
 CERT_ISSUER_NAME="${LOCAL_DEV_CERT_ISSUER_NAME:-local-ca-issuer}"
@@ -411,6 +413,102 @@ EOF
   " >/dev/null
 }
 
+load_admin_root_cert_pem() {
+  if [[ -n "${VAULT_ADMIN_CA_FILE}" ]]; then
+    if [[ ! -f "${VAULT_ADMIN_CA_FILE}" || ! -r "${VAULT_ADMIN_CA_FILE}" ]]; then
+      printf 'Vault admin CA file is not a readable regular file: %s\n' \
+        "${VAULT_ADMIN_CA_FILE}" >&2
+      exit 1
+    fi
+    ADMIN_ROOT_CERT_PEM="$(<"${VAULT_ADMIN_CA_FILE}")"
+  elif [[ "${INSTALL_VAULT}" == "1" ]]; then
+    log "Reading the local Vault PKI CA for Core admin-client trust"
+    ADMIN_ROOT_CERT_PEM="$(
+      kubectl exec -n "${VAULT_NAMESPACE}" statefulset/vault -- \
+        env VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN="${VAULT_TOKEN}" \
+        vault read -field=certificate "${VAULT_PKI_MOUNT}/cert/ca"
+    )"
+  else
+    return
+  fi
+
+  require_bin awk
+  require_bin openssl
+
+  if ! printf '%s\n' "${ADMIN_ROOT_CERT_PEM}" | awk '
+    BEGIN {
+      in_certificate = 0
+      certificate_count = 0
+      certificate_has_data = 0
+      invalid = 0
+    }
+    {
+      sub(/\r$/, "")
+      if ($0 == "-----BEGIN CERTIFICATE-----") {
+        if (in_certificate) {
+          invalid = 1
+          exit
+        }
+        in_certificate = 1
+        certificate_has_data = 0
+        next
+      }
+      if ($0 == "-----END CERTIFICATE-----") {
+        if (!in_certificate || !certificate_has_data) {
+          invalid = 1
+          exit
+        }
+        in_certificate = 0
+        certificate_count++
+        next
+      }
+      if (in_certificate) {
+        if ($0 !~ /^[A-Za-z0-9+\/=]+$/) {
+          invalid = 1
+          exit
+        }
+        certificate_has_data = 1
+        next
+      }
+      if ($0 !~ /^[[:space:]]*$/) {
+        invalid = 1
+        exit
+      }
+    }
+    END {
+      exit(invalid || in_certificate || certificate_count == 0)
+    }
+  '; then
+    printf '%s\n' \
+      'Vault admin CA must contain only bare PEM CERTIFICATE blocks and whitespace' >&2
+    exit 1
+  fi
+
+  local certificate_pem=""
+  local line
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line%$'\r'}"
+    if [[ "${line}" == "-----BEGIN CERTIFICATE-----" ]]; then
+      certificate_pem="${line}"$'\n'
+      continue
+    fi
+    if [[ -z "${certificate_pem}" ]]; then
+      continue
+    fi
+
+    certificate_pem+="${line}"$'\n'
+    if [[ "${line}" != "-----END CERTIFICATE-----" ]]; then
+      continue
+    fi
+    if ! openssl x509 -noout <<<"${certificate_pem}" >/dev/null 2>&1; then
+      printf '%s\n' \
+        'Vault admin CA contains a CERTIFICATE block that is not valid X.509' >&2
+      exit 1
+    fi
+    certificate_pem=""
+  done <<<"${ADMIN_ROOT_CERT_PEM}"
+}
+
 apply_local_issuer() {
   if [[ "${INSTALL_LOCAL_ISSUER}" != "1" ]]; then
     return
@@ -597,7 +695,8 @@ write_generated_values() {
   fi
 
   mkdir -p "$(dirname -- "${VALUES_FILE}")"
-  cat > "${VALUES_FILE}" <<EOF
+  {
+    cat <<EOF
 global:
   certificate:
     issuerRef:
@@ -606,6 +705,14 @@ global:
       group: ${CERT_ISSUER_GROUP}
 
 nico-api:
+EOF
+    if [[ -n "${ADMIN_ROOT_CERT_PEM}" ]]; then
+      printf '%s\n' \
+        '  siteConfig:' \
+        '    adminRootCertPem: |'
+      printf '%s\n' "${ADMIN_ROOT_CERT_PEM}" | sed 's/^/      /'
+    fi
+    cat <<EOF
   automountServiceAccountToken: ${automount}
   migrationJob:
     enabled: true
@@ -626,6 +733,7 @@ nico-bmc-proxy:
   databaseConfig: {}
 ${disable_tls_enforcement}
 EOF
+  } > "${VALUES_FILE}"
 }
 
 print_summary() {
@@ -654,6 +762,7 @@ main() {
   apply_core_objects
   apply_local_postgres
   apply_local_vault
+  load_admin_root_cert_pem
   apply_local_issuer
   sync_nico_roots_secret
   apply_rest_ca

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -64,7 +64,10 @@ functions:
   build_local_images: |-
     build_images core-artifacts nico-rest-api nico-rest-workflow \
       nico-rest-site-manager nico-rest-site-agent nico-rest-db \
-      nico-rest-cert-manager nico-mcp
+      nico-rest-cert-manager
+    if [ "${LOCAL_DEV_DSX_GATEWAY_PROFILE}" = "1" ]; then
+      build_images nico-mcp
+    fi
     # Custom-build onChange state can outlive the corresponding local Docker
     # image. Always invoke these inexpensive second-stage builds so the tags
     # consumed by the Kind image-loading hook are guaranteed to exist.


### PR DESCRIPTION
The local admin CLI certificate is issued by the Vault PKI, but Core did not
trust that issuer. Authenticated bootstrap operations such as dynamic
configuration updates could therefore fail with HTTP 403. This change loads
the managed local Vault PKI CA into the generated Core admin-client trust
bundle.

An external CA bundle can be supplied through
`LOCAL_DEV_VAULT_ADMIN_CA_FILE`. External-Vault deployments that omit the
variable retain their existing behavior, and generated values omit
`adminRootCertPem`.

The default DevSpace build also requested `nico-mcp` even though that image is
defined only by the optional `dsx-exchange` profile. The build is now requested
only when that profile is enabled.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Manual validation:

- `bash -n dev/deployment/devspace/bootstrap-prereqs.sh`
- `shellcheck -S error dev/deployment/devspace/bootstrap-prereqs.sh`
- `rumdl check --config docs/.rumdl.toml AGENTS.md dev/deployment/devspace/README.md`
- parsed `devspace.yaml` and confirmed that the default build is profile-gated
  while `dsx-exchange` defines `images.nico-mcp`
- `git diff --check`

## Additional Notes

Managed local Vault deployments gain the required admin-client trust
automatically. External Vault deployments remain unchanged unless
`LOCAL_DEV_VAULT_ADMIN_CA_FILE` is explicitly set.

Default DevSpace deployments no longer request an undefined MCP image.
Deployments using `dsx-exchange` continue to build `nico-mcp` through that
profile.
