### PR TITLE
fix(cli): separate instance update and reboot payloads

### DIFF
--- a/rest-api/cli/tui/commands.go
+++ b/rest-api/cli/tui/commands.go
@@ -53,7 +53,7 @@ func AllCommands() []Command {
 		{Name: "instance list", Description: "List all instances", Run: cmdInstanceList},
 		{Name: "instance get", Description: "Get instance details", Run: cmdInstanceGet},
 		{Name: "instance create", Description: "Create an instance on a machine", Run: cmdInstanceCreate},
-		{Name: "instance update", Description: "Update an instance (rename, change OS, rotate ssh key groups, trigger reboot)", Run: cmdInstanceUpdate},
+		{Name: "instance update", Description: "Update an instance (rename, change OS, rotate ssh key groups)", Run: cmdInstanceUpdate},
 		{Name: "instance reboot", Description: "Reboot an instance, optionally with custom iPXE / pending updates", Run: cmdInstanceReboot},
 		{Name: "instance delete", Description: "Delete an instance", Run: cmdInstanceDelete},
 
@@ -2866,20 +2866,14 @@ func promptOptionalResourceIDs(s *Session, ctx context.Context, resourceType, si
 	}
 }
 
-// instanceUpdateInputs collects the optional fields exposed by the TUI
-// instance update form. Extracted so cmdInstanceUpdate stays linear and
-// cmdInstanceReboot can drive a stripped-down version of the same flow.
-type instanceUpdateInputs struct {
-	name                 string
-	description          string
-	osID                 string
-	sshKeyGroupIDs       []string
-	triggerReboot        bool
-	rebootWithCustomIpxe bool
-	applyUpdatesOnReboot bool
+type instanceAttributeUpdateInputs struct {
+	name           string
+	description    string
+	osID           string
+	sshKeyGroupIDs []string
 }
 
-func (u instanceUpdateInputs) toBody() map[string]interface{} {
+func (u instanceAttributeUpdateInputs) attributeBody() map[string]interface{} {
 	body := map[string]interface{}{}
 	if strings.TrimSpace(u.name) != "" {
 		body["name"] = strings.TrimSpace(u.name)
@@ -2893,14 +2887,21 @@ func (u instanceUpdateInputs) toBody() map[string]interface{} {
 	if len(u.sshKeyGroupIDs) > 0 {
 		body["sshKeyGroupIds"] = u.sshKeyGroupIDs
 	}
-	if u.triggerReboot {
-		body["triggerReboot"] = true
-		if u.rebootWithCustomIpxe {
-			body["rebootWithCustomIpxe"] = true
-		}
-		if u.applyUpdatesOnReboot {
-			body["applyUpdatesOnReboot"] = true
-		}
+	return body
+}
+
+type instanceRebootInputs struct {
+	rebootWithCustomIpxe bool
+	applyUpdatesOnReboot bool
+}
+
+func (u instanceRebootInputs) rebootBody() map[string]interface{} {
+	body := map[string]interface{}{"triggerReboot": true}
+	if u.rebootWithCustomIpxe {
+		body["rebootWithCustomIpxe"] = true
+	}
+	if u.applyUpdatesOnReboot {
+		body["applyUpdatesOnReboot"] = true
 	}
 	return body
 }
@@ -2911,7 +2912,7 @@ func cmdInstanceUpdate(s *Session, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputs := instanceUpdateInputs{}
+	inputs := instanceAttributeUpdateInputs{}
 	inputs.name, err = PromptText("New name (optional)", false)
 	if err != nil {
 		return err
@@ -2946,22 +2947,7 @@ func cmdInstanceUpdate(s *Session, args []string) error {
 		}
 	}
 
-	inputs.triggerReboot, err = PromptConfirm("Trigger reboot now?")
-	if err != nil {
-		return err
-	}
-	if inputs.triggerReboot {
-		inputs.rebootWithCustomIpxe, err = PromptConfirm("Reboot with custom iPXE (one-time)?")
-		if err != nil {
-			return err
-		}
-		inputs.applyUpdatesOnReboot, err = PromptConfirm("Apply pending updates on reboot?")
-		if err != nil {
-			return err
-		}
-	}
-
-	body := inputs.toBody()
+	body := inputs.attributeBody()
 	if len(body) == 0 {
 		return fmt.Errorf("no updates provided")
 	}
@@ -2977,6 +2963,7 @@ func cmdInstanceUpdate(s *Session, args []string) error {
 	var updated map[string]interface{}
 	json.Unmarshal(resp, &updated)
 	fmt.Printf("%s Instance updated: %s (%s)\n", Green("OK"), str(updated, "name"), str(updated, "id"))
+	fmt.Fprintf(os.Stderr, "%s run `instance reboot` when ready\n", Dim("note:"))
 	return nil
 }
 
@@ -2999,11 +2986,10 @@ func cmdInstanceReboot(s *Session, args []string) error {
 		return err
 	}
 
-	body := instanceUpdateInputs{
-		triggerReboot:        true,
+	body := instanceRebootInputs{
 		rebootWithCustomIpxe: rebootWithCustomIpxe,
 		applyUpdatesOnReboot: applyUpdatesOnReboot,
-	}.toBody()
+	}.rebootBody()
 
 	LogCmd(s, "instance", "update", item.ID, "--trigger-reboot=true")
 	bodyJSON, _ := json.Marshal(body)

--- a/rest-api/cli/tui/commands_test.go
+++ b/rest-api/cli/tui/commands_test.go
@@ -403,20 +403,20 @@ func TestMachineSelectLabel(t *testing.T) {
 	}
 }
 
-func TestInstanceUpdateInputs_ToBody(t *testing.T) {
+func TestInstanceAttributeUpdateInputs_AttributeBody(t *testing.T) {
 	cases := []struct {
 		name   string
-		inputs instanceUpdateInputs
+		inputs instanceAttributeUpdateInputs
 		want   map[string]interface{}
 	}{
 		{
 			name:   "empty inputs produce empty body",
-			inputs: instanceUpdateInputs{},
+			inputs: instanceAttributeUpdateInputs{},
 			want:   map[string]interface{}{},
 		},
 		{
 			name:   "name and description trimmed",
-			inputs: instanceUpdateInputs{name: "  new-name  ", description: " new description "},
+			inputs: instanceAttributeUpdateInputs{name: "  new-name  ", description: " new description "},
 			want: map[string]interface{}{
 				"name":        "new-name",
 				"description": "new description",
@@ -424,65 +424,33 @@ func TestInstanceUpdateInputs_ToBody(t *testing.T) {
 		},
 		{
 			name:   "blank name and description omitted",
-			inputs: instanceUpdateInputs{name: "   ", description: ""},
+			inputs: instanceAttributeUpdateInputs{name: "   ", description: ""},
 			want:   map[string]interface{}{},
 		},
 		{
 			name:   "ssh key group ids included only when non-empty",
-			inputs: instanceUpdateInputs{sshKeyGroupIDs: []string{"g1", "g2"}},
+			inputs: instanceAttributeUpdateInputs{sshKeyGroupIDs: []string{"g1", "g2"}},
 			want:   map[string]interface{}{"sshKeyGroupIds": []string{"g1", "g2"}},
 		},
 		{
-			name:   "trigger reboot alone",
-			inputs: instanceUpdateInputs{triggerReboot: true},
-			want:   map[string]interface{}{"triggerReboot": true},
-		},
-		{
-			name: "trigger reboot with custom ipxe and apply updates",
-			inputs: instanceUpdateInputs{
-				triggerReboot:        true,
-				rebootWithCustomIpxe: true,
-				applyUpdatesOnReboot: true,
+			name: "all attribute fields included without reboot fields",
+			inputs: instanceAttributeUpdateInputs{
+				name:           "new-name",
+				description:    "new desc",
+				osID:           "os-1",
+				sshKeyGroupIDs: []string{"g1"},
 			},
 			want: map[string]interface{}{
-				"triggerReboot":        true,
-				"rebootWithCustomIpxe": true,
-				"applyUpdatesOnReboot": true,
-			},
-		},
-		{
-			name: "reboot modifiers ignored when triggerReboot is false (server would reject them anyway)",
-			inputs: instanceUpdateInputs{
-				rebootWithCustomIpxe: true,
-				applyUpdatesOnReboot: true,
-			},
-			want: map[string]interface{}{},
-		},
-		{
-			name: "everything together marshals to a clean JSON body",
-			inputs: instanceUpdateInputs{
-				name:                 "new-name",
-				description:          "new desc",
-				osID:                 "os-1",
-				sshKeyGroupIDs:       []string{"g1"},
-				triggerReboot:        true,
-				rebootWithCustomIpxe: true,
-				applyUpdatesOnReboot: true,
-			},
-			want: map[string]interface{}{
-				"name":                 "new-name",
-				"description":          "new desc",
-				"operatingSystemId":    "os-1",
-				"sshKeyGroupIds":       []string{"g1"},
-				"triggerReboot":        true,
-				"rebootWithCustomIpxe": true,
-				"applyUpdatesOnReboot": true,
+				"name":              "new-name",
+				"description":       "new desc",
+				"operatingSystemId": "os-1",
+				"sshKeyGroupIds":    []string{"g1"},
 			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.inputs.toBody()
+			got := tc.inputs.attributeBody()
 			// Compare via JSON round-trip so []string and []interface{} are
 			// treated as equal when their contents match -- keeps the table
 			// readable without forcing every test row to use interface{} slices.
@@ -495,28 +463,67 @@ func TestInstanceUpdateInputs_ToBody(t *testing.T) {
 	}
 }
 
-func TestInstanceReboot_Body_AlwaysSetsTriggerReboot(t *testing.T) {
-	// Documents the cmdInstanceReboot contract: the body MUST include
-	// triggerReboot=true even when the user declines both modifiers, so a
-	// future refactor that switches to a different body builder cannot
-	// silently produce a no-op PATCH.
-	body := instanceUpdateInputs{triggerReboot: true}.toBody()
-	assert.Equal(t, true, body["triggerReboot"])
-	assert.NotContains(t, body, "rebootWithCustomIpxe")
-	assert.NotContains(t, body, "applyUpdatesOnReboot")
+func TestInstanceRebootInputs_RebootBody(t *testing.T) {
+	cases := []struct {
+		name   string
+		inputs instanceRebootInputs
+		want   map[string]interface{}
+	}{
+		{
+			// A zero-value instanceRebootInputs means a plain reboot. Its body
+			// must still contain triggerReboot=true so the PATCH is not a no-op.
+			name:   "plain reboot",
+			inputs: instanceRebootInputs{},
+			want:   map[string]interface{}{"triggerReboot": true},
+		},
+		{
+			name:   "custom ipxe only",
+			inputs: instanceRebootInputs{rebootWithCustomIpxe: true},
+			want: map[string]interface{}{
+				"triggerReboot":        true,
+				"rebootWithCustomIpxe": true,
+			},
+		},
+		{
+			name:   "apply updates only",
+			inputs: instanceRebootInputs{applyUpdatesOnReboot: true},
+			want: map[string]interface{}{
+				"triggerReboot":        true,
+				"applyUpdatesOnReboot": true,
+			},
+		},
+		{
+			name: "custom ipxe and apply updates",
+			inputs: instanceRebootInputs{
+				rebootWithCustomIpxe: true,
+				applyUpdatesOnReboot: true,
+			},
+			want: map[string]interface{}{
+				"triggerReboot":        true,
+				"rebootWithCustomIpxe": true,
+				"applyUpdatesOnReboot": true,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.inputs.rebootBody())
+		})
+	}
 }
 
 func TestAllCommands_HasInstanceUpdateAndReboot(t *testing.T) {
 	// Regression guard: the TUI command registry must expose
 	// `instance update` (so users can rename, swap OS, rotate ssh key
-	// groups, or trigger a reboot) and `instance reboot` (the dedicated
-	// reboot abstraction).
-	names := make(map[string]bool)
+	// groups) and `instance reboot` as a distinct operation.
+	commands := make(map[string]Command)
 	for _, c := range AllCommands() {
-		names[c.Name] = true
+		commands[c.Name] = c
 	}
-	assert.True(t, names["instance update"], "TUI must expose `instance update`")
-	assert.True(t, names["instance reboot"], "TUI must expose `instance reboot`")
+	assert.Contains(t, commands, "instance update", "TUI must expose `instance update`")
+	assert.Contains(t, commands, "instance reboot", "TUI must expose `instance reboot`")
+	assert.NotContains(t, commands["instance update"].Description, "reboot")
+	assert.Contains(t, commands["instance reboot"].Description, "Reboot")
 }
 
 func TestSetSiteScopeFromID_UpdatesScopeAndInvalidatesFiltered(t *testing.T) {

--- a/rest-api/cli/tui/regression_specialized_test.go
+++ b/rest-api/cli/tui/regression_specialized_test.go
@@ -410,16 +410,19 @@ func TestCmdInstanceUpdate_SendsAttributeOnlyPatch(t *testing.T) {
 	var requestCount atomic.Int32
 	requests := make(chan specializedRequestSnapshot, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
+		requestNumber := requestCount.Add(1)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		requests <- specializedRequestSnapshot{
+		snapshot := specializedRequestSnapshot{
 			method: r.Method,
 			path:   r.URL.Path,
 			body:   string(body),
+		}
+		if requestNumber == 1 {
+			requests <- snapshot
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"id":"instance-1","name":"new-name"}`)

--- a/rest-api/cli/tui/regression_specialized_test.go
+++ b/rest-api/cli/tui/regression_specialized_test.go
@@ -406,6 +406,47 @@ func TestSpecializedCommand_StructuredAPIErrorsRemainActionable(t *testing.T) {
 	assert.NotContains(t, output, "metadata unavailable")
 }
 
+func TestCmdInstanceUpdate_SendsAttributeOnlyPatch(t *testing.T) {
+	var requestCount atomic.Int32
+	requests := make(chan specializedRequestSnapshot, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		requests <- specializedRequestSnapshot{
+			method: r.Method,
+			path:   r.URL.Path,
+			body:   string(body),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"instance-1","name":"new-name"}`)
+	}))
+	defer server.Close()
+
+	session := NewSession(
+		appcli.NewClient(server.URL, "acme", "token", nil, false),
+		"acme",
+		"",
+	)
+	session.Cache.Set("instance", []NamedItem{{Name: "instance-one", ID: "instance-1"}})
+	session.Cache.Set("operating-system", []NamedItem{})
+
+	output, runErr := runSpecializedCommandWithInput(t, "new-name\n\nn\n", func() error {
+		return specializedRegressionCommand(t, "instance update").Run(session, []string{"instance-1"})
+	})
+
+	require.NoError(t, runErr)
+	request := <-requests
+	assert.Equal(t, int32(1), requestCount.Load())
+	assert.Equal(t, http.MethodPatch, request.method)
+	assert.Equal(t, "/v2/org/acme/nico/instance/instance-1", request.path)
+	assert.JSONEq(t, `{"name":"new-name"}`, request.body)
+	assert.Contains(t, output, "Instance updated: new-name (instance-1)")
+}
+
 func specializedRegressionCommand(t *testing.T, name string) Command {
 	t.Helper()
 	for _, command := range AllCommands() {


### PR DESCRIPTION
The API rejects requests that combine instance attribute changes with
`triggerReboot`, but the TUI allowed users to construct that request.

This change keeps `instance update` and `instance reboot` separate and uses
distinct payload types, preventing the invalid combination.

## Related issues

Fixes #5089

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

A two-call approach was considered, but it introduces cases where the update
succeeds and the reboot fails. Keeping the operations separate avoids that
partial-success state.

Scripts that pipe answers into `instance update` must be updated because the
"Trigger reboot now?" prompt has been removed.

Checks run locally:

- `go test ./cli/tui`
- `go test ./cli/...`
- `go vet ./cli/...`
- `go tool revive -config .revive.toml -set_exit_status ./...`
- `gofmt` on the changed Go files
- `make check-command-bundle`
- `make check-source-headers`
- `git diff --check`