### PR TITLE
feat(config): define tenant prefix overlap eligibility

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -42,6 +42,7 @@ Use `site_explorer.dpu_policy` instead.
 | `enable_route_servers` | `bool` | `false` | `networking` | Enables route server injection into DPU FRR configs for L2VPN. |
 | `deny_prefixes` | `Vec<IpNetwork>` | `[]` | `networking` | IPv4 and IPv6 CIDR prefixes that tenant instances are blocked from reaching. FNN generates family-specific NVUE ACL policies; all non-FNN virtualizers apply the IPv4 prefixes only. |
 | `site_fabric_prefixes` | `Vec<IpNetwork>` | `[]` | `networking` | IP prefixes (v4/v6) assigned for tenant use within this site. |
+| `tenant_prefix_overlap_enabled` | `bool` | `false` | `networking` | Site opt-in for tenant prefix overlap admission. This setting has no effect until [#3890](https://github.com/NVIDIA/infra-controller/issues/3890) lands and does not change the existing database prefix constraints. Admission will also require site-wide `vpc_isolation_behavior = "mutual_isolation"` and participating FNN base profiles with `tenant_prefix_overlap_eligible = true`. |
 | `max_site_prefixes_per_tenant` | `u32` | `8` | `networking` | Maximum tenant-managed SitePrefixes retained for one tenant at this site. Prefixes awaiting removal still count against this limit and keep their CIDR reserved. |
 | `anycast_site_prefixes` | `Vec<Ipv4Network>` | `[]` | `networking` | Aggregate IPv4 prefixes containing tenant-announced prefixes (e.g., BYOIP). **Deprecated.** Use [`routing_profiles.allowed_anycast_prefixes`](#fnnroutingprofileconfig) instead. |
 | `common_tenant_host_asn` | `Option<u32>` | — | `networking` | ASN that tenants use to peer with the DPU. If unset, any ASN is accepted. |
@@ -669,6 +670,7 @@ client-certificate authentication is not used.
 | `route_target_imports` | `Option<Vec<RouteTargetConfig>>` | — (effective `[]`) | Route targets imported into DPU VRFs for VPC routes. |
 | `route_targets_on_exports` | `Option<Vec<RouteTargetConfig>>` | — (effective `[]`) | Route targets added to routes exported by the DPU. |
 | `internal` | `Option<bool>` | — (effective `false`) | Whether the profile uses internal VNI allocation. This property cannot be overridden on a VPC. |
+| `tenant_prefix_overlap_eligible` | `bool` | `false` | Base-profile opt-in for tenant prefix overlap admission. This setting has no effect until [#3890](https://github.com/NVIDIA/infra-controller/issues/3890) lands and cannot be overridden on a VPC. |
 | `leak_default_route_from_underlay` | `Option<bool>` | — (effective `false`) | Leak the default route from the underlay/default VRF into tenant VRFs. |
 | `leak_tenant_host_routes_to_underlay` | `Option<bool>` | — (effective `false`) | Leak tenant host routes into the underlay/default VRF. |
 | `tenant_leak_communities_accepted` | `Option<bool>` | — (effective `false`) | Honor route-leak communities sent by the tenant host OS. |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -223,6 +223,14 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub site_fabric_prefixes: Vec<IpNetwork>,
 
+    /// Opts this site into tenant prefix overlap admission.
+    ///
+    /// Defaults to `false`. Participating FNN base profiles must separately
+    /// set `tenant_prefix_overlap_eligible`, and configuration alone does not permit
+    /// duplicate prefix persistence while database exclusions remain active.
+    #[serde(default)]
+    pub tenant_prefix_overlap_enabled: bool,
+
     /// Maximum number of tenant-managed SitePrefixes retained for one tenant
     /// at this site. Prefixes awaiting removal still count against this limit
     /// and keep their CIDR reserved.
@@ -2445,6 +2453,15 @@ pub struct FnnRoutingProfileConfig {
     #[serde(default)]
     pub internal: Option<bool>,
 
+    /// Opts VPCs based on this profile into future tenant prefix overlap admission.
+    ///
+    /// This base-profile setting defaults to `false` and cannot be overridden
+    /// by a VPC. Admission support is tracked by
+    /// <https://github.com/NVIDIA/infra-controller/issues/3890>; this value
+    /// alone changes neither routing nor prefix persistence.
+    #[serde(default)]
+    pub tenant_prefix_overlap_eligible: bool,
+
     /// Should DPUs leak the default route from the
     /// underlay into the tenant VRF?
     #[serde(default)]
@@ -2487,6 +2504,47 @@ pub struct FnnRoutingProfileConfig {
     pub access_tier: Option<u32>,
 }
 
+impl FnnRoutingProfileConfig {
+    /// Returns whether this resolved profile satisfies the profile-local overlap policy.
+    ///
+    /// Evaluate the profile returned by [`FnnConfig::resolve_vpc_routing_profile`],
+    /// not the raw base profile, so VPC overrides participate in the decision.
+    /// This check cannot see site-wide route targets, additional FNN imports,
+    /// VPC peering, or retained routing state. Callers must reject those paths
+    /// between overlapping VPCs and separately require the site gate and
+    /// site-wide `vpc_isolation_behavior = "mutual_isolation"`.
+    #[allow(dead_code)] // Staged for https://github.com/NVIDIA/infra-controller/issues/3890.
+    pub(crate) fn is_eligible_for_tenant_prefix_overlap(&self) -> bool {
+        // Keep this exhaustive so new profile fields require an explicit eligibility decision.
+        let Self {
+            tenant_prefix_overlap_eligible,
+            route_target_imports,
+            route_targets_on_exports,
+            // External profiles are outside the initial overlap-admission scope.
+            internal,
+            leak_default_route_from_underlay,
+            leak_tenant_host_routes_to_underlay,
+            tenant_leak_communities_accepted,
+            accepted_leaks_from_underlay,
+            allowed_anycast_prefixes,
+            // Access tiers control profile selection, not rendered routes.
+            access_tier: _,
+        } = self;
+
+        *tenant_prefix_overlap_eligible
+            && *internal == Some(true)
+            && route_target_imports.as_ref().is_none_or(Vec::is_empty)
+            && route_targets_on_exports.as_ref().is_none_or(Vec::is_empty)
+            && !leak_default_route_from_underlay.unwrap_or_default()
+            && !leak_tenant_host_routes_to_underlay.unwrap_or_default()
+            && !tenant_leak_communities_accepted.unwrap_or_default()
+            && accepted_leaks_from_underlay
+                .as_ref()
+                .is_none_or(Vec::is_empty)
+            && allowed_anycast_prefixes.as_ref().is_none_or(Vec::is_empty)
+    }
+}
+
 impl FnnConfig {
     /// Resolves the named routing profile and applies properties set on the VPC.
     pub(crate) fn resolve_vpc_routing_profile(
@@ -2521,8 +2579,6 @@ impl FnnConfig {
                 .route_targets_on_exports
                 .clone()
                 .or_else(|| base_profile.route_targets_on_exports.clone()),
-            // VPCs must inherit the base profile's allocation and access controls.
-            internal: base_profile.internal,
             leak_default_route_from_underlay: overrides
                 .leak_default_route_from_underlay
                 .or(base_profile.leak_default_route_from_underlay),
@@ -2540,6 +2596,9 @@ impl FnnConfig {
                 .allowed_anycast_prefixes
                 .clone()
                 .or_else(|| base_profile.allowed_anycast_prefixes.clone()),
+            // These base-profile properties cannot be overridden on a VPC.
+            tenant_prefix_overlap_eligible: base_profile.tenant_prefix_overlap_eligible,
+            internal: base_profile.internal,
             access_tier: base_profile.access_tier,
         }))
     }
@@ -4321,6 +4380,220 @@ mod tests {
         }
     }
 
+    #[test]
+    fn tenant_prefix_overlap_site_gate_defaults_false_and_parses() {
+        value_scenarios!(
+            run = |patch| Figment::new()
+                .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
+                .merge(Toml::string(patch))
+                .extract::<CarbideConfig>()
+                .expect("tenant prefix overlap site setting must parse")
+                .tenant_prefix_overlap_enabled;
+            "site setting" {
+                "" => false,
+                "tenant_prefix_overlap_enabled = false" => false,
+                "tenant_prefix_overlap_enabled = true" => true,
+            }
+        );
+    }
+
+    #[test]
+    fn fnn_overlap_eligibility_opt_in_defaults_false_and_parses() {
+        value_scenarios!(
+            run = |input| toml::from_str::<FnnRoutingProfileConfig>(input)
+                .expect("FNN overlap eligibility setting must parse")
+                .tenant_prefix_overlap_eligible;
+            "base profile setting" {
+                "" => false,
+                "tenant_prefix_overlap_eligible = false" => false,
+                "tenant_prefix_overlap_eligible = true" => true,
+            }
+        );
+    }
+
+    #[test]
+    fn fnn_profile_overlap_eligibility_fails_closed_for_route_policy() {
+        let safe_profile = FnnRoutingProfileConfig {
+            tenant_prefix_overlap_eligible: true,
+            internal: Some(true),
+            ..Default::default()
+        };
+        let explicit_safe_profile = FnnRoutingProfileConfig {
+            tenant_prefix_overlap_eligible: true,
+            route_target_imports: Some(vec![]),
+            route_targets_on_exports: Some(vec![]),
+            internal: Some(true),
+            leak_default_route_from_underlay: Some(false),
+            leak_tenant_host_routes_to_underlay: Some(false),
+            tenant_leak_communities_accepted: Some(false),
+            accepted_leaks_from_underlay: Some(vec![]),
+            allowed_anycast_prefixes: Some(vec![]),
+            access_tier: Some(2),
+        };
+        let route_target = RouteTargetConfig {
+            asn: 64512,
+            vni: 1001,
+        };
+        let prefix_filter = PrefixFilterPolicyEntry {
+            prefix: "192.0.2.0/24".parse().expect("valid test prefix"),
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "omitted neutral policy inputs",
+                    input: safe_profile.clone(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "explicit neutral policy inputs",
+                    input: explicit_safe_profile,
+                    expect: true,
+                },
+                Check {
+                    scenario: "profile opt-in disabled",
+                    input: FnnRoutingProfileConfig {
+                        tenant_prefix_overlap_eligible: false,
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "public profile",
+                    input: FnnRoutingProfileConfig {
+                        internal: Some(false),
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "missing internal classification",
+                    input: FnnRoutingProfileConfig {
+                        internal: None,
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "route-target import",
+                    input: FnnRoutingProfileConfig {
+                        route_target_imports: Some(vec![route_target.clone()]),
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "route-target export",
+                    input: FnnRoutingProfileConfig {
+                        route_targets_on_exports: Some(vec![route_target]),
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "default-route leak from underlay",
+                    input: FnnRoutingProfileConfig {
+                        leak_default_route_from_underlay: Some(true),
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "tenant host-route leak to underlay",
+                    input: FnnRoutingProfileConfig {
+                        leak_tenant_host_routes_to_underlay: Some(true),
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "tenant leak communities",
+                    input: FnnRoutingProfileConfig {
+                        tenant_leak_communities_accepted: Some(true),
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "accepted underlay leak",
+                    input: FnnRoutingProfileConfig {
+                        accepted_leaks_from_underlay: Some(vec![prefix_filter.clone()]),
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "allowed anycast prefix",
+                    input: FnnRoutingProfileConfig {
+                        allowed_anycast_prefixes: Some(vec![prefix_filter]),
+                        ..safe_profile.clone()
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "access tier does not alter routes",
+                    input: FnnRoutingProfileConfig {
+                        access_tier: Some(u32::MAX),
+                        ..safe_profile
+                    },
+                    expect: true,
+                },
+            ],
+            |profile| profile.is_eligible_for_tenant_prefix_overlap(),
+        );
+    }
+
+    #[test]
+    fn resolved_profile_overlap_eligibility_includes_vpc_overrides() {
+        let fnn = FnnConfig {
+            admin_vpc: None,
+            common_internal_route_target: None,
+            additional_route_target_imports: vec![],
+            routing_profiles: HashMap::from([(
+                "BASE".to_string(),
+                FnnRoutingProfileConfig {
+                    tenant_prefix_overlap_eligible: true,
+                    internal: Some(true),
+                    ..Default::default()
+                },
+            )]),
+            use_vpc_vrf_loopback: false,
+        };
+        assert!(
+            fnn.routing_profiles["BASE"].is_eligible_for_tenant_prefix_overlap(),
+            "base profile should be eligible before VPC overrides"
+        );
+
+        let vpc = vpc_config(
+            Some("BASE"),
+            Some(VpcRoutingProfileOverrides {
+                leak_default_route_from_underlay: Some(true),
+                ..Default::default()
+            }),
+        );
+        let resolved = fnn
+            .resolve_vpc_routing_profile(&vpc)
+            .expect("base profile must resolve");
+
+        assert!(
+            !resolved.is_eligible_for_tenant_prefix_overlap(),
+            "resolved VPC leak must make the profile ineligible"
+        );
+    }
+
+    #[test]
+    fn vpc_cannot_override_overlap_eligibility() {
+        let error =
+            toml::from_str::<VpcRoutingProfileOverrides>("tenant_prefix_overlap_eligible = true")
+                .expect_err("overlap eligibility must remain a base-profile setting");
+
+        assert!(
+            error
+                .to_string()
+                .contains("unknown field `tenant_prefix_overlap_eligible`")
+        );
+    }
+
     /// Verifies existing routing-profile TOML values deserialize unchanged
     /// after the fields become presence-aware.
     #[test]
@@ -4345,6 +4618,7 @@ mod tests {
         assert_eq!(
             profile,
             FnnRoutingProfileConfig {
+                tenant_prefix_overlap_eligible: false,
                 route_target_imports: Some(vec![RouteTargetConfig {
                     asn: 64512,
                     vni: 10,
@@ -4411,8 +4685,9 @@ mod tests {
         );
     }
 
-    /// Verifies VPC properties override only present fields while `internal`
-    /// and `access_tier` remain owned by the base profile.
+    /// Verifies VPC properties override only present fields while
+    /// `tenant_prefix_overlap_eligible`, `internal`, and `access_tier` remain owned by the
+    /// base profile.
     #[test]
     fn vpc_routing_profile_overrides_are_presence_aware() {
         // Build a complete base and an override containing explicit default values.
@@ -4421,6 +4696,7 @@ mod tests {
             prefix: "192.0.2.0/24".parse().expect("valid test prefix"),
         };
         let base = FnnRoutingProfileConfig {
+            tenant_prefix_overlap_eligible: true,
             route_target_imports: Some(vec![RouteTargetConfig { asn: 3, vni: 4 }]),
             route_targets_on_exports: Some(vec![inherited_export.clone()]),
             internal: Some(true),
@@ -4453,6 +4729,7 @@ mod tests {
         assert_eq!(
             fnn.resolve_vpc_routing_profile(&vpc).unwrap().as_ref(),
             &FnnRoutingProfileConfig {
+                tenant_prefix_overlap_eligible: true,
                 route_target_imports: Some(vec![]),
                 route_targets_on_exports: Some(vec![inherited_export]),
                 internal: Some(true),

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -180,6 +180,7 @@ pub fn get() -> CarbideConfig {
         enable_route_servers: false,
         deny_prefixes: vec![],
         site_fabric_prefixes: vec![],
+        tenant_prefix_overlap_enabled: false,
         max_site_prefixes_per_tenant: default_max_site_prefixes_per_tenant(),
         anycast_site_prefixes: vec![],
         common_tenant_host_asn: None,

--- a/crates/api-model/src/vpc/routing_profile.rs
+++ b/crates/api-model/src/vpc/routing_profile.rs
@@ -42,9 +42,9 @@ pub struct PrefixFilterPolicyEntry {
 /// Routing-profile values set directly on a VPC.
 ///
 /// Each present value overrides the corresponding property from the VPC's
-/// named routing profile. `internal` and `access_tier` are intentionally absent
-/// because VPCs cannot override the base profile's allocation and access
-/// controls.
+/// named routing profile. `tenant_prefix_overlap_eligible`, `internal`, and
+/// `access_tier` are intentionally absent because VPCs cannot override the base
+/// profile's overlap admission, allocation, or access controls.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct VpcRoutingProfileOverrides {


### PR DESCRIPTION
This introduces the configuration contract for tenant prefix overlap without enabling overlap admission or duplicate prefix persistence yet. Sites and FNN base profiles must opt in independently, and the profile eligibility check fails closed when a resolved VPC profile imports, exports, or leaks routes outside its routing domain.

Keeping this as a configuration-only prerequisite makes the policy reviewable independently from the database lock and writer-adoption work that was combined in draft #4940.

## Related issues

- Closes #5110
- Part of #3890

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

- Both settings default to `false`, so omitted configuration preserves existing behavior.
- Eligibility is evaluated on the resolved VPC routing profile; a VPC override that introduces a route leak makes the profile ineligible.
- `tenant_prefix_overlap_eligible` remains a base-profile property and cannot be set as a per-VPC override.
- No handler, database lock, startup gate, or uniqueness constraint changes are included here. Follow-up PRs under #3890 will consume this policy.
