### PR TITLE
fix(dhcp-server): reject empty IPv4 host prefixes

### DIFF
--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -117,13 +117,14 @@ impl TryFrom<proto::InterfaceInfo> for ModelInterfaceInfo {
 
     fn try_from(i: proto::InterfaceInfo) -> Result<Self, Self::Error> {
         let (address, gateway, prefix) = match (i.address, i.gateway, i.prefix) {
-            (Some(address), Some(gateway), Some(prefix)) => {
+            (Some(address), Some(gateway), Some(prefix)) if !prefix.is_empty() => {
                 (Some(address.parse()?), Some(gateway.parse()?), Some(prefix))
             }
             (None, None, None) => (None, None, None),
             _ => {
                 return Err(DhcpError::InvalidInput(
-                    "IPv4 address, gateway, and prefix must be configured together".to_string(),
+                    "IPv4 address, gateway, and non-empty prefix must be configured together"
+                        .to_string(),
                 ));
             }
         };
@@ -298,7 +299,7 @@ mod tests {
                     Some("192.0.2.0/24".to_string()),
                 )),
             }
-            "IPv6-only configuration" {
+            "all IPv4 fields absent in IPv6-only configuration" {
                 proto::InterfaceInfo {
                     ipv6: Some(proto::InterfaceInfoV6 {
                         address: Some("2001:db8::10".to_string()),
@@ -325,6 +326,32 @@ mod tests {
                 proto::InterfaceInfo {
                     address: Some("192.0.2.10".to_string()),
                     gateway: Some("192.0.2.1".to_string()),
+                    ..Default::default()
+                } => Fails,
+            }
+            "IPv4 address only" {
+                proto::InterfaceInfo {
+                    address: Some("192.0.2.10".to_string()),
+                    ..Default::default()
+                } => Fails,
+            }
+            "IPv4 gateway only" {
+                proto::InterfaceInfo {
+                    gateway: Some("192.0.2.1".to_string()),
+                    ..Default::default()
+                } => Fails,
+            }
+            "IPv4 prefix only" {
+                proto::InterfaceInfo {
+                    prefix: Some("192.0.2.0/24".to_string()),
+                    ..Default::default()
+                } => Fails,
+            }
+            "empty IPv4 prefix" {
+                proto::InterfaceInfo {
+                    address: Some("192.0.2.10".to_string()),
+                    gateway: Some("192.0.2.1".to_string()),
+                    prefix: Some(String::new()),
                     ..Default::default()
                 } => Fails,
             }

--- a/crates/dhcp-server/src/modes/dpu.rs
+++ b/crates/dhcp-server/src/modes/dpu.rs
@@ -107,13 +107,14 @@ impl DhcpMode for Dpu {
 
 fn validate_host_config(host_config: &HostConfig) -> Result<(), DhcpError> {
     for (circuit_id, interface) in &host_config.host_ip_addresses {
-        if !matches!(
-            (&interface.address, &interface.gateway, &interface.prefix),
-            (Some(_), Some(_), Some(_)) | (None, None, None)
-        ) {
-            return Err(DhcpError::InvalidInput(format!(
-                "IPv4 address, gateway, and prefix for {circuit_id} must be configured together"
-            )));
+        match (&interface.address, &interface.gateway, &interface.prefix) {
+            (Some(_), Some(_), Some(prefix)) if !prefix.is_empty() => {}
+            (None, None, None) => {}
+            _ => {
+                return Err(DhcpError::InvalidInput(format!(
+                    "IPv4 address, gateway, and non-empty prefix for {circuit_id} must be configured together"
+                )));
+            }
         }
     }
 
@@ -163,6 +164,14 @@ mod tests {
             host_ip_addresses: [("vlan100".to_string(), interface)].into(),
         };
         validate_host_config(&host_config).map_err(drop)
+    }
+
+    fn validate_yaml_interface_prefix(prefix: &str) -> Result<(), ()> {
+        let yaml = format!(
+            "address: 192.0.2.10\ngateway: 192.0.2.1\nprefix: \"{prefix}\"\nfqdn: host.example.com\nbooturl: null\n"
+        );
+        let interface = serde_yaml::from_str(&yaml).map_err(drop)?;
+        validate_interface_presence(interface)
     }
 
     #[test]
@@ -217,7 +226,7 @@ mod tests {
                     ..Default::default()
                 } => Yields(()),
             }
-            "IPv6-only configuration" {
+            "all IPv4 fields absent in IPv6-only configuration" {
                 InterfaceInfo {
                     ipv6: Some(InterfaceInfoV6 {
                         address: Some("2001:db8::10".parse().unwrap()),
@@ -246,6 +255,36 @@ mod tests {
                     gateway: Some(Ipv4Addr::new(192, 0, 2, 1)),
                     ..Default::default()
                 } => Fails,
+            }
+            "IPv4 address only" {
+                InterfaceInfo {
+                    address: Some(Ipv4Addr::new(192, 0, 2, 10)),
+                    ..Default::default()
+                } => Fails,
+            }
+            "IPv4 gateway only" {
+                InterfaceInfo {
+                    gateway: Some(Ipv4Addr::new(192, 0, 2, 1)),
+                    ..Default::default()
+                } => Fails,
+            }
+            "IPv4 prefix only" {
+                InterfaceInfo {
+                    prefix: Some("192.0.2.0/24".to_string()),
+                    ..Default::default()
+                } => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn host_config_rejects_empty_ipv4_prefix_from_yaml() {
+        scenarios!(run = validate_yaml_interface_prefix;
+            "configured IPv4 prefix" {
+                "192.0.2.0/24" => Yields(()),
+            }
+            "empty IPv4 prefix" {
+                "" => Fails,
             }
         );
     }


### PR DESCRIPTION
`InterfaceInfo` used `Option` presence to enforce the deprecated IPv4 tuple, which meant `prefix: ""` looked complete and made it through both gRPC conversion and YAML loading before failing later.

So this requires a non-empty prefix at both entry points while preserving the all-absent tuple used by IPv6-only interfaces. The table-driven conversion and YAML tests cover every presence combination plus the empty string.

Tests updated!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5104

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`cargo test -p carbide-dhcp-server` -- 33 passed.

The complete local lint gate also passed: `cargo make format-nightly`, `cargo make check-format-nightly`, `cargo make clippy`, and the cached `carbide-lints --all-targets --all-features` workflow.

## Additional Notes

<details>
<summary>Model Findings Overview</summary>

All three local reviewers completely covered the same stable pre-fix tree; the active model then completed a bounded post-review closure pass of the final diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 0 | 0 | 0 |
| **Total** | **0** | **0** | **0** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

No findings.

</details>
