### PR TITLE
feat(db): add routing graph write transaction

### DIFF
--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -86,6 +86,7 @@ pub mod redfish_actions;
 pub mod resource_pool;
 pub mod retained_boot_interface;
 pub mod route_servers;
+pub mod routing_graph_admission;
 pub mod secrets;
 pub mod site_exploration_report;
 pub mod site_explorer_run_status;

--- a/crates/api-db/src/routing_graph_admission.rs
+++ b/crates/api-db/src/routing_graph_admission.rs
@@ -1,0 +1,416 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Transaction-scoped admission locking for routing-graph writes.
+//!
+//! A NICo database belongs to one site, so one stable database-local key
+//! serializes only writers whose cross-table routing decisions must share a
+//! committed view. This graph-wide boundary is initially conservative because
+//! the participating routing-key set is not knowable until the transaction has
+//! read the graph.
+
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::time::Duration;
+
+use sqlx::{PgPool, PgTransaction};
+use tokio::sync::{Semaphore, SemaphorePermit};
+
+use crate::{DatabaseError, DatabaseResult, Transaction};
+
+const GLOBAL_DB_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Defines one database-global write lock.
+pub trait GlobalDbLock {
+    /// Returns the stable identifier used for the PostgreSQL advisory lock.
+    fn lock_key() -> &'static str;
+
+    /// Returns the process-local admission semaphore for the same lock.
+    ///
+    /// The semaphore must have one permit and must never be closed.
+    fn semaphore() -> &'static Semaphore;
+}
+
+/// A transaction admitted to make writes protected by a database-global lock.
+///
+/// The transaction and in-process permit share one owner so callers cannot
+/// release local admission before commit or rollback. Use [`Self::as_mut`] or
+/// [`Self::as_pgconn`] with existing API-DB operations, then finish with
+/// [`Self::commit`] or [`Self::rollback`].
+#[must_use = "commit or roll back the globally locked transaction"]
+pub struct GlobalLockedTransaction<'a, T: GlobalDbLock> {
+    transaction: Transaction<'a>,
+    _permit: SemaphorePermit<'static>,
+    _lock: PhantomData<T>,
+}
+
+/// Routing-graph write lock configuration.
+pub struct RoutingGraphGlobalDbLock;
+
+impl GlobalDbLock for RoutingGraphGlobalDbLock {
+    fn lock_key() -> &'static str {
+        "routing_graph:write"
+    }
+
+    fn semaphore() -> &'static Semaphore {
+        static ROUTING_GRAPH_WRITE_ADMISSION: Semaphore = Semaphore::const_new(1);
+
+        &ROUTING_GRAPH_WRITE_ADMISSION
+    }
+}
+
+/// A transaction admitted to make routing-graph writes.
+pub type RoutingGraphWriteTransaction<'a> = GlobalLockedTransaction<'a, RoutingGraphGlobalDbLock>;
+
+async fn try_lock_identifier(
+    txn: &mut PgTransaction<'_>,
+    identifier: &str,
+) -> DatabaseResult<bool> {
+    let query = "SELECT pg_try_advisory_xact_lock(hashtextextended($1, 0))";
+    sqlx::query_scalar::<_, bool>(query)
+        .bind(identifier)
+        .fetch_one(txn.as_mut())
+        .await
+        .map_err(|error| DatabaseError::query(query, error))
+}
+
+impl<'a, T: GlobalDbLock> GlobalLockedTransaction<'a, T> {
+    /// Begins a transaction holding both database-global admission boundaries.
+    ///
+    /// Same-process writers first queue without occupying a pool connection.
+    /// Each cross-process lock attempt uses a short transaction; an unsuccessful
+    /// attempt rolls back before the retry wait, so contention does not leave a
+    /// pooled connection or transaction parked during that wait. The successful
+    /// transaction acquires the global database lock before any resource-specific
+    /// lock and retains it through commit or rollback.
+    ///
+    /// Total waiting is bounded by the caller's request deadline or controller
+    /// task lifetime. The helper deliberately does not add another deadline.
+    #[track_caller]
+    pub fn begin(pool: &'a PgPool) -> impl Future<Output = DatabaseResult<Self>> + Send + 'a {
+        let caller = std::panic::Location::caller();
+        async move {
+            let permit = T::semaphore()
+                .acquire()
+                .await
+                .expect("global database lock admission semaphore is never closed");
+            loop {
+                let mut transaction = Transaction::begin_with_location(pool, caller).await?;
+                if try_lock_identifier(transaction.as_mut(), T::lock_key()).await? {
+                    return Ok(Self {
+                        transaction,
+                        _permit: permit,
+                        _lock: PhantomData,
+                    });
+                }
+                transaction.rollback().await?;
+                tokio::time::sleep(GLOBAL_DB_LOCK_RETRY_INTERVAL).await;
+            }
+        }
+    }
+
+    /// Returns the underlying PostgreSQL connection for existing DB helpers.
+    pub fn as_pgconn(&mut self) -> &mut sqlx::PgConnection {
+        self.transaction.as_pgconn()
+    }
+
+    /// Commits the transaction before releasing in-process admission.
+    ///
+    /// The boxed future invokes the inner commit synchronously, preserving its
+    /// `#[track_caller]` location.
+    #[track_caller]
+    pub fn commit(self) -> Pin<Box<dyn Future<Output = DatabaseResult<()>> + Send + 'a>> {
+        let Self {
+            transaction,
+            _permit,
+            _lock,
+        } = self;
+        let commit = transaction.commit();
+        Box::pin(async move {
+            let result = commit.await;
+            drop(_permit);
+            result
+        })
+    }
+
+    /// Rolls back the transaction before releasing in-process admission.
+    ///
+    /// The boxed future invokes the inner rollback synchronously, preserving
+    /// its `#[track_caller]` location.
+    #[track_caller]
+    pub fn rollback(self) -> Pin<Box<dyn Future<Output = DatabaseResult<()>> + Send + 'a>> {
+        let Self {
+            transaction,
+            _permit,
+            _lock,
+        } = self;
+        let rollback = transaction.rollback();
+        Box::pin(async move {
+            let result = rollback.await;
+            drop(_permit);
+            result
+        })
+    }
+}
+
+impl<'a, T: GlobalDbLock> AsMut<PgTransaction<'a>> for GlobalLockedTransaction<'a, T> {
+    fn as_mut(&mut self) -> &mut PgTransaction<'a> {
+        self.transaction.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::PgPool;
+    use sqlx::postgres::PgPoolOptions;
+    use tokio::task::JoinHandle;
+
+    use super::*;
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+    static TEST_SERIALIZATION: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    async fn routing_graph_write_admission() -> SemaphorePermit<'static> {
+        RoutingGraphGlobalDbLock::semaphore()
+            .acquire()
+            .await
+            .expect("routing-graph write admission semaphore is never closed")
+    }
+
+    fn spawn_routing_graph_write(pool: PgPool) -> JoinHandle<Result<(), String>> {
+        tokio::spawn(async move {
+            let transaction = RoutingGraphWriteTransaction::begin(&pool)
+                .await
+                .map_err(|error| error.to_string())?;
+            transaction
+                .rollback()
+                .await
+                .map_err(|error| error.to_string())
+        })
+    }
+
+    async fn hold_routing_graph_lock(txn: &mut PgTransaction<'_>) -> Result<(), sqlx::Error> {
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind(RoutingGraphGlobalDbLock::lock_key())
+            .execute(txn.as_mut())
+            .await?;
+        Ok(())
+    }
+
+    async fn assert_writer_is_waiting(task: &mut JoinHandle<Result<(), String>>) {
+        assert!(
+            tokio::time::timeout(GLOBAL_DB_LOCK_RETRY_INTERVAL * 3, task)
+                .await
+                .is_err(),
+            "routing-graph writer passed held admission"
+        );
+    }
+
+    async fn await_routing_graph_write(
+        mut task: JoinHandle<Result<(), String>>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match tokio::time::timeout(TEST_TIMEOUT, &mut task).await {
+            Ok(result) => {
+                result
+                    .map_err(|error| std::io::Error::other(error.to_string()))?
+                    .map_err(std::io::Error::other)?;
+                Ok(())
+            }
+            Err(_) => {
+                task.abort();
+                task.await.ok();
+                Err(std::io::Error::other("routing-graph writer remained blocked").into())
+            }
+        }
+    }
+
+    async fn assert_pool_usable(pool: &PgPool) -> Result<(), sqlx::Error> {
+        let value: i32 = sqlx::query_scalar("SELECT 1").fetch_one(pool).await?;
+        assert_eq!(value, 1);
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn local_routing_graph_writers_serialize_until_commit(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let _test_guard = TEST_SERIALIZATION.lock().await;
+        let holder = RoutingGraphWriteTransaction::begin(&pool).await?;
+
+        let mut waiter = spawn_routing_graph_write(pool.clone());
+        assert_writer_is_waiting(&mut waiter).await;
+
+        holder.commit().await?;
+        await_routing_graph_write(waiter).await?;
+        assert_pool_usable(&pool).await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn local_routing_graph_writers_serialize_until_rollback(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let _test_guard = TEST_SERIALIZATION.lock().await;
+        let holder = RoutingGraphWriteTransaction::begin(&pool).await?;
+
+        let mut waiter = spawn_routing_graph_write(pool.clone());
+        assert_writer_is_waiting(&mut waiter).await;
+
+        holder.rollback().await?;
+        await_routing_graph_write(waiter).await?;
+        assert_pool_usable(&pool).await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn local_waiter_queues_before_pool_checkout(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let _test_guard = TEST_SERIALIZATION.lock().await;
+        let admission = routing_graph_write_admission().await;
+        let limited_pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_with(pool.connect_options().as_ref().clone())
+            .await?;
+
+        let mut waiter = spawn_routing_graph_write(limited_pool.clone());
+        assert_writer_is_waiting(&mut waiter).await;
+        assert_pool_usable(&limited_pool).await?;
+
+        drop(admission);
+        await_routing_graph_write(waiter).await?;
+        limited_pool.close().await;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn routing_graph_writer_waits_for_another_process(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let _test_guard = TEST_SERIALIZATION.lock().await;
+        let mut external_holder = pool.begin().await?;
+        hold_routing_graph_lock(&mut external_holder).await?;
+
+        let mut waiter = spawn_routing_graph_write(pool.clone());
+        assert_writer_is_waiting(&mut waiter).await;
+
+        external_holder.commit().await?;
+        await_routing_graph_write(waiter).await?;
+        assert_pool_usable(&pool).await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn cancelled_routing_graph_waiter_returns_its_pool_connection(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let _test_guard = TEST_SERIALIZATION.lock().await;
+        let limited_pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect_with(pool.connect_options().as_ref().clone())
+            .await?;
+        let mut holder = limited_pool.begin().await?;
+        hold_routing_graph_lock(&mut holder).await?;
+
+        let mut waiter = spawn_routing_graph_write(limited_pool.clone());
+        assert_writer_is_waiting(&mut waiter).await;
+
+        let value_while_waiting: i32 = tokio::time::timeout(
+            TEST_TIMEOUT,
+            sqlx::query_scalar("SELECT 1").fetch_one(&limited_pool),
+        )
+        .await
+        .map_err(|_| std::io::Error::other("lock waiter kept its pool connection while idle"))??;
+        assert_eq!(value_while_waiting, 1);
+
+        waiter.abort();
+        let cancellation = waiter
+            .await
+            .expect_err("aborted lock waiter task must report cancellation");
+        assert!(cancellation.is_cancelled());
+
+        let released_admission =
+            tokio::time::timeout(TEST_TIMEOUT, routing_graph_write_admission())
+                .await
+                .expect("cancelled waiter must release local admission");
+        drop(released_admission);
+
+        holder.rollback().await?;
+
+        let replacement = tokio::time::timeout(
+            TEST_TIMEOUT,
+            RoutingGraphWriteTransaction::begin(&limited_pool),
+        )
+        .await
+        .map_err(|_| std::io::Error::other("cancelled waiter did not release admission"))??;
+        replacement.rollback().await?;
+        assert_pool_usable(&limited_pool).await?;
+        limited_pool.close().await;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn cancelled_routing_graph_holder_releases_admission(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let _test_guard = TEST_SERIALIZATION.lock().await;
+        let holder_pool = pool.clone();
+        let (ready_sender, ready_receiver) = tokio::sync::oneshot::channel();
+        let holder = tokio::spawn(async move {
+            let transaction = RoutingGraphWriteTransaction::begin(&holder_pool)
+                .await
+                .map_err(|error| error.to_string())?;
+            ready_sender
+                .send(())
+                .map_err(|_| "could not report routing-graph holder readiness".to_string())?;
+            // Rollback is deliberately unreachable so the transaction stays live until abort.
+            std::future::pending::<()>().await;
+            transaction
+                .rollback()
+                .await
+                .map_err(|error| error.to_string())
+        });
+
+        match tokio::time::timeout(TEST_TIMEOUT, ready_receiver).await {
+            Ok(readiness) => readiness?,
+            Err(_) => {
+                holder.abort();
+                holder.await.ok();
+                return Err(std::io::Error::other(
+                    "routing-graph holder did not acquire admission",
+                )
+                .into());
+            }
+        }
+        holder.abort();
+        let cancellation = holder
+            .await
+            .expect_err("aborted routing-graph holder must report cancellation");
+        assert!(cancellation.is_cancelled());
+
+        let replacement =
+            tokio::time::timeout(TEST_TIMEOUT, RoutingGraphWriteTransaction::begin(&pool))
+                .await
+                .map_err(|_| {
+                    std::io::Error::other("cancelled holder did not release admission")
+                })??;
+        replacement.rollback().await?;
+        assert_pool_usable(&pool).await?;
+        Ok(())
+    }
+}

--- a/lints/carbide-lints/src/txn_held_across_await.rs
+++ b/lints/carbide-lints/src/txn_held_across_await.rs
@@ -124,6 +124,7 @@ impl Default for TxnHeldAcrossAwait {
             "sqlx_core::pool::connection::PoolConnection",
             "sqlx_postgres::PgTransaction",
             "db::Transaction",
+            "db::routing_graph_admission::GlobalLockedTransaction",
             "db::db_read::DbReader",
             "sqlx_postgres::connection::PgConnection",
             "sqlx_core::pool::connection::PoolConnection",

--- a/lints/carbide-lints/src/txn_without_commit.rs
+++ b/lints/carbide-lints/src/txn_without_commit.rs
@@ -63,6 +63,7 @@ impl Default for TxnWithoutCommit {
             "sqlx_core::transaction::Transaction",
             "sqlx_postgres::PgTransaction",
             "db::Transaction",
+            "db::routing_graph_admission::GlobalLockedTransaction",
         ]
         .into_iter()
         .map(|txn| {

--- a/lints/carbide-lints/tests/fixtures/app/Cargo.lock
+++ b/lints/carbide-lints/tests/fixtures/app/Cargo.lock
@@ -136,6 +136,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "db"
+version = "0.1.0"
+dependencies = [
+ "sqlx",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1185,7 @@ dependencies = [
 name = "sqlx_app"
 version = "0.1.0"
 dependencies = [
+ "db",
  "sqlx",
  "tokio",
 ]

--- a/lints/carbide-lints/tests/fixtures/app/src/main.rs
+++ b/lints/carbide-lints/tests/fixtures/app/src/main.rs
@@ -220,6 +220,29 @@ fn make_pgpoolconn() -> PoolConnection<Postgres> {
     todo!()
 }
 
+fn make_routing_graph_write_transaction()
+-> routing_db::routing_graph_admission::RoutingGraphWriteTransaction<'static> {
+    todo!()
+}
+
+async fn good_routing_graph_write_transaction() {
+    let mut txn = make_routing_graph_write_transaction();
+    db::actually_use_txn(txn.as_pgconn()).await;
+    txn.commit().await;
+}
+
+async fn bad_routing_graph_write_transaction_await() {
+    let mut txn = make_routing_graph_write_transaction();
+    unrelated_async_work("bad").await;
+    db::actually_use_txn(txn.as_pgconn()).await;
+    txn.commit().await;
+}
+
+fn bad_missing_routing_graph_write_transaction_commit() {
+    let _txn = make_routing_graph_write_transaction();
+    non_async_work();
+}
+
 async fn pgconn_calls() {
     let mut conn = make_pgconn();
     bad_pgconn_fn(&mut conn).await;
@@ -395,6 +418,9 @@ async fn main() {
     bad_call_bad_db_wrapper().await;
     call_methods().await;
     good_txn_as_receiver().await;
+    good_routing_graph_write_transaction().await;
+    bad_routing_graph_write_transaction_await().await;
+    bad_missing_routing_graph_write_transaction_commit();
     do_txn_by_value().await;
     pgconn_calls().await;
     good_direct_nested_transaction().await;
@@ -471,4 +497,10 @@ pub mod db_read {
     pub trait DbReader<'c>: sqlx::PgExecutor<'c> {}
 
     impl<'c> DbReader<'c> for &'c mut sqlx::PgConnection {}
+}
+
+#[allow(dead_code)]
+async fn good_routing_graph_write_transaction_rollback() {
+    let txn = make_routing_graph_write_transaction();
+    txn.rollback().await;
 }

--- a/lints/carbide-lints/tests/fixtures/app/src/main.stderr
+++ b/lints/carbide-lints/tests/fixtures/app/src/main.stderr
@@ -97,126 +97,144 @@ note: Transaction declared here
     |                            ^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:234:33
+   --> src/main.rs:236:33
     |
-234 |     unrelated_async_work("bad").await
+236 |     unrelated_async_work("bad").await;
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:233:24
+   --> src/main.rs:235:9
     |
-233 | async fn bad_pgconn_fn(_conn: &mut PgConnection) {
+235 |     let mut txn = make_routing_graph_write_transaction();
+    |         ^^^^^^^
+
+error: A sqlx::Transaction is being held across this 'await' point
+   --> src/main.rs:257:33
+    |
+257 |     unrelated_async_work("bad").await
+    |                                 ^^^^^
+    |
+note: Transaction declared here
+   --> src/main.rs:256:24
+    |
+256 | async fn bad_pgconn_fn(_conn: &mut PgConnection) {
     |                        ^^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:243:33
+   --> src/main.rs:266:33
     |
-243 |     unrelated_async_work("bad").await
+266 |     unrelated_async_work("bad").await
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:242:28
+   --> src/main.rs:265:28
     |
-242 | async fn bad_pgpoolconn_fn(_conn: &mut PoolConnection<Postgres>) {
+265 | async fn bad_pgpoolconn_fn(_conn: &mut PoolConnection<Postgres>) {
     |                            ^^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:288:33
+   --> src/main.rs:311:33
     |
-288 |     unrelated_async_work("bad").await;
+311 |     unrelated_async_work("bad").await;
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:286:9
+   --> src/main.rs:309:9
     |
-286 |     let mut outer = make_transaction();
+309 |     let mut outer = make_transaction();
     |         ^^^^^^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:288:33
+   --> src/main.rs:311:33
     |
-288 |     unrelated_async_work("bad").await;
+311 |     unrelated_async_work("bad").await;
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:287:9
+   --> src/main.rs:310:9
     |
-287 |     let inner = db::Transaction::begin_inner(&mut outer).await;
+310 |     let inner = db::Transaction::begin_inner(&mut outer).await;
     |         ^^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:298:45
+   --> src/main.rs:321:45
     |
-298 |     db::actually_use_txn(inner.deref_mut()).await;
+321 |     db::actually_use_txn(inner.deref_mut()).await;
     |                                             ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:297:9
+   --> src/main.rs:320:9
     |
-297 |     let second = make_transaction();
+320 |     let second = make_transaction();
     |         ^^^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:308:33
+   --> src/main.rs:331:33
     |
-308 |     unrelated_async_work("bad").await;
+331 |     unrelated_async_work("bad").await;
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:305:9
+   --> src/main.rs:328:9
     |
-305 |     let mut outer = make_transaction();
+328 |     let mut outer = make_transaction();
     |         ^^^^^^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:315:37
+   --> src/main.rs:338:37
     |
-315 |         unrelated_async_work("bad").await;
+338 |         unrelated_async_work("bad").await;
     |                                     ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:313:9
+   --> src/main.rs:336:9
     |
-313 |     let txn = make_transaction();
+336 |     let txn = make_transaction();
     |         ^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:335:37
+   --> src/main.rs:358:37
     |
-335 |         unrelated_async_work("bad").await;
+358 |         unrelated_async_work("bad").await;
     |                                     ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:334:13
+   --> src/main.rs:357:13
     |
-334 |         let txn = make_transaction();
+357 |         let txn = make_transaction();
     |             ^^^
 
 error: sqlx::Transaction is dropped by this function without commit()/rollback(), or being moved out
-   --> src/main.rs:357:9
+   --> src/main.rs:380:9
     |
-357 |     let txn = make_transaction();
+380 |     let txn = make_transaction();
     |         ^^^
     |
     = note: `-D txn-without-commit` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(txn_without_commit)]`
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:381:33
+   --> src/main.rs:404:33
     |
-381 |     unrelated_async_work("bad").await;
+404 |     unrelated_async_work("bad").await;
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:377:40
+   --> src/main.rs:400:40
     |
-377 | async fn bad_takes_db_reader_inner<DB>(_db: &mut DB)
+400 | async fn bad_takes_db_reader_inner<DB>(_db: &mut DB)
     |                                        ^^^
 
 error: sqlx::Transaction is dropped by this function without commit()/rollback(), or being moved out
-   --> src/main.rs:362:29
+   --> src/main.rs:242:9
     |
-362 | fn bad_missing_commit_param(_txn: PgTransaction<'_>) {
+242 |     let _txn = make_routing_graph_write_transaction();
+    |         ^^^^
+
+error: sqlx::Transaction is dropped by this function without commit()/rollback(), or being moved out
+   --> src/main.rs:385:29
+    |
+385 | fn bad_missing_commit_param(_txn: PgTransaction<'_>) {
     |                             ^^^^
 
-error: could not compile `sqlx_app` (bin "sqlx_app") due to 19 previous errors
+error: could not compile `sqlx_app` (bin "sqlx_app") due to 21 previous errors

--- a/lints/carbide-lints/tests/fixtures/db/Cargo.toml
+++ b/lints/carbide-lints/tests/fixtures/db/Cargo.toml
@@ -15,14 +15,9 @@
 # limitations under the License.
 #
 [package]
-name = "sqlx_app"
+name = "db"
 version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-routing-db = { package = "db", path = "../db" }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
-tokio = { version = "1", features = ["full"] }
-
-[workspace]
-# Needs empty workspace to not confuse Cargo

--- a/lints/carbide-lints/tests/fixtures/db/src/lib.rs
+++ b/lints/carbide-lints/tests/fixtures/db/src/lib.rs
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod routing_graph_admission {
+    use std::marker::PhantomData;
+
+    use sqlx::{PgConnection, PgTransaction};
+
+    pub trait GlobalDbLock {}
+
+    pub struct GlobalLockedTransaction<'a, T: GlobalDbLock> {
+        inner: PgTransaction<'a>,
+        _lock: PhantomData<T>,
+    }
+
+    impl<T: GlobalDbLock> GlobalLockedTransaction<'_, T> {
+        pub fn as_pgconn(&mut self) -> &mut PgConnection {
+            &mut self.inner
+        }
+
+        pub async fn commit(self) {
+            self.inner.commit().await.unwrap();
+        }
+
+        pub async fn rollback(self) {
+            self.inner.rollback().await.unwrap();
+        }
+    }
+
+    pub struct RoutingGraphGlobalDbLock;
+
+    impl GlobalDbLock for RoutingGraphGlobalDbLock {}
+
+    pub type RoutingGraphWriteTransaction<'a> =
+        GlobalLockedTransaction<'a, RoutingGraphGlobalDbLock>;
+}


### PR DESCRIPTION
As part of introducing tenant-managed `SitePrefix` resources, we want separate FNN VPCs to be able to use the same CIDR when they are eligible to overlap, while their networks remain isolated. Every change that adds address space or connects VPCs will need to check the latest saved prefixes and routing relationships before it writes anything. Without one shared ordering point, two requests can both see a safe starting point and then save changes that are unsafe when combined.

So, this change adds `RoutingGraphWriteTransaction`, the mechanism those routing changes will use to run one at a time. Requests in the same NICo process wait before taking a database connection. Across NICo processes, a PostgreSQL advisory lock held for the transaction ensures that only one participating request can continue at a time. If another process is already making a protected change, the waiting request ends its short database attempt before retrying, so it does not hold a pool connection while idle.

A small `GlobalLockedTransaction` wrapper keeps both protections in place until the caller commits or rolls back. Existing `carbide-api-db` helpers can still use the underlying transaction, and the custom transaction lints treat this wrapper like the existing transaction type.

This PR only establishes the ordering mechanism. It does not evaluate prefix overlap, change any production routing path, or perform external work while a database transaction is open.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5111.

This is part of https://github.com/NVIDIA/infra-controller/issues/3890.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Integration tests against PostgreSQL verify that protected transactions run one at a time within one NICo process and across separate processes, that waiting does not occupy a pool connection, and that commit, rollback, or cancellation leaves the ordering mechanism and connection pool usable. The custom lint fixture verifies that aliases of the new wrapper remain covered by both transaction lints.
