### PR TITLE
fix(machine-a-tron): align DHCP relays with network segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,6 +1465,7 @@ dependencies = [
  "ctor",
  "eyre",
  "futures",
+ "ipnet",
  "itertools 0.14.0",
  "lazy_static",
  "librms",

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -25,6 +25,7 @@ use ::carbide_utils::HostPortPair;
 use ::machine_a_tron::{
     BmcMockRegistry, DeviceHandle, DhcpType, LogFormat, MachineATronConfig, MachineConfig,
 };
+use api_test_helper::api_server::{TEST_BMC_DHCP_RELAY_ADDRESS, TEST_BMC_NETWORK_PREFIX};
 use api_test_helper::utils::TestApiServerArgs;
 use api_test_helper::{
     IntegrationTestEnvironment, domain, instance, machine, metrics, subnet, tenant, utils, vpc,
@@ -40,7 +41,7 @@ use sqlx::{Postgres, Row};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-const DPU_UNDERLAY_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 20, 1, 1);
+const UNDERLAY_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 20, 1, 1);
 
 #[ctor::ctor(unsafe)]
 fn setup() {
@@ -151,7 +152,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -159,7 +160,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -167,7 +168,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -175,7 +176,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -183,7 +184,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -191,7 +192,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_zerodpu(
@@ -245,7 +246,7 @@ async fn test_integration() -> eyre::Result<()> {
             tenant_org_id,
             &v4_vpc_prefix_id,
             &v6_vpc_prefix_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_dual_stack_l2(
@@ -253,7 +254,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &dual_stack_l2_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
     ]);
@@ -467,7 +468,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
         false,
         &test_env,
         &bmc_address_registry,
-        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+        UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let db_pool = db_pool.clone();
             let carbide_api_addrs = carbide_api_addrs.to_vec();
@@ -605,7 +606,7 @@ async fn test_machine_a_tron_multidpu(
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     segment_id: &str,
-    admin_dhcp_relay_address: Ipv4Addr,
+    dpu_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     run_machine_a_tron_machine_test(
         hw_type,
@@ -614,7 +615,7 @@ async fn test_machine_a_tron_multidpu(
         false,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        dpu_dhcp_relay_address,
         |machine_handle| {
             let segment_id = segment_id.to_string();
             let carbide_api_addrs = &test_env.carbide_api_addrs;
@@ -703,7 +704,7 @@ async fn test_machine_a_tron_zerodpu(
         false,
         test_env,
         bmc_mock_registry,
-        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+        UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             let flat_vpc_id = flat_vpc_id.to_string();
@@ -765,7 +766,7 @@ async fn test_machine_a_tron_nic_mode(
         true,
         test_env,
         bmc_mock_registry,
-        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+        UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             let flat_vpc_id = flat_vpc_id.to_string();
@@ -936,7 +937,7 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
     hw_type: HardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
-    admin_dhcp_relay_address: Ipv4Addr,
+    dpu_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     run_machine_a_tron_machine_test(
         hw_type,
@@ -947,7 +948,7 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
         false,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        dpu_dhcp_relay_address,
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             async move {
@@ -1165,7 +1166,7 @@ async fn test_machine_a_tron_dual_stack(
     tenant_organization_id: &str,
     v4_vpc_prefix_id: &str,
     v6_vpc_prefix_id: &str,
-    admin_dhcp_relay_address: Ipv4Addr,
+    dpu_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     run_machine_a_tron_machine_test(
         hw_type,
@@ -1174,7 +1175,7 @@ async fn test_machine_a_tron_dual_stack(
         false,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        dpu_dhcp_relay_address,
         |machine_handle| {
             let v4_prefix_id = v4_vpc_prefix_id.to_string();
             let v6_prefix_id = v6_vpc_prefix_id.to_string();
@@ -1278,7 +1279,7 @@ async fn test_machine_a_tron_dual_stack_l2(
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     dual_stack_segment_id: &str,
-    admin_dhcp_relay_address: Ipv4Addr,
+    dpu_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     run_machine_a_tron_machine_test(
         hw_type,
@@ -1287,7 +1288,7 @@ async fn test_machine_a_tron_dual_stack_l2(
         false,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        dpu_dhcp_relay_address,
         |machine_handle| {
             let segment_id = dual_stack_segment_id.to_string();
             let carbide_api_addrs = &test_env.carbide_api_addrs;
@@ -1349,7 +1350,7 @@ async fn run_machine_a_tron_machine_test<F, O>(
     dpus_in_nic_mode: bool,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
-    admin_dhcp_relay_address: Ipv4Addr,
+    dpu_dhcp_relay_address: Ipv4Addr,
     run_assertions: F,
 ) -> eyre::Result<()>
 where
@@ -1377,13 +1378,11 @@ where
                 dpu_per_host_count,
                 dpu_reboot_delay: 1,
                 host_reboot_delay: 1,
-                // MAT currently uses this legacy-named field for DPU OS DHCP. Route that
-                // request through Underlay so it matches the predicted DPU interface.
-                admin_dhcp_relay_address,
-                // Keep this distinct from the DPU Underlay relay so NIC-mode tests fail if
-                // machine-a-tron sends direct host DHCP through the DPU network.
+                underlay_dhcp_relay_address: dpu_dhcp_relay_address,
+                // Keep this distinct from the shared Underlay relay so NIC-mode tests fail if
+                // machine-a-tron sends direct host DHCP through the Underlay network.
                 host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
-                oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
+                bmc_dhcp_relay_address: TEST_BMC_DHCP_RELAY_ADDRESS,
                 vpc_count: 0,
                 subnets_per_vpc: 0,
                 run_interval_idle: Duration::from_secs(1),
@@ -1433,7 +1432,15 @@ where
     .await
     .unwrap();
 
-    let results = join_all(provisionable_handles.into_iter().map(run_assertions)).await;
+    let results = join_all(provisionable_handles.into_iter().map(|machine_handle| {
+        let relay_assertion_handle = machine_handle.clone();
+        let assertions = run_assertions(machine_handle);
+        async move {
+            assertions.await?;
+            assert_relay_selection(&relay_assertion_handle, dpus_in_nic_mode)
+        }
+    }))
+    .await;
     let result_count = results.len();
     let assertion_result: eyre::Result<()> = results.into_iter().try_collect();
     let shutdown_result = mat_handle.shutdown().await;
@@ -1441,6 +1448,38 @@ where
     assert_eq!(result_count, host_count as usize);
     assertion_result?;
     shutdown_result
+}
+
+fn assert_relay_selection(
+    machine_handle: &DeviceHandle,
+    dpus_in_nic_mode: bool,
+) -> eyre::Result<()> {
+    let host_bmc_ip = machine_handle
+        .bmc_ip()
+        .context("host BMC DHCP did not return an address")?;
+    eyre::ensure!(
+        TEST_BMC_NETWORK_PREFIX.contains(&host_bmc_ip),
+        "host BMC DHCP used the underlay relay: {host_bmc_ip}"
+    );
+
+    for dpu in machine_handle.dpus() {
+        let details = dpu.host_details();
+        let dpu_bmc_ip: Ipv4Addr = details.oob_ip.parse()?;
+        eyre::ensure!(
+            TEST_BMC_NETWORK_PREFIX.contains(&dpu_bmc_ip),
+            "DPU BMC DHCP used the underlay relay: {dpu_bmc_ip}"
+        );
+
+        if !dpus_in_nic_mode {
+            let dpu_underlay_ip: Ipv4Addr = details.machine_ip.parse()?;
+            eyre::ensure!(
+                dpu_underlay_ip.octets()[..3] == UNDERLAY_DHCP_RELAY_ADDRESS.octets()[..3],
+                "DPU OOB boot DHCP used the BMC relay: {dpu_underlay_ip}"
+            );
+        }
+    }
+
+    Ok(())
 }
 
 // Get the current number of rows in the dns_records view,

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -19,6 +19,7 @@ use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, TcpListener};
 use std::time::Duration;
 
+use api_test_helper::api_server::{TEST_BMC_DHCP_RELAY_ADDRESS, TEST_BMC_NETWORK_PREFIX};
 use api_test_helper::utils::TestApiServerArgs;
 use api_test_helper::{IntegrationTestEnvironment, utils};
 use bmc_mock::ListenerOrAddress;
@@ -32,6 +33,8 @@ use machine_a_tron::{
     RackModelConfig, WiwynnGb200RackConfig,
 };
 use tokio_util::sync::CancellationToken;
+
+const UNDERLAY_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 20, 1, 1);
 
 #[ctor::ctor(unsafe)]
 fn setup() {
@@ -81,8 +84,8 @@ async fn test_machine_a_tron_racks_integration() -> eyre::Result<()> {
     run_machine_a_tron_racks_test(
         &test_env,
         &bmc_address_registry,
-        // MAT currently uses admin_dhcp_relay_address for DPU OS DHCP.
-        Ipv4Addr::new(172, 20, 1, 1),
+        // DPU OOB boot and switch NVOS DHCP use the shared Underlay network.
+        UNDERLAY_DHCP_RELAY_ADDRESS,
     )
     .await?;
 
@@ -96,7 +99,7 @@ async fn test_machine_a_tron_racks_integration() -> eyre::Result<()> {
 async fn run_machine_a_tron_racks_test(
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
-    admin_dhcp_relay_address: Ipv4Addr,
+    underlay_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     let gb200_rack_id = RackId::new("machine-a-tron-gb200-nvl72");
     let gb300_rack_id = RackId::new("machine-a-tron-gb300-nvl72");
@@ -122,8 +125,8 @@ async fn run_machine_a_tron_racks_test(
                             host_reboot_delay: 1,
                             scout_run_interval: Duration::from_secs(1),
                             discovery_retry_interval: Duration::from_millis(100),
-                            oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
-                            admin_dhcp_relay_address,
+                            bmc_dhcp_relay_address: TEST_BMC_DHCP_RELAY_ADDRESS,
+                            underlay_dhcp_relay_address,
                             host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
                             run_interval_working: Duration::from_millis(100),
                             run_interval_idle: Duration::from_secs(1),
@@ -147,8 +150,8 @@ async fn run_machine_a_tron_racks_test(
                             host_reboot_delay: 1,
                             scout_run_interval: Duration::from_secs(1),
                             discovery_retry_interval: Duration::from_millis(100),
-                            oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
-                            admin_dhcp_relay_address,
+                            bmc_dhcp_relay_address: TEST_BMC_DHCP_RELAY_ADDRESS,
+                            underlay_dhcp_relay_address,
                             host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
                             run_interval_working: Duration::from_millis(100),
                             run_interval_idle: Duration::from_secs(1),
@@ -243,6 +246,46 @@ async fn run_machine_a_tron_racks_test(
                     .fetch_one(&test_env.db_pool)
                     .await?;
             assert_eq!(expected_switch_count, 9, "rack {rack_id}");
+
+            let switch_bmc_ips: Vec<String> = sqlx::query_scalar(
+                "SELECT host(mia.address) \
+                 FROM expected_switches es \
+                 JOIN machine_interfaces mi ON mi.mac_address = es.bmc_mac_address \
+                 JOIN machine_interface_addresses mia ON mia.interface_id = mi.id \
+                 WHERE es.rack_id = $1",
+            )
+            .bind(rack_id.as_str())
+            .fetch_all(&test_env.db_pool)
+            .await?;
+            let switch_bmc_ips: Vec<Ipv4Addr> = switch_bmc_ips
+                .into_iter()
+                .map(|address| address.parse())
+                .collect::<Result<_, _>>()?;
+            assert_eq!(switch_bmc_ips.len(), 9, "rack {rack_id}");
+            assert!(
+                switch_bmc_ips
+                    .iter()
+                    .all(|address| TEST_BMC_NETWORK_PREFIX.contains(address)),
+                "rack {rack_id} switch BMC DHCP used the Underlay relay: {switch_bmc_ips:?}"
+            );
+
+            let switch_nvos_ips: Vec<String> = sqlx::query_scalar(
+                "SELECT host(mia.address) \
+                 FROM expected_switches es \
+                 JOIN machine_interfaces mi ON mi.mac_address = ANY(es.nvos_mac_addresses) \
+                 JOIN machine_interface_addresses mia ON mia.interface_id = mi.id \
+                 WHERE es.rack_id = $1",
+            )
+            .bind(rack_id.as_str())
+            .fetch_all(&test_env.db_pool)
+            .await?;
+            assert_eq!(switch_nvos_ips.len(), 9, "rack {rack_id}");
+            assert!(
+                switch_nvos_ips
+                    .iter()
+                    .all(|address| address.starts_with("172.20.1.")),
+                "rack {rack_id} switch NVOS DHCP used the BMC relay: {switch_nvos_ips:?}"
+            );
 
             let actual_power_shelf_count: i64 = sqlx::query_scalar(
                 "SELECT COUNT(*) FROM expected_power_shelves WHERE rack_id = $1",

--- a/crates/api-test-helper/Cargo.toml
+++ b/crates/api-test-helper/Cargo.toml
@@ -73,6 +73,7 @@ tracing-subscriber = { features = [
 futures = { workspace = true }
 librms = { workspace = true }
 itertools = { workspace = true }
+ipnet = { workspace = true }
 ctor = { workspace = true }
 temp-dir = { workspace = true }
 rand = { workspace = true }

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -14,17 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use carbide_secrets::CredentialConfig;
 use carbide_utils::HostPortPair;
+use ipnet::Ipv4Net;
 use tokio::sync::oneshot::Sender;
 use tokio_util::sync::CancellationToken;
 
 use crate::utils::LOCALHOST_CERTS;
 
 const DOMAIN_NAME: &str = "forge.integrationtest";
+
+/// BMC network used by API integration tests. The `/23` accommodates both 71-BMC rack fixtures
+/// while keeping the SQL allocator's candidate scan bounded.
+pub const TEST_BMC_NETWORK_PREFIX: Ipv4Net = Ipv4Net::new_assert(Ipv4Addr::new(127, 0, 0, 0), 23);
+
+/// DHCP relay address for [`TEST_BMC_NETWORK_PREFIX`].
+pub const TEST_BMC_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 10);
 
 // Use a struct for the args to start() so that callers can see argument names
 pub struct StartArgs {
@@ -185,8 +193,8 @@ pub async fn start(
 
         [networks.DEV1-C09-IPMI-01]
         type = "underlay"
-        prefix = "127.0.0.0/8"
-        gateway = "127.0.0.10"
+        prefix = "{TEST_BMC_NETWORK_PREFIX}"
+        gateway = "{TEST_BMC_DHCP_RELAY_ADDRESS}"
         mtu = 1490
         reserve_first = 0
 

--- a/crates/machine-a-tron/config/mac.toml
+++ b/crates/machine-a-tron/config/mac.toml
@@ -93,12 +93,10 @@ host_reboot_delay = 10 # in units of seconds
 # carbide-api-site-config.toml. Nothing actually binds to these addresses, it is
 # only used for filling in gateway/relay fields in the DHCP request object
 # (which carbide uses to determine what network the request came from.)
-admin_dhcp_relay_address = "192.168.252.1"
 # Direct host DHCP for zero-DPU hosts and DPUs operating as plain NICs.
 host_inband_dhcp_relay_address = "192.168.253.1"
-oob_dhcp_relay_address = "192.168.2.1"
-# oob_dhcp_relay_address = "192.168.2.1"
-# admin_dhcp_relay_address = "192.164.0.1"
+bmc_dhcp_relay_address = "192.168.2.1"
+underlay_dhcp_relay_address = "192.168.2.1"
 
 # Set this to a hostname or IP If you want machine-a-tron to register its BMC-mock as the bmc_proxy host through the
 # dynamic configuration API. (this will be combined with bmc_mock_port to form a host:port pair.) This is useful if you

--- a/crates/machine-a-tron/config/mat.toml
+++ b/crates/machine-a-tron/config/mat.toml
@@ -92,8 +92,8 @@ enable_ipmi_simulation = false
 # ids = ["rack-001", "rack-002"]
 # dpu_reboot_delay = 20
 # host_reboot_delay = 10
-# oob_dhcp_relay_address = "192.168.192.1"
-# admin_dhcp_relay_address = "192.168.176.1"
+# bmc_dhcp_relay_address = "192.168.192.1"
+# underlay_dhcp_relay_address = "192.168.128.1"
 # host_inband_dhcp_relay_address = "192.168.177.1"
 
 [machines.config]
@@ -111,8 +111,8 @@ host_reboot_delay = 20 # in units of seconds
 # carbide-api-site-config.toml. Nothing actually binds to these addresses, it is
 # only used for filling in gateway/relay fields in the DHCP request object
 # (which carbide uses to determine what network the request came from.)
-oob_dhcp_relay_address = "192.168.2.1"
-admin_dhcp_relay_address = "192.164.0.1"
+bmc_dhcp_relay_address = "192.168.2.1"
+underlay_dhcp_relay_address = "192.168.2.1"
 # Direct host DHCP for zero-DPU hosts and DPUs operating as plain NICs.
 host_inband_dhcp_relay_address = "192.165.0.1"
 

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -44,6 +44,7 @@ use crate::api_client::ApiClient;
 use crate::api_throttler::ApiThrottler;
 use crate::machine_state_machine::OsImage;
 use crate::rack::{RackMemberRegistration, RackRegistration};
+use crate::status::DeviceKind;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
 #[clap(name = "machine-sim")]
@@ -101,10 +102,13 @@ pub struct MachineConfig {
         serialize_with = "as_std_duration"
     )]
     pub discovery_retry_interval: Duration,
-    pub oob_dhcp_relay_address: Ipv4Addr,
-    pub admin_dhcp_relay_address: Ipv4Addr,
+    /// Relay address for BMC DHCP traffic.
+    pub bmc_dhcp_relay_address: Ipv4Addr,
+    /// Underlay relay address for DPU OOB boot and switch NVOS DHCP traffic.
+    pub underlay_dhcp_relay_address: Ipv4Addr,
     /// Relay address used when a host DHCPs directly through a plain NIC rather than a managed DPU.
-    /// If omitted, direct host DHCP falls back to `admin_dhcp_relay_address` for compatibility.
+    /// Required for zero-DPU and NIC-mode compute hosts; ignored for managed-DPU hosts and
+    /// non-machine devices.
     #[serde(default)]
     pub host_inband_dhcp_relay_address: Option<Ipv4Addr>,
 
@@ -155,9 +159,15 @@ pub struct MachineConfig {
 }
 
 impl MachineConfig {
-    pub(crate) fn missing_host_inband_relay_for_direct_host_dhcp(&self) -> bool {
-        self.host_inband_dhcp_relay_address.is_none()
-            && (self.dpu_per_host_count == 0 || self.dpus_in_nic_mode)
+    fn validate(&self, machine_group: &str) -> eyre::Result<()> {
+        let requires_host_inband_relay = DeviceKind::from(self.hw_type) == DeviceKind::Machine
+            && (self.dpu_per_host_count == 0 || self.dpus_in_nic_mode);
+        eyre::ensure!(
+            self.host_inband_dhcp_relay_address.is_some() || !requires_host_inband_relay,
+            "machines.{machine_group}.host_inband_dhcp_relay_address is required when dpu_per_host_count is zero or dpus_in_nic_mode is true"
+        );
+
+        Ok(())
     }
 }
 
@@ -177,8 +187,11 @@ pub struct WiwynnGb200RackConfig {
         serialize_with = "as_std_duration"
     )]
     pub discovery_retry_interval: Duration,
-    pub oob_dhcp_relay_address: Ipv4Addr,
-    pub admin_dhcp_relay_address: Ipv4Addr,
+    /// Relay address for BMC DHCP traffic.
+    pub bmc_dhcp_relay_address: Ipv4Addr,
+    /// Underlay relay address for DPU OOB boot and switch NVOS DHCP traffic.
+    pub underlay_dhcp_relay_address: Ipv4Addr,
+    /// Relay address used when a host DHCPs directly through a plain NIC.
     #[serde(default)]
     pub host_inband_dhcp_relay_address: Option<Ipv4Addr>,
     #[serde(
@@ -229,8 +242,8 @@ impl WiwynnGb200RackConfig {
             host_reboot_delay: self.host_reboot_delay,
             scout_run_interval: self.scout_run_interval,
             discovery_retry_interval: self.discovery_retry_interval,
-            oob_dhcp_relay_address: self.oob_dhcp_relay_address,
-            admin_dhcp_relay_address: self.admin_dhcp_relay_address,
+            bmc_dhcp_relay_address: self.bmc_dhcp_relay_address,
+            underlay_dhcp_relay_address: self.underlay_dhcp_relay_address,
             host_inband_dhcp_relay_address: self.host_inband_dhcp_relay_address,
             run_interval_working: self.run_interval_working,
             run_interval_idle: self.run_interval_idle,
@@ -260,8 +273,11 @@ pub struct LenovoGb300RackConfig {
         serialize_with = "as_std_duration"
     )]
     pub discovery_retry_interval: Duration,
-    pub oob_dhcp_relay_address: Ipv4Addr,
-    pub admin_dhcp_relay_address: Ipv4Addr,
+    /// Relay address for BMC DHCP traffic.
+    pub bmc_dhcp_relay_address: Ipv4Addr,
+    /// Underlay relay address for DPU OOB boot and switch NVOS DHCP traffic.
+    pub underlay_dhcp_relay_address: Ipv4Addr,
+    /// Relay address used when a host DHCPs directly through a plain NIC.
     #[serde(default)]
     pub host_inband_dhcp_relay_address: Option<Ipv4Addr>,
     #[serde(
@@ -312,8 +328,8 @@ impl LenovoGb300RackConfig {
             host_reboot_delay: self.host_reboot_delay,
             scout_run_interval: self.scout_run_interval,
             discovery_retry_interval: self.discovery_retry_interval,
-            oob_dhcp_relay_address: self.oob_dhcp_relay_address,
-            admin_dhcp_relay_address: self.admin_dhcp_relay_address,
+            bmc_dhcp_relay_address: self.bmc_dhcp_relay_address,
+            underlay_dhcp_relay_address: self.underlay_dhcp_relay_address,
             host_inband_dhcp_relay_address: self.host_inband_dhcp_relay_address,
             run_interval_working: self.run_interval_working,
             run_interval_idle: self.run_interval_idle,
@@ -559,6 +575,10 @@ pub struct MachineATronConfig {
 
 impl MachineATronConfig {
     pub fn validate(&self) -> eyre::Result<()> {
+        self.resolved_device_configs().map(|_| ())
+    }
+
+    fn validate_unresolved(&self) -> eyre::Result<()> {
         if let Some(ufm_mock) = self.ufm_mock.as_ref() {
             ufm_mock.validate()?;
         }
@@ -623,6 +643,7 @@ impl MachineATronConfig {
         }
 
         for (machine_group, machine) in &self.machines {
+            machine.validate(machine_group)?;
             if let Some(rack_id) = machine.rack_id.as_ref() {
                 eyre::ensure!(
                     !simulated_rack_ids.contains(rack_id),
@@ -635,7 +656,7 @@ impl MachineATronConfig {
     }
 
     pub(crate) fn resolved_device_configs(&self) -> eyre::Result<ResolvedDeviceConfigs> {
-        self.validate()?;
+        self.validate_unresolved()?;
 
         let mut machines = self.machines.clone();
         let mut racks = Vec::new();
@@ -663,17 +684,16 @@ impl MachineATronConfig {
                     .fixed_number_of_dpu()
                     .expect("rack hardware must have a fixed number of DPUs")
                     .into();
+                let machine_config = rack.model.component_machine_config(
+                    rack_id.clone(),
+                    placement,
+                    unit.hardware_type,
+                    dpu_per_host_count,
+                );
+                machine_config.validate(&machine_config_section)?;
                 eyre::ensure!(
                     machines
-                        .insert(
-                            machine_config_section.clone(),
-                            Arc::new(rack.model.component_machine_config(
-                                rack_id.clone(),
-                                placement,
-                                unit.hardware_type,
-                                dpu_per_host_count,
-                            )),
-                        )
+                        .insert(machine_config_section.clone(), Arc::new(machine_config))
                         .is_none(),
                     "rack {rack_id} generated duplicate device identity {machine_config_section}"
                 );
@@ -1014,9 +1034,9 @@ dpu_per_host_count = 2
 dpu_reboot_delay = 1 # in units of seconds
 host_reboot_delay = 1 # in units of seconds
 vpc_count = 0
-admin_dhcp_relay_address = "192.168.176.1"
+underlay_dhcp_relay_address = "192.168.128.1"
 host_inband_dhcp_relay_address = "192.168.177.1"
-oob_dhcp_relay_address = "192.168.192.1"
+bmc_dhcp_relay_address = "192.168.192.1"
 subnets_per_vpc = 0
 run_interval_working = "100ms"
 run_interval_idle = "1s"
@@ -1033,8 +1053,8 @@ scout_run_interval = "5s"
             host_reboot_delay: machine.host_reboot_delay,
             scout_run_interval: machine.scout_run_interval,
             discovery_retry_interval: machine.discovery_retry_interval,
-            oob_dhcp_relay_address: machine.oob_dhcp_relay_address,
-            admin_dhcp_relay_address: machine.admin_dhcp_relay_address,
+            bmc_dhcp_relay_address: machine.bmc_dhcp_relay_address,
+            underlay_dhcp_relay_address: machine.underlay_dhcp_relay_address,
             host_inband_dhcp_relay_address: machine.host_inband_dhcp_relay_address,
             run_interval_working: machine.run_interval_working,
             run_interval_idle: machine.run_interval_idle,
@@ -1052,8 +1072,8 @@ scout_run_interval = "5s"
             host_reboot_delay: machine.host_reboot_delay,
             scout_run_interval: machine.scout_run_interval,
             discovery_retry_interval: machine.discovery_retry_interval,
-            oob_dhcp_relay_address: machine.oob_dhcp_relay_address,
-            admin_dhcp_relay_address: machine.admin_dhcp_relay_address,
+            bmc_dhcp_relay_address: machine.bmc_dhcp_relay_address,
+            underlay_dhcp_relay_address: machine.underlay_dhcp_relay_address,
             host_inband_dhcp_relay_address: machine.host_inband_dhcp_relay_address,
             run_interval_working: machine.run_interval_working,
             run_interval_idle: machine.run_interval_idle,
@@ -1524,7 +1544,7 @@ server_address = "127.0.0.1:6767""#,
     }
 
     #[test]
-    fn host_inband_dhcp_relay_is_optional() {
+    fn host_inband_dhcp_relay_may_be_omitted() {
         let mut serialized =
             toml::Value::try_from(rack_config()).expect("Could not serialize config");
         serialized["machines"]["config"]
@@ -1534,8 +1554,152 @@ server_address = "127.0.0.1:6767""#,
 
         let cfg: MachineATronConfig = serialized
             .try_into()
-            .expect("legacy config without host_inband_dhcp_relay_address should deserialize");
+            .expect("config without host_inband_dhcp_relay_address should deserialize");
         assert_eq!(cfg.machines["config"].host_inband_dhcp_relay_address, None);
+    }
+
+    #[test]
+    fn host_inband_dhcp_relay_requirement_is_validated() {
+        let host_inband = Ipv4Addr::new(192, 168, 177, 1);
+        let compute = HardwareType::DellPowerEdgeR750;
+
+        check_cases(
+            [
+                Case {
+                    scenario: "managed-DPU host without HostInband relay",
+                    input: (compute, 2, false, None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "managed-DPU host with HostInband relay",
+                    input: (compute, 2, false, Some(host_inband)),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "zero-DPU host without HostInband relay",
+                    input: (compute, 0, false, None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "zero-DPU host with HostInband relay",
+                    input: (compute, 0, false, Some(host_inband)),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "NIC-mode host without HostInband relay",
+                    input: (compute, 2, true, None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "NIC-mode host with HostInband relay",
+                    input: (compute, 2, true, Some(host_inband)),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "zero-DPU NIC-mode host without HostInband relay",
+                    input: (compute, 0, true, None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "zero-DPU NIC-mode host with HostInband relay",
+                    input: (compute, 0, true, Some(host_inband)),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "switch without HostInband relay",
+                    input: (HardwareType::NvidiaSwitchNd5200Ld, 0, false, None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "power shelf without HostInband relay",
+                    input: (HardwareType::LiteOnPowerShelf, 0, false, None),
+                    expect: Yields(()),
+                },
+            ],
+            |(hw_type, dpu_per_host_count, dpus_in_nic_mode, host_inband_dhcp_relay_address)| {
+                let mut config = rack_config();
+                let machine = Arc::make_mut(config.machines.get_mut("config").unwrap());
+                machine.hw_type = hw_type;
+                machine.dpu_per_host_count = dpu_per_host_count;
+                machine.dpus_in_nic_mode = dpus_in_nic_mode;
+                machine.host_inband_dhcp_relay_address = host_inband_dhcp_relay_address;
+                config.validate().map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn rack_derived_host_inband_dhcp_relay_requirement_is_validated() {
+        let mut gb200 = gb200_rack_config();
+        let RackModelConfig::WiwynnGb200Nvl72 { simulation } =
+            &mut gb200.racks.get_mut("default").unwrap().model
+        else {
+            unreachable!("GB200 fixture must use the WIWYNN rack model")
+        };
+        simulation.host_inband_dhcp_relay_address = None;
+        let mut gb200_nic_mode = gb200.clone();
+        let RackModelConfig::WiwynnGb200Nvl72 { simulation } =
+            &mut gb200_nic_mode.racks.get_mut("default").unwrap().model
+        else {
+            unreachable!("GB200 fixture must use the WIWYNN rack model")
+        };
+        simulation.dpus_in_nic_mode = true;
+
+        let mut gb300 = gb300_rack_config();
+        let RackModelConfig::LenovoGb300Nvl72 { simulation } =
+            &mut gb300.racks.get_mut("default").unwrap().model
+        else {
+            unreachable!("GB300 fixture must use the Lenovo rack model")
+        };
+        simulation.host_inband_dhcp_relay_address = None;
+
+        check_cases(
+            [
+                Case {
+                    scenario: "WIWYNN GB200 rack without HostInband relay",
+                    input: gb200,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "WIWYNN GB200 NIC-mode rack without HostInband relay",
+                    input: gb200_nic_mode,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "Lenovo GB300 rack without HostInband relay",
+                    input: gb300,
+                    expect: Yields(()),
+                },
+            ],
+            |config| config.validate().map_err(drop),
+        );
+    }
+
+    #[test]
+    fn bmc_and_underlay_dhcp_relays_are_required() {
+        check_cases(
+            [
+                Case {
+                    scenario: "missing BMC relay",
+                    input: "bmc_dhcp_relay_address",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing Underlay relay",
+                    input: "underlay_dhcp_relay_address",
+                    expect: Fails,
+                },
+            ],
+            |relay_key| {
+                let mut serialized =
+                    toml::Value::try_from(rack_config()).expect("Could not serialize config");
+                serialized["machines"]["config"]
+                    .as_table_mut()
+                    .expect("machine config should be a TOML table")
+                    .remove(relay_key);
+                serialized.try_into::<MachineATronConfig>().map_err(drop)
+            },
+        );
     }
 
     #[test]
@@ -1607,44 +1771,6 @@ server_address = "127.0.0.1:6767""#,
                 },
             ],
             |config| config.validate().map_err(drop),
-        );
-    }
-
-    #[test]
-    fn missing_host_inband_relay_warning_selection() {
-        let host_inband = Ipv4Addr::new(192, 168, 177, 1);
-
-        check_values(
-            [
-                Check {
-                    scenario: "zero-DPU host without HostInband",
-                    input: (0, false, None),
-                    expect: true,
-                },
-                Check {
-                    scenario: "NIC-mode host without HostInband",
-                    input: (1, true, None),
-                    expect: true,
-                },
-                Check {
-                    scenario: "managed-DPU host without HostInband",
-                    input: (1, false, None),
-                    expect: false,
-                },
-                Check {
-                    scenario: "zero-DPU host with HostInband",
-                    input: (0, false, Some(host_inband)),
-                    expect: false,
-                },
-            ],
-            |(dpu_per_host_count, dpus_in_nic_mode, host_inband_dhcp_relay_address)| {
-                let mut config = rack_config();
-                let machine = Arc::make_mut(config.machines.get_mut("config").unwrap());
-                machine.dpu_per_host_count = dpu_per_host_count;
-                machine.dpus_in_nic_mode = dpus_in_nic_mode;
-                machine.host_inband_dhcp_relay_address = host_inband_dhcp_relay_address;
-                machine.missing_host_inband_relay_for_direct_host_dhcp()
-            },
         );
     }
 }

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -88,18 +88,6 @@ impl MachineATron {
     pub async fn make_devices(&self, paused: bool) -> eyre::Result<SimulatorRegistry> {
         let resolved_configs = self.app_context.app_config.resolved_device_configs()?;
 
-        for (machine_group, machine) in &resolved_configs.machines {
-            if machine.missing_host_inband_relay_for_direct_host_dhcp() {
-                tracing::warn!(
-                    machine_group,
-                    dpu_per_host_count = machine.dpu_per_host_count,
-                    dpus_in_nic_mode = machine.dpus_in_nic_mode,
-                    admin_dhcp_relay_address = %machine.admin_dhcp_relay_address,
-                    "host_inband_dhcp_relay_address is not configured for a zero-DPU or NIC-mode host; direct host DHCP will fall back to admin_dhcp_relay_address"
-                );
-            }
-        }
-
         let mut persisted_devices = self
             .app_context
             .app_config

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -139,13 +139,13 @@ fn abandon_machine_actions_on_power_change(
 
 fn direct_dhcp_relay_address(
     is_host: bool,
-    admin_relay_address: Ipv4Addr,
+    underlay_relay_address: Ipv4Addr,
     host_inband_relay_address: Option<Ipv4Addr>,
-) -> Ipv4Addr {
+) -> Option<Ipv4Addr> {
     if is_host {
-        host_inband_relay_address.unwrap_or(admin_relay_address)
+        host_inband_relay_address
     } else {
-        admin_relay_address
+        Some(underlay_relay_address)
     }
 }
 
@@ -689,7 +689,7 @@ impl MachineStateMachine {
             .dhcp_client
             .request_ip(DhcpRequestInfo {
                 mac_address: self.machine_info.bmc_mac_address(),
-                relay_address: self.config.oob_dhcp_relay_address,
+                relay_address: self.config.bmc_dhcp_relay_address,
                 vendor_class: vendor_class(&self.machine_info, DhcpRequester::Bmc),
             })
             .await
@@ -754,9 +754,10 @@ impl MachineStateMachine {
         } else {
             let direct_relay_address = direct_dhcp_relay_address(
                 matches!(&self.machine_info, MachineInfo::Host(_)),
-                self.config.admin_dhcp_relay_address,
+                self.config.underlay_dhcp_relay_address,
                 self.config.host_inband_dhcp_relay_address,
-            );
+            )
+            .ok_or(MachineStateError::MissingHostInbandDhcpRelayAddress)?;
             tracing::debug!(
                 primary_mac_address = %primary_mac,
                 %direct_relay_address,
@@ -1393,6 +1394,8 @@ pub(super) enum MachineStateError {
     DhcpError(#[from] DhcpRelayError),
     #[error("DPU DHCP relay is unavailable")]
     DpuDhcpRelayUnavailable,
+    #[error("host_inband_dhcp_relay_address is required for direct host DHCP")]
+    MissingHostInbandDhcpRelayAddress,
     #[error("failed to get PXE response: {0}")]
     PxeError(#[from] PxeError),
     #[error("BMC mock TLS error: {0}")]
@@ -1427,7 +1430,7 @@ mod tests {
 
     #[test]
     fn direct_dhcp_relay_selection() {
-        let admin = Ipv4Addr::new(172, 21, 0, 1);
+        let underlay = Ipv4Addr::new(172, 20, 0, 1);
         let host_inband = Ipv4Addr::new(172, 22, 0, 1);
 
         check_values(
@@ -1435,20 +1438,20 @@ mod tests {
                 Check {
                     scenario: "NIC-mode or zero-DPU host",
                     input: (true, Some(host_inband)),
-                    expect: host_inband,
+                    expect: Some(host_inband),
                 },
                 Check {
-                    scenario: "legacy host without HostInband configuration",
+                    scenario: "host without HostInband configuration",
                     input: (true, None),
-                    expect: admin,
+                    expect: None,
                 },
                 Check {
                     scenario: "DPU ignores HostInband configuration",
                     input: (false, Some(host_inband)),
-                    expect: admin,
+                    expect: Some(underlay),
                 },
             ],
-            |(is_host, host_inband)| direct_dhcp_relay_address(is_host, admin, host_inband),
+            |(is_host, host_inband)| direct_dhcp_relay_address(is_host, underlay, host_inband),
         );
     }
 

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -305,7 +305,7 @@ impl PowerShelfActor {
             .dhcp_client
             .request_ip(DhcpRequestInfo {
                 mac_address: self.host_info.bmc_mac_address,
-                relay_address: self.config.oob_dhcp_relay_address,
+                relay_address: self.config.bmc_dhcp_relay_address,
                 vendor_class: vendor_class(&machine_info, DhcpRequester::Bmc),
             })
             .await

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -323,7 +323,7 @@ impl SwitchActor {
             .dhcp_client
             .request_ip(DhcpRequestInfo {
                 mac_address: self.host_info.bmc_mac_address,
-                relay_address: self.config.oob_dhcp_relay_address,
+                relay_address: self.config.bmc_dhcp_relay_address,
                 vendor_class: vendor_class(&machine_info, DhcpRequester::Bmc),
             })
             .await
@@ -342,7 +342,7 @@ impl SwitchActor {
             .dhcp_client
             .request_ip(DhcpRequestInfo {
                 mac_address: *nvos_mac_address,
-                relay_address: self.config.admin_dhcp_relay_address,
+                relay_address: self.config.underlay_dhcp_relay_address,
                 // No DHCP option 60 value has been verified for NVOS.
                 vendor_class: None,
             })

--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -180,8 +180,8 @@ nico-machine-a-tron:
           hwType: wiwynn_gb200_nvl
           hostCount: 2
           dpuPerHostCount: 2
-          oobDhcpRelayAddress: "192.168.192.1"
-          adminDhcpRelayAddress: "192.168.176.1"
+          bmcDhcpRelayAddress: "192.168.192.1"
+          underlayDhcpRelayAddress: "192.168.128.1"
 nico-dhcp:
   enabled: false
 nico-dns:

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -194,15 +194,15 @@ nico-machine-a-tron:
             - rack-001
           dpu_reboot_delay: 20
           host_reboot_delay: 10
-          oob_dhcp_relay_address: 192.168.192.1
-          admin_dhcp_relay_address: 192.168.176.1
+          bmc_dhcp_relay_address: 192.168.192.1
+          underlay_dhcp_relay_address: 192.168.128.1
       machines:
         rack-machines:
           hwType: wiwynn_gb200_nvl
           hostCount: 2
           dpuPerHostCount: 2
-          oobDhcpRelayAddress: 192.168.192.1
-          adminDhcpRelayAddress: 192.168.176.1
+          bmcDhcpRelayAddress: 192.168.192.1
+          underlayDhcpRelayAddress: 192.168.128.1
 
 tilt:
   profiles: # Toggle optional stacks; required dependencies follow automatically.

--- a/dev/docker-env/mat.toml
+++ b/dev/docker-env/mat.toml
@@ -74,7 +74,7 @@ subnets_per_vpc = 2
 # carbide-api-site-config.toml. Nothing actually binds to these addresses, it is
 # only used for filling in gateway/relay fields in the DHCP request object
 # (which carbide uses to determine what network the request came from.)
-oob_dhcp_relay_address = "172.21.0.1"
-admin_dhcp_relay_address = "172.20.0.1"
+bmc_dhcp_relay_address = "172.21.0.1"
+underlay_dhcp_relay_address = "172.21.0.1"
 # Direct host DHCP for zero-DPU hosts and DPUs operating as plain NICs.
 host_inband_dhcp_relay_address = "172.22.0.1"

--- a/docs/development/machine-a-tron-deployment.md
+++ b/docs/development/machine-a-tron-deployment.md
@@ -228,9 +228,10 @@ Copy `helm-prereqs/values/machine-a-tron.yaml` and fill in the site-specific val
 | Field | Description |
 |-------|-------------|
 | `image.tag` | Tag produced by [building the container image](#building-the-container-image) (e.g. `8c35783af-amd64`) |
-| `machines.dell-hosts.oobDhcpRelayAddress` | Gateway of the OOB/underlay network from nico-core site config |
-| `machines.dell-hosts.adminDhcpRelayAddress` | Gateway of the admin network from nico-core site config |
-| `machines.dell-hosts.hostCount` | Must not exceed available OOB DHCP addresses (`hostCount + hostCount×dpuPerHostCount`) |
+| `pods.default.machines.dell-hosts.bmcDhcpRelayAddress` | Gateway used by BMC DHCP requests |
+| `pods.default.machines.dell-hosts.underlayDhcpRelayAddress` | Underlay gateway used by DPU OS DHCP requests |
+| `pods.default.machines.dell-hosts.hostInbandDhcpRelayAddress` | Host Inband gateway used for direct host DHCP; required when `dpuPerHostCount` is `0` or `dpusInNicMode` is `true`, and optional otherwise |
+| `pods.default.machines.dell-hosts.hostCount` | Must fit the BMC and DPU Underlay DHCP pools, plus the Host Inband pool when direct-host DHCP is enabled |
 
 ### SPIFFE URI override
 
@@ -329,7 +330,7 @@ with ClusterIP = BMC IP assigned by NICo DHCP. NICo dials each BMC IP directly
 Everything single-pod mode needs still applies (namespaces, CA copy, Vault
 seeds, SPIFFE URI). Multi-pod with controller adds the following requirements:
 
-1. **`oobDhcpRelayAddress` must be within Kubernetes ServiceCIDR.** All pods
+1. **`bmcDhcpRelayAddress` must be within Kubernetes ServiceCIDR.** All pods
    can share the same relay address — NICo assigns unique IPs from the network.
    Default ServiceCIDR ranges:
    - `10.96.0.0/12` - vanilla Kubernetes (kubeadm)
@@ -375,16 +376,16 @@ seeds, SPIFFE URI). Multi-pod with controller adds the following requirements:
             hwType: wiwynn_gb200_nvl
             hostCount: 100
             dpuPerHostCount: 2
-            oobDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-            adminDhcpRelayAddress: "192.168.176.1"
+            bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
+            underlayDhcpRelayAddress: "192.168.176.1"
       mat-1:
         machines:
           compute:
             hwType: wiwynn_gb200_nvl
             hostCount: 100
             dpuPerHostCount: 2
-            oobDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
-            adminDhcpRelayAddress: "192.168.176.1"
+            bmcDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
+            underlayDhcpRelayAddress: "192.168.176.1"
 
     macAddressPool:
       enabled: true
@@ -425,14 +426,21 @@ kubectl logs -n nico-system deployment/nico-api | grep "Request denied.*machine-
 
 ## DHCP Address Space
 
-machine-a-tron allocates one OOB IP per BMC interface (1 per host + 1 per DPU). With
-5 hosts and 2 DPUs each that is **15 IPs** (`5 + 5×2`). Ensure the OOB DHCP prefix in
-nico-core is large enough. Note the usable count is smaller than the raw CIDR: a
-`/28` (16 addresses) yields only ~10–13 usable after subtracting network,
-broadcast, gateway, and any reserved addresses — on dev6 a `/28` yielded 10, so
-`hostCount: 3 × 2 DPUs = 9` fit but `5 × 2 = 15` did not. Use at least a `/27`
-for the default counts, or reduce `hostCount` / `dpuPerHostCount`. Symptom of
-overflow: `No IP addresses left in prefix ...` and machines stuck in `BmcInit`.
+For a machine group with `H = hostCount` hosts and `D = dpuPerHostCount` DPUs per
+host, machine-a-tron needs:
+
+- `H×(1+D)` addresses from the BMC pool: one per host and DPU
+- `H×D` addresses from the DPU Underlay pool: one DPU OS address per DPU
+- `H` addresses from the Host Inband pool when `D` is `0` or `dpusInNicMode` is
+  `true`; otherwise none
+
+For 5 hosts with 2 DPUs each, the BMC pool needs **15 addresses** (`5 + 5×2`)
+and the DPU Underlay pool needs **10 addresses** (`5×2`). NIC mode additionally
+needs **5 Host Inband addresses**. When multiple relay addresses select the same
+network segment, add their demands. The usable count is smaller than the raw
+CIDR after subtracting the network, broadcast, gateway, and reserved addresses.
+An exhausted pool produces `No IP addresses left in prefix ...` and leaves
+machines stuck during discovery.
 
 If the prefix is exhausted from previous runs, do one of the following:
 
@@ -466,8 +474,8 @@ The `machine_dhcp_records` view inner-joins the singleton control row `machine_i
 | `git fetch ... (exit status: 127)` | `libredfish` is a git dependency, `git` not in slim image | Add `git` to builder stage |
 | Host BMCs 401 while DPUs explore fine | Host and DPU factory passwords differ (`factory_password` vs `0penBmc`); host factory cred missing or wrong | Seed `machines/all_hosts/factory_default/bmc-metadata-items/dell` = `root`/`factory_password` (lowercase `dell`) |
 | HTTP 403 on every gRPC call | machine-a-tron cert SPIFFE URI not in nico-api's `service_base_paths` | Set `certificate.uris: ["spiffe://nico.local/nico-system/sa/machine-a-tron"]` in values |
-| Machine creation fails `No IP addresses left in prefix <admin-cidr>` | Admin pool too small: creation needs one host-PF IP per DPU | Fit `hostCount×dpuPerHostCount` ≤ usable admin-pool IPs (the script auto-fits) |
-| `No IP addresses left in prefix ...`; machines stuck in `BmcInit` | OOB DHCP pool too small for host×DPU count | Sizing: `hostCount + hostCount×dpuPerHostCount` ≤ usable pool IPs; use ≥ /27 or reduce counts |
+| Machine creation fails `No IP addresses left in prefix <admin-cidr>` | Admin pool too small for host interface allocation | Fit `hostCount` ≤ usable admin-pool IPs (the script auto-fits) |
+| `No IP addresses left in prefix ...`; machines stuck during DHCP discovery | BMC, DPU Underlay, or Host Inband DHCP pool is too small | Size BMC as `hostCount×(1+dpuPerHostCount)`, DPU Underlay as `hostCount×dpuPerHostCount`, and Host Inband as `hostCount` for zero-DPU or NIC-mode groups; add demands when relays use one segment |
 | Redfish `connection refused` on every endpoint despite bmc_proxy set | Bare service name resolves against nico-system, not nico-mat | Use the cross-namespace FQDN in `bmc_proxy` |
 | Redfish redirect ignored; `endpoint_explorations=0` | Wrong config field (`override_target_host` is not real) | Use `bmc_proxy = "nico-machine-a-tron-bmc-mock.nico-mat.svc.cluster.local:1266"` under `[site_explorer]` |
 | `Refusing to create managed host, expected machines entry not found` | No `expected_machines` row for the discovered BMC MAC | Set `machineATron.registerExpectedMachines: true` (default) so machine-a-tron auto-registers them |

--- a/docs/development/machine-a-tron-scale-testing.md
+++ b/docs/development/machine-a-tron-scale-testing.md
@@ -33,7 +33,7 @@ The `mat-k8s-controller` dynamically creates one ClusterIP Service per BMC:
 - Services route to correct pod via `nvidia-infra-controller/pod-name` selector
 
 **Requirements:**
-- `oobDhcpRelayAddress` must be within Kubernetes ServiceCIDR
+- `bmcDhcpRelayAddress` must be within Kubernetes ServiceCIDR
 - NICo siteConfig needs `allow_insecure_discovery = true` and a network
   covering the BMC IP range
 - Leave `site_explorer.bmc_proxy` unset — NICo dials each BMC's ClusterIP directly

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -115,9 +115,10 @@
 #   BMC_PASSWORD           Site BMC root password (rotation target). MUST
 #                          differ from the mock factory defaults.
 #                          Default: NicoSiteRoot1
-#   OOB_DHCP_RELAY         OOB/underlay gateway (BMC DHCP relay). Auto-detected
-#                          from nico-core site config if unset.
-#   ADMIN_DHCP_RELAY       Admin network gateway. Auto-detected if unset.
+#   BMC_DHCP_RELAY         BMC DHCP relay address. Auto-detected from nico-core
+#                          site config if unset.
+#   UNDERLAY_DHCP_RELAY    Shared Underlay DHCP relay for DPU OOB boot and switch
+#                          NVOS discovery. Defaults to the BMC relay.
 #   HOST_COUNT             Override machines.dell-hosts.hostCount.
 #   DPU_PER_HOST           Override machines.dell-hosts.dpuPerHostCount.
 #   CHART_DIR              Path to the nico-machine-a-tron chart.
@@ -198,7 +199,7 @@ NICO_DB="nico_system_nico"
 #   NICo network covering the BMC IP range. See the chart README "Controller Mode".
 MAT_MODE="${MAT_MODE:-override}"
 # Network for scale mode — must be within Kubernetes ServiceCIDR and match the
-# scale values file (oobDhcpRelayAddress).
+# scale values file (bmcDhcpRelayAddress).
 SCALE_OOB_PREFIX="${SCALE_OOB_PREFIX:-10.96.64.0/18}";  SCALE_OOB_GW="${SCALE_OOB_GW:-10.96.64.1}"
 SCALE_ADMIN_PREFIX="${SCALE_ADMIN_PREFIX:-192.168.176.0/20}"; SCALE_ADMIN_GW="${SCALE_ADMIN_GW:-192.168.176.1}"
 SCALE_RESERVE=1
@@ -1007,8 +1008,9 @@ phase "Phase 6 — DHCP relays + pool sizing (${MAT_MODE})"
 if [[ "$MAT_MODE" == "scale" ]]; then
     # scale mode uses the SIMULATED networks added in Phase 5 — constants,
     # no live-config parsing needed.
-    OOB_PREFIX="$SCALE_OOB_PREFIX";   OOB_DHCP_RELAY="${OOB_DHCP_RELAY:-$SCALE_OOB_GW}"
-    ADMIN_PREFIX="$SCALE_ADMIN_PREFIX"; ADMIN_DHCP_RELAY="${ADMIN_DHCP_RELAY:-$SCALE_ADMIN_GW}"
+    OOB_PREFIX="$SCALE_OOB_PREFIX"; BMC_DHCP_RELAY="${BMC_DHCP_RELAY:-$SCALE_OOB_GW}"
+    UNDERLAY_DHCP_RELAY="${UNDERLAY_DHCP_RELAY:-$BMC_DHCP_RELAY}"
+    ADMIN_PREFIX="$SCALE_ADMIN_PREFIX"
     OOB_RESERVE="$SCALE_RESERVE"; ADMIN_RESERVE="$SCALE_RESERVE"
 else
     SITE_CFG="$(kubectl get cm nico-api-site-config-files -n "$NICO_SYSTEM_NS" \
@@ -1027,29 +1029,31 @@ else
     # admin segment is the FIRST prefix/gateway pair, OOB/underlay the LAST.
     ADMIN_PREFIX="$(printf '%s\n' "$PFX_LIST" | head -1)"
     OOB_PREFIX="$(printf '%s\n' "$PFX_LIST" | tail -1)"
-    OOB_DHCP_RELAY="${OOB_DHCP_RELAY:-$(printf '%s\n' "$GW_LIST" | tail -1)}"
-    ADMIN_DHCP_RELAY="${ADMIN_DHCP_RELAY:-$(printf '%s\n' "$GW_LIST" | head -1)}"
+    BMC_DHCP_RELAY="${BMC_DHCP_RELAY:-$(printf '%s\n' "$GW_LIST" | tail -1)}"
+    UNDERLAY_DHCP_RELAY="${UNDERLAY_DHCP_RELAY:-$BMC_DHCP_RELAY}"
     # Usable IPs per pool = 2^(32-mask) − reserve_first − 1 (broadcast).
     # reserve_first covers the network address, gateway, and operator-reserved
     # leading addresses — verified live: /28 with reserve_first=5 → 10 usable.
     ADMIN_RESERVE="$(printf '%s\n' "$RSV_LIST" | head -1)"; ADMIN_RESERVE="${ADMIN_RESERVE:-5}"
     OOB_RESERVE="$(printf '%s\n' "$RSV_LIST" | tail -1)"; OOB_RESERVE="${OOB_RESERVE:-5}"
 fi
-[[ -n "$OOB_DHCP_RELAY" && -n "$ADMIN_DHCP_RELAY" ]] \
-    || die "could not resolve DHCP relays; set OOB_DHCP_RELAY and ADMIN_DHCP_RELAY"
-ok "OOB:   relay ${OOB_DHCP_RELAY}   prefix ${OOB_PREFIX:-unknown}"
-ok "admin: relay ${ADMIN_DHCP_RELAY}   prefix ${ADMIN_PREFIX:-unknown}"
+[[ -n "$BMC_DHCP_RELAY" && -n "$UNDERLAY_DHCP_RELAY" ]] \
+    || die "could not resolve DHCP relays; set BMC_DHCP_RELAY and UNDERLAY_DHCP_RELAY"
+[[ "$UNDERLAY_DHCP_RELAY" == "$BMC_DHCP_RELAY" ]] \
+    || die "setup-machine-a-tron.sh only supports a shared BMC/DPU Underlay relay"
+ok "BMC: relay ${BMC_DHCP_RELAY}   prefix ${OOB_PREFIX:-unknown}"
+ok "DPU Underlay: relay ${UNDERLAY_DHCP_RELAY}"
+ok "admin pool: ${ADMIN_PREFIX:-unknown}"
 _usable() { local m="${1##*/}" r="$2"; local u=$(( (1 << (32 - m)) - r - 1 )); (( u < 0 )) && u=0; echo "$u"; }
 # Demand per pool (measured live):
-#   OOB   = hostCount*(1 + dpuPerHost)   — one BMC IP per host and per DPU
-#   admin = hostCount*(dpuPerHost + 1)   — one host-PF IP per DPU at DHCP time,
-#           PLUS one admin IP per host allocated by machine creation (creation
-#           fails with "No IP addresses left in prefix <admin>" without it)
+#   OOB/Underlay = hostCount*(1 + 2*dpuPerHost) — one host BMC IP plus a BMC
+#                  and DPU OS IP for every DPU
+#   admin         = hostCount — one host IP allocated by machine creation
 if [[ "${OOB_PREFIX:-}" == */* && "${ADMIN_PREFIX:-}" == */* ]]; then
     OOB_USABLE="$(_usable "$OOB_PREFIX" "$OOB_RESERVE")"; ADMIN_USABLE="$(_usable "$ADMIN_PREFIX" "$ADMIN_RESERVE")"
     # max hosts each pool supports, then take the min
-    FIT_OOB=$(( OOB_USABLE / (1 + DPU_PER_HOST) ))
-    FIT_ADMIN=$(( ADMIN_USABLE / (DPU_PER_HOST + 1) ))
+    FIT_OOB=$(( OOB_USABLE / (1 + 2 * DPU_PER_HOST) ))
+    FIT_ADMIN=$ADMIN_USABLE
     FIT=$(( FIT_OOB < FIT_ADMIN ? FIT_OOB : FIT_ADMIN ))
     info "pool fit: OOB ${OOB_PREFIX} ≈${OOB_USABLE} usable → ≤${FIT_OOB} hosts; admin ${ADMIN_PREFIX} ≈${ADMIN_USABLE} usable → ≤${FIT_ADMIN} hosts"
     if [[ "${MAT_MULTIPOD:-0}" == "1" ]]; then
@@ -1066,7 +1070,7 @@ values_file, default_prefix, default_reserve = sys.argv[1], sys.argv[2], sys.arg
 text = open(values_file).read()
 
 def groups_from_yaml(doc):
-    """Structural walk of a parsed values doc -> [{hosts,dpus,relay}]."""
+    """Structural walk of a parsed values doc into machine-group DHCP demand inputs."""
     out = []
     for pod in (doc.get("pods") or {}).values():
         if not isinstance(pod, dict):
@@ -1080,7 +1084,8 @@ def groups_from_yaml(doc):
             out.append({
                 "hosts": hosts,
                 "dpus": int(grp.get("dpuPerHostCount") or 0),
-                "relay": str(grp.get("oobDhcpRelayAddress") or "").strip(),
+                "bmc_relay": str(grp.get("bmcDhcpRelayAddress") or "").strip(),
+                "underlay_relay": str(grp.get("underlayDhcpRelayAddress") or "").strip(),
             })
     return out
 
@@ -1098,7 +1103,8 @@ except Exception as e:                      # malformed values file
 
 # Dependency-free scan: walk the values file line by line and close off a
 # machine group whenever a line appears at or above the group's indentation.
-# Each group contributes hostCount*(1+dpuPerHostCount) BMC IPs to its relay.
+# Each group contributes BMC IPs to its BMC relay and DPU OS IPs to its
+# Underlay relay. If both relays are the same, their demand is additive.
 groups, cur, cur_indent = [], None, None
 for raw in text.splitlines():
     if not raw.strip() or raw.lstrip().startswith("#"):
@@ -1114,12 +1120,19 @@ for raw in text.splitlines():
         groups.append(cur); cur, cur_indent = None, None
     if key == "hostCount":
         if cur is None:
-            cur, cur_indent = {"hosts": 0, "dpus": 0, "relay": ""}, indent
+            cur, cur_indent = {
+                "hosts": 0,
+                "dpus": 0,
+                "bmc_relay": "",
+                "underlay_relay": "",
+            }, indent
         cur["hosts"] = int(re.sub(r"\D", "", val) or 0)
     elif key == "dpuPerHostCount" and cur is not None:
         cur["dpus"] = int(re.sub(r"\D", "", val) or 0)
-    elif key == "oobDhcpRelayAddress" and cur is not None:
-        cur["relay"] = val.strip('"\'')
+    elif key == "bmcDhcpRelayAddress" and cur is not None:
+        cur["bmc_relay"] = val.strip('"\'')
+    elif key == "underlayDhcpRelayAddress" and cur is not None:
+        cur["underlay_relay"] = val.strip('"\'')
 if cur is not None:
     groups.append(cur)
 
@@ -1132,8 +1145,10 @@ if not groups:
 
 demand = {}
 for g in groups:
-    relay = g["relay"] or "<default>"
-    demand[relay] = demand.get(relay, 0) + g["hosts"] * (1 + g["dpus"])
+    bmc_relay = g["bmc_relay"] or "<default>"
+    underlay_relay = g["underlay_relay"] or bmc_relay
+    demand[bmc_relay] = demand.get(bmc_relay, 0) + g["hosts"] * (1 + g["dpus"])
+    demand[underlay_relay] = demand.get(underlay_relay, 0) + g["hosts"] * g["dpus"]
 
 def usable(cidr, reserve):
     net = ipaddress.ip_network(cidr, strict=False)
@@ -1272,8 +1287,8 @@ pods:
       dell-hosts:
         hostCount: ${HOST_COUNT}
         dpuPerHostCount: ${DPU_PER_HOST}
-        oobDhcpRelayAddress: "${OOB_DHCP_RELAY}"
-        adminDhcpRelayAddress: "${ADMIN_DHCP_RELAY}"
+        bmcDhcpRelayAddress: "${BMC_DHCP_RELAY}"
+        underlayDhcpRelayAddress: "${UNDERLAY_DHCP_RELAY}"
 EOF
 fi
 if [[ "$MAT_MODE" == "scale" ]]; then
@@ -1291,7 +1306,7 @@ machineATron:
   dpuBmcPassword: "${BMC_PASSWORD}"
 EOF
 fi
-info "values: image=${MAT_IMAGE_REPO}:${MAT_IMAGE_TAG} hosts=${HOST_COUNT} dpus=${DPU_PER_HOST} oob=${OOB_DHCP_RELAY} admin=${ADMIN_DHCP_RELAY}"
+info "values: image=${MAT_IMAGE_REPO}:${MAT_IMAGE_TAG} hosts=${HOST_COUNT} dpus=${DPU_PER_HOST} bmc=${BMC_DHCP_RELAY} underlay=${UNDERLAY_DHCP_RELAY}"
 confirm "Deploy ${RELEASE} to ${MAT_NAMESPACE}?" || die "aborted before deploy"
 # --qps/--burst-limit: scale mode creates one Service per BMC (hundreds to
 # thousands); helm's default burst (100 concurrent API calls) overwhelms

--- a/helm-prereqs/values/machine-a-tron-multipod.yaml
+++ b/helm-prereqs/values/machine-a-tron-multipod.yaml
@@ -9,7 +9,7 @@
 #       -n nico-system -f <your-copy>.yaml
 #
 # Requirements:
-#  * oobDhcpRelayAddress must be within Kubernetes ServiceCIDR
+#  * bmcDhcpRelayAddress must be within Kubernetes ServiceCIDR
 #    - vanilla k8s: 10.96.0.0/12
 #    - kind: 10.96.0.0/16
 #    - k3d: 10.43.0.0/16
@@ -66,16 +66,16 @@ pods:
         hwType: wiwynn_gb200_nvl
         hostCount: 100
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
+        underlayDhcpRelayAddress: "10.96.64.1"
   mat-1:
     machines:
       compute:
         hwType: wiwynn_gb200_nvl
         hostCount: 100
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
+        underlayDhcpRelayAddress: "10.96.64.1"
 
 resources:
   limits:

--- a/helm-prereqs/values/machine-a-tron-scale-4500.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500.yaml
@@ -105,8 +105,8 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.233.16.1"
-        adminDhcpRelayAddress: "10.102.0.1"
+        bmcDhcpRelayAddress: "10.233.16.1"
+        underlayDhcpRelayAddress: "10.233.16.1"
         networkVirtualizationType: ""
         dpusInNicMode: false
   mat-1:
@@ -123,8 +123,8 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.233.32.1"
-        adminDhcpRelayAddress: "10.102.0.1"
+        bmcDhcpRelayAddress: "10.233.32.1"
+        underlayDhcpRelayAddress: "10.233.32.1"
         networkVirtualizationType: ""
         dpusInNicMode: false
   mat-2:
@@ -141,8 +141,8 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.233.8.1"
-        adminDhcpRelayAddress: "10.102.0.1"
+        bmcDhcpRelayAddress: "10.233.8.1"
+        underlayDhcpRelayAddress: "10.233.8.1"
         networkVirtualizationType: ""
         dpusInNicMode: false
 

--- a/helm-prereqs/values/machine-a-tron-scale.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale.yaml
@@ -17,7 +17,7 @@
 #       prefix = "10.96.64.0/18"
 #       gateway = "10.96.64.1"
 #       mtu = 1500
-#   - oobDhcpRelayAddress must be within Kubernetes ServiceCIDR
+#   - bmcDhcpRelayAddress must be within Kubernetes ServiceCIDR
 # =============================================================================
 
 image:
@@ -116,8 +116,8 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.96.64.1"  # Must be within K8s ServiceCIDR
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"  # Must be within K8s ServiceCIDR
+        underlayDhcpRelayAddress: "10.96.64.1"
         networkVirtualizationType: ""
         dpusInNicMode: false
 

--- a/helm-prereqs/values/machine-a-tron.yaml
+++ b/helm-prereqs/values/machine-a-tron.yaml
@@ -72,13 +72,12 @@ pods:
       rack-machines: null
       dell-hosts:
         hwType: dell_poweredge_r750
-        # SIZING: machine-a-tron allocates one OOB DHCP IP per BMC interface —
-        # 1 per host + 1 per DPU. Total = hostCount + hostCount*dpuPerHostCount.
-        # This MUST fit the usable addresses in the OOB/underlay DHCP pool of your
-        # nico-core site config, or discovery reports "No IP addresses left in
-        # prefix ..." and machines never register.
-        #   e.g. a /28 pool with a gateway and a few reserved addresses yields
-        #   ~10 usable → hostCount:3 * dpuPerHostCount:2 = 9 fits; 5*2=15 does not.
+        # SIZING: BMC DHCP needs hostCount*(1+dpuPerHostCount) addresses. DPU OS
+        # DHCP needs hostCount*dpuPerHostCount addresses from the Underlay pool.
+        # If both relay addresses select the same segment, add both demands.
+        # These totals MUST fit the usable addresses in the corresponding
+        # nico-core pools, or discovery reports "No IP addresses left in prefix
+        # ..." and machines never register.
         # setup-machine-a-tron.sh estimates the pool size and warns if you overflow.
         hostCount: 3
         dpuPerHostCount: 2
@@ -90,11 +89,11 @@ pods:
         runIntervalWorking: "1s"
         runIntervalIdle: "10s"
         networkStatusRunInterval: "20s"
-        # Set to the gateway of the OOB/underlay network in nico-core site config.
+        # Set to the gateway of the BMC network in nico-core site config.
         # (setup-machine-a-tron.sh fills this from the running nico-core config.)
-        oobDhcpRelayAddress: "FILL_IN"
-        # Set to the gateway of the admin network in nico-core site config.
-        adminDhcpRelayAddress: "FILL_IN"
+        bmcDhcpRelayAddress: "FILL_IN"
+        # Set to the gateway of the DPU OS Underlay network in nico-core site config.
+        underlayDhcpRelayAddress: "FILL_IN"
         networkVirtualizationType: ""
         dpusInNicMode: false
 

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -117,7 +117,7 @@ dynamically creates/updates/deletes Kubernetes Services as machines come online.
 
 ### Setup
 
-All pods can share the same `oobDhcpRelayAddress` - NICo assigns unique IPs
+All pods can share the same `bmcDhcpRelayAddress` - NICo assigns unique IPs
 from the subnet.
 
 ```yaml
@@ -133,16 +133,16 @@ pods:
         hwType: wiwynn_gb200_nvl
         hostCount: 5
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
+        underlayDhcpRelayAddress: "192.168.176.1"
   mat-1:
     machines:
       rack-machines:
         hwType: wiwynn_gb200_nvl
         hostCount: 5
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"
+        underlayDhcpRelayAddress: "192.168.176.1"
 
 macAddressPool:
   enabled: true
@@ -210,7 +210,7 @@ adds a dynamic target UDP port for IPMI access.
 
 ### Requirements
 
-- `oobDhcpRelayAddress` must be within Kubernetes ServiceCIDR
+- `bmcDhcpRelayAddress` must be within Kubernetes ServiceCIDR
 - NICo assigns unique BMC IPs from the configured network
 - Default ServiceCIDR ranges:
   - `10.96.0.0/12` - vanilla Kubernetes (kubeadm)
@@ -262,9 +262,14 @@ pods:
         hwType: wiwynn_gb200_nvl
         hostCount: 10
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"
+        underlayDhcpRelayAddress: "192.168.176.1"
 ```
+
+`hostInbandDhcpRelayAddress` is required for machine groups with no DPUs
+(`dpuPerHostCount: 0`) or with DPUs operating in NIC mode
+(`dpusInNicMode: true`). It is rendered as
+`host_inband_dhcp_relay_address` in the MAT configuration.
 
 ### IPMI/SOL Simulation
 
@@ -400,7 +405,7 @@ provided IP is already allocated
 
 The BMC IP conflicts with an existing Service. Either:
 
-- Use a different `oobDhcpRelayAddress` range
+- Use a different `bmcDhcpRelayAddress` range
 - Reserve a ServiceCIDR for machine-a-tron (K8s 1.29+)
 
 ### ClusterIP outside ServiceCIDR

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -174,8 +174,8 @@ data:
     dpu_reboot_delay = {{ $section.dpu_reboot_delay | default $defaults.dpuRebootDelay | int }}
     host_reboot_delay = {{ $section.host_reboot_delay | default $defaults.hostRebootDelay | int }}
     discovery_retry_interval = {{ $section.discovery_retry_interval | default $defaults.discoveryRetryInterval | default "60s" | quote }}
-    oob_dhcp_relay_address = {{ $section.oob_dhcp_relay_address | quote }}
-    admin_dhcp_relay_address = {{ $section.admin_dhcp_relay_address | quote }}
+    bmc_dhcp_relay_address = {{ required (printf "pods.%s.racks.%s.bmc_dhcp_relay_address is required" $podName $sectionName) $section.bmc_dhcp_relay_address | quote }}
+    underlay_dhcp_relay_address = {{ required (printf "pods.%s.racks.%s.underlay_dhcp_relay_address is required" $podName $sectionName) $section.underlay_dhcp_relay_address | quote }}
     {{- end }}
 
     {{- range $sectionName, $section := $machines }}
@@ -185,10 +185,15 @@ data:
     {{- if $section.hwType }}
     hw_type = {{ $section.hwType | quote }}
     {{- end }}
+    {{- $dpuPerHostCount := $section.dpuPerHostCount | default 0 }}
+    {{- $dpusInNicMode := $defaults.dpusInNicMode | default false }}
+    {{- if hasKey $section "dpusInNicMode" }}
+    {{- $dpusInNicMode = $section.dpusInNicMode }}
+    {{- end }}
     host_count = {{ $section.hostCount | default 1 }}
     vpc_count = {{ $section.vpcCount | default $defaults.vpcCount | default 0 }}
     subnets_per_vpc = {{ $section.subnetsPerVpc | default $defaults.subnetsPerVpc | default 0 }}
-    dpu_per_host_count = {{ $section.dpuPerHostCount | default 0 }}
+    dpu_per_host_count = {{ $dpuPerHostCount }}
     dpu_reboot_delay = {{ $section.dpuRebootDelay | default $defaults.dpuRebootDelay | default 1 }}
     host_reboot_delay = {{ $section.hostRebootDelay | default $defaults.hostRebootDelay | default 1 }}
     scout_run_interval = {{ $section.scoutRunInterval | default $defaults.scoutRunInterval | default "60s" | quote }}
@@ -196,13 +201,20 @@ data:
     run_interval_working = {{ $section.runIntervalWorking | default $defaults.runIntervalWorking | default "1s" | quote }}
     run_interval_idle = {{ $section.runIntervalIdle | default $defaults.runIntervalIdle | default "10s" | quote }}
     network_status_run_interval = {{ $section.networkStatusRunInterval | default $defaults.networkStatusRunInterval | default "20s" | quote }}
-    oob_dhcp_relay_address = {{ $section.oobDhcpRelayAddress | default "192.168.192.1" | quote }}
-    admin_dhcp_relay_address = {{ $section.adminDhcpRelayAddress | default "192.168.176.1" | quote }}
+    bmc_dhcp_relay_address = {{ $section.bmcDhcpRelayAddress | default "192.168.192.1" | quote }}
+    underlay_dhcp_relay_address = {{ required (printf "pods.%s.machines.%s.underlayDhcpRelayAddress is required" $podName $sectionName) $section.underlayDhcpRelayAddress | quote }}
+    {{- if or (eq (int $dpuPerHostCount) 0) $dpusInNicMode }}
+    host_inband_dhcp_relay_address = {{ required (printf "pods.%s.machines.%s.hostInbandDhcpRelayAddress is required when dpuPerHostCount is 0 or dpusInNicMode is true" $podName $sectionName) $section.hostInbandDhcpRelayAddress | quote }}
+    {{- else }}
+    {{- with $section.hostInbandDhcpRelayAddress }}
+    host_inband_dhcp_relay_address = {{ . | quote }}
+    {{- end }}
+    {{- end }}
     {{- $nvType := $section.networkVirtualizationType | default $defaults.networkVirtualizationType }}
     {{- if $nvType }}
     network_virtualization_type = {{ $nvType | quote }}
     {{- end }}
-    dpus_in_nic_mode = {{ $section.dpusInNicMode | default $defaults.dpusInNicMode | default false }}
+    dpus_in_nic_mode = {{ $dpusInNicMode }}
     {{- with $section.hostFirmwareVersions }}
 
     [machines.{{ $sectionName }}.host_firmware_versions]

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -40,6 +40,7 @@ tests:
               hwType: dell_poweredge_r750
               hostCount: 20
               dpuPerHostCount: 2
+              underlayDhcpRelayAddress: 192.168.176.1
     asserts:
       - matchRegex:
           path: data["mat.toml"]
@@ -72,11 +73,15 @@ tests:
             compute:
               hwType: supermicro_gb300_nvl
               hostCount: 10
+              underlayDhcpRelayAddress: 192.168.176.1
+              hostInbandDhcpRelayAddress: 192.168.177.1
         mat-1:
           machines:
             compute:
               hwType: supermicro_gb300_nvl
               hostCount: 20
+              underlayDhcpRelayAddress: 192.168.176.1
+              hostInbandDhcpRelayAddress: 192.168.177.1
     asserts:
       - hasDocuments:
           count: 2
@@ -95,8 +100,8 @@ tests:
                 - rack-001
               dpu_reboot_delay: 20
               host_reboot_delay: 10
-              oob_dhcp_relay_address: 10.96.64.1
-              admin_dhcp_relay_address: 192.168.176.1
+              bmc_dhcp_relay_address: 10.96.64.1
+              underlay_dhcp_relay_address: 192.168.176.1
     asserts:
       - matchRegex:
           path: data["mat.toml"]
@@ -123,8 +128,8 @@ tests:
                 - rack-001
               dpu_reboot_delay: 20
               host_reboot_delay: 10
-              oob_dhcp_relay_address: 10.96.64.1
-              admin_dhcp_relay_address: 192.168.176.1
+              bmc_dhcp_relay_address: 10.96.64.1
+              underlay_dhcp_relay_address: 192.168.176.1
     asserts:
       - matchRegex:
           path: data["mat.toml"]
@@ -132,6 +137,23 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: '\[machines\.rack-machines\]'
+
+  - it: should require a BMC relay for every rack
+    set:
+      pods:
+        mat-0:
+          machines:
+            rack-machines: null
+          racks:
+            gb200:
+              type: wiwynn_gb200_nvl72
+              rack_profile_id: NVL72
+              ids:
+                - rack-001
+              underlay_dhcp_relay_address: 192.168.176.1
+    asserts:
+      - failedTemplate:
+          errorMessage: "pods.mat-0.racks.gb200.bmc_dhcp_relay_address is required"
 
   - it: should use machineDefaults for all machine groups
     set:
@@ -145,6 +167,8 @@ tests:
             compute:
               hwType: supermicro_gb300_nvl
               hostCount: 5
+              underlayDhcpRelayAddress: 192.168.176.1
+              hostInbandDhcpRelayAddress: 192.168.177.1
     asserts:
       - matchRegex:
           path: data["mat.toml"]
@@ -155,6 +179,84 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: 'discovery_retry_interval = "7s"'
+
+  - it: should require an Underlay relay for every machine group
+    set:
+      pods:
+        mat-0:
+          machines:
+            rack-machines: null
+            compute:
+              hwType: supermicro_gb300_nvl
+              hostCount: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: "pods.mat-0.machines.compute.underlayDhcpRelayAddress is required"
+
+  - it: should render a HostInband relay for a zero-DPU machine group
+    set:
+      pods:
+        mat-0:
+          machines:
+            rack-machines: null
+            compute:
+              hwType: supermicro_gb300_nvl
+              hostCount: 1
+              underlayDhcpRelayAddress: 192.168.176.1
+              hostInbandDhcpRelayAddress: 192.168.177.1
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'host_inband_dhcp_relay_address = "192.168.177.1"'
+
+  - it: should require a HostInband relay for a zero-DPU machine group
+    set:
+      pods:
+        mat-0:
+          machines:
+            rack-machines: null
+            compute:
+              hwType: supermicro_gb300_nvl
+              hostCount: 1
+              underlayDhcpRelayAddress: 192.168.176.1
+    asserts:
+      - failedTemplate:
+          errorMessage: "pods.mat-0.machines.compute.hostInbandDhcpRelayAddress is required when dpuPerHostCount is 0 or dpusInNicMode is true"
+
+  - it: should require a HostInband relay for a NIC-mode machine group
+    set:
+      pods:
+        mat-0:
+          machines:
+            rack-machines: null
+            compute:
+              hwType: supermicro_gb300_nvl
+              hostCount: 1
+              dpuPerHostCount: 2
+              dpusInNicMode: true
+              underlayDhcpRelayAddress: 192.168.176.1
+    asserts:
+      - failedTemplate:
+          errorMessage: "pods.mat-0.machines.compute.hostInbandDhcpRelayAddress is required when dpuPerHostCount is 0 or dpusInNicMode is true"
+
+  - it: should preserve a false machine-group dpusInNicMode override
+    set:
+      machineDefaults:
+        dpusInNicMode: true
+      pods:
+        mat-0:
+          machines:
+            rack-machines: null
+            compute:
+              hwType: supermicro_gb300_nvl
+              hostCount: 1
+              dpuPerHostCount: 2
+              dpusInNicMode: false
+              underlayDhcpRelayAddress: 192.168.176.1
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'dpus_in_nic_mode = false'
 
   - it: should not include enable_ipmi_simulation by default
     asserts:

--- a/helm/charts/nico-machine-a-tron/tests/deployment_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/deployment_test.yaml
@@ -108,11 +108,15 @@ tests:
             compute:
               hwType: supermicro_gb300_nvl
               hostCount: 5
+              underlayDhcpRelayAddress: 192.168.176.1
+              hostInbandDhcpRelayAddress: 192.168.177.1
         mat-1:
           machines:
             compute:
               hwType: supermicro_gb300_nvl
               hostCount: 5
+              underlayDhcpRelayAddress: 192.168.176.1
+              hostInbandDhcpRelayAddress: 192.168.177.1
     asserts:
       - hasDocuments:
           count: 2
@@ -139,8 +143,8 @@ tests:
               rack_profile_id: NVL72
               ids:
                 - rack-001
-              oob_dhcp_relay_address: 10.96.64.1
-              admin_dhcp_relay_address: 192.168.176.1
+              bmc_dhcp_relay_address: 10.96.64.1
+              underlay_dhcp_relay_address: 192.168.176.1
     asserts:
       - equal:
           path: metadata.name

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -262,8 +262,11 @@ hwMacAddressRanges:
 ##   - hwType: Hardware type (required)
 ##   - hostCount: Number of hosts (required)
 ##   - dpuPerHostCount: DPUs per host (default: 0)
-##   - oobDhcpRelayAddress: OOB network gateway
-##   - adminDhcpRelayAddress: Admin network gateway
+##   - bmcDhcpRelayAddress: BMC DHCP relay address
+##   - underlayDhcpRelayAddress: Shared Underlay DHCP relay address for DPU OOB
+##     boot and switch NVOS discovery (required)
+##   - hostInbandDhcpRelayAddress: HostInband network relay (required when
+##     dpuPerHostCount is 0 or dpusInNicMode is true)
 ##
 ## All other settings inherit from machineDefaults above.
 ##
@@ -281,8 +284,8 @@ pods:
     #       - rack-001
     #     dpu_reboot_delay: 20
     #     host_reboot_delay: 10
-    #     oob_dhcp_relay_address: "192.168.192.1"
-    #     admin_dhcp_relay_address: "192.168.176.1"
+    #     bmc_dhcp_relay_address: "192.168.192.1"
+    #     underlay_dhcp_relay_address: "192.168.176.1"
 
     ## Machine groups for this pod
     machines:
@@ -290,8 +293,8 @@ pods:
         hwType: wiwynn_gb200_nvl
         hostCount: 10
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "192.168.192.1"
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "192.168.192.1"
+        underlayDhcpRelayAddress: "192.168.176.1"
 
 ## =============================================================================
 ## Multi-Pod Example (mat-k8s-controller.enabled is required)
@@ -304,18 +307,20 @@ pods:
 #        hwType: wiwynn_gb200_nvl
 #        hostCount: 252       # 18 trays × 14 racks
 #        dpuPerHostCount: 2   # 2 BF3 per tray
-#        oobDhcpRelayAddress: "10.96.64.1"
-#        adminDhcpRelayAddress: "192.168.176.1"
+#        bmcDhcpRelayAddress: "10.96.64.1"
+#        underlayDhcpRelayAddress: "192.168.176.1"
 #      switches:
 #        hwType: nvidia_switch_nd5200_ld
 #        hostCount: 126       # 9 switches × 14 racks
-#        oobDhcpRelayAddress: "10.96.64.1"
-#        adminDhcpRelayAddress: "192.168.176.1"
+#        bmcDhcpRelayAddress: "10.96.64.1"
+#        underlayDhcpRelayAddress: "192.168.176.1"
+#        hostInbandDhcpRelayAddress: "192.168.177.1"
 #      power:
 #        hwType: liteon_power_shelf
 #        hostCount: 112       # 8 shelves × 14 racks
-#        oobDhcpRelayAddress: "10.96.64.1"
-#        adminDhcpRelayAddress: "192.168.176.1"
+#        bmcDhcpRelayAddress: "10.96.64.1"
+#        underlayDhcpRelayAddress: "192.168.176.1"
+#        hostInbandDhcpRelayAddress: "192.168.177.1"
 #
 #  mat-1:
 #    machines:
@@ -323,8 +328,8 @@ pods:
 #        hwType: wiwynn_gb200_nvl
 #        hostCount: 252
 #        dpuPerHostCount: 2
-#        oobDhcpRelayAddress: "10.96.64.1"
-#        adminDhcpRelayAddress: "192.168.176.1"
+#        bmcDhcpRelayAddress: "10.96.64.1"
+#        underlayDhcpRelayAddress: "192.168.176.1"
 #      # ... same pattern
 
 ## Persistence volume for machine state
@@ -365,15 +370,15 @@ configFiles:
   #     hw_type = "supermicro_gb300_nvl"
   #     host_count = 10
   #     dpu_per_host_count = 2
-  #     oob_dhcp_relay_address = "10.96.64.1"
-  #     admin_dhcp_relay_address = "192.168.176.1"
+  #     bmc_dhcp_relay_address = "10.96.64.1"
+  #     underlay_dhcp_relay_address = "192.168.176.1"
   #
   #     [machines.switches]
   #     hw_type = "nvidia_switch_nd5200_ld"
   #     host_count = 5
   #     dpu_per_host_count = 0
-  #     oob_dhcp_relay_address = "10.96.64.1"
-  #     admin_dhcp_relay_address = "192.168.176.1"
+  #     bmc_dhcp_relay_address = "10.96.64.1"
+  #     underlay_dhcp_relay_address = "192.168.176.1"
   matConfigs: {}
 
 ## =============================================================================


### PR DESCRIPTION
Today, machine-a-tron uses the confusingly named admin_dhcp_relay_address configuration parameter for DHCP requests from the DPU OOB interface. According to the documentation, this interface belongs to an Underlay segment.

It also uses oob_dhcp_relay_address for all BMC DHCP requests, even though the BMC network may or may not be the same Underlay segment used by DPU OOB.

This change clarifies the naming:
- all BMC DHCP requests use the relay identified by bmc_dhcp_relay_address
- all DPU boot DHCP requests (DPU OOB) use the Underlay relay identified by underlay_dhcp_relay_address
- all NVOS boot DHCP requests use Underlay relay identified by underlay_dhcp_relay_address

## Related issues

- Follow-up to #5084
- Related to #3366

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

