### PR TITLE
docs: give agents our database-migration expectations in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,10 +185,60 @@ Use the narrowest Rust visibility required by actual callers. Do not use `pub`
 to suppress dead-code warnings or widen production visibility solely for unit
 tests. Follow the [visibility guidance](STYLE_GUIDE.md#visibility).
 
-Name new Core database migrations with the fully populated
+### Database migrations
+
+Core migrations live in `crates/api-db/migrations/` and use the fully populated
 `YYYYMMDDhhmmss_description.sql` format described in
 [`STYLE_GUIDE.md`](STYLE_GUIDE.md#database-migrations). The `migration-police`
-CI job checks only newly added migrations, so existing filenames remain accepted.
+CI job checks only newly added migrations, so existing filenames remain
+accepted.
+
+Most of what makes a migration wrong here is not something CI can catch, because
+an over-built migration still applies cleanly. Write the smallest exact forward
+change from the schema on `main`: the median migration in this repository is two
+statements and eight lines, and most do exactly one thing.
+
+- **Never edit a migration that has merged.** Its checksum is recorded by every
+  deployment that has applied it. Assume any migration on `main` is already
+  running somewhere, since this is a public repository and we cannot know where.
+  Correct it with a new forward migration instead.
+
+- **Do not hand-roll safety the runner already provides.** `sqlx` runs each file
+  in a transaction and records it once, so a migration cannot half-apply or run
+  twice. Leave out `IF EXISTS` and `IF NOT EXISTS`, `ON CONFLICT DO NOTHING`
+  added for rerunnability, `DO $$ ... RAISE EXCEPTION` preflight checks, system
+  catalog probes, `BEGIN` and `COMMIT`, and `NOT VALID` paired with
+  `VALIDATE CONSTRAINT` in the same file. These pass CI and read as caution, but
+  they convert a diagnosable failure into a silent skip.
+
+- **The migration has to apply while a `nico-api` instance is still running.**
+  Nothing stops the running instance first, so assume a live writer throughout.
+  A migration's contract is with the incoming binary, so leave the schema that
+  version expects rather than preserving the outgoing one, but it still has to
+  succeed against that writer.
+
+- **Keep domain logic in Rust.** Do not reimplement a Rust helper in PL/pgSQL,
+  and do not add a view, function, or trigger without a live consumer or an
+  invariant the database has to own.
+
+- **Use `NULL` for genuine absence.** Add a column as nullable, or `NOT NULL`
+  with a default that is true for every row it reaches. Do not invent an empty
+  string, an epoch timestamp, a placeholder version, or `UNKNOWN` to satisfy
+  `NOT NULL`. A `jsonb` default has to deserialize into the current Rust type.
+
+- **Remove things in two steps.** Ship the code that stops reading and writing
+  it, then drop it in a later migration.
+
+- **Comment intent, briefly.** A sentence or two on why the change exists. A
+  safety argument or design rationale belongs in the pull request, not in the
+  migration.
+
+- **Test anything with data semantics** against a database at the predecessor
+  schema populated with realistic rows, including a backfill, a default, a new
+  requiredness, a constraint, or a type conversion. Reference the file with
+  `include_str!` so the test cannot drift from what ships, as
+  [`test_backfill.rs`](crates/api-db/src/credential_rotation/test_backfill.rs)
+  does. A purely additive nullable column is already covered by the suite.
 
 ### Documentation
 


### PR DESCRIPTION
This PR has been reworked a bit, but, it's entire goal is to frame the approach to how we write database migrations, specifically so LLMs have some modeling to guide them, in the hopes that they don't go off the rails writing overly complex database migrations to accompany PRs, which seems to be happening more and more.

The general idea here was to:
- Have an agent look through all of our historical migrations.
- Find the corresponding MR/PR and any subsequent review/discussion that might have happened specific to the migration.
- Build up an understanding of the choices we have made around writing migrations, to pick up the general pattern of how we have done things over the years.

I then had it go through, verifying migrations that appear/ed as outliers to our pattern (which gave me some confidence that it knew human vs. more recent LLM-written migrations), and then had it put together a guide it that other agents could use going forward.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5108

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

`AGENTS.md` is the only file changed.

<details>
<summary>Model Findings Overview</summary>

Local reviews were re-run against the reshaped `AGENTS.md` change.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Claude self-review | 1 | 1 | 0 |
| Codex CLI | 1 | 1 | 0 |
| CodeRabbit CLI | 1 | 0 | 1 |
| **Total** | **3** | **2** | **1** |

</details>

<details>
<summary>Model Findings Details</summary>

### Claude self-review

1. **Adopted** -- `sqlx` was capitalized inconsistently with the rest of the section, which backticks identifiers. **Resolution:** uses the backticked crate name.

### Codex CLI

1. **Adopted** -- the draft asserted that the migration Job completes before the new pod rolls out. That holds for the Helm and Argo paths, but `deploy/README.md` documents a `kubectl apply -k` workflow where the Argo `PreSync` annotation is inert and the Job and Deployment apply together. **Resolution:** the ordering claim is gone. The bullet now says only what an author must assume, that a live writer is present throughout, which is true on every path.

### CodeRabbit CLI

1. **Declined** -- require compatibility with both the outgoing and incoming binaries, and add an expand/contract sequence. **Reason:** a migration's contract here is with the incoming binary; we do not hold the schema back to keep the version being replaced working. The expand/contract ladder was also cut from this change deliberately, as guidance a competent author does not need.

</details>

Closes #5108
