### PR TITLE
Fix rms rack firmware completion 2.1

### DIFF
--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -8208,13 +8208,18 @@ impl StateHandler for InstanceStateHandler {
                         .host_reprovision_requested
                         .is_some()
                     {
+                        let reprovision_state = if is_rack_level_reprovisioning(mh_snapshot) {
+                            HostReprovisionState::WaitingForRackFirmwareUpgrade
+                        } else {
+                            HostReprovisionState::CheckingFirmwareV2 {
+                                firmware_type: None,
+                                firmware_number: None,
+                            }
+                        };
                         Ok(StateHandlerOutcome::transition(
                             ManagedHostState::Assigned {
                                 instance_state: InstanceState::HostReprovision {
-                                    reprovision_state: HostReprovisionState::CheckingFirmwareV2 {
-                                        firmware_type: None,
-                                        firmware_number: None,
-                                    },
+                                    reprovision_state,
                                 },
                             },
                         ))
@@ -9322,7 +9327,7 @@ impl HostUpgradeState {
 
         // Treat Ready (but flagged to do updates) the same as HostReprovisionState/CheckingFirmware
         let original_state = &state.managed_state.clone();
-        let (mut host_reprovision_state, retry_count) = match &state.managed_state {
+        let (mut host_reprovision_state, mut retry_count) = match &state.managed_state {
             ManagedHostState::HostReprovision {
                 reprovision_state,
                 retry_count,
@@ -9367,6 +9372,7 @@ impl HostUpgradeState {
             })
         {
             tracing::info!(%machine_id, "Host firmware upgrade reset requested, returning to CheckingFirmwareRepeat");
+            retry_count = 0;
             host_reprovision_state = &HostReprovisionState::CheckingFirmwareRepeatV2 {
                 firmware_type: None,
                 firmware_number: None,
@@ -9383,6 +9389,25 @@ impl HostUpgradeState {
                     machine_id: *machine_id,
                     clear_reset: true,
                 });
+        }
+
+        if is_rack_level_reprovisioning(state)
+            && matches!(
+                host_reprovision_state,
+                HostReprovisionState::CheckingFirmware
+                    | HostReprovisionState::CheckingFirmwareRepeat
+                    | HostReprovisionState::CheckingFirmwareV2 { .. }
+                    | HostReprovisionState::CheckingFirmwareRepeatV2 { .. }
+            )
+        {
+            tracing::info!(
+                %machine_id,
+                "Rack-level firmware upgrade bypassing legacy host firmware checks"
+            );
+            return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
+                HostReprovisionState::WaitingForRackFirmwareUpgrade,
+                retry_count,
+            )));
         }
 
         match host_reprovision_state {

--- a/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
+++ b/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
@@ -192,7 +192,52 @@ async fn advances_on_completion(pool: PgPool) {
 }
 
 #[sqlx_test]
-async fn assigned_host_returns_to_assigned_ready_on_completion(pool: PgPool) {
+async fn rack_reset_clears_host_reprovision_retry_count(pool: PgPool) {
+    let mut env = Env::builder(pool).build().await;
+    let host = managed_host(&env.test_harness).await;
+    prepare_rack_upgrade(
+        &env.test_harness,
+        &host,
+        ManagedHostState::HostReprovision {
+            reprovision_state: HostReprovisionState::CheckingFirmwareV2 {
+                firmware_type: None,
+                firmware_number: None,
+            },
+            retry_count: 3,
+        },
+        RackFirmwareUpgradeState::InProgress,
+        chrono::Duration::zero(),
+        None,
+    )
+    .await;
+
+    let mut txn = env.test_harness.db_txn().await;
+    db::host_machine_update::reset_host_reprovisioning_request(txn.as_mut(), &host.host.id, false)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_single_iteration().await;
+
+    let machine = host.host.machine().await;
+    assert!(matches!(
+        machine.current_state(),
+        ManagedHostState::HostReprovision {
+            reprovision_state: HostReprovisionState::WaitingForRackFirmwareUpgrade,
+            retry_count: 0,
+        }
+    ));
+    assert_eq!(
+        machine
+            .host_reprovision_requested
+            .as_ref()
+            .and_then(|request| request.request_reset),
+        Some(false)
+    );
+}
+
+#[sqlx_test]
+async fn assigned_host_bypasses_legacy_check_and_returns_ready_on_completion(pool: PgPool) {
     let mut env = Env::builder(pool).build().await;
     let host = managed_host(&env.test_harness).await;
     let instance_id = create_instance(&env.test_harness, &host).await;
@@ -201,7 +246,10 @@ async fn assigned_host_returns_to_assigned_ready_on_completion(pool: PgPool) {
         &host,
         ManagedHostState::Assigned {
             instance_state: InstanceState::HostReprovision {
-                reprovision_state: HostReprovisionState::WaitingForRackFirmwareUpgrade,
+                reprovision_state: HostReprovisionState::CheckingFirmwareV2 {
+                    firmware_type: None,
+                    firmware_number: None,
+                },
             },
         },
         RackFirmwareUpgradeState::Completed,
@@ -209,6 +257,19 @@ async fn assigned_host_returns_to_assigned_ready_on_completion(pool: PgPool) {
         Some(chrono::Duration::zero()),
     )
     .await;
+
+    env.run_single_iteration().await;
+
+    let machine = host.host.machine().await;
+    assert!(matches!(
+        machine.current_state(),
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::HostReprovision {
+                reprovision_state: HostReprovisionState::WaitingForRackFirmwareUpgrade,
+            },
+        }
+    ));
+    assert!(machine.host_reprovision_requested.is_some());
 
     env.run_single_iteration().await;
 


### PR DESCRIPTION
Direct compute-tray firmware updates handled by RMS complete at the rack firmware layer. After RMS reported success, the machine controller incorrectly transitioned the host to CheckingFirmwareRepeatV2, causing a second firmware update through the legacy Redfish path. This duplicate attempt could fail with Invalid FW Package, leaving the host in FailedFirmwareUpgrade even though the RMS update had already succeeded.
## Related issues
https://github.com/NVIDIA/infra-controller/issues/2016

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

