### PR TITLE
fix(rest-api): protect both resolved VPC prefixes

### DIFF
--- a/rest-api/api/pkg/api/handler/vpcprefix_test.go
+++ b/rest-api/api/pkg/api/handler/vpcprefix_test.go
@@ -1785,6 +1785,8 @@ func TestVpcPrefixHandler_Delete(t *testing.T) {
 
 	okBody2, err := json.Marshal(model.APIVpcPrefixCreateRequest{Name: "test-vpc-prefix-2", VpcID: vpc1.ID.String(), IPBlockID: cutil.GetPtr(ipb1.ID.String()), PrefixLength: prefixLen})
 	assert.Nil(t, err)
+	okBody3, err := json.Marshal(model.APIVpcPrefixCreateRequest{Name: "test-vpc-prefix-3", VpcID: vpc1.ID.String(), IPBlockID: cutil.GetPtr(ipb1.ID.String()), PrefixLength: prefixLen})
+	assert.Nil(t, err)
 
 	okBodyFG, err := json.Marshal(model.APIVpcPrefixCreateRequest{Name: "test-vpc-prefix-full-grant", VpcID: vpc1.ID.String(), IPBlockID: cutil.GetPtr(ipbFG.ID.String()), PrefixLength: prefixLen})
 	assert.Nil(t, err)
@@ -1793,11 +1795,18 @@ func TestVpcPrefixHandler_Delete(t *testing.T) {
 
 	vpcp2 := testCreateVpcPrefix(t, dbSession, scp, ipamStorage, tnu, tnOrg1, string(okBody2))
 	vpcp2ID := uuid.MustParse(vpcp2.ID)
+	vpcp3 := testCreateVpcPrefix(t, dbSession, scp, ipamStorage, tnu, tnOrg1, string(okBody3))
+	vpcp3ID := uuid.MustParse(vpcp3.ID)
 
 	vpcp1FG := testCreateVpcPrefix(t, dbSession, scp, ipamStorage, tnu, tnOrg1, string(okBodyFG))
 
 	ins1 := common.TestBuildInstance(t, dbSession, "test-instance-1", tn1.ID, ip.ID, site.ID, it1.ID, vpc1.ID, cutil.GetPtr(m1.ID), os1.ID)
-	common.TestBuildInterface(t, dbSession, ins1.ID, nil, &vpcp2ID, true, nil, nil, nil, cutil.GetPtr(cdbm.InterfaceStatusReady), tnu)
+	dualStackInterface := common.TestBuildInterface(t, dbSession, ins1.ID, nil, &vpcp2ID, true, nil, nil, nil, cutil.GetPtr(cdbm.InterfaceStatusReady), tnu)
+	_, err = cdbm.NewInterfaceDAO(dbSession).Update(ctx, nil, cdbm.InterfaceUpdateInput{
+		InterfaceID:          dualStackInterface.ID,
+		SecondaryVpcPrefixID: &vpcp3ID,
+	})
+	require.NoError(t, err)
 
 	// OTEL Spanner configuration
 	tracer, _, ctx := common.TestCommonTraceProviderSetup(t, ctx)
@@ -1892,6 +1901,15 @@ func TestVpcPrefixHandler_Delete(t *testing.T) {
 			reqOrgName:       tnOrg1,
 			user:             tnu,
 			id:               vpcp2.ID,
+			expectedErr:      true,
+			expectedStatus:   http.StatusBadRequest,
+			expectedErrorMsg: cutil.GetPtr("VPC Prefix is being used by one or more Instances and cannot be deleted"),
+		},
+		{
+			name:             "error when VPC Prefix is used as a secondary dual-stack prefix",
+			reqOrgName:       tnOrg1,
+			user:             tnu,
+			id:               vpcp3.ID,
 			expectedErr:      true,
 			expectedStatus:   http.StatusBadRequest,
 			expectedErrorMsg: cutil.GetPtr("VPC Prefix is being used by one or more Instances and cannot be deleted"),

--- a/rest-api/db/pkg/db/model/interface.go
+++ b/rest-api/db/pkg/db/model/interface.go
@@ -114,6 +114,7 @@ type Interface struct {
 	VpcIPFamilyMode      *InterfaceVpcIPFamilyMode      `bun:"vpc_ip_family_mode"`
 	VpcPrefixID          *uuid.UUID                     `bun:"vpc_prefix_id,type:uuid"`
 	VpcPrefix            *VpcPrefix                     `bun:"rel:belongs-to,join:vpc_prefix_id=id"`
+	SecondaryVpcPrefixID *uuid.UUID                     `bun:"secondary_vpc_prefix_id,type:uuid"`
 	MachineInterfaceID   *uuid.UUID                     `bun:"machine_interface_id,type:uuid"`
 	MachineInterface     *MachineInterface              `bun:"rel:belongs-to,join:machine_interface_id=id"`
 	Device               *string                        `bun:"device"`
@@ -156,6 +157,7 @@ type InterfaceUpdateInput struct {
 	VpcID                *uuid.UUID
 	VpcIPFamilyMode      *InterfaceVpcIPFamilyMode
 	VpcPrefixID          *uuid.UUID
+	SecondaryVpcPrefixID *uuid.UUID
 	Device               *string
 	DeviceInstance       *int
 	VirtualFunctionID    *int
@@ -182,6 +184,7 @@ type InterfaceFilterInput struct {
 type InterfaceClearInput struct {
 	InterfaceID          uuid.UUID
 	VpcPrefixID          bool
+	SecondaryVpcPrefixID bool
 	RequestedIpAddress   bool
 	InlineRoutingProfile bool
 }
@@ -305,7 +308,11 @@ func (ifcd InterfaceSQLDAO) setQueryWithFilter(filter InterfaceFilterInput, quer
 	}
 
 	if filter.VpcPrefixID != nil {
-		query = query.Where("ifc.vpc_prefix_id = ?", *filter.VpcPrefixID)
+		query = query.Where(
+			"(ifc.vpc_prefix_id = ? OR ifc.secondary_vpc_prefix_id = ?)",
+			*filter.VpcPrefixID,
+			*filter.VpcPrefixID,
+		)
 
 		if interfaceDAOSpan != nil {
 			ifcd.tracerSpan.SetAttribute(interfaceDAOSpan, "vpc_prefix_id", filter.VpcPrefixID.String())
@@ -454,6 +461,14 @@ func (ifcd InterfaceSQLDAO) Update(ctx context.Context, tx *db.Tx, input Interfa
 
 		if interfaceDAOSpan != nil {
 			ifcd.tracerSpan.SetAttribute(interfaceDAOSpan, "vpc_prefix_id", input.VpcPrefixID.String())
+		}
+	}
+	if input.SecondaryVpcPrefixID != nil {
+		is.SecondaryVpcPrefixID = input.SecondaryVpcPrefixID
+		updatedFields = append(updatedFields, "secondary_vpc_prefix_id")
+
+		if interfaceDAOSpan != nil {
+			ifcd.tracerSpan.SetAttribute(interfaceDAOSpan, "secondary_vpc_prefix_id", input.SecondaryVpcPrefixID.String())
 		}
 	}
 	if input.Device != nil {
@@ -692,6 +707,10 @@ func (ifcd InterfaceSQLDAO) Clear(ctx context.Context, tx *db.Tx, input Interfac
 	if input.VpcPrefixID {
 		i.VpcPrefixID = nil
 		updatedFields = append(updatedFields, "vpc_prefix_id")
+	}
+	if input.SecondaryVpcPrefixID {
+		i.SecondaryVpcPrefixID = nil
+		updatedFields = append(updatedFields, "secondary_vpc_prefix_id")
 	}
 	if input.RequestedIpAddress {
 		i.RequestedIpAddress = nil

--- a/rest-api/db/pkg/db/model/interface_test.go
+++ b/rest-api/db/pkg/db/model/interface_test.go
@@ -766,6 +766,11 @@ func TestInterfaceSQLDAO_GetAll(t *testing.T) {
 
 	// OTEL Spanner configuration
 	_, _, ctx = testCommonTraceProviderSetup(t, ctx)
+	_, err = ifcd.Update(ctx, nil, InterfaceUpdateInput{
+		InterfaceID:          instance1VpcPrefixes[0].ID,
+		SecondaryVpcPrefixID: &vpcPrefix1.ID,
+	})
+	require.NoError(t, err)
 
 	// Create separate interfaces with IP addresses for IP filtering tests (don't modify existing ones)
 	ifcWithIP1, err := ifcd.Create(ctx, nil, InterfaceCreateInput{InstanceID: instances[0].ID, SubnetID: &subnet1.ID, IsPhysical: false, Status: InterfaceStatusPending, CreatedBy: user.ID})
@@ -826,9 +831,9 @@ func TestInterfaceSQLDAO_GetAll(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			desc:          "GetAll with VpcPrefix ID filter returns objects",
-			VpcPrefixID:   &vpcPrefix.ID,
-			expectedCount: totalCount / 2,
+			desc:          "GetAll with VpcPrefix ID filter returns primary and secondary objects",
+			VpcPrefixID:   &vpcPrefix1.ID,
+			expectedCount: totalCount/2 + 1,
 			expectedError: false,
 		},
 		{
@@ -1075,6 +1080,24 @@ func TestInterfaceSQLDAO_Clear(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, ifc)
+	secondaryVpcPrefix, err := NewVpcPrefixDAO(dbSession).Create(ctx, nil, VpcPrefixCreateInput{
+		Name:         "secondary-vpc-prefix",
+		TenantOrg:    "test",
+		SiteID:       site.ID,
+		VpcID:        vpc.ID,
+		TenantID:     tenant.ID,
+		IpBlockID:    &ipv4Block.ID,
+		Prefix:       "192.0.3.0/24",
+		PrefixLength: 24,
+		Status:       VpcPrefixStatusReady,
+		CreatedBy:    user.ID,
+	})
+	require.NoError(t, err)
+	_, err = ifcd.Update(ctx, nil, InterfaceUpdateInput{
+		InterfaceID:          ifc.ID,
+		SecondaryVpcPrefixID: &secondaryVpcPrefix.ID,
+	})
+	require.NoError(t, err)
 
 	badSession, err := db.NewSession(context.Background(), "localhost", 1234, "postgres", "postgres", "postgres", "")
 	assert.Nil(t, err)
@@ -1087,6 +1110,7 @@ func TestInterfaceSQLDAO_Clear(t *testing.T) {
 		dao                InterfaceDAO
 		input              InterfaceClearInput
 		expectError        bool
+		expectSecondaryID  *uuid.UUID
 		expectRequestedIP  *string
 		expectRouting      *InterfaceInlineRoutingProfile
 		verifyChildSpanner bool
@@ -1096,6 +1120,7 @@ func TestInterfaceSQLDAO_Clear(t *testing.T) {
 			dao:                badDAO,
 			input:              InterfaceClearInput{InterfaceID: ifc.ID, RequestedIpAddress: true},
 			expectError:        true,
+			expectSecondaryID:  &secondaryVpcPrefix.ID,
 			expectRequestedIP:  requestedIpAddress,
 			expectRouting:      routingProfile,
 			verifyChildSpanner: true,
@@ -1105,6 +1130,7 @@ func TestInterfaceSQLDAO_Clear(t *testing.T) {
 			dao:                ifcd,
 			input:              InterfaceClearInput{InterfaceID: ifc.ID, InlineRoutingProfile: true},
 			expectError:        false,
+			expectSecondaryID:  &secondaryVpcPrefix.ID,
 			expectRequestedIP:  requestedIpAddress,
 			expectRouting:      nil,
 			verifyChildSpanner: true,
@@ -1114,6 +1140,17 @@ func TestInterfaceSQLDAO_Clear(t *testing.T) {
 			dao:                ifcd,
 			input:              InterfaceClearInput{InterfaceID: ifc.ID, RequestedIpAddress: true},
 			expectError:        false,
+			expectSecondaryID:  &secondaryVpcPrefix.ID,
+			expectRequestedIP:  nil,
+			expectRouting:      nil,
+			verifyChildSpanner: true,
+		},
+		{
+			desc:               "can clear secondary VPC prefix ID",
+			dao:                ifcd,
+			input:              InterfaceClearInput{InterfaceID: ifc.ID, SecondaryVpcPrefixID: true},
+			expectError:        false,
+			expectSecondaryID:  nil,
 			expectRequestedIP:  nil,
 			expectRouting:      nil,
 			verifyChildSpanner: true,
@@ -1131,6 +1168,7 @@ func TestInterfaceSQLDAO_Clear(t *testing.T) {
 
 			assert.Equal(t, tc.expectRequestedIP, got.RequestedIpAddress)
 			assert.Equal(t, tc.expectRouting, got.InlineRoutingProfile)
+			assert.Equal(t, tc.expectSecondaryID, got.SecondaryVpcPrefixID)
 
 			if tc.verifyChildSpanner {
 				span := otrace.SpanFromContext(ctx)
@@ -1331,35 +1369,37 @@ func TestInterfaceSQLDAO_Update(t *testing.T) {
 	_, _, ctx = testCommonTraceProviderSetup(t, ctx)
 
 	tests := []struct {
-		desc                    string
-		id                      uuid.UUID
-		paramInstanceID         *uuid.UUID
-		paramSubnetID           *uuid.UUID
-		paramVpcID              *uuid.UUID
-		paramVpcIPFamilyMode    *InterfaceVpcIPFamilyMode
-		paramVpcPrefixID        *uuid.UUID
-		paramDevice             *string
-		paramDeviceInstance     *int
-		paramVirtualFunctionID  *int
-		paramRequestedIpAddress *string
-		paramRoutingProfile     *InterfaceInlineRoutingProfile
-		paramMacAddress         *string
-		paramIPAddresses        []string
-		paramStatus             *string
+		desc                      string
+		id                        uuid.UUID
+		paramInstanceID           *uuid.UUID
+		paramSubnetID             *uuid.UUID
+		paramVpcID                *uuid.UUID
+		paramVpcIPFamilyMode      *InterfaceVpcIPFamilyMode
+		paramVpcPrefixID          *uuid.UUID
+		paramSecondaryVpcPrefixID *uuid.UUID
+		paramDevice               *string
+		paramDeviceInstance       *int
+		paramVirtualFunctionID    *int
+		paramRequestedIpAddress   *string
+		paramRoutingProfile       *InterfaceInlineRoutingProfile
+		paramMacAddress           *string
+		paramIPAddresses          []string
+		paramStatus               *string
 
-		expectedInstanceID         *uuid.UUID
-		expectedSubnetID           *uuid.UUID
-		expectedVpcID              *uuid.UUID
-		expectedVpcIPFamilyMode    *InterfaceVpcIPFamilyMode
-		expectedVpcPrefixID        *uuid.UUID
-		expectedDevice             *string
-		expectedDeviceInstance     *int
-		expectedVirtualFunctionID  *int
-		expectedRequestedIpAddress *string
-		expectedRoutingProfile     *InterfaceInlineRoutingProfile
-		expectedMacAddress         *string
-		expectedIPAddresses        []string
-		expectedStatus             *string
+		expectedInstanceID           *uuid.UUID
+		expectedSubnetID             *uuid.UUID
+		expectedVpcID                *uuid.UUID
+		expectedVpcIPFamilyMode      *InterfaceVpcIPFamilyMode
+		expectedVpcPrefixID          *uuid.UUID
+		expectedSecondaryVpcPrefixID *uuid.UUID
+		expectedDevice               *string
+		expectedDeviceInstance       *int
+		expectedVirtualFunctionID    *int
+		expectedRequestedIpAddress   *string
+		expectedRoutingProfile       *InterfaceInlineRoutingProfile
+		expectedMacAddress           *string
+		expectedIPAddresses          []string
+		expectedStatus               *string
 
 		expectError        bool
 		verifyChildSpanner bool
@@ -1387,29 +1427,31 @@ func TestInterfaceSQLDAO_Update(t *testing.T) {
 			verifyChildSpanner: true,
 		},
 		{
-			desc:                    "success wth vpcprefix fields updated",
-			id:                      ifcRouting.ID,
-			paramInstanceID:         &i2.ID,
-			paramVpcID:              &vpc.ID,
-			paramVpcIPFamilyMode:    cutil.GetPtr(InterfaceVpcIPFamilyModeIPv4Only),
-			paramVpcPrefixID:        &vpcPrefix2.ID,
-			paramVirtualFunctionID:  &vfID,
-			paramRequestedIpAddress: cutil.GetPtr("192.0.2.31"),
-			paramRoutingProfile:     routingProfile,
-			paramMacAddress:         &macAddress,
-			paramIPAddresses:        ipAddresses,
-			paramStatus:             cutil.GetPtr(InterfaceStatusReady),
+			desc:                      "success wth vpcprefix fields updated",
+			id:                        ifcRouting.ID,
+			paramInstanceID:           &i2.ID,
+			paramVpcID:                &vpc.ID,
+			paramVpcIPFamilyMode:      cutil.GetPtr(InterfaceVpcIPFamilyModeIPv4Only),
+			paramVpcPrefixID:          &vpcPrefix2.ID,
+			paramSecondaryVpcPrefixID: &vpcPrefix1.ID,
+			paramVirtualFunctionID:    &vfID,
+			paramRequestedIpAddress:   cutil.GetPtr("192.0.2.31"),
+			paramRoutingProfile:       routingProfile,
+			paramMacAddress:           &macAddress,
+			paramIPAddresses:          ipAddresses,
+			paramStatus:               cutil.GetPtr(InterfaceStatusReady),
 
-			expectedInstanceID:         &i2.ID,
-			expectedVpcID:              &vpc.ID,
-			expectedVpcIPFamilyMode:    cutil.GetPtr(InterfaceVpcIPFamilyModeIPv4Only),
-			expectedVpcPrefixID:        &vpcPrefix2.ID,
-			expectedVirtualFunctionID:  &vfID,
-			expectedRequestedIpAddress: cutil.GetPtr("192.0.2.31"),
-			expectedRoutingProfile:     routingProfile,
-			expectedMacAddress:         &macAddress,
-			expectedIPAddresses:        ipAddresses,
-			expectedStatus:             cutil.GetPtr(InterfaceStatusReady),
+			expectedInstanceID:           &i2.ID,
+			expectedVpcID:                &vpc.ID,
+			expectedVpcIPFamilyMode:      cutil.GetPtr(InterfaceVpcIPFamilyModeIPv4Only),
+			expectedVpcPrefixID:          &vpcPrefix2.ID,
+			expectedSecondaryVpcPrefixID: &vpcPrefix1.ID,
+			expectedVirtualFunctionID:    &vfID,
+			expectedRequestedIpAddress:   cutil.GetPtr("192.0.2.31"),
+			expectedRoutingProfile:       routingProfile,
+			expectedMacAddress:           &macAddress,
+			expectedIPAddresses:          ipAddresses,
+			expectedStatus:               cutil.GetPtr(InterfaceStatusReady),
 
 			expectError:        false,
 			verifyChildSpanner: true,
@@ -1454,6 +1496,7 @@ func TestInterfaceSQLDAO_Update(t *testing.T) {
 				VpcID:                tc.paramVpcID,
 				VpcIPFamilyMode:      tc.paramVpcIPFamilyMode,
 				VpcPrefixID:          tc.paramVpcPrefixID,
+				SecondaryVpcPrefixID: tc.paramSecondaryVpcPrefixID,
 				Device:               tc.paramDevice,
 				DeviceInstance:       tc.paramDeviceInstance,
 				VirtualFunctionID:    tc.paramVirtualFunctionID,
@@ -1482,6 +1525,7 @@ func TestInterfaceSQLDAO_Update(t *testing.T) {
 				if tc.expectedVpcPrefixID != nil {
 					assert.Equal(t, *tc.expectedVpcPrefixID, *got.VpcPrefixID)
 				}
+				assert.Equal(t, tc.expectedSecondaryVpcPrefixID, got.SecondaryVpcPrefixID)
 				assert.Equal(t, *tc.expectedVirtualFunctionID, *got.VirtualFunctionID)
 				assert.Equal(t, tc.expectedRequestedIpAddress, got.RequestedIpAddress)
 				assert.Equal(t, tc.expectedRoutingProfile, got.InlineRoutingProfile)

--- a/rest-api/db/pkg/migrations/20260815003633_interface_secondary_vpc_prefix.go
+++ b/rest-api/db/pkg/migrations/20260815003633_interface_secondary_vpc_prefix.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+		if err != nil {
+			handlePanic(err, "failed to begin transaction")
+		}
+
+		// REST never persisted Core's secondary VPC prefix ID, so there is no
+		// value to backfill. `UpdateInstancesInDB` populates this column from the
+		// next aligned inventory.
+		_, err = tx.ExecContext(ctx, `
+			ALTER TABLE "interface"
+			ADD COLUMN IF NOT EXISTS secondary_vpc_prefix_id UUID
+		`)
+		handleError(tx, err)
+		_, err = tx.ExecContext(ctx, `
+			ALTER TABLE "interface"
+			DROP CONSTRAINT IF EXISTS interface_secondary_vpc_prefix_id_fkey
+		`)
+		handleError(tx, err)
+		_, err = tx.ExecContext(ctx, `
+			ALTER TABLE "interface"
+			ADD CONSTRAINT interface_secondary_vpc_prefix_id_fkey
+			FOREIGN KEY (secondary_vpc_prefix_id)
+			REFERENCES public.vpc_prefix(id)
+		`)
+		handleError(tx, err)
+		// The original migration used this name for an index on vpc_prefix(id).
+		// Replace that redundant index so the name describes the indexed column.
+		_, err = tx.ExecContext(ctx, `
+			DROP INDEX IF EXISTS interface_vpc_prefix_id_idx
+		`)
+		handleError(tx, err)
+		_, err = tx.ExecContext(ctx, `
+			CREATE INDEX interface_vpc_prefix_id_idx
+			ON "interface" (vpc_prefix_id)
+		`)
+		handleError(tx, err)
+		_, err = tx.ExecContext(ctx, `
+			CREATE INDEX IF NOT EXISTS interface_secondary_vpc_prefix_id_idx
+			ON "interface" (secondary_vpc_prefix_id)
+		`)
+		handleError(tx, err)
+
+		if err = tx.Commit(); err != nil {
+			handlePanic(err, "failed to commit transaction")
+		}
+
+		fmt.Print(" [up migration] Added secondary VPC prefix resolution to 'interface' table successfully. ")
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+		if err != nil {
+			return err
+		}
+
+		if _, err = tx.ExecContext(ctx, `
+			DROP INDEX IF EXISTS interface_secondary_vpc_prefix_id_idx
+		`); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if _, err = tx.ExecContext(ctx, `
+			DROP INDEX IF EXISTS interface_vpc_prefix_id_idx
+		`); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if _, err = tx.ExecContext(ctx, `
+			CREATE INDEX interface_vpc_prefix_id_idx
+			ON public.vpc_prefix (id)
+		`); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if _, err = tx.ExecContext(ctx, `
+			ALTER TABLE "interface"
+			DROP CONSTRAINT IF EXISTS interface_secondary_vpc_prefix_id_fkey
+		`); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if _, err = tx.ExecContext(ctx, `
+			ALTER TABLE "interface"
+			DROP COLUMN IF EXISTS secondary_vpc_prefix_id
+		`); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err = tx.Commit(); err != nil {
+			return err
+		}
+
+		fmt.Print(" [down migration] Dropped secondary VPC prefix resolution from 'interface' table successfully. ")
+		return nil
+	})
+}

--- a/rest-api/workflow/pkg/activity/instance/instance.go
+++ b/rest-api/workflow/pkg/activity/instance/instance.go
@@ -43,16 +43,16 @@ type ManageInstance struct {
 	cfg            *config.Config
 }
 
-// primaryResolvedVpcPrefixID preserves the scalar REST cache contract: IPv4 is
-// primary for dual-stack selections, while IPv6 is primary for IPv6-only selections.
-func primaryResolvedVpcPrefixID(prefixes *corev1.InstanceInterfaceResolvedVpcPrefixes) *corev1.VpcPrefixId {
+// resolvedVpcPrefixIDs preserves the REST cache contract: IPv4 is primary for
+// dual-stack selections, while IPv6 is primary for IPv6-only selections.
+func resolvedVpcPrefixIDs(prefixes *corev1.InstanceInterfaceResolvedVpcPrefixes) (primary, secondary *corev1.VpcPrefixId) {
 	if prefixes == nil {
-		return nil
+		return nil, nil
 	}
 	if prefixes.Ipv4VpcPrefixId != nil {
-		return prefixes.Ipv4VpcPrefixId
+		return prefixes.Ipv4VpcPrefixId, prefixes.Ipv6VpcPrefixId
 	}
-	return prefixes.Ipv6VpcPrefixId
+	return prefixes.Ipv6VpcPrefixId, nil
 }
 
 // Activity functions
@@ -481,33 +481,50 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 					}
 
 					// A VPC selector remains the desired intent; synchronize Core's
-					// primary resolved prefix from the aligned status.
+					// resolved prefix IDs from the aligned status.
 					var vpcPrefixID *uuid.UUID
+					var secondaryVpcPrefixID *uuid.UUID
 					clearResolvedVpcPrefix := false
+					clearSecondaryVpcPrefix := false
 					if usesVpcSelection {
-						resolvedPrefix := primaryResolvedVpcPrefixID(interfaceStatus.ResolvedVpcPrefixes)
+						resolvedPrefix, secondaryResolvedPrefix := resolvedVpcPrefixIDs(interfaceStatus.ResolvedVpcPrefixes)
 						if resolvedPrefix == nil {
-							clearResolvedVpcPrefix = controllerInstance.Status.Network.ConfigsSynced == corev1.SyncState_SYNCED &&
-								ifc.VpcPrefixID != nil
+							if controllerInstance.Status.Network.ConfigsSynced == corev1.SyncState_SYNCED {
+								clearResolvedVpcPrefix = ifc.VpcPrefixID != nil
+								clearSecondaryVpcPrefix = ifc.SecondaryVpcPrefixID != nil
+							}
 						} else {
 							resolvedPrefixID, prefixErr := uuid.Parse(resolvedPrefix.Value)
 							if prefixErr != nil {
 								slogger.Error().Err(prefixErr).Str("Interface ID", ifc.ID.String()).Msg("failed to parse resolved VPC Prefix ID")
 							} else {
 								vpcPrefixID = &resolvedPrefixID
+
+								if secondaryResolvedPrefix == nil {
+									clearSecondaryVpcPrefix = controllerInstance.Status.Network.ConfigsSynced == corev1.SyncState_SYNCED &&
+										ifc.SecondaryVpcPrefixID != nil
+								} else {
+									resolvedPrefixID, prefixErr := uuid.Parse(secondaryResolvedPrefix.Value)
+									if prefixErr != nil {
+										slogger.Error().Err(prefixErr).Str("Interface ID", ifc.ID.String()).Msg("failed to parse secondary resolved VPC Prefix ID")
+									} else {
+										secondaryVpcPrefixID = &resolvedPrefixID
+									}
+								}
 							}
 						}
 					}
 
 					clearInput := cdbm.InterfaceClearInput{InterfaceID: ifc.ID}
 					clearInput.VpcPrefixID = clearResolvedVpcPrefix
+					clearInput.SecondaryVpcPrefixID = clearSecondaryVpcPrefix
 					if ifc.RequestedIpAddress != nil && interfaceConfig.IpAddress == nil {
 						clearInput.RequestedIpAddress = true
 					}
 					if ifc.InlineRoutingProfile != nil && interfaceConfig.RoutingProfile == nil {
 						clearInput.InlineRoutingProfile = true
 					}
-					if clearInput.VpcPrefixID || clearInput.RequestedIpAddress || clearInput.InlineRoutingProfile {
+					if clearInput.VpcPrefixID || clearInput.SecondaryVpcPrefixID || clearInput.RequestedIpAddress || clearInput.InlineRoutingProfile {
 						_, serr := interfaceDAO.Clear(ctx, nil, clearInput)
 						if serr != nil {
 							slogger.Error().Err(serr).Str("Interface ID", ifc.ID.String()).Msg("failed to update Interface in DB")
@@ -523,6 +540,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 					_, updateErr := interfaceDAO.Update(ctx, nil, cdbm.InterfaceUpdateInput{
 						InterfaceID:          ifc.ID,
 						VpcPrefixID:          vpcPrefixID,
+						SecondaryVpcPrefixID: secondaryVpcPrefixID,
 						Device:               device,
 						DeviceInstance:       deviceInstance,
 						VirtualFunctionID:    vfID,

--- a/rest-api/workflow/pkg/activity/instance/instance_test.go
+++ b/rest-api/workflow/pkg/activity/instance/instance_test.go
@@ -57,29 +57,30 @@ func testTemporalSiteClientPool(t *testing.T) *sc.ClientPool {
 	return tSiteClientPool
 }
 
-func TestPrimaryResolvedVpcPrefixID(t *testing.T) {
+func TestResolvedVpcPrefixIDs(t *testing.T) {
 	ipv4 := &corev1.VpcPrefixId{Value: uuid.NewString()}
 	ipv6 := &corev1.VpcPrefixId{Value: uuid.NewString()}
 
 	tests := []struct {
-		name     string
-		prefixes *corev1.InstanceInterfaceResolvedVpcPrefixes
-		want     *corev1.VpcPrefixId
+		name          string
+		prefixes      *corev1.InstanceInterfaceResolvedVpcPrefixes
+		wantPrimary   *corev1.VpcPrefixId
+		wantSecondary *corev1.VpcPrefixId
 	}{
-		{name: "unresolved", prefixes: nil, want: nil},
+		{name: "unresolved", prefixes: nil},
 		{
 			name: "IPv4-only uses IPv4",
 			prefixes: &corev1.InstanceInterfaceResolvedVpcPrefixes{
 				Ipv4VpcPrefixId: ipv4,
 			},
-			want: ipv4,
+			wantPrimary: ipv4,
 		},
 		{
 			name: "IPv6-only uses IPv6",
 			prefixes: &corev1.InstanceInterfaceResolvedVpcPrefixes{
 				Ipv6VpcPrefixId: ipv6,
 			},
-			want: ipv6,
+			wantPrimary: ipv6,
 		},
 		{
 			name: "dual-stack keeps IPv4 primary",
@@ -87,13 +88,16 @@ func TestPrimaryResolvedVpcPrefixID(t *testing.T) {
 				Ipv4VpcPrefixId: ipv4,
 				Ipv6VpcPrefixId: ipv6,
 			},
-			want: ipv4,
+			wantPrimary:   ipv4,
+			wantSecondary: ipv6,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, primaryResolvedVpcPrefixID(tt.prefixes))
+			primary, secondary := resolvedVpcPrefixIDs(tt.prefixes)
+			assert.Equal(t, tt.wantPrimary, primary)
+			assert.Equal(t, tt.wantSecondary, secondary)
 		})
 	}
 }
@@ -135,6 +139,22 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 		tnu,
 	)
 	require.NotNil(t, ipBlock)
+	ipv6IPBlock := util.TestBuildBuildIPBlock(
+		t,
+		dbSession,
+		"test-vpc-selection-ipv6-block",
+		site,
+		ip,
+		&tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly,
+		"2001:db8::",
+		64,
+		cdbm.IPBlockProtocolVersionV6,
+		false,
+		cdbm.IPBlockStatusReady,
+		tnu,
+	)
+	require.NotNil(t, ipv6IPBlock)
 	buildPrefix := func(name, prefix string) *cdbm.VpcPrefix {
 		vpcPrefix := util.TestBuildVPCPrefix(
 			t,
@@ -154,6 +174,21 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	}
 	deviceLessPrefix := buildPrefix("test-vpc-selection-prefix-1", "192.0.2.0/28")
 	devicePrefix := buildPrefix("test-vpc-selection-prefix-2", "192.0.2.16/28")
+	ipv6PrefixValue := "2001:db8::/120"
+	ipv6Prefix := util.TestBuildVPCPrefix(
+		t,
+		dbSession,
+		"test-vpc-selection-ipv6-prefix",
+		site,
+		tenant,
+		vpc.ID,
+		&ipv6IPBlock.ID,
+		&ipv6PrefixValue,
+		cutil.GetPtr(120),
+		cdbm.VpcPrefixStatusReady,
+		tnu,
+	)
+	require.NotNil(t, ipv6Prefix)
 
 	instanceDAO := cdbm.NewInstanceDAO(dbSession)
 	buildInstance := func(name string) *cdbm.Instance {
@@ -182,8 +217,7 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	deviceInstance := buildInstance("device-vpc-selection")
 	shortStatusInstance := buildInstance("short-vpc-selection-status")
 	interfaceDAO := cdbm.NewInterfaceDAO(dbSession)
-	familyMode := cdbm.InterfaceVpcIPFamilyModeIPv4Only
-	createInterface := func(instanceID uuid.UUID, isPhysical bool, device *string, deviceInstance, virtualFunctionID *int) *cdbm.Interface {
+	createInterface := func(instanceID uuid.UUID, familyMode cdbm.InterfaceVpcIPFamilyMode, isPhysical bool, device *string, deviceInstance, virtualFunctionID *int) *cdbm.Interface {
 		ifc, createErr := interfaceDAO.Create(ctx, nil, cdbm.InterfaceCreateInput{
 			InstanceID:        instanceID,
 			VpcID:             &vpc.ID,
@@ -201,19 +235,19 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 
 	// Keep device-less and device-selected modes on separate Instances, as API
 	// validation requires.
-	deviceLessIfc := createInterface(deviceLessInstance.ID, true, nil, nil, nil)
+	deviceLessIfc := createInterface(deviceLessInstance.ID, cdbm.InterfaceVpcIPFamilyModeDualStack, true, nil, nil, nil)
 	device := "BlueField"
 	deviceInstanceID := 1
 	virtualFunctionID := 2
-	deviceIfc := createInterface(deviceInstance.ID, false, &device, &deviceInstanceID, &virtualFunctionID)
-	shortStatusIfc := createInterface(shortStatusInstance.ID, true, nil, nil, nil)
+	deviceIfc := createInterface(deviceInstance.ID, cdbm.InterfaceVpcIPFamilyModeIPv4Only, false, &device, &deviceInstanceID, &virtualFunctionID)
+	shortStatusIfc := createInterface(shortStatusInstance.ID, cdbm.InterfaceVpcIPFamilyModeIPv4Only, true, nil, nil, nil)
 
 	deviceLessMac := "02:00:00:00:00:01"
 	deviceMac := "02:00:00:00:00:02"
-	selection := func() *corev1.InstanceInterfaceConfig_Vpc {
+	selection := func(familyMode corev1.InstanceInterfaceIpFamilyMode) *corev1.InstanceInterfaceConfig_Vpc {
 		return &corev1.InstanceInterfaceConfig_Vpc{Vpc: &corev1.InstanceInterfaceVpcSelection{
 			VpcId:      &corev1.VpcId{Value: controllerVpcID.String()},
-			FamilyMode: corev1.InstanceInterfaceIpFamilyMode_INSTANCE_INTERFACE_IP_FAMILY_MODE_IPV4_ONLY,
+			FamilyMode: familyMode,
 		}}
 	}
 	status := func(prefixID uuid.UUID, macAddress, address string, virtualFunctionID *uint32) *corev1.InstanceInterfaceStatus {
@@ -232,6 +266,8 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	// select a device. Repeated inventory must continue matching it by VPC intent.
 	observedDevice := "observed-device"
 	deviceLessStatus := status(deviceLessPrefix.ID, deviceLessMac, "192.0.2.10", nil)
+	deviceLessStatus.Addresses = append(deviceLessStatus.Addresses, "2001:db8::10")
+	deviceLessStatus.ResolvedVpcPrefixes.Ipv6VpcPrefixId = &corev1.VpcPrefixId{Value: ipv6Prefix.ID.String()}
 	deviceLessStatus.Device = &observedDevice
 	deviceStatus := status(devicePrefix.ID, deviceMac, "192.0.2.20", cutil.GetPtr(uint32(virtualFunctionID)))
 	deviceStatus.Device = &device
@@ -241,7 +277,12 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 		{
 			Id: &corev1.InstanceId{Value: deviceLessInstance.ControllerInstanceID.String()},
 			Config: &corev1.InstanceConfig{Network: &corev1.InstanceNetworkConfig{Interfaces: []*corev1.InstanceInterfaceConfig{
-				{FunctionType: corev1.InterfaceFunctionType_PHYSICAL_FUNCTION, NetworkDetails: selection()},
+				{
+					FunctionType: corev1.InterfaceFunctionType_PHYSICAL_FUNCTION,
+					NetworkDetails: selection(
+						corev1.InstanceInterfaceIpFamilyMode_INSTANCE_INTERFACE_IP_FAMILY_MODE_DUAL_STACK,
+					),
+				},
 			}}},
 			Status: &corev1.InstanceStatus{
 				Tenant: &corev1.InstanceTenantStatus{State: corev1.TenantState_READY},
@@ -255,8 +296,10 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 			Id: &corev1.InstanceId{Value: deviceInstance.ControllerInstanceID.String()},
 			Config: &corev1.InstanceConfig{Network: &corev1.InstanceNetworkConfig{Interfaces: []*corev1.InstanceInterfaceConfig{
 				{
-					FunctionType:      corev1.InterfaceFunctionType_VIRTUAL_FUNCTION,
-					NetworkDetails:    selection(),
+					FunctionType: corev1.InterfaceFunctionType_VIRTUAL_FUNCTION,
+					NetworkDetails: selection(
+						corev1.InstanceInterfaceIpFamilyMode_INSTANCE_INTERFACE_IP_FAMILY_MODE_IPV4_ONLY,
+					),
 					Device:            &device,
 					DeviceInstance:    uint32(deviceInstanceID),
 					VirtualFunctionId: cutil.GetPtr(uint32(virtualFunctionID)),
@@ -273,7 +316,12 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 		{
 			Id: &corev1.InstanceId{Value: shortStatusInstance.ControllerInstanceID.String()},
 			Config: &corev1.InstanceConfig{Network: &corev1.InstanceNetworkConfig{Interfaces: []*corev1.InstanceInterfaceConfig{
-				{FunctionType: corev1.InterfaceFunctionType_PHYSICAL_FUNCTION, NetworkDetails: selection()},
+				{
+					FunctionType: corev1.InterfaceFunctionType_PHYSICAL_FUNCTION,
+					NetworkDetails: selection(
+						corev1.InstanceInterfaceIpFamilyMode_INSTANCE_INTERFACE_IP_FAMILY_MODE_IPV4_ONLY,
+					),
+				},
 			}}},
 			Status: &corev1.InstanceStatus{
 				Tenant: &corev1.InstanceTenantStatus{State: corev1.TenantState_READY},
@@ -291,7 +339,14 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify both resolved data and the original VPC selection intent persisted.
-	assertResolvedInterface := func(ifc *cdbm.Interface, expectedPrefixID uuid.UUID, expectedMac, expectedAddress string) *cdbm.Interface {
+	assertResolvedInterface := func(
+		ifc *cdbm.Interface,
+		expectedPrefixID uuid.UUID,
+		expectedSecondaryPrefixID *uuid.UUID,
+		expectedFamilyMode cdbm.InterfaceVpcIPFamilyMode,
+		expectedMac string,
+		expectedAddresses []string,
+	) *cdbm.Interface {
 		updated, getErr := interfaceDAO.GetByID(ctx, nil, ifc.ID, nil)
 		require.NoError(t, getErr)
 		require.NotNil(t, updated.VpcPrefixID)
@@ -300,16 +355,31 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 		require.NotNil(t, updated.MacAddress)
 		assert.Equal(t, expectedPrefixID, *updated.VpcPrefixID)
 		assert.Equal(t, vpc.ID, *updated.VpcID)
-		assert.Equal(t, cdbm.InterfaceVpcIPFamilyModeIPv4Only, *updated.VpcIPFamilyMode)
+		assert.Equal(t, expectedSecondaryPrefixID, updated.SecondaryVpcPrefixID)
+		assert.Equal(t, expectedFamilyMode, *updated.VpcIPFamilyMode)
 		assert.Equal(t, expectedMac, *updated.MacAddress)
-		assert.Equal(t, []string{expectedAddress}, updated.IPAddresses)
+		assert.Equal(t, expectedAddresses, updated.IPAddresses)
 		assert.Equal(t, cdbm.InterfaceStatusReady, updated.Status)
 		return updated
 	}
-	updatedDeviceLessIfc := assertResolvedInterface(deviceLessIfc, deviceLessPrefix.ID, deviceLessMac, "192.0.2.10")
+	updatedDeviceLessIfc := assertResolvedInterface(
+		deviceLessIfc,
+		deviceLessPrefix.ID,
+		&ipv6Prefix.ID,
+		cdbm.InterfaceVpcIPFamilyModeDualStack,
+		deviceLessMac,
+		[]string{"192.0.2.10", "2001:db8::10"},
+	)
 	require.NotNil(t, updatedDeviceLessIfc.Device)
 	assert.Equal(t, observedDevice, *updatedDeviceLessIfc.Device)
-	updatedDeviceIfc := assertResolvedInterface(deviceIfc, devicePrefix.ID, deviceMac, "192.0.2.20")
+	updatedDeviceIfc := assertResolvedInterface(
+		deviceIfc,
+		devicePrefix.ID,
+		nil,
+		cdbm.InterfaceVpcIPFamilyModeIPv4Only,
+		deviceMac,
+		[]string{"192.0.2.20"},
+	)
 	require.NotNil(t, updatedDeviceIfc.Device)
 	assert.Equal(t, device, *updatedDeviceIfc.Device)
 
@@ -317,14 +387,35 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	shortStatusUnchanged, err := interfaceDAO.GetByID(ctx, nil, shortStatusIfc.ID, nil)
 	require.NoError(t, err)
 	assert.Nil(t, shortStatusUnchanged.VpcPrefixID)
+	assert.Nil(t, shortStatusUnchanged.SecondaryVpcPrefixID)
 	assert.Equal(t, vpc.ID, *shortStatusUnchanged.VpcID)
 	assert.Equal(t, cdbm.InterfaceVpcIPFamilyModeIPv4Only, *shortStatusUnchanged.VpcIPFamilyMode)
 	assert.Nil(t, shortStatusUnchanged.MacAddress)
 	assert.Equal(t, cdbm.InterfaceStatusPending, shortStatusUnchanged.Status)
 
-	// Pending inventory is not authoritative enough to clear resolution.
+	// Pending inventory is not authoritative enough to clear either resolution.
 	inventory.Instances[0].Status.Network.Interfaces[0].ResolvedVpcPrefixes = nil
 	inventory.Instances[0].Status.Network.ConfigsSynced = corev1.SyncState_PENDING
+	_, err = dbSession.DB.Exec(
+		"UPDATE instance SET updated = ? WHERE id = ?",
+		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		deviceLessInstance.ID,
+	)
+	require.NoError(t, err)
+	_, err = manager.UpdateInstancesInDB(ctx, site.ID, inventory)
+	require.NoError(t, err)
+
+	pendingEmptyResolution, err := interfaceDAO.GetByID(ctx, nil, deviceLessIfc.ID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pendingEmptyResolution.VpcPrefixID)
+	assert.Equal(t, deviceLessPrefix.ID, *pendingEmptyResolution.VpcPrefixID)
+	require.NotNil(t, pendingEmptyResolution.SecondaryVpcPrefixID)
+	assert.Equal(t, ipv6Prefix.ID, *pendingEmptyResolution.SecondaryVpcPrefixID)
+
+	// Pending partial inventory also preserves an omitted secondary resolution.
+	inventory.Instances[0].Status.Network.Interfaces[0].ResolvedVpcPrefixes = &corev1.InstanceInterfaceResolvedVpcPrefixes{
+		Ipv4VpcPrefixId: &corev1.VpcPrefixId{Value: deviceLessPrefix.ID.String()},
+	}
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET updated = ? WHERE id = ?",
 		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
@@ -338,14 +429,34 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pendingResolution.VpcPrefixID)
 	assert.Equal(t, deviceLessPrefix.ID, *pendingResolution.VpcPrefixID)
+	require.NotNil(t, pendingResolution.SecondaryVpcPrefixID)
+	assert.Equal(t, ipv6Prefix.ID, *pendingResolution.SecondaryVpcPrefixID)
 	assert.Equal(t, cdbm.InterfaceStatusReady, pendingResolution.Status)
 	require.NotNil(t, pendingResolution.VpcID)
 	assert.Equal(t, vpc.ID, *pendingResolution.VpcID)
 	require.NotNil(t, pendingResolution.VpcIPFamilyMode)
-	assert.Equal(t, cdbm.InterfaceVpcIPFamilyModeIPv4Only, *pendingResolution.VpcIPFamilyMode)
+	assert.Equal(t, cdbm.InterfaceVpcIPFamilyModeDualStack, *pendingResolution.VpcIPFamilyMode)
 
-	// Synchronized inventory authoritatively clears stale resolution.
+	// Synchronized partial inventory authoritatively clears only the stale
+	// secondary resolution while preserving the reported primary.
 	inventory.Instances[0].Status.Network.ConfigsSynced = corev1.SyncState_SYNCED
+	_, err = dbSession.DB.Exec(
+		"UPDATE instance SET updated = ? WHERE id = ?",
+		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		deviceLessInstance.ID,
+	)
+	require.NoError(t, err)
+	_, err = manager.UpdateInstancesInDB(ctx, site.ID, inventory)
+	require.NoError(t, err)
+
+	primaryOnlyResolution, err := interfaceDAO.GetByID(ctx, nil, deviceLessIfc.ID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, primaryOnlyResolution.VpcPrefixID)
+	assert.Equal(t, deviceLessPrefix.ID, *primaryOnlyResolution.VpcPrefixID)
+	assert.Nil(t, primaryOnlyResolution.SecondaryVpcPrefixID)
+
+	// Synchronized inventory with no resolution clears the remaining primary.
+	inventory.Instances[0].Status.Network.Interfaces[0].ResolvedVpcPrefixes = nil
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET updated = ? WHERE id = ?",
 		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
@@ -358,10 +469,11 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	clearedResolution, err := interfaceDAO.GetByID(ctx, nil, deviceLessIfc.ID, nil)
 	require.NoError(t, err)
 	assert.Nil(t, clearedResolution.VpcPrefixID)
+	assert.Nil(t, clearedResolution.SecondaryVpcPrefixID)
 	require.NotNil(t, clearedResolution.VpcID)
 	assert.Equal(t, vpc.ID, *clearedResolution.VpcID)
 	require.NotNil(t, clearedResolution.VpcIPFamilyMode)
-	assert.Equal(t, cdbm.InterfaceVpcIPFamilyModeIPv4Only, *clearedResolution.VpcIPFamilyMode)
+	assert.Equal(t, cdbm.InterfaceVpcIPFamilyModeDualStack, *clearedResolution.VpcIPFamilyMode)
 }
 
 func TestManageInstance_deleteInstanceFromDB(t *testing.T) {


### PR DESCRIPTION
REST kept only one resolved VPC prefix on each `Interface`. For a dual-stack selection, that meant the IPv6 prefix disappeared at the cache boundary and the VPC prefix delete check could miss an interface that was still using it.

So this adds nullable `interface.secondary_vpc_prefix_id` storage next to the existing primary compatibility field. `UpdateInstancesInDB` now synchronizes both family-keyed IDs reported by Core, preserves known values across pending or partial inventory, and clears stale values only when `ConfigsSynced` makes an omission authoritative. `InterfaceFilterInput.VpcPrefixID` checks both indexed columns, while the public interface response stays unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5102

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Tests cover persisting, filtering, updating, and clearing both resolved VPC Prefix IDs; restoring both IDs from Core inventory; and preventing VPC Prefix deletion while either reference is live. Migration coverage exercises a fresh REST schema, and a direct PostgreSQL catalogue check confirmed the nullable UUID column, foreign key, and both indexes.

## Additional Notes

Migration compatibility: `20260815003633_interface_secondary_vpc_prefix.go` assumes the schema through `20260731215443_vpc_routing_profiles.go` and adds one nullable UUID column, one foreign key, and two ordinary B-tree indexes. It replaces the legacy `interface_vpc_prefix_id_idx`, which redundantly indexed the primary-key `vpc_prefix(id)`, with the conventionally named index on `interface(vpc_prefix_id)`; the down migration restores the prior definition. There is no authoritative database-local value to backfill; the next aligned Core inventory supplies it. Existing REST binaries ignore the extra column, the new binary accepts `NULL`, and rollback to the previous binary remains compatible while the expanded schema is retained. No public REST or OpenAPI contract changes. No rows are rewritten; the ordinary index builds scan and lock the `interface` table, and representative site size was not measured.

Scope stays with issue #5102: this PR persists the second resolved ID, keeps inventory reconciliation correct, makes the existing prefix-deletion guard see either ID, and repairs the legacy index target required for the canonical index name.

<details>
<summary>Model Findings Overview</summary>

All three local reviewers completely covered the same stable five-path pre-fix tree; the active model then completed a bounded post-fix closure review of the final six-path diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 0 | 1 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 9 | 4 | 5 |
| **Total** | **10** | **4** | **6** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Declined (initial)** -- `rest-api/workflow/pkg/activity/instance/instance.go:48`: A sparse IPv6-only result might be mistaken for the primary value of a dual-stack selection. **Reason:** Core's `resolved_vpc_prefixes` contract always reports IPv4 as the dual-stack primary; the supported partial form omits only the IPv6 sidecar, which the reconciliation test covers.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- `rest-api/workflow/pkg/activity/instance/instance_test.go`: Replacing the pending/no-resolution step dropped coverage for the branch that preserves both known IDs while inventory is not authoritative. **Resolution:** Restored that step and kept a separate pending/partial step for the secondary ID.
2. **Adopted** -- `rest-api/db/pkg/db/model/interface_test.go`: The new filter, update, and clear DAO behavior had only indirect coverage. **Resolution:** Extended the existing table-driven DAO tests for both-position filtering, secondary updates, and secondary clears.
3. **Adopted** -- `rest-api/api/pkg/api/handler/vpcprefix_test.go`: The handler test populated the new column with raw Bun SQL even though the production DAO now supports it. **Resolution:** The test uses `InterfaceDAO.Update`.
4. **Declined** -- `rest-api/db/pkg/db/model/interface.go`: Rename or comment `InterfaceFilterInput.VpcPrefixID` after widening it to both columns. **Reason:** The input still asks whether a VPC prefix is used by an interface, and the adjacent SQL names both storage positions directly; a new filter contract would add terminology without another caller.
5. **Declined** -- `rest-api/db/pkg/db/model/interface.go`: Add another source comment for the secondary-column invariant. **Reason:** The family mapping is already documented and tested at `resolvedVpcPrefixIDs`, the boundary that owns the Core-to-REST mapping.
6. **Adopted** -- `rest-api/db/pkg/migrations/20260815003633_interface_secondary_vpc_prefix.go`: Explain the primary index name in the migration. **Resolution:** The migration now documents and replaces the legacy same-named index on `vpc_prefix(id)`, so `interface_vpc_prefix_id_idx` follows the table-and-column convention and indexes `interface(vpc_prefix_id)`.
7. **Declined** -- `rest-api/workflow/pkg/activity/instance/instance.go`: Rename a shadowed parse variable and hoist the synchronized-state comparison. **Reason:** Both scopes are short, the error messages distinguish primary from secondary, and this is a readability preference with no behavioral effect.
8. **Declined** -- `rest-api/workflow/pkg/activity/instance/instance.go`: Document why a malformed primary ID also skips secondary processing. **Reason:** Core produces both IDs from typed internal identifiers; the defensive parse failure logs the invalid trusted status and preserves the last known cache rather than applying part of a suspect report.
9. **Declined** -- `rest-api/workflow/pkg/activity/instance/instance_test.go`: Generalize IPv4-named test helpers and deduplicate the IPv6 fixture. **Reason:** The helper name and fixture layout predate this issue; changing them would be unrelated test cleanup.

</details>
