### PR TITLE
feat(flow): support firmware authentication data

### DIFF
--- a/rest-api/flow/.gitignore
+++ b/rest-api/flow/.gitignore
@@ -4,6 +4,7 @@
 build
 flow
 .local_envrc
+.flow-data-encryption-key
 ignore
 
 # Go event-rule target package; override the repository-wide Rust target ignore.

--- a/rest-api/flow/README.md
+++ b/rest-api/flow/README.md
@@ -10,6 +10,7 @@
 ## How to run Flow on local machine (direct)
 
 ### Prerequisites
+
 ```bash
 # 1. Start PostgreSQL
 ./scripts/start-test-postgres.sh
@@ -20,6 +21,7 @@ temporal server start-dev --namespace flow --port 7233
 ```
 
 ### Build and Run
+
 ```bash
 # Build
 go build -o flow
@@ -27,6 +29,21 @@ go build -o flow
 # Set environment (or use direnv with .envrc)
 export DB_ADDR=localhost DB_PORT=30432 DB_USER=postgres DB_PASSWORD=postgres DB_DATABASE=flow_test
 export TEMPORAL_HOST=localhost TEMPORAL_PORT=7233 TEMPORAL_NAMESPACE=flow
+# Generate this key once and reuse it so persisted encrypted data remains readable.
+(
+  set -eu
+  umask 077
+  key_file=.flow-data-encryption-key
+  if [ ! -s "$key_file" ]; then
+    key_tmp=$(mktemp .flow-data-encryption-key.XXXXXX)
+    trap 'rm -f "$key_tmp"' EXIT
+    openssl rand -base64 32 > "$key_tmp"
+    test -s "$key_tmp"
+    mv "$key_tmp" "$key_file"
+    trap - EXIT
+  fi
+  chmod 0600 "$key_file"
+) && export FLOW_DATA_ENCRYPTION_KEY_PATH="$PWD/.flow-data-encryption-key"
 
 # Run migrations
 ./flow db migrate
@@ -39,6 +56,7 @@ export TEMPORAL_HOST=localhost TEMPORAL_PORT=7233 TEMPORAL_NAMESPACE=flow
 **Note:** NICo is not available locally; power/firmware operations will fail. Use dev/staging for those tests.
 
 ### Test with grpcui
+
 ```bash
 go install github.com/fullstorydev/grpcui/cmd/grpcui@latest
 grpcui -plaintext localhost:50051
@@ -58,7 +76,7 @@ grpcui -plaintext localhost:50051
 
 ### Data Flow
 
-```
+```text
 gRPC Request → Server (convert to TaskSpec)
              → Task Manager (resolve + split by rack → create Tasks)
              → Executor (start Temporal Workflow per Task)
@@ -71,16 +89,19 @@ gRPC Request → Server (convert to TaskSpec)
 > The examples below require the server to be running with `--dev-mode` (enables gRPC reflection).
 
 List all available APIs:
+
 ```bash
 grpcurl -plaintext localhost:50051 list v1.Flow
 ```
 
 Describe a specific API:
+
 ```bash
 grpcurl -plaintext localhost:50051 describe v1.Flow/CreateExpectedRack
 ```
 
 ### Example: GetComponentInfoBySerial
+
 ```bash
 grpcurl -plaintext -d '{
   "serial_info": {"manufacturer": "Wiwynn", "serial_number": "B8111801000851500108Y0SA"},
@@ -89,6 +110,7 @@ grpcurl -plaintext -d '{
 ```
 
 Response:
+
 ```json
 {
   "component": {
@@ -142,6 +164,7 @@ Response:
   }
 }
 ```
+
 ## Power Shelf and NVSwitch Management
 
 Power shelf and NVSwitch power/firmware operations go through Core (NICo) via

--- a/rest-api/flow/cmd/serve.go
+++ b/rest-api/flow/cmd/serve.go
@@ -21,6 +21,7 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/authz"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/config"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	svc "github.com/NVIDIA/infra-controller/rest-api/flow/internal/service"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
 	cmbuiltin "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/builtin"
@@ -217,6 +218,11 @@ func doServe() {
 		log.Fatal().Msgf("failed to retrieve Temporal conn information: %v", err)
 	}
 
+	dataCipher, err := loadDataCipherFromEnv()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to load Flow data encryption key")
+	}
+
 	ctx := context.Background()
 
 	// Load component manager configuration
@@ -270,6 +276,7 @@ func doServe() {
 			temporalmanager.WorkflowQueue: {},
 		},
 		ComponentManagerRegistry: cmRegistry,
+		DataCipher:               dataCipher,
 	}
 
 	if os.Getenv("REPORT_NICO_API_VERSION") != "" {
@@ -311,6 +318,7 @@ func doServe() {
 			FlowConfig:       flowConfig,
 			CMConfig:         cmConfig,
 			ProviderRegistry: providerRegistry,
+			DataCipher:       dataCipher,
 			DevMode:          devMode,
 			Authorization:    authorization,
 			CertConfig: pkgcerts.Config{
@@ -327,7 +335,7 @@ func doServe() {
 
 	log.Info().Msg("New Flow service is created\n")
 	log.Info().Msgf("DB config: %+v", dbConf)
-	log.Info().Msgf("Temporal config: %+v", temporalManagerConf)
+	log.Info().Msgf("Temporal config: %+v", temporalManagerConf.ClientConf)
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
@@ -339,6 +347,15 @@ func doServe() {
 	if err := service.Start(ctx); err != nil {
 		log.Fatal().Msgf("failed to start the service: %v\n", err)
 	}
+}
+
+func loadDataCipherFromEnv() (*secret.Cipher, error) {
+	path := strings.TrimSpace(os.Getenv(secret.EncryptionKeyPathEnvVar))
+	if path == "" {
+		return nil, fmt.Errorf("%s is not set", secret.EncryptionKeyPathEnvVar)
+	}
+
+	return secret.NewCipherFromFile(path)
 }
 
 func loadAuthorizationConfig() (authz.Config, error) {

--- a/rest-api/flow/cmd/serve_test.go
+++ b/rest-api/flow/cmd/serve_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/authz"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	cmconfig "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 )
@@ -181,3 +183,45 @@ func TestLoadAuthorizationConfig(t *testing.T) {
 }
 
 const allowedServiceIdentityForTest = "spiffe://example.test/ns/site/sa/site-workflow"
+
+func TestLoadDataCipherFromEnv(t *testing.T) {
+	validKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	emptyKey := ""
+	tests := []struct {
+		name        string
+		keyContents *string
+		wantErr     string
+	}{
+		{name: "missing environment variable", wantErr: secret.EncryptionKeyPathEnvVar + " is not set"},
+		{name: "valid key", keyContents: &validKey},
+		{
+			name:        "invalid key",
+			keyContents: &emptyKey,
+			wantErr:     "data encryption key is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(secret.EncryptionKeyPathEnvVar, "")
+			if tt.keyContents != nil {
+				path := filepath.Join(t.TempDir(), "encryption-key")
+				require.NoError(
+					t,
+					os.WriteFile(path, []byte(*tt.keyContents), 0o600),
+				)
+				t.Setenv(secret.EncryptionKeyPathEnvVar, path)
+			}
+
+			cipher, err := loadDataCipherFromEnv()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, cipher)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cipher)
+		})
+	}
+}

--- a/rest-api/flow/docs/flow-architecture.md
+++ b/rest-api/flow/docs/flow-architecture.md
@@ -660,6 +660,23 @@ Stores task execution records.
 | `TEMPORAL_PORT` | Temporal server port | 7233 |
 | `TEMPORAL_NAMESPACE` | Workflow namespace | flow |
 
+#### Data Encryption
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FLOW_DATA_ENCRYPTION_KEY_PATH` | Path to the base64-encoded 32-byte key used to protect persisted sensitive Flow data | Required; the Helm chart mounts this automatically |
+
+Flow encrypts firmware authentication data before task, schedule, operation-run,
+or Temporal persistence. Ciphertext envelope version 1 records the encryption
+key's non-secret SHA-256 fingerprint so a mismatched key fails explicitly. The
+AES-GCM additional authenticated data provides firmware-authentication domain
+separation and authenticates the envelope version and key ID. It does not bind
+an entire envelope to a particular database row or Temporal execution; database
+authorization and integrity controls must prevent replay or relocation of a
+complete envelope. The scope of
+[issue #4392](https://github.com/NVIDIA/infra-controller/issues/4392) uses one
+preserved key and does not provide a key-rotation operation.
+
 ### Component Manager Configuration
 
 **File**: `configs/componentmanager.prod.yaml` (or set via `COMPONENT_MANAGER_CONFIG`)
@@ -691,7 +708,7 @@ Flags:
 
 ## Directory Structure
 
-```
+```text
 flow/
 ├── cmd/                          # CLI commands
 │   ├── root.go                   # Root command

--- a/rest-api/flow/internal/converter/protobuf/operationrun_converter.go
+++ b/rest-api/flow/internal/converter/protobuf/operationrun_converter.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	operationrun "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -26,8 +27,23 @@ import (
 // server-owned defaults such as generated seeds and conflict retry durations.
 // The returned OperationRun stores each normalized policy/configuration value
 // as internal JSON for dispatcher use.
-func OperationRunFrom(
+func OperationRunFrom(req *pb.CreateOperationRunRequest) (*operationrun.OperationRun, error) {
+	return operationRunFrom(req, nil)
+}
+
+// OperationRunFromWithFirmwareAuthentication converts a request while adding
+// already-encrypted firmware authentication data to the persisted operation
+// template before its first serialization.
+func OperationRunFromWithFirmwareAuthentication(
 	req *pb.CreateOperationRunRequest,
+	authenticationData *secret.EncryptedData,
+) (*operationrun.OperationRun, error) {
+	return operationRunFrom(req, authenticationData)
+}
+
+func operationRunFrom(
+	req *pb.CreateOperationRunRequest,
+	firmwareAuthenticationData *secret.EncryptedData,
 ) (*operationrun.OperationRun, error) {
 	if req == nil {
 		return nil, fmt.Errorf("create operation run request is required")
@@ -46,6 +62,9 @@ func OperationRunFrom(
 	operation, err := operationFrom(configuration.GetOperation())
 	if err != nil {
 		return nil, err
+	}
+	if firmwareInfo, ok := operation.Payload.(*operations.FirmwareControlTaskInfo); ok {
+		firmwareInfo.AuthenticationData = firmwareAuthenticationData
 	}
 
 	selector, err := selectorFrom(configuration.GetSelector())

--- a/rest-api/flow/internal/firmwareauth/authentication.go
+++ b/rest-api/flow/internal/firmwareauth/authentication.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package firmwareauth protects and selects authentication data used for
+// firmware downloads.
+package firmwareauth
+
+import (
+	"errors"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/firmwarecomponents"
+	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
+)
+
+// authenticationAAD provides purpose-level domain separation. It does not
+// bind an entire encrypted envelope to a database row or Temporal execution;
+// persistence-layer authorization and integrity must prevent envelope replay
+// or relocation between otherwise valid firmware operations.
+const authenticationAAD = "flow:firmware-authentication"
+
+// InvalidDataError identifies authentication data rejected at the API
+// boundary. Other errors returned by this package are internal failures.
+type InvalidDataError struct {
+	err error
+}
+
+func (e *InvalidDataError) Error() string {
+	return e.err.Error()
+}
+
+func (e *InvalidDataError) Unwrap() error {
+	return e.err
+}
+
+// IsInvalidData reports whether err represents invalid caller input.
+func IsInvalidData(err error) bool {
+	var target *InvalidDataError
+	return errors.As(err, &target)
+}
+
+// Encrypt validates authenticationData against the firmware subtargets and
+// encrypts it. An absent or explicitly empty value is represented by nil so
+// callers can omit it from persisted payloads.
+func Encrypt(
+	cipher *secret.Cipher,
+	authenticationData *pb.FirmwareAuthenticationData,
+	subTargets []string,
+) (*secret.EncryptedData, error) {
+	empty, err := validate(authenticationData)
+	if err != nil {
+		return nil, &InvalidDataError{err: err}
+	}
+	if empty {
+		return nil, nil
+	}
+	if firmwarecomponents.IsNICoDPUOnlySubTargets(subTargets) {
+		return nil, &InvalidDataError{err: errors.New(
+			"dpu-only firmware updates do not support authentication data",
+		)}
+	}
+	if cipher == nil {
+		return nil, fmt.Errorf("data encryption cipher is not configured")
+	}
+
+	plaintext, err := proto.MarshalOptions{Deterministic: true}.Marshal(
+		authenticationData,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("marshal firmware authentication data: %w", err)
+	}
+
+	encrypted, err := cipher.EncryptData(plaintext, []byte(authenticationAAD))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt firmware authentication data: %w", err)
+	}
+
+	return encrypted, nil
+}
+
+// DecryptFor decrypts authentication data and selects the value for the target
+// component type. A shared value applies to every supported component type. A
+// missing per-component field means that type receives no authentication data.
+func DecryptFor(
+	cipher *secret.Cipher,
+	encrypted *secret.EncryptedData,
+	componentType devicetypes.ComponentType,
+) (string, error) {
+	if encrypted == nil {
+		return "", nil
+	}
+	if cipher == nil {
+		return "", fmt.Errorf("data encryption cipher is not configured")
+	}
+
+	plaintext, err := cipher.DecryptData(encrypted, []byte(authenticationAAD))
+	if err != nil {
+		return "", fmt.Errorf("decrypt firmware authentication data: %w", err)
+	}
+
+	var authenticationData pb.FirmwareAuthenticationData
+	if err := proto.Unmarshal(plaintext, &authenticationData); err != nil {
+		return "", fmt.Errorf("unmarshal firmware authentication data: %w", err)
+	}
+	if _, err := validate(&authenticationData); err != nil {
+		return "", fmt.Errorf("validate decrypted firmware authentication data: %w", err)
+	}
+	return selectForComponent(&authenticationData, componentType)
+}
+
+func validate(authenticationData *pb.FirmwareAuthenticationData) (bool, error) {
+	if authenticationData == nil {
+		return true, nil
+	}
+
+	switch value := authenticationData.GetValue().(type) {
+	case *pb.FirmwareAuthenticationData_Shared:
+		return value.Shared == "", nil
+	case *pb.FirmwareAuthenticationData_PerComponent:
+		if value.PerComponent == nil {
+			return false, fmt.Errorf("per-component authentication data is required")
+		}
+		return value.PerComponent.GetCompute() == "" &&
+			value.PerComponent.GetNvswitch() == "" &&
+			value.PerComponent.GetPowershelf() == "", nil
+	default:
+		return false, fmt.Errorf("authentication data value is required")
+	}
+}
+
+func selectForComponent(
+	authenticationData *pb.FirmwareAuthenticationData,
+	componentType devicetypes.ComponentType,
+) (string, error) {
+	var perComponentValue string
+	switch componentType {
+	case devicetypes.ComponentTypeCompute:
+		perComponentValue = authenticationData.GetPerComponent().GetCompute()
+	case devicetypes.ComponentTypeNVSwitch:
+		perComponentValue = authenticationData.GetPerComponent().GetNvswitch()
+	case devicetypes.ComponentTypePowerShelf:
+		perComponentValue = authenticationData.GetPerComponent().GetPowershelf()
+	default:
+		return "", fmt.Errorf(
+			"firmware authentication data does not support component type %q",
+			devicetypes.ComponentTypeToString(componentType),
+		)
+	}
+
+	switch value := authenticationData.GetValue().(type) {
+	case *pb.FirmwareAuthenticationData_Shared:
+		return value.Shared, nil
+	case *pb.FirmwareAuthenticationData_PerComponent:
+		return perComponentValue, nil
+	default:
+		return "", fmt.Errorf("firmware authentication data value is not configured")
+	}
+}

--- a/rest-api/flow/internal/firmwareauth/authentication_test.go
+++ b/rest-api/flow/internal/firmwareauth/authentication_test.go
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package firmwareauth
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
+)
+
+func TestEncryptAndDecryptFor(t *testing.T) {
+	cipher := newTestCipher(t, 1)
+
+	tests := []struct {
+		name               string
+		authenticationData *pb.FirmwareAuthenticationData
+		componentType      devicetypes.ComponentType
+		want               string
+	}{
+		{
+			name:               "shared value",
+			authenticationData: sharedAuthenticationData("shared-token"),
+			componentType:      devicetypes.ComponentTypeNVSwitch,
+			want:               "shared-token",
+		},
+		{
+			name: "shared JSON value remains opaque",
+			authenticationData: sharedAuthenticationData(
+				`{"header":"opaque-value"}`,
+			),
+			componentType: devicetypes.ComponentTypeCompute,
+			want:          `{"header":"opaque-value"}`,
+		},
+		{
+			name: "mapped value",
+			authenticationData: perComponentAuthenticationData(
+				proto.String("compute-token"),
+				proto.String("switch-token"),
+				nil,
+			),
+			componentType: devicetypes.ComponentTypeCompute,
+			want:          "compute-token",
+		},
+		{
+			name: "missing mapped value means no authentication",
+			authenticationData: perComponentAuthenticationData(
+				proto.String("compute-token"),
+				nil,
+				nil,
+			),
+			componentType: devicetypes.ComponentTypePowerShelf,
+			want:          "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encrypted, err := Encrypt(cipher, tt.authenticationData, nil)
+			require.NoError(t, err)
+			require.NotNil(t, encrypted)
+			require.Equal(t, secret.EncryptedDataVersion, encrypted.Version)
+			require.NotEmpty(t, encrypted.KeyID)
+			if tt.want != "" {
+				require.NotContains(t, string(encrypted.Ciphertext), tt.want)
+			}
+
+			got, err := DecryptFor(cipher, encrypted, tt.componentType)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEncryptRejectsInvalidTypedData(t *testing.T) {
+	cipher := newTestCipher(t, 1)
+
+	tests := []struct {
+		name               string
+		authenticationData *pb.FirmwareAuthenticationData
+		subTargets         []string
+	}{
+		{
+			name:               "missing value",
+			authenticationData: &pb.FirmwareAuthenticationData{},
+		},
+		{
+			name: "missing per-component data",
+			authenticationData: &pb.FirmwareAuthenticationData{
+				Value: &pb.FirmwareAuthenticationData_PerComponent{},
+			},
+		},
+		{
+			name:               "authentication with dpu-only subtargets",
+			authenticationData: sharedAuthenticationData("token"),
+			subTargets:         []string{"DPU"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Encrypt(cipher, tt.authenticationData, tt.subTargets)
+			require.Error(t, err)
+			require.True(t, IsInvalidData(err))
+		})
+	}
+}
+
+func TestDecryptRejectsEnvelopeFailures(t *testing.T) {
+	cipher := newTestCipher(t, 1)
+	encrypted, err := Encrypt(cipher, sharedAuthenticationData("token"), nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		cipher  *secret.Cipher
+		mutate  func(*secret.EncryptedData)
+		wantErr string
+	}{
+		{
+			name:    "wrong key",
+			cipher:  newTestCipher(t, 2),
+			wantErr: "does not match configured key ID",
+		},
+		{
+			name:   "wrong key ID",
+			cipher: cipher,
+			mutate: func(data *secret.EncryptedData) {
+				data.KeyID = "different-key"
+			},
+			wantErr: "does not match configured key ID",
+		},
+		{
+			name:   "unsupported envelope version",
+			cipher: cipher,
+			mutate: func(data *secret.EncryptedData) {
+				data.Version++
+			},
+			wantErr: "unsupported encrypted data version",
+		},
+		{
+			name:   "malformed ciphertext",
+			cipher: cipher,
+			mutate: func(data *secret.EncryptedData) {
+				data.Ciphertext = []byte("short")
+			},
+			wantErr: "encrypted data is too short",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := *encrypted
+			candidate.Ciphertext = append([]byte(nil), encrypted.Ciphertext...)
+			if tt.mutate != nil {
+				tt.mutate(&candidate)
+			}
+
+			_, err := DecryptFor(
+				tt.cipher,
+				&candidate,
+				devicetypes.ComponentTypeCompute,
+			)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestDecryptRejectsUnsupportedComponentType(t *testing.T) {
+	cipher := newTestCipher(t, 1)
+	tests := []struct {
+		name               string
+		authenticationData *pb.FirmwareAuthenticationData
+	}{
+		{
+			name:               "shared",
+			authenticationData: sharedAuthenticationData("token"),
+		},
+		{
+			name: "per-component",
+			authenticationData: perComponentAuthenticationData(
+				proto.String("token"), nil, nil,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encrypted, err := Encrypt(cipher, tt.authenticationData, nil)
+			require.NoError(t, err)
+
+			_, err = DecryptFor(
+				cipher,
+				encrypted,
+				devicetypes.ComponentTypeToRSwitch,
+			)
+			require.ErrorContains(t, err, "does not support component type")
+		})
+	}
+}
+
+func TestDecryptRejectsMalformedPlaintext(t *testing.T) {
+	cipher := newTestCipher(t, 1)
+	encrypted, err := cipher.EncryptData(
+		[]byte{0xff},
+		[]byte(authenticationAAD),
+	)
+	require.NoError(t, err)
+
+	_, err = DecryptFor(
+		cipher,
+		encrypted,
+		devicetypes.ComponentTypeCompute,
+	)
+	require.ErrorContains(t, err, "unmarshal firmware authentication data")
+}
+
+func TestEmptyAuthenticationData(t *testing.T) {
+	tests := []struct {
+		name               string
+		authenticationData *pb.FirmwareAuthenticationData
+	}{
+		{name: "absent"},
+		{name: "empty shared", authenticationData: sharedAuthenticationData("")},
+		{
+			name: "empty per-component",
+			authenticationData: perComponentAuthenticationData(
+				proto.String(""), nil, nil,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encrypted, err := Encrypt(nil, tt.authenticationData, nil)
+			require.NoError(t, err)
+			require.Nil(t, encrypted)
+		})
+	}
+
+	got, err := DecryptFor(nil, nil, devicetypes.ComponentTypeCompute)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func sharedAuthenticationData(value string) *pb.FirmwareAuthenticationData {
+	return &pb.FirmwareAuthenticationData{
+		Value: &pb.FirmwareAuthenticationData_Shared{Shared: value},
+	}
+}
+
+func perComponentAuthenticationData(
+	compute, nvswitch, powershelf *string,
+) *pb.FirmwareAuthenticationData {
+	return &pb.FirmwareAuthenticationData{
+		Value: &pb.FirmwareAuthenticationData_PerComponent{
+			PerComponent: &pb.PerComponentFirmwareAuthenticationData{
+				Compute:    compute,
+				Nvswitch:   nvswitch,
+				Powershelf: powershelf,
+			},
+		},
+	}
+}
+
+func newTestCipher(t *testing.T, fill byte) *secret.Cipher {
+	t.Helper()
+
+	key := make([]byte, 32)
+	for idx := range key {
+		key[idx] = fill
+	}
+	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
+	require.NoError(t, err)
+	return cipher
+}

--- a/rest-api/flow/internal/nicoapi/mock.go
+++ b/rest-api/flow/internal/nicoapi/mock.go
@@ -22,6 +22,7 @@ type mockClient struct {
 	firmwareUpdateTimeWindowErr error // If set, SetFirmwareUpdateTimeWindow will return this error
 	adminPowerControlErr        error // If set, AdminPowerControl will return this error
 	desiredFirmwareVersions     []*corev1.DesiredFirmwareVersionEntry
+	lastUpdateFirmwareRequest   *corev1.UpdateComponentFirmwareRequest
 	// Topology lookups exercised by the rack-assignment safety check. Tests
 	// populate these via Set...RackId / Set...HostMachineIds helpers.
 	switchRackIDs              map[string]string // switch ID → rack ID
@@ -61,6 +62,13 @@ type mockClient struct {
 	invokeInstancePowerErr        error                   // if set, InvokeInstancePower returns this
 }
 
+// MockClient is a Client with accessors for requests captured by the in-memory
+// test implementation.
+type MockClient interface {
+	Client
+	LastUpdateComponentFirmwareRequest() *corev1.UpdateComponentFirmwareRequest
+}
+
 // DpuReprovisioningCall captures a TriggerDpuReprovisioning invocation
 // for assertion in tests.
 type DpuReprovisioningCall struct {
@@ -76,7 +84,7 @@ type InstancePowerCall struct {
 }
 
 // NewMockClient returns a "GRPC" client that returns mock values so it can be used in unit tests.
-func NewMockClient() Client {
+func NewMockClient() MockClient {
 	return &mockClient{
 		machines:                      map[string]MachineDetail{},
 		powerStates:                   map[string]PowerState{},
@@ -368,7 +376,14 @@ func (c *mockClient) ComponentPowerControl(ctx context.Context, req *corev1.Comp
 }
 
 func (c *mockClient) UpdateComponentFirmware(ctx context.Context, req *corev1.UpdateComponentFirmwareRequest) (*corev1.UpdateComponentFirmwareResponse, error) {
+	c.lastUpdateFirmwareRequest = req
 	return &corev1.UpdateComponentFirmwareResponse{}, nil
+}
+
+// LastUpdateComponentFirmwareRequest returns the most recent firmware update
+// request received by this mock.
+func (c *mockClient) LastUpdateComponentFirmwareRequest() *corev1.UpdateComponentFirmwareRequest {
+	return c.lastUpdateFirmwareRequest
 }
 
 func (c *mockClient) GetComponentFirmwareStatus(ctx context.Context, req *corev1.GetComponentFirmwareStatusRequest) (*corev1.GetComponentFirmwareStatusResponse, error) {

--- a/rest-api/flow/internal/secret/cipher.go
+++ b/rest-api/flow/internal/secret/cipher.go
@@ -9,7 +9,10 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -17,9 +20,26 @@ import (
 	"strings"
 )
 
+// EncryptionKeyPathEnvVar names the environment variable containing the path
+// to Flow's mounted data-encryption key.
+const EncryptionKeyPathEnvVar = "FLOW_DATA_ENCRYPTION_KEY_PATH"
+
+// EncryptedDataVersion identifies the persisted ciphertext envelope format.
+const EncryptedDataVersion uint32 = 1
+
+// EncryptedData is a serializable, versioned ciphertext envelope. KeyID is a
+// non-secret SHA-256 fingerprint used to reject key mismatches explicitly and
+// to support a future multi-key rotation workflow.
+type EncryptedData struct {
+	Version    uint32 `json:"version"`
+	KeyID      string `json:"key_id"`
+	Ciphertext []byte `json:"ciphertext"`
+}
+
 // Cipher encrypts and decrypts sensitive data using AES-GCM.
 type Cipher struct {
-	aead cipher.AEAD
+	aead  cipher.AEAD
+	keyID string
 }
 
 // NewCipher decodes a base64-encoded 256-bit key and constructs a Cipher.
@@ -47,7 +67,12 @@ func NewCipher(key string) (*Cipher, error) {
 		return nil, fmt.Errorf("create data encryption GCM: %w", err)
 	}
 
-	return &Cipher{aead: aead}, nil
+	keyDigest := sha256.Sum256(keyBytes)
+
+	return &Cipher{
+		aead:  aead,
+		keyID: hex.EncodeToString(keyDigest[:]),
+	}, nil
 }
 
 // NewCipherFromFile reads and trims the key at path before constructing a
@@ -61,11 +86,10 @@ func NewCipherFromFile(path string) (*Cipher, error) {
 	return NewCipher(string(data))
 }
 
-// Encrypt returns nonce-prefixed AES-GCM ciphertext bound to additionalData.
-// Callers must use stable, record-specific data and limit each key to
-// substantially fewer than 2^32 encryptions to keep random-nonce collision risk
-// negligible.
-func (c *Cipher) Encrypt(plaintext, additionalData []byte) ([]byte, error) {
+// encrypt returns nonce-prefixed AES-GCM ciphertext bound to additionalData.
+// Callers must use purpose-specific data and limit each key to substantially
+// fewer than 2^32 encryptions to keep random-nonce collision risk negligible.
+func (c *Cipher) encrypt(plaintext, additionalData []byte) ([]byte, error) {
 	if len(additionalData) == 0 {
 		return nil, errors.New("additional authenticated data is empty")
 	}
@@ -79,9 +103,34 @@ func (c *Cipher) Encrypt(plaintext, additionalData []byte) ([]byte, error) {
 	return c.aead.Seal(nonce, nonce, plaintext, additionalData), nil
 }
 
-// Decrypt opens nonce-prefixed AES-GCM ciphertext using the same additionalData
+// EncryptData encrypts plaintext into the current persisted envelope format.
+// The caller-provided additionalData and envelope metadata are authenticated.
+func (c *Cipher) EncryptData(
+	plaintext, additionalData []byte,
+) (*EncryptedData, error) {
+	if len(additionalData) == 0 {
+		return nil, errors.New("additional authenticated data is empty")
+	}
+
+	version := EncryptedDataVersion
+	ciphertext, err := c.encrypt(
+		plaintext,
+		envelopeAdditionalData(additionalData, version, c.keyID),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EncryptedData{
+		Version:    version,
+		KeyID:      c.keyID,
+		Ciphertext: ciphertext,
+	}, nil
+}
+
+// decrypt opens nonce-prefixed AES-GCM ciphertext using the same additionalData
 // supplied during encryption.
-func (c *Cipher) Decrypt(ciphertext, additionalData []byte) ([]byte, error) {
+func (c *Cipher) decrypt(ciphertext, additionalData []byte) ([]byte, error) {
 	if len(additionalData) == 0 {
 		return nil, errors.New("additional authenticated data is empty")
 	}
@@ -98,4 +147,56 @@ func (c *Cipher) Decrypt(ciphertext, additionalData []byte) ([]byte, error) {
 	}
 
 	return plaintext, nil
+}
+
+// DecryptData validates and decrypts a persisted ciphertext envelope.
+func (c *Cipher) DecryptData(
+	encrypted *EncryptedData,
+	additionalData []byte,
+) ([]byte, error) {
+	if encrypted == nil {
+		return nil, errors.New("encrypted data is nil")
+	}
+	if len(additionalData) == 0 {
+		return nil, errors.New("additional authenticated data is empty")
+	}
+	if encrypted.Version != EncryptedDataVersion {
+		return nil, fmt.Errorf(
+			"unsupported encrypted data version %d",
+			encrypted.Version,
+		)
+	}
+	if encrypted.KeyID == "" {
+		return nil, errors.New("encrypted data key ID is empty")
+	}
+	if encrypted.KeyID != c.keyID {
+		return nil, fmt.Errorf(
+			"encrypted data key ID %q does not match configured key ID",
+			encrypted.KeyID,
+		)
+	}
+
+	return c.decrypt(
+		encrypted.Ciphertext,
+		envelopeAdditionalData(
+			additionalData,
+			encrypted.Version,
+			encrypted.KeyID,
+		),
+	)
+}
+
+func envelopeAdditionalData(
+	additionalData []byte,
+	version uint32,
+	keyID string,
+) []byte {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte("flow-encrypted-data-envelope"))
+	var versionBytes [4]byte
+	binary.BigEndian.PutUint32(versionBytes[:], version)
+	_, _ = hash.Write(versionBytes[:])
+	_, _ = hash.Write([]byte(keyID))
+	_, _ = hash.Write(additionalData)
+	return hash.Sum(nil)
 }

--- a/rest-api/flow/internal/secret/cipher_test.go
+++ b/rest-api/flow/internal/secret/cipher_test.go
@@ -45,6 +45,19 @@ func TestNewCipher(t *testing.T) {
 	}
 }
 
+func TestCipherKeyIDIsStableAndKeySpecific(t *testing.T) {
+	first, err := NewCipher(testKey)
+	require.NoError(t, err)
+	second, err := NewCipher(testKey)
+	require.NoError(t, err)
+	other, err := NewCipher(otherTestKey)
+	require.NoError(t, err)
+
+	require.Equal(t, first.keyID, second.keyID)
+	require.Len(t, first.keyID, 64)
+	require.NotEqual(t, first.keyID, other.keyID)
+}
+
 func TestNewCipherFromFile(t *testing.T) {
 	dir := t.TempDir()
 	validPath := filepath.Join(dir, "valid-key")
@@ -83,18 +96,18 @@ func TestCipher_Encrypt(t *testing.T) {
 	cipher, err := NewCipher(testKey)
 	require.NoError(t, err)
 
-	first, err := cipher.Encrypt(plaintext, additionalData)
+	first, err := cipher.encrypt(plaintext, additionalData)
 	require.NoError(t, err)
-	second, err := cipher.Encrypt(plaintext, additionalData)
+	second, err := cipher.encrypt(plaintext, additionalData)
 	require.NoError(t, err)
 	require.NotEqual(t, first, second)
 	require.NotContains(t, string(first), string(plaintext))
 
-	decrypted, err := cipher.Decrypt(first, additionalData)
+	decrypted, err := cipher.decrypt(first, additionalData)
 	require.NoError(t, err)
 	require.Equal(t, plaintext, decrypted)
 
-	ciphertext, err := cipher.Encrypt(plaintext, nil)
+	ciphertext, err := cipher.encrypt(plaintext, nil)
 	require.EqualError(t, err, "additional authenticated data is empty")
 	require.Nil(t, ciphertext)
 }
@@ -106,7 +119,7 @@ func TestCipher_Decrypt(t *testing.T) {
 	otherCipher, err := NewCipher(otherTestKey)
 	require.NoError(t, err)
 
-	ciphertext, err := cipher.Encrypt([]byte("download-credential"), additionalData)
+	ciphertext, err := cipher.encrypt([]byte("download-credential"), additionalData)
 	require.NoError(t, err)
 	tamperedCiphertext := append([]byte(nil), ciphertext...)
 	tamperedCiphertext[len(tamperedCiphertext)-1] ^= 1
@@ -127,9 +140,51 @@ func TestCipher_Decrypt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plaintext, err := tt.cipher.Decrypt(tt.ciphertext, tt.additionalData)
+			plaintext, err := tt.cipher.decrypt(tt.ciphertext, tt.additionalData)
 			require.ErrorContains(t, err, tt.wantErr)
 			require.Nil(t, plaintext)
 		})
 	}
+}
+
+func TestCipherEncryptedDataEnvelope(t *testing.T) {
+	cipher, err := NewCipher(testKey)
+	require.NoError(t, err)
+	additionalData := []byte("flow:firmware-authentication")
+
+	encrypted, err := cipher.EncryptData(
+		[]byte("download-credential"),
+		additionalData,
+	)
+	require.NoError(t, err)
+	require.Equal(t, EncryptedDataVersion, encrypted.Version)
+	require.Equal(t, cipher.keyID, encrypted.KeyID)
+
+	plaintext, err := cipher.DecryptData(encrypted, additionalData)
+	require.NoError(t, err)
+	require.Equal(t, []byte("download-credential"), plaintext)
+
+	t.Run("wrong purpose AAD", func(t *testing.T) {
+		_, err := cipher.DecryptData(encrypted, []byte("flow:another-purpose"))
+		require.ErrorContains(t, err, "decrypt data")
+	})
+
+	t.Run("empty purpose AAD", func(t *testing.T) {
+		_, err := cipher.DecryptData(encrypted, nil)
+		require.EqualError(t, err, "additional authenticated data is empty")
+	})
+
+	t.Run("wrong version", func(t *testing.T) {
+		candidate := *encrypted
+		candidate.Version++
+		_, err := cipher.DecryptData(&candidate, additionalData)
+		require.ErrorContains(t, err, "unsupported encrypted data version")
+	})
+
+	t.Run("wrong key ID", func(t *testing.T) {
+		candidate := *encrypted
+		candidate.KeyID = "different"
+		_, err := cipher.DecryptData(&candidate, additionalData)
+		require.ErrorContains(t, err, "does not match configured key ID")
+	})
 }

--- a/rest-api/flow/internal/service/config.go
+++ b/rest-api/flow/internal/service/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/certs"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/clients/temporal"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/config"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	cmconfig "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/providerapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/executor"
@@ -68,6 +69,7 @@ type Config struct {
 	FlowConfig       config.Config
 	CMConfig         cmconfig.Config
 	ProviderRegistry *providerapi.ProviderRegistry
+	DataCipher       *secret.Cipher
 
 	// DevMode enables developer options such as gRPC reflection and debug
 	// logging. Must not be set in staging/production environments.
@@ -88,9 +90,10 @@ type Config struct {
 //
 //  1. Unknown or unset FLOW_ENV — always rejected regardless of other settings.
 //  2. DevMode in a non-development environment — staging and production block it.
-//  3. Partial CertConfig — all three cert paths must be set together or not at all.
-//  4. Missing TLS in staging or production — those environments require mTLS.
-//  5. Secure gRPC without a valid service-identity allowlist.
+//  3. Missing data-encryption cipher.
+//  4. Partial CertConfig — all three cert paths must be set together or not at all.
+//  5. Missing TLS in staging or production — those environments require mTLS.
+//  6. Secure gRPC without a valid service-identity allowlist.
 func (c Config) Validate() error {
 	envStr, err := GetDeploymentEnv()
 	if err != nil {
@@ -99,12 +102,15 @@ func (c Config) Validate() error {
 
 	env := deploymentEnv(envStr)
 
-	// Rule 1: dev-mode is only allowed in development.
+	// Dev-mode is only allowed in development.
 	if c.DevMode && env != envDevelopment {
 		return fmt.Errorf("--dev-mode is not allowed in %q environment", env)
 	}
+	if c.DataCipher == nil {
+		return errors.New("data encryption cipher is required")
+	}
 
-	// Rule 2: reject partial CertConfig before reaching IsTLSAvailable. A
+	// Reject partial CertConfig before reaching IsTLSAvailable. A
 	// partial config would cause IsSet() to return false, letting the CERTDIR /
 	// SPIFFE fallback satisfy the TLS check even though those certs would never
 	// be used by the server (it would attempt to load the incomplete paths).

--- a/rest-api/flow/internal/service/config_test.go
+++ b/rest-api/flow/internal/service/config_test.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/authz"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	pkgcerts "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/certs"
 )
 
@@ -229,6 +231,7 @@ func TestConfigValidate(t *testing.T) {
 				DevMode:       tt.devMode,
 				CertConfig:    tt.certConf,
 				Authorization: authorization,
+				DataCipher:    testDataCipher(t),
 			}
 			err := c.Validate()
 
@@ -304,6 +307,7 @@ func TestConfigValidateAuthorization(t *testing.T) {
 			config := Config{
 				CertConfig:    test.certConfig,
 				Authorization: test.authorization,
+				DataCipher:    testDataCipher(t),
 			}
 			err := config.Validate()
 			if test.wantErr != "" {
@@ -313,4 +317,24 @@ func TestConfigValidateAuthorization(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestConfigValidateRequiresDataCipher(t *testing.T) {
+	t.Setenv("CERTDIR", t.TempDir())
+	t.Setenv(EnvVarName, string(envDevelopment))
+
+	err := (Config{
+		Authorization: authz.Config{Mode: authz.ModeAudit},
+	}).Validate()
+
+	require.EqualError(t, err, "data encryption cipher is required")
+}
+
+func testDataCipher(t *testing.T) *secret.Cipher {
+	t.Helper()
+
+	key := make([]byte, 32)
+	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
+	require.NoError(t, err)
+	return cipher
 }

--- a/rest-api/flow/internal/service/server_impl.go
+++ b/rest-api/flow/internal/service/server_impl.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/protobuf"
 	dbquery "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/query"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
 	inventorymanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/manager"
 	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	operationrunmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun/manager"
 	taskschedule "github.com/NVIDIA/infra-controller/rest-api/flow/internal/scheduler/taskschedule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/conflict"
 	taskmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/manager"
@@ -53,7 +55,8 @@ type FlowServerImpl struct {
 	taskScheduleDispatcher     *taskschedule.Dispatcher    // Background poller that fires due task schedules
 	operationRunManager        operationrunmanager.Manager // Operation-run manager for run planning and persistence
 	conflictResolver           *conflict.Resolver          // Reused for inter-schedule conflict detection
-	pb.UnimplementedFlowServer                             // Embedded protobuf server interface for forward compatibility
+	dataCipher                 *secret.Cipher
+	pb.UnimplementedFlowServer // Embedded protobuf server interface for forward compatibility
 }
 
 // newServerImplementation creates a new Flow gRPC server implementation.
@@ -75,6 +78,7 @@ func newServerImplementation(
 	taskScheduleStore taskschedule.Store,
 	taskScheduleDispatcher *taskschedule.Dispatcher,
 	operationRunManager operationrunmanager.Manager,
+	dataCipher *secret.Cipher,
 ) (*FlowServerImpl, error) {
 	return &FlowServerImpl{
 		inventoryManager:       inventoryManager,
@@ -83,6 +87,7 @@ func newServerImplementation(
 		taskScheduleStore:      taskScheduleStore,
 		taskScheduleDispatcher: taskScheduleDispatcher,
 		operationRunManager:    operationRunManager,
+		dataCipher:             dataCipher,
 		conflictResolver:       conflict.NewResolver(taskStore),
 	}, nil
 }
@@ -1332,6 +1337,10 @@ func (rs *FlowServerImpl) UpgradeFirmware(
 		SubTargets:             req.GetSubTargets(),
 		OverrideReadinessCheck: req.GetOverrideReadinessCheck(),
 	}
+	err := rs.encryptFirmwareAuthenticationData(info, req.GetAuthenticationData())
+	if err != nil {
+		return nil, firmwareAuthenticationStatusError(err)
+	}
 
 	// Parse optional time parameters for scheduled upgrade
 	if req.GetStartTime() != nil {
@@ -1363,6 +1372,31 @@ func (rs *FlowServerImpl) UpgradeFirmware(
 	}
 
 	return &pb.SubmitTaskResponse{TaskIds: protobuf.UUIDsTo(taskIDs)}, nil
+}
+
+func (rs *FlowServerImpl) encryptFirmwareAuthenticationData(
+	info *operations.FirmwareControlTaskInfo,
+	authenticationData *pb.FirmwareAuthenticationData,
+) error {
+	encrypted, err := firmwareauth.Encrypt(
+		rs.dataCipher,
+		authenticationData,
+		info.SubTargets,
+	)
+	if err != nil {
+		return err
+	}
+
+	info.AuthenticationData = encrypted
+	return nil
+}
+
+func firmwareAuthenticationStatusError(err error) error {
+	if firmwareauth.IsInvalidData(err) {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	return status.Error(codes.Internal, err.Error())
 }
 
 // GetComponents retrieves components from local database with filtering, pagination, and ordering support.

--- a/rest-api/flow/internal/service/server_impl_firmware_test.go
+++ b/rest-api/flow/internal/service/server_impl_firmware_test.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
+)
+
+func TestUpgradeFirmwareEncryptsAuthenticationDataBeforeSubmittingTask(t *testing.T) {
+	cipher := newServiceTestCipher(t)
+	manager := &firmwareTaskManager{}
+	server := &FlowServerImpl{taskManager: manager, dataCipher: cipher}
+	authenticationData := perComponentServiceAuthenticationData(
+		proto.String("compute-token"), nil, nil,
+	)
+	targetVersion := "1.2.3"
+
+	_, err := server.UpgradeFirmware(
+		context.Background(),
+		&pb.UpgradeFirmwareRequest{
+			TargetSpec: &pb.OperationTargetSpec{
+				Targets: &pb.OperationTargetSpec_Components{
+					Components: &pb.ComponentTargets{
+						Targets: []*pb.ComponentTarget{
+							{
+								Identifier: &pb.ComponentTarget_Id{
+									Id: &pb.UUID{Id: uuid.NewString()},
+								},
+							},
+						},
+					},
+				},
+			},
+			TargetVersion:      &targetVersion,
+			AuthenticationData: authenticationData,
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, manager.request)
+	require.NotContains(t, string(manager.request.Operation.Info), "compute-token")
+
+	var info operations.FirmwareControlTaskInfo
+	require.NoError(t, info.Unmarshal(manager.request.Operation.Info))
+	got, err := firmwareauth.DecryptFor(
+		cipher,
+		info.AuthenticationData,
+		devicetypes.ComponentTypeCompute,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "compute-token", got)
+}
+
+func TestUpgradeFirmwareAuthenticationDataStatusCodes(t *testing.T) {
+	tests := []struct {
+		name               string
+		cipher             *secret.Cipher
+		authenticationData *pb.FirmwareAuthenticationData
+		subTargets         []string
+		wantCode           codes.Code
+	}{
+		{
+			name:               "invalid input",
+			cipher:             newServiceTestCipher(t),
+			authenticationData: &pb.FirmwareAuthenticationData{},
+			wantCode:           codes.InvalidArgument,
+		},
+		{
+			name:               "missing cipher",
+			authenticationData: sharedServiceAuthenticationData("token"),
+			wantCode:           codes.Internal,
+		},
+		{
+			name:               "authentication with dpu-only subtargets",
+			cipher:             newServiceTestCipher(t),
+			authenticationData: sharedServiceAuthenticationData("token"),
+			subTargets:         []string{"dpu"},
+			wantCode:           codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &FlowServerImpl{
+				taskManager: &firmwareTaskManager{},
+				dataCipher:  tt.cipher,
+			}
+			_, err := server.UpgradeFirmware(
+				context.Background(),
+				&pb.UpgradeFirmwareRequest{
+					SubTargets: tt.subTargets,
+					TargetSpec: &pb.OperationTargetSpec{
+						Targets: &pb.OperationTargetSpec_Components{
+							Components: &pb.ComponentTargets{},
+						},
+					},
+					AuthenticationData: tt.authenticationData,
+				},
+			)
+			require.Equal(t, tt.wantCode, status.Code(err))
+		})
+	}
+}
+
+type firmwareTaskManager struct {
+	request *operation.Request
+}
+
+func (*firmwareTaskManager) Start(context.Context) error { return nil }
+func (*firmwareTaskManager) Stop(context.Context)        {}
+func (m *firmwareTaskManager) SubmitTask(
+	_ context.Context,
+	req *operation.Request,
+) ([]uuid.UUID, error) {
+	m.request = req
+	return []uuid.UUID{uuid.New()}, nil
+}
+func (*firmwareTaskManager) CancelTask(context.Context, uuid.UUID) error { return nil }
+
+func newServiceTestCipher(t *testing.T) *secret.Cipher {
+	t.Helper()
+
+	key := make([]byte, 32)
+	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
+	require.NoError(t, err)
+	return cipher
+}
+
+func sharedServiceAuthenticationData(
+	value string,
+) *pb.FirmwareAuthenticationData {
+	return &pb.FirmwareAuthenticationData{
+		Value: &pb.FirmwareAuthenticationData_Shared{Shared: value},
+	}
+}
+
+func perComponentServiceAuthenticationData(
+	compute, nvswitch, powershelf *string,
+) *pb.FirmwareAuthenticationData {
+	return &pb.FirmwareAuthenticationData{
+		Value: &pb.FirmwareAuthenticationData_PerComponent{
+			PerComponent: &pb.PerComponentFirmwareAuthenticationData{
+				Compute:    compute,
+				Nvswitch:   nvswitch,
+				Powershelf: powershelf,
+			},
+		},
+	}
+}

--- a/rest-api/flow/internal/service/server_impl_operation_run.go
+++ b/rest-api/flow/internal/service/server_impl_operation_run.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/protobuf"
 	dbquery "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/query"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
 	operationrun "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun"
 	operationrunmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun/manager"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
@@ -23,7 +24,20 @@ func (rs *FlowServerImpl) CreateOperationRun(
 	ctx context.Context,
 	req *pb.CreateOperationRunRequest,
 ) (*pb.CreateOperationRunResponse, error) {
-	run, err := protobuf.OperationRunFrom(req)
+	upgrade := req.GetConfiguration().GetOperation().GetUpgradeFirmware()
+	authenticationData, err := firmwareauth.Encrypt(
+		rs.dataCipher,
+		upgrade.GetAuthenticationData(),
+		upgrade.GetSubTargets(),
+	)
+	if err != nil {
+		return nil, firmwareAuthenticationStatusError(err)
+	}
+
+	run, err := protobuf.OperationRunFromWithFirmwareAuthentication(
+		req,
+		authenticationData,
+	)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/rest-api/flow/internal/service/server_impl_operation_run_test.go
+++ b/rest-api/flow/internal/service/server_impl_operation_run_test.go
@@ -17,9 +17,13 @@ import (
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/protobuf"
 	dbquery "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/query"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	operationrun "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun"
 	operationrunmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun/manager"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
 )
 
@@ -44,6 +48,92 @@ func TestCreateOperationRunCallsManager(t *testing.T) {
 	require.NotEmpty(t, manager.createdRun.Selector)
 	require.NotEmpty(t, manager.createdRun.Options)
 	require.NotEmpty(t, manager.createdRun.OperationTemplate)
+}
+
+func TestCreateOperationRunEncryptsFirmwareAuthenticationData(t *testing.T) {
+	manager := &mockOperationRunManager{createID: uuid.New()}
+	cipher := newServiceTestCipher(t)
+	server := &FlowServerImpl{
+		operationRunManager: manager,
+		dataCipher:          cipher,
+	}
+	req := validCreateOperationRunRequest()
+	authenticationData := "shared-token"
+	req.Configuration.Operation.GetUpgradeFirmware().AuthenticationData =
+		sharedServiceAuthenticationData(authenticationData)
+
+	_, err := server.CreateOperationRun(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotContains(
+		t,
+		string(manager.createdRun.OperationTemplate),
+		authenticationData,
+	)
+	var operationTemplate operationrun.Operation
+	require.NoError(
+		t,
+		operationrun.UnmarshalConfig(
+			manager.createdRun.OperationTemplate,
+			&operationTemplate,
+		),
+	)
+	firmwareInfo, ok := operationTemplate.Payload.(*operations.FirmwareControlTaskInfo)
+	require.True(t, ok)
+	got, err := firmwareauth.DecryptFor(
+		cipher,
+		firmwareInfo.AuthenticationData,
+		devicetypes.ComponentTypeCompute,
+	)
+	require.NoError(t, err)
+	require.Equal(t, authenticationData, got)
+}
+
+func TestCreateOperationRunAuthenticationDataStatusCodes(t *testing.T) {
+	tests := []struct {
+		name               string
+		cipher             *secret.Cipher
+		authenticationData *pb.FirmwareAuthenticationData
+		subTargets         []string
+		wantCode           codes.Code
+	}{
+		{
+			name:               "invalid input",
+			cipher:             newServiceTestCipher(t),
+			authenticationData: &pb.FirmwareAuthenticationData{},
+			wantCode:           codes.InvalidArgument,
+		},
+		{
+			name:               "missing cipher",
+			authenticationData: sharedServiceAuthenticationData("token"),
+			wantCode:           codes.Internal,
+		},
+		{
+			name:               "authentication with dpu-only subtargets",
+			cipher:             newServiceTestCipher(t),
+			authenticationData: sharedServiceAuthenticationData("token"),
+			subTargets:         []string{"dpu"},
+			wantCode:           codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validCreateOperationRunRequest()
+			req.Configuration.Operation.GetUpgradeFirmware().AuthenticationData =
+				tt.authenticationData
+			req.Configuration.Operation.GetUpgradeFirmware().SubTargets =
+				tt.subTargets
+			server := &FlowServerImpl{
+				operationRunManager: &mockOperationRunManager{},
+				dataCipher:          tt.cipher,
+			}
+
+			_, err := server.CreateOperationRun(context.Background(), req)
+
+			require.Equal(t, tt.wantCode, status.Code(err))
+		})
+	}
 }
 
 func TestCreateOperationRunRejectsInvalidRequest(t *testing.T) {

--- a/rest-api/flow/internal/service/server_impl_task_schedule.go
+++ b/rest-api/flow/internal/service/server_impl_task_schedule.go
@@ -26,6 +26,7 @@ import (
 	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	taskschedule "github.com/NVIDIA/infra-controller/rest-api/flow/internal/scheduler/taskschedule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
 )
@@ -60,6 +61,16 @@ func (rs *FlowServerImpl) CreateTaskSchedule(
 	opInfo, targetSpec, pbQueueOpts, pbRuleID, err := protobuf.ScheduledOperationFrom(req.GetOperation())
 	if err != nil {
 		return nil, err
+	}
+	firmwareInfo, isFirmware := opInfo.(*operations.FirmwareControlTaskInfo)
+	if isFirmware {
+		err = rs.encryptFirmwareAuthenticationData(
+			firmwareInfo,
+			req.GetOperation().GetUpgradeFirmware().GetAuthenticationData(),
+		)
+		if err != nil {
+			return nil, firmwareAuthenticationStatusError(err)
+		}
 	}
 
 	raw, err := opInfo.Marshal()

--- a/rest-api/flow/internal/service/server_impl_task_schedule_test.go
+++ b/rest-api/flow/internal/service/server_impl_task_schedule_test.go
@@ -13,11 +13,16 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	taskschedule "github.com/NVIDIA/infra-controller/rest-api/flow/internal/scheduler/taskschedule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	identifier "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/Identifier"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/deviceinfo"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -25,6 +30,163 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
 )
+
+func TestCreateTaskScheduleEncryptsFirmwareAuthenticationData(t *testing.T) {
+	rackID := uuid.New()
+	componentID := uuid.New()
+	inventory := newMockManager()
+	inventory.components[componentID] = &component.Component{
+		Info:   deviceinfo.DeviceInfo{ID: componentID},
+		RackID: rackID,
+		Type:   devicetypes.ComponentTypeCompute,
+	}
+	store := &capturingScheduleStore{id: uuid.New()}
+	cipher := newServiceTestCipher(t)
+	server := &FlowServerImpl{
+		inventoryManager:  inventory,
+		taskScheduleStore: store,
+		dataCipher:        cipher,
+	}
+	authenticationData := "schedule-token"
+
+	_, err := server.CreateTaskSchedule(
+		context.Background(),
+		firmwareScheduleRequest(
+			componentID,
+			sharedServiceAuthenticationData(authenticationData),
+		),
+	)
+
+	require.NoError(t, err)
+	require.NotContains(t, string(store.row.OperationTemplate), authenticationData)
+	wrapper, err := taskschedule.WrapperFromTemplate(store.row.OperationTemplate)
+	require.NoError(t, err)
+	var info operations.FirmwareControlTaskInfo
+	require.NoError(t, info.Unmarshal(wrapper.Info))
+	got, err := firmwareauth.DecryptFor(
+		cipher,
+		info.AuthenticationData,
+		devicetypes.ComponentTypeCompute,
+	)
+	require.NoError(t, err)
+	require.Equal(t, authenticationData, got)
+}
+
+func TestCreateTaskScheduleAuthenticationDataStatusCodes(t *testing.T) {
+	componentID := uuid.New()
+	tests := []struct {
+		name               string
+		cipher             *secret.Cipher
+		authenticationData *pb.FirmwareAuthenticationData
+		subTargets         []string
+		wantCode           codes.Code
+	}{
+		{
+			name:               "invalid input",
+			cipher:             newServiceTestCipher(t),
+			authenticationData: &pb.FirmwareAuthenticationData{},
+			wantCode:           codes.InvalidArgument,
+		},
+		{
+			name:               "missing cipher",
+			authenticationData: sharedServiceAuthenticationData("token"),
+			wantCode:           codes.Internal,
+		},
+		{
+			name:               "authentication with dpu-only subtargets",
+			cipher:             newServiceTestCipher(t),
+			authenticationData: sharedServiceAuthenticationData("token"),
+			subTargets:         []string{"dpu"},
+			wantCode:           codes.InvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &FlowServerImpl{dataCipher: tt.cipher}
+			req := firmwareScheduleRequest(componentID, tt.authenticationData)
+			req.Operation.GetUpgradeFirmware().SubTargets = tt.subTargets
+			_, err := server.CreateTaskSchedule(
+				context.Background(),
+				req,
+			)
+			require.Equal(t, tt.wantCode, status.Code(err))
+		})
+	}
+}
+
+func firmwareScheduleRequest(
+	componentID uuid.UUID,
+	authenticationData *pb.FirmwareAuthenticationData,
+) *pb.CreateTaskScheduleRequest {
+	return &pb.CreateTaskScheduleRequest{
+		Schedule: &pb.ScheduleConfig{
+			Name: "firmware-schedule",
+			Spec: &pb.ScheduleSpec{
+				Type: pb.ScheduleSpecType_SCHEDULE_SPEC_TYPE_INTERVAL,
+				Spec: "1h",
+			},
+		},
+		Operation: &pb.ScheduledOperation{
+			Operation: &pb.ScheduledOperation_UpgradeFirmware{
+				UpgradeFirmware: &pb.UpgradeFirmwareRequest{
+					TargetSpec: &pb.OperationTargetSpec{
+						Targets: &pb.OperationTargetSpec_Components{
+							Components: &pb.ComponentTargets{
+								Targets: []*pb.ComponentTarget{
+									{
+										Identifier: &pb.ComponentTarget_Id{
+											Id: &pb.UUID{Id: componentID.String()},
+										},
+									},
+								},
+							},
+						},
+					},
+					AuthenticationData: authenticationData,
+				},
+			},
+		},
+	}
+}
+
+type capturingScheduleStore struct {
+	taskschedule.Store
+	id  uuid.UUID
+	row *dbmodel.TaskSchedule
+}
+
+func (s *capturingScheduleStore) RunInTransaction(
+	ctx context.Context,
+	fn func(context.Context) error,
+) error {
+	return fn(ctx)
+}
+
+func (s *capturingScheduleStore) Create(
+	_ context.Context,
+	row *dbmodel.TaskSchedule,
+) (uuid.UUID, error) {
+	s.row = row
+	s.row.ID = s.id
+	s.row.CreatedAt = time.Now()
+	s.row.UpdatedAt = s.row.CreatedAt
+	return s.id, nil
+}
+
+func (*capturingScheduleStore) CreateScopes(
+	context.Context,
+	[]*dbmodel.TaskScheduleScope,
+) error {
+	return nil
+}
+
+func (s *capturingScheduleStore) Get(
+	context.Context,
+	uuid.UUID,
+) (*dbmodel.TaskSchedule, error) {
+	return s.row, nil
+}
 
 // ─── enum converters ─────────────────────────────────────────────────────────
 

--- a/rest-api/flow/internal/service/service.go
+++ b/rest-api/flow/internal/service/service.go
@@ -246,6 +246,7 @@ func (s *Service) Start(ctx context.Context) (retErr error) {
 		s.taskScheduleStore,
 		dispatcher,
 		s.operationRunManager,
+		s.conf.DataCipher,
 	)
 	if err != nil {
 		return err

--- a/rest-api/flow/internal/task/componentmanager/compute/nico/nico.go
+++ b/rest-api/flow/internal/task/componentmanager/compute/nico/nico.go
@@ -368,10 +368,20 @@ func (m *Manager) FirmwareControl(
 	// UpdateComponentFirmware with an empty Components list means
 	// "update everything in the bundle", which is NOT what the caller
 	// asked for in a DPU-only request.
-	dpuOnly := hasDpu && len(info.SubTargets) > 0 && len(computeTraySubs) == 0
+	dpuOnly := firmwarecomponents.IsNICoDPUOnlySubTargets(info.SubTargets)
+	if dpuOnly && info.AccessToken != "" {
+		return fmt.Errorf(
+			"dpu-only firmware updates do not support authentication data",
+		)
+	}
 	if !dpuOnly {
 		if err := m.firmwareControlComputeTrays(
-			ctx, target, info.TargetVersion, computeTraySubs, info.OverrideReadinessCheck,
+			ctx,
+			target,
+			info.TargetVersion,
+			computeTraySubs,
+			info.AccessToken,
+			info.OverrideReadinessCheck,
 		); err != nil {
 			return err
 		}
@@ -400,6 +410,7 @@ func (m *Manager) firmwareControlComputeTrays(
 	target common.Target,
 	targetVersion string,
 	computeTraySubs []string,
+	accessToken string,
 	bypassStateController bool,
 ) error {
 	subComponents, err := firmwarecomponents.ParseNICoComputeTray(computeTraySubs)
@@ -416,6 +427,9 @@ func (m *Manager) firmwareControlComputeTrays(
 		},
 		TargetVersion:         targetVersion,
 		BypassStateController: bypassStateController,
+	}
+	if accessToken != "" {
+		req.AccessToken = &accessToken
 	}
 
 	resp, err := m.nicoClient.UpdateComponentFirmware(ctx, req)

--- a/rest-api/flow/internal/task/componentmanager/compute/nico/nico_test.go
+++ b/rest-api/flow/internal/task/componentmanager/compute/nico/nico_test.go
@@ -136,7 +136,8 @@ func TestPowerControl_RejectsUnsupportedOperation(t *testing.T) {
 }
 
 func TestFirmwareControl_HappyPath(t *testing.T) {
-	m := New(nicoapi.NewMockClient(), nil)
+	client := nicoapi.NewMockClient()
+	m := New(client, nil)
 
 	target := common.Target{
 		Type:         devicetypes.ComponentTypeCompute,
@@ -147,8 +148,14 @@ func TestFirmwareControl_HappyPath(t *testing.T) {
 		Operation:     operations.FirmwareOperationUpgrade,
 		TargetVersion: "fw-bundle-id-v1",
 		SubTargets:    []string{"bmc", "bios"},
+		AccessToken:   "compute-token",
 	})
 	require.NoError(t, err)
+	require.Equal(
+		t,
+		"compute-token",
+		client.LastUpdateComponentFirmwareRequest().GetAccessToken(),
+	)
 }
 
 func TestFirmwareControl_RejectsUnknownSubTarget(t *testing.T) {
@@ -200,6 +207,33 @@ func TestFirmwareControl_DpuOnlyTarget(t *testing.T) {
 	power := client.InstancePowerCalls()
 	require.Len(t, power, 1)
 	assert.True(t, power[0].ApplyUpdates)
+}
+
+func TestFirmwareControl_DpuOnlyRejectsAuthenticationData(t *testing.T) {
+	client := nicoapi.NewMockClient()
+	m := New(client, nil)
+	target := common.Target{
+		Type:         devicetypes.ComponentTypeCompute,
+		ComponentIDs: []string{testHostMachineID},
+	}
+
+	err := m.FirmwareControl(
+		context.Background(),
+		target,
+		operations.FirmwareControlTaskInfo{
+			Operation:   operations.FirmwareOperationUpgrade,
+			SubTargets:  []string{"dpu"},
+			AccessToken: "compute-token",
+		},
+	)
+
+	require.ErrorContains(
+		t,
+		err,
+		"dpu-only firmware updates do not support authentication data",
+	)
+	require.Nil(t, client.LastUpdateComponentFirmwareRequest())
+	require.Empty(t, client.DpuReprovisioningTriggers())
 }
 
 // TestFirmwareControl_MixedDpuAndComputeTargets pins the

--- a/rest-api/flow/internal/task/componentmanager/compute/nicolegacy/nicolegacy.go
+++ b/rest-api/flow/internal/task/componentmanager/compute/nicolegacy/nicolegacy.go
@@ -357,6 +357,10 @@ func nicoPowerStateToOperationsPowerStatus(state nicoapi.PowerState) operations.
 // info.TargetVersion is ignored on the DPU branch because Core's
 // reprovisioning state machine does not accept a per-request version.
 func (m *Manager) FirmwareControl(ctx context.Context, target common.Target, info operations.FirmwareControlTaskInfo) error {
+	if info.AccessToken != "" {
+		return fmt.Errorf("firmware authentication data is not supported by the nicolegacy compute manager")
+	}
+
 	log.Debug().
 		Str("components", target.String()).
 		Str("target_version", info.TargetVersion).

--- a/rest-api/flow/internal/task/componentmanager/compute/nicolegacy/nicolegacy_test.go
+++ b/rest-api/flow/internal/task/componentmanager/compute/nicolegacy/nicolegacy_test.go
@@ -143,6 +143,18 @@ func managerYAMLNode(t *testing.T, data string) yaml.Node {
 // NICo, so the manager only logs a warning and proceeds; we exercise
 // that branch here. The replacement compute/nico implementation routes
 // through Core's UpdateComponentFirmware which does honour sub-targets.
+func TestFirmwareControlRejectsAuthenticationData(t *testing.T) {
+	m := &Manager{}
+
+	err := m.FirmwareControl(
+		context.Background(),
+		common.Target{},
+		operations.FirmwareControlTaskInfo{AccessToken: "token"},
+	)
+
+	require.ErrorContains(t, err, "not supported by the nicolegacy compute manager")
+}
+
 func TestFirmwareControl_SubTargetsAccepted(t *testing.T) {
 	tests := map[string]struct {
 		subTargets []string

--- a/rest-api/flow/internal/task/componentmanager/nvswitch/nico/nico.go
+++ b/rest-api/flow/internal/task/componentmanager/nvswitch/nico/nico.go
@@ -364,6 +364,9 @@ func (m *Manager) FirmwareControl(ctx context.Context, target common.Target, inf
 		TargetVersion:         info.TargetVersion,
 		BypassStateController: info.OverrideReadinessCheck,
 	}
+	if info.AccessToken != "" {
+		req.AccessToken = &info.AccessToken
+	}
 
 	resp, err := m.nicoClient.UpdateComponentFirmware(ctx, req)
 	if err != nil {

--- a/rest-api/flow/internal/task/componentmanager/nvswitch/nico/nico_test.go
+++ b/rest-api/flow/internal/task/componentmanager/nvswitch/nico/nico_test.go
@@ -97,7 +97,8 @@ func TestPowerControl(t *testing.T) {
 }
 
 func TestFirmwareControl(t *testing.T) {
-	m := New(nicoapi.NewMockClient(), nil)
+	client := nicoapi.NewMockClient()
+	m := New(client, nil)
 
 	target := common.Target{
 		Type:         devicetypes.ComponentTypeNVSwitch,
@@ -106,8 +107,14 @@ func TestFirmwareControl(t *testing.T) {
 
 	err := m.FirmwareControl(context.Background(), target, operations.FirmwareControlTaskInfo{
 		TargetVersion: "2.0.0",
+		AccessToken:   "switch-token",
 	})
 	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"switch-token",
+		client.LastUpdateComponentFirmwareRequest().GetAccessToken(),
+	)
 }
 
 func TestGetFirmwareStatus(t *testing.T) {

--- a/rest-api/flow/internal/task/componentmanager/powershelf/nico/nico.go
+++ b/rest-api/flow/internal/task/componentmanager/powershelf/nico/nico.go
@@ -331,6 +331,9 @@ func (m *Manager) FirmwareControl(
 		TargetVersion:         info.TargetVersion,
 		BypassStateController: info.OverrideReadinessCheck,
 	}
+	if info.AccessToken != "" {
+		req.AccessToken = &info.AccessToken
+	}
 
 	resp, err := m.nicoClient.UpdateComponentFirmware(ctx, req)
 	if err != nil {

--- a/rest-api/flow/internal/task/componentmanager/powershelf/nico/nico_test.go
+++ b/rest-api/flow/internal/task/componentmanager/powershelf/nico/nico_test.go
@@ -97,7 +97,8 @@ func TestPowerControl(t *testing.T) {
 }
 
 func TestFirmwareControl(t *testing.T) {
-	m := New(nicoapi.NewMockClient(), nil)
+	client := nicoapi.NewMockClient()
+	m := New(client, nil)
 
 	target := common.Target{
 		Type:         devicetypes.ComponentTypePowerShelf,
@@ -106,8 +107,14 @@ func TestFirmwareControl(t *testing.T) {
 
 	err := m.FirmwareControl(context.Background(), target, operations.FirmwareControlTaskInfo{
 		TargetVersion: "1.2.3",
+		AccessToken:   "powershelf-token",
 	})
 	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"powershelf-token",
+		client.LastUpdateComponentFirmwareRequest().GetAccessToken(),
+	)
 }
 
 func TestGetFirmwareStatus(t *testing.T) {

--- a/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/executor/temporalworkflow/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/task"
@@ -117,6 +118,15 @@ func (a *Activities) FirmwareControl(
 	info operations.FirmwareControlTaskInfo,
 ) error {
 	controller, err := requireFirmwareController(a.registry, target)
+	if err != nil {
+		return err
+	}
+
+	info.AccessToken, err = firmwareauth.DecryptFor(
+		a.dataCipher,
+		info.AuthenticationData,
+		target.Type,
+	)
 	if err != nil {
 		return err
 	}

--- a/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
@@ -5,11 +5,15 @@ package activity
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/capability"
 	cmcatalog "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/catalog"
@@ -18,10 +22,11 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/executor/temporalworkflow/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
 )
 
 func TestActivitiesReturnErrorWhenComponentManagerRegistryIsMissing(t *testing.T) {
-	acts := New(nil, nil, nil)
+	acts := New(nil, nil, nil, nil)
 
 	for name, call := range activityCallsForMissingManagerTest(t, acts) {
 		t.Run(name, func(t *testing.T) {
@@ -40,7 +45,7 @@ func TestActivitiesReturnErrorWhenComponentManagerIsMissing(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	acts := New(nil, nil, registry)
+	acts := New(nil, nil, registry, nil)
 
 	for name, call := range activityCallsForMissingManagerTest(t, acts) {
 		t.Run(name, func(t *testing.T) {
@@ -81,6 +86,40 @@ func TestActivityCallsManagerWhenCapabilityIsSupported(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, manager.called)
+}
+
+func TestFirmwareControlDecryptsAuthenticationDataInActivity(t *testing.T) {
+	acts, manager := newCapabilityTestActivities(
+		t,
+		capability.CapabilityFirmwareControl,
+	)
+	cipher := newActivityTestCipher(t)
+	acts.dataCipher = cipher
+	encrypted, err := firmwareauth.Encrypt(
+		cipher,
+		&pb.FirmwareAuthenticationData{
+			Value: &pb.FirmwareAuthenticationData_PerComponent{
+				PerComponent: &pb.PerComponentFirmwareAuthenticationData{
+					Compute:  proto.String("compute-token"),
+					Nvswitch: proto.String("switch-token"),
+				},
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	err = acts.FirmwareControl(
+		context.Background(),
+		newActivityTestTarget(),
+		operations.FirmwareControlTaskInfo{
+			Operation:          operations.FirmwareOperationUpgrade,
+			AuthenticationData: encrypted,
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "compute-token", manager.firmwareInfo.AccessToken)
 }
 
 func TestActivityRequiresOperationInterfaceAfterCapabilityValidation(t *testing.T) {
@@ -216,8 +255,9 @@ func capabilityCheckedActivityCalls(
 }
 
 type capabilityTestManager struct {
-	descriptor cmcatalog.Descriptor
-	called     bool
+	descriptor   cmcatalog.Descriptor
+	called       bool
+	firmwareInfo operations.FirmwareControlTaskInfo
 }
 
 func (m *capabilityTestManager) Descriptor() cmcatalog.Descriptor {
@@ -251,11 +291,12 @@ func (m *capabilityTestManager) GetPowerStatus(
 }
 
 func (m *capabilityTestManager) FirmwareControl(
-	context.Context,
-	common.Target,
-	operations.FirmwareControlTaskInfo,
+	_ context.Context,
+	_ common.Target,
+	info operations.FirmwareControlTaskInfo,
 ) error {
 	m.called = true
+	m.firmwareInfo = info
 	return nil
 }
 
@@ -265,6 +306,16 @@ func (m *capabilityTestManager) GetFirmwareStatus(
 ) (map[string]operations.FirmwareUpdateStatus, error) {
 	m.called = true
 	return nil, nil
+}
+
+func newActivityTestCipher(t *testing.T) *secret.Cipher {
+	t.Helper()
+
+	key := make([]byte, 32)
+	encodedKey := base64.StdEncoding.EncodeToString(key)
+	cipher, err := secret.NewCipher(encodedKey)
+	require.NoError(t, err)
+	return cipher
 }
 
 func newCapabilityTestActivities(
@@ -301,7 +352,7 @@ func newCapabilityTestActivities(
 	)
 	require.NoError(t, err)
 
-	return New(nil, nil, registry), manager
+	return New(nil, nil, registry, nil), manager
 }
 
 type descriptorOnlyManager struct {
@@ -345,7 +396,7 @@ func newDescriptorOnlyActivities(
 	)
 	require.NoError(t, err)
 
-	return New(nil, nil, registry)
+	return New(nil, nil, registry, nil)
 }
 
 func newActivityTestTarget() common.Target {

--- a/rest-api/flow/internal/task/executor/temporalworkflow/activity/registry.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/activity/registry.go
@@ -4,6 +4,7 @@
 package activity
 
 import (
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/task"
 )
@@ -17,6 +18,7 @@ type Activities struct {
 	updater       task.TaskStatusUpdater
 	reportUpdater task.TaskReportUpdater
 	registry      *componentmanager.Registry
+	dataCipher    *secret.Cipher
 }
 
 // New creates an Activities instance. Any argument may be nil; activity
@@ -25,11 +27,13 @@ func New(
 	updater task.TaskStatusUpdater,
 	reportUpdater task.TaskReportUpdater,
 	registry *componentmanager.Registry,
+	dataCipher *secret.Cipher,
 ) *Activities {
 	return &Activities{
 		updater:       updater,
 		reportUpdater: reportUpdater,
 		registry:      registry,
+		dataCipher:    dataCipher,
 	}
 }
 

--- a/rest-api/flow/internal/task/executor/temporalworkflow/activity/registry_test.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/activity/registry_test.go
@@ -13,7 +13,7 @@ import (
 // TestActivities_All_ContainsAllActivities verifies that All() returns every
 // expected activity name with a non-nil function value.
 func TestActivities_All_ContainsAllActivities(t *testing.T) {
-	acts := New(nil, nil, nil)
+	acts := New(nil, nil, nil, nil)
 	all := acts.All()
 
 	expectedNames := []string{
@@ -41,7 +41,7 @@ func TestActivities_All_ContainsAllActivities(t *testing.T) {
 // TestActivities_All_ReturnsCopy verifies that mutating the returned map does
 // not affect subsequent calls — each call produces an independent map.
 func TestActivities_All_ReturnsCopy(t *testing.T) {
-	acts := New(nil, nil, nil)
+	acts := New(nil, nil, nil, nil)
 	first := acts.All()
 	firstLen := len(first)
 
@@ -55,8 +55,8 @@ func TestActivities_All_ReturnsCopy(t *testing.T) {
 // TestActivities_Isolation verifies that two Activities instances do not share
 // state: mutations to one instance's map must not affect the other.
 func TestActivities_Isolation(t *testing.T) {
-	a1 := New(nil, nil, nil)
-	a2 := New(nil, nil, nil)
+	a1 := New(nil, nil, nil, nil)
+	a2 := New(nil, nil, nil, nil)
 
 	m1 := a1.All()
 	m1["isolation-sentinel"] = func() {}

--- a/rest-api/flow/internal/task/executor/temporalworkflow/manager/config_test.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/manager/config_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package manager
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/endpoint"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/clients/temporal"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+)
+
+func TestConfigValidateRequiresDataCipher(t *testing.T) {
+	conf := Config{
+		ClientConf: temporal.Config{
+			Endpoint: endpoint.Config{Host: "temporal", Port: 7233},
+		},
+		WorkerOptions: map[string]worker.Options{
+			WorkflowQueue: {},
+		},
+	}
+
+	err := conf.Validate()
+
+	require.EqualError(t, err, "data encryption cipher is required")
+}
+
+func TestConfigValidateAcceptsDataCipher(t *testing.T) {
+	key := make([]byte, 32)
+	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
+	require.NoError(t, err)
+	conf := Config{
+		ClientConf: temporal.Config{
+			Endpoint: endpoint.Config{Host: "temporal", Port: 7233},
+		},
+		WorkerOptions: map[string]worker.Options{
+			WorkflowQueue: {},
+		},
+		DataCipher: cipher,
+	}
+
+	require.NoError(t, conf.Validate())
+}

--- a/rest-api/flow/internal/task/executor/temporalworkflow/manager/manager.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/manager/manager.go
@@ -15,6 +15,7 @@ import (
 	temporalworkflow "go.temporal.io/sdk/workflow"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/clients/temporal"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/capabilityrequirements"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
@@ -39,6 +40,10 @@ type Config struct {
 
 	// ComponentManagerRegistry is the registry containing initialized component managers.
 	ComponentManagerRegistry *componentmanager.Registry
+
+	// DataCipher decrypts sensitive operation fields only inside the final
+	// activity that needs their plaintext value.
+	DataCipher *secret.Cipher
 }
 
 // Validate checks that the configuration is complete and consistent.
@@ -61,6 +66,9 @@ func (c *Config) Validate() error {
 			"worker options must include workflow queue %q",
 			WorkflowQueue,
 		)
+	}
+	if c.DataCipher == nil {
+		return errors.New("data encryption cipher is required")
 	}
 
 	return nil
@@ -100,7 +108,12 @@ func (c *Config) Build(
 
 	// Bind dependencies into an Activities instance so each manager has its
 	// own isolated copy — no shared mutable globals between managers.
-	acts := activity.New(updater, reportUpdater, c.ComponentManagerRegistry)
+	acts := activity.New(
+		updater,
+		reportUpdater,
+		c.ComponentManagerRegistry,
+		c.DataCipher,
+	)
 
 	publisherClient, err := temporal.New(c.ClientConf)
 	if err != nil {

--- a/rest-api/flow/internal/task/operations/operations.go
+++ b/rest-api/flow/internal/task/operations/operations.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 )
 
@@ -240,6 +241,11 @@ type FirmwareControlTaskInfo struct {
 	// maintenance windows and recorded as a warning log on the worker
 	// that executes the task; authorisation lives upstream.
 	OverrideReadinessCheck bool `json:"override_readiness_check,omitempty"`
+	// AuthenticationData remains encrypted while this payload is persisted in
+	// Flow or carried by Temporal. The final FirmwareControl activity decrypts
+	// it and sets AccessToken only on its in-memory copy.
+	AuthenticationData *secret.EncryptedData `json:"authentication_data,omitempty"`
+	AccessToken        string                `json:"-"`
 }
 
 func (t *FirmwareControlTaskInfo) Validate() error {

--- a/rest-api/flow/pkg/common/firmwarecomponents/firmwarecomponents.go
+++ b/rest-api/flow/pkg/common/firmwarecomponents/firmwarecomponents.go
@@ -130,6 +130,13 @@ func SplitNICoComputeTraySubTargets(names []string) (computeTraySubs []string, h
 	return computeTraySubs, hasDpu
 }
 
+// IsNICoDPUOnlySubTargets reports whether names request DPU reprovisioning
+// without any compute-tray-internal firmware update.
+func IsNICoDPUOnlySubTargets(names []string) bool {
+	computeTraySubs, hasDpu := SplitNICoComputeTraySubTargets(names)
+	return hasDpu && len(names) > 0 && len(computeTraySubs) == 0
+}
+
 // SupportedNICoNVSwitchNames returns the lowercase names accepted by
 // ParseNICoNVSwitch in deterministic order. Useful for surfacing the set
 // in API documentation or operator tooling.

--- a/rest-api/flow/pkg/common/firmwarecomponents/firmwarecomponents_test.go
+++ b/rest-api/flow/pkg/common/firmwarecomponents/firmwarecomponents_test.go
@@ -138,6 +138,26 @@ func TestSplitNICoComputeTraySubTargets(t *testing.T) {
 	}
 }
 
+func TestIsNICoDPUOnlySubTargets(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want bool
+	}{
+		{name: "empty"},
+		{name: "dpu only", in: []string{"dpu"}, want: true},
+		{name: "repeated dpu", in: []string{"DPU", " dpu "}, want: true},
+		{name: "compute only", in: []string{"bmc"}},
+		{name: "mixed compute and dpu", in: []string{"bmc", "dpu"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsNICoDPUOnlySubTargets(tt.in))
+		})
+	}
+}
+
 func TestSupportedNamesAreSortedAndImmutable(t *testing.T) {
 	names := SupportedNICoNVSwitchNames()
 	require.Equal(t, []string{"bios", "bmc", "cpld", "nvos"}, names)

--- a/rest-api/flow/pkg/proto/v1/flow.pb.go
+++ b/rest-api/flow/pkg/proto/v1/flow.pb.go
@@ -1252,7 +1252,7 @@ func (x OperationRunPhysicalLocationOrdering_Strategy) Number() protoreflect.Enu
 
 // Deprecated: Use OperationRunPhysicalLocationOrdering_Strategy.Descriptor instead.
 func (OperationRunPhysicalLocationOrdering_Strategy) EnumDescriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{144, 0}
+	return file_flow_proto_rawDescGZIP(), []int{146, 0}
 }
 
 type UUID struct {
@@ -4076,8 +4076,12 @@ type UpgradeFirmwareRequest struct {
 	// that would otherwise block disruptive operations against tenanted
 	// hardware. The bypass is recorded in the server log.
 	OverrideReadinessCheck bool `protobuf:"varint,9,opt,name=override_readiness_check,json=overrideReadinessCheck,proto3" json:"override_readiness_check,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// Optional, write-only authentication data for firmware downloads. It is
+	// not supported for DPU-only updates or by the legacy NICo compute
+	// firmware controller.
+	AuthenticationData *FirmwareAuthenticationData `protobuf:"bytes,10,opt,name=authentication_data,json=authenticationData,proto3" json:"authentication_data,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *UpgradeFirmwareRequest) Reset() {
@@ -4173,6 +4177,160 @@ func (x *UpgradeFirmwareRequest) GetOverrideReadinessCheck() bool {
 	return false
 }
 
+func (x *UpgradeFirmwareRequest) GetAuthenticationData() *FirmwareAuthenticationData {
+	if x != nil {
+		return x.AuthenticationData
+	}
+	return nil
+}
+
+// FirmwareAuthenticationData selects either one value shared by every target
+// or values scoped to supported firmware tray types.
+type FirmwareAuthenticationData struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Value:
+	//
+	//	*FirmwareAuthenticationData_Shared
+	//	*FirmwareAuthenticationData_PerComponent
+	Value         isFirmwareAuthenticationData_Value `protobuf_oneof:"value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FirmwareAuthenticationData) Reset() {
+	*x = FirmwareAuthenticationData{}
+	mi := &file_flow_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FirmwareAuthenticationData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FirmwareAuthenticationData) ProtoMessage() {}
+
+func (x *FirmwareAuthenticationData) ProtoReflect() protoreflect.Message {
+	mi := &file_flow_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FirmwareAuthenticationData.ProtoReflect.Descriptor instead.
+func (*FirmwareAuthenticationData) Descriptor() ([]byte, []int) {
+	return file_flow_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *FirmwareAuthenticationData) GetValue() isFirmwareAuthenticationData_Value {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *FirmwareAuthenticationData) GetShared() string {
+	if x != nil {
+		if x, ok := x.Value.(*FirmwareAuthenticationData_Shared); ok {
+			return x.Shared
+		}
+	}
+	return ""
+}
+
+func (x *FirmwareAuthenticationData) GetPerComponent() *PerComponentFirmwareAuthenticationData {
+	if x != nil {
+		if x, ok := x.Value.(*FirmwareAuthenticationData_PerComponent); ok {
+			return x.PerComponent
+		}
+	}
+	return nil
+}
+
+type isFirmwareAuthenticationData_Value interface {
+	isFirmwareAuthenticationData_Value()
+}
+
+type FirmwareAuthenticationData_Shared struct {
+	Shared string `protobuf:"bytes,1,opt,name=shared,proto3,oneof"`
+}
+
+type FirmwareAuthenticationData_PerComponent struct {
+	PerComponent *PerComponentFirmwareAuthenticationData `protobuf:"bytes,2,opt,name=per_component,json=perComponent,proto3,oneof"`
+}
+
+func (*FirmwareAuthenticationData_Shared) isFirmwareAuthenticationData_Value() {}
+
+func (*FirmwareAuthenticationData_PerComponent) isFirmwareAuthenticationData_Value() {}
+
+// PerComponentFirmwareAuthenticationData carries independent authentication
+// data for each supported firmware tray type. An omitted field means that tray
+// type receives no authentication data.
+type PerComponentFirmwareAuthenticationData struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Compute       *string                `protobuf:"bytes,1,opt,name=compute,proto3,oneof" json:"compute,omitempty"`
+	Nvswitch      *string                `protobuf:"bytes,2,opt,name=nvswitch,proto3,oneof" json:"nvswitch,omitempty"`
+	Powershelf    *string                `protobuf:"bytes,3,opt,name=powershelf,proto3,oneof" json:"powershelf,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PerComponentFirmwareAuthenticationData) Reset() {
+	*x = PerComponentFirmwareAuthenticationData{}
+	mi := &file_flow_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PerComponentFirmwareAuthenticationData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PerComponentFirmwareAuthenticationData) ProtoMessage() {}
+
+func (x *PerComponentFirmwareAuthenticationData) ProtoReflect() protoreflect.Message {
+	mi := &file_flow_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PerComponentFirmwareAuthenticationData.ProtoReflect.Descriptor instead.
+func (*PerComponentFirmwareAuthenticationData) Descriptor() ([]byte, []int) {
+	return file_flow_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *PerComponentFirmwareAuthenticationData) GetCompute() string {
+	if x != nil && x.Compute != nil {
+		return *x.Compute
+	}
+	return ""
+}
+
+func (x *PerComponentFirmwareAuthenticationData) GetNvswitch() string {
+	if x != nil && x.Nvswitch != nil {
+		return *x.Nvswitch
+	}
+	return ""
+}
+
+func (x *PerComponentFirmwareAuthenticationData) GetPowershelf() string {
+	if x != nil && x.Powershelf != nil {
+		return *x.Powershelf
+	}
+	return ""
+}
+
 // GetComponents - retrieves components from local database
 type GetComponentsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -4186,7 +4344,7 @@ type GetComponentsRequest struct {
 
 func (x *GetComponentsRequest) Reset() {
 	*x = GetComponentsRequest{}
-	mi := &file_flow_proto_msgTypes[47]
+	mi := &file_flow_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4198,7 +4356,7 @@ func (x *GetComponentsRequest) String() string {
 func (*GetComponentsRequest) ProtoMessage() {}
 
 func (x *GetComponentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[47]
+	mi := &file_flow_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4211,7 +4369,7 @@ func (x *GetComponentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetComponentsRequest.ProtoReflect.Descriptor instead.
 func (*GetComponentsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{47}
+	return file_flow_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetComponentsRequest) GetTargetSpec() *OperationTargetSpec {
@@ -4252,7 +4410,7 @@ type GetComponentsResponse struct {
 
 func (x *GetComponentsResponse) Reset() {
 	*x = GetComponentsResponse{}
-	mi := &file_flow_proto_msgTypes[48]
+	mi := &file_flow_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4264,7 +4422,7 @@ func (x *GetComponentsResponse) String() string {
 func (*GetComponentsResponse) ProtoMessage() {}
 
 func (x *GetComponentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[48]
+	mi := &file_flow_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4277,7 +4435,7 @@ func (x *GetComponentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetComponentsResponse.ProtoReflect.Descriptor instead.
 func (*GetComponentsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{48}
+	return file_flow_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GetComponentsResponse) GetComponents() []*Component {
@@ -4306,7 +4464,7 @@ type ValidateComponentsRequest struct {
 
 func (x *ValidateComponentsRequest) Reset() {
 	*x = ValidateComponentsRequest{}
-	mi := &file_flow_proto_msgTypes[49]
+	mi := &file_flow_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4318,7 +4476,7 @@ func (x *ValidateComponentsRequest) String() string {
 func (*ValidateComponentsRequest) ProtoMessage() {}
 
 func (x *ValidateComponentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[49]
+	mi := &file_flow_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4331,7 +4489,7 @@ func (x *ValidateComponentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateComponentsRequest.ProtoReflect.Descriptor instead.
 func (*ValidateComponentsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{49}
+	return file_flow_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ValidateComponentsRequest) GetTargetSpec() *OperationTargetSpec {
@@ -4377,7 +4535,7 @@ type ValidateComponentsResponse struct {
 
 func (x *ValidateComponentsResponse) Reset() {
 	*x = ValidateComponentsResponse{}
-	mi := &file_flow_proto_msgTypes[50]
+	mi := &file_flow_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4389,7 +4547,7 @@ func (x *ValidateComponentsResponse) String() string {
 func (*ValidateComponentsResponse) ProtoMessage() {}
 
 func (x *ValidateComponentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[50]
+	mi := &file_flow_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4402,7 +4560,7 @@ func (x *ValidateComponentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateComponentsResponse.ProtoReflect.Descriptor instead.
 func (*ValidateComponentsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{50}
+	return file_flow_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ValidateComponentsResponse) GetDiffs() []*ComponentDiff {
@@ -4461,7 +4619,7 @@ type ComponentDiff struct {
 
 func (x *ComponentDiff) Reset() {
 	*x = ComponentDiff{}
-	mi := &file_flow_proto_msgTypes[51]
+	mi := &file_flow_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4473,7 +4631,7 @@ func (x *ComponentDiff) String() string {
 func (*ComponentDiff) ProtoMessage() {}
 
 func (x *ComponentDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[51]
+	mi := &file_flow_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4486,7 +4644,7 @@ func (x *ComponentDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComponentDiff.ProtoReflect.Descriptor instead.
 func (*ComponentDiff) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{51}
+	return file_flow_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ComponentDiff) GetType() DiffType {
@@ -4542,7 +4700,7 @@ type FieldDiff struct {
 
 func (x *FieldDiff) Reset() {
 	*x = FieldDiff{}
-	mi := &file_flow_proto_msgTypes[52]
+	mi := &file_flow_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4554,7 +4712,7 @@ func (x *FieldDiff) String() string {
 func (*FieldDiff) ProtoMessage() {}
 
 func (x *FieldDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[52]
+	mi := &file_flow_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4567,7 +4725,7 @@ func (x *FieldDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldDiff.ProtoReflect.Descriptor instead.
 func (*FieldDiff) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{52}
+	return file_flow_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *FieldDiff) GetFieldName() string {
@@ -4604,7 +4762,7 @@ type AddComponentRequest struct {
 
 func (x *AddComponentRequest) Reset() {
 	*x = AddComponentRequest{}
-	mi := &file_flow_proto_msgTypes[53]
+	mi := &file_flow_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4616,7 +4774,7 @@ func (x *AddComponentRequest) String() string {
 func (*AddComponentRequest) ProtoMessage() {}
 
 func (x *AddComponentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[53]
+	mi := &file_flow_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4629,7 +4787,7 @@ func (x *AddComponentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddComponentRequest.ProtoReflect.Descriptor instead.
 func (*AddComponentRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{53}
+	return file_flow_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *AddComponentRequest) GetComponent() *Component {
@@ -4648,7 +4806,7 @@ type AddComponentResponse struct {
 
 func (x *AddComponentResponse) Reset() {
 	*x = AddComponentResponse{}
-	mi := &file_flow_proto_msgTypes[54]
+	mi := &file_flow_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4660,7 +4818,7 @@ func (x *AddComponentResponse) String() string {
 func (*AddComponentResponse) ProtoMessage() {}
 
 func (x *AddComponentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[54]
+	mi := &file_flow_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4673,7 +4831,7 @@ func (x *AddComponentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddComponentResponse.ProtoReflect.Descriptor instead.
 func (*AddComponentResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{54}
+	return file_flow_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *AddComponentResponse) GetComponent() *Component {
@@ -4693,7 +4851,7 @@ type DeleteComponentRequest struct {
 
 func (x *DeleteComponentRequest) Reset() {
 	*x = DeleteComponentRequest{}
-	mi := &file_flow_proto_msgTypes[55]
+	mi := &file_flow_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4705,7 +4863,7 @@ func (x *DeleteComponentRequest) String() string {
 func (*DeleteComponentRequest) ProtoMessage() {}
 
 func (x *DeleteComponentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[55]
+	mi := &file_flow_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4718,7 +4876,7 @@ func (x *DeleteComponentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteComponentRequest.ProtoReflect.Descriptor instead.
 func (*DeleteComponentRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{55}
+	return file_flow_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *DeleteComponentRequest) GetId() *UUID {
@@ -4736,7 +4894,7 @@ type DeleteComponentResponse struct {
 
 func (x *DeleteComponentResponse) Reset() {
 	*x = DeleteComponentResponse{}
-	mi := &file_flow_proto_msgTypes[56]
+	mi := &file_flow_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4748,7 +4906,7 @@ func (x *DeleteComponentResponse) String() string {
 func (*DeleteComponentResponse) ProtoMessage() {}
 
 func (x *DeleteComponentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[56]
+	mi := &file_flow_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4761,7 +4919,7 @@ func (x *DeleteComponentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteComponentResponse.ProtoReflect.Descriptor instead.
 func (*DeleteComponentResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{56}
+	return file_flow_proto_rawDescGZIP(), []int{58}
 }
 
 // DeleteRack - soft-delete a rack and cascade to its components
@@ -4774,7 +4932,7 @@ type DeleteRackRequest struct {
 
 func (x *DeleteRackRequest) Reset() {
 	*x = DeleteRackRequest{}
-	mi := &file_flow_proto_msgTypes[57]
+	mi := &file_flow_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4786,7 +4944,7 @@ func (x *DeleteRackRequest) String() string {
 func (*DeleteRackRequest) ProtoMessage() {}
 
 func (x *DeleteRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[57]
+	mi := &file_flow_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4799,7 +4957,7 @@ func (x *DeleteRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRackRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{57}
+	return file_flow_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *DeleteRackRequest) GetId() *UUID {
@@ -4817,7 +4975,7 @@ type DeleteRackResponse struct {
 
 func (x *DeleteRackResponse) Reset() {
 	*x = DeleteRackResponse{}
-	mi := &file_flow_proto_msgTypes[58]
+	mi := &file_flow_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4829,7 +4987,7 @@ func (x *DeleteRackResponse) String() string {
 func (*DeleteRackResponse) ProtoMessage() {}
 
 func (x *DeleteRackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[58]
+	mi := &file_flow_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4842,7 +5000,7 @@ func (x *DeleteRackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRackResponse.ProtoReflect.Descriptor instead.
 func (*DeleteRackResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{58}
+	return file_flow_proto_rawDescGZIP(), []int{60}
 }
 
 // PurgeRack - permanently remove a soft-deleted rack and its components
@@ -4855,7 +5013,7 @@ type PurgeRackRequest struct {
 
 func (x *PurgeRackRequest) Reset() {
 	*x = PurgeRackRequest{}
-	mi := &file_flow_proto_msgTypes[59]
+	mi := &file_flow_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4867,7 +5025,7 @@ func (x *PurgeRackRequest) String() string {
 func (*PurgeRackRequest) ProtoMessage() {}
 
 func (x *PurgeRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[59]
+	mi := &file_flow_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4880,7 +5038,7 @@ func (x *PurgeRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeRackRequest.ProtoReflect.Descriptor instead.
 func (*PurgeRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{59}
+	return file_flow_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *PurgeRackRequest) GetId() *UUID {
@@ -4898,7 +5056,7 @@ type PurgeRackResponse struct {
 
 func (x *PurgeRackResponse) Reset() {
 	*x = PurgeRackResponse{}
-	mi := &file_flow_proto_msgTypes[60]
+	mi := &file_flow_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4910,7 +5068,7 @@ func (x *PurgeRackResponse) String() string {
 func (*PurgeRackResponse) ProtoMessage() {}
 
 func (x *PurgeRackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[60]
+	mi := &file_flow_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4923,7 +5081,7 @@ func (x *PurgeRackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeRackResponse.ProtoReflect.Descriptor instead.
 func (*PurgeRackResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{60}
+	return file_flow_proto_rawDescGZIP(), []int{62}
 }
 
 // PurgeComponent - permanently remove a soft-deleted component
@@ -4936,7 +5094,7 @@ type PurgeComponentRequest struct {
 
 func (x *PurgeComponentRequest) Reset() {
 	*x = PurgeComponentRequest{}
-	mi := &file_flow_proto_msgTypes[61]
+	mi := &file_flow_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4948,7 +5106,7 @@ func (x *PurgeComponentRequest) String() string {
 func (*PurgeComponentRequest) ProtoMessage() {}
 
 func (x *PurgeComponentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[61]
+	mi := &file_flow_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4961,7 +5119,7 @@ func (x *PurgeComponentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeComponentRequest.ProtoReflect.Descriptor instead.
 func (*PurgeComponentRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{61}
+	return file_flow_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *PurgeComponentRequest) GetId() *UUID {
@@ -4979,7 +5137,7 @@ type PurgeComponentResponse struct {
 
 func (x *PurgeComponentResponse) Reset() {
 	*x = PurgeComponentResponse{}
-	mi := &file_flow_proto_msgTypes[62]
+	mi := &file_flow_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4991,7 +5149,7 @@ func (x *PurgeComponentResponse) String() string {
 func (*PurgeComponentResponse) ProtoMessage() {}
 
 func (x *PurgeComponentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[62]
+	mi := &file_flow_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5004,7 +5162,7 @@ func (x *PurgeComponentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeComponentResponse.ProtoReflect.Descriptor instead.
 func (*PurgeComponentResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{62}
+	return file_flow_proto_rawDescGZIP(), []int{64}
 }
 
 // PatchComponent - update a single component's fields
@@ -5022,7 +5180,7 @@ type PatchComponentRequest struct {
 
 func (x *PatchComponentRequest) Reset() {
 	*x = PatchComponentRequest{}
-	mi := &file_flow_proto_msgTypes[63]
+	mi := &file_flow_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5034,7 +5192,7 @@ func (x *PatchComponentRequest) String() string {
 func (*PatchComponentRequest) ProtoMessage() {}
 
 func (x *PatchComponentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[63]
+	mi := &file_flow_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5047,7 +5205,7 @@ func (x *PatchComponentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PatchComponentRequest.ProtoReflect.Descriptor instead.
 func (*PatchComponentRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{63}
+	return file_flow_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *PatchComponentRequest) GetId() *UUID {
@@ -5101,7 +5259,7 @@ type PatchComponentResponse struct {
 
 func (x *PatchComponentResponse) Reset() {
 	*x = PatchComponentResponse{}
-	mi := &file_flow_proto_msgTypes[64]
+	mi := &file_flow_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5113,7 +5271,7 @@ func (x *PatchComponentResponse) String() string {
 func (*PatchComponentResponse) ProtoMessage() {}
 
 func (x *PatchComponentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[64]
+	mi := &file_flow_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5126,7 +5284,7 @@ func (x *PatchComponentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PatchComponentResponse.ProtoReflect.Descriptor instead.
 func (*PatchComponentResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{64}
+	return file_flow_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *PatchComponentResponse) GetComponent() *Component {
@@ -5145,7 +5303,7 @@ type SubmitTaskResponse struct {
 
 func (x *SubmitTaskResponse) Reset() {
 	*x = SubmitTaskResponse{}
-	mi := &file_flow_proto_msgTypes[65]
+	mi := &file_flow_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5157,7 +5315,7 @@ func (x *SubmitTaskResponse) String() string {
 func (*SubmitTaskResponse) ProtoMessage() {}
 
 func (x *SubmitTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[65]
+	mi := &file_flow_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5170,7 +5328,7 @@ func (x *SubmitTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitTaskResponse.ProtoReflect.Descriptor instead.
 func (*SubmitTaskResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{65}
+	return file_flow_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *SubmitTaskResponse) GetTaskIds() []*UUID {
@@ -5196,7 +5354,7 @@ type QueueOptions struct {
 
 func (x *QueueOptions) Reset() {
 	*x = QueueOptions{}
-	mi := &file_flow_proto_msgTypes[66]
+	mi := &file_flow_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5208,7 +5366,7 @@ func (x *QueueOptions) String() string {
 func (*QueueOptions) ProtoMessage() {}
 
 func (x *QueueOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[66]
+	mi := &file_flow_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5221,7 +5379,7 @@ func (x *QueueOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueOptions.ProtoReflect.Descriptor instead.
 func (*QueueOptions) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{66}
+	return file_flow_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *QueueOptions) GetConflictStrategy() ConflictStrategy {
@@ -5257,7 +5415,7 @@ type PowerOnRackRequest struct {
 
 func (x *PowerOnRackRequest) Reset() {
 	*x = PowerOnRackRequest{}
-	mi := &file_flow_proto_msgTypes[67]
+	mi := &file_flow_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5269,7 +5427,7 @@ func (x *PowerOnRackRequest) String() string {
 func (*PowerOnRackRequest) ProtoMessage() {}
 
 func (x *PowerOnRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[67]
+	mi := &file_flow_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5282,7 +5440,7 @@ func (x *PowerOnRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerOnRackRequest.ProtoReflect.Descriptor instead.
 func (*PowerOnRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{67}
+	return file_flow_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *PowerOnRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5340,7 +5498,7 @@ type PowerOffRackRequest struct {
 
 func (x *PowerOffRackRequest) Reset() {
 	*x = PowerOffRackRequest{}
-	mi := &file_flow_proto_msgTypes[68]
+	mi := &file_flow_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5352,7 +5510,7 @@ func (x *PowerOffRackRequest) String() string {
 func (*PowerOffRackRequest) ProtoMessage() {}
 
 func (x *PowerOffRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[68]
+	mi := &file_flow_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5365,7 +5523,7 @@ func (x *PowerOffRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerOffRackRequest.ProtoReflect.Descriptor instead.
 func (*PowerOffRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{68}
+	return file_flow_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *PowerOffRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5430,7 +5588,7 @@ type PowerResetRackRequest struct {
 
 func (x *PowerResetRackRequest) Reset() {
 	*x = PowerResetRackRequest{}
-	mi := &file_flow_proto_msgTypes[69]
+	mi := &file_flow_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5442,7 +5600,7 @@ func (x *PowerResetRackRequest) String() string {
 func (*PowerResetRackRequest) ProtoMessage() {}
 
 func (x *PowerResetRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[69]
+	mi := &file_flow_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5455,7 +5613,7 @@ func (x *PowerResetRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerResetRackRequest.ProtoReflect.Descriptor instead.
 func (*PowerResetRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{69}
+	return file_flow_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *PowerResetRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5518,7 +5676,7 @@ type BringUpRackRequest struct {
 
 func (x *BringUpRackRequest) Reset() {
 	*x = BringUpRackRequest{}
-	mi := &file_flow_proto_msgTypes[70]
+	mi := &file_flow_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5530,7 +5688,7 @@ func (x *BringUpRackRequest) String() string {
 func (*BringUpRackRequest) ProtoMessage() {}
 
 func (x *BringUpRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[70]
+	mi := &file_flow_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5543,7 +5701,7 @@ func (x *BringUpRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BringUpRackRequest.ProtoReflect.Descriptor instead.
 func (*BringUpRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{70}
+	return file_flow_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *BringUpRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5586,7 +5744,7 @@ type IngestRackRequest struct {
 
 func (x *IngestRackRequest) Reset() {
 	*x = IngestRackRequest{}
-	mi := &file_flow_proto_msgTypes[71]
+	mi := &file_flow_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5598,7 +5756,7 @@ func (x *IngestRackRequest) String() string {
 func (*IngestRackRequest) ProtoMessage() {}
 
 func (x *IngestRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[71]
+	mi := &file_flow_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5611,7 +5769,7 @@ func (x *IngestRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IngestRackRequest.ProtoReflect.Descriptor instead.
 func (*IngestRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{71}
+	return file_flow_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *IngestRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5654,7 +5812,7 @@ type DecommissionRackRequest struct {
 
 func (x *DecommissionRackRequest) Reset() {
 	*x = DecommissionRackRequest{}
-	mi := &file_flow_proto_msgTypes[72]
+	mi := &file_flow_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5666,7 +5824,7 @@ func (x *DecommissionRackRequest) String() string {
 func (*DecommissionRackRequest) ProtoMessage() {}
 
 func (x *DecommissionRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[72]
+	mi := &file_flow_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5679,7 +5837,7 @@ func (x *DecommissionRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecommissionRackRequest.ProtoReflect.Descriptor instead.
 func (*DecommissionRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{72}
+	return file_flow_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *DecommissionRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5738,7 +5896,7 @@ type ListTasksRequest struct {
 
 func (x *ListTasksRequest) Reset() {
 	*x = ListTasksRequest{}
-	mi := &file_flow_proto_msgTypes[73]
+	mi := &file_flow_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5750,7 +5908,7 @@ func (x *ListTasksRequest) String() string {
 func (*ListTasksRequest) ProtoMessage() {}
 
 func (x *ListTasksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[73]
+	mi := &file_flow_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5763,7 +5921,7 @@ func (x *ListTasksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTasksRequest.ProtoReflect.Descriptor instead.
 func (*ListTasksRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{73}
+	return file_flow_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *ListTasksRequest) GetRackId() *UUID {
@@ -5811,7 +5969,7 @@ type ListTasksResponse struct {
 
 func (x *ListTasksResponse) Reset() {
 	*x = ListTasksResponse{}
-	mi := &file_flow_proto_msgTypes[74]
+	mi := &file_flow_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5823,7 +5981,7 @@ func (x *ListTasksResponse) String() string {
 func (*ListTasksResponse) ProtoMessage() {}
 
 func (x *ListTasksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[74]
+	mi := &file_flow_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5836,7 +5994,7 @@ func (x *ListTasksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTasksResponse.ProtoReflect.Descriptor instead.
 func (*ListTasksResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{74}
+	return file_flow_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *ListTasksResponse) GetTasks() []*Task {
@@ -5862,7 +6020,7 @@ type GetTasksByIDsRequest struct {
 
 func (x *GetTasksByIDsRequest) Reset() {
 	*x = GetTasksByIDsRequest{}
-	mi := &file_flow_proto_msgTypes[75]
+	mi := &file_flow_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5874,7 +6032,7 @@ func (x *GetTasksByIDsRequest) String() string {
 func (*GetTasksByIDsRequest) ProtoMessage() {}
 
 func (x *GetTasksByIDsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[75]
+	mi := &file_flow_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5887,7 +6045,7 @@ func (x *GetTasksByIDsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTasksByIDsRequest.ProtoReflect.Descriptor instead.
 func (*GetTasksByIDsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{75}
+	return file_flow_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *GetTasksByIDsRequest) GetTaskIds() []*UUID {
@@ -5906,7 +6064,7 @@ type GetTasksByIDsResponse struct {
 
 func (x *GetTasksByIDsResponse) Reset() {
 	*x = GetTasksByIDsResponse{}
-	mi := &file_flow_proto_msgTypes[76]
+	mi := &file_flow_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5918,7 +6076,7 @@ func (x *GetTasksByIDsResponse) String() string {
 func (*GetTasksByIDsResponse) ProtoMessage() {}
 
 func (x *GetTasksByIDsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[76]
+	mi := &file_flow_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5931,7 +6089,7 @@ func (x *GetTasksByIDsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTasksByIDsResponse.ProtoReflect.Descriptor instead.
 func (*GetTasksByIDsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{76}
+	return file_flow_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *GetTasksByIDsResponse) GetTasks() []*Task {
@@ -5950,7 +6108,7 @@ type CancelTaskRequest struct {
 
 func (x *CancelTaskRequest) Reset() {
 	*x = CancelTaskRequest{}
-	mi := &file_flow_proto_msgTypes[77]
+	mi := &file_flow_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5962,7 +6120,7 @@ func (x *CancelTaskRequest) String() string {
 func (*CancelTaskRequest) ProtoMessage() {}
 
 func (x *CancelTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[77]
+	mi := &file_flow_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5975,7 +6133,7 @@ func (x *CancelTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelTaskRequest.ProtoReflect.Descriptor instead.
 func (*CancelTaskRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{77}
+	return file_flow_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *CancelTaskRequest) GetTaskId() *UUID {
@@ -5994,7 +6152,7 @@ type CancelTaskResponse struct {
 
 func (x *CancelTaskResponse) Reset() {
 	*x = CancelTaskResponse{}
-	mi := &file_flow_proto_msgTypes[78]
+	mi := &file_flow_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6006,7 +6164,7 @@ func (x *CancelTaskResponse) String() string {
 func (*CancelTaskResponse) ProtoMessage() {}
 
 func (x *CancelTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[78]
+	mi := &file_flow_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6019,7 +6177,7 @@ func (x *CancelTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelTaskResponse.ProtoReflect.Descriptor instead.
 func (*CancelTaskResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{78}
+	return file_flow_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *CancelTaskResponse) GetTask() *Task {
@@ -6038,7 +6196,7 @@ type VersionRequest struct {
 
 func (x *VersionRequest) Reset() {
 	*x = VersionRequest{}
-	mi := &file_flow_proto_msgTypes[79]
+	mi := &file_flow_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6050,7 +6208,7 @@ func (x *VersionRequest) String() string {
 func (*VersionRequest) ProtoMessage() {}
 
 func (x *VersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[79]
+	mi := &file_flow_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6063,7 +6221,7 @@ func (x *VersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionRequest.ProtoReflect.Descriptor instead.
 func (*VersionRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{79}
+	return file_flow_proto_rawDescGZIP(), []int{81}
 }
 
 type BuildInfo struct {
@@ -6077,7 +6235,7 @@ type BuildInfo struct {
 
 func (x *BuildInfo) Reset() {
 	*x = BuildInfo{}
-	mi := &file_flow_proto_msgTypes[80]
+	mi := &file_flow_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6089,7 +6247,7 @@ func (x *BuildInfo) String() string {
 func (*BuildInfo) ProtoMessage() {}
 
 func (x *BuildInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[80]
+	mi := &file_flow_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6102,7 +6260,7 @@ func (x *BuildInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildInfo.ProtoReflect.Descriptor instead.
 func (*BuildInfo) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{80}
+	return file_flow_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *BuildInfo) GetVersion() string {
@@ -6143,7 +6301,7 @@ type OperationRule struct {
 
 func (x *OperationRule) Reset() {
 	*x = OperationRule{}
-	mi := &file_flow_proto_msgTypes[81]
+	mi := &file_flow_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6155,7 +6313,7 @@ func (x *OperationRule) String() string {
 func (*OperationRule) ProtoMessage() {}
 
 func (x *OperationRule) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[81]
+	mi := &file_flow_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6168,7 +6326,7 @@ func (x *OperationRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRule.ProtoReflect.Descriptor instead.
 func (*OperationRule) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{81}
+	return file_flow_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *OperationRule) GetId() *UUID {
@@ -6248,7 +6406,7 @@ type CreateOperationRuleRequest struct {
 
 func (x *CreateOperationRuleRequest) Reset() {
 	*x = CreateOperationRuleRequest{}
-	mi := &file_flow_proto_msgTypes[82]
+	mi := &file_flow_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6260,7 +6418,7 @@ func (x *CreateOperationRuleRequest) String() string {
 func (*CreateOperationRuleRequest) ProtoMessage() {}
 
 func (x *CreateOperationRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[82]
+	mi := &file_flow_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6273,7 +6431,7 @@ func (x *CreateOperationRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOperationRuleRequest.ProtoReflect.Descriptor instead.
 func (*CreateOperationRuleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{82}
+	return file_flow_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *CreateOperationRuleRequest) GetName() string {
@@ -6327,7 +6485,7 @@ type CreateOperationRuleResponse struct {
 
 func (x *CreateOperationRuleResponse) Reset() {
 	*x = CreateOperationRuleResponse{}
-	mi := &file_flow_proto_msgTypes[83]
+	mi := &file_flow_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6339,7 +6497,7 @@ func (x *CreateOperationRuleResponse) String() string {
 func (*CreateOperationRuleResponse) ProtoMessage() {}
 
 func (x *CreateOperationRuleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[83]
+	mi := &file_flow_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6352,7 +6510,7 @@ func (x *CreateOperationRuleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOperationRuleResponse.ProtoReflect.Descriptor instead.
 func (*CreateOperationRuleResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{83}
+	return file_flow_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *CreateOperationRuleResponse) GetId() *UUID {
@@ -6374,7 +6532,7 @@ type UpdateOperationRuleRequest struct {
 
 func (x *UpdateOperationRuleRequest) Reset() {
 	*x = UpdateOperationRuleRequest{}
-	mi := &file_flow_proto_msgTypes[84]
+	mi := &file_flow_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6386,7 +6544,7 @@ func (x *UpdateOperationRuleRequest) String() string {
 func (*UpdateOperationRuleRequest) ProtoMessage() {}
 
 func (x *UpdateOperationRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[84]
+	mi := &file_flow_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6399,7 +6557,7 @@ func (x *UpdateOperationRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateOperationRuleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateOperationRuleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{84}
+	return file_flow_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *UpdateOperationRuleRequest) GetRuleId() *UUID {
@@ -6439,7 +6597,7 @@ type DeleteOperationRuleRequest struct {
 
 func (x *DeleteOperationRuleRequest) Reset() {
 	*x = DeleteOperationRuleRequest{}
-	mi := &file_flow_proto_msgTypes[85]
+	mi := &file_flow_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6451,7 +6609,7 @@ func (x *DeleteOperationRuleRequest) String() string {
 func (*DeleteOperationRuleRequest) ProtoMessage() {}
 
 func (x *DeleteOperationRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[85]
+	mi := &file_flow_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6464,7 +6622,7 @@ func (x *DeleteOperationRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteOperationRuleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteOperationRuleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{85}
+	return file_flow_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *DeleteOperationRuleRequest) GetRuleId() *UUID {
@@ -6483,7 +6641,7 @@ type SetRuleAsDefaultRequest struct {
 
 func (x *SetRuleAsDefaultRequest) Reset() {
 	*x = SetRuleAsDefaultRequest{}
-	mi := &file_flow_proto_msgTypes[86]
+	mi := &file_flow_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6495,7 +6653,7 @@ func (x *SetRuleAsDefaultRequest) String() string {
 func (*SetRuleAsDefaultRequest) ProtoMessage() {}
 
 func (x *SetRuleAsDefaultRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[86]
+	mi := &file_flow_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6508,7 +6666,7 @@ func (x *SetRuleAsDefaultRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetRuleAsDefaultRequest.ProtoReflect.Descriptor instead.
 func (*SetRuleAsDefaultRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{86}
+	return file_flow_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *SetRuleAsDefaultRequest) GetRuleId() *UUID {
@@ -6527,7 +6685,7 @@ type GetOperationRuleRequest struct {
 
 func (x *GetOperationRuleRequest) Reset() {
 	*x = GetOperationRuleRequest{}
-	mi := &file_flow_proto_msgTypes[87]
+	mi := &file_flow_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6539,7 +6697,7 @@ func (x *GetOperationRuleRequest) String() string {
 func (*GetOperationRuleRequest) ProtoMessage() {}
 
 func (x *GetOperationRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[87]
+	mi := &file_flow_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6552,7 +6710,7 @@ func (x *GetOperationRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRuleRequest.ProtoReflect.Descriptor instead.
 func (*GetOperationRuleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{87}
+	return file_flow_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *GetOperationRuleRequest) GetRuleId() *UUID {
@@ -6574,7 +6732,7 @@ type ListOperationRulesRequest struct {
 
 func (x *ListOperationRulesRequest) Reset() {
 	*x = ListOperationRulesRequest{}
-	mi := &file_flow_proto_msgTypes[88]
+	mi := &file_flow_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6586,7 +6744,7 @@ func (x *ListOperationRulesRequest) String() string {
 func (*ListOperationRulesRequest) ProtoMessage() {}
 
 func (x *ListOperationRulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[88]
+	mi := &file_flow_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6599,7 +6757,7 @@ func (x *ListOperationRulesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRulesRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationRulesRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{88}
+	return file_flow_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ListOperationRulesRequest) GetOperationType() OperationType {
@@ -6640,7 +6798,7 @@ type ListOperationRulesResponse struct {
 
 func (x *ListOperationRulesResponse) Reset() {
 	*x = ListOperationRulesResponse{}
-	mi := &file_flow_proto_msgTypes[89]
+	mi := &file_flow_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6652,7 +6810,7 @@ func (x *ListOperationRulesResponse) String() string {
 func (*ListOperationRulesResponse) ProtoMessage() {}
 
 func (x *ListOperationRulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[89]
+	mi := &file_flow_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6665,7 +6823,7 @@ func (x *ListOperationRulesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRulesResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationRulesResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{89}
+	return file_flow_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *ListOperationRulesResponse) GetRules() []*OperationRule {
@@ -6692,7 +6850,7 @@ type AssociateRuleWithRackRequest struct {
 
 func (x *AssociateRuleWithRackRequest) Reset() {
 	*x = AssociateRuleWithRackRequest{}
-	mi := &file_flow_proto_msgTypes[90]
+	mi := &file_flow_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6704,7 +6862,7 @@ func (x *AssociateRuleWithRackRequest) String() string {
 func (*AssociateRuleWithRackRequest) ProtoMessage() {}
 
 func (x *AssociateRuleWithRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[90]
+	mi := &file_flow_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6717,7 +6875,7 @@ func (x *AssociateRuleWithRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssociateRuleWithRackRequest.ProtoReflect.Descriptor instead.
 func (*AssociateRuleWithRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{90}
+	return file_flow_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *AssociateRuleWithRackRequest) GetRackId() *UUID {
@@ -6745,7 +6903,7 @@ type DisassociateRuleFromRackRequest struct {
 
 func (x *DisassociateRuleFromRackRequest) Reset() {
 	*x = DisassociateRuleFromRackRequest{}
-	mi := &file_flow_proto_msgTypes[91]
+	mi := &file_flow_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6757,7 +6915,7 @@ func (x *DisassociateRuleFromRackRequest) String() string {
 func (*DisassociateRuleFromRackRequest) ProtoMessage() {}
 
 func (x *DisassociateRuleFromRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[91]
+	mi := &file_flow_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6770,7 +6928,7 @@ func (x *DisassociateRuleFromRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DisassociateRuleFromRackRequest.ProtoReflect.Descriptor instead.
 func (*DisassociateRuleFromRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{91}
+	return file_flow_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *DisassociateRuleFromRackRequest) GetRackId() *UUID {
@@ -6805,7 +6963,7 @@ type GetRackRuleAssociationRequest struct {
 
 func (x *GetRackRuleAssociationRequest) Reset() {
 	*x = GetRackRuleAssociationRequest{}
-	mi := &file_flow_proto_msgTypes[92]
+	mi := &file_flow_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6817,7 +6975,7 @@ func (x *GetRackRuleAssociationRequest) String() string {
 func (*GetRackRuleAssociationRequest) ProtoMessage() {}
 
 func (x *GetRackRuleAssociationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[92]
+	mi := &file_flow_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6830,7 +6988,7 @@ func (x *GetRackRuleAssociationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRackRuleAssociationRequest.ProtoReflect.Descriptor instead.
 func (*GetRackRuleAssociationRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{92}
+	return file_flow_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *GetRackRuleAssociationRequest) GetRackId() *UUID {
@@ -6863,7 +7021,7 @@ type GetRackRuleAssociationResponse struct {
 
 func (x *GetRackRuleAssociationResponse) Reset() {
 	*x = GetRackRuleAssociationResponse{}
-	mi := &file_flow_proto_msgTypes[93]
+	mi := &file_flow_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6875,7 +7033,7 @@ func (x *GetRackRuleAssociationResponse) String() string {
 func (*GetRackRuleAssociationResponse) ProtoMessage() {}
 
 func (x *GetRackRuleAssociationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[93]
+	mi := &file_flow_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6888,7 +7046,7 @@ func (x *GetRackRuleAssociationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRackRuleAssociationResponse.ProtoReflect.Descriptor instead.
 func (*GetRackRuleAssociationResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{93}
+	return file_flow_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *GetRackRuleAssociationResponse) GetRuleId() *UUID {
@@ -6907,7 +7065,7 @@ type ListRackRuleAssociationsRequest struct {
 
 func (x *ListRackRuleAssociationsRequest) Reset() {
 	*x = ListRackRuleAssociationsRequest{}
-	mi := &file_flow_proto_msgTypes[94]
+	mi := &file_flow_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6919,7 +7077,7 @@ func (x *ListRackRuleAssociationsRequest) String() string {
 func (*ListRackRuleAssociationsRequest) ProtoMessage() {}
 
 func (x *ListRackRuleAssociationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[94]
+	mi := &file_flow_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6932,7 +7090,7 @@ func (x *ListRackRuleAssociationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRackRuleAssociationsRequest.ProtoReflect.Descriptor instead.
 func (*ListRackRuleAssociationsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{94}
+	return file_flow_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ListRackRuleAssociationsRequest) GetRackId() *UUID {
@@ -6956,7 +7114,7 @@ type RackRuleAssociation struct {
 
 func (x *RackRuleAssociation) Reset() {
 	*x = RackRuleAssociation{}
-	mi := &file_flow_proto_msgTypes[95]
+	mi := &file_flow_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6968,7 +7126,7 @@ func (x *RackRuleAssociation) String() string {
 func (*RackRuleAssociation) ProtoMessage() {}
 
 func (x *RackRuleAssociation) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[95]
+	mi := &file_flow_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6981,7 +7139,7 @@ func (x *RackRuleAssociation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RackRuleAssociation.ProtoReflect.Descriptor instead.
 func (*RackRuleAssociation) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{95}
+	return file_flow_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *RackRuleAssociation) GetRackId() *UUID {
@@ -7035,7 +7193,7 @@ type ListRackRuleAssociationsResponse struct {
 
 func (x *ListRackRuleAssociationsResponse) Reset() {
 	*x = ListRackRuleAssociationsResponse{}
-	mi := &file_flow_proto_msgTypes[96]
+	mi := &file_flow_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7047,7 +7205,7 @@ func (x *ListRackRuleAssociationsResponse) String() string {
 func (*ListRackRuleAssociationsResponse) ProtoMessage() {}
 
 func (x *ListRackRuleAssociationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[96]
+	mi := &file_flow_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7060,7 +7218,7 @@ func (x *ListRackRuleAssociationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRackRuleAssociationsResponse.ProtoReflect.Descriptor instead.
 func (*ListRackRuleAssociationsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{96}
+	return file_flow_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *ListRackRuleAssociationsResponse) GetAssociations() []*RackRuleAssociation {
@@ -7083,7 +7241,7 @@ type ScheduleSpec struct {
 
 func (x *ScheduleSpec) Reset() {
 	*x = ScheduleSpec{}
-	mi := &file_flow_proto_msgTypes[97]
+	mi := &file_flow_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7095,7 +7253,7 @@ func (x *ScheduleSpec) String() string {
 func (*ScheduleSpec) ProtoMessage() {}
 
 func (x *ScheduleSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[97]
+	mi := &file_flow_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7108,7 +7266,7 @@ func (x *ScheduleSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleSpec.ProtoReflect.Descriptor instead.
 func (*ScheduleSpec) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{97}
+	return file_flow_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *ScheduleSpec) GetType() ScheduleSpecType {
@@ -7144,7 +7302,7 @@ type ScheduleConfig struct {
 
 func (x *ScheduleConfig) Reset() {
 	*x = ScheduleConfig{}
-	mi := &file_flow_proto_msgTypes[98]
+	mi := &file_flow_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7156,7 +7314,7 @@ func (x *ScheduleConfig) String() string {
 func (*ScheduleConfig) ProtoMessage() {}
 
 func (x *ScheduleConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[98]
+	mi := &file_flow_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7169,7 +7327,7 @@ func (x *ScheduleConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleConfig.ProtoReflect.Descriptor instead.
 func (*ScheduleConfig) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{98}
+	return file_flow_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ScheduleConfig) GetName() string {
@@ -7221,7 +7379,7 @@ type TaskSchedule struct {
 
 func (x *TaskSchedule) Reset() {
 	*x = TaskSchedule{}
-	mi := &file_flow_proto_msgTypes[99]
+	mi := &file_flow_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7233,7 +7391,7 @@ func (x *TaskSchedule) String() string {
 func (*TaskSchedule) ProtoMessage() {}
 
 func (x *TaskSchedule) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[99]
+	mi := &file_flow_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7246,7 +7404,7 @@ func (x *TaskSchedule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskSchedule.ProtoReflect.Descriptor instead.
 func (*TaskSchedule) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{99}
+	return file_flow_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *TaskSchedule) GetId() *UUID {
@@ -7352,7 +7510,7 @@ type ScheduledOperation struct {
 
 func (x *ScheduledOperation) Reset() {
 	*x = ScheduledOperation{}
-	mi := &file_flow_proto_msgTypes[100]
+	mi := &file_flow_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7364,7 +7522,7 @@ func (x *ScheduledOperation) String() string {
 func (*ScheduledOperation) ProtoMessage() {}
 
 func (x *ScheduledOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[100]
+	mi := &file_flow_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7377,7 +7535,7 @@ func (x *ScheduledOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduledOperation.ProtoReflect.Descriptor instead.
 func (*ScheduledOperation) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{100}
+	return file_flow_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *ScheduledOperation) GetOperation() isScheduledOperation_Operation {
@@ -7495,7 +7653,7 @@ type CreateTaskScheduleRequest struct {
 
 func (x *CreateTaskScheduleRequest) Reset() {
 	*x = CreateTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[101]
+	mi := &file_flow_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7507,7 +7665,7 @@ func (x *CreateTaskScheduleRequest) String() string {
 func (*CreateTaskScheduleRequest) ProtoMessage() {}
 
 func (x *CreateTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[101]
+	mi := &file_flow_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7520,7 +7678,7 @@ func (x *CreateTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*CreateTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{101}
+	return file_flow_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *CreateTaskScheduleRequest) GetSchedule() *ScheduleConfig {
@@ -7546,7 +7704,7 @@ type GetTaskScheduleRequest struct {
 
 func (x *GetTaskScheduleRequest) Reset() {
 	*x = GetTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[102]
+	mi := &file_flow_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7558,7 +7716,7 @@ func (x *GetTaskScheduleRequest) String() string {
 func (*GetTaskScheduleRequest) ProtoMessage() {}
 
 func (x *GetTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[102]
+	mi := &file_flow_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7571,7 +7729,7 @@ func (x *GetTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*GetTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{102}
+	return file_flow_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *GetTaskScheduleRequest) GetId() *UUID {
@@ -7594,7 +7752,7 @@ type ListTaskSchedulesRequest struct {
 
 func (x *ListTaskSchedulesRequest) Reset() {
 	*x = ListTaskSchedulesRequest{}
-	mi := &file_flow_proto_msgTypes[103]
+	mi := &file_flow_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7606,7 +7764,7 @@ func (x *ListTaskSchedulesRequest) String() string {
 func (*ListTaskSchedulesRequest) ProtoMessage() {}
 
 func (x *ListTaskSchedulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[103]
+	mi := &file_flow_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7619,7 +7777,7 @@ func (x *ListTaskSchedulesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskSchedulesRequest.ProtoReflect.Descriptor instead.
 func (*ListTaskSchedulesRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{103}
+	return file_flow_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *ListTaskSchedulesRequest) GetRackId() *UUID {
@@ -7653,7 +7811,7 @@ type ListTaskSchedulesResponse struct {
 
 func (x *ListTaskSchedulesResponse) Reset() {
 	*x = ListTaskSchedulesResponse{}
-	mi := &file_flow_proto_msgTypes[104]
+	mi := &file_flow_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7665,7 +7823,7 @@ func (x *ListTaskSchedulesResponse) String() string {
 func (*ListTaskSchedulesResponse) ProtoMessage() {}
 
 func (x *ListTaskSchedulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[104]
+	mi := &file_flow_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7678,7 +7836,7 @@ func (x *ListTaskSchedulesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskSchedulesResponse.ProtoReflect.Descriptor instead.
 func (*ListTaskSchedulesResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{104}
+	return file_flow_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *ListTaskSchedulesResponse) GetTaskSchedules() []*TaskSchedule {
@@ -7716,7 +7874,7 @@ type UpdateTaskScheduleRequest struct {
 
 func (x *UpdateTaskScheduleRequest) Reset() {
 	*x = UpdateTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[105]
+	mi := &file_flow_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7728,7 +7886,7 @@ func (x *UpdateTaskScheduleRequest) String() string {
 func (*UpdateTaskScheduleRequest) ProtoMessage() {}
 
 func (x *UpdateTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[105]
+	mi := &file_flow_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7741,7 +7899,7 @@ func (x *UpdateTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{105}
+	return file_flow_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *UpdateTaskScheduleRequest) GetId() *UUID {
@@ -7777,7 +7935,7 @@ type PauseTaskScheduleRequest struct {
 
 func (x *PauseTaskScheduleRequest) Reset() {
 	*x = PauseTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[106]
+	mi := &file_flow_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7789,7 +7947,7 @@ func (x *PauseTaskScheduleRequest) String() string {
 func (*PauseTaskScheduleRequest) ProtoMessage() {}
 
 func (x *PauseTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[106]
+	mi := &file_flow_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7802,7 +7960,7 @@ func (x *PauseTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*PauseTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{106}
+	return file_flow_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *PauseTaskScheduleRequest) GetId() *UUID {
@@ -7824,7 +7982,7 @@ type ResumeTaskScheduleRequest struct {
 
 func (x *ResumeTaskScheduleRequest) Reset() {
 	*x = ResumeTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[107]
+	mi := &file_flow_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7836,7 +7994,7 @@ func (x *ResumeTaskScheduleRequest) String() string {
 func (*ResumeTaskScheduleRequest) ProtoMessage() {}
 
 func (x *ResumeTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[107]
+	mi := &file_flow_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7849,7 +8007,7 @@ func (x *ResumeTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*ResumeTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{107}
+	return file_flow_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *ResumeTaskScheduleRequest) GetId() *UUID {
@@ -7870,7 +8028,7 @@ type DeleteTaskScheduleRequest struct {
 
 func (x *DeleteTaskScheduleRequest) Reset() {
 	*x = DeleteTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[108]
+	mi := &file_flow_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7882,7 +8040,7 @@ func (x *DeleteTaskScheduleRequest) String() string {
 func (*DeleteTaskScheduleRequest) ProtoMessage() {}
 
 func (x *DeleteTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[108]
+	mi := &file_flow_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7895,7 +8053,7 @@ func (x *DeleteTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{108}
+	return file_flow_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *DeleteTaskScheduleRequest) GetId() *UUID {
@@ -7918,7 +8076,7 @@ type TriggerTaskScheduleRequest struct {
 
 func (x *TriggerTaskScheduleRequest) Reset() {
 	*x = TriggerTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[109]
+	mi := &file_flow_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7930,7 +8088,7 @@ func (x *TriggerTaskScheduleRequest) String() string {
 func (*TriggerTaskScheduleRequest) ProtoMessage() {}
 
 func (x *TriggerTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[109]
+	mi := &file_flow_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7943,7 +8101,7 @@ func (x *TriggerTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*TriggerTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{109}
+	return file_flow_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *TriggerTaskScheduleRequest) GetId() *UUID {
@@ -7979,7 +8137,7 @@ type TaskScheduleScope struct {
 
 func (x *TaskScheduleScope) Reset() {
 	*x = TaskScheduleScope{}
-	mi := &file_flow_proto_msgTypes[110]
+	mi := &file_flow_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7991,7 +8149,7 @@ func (x *TaskScheduleScope) String() string {
 func (*TaskScheduleScope) ProtoMessage() {}
 
 func (x *TaskScheduleScope) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[110]
+	mi := &file_flow_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8004,7 +8162,7 @@ func (x *TaskScheduleScope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskScheduleScope.ProtoReflect.Descriptor instead.
 func (*TaskScheduleScope) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{110}
+	return file_flow_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *TaskScheduleScope) GetId() *UUID {
@@ -8104,7 +8262,7 @@ type AddTaskScheduleScopeRequest struct {
 
 func (x *AddTaskScheduleScopeRequest) Reset() {
 	*x = AddTaskScheduleScopeRequest{}
-	mi := &file_flow_proto_msgTypes[111]
+	mi := &file_flow_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8116,7 +8274,7 @@ func (x *AddTaskScheduleScopeRequest) String() string {
 func (*AddTaskScheduleScopeRequest) ProtoMessage() {}
 
 func (x *AddTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[111]
+	mi := &file_flow_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8129,7 +8287,7 @@ func (x *AddTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddTaskScheduleScopeRequest.ProtoReflect.Descriptor instead.
 func (*AddTaskScheduleScopeRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{111}
+	return file_flow_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *AddTaskScheduleScopeRequest) GetScheduleId() *UUID {
@@ -8156,7 +8314,7 @@ type AddTaskScheduleScopeResponse struct {
 
 func (x *AddTaskScheduleScopeResponse) Reset() {
 	*x = AddTaskScheduleScopeResponse{}
-	mi := &file_flow_proto_msgTypes[112]
+	mi := &file_flow_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8168,7 +8326,7 @@ func (x *AddTaskScheduleScopeResponse) String() string {
 func (*AddTaskScheduleScopeResponse) ProtoMessage() {}
 
 func (x *AddTaskScheduleScopeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[112]
+	mi := &file_flow_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8181,7 +8339,7 @@ func (x *AddTaskScheduleScopeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddTaskScheduleScopeResponse.ProtoReflect.Descriptor instead.
 func (*AddTaskScheduleScopeResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{112}
+	return file_flow_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *AddTaskScheduleScopeResponse) GetScopes() []*TaskScheduleScope {
@@ -8202,7 +8360,7 @@ type RemoveTaskScheduleScopeRequest struct {
 
 func (x *RemoveTaskScheduleScopeRequest) Reset() {
 	*x = RemoveTaskScheduleScopeRequest{}
-	mi := &file_flow_proto_msgTypes[113]
+	mi := &file_flow_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8214,7 +8372,7 @@ func (x *RemoveTaskScheduleScopeRequest) String() string {
 func (*RemoveTaskScheduleScopeRequest) ProtoMessage() {}
 
 func (x *RemoveTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[113]
+	mi := &file_flow_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8227,7 +8385,7 @@ func (x *RemoveTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveTaskScheduleScopeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveTaskScheduleScopeRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{113}
+	return file_flow_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *RemoveTaskScheduleScopeRequest) GetScopeId() *UUID {
@@ -8252,7 +8410,7 @@ type UpdateTaskScheduleScopeRequest struct {
 
 func (x *UpdateTaskScheduleScopeRequest) Reset() {
 	*x = UpdateTaskScheduleScopeRequest{}
-	mi := &file_flow_proto_msgTypes[114]
+	mi := &file_flow_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8264,7 +8422,7 @@ func (x *UpdateTaskScheduleScopeRequest) String() string {
 func (*UpdateTaskScheduleScopeRequest) ProtoMessage() {}
 
 func (x *UpdateTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[114]
+	mi := &file_flow_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8277,7 +8435,7 @@ func (x *UpdateTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskScheduleScopeRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTaskScheduleScopeRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{114}
+	return file_flow_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *UpdateTaskScheduleScopeRequest) GetScheduleId() *UUID {
@@ -8307,7 +8465,7 @@ type UpdateTaskScheduleScopeResponse struct {
 
 func (x *UpdateTaskScheduleScopeResponse) Reset() {
 	*x = UpdateTaskScheduleScopeResponse{}
-	mi := &file_flow_proto_msgTypes[115]
+	mi := &file_flow_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8319,7 +8477,7 @@ func (x *UpdateTaskScheduleScopeResponse) String() string {
 func (*UpdateTaskScheduleScopeResponse) ProtoMessage() {}
 
 func (x *UpdateTaskScheduleScopeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[115]
+	mi := &file_flow_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8332,7 +8490,7 @@ func (x *UpdateTaskScheduleScopeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskScheduleScopeResponse.ProtoReflect.Descriptor instead.
 func (*UpdateTaskScheduleScopeResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{115}
+	return file_flow_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *UpdateTaskScheduleScopeResponse) GetScopes() []*TaskScheduleScope {
@@ -8373,7 +8531,7 @@ type ListTaskScheduleScopesRequest struct {
 
 func (x *ListTaskScheduleScopesRequest) Reset() {
 	*x = ListTaskScheduleScopesRequest{}
-	mi := &file_flow_proto_msgTypes[116]
+	mi := &file_flow_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8385,7 +8543,7 @@ func (x *ListTaskScheduleScopesRequest) String() string {
 func (*ListTaskScheduleScopesRequest) ProtoMessage() {}
 
 func (x *ListTaskScheduleScopesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[116]
+	mi := &file_flow_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8398,7 +8556,7 @@ func (x *ListTaskScheduleScopesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskScheduleScopesRequest.ProtoReflect.Descriptor instead.
 func (*ListTaskScheduleScopesRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{116}
+	return file_flow_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *ListTaskScheduleScopesRequest) GetScheduleId() *UUID {
@@ -8417,7 +8575,7 @@ type ListTaskScheduleScopesResponse struct {
 
 func (x *ListTaskScheduleScopesResponse) Reset() {
 	*x = ListTaskScheduleScopesResponse{}
-	mi := &file_flow_proto_msgTypes[117]
+	mi := &file_flow_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8429,7 +8587,7 @@ func (x *ListTaskScheduleScopesResponse) String() string {
 func (*ListTaskScheduleScopesResponse) ProtoMessage() {}
 
 func (x *ListTaskScheduleScopesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[117]
+	mi := &file_flow_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8442,7 +8600,7 @@ func (x *ListTaskScheduleScopesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskScheduleScopesResponse.ProtoReflect.Descriptor instead.
 func (*ListTaskScheduleScopesResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{117}
+	return file_flow_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *ListTaskScheduleScopesResponse) GetScopes() []*TaskScheduleScope {
@@ -8478,7 +8636,7 @@ type CheckScheduleConflictsRequest struct {
 
 func (x *CheckScheduleConflictsRequest) Reset() {
 	*x = CheckScheduleConflictsRequest{}
-	mi := &file_flow_proto_msgTypes[118]
+	mi := &file_flow_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8490,7 +8648,7 @@ func (x *CheckScheduleConflictsRequest) String() string {
 func (*CheckScheduleConflictsRequest) ProtoMessage() {}
 
 func (x *CheckScheduleConflictsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[118]
+	mi := &file_flow_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8503,7 +8661,7 @@ func (x *CheckScheduleConflictsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckScheduleConflictsRequest.ProtoReflect.Descriptor instead.
 func (*CheckScheduleConflictsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{118}
+	return file_flow_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *CheckScheduleConflictsRequest) GetOperation() *ScheduledOperation {
@@ -8532,7 +8690,7 @@ type CheckScheduleConflictsResponse struct {
 
 func (x *CheckScheduleConflictsResponse) Reset() {
 	*x = CheckScheduleConflictsResponse{}
-	mi := &file_flow_proto_msgTypes[119]
+	mi := &file_flow_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8544,7 +8702,7 @@ func (x *CheckScheduleConflictsResponse) String() string {
 func (*CheckScheduleConflictsResponse) ProtoMessage() {}
 
 func (x *CheckScheduleConflictsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[119]
+	mi := &file_flow_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8557,7 +8715,7 @@ func (x *CheckScheduleConflictsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckScheduleConflictsResponse.ProtoReflect.Descriptor instead.
 func (*CheckScheduleConflictsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{119}
+	return file_flow_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *CheckScheduleConflictsResponse) GetConflicts() []*TaskSchedule {
@@ -8585,7 +8743,7 @@ type CreateOperationRunRequest struct {
 
 func (x *CreateOperationRunRequest) Reset() {
 	*x = CreateOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[120]
+	mi := &file_flow_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8597,7 +8755,7 @@ func (x *CreateOperationRunRequest) String() string {
 func (*CreateOperationRunRequest) ProtoMessage() {}
 
 func (x *CreateOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[120]
+	mi := &file_flow_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8610,7 +8768,7 @@ func (x *CreateOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*CreateOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{120}
+	return file_flow_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *CreateOperationRunRequest) GetName() string {
@@ -8643,7 +8801,7 @@ type CreateOperationRunResponse struct {
 
 func (x *CreateOperationRunResponse) Reset() {
 	*x = CreateOperationRunResponse{}
-	mi := &file_flow_proto_msgTypes[121]
+	mi := &file_flow_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8655,7 +8813,7 @@ func (x *CreateOperationRunResponse) String() string {
 func (*CreateOperationRunResponse) ProtoMessage() {}
 
 func (x *CreateOperationRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[121]
+	mi := &file_flow_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8668,7 +8826,7 @@ func (x *CreateOperationRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOperationRunResponse.ProtoReflect.Descriptor instead.
 func (*CreateOperationRunResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{121}
+	return file_flow_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *CreateOperationRunResponse) GetId() *UUID {
@@ -8691,7 +8849,7 @@ type OperationRunConfiguration struct {
 
 func (x *OperationRunConfiguration) Reset() {
 	*x = OperationRunConfiguration{}
-	mi := &file_flow_proto_msgTypes[122]
+	mi := &file_flow_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8703,7 +8861,7 @@ func (x *OperationRunConfiguration) String() string {
 func (*OperationRunConfiguration) ProtoMessage() {}
 
 func (x *OperationRunConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[122]
+	mi := &file_flow_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8716,7 +8874,7 @@ func (x *OperationRunConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunConfiguration.ProtoReflect.Descriptor instead.
 func (*OperationRunConfiguration) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{122}
+	return file_flow_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *OperationRunConfiguration) GetSelector() *OperationRunSelector {
@@ -8752,7 +8910,7 @@ type GetOperationRunRequest struct {
 
 func (x *GetOperationRunRequest) Reset() {
 	*x = GetOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[123]
+	mi := &file_flow_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8764,7 +8922,7 @@ func (x *GetOperationRunRequest) String() string {
 func (*GetOperationRunRequest) ProtoMessage() {}
 
 func (x *GetOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[123]
+	mi := &file_flow_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8777,7 +8935,7 @@ func (x *GetOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*GetOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{123}
+	return file_flow_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *GetOperationRunRequest) GetId() *UUID {
@@ -8803,7 +8961,7 @@ type GetOperationRunResponse struct {
 
 func (x *GetOperationRunResponse) Reset() {
 	*x = GetOperationRunResponse{}
-	mi := &file_flow_proto_msgTypes[124]
+	mi := &file_flow_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8815,7 +8973,7 @@ func (x *GetOperationRunResponse) String() string {
 func (*GetOperationRunResponse) ProtoMessage() {}
 
 func (x *GetOperationRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[124]
+	mi := &file_flow_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8828,7 +8986,7 @@ func (x *GetOperationRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRunResponse.ProtoReflect.Descriptor instead.
 func (*GetOperationRunResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{124}
+	return file_flow_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *GetOperationRunResponse) GetOperationRun() *OperationRun {
@@ -8849,7 +9007,7 @@ type ListOperationRunsRequest struct {
 
 func (x *ListOperationRunsRequest) Reset() {
 	*x = ListOperationRunsRequest{}
-	mi := &file_flow_proto_msgTypes[125]
+	mi := &file_flow_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8861,7 +9019,7 @@ func (x *ListOperationRunsRequest) String() string {
 func (*ListOperationRunsRequest) ProtoMessage() {}
 
 func (x *ListOperationRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[125]
+	mi := &file_flow_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8874,7 +9032,7 @@ func (x *ListOperationRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationRunsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{125}
+	return file_flow_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *ListOperationRunsRequest) GetFilter() *OperationRunFilter {
@@ -8901,7 +9059,7 @@ type ListOperationRunsResponse struct {
 
 func (x *ListOperationRunsResponse) Reset() {
 	*x = ListOperationRunsResponse{}
-	mi := &file_flow_proto_msgTypes[126]
+	mi := &file_flow_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8913,7 +9071,7 @@ func (x *ListOperationRunsResponse) String() string {
 func (*ListOperationRunsResponse) ProtoMessage() {}
 
 func (x *ListOperationRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[126]
+	mi := &file_flow_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8926,7 +9084,7 @@ func (x *ListOperationRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationRunsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{126}
+	return file_flow_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *ListOperationRunsResponse) GetOperationRuns() []*OperationRunSummary {
@@ -8959,7 +9117,7 @@ type OperationRunFilter struct {
 
 func (x *OperationRunFilter) Reset() {
 	*x = OperationRunFilter{}
-	mi := &file_flow_proto_msgTypes[127]
+	mi := &file_flow_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8971,7 +9129,7 @@ func (x *OperationRunFilter) String() string {
 func (*OperationRunFilter) ProtoMessage() {}
 
 func (x *OperationRunFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[127]
+	mi := &file_flow_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8984,7 +9142,7 @@ func (x *OperationRunFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunFilter.ProtoReflect.Descriptor instead.
 func (*OperationRunFilter) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{127}
+	return file_flow_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *OperationRunFilter) GetName() *StringQueryInfo {
@@ -9018,7 +9176,7 @@ type OperationRunStateFilter struct {
 
 func (x *OperationRunStateFilter) Reset() {
 	*x = OperationRunStateFilter{}
-	mi := &file_flow_proto_msgTypes[128]
+	mi := &file_flow_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9030,7 +9188,7 @@ func (x *OperationRunStateFilter) String() string {
 func (*OperationRunStateFilter) ProtoMessage() {}
 
 func (x *OperationRunStateFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[128]
+	mi := &file_flow_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9043,7 +9201,7 @@ func (x *OperationRunStateFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunStateFilter.ProtoReflect.Descriptor instead.
 func (*OperationRunStateFilter) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{128}
+	return file_flow_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *OperationRunStateFilter) GetStatus() OperationRunStatus {
@@ -9075,7 +9233,7 @@ type ListOperationRunTargetsRequest struct {
 
 func (x *ListOperationRunTargetsRequest) Reset() {
 	*x = ListOperationRunTargetsRequest{}
-	mi := &file_flow_proto_msgTypes[129]
+	mi := &file_flow_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9087,7 +9245,7 @@ func (x *ListOperationRunTargetsRequest) String() string {
 func (*ListOperationRunTargetsRequest) ProtoMessage() {}
 
 func (x *ListOperationRunTargetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[129]
+	mi := &file_flow_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9100,7 +9258,7 @@ func (x *ListOperationRunTargetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRunTargetsRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationRunTargetsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{129}
+	return file_flow_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *ListOperationRunTargetsRequest) GetOperationRunId() *UUID {
@@ -9141,7 +9299,7 @@ type ListOperationRunTargetsResponse struct {
 
 func (x *ListOperationRunTargetsResponse) Reset() {
 	*x = ListOperationRunTargetsResponse{}
-	mi := &file_flow_proto_msgTypes[130]
+	mi := &file_flow_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9153,7 +9311,7 @@ func (x *ListOperationRunTargetsResponse) String() string {
 func (*ListOperationRunTargetsResponse) ProtoMessage() {}
 
 func (x *ListOperationRunTargetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[130]
+	mi := &file_flow_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9166,7 +9324,7 @@ func (x *ListOperationRunTargetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRunTargetsResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationRunTargetsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{130}
+	return file_flow_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *ListOperationRunTargetsResponse) GetTargets() []*OperationRunTarget {
@@ -9192,7 +9350,7 @@ type PauseOperationRunRequest struct {
 
 func (x *PauseOperationRunRequest) Reset() {
 	*x = PauseOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[131]
+	mi := &file_flow_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9204,7 +9362,7 @@ func (x *PauseOperationRunRequest) String() string {
 func (*PauseOperationRunRequest) ProtoMessage() {}
 
 func (x *PauseOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[131]
+	mi := &file_flow_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9217,7 +9375,7 @@ func (x *PauseOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*PauseOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{131}
+	return file_flow_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *PauseOperationRunRequest) GetId() *UUID {
@@ -9236,7 +9394,7 @@ type ResumeOperationRunRequest struct {
 
 func (x *ResumeOperationRunRequest) Reset() {
 	*x = ResumeOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[132]
+	mi := &file_flow_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9248,7 +9406,7 @@ func (x *ResumeOperationRunRequest) String() string {
 func (*ResumeOperationRunRequest) ProtoMessage() {}
 
 func (x *ResumeOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[132]
+	mi := &file_flow_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9261,7 +9419,7 @@ func (x *ResumeOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*ResumeOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{132}
+	return file_flow_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *ResumeOperationRunRequest) GetId() *UUID {
@@ -9282,7 +9440,7 @@ type AdvanceOperationRunPhaseRequest struct {
 
 func (x *AdvanceOperationRunPhaseRequest) Reset() {
 	*x = AdvanceOperationRunPhaseRequest{}
-	mi := &file_flow_proto_msgTypes[133]
+	mi := &file_flow_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9294,7 +9452,7 @@ func (x *AdvanceOperationRunPhaseRequest) String() string {
 func (*AdvanceOperationRunPhaseRequest) ProtoMessage() {}
 
 func (x *AdvanceOperationRunPhaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[133]
+	mi := &file_flow_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9307,7 +9465,7 @@ func (x *AdvanceOperationRunPhaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdvanceOperationRunPhaseRequest.ProtoReflect.Descriptor instead.
 func (*AdvanceOperationRunPhaseRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{133}
+	return file_flow_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *AdvanceOperationRunPhaseRequest) GetId() *UUID {
@@ -9334,7 +9492,7 @@ type CancelOperationRunRequest struct {
 
 func (x *CancelOperationRunRequest) Reset() {
 	*x = CancelOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[134]
+	mi := &file_flow_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9346,7 +9504,7 @@ func (x *CancelOperationRunRequest) String() string {
 func (*CancelOperationRunRequest) ProtoMessage() {}
 
 func (x *CancelOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[134]
+	mi := &file_flow_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9359,7 +9517,7 @@ func (x *CancelOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*CancelOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{134}
+	return file_flow_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *CancelOperationRunRequest) GetId() *UUID {
@@ -9388,7 +9546,7 @@ type OperationRunSelector struct {
 
 func (x *OperationRunSelector) Reset() {
 	*x = OperationRunSelector{}
-	mi := &file_flow_proto_msgTypes[135]
+	mi := &file_flow_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9400,7 +9558,7 @@ func (x *OperationRunSelector) String() string {
 func (*OperationRunSelector) ProtoMessage() {}
 
 func (x *OperationRunSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[135]
+	mi := &file_flow_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9413,7 +9571,7 @@ func (x *OperationRunSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunSelector.ProtoReflect.Descriptor instead.
 func (*OperationRunSelector) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{135}
+	return file_flow_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *OperationRunSelector) GetSelector() isOperationRunSelector_Selector {
@@ -9455,7 +9613,7 @@ type PercentageSelector struct {
 
 func (x *PercentageSelector) Reset() {
 	*x = PercentageSelector{}
-	mi := &file_flow_proto_msgTypes[136]
+	mi := &file_flow_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9467,7 +9625,7 @@ func (x *PercentageSelector) String() string {
 func (*PercentageSelector) ProtoMessage() {}
 
 func (x *PercentageSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[136]
+	mi := &file_flow_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9480,7 +9638,7 @@ func (x *PercentageSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PercentageSelector.ProtoReflect.Descriptor instead.
 func (*PercentageSelector) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{136}
+	return file_flow_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *PercentageSelector) GetPercentage() int32 {
@@ -9519,7 +9677,7 @@ type OperationRunOptions struct {
 
 func (x *OperationRunOptions) Reset() {
 	*x = OperationRunOptions{}
-	mi := &file_flow_proto_msgTypes[137]
+	mi := &file_flow_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9531,7 +9689,7 @@ func (x *OperationRunOptions) String() string {
 func (*OperationRunOptions) ProtoMessage() {}
 
 func (x *OperationRunOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[137]
+	mi := &file_flow_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9544,7 +9702,7 @@ func (x *OperationRunOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunOptions.ProtoReflect.Descriptor instead.
 func (*OperationRunOptions) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{137}
+	return file_flow_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *OperationRunOptions) GetMaxConcurrentTargets() int32 {
@@ -9593,7 +9751,7 @@ type OperationRunSafetyPolicy struct {
 
 func (x *OperationRunSafetyPolicy) Reset() {
 	*x = OperationRunSafetyPolicy{}
-	mi := &file_flow_proto_msgTypes[138]
+	mi := &file_flow_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9605,7 +9763,7 @@ func (x *OperationRunSafetyPolicy) String() string {
 func (*OperationRunSafetyPolicy) ProtoMessage() {}
 
 func (x *OperationRunSafetyPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[138]
+	mi := &file_flow_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9618,7 +9776,7 @@ func (x *OperationRunSafetyPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunSafetyPolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunSafetyPolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{138}
+	return file_flow_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *OperationRunSafetyPolicy) GetGates() []*OperationRunSafetyGate {
@@ -9641,7 +9799,7 @@ type OperationRunSafetyGate struct {
 
 func (x *OperationRunSafetyGate) Reset() {
 	*x = OperationRunSafetyGate{}
-	mi := &file_flow_proto_msgTypes[139]
+	mi := &file_flow_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9653,7 +9811,7 @@ func (x *OperationRunSafetyGate) String() string {
 func (*OperationRunSafetyGate) ProtoMessage() {}
 
 func (x *OperationRunSafetyGate) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[139]
+	mi := &file_flow_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9666,7 +9824,7 @@ func (x *OperationRunSafetyGate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunSafetyGate.ProtoReflect.Descriptor instead.
 func (*OperationRunSafetyGate) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{139}
+	return file_flow_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *OperationRunSafetyGate) GetGate() isOperationRunSafetyGate_Gate {
@@ -9723,7 +9881,7 @@ type OperationRunFailureRateGate struct {
 
 func (x *OperationRunFailureRateGate) Reset() {
 	*x = OperationRunFailureRateGate{}
-	mi := &file_flow_proto_msgTypes[140]
+	mi := &file_flow_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9735,7 +9893,7 @@ func (x *OperationRunFailureRateGate) String() string {
 func (*OperationRunFailureRateGate) ProtoMessage() {}
 
 func (x *OperationRunFailureRateGate) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[140]
+	mi := &file_flow_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9748,7 +9906,7 @@ func (x *OperationRunFailureRateGate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunFailureRateGate.ProtoReflect.Descriptor instead.
 func (*OperationRunFailureRateGate) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{140}
+	return file_flow_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *OperationRunFailureRateGate) GetScope() OperationRunSafetyGateScope {
@@ -9778,7 +9936,7 @@ type OperationRunFailureCountGate struct {
 
 func (x *OperationRunFailureCountGate) Reset() {
 	*x = OperationRunFailureCountGate{}
-	mi := &file_flow_proto_msgTypes[141]
+	mi := &file_flow_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9790,7 +9948,7 @@ func (x *OperationRunFailureCountGate) String() string {
 func (*OperationRunFailureCountGate) ProtoMessage() {}
 
 func (x *OperationRunFailureCountGate) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[141]
+	mi := &file_flow_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9803,7 +9961,7 @@ func (x *OperationRunFailureCountGate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunFailureCountGate.ProtoReflect.Descriptor instead.
 func (*OperationRunFailureCountGate) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{141}
+	return file_flow_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *OperationRunFailureCountGate) GetScope() OperationRunSafetyGateScope {
@@ -9833,7 +9991,7 @@ type OperationRunOrderingPolicy struct {
 
 func (x *OperationRunOrderingPolicy) Reset() {
 	*x = OperationRunOrderingPolicy{}
-	mi := &file_flow_proto_msgTypes[142]
+	mi := &file_flow_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9845,7 +10003,7 @@ func (x *OperationRunOrderingPolicy) String() string {
 func (*OperationRunOrderingPolicy) ProtoMessage() {}
 
 func (x *OperationRunOrderingPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[142]
+	mi := &file_flow_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9858,7 +10016,7 @@ func (x *OperationRunOrderingPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunOrderingPolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunOrderingPolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{142}
+	return file_flow_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *OperationRunOrderingPolicy) GetOrdering() isOperationRunOrderingPolicy_Ordering {
@@ -9914,7 +10072,7 @@ type OperationRunRandomOrdering struct {
 
 func (x *OperationRunRandomOrdering) Reset() {
 	*x = OperationRunRandomOrdering{}
-	mi := &file_flow_proto_msgTypes[143]
+	mi := &file_flow_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9926,7 +10084,7 @@ func (x *OperationRunRandomOrdering) String() string {
 func (*OperationRunRandomOrdering) ProtoMessage() {}
 
 func (x *OperationRunRandomOrdering) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[143]
+	mi := &file_flow_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9939,7 +10097,7 @@ func (x *OperationRunRandomOrdering) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunRandomOrdering.ProtoReflect.Descriptor instead.
 func (*OperationRunRandomOrdering) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{143}
+	return file_flow_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *OperationRunRandomOrdering) GetSeed() string {
@@ -9958,7 +10116,7 @@ type OperationRunPhysicalLocationOrdering struct {
 
 func (x *OperationRunPhysicalLocationOrdering) Reset() {
 	*x = OperationRunPhysicalLocationOrdering{}
-	mi := &file_flow_proto_msgTypes[144]
+	mi := &file_flow_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9970,7 +10128,7 @@ func (x *OperationRunPhysicalLocationOrdering) String() string {
 func (*OperationRunPhysicalLocationOrdering) ProtoMessage() {}
 
 func (x *OperationRunPhysicalLocationOrdering) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[144]
+	mi := &file_flow_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9983,7 +10141,7 @@ func (x *OperationRunPhysicalLocationOrdering) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use OperationRunPhysicalLocationOrdering.ProtoReflect.Descriptor instead.
 func (*OperationRunPhysicalLocationOrdering) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{144}
+	return file_flow_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *OperationRunPhysicalLocationOrdering) GetStrategy() OperationRunPhysicalLocationOrdering_Strategy {
@@ -10009,7 +10167,7 @@ type OperationRunPhasePolicy struct {
 
 func (x *OperationRunPhasePolicy) Reset() {
 	*x = OperationRunPhasePolicy{}
-	mi := &file_flow_proto_msgTypes[145]
+	mi := &file_flow_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10021,7 +10179,7 @@ func (x *OperationRunPhasePolicy) String() string {
 func (*OperationRunPhasePolicy) ProtoMessage() {}
 
 func (x *OperationRunPhasePolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[145]
+	mi := &file_flow_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10034,7 +10192,7 @@ func (x *OperationRunPhasePolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunPhasePolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunPhasePolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{145}
+	return file_flow_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *OperationRunPhasePolicy) GetPlan() isOperationRunPhasePolicy_Plan {
@@ -10110,7 +10268,7 @@ type EqualOperationRunPhases struct {
 
 func (x *EqualOperationRunPhases) Reset() {
 	*x = EqualOperationRunPhases{}
-	mi := &file_flow_proto_msgTypes[146]
+	mi := &file_flow_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10122,7 +10280,7 @@ func (x *EqualOperationRunPhases) String() string {
 func (*EqualOperationRunPhases) ProtoMessage() {}
 
 func (x *EqualOperationRunPhases) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[146]
+	mi := &file_flow_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10135,7 +10293,7 @@ func (x *EqualOperationRunPhases) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EqualOperationRunPhases.ProtoReflect.Descriptor instead.
 func (*EqualOperationRunPhases) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{146}
+	return file_flow_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *EqualOperationRunPhases) GetPhaseCount() int32 {
@@ -10154,7 +10312,7 @@ type PercentageOperationRunPhases struct {
 
 func (x *PercentageOperationRunPhases) Reset() {
 	*x = PercentageOperationRunPhases{}
-	mi := &file_flow_proto_msgTypes[147]
+	mi := &file_flow_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10166,7 +10324,7 @@ func (x *PercentageOperationRunPhases) String() string {
 func (*PercentageOperationRunPhases) ProtoMessage() {}
 
 func (x *PercentageOperationRunPhases) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[147]
+	mi := &file_flow_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10179,7 +10337,7 @@ func (x *PercentageOperationRunPhases) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PercentageOperationRunPhases.ProtoReflect.Descriptor instead.
 func (*PercentageOperationRunPhases) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{147}
+	return file_flow_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *PercentageOperationRunPhases) GetPhases() []*OperationRunPercentagePhase {
@@ -10199,7 +10357,7 @@ type OperationRunPercentagePhase struct {
 
 func (x *OperationRunPercentagePhase) Reset() {
 	*x = OperationRunPercentagePhase{}
-	mi := &file_flow_proto_msgTypes[148]
+	mi := &file_flow_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10211,7 +10369,7 @@ func (x *OperationRunPercentagePhase) String() string {
 func (*OperationRunPercentagePhase) ProtoMessage() {}
 
 func (x *OperationRunPercentagePhase) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[148]
+	mi := &file_flow_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10224,7 +10382,7 @@ func (x *OperationRunPercentagePhase) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunPercentagePhase.ProtoReflect.Descriptor instead.
 func (*OperationRunPercentagePhase) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{148}
+	return file_flow_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *OperationRunPercentagePhase) GetPercentage() int32 {
@@ -10246,7 +10404,7 @@ type CountOperationRunPhases struct {
 
 func (x *CountOperationRunPhases) Reset() {
 	*x = CountOperationRunPhases{}
-	mi := &file_flow_proto_msgTypes[149]
+	mi := &file_flow_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10258,7 +10416,7 @@ func (x *CountOperationRunPhases) String() string {
 func (*CountOperationRunPhases) ProtoMessage() {}
 
 func (x *CountOperationRunPhases) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[149]
+	mi := &file_flow_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10271,7 +10429,7 @@ func (x *CountOperationRunPhases) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountOperationRunPhases.ProtoReflect.Descriptor instead.
 func (*CountOperationRunPhases) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{149}
+	return file_flow_proto_rawDescGZIP(), []int{151}
 }
 
 func (x *CountOperationRunPhases) GetPhases() []*OperationRunCountPhase {
@@ -10291,7 +10449,7 @@ type OperationRunCountPhase struct {
 
 func (x *OperationRunCountPhase) Reset() {
 	*x = OperationRunCountPhase{}
-	mi := &file_flow_proto_msgTypes[150]
+	mi := &file_flow_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10303,7 +10461,7 @@ func (x *OperationRunCountPhase) String() string {
 func (*OperationRunCountPhase) ProtoMessage() {}
 
 func (x *OperationRunCountPhase) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[150]
+	mi := &file_flow_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10316,7 +10474,7 @@ func (x *OperationRunCountPhase) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunCountPhase.ProtoReflect.Descriptor instead.
 func (*OperationRunCountPhase) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{150}
+	return file_flow_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *OperationRunCountPhase) GetCount() int32 {
@@ -10338,7 +10496,7 @@ type OperationRunPhaseAdvancePolicy struct {
 
 func (x *OperationRunPhaseAdvancePolicy) Reset() {
 	*x = OperationRunPhaseAdvancePolicy{}
-	mi := &file_flow_proto_msgTypes[151]
+	mi := &file_flow_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10350,7 +10508,7 @@ func (x *OperationRunPhaseAdvancePolicy) String() string {
 func (*OperationRunPhaseAdvancePolicy) ProtoMessage() {}
 
 func (x *OperationRunPhaseAdvancePolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[151]
+	mi := &file_flow_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10363,7 +10521,7 @@ func (x *OperationRunPhaseAdvancePolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunPhaseAdvancePolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunPhaseAdvancePolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{151}
+	return file_flow_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *OperationRunPhaseAdvancePolicy) GetAutoAdvance() bool {
@@ -10385,7 +10543,7 @@ type OperationRunConflictPolicy struct {
 
 func (x *OperationRunConflictPolicy) Reset() {
 	*x = OperationRunConflictPolicy{}
-	mi := &file_flow_proto_msgTypes[152]
+	mi := &file_flow_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10397,7 +10555,7 @@ func (x *OperationRunConflictPolicy) String() string {
 func (*OperationRunConflictPolicy) ProtoMessage() {}
 
 func (x *OperationRunConflictPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[152]
+	mi := &file_flow_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10410,7 +10568,7 @@ func (x *OperationRunConflictPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunConflictPolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunConflictPolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{152}
+	return file_flow_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *OperationRunConflictPolicy) GetStrategy() isOperationRunConflictPolicy_Strategy {
@@ -10451,7 +10609,7 @@ type OperationRunConflictRetryPolicy struct {
 
 func (x *OperationRunConflictRetryPolicy) Reset() {
 	*x = OperationRunConflictRetryPolicy{}
-	mi := &file_flow_proto_msgTypes[153]
+	mi := &file_flow_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10463,7 +10621,7 @@ func (x *OperationRunConflictRetryPolicy) String() string {
 func (*OperationRunConflictRetryPolicy) ProtoMessage() {}
 
 func (x *OperationRunConflictRetryPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[153]
+	mi := &file_flow_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10476,7 +10634,7 @@ func (x *OperationRunConflictRetryPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunConflictRetryPolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunConflictRetryPolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{153}
+	return file_flow_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *OperationRunConflictRetryPolicy) GetRetryTimeout() *durationpb.Duration {
@@ -10518,7 +10676,7 @@ type OperationRunTargetScope struct {
 
 func (x *OperationRunTargetScope) Reset() {
 	*x = OperationRunTargetScope{}
-	mi := &file_flow_proto_msgTypes[154]
+	mi := &file_flow_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10530,7 +10688,7 @@ func (x *OperationRunTargetScope) String() string {
 func (*OperationRunTargetScope) ProtoMessage() {}
 
 func (x *OperationRunTargetScope) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[154]
+	mi := &file_flow_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10543,7 +10701,7 @@ func (x *OperationRunTargetScope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunTargetScope.ProtoReflect.Descriptor instead.
 func (*OperationRunTargetScope) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{154}
+	return file_flow_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *OperationRunTargetScope) GetExcludeOperationRunIds() []*UUID {
@@ -10575,7 +10733,7 @@ type OperationRunOperation struct {
 
 func (x *OperationRunOperation) Reset() {
 	*x = OperationRunOperation{}
-	mi := &file_flow_proto_msgTypes[155]
+	mi := &file_flow_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10587,7 +10745,7 @@ func (x *OperationRunOperation) String() string {
 func (*OperationRunOperation) ProtoMessage() {}
 
 func (x *OperationRunOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[155]
+	mi := &file_flow_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10600,7 +10758,7 @@ func (x *OperationRunOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunOperation.ProtoReflect.Descriptor instead.
 func (*OperationRunOperation) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{155}
+	return file_flow_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *OperationRunOperation) GetOperation() isOperationRunOperation_Operation {
@@ -10649,7 +10807,7 @@ type OperationRunState struct {
 
 func (x *OperationRunState) Reset() {
 	*x = OperationRunState{}
-	mi := &file_flow_proto_msgTypes[156]
+	mi := &file_flow_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10661,7 +10819,7 @@ func (x *OperationRunState) String() string {
 func (*OperationRunState) ProtoMessage() {}
 
 func (x *OperationRunState) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[156]
+	mi := &file_flow_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10674,7 +10832,7 @@ func (x *OperationRunState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunState.ProtoReflect.Descriptor instead.
 func (*OperationRunState) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{156}
+	return file_flow_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *OperationRunState) GetStatus() OperationRunStatus {
@@ -10701,7 +10859,7 @@ type OperationKind struct {
 
 func (x *OperationKind) Reset() {
 	*x = OperationKind{}
-	mi := &file_flow_proto_msgTypes[157]
+	mi := &file_flow_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10713,7 +10871,7 @@ func (x *OperationKind) String() string {
 func (*OperationKind) ProtoMessage() {}
 
 func (x *OperationKind) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[157]
+	mi := &file_flow_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10726,7 +10884,7 @@ func (x *OperationKind) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationKind.ProtoReflect.Descriptor instead.
 func (*OperationKind) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{157}
+	return file_flow_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *OperationKind) GetType() OperationType {
@@ -10755,7 +10913,7 @@ type OperationRun struct {
 
 func (x *OperationRun) Reset() {
 	*x = OperationRun{}
-	mi := &file_flow_proto_msgTypes[158]
+	mi := &file_flow_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10767,7 +10925,7 @@ func (x *OperationRun) String() string {
 func (*OperationRun) ProtoMessage() {}
 
 func (x *OperationRun) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[158]
+	mi := &file_flow_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10780,7 +10938,7 @@ func (x *OperationRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRun.ProtoReflect.Descriptor instead.
 func (*OperationRun) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{158}
+	return file_flow_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *OperationRun) GetSummary() *OperationRunSummary {
@@ -10826,7 +10984,7 @@ type OperationRunSummary struct {
 
 func (x *OperationRunSummary) Reset() {
 	*x = OperationRunSummary{}
-	mi := &file_flow_proto_msgTypes[159]
+	mi := &file_flow_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10838,7 +10996,7 @@ func (x *OperationRunSummary) String() string {
 func (*OperationRunSummary) ProtoMessage() {}
 
 func (x *OperationRunSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[159]
+	mi := &file_flow_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10851,7 +11009,7 @@ func (x *OperationRunSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunSummary.ProtoReflect.Descriptor instead.
 func (*OperationRunSummary) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{159}
+	return file_flow_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *OperationRunSummary) GetId() *UUID {
@@ -10941,7 +11099,7 @@ type OperationRunStats struct {
 
 func (x *OperationRunStats) Reset() {
 	*x = OperationRunStats{}
-	mi := &file_flow_proto_msgTypes[160]
+	mi := &file_flow_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10953,7 +11111,7 @@ func (x *OperationRunStats) String() string {
 func (*OperationRunStats) ProtoMessage() {}
 
 func (x *OperationRunStats) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[160]
+	mi := &file_flow_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10966,7 +11124,7 @@ func (x *OperationRunStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunStats.ProtoReflect.Descriptor instead.
 func (*OperationRunStats) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{160}
+	return file_flow_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *OperationRunStats) GetCurrentPhaseStats() *OperationRunPhaseStats {
@@ -10996,7 +11154,7 @@ type OperationRunPhaseStats struct {
 
 func (x *OperationRunPhaseStats) Reset() {
 	*x = OperationRunPhaseStats{}
-	mi := &file_flow_proto_msgTypes[161]
+	mi := &file_flow_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11008,7 +11166,7 @@ func (x *OperationRunPhaseStats) String() string {
 func (*OperationRunPhaseStats) ProtoMessage() {}
 
 func (x *OperationRunPhaseStats) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[161]
+	mi := &file_flow_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11021,7 +11179,7 @@ func (x *OperationRunPhaseStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunPhaseStats.ProtoReflect.Descriptor instead.
 func (*OperationRunPhaseStats) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{161}
+	return file_flow_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *OperationRunPhaseStats) GetPhaseIndex() int32 {
@@ -11057,7 +11215,7 @@ type OperationRunTargetOutcomeCounts struct {
 
 func (x *OperationRunTargetOutcomeCounts) Reset() {
 	*x = OperationRunTargetOutcomeCounts{}
-	mi := &file_flow_proto_msgTypes[162]
+	mi := &file_flow_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11069,7 +11227,7 @@ func (x *OperationRunTargetOutcomeCounts) String() string {
 func (*OperationRunTargetOutcomeCounts) ProtoMessage() {}
 
 func (x *OperationRunTargetOutcomeCounts) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[162]
+	mi := &file_flow_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11082,7 +11240,7 @@ func (x *OperationRunTargetOutcomeCounts) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunTargetOutcomeCounts.ProtoReflect.Descriptor instead.
 func (*OperationRunTargetOutcomeCounts) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{162}
+	return file_flow_proto_rawDescGZIP(), []int{164}
 }
 
 func (x *OperationRunTargetOutcomeCounts) GetCompleted() int32 {
@@ -11132,7 +11290,7 @@ type OperationRunTarget struct {
 
 func (x *OperationRunTarget) Reset() {
 	*x = OperationRunTarget{}
-	mi := &file_flow_proto_msgTypes[163]
+	mi := &file_flow_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11144,7 +11302,7 @@ func (x *OperationRunTarget) String() string {
 func (*OperationRunTarget) ProtoMessage() {}
 
 func (x *OperationRunTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[163]
+	mi := &file_flow_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11157,7 +11315,7 @@ func (x *OperationRunTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunTarget.ProtoReflect.Descriptor instead.
 func (*OperationRunTarget) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{163}
+	return file_flow_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *OperationRunTarget) GetId() *UUID {
@@ -11247,7 +11405,7 @@ type NVLDomainTargets struct {
 
 func (x *NVLDomainTargets) Reset() {
 	*x = NVLDomainTargets{}
-	mi := &file_flow_proto_msgTypes[164]
+	mi := &file_flow_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11259,7 +11417,7 @@ func (x *NVLDomainTargets) String() string {
 func (*NVLDomainTargets) ProtoMessage() {}
 
 func (x *NVLDomainTargets) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[164]
+	mi := &file_flow_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11272,7 +11430,7 @@ func (x *NVLDomainTargets) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NVLDomainTargets.ProtoReflect.Descriptor instead.
 func (*NVLDomainTargets) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{164}
+	return file_flow_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *NVLDomainTargets) GetTargets() []*NVLDomainTarget {
@@ -11299,7 +11457,7 @@ type NVLDomainTarget struct {
 
 func (x *NVLDomainTarget) Reset() {
 	*x = NVLDomainTarget{}
-	mi := &file_flow_proto_msgTypes[165]
+	mi := &file_flow_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11311,7 +11469,7 @@ func (x *NVLDomainTarget) String() string {
 func (*NVLDomainTarget) ProtoMessage() {}
 
 func (x *NVLDomainTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[165]
+	mi := &file_flow_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11324,7 +11482,7 @@ func (x *NVLDomainTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NVLDomainTarget.ProtoReflect.Descriptor instead.
 func (*NVLDomainTarget) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{165}
+	return file_flow_proto_rawDescGZIP(), []int{167}
 }
 
 func (x *NVLDomainTarget) GetIdentifier() isNVLDomainTarget_Identifier {
@@ -11597,7 +11755,7 @@ const file_flow_proto_rawDesc = "" +
 	"\x1bGetRacksForNVLDomainRequest\x12B\n" +
 	"\x15nvl_domain_identifier\x18\x01 \x01(\v2\x0e.v1.IdentifierR\x13nvlDomainIdentifier\">\n" +
 	"\x1cGetRacksForNVLDomainResponse\x12\x1e\n" +
-	"\x05racks\x18\x01 \x03(\v2\b.v1.RackR\x05racks\"\xa8\x04\n" +
+	"\x05racks\x18\x01 \x03(\v2\b.v1.RackR\x05racks\"\xf9\x04\n" +
 	"\x16UpgradeFirmwareRequest\x128\n" +
 	"\vtarget_spec\x18\x01 \x01(\v2\x17.v1.OperationTargetSpecR\n" +
 	"targetSpec\x12*\n" +
@@ -11610,13 +11768,29 @@ const file_flow_proto_rawDesc = "" +
 	"\arule_id\x18\a \x01(\v2\b.v1.UUIDH\x04R\x06ruleId\x88\x01\x01\x12\x1f\n" +
 	"\vsub_targets\x18\b \x03(\tR\n" +
 	"subTargets\x128\n" +
-	"\x18override_readiness_check\x18\t \x01(\bR\x16overrideReadinessCheckB\x11\n" +
+	"\x18override_readiness_check\x18\t \x01(\bR\x16overrideReadinessCheck\x12O\n" +
+	"\x13authentication_data\x18\n" +
+	" \x01(\v2\x1e.v1.FirmwareAuthenticationDataR\x12authenticationDataB\x11\n" +
 	"\x0f_target_versionB\r\n" +
 	"\v_start_timeB\v\n" +
 	"\t_end_timeB\x10\n" +
 	"\x0e_queue_optionsB\n" +
 	"\n" +
-	"\b_rule_id\"\x89\x02\n" +
+	"\b_rule_id\"\x92\x01\n" +
+	"\x1aFirmwareAuthenticationData\x12\x18\n" +
+	"\x06shared\x18\x01 \x01(\tH\x00R\x06shared\x12Q\n" +
+	"\rper_component\x18\x02 \x01(\v2*.v1.PerComponentFirmwareAuthenticationDataH\x00R\fperComponentB\a\n" +
+	"\x05value\"\xb5\x01\n" +
+	"&PerComponentFirmwareAuthenticationData\x12\x1d\n" +
+	"\acompute\x18\x01 \x01(\tH\x00R\acompute\x88\x01\x01\x12\x1f\n" +
+	"\bnvswitch\x18\x02 \x01(\tH\x01R\bnvswitch\x88\x01\x01\x12#\n" +
+	"\n" +
+	"powershelf\x18\x03 \x01(\tH\x02R\n" +
+	"powershelf\x88\x01\x01B\n" +
+	"\n" +
+	"\b_computeB\v\n" +
+	"\t_nvswitchB\r\n" +
+	"\v_powershelf\"\x89\x02\n" +
 	"\x14GetComponentsRequest\x12=\n" +
 	"\vtarget_spec\x18\x01 \x01(\v2\x17.v1.OperationTargetSpecH\x00R\n" +
 	"targetSpec\x88\x01\x01\x12$\n" +
@@ -12388,7 +12562,7 @@ func file_flow_proto_rawDescGZIP() []byte {
 }
 
 var file_flow_proto_enumTypes = make([]protoimpl.EnumInfo, 22)
-var file_flow_proto_msgTypes = make([]protoimpl.MessageInfo, 166)
+var file_flow_proto_msgTypes = make([]protoimpl.MessageInfo, 168)
 var file_flow_proto_goTypes = []any{
 	(BMCType)(0),                      // 0: v1.BMCType
 	(ComponentType)(0),                // 1: v1.ComponentType
@@ -12412,176 +12586,178 @@ var file_flow_proto_goTypes = []any{
 	(OperationRunStatusReason)(0),     // 19: v1.OperationRunStatusReason
 	(OperationRunTargetStatus)(0),     // 20: v1.OperationRunTargetStatus
 	(OperationRunPhysicalLocationOrdering_Strategy)(0), // 21: v1.OperationRunPhysicalLocationOrdering.Strategy
-	(*UUID)(nil),                                 // 22: v1.UUID
-	(*DeviceInfo)(nil),                           // 23: v1.DeviceInfo
-	(*Location)(nil),                             // 24: v1.Location
-	(*DeviceSerialInfo)(nil),                     // 25: v1.DeviceSerialInfo
-	(*BMCInfo)(nil),                              // 26: v1.BMCInfo
-	(*RackPosition)(nil),                         // 27: v1.RackPosition
-	(*ComponentOperationStatus)(nil),             // 28: v1.ComponentOperationStatus
-	(*Component)(nil),                            // 29: v1.Component
-	(*Rack)(nil),                                 // 30: v1.Rack
-	(*Identifier)(nil),                           // 31: v1.Identifier
-	(*OperationTargetSpec)(nil),                  // 32: v1.OperationTargetSpec
-	(*RackTargets)(nil),                          // 33: v1.RackTargets
-	(*ComponentTargets)(nil),                     // 34: v1.ComponentTargets
-	(*ComponentTypes)(nil),                       // 35: v1.ComponentTypes
-	(*ComponentFilter)(nil),                      // 36: v1.ComponentFilter
-	(*ComponentsByType)(nil),                     // 37: v1.ComponentsByType
-	(*ComponentsForType)(nil),                    // 38: v1.ComponentsForType
-	(*RackTarget)(nil),                           // 39: v1.RackTarget
-	(*ComponentTarget)(nil),                      // 40: v1.ComponentTarget
-	(*ExternalRef)(nil),                          // 41: v1.ExternalRef
-	(*NVLDomain)(nil),                            // 42: v1.NVLDomain
-	(*Pagination)(nil),                           // 43: v1.Pagination
-	(*StringQueryInfo)(nil),                      // 44: v1.StringQueryInfo
-	(*Filter)(nil),                               // 45: v1.Filter
-	(*OrderBy)(nil),                              // 46: v1.OrderBy
-	(*Task)(nil),                                 // 47: v1.Task
-	(*CreateExpectedRackRequest)(nil),            // 48: v1.CreateExpectedRackRequest
-	(*CreateExpectedRackResponse)(nil),           // 49: v1.CreateExpectedRackResponse
-	(*GetRackInfoByIDRequest)(nil),               // 50: v1.GetRackInfoByIDRequest
-	(*GetRackInfoBySerialRequest)(nil),           // 51: v1.GetRackInfoBySerialRequest
-	(*GetRackInfoResponse)(nil),                  // 52: v1.GetRackInfoResponse
-	(*PatchRackRequest)(nil),                     // 53: v1.PatchRackRequest
-	(*PatchRackResponse)(nil),                    // 54: v1.PatchRackResponse
-	(*GetComponentInfoByIDRequest)(nil),          // 55: v1.GetComponentInfoByIDRequest
-	(*GetComponentInfoBySerialRequest)(nil),      // 56: v1.GetComponentInfoBySerialRequest
-	(*GetComponentInfoResponse)(nil),             // 57: v1.GetComponentInfoResponse
-	(*GetListOfRacksRequest)(nil),                // 58: v1.GetListOfRacksRequest
-	(*GetListOfRacksResponse)(nil),               // 59: v1.GetListOfRacksResponse
-	(*CreateNVLDomainRequest)(nil),               // 60: v1.CreateNVLDomainRequest
-	(*CreateNVLDomainResponse)(nil),              // 61: v1.CreateNVLDomainResponse
-	(*AttachRacksToNVLDomainRequest)(nil),        // 62: v1.AttachRacksToNVLDomainRequest
-	(*DetachRacksFromNVLDomainRequest)(nil),      // 63: v1.DetachRacksFromNVLDomainRequest
-	(*GetListOfNVLDomainsRequest)(nil),           // 64: v1.GetListOfNVLDomainsRequest
-	(*GetListOfNVLDomainsResponse)(nil),          // 65: v1.GetListOfNVLDomainsResponse
-	(*GetRacksForNVLDomainRequest)(nil),          // 66: v1.GetRacksForNVLDomainRequest
-	(*GetRacksForNVLDomainResponse)(nil),         // 67: v1.GetRacksForNVLDomainResponse
-	(*UpgradeFirmwareRequest)(nil),               // 68: v1.UpgradeFirmwareRequest
-	(*GetComponentsRequest)(nil),                 // 69: v1.GetComponentsRequest
-	(*GetComponentsResponse)(nil),                // 70: v1.GetComponentsResponse
-	(*ValidateComponentsRequest)(nil),            // 71: v1.ValidateComponentsRequest
-	(*ValidateComponentsResponse)(nil),           // 72: v1.ValidateComponentsResponse
-	(*ComponentDiff)(nil),                        // 73: v1.ComponentDiff
-	(*FieldDiff)(nil),                            // 74: v1.FieldDiff
-	(*AddComponentRequest)(nil),                  // 75: v1.AddComponentRequest
-	(*AddComponentResponse)(nil),                 // 76: v1.AddComponentResponse
-	(*DeleteComponentRequest)(nil),               // 77: v1.DeleteComponentRequest
-	(*DeleteComponentResponse)(nil),              // 78: v1.DeleteComponentResponse
-	(*DeleteRackRequest)(nil),                    // 79: v1.DeleteRackRequest
-	(*DeleteRackResponse)(nil),                   // 80: v1.DeleteRackResponse
-	(*PurgeRackRequest)(nil),                     // 81: v1.PurgeRackRequest
-	(*PurgeRackResponse)(nil),                    // 82: v1.PurgeRackResponse
-	(*PurgeComponentRequest)(nil),                // 83: v1.PurgeComponentRequest
-	(*PurgeComponentResponse)(nil),               // 84: v1.PurgeComponentResponse
-	(*PatchComponentRequest)(nil),                // 85: v1.PatchComponentRequest
-	(*PatchComponentResponse)(nil),               // 86: v1.PatchComponentResponse
-	(*SubmitTaskResponse)(nil),                   // 87: v1.SubmitTaskResponse
-	(*QueueOptions)(nil),                         // 88: v1.QueueOptions
-	(*PowerOnRackRequest)(nil),                   // 89: v1.PowerOnRackRequest
-	(*PowerOffRackRequest)(nil),                  // 90: v1.PowerOffRackRequest
-	(*PowerResetRackRequest)(nil),                // 91: v1.PowerResetRackRequest
-	(*BringUpRackRequest)(nil),                   // 92: v1.BringUpRackRequest
-	(*IngestRackRequest)(nil),                    // 93: v1.IngestRackRequest
-	(*DecommissionRackRequest)(nil),              // 94: v1.DecommissionRackRequest
-	(*ListTasksRequest)(nil),                     // 95: v1.ListTasksRequest
-	(*ListTasksResponse)(nil),                    // 96: v1.ListTasksResponse
-	(*GetTasksByIDsRequest)(nil),                 // 97: v1.GetTasksByIDsRequest
-	(*GetTasksByIDsResponse)(nil),                // 98: v1.GetTasksByIDsResponse
-	(*CancelTaskRequest)(nil),                    // 99: v1.CancelTaskRequest
-	(*CancelTaskResponse)(nil),                   // 100: v1.CancelTaskResponse
-	(*VersionRequest)(nil),                       // 101: v1.VersionRequest
-	(*BuildInfo)(nil),                            // 102: v1.BuildInfo
-	(*OperationRule)(nil),                        // 103: v1.OperationRule
-	(*CreateOperationRuleRequest)(nil),           // 104: v1.CreateOperationRuleRequest
-	(*CreateOperationRuleResponse)(nil),          // 105: v1.CreateOperationRuleResponse
-	(*UpdateOperationRuleRequest)(nil),           // 106: v1.UpdateOperationRuleRequest
-	(*DeleteOperationRuleRequest)(nil),           // 107: v1.DeleteOperationRuleRequest
-	(*SetRuleAsDefaultRequest)(nil),              // 108: v1.SetRuleAsDefaultRequest
-	(*GetOperationRuleRequest)(nil),              // 109: v1.GetOperationRuleRequest
-	(*ListOperationRulesRequest)(nil),            // 110: v1.ListOperationRulesRequest
-	(*ListOperationRulesResponse)(nil),           // 111: v1.ListOperationRulesResponse
-	(*AssociateRuleWithRackRequest)(nil),         // 112: v1.AssociateRuleWithRackRequest
-	(*DisassociateRuleFromRackRequest)(nil),      // 113: v1.DisassociateRuleFromRackRequest
-	(*GetRackRuleAssociationRequest)(nil),        // 114: v1.GetRackRuleAssociationRequest
-	(*GetRackRuleAssociationResponse)(nil),       // 115: v1.GetRackRuleAssociationResponse
-	(*ListRackRuleAssociationsRequest)(nil),      // 116: v1.ListRackRuleAssociationsRequest
-	(*RackRuleAssociation)(nil),                  // 117: v1.RackRuleAssociation
-	(*ListRackRuleAssociationsResponse)(nil),     // 118: v1.ListRackRuleAssociationsResponse
-	(*ScheduleSpec)(nil),                         // 119: v1.ScheduleSpec
-	(*ScheduleConfig)(nil),                       // 120: v1.ScheduleConfig
-	(*TaskSchedule)(nil),                         // 121: v1.TaskSchedule
-	(*ScheduledOperation)(nil),                   // 122: v1.ScheduledOperation
-	(*CreateTaskScheduleRequest)(nil),            // 123: v1.CreateTaskScheduleRequest
-	(*GetTaskScheduleRequest)(nil),               // 124: v1.GetTaskScheduleRequest
-	(*ListTaskSchedulesRequest)(nil),             // 125: v1.ListTaskSchedulesRequest
-	(*ListTaskSchedulesResponse)(nil),            // 126: v1.ListTaskSchedulesResponse
-	(*UpdateTaskScheduleRequest)(nil),            // 127: v1.UpdateTaskScheduleRequest
-	(*PauseTaskScheduleRequest)(nil),             // 128: v1.PauseTaskScheduleRequest
-	(*ResumeTaskScheduleRequest)(nil),            // 129: v1.ResumeTaskScheduleRequest
-	(*DeleteTaskScheduleRequest)(nil),            // 130: v1.DeleteTaskScheduleRequest
-	(*TriggerTaskScheduleRequest)(nil),           // 131: v1.TriggerTaskScheduleRequest
-	(*TaskScheduleScope)(nil),                    // 132: v1.TaskScheduleScope
-	(*AddTaskScheduleScopeRequest)(nil),          // 133: v1.AddTaskScheduleScopeRequest
-	(*AddTaskScheduleScopeResponse)(nil),         // 134: v1.AddTaskScheduleScopeResponse
-	(*RemoveTaskScheduleScopeRequest)(nil),       // 135: v1.RemoveTaskScheduleScopeRequest
-	(*UpdateTaskScheduleScopeRequest)(nil),       // 136: v1.UpdateTaskScheduleScopeRequest
-	(*UpdateTaskScheduleScopeResponse)(nil),      // 137: v1.UpdateTaskScheduleScopeResponse
-	(*ListTaskScheduleScopesRequest)(nil),        // 138: v1.ListTaskScheduleScopesRequest
-	(*ListTaskScheduleScopesResponse)(nil),       // 139: v1.ListTaskScheduleScopesResponse
-	(*CheckScheduleConflictsRequest)(nil),        // 140: v1.CheckScheduleConflictsRequest
-	(*CheckScheduleConflictsResponse)(nil),       // 141: v1.CheckScheduleConflictsResponse
-	(*CreateOperationRunRequest)(nil),            // 142: v1.CreateOperationRunRequest
-	(*CreateOperationRunResponse)(nil),           // 143: v1.CreateOperationRunResponse
-	(*OperationRunConfiguration)(nil),            // 144: v1.OperationRunConfiguration
-	(*GetOperationRunRequest)(nil),               // 145: v1.GetOperationRunRequest
-	(*GetOperationRunResponse)(nil),              // 146: v1.GetOperationRunResponse
-	(*ListOperationRunsRequest)(nil),             // 147: v1.ListOperationRunsRequest
-	(*ListOperationRunsResponse)(nil),            // 148: v1.ListOperationRunsResponse
-	(*OperationRunFilter)(nil),                   // 149: v1.OperationRunFilter
-	(*OperationRunStateFilter)(nil),              // 150: v1.OperationRunStateFilter
-	(*ListOperationRunTargetsRequest)(nil),       // 151: v1.ListOperationRunTargetsRequest
-	(*ListOperationRunTargetsResponse)(nil),      // 152: v1.ListOperationRunTargetsResponse
-	(*PauseOperationRunRequest)(nil),             // 153: v1.PauseOperationRunRequest
-	(*ResumeOperationRunRequest)(nil),            // 154: v1.ResumeOperationRunRequest
-	(*AdvanceOperationRunPhaseRequest)(nil),      // 155: v1.AdvanceOperationRunPhaseRequest
-	(*CancelOperationRunRequest)(nil),            // 156: v1.CancelOperationRunRequest
-	(*OperationRunSelector)(nil),                 // 157: v1.OperationRunSelector
-	(*PercentageSelector)(nil),                   // 158: v1.PercentageSelector
-	(*OperationRunOptions)(nil),                  // 159: v1.OperationRunOptions
-	(*OperationRunSafetyPolicy)(nil),             // 160: v1.OperationRunSafetyPolicy
-	(*OperationRunSafetyGate)(nil),               // 161: v1.OperationRunSafetyGate
-	(*OperationRunFailureRateGate)(nil),          // 162: v1.OperationRunFailureRateGate
-	(*OperationRunFailureCountGate)(nil),         // 163: v1.OperationRunFailureCountGate
-	(*OperationRunOrderingPolicy)(nil),           // 164: v1.OperationRunOrderingPolicy
-	(*OperationRunRandomOrdering)(nil),           // 165: v1.OperationRunRandomOrdering
-	(*OperationRunPhysicalLocationOrdering)(nil), // 166: v1.OperationRunPhysicalLocationOrdering
-	(*OperationRunPhasePolicy)(nil),              // 167: v1.OperationRunPhasePolicy
-	(*EqualOperationRunPhases)(nil),              // 168: v1.EqualOperationRunPhases
-	(*PercentageOperationRunPhases)(nil),         // 169: v1.PercentageOperationRunPhases
-	(*OperationRunPercentagePhase)(nil),          // 170: v1.OperationRunPercentagePhase
-	(*CountOperationRunPhases)(nil),              // 171: v1.CountOperationRunPhases
-	(*OperationRunCountPhase)(nil),               // 172: v1.OperationRunCountPhase
-	(*OperationRunPhaseAdvancePolicy)(nil),       // 173: v1.OperationRunPhaseAdvancePolicy
-	(*OperationRunConflictPolicy)(nil),           // 174: v1.OperationRunConflictPolicy
-	(*OperationRunConflictRetryPolicy)(nil),      // 175: v1.OperationRunConflictRetryPolicy
-	(*OperationRunTargetScope)(nil),              // 176: v1.OperationRunTargetScope
-	(*OperationRunOperation)(nil),                // 177: v1.OperationRunOperation
-	(*OperationRunState)(nil),                    // 178: v1.OperationRunState
-	(*OperationKind)(nil),                        // 179: v1.OperationKind
-	(*OperationRun)(nil),                         // 180: v1.OperationRun
-	(*OperationRunSummary)(nil),                  // 181: v1.OperationRunSummary
-	(*OperationRunStats)(nil),                    // 182: v1.OperationRunStats
-	(*OperationRunPhaseStats)(nil),               // 183: v1.OperationRunPhaseStats
-	(*OperationRunTargetOutcomeCounts)(nil),      // 184: v1.OperationRunTargetOutcomeCounts
-	(*OperationRunTarget)(nil),                   // 185: v1.OperationRunTarget
-	(*NVLDomainTargets)(nil),                     // 186: v1.NVLDomainTargets
-	(*NVLDomainTarget)(nil),                      // 187: v1.NVLDomainTarget
-	(*timestamppb.Timestamp)(nil),                // 188: google.protobuf.Timestamp
-	(*fieldmaskpb.FieldMask)(nil),                // 189: google.protobuf.FieldMask
-	(*durationpb.Duration)(nil),                  // 190: google.protobuf.Duration
-	(*emptypb.Empty)(nil),                        // 191: google.protobuf.Empty
+	(*UUID)(nil),                                   // 22: v1.UUID
+	(*DeviceInfo)(nil),                             // 23: v1.DeviceInfo
+	(*Location)(nil),                               // 24: v1.Location
+	(*DeviceSerialInfo)(nil),                       // 25: v1.DeviceSerialInfo
+	(*BMCInfo)(nil),                                // 26: v1.BMCInfo
+	(*RackPosition)(nil),                           // 27: v1.RackPosition
+	(*ComponentOperationStatus)(nil),               // 28: v1.ComponentOperationStatus
+	(*Component)(nil),                              // 29: v1.Component
+	(*Rack)(nil),                                   // 30: v1.Rack
+	(*Identifier)(nil),                             // 31: v1.Identifier
+	(*OperationTargetSpec)(nil),                    // 32: v1.OperationTargetSpec
+	(*RackTargets)(nil),                            // 33: v1.RackTargets
+	(*ComponentTargets)(nil),                       // 34: v1.ComponentTargets
+	(*ComponentTypes)(nil),                         // 35: v1.ComponentTypes
+	(*ComponentFilter)(nil),                        // 36: v1.ComponentFilter
+	(*ComponentsByType)(nil),                       // 37: v1.ComponentsByType
+	(*ComponentsForType)(nil),                      // 38: v1.ComponentsForType
+	(*RackTarget)(nil),                             // 39: v1.RackTarget
+	(*ComponentTarget)(nil),                        // 40: v1.ComponentTarget
+	(*ExternalRef)(nil),                            // 41: v1.ExternalRef
+	(*NVLDomain)(nil),                              // 42: v1.NVLDomain
+	(*Pagination)(nil),                             // 43: v1.Pagination
+	(*StringQueryInfo)(nil),                        // 44: v1.StringQueryInfo
+	(*Filter)(nil),                                 // 45: v1.Filter
+	(*OrderBy)(nil),                                // 46: v1.OrderBy
+	(*Task)(nil),                                   // 47: v1.Task
+	(*CreateExpectedRackRequest)(nil),              // 48: v1.CreateExpectedRackRequest
+	(*CreateExpectedRackResponse)(nil),             // 49: v1.CreateExpectedRackResponse
+	(*GetRackInfoByIDRequest)(nil),                 // 50: v1.GetRackInfoByIDRequest
+	(*GetRackInfoBySerialRequest)(nil),             // 51: v1.GetRackInfoBySerialRequest
+	(*GetRackInfoResponse)(nil),                    // 52: v1.GetRackInfoResponse
+	(*PatchRackRequest)(nil),                       // 53: v1.PatchRackRequest
+	(*PatchRackResponse)(nil),                      // 54: v1.PatchRackResponse
+	(*GetComponentInfoByIDRequest)(nil),            // 55: v1.GetComponentInfoByIDRequest
+	(*GetComponentInfoBySerialRequest)(nil),        // 56: v1.GetComponentInfoBySerialRequest
+	(*GetComponentInfoResponse)(nil),               // 57: v1.GetComponentInfoResponse
+	(*GetListOfRacksRequest)(nil),                  // 58: v1.GetListOfRacksRequest
+	(*GetListOfRacksResponse)(nil),                 // 59: v1.GetListOfRacksResponse
+	(*CreateNVLDomainRequest)(nil),                 // 60: v1.CreateNVLDomainRequest
+	(*CreateNVLDomainResponse)(nil),                // 61: v1.CreateNVLDomainResponse
+	(*AttachRacksToNVLDomainRequest)(nil),          // 62: v1.AttachRacksToNVLDomainRequest
+	(*DetachRacksFromNVLDomainRequest)(nil),        // 63: v1.DetachRacksFromNVLDomainRequest
+	(*GetListOfNVLDomainsRequest)(nil),             // 64: v1.GetListOfNVLDomainsRequest
+	(*GetListOfNVLDomainsResponse)(nil),            // 65: v1.GetListOfNVLDomainsResponse
+	(*GetRacksForNVLDomainRequest)(nil),            // 66: v1.GetRacksForNVLDomainRequest
+	(*GetRacksForNVLDomainResponse)(nil),           // 67: v1.GetRacksForNVLDomainResponse
+	(*UpgradeFirmwareRequest)(nil),                 // 68: v1.UpgradeFirmwareRequest
+	(*FirmwareAuthenticationData)(nil),             // 69: v1.FirmwareAuthenticationData
+	(*PerComponentFirmwareAuthenticationData)(nil), // 70: v1.PerComponentFirmwareAuthenticationData
+	(*GetComponentsRequest)(nil),                   // 71: v1.GetComponentsRequest
+	(*GetComponentsResponse)(nil),                  // 72: v1.GetComponentsResponse
+	(*ValidateComponentsRequest)(nil),              // 73: v1.ValidateComponentsRequest
+	(*ValidateComponentsResponse)(nil),             // 74: v1.ValidateComponentsResponse
+	(*ComponentDiff)(nil),                          // 75: v1.ComponentDiff
+	(*FieldDiff)(nil),                              // 76: v1.FieldDiff
+	(*AddComponentRequest)(nil),                    // 77: v1.AddComponentRequest
+	(*AddComponentResponse)(nil),                   // 78: v1.AddComponentResponse
+	(*DeleteComponentRequest)(nil),                 // 79: v1.DeleteComponentRequest
+	(*DeleteComponentResponse)(nil),                // 80: v1.DeleteComponentResponse
+	(*DeleteRackRequest)(nil),                      // 81: v1.DeleteRackRequest
+	(*DeleteRackResponse)(nil),                     // 82: v1.DeleteRackResponse
+	(*PurgeRackRequest)(nil),                       // 83: v1.PurgeRackRequest
+	(*PurgeRackResponse)(nil),                      // 84: v1.PurgeRackResponse
+	(*PurgeComponentRequest)(nil),                  // 85: v1.PurgeComponentRequest
+	(*PurgeComponentResponse)(nil),                 // 86: v1.PurgeComponentResponse
+	(*PatchComponentRequest)(nil),                  // 87: v1.PatchComponentRequest
+	(*PatchComponentResponse)(nil),                 // 88: v1.PatchComponentResponse
+	(*SubmitTaskResponse)(nil),                     // 89: v1.SubmitTaskResponse
+	(*QueueOptions)(nil),                           // 90: v1.QueueOptions
+	(*PowerOnRackRequest)(nil),                     // 91: v1.PowerOnRackRequest
+	(*PowerOffRackRequest)(nil),                    // 92: v1.PowerOffRackRequest
+	(*PowerResetRackRequest)(nil),                  // 93: v1.PowerResetRackRequest
+	(*BringUpRackRequest)(nil),                     // 94: v1.BringUpRackRequest
+	(*IngestRackRequest)(nil),                      // 95: v1.IngestRackRequest
+	(*DecommissionRackRequest)(nil),                // 96: v1.DecommissionRackRequest
+	(*ListTasksRequest)(nil),                       // 97: v1.ListTasksRequest
+	(*ListTasksResponse)(nil),                      // 98: v1.ListTasksResponse
+	(*GetTasksByIDsRequest)(nil),                   // 99: v1.GetTasksByIDsRequest
+	(*GetTasksByIDsResponse)(nil),                  // 100: v1.GetTasksByIDsResponse
+	(*CancelTaskRequest)(nil),                      // 101: v1.CancelTaskRequest
+	(*CancelTaskResponse)(nil),                     // 102: v1.CancelTaskResponse
+	(*VersionRequest)(nil),                         // 103: v1.VersionRequest
+	(*BuildInfo)(nil),                              // 104: v1.BuildInfo
+	(*OperationRule)(nil),                          // 105: v1.OperationRule
+	(*CreateOperationRuleRequest)(nil),             // 106: v1.CreateOperationRuleRequest
+	(*CreateOperationRuleResponse)(nil),            // 107: v1.CreateOperationRuleResponse
+	(*UpdateOperationRuleRequest)(nil),             // 108: v1.UpdateOperationRuleRequest
+	(*DeleteOperationRuleRequest)(nil),             // 109: v1.DeleteOperationRuleRequest
+	(*SetRuleAsDefaultRequest)(nil),                // 110: v1.SetRuleAsDefaultRequest
+	(*GetOperationRuleRequest)(nil),                // 111: v1.GetOperationRuleRequest
+	(*ListOperationRulesRequest)(nil),              // 112: v1.ListOperationRulesRequest
+	(*ListOperationRulesResponse)(nil),             // 113: v1.ListOperationRulesResponse
+	(*AssociateRuleWithRackRequest)(nil),           // 114: v1.AssociateRuleWithRackRequest
+	(*DisassociateRuleFromRackRequest)(nil),        // 115: v1.DisassociateRuleFromRackRequest
+	(*GetRackRuleAssociationRequest)(nil),          // 116: v1.GetRackRuleAssociationRequest
+	(*GetRackRuleAssociationResponse)(nil),         // 117: v1.GetRackRuleAssociationResponse
+	(*ListRackRuleAssociationsRequest)(nil),        // 118: v1.ListRackRuleAssociationsRequest
+	(*RackRuleAssociation)(nil),                    // 119: v1.RackRuleAssociation
+	(*ListRackRuleAssociationsResponse)(nil),       // 120: v1.ListRackRuleAssociationsResponse
+	(*ScheduleSpec)(nil),                           // 121: v1.ScheduleSpec
+	(*ScheduleConfig)(nil),                         // 122: v1.ScheduleConfig
+	(*TaskSchedule)(nil),                           // 123: v1.TaskSchedule
+	(*ScheduledOperation)(nil),                     // 124: v1.ScheduledOperation
+	(*CreateTaskScheduleRequest)(nil),              // 125: v1.CreateTaskScheduleRequest
+	(*GetTaskScheduleRequest)(nil),                 // 126: v1.GetTaskScheduleRequest
+	(*ListTaskSchedulesRequest)(nil),               // 127: v1.ListTaskSchedulesRequest
+	(*ListTaskSchedulesResponse)(nil),              // 128: v1.ListTaskSchedulesResponse
+	(*UpdateTaskScheduleRequest)(nil),              // 129: v1.UpdateTaskScheduleRequest
+	(*PauseTaskScheduleRequest)(nil),               // 130: v1.PauseTaskScheduleRequest
+	(*ResumeTaskScheduleRequest)(nil),              // 131: v1.ResumeTaskScheduleRequest
+	(*DeleteTaskScheduleRequest)(nil),              // 132: v1.DeleteTaskScheduleRequest
+	(*TriggerTaskScheduleRequest)(nil),             // 133: v1.TriggerTaskScheduleRequest
+	(*TaskScheduleScope)(nil),                      // 134: v1.TaskScheduleScope
+	(*AddTaskScheduleScopeRequest)(nil),            // 135: v1.AddTaskScheduleScopeRequest
+	(*AddTaskScheduleScopeResponse)(nil),           // 136: v1.AddTaskScheduleScopeResponse
+	(*RemoveTaskScheduleScopeRequest)(nil),         // 137: v1.RemoveTaskScheduleScopeRequest
+	(*UpdateTaskScheduleScopeRequest)(nil),         // 138: v1.UpdateTaskScheduleScopeRequest
+	(*UpdateTaskScheduleScopeResponse)(nil),        // 139: v1.UpdateTaskScheduleScopeResponse
+	(*ListTaskScheduleScopesRequest)(nil),          // 140: v1.ListTaskScheduleScopesRequest
+	(*ListTaskScheduleScopesResponse)(nil),         // 141: v1.ListTaskScheduleScopesResponse
+	(*CheckScheduleConflictsRequest)(nil),          // 142: v1.CheckScheduleConflictsRequest
+	(*CheckScheduleConflictsResponse)(nil),         // 143: v1.CheckScheduleConflictsResponse
+	(*CreateOperationRunRequest)(nil),              // 144: v1.CreateOperationRunRequest
+	(*CreateOperationRunResponse)(nil),             // 145: v1.CreateOperationRunResponse
+	(*OperationRunConfiguration)(nil),              // 146: v1.OperationRunConfiguration
+	(*GetOperationRunRequest)(nil),                 // 147: v1.GetOperationRunRequest
+	(*GetOperationRunResponse)(nil),                // 148: v1.GetOperationRunResponse
+	(*ListOperationRunsRequest)(nil),               // 149: v1.ListOperationRunsRequest
+	(*ListOperationRunsResponse)(nil),              // 150: v1.ListOperationRunsResponse
+	(*OperationRunFilter)(nil),                     // 151: v1.OperationRunFilter
+	(*OperationRunStateFilter)(nil),                // 152: v1.OperationRunStateFilter
+	(*ListOperationRunTargetsRequest)(nil),         // 153: v1.ListOperationRunTargetsRequest
+	(*ListOperationRunTargetsResponse)(nil),        // 154: v1.ListOperationRunTargetsResponse
+	(*PauseOperationRunRequest)(nil),               // 155: v1.PauseOperationRunRequest
+	(*ResumeOperationRunRequest)(nil),              // 156: v1.ResumeOperationRunRequest
+	(*AdvanceOperationRunPhaseRequest)(nil),        // 157: v1.AdvanceOperationRunPhaseRequest
+	(*CancelOperationRunRequest)(nil),              // 158: v1.CancelOperationRunRequest
+	(*OperationRunSelector)(nil),                   // 159: v1.OperationRunSelector
+	(*PercentageSelector)(nil),                     // 160: v1.PercentageSelector
+	(*OperationRunOptions)(nil),                    // 161: v1.OperationRunOptions
+	(*OperationRunSafetyPolicy)(nil),               // 162: v1.OperationRunSafetyPolicy
+	(*OperationRunSafetyGate)(nil),                 // 163: v1.OperationRunSafetyGate
+	(*OperationRunFailureRateGate)(nil),            // 164: v1.OperationRunFailureRateGate
+	(*OperationRunFailureCountGate)(nil),           // 165: v1.OperationRunFailureCountGate
+	(*OperationRunOrderingPolicy)(nil),             // 166: v1.OperationRunOrderingPolicy
+	(*OperationRunRandomOrdering)(nil),             // 167: v1.OperationRunRandomOrdering
+	(*OperationRunPhysicalLocationOrdering)(nil),   // 168: v1.OperationRunPhysicalLocationOrdering
+	(*OperationRunPhasePolicy)(nil),                // 169: v1.OperationRunPhasePolicy
+	(*EqualOperationRunPhases)(nil),                // 170: v1.EqualOperationRunPhases
+	(*PercentageOperationRunPhases)(nil),           // 171: v1.PercentageOperationRunPhases
+	(*OperationRunPercentagePhase)(nil),            // 172: v1.OperationRunPercentagePhase
+	(*CountOperationRunPhases)(nil),                // 173: v1.CountOperationRunPhases
+	(*OperationRunCountPhase)(nil),                 // 174: v1.OperationRunCountPhase
+	(*OperationRunPhaseAdvancePolicy)(nil),         // 175: v1.OperationRunPhaseAdvancePolicy
+	(*OperationRunConflictPolicy)(nil),             // 176: v1.OperationRunConflictPolicy
+	(*OperationRunConflictRetryPolicy)(nil),        // 177: v1.OperationRunConflictRetryPolicy
+	(*OperationRunTargetScope)(nil),                // 178: v1.OperationRunTargetScope
+	(*OperationRunOperation)(nil),                  // 179: v1.OperationRunOperation
+	(*OperationRunState)(nil),                      // 180: v1.OperationRunState
+	(*OperationKind)(nil),                          // 181: v1.OperationKind
+	(*OperationRun)(nil),                           // 182: v1.OperationRun
+	(*OperationRunSummary)(nil),                    // 183: v1.OperationRunSummary
+	(*OperationRunStats)(nil),                      // 184: v1.OperationRunStats
+	(*OperationRunPhaseStats)(nil),                 // 185: v1.OperationRunPhaseStats
+	(*OperationRunTargetOutcomeCounts)(nil),        // 186: v1.OperationRunTargetOutcomeCounts
+	(*OperationRunTarget)(nil),                     // 187: v1.OperationRunTarget
+	(*NVLDomainTargets)(nil),                       // 188: v1.NVLDomainTargets
+	(*NVLDomainTarget)(nil),                        // 189: v1.NVLDomainTarget
+	(*timestamppb.Timestamp)(nil),                  // 190: google.protobuf.Timestamp
+	(*fieldmaskpb.FieldMask)(nil),                  // 191: google.protobuf.FieldMask
+	(*durationpb.Duration)(nil),                    // 192: google.protobuf.Duration
+	(*emptypb.Empty)(nil),                          // 193: google.protobuf.Empty
 }
 var file_flow_proto_depIdxs = []int32{
 	22,  // 0: v1.DeviceInfo.id:type_name -> v1.UUID
@@ -12601,7 +12777,7 @@ var file_flow_proto_depIdxs = []int32{
 	22,  // 14: v1.Identifier.id:type_name -> v1.UUID
 	33,  // 15: v1.OperationTargetSpec.racks:type_name -> v1.RackTargets
 	34,  // 16: v1.OperationTargetSpec.components:type_name -> v1.ComponentTargets
-	186, // 17: v1.OperationTargetSpec.nvl_domains:type_name -> v1.NVLDomainTargets
+	188, // 17: v1.OperationTargetSpec.nvl_domains:type_name -> v1.NVLDomainTargets
 	39,  // 18: v1.RackTargets.targets:type_name -> v1.RackTarget
 	40,  // 19: v1.ComponentTargets.targets:type_name -> v1.ComponentTarget
 	1,   // 20: v1.ComponentTypes.types:type_name -> v1.ComponentType
@@ -12626,12 +12802,12 @@ var file_flow_proto_depIdxs = []int32{
 	22,  // 39: v1.Task.component_uuids:type_name -> v1.UUID
 	8,   // 40: v1.Task.executor_type:type_name -> v1.TaskExecutorType
 	7,   // 41: v1.Task.status:type_name -> v1.TaskStatus
-	188, // 42: v1.Task.queue_expires_at:type_name -> google.protobuf.Timestamp
-	188, // 43: v1.Task.created_at:type_name -> google.protobuf.Timestamp
-	188, // 44: v1.Task.finished_at:type_name -> google.protobuf.Timestamp
+	190, // 42: v1.Task.queue_expires_at:type_name -> google.protobuf.Timestamp
+	190, // 43: v1.Task.created_at:type_name -> google.protobuf.Timestamp
+	190, // 44: v1.Task.finished_at:type_name -> google.protobuf.Timestamp
 	22,  // 45: v1.Task.applied_rule_id:type_name -> v1.UUID
-	188, // 46: v1.Task.updated_at:type_name -> google.protobuf.Timestamp
-	188, // 47: v1.Task.started_at:type_name -> google.protobuf.Timestamp
+	190, // 46: v1.Task.updated_at:type_name -> google.protobuf.Timestamp
+	190, // 47: v1.Task.started_at:type_name -> google.protobuf.Timestamp
 	30,  // 48: v1.CreateExpectedRackRequest.rack:type_name -> v1.Rack
 	22,  // 49: v1.CreateExpectedRackResponse.id:type_name -> v1.UUID
 	22,  // 50: v1.GetRackInfoByIDRequest.id:type_name -> v1.UUID
@@ -12657,344 +12833,346 @@ var file_flow_proto_depIdxs = []int32{
 	31,  // 70: v1.GetRacksForNVLDomainRequest.nvl_domain_identifier:type_name -> v1.Identifier
 	30,  // 71: v1.GetRacksForNVLDomainResponse.racks:type_name -> v1.Rack
 	32,  // 72: v1.UpgradeFirmwareRequest.target_spec:type_name -> v1.OperationTargetSpec
-	188, // 73: v1.UpgradeFirmwareRequest.start_time:type_name -> google.protobuf.Timestamp
-	188, // 74: v1.UpgradeFirmwareRequest.end_time:type_name -> google.protobuf.Timestamp
-	88,  // 75: v1.UpgradeFirmwareRequest.queue_options:type_name -> v1.QueueOptions
+	190, // 73: v1.UpgradeFirmwareRequest.start_time:type_name -> google.protobuf.Timestamp
+	190, // 74: v1.UpgradeFirmwareRequest.end_time:type_name -> google.protobuf.Timestamp
+	90,  // 75: v1.UpgradeFirmwareRequest.queue_options:type_name -> v1.QueueOptions
 	22,  // 76: v1.UpgradeFirmwareRequest.rule_id:type_name -> v1.UUID
-	32,  // 77: v1.GetComponentsRequest.target_spec:type_name -> v1.OperationTargetSpec
-	45,  // 78: v1.GetComponentsRequest.filters:type_name -> v1.Filter
-	43,  // 79: v1.GetComponentsRequest.pagination:type_name -> v1.Pagination
-	46,  // 80: v1.GetComponentsRequest.order_by:type_name -> v1.OrderBy
-	29,  // 81: v1.GetComponentsResponse.components:type_name -> v1.Component
-	32,  // 82: v1.ValidateComponentsRequest.target_spec:type_name -> v1.OperationTargetSpec
-	45,  // 83: v1.ValidateComponentsRequest.filters:type_name -> v1.Filter
-	43,  // 84: v1.ValidateComponentsRequest.pagination:type_name -> v1.Pagination
-	46,  // 85: v1.ValidateComponentsRequest.order_by:type_name -> v1.OrderBy
-	73,  // 86: v1.ValidateComponentsResponse.diffs:type_name -> v1.ComponentDiff
-	11,  // 87: v1.ComponentDiff.type:type_name -> v1.DiffType
-	29,  // 88: v1.ComponentDiff.expected:type_name -> v1.Component
-	29,  // 89: v1.ComponentDiff.actual:type_name -> v1.Component
-	74,  // 90: v1.ComponentDiff.field_diffs:type_name -> v1.FieldDiff
-	22,  // 91: v1.ComponentDiff.id:type_name -> v1.UUID
-	29,  // 92: v1.AddComponentRequest.component:type_name -> v1.Component
-	29,  // 93: v1.AddComponentResponse.component:type_name -> v1.Component
-	22,  // 94: v1.DeleteComponentRequest.id:type_name -> v1.UUID
-	22,  // 95: v1.DeleteRackRequest.id:type_name -> v1.UUID
-	22,  // 96: v1.PurgeRackRequest.id:type_name -> v1.UUID
-	22,  // 97: v1.PurgeComponentRequest.id:type_name -> v1.UUID
-	22,  // 98: v1.PatchComponentRequest.id:type_name -> v1.UUID
-	27,  // 99: v1.PatchComponentRequest.position:type_name -> v1.RackPosition
-	22,  // 100: v1.PatchComponentRequest.rack_id:type_name -> v1.UUID
-	26,  // 101: v1.PatchComponentRequest.bmcs:type_name -> v1.BMCInfo
-	29,  // 102: v1.PatchComponentResponse.component:type_name -> v1.Component
-	22,  // 103: v1.SubmitTaskResponse.task_ids:type_name -> v1.UUID
-	12,  // 104: v1.QueueOptions.conflict_strategy:type_name -> v1.ConflictStrategy
-	32,  // 105: v1.PowerOnRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	88,  // 106: v1.PowerOnRackRequest.queue_options:type_name -> v1.QueueOptions
-	22,  // 107: v1.PowerOnRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 108: v1.PowerOffRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	88,  // 109: v1.PowerOffRackRequest.queue_options:type_name -> v1.QueueOptions
-	22,  // 110: v1.PowerOffRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 111: v1.PowerResetRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	88,  // 112: v1.PowerResetRackRequest.queue_options:type_name -> v1.QueueOptions
-	22,  // 113: v1.PowerResetRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 114: v1.BringUpRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	22,  // 115: v1.BringUpRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 116: v1.IngestRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	45,  // 117: v1.IngestRackRequest.filters:type_name -> v1.Filter
-	22,  // 118: v1.IngestRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 119: v1.DecommissionRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	88,  // 120: v1.DecommissionRackRequest.queue_options:type_name -> v1.QueueOptions
-	22,  // 121: v1.DecommissionRackRequest.rule_id:type_name -> v1.UUID
-	22,  // 122: v1.ListTasksRequest.rack_id:type_name -> v1.UUID
-	43,  // 123: v1.ListTasksRequest.pagination:type_name -> v1.Pagination
-	22,  // 124: v1.ListTasksRequest.component_id:type_name -> v1.UUID
-	47,  // 125: v1.ListTasksResponse.tasks:type_name -> v1.Task
-	22,  // 126: v1.GetTasksByIDsRequest.task_ids:type_name -> v1.UUID
-	47,  // 127: v1.GetTasksByIDsResponse.tasks:type_name -> v1.Task
-	22,  // 128: v1.CancelTaskRequest.task_id:type_name -> v1.UUID
-	47,  // 129: v1.CancelTaskResponse.task:type_name -> v1.Task
-	22,  // 130: v1.OperationRule.id:type_name -> v1.UUID
-	13,  // 131: v1.OperationRule.operation_type:type_name -> v1.OperationType
-	188, // 132: v1.OperationRule.created_at:type_name -> google.protobuf.Timestamp
-	188, // 133: v1.OperationRule.updated_at:type_name -> google.protobuf.Timestamp
-	13,  // 134: v1.CreateOperationRuleRequest.operation_type:type_name -> v1.OperationType
-	22,  // 135: v1.CreateOperationRuleResponse.id:type_name -> v1.UUID
-	22,  // 136: v1.UpdateOperationRuleRequest.rule_id:type_name -> v1.UUID
-	22,  // 137: v1.DeleteOperationRuleRequest.rule_id:type_name -> v1.UUID
-	22,  // 138: v1.SetRuleAsDefaultRequest.rule_id:type_name -> v1.UUID
-	22,  // 139: v1.GetOperationRuleRequest.rule_id:type_name -> v1.UUID
-	13,  // 140: v1.ListOperationRulesRequest.operation_type:type_name -> v1.OperationType
-	103, // 141: v1.ListOperationRulesResponse.rules:type_name -> v1.OperationRule
-	22,  // 142: v1.AssociateRuleWithRackRequest.rack_id:type_name -> v1.UUID
-	22,  // 143: v1.AssociateRuleWithRackRequest.rule_id:type_name -> v1.UUID
-	22,  // 144: v1.DisassociateRuleFromRackRequest.rack_id:type_name -> v1.UUID
-	13,  // 145: v1.DisassociateRuleFromRackRequest.operation_type:type_name -> v1.OperationType
-	22,  // 146: v1.GetRackRuleAssociationRequest.rack_id:type_name -> v1.UUID
-	13,  // 147: v1.GetRackRuleAssociationRequest.operation_type:type_name -> v1.OperationType
-	22,  // 148: v1.GetRackRuleAssociationResponse.rule_id:type_name -> v1.UUID
-	22,  // 149: v1.ListRackRuleAssociationsRequest.rack_id:type_name -> v1.UUID
-	22,  // 150: v1.RackRuleAssociation.rack_id:type_name -> v1.UUID
-	13,  // 151: v1.RackRuleAssociation.operation_type:type_name -> v1.OperationType
-	22,  // 152: v1.RackRuleAssociation.rule_id:type_name -> v1.UUID
-	188, // 153: v1.RackRuleAssociation.created_at:type_name -> google.protobuf.Timestamp
-	188, // 154: v1.RackRuleAssociation.updated_at:type_name -> google.protobuf.Timestamp
-	117, // 155: v1.ListRackRuleAssociationsResponse.associations:type_name -> v1.RackRuleAssociation
-	14,  // 156: v1.ScheduleSpec.type:type_name -> v1.ScheduleSpecType
-	119, // 157: v1.ScheduleConfig.spec:type_name -> v1.ScheduleSpec
-	15,  // 158: v1.ScheduleConfig.overlap_policy:type_name -> v1.OverlapPolicy
-	22,  // 159: v1.TaskSchedule.id:type_name -> v1.UUID
-	119, // 160: v1.TaskSchedule.spec:type_name -> v1.ScheduleSpec
-	15,  // 161: v1.TaskSchedule.overlap_policy:type_name -> v1.OverlapPolicy
-	188, // 162: v1.TaskSchedule.next_run_at:type_name -> google.protobuf.Timestamp
-	188, // 163: v1.TaskSchedule.last_run_at:type_name -> google.protobuf.Timestamp
-	188, // 164: v1.TaskSchedule.created_at:type_name -> google.protobuf.Timestamp
-	188, // 165: v1.TaskSchedule.updated_at:type_name -> google.protobuf.Timestamp
-	89,  // 166: v1.ScheduledOperation.power_on:type_name -> v1.PowerOnRackRequest
-	90,  // 167: v1.ScheduledOperation.power_off:type_name -> v1.PowerOffRackRequest
-	91,  // 168: v1.ScheduledOperation.power_reset:type_name -> v1.PowerResetRackRequest
-	92,  // 169: v1.ScheduledOperation.bring_up:type_name -> v1.BringUpRackRequest
-	68,  // 170: v1.ScheduledOperation.upgrade_firmware:type_name -> v1.UpgradeFirmwareRequest
-	93,  // 171: v1.ScheduledOperation.ingest:type_name -> v1.IngestRackRequest
-	120, // 172: v1.CreateTaskScheduleRequest.schedule:type_name -> v1.ScheduleConfig
-	122, // 173: v1.CreateTaskScheduleRequest.operation:type_name -> v1.ScheduledOperation
-	22,  // 174: v1.GetTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 175: v1.ListTaskSchedulesRequest.rack_id:type_name -> v1.UUID
-	43,  // 176: v1.ListTaskSchedulesRequest.pagination:type_name -> v1.Pagination
-	121, // 177: v1.ListTaskSchedulesResponse.task_schedules:type_name -> v1.TaskSchedule
-	22,  // 178: v1.UpdateTaskScheduleRequest.id:type_name -> v1.UUID
-	120, // 179: v1.UpdateTaskScheduleRequest.schedule:type_name -> v1.ScheduleConfig
-	189, // 180: v1.UpdateTaskScheduleRequest.update_mask:type_name -> google.protobuf.FieldMask
-	22,  // 181: v1.PauseTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 182: v1.ResumeTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 183: v1.DeleteTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 184: v1.TriggerTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 185: v1.TaskScheduleScope.id:type_name -> v1.UUID
-	22,  // 186: v1.TaskScheduleScope.schedule_id:type_name -> v1.UUID
-	22,  // 187: v1.TaskScheduleScope.rack_id:type_name -> v1.UUID
-	35,  // 188: v1.TaskScheduleScope.types:type_name -> v1.ComponentTypes
-	34,  // 189: v1.TaskScheduleScope.components:type_name -> v1.ComponentTargets
-	22,  // 190: v1.TaskScheduleScope.last_task_id:type_name -> v1.UUID
-	188, // 191: v1.TaskScheduleScope.created_at:type_name -> google.protobuf.Timestamp
-	22,  // 192: v1.AddTaskScheduleScopeRequest.schedule_id:type_name -> v1.UUID
-	32,  // 193: v1.AddTaskScheduleScopeRequest.target_spec:type_name -> v1.OperationTargetSpec
-	132, // 194: v1.AddTaskScheduleScopeResponse.scopes:type_name -> v1.TaskScheduleScope
-	22,  // 195: v1.RemoveTaskScheduleScopeRequest.scope_id:type_name -> v1.UUID
-	22,  // 196: v1.UpdateTaskScheduleScopeRequest.schedule_id:type_name -> v1.UUID
-	32,  // 197: v1.UpdateTaskScheduleScopeRequest.desired_scope:type_name -> v1.OperationTargetSpec
-	132, // 198: v1.UpdateTaskScheduleScopeResponse.scopes:type_name -> v1.TaskScheduleScope
-	22,  // 199: v1.ListTaskScheduleScopesRequest.schedule_id:type_name -> v1.UUID
-	132, // 200: v1.ListTaskScheduleScopesResponse.scopes:type_name -> v1.TaskScheduleScope
-	122, // 201: v1.CheckScheduleConflictsRequest.operation:type_name -> v1.ScheduledOperation
-	22,  // 202: v1.CheckScheduleConflictsRequest.exclude_schedule_id:type_name -> v1.UUID
-	121, // 203: v1.CheckScheduleConflictsResponse.conflicts:type_name -> v1.TaskSchedule
-	144, // 204: v1.CreateOperationRunRequest.configuration:type_name -> v1.OperationRunConfiguration
-	22,  // 205: v1.CreateOperationRunResponse.id:type_name -> v1.UUID
-	157, // 206: v1.OperationRunConfiguration.selector:type_name -> v1.OperationRunSelector
-	159, // 207: v1.OperationRunConfiguration.options:type_name -> v1.OperationRunOptions
-	177, // 208: v1.OperationRunConfiguration.operation:type_name -> v1.OperationRunOperation
-	22,  // 209: v1.GetOperationRunRequest.id:type_name -> v1.UUID
-	180, // 210: v1.GetOperationRunResponse.operation_run:type_name -> v1.OperationRun
-	149, // 211: v1.ListOperationRunsRequest.filter:type_name -> v1.OperationRunFilter
-	43,  // 212: v1.ListOperationRunsRequest.pagination:type_name -> v1.Pagination
-	181, // 213: v1.ListOperationRunsResponse.operation_runs:type_name -> v1.OperationRunSummary
-	44,  // 214: v1.OperationRunFilter.name:type_name -> v1.StringQueryInfo
-	150, // 215: v1.OperationRunFilter.states:type_name -> v1.OperationRunStateFilter
-	179, // 216: v1.OperationRunFilter.operation_kinds:type_name -> v1.OperationKind
-	18,  // 217: v1.OperationRunStateFilter.status:type_name -> v1.OperationRunStatus
-	19,  // 218: v1.OperationRunStateFilter.reason:type_name -> v1.OperationRunStatusReason
-	22,  // 219: v1.ListOperationRunTargetsRequest.operation_run_id:type_name -> v1.UUID
-	20,  // 220: v1.ListOperationRunTargetsRequest.status:type_name -> v1.OperationRunTargetStatus
-	43,  // 221: v1.ListOperationRunTargetsRequest.pagination:type_name -> v1.Pagination
-	16,  // 222: v1.ListOperationRunTargetsRequest.phase_scope:type_name -> v1.OperationRunTargetPhaseScope
-	185, // 223: v1.ListOperationRunTargetsResponse.targets:type_name -> v1.OperationRunTarget
-	22,  // 224: v1.PauseOperationRunRequest.id:type_name -> v1.UUID
-	22,  // 225: v1.ResumeOperationRunRequest.id:type_name -> v1.UUID
-	22,  // 226: v1.AdvanceOperationRunPhaseRequest.id:type_name -> v1.UUID
-	22,  // 227: v1.CancelOperationRunRequest.id:type_name -> v1.UUID
-	158, // 228: v1.OperationRunSelector.percentage:type_name -> v1.PercentageSelector
-	160, // 229: v1.OperationRunOptions.safety_policy:type_name -> v1.OperationRunSafetyPolicy
-	174, // 230: v1.OperationRunOptions.conflict_policy:type_name -> v1.OperationRunConflictPolicy
-	164, // 231: v1.OperationRunOptions.ordering_policy:type_name -> v1.OperationRunOrderingPolicy
-	167, // 232: v1.OperationRunOptions.phase_policy:type_name -> v1.OperationRunPhasePolicy
-	161, // 233: v1.OperationRunSafetyPolicy.gates:type_name -> v1.OperationRunSafetyGate
-	162, // 234: v1.OperationRunSafetyGate.failure_rate:type_name -> v1.OperationRunFailureRateGate
-	163, // 235: v1.OperationRunSafetyGate.failure_count:type_name -> v1.OperationRunFailureCountGate
-	17,  // 236: v1.OperationRunFailureRateGate.scope:type_name -> v1.OperationRunSafetyGateScope
-	17,  // 237: v1.OperationRunFailureCountGate.scope:type_name -> v1.OperationRunSafetyGateScope
-	165, // 238: v1.OperationRunOrderingPolicy.random:type_name -> v1.OperationRunRandomOrdering
-	166, // 239: v1.OperationRunOrderingPolicy.physical_location:type_name -> v1.OperationRunPhysicalLocationOrdering
-	21,  // 240: v1.OperationRunPhysicalLocationOrdering.strategy:type_name -> v1.OperationRunPhysicalLocationOrdering.Strategy
-	168, // 241: v1.OperationRunPhasePolicy.equal:type_name -> v1.EqualOperationRunPhases
-	169, // 242: v1.OperationRunPhasePolicy.percentage:type_name -> v1.PercentageOperationRunPhases
-	171, // 243: v1.OperationRunPhasePolicy.count:type_name -> v1.CountOperationRunPhases
-	173, // 244: v1.OperationRunPhasePolicy.advance_policy:type_name -> v1.OperationRunPhaseAdvancePolicy
-	170, // 245: v1.PercentageOperationRunPhases.phases:type_name -> v1.OperationRunPercentagePhase
-	172, // 246: v1.CountOperationRunPhases.phases:type_name -> v1.OperationRunCountPhase
-	175, // 247: v1.OperationRunConflictPolicy.retry:type_name -> v1.OperationRunConflictRetryPolicy
-	190, // 248: v1.OperationRunConflictRetryPolicy.retry_timeout:type_name -> google.protobuf.Duration
-	190, // 249: v1.OperationRunConflictRetryPolicy.initial_retry_delay:type_name -> google.protobuf.Duration
-	190, // 250: v1.OperationRunConflictRetryPolicy.max_retry_delay:type_name -> google.protobuf.Duration
-	22,  // 251: v1.OperationRunTargetScope.exclude_operation_run_ids:type_name -> v1.UUID
-	36,  // 252: v1.OperationRunTargetScope.default_scope_component_filter:type_name -> v1.ComponentFilter
-	68,  // 253: v1.OperationRunOperation.upgrade_firmware:type_name -> v1.UpgradeFirmwareRequest
-	176, // 254: v1.OperationRunOperation.target_scope:type_name -> v1.OperationRunTargetScope
-	18,  // 255: v1.OperationRunState.status:type_name -> v1.OperationRunStatus
-	19,  // 256: v1.OperationRunState.reason:type_name -> v1.OperationRunStatusReason
-	13,  // 257: v1.OperationKind.type:type_name -> v1.OperationType
-	181, // 258: v1.OperationRun.summary:type_name -> v1.OperationRunSummary
-	144, // 259: v1.OperationRun.configuration:type_name -> v1.OperationRunConfiguration
-	182, // 260: v1.OperationRun.stats:type_name -> v1.OperationRunStats
-	22,  // 261: v1.OperationRunSummary.id:type_name -> v1.UUID
-	179, // 262: v1.OperationRunSummary.operation_kind:type_name -> v1.OperationKind
-	178, // 263: v1.OperationRunSummary.state:type_name -> v1.OperationRunState
-	188, // 264: v1.OperationRunSummary.created_at:type_name -> google.protobuf.Timestamp
-	188, // 265: v1.OperationRunSummary.updated_at:type_name -> google.protobuf.Timestamp
-	188, // 266: v1.OperationRunSummary.started_at:type_name -> google.protobuf.Timestamp
-	188, // 267: v1.OperationRunSummary.finished_at:type_name -> google.protobuf.Timestamp
-	183, // 268: v1.OperationRunStats.current_phase_stats:type_name -> v1.OperationRunPhaseStats
-	183, // 269: v1.OperationRunStats.cumulative_phase_stats:type_name -> v1.OperationRunPhaseStats
-	184, // 270: v1.OperationRunPhaseStats.outcome_counts:type_name -> v1.OperationRunTargetOutcomeCounts
-	22,  // 271: v1.OperationRunTarget.id:type_name -> v1.UUID
-	22,  // 272: v1.OperationRunTarget.operation_run_id:type_name -> v1.UUID
-	22,  // 273: v1.OperationRunTarget.rack_id:type_name -> v1.UUID
-	22,  // 274: v1.OperationRunTarget.task_id:type_name -> v1.UUID
-	20,  // 275: v1.OperationRunTarget.status:type_name -> v1.OperationRunTargetStatus
-	37,  // 276: v1.OperationRunTarget.components_by_type:type_name -> v1.ComponentsByType
-	188, // 277: v1.OperationRunTarget.created_at:type_name -> google.protobuf.Timestamp
-	188, // 278: v1.OperationRunTarget.updated_at:type_name -> google.protobuf.Timestamp
-	187, // 279: v1.NVLDomainTargets.targets:type_name -> v1.NVLDomainTarget
-	22,  // 280: v1.NVLDomainTarget.id:type_name -> v1.UUID
-	1,   // 281: v1.NVLDomainTarget.component_types:type_name -> v1.ComponentType
-	101, // 282: v1.Flow.Version:input_type -> v1.VersionRequest
-	123, // 283: v1.Flow.CreateTaskSchedule:input_type -> v1.CreateTaskScheduleRequest
-	124, // 284: v1.Flow.GetTaskSchedule:input_type -> v1.GetTaskScheduleRequest
-	125, // 285: v1.Flow.ListTaskSchedules:input_type -> v1.ListTaskSchedulesRequest
-	127, // 286: v1.Flow.UpdateTaskSchedule:input_type -> v1.UpdateTaskScheduleRequest
-	128, // 287: v1.Flow.PauseTaskSchedule:input_type -> v1.PauseTaskScheduleRequest
-	129, // 288: v1.Flow.ResumeTaskSchedule:input_type -> v1.ResumeTaskScheduleRequest
-	130, // 289: v1.Flow.DeleteTaskSchedule:input_type -> v1.DeleteTaskScheduleRequest
-	131, // 290: v1.Flow.TriggerTaskSchedule:input_type -> v1.TriggerTaskScheduleRequest
-	133, // 291: v1.Flow.AddTaskScheduleScope:input_type -> v1.AddTaskScheduleScopeRequest
-	135, // 292: v1.Flow.RemoveTaskScheduleScope:input_type -> v1.RemoveTaskScheduleScopeRequest
-	136, // 293: v1.Flow.UpdateTaskScheduleScope:input_type -> v1.UpdateTaskScheduleScopeRequest
-	138, // 294: v1.Flow.ListTaskScheduleScopes:input_type -> v1.ListTaskScheduleScopesRequest
-	140, // 295: v1.Flow.CheckScheduleConflicts:input_type -> v1.CheckScheduleConflictsRequest
-	48,  // 296: v1.Flow.CreateExpectedRack:input_type -> v1.CreateExpectedRackRequest
-	50,  // 297: v1.Flow.GetRackInfoByID:input_type -> v1.GetRackInfoByIDRequest
-	51,  // 298: v1.Flow.GetRackInfoBySerial:input_type -> v1.GetRackInfoBySerialRequest
-	58,  // 299: v1.Flow.GetListOfRacks:input_type -> v1.GetListOfRacksRequest
-	53,  // 300: v1.Flow.PatchRack:input_type -> v1.PatchRackRequest
-	79,  // 301: v1.Flow.DeleteRack:input_type -> v1.DeleteRackRequest
-	81,  // 302: v1.Flow.PurgeRack:input_type -> v1.PurgeRackRequest
-	68,  // 303: v1.Flow.UpgradeFirmware:input_type -> v1.UpgradeFirmwareRequest
-	92,  // 304: v1.Flow.BringUpRack:input_type -> v1.BringUpRackRequest
-	93,  // 305: v1.Flow.IngestRack:input_type -> v1.IngestRackRequest
-	94,  // 306: v1.Flow.DecommissionRack:input_type -> v1.DecommissionRackRequest
-	89,  // 307: v1.Flow.PowerOnRack:input_type -> v1.PowerOnRackRequest
-	90,  // 308: v1.Flow.PowerOffRack:input_type -> v1.PowerOffRackRequest
-	91,  // 309: v1.Flow.PowerResetRack:input_type -> v1.PowerResetRackRequest
-	55,  // 310: v1.Flow.GetComponentInfoByID:input_type -> v1.GetComponentInfoByIDRequest
-	56,  // 311: v1.Flow.GetComponentInfoBySerial:input_type -> v1.GetComponentInfoBySerialRequest
-	69,  // 312: v1.Flow.GetComponents:input_type -> v1.GetComponentsRequest
-	71,  // 313: v1.Flow.ValidateComponents:input_type -> v1.ValidateComponentsRequest
-	75,  // 314: v1.Flow.AddComponent:input_type -> v1.AddComponentRequest
-	85,  // 315: v1.Flow.PatchComponent:input_type -> v1.PatchComponentRequest
-	77,  // 316: v1.Flow.DeleteComponent:input_type -> v1.DeleteComponentRequest
-	83,  // 317: v1.Flow.PurgeComponent:input_type -> v1.PurgeComponentRequest
-	60,  // 318: v1.Flow.CreateNVLDomain:input_type -> v1.CreateNVLDomainRequest
-	62,  // 319: v1.Flow.AttachRacksToNVLDomain:input_type -> v1.AttachRacksToNVLDomainRequest
-	63,  // 320: v1.Flow.DetachRacksFromNVLDomain:input_type -> v1.DetachRacksFromNVLDomainRequest
-	64,  // 321: v1.Flow.GetListOfNVLDomains:input_type -> v1.GetListOfNVLDomainsRequest
-	66,  // 322: v1.Flow.GetRacksForNVLDomain:input_type -> v1.GetRacksForNVLDomainRequest
-	95,  // 323: v1.Flow.ListTasks:input_type -> v1.ListTasksRequest
-	97,  // 324: v1.Flow.GetTasksByIDs:input_type -> v1.GetTasksByIDsRequest
-	99,  // 325: v1.Flow.CancelTask:input_type -> v1.CancelTaskRequest
-	104, // 326: v1.Flow.CreateOperationRule:input_type -> v1.CreateOperationRuleRequest
-	106, // 327: v1.Flow.UpdateOperationRule:input_type -> v1.UpdateOperationRuleRequest
-	107, // 328: v1.Flow.DeleteOperationRule:input_type -> v1.DeleteOperationRuleRequest
-	109, // 329: v1.Flow.GetOperationRule:input_type -> v1.GetOperationRuleRequest
-	110, // 330: v1.Flow.ListOperationRules:input_type -> v1.ListOperationRulesRequest
-	108, // 331: v1.Flow.SetRuleAsDefault:input_type -> v1.SetRuleAsDefaultRequest
-	112, // 332: v1.Flow.AssociateRuleWithRack:input_type -> v1.AssociateRuleWithRackRequest
-	113, // 333: v1.Flow.DisassociateRuleFromRack:input_type -> v1.DisassociateRuleFromRackRequest
-	114, // 334: v1.Flow.GetRackRuleAssociation:input_type -> v1.GetRackRuleAssociationRequest
-	116, // 335: v1.Flow.ListRackRuleAssociations:input_type -> v1.ListRackRuleAssociationsRequest
-	142, // 336: v1.Flow.CreateOperationRun:input_type -> v1.CreateOperationRunRequest
-	145, // 337: v1.Flow.GetOperationRun:input_type -> v1.GetOperationRunRequest
-	147, // 338: v1.Flow.ListOperationRuns:input_type -> v1.ListOperationRunsRequest
-	151, // 339: v1.Flow.ListOperationRunTargets:input_type -> v1.ListOperationRunTargetsRequest
-	153, // 340: v1.Flow.PauseOperationRun:input_type -> v1.PauseOperationRunRequest
-	154, // 341: v1.Flow.ResumeOperationRun:input_type -> v1.ResumeOperationRunRequest
-	155, // 342: v1.Flow.AdvanceOperationRunPhase:input_type -> v1.AdvanceOperationRunPhaseRequest
-	156, // 343: v1.Flow.CancelOperationRun:input_type -> v1.CancelOperationRunRequest
-	102, // 344: v1.Flow.Version:output_type -> v1.BuildInfo
-	121, // 345: v1.Flow.CreateTaskSchedule:output_type -> v1.TaskSchedule
-	121, // 346: v1.Flow.GetTaskSchedule:output_type -> v1.TaskSchedule
-	126, // 347: v1.Flow.ListTaskSchedules:output_type -> v1.ListTaskSchedulesResponse
-	121, // 348: v1.Flow.UpdateTaskSchedule:output_type -> v1.TaskSchedule
-	121, // 349: v1.Flow.PauseTaskSchedule:output_type -> v1.TaskSchedule
-	121, // 350: v1.Flow.ResumeTaskSchedule:output_type -> v1.TaskSchedule
-	191, // 351: v1.Flow.DeleteTaskSchedule:output_type -> google.protobuf.Empty
-	87,  // 352: v1.Flow.TriggerTaskSchedule:output_type -> v1.SubmitTaskResponse
-	134, // 353: v1.Flow.AddTaskScheduleScope:output_type -> v1.AddTaskScheduleScopeResponse
-	191, // 354: v1.Flow.RemoveTaskScheduleScope:output_type -> google.protobuf.Empty
-	137, // 355: v1.Flow.UpdateTaskScheduleScope:output_type -> v1.UpdateTaskScheduleScopeResponse
-	139, // 356: v1.Flow.ListTaskScheduleScopes:output_type -> v1.ListTaskScheduleScopesResponse
-	141, // 357: v1.Flow.CheckScheduleConflicts:output_type -> v1.CheckScheduleConflictsResponse
-	49,  // 358: v1.Flow.CreateExpectedRack:output_type -> v1.CreateExpectedRackResponse
-	52,  // 359: v1.Flow.GetRackInfoByID:output_type -> v1.GetRackInfoResponse
-	52,  // 360: v1.Flow.GetRackInfoBySerial:output_type -> v1.GetRackInfoResponse
-	59,  // 361: v1.Flow.GetListOfRacks:output_type -> v1.GetListOfRacksResponse
-	54,  // 362: v1.Flow.PatchRack:output_type -> v1.PatchRackResponse
-	80,  // 363: v1.Flow.DeleteRack:output_type -> v1.DeleteRackResponse
-	82,  // 364: v1.Flow.PurgeRack:output_type -> v1.PurgeRackResponse
-	87,  // 365: v1.Flow.UpgradeFirmware:output_type -> v1.SubmitTaskResponse
-	87,  // 366: v1.Flow.BringUpRack:output_type -> v1.SubmitTaskResponse
-	87,  // 367: v1.Flow.IngestRack:output_type -> v1.SubmitTaskResponse
-	87,  // 368: v1.Flow.DecommissionRack:output_type -> v1.SubmitTaskResponse
-	87,  // 369: v1.Flow.PowerOnRack:output_type -> v1.SubmitTaskResponse
-	87,  // 370: v1.Flow.PowerOffRack:output_type -> v1.SubmitTaskResponse
-	87,  // 371: v1.Flow.PowerResetRack:output_type -> v1.SubmitTaskResponse
-	57,  // 372: v1.Flow.GetComponentInfoByID:output_type -> v1.GetComponentInfoResponse
-	57,  // 373: v1.Flow.GetComponentInfoBySerial:output_type -> v1.GetComponentInfoResponse
-	70,  // 374: v1.Flow.GetComponents:output_type -> v1.GetComponentsResponse
-	72,  // 375: v1.Flow.ValidateComponents:output_type -> v1.ValidateComponentsResponse
-	76,  // 376: v1.Flow.AddComponent:output_type -> v1.AddComponentResponse
-	86,  // 377: v1.Flow.PatchComponent:output_type -> v1.PatchComponentResponse
-	78,  // 378: v1.Flow.DeleteComponent:output_type -> v1.DeleteComponentResponse
-	84,  // 379: v1.Flow.PurgeComponent:output_type -> v1.PurgeComponentResponse
-	61,  // 380: v1.Flow.CreateNVLDomain:output_type -> v1.CreateNVLDomainResponse
-	191, // 381: v1.Flow.AttachRacksToNVLDomain:output_type -> google.protobuf.Empty
-	191, // 382: v1.Flow.DetachRacksFromNVLDomain:output_type -> google.protobuf.Empty
-	65,  // 383: v1.Flow.GetListOfNVLDomains:output_type -> v1.GetListOfNVLDomainsResponse
-	67,  // 384: v1.Flow.GetRacksForNVLDomain:output_type -> v1.GetRacksForNVLDomainResponse
-	96,  // 385: v1.Flow.ListTasks:output_type -> v1.ListTasksResponse
-	98,  // 386: v1.Flow.GetTasksByIDs:output_type -> v1.GetTasksByIDsResponse
-	100, // 387: v1.Flow.CancelTask:output_type -> v1.CancelTaskResponse
-	105, // 388: v1.Flow.CreateOperationRule:output_type -> v1.CreateOperationRuleResponse
-	191, // 389: v1.Flow.UpdateOperationRule:output_type -> google.protobuf.Empty
-	191, // 390: v1.Flow.DeleteOperationRule:output_type -> google.protobuf.Empty
-	103, // 391: v1.Flow.GetOperationRule:output_type -> v1.OperationRule
-	111, // 392: v1.Flow.ListOperationRules:output_type -> v1.ListOperationRulesResponse
-	191, // 393: v1.Flow.SetRuleAsDefault:output_type -> google.protobuf.Empty
-	191, // 394: v1.Flow.AssociateRuleWithRack:output_type -> google.protobuf.Empty
-	191, // 395: v1.Flow.DisassociateRuleFromRack:output_type -> google.protobuf.Empty
-	115, // 396: v1.Flow.GetRackRuleAssociation:output_type -> v1.GetRackRuleAssociationResponse
-	118, // 397: v1.Flow.ListRackRuleAssociations:output_type -> v1.ListRackRuleAssociationsResponse
-	143, // 398: v1.Flow.CreateOperationRun:output_type -> v1.CreateOperationRunResponse
-	146, // 399: v1.Flow.GetOperationRun:output_type -> v1.GetOperationRunResponse
-	148, // 400: v1.Flow.ListOperationRuns:output_type -> v1.ListOperationRunsResponse
-	152, // 401: v1.Flow.ListOperationRunTargets:output_type -> v1.ListOperationRunTargetsResponse
-	180, // 402: v1.Flow.PauseOperationRun:output_type -> v1.OperationRun
-	180, // 403: v1.Flow.ResumeOperationRun:output_type -> v1.OperationRun
-	180, // 404: v1.Flow.AdvanceOperationRunPhase:output_type -> v1.OperationRun
-	180, // 405: v1.Flow.CancelOperationRun:output_type -> v1.OperationRun
-	344, // [344:406] is the sub-list for method output_type
-	282, // [282:344] is the sub-list for method input_type
-	282, // [282:282] is the sub-list for extension type_name
-	282, // [282:282] is the sub-list for extension extendee
-	0,   // [0:282] is the sub-list for field type_name
+	69,  // 77: v1.UpgradeFirmwareRequest.authentication_data:type_name -> v1.FirmwareAuthenticationData
+	70,  // 78: v1.FirmwareAuthenticationData.per_component:type_name -> v1.PerComponentFirmwareAuthenticationData
+	32,  // 79: v1.GetComponentsRequest.target_spec:type_name -> v1.OperationTargetSpec
+	45,  // 80: v1.GetComponentsRequest.filters:type_name -> v1.Filter
+	43,  // 81: v1.GetComponentsRequest.pagination:type_name -> v1.Pagination
+	46,  // 82: v1.GetComponentsRequest.order_by:type_name -> v1.OrderBy
+	29,  // 83: v1.GetComponentsResponse.components:type_name -> v1.Component
+	32,  // 84: v1.ValidateComponentsRequest.target_spec:type_name -> v1.OperationTargetSpec
+	45,  // 85: v1.ValidateComponentsRequest.filters:type_name -> v1.Filter
+	43,  // 86: v1.ValidateComponentsRequest.pagination:type_name -> v1.Pagination
+	46,  // 87: v1.ValidateComponentsRequest.order_by:type_name -> v1.OrderBy
+	75,  // 88: v1.ValidateComponentsResponse.diffs:type_name -> v1.ComponentDiff
+	11,  // 89: v1.ComponentDiff.type:type_name -> v1.DiffType
+	29,  // 90: v1.ComponentDiff.expected:type_name -> v1.Component
+	29,  // 91: v1.ComponentDiff.actual:type_name -> v1.Component
+	76,  // 92: v1.ComponentDiff.field_diffs:type_name -> v1.FieldDiff
+	22,  // 93: v1.ComponentDiff.id:type_name -> v1.UUID
+	29,  // 94: v1.AddComponentRequest.component:type_name -> v1.Component
+	29,  // 95: v1.AddComponentResponse.component:type_name -> v1.Component
+	22,  // 96: v1.DeleteComponentRequest.id:type_name -> v1.UUID
+	22,  // 97: v1.DeleteRackRequest.id:type_name -> v1.UUID
+	22,  // 98: v1.PurgeRackRequest.id:type_name -> v1.UUID
+	22,  // 99: v1.PurgeComponentRequest.id:type_name -> v1.UUID
+	22,  // 100: v1.PatchComponentRequest.id:type_name -> v1.UUID
+	27,  // 101: v1.PatchComponentRequest.position:type_name -> v1.RackPosition
+	22,  // 102: v1.PatchComponentRequest.rack_id:type_name -> v1.UUID
+	26,  // 103: v1.PatchComponentRequest.bmcs:type_name -> v1.BMCInfo
+	29,  // 104: v1.PatchComponentResponse.component:type_name -> v1.Component
+	22,  // 105: v1.SubmitTaskResponse.task_ids:type_name -> v1.UUID
+	12,  // 106: v1.QueueOptions.conflict_strategy:type_name -> v1.ConflictStrategy
+	32,  // 107: v1.PowerOnRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	90,  // 108: v1.PowerOnRackRequest.queue_options:type_name -> v1.QueueOptions
+	22,  // 109: v1.PowerOnRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 110: v1.PowerOffRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	90,  // 111: v1.PowerOffRackRequest.queue_options:type_name -> v1.QueueOptions
+	22,  // 112: v1.PowerOffRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 113: v1.PowerResetRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	90,  // 114: v1.PowerResetRackRequest.queue_options:type_name -> v1.QueueOptions
+	22,  // 115: v1.PowerResetRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 116: v1.BringUpRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	22,  // 117: v1.BringUpRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 118: v1.IngestRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	45,  // 119: v1.IngestRackRequest.filters:type_name -> v1.Filter
+	22,  // 120: v1.IngestRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 121: v1.DecommissionRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	90,  // 122: v1.DecommissionRackRequest.queue_options:type_name -> v1.QueueOptions
+	22,  // 123: v1.DecommissionRackRequest.rule_id:type_name -> v1.UUID
+	22,  // 124: v1.ListTasksRequest.rack_id:type_name -> v1.UUID
+	43,  // 125: v1.ListTasksRequest.pagination:type_name -> v1.Pagination
+	22,  // 126: v1.ListTasksRequest.component_id:type_name -> v1.UUID
+	47,  // 127: v1.ListTasksResponse.tasks:type_name -> v1.Task
+	22,  // 128: v1.GetTasksByIDsRequest.task_ids:type_name -> v1.UUID
+	47,  // 129: v1.GetTasksByIDsResponse.tasks:type_name -> v1.Task
+	22,  // 130: v1.CancelTaskRequest.task_id:type_name -> v1.UUID
+	47,  // 131: v1.CancelTaskResponse.task:type_name -> v1.Task
+	22,  // 132: v1.OperationRule.id:type_name -> v1.UUID
+	13,  // 133: v1.OperationRule.operation_type:type_name -> v1.OperationType
+	190, // 134: v1.OperationRule.created_at:type_name -> google.protobuf.Timestamp
+	190, // 135: v1.OperationRule.updated_at:type_name -> google.protobuf.Timestamp
+	13,  // 136: v1.CreateOperationRuleRequest.operation_type:type_name -> v1.OperationType
+	22,  // 137: v1.CreateOperationRuleResponse.id:type_name -> v1.UUID
+	22,  // 138: v1.UpdateOperationRuleRequest.rule_id:type_name -> v1.UUID
+	22,  // 139: v1.DeleteOperationRuleRequest.rule_id:type_name -> v1.UUID
+	22,  // 140: v1.SetRuleAsDefaultRequest.rule_id:type_name -> v1.UUID
+	22,  // 141: v1.GetOperationRuleRequest.rule_id:type_name -> v1.UUID
+	13,  // 142: v1.ListOperationRulesRequest.operation_type:type_name -> v1.OperationType
+	105, // 143: v1.ListOperationRulesResponse.rules:type_name -> v1.OperationRule
+	22,  // 144: v1.AssociateRuleWithRackRequest.rack_id:type_name -> v1.UUID
+	22,  // 145: v1.AssociateRuleWithRackRequest.rule_id:type_name -> v1.UUID
+	22,  // 146: v1.DisassociateRuleFromRackRequest.rack_id:type_name -> v1.UUID
+	13,  // 147: v1.DisassociateRuleFromRackRequest.operation_type:type_name -> v1.OperationType
+	22,  // 148: v1.GetRackRuleAssociationRequest.rack_id:type_name -> v1.UUID
+	13,  // 149: v1.GetRackRuleAssociationRequest.operation_type:type_name -> v1.OperationType
+	22,  // 150: v1.GetRackRuleAssociationResponse.rule_id:type_name -> v1.UUID
+	22,  // 151: v1.ListRackRuleAssociationsRequest.rack_id:type_name -> v1.UUID
+	22,  // 152: v1.RackRuleAssociation.rack_id:type_name -> v1.UUID
+	13,  // 153: v1.RackRuleAssociation.operation_type:type_name -> v1.OperationType
+	22,  // 154: v1.RackRuleAssociation.rule_id:type_name -> v1.UUID
+	190, // 155: v1.RackRuleAssociation.created_at:type_name -> google.protobuf.Timestamp
+	190, // 156: v1.RackRuleAssociation.updated_at:type_name -> google.protobuf.Timestamp
+	119, // 157: v1.ListRackRuleAssociationsResponse.associations:type_name -> v1.RackRuleAssociation
+	14,  // 158: v1.ScheduleSpec.type:type_name -> v1.ScheduleSpecType
+	121, // 159: v1.ScheduleConfig.spec:type_name -> v1.ScheduleSpec
+	15,  // 160: v1.ScheduleConfig.overlap_policy:type_name -> v1.OverlapPolicy
+	22,  // 161: v1.TaskSchedule.id:type_name -> v1.UUID
+	121, // 162: v1.TaskSchedule.spec:type_name -> v1.ScheduleSpec
+	15,  // 163: v1.TaskSchedule.overlap_policy:type_name -> v1.OverlapPolicy
+	190, // 164: v1.TaskSchedule.next_run_at:type_name -> google.protobuf.Timestamp
+	190, // 165: v1.TaskSchedule.last_run_at:type_name -> google.protobuf.Timestamp
+	190, // 166: v1.TaskSchedule.created_at:type_name -> google.protobuf.Timestamp
+	190, // 167: v1.TaskSchedule.updated_at:type_name -> google.protobuf.Timestamp
+	91,  // 168: v1.ScheduledOperation.power_on:type_name -> v1.PowerOnRackRequest
+	92,  // 169: v1.ScheduledOperation.power_off:type_name -> v1.PowerOffRackRequest
+	93,  // 170: v1.ScheduledOperation.power_reset:type_name -> v1.PowerResetRackRequest
+	94,  // 171: v1.ScheduledOperation.bring_up:type_name -> v1.BringUpRackRequest
+	68,  // 172: v1.ScheduledOperation.upgrade_firmware:type_name -> v1.UpgradeFirmwareRequest
+	95,  // 173: v1.ScheduledOperation.ingest:type_name -> v1.IngestRackRequest
+	122, // 174: v1.CreateTaskScheduleRequest.schedule:type_name -> v1.ScheduleConfig
+	124, // 175: v1.CreateTaskScheduleRequest.operation:type_name -> v1.ScheduledOperation
+	22,  // 176: v1.GetTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 177: v1.ListTaskSchedulesRequest.rack_id:type_name -> v1.UUID
+	43,  // 178: v1.ListTaskSchedulesRequest.pagination:type_name -> v1.Pagination
+	123, // 179: v1.ListTaskSchedulesResponse.task_schedules:type_name -> v1.TaskSchedule
+	22,  // 180: v1.UpdateTaskScheduleRequest.id:type_name -> v1.UUID
+	122, // 181: v1.UpdateTaskScheduleRequest.schedule:type_name -> v1.ScheduleConfig
+	191, // 182: v1.UpdateTaskScheduleRequest.update_mask:type_name -> google.protobuf.FieldMask
+	22,  // 183: v1.PauseTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 184: v1.ResumeTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 185: v1.DeleteTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 186: v1.TriggerTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 187: v1.TaskScheduleScope.id:type_name -> v1.UUID
+	22,  // 188: v1.TaskScheduleScope.schedule_id:type_name -> v1.UUID
+	22,  // 189: v1.TaskScheduleScope.rack_id:type_name -> v1.UUID
+	35,  // 190: v1.TaskScheduleScope.types:type_name -> v1.ComponentTypes
+	34,  // 191: v1.TaskScheduleScope.components:type_name -> v1.ComponentTargets
+	22,  // 192: v1.TaskScheduleScope.last_task_id:type_name -> v1.UUID
+	190, // 193: v1.TaskScheduleScope.created_at:type_name -> google.protobuf.Timestamp
+	22,  // 194: v1.AddTaskScheduleScopeRequest.schedule_id:type_name -> v1.UUID
+	32,  // 195: v1.AddTaskScheduleScopeRequest.target_spec:type_name -> v1.OperationTargetSpec
+	134, // 196: v1.AddTaskScheduleScopeResponse.scopes:type_name -> v1.TaskScheduleScope
+	22,  // 197: v1.RemoveTaskScheduleScopeRequest.scope_id:type_name -> v1.UUID
+	22,  // 198: v1.UpdateTaskScheduleScopeRequest.schedule_id:type_name -> v1.UUID
+	32,  // 199: v1.UpdateTaskScheduleScopeRequest.desired_scope:type_name -> v1.OperationTargetSpec
+	134, // 200: v1.UpdateTaskScheduleScopeResponse.scopes:type_name -> v1.TaskScheduleScope
+	22,  // 201: v1.ListTaskScheduleScopesRequest.schedule_id:type_name -> v1.UUID
+	134, // 202: v1.ListTaskScheduleScopesResponse.scopes:type_name -> v1.TaskScheduleScope
+	124, // 203: v1.CheckScheduleConflictsRequest.operation:type_name -> v1.ScheduledOperation
+	22,  // 204: v1.CheckScheduleConflictsRequest.exclude_schedule_id:type_name -> v1.UUID
+	123, // 205: v1.CheckScheduleConflictsResponse.conflicts:type_name -> v1.TaskSchedule
+	146, // 206: v1.CreateOperationRunRequest.configuration:type_name -> v1.OperationRunConfiguration
+	22,  // 207: v1.CreateOperationRunResponse.id:type_name -> v1.UUID
+	159, // 208: v1.OperationRunConfiguration.selector:type_name -> v1.OperationRunSelector
+	161, // 209: v1.OperationRunConfiguration.options:type_name -> v1.OperationRunOptions
+	179, // 210: v1.OperationRunConfiguration.operation:type_name -> v1.OperationRunOperation
+	22,  // 211: v1.GetOperationRunRequest.id:type_name -> v1.UUID
+	182, // 212: v1.GetOperationRunResponse.operation_run:type_name -> v1.OperationRun
+	151, // 213: v1.ListOperationRunsRequest.filter:type_name -> v1.OperationRunFilter
+	43,  // 214: v1.ListOperationRunsRequest.pagination:type_name -> v1.Pagination
+	183, // 215: v1.ListOperationRunsResponse.operation_runs:type_name -> v1.OperationRunSummary
+	44,  // 216: v1.OperationRunFilter.name:type_name -> v1.StringQueryInfo
+	152, // 217: v1.OperationRunFilter.states:type_name -> v1.OperationRunStateFilter
+	181, // 218: v1.OperationRunFilter.operation_kinds:type_name -> v1.OperationKind
+	18,  // 219: v1.OperationRunStateFilter.status:type_name -> v1.OperationRunStatus
+	19,  // 220: v1.OperationRunStateFilter.reason:type_name -> v1.OperationRunStatusReason
+	22,  // 221: v1.ListOperationRunTargetsRequest.operation_run_id:type_name -> v1.UUID
+	20,  // 222: v1.ListOperationRunTargetsRequest.status:type_name -> v1.OperationRunTargetStatus
+	43,  // 223: v1.ListOperationRunTargetsRequest.pagination:type_name -> v1.Pagination
+	16,  // 224: v1.ListOperationRunTargetsRequest.phase_scope:type_name -> v1.OperationRunTargetPhaseScope
+	187, // 225: v1.ListOperationRunTargetsResponse.targets:type_name -> v1.OperationRunTarget
+	22,  // 226: v1.PauseOperationRunRequest.id:type_name -> v1.UUID
+	22,  // 227: v1.ResumeOperationRunRequest.id:type_name -> v1.UUID
+	22,  // 228: v1.AdvanceOperationRunPhaseRequest.id:type_name -> v1.UUID
+	22,  // 229: v1.CancelOperationRunRequest.id:type_name -> v1.UUID
+	160, // 230: v1.OperationRunSelector.percentage:type_name -> v1.PercentageSelector
+	162, // 231: v1.OperationRunOptions.safety_policy:type_name -> v1.OperationRunSafetyPolicy
+	176, // 232: v1.OperationRunOptions.conflict_policy:type_name -> v1.OperationRunConflictPolicy
+	166, // 233: v1.OperationRunOptions.ordering_policy:type_name -> v1.OperationRunOrderingPolicy
+	169, // 234: v1.OperationRunOptions.phase_policy:type_name -> v1.OperationRunPhasePolicy
+	163, // 235: v1.OperationRunSafetyPolicy.gates:type_name -> v1.OperationRunSafetyGate
+	164, // 236: v1.OperationRunSafetyGate.failure_rate:type_name -> v1.OperationRunFailureRateGate
+	165, // 237: v1.OperationRunSafetyGate.failure_count:type_name -> v1.OperationRunFailureCountGate
+	17,  // 238: v1.OperationRunFailureRateGate.scope:type_name -> v1.OperationRunSafetyGateScope
+	17,  // 239: v1.OperationRunFailureCountGate.scope:type_name -> v1.OperationRunSafetyGateScope
+	167, // 240: v1.OperationRunOrderingPolicy.random:type_name -> v1.OperationRunRandomOrdering
+	168, // 241: v1.OperationRunOrderingPolicy.physical_location:type_name -> v1.OperationRunPhysicalLocationOrdering
+	21,  // 242: v1.OperationRunPhysicalLocationOrdering.strategy:type_name -> v1.OperationRunPhysicalLocationOrdering.Strategy
+	170, // 243: v1.OperationRunPhasePolicy.equal:type_name -> v1.EqualOperationRunPhases
+	171, // 244: v1.OperationRunPhasePolicy.percentage:type_name -> v1.PercentageOperationRunPhases
+	173, // 245: v1.OperationRunPhasePolicy.count:type_name -> v1.CountOperationRunPhases
+	175, // 246: v1.OperationRunPhasePolicy.advance_policy:type_name -> v1.OperationRunPhaseAdvancePolicy
+	172, // 247: v1.PercentageOperationRunPhases.phases:type_name -> v1.OperationRunPercentagePhase
+	174, // 248: v1.CountOperationRunPhases.phases:type_name -> v1.OperationRunCountPhase
+	177, // 249: v1.OperationRunConflictPolicy.retry:type_name -> v1.OperationRunConflictRetryPolicy
+	192, // 250: v1.OperationRunConflictRetryPolicy.retry_timeout:type_name -> google.protobuf.Duration
+	192, // 251: v1.OperationRunConflictRetryPolicy.initial_retry_delay:type_name -> google.protobuf.Duration
+	192, // 252: v1.OperationRunConflictRetryPolicy.max_retry_delay:type_name -> google.protobuf.Duration
+	22,  // 253: v1.OperationRunTargetScope.exclude_operation_run_ids:type_name -> v1.UUID
+	36,  // 254: v1.OperationRunTargetScope.default_scope_component_filter:type_name -> v1.ComponentFilter
+	68,  // 255: v1.OperationRunOperation.upgrade_firmware:type_name -> v1.UpgradeFirmwareRequest
+	178, // 256: v1.OperationRunOperation.target_scope:type_name -> v1.OperationRunTargetScope
+	18,  // 257: v1.OperationRunState.status:type_name -> v1.OperationRunStatus
+	19,  // 258: v1.OperationRunState.reason:type_name -> v1.OperationRunStatusReason
+	13,  // 259: v1.OperationKind.type:type_name -> v1.OperationType
+	183, // 260: v1.OperationRun.summary:type_name -> v1.OperationRunSummary
+	146, // 261: v1.OperationRun.configuration:type_name -> v1.OperationRunConfiguration
+	184, // 262: v1.OperationRun.stats:type_name -> v1.OperationRunStats
+	22,  // 263: v1.OperationRunSummary.id:type_name -> v1.UUID
+	181, // 264: v1.OperationRunSummary.operation_kind:type_name -> v1.OperationKind
+	180, // 265: v1.OperationRunSummary.state:type_name -> v1.OperationRunState
+	190, // 266: v1.OperationRunSummary.created_at:type_name -> google.protobuf.Timestamp
+	190, // 267: v1.OperationRunSummary.updated_at:type_name -> google.protobuf.Timestamp
+	190, // 268: v1.OperationRunSummary.started_at:type_name -> google.protobuf.Timestamp
+	190, // 269: v1.OperationRunSummary.finished_at:type_name -> google.protobuf.Timestamp
+	185, // 270: v1.OperationRunStats.current_phase_stats:type_name -> v1.OperationRunPhaseStats
+	185, // 271: v1.OperationRunStats.cumulative_phase_stats:type_name -> v1.OperationRunPhaseStats
+	186, // 272: v1.OperationRunPhaseStats.outcome_counts:type_name -> v1.OperationRunTargetOutcomeCounts
+	22,  // 273: v1.OperationRunTarget.id:type_name -> v1.UUID
+	22,  // 274: v1.OperationRunTarget.operation_run_id:type_name -> v1.UUID
+	22,  // 275: v1.OperationRunTarget.rack_id:type_name -> v1.UUID
+	22,  // 276: v1.OperationRunTarget.task_id:type_name -> v1.UUID
+	20,  // 277: v1.OperationRunTarget.status:type_name -> v1.OperationRunTargetStatus
+	37,  // 278: v1.OperationRunTarget.components_by_type:type_name -> v1.ComponentsByType
+	190, // 279: v1.OperationRunTarget.created_at:type_name -> google.protobuf.Timestamp
+	190, // 280: v1.OperationRunTarget.updated_at:type_name -> google.protobuf.Timestamp
+	189, // 281: v1.NVLDomainTargets.targets:type_name -> v1.NVLDomainTarget
+	22,  // 282: v1.NVLDomainTarget.id:type_name -> v1.UUID
+	1,   // 283: v1.NVLDomainTarget.component_types:type_name -> v1.ComponentType
+	103, // 284: v1.Flow.Version:input_type -> v1.VersionRequest
+	125, // 285: v1.Flow.CreateTaskSchedule:input_type -> v1.CreateTaskScheduleRequest
+	126, // 286: v1.Flow.GetTaskSchedule:input_type -> v1.GetTaskScheduleRequest
+	127, // 287: v1.Flow.ListTaskSchedules:input_type -> v1.ListTaskSchedulesRequest
+	129, // 288: v1.Flow.UpdateTaskSchedule:input_type -> v1.UpdateTaskScheduleRequest
+	130, // 289: v1.Flow.PauseTaskSchedule:input_type -> v1.PauseTaskScheduleRequest
+	131, // 290: v1.Flow.ResumeTaskSchedule:input_type -> v1.ResumeTaskScheduleRequest
+	132, // 291: v1.Flow.DeleteTaskSchedule:input_type -> v1.DeleteTaskScheduleRequest
+	133, // 292: v1.Flow.TriggerTaskSchedule:input_type -> v1.TriggerTaskScheduleRequest
+	135, // 293: v1.Flow.AddTaskScheduleScope:input_type -> v1.AddTaskScheduleScopeRequest
+	137, // 294: v1.Flow.RemoveTaskScheduleScope:input_type -> v1.RemoveTaskScheduleScopeRequest
+	138, // 295: v1.Flow.UpdateTaskScheduleScope:input_type -> v1.UpdateTaskScheduleScopeRequest
+	140, // 296: v1.Flow.ListTaskScheduleScopes:input_type -> v1.ListTaskScheduleScopesRequest
+	142, // 297: v1.Flow.CheckScheduleConflicts:input_type -> v1.CheckScheduleConflictsRequest
+	48,  // 298: v1.Flow.CreateExpectedRack:input_type -> v1.CreateExpectedRackRequest
+	50,  // 299: v1.Flow.GetRackInfoByID:input_type -> v1.GetRackInfoByIDRequest
+	51,  // 300: v1.Flow.GetRackInfoBySerial:input_type -> v1.GetRackInfoBySerialRequest
+	58,  // 301: v1.Flow.GetListOfRacks:input_type -> v1.GetListOfRacksRequest
+	53,  // 302: v1.Flow.PatchRack:input_type -> v1.PatchRackRequest
+	81,  // 303: v1.Flow.DeleteRack:input_type -> v1.DeleteRackRequest
+	83,  // 304: v1.Flow.PurgeRack:input_type -> v1.PurgeRackRequest
+	68,  // 305: v1.Flow.UpgradeFirmware:input_type -> v1.UpgradeFirmwareRequest
+	94,  // 306: v1.Flow.BringUpRack:input_type -> v1.BringUpRackRequest
+	95,  // 307: v1.Flow.IngestRack:input_type -> v1.IngestRackRequest
+	96,  // 308: v1.Flow.DecommissionRack:input_type -> v1.DecommissionRackRequest
+	91,  // 309: v1.Flow.PowerOnRack:input_type -> v1.PowerOnRackRequest
+	92,  // 310: v1.Flow.PowerOffRack:input_type -> v1.PowerOffRackRequest
+	93,  // 311: v1.Flow.PowerResetRack:input_type -> v1.PowerResetRackRequest
+	55,  // 312: v1.Flow.GetComponentInfoByID:input_type -> v1.GetComponentInfoByIDRequest
+	56,  // 313: v1.Flow.GetComponentInfoBySerial:input_type -> v1.GetComponentInfoBySerialRequest
+	71,  // 314: v1.Flow.GetComponents:input_type -> v1.GetComponentsRequest
+	73,  // 315: v1.Flow.ValidateComponents:input_type -> v1.ValidateComponentsRequest
+	77,  // 316: v1.Flow.AddComponent:input_type -> v1.AddComponentRequest
+	87,  // 317: v1.Flow.PatchComponent:input_type -> v1.PatchComponentRequest
+	79,  // 318: v1.Flow.DeleteComponent:input_type -> v1.DeleteComponentRequest
+	85,  // 319: v1.Flow.PurgeComponent:input_type -> v1.PurgeComponentRequest
+	60,  // 320: v1.Flow.CreateNVLDomain:input_type -> v1.CreateNVLDomainRequest
+	62,  // 321: v1.Flow.AttachRacksToNVLDomain:input_type -> v1.AttachRacksToNVLDomainRequest
+	63,  // 322: v1.Flow.DetachRacksFromNVLDomain:input_type -> v1.DetachRacksFromNVLDomainRequest
+	64,  // 323: v1.Flow.GetListOfNVLDomains:input_type -> v1.GetListOfNVLDomainsRequest
+	66,  // 324: v1.Flow.GetRacksForNVLDomain:input_type -> v1.GetRacksForNVLDomainRequest
+	97,  // 325: v1.Flow.ListTasks:input_type -> v1.ListTasksRequest
+	99,  // 326: v1.Flow.GetTasksByIDs:input_type -> v1.GetTasksByIDsRequest
+	101, // 327: v1.Flow.CancelTask:input_type -> v1.CancelTaskRequest
+	106, // 328: v1.Flow.CreateOperationRule:input_type -> v1.CreateOperationRuleRequest
+	108, // 329: v1.Flow.UpdateOperationRule:input_type -> v1.UpdateOperationRuleRequest
+	109, // 330: v1.Flow.DeleteOperationRule:input_type -> v1.DeleteOperationRuleRequest
+	111, // 331: v1.Flow.GetOperationRule:input_type -> v1.GetOperationRuleRequest
+	112, // 332: v1.Flow.ListOperationRules:input_type -> v1.ListOperationRulesRequest
+	110, // 333: v1.Flow.SetRuleAsDefault:input_type -> v1.SetRuleAsDefaultRequest
+	114, // 334: v1.Flow.AssociateRuleWithRack:input_type -> v1.AssociateRuleWithRackRequest
+	115, // 335: v1.Flow.DisassociateRuleFromRack:input_type -> v1.DisassociateRuleFromRackRequest
+	116, // 336: v1.Flow.GetRackRuleAssociation:input_type -> v1.GetRackRuleAssociationRequest
+	118, // 337: v1.Flow.ListRackRuleAssociations:input_type -> v1.ListRackRuleAssociationsRequest
+	144, // 338: v1.Flow.CreateOperationRun:input_type -> v1.CreateOperationRunRequest
+	147, // 339: v1.Flow.GetOperationRun:input_type -> v1.GetOperationRunRequest
+	149, // 340: v1.Flow.ListOperationRuns:input_type -> v1.ListOperationRunsRequest
+	153, // 341: v1.Flow.ListOperationRunTargets:input_type -> v1.ListOperationRunTargetsRequest
+	155, // 342: v1.Flow.PauseOperationRun:input_type -> v1.PauseOperationRunRequest
+	156, // 343: v1.Flow.ResumeOperationRun:input_type -> v1.ResumeOperationRunRequest
+	157, // 344: v1.Flow.AdvanceOperationRunPhase:input_type -> v1.AdvanceOperationRunPhaseRequest
+	158, // 345: v1.Flow.CancelOperationRun:input_type -> v1.CancelOperationRunRequest
+	104, // 346: v1.Flow.Version:output_type -> v1.BuildInfo
+	123, // 347: v1.Flow.CreateTaskSchedule:output_type -> v1.TaskSchedule
+	123, // 348: v1.Flow.GetTaskSchedule:output_type -> v1.TaskSchedule
+	128, // 349: v1.Flow.ListTaskSchedules:output_type -> v1.ListTaskSchedulesResponse
+	123, // 350: v1.Flow.UpdateTaskSchedule:output_type -> v1.TaskSchedule
+	123, // 351: v1.Flow.PauseTaskSchedule:output_type -> v1.TaskSchedule
+	123, // 352: v1.Flow.ResumeTaskSchedule:output_type -> v1.TaskSchedule
+	193, // 353: v1.Flow.DeleteTaskSchedule:output_type -> google.protobuf.Empty
+	89,  // 354: v1.Flow.TriggerTaskSchedule:output_type -> v1.SubmitTaskResponse
+	136, // 355: v1.Flow.AddTaskScheduleScope:output_type -> v1.AddTaskScheduleScopeResponse
+	193, // 356: v1.Flow.RemoveTaskScheduleScope:output_type -> google.protobuf.Empty
+	139, // 357: v1.Flow.UpdateTaskScheduleScope:output_type -> v1.UpdateTaskScheduleScopeResponse
+	141, // 358: v1.Flow.ListTaskScheduleScopes:output_type -> v1.ListTaskScheduleScopesResponse
+	143, // 359: v1.Flow.CheckScheduleConflicts:output_type -> v1.CheckScheduleConflictsResponse
+	49,  // 360: v1.Flow.CreateExpectedRack:output_type -> v1.CreateExpectedRackResponse
+	52,  // 361: v1.Flow.GetRackInfoByID:output_type -> v1.GetRackInfoResponse
+	52,  // 362: v1.Flow.GetRackInfoBySerial:output_type -> v1.GetRackInfoResponse
+	59,  // 363: v1.Flow.GetListOfRacks:output_type -> v1.GetListOfRacksResponse
+	54,  // 364: v1.Flow.PatchRack:output_type -> v1.PatchRackResponse
+	82,  // 365: v1.Flow.DeleteRack:output_type -> v1.DeleteRackResponse
+	84,  // 366: v1.Flow.PurgeRack:output_type -> v1.PurgeRackResponse
+	89,  // 367: v1.Flow.UpgradeFirmware:output_type -> v1.SubmitTaskResponse
+	89,  // 368: v1.Flow.BringUpRack:output_type -> v1.SubmitTaskResponse
+	89,  // 369: v1.Flow.IngestRack:output_type -> v1.SubmitTaskResponse
+	89,  // 370: v1.Flow.DecommissionRack:output_type -> v1.SubmitTaskResponse
+	89,  // 371: v1.Flow.PowerOnRack:output_type -> v1.SubmitTaskResponse
+	89,  // 372: v1.Flow.PowerOffRack:output_type -> v1.SubmitTaskResponse
+	89,  // 373: v1.Flow.PowerResetRack:output_type -> v1.SubmitTaskResponse
+	57,  // 374: v1.Flow.GetComponentInfoByID:output_type -> v1.GetComponentInfoResponse
+	57,  // 375: v1.Flow.GetComponentInfoBySerial:output_type -> v1.GetComponentInfoResponse
+	72,  // 376: v1.Flow.GetComponents:output_type -> v1.GetComponentsResponse
+	74,  // 377: v1.Flow.ValidateComponents:output_type -> v1.ValidateComponentsResponse
+	78,  // 378: v1.Flow.AddComponent:output_type -> v1.AddComponentResponse
+	88,  // 379: v1.Flow.PatchComponent:output_type -> v1.PatchComponentResponse
+	80,  // 380: v1.Flow.DeleteComponent:output_type -> v1.DeleteComponentResponse
+	86,  // 381: v1.Flow.PurgeComponent:output_type -> v1.PurgeComponentResponse
+	61,  // 382: v1.Flow.CreateNVLDomain:output_type -> v1.CreateNVLDomainResponse
+	193, // 383: v1.Flow.AttachRacksToNVLDomain:output_type -> google.protobuf.Empty
+	193, // 384: v1.Flow.DetachRacksFromNVLDomain:output_type -> google.protobuf.Empty
+	65,  // 385: v1.Flow.GetListOfNVLDomains:output_type -> v1.GetListOfNVLDomainsResponse
+	67,  // 386: v1.Flow.GetRacksForNVLDomain:output_type -> v1.GetRacksForNVLDomainResponse
+	98,  // 387: v1.Flow.ListTasks:output_type -> v1.ListTasksResponse
+	100, // 388: v1.Flow.GetTasksByIDs:output_type -> v1.GetTasksByIDsResponse
+	102, // 389: v1.Flow.CancelTask:output_type -> v1.CancelTaskResponse
+	107, // 390: v1.Flow.CreateOperationRule:output_type -> v1.CreateOperationRuleResponse
+	193, // 391: v1.Flow.UpdateOperationRule:output_type -> google.protobuf.Empty
+	193, // 392: v1.Flow.DeleteOperationRule:output_type -> google.protobuf.Empty
+	105, // 393: v1.Flow.GetOperationRule:output_type -> v1.OperationRule
+	113, // 394: v1.Flow.ListOperationRules:output_type -> v1.ListOperationRulesResponse
+	193, // 395: v1.Flow.SetRuleAsDefault:output_type -> google.protobuf.Empty
+	193, // 396: v1.Flow.AssociateRuleWithRack:output_type -> google.protobuf.Empty
+	193, // 397: v1.Flow.DisassociateRuleFromRack:output_type -> google.protobuf.Empty
+	117, // 398: v1.Flow.GetRackRuleAssociation:output_type -> v1.GetRackRuleAssociationResponse
+	120, // 399: v1.Flow.ListRackRuleAssociations:output_type -> v1.ListRackRuleAssociationsResponse
+	145, // 400: v1.Flow.CreateOperationRun:output_type -> v1.CreateOperationRunResponse
+	148, // 401: v1.Flow.GetOperationRun:output_type -> v1.GetOperationRunResponse
+	150, // 402: v1.Flow.ListOperationRuns:output_type -> v1.ListOperationRunsResponse
+	154, // 403: v1.Flow.ListOperationRunTargets:output_type -> v1.ListOperationRunTargetsResponse
+	182, // 404: v1.Flow.PauseOperationRun:output_type -> v1.OperationRun
+	182, // 405: v1.Flow.ResumeOperationRun:output_type -> v1.OperationRun
+	182, // 406: v1.Flow.AdvanceOperationRunPhase:output_type -> v1.OperationRun
+	182, // 407: v1.Flow.CancelOperationRun:output_type -> v1.OperationRun
+	346, // [346:408] is the sub-list for method output_type
+	284, // [284:346] is the sub-list for method input_type
+	284, // [284:284] is the sub-list for extension type_name
+	284, // [284:284] is the sub-list for extension extendee
+	0,   // [0:284] is the sub-list for field type_name
 }
 
 func init() { file_flow_proto_init() }
@@ -13033,20 +13211,25 @@ func file_flow_proto_init() {
 	file_flow_proto_msgTypes[36].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[42].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[46].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[47].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[47].OneofWrappers = []any{
+		(*FirmwareAuthenticationData_Shared)(nil),
+		(*FirmwareAuthenticationData_PerComponent)(nil),
+	}
+	file_flow_proto_msgTypes[48].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[49].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[63].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[67].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[68].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[51].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[65].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[69].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[70].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[71].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[72].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[73].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[84].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[88].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[99].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[100].OneofWrappers = []any{
+	file_flow_proto_msgTypes[74].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[75].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[86].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[90].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[101].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[102].OneofWrappers = []any{
 		(*ScheduledOperation_PowerOn)(nil),
 		(*ScheduledOperation_PowerOff)(nil),
 		(*ScheduledOperation_PowerReset)(nil),
@@ -13054,41 +13237,41 @@ func file_flow_proto_init() {
 		(*ScheduledOperation_UpgradeFirmware)(nil),
 		(*ScheduledOperation_Ingest)(nil),
 	}
-	file_flow_proto_msgTypes[103].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[110].OneofWrappers = []any{
+	file_flow_proto_msgTypes[105].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[112].OneofWrappers = []any{
 		(*TaskScheduleScope_Types)(nil),
 		(*TaskScheduleScope_Components)(nil),
 	}
-	file_flow_proto_msgTypes[118].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[125].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[128].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[129].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[133].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[135].OneofWrappers = []any{
+	file_flow_proto_msgTypes[120].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[127].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[130].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[131].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[135].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[137].OneofWrappers = []any{
 		(*OperationRunSelector_Percentage)(nil),
 	}
-	file_flow_proto_msgTypes[139].OneofWrappers = []any{
+	file_flow_proto_msgTypes[141].OneofWrappers = []any{
 		(*OperationRunSafetyGate_FailureRate)(nil),
 		(*OperationRunSafetyGate_FailureCount)(nil),
 	}
-	file_flow_proto_msgTypes[142].OneofWrappers = []any{
+	file_flow_proto_msgTypes[144].OneofWrappers = []any{
 		(*OperationRunOrderingPolicy_Random)(nil),
 		(*OperationRunOrderingPolicy_PhysicalLocation)(nil),
 	}
-	file_flow_proto_msgTypes[145].OneofWrappers = []any{
+	file_flow_proto_msgTypes[147].OneofWrappers = []any{
 		(*OperationRunPhasePolicy_Equal)(nil),
 		(*OperationRunPhasePolicy_Percentage)(nil),
 		(*OperationRunPhasePolicy_Count)(nil),
 	}
-	file_flow_proto_msgTypes[152].OneofWrappers = []any{
+	file_flow_proto_msgTypes[154].OneofWrappers = []any{
 		(*OperationRunConflictPolicy_Retry)(nil),
 	}
-	file_flow_proto_msgTypes[155].OneofWrappers = []any{
+	file_flow_proto_msgTypes[157].OneofWrappers = []any{
 		(*OperationRunOperation_UpgradeFirmware)(nil),
 	}
-	file_flow_proto_msgTypes[157].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[159].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[165].OneofWrappers = []any{
+	file_flow_proto_msgTypes[161].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[167].OneofWrappers = []any{
 		(*NVLDomainTarget_Id)(nil),
 		(*NVLDomainTarget_Name)(nil),
 	}
@@ -13098,7 +13281,7 @@ func file_flow_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_flow_proto_rawDesc), len(file_flow_proto_rawDesc)),
 			NumEnums:      22,
-			NumMessages:   166,
+			NumMessages:   168,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rest-api/flow/proto/v1/flow.proto
+++ b/rest-api/flow/proto/v1/flow.proto
@@ -522,6 +522,28 @@ message UpgradeFirmwareRequest {
     // that would otherwise block disruptive operations against tenanted
     // hardware. The bypass is recorded in the server log.
     bool override_readiness_check = 9;
+    // Optional, write-only authentication data for firmware downloads. It is
+    // not supported for DPU-only updates or by the legacy NICo compute
+    // firmware controller.
+    FirmwareAuthenticationData authentication_data = 10;
+}
+
+// FirmwareAuthenticationData selects either one value shared by every target
+// or values scoped to supported firmware tray types.
+message FirmwareAuthenticationData {
+    oneof value {
+        string shared = 1;
+        PerComponentFirmwareAuthenticationData per_component = 2;
+    }
+}
+
+// PerComponentFirmwareAuthenticationData carries independent authentication
+// data for each supported firmware tray type. An omitted field means that tray
+// type receives no authentication data.
+message PerComponentFirmwareAuthenticationData {
+    optional string compute = 1;
+    optional string nvswitch = 2;
+    optional string powershelf = 3;
 }
 
 // GetComponents - retrieves components from local database

--- a/rest-api/proto/flow/gen/v1/flow.pb.go
+++ b/rest-api/proto/flow/gen/v1/flow.pb.go
@@ -1252,7 +1252,7 @@ func (x OperationRunPhysicalLocationOrdering_Strategy) Number() protoreflect.Enu
 
 // Deprecated: Use OperationRunPhysicalLocationOrdering_Strategy.Descriptor instead.
 func (OperationRunPhysicalLocationOrdering_Strategy) EnumDescriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{143, 0}
+	return file_flow_proto_rawDescGZIP(), []int{145, 0}
 }
 
 type UUID struct {
@@ -4076,8 +4076,12 @@ type UpgradeFirmwareRequest struct {
 	// that would otherwise block disruptive operations against tenanted
 	// hardware. The bypass is recorded in the server log.
 	OverrideReadinessCheck bool `protobuf:"varint,9,opt,name=override_readiness_check,json=overrideReadinessCheck,proto3" json:"override_readiness_check,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// Optional, write-only authentication data for firmware downloads. It is
+	// not supported for DPU-only updates or by the legacy NICo compute
+	// firmware controller.
+	AuthenticationData *FirmwareAuthenticationData `protobuf:"bytes,10,opt,name=authentication_data,json=authenticationData,proto3" json:"authentication_data,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *UpgradeFirmwareRequest) Reset() {
@@ -4173,6 +4177,160 @@ func (x *UpgradeFirmwareRequest) GetOverrideReadinessCheck() bool {
 	return false
 }
 
+func (x *UpgradeFirmwareRequest) GetAuthenticationData() *FirmwareAuthenticationData {
+	if x != nil {
+		return x.AuthenticationData
+	}
+	return nil
+}
+
+// FirmwareAuthenticationData selects either one value shared by every target
+// or values scoped to supported firmware tray types.
+type FirmwareAuthenticationData struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Value:
+	//
+	//	*FirmwareAuthenticationData_Shared
+	//	*FirmwareAuthenticationData_PerComponent
+	Value         isFirmwareAuthenticationData_Value `protobuf_oneof:"value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FirmwareAuthenticationData) Reset() {
+	*x = FirmwareAuthenticationData{}
+	mi := &file_flow_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FirmwareAuthenticationData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FirmwareAuthenticationData) ProtoMessage() {}
+
+func (x *FirmwareAuthenticationData) ProtoReflect() protoreflect.Message {
+	mi := &file_flow_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FirmwareAuthenticationData.ProtoReflect.Descriptor instead.
+func (*FirmwareAuthenticationData) Descriptor() ([]byte, []int) {
+	return file_flow_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *FirmwareAuthenticationData) GetValue() isFirmwareAuthenticationData_Value {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *FirmwareAuthenticationData) GetShared() string {
+	if x != nil {
+		if x, ok := x.Value.(*FirmwareAuthenticationData_Shared); ok {
+			return x.Shared
+		}
+	}
+	return ""
+}
+
+func (x *FirmwareAuthenticationData) GetPerComponent() *PerComponentFirmwareAuthenticationData {
+	if x != nil {
+		if x, ok := x.Value.(*FirmwareAuthenticationData_PerComponent); ok {
+			return x.PerComponent
+		}
+	}
+	return nil
+}
+
+type isFirmwareAuthenticationData_Value interface {
+	isFirmwareAuthenticationData_Value()
+}
+
+type FirmwareAuthenticationData_Shared struct {
+	Shared string `protobuf:"bytes,1,opt,name=shared,proto3,oneof"`
+}
+
+type FirmwareAuthenticationData_PerComponent struct {
+	PerComponent *PerComponentFirmwareAuthenticationData `protobuf:"bytes,2,opt,name=per_component,json=perComponent,proto3,oneof"`
+}
+
+func (*FirmwareAuthenticationData_Shared) isFirmwareAuthenticationData_Value() {}
+
+func (*FirmwareAuthenticationData_PerComponent) isFirmwareAuthenticationData_Value() {}
+
+// PerComponentFirmwareAuthenticationData carries independent authentication
+// data for each supported firmware tray type. An omitted field means that tray
+// type receives no authentication data.
+type PerComponentFirmwareAuthenticationData struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Compute       *string                `protobuf:"bytes,1,opt,name=compute,proto3,oneof" json:"compute,omitempty"`
+	Nvswitch      *string                `protobuf:"bytes,2,opt,name=nvswitch,proto3,oneof" json:"nvswitch,omitempty"`
+	Powershelf    *string                `protobuf:"bytes,3,opt,name=powershelf,proto3,oneof" json:"powershelf,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PerComponentFirmwareAuthenticationData) Reset() {
+	*x = PerComponentFirmwareAuthenticationData{}
+	mi := &file_flow_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PerComponentFirmwareAuthenticationData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PerComponentFirmwareAuthenticationData) ProtoMessage() {}
+
+func (x *PerComponentFirmwareAuthenticationData) ProtoReflect() protoreflect.Message {
+	mi := &file_flow_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PerComponentFirmwareAuthenticationData.ProtoReflect.Descriptor instead.
+func (*PerComponentFirmwareAuthenticationData) Descriptor() ([]byte, []int) {
+	return file_flow_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *PerComponentFirmwareAuthenticationData) GetCompute() string {
+	if x != nil && x.Compute != nil {
+		return *x.Compute
+	}
+	return ""
+}
+
+func (x *PerComponentFirmwareAuthenticationData) GetNvswitch() string {
+	if x != nil && x.Nvswitch != nil {
+		return *x.Nvswitch
+	}
+	return ""
+}
+
+func (x *PerComponentFirmwareAuthenticationData) GetPowershelf() string {
+	if x != nil && x.Powershelf != nil {
+		return *x.Powershelf
+	}
+	return ""
+}
+
 // GetComponents - retrieves components from local database
 type GetComponentsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -4186,7 +4344,7 @@ type GetComponentsRequest struct {
 
 func (x *GetComponentsRequest) Reset() {
 	*x = GetComponentsRequest{}
-	mi := &file_flow_proto_msgTypes[47]
+	mi := &file_flow_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4198,7 +4356,7 @@ func (x *GetComponentsRequest) String() string {
 func (*GetComponentsRequest) ProtoMessage() {}
 
 func (x *GetComponentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[47]
+	mi := &file_flow_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4211,7 +4369,7 @@ func (x *GetComponentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetComponentsRequest.ProtoReflect.Descriptor instead.
 func (*GetComponentsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{47}
+	return file_flow_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetComponentsRequest) GetTargetSpec() *OperationTargetSpec {
@@ -4252,7 +4410,7 @@ type GetComponentsResponse struct {
 
 func (x *GetComponentsResponse) Reset() {
 	*x = GetComponentsResponse{}
-	mi := &file_flow_proto_msgTypes[48]
+	mi := &file_flow_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4264,7 +4422,7 @@ func (x *GetComponentsResponse) String() string {
 func (*GetComponentsResponse) ProtoMessage() {}
 
 func (x *GetComponentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[48]
+	mi := &file_flow_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4277,7 +4435,7 @@ func (x *GetComponentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetComponentsResponse.ProtoReflect.Descriptor instead.
 func (*GetComponentsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{48}
+	return file_flow_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GetComponentsResponse) GetComponents() []*Component {
@@ -4306,7 +4464,7 @@ type ValidateComponentsRequest struct {
 
 func (x *ValidateComponentsRequest) Reset() {
 	*x = ValidateComponentsRequest{}
-	mi := &file_flow_proto_msgTypes[49]
+	mi := &file_flow_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4318,7 +4476,7 @@ func (x *ValidateComponentsRequest) String() string {
 func (*ValidateComponentsRequest) ProtoMessage() {}
 
 func (x *ValidateComponentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[49]
+	mi := &file_flow_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4331,7 +4489,7 @@ func (x *ValidateComponentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateComponentsRequest.ProtoReflect.Descriptor instead.
 func (*ValidateComponentsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{49}
+	return file_flow_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ValidateComponentsRequest) GetTargetSpec() *OperationTargetSpec {
@@ -4377,7 +4535,7 @@ type ValidateComponentsResponse struct {
 
 func (x *ValidateComponentsResponse) Reset() {
 	*x = ValidateComponentsResponse{}
-	mi := &file_flow_proto_msgTypes[50]
+	mi := &file_flow_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4389,7 +4547,7 @@ func (x *ValidateComponentsResponse) String() string {
 func (*ValidateComponentsResponse) ProtoMessage() {}
 
 func (x *ValidateComponentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[50]
+	mi := &file_flow_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4402,7 +4560,7 @@ func (x *ValidateComponentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateComponentsResponse.ProtoReflect.Descriptor instead.
 func (*ValidateComponentsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{50}
+	return file_flow_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ValidateComponentsResponse) GetDiffs() []*ComponentDiff {
@@ -4461,7 +4619,7 @@ type ComponentDiff struct {
 
 func (x *ComponentDiff) Reset() {
 	*x = ComponentDiff{}
-	mi := &file_flow_proto_msgTypes[51]
+	mi := &file_flow_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4473,7 +4631,7 @@ func (x *ComponentDiff) String() string {
 func (*ComponentDiff) ProtoMessage() {}
 
 func (x *ComponentDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[51]
+	mi := &file_flow_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4486,7 +4644,7 @@ func (x *ComponentDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComponentDiff.ProtoReflect.Descriptor instead.
 func (*ComponentDiff) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{51}
+	return file_flow_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ComponentDiff) GetType() DiffType {
@@ -4542,7 +4700,7 @@ type FieldDiff struct {
 
 func (x *FieldDiff) Reset() {
 	*x = FieldDiff{}
-	mi := &file_flow_proto_msgTypes[52]
+	mi := &file_flow_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4554,7 +4712,7 @@ func (x *FieldDiff) String() string {
 func (*FieldDiff) ProtoMessage() {}
 
 func (x *FieldDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[52]
+	mi := &file_flow_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4567,7 +4725,7 @@ func (x *FieldDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldDiff.ProtoReflect.Descriptor instead.
 func (*FieldDiff) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{52}
+	return file_flow_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *FieldDiff) GetFieldName() string {
@@ -4604,7 +4762,7 @@ type AddComponentRequest struct {
 
 func (x *AddComponentRequest) Reset() {
 	*x = AddComponentRequest{}
-	mi := &file_flow_proto_msgTypes[53]
+	mi := &file_flow_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4616,7 +4774,7 @@ func (x *AddComponentRequest) String() string {
 func (*AddComponentRequest) ProtoMessage() {}
 
 func (x *AddComponentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[53]
+	mi := &file_flow_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4629,7 +4787,7 @@ func (x *AddComponentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddComponentRequest.ProtoReflect.Descriptor instead.
 func (*AddComponentRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{53}
+	return file_flow_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *AddComponentRequest) GetComponent() *Component {
@@ -4648,7 +4806,7 @@ type AddComponentResponse struct {
 
 func (x *AddComponentResponse) Reset() {
 	*x = AddComponentResponse{}
-	mi := &file_flow_proto_msgTypes[54]
+	mi := &file_flow_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4660,7 +4818,7 @@ func (x *AddComponentResponse) String() string {
 func (*AddComponentResponse) ProtoMessage() {}
 
 func (x *AddComponentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[54]
+	mi := &file_flow_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4673,7 +4831,7 @@ func (x *AddComponentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddComponentResponse.ProtoReflect.Descriptor instead.
 func (*AddComponentResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{54}
+	return file_flow_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *AddComponentResponse) GetComponent() *Component {
@@ -4693,7 +4851,7 @@ type DeleteComponentRequest struct {
 
 func (x *DeleteComponentRequest) Reset() {
 	*x = DeleteComponentRequest{}
-	mi := &file_flow_proto_msgTypes[55]
+	mi := &file_flow_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4705,7 +4863,7 @@ func (x *DeleteComponentRequest) String() string {
 func (*DeleteComponentRequest) ProtoMessage() {}
 
 func (x *DeleteComponentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[55]
+	mi := &file_flow_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4718,7 +4876,7 @@ func (x *DeleteComponentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteComponentRequest.ProtoReflect.Descriptor instead.
 func (*DeleteComponentRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{55}
+	return file_flow_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *DeleteComponentRequest) GetId() *UUID {
@@ -4736,7 +4894,7 @@ type DeleteComponentResponse struct {
 
 func (x *DeleteComponentResponse) Reset() {
 	*x = DeleteComponentResponse{}
-	mi := &file_flow_proto_msgTypes[56]
+	mi := &file_flow_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4748,7 +4906,7 @@ func (x *DeleteComponentResponse) String() string {
 func (*DeleteComponentResponse) ProtoMessage() {}
 
 func (x *DeleteComponentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[56]
+	mi := &file_flow_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4761,7 +4919,7 @@ func (x *DeleteComponentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteComponentResponse.ProtoReflect.Descriptor instead.
 func (*DeleteComponentResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{56}
+	return file_flow_proto_rawDescGZIP(), []int{58}
 }
 
 // DeleteRack - soft-delete a rack and cascade to its components
@@ -4774,7 +4932,7 @@ type DeleteRackRequest struct {
 
 func (x *DeleteRackRequest) Reset() {
 	*x = DeleteRackRequest{}
-	mi := &file_flow_proto_msgTypes[57]
+	mi := &file_flow_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4786,7 +4944,7 @@ func (x *DeleteRackRequest) String() string {
 func (*DeleteRackRequest) ProtoMessage() {}
 
 func (x *DeleteRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[57]
+	mi := &file_flow_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4799,7 +4957,7 @@ func (x *DeleteRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRackRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{57}
+	return file_flow_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *DeleteRackRequest) GetId() *UUID {
@@ -4817,7 +4975,7 @@ type DeleteRackResponse struct {
 
 func (x *DeleteRackResponse) Reset() {
 	*x = DeleteRackResponse{}
-	mi := &file_flow_proto_msgTypes[58]
+	mi := &file_flow_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4829,7 +4987,7 @@ func (x *DeleteRackResponse) String() string {
 func (*DeleteRackResponse) ProtoMessage() {}
 
 func (x *DeleteRackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[58]
+	mi := &file_flow_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4842,7 +5000,7 @@ func (x *DeleteRackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRackResponse.ProtoReflect.Descriptor instead.
 func (*DeleteRackResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{58}
+	return file_flow_proto_rawDescGZIP(), []int{60}
 }
 
 // PurgeRack - permanently remove a soft-deleted rack and its components
@@ -4855,7 +5013,7 @@ type PurgeRackRequest struct {
 
 func (x *PurgeRackRequest) Reset() {
 	*x = PurgeRackRequest{}
-	mi := &file_flow_proto_msgTypes[59]
+	mi := &file_flow_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4867,7 +5025,7 @@ func (x *PurgeRackRequest) String() string {
 func (*PurgeRackRequest) ProtoMessage() {}
 
 func (x *PurgeRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[59]
+	mi := &file_flow_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4880,7 +5038,7 @@ func (x *PurgeRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeRackRequest.ProtoReflect.Descriptor instead.
 func (*PurgeRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{59}
+	return file_flow_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *PurgeRackRequest) GetId() *UUID {
@@ -4898,7 +5056,7 @@ type PurgeRackResponse struct {
 
 func (x *PurgeRackResponse) Reset() {
 	*x = PurgeRackResponse{}
-	mi := &file_flow_proto_msgTypes[60]
+	mi := &file_flow_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4910,7 +5068,7 @@ func (x *PurgeRackResponse) String() string {
 func (*PurgeRackResponse) ProtoMessage() {}
 
 func (x *PurgeRackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[60]
+	mi := &file_flow_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4923,7 +5081,7 @@ func (x *PurgeRackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeRackResponse.ProtoReflect.Descriptor instead.
 func (*PurgeRackResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{60}
+	return file_flow_proto_rawDescGZIP(), []int{62}
 }
 
 // PurgeComponent - permanently remove a soft-deleted component
@@ -4936,7 +5094,7 @@ type PurgeComponentRequest struct {
 
 func (x *PurgeComponentRequest) Reset() {
 	*x = PurgeComponentRequest{}
-	mi := &file_flow_proto_msgTypes[61]
+	mi := &file_flow_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4948,7 +5106,7 @@ func (x *PurgeComponentRequest) String() string {
 func (*PurgeComponentRequest) ProtoMessage() {}
 
 func (x *PurgeComponentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[61]
+	mi := &file_flow_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4961,7 +5119,7 @@ func (x *PurgeComponentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeComponentRequest.ProtoReflect.Descriptor instead.
 func (*PurgeComponentRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{61}
+	return file_flow_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *PurgeComponentRequest) GetId() *UUID {
@@ -4979,7 +5137,7 @@ type PurgeComponentResponse struct {
 
 func (x *PurgeComponentResponse) Reset() {
 	*x = PurgeComponentResponse{}
-	mi := &file_flow_proto_msgTypes[62]
+	mi := &file_flow_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4991,7 +5149,7 @@ func (x *PurgeComponentResponse) String() string {
 func (*PurgeComponentResponse) ProtoMessage() {}
 
 func (x *PurgeComponentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[62]
+	mi := &file_flow_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5004,7 +5162,7 @@ func (x *PurgeComponentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeComponentResponse.ProtoReflect.Descriptor instead.
 func (*PurgeComponentResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{62}
+	return file_flow_proto_rawDescGZIP(), []int{64}
 }
 
 // PatchComponent - update a single component's fields
@@ -5022,7 +5180,7 @@ type PatchComponentRequest struct {
 
 func (x *PatchComponentRequest) Reset() {
 	*x = PatchComponentRequest{}
-	mi := &file_flow_proto_msgTypes[63]
+	mi := &file_flow_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5034,7 +5192,7 @@ func (x *PatchComponentRequest) String() string {
 func (*PatchComponentRequest) ProtoMessage() {}
 
 func (x *PatchComponentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[63]
+	mi := &file_flow_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5047,7 +5205,7 @@ func (x *PatchComponentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PatchComponentRequest.ProtoReflect.Descriptor instead.
 func (*PatchComponentRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{63}
+	return file_flow_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *PatchComponentRequest) GetId() *UUID {
@@ -5101,7 +5259,7 @@ type PatchComponentResponse struct {
 
 func (x *PatchComponentResponse) Reset() {
 	*x = PatchComponentResponse{}
-	mi := &file_flow_proto_msgTypes[64]
+	mi := &file_flow_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5113,7 +5271,7 @@ func (x *PatchComponentResponse) String() string {
 func (*PatchComponentResponse) ProtoMessage() {}
 
 func (x *PatchComponentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[64]
+	mi := &file_flow_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5126,7 +5284,7 @@ func (x *PatchComponentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PatchComponentResponse.ProtoReflect.Descriptor instead.
 func (*PatchComponentResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{64}
+	return file_flow_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *PatchComponentResponse) GetComponent() *Component {
@@ -5145,7 +5303,7 @@ type SubmitTaskResponse struct {
 
 func (x *SubmitTaskResponse) Reset() {
 	*x = SubmitTaskResponse{}
-	mi := &file_flow_proto_msgTypes[65]
+	mi := &file_flow_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5157,7 +5315,7 @@ func (x *SubmitTaskResponse) String() string {
 func (*SubmitTaskResponse) ProtoMessage() {}
 
 func (x *SubmitTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[65]
+	mi := &file_flow_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5170,7 +5328,7 @@ func (x *SubmitTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitTaskResponse.ProtoReflect.Descriptor instead.
 func (*SubmitTaskResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{65}
+	return file_flow_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *SubmitTaskResponse) GetTaskIds() []*UUID {
@@ -5196,7 +5354,7 @@ type QueueOptions struct {
 
 func (x *QueueOptions) Reset() {
 	*x = QueueOptions{}
-	mi := &file_flow_proto_msgTypes[66]
+	mi := &file_flow_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5208,7 +5366,7 @@ func (x *QueueOptions) String() string {
 func (*QueueOptions) ProtoMessage() {}
 
 func (x *QueueOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[66]
+	mi := &file_flow_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5221,7 +5379,7 @@ func (x *QueueOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueOptions.ProtoReflect.Descriptor instead.
 func (*QueueOptions) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{66}
+	return file_flow_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *QueueOptions) GetConflictStrategy() ConflictStrategy {
@@ -5257,7 +5415,7 @@ type PowerOnRackRequest struct {
 
 func (x *PowerOnRackRequest) Reset() {
 	*x = PowerOnRackRequest{}
-	mi := &file_flow_proto_msgTypes[67]
+	mi := &file_flow_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5269,7 +5427,7 @@ func (x *PowerOnRackRequest) String() string {
 func (*PowerOnRackRequest) ProtoMessage() {}
 
 func (x *PowerOnRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[67]
+	mi := &file_flow_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5282,7 +5440,7 @@ func (x *PowerOnRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerOnRackRequest.ProtoReflect.Descriptor instead.
 func (*PowerOnRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{67}
+	return file_flow_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *PowerOnRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5340,7 +5498,7 @@ type PowerOffRackRequest struct {
 
 func (x *PowerOffRackRequest) Reset() {
 	*x = PowerOffRackRequest{}
-	mi := &file_flow_proto_msgTypes[68]
+	mi := &file_flow_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5352,7 +5510,7 @@ func (x *PowerOffRackRequest) String() string {
 func (*PowerOffRackRequest) ProtoMessage() {}
 
 func (x *PowerOffRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[68]
+	mi := &file_flow_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5365,7 +5523,7 @@ func (x *PowerOffRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerOffRackRequest.ProtoReflect.Descriptor instead.
 func (*PowerOffRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{68}
+	return file_flow_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *PowerOffRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5430,7 +5588,7 @@ type PowerResetRackRequest struct {
 
 func (x *PowerResetRackRequest) Reset() {
 	*x = PowerResetRackRequest{}
-	mi := &file_flow_proto_msgTypes[69]
+	mi := &file_flow_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5442,7 +5600,7 @@ func (x *PowerResetRackRequest) String() string {
 func (*PowerResetRackRequest) ProtoMessage() {}
 
 func (x *PowerResetRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[69]
+	mi := &file_flow_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5455,7 +5613,7 @@ func (x *PowerResetRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PowerResetRackRequest.ProtoReflect.Descriptor instead.
 func (*PowerResetRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{69}
+	return file_flow_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *PowerResetRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5518,7 +5676,7 @@ type BringUpRackRequest struct {
 
 func (x *BringUpRackRequest) Reset() {
 	*x = BringUpRackRequest{}
-	mi := &file_flow_proto_msgTypes[70]
+	mi := &file_flow_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5530,7 +5688,7 @@ func (x *BringUpRackRequest) String() string {
 func (*BringUpRackRequest) ProtoMessage() {}
 
 func (x *BringUpRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[70]
+	mi := &file_flow_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5543,7 +5701,7 @@ func (x *BringUpRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BringUpRackRequest.ProtoReflect.Descriptor instead.
 func (*BringUpRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{70}
+	return file_flow_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *BringUpRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5586,7 +5744,7 @@ type IngestRackRequest struct {
 
 func (x *IngestRackRequest) Reset() {
 	*x = IngestRackRequest{}
-	mi := &file_flow_proto_msgTypes[71]
+	mi := &file_flow_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5598,7 +5756,7 @@ func (x *IngestRackRequest) String() string {
 func (*IngestRackRequest) ProtoMessage() {}
 
 func (x *IngestRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[71]
+	mi := &file_flow_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5611,7 +5769,7 @@ func (x *IngestRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IngestRackRequest.ProtoReflect.Descriptor instead.
 func (*IngestRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{71}
+	return file_flow_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *IngestRackRequest) GetTargetSpec() *OperationTargetSpec {
@@ -5670,7 +5828,7 @@ type ListTasksRequest struct {
 
 func (x *ListTasksRequest) Reset() {
 	*x = ListTasksRequest{}
-	mi := &file_flow_proto_msgTypes[72]
+	mi := &file_flow_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5682,7 +5840,7 @@ func (x *ListTasksRequest) String() string {
 func (*ListTasksRequest) ProtoMessage() {}
 
 func (x *ListTasksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[72]
+	mi := &file_flow_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5695,7 +5853,7 @@ func (x *ListTasksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTasksRequest.ProtoReflect.Descriptor instead.
 func (*ListTasksRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{72}
+	return file_flow_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ListTasksRequest) GetRackId() *UUID {
@@ -5743,7 +5901,7 @@ type ListTasksResponse struct {
 
 func (x *ListTasksResponse) Reset() {
 	*x = ListTasksResponse{}
-	mi := &file_flow_proto_msgTypes[73]
+	mi := &file_flow_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5755,7 +5913,7 @@ func (x *ListTasksResponse) String() string {
 func (*ListTasksResponse) ProtoMessage() {}
 
 func (x *ListTasksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[73]
+	mi := &file_flow_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5768,7 +5926,7 @@ func (x *ListTasksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTasksResponse.ProtoReflect.Descriptor instead.
 func (*ListTasksResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{73}
+	return file_flow_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *ListTasksResponse) GetTasks() []*Task {
@@ -5794,7 +5952,7 @@ type GetTasksByIDsRequest struct {
 
 func (x *GetTasksByIDsRequest) Reset() {
 	*x = GetTasksByIDsRequest{}
-	mi := &file_flow_proto_msgTypes[74]
+	mi := &file_flow_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5806,7 +5964,7 @@ func (x *GetTasksByIDsRequest) String() string {
 func (*GetTasksByIDsRequest) ProtoMessage() {}
 
 func (x *GetTasksByIDsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[74]
+	mi := &file_flow_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5819,7 +5977,7 @@ func (x *GetTasksByIDsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTasksByIDsRequest.ProtoReflect.Descriptor instead.
 func (*GetTasksByIDsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{74}
+	return file_flow_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *GetTasksByIDsRequest) GetTaskIds() []*UUID {
@@ -5838,7 +5996,7 @@ type GetTasksByIDsResponse struct {
 
 func (x *GetTasksByIDsResponse) Reset() {
 	*x = GetTasksByIDsResponse{}
-	mi := &file_flow_proto_msgTypes[75]
+	mi := &file_flow_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5850,7 +6008,7 @@ func (x *GetTasksByIDsResponse) String() string {
 func (*GetTasksByIDsResponse) ProtoMessage() {}
 
 func (x *GetTasksByIDsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[75]
+	mi := &file_flow_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5863,7 +6021,7 @@ func (x *GetTasksByIDsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTasksByIDsResponse.ProtoReflect.Descriptor instead.
 func (*GetTasksByIDsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{75}
+	return file_flow_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *GetTasksByIDsResponse) GetTasks() []*Task {
@@ -5882,7 +6040,7 @@ type CancelTaskRequest struct {
 
 func (x *CancelTaskRequest) Reset() {
 	*x = CancelTaskRequest{}
-	mi := &file_flow_proto_msgTypes[76]
+	mi := &file_flow_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5894,7 +6052,7 @@ func (x *CancelTaskRequest) String() string {
 func (*CancelTaskRequest) ProtoMessage() {}
 
 func (x *CancelTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[76]
+	mi := &file_flow_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5907,7 +6065,7 @@ func (x *CancelTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelTaskRequest.ProtoReflect.Descriptor instead.
 func (*CancelTaskRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{76}
+	return file_flow_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *CancelTaskRequest) GetTaskId() *UUID {
@@ -5926,7 +6084,7 @@ type CancelTaskResponse struct {
 
 func (x *CancelTaskResponse) Reset() {
 	*x = CancelTaskResponse{}
-	mi := &file_flow_proto_msgTypes[77]
+	mi := &file_flow_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5938,7 +6096,7 @@ func (x *CancelTaskResponse) String() string {
 func (*CancelTaskResponse) ProtoMessage() {}
 
 func (x *CancelTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[77]
+	mi := &file_flow_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5951,7 +6109,7 @@ func (x *CancelTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelTaskResponse.ProtoReflect.Descriptor instead.
 func (*CancelTaskResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{77}
+	return file_flow_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *CancelTaskResponse) GetTask() *Task {
@@ -5970,7 +6128,7 @@ type VersionRequest struct {
 
 func (x *VersionRequest) Reset() {
 	*x = VersionRequest{}
-	mi := &file_flow_proto_msgTypes[78]
+	mi := &file_flow_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5982,7 +6140,7 @@ func (x *VersionRequest) String() string {
 func (*VersionRequest) ProtoMessage() {}
 
 func (x *VersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[78]
+	mi := &file_flow_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5995,7 +6153,7 @@ func (x *VersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionRequest.ProtoReflect.Descriptor instead.
 func (*VersionRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{78}
+	return file_flow_proto_rawDescGZIP(), []int{80}
 }
 
 type BuildInfo struct {
@@ -6009,7 +6167,7 @@ type BuildInfo struct {
 
 func (x *BuildInfo) Reset() {
 	*x = BuildInfo{}
-	mi := &file_flow_proto_msgTypes[79]
+	mi := &file_flow_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6021,7 +6179,7 @@ func (x *BuildInfo) String() string {
 func (*BuildInfo) ProtoMessage() {}
 
 func (x *BuildInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[79]
+	mi := &file_flow_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6034,7 +6192,7 @@ func (x *BuildInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildInfo.ProtoReflect.Descriptor instead.
 func (*BuildInfo) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{79}
+	return file_flow_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *BuildInfo) GetVersion() string {
@@ -6075,7 +6233,7 @@ type OperationRule struct {
 
 func (x *OperationRule) Reset() {
 	*x = OperationRule{}
-	mi := &file_flow_proto_msgTypes[80]
+	mi := &file_flow_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6087,7 +6245,7 @@ func (x *OperationRule) String() string {
 func (*OperationRule) ProtoMessage() {}
 
 func (x *OperationRule) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[80]
+	mi := &file_flow_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6100,7 +6258,7 @@ func (x *OperationRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRule.ProtoReflect.Descriptor instead.
 func (*OperationRule) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{80}
+	return file_flow_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *OperationRule) GetId() *UUID {
@@ -6180,7 +6338,7 @@ type CreateOperationRuleRequest struct {
 
 func (x *CreateOperationRuleRequest) Reset() {
 	*x = CreateOperationRuleRequest{}
-	mi := &file_flow_proto_msgTypes[81]
+	mi := &file_flow_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6192,7 +6350,7 @@ func (x *CreateOperationRuleRequest) String() string {
 func (*CreateOperationRuleRequest) ProtoMessage() {}
 
 func (x *CreateOperationRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[81]
+	mi := &file_flow_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6205,7 +6363,7 @@ func (x *CreateOperationRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOperationRuleRequest.ProtoReflect.Descriptor instead.
 func (*CreateOperationRuleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{81}
+	return file_flow_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *CreateOperationRuleRequest) GetName() string {
@@ -6259,7 +6417,7 @@ type CreateOperationRuleResponse struct {
 
 func (x *CreateOperationRuleResponse) Reset() {
 	*x = CreateOperationRuleResponse{}
-	mi := &file_flow_proto_msgTypes[82]
+	mi := &file_flow_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6271,7 +6429,7 @@ func (x *CreateOperationRuleResponse) String() string {
 func (*CreateOperationRuleResponse) ProtoMessage() {}
 
 func (x *CreateOperationRuleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[82]
+	mi := &file_flow_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6284,7 +6442,7 @@ func (x *CreateOperationRuleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOperationRuleResponse.ProtoReflect.Descriptor instead.
 func (*CreateOperationRuleResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{82}
+	return file_flow_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *CreateOperationRuleResponse) GetId() *UUID {
@@ -6306,7 +6464,7 @@ type UpdateOperationRuleRequest struct {
 
 func (x *UpdateOperationRuleRequest) Reset() {
 	*x = UpdateOperationRuleRequest{}
-	mi := &file_flow_proto_msgTypes[83]
+	mi := &file_flow_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6318,7 +6476,7 @@ func (x *UpdateOperationRuleRequest) String() string {
 func (*UpdateOperationRuleRequest) ProtoMessage() {}
 
 func (x *UpdateOperationRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[83]
+	mi := &file_flow_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6331,7 +6489,7 @@ func (x *UpdateOperationRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateOperationRuleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateOperationRuleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{83}
+	return file_flow_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *UpdateOperationRuleRequest) GetRuleId() *UUID {
@@ -6371,7 +6529,7 @@ type DeleteOperationRuleRequest struct {
 
 func (x *DeleteOperationRuleRequest) Reset() {
 	*x = DeleteOperationRuleRequest{}
-	mi := &file_flow_proto_msgTypes[84]
+	mi := &file_flow_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6383,7 +6541,7 @@ func (x *DeleteOperationRuleRequest) String() string {
 func (*DeleteOperationRuleRequest) ProtoMessage() {}
 
 func (x *DeleteOperationRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[84]
+	mi := &file_flow_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6396,7 +6554,7 @@ func (x *DeleteOperationRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteOperationRuleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteOperationRuleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{84}
+	return file_flow_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *DeleteOperationRuleRequest) GetRuleId() *UUID {
@@ -6415,7 +6573,7 @@ type SetRuleAsDefaultRequest struct {
 
 func (x *SetRuleAsDefaultRequest) Reset() {
 	*x = SetRuleAsDefaultRequest{}
-	mi := &file_flow_proto_msgTypes[85]
+	mi := &file_flow_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6427,7 +6585,7 @@ func (x *SetRuleAsDefaultRequest) String() string {
 func (*SetRuleAsDefaultRequest) ProtoMessage() {}
 
 func (x *SetRuleAsDefaultRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[85]
+	mi := &file_flow_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6440,7 +6598,7 @@ func (x *SetRuleAsDefaultRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetRuleAsDefaultRequest.ProtoReflect.Descriptor instead.
 func (*SetRuleAsDefaultRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{85}
+	return file_flow_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *SetRuleAsDefaultRequest) GetRuleId() *UUID {
@@ -6459,7 +6617,7 @@ type GetOperationRuleRequest struct {
 
 func (x *GetOperationRuleRequest) Reset() {
 	*x = GetOperationRuleRequest{}
-	mi := &file_flow_proto_msgTypes[86]
+	mi := &file_flow_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6471,7 +6629,7 @@ func (x *GetOperationRuleRequest) String() string {
 func (*GetOperationRuleRequest) ProtoMessage() {}
 
 func (x *GetOperationRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[86]
+	mi := &file_flow_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6484,7 +6642,7 @@ func (x *GetOperationRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRuleRequest.ProtoReflect.Descriptor instead.
 func (*GetOperationRuleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{86}
+	return file_flow_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *GetOperationRuleRequest) GetRuleId() *UUID {
@@ -6506,7 +6664,7 @@ type ListOperationRulesRequest struct {
 
 func (x *ListOperationRulesRequest) Reset() {
 	*x = ListOperationRulesRequest{}
-	mi := &file_flow_proto_msgTypes[87]
+	mi := &file_flow_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6518,7 +6676,7 @@ func (x *ListOperationRulesRequest) String() string {
 func (*ListOperationRulesRequest) ProtoMessage() {}
 
 func (x *ListOperationRulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[87]
+	mi := &file_flow_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6531,7 +6689,7 @@ func (x *ListOperationRulesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRulesRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationRulesRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{87}
+	return file_flow_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *ListOperationRulesRequest) GetOperationType() OperationType {
@@ -6572,7 +6730,7 @@ type ListOperationRulesResponse struct {
 
 func (x *ListOperationRulesResponse) Reset() {
 	*x = ListOperationRulesResponse{}
-	mi := &file_flow_proto_msgTypes[88]
+	mi := &file_flow_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6584,7 +6742,7 @@ func (x *ListOperationRulesResponse) String() string {
 func (*ListOperationRulesResponse) ProtoMessage() {}
 
 func (x *ListOperationRulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[88]
+	mi := &file_flow_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6597,7 +6755,7 @@ func (x *ListOperationRulesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRulesResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationRulesResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{88}
+	return file_flow_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ListOperationRulesResponse) GetRules() []*OperationRule {
@@ -6624,7 +6782,7 @@ type AssociateRuleWithRackRequest struct {
 
 func (x *AssociateRuleWithRackRequest) Reset() {
 	*x = AssociateRuleWithRackRequest{}
-	mi := &file_flow_proto_msgTypes[89]
+	mi := &file_flow_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6636,7 +6794,7 @@ func (x *AssociateRuleWithRackRequest) String() string {
 func (*AssociateRuleWithRackRequest) ProtoMessage() {}
 
 func (x *AssociateRuleWithRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[89]
+	mi := &file_flow_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6649,7 +6807,7 @@ func (x *AssociateRuleWithRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssociateRuleWithRackRequest.ProtoReflect.Descriptor instead.
 func (*AssociateRuleWithRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{89}
+	return file_flow_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *AssociateRuleWithRackRequest) GetRackId() *UUID {
@@ -6677,7 +6835,7 @@ type DisassociateRuleFromRackRequest struct {
 
 func (x *DisassociateRuleFromRackRequest) Reset() {
 	*x = DisassociateRuleFromRackRequest{}
-	mi := &file_flow_proto_msgTypes[90]
+	mi := &file_flow_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6689,7 +6847,7 @@ func (x *DisassociateRuleFromRackRequest) String() string {
 func (*DisassociateRuleFromRackRequest) ProtoMessage() {}
 
 func (x *DisassociateRuleFromRackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[90]
+	mi := &file_flow_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6702,7 +6860,7 @@ func (x *DisassociateRuleFromRackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DisassociateRuleFromRackRequest.ProtoReflect.Descriptor instead.
 func (*DisassociateRuleFromRackRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{90}
+	return file_flow_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *DisassociateRuleFromRackRequest) GetRackId() *UUID {
@@ -6737,7 +6895,7 @@ type GetRackRuleAssociationRequest struct {
 
 func (x *GetRackRuleAssociationRequest) Reset() {
 	*x = GetRackRuleAssociationRequest{}
-	mi := &file_flow_proto_msgTypes[91]
+	mi := &file_flow_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6749,7 +6907,7 @@ func (x *GetRackRuleAssociationRequest) String() string {
 func (*GetRackRuleAssociationRequest) ProtoMessage() {}
 
 func (x *GetRackRuleAssociationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[91]
+	mi := &file_flow_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6762,7 +6920,7 @@ func (x *GetRackRuleAssociationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRackRuleAssociationRequest.ProtoReflect.Descriptor instead.
 func (*GetRackRuleAssociationRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{91}
+	return file_flow_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *GetRackRuleAssociationRequest) GetRackId() *UUID {
@@ -6795,7 +6953,7 @@ type GetRackRuleAssociationResponse struct {
 
 func (x *GetRackRuleAssociationResponse) Reset() {
 	*x = GetRackRuleAssociationResponse{}
-	mi := &file_flow_proto_msgTypes[92]
+	mi := &file_flow_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6807,7 +6965,7 @@ func (x *GetRackRuleAssociationResponse) String() string {
 func (*GetRackRuleAssociationResponse) ProtoMessage() {}
 
 func (x *GetRackRuleAssociationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[92]
+	mi := &file_flow_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6820,7 +6978,7 @@ func (x *GetRackRuleAssociationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRackRuleAssociationResponse.ProtoReflect.Descriptor instead.
 func (*GetRackRuleAssociationResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{92}
+	return file_flow_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *GetRackRuleAssociationResponse) GetRuleId() *UUID {
@@ -6839,7 +6997,7 @@ type ListRackRuleAssociationsRequest struct {
 
 func (x *ListRackRuleAssociationsRequest) Reset() {
 	*x = ListRackRuleAssociationsRequest{}
-	mi := &file_flow_proto_msgTypes[93]
+	mi := &file_flow_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6851,7 +7009,7 @@ func (x *ListRackRuleAssociationsRequest) String() string {
 func (*ListRackRuleAssociationsRequest) ProtoMessage() {}
 
 func (x *ListRackRuleAssociationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[93]
+	mi := &file_flow_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6864,7 +7022,7 @@ func (x *ListRackRuleAssociationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRackRuleAssociationsRequest.ProtoReflect.Descriptor instead.
 func (*ListRackRuleAssociationsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{93}
+	return file_flow_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *ListRackRuleAssociationsRequest) GetRackId() *UUID {
@@ -6888,7 +7046,7 @@ type RackRuleAssociation struct {
 
 func (x *RackRuleAssociation) Reset() {
 	*x = RackRuleAssociation{}
-	mi := &file_flow_proto_msgTypes[94]
+	mi := &file_flow_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6900,7 +7058,7 @@ func (x *RackRuleAssociation) String() string {
 func (*RackRuleAssociation) ProtoMessage() {}
 
 func (x *RackRuleAssociation) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[94]
+	mi := &file_flow_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6913,7 +7071,7 @@ func (x *RackRuleAssociation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RackRuleAssociation.ProtoReflect.Descriptor instead.
 func (*RackRuleAssociation) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{94}
+	return file_flow_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *RackRuleAssociation) GetRackId() *UUID {
@@ -6967,7 +7125,7 @@ type ListRackRuleAssociationsResponse struct {
 
 func (x *ListRackRuleAssociationsResponse) Reset() {
 	*x = ListRackRuleAssociationsResponse{}
-	mi := &file_flow_proto_msgTypes[95]
+	mi := &file_flow_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6979,7 +7137,7 @@ func (x *ListRackRuleAssociationsResponse) String() string {
 func (*ListRackRuleAssociationsResponse) ProtoMessage() {}
 
 func (x *ListRackRuleAssociationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[95]
+	mi := &file_flow_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6992,7 +7150,7 @@ func (x *ListRackRuleAssociationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRackRuleAssociationsResponse.ProtoReflect.Descriptor instead.
 func (*ListRackRuleAssociationsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{95}
+	return file_flow_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ListRackRuleAssociationsResponse) GetAssociations() []*RackRuleAssociation {
@@ -7015,7 +7173,7 @@ type ScheduleSpec struct {
 
 func (x *ScheduleSpec) Reset() {
 	*x = ScheduleSpec{}
-	mi := &file_flow_proto_msgTypes[96]
+	mi := &file_flow_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7027,7 +7185,7 @@ func (x *ScheduleSpec) String() string {
 func (*ScheduleSpec) ProtoMessage() {}
 
 func (x *ScheduleSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[96]
+	mi := &file_flow_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7040,7 +7198,7 @@ func (x *ScheduleSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleSpec.ProtoReflect.Descriptor instead.
 func (*ScheduleSpec) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{96}
+	return file_flow_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *ScheduleSpec) GetType() ScheduleSpecType {
@@ -7076,7 +7234,7 @@ type ScheduleConfig struct {
 
 func (x *ScheduleConfig) Reset() {
 	*x = ScheduleConfig{}
-	mi := &file_flow_proto_msgTypes[97]
+	mi := &file_flow_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7088,7 +7246,7 @@ func (x *ScheduleConfig) String() string {
 func (*ScheduleConfig) ProtoMessage() {}
 
 func (x *ScheduleConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[97]
+	mi := &file_flow_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7101,7 +7259,7 @@ func (x *ScheduleConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleConfig.ProtoReflect.Descriptor instead.
 func (*ScheduleConfig) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{97}
+	return file_flow_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *ScheduleConfig) GetName() string {
@@ -7153,7 +7311,7 @@ type TaskSchedule struct {
 
 func (x *TaskSchedule) Reset() {
 	*x = TaskSchedule{}
-	mi := &file_flow_proto_msgTypes[98]
+	mi := &file_flow_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7165,7 +7323,7 @@ func (x *TaskSchedule) String() string {
 func (*TaskSchedule) ProtoMessage() {}
 
 func (x *TaskSchedule) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[98]
+	mi := &file_flow_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7178,7 +7336,7 @@ func (x *TaskSchedule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskSchedule.ProtoReflect.Descriptor instead.
 func (*TaskSchedule) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{98}
+	return file_flow_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *TaskSchedule) GetId() *UUID {
@@ -7284,7 +7442,7 @@ type ScheduledOperation struct {
 
 func (x *ScheduledOperation) Reset() {
 	*x = ScheduledOperation{}
-	mi := &file_flow_proto_msgTypes[99]
+	mi := &file_flow_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7296,7 +7454,7 @@ func (x *ScheduledOperation) String() string {
 func (*ScheduledOperation) ProtoMessage() {}
 
 func (x *ScheduledOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[99]
+	mi := &file_flow_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7309,7 +7467,7 @@ func (x *ScheduledOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduledOperation.ProtoReflect.Descriptor instead.
 func (*ScheduledOperation) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{99}
+	return file_flow_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *ScheduledOperation) GetOperation() isScheduledOperation_Operation {
@@ -7427,7 +7585,7 @@ type CreateTaskScheduleRequest struct {
 
 func (x *CreateTaskScheduleRequest) Reset() {
 	*x = CreateTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[100]
+	mi := &file_flow_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7439,7 +7597,7 @@ func (x *CreateTaskScheduleRequest) String() string {
 func (*CreateTaskScheduleRequest) ProtoMessage() {}
 
 func (x *CreateTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[100]
+	mi := &file_flow_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7452,7 +7610,7 @@ func (x *CreateTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*CreateTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{100}
+	return file_flow_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *CreateTaskScheduleRequest) GetSchedule() *ScheduleConfig {
@@ -7478,7 +7636,7 @@ type GetTaskScheduleRequest struct {
 
 func (x *GetTaskScheduleRequest) Reset() {
 	*x = GetTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[101]
+	mi := &file_flow_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7490,7 +7648,7 @@ func (x *GetTaskScheduleRequest) String() string {
 func (*GetTaskScheduleRequest) ProtoMessage() {}
 
 func (x *GetTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[101]
+	mi := &file_flow_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7503,7 +7661,7 @@ func (x *GetTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*GetTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{101}
+	return file_flow_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *GetTaskScheduleRequest) GetId() *UUID {
@@ -7526,7 +7684,7 @@ type ListTaskSchedulesRequest struct {
 
 func (x *ListTaskSchedulesRequest) Reset() {
 	*x = ListTaskSchedulesRequest{}
-	mi := &file_flow_proto_msgTypes[102]
+	mi := &file_flow_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7538,7 +7696,7 @@ func (x *ListTaskSchedulesRequest) String() string {
 func (*ListTaskSchedulesRequest) ProtoMessage() {}
 
 func (x *ListTaskSchedulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[102]
+	mi := &file_flow_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7551,7 +7709,7 @@ func (x *ListTaskSchedulesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskSchedulesRequest.ProtoReflect.Descriptor instead.
 func (*ListTaskSchedulesRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{102}
+	return file_flow_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *ListTaskSchedulesRequest) GetRackId() *UUID {
@@ -7585,7 +7743,7 @@ type ListTaskSchedulesResponse struct {
 
 func (x *ListTaskSchedulesResponse) Reset() {
 	*x = ListTaskSchedulesResponse{}
-	mi := &file_flow_proto_msgTypes[103]
+	mi := &file_flow_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7597,7 +7755,7 @@ func (x *ListTaskSchedulesResponse) String() string {
 func (*ListTaskSchedulesResponse) ProtoMessage() {}
 
 func (x *ListTaskSchedulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[103]
+	mi := &file_flow_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7610,7 +7768,7 @@ func (x *ListTaskSchedulesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskSchedulesResponse.ProtoReflect.Descriptor instead.
 func (*ListTaskSchedulesResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{103}
+	return file_flow_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *ListTaskSchedulesResponse) GetTaskSchedules() []*TaskSchedule {
@@ -7648,7 +7806,7 @@ type UpdateTaskScheduleRequest struct {
 
 func (x *UpdateTaskScheduleRequest) Reset() {
 	*x = UpdateTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[104]
+	mi := &file_flow_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7660,7 +7818,7 @@ func (x *UpdateTaskScheduleRequest) String() string {
 func (*UpdateTaskScheduleRequest) ProtoMessage() {}
 
 func (x *UpdateTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[104]
+	mi := &file_flow_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7673,7 +7831,7 @@ func (x *UpdateTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{104}
+	return file_flow_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *UpdateTaskScheduleRequest) GetId() *UUID {
@@ -7709,7 +7867,7 @@ type PauseTaskScheduleRequest struct {
 
 func (x *PauseTaskScheduleRequest) Reset() {
 	*x = PauseTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[105]
+	mi := &file_flow_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7721,7 +7879,7 @@ func (x *PauseTaskScheduleRequest) String() string {
 func (*PauseTaskScheduleRequest) ProtoMessage() {}
 
 func (x *PauseTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[105]
+	mi := &file_flow_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7734,7 +7892,7 @@ func (x *PauseTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*PauseTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{105}
+	return file_flow_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *PauseTaskScheduleRequest) GetId() *UUID {
@@ -7756,7 +7914,7 @@ type ResumeTaskScheduleRequest struct {
 
 func (x *ResumeTaskScheduleRequest) Reset() {
 	*x = ResumeTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[106]
+	mi := &file_flow_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7768,7 +7926,7 @@ func (x *ResumeTaskScheduleRequest) String() string {
 func (*ResumeTaskScheduleRequest) ProtoMessage() {}
 
 func (x *ResumeTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[106]
+	mi := &file_flow_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7781,7 +7939,7 @@ func (x *ResumeTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*ResumeTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{106}
+	return file_flow_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *ResumeTaskScheduleRequest) GetId() *UUID {
@@ -7802,7 +7960,7 @@ type DeleteTaskScheduleRequest struct {
 
 func (x *DeleteTaskScheduleRequest) Reset() {
 	*x = DeleteTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[107]
+	mi := &file_flow_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7814,7 +7972,7 @@ func (x *DeleteTaskScheduleRequest) String() string {
 func (*DeleteTaskScheduleRequest) ProtoMessage() {}
 
 func (x *DeleteTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[107]
+	mi := &file_flow_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7827,7 +7985,7 @@ func (x *DeleteTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{107}
+	return file_flow_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *DeleteTaskScheduleRequest) GetId() *UUID {
@@ -7850,7 +8008,7 @@ type TriggerTaskScheduleRequest struct {
 
 func (x *TriggerTaskScheduleRequest) Reset() {
 	*x = TriggerTaskScheduleRequest{}
-	mi := &file_flow_proto_msgTypes[108]
+	mi := &file_flow_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7862,7 +8020,7 @@ func (x *TriggerTaskScheduleRequest) String() string {
 func (*TriggerTaskScheduleRequest) ProtoMessage() {}
 
 func (x *TriggerTaskScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[108]
+	mi := &file_flow_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7875,7 +8033,7 @@ func (x *TriggerTaskScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerTaskScheduleRequest.ProtoReflect.Descriptor instead.
 func (*TriggerTaskScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{108}
+	return file_flow_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *TriggerTaskScheduleRequest) GetId() *UUID {
@@ -7911,7 +8069,7 @@ type TaskScheduleScope struct {
 
 func (x *TaskScheduleScope) Reset() {
 	*x = TaskScheduleScope{}
-	mi := &file_flow_proto_msgTypes[109]
+	mi := &file_flow_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7923,7 +8081,7 @@ func (x *TaskScheduleScope) String() string {
 func (*TaskScheduleScope) ProtoMessage() {}
 
 func (x *TaskScheduleScope) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[109]
+	mi := &file_flow_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7936,7 +8094,7 @@ func (x *TaskScheduleScope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskScheduleScope.ProtoReflect.Descriptor instead.
 func (*TaskScheduleScope) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{109}
+	return file_flow_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *TaskScheduleScope) GetId() *UUID {
@@ -8036,7 +8194,7 @@ type AddTaskScheduleScopeRequest struct {
 
 func (x *AddTaskScheduleScopeRequest) Reset() {
 	*x = AddTaskScheduleScopeRequest{}
-	mi := &file_flow_proto_msgTypes[110]
+	mi := &file_flow_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8048,7 +8206,7 @@ func (x *AddTaskScheduleScopeRequest) String() string {
 func (*AddTaskScheduleScopeRequest) ProtoMessage() {}
 
 func (x *AddTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[110]
+	mi := &file_flow_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8061,7 +8219,7 @@ func (x *AddTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddTaskScheduleScopeRequest.ProtoReflect.Descriptor instead.
 func (*AddTaskScheduleScopeRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{110}
+	return file_flow_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *AddTaskScheduleScopeRequest) GetScheduleId() *UUID {
@@ -8088,7 +8246,7 @@ type AddTaskScheduleScopeResponse struct {
 
 func (x *AddTaskScheduleScopeResponse) Reset() {
 	*x = AddTaskScheduleScopeResponse{}
-	mi := &file_flow_proto_msgTypes[111]
+	mi := &file_flow_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8100,7 +8258,7 @@ func (x *AddTaskScheduleScopeResponse) String() string {
 func (*AddTaskScheduleScopeResponse) ProtoMessage() {}
 
 func (x *AddTaskScheduleScopeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[111]
+	mi := &file_flow_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8113,7 +8271,7 @@ func (x *AddTaskScheduleScopeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddTaskScheduleScopeResponse.ProtoReflect.Descriptor instead.
 func (*AddTaskScheduleScopeResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{111}
+	return file_flow_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *AddTaskScheduleScopeResponse) GetScopes() []*TaskScheduleScope {
@@ -8134,7 +8292,7 @@ type RemoveTaskScheduleScopeRequest struct {
 
 func (x *RemoveTaskScheduleScopeRequest) Reset() {
 	*x = RemoveTaskScheduleScopeRequest{}
-	mi := &file_flow_proto_msgTypes[112]
+	mi := &file_flow_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8146,7 +8304,7 @@ func (x *RemoveTaskScheduleScopeRequest) String() string {
 func (*RemoveTaskScheduleScopeRequest) ProtoMessage() {}
 
 func (x *RemoveTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[112]
+	mi := &file_flow_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8159,7 +8317,7 @@ func (x *RemoveTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveTaskScheduleScopeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveTaskScheduleScopeRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{112}
+	return file_flow_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *RemoveTaskScheduleScopeRequest) GetScopeId() *UUID {
@@ -8184,7 +8342,7 @@ type UpdateTaskScheduleScopeRequest struct {
 
 func (x *UpdateTaskScheduleScopeRequest) Reset() {
 	*x = UpdateTaskScheduleScopeRequest{}
-	mi := &file_flow_proto_msgTypes[113]
+	mi := &file_flow_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8196,7 +8354,7 @@ func (x *UpdateTaskScheduleScopeRequest) String() string {
 func (*UpdateTaskScheduleScopeRequest) ProtoMessage() {}
 
 func (x *UpdateTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[113]
+	mi := &file_flow_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8209,7 +8367,7 @@ func (x *UpdateTaskScheduleScopeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskScheduleScopeRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTaskScheduleScopeRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{113}
+	return file_flow_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *UpdateTaskScheduleScopeRequest) GetScheduleId() *UUID {
@@ -8239,7 +8397,7 @@ type UpdateTaskScheduleScopeResponse struct {
 
 func (x *UpdateTaskScheduleScopeResponse) Reset() {
 	*x = UpdateTaskScheduleScopeResponse{}
-	mi := &file_flow_proto_msgTypes[114]
+	mi := &file_flow_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8251,7 +8409,7 @@ func (x *UpdateTaskScheduleScopeResponse) String() string {
 func (*UpdateTaskScheduleScopeResponse) ProtoMessage() {}
 
 func (x *UpdateTaskScheduleScopeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[114]
+	mi := &file_flow_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8264,7 +8422,7 @@ func (x *UpdateTaskScheduleScopeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskScheduleScopeResponse.ProtoReflect.Descriptor instead.
 func (*UpdateTaskScheduleScopeResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{114}
+	return file_flow_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *UpdateTaskScheduleScopeResponse) GetScopes() []*TaskScheduleScope {
@@ -8305,7 +8463,7 @@ type ListTaskScheduleScopesRequest struct {
 
 func (x *ListTaskScheduleScopesRequest) Reset() {
 	*x = ListTaskScheduleScopesRequest{}
-	mi := &file_flow_proto_msgTypes[115]
+	mi := &file_flow_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8317,7 +8475,7 @@ func (x *ListTaskScheduleScopesRequest) String() string {
 func (*ListTaskScheduleScopesRequest) ProtoMessage() {}
 
 func (x *ListTaskScheduleScopesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[115]
+	mi := &file_flow_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8330,7 +8488,7 @@ func (x *ListTaskScheduleScopesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskScheduleScopesRequest.ProtoReflect.Descriptor instead.
 func (*ListTaskScheduleScopesRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{115}
+	return file_flow_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *ListTaskScheduleScopesRequest) GetScheduleId() *UUID {
@@ -8349,7 +8507,7 @@ type ListTaskScheduleScopesResponse struct {
 
 func (x *ListTaskScheduleScopesResponse) Reset() {
 	*x = ListTaskScheduleScopesResponse{}
-	mi := &file_flow_proto_msgTypes[116]
+	mi := &file_flow_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8361,7 +8519,7 @@ func (x *ListTaskScheduleScopesResponse) String() string {
 func (*ListTaskScheduleScopesResponse) ProtoMessage() {}
 
 func (x *ListTaskScheduleScopesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[116]
+	mi := &file_flow_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8374,7 +8532,7 @@ func (x *ListTaskScheduleScopesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTaskScheduleScopesResponse.ProtoReflect.Descriptor instead.
 func (*ListTaskScheduleScopesResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{116}
+	return file_flow_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *ListTaskScheduleScopesResponse) GetScopes() []*TaskScheduleScope {
@@ -8410,7 +8568,7 @@ type CheckScheduleConflictsRequest struct {
 
 func (x *CheckScheduleConflictsRequest) Reset() {
 	*x = CheckScheduleConflictsRequest{}
-	mi := &file_flow_proto_msgTypes[117]
+	mi := &file_flow_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8422,7 +8580,7 @@ func (x *CheckScheduleConflictsRequest) String() string {
 func (*CheckScheduleConflictsRequest) ProtoMessage() {}
 
 func (x *CheckScheduleConflictsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[117]
+	mi := &file_flow_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8435,7 +8593,7 @@ func (x *CheckScheduleConflictsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckScheduleConflictsRequest.ProtoReflect.Descriptor instead.
 func (*CheckScheduleConflictsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{117}
+	return file_flow_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *CheckScheduleConflictsRequest) GetOperation() *ScheduledOperation {
@@ -8464,7 +8622,7 @@ type CheckScheduleConflictsResponse struct {
 
 func (x *CheckScheduleConflictsResponse) Reset() {
 	*x = CheckScheduleConflictsResponse{}
-	mi := &file_flow_proto_msgTypes[118]
+	mi := &file_flow_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8476,7 +8634,7 @@ func (x *CheckScheduleConflictsResponse) String() string {
 func (*CheckScheduleConflictsResponse) ProtoMessage() {}
 
 func (x *CheckScheduleConflictsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[118]
+	mi := &file_flow_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8489,7 +8647,7 @@ func (x *CheckScheduleConflictsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckScheduleConflictsResponse.ProtoReflect.Descriptor instead.
 func (*CheckScheduleConflictsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{118}
+	return file_flow_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *CheckScheduleConflictsResponse) GetConflicts() []*TaskSchedule {
@@ -8517,7 +8675,7 @@ type CreateOperationRunRequest struct {
 
 func (x *CreateOperationRunRequest) Reset() {
 	*x = CreateOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[119]
+	mi := &file_flow_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8529,7 +8687,7 @@ func (x *CreateOperationRunRequest) String() string {
 func (*CreateOperationRunRequest) ProtoMessage() {}
 
 func (x *CreateOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[119]
+	mi := &file_flow_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8542,7 +8700,7 @@ func (x *CreateOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*CreateOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{119}
+	return file_flow_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *CreateOperationRunRequest) GetName() string {
@@ -8575,7 +8733,7 @@ type CreateOperationRunResponse struct {
 
 func (x *CreateOperationRunResponse) Reset() {
 	*x = CreateOperationRunResponse{}
-	mi := &file_flow_proto_msgTypes[120]
+	mi := &file_flow_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8587,7 +8745,7 @@ func (x *CreateOperationRunResponse) String() string {
 func (*CreateOperationRunResponse) ProtoMessage() {}
 
 func (x *CreateOperationRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[120]
+	mi := &file_flow_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8600,7 +8758,7 @@ func (x *CreateOperationRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOperationRunResponse.ProtoReflect.Descriptor instead.
 func (*CreateOperationRunResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{120}
+	return file_flow_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *CreateOperationRunResponse) GetId() *UUID {
@@ -8623,7 +8781,7 @@ type OperationRunConfiguration struct {
 
 func (x *OperationRunConfiguration) Reset() {
 	*x = OperationRunConfiguration{}
-	mi := &file_flow_proto_msgTypes[121]
+	mi := &file_flow_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8635,7 +8793,7 @@ func (x *OperationRunConfiguration) String() string {
 func (*OperationRunConfiguration) ProtoMessage() {}
 
 func (x *OperationRunConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[121]
+	mi := &file_flow_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8648,7 +8806,7 @@ func (x *OperationRunConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunConfiguration.ProtoReflect.Descriptor instead.
 func (*OperationRunConfiguration) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{121}
+	return file_flow_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *OperationRunConfiguration) GetSelector() *OperationRunSelector {
@@ -8684,7 +8842,7 @@ type GetOperationRunRequest struct {
 
 func (x *GetOperationRunRequest) Reset() {
 	*x = GetOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[122]
+	mi := &file_flow_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8696,7 +8854,7 @@ func (x *GetOperationRunRequest) String() string {
 func (*GetOperationRunRequest) ProtoMessage() {}
 
 func (x *GetOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[122]
+	mi := &file_flow_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8709,7 +8867,7 @@ func (x *GetOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*GetOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{122}
+	return file_flow_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *GetOperationRunRequest) GetId() *UUID {
@@ -8735,7 +8893,7 @@ type GetOperationRunResponse struct {
 
 func (x *GetOperationRunResponse) Reset() {
 	*x = GetOperationRunResponse{}
-	mi := &file_flow_proto_msgTypes[123]
+	mi := &file_flow_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8747,7 +8905,7 @@ func (x *GetOperationRunResponse) String() string {
 func (*GetOperationRunResponse) ProtoMessage() {}
 
 func (x *GetOperationRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[123]
+	mi := &file_flow_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8760,7 +8918,7 @@ func (x *GetOperationRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRunResponse.ProtoReflect.Descriptor instead.
 func (*GetOperationRunResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{123}
+	return file_flow_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *GetOperationRunResponse) GetOperationRun() *OperationRun {
@@ -8781,7 +8939,7 @@ type ListOperationRunsRequest struct {
 
 func (x *ListOperationRunsRequest) Reset() {
 	*x = ListOperationRunsRequest{}
-	mi := &file_flow_proto_msgTypes[124]
+	mi := &file_flow_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8793,7 +8951,7 @@ func (x *ListOperationRunsRequest) String() string {
 func (*ListOperationRunsRequest) ProtoMessage() {}
 
 func (x *ListOperationRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[124]
+	mi := &file_flow_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8806,7 +8964,7 @@ func (x *ListOperationRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationRunsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{124}
+	return file_flow_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *ListOperationRunsRequest) GetFilter() *OperationRunFilter {
@@ -8833,7 +8991,7 @@ type ListOperationRunsResponse struct {
 
 func (x *ListOperationRunsResponse) Reset() {
 	*x = ListOperationRunsResponse{}
-	mi := &file_flow_proto_msgTypes[125]
+	mi := &file_flow_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8845,7 +9003,7 @@ func (x *ListOperationRunsResponse) String() string {
 func (*ListOperationRunsResponse) ProtoMessage() {}
 
 func (x *ListOperationRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[125]
+	mi := &file_flow_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8858,7 +9016,7 @@ func (x *ListOperationRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationRunsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{125}
+	return file_flow_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *ListOperationRunsResponse) GetOperationRuns() []*OperationRunSummary {
@@ -8891,7 +9049,7 @@ type OperationRunFilter struct {
 
 func (x *OperationRunFilter) Reset() {
 	*x = OperationRunFilter{}
-	mi := &file_flow_proto_msgTypes[126]
+	mi := &file_flow_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8903,7 +9061,7 @@ func (x *OperationRunFilter) String() string {
 func (*OperationRunFilter) ProtoMessage() {}
 
 func (x *OperationRunFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[126]
+	mi := &file_flow_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8916,7 +9074,7 @@ func (x *OperationRunFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunFilter.ProtoReflect.Descriptor instead.
 func (*OperationRunFilter) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{126}
+	return file_flow_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *OperationRunFilter) GetName() *StringQueryInfo {
@@ -8950,7 +9108,7 @@ type OperationRunStateFilter struct {
 
 func (x *OperationRunStateFilter) Reset() {
 	*x = OperationRunStateFilter{}
-	mi := &file_flow_proto_msgTypes[127]
+	mi := &file_flow_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8962,7 +9120,7 @@ func (x *OperationRunStateFilter) String() string {
 func (*OperationRunStateFilter) ProtoMessage() {}
 
 func (x *OperationRunStateFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[127]
+	mi := &file_flow_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8975,7 +9133,7 @@ func (x *OperationRunStateFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunStateFilter.ProtoReflect.Descriptor instead.
 func (*OperationRunStateFilter) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{127}
+	return file_flow_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *OperationRunStateFilter) GetStatus() OperationRunStatus {
@@ -9007,7 +9165,7 @@ type ListOperationRunTargetsRequest struct {
 
 func (x *ListOperationRunTargetsRequest) Reset() {
 	*x = ListOperationRunTargetsRequest{}
-	mi := &file_flow_proto_msgTypes[128]
+	mi := &file_flow_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9019,7 +9177,7 @@ func (x *ListOperationRunTargetsRequest) String() string {
 func (*ListOperationRunTargetsRequest) ProtoMessage() {}
 
 func (x *ListOperationRunTargetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[128]
+	mi := &file_flow_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9032,7 +9190,7 @@ func (x *ListOperationRunTargetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRunTargetsRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationRunTargetsRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{128}
+	return file_flow_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *ListOperationRunTargetsRequest) GetOperationRunId() *UUID {
@@ -9073,7 +9231,7 @@ type ListOperationRunTargetsResponse struct {
 
 func (x *ListOperationRunTargetsResponse) Reset() {
 	*x = ListOperationRunTargetsResponse{}
-	mi := &file_flow_proto_msgTypes[129]
+	mi := &file_flow_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9085,7 +9243,7 @@ func (x *ListOperationRunTargetsResponse) String() string {
 func (*ListOperationRunTargetsResponse) ProtoMessage() {}
 
 func (x *ListOperationRunTargetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[129]
+	mi := &file_flow_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9098,7 +9256,7 @@ func (x *ListOperationRunTargetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationRunTargetsResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationRunTargetsResponse) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{129}
+	return file_flow_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *ListOperationRunTargetsResponse) GetTargets() []*OperationRunTarget {
@@ -9124,7 +9282,7 @@ type PauseOperationRunRequest struct {
 
 func (x *PauseOperationRunRequest) Reset() {
 	*x = PauseOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[130]
+	mi := &file_flow_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9136,7 +9294,7 @@ func (x *PauseOperationRunRequest) String() string {
 func (*PauseOperationRunRequest) ProtoMessage() {}
 
 func (x *PauseOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[130]
+	mi := &file_flow_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9149,7 +9307,7 @@ func (x *PauseOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*PauseOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{130}
+	return file_flow_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *PauseOperationRunRequest) GetId() *UUID {
@@ -9168,7 +9326,7 @@ type ResumeOperationRunRequest struct {
 
 func (x *ResumeOperationRunRequest) Reset() {
 	*x = ResumeOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[131]
+	mi := &file_flow_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9180,7 +9338,7 @@ func (x *ResumeOperationRunRequest) String() string {
 func (*ResumeOperationRunRequest) ProtoMessage() {}
 
 func (x *ResumeOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[131]
+	mi := &file_flow_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9193,7 +9351,7 @@ func (x *ResumeOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*ResumeOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{131}
+	return file_flow_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *ResumeOperationRunRequest) GetId() *UUID {
@@ -9214,7 +9372,7 @@ type AdvanceOperationRunPhaseRequest struct {
 
 func (x *AdvanceOperationRunPhaseRequest) Reset() {
 	*x = AdvanceOperationRunPhaseRequest{}
-	mi := &file_flow_proto_msgTypes[132]
+	mi := &file_flow_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9226,7 +9384,7 @@ func (x *AdvanceOperationRunPhaseRequest) String() string {
 func (*AdvanceOperationRunPhaseRequest) ProtoMessage() {}
 
 func (x *AdvanceOperationRunPhaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[132]
+	mi := &file_flow_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9239,7 +9397,7 @@ func (x *AdvanceOperationRunPhaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdvanceOperationRunPhaseRequest.ProtoReflect.Descriptor instead.
 func (*AdvanceOperationRunPhaseRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{132}
+	return file_flow_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *AdvanceOperationRunPhaseRequest) GetId() *UUID {
@@ -9266,7 +9424,7 @@ type CancelOperationRunRequest struct {
 
 func (x *CancelOperationRunRequest) Reset() {
 	*x = CancelOperationRunRequest{}
-	mi := &file_flow_proto_msgTypes[133]
+	mi := &file_flow_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9278,7 +9436,7 @@ func (x *CancelOperationRunRequest) String() string {
 func (*CancelOperationRunRequest) ProtoMessage() {}
 
 func (x *CancelOperationRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[133]
+	mi := &file_flow_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9291,7 +9449,7 @@ func (x *CancelOperationRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelOperationRunRequest.ProtoReflect.Descriptor instead.
 func (*CancelOperationRunRequest) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{133}
+	return file_flow_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *CancelOperationRunRequest) GetId() *UUID {
@@ -9320,7 +9478,7 @@ type OperationRunSelector struct {
 
 func (x *OperationRunSelector) Reset() {
 	*x = OperationRunSelector{}
-	mi := &file_flow_proto_msgTypes[134]
+	mi := &file_flow_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9332,7 +9490,7 @@ func (x *OperationRunSelector) String() string {
 func (*OperationRunSelector) ProtoMessage() {}
 
 func (x *OperationRunSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[134]
+	mi := &file_flow_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9345,7 +9503,7 @@ func (x *OperationRunSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunSelector.ProtoReflect.Descriptor instead.
 func (*OperationRunSelector) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{134}
+	return file_flow_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *OperationRunSelector) GetSelector() isOperationRunSelector_Selector {
@@ -9387,7 +9545,7 @@ type PercentageSelector struct {
 
 func (x *PercentageSelector) Reset() {
 	*x = PercentageSelector{}
-	mi := &file_flow_proto_msgTypes[135]
+	mi := &file_flow_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9399,7 +9557,7 @@ func (x *PercentageSelector) String() string {
 func (*PercentageSelector) ProtoMessage() {}
 
 func (x *PercentageSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[135]
+	mi := &file_flow_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9412,7 +9570,7 @@ func (x *PercentageSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PercentageSelector.ProtoReflect.Descriptor instead.
 func (*PercentageSelector) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{135}
+	return file_flow_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *PercentageSelector) GetPercentage() int32 {
@@ -9451,7 +9609,7 @@ type OperationRunOptions struct {
 
 func (x *OperationRunOptions) Reset() {
 	*x = OperationRunOptions{}
-	mi := &file_flow_proto_msgTypes[136]
+	mi := &file_flow_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9463,7 +9621,7 @@ func (x *OperationRunOptions) String() string {
 func (*OperationRunOptions) ProtoMessage() {}
 
 func (x *OperationRunOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[136]
+	mi := &file_flow_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9476,7 +9634,7 @@ func (x *OperationRunOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunOptions.ProtoReflect.Descriptor instead.
 func (*OperationRunOptions) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{136}
+	return file_flow_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *OperationRunOptions) GetMaxConcurrentTargets() int32 {
@@ -9525,7 +9683,7 @@ type OperationRunSafetyPolicy struct {
 
 func (x *OperationRunSafetyPolicy) Reset() {
 	*x = OperationRunSafetyPolicy{}
-	mi := &file_flow_proto_msgTypes[137]
+	mi := &file_flow_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9537,7 +9695,7 @@ func (x *OperationRunSafetyPolicy) String() string {
 func (*OperationRunSafetyPolicy) ProtoMessage() {}
 
 func (x *OperationRunSafetyPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[137]
+	mi := &file_flow_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9550,7 +9708,7 @@ func (x *OperationRunSafetyPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunSafetyPolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunSafetyPolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{137}
+	return file_flow_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *OperationRunSafetyPolicy) GetGates() []*OperationRunSafetyGate {
@@ -9573,7 +9731,7 @@ type OperationRunSafetyGate struct {
 
 func (x *OperationRunSafetyGate) Reset() {
 	*x = OperationRunSafetyGate{}
-	mi := &file_flow_proto_msgTypes[138]
+	mi := &file_flow_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9585,7 +9743,7 @@ func (x *OperationRunSafetyGate) String() string {
 func (*OperationRunSafetyGate) ProtoMessage() {}
 
 func (x *OperationRunSafetyGate) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[138]
+	mi := &file_flow_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9598,7 +9756,7 @@ func (x *OperationRunSafetyGate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunSafetyGate.ProtoReflect.Descriptor instead.
 func (*OperationRunSafetyGate) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{138}
+	return file_flow_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *OperationRunSafetyGate) GetGate() isOperationRunSafetyGate_Gate {
@@ -9655,7 +9813,7 @@ type OperationRunFailureRateGate struct {
 
 func (x *OperationRunFailureRateGate) Reset() {
 	*x = OperationRunFailureRateGate{}
-	mi := &file_flow_proto_msgTypes[139]
+	mi := &file_flow_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9667,7 +9825,7 @@ func (x *OperationRunFailureRateGate) String() string {
 func (*OperationRunFailureRateGate) ProtoMessage() {}
 
 func (x *OperationRunFailureRateGate) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[139]
+	mi := &file_flow_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9680,7 +9838,7 @@ func (x *OperationRunFailureRateGate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunFailureRateGate.ProtoReflect.Descriptor instead.
 func (*OperationRunFailureRateGate) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{139}
+	return file_flow_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *OperationRunFailureRateGate) GetScope() OperationRunSafetyGateScope {
@@ -9710,7 +9868,7 @@ type OperationRunFailureCountGate struct {
 
 func (x *OperationRunFailureCountGate) Reset() {
 	*x = OperationRunFailureCountGate{}
-	mi := &file_flow_proto_msgTypes[140]
+	mi := &file_flow_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9722,7 +9880,7 @@ func (x *OperationRunFailureCountGate) String() string {
 func (*OperationRunFailureCountGate) ProtoMessage() {}
 
 func (x *OperationRunFailureCountGate) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[140]
+	mi := &file_flow_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9735,7 +9893,7 @@ func (x *OperationRunFailureCountGate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunFailureCountGate.ProtoReflect.Descriptor instead.
 func (*OperationRunFailureCountGate) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{140}
+	return file_flow_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *OperationRunFailureCountGate) GetScope() OperationRunSafetyGateScope {
@@ -9765,7 +9923,7 @@ type OperationRunOrderingPolicy struct {
 
 func (x *OperationRunOrderingPolicy) Reset() {
 	*x = OperationRunOrderingPolicy{}
-	mi := &file_flow_proto_msgTypes[141]
+	mi := &file_flow_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9777,7 +9935,7 @@ func (x *OperationRunOrderingPolicy) String() string {
 func (*OperationRunOrderingPolicy) ProtoMessage() {}
 
 func (x *OperationRunOrderingPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[141]
+	mi := &file_flow_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9790,7 +9948,7 @@ func (x *OperationRunOrderingPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunOrderingPolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunOrderingPolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{141}
+	return file_flow_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *OperationRunOrderingPolicy) GetOrdering() isOperationRunOrderingPolicy_Ordering {
@@ -9846,7 +10004,7 @@ type OperationRunRandomOrdering struct {
 
 func (x *OperationRunRandomOrdering) Reset() {
 	*x = OperationRunRandomOrdering{}
-	mi := &file_flow_proto_msgTypes[142]
+	mi := &file_flow_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9858,7 +10016,7 @@ func (x *OperationRunRandomOrdering) String() string {
 func (*OperationRunRandomOrdering) ProtoMessage() {}
 
 func (x *OperationRunRandomOrdering) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[142]
+	mi := &file_flow_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9871,7 +10029,7 @@ func (x *OperationRunRandomOrdering) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunRandomOrdering.ProtoReflect.Descriptor instead.
 func (*OperationRunRandomOrdering) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{142}
+	return file_flow_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *OperationRunRandomOrdering) GetSeed() string {
@@ -9890,7 +10048,7 @@ type OperationRunPhysicalLocationOrdering struct {
 
 func (x *OperationRunPhysicalLocationOrdering) Reset() {
 	*x = OperationRunPhysicalLocationOrdering{}
-	mi := &file_flow_proto_msgTypes[143]
+	mi := &file_flow_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9902,7 +10060,7 @@ func (x *OperationRunPhysicalLocationOrdering) String() string {
 func (*OperationRunPhysicalLocationOrdering) ProtoMessage() {}
 
 func (x *OperationRunPhysicalLocationOrdering) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[143]
+	mi := &file_flow_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9915,7 +10073,7 @@ func (x *OperationRunPhysicalLocationOrdering) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use OperationRunPhysicalLocationOrdering.ProtoReflect.Descriptor instead.
 func (*OperationRunPhysicalLocationOrdering) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{143}
+	return file_flow_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *OperationRunPhysicalLocationOrdering) GetStrategy() OperationRunPhysicalLocationOrdering_Strategy {
@@ -9941,7 +10099,7 @@ type OperationRunPhasePolicy struct {
 
 func (x *OperationRunPhasePolicy) Reset() {
 	*x = OperationRunPhasePolicy{}
-	mi := &file_flow_proto_msgTypes[144]
+	mi := &file_flow_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9953,7 +10111,7 @@ func (x *OperationRunPhasePolicy) String() string {
 func (*OperationRunPhasePolicy) ProtoMessage() {}
 
 func (x *OperationRunPhasePolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[144]
+	mi := &file_flow_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9966,7 +10124,7 @@ func (x *OperationRunPhasePolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunPhasePolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunPhasePolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{144}
+	return file_flow_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *OperationRunPhasePolicy) GetPlan() isOperationRunPhasePolicy_Plan {
@@ -10042,7 +10200,7 @@ type EqualOperationRunPhases struct {
 
 func (x *EqualOperationRunPhases) Reset() {
 	*x = EqualOperationRunPhases{}
-	mi := &file_flow_proto_msgTypes[145]
+	mi := &file_flow_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10054,7 +10212,7 @@ func (x *EqualOperationRunPhases) String() string {
 func (*EqualOperationRunPhases) ProtoMessage() {}
 
 func (x *EqualOperationRunPhases) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[145]
+	mi := &file_flow_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10067,7 +10225,7 @@ func (x *EqualOperationRunPhases) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EqualOperationRunPhases.ProtoReflect.Descriptor instead.
 func (*EqualOperationRunPhases) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{145}
+	return file_flow_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *EqualOperationRunPhases) GetPhaseCount() int32 {
@@ -10086,7 +10244,7 @@ type PercentageOperationRunPhases struct {
 
 func (x *PercentageOperationRunPhases) Reset() {
 	*x = PercentageOperationRunPhases{}
-	mi := &file_flow_proto_msgTypes[146]
+	mi := &file_flow_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10098,7 +10256,7 @@ func (x *PercentageOperationRunPhases) String() string {
 func (*PercentageOperationRunPhases) ProtoMessage() {}
 
 func (x *PercentageOperationRunPhases) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[146]
+	mi := &file_flow_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10111,7 +10269,7 @@ func (x *PercentageOperationRunPhases) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PercentageOperationRunPhases.ProtoReflect.Descriptor instead.
 func (*PercentageOperationRunPhases) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{146}
+	return file_flow_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *PercentageOperationRunPhases) GetPhases() []*OperationRunPercentagePhase {
@@ -10131,7 +10289,7 @@ type OperationRunPercentagePhase struct {
 
 func (x *OperationRunPercentagePhase) Reset() {
 	*x = OperationRunPercentagePhase{}
-	mi := &file_flow_proto_msgTypes[147]
+	mi := &file_flow_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10143,7 +10301,7 @@ func (x *OperationRunPercentagePhase) String() string {
 func (*OperationRunPercentagePhase) ProtoMessage() {}
 
 func (x *OperationRunPercentagePhase) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[147]
+	mi := &file_flow_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10156,7 +10314,7 @@ func (x *OperationRunPercentagePhase) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunPercentagePhase.ProtoReflect.Descriptor instead.
 func (*OperationRunPercentagePhase) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{147}
+	return file_flow_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *OperationRunPercentagePhase) GetPercentage() int32 {
@@ -10178,7 +10336,7 @@ type CountOperationRunPhases struct {
 
 func (x *CountOperationRunPhases) Reset() {
 	*x = CountOperationRunPhases{}
-	mi := &file_flow_proto_msgTypes[148]
+	mi := &file_flow_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10190,7 +10348,7 @@ func (x *CountOperationRunPhases) String() string {
 func (*CountOperationRunPhases) ProtoMessage() {}
 
 func (x *CountOperationRunPhases) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[148]
+	mi := &file_flow_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10203,7 +10361,7 @@ func (x *CountOperationRunPhases) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountOperationRunPhases.ProtoReflect.Descriptor instead.
 func (*CountOperationRunPhases) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{148}
+	return file_flow_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *CountOperationRunPhases) GetPhases() []*OperationRunCountPhase {
@@ -10223,7 +10381,7 @@ type OperationRunCountPhase struct {
 
 func (x *OperationRunCountPhase) Reset() {
 	*x = OperationRunCountPhase{}
-	mi := &file_flow_proto_msgTypes[149]
+	mi := &file_flow_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10235,7 +10393,7 @@ func (x *OperationRunCountPhase) String() string {
 func (*OperationRunCountPhase) ProtoMessage() {}
 
 func (x *OperationRunCountPhase) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[149]
+	mi := &file_flow_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10248,7 +10406,7 @@ func (x *OperationRunCountPhase) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunCountPhase.ProtoReflect.Descriptor instead.
 func (*OperationRunCountPhase) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{149}
+	return file_flow_proto_rawDescGZIP(), []int{151}
 }
 
 func (x *OperationRunCountPhase) GetCount() int32 {
@@ -10270,7 +10428,7 @@ type OperationRunPhaseAdvancePolicy struct {
 
 func (x *OperationRunPhaseAdvancePolicy) Reset() {
 	*x = OperationRunPhaseAdvancePolicy{}
-	mi := &file_flow_proto_msgTypes[150]
+	mi := &file_flow_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10282,7 +10440,7 @@ func (x *OperationRunPhaseAdvancePolicy) String() string {
 func (*OperationRunPhaseAdvancePolicy) ProtoMessage() {}
 
 func (x *OperationRunPhaseAdvancePolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[150]
+	mi := &file_flow_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10295,7 +10453,7 @@ func (x *OperationRunPhaseAdvancePolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunPhaseAdvancePolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunPhaseAdvancePolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{150}
+	return file_flow_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *OperationRunPhaseAdvancePolicy) GetAutoAdvance() bool {
@@ -10317,7 +10475,7 @@ type OperationRunConflictPolicy struct {
 
 func (x *OperationRunConflictPolicy) Reset() {
 	*x = OperationRunConflictPolicy{}
-	mi := &file_flow_proto_msgTypes[151]
+	mi := &file_flow_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10329,7 +10487,7 @@ func (x *OperationRunConflictPolicy) String() string {
 func (*OperationRunConflictPolicy) ProtoMessage() {}
 
 func (x *OperationRunConflictPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[151]
+	mi := &file_flow_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10342,7 +10500,7 @@ func (x *OperationRunConflictPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunConflictPolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunConflictPolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{151}
+	return file_flow_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *OperationRunConflictPolicy) GetStrategy() isOperationRunConflictPolicy_Strategy {
@@ -10383,7 +10541,7 @@ type OperationRunConflictRetryPolicy struct {
 
 func (x *OperationRunConflictRetryPolicy) Reset() {
 	*x = OperationRunConflictRetryPolicy{}
-	mi := &file_flow_proto_msgTypes[152]
+	mi := &file_flow_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10395,7 +10553,7 @@ func (x *OperationRunConflictRetryPolicy) String() string {
 func (*OperationRunConflictRetryPolicy) ProtoMessage() {}
 
 func (x *OperationRunConflictRetryPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[152]
+	mi := &file_flow_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10408,7 +10566,7 @@ func (x *OperationRunConflictRetryPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunConflictRetryPolicy.ProtoReflect.Descriptor instead.
 func (*OperationRunConflictRetryPolicy) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{152}
+	return file_flow_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *OperationRunConflictRetryPolicy) GetRetryTimeout() *durationpb.Duration {
@@ -10450,7 +10608,7 @@ type OperationRunTargetScope struct {
 
 func (x *OperationRunTargetScope) Reset() {
 	*x = OperationRunTargetScope{}
-	mi := &file_flow_proto_msgTypes[153]
+	mi := &file_flow_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10462,7 +10620,7 @@ func (x *OperationRunTargetScope) String() string {
 func (*OperationRunTargetScope) ProtoMessage() {}
 
 func (x *OperationRunTargetScope) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[153]
+	mi := &file_flow_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10475,7 +10633,7 @@ func (x *OperationRunTargetScope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunTargetScope.ProtoReflect.Descriptor instead.
 func (*OperationRunTargetScope) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{153}
+	return file_flow_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *OperationRunTargetScope) GetExcludeOperationRunIds() []*UUID {
@@ -10507,7 +10665,7 @@ type OperationRunOperation struct {
 
 func (x *OperationRunOperation) Reset() {
 	*x = OperationRunOperation{}
-	mi := &file_flow_proto_msgTypes[154]
+	mi := &file_flow_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10519,7 +10677,7 @@ func (x *OperationRunOperation) String() string {
 func (*OperationRunOperation) ProtoMessage() {}
 
 func (x *OperationRunOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[154]
+	mi := &file_flow_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10532,7 +10690,7 @@ func (x *OperationRunOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunOperation.ProtoReflect.Descriptor instead.
 func (*OperationRunOperation) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{154}
+	return file_flow_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *OperationRunOperation) GetOperation() isOperationRunOperation_Operation {
@@ -10581,7 +10739,7 @@ type OperationRunState struct {
 
 func (x *OperationRunState) Reset() {
 	*x = OperationRunState{}
-	mi := &file_flow_proto_msgTypes[155]
+	mi := &file_flow_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10593,7 +10751,7 @@ func (x *OperationRunState) String() string {
 func (*OperationRunState) ProtoMessage() {}
 
 func (x *OperationRunState) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[155]
+	mi := &file_flow_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10606,7 +10764,7 @@ func (x *OperationRunState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunState.ProtoReflect.Descriptor instead.
 func (*OperationRunState) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{155}
+	return file_flow_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *OperationRunState) GetStatus() OperationRunStatus {
@@ -10633,7 +10791,7 @@ type OperationKind struct {
 
 func (x *OperationKind) Reset() {
 	*x = OperationKind{}
-	mi := &file_flow_proto_msgTypes[156]
+	mi := &file_flow_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10645,7 +10803,7 @@ func (x *OperationKind) String() string {
 func (*OperationKind) ProtoMessage() {}
 
 func (x *OperationKind) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[156]
+	mi := &file_flow_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10658,7 +10816,7 @@ func (x *OperationKind) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationKind.ProtoReflect.Descriptor instead.
 func (*OperationKind) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{156}
+	return file_flow_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *OperationKind) GetType() OperationType {
@@ -10687,7 +10845,7 @@ type OperationRun struct {
 
 func (x *OperationRun) Reset() {
 	*x = OperationRun{}
-	mi := &file_flow_proto_msgTypes[157]
+	mi := &file_flow_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10699,7 +10857,7 @@ func (x *OperationRun) String() string {
 func (*OperationRun) ProtoMessage() {}
 
 func (x *OperationRun) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[157]
+	mi := &file_flow_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10712,7 +10870,7 @@ func (x *OperationRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRun.ProtoReflect.Descriptor instead.
 func (*OperationRun) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{157}
+	return file_flow_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *OperationRun) GetSummary() *OperationRunSummary {
@@ -10758,7 +10916,7 @@ type OperationRunSummary struct {
 
 func (x *OperationRunSummary) Reset() {
 	*x = OperationRunSummary{}
-	mi := &file_flow_proto_msgTypes[158]
+	mi := &file_flow_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10770,7 +10928,7 @@ func (x *OperationRunSummary) String() string {
 func (*OperationRunSummary) ProtoMessage() {}
 
 func (x *OperationRunSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[158]
+	mi := &file_flow_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10783,7 +10941,7 @@ func (x *OperationRunSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunSummary.ProtoReflect.Descriptor instead.
 func (*OperationRunSummary) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{158}
+	return file_flow_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *OperationRunSummary) GetId() *UUID {
@@ -10873,7 +11031,7 @@ type OperationRunStats struct {
 
 func (x *OperationRunStats) Reset() {
 	*x = OperationRunStats{}
-	mi := &file_flow_proto_msgTypes[159]
+	mi := &file_flow_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10885,7 +11043,7 @@ func (x *OperationRunStats) String() string {
 func (*OperationRunStats) ProtoMessage() {}
 
 func (x *OperationRunStats) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[159]
+	mi := &file_flow_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10898,7 +11056,7 @@ func (x *OperationRunStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunStats.ProtoReflect.Descriptor instead.
 func (*OperationRunStats) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{159}
+	return file_flow_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *OperationRunStats) GetCurrentPhaseStats() *OperationRunPhaseStats {
@@ -10928,7 +11086,7 @@ type OperationRunPhaseStats struct {
 
 func (x *OperationRunPhaseStats) Reset() {
 	*x = OperationRunPhaseStats{}
-	mi := &file_flow_proto_msgTypes[160]
+	mi := &file_flow_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10940,7 +11098,7 @@ func (x *OperationRunPhaseStats) String() string {
 func (*OperationRunPhaseStats) ProtoMessage() {}
 
 func (x *OperationRunPhaseStats) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[160]
+	mi := &file_flow_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10953,7 +11111,7 @@ func (x *OperationRunPhaseStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunPhaseStats.ProtoReflect.Descriptor instead.
 func (*OperationRunPhaseStats) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{160}
+	return file_flow_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *OperationRunPhaseStats) GetPhaseIndex() int32 {
@@ -10989,7 +11147,7 @@ type OperationRunTargetOutcomeCounts struct {
 
 func (x *OperationRunTargetOutcomeCounts) Reset() {
 	*x = OperationRunTargetOutcomeCounts{}
-	mi := &file_flow_proto_msgTypes[161]
+	mi := &file_flow_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11001,7 +11159,7 @@ func (x *OperationRunTargetOutcomeCounts) String() string {
 func (*OperationRunTargetOutcomeCounts) ProtoMessage() {}
 
 func (x *OperationRunTargetOutcomeCounts) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[161]
+	mi := &file_flow_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11014,7 +11172,7 @@ func (x *OperationRunTargetOutcomeCounts) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunTargetOutcomeCounts.ProtoReflect.Descriptor instead.
 func (*OperationRunTargetOutcomeCounts) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{161}
+	return file_flow_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *OperationRunTargetOutcomeCounts) GetCompleted() int32 {
@@ -11064,7 +11222,7 @@ type OperationRunTarget struct {
 
 func (x *OperationRunTarget) Reset() {
 	*x = OperationRunTarget{}
-	mi := &file_flow_proto_msgTypes[162]
+	mi := &file_flow_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11076,7 +11234,7 @@ func (x *OperationRunTarget) String() string {
 func (*OperationRunTarget) ProtoMessage() {}
 
 func (x *OperationRunTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[162]
+	mi := &file_flow_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11089,7 +11247,7 @@ func (x *OperationRunTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationRunTarget.ProtoReflect.Descriptor instead.
 func (*OperationRunTarget) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{162}
+	return file_flow_proto_rawDescGZIP(), []int{164}
 }
 
 func (x *OperationRunTarget) GetId() *UUID {
@@ -11179,7 +11337,7 @@ type NVLDomainTargets struct {
 
 func (x *NVLDomainTargets) Reset() {
 	*x = NVLDomainTargets{}
-	mi := &file_flow_proto_msgTypes[163]
+	mi := &file_flow_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11191,7 +11349,7 @@ func (x *NVLDomainTargets) String() string {
 func (*NVLDomainTargets) ProtoMessage() {}
 
 func (x *NVLDomainTargets) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[163]
+	mi := &file_flow_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11204,7 +11362,7 @@ func (x *NVLDomainTargets) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NVLDomainTargets.ProtoReflect.Descriptor instead.
 func (*NVLDomainTargets) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{163}
+	return file_flow_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *NVLDomainTargets) GetTargets() []*NVLDomainTarget {
@@ -11231,7 +11389,7 @@ type NVLDomainTarget struct {
 
 func (x *NVLDomainTarget) Reset() {
 	*x = NVLDomainTarget{}
-	mi := &file_flow_proto_msgTypes[164]
+	mi := &file_flow_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11243,7 +11401,7 @@ func (x *NVLDomainTarget) String() string {
 func (*NVLDomainTarget) ProtoMessage() {}
 
 func (x *NVLDomainTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_proto_msgTypes[164]
+	mi := &file_flow_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11256,7 +11414,7 @@ func (x *NVLDomainTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NVLDomainTarget.ProtoReflect.Descriptor instead.
 func (*NVLDomainTarget) Descriptor() ([]byte, []int) {
-	return file_flow_proto_rawDescGZIP(), []int{164}
+	return file_flow_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *NVLDomainTarget) GetIdentifier() isNVLDomainTarget_Identifier {
@@ -11529,7 +11687,7 @@ const file_flow_proto_rawDesc = "" +
 	"\x1bGetRacksForNVLDomainRequest\x12B\n" +
 	"\x15nvl_domain_identifier\x18\x01 \x01(\v2\x0e.v1.IdentifierR\x13nvlDomainIdentifier\">\n" +
 	"\x1cGetRacksForNVLDomainResponse\x12\x1e\n" +
-	"\x05racks\x18\x01 \x03(\v2\b.v1.RackR\x05racks\"\xa8\x04\n" +
+	"\x05racks\x18\x01 \x03(\v2\b.v1.RackR\x05racks\"\xf9\x04\n" +
 	"\x16UpgradeFirmwareRequest\x128\n" +
 	"\vtarget_spec\x18\x01 \x01(\v2\x17.v1.OperationTargetSpecR\n" +
 	"targetSpec\x12*\n" +
@@ -11542,13 +11700,29 @@ const file_flow_proto_rawDesc = "" +
 	"\arule_id\x18\a \x01(\v2\b.v1.UUIDH\x04R\x06ruleId\x88\x01\x01\x12\x1f\n" +
 	"\vsub_targets\x18\b \x03(\tR\n" +
 	"subTargets\x128\n" +
-	"\x18override_readiness_check\x18\t \x01(\bR\x16overrideReadinessCheckB\x11\n" +
+	"\x18override_readiness_check\x18\t \x01(\bR\x16overrideReadinessCheck\x12O\n" +
+	"\x13authentication_data\x18\n" +
+	" \x01(\v2\x1e.v1.FirmwareAuthenticationDataR\x12authenticationDataB\x11\n" +
 	"\x0f_target_versionB\r\n" +
 	"\v_start_timeB\v\n" +
 	"\t_end_timeB\x10\n" +
 	"\x0e_queue_optionsB\n" +
 	"\n" +
-	"\b_rule_id\"\x89\x02\n" +
+	"\b_rule_id\"\x92\x01\n" +
+	"\x1aFirmwareAuthenticationData\x12\x18\n" +
+	"\x06shared\x18\x01 \x01(\tH\x00R\x06shared\x12Q\n" +
+	"\rper_component\x18\x02 \x01(\v2*.v1.PerComponentFirmwareAuthenticationDataH\x00R\fperComponentB\a\n" +
+	"\x05value\"\xb5\x01\n" +
+	"&PerComponentFirmwareAuthenticationData\x12\x1d\n" +
+	"\acompute\x18\x01 \x01(\tH\x00R\acompute\x88\x01\x01\x12\x1f\n" +
+	"\bnvswitch\x18\x02 \x01(\tH\x01R\bnvswitch\x88\x01\x01\x12#\n" +
+	"\n" +
+	"powershelf\x18\x03 \x01(\tH\x02R\n" +
+	"powershelf\x88\x01\x01B\n" +
+	"\n" +
+	"\b_computeB\v\n" +
+	"\t_nvswitchB\r\n" +
+	"\v_powershelf\"\x89\x02\n" +
 	"\x14GetComponentsRequest\x12=\n" +
 	"\vtarget_spec\x18\x01 \x01(\v2\x17.v1.OperationTargetSpecH\x00R\n" +
 	"targetSpec\x88\x01\x01\x12$\n" +
@@ -12310,7 +12484,7 @@ func file_flow_proto_rawDescGZIP() []byte {
 }
 
 var file_flow_proto_enumTypes = make([]protoimpl.EnumInfo, 22)
-var file_flow_proto_msgTypes = make([]protoimpl.MessageInfo, 165)
+var file_flow_proto_msgTypes = make([]protoimpl.MessageInfo, 167)
 var file_flow_proto_goTypes = []any{
 	(BMCType)(0),                      // 0: v1.BMCType
 	(ComponentType)(0),                // 1: v1.ComponentType
@@ -12334,175 +12508,177 @@ var file_flow_proto_goTypes = []any{
 	(OperationRunStatusReason)(0),     // 19: v1.OperationRunStatusReason
 	(OperationRunTargetStatus)(0),     // 20: v1.OperationRunTargetStatus
 	(OperationRunPhysicalLocationOrdering_Strategy)(0), // 21: v1.OperationRunPhysicalLocationOrdering.Strategy
-	(*UUID)(nil),                                 // 22: v1.UUID
-	(*DeviceInfo)(nil),                           // 23: v1.DeviceInfo
-	(*Location)(nil),                             // 24: v1.Location
-	(*DeviceSerialInfo)(nil),                     // 25: v1.DeviceSerialInfo
-	(*BMCInfo)(nil),                              // 26: v1.BMCInfo
-	(*RackPosition)(nil),                         // 27: v1.RackPosition
-	(*ComponentOperationStatus)(nil),             // 28: v1.ComponentOperationStatus
-	(*Component)(nil),                            // 29: v1.Component
-	(*Rack)(nil),                                 // 30: v1.Rack
-	(*Identifier)(nil),                           // 31: v1.Identifier
-	(*OperationTargetSpec)(nil),                  // 32: v1.OperationTargetSpec
-	(*RackTargets)(nil),                          // 33: v1.RackTargets
-	(*ComponentTargets)(nil),                     // 34: v1.ComponentTargets
-	(*ComponentTypes)(nil),                       // 35: v1.ComponentTypes
-	(*ComponentFilter)(nil),                      // 36: v1.ComponentFilter
-	(*ComponentsByType)(nil),                     // 37: v1.ComponentsByType
-	(*ComponentsForType)(nil),                    // 38: v1.ComponentsForType
-	(*RackTarget)(nil),                           // 39: v1.RackTarget
-	(*ComponentTarget)(nil),                      // 40: v1.ComponentTarget
-	(*ExternalRef)(nil),                          // 41: v1.ExternalRef
-	(*NVLDomain)(nil),                            // 42: v1.NVLDomain
-	(*Pagination)(nil),                           // 43: v1.Pagination
-	(*StringQueryInfo)(nil),                      // 44: v1.StringQueryInfo
-	(*Filter)(nil),                               // 45: v1.Filter
-	(*OrderBy)(nil),                              // 46: v1.OrderBy
-	(*Task)(nil),                                 // 47: v1.Task
-	(*CreateExpectedRackRequest)(nil),            // 48: v1.CreateExpectedRackRequest
-	(*CreateExpectedRackResponse)(nil),           // 49: v1.CreateExpectedRackResponse
-	(*GetRackInfoByIDRequest)(nil),               // 50: v1.GetRackInfoByIDRequest
-	(*GetRackInfoBySerialRequest)(nil),           // 51: v1.GetRackInfoBySerialRequest
-	(*GetRackInfoResponse)(nil),                  // 52: v1.GetRackInfoResponse
-	(*PatchRackRequest)(nil),                     // 53: v1.PatchRackRequest
-	(*PatchRackResponse)(nil),                    // 54: v1.PatchRackResponse
-	(*GetComponentInfoByIDRequest)(nil),          // 55: v1.GetComponentInfoByIDRequest
-	(*GetComponentInfoBySerialRequest)(nil),      // 56: v1.GetComponentInfoBySerialRequest
-	(*GetComponentInfoResponse)(nil),             // 57: v1.GetComponentInfoResponse
-	(*GetListOfRacksRequest)(nil),                // 58: v1.GetListOfRacksRequest
-	(*GetListOfRacksResponse)(nil),               // 59: v1.GetListOfRacksResponse
-	(*CreateNVLDomainRequest)(nil),               // 60: v1.CreateNVLDomainRequest
-	(*CreateNVLDomainResponse)(nil),              // 61: v1.CreateNVLDomainResponse
-	(*AttachRacksToNVLDomainRequest)(nil),        // 62: v1.AttachRacksToNVLDomainRequest
-	(*DetachRacksFromNVLDomainRequest)(nil),      // 63: v1.DetachRacksFromNVLDomainRequest
-	(*GetListOfNVLDomainsRequest)(nil),           // 64: v1.GetListOfNVLDomainsRequest
-	(*GetListOfNVLDomainsResponse)(nil),          // 65: v1.GetListOfNVLDomainsResponse
-	(*GetRacksForNVLDomainRequest)(nil),          // 66: v1.GetRacksForNVLDomainRequest
-	(*GetRacksForNVLDomainResponse)(nil),         // 67: v1.GetRacksForNVLDomainResponse
-	(*UpgradeFirmwareRequest)(nil),               // 68: v1.UpgradeFirmwareRequest
-	(*GetComponentsRequest)(nil),                 // 69: v1.GetComponentsRequest
-	(*GetComponentsResponse)(nil),                // 70: v1.GetComponentsResponse
-	(*ValidateComponentsRequest)(nil),            // 71: v1.ValidateComponentsRequest
-	(*ValidateComponentsResponse)(nil),           // 72: v1.ValidateComponentsResponse
-	(*ComponentDiff)(nil),                        // 73: v1.ComponentDiff
-	(*FieldDiff)(nil),                            // 74: v1.FieldDiff
-	(*AddComponentRequest)(nil),                  // 75: v1.AddComponentRequest
-	(*AddComponentResponse)(nil),                 // 76: v1.AddComponentResponse
-	(*DeleteComponentRequest)(nil),               // 77: v1.DeleteComponentRequest
-	(*DeleteComponentResponse)(nil),              // 78: v1.DeleteComponentResponse
-	(*DeleteRackRequest)(nil),                    // 79: v1.DeleteRackRequest
-	(*DeleteRackResponse)(nil),                   // 80: v1.DeleteRackResponse
-	(*PurgeRackRequest)(nil),                     // 81: v1.PurgeRackRequest
-	(*PurgeRackResponse)(nil),                    // 82: v1.PurgeRackResponse
-	(*PurgeComponentRequest)(nil),                // 83: v1.PurgeComponentRequest
-	(*PurgeComponentResponse)(nil),               // 84: v1.PurgeComponentResponse
-	(*PatchComponentRequest)(nil),                // 85: v1.PatchComponentRequest
-	(*PatchComponentResponse)(nil),               // 86: v1.PatchComponentResponse
-	(*SubmitTaskResponse)(nil),                   // 87: v1.SubmitTaskResponse
-	(*QueueOptions)(nil),                         // 88: v1.QueueOptions
-	(*PowerOnRackRequest)(nil),                   // 89: v1.PowerOnRackRequest
-	(*PowerOffRackRequest)(nil),                  // 90: v1.PowerOffRackRequest
-	(*PowerResetRackRequest)(nil),                // 91: v1.PowerResetRackRequest
-	(*BringUpRackRequest)(nil),                   // 92: v1.BringUpRackRequest
-	(*IngestRackRequest)(nil),                    // 93: v1.IngestRackRequest
-	(*ListTasksRequest)(nil),                     // 94: v1.ListTasksRequest
-	(*ListTasksResponse)(nil),                    // 95: v1.ListTasksResponse
-	(*GetTasksByIDsRequest)(nil),                 // 96: v1.GetTasksByIDsRequest
-	(*GetTasksByIDsResponse)(nil),                // 97: v1.GetTasksByIDsResponse
-	(*CancelTaskRequest)(nil),                    // 98: v1.CancelTaskRequest
-	(*CancelTaskResponse)(nil),                   // 99: v1.CancelTaskResponse
-	(*VersionRequest)(nil),                       // 100: v1.VersionRequest
-	(*BuildInfo)(nil),                            // 101: v1.BuildInfo
-	(*OperationRule)(nil),                        // 102: v1.OperationRule
-	(*CreateOperationRuleRequest)(nil),           // 103: v1.CreateOperationRuleRequest
-	(*CreateOperationRuleResponse)(nil),          // 104: v1.CreateOperationRuleResponse
-	(*UpdateOperationRuleRequest)(nil),           // 105: v1.UpdateOperationRuleRequest
-	(*DeleteOperationRuleRequest)(nil),           // 106: v1.DeleteOperationRuleRequest
-	(*SetRuleAsDefaultRequest)(nil),              // 107: v1.SetRuleAsDefaultRequest
-	(*GetOperationRuleRequest)(nil),              // 108: v1.GetOperationRuleRequest
-	(*ListOperationRulesRequest)(nil),            // 109: v1.ListOperationRulesRequest
-	(*ListOperationRulesResponse)(nil),           // 110: v1.ListOperationRulesResponse
-	(*AssociateRuleWithRackRequest)(nil),         // 111: v1.AssociateRuleWithRackRequest
-	(*DisassociateRuleFromRackRequest)(nil),      // 112: v1.DisassociateRuleFromRackRequest
-	(*GetRackRuleAssociationRequest)(nil),        // 113: v1.GetRackRuleAssociationRequest
-	(*GetRackRuleAssociationResponse)(nil),       // 114: v1.GetRackRuleAssociationResponse
-	(*ListRackRuleAssociationsRequest)(nil),      // 115: v1.ListRackRuleAssociationsRequest
-	(*RackRuleAssociation)(nil),                  // 116: v1.RackRuleAssociation
-	(*ListRackRuleAssociationsResponse)(nil),     // 117: v1.ListRackRuleAssociationsResponse
-	(*ScheduleSpec)(nil),                         // 118: v1.ScheduleSpec
-	(*ScheduleConfig)(nil),                       // 119: v1.ScheduleConfig
-	(*TaskSchedule)(nil),                         // 120: v1.TaskSchedule
-	(*ScheduledOperation)(nil),                   // 121: v1.ScheduledOperation
-	(*CreateTaskScheduleRequest)(nil),            // 122: v1.CreateTaskScheduleRequest
-	(*GetTaskScheduleRequest)(nil),               // 123: v1.GetTaskScheduleRequest
-	(*ListTaskSchedulesRequest)(nil),             // 124: v1.ListTaskSchedulesRequest
-	(*ListTaskSchedulesResponse)(nil),            // 125: v1.ListTaskSchedulesResponse
-	(*UpdateTaskScheduleRequest)(nil),            // 126: v1.UpdateTaskScheduleRequest
-	(*PauseTaskScheduleRequest)(nil),             // 127: v1.PauseTaskScheduleRequest
-	(*ResumeTaskScheduleRequest)(nil),            // 128: v1.ResumeTaskScheduleRequest
-	(*DeleteTaskScheduleRequest)(nil),            // 129: v1.DeleteTaskScheduleRequest
-	(*TriggerTaskScheduleRequest)(nil),           // 130: v1.TriggerTaskScheduleRequest
-	(*TaskScheduleScope)(nil),                    // 131: v1.TaskScheduleScope
-	(*AddTaskScheduleScopeRequest)(nil),          // 132: v1.AddTaskScheduleScopeRequest
-	(*AddTaskScheduleScopeResponse)(nil),         // 133: v1.AddTaskScheduleScopeResponse
-	(*RemoveTaskScheduleScopeRequest)(nil),       // 134: v1.RemoveTaskScheduleScopeRequest
-	(*UpdateTaskScheduleScopeRequest)(nil),       // 135: v1.UpdateTaskScheduleScopeRequest
-	(*UpdateTaskScheduleScopeResponse)(nil),      // 136: v1.UpdateTaskScheduleScopeResponse
-	(*ListTaskScheduleScopesRequest)(nil),        // 137: v1.ListTaskScheduleScopesRequest
-	(*ListTaskScheduleScopesResponse)(nil),       // 138: v1.ListTaskScheduleScopesResponse
-	(*CheckScheduleConflictsRequest)(nil),        // 139: v1.CheckScheduleConflictsRequest
-	(*CheckScheduleConflictsResponse)(nil),       // 140: v1.CheckScheduleConflictsResponse
-	(*CreateOperationRunRequest)(nil),            // 141: v1.CreateOperationRunRequest
-	(*CreateOperationRunResponse)(nil),           // 142: v1.CreateOperationRunResponse
-	(*OperationRunConfiguration)(nil),            // 143: v1.OperationRunConfiguration
-	(*GetOperationRunRequest)(nil),               // 144: v1.GetOperationRunRequest
-	(*GetOperationRunResponse)(nil),              // 145: v1.GetOperationRunResponse
-	(*ListOperationRunsRequest)(nil),             // 146: v1.ListOperationRunsRequest
-	(*ListOperationRunsResponse)(nil),            // 147: v1.ListOperationRunsResponse
-	(*OperationRunFilter)(nil),                   // 148: v1.OperationRunFilter
-	(*OperationRunStateFilter)(nil),              // 149: v1.OperationRunStateFilter
-	(*ListOperationRunTargetsRequest)(nil),       // 150: v1.ListOperationRunTargetsRequest
-	(*ListOperationRunTargetsResponse)(nil),      // 151: v1.ListOperationRunTargetsResponse
-	(*PauseOperationRunRequest)(nil),             // 152: v1.PauseOperationRunRequest
-	(*ResumeOperationRunRequest)(nil),            // 153: v1.ResumeOperationRunRequest
-	(*AdvanceOperationRunPhaseRequest)(nil),      // 154: v1.AdvanceOperationRunPhaseRequest
-	(*CancelOperationRunRequest)(nil),            // 155: v1.CancelOperationRunRequest
-	(*OperationRunSelector)(nil),                 // 156: v1.OperationRunSelector
-	(*PercentageSelector)(nil),                   // 157: v1.PercentageSelector
-	(*OperationRunOptions)(nil),                  // 158: v1.OperationRunOptions
-	(*OperationRunSafetyPolicy)(nil),             // 159: v1.OperationRunSafetyPolicy
-	(*OperationRunSafetyGate)(nil),               // 160: v1.OperationRunSafetyGate
-	(*OperationRunFailureRateGate)(nil),          // 161: v1.OperationRunFailureRateGate
-	(*OperationRunFailureCountGate)(nil),         // 162: v1.OperationRunFailureCountGate
-	(*OperationRunOrderingPolicy)(nil),           // 163: v1.OperationRunOrderingPolicy
-	(*OperationRunRandomOrdering)(nil),           // 164: v1.OperationRunRandomOrdering
-	(*OperationRunPhysicalLocationOrdering)(nil), // 165: v1.OperationRunPhysicalLocationOrdering
-	(*OperationRunPhasePolicy)(nil),              // 166: v1.OperationRunPhasePolicy
-	(*EqualOperationRunPhases)(nil),              // 167: v1.EqualOperationRunPhases
-	(*PercentageOperationRunPhases)(nil),         // 168: v1.PercentageOperationRunPhases
-	(*OperationRunPercentagePhase)(nil),          // 169: v1.OperationRunPercentagePhase
-	(*CountOperationRunPhases)(nil),              // 170: v1.CountOperationRunPhases
-	(*OperationRunCountPhase)(nil),               // 171: v1.OperationRunCountPhase
-	(*OperationRunPhaseAdvancePolicy)(nil),       // 172: v1.OperationRunPhaseAdvancePolicy
-	(*OperationRunConflictPolicy)(nil),           // 173: v1.OperationRunConflictPolicy
-	(*OperationRunConflictRetryPolicy)(nil),      // 174: v1.OperationRunConflictRetryPolicy
-	(*OperationRunTargetScope)(nil),              // 175: v1.OperationRunTargetScope
-	(*OperationRunOperation)(nil),                // 176: v1.OperationRunOperation
-	(*OperationRunState)(nil),                    // 177: v1.OperationRunState
-	(*OperationKind)(nil),                        // 178: v1.OperationKind
-	(*OperationRun)(nil),                         // 179: v1.OperationRun
-	(*OperationRunSummary)(nil),                  // 180: v1.OperationRunSummary
-	(*OperationRunStats)(nil),                    // 181: v1.OperationRunStats
-	(*OperationRunPhaseStats)(nil),               // 182: v1.OperationRunPhaseStats
-	(*OperationRunTargetOutcomeCounts)(nil),      // 183: v1.OperationRunTargetOutcomeCounts
-	(*OperationRunTarget)(nil),                   // 184: v1.OperationRunTarget
-	(*NVLDomainTargets)(nil),                     // 185: v1.NVLDomainTargets
-	(*NVLDomainTarget)(nil),                      // 186: v1.NVLDomainTarget
-	(*timestamppb.Timestamp)(nil),                // 187: google.protobuf.Timestamp
-	(*fieldmaskpb.FieldMask)(nil),                // 188: google.protobuf.FieldMask
-	(*durationpb.Duration)(nil),                  // 189: google.protobuf.Duration
-	(*emptypb.Empty)(nil),                        // 190: google.protobuf.Empty
+	(*UUID)(nil),                                   // 22: v1.UUID
+	(*DeviceInfo)(nil),                             // 23: v1.DeviceInfo
+	(*Location)(nil),                               // 24: v1.Location
+	(*DeviceSerialInfo)(nil),                       // 25: v1.DeviceSerialInfo
+	(*BMCInfo)(nil),                                // 26: v1.BMCInfo
+	(*RackPosition)(nil),                           // 27: v1.RackPosition
+	(*ComponentOperationStatus)(nil),               // 28: v1.ComponentOperationStatus
+	(*Component)(nil),                              // 29: v1.Component
+	(*Rack)(nil),                                   // 30: v1.Rack
+	(*Identifier)(nil),                             // 31: v1.Identifier
+	(*OperationTargetSpec)(nil),                    // 32: v1.OperationTargetSpec
+	(*RackTargets)(nil),                            // 33: v1.RackTargets
+	(*ComponentTargets)(nil),                       // 34: v1.ComponentTargets
+	(*ComponentTypes)(nil),                         // 35: v1.ComponentTypes
+	(*ComponentFilter)(nil),                        // 36: v1.ComponentFilter
+	(*ComponentsByType)(nil),                       // 37: v1.ComponentsByType
+	(*ComponentsForType)(nil),                      // 38: v1.ComponentsForType
+	(*RackTarget)(nil),                             // 39: v1.RackTarget
+	(*ComponentTarget)(nil),                        // 40: v1.ComponentTarget
+	(*ExternalRef)(nil),                            // 41: v1.ExternalRef
+	(*NVLDomain)(nil),                              // 42: v1.NVLDomain
+	(*Pagination)(nil),                             // 43: v1.Pagination
+	(*StringQueryInfo)(nil),                        // 44: v1.StringQueryInfo
+	(*Filter)(nil),                                 // 45: v1.Filter
+	(*OrderBy)(nil),                                // 46: v1.OrderBy
+	(*Task)(nil),                                   // 47: v1.Task
+	(*CreateExpectedRackRequest)(nil),              // 48: v1.CreateExpectedRackRequest
+	(*CreateExpectedRackResponse)(nil),             // 49: v1.CreateExpectedRackResponse
+	(*GetRackInfoByIDRequest)(nil),                 // 50: v1.GetRackInfoByIDRequest
+	(*GetRackInfoBySerialRequest)(nil),             // 51: v1.GetRackInfoBySerialRequest
+	(*GetRackInfoResponse)(nil),                    // 52: v1.GetRackInfoResponse
+	(*PatchRackRequest)(nil),                       // 53: v1.PatchRackRequest
+	(*PatchRackResponse)(nil),                      // 54: v1.PatchRackResponse
+	(*GetComponentInfoByIDRequest)(nil),            // 55: v1.GetComponentInfoByIDRequest
+	(*GetComponentInfoBySerialRequest)(nil),        // 56: v1.GetComponentInfoBySerialRequest
+	(*GetComponentInfoResponse)(nil),               // 57: v1.GetComponentInfoResponse
+	(*GetListOfRacksRequest)(nil),                  // 58: v1.GetListOfRacksRequest
+	(*GetListOfRacksResponse)(nil),                 // 59: v1.GetListOfRacksResponse
+	(*CreateNVLDomainRequest)(nil),                 // 60: v1.CreateNVLDomainRequest
+	(*CreateNVLDomainResponse)(nil),                // 61: v1.CreateNVLDomainResponse
+	(*AttachRacksToNVLDomainRequest)(nil),          // 62: v1.AttachRacksToNVLDomainRequest
+	(*DetachRacksFromNVLDomainRequest)(nil),        // 63: v1.DetachRacksFromNVLDomainRequest
+	(*GetListOfNVLDomainsRequest)(nil),             // 64: v1.GetListOfNVLDomainsRequest
+	(*GetListOfNVLDomainsResponse)(nil),            // 65: v1.GetListOfNVLDomainsResponse
+	(*GetRacksForNVLDomainRequest)(nil),            // 66: v1.GetRacksForNVLDomainRequest
+	(*GetRacksForNVLDomainResponse)(nil),           // 67: v1.GetRacksForNVLDomainResponse
+	(*UpgradeFirmwareRequest)(nil),                 // 68: v1.UpgradeFirmwareRequest
+	(*FirmwareAuthenticationData)(nil),             // 69: v1.FirmwareAuthenticationData
+	(*PerComponentFirmwareAuthenticationData)(nil), // 70: v1.PerComponentFirmwareAuthenticationData
+	(*GetComponentsRequest)(nil),                   // 71: v1.GetComponentsRequest
+	(*GetComponentsResponse)(nil),                  // 72: v1.GetComponentsResponse
+	(*ValidateComponentsRequest)(nil),              // 73: v1.ValidateComponentsRequest
+	(*ValidateComponentsResponse)(nil),             // 74: v1.ValidateComponentsResponse
+	(*ComponentDiff)(nil),                          // 75: v1.ComponentDiff
+	(*FieldDiff)(nil),                              // 76: v1.FieldDiff
+	(*AddComponentRequest)(nil),                    // 77: v1.AddComponentRequest
+	(*AddComponentResponse)(nil),                   // 78: v1.AddComponentResponse
+	(*DeleteComponentRequest)(nil),                 // 79: v1.DeleteComponentRequest
+	(*DeleteComponentResponse)(nil),                // 80: v1.DeleteComponentResponse
+	(*DeleteRackRequest)(nil),                      // 81: v1.DeleteRackRequest
+	(*DeleteRackResponse)(nil),                     // 82: v1.DeleteRackResponse
+	(*PurgeRackRequest)(nil),                       // 83: v1.PurgeRackRequest
+	(*PurgeRackResponse)(nil),                      // 84: v1.PurgeRackResponse
+	(*PurgeComponentRequest)(nil),                  // 85: v1.PurgeComponentRequest
+	(*PurgeComponentResponse)(nil),                 // 86: v1.PurgeComponentResponse
+	(*PatchComponentRequest)(nil),                  // 87: v1.PatchComponentRequest
+	(*PatchComponentResponse)(nil),                 // 88: v1.PatchComponentResponse
+	(*SubmitTaskResponse)(nil),                     // 89: v1.SubmitTaskResponse
+	(*QueueOptions)(nil),                           // 90: v1.QueueOptions
+	(*PowerOnRackRequest)(nil),                     // 91: v1.PowerOnRackRequest
+	(*PowerOffRackRequest)(nil),                    // 92: v1.PowerOffRackRequest
+	(*PowerResetRackRequest)(nil),                  // 93: v1.PowerResetRackRequest
+	(*BringUpRackRequest)(nil),                     // 94: v1.BringUpRackRequest
+	(*IngestRackRequest)(nil),                      // 95: v1.IngestRackRequest
+	(*ListTasksRequest)(nil),                       // 96: v1.ListTasksRequest
+	(*ListTasksResponse)(nil),                      // 97: v1.ListTasksResponse
+	(*GetTasksByIDsRequest)(nil),                   // 98: v1.GetTasksByIDsRequest
+	(*GetTasksByIDsResponse)(nil),                  // 99: v1.GetTasksByIDsResponse
+	(*CancelTaskRequest)(nil),                      // 100: v1.CancelTaskRequest
+	(*CancelTaskResponse)(nil),                     // 101: v1.CancelTaskResponse
+	(*VersionRequest)(nil),                         // 102: v1.VersionRequest
+	(*BuildInfo)(nil),                              // 103: v1.BuildInfo
+	(*OperationRule)(nil),                          // 104: v1.OperationRule
+	(*CreateOperationRuleRequest)(nil),             // 105: v1.CreateOperationRuleRequest
+	(*CreateOperationRuleResponse)(nil),            // 106: v1.CreateOperationRuleResponse
+	(*UpdateOperationRuleRequest)(nil),             // 107: v1.UpdateOperationRuleRequest
+	(*DeleteOperationRuleRequest)(nil),             // 108: v1.DeleteOperationRuleRequest
+	(*SetRuleAsDefaultRequest)(nil),                // 109: v1.SetRuleAsDefaultRequest
+	(*GetOperationRuleRequest)(nil),                // 110: v1.GetOperationRuleRequest
+	(*ListOperationRulesRequest)(nil),              // 111: v1.ListOperationRulesRequest
+	(*ListOperationRulesResponse)(nil),             // 112: v1.ListOperationRulesResponse
+	(*AssociateRuleWithRackRequest)(nil),           // 113: v1.AssociateRuleWithRackRequest
+	(*DisassociateRuleFromRackRequest)(nil),        // 114: v1.DisassociateRuleFromRackRequest
+	(*GetRackRuleAssociationRequest)(nil),          // 115: v1.GetRackRuleAssociationRequest
+	(*GetRackRuleAssociationResponse)(nil),         // 116: v1.GetRackRuleAssociationResponse
+	(*ListRackRuleAssociationsRequest)(nil),        // 117: v1.ListRackRuleAssociationsRequest
+	(*RackRuleAssociation)(nil),                    // 118: v1.RackRuleAssociation
+	(*ListRackRuleAssociationsResponse)(nil),       // 119: v1.ListRackRuleAssociationsResponse
+	(*ScheduleSpec)(nil),                           // 120: v1.ScheduleSpec
+	(*ScheduleConfig)(nil),                         // 121: v1.ScheduleConfig
+	(*TaskSchedule)(nil),                           // 122: v1.TaskSchedule
+	(*ScheduledOperation)(nil),                     // 123: v1.ScheduledOperation
+	(*CreateTaskScheduleRequest)(nil),              // 124: v1.CreateTaskScheduleRequest
+	(*GetTaskScheduleRequest)(nil),                 // 125: v1.GetTaskScheduleRequest
+	(*ListTaskSchedulesRequest)(nil),               // 126: v1.ListTaskSchedulesRequest
+	(*ListTaskSchedulesResponse)(nil),              // 127: v1.ListTaskSchedulesResponse
+	(*UpdateTaskScheduleRequest)(nil),              // 128: v1.UpdateTaskScheduleRequest
+	(*PauseTaskScheduleRequest)(nil),               // 129: v1.PauseTaskScheduleRequest
+	(*ResumeTaskScheduleRequest)(nil),              // 130: v1.ResumeTaskScheduleRequest
+	(*DeleteTaskScheduleRequest)(nil),              // 131: v1.DeleteTaskScheduleRequest
+	(*TriggerTaskScheduleRequest)(nil),             // 132: v1.TriggerTaskScheduleRequest
+	(*TaskScheduleScope)(nil),                      // 133: v1.TaskScheduleScope
+	(*AddTaskScheduleScopeRequest)(nil),            // 134: v1.AddTaskScheduleScopeRequest
+	(*AddTaskScheduleScopeResponse)(nil),           // 135: v1.AddTaskScheduleScopeResponse
+	(*RemoveTaskScheduleScopeRequest)(nil),         // 136: v1.RemoveTaskScheduleScopeRequest
+	(*UpdateTaskScheduleScopeRequest)(nil),         // 137: v1.UpdateTaskScheduleScopeRequest
+	(*UpdateTaskScheduleScopeResponse)(nil),        // 138: v1.UpdateTaskScheduleScopeResponse
+	(*ListTaskScheduleScopesRequest)(nil),          // 139: v1.ListTaskScheduleScopesRequest
+	(*ListTaskScheduleScopesResponse)(nil),         // 140: v1.ListTaskScheduleScopesResponse
+	(*CheckScheduleConflictsRequest)(nil),          // 141: v1.CheckScheduleConflictsRequest
+	(*CheckScheduleConflictsResponse)(nil),         // 142: v1.CheckScheduleConflictsResponse
+	(*CreateOperationRunRequest)(nil),              // 143: v1.CreateOperationRunRequest
+	(*CreateOperationRunResponse)(nil),             // 144: v1.CreateOperationRunResponse
+	(*OperationRunConfiguration)(nil),              // 145: v1.OperationRunConfiguration
+	(*GetOperationRunRequest)(nil),                 // 146: v1.GetOperationRunRequest
+	(*GetOperationRunResponse)(nil),                // 147: v1.GetOperationRunResponse
+	(*ListOperationRunsRequest)(nil),               // 148: v1.ListOperationRunsRequest
+	(*ListOperationRunsResponse)(nil),              // 149: v1.ListOperationRunsResponse
+	(*OperationRunFilter)(nil),                     // 150: v1.OperationRunFilter
+	(*OperationRunStateFilter)(nil),                // 151: v1.OperationRunStateFilter
+	(*ListOperationRunTargetsRequest)(nil),         // 152: v1.ListOperationRunTargetsRequest
+	(*ListOperationRunTargetsResponse)(nil),        // 153: v1.ListOperationRunTargetsResponse
+	(*PauseOperationRunRequest)(nil),               // 154: v1.PauseOperationRunRequest
+	(*ResumeOperationRunRequest)(nil),              // 155: v1.ResumeOperationRunRequest
+	(*AdvanceOperationRunPhaseRequest)(nil),        // 156: v1.AdvanceOperationRunPhaseRequest
+	(*CancelOperationRunRequest)(nil),              // 157: v1.CancelOperationRunRequest
+	(*OperationRunSelector)(nil),                   // 158: v1.OperationRunSelector
+	(*PercentageSelector)(nil),                     // 159: v1.PercentageSelector
+	(*OperationRunOptions)(nil),                    // 160: v1.OperationRunOptions
+	(*OperationRunSafetyPolicy)(nil),               // 161: v1.OperationRunSafetyPolicy
+	(*OperationRunSafetyGate)(nil),                 // 162: v1.OperationRunSafetyGate
+	(*OperationRunFailureRateGate)(nil),            // 163: v1.OperationRunFailureRateGate
+	(*OperationRunFailureCountGate)(nil),           // 164: v1.OperationRunFailureCountGate
+	(*OperationRunOrderingPolicy)(nil),             // 165: v1.OperationRunOrderingPolicy
+	(*OperationRunRandomOrdering)(nil),             // 166: v1.OperationRunRandomOrdering
+	(*OperationRunPhysicalLocationOrdering)(nil),   // 167: v1.OperationRunPhysicalLocationOrdering
+	(*OperationRunPhasePolicy)(nil),                // 168: v1.OperationRunPhasePolicy
+	(*EqualOperationRunPhases)(nil),                // 169: v1.EqualOperationRunPhases
+	(*PercentageOperationRunPhases)(nil),           // 170: v1.PercentageOperationRunPhases
+	(*OperationRunPercentagePhase)(nil),            // 171: v1.OperationRunPercentagePhase
+	(*CountOperationRunPhases)(nil),                // 172: v1.CountOperationRunPhases
+	(*OperationRunCountPhase)(nil),                 // 173: v1.OperationRunCountPhase
+	(*OperationRunPhaseAdvancePolicy)(nil),         // 174: v1.OperationRunPhaseAdvancePolicy
+	(*OperationRunConflictPolicy)(nil),             // 175: v1.OperationRunConflictPolicy
+	(*OperationRunConflictRetryPolicy)(nil),        // 176: v1.OperationRunConflictRetryPolicy
+	(*OperationRunTargetScope)(nil),                // 177: v1.OperationRunTargetScope
+	(*OperationRunOperation)(nil),                  // 178: v1.OperationRunOperation
+	(*OperationRunState)(nil),                      // 179: v1.OperationRunState
+	(*OperationKind)(nil),                          // 180: v1.OperationKind
+	(*OperationRun)(nil),                           // 181: v1.OperationRun
+	(*OperationRunSummary)(nil),                    // 182: v1.OperationRunSummary
+	(*OperationRunStats)(nil),                      // 183: v1.OperationRunStats
+	(*OperationRunPhaseStats)(nil),                 // 184: v1.OperationRunPhaseStats
+	(*OperationRunTargetOutcomeCounts)(nil),        // 185: v1.OperationRunTargetOutcomeCounts
+	(*OperationRunTarget)(nil),                     // 186: v1.OperationRunTarget
+	(*NVLDomainTargets)(nil),                       // 187: v1.NVLDomainTargets
+	(*NVLDomainTarget)(nil),                        // 188: v1.NVLDomainTarget
+	(*timestamppb.Timestamp)(nil),                  // 189: google.protobuf.Timestamp
+	(*fieldmaskpb.FieldMask)(nil),                  // 190: google.protobuf.FieldMask
+	(*durationpb.Duration)(nil),                    // 191: google.protobuf.Duration
+	(*emptypb.Empty)(nil),                          // 192: google.protobuf.Empty
 }
 var file_flow_proto_depIdxs = []int32{
 	22,  // 0: v1.DeviceInfo.id:type_name -> v1.UUID
@@ -12522,7 +12698,7 @@ var file_flow_proto_depIdxs = []int32{
 	22,  // 14: v1.Identifier.id:type_name -> v1.UUID
 	33,  // 15: v1.OperationTargetSpec.racks:type_name -> v1.RackTargets
 	34,  // 16: v1.OperationTargetSpec.components:type_name -> v1.ComponentTargets
-	185, // 17: v1.OperationTargetSpec.nvl_domains:type_name -> v1.NVLDomainTargets
+	187, // 17: v1.OperationTargetSpec.nvl_domains:type_name -> v1.NVLDomainTargets
 	39,  // 18: v1.RackTargets.targets:type_name -> v1.RackTarget
 	40,  // 19: v1.ComponentTargets.targets:type_name -> v1.ComponentTarget
 	1,   // 20: v1.ComponentTypes.types:type_name -> v1.ComponentType
@@ -12547,12 +12723,12 @@ var file_flow_proto_depIdxs = []int32{
 	22,  // 39: v1.Task.component_uuids:type_name -> v1.UUID
 	8,   // 40: v1.Task.executor_type:type_name -> v1.TaskExecutorType
 	7,   // 41: v1.Task.status:type_name -> v1.TaskStatus
-	187, // 42: v1.Task.queue_expires_at:type_name -> google.protobuf.Timestamp
-	187, // 43: v1.Task.created_at:type_name -> google.protobuf.Timestamp
-	187, // 44: v1.Task.finished_at:type_name -> google.protobuf.Timestamp
+	189, // 42: v1.Task.queue_expires_at:type_name -> google.protobuf.Timestamp
+	189, // 43: v1.Task.created_at:type_name -> google.protobuf.Timestamp
+	189, // 44: v1.Task.finished_at:type_name -> google.protobuf.Timestamp
 	22,  // 45: v1.Task.applied_rule_id:type_name -> v1.UUID
-	187, // 46: v1.Task.updated_at:type_name -> google.protobuf.Timestamp
-	187, // 47: v1.Task.started_at:type_name -> google.protobuf.Timestamp
+	189, // 46: v1.Task.updated_at:type_name -> google.protobuf.Timestamp
+	189, // 47: v1.Task.started_at:type_name -> google.protobuf.Timestamp
 	30,  // 48: v1.CreateExpectedRackRequest.rack:type_name -> v1.Rack
 	22,  // 49: v1.CreateExpectedRackResponse.id:type_name -> v1.UUID
 	22,  // 50: v1.GetRackInfoByIDRequest.id:type_name -> v1.UUID
@@ -12578,339 +12754,341 @@ var file_flow_proto_depIdxs = []int32{
 	31,  // 70: v1.GetRacksForNVLDomainRequest.nvl_domain_identifier:type_name -> v1.Identifier
 	30,  // 71: v1.GetRacksForNVLDomainResponse.racks:type_name -> v1.Rack
 	32,  // 72: v1.UpgradeFirmwareRequest.target_spec:type_name -> v1.OperationTargetSpec
-	187, // 73: v1.UpgradeFirmwareRequest.start_time:type_name -> google.protobuf.Timestamp
-	187, // 74: v1.UpgradeFirmwareRequest.end_time:type_name -> google.protobuf.Timestamp
-	88,  // 75: v1.UpgradeFirmwareRequest.queue_options:type_name -> v1.QueueOptions
+	189, // 73: v1.UpgradeFirmwareRequest.start_time:type_name -> google.protobuf.Timestamp
+	189, // 74: v1.UpgradeFirmwareRequest.end_time:type_name -> google.protobuf.Timestamp
+	90,  // 75: v1.UpgradeFirmwareRequest.queue_options:type_name -> v1.QueueOptions
 	22,  // 76: v1.UpgradeFirmwareRequest.rule_id:type_name -> v1.UUID
-	32,  // 77: v1.GetComponentsRequest.target_spec:type_name -> v1.OperationTargetSpec
-	45,  // 78: v1.GetComponentsRequest.filters:type_name -> v1.Filter
-	43,  // 79: v1.GetComponentsRequest.pagination:type_name -> v1.Pagination
-	46,  // 80: v1.GetComponentsRequest.order_by:type_name -> v1.OrderBy
-	29,  // 81: v1.GetComponentsResponse.components:type_name -> v1.Component
-	32,  // 82: v1.ValidateComponentsRequest.target_spec:type_name -> v1.OperationTargetSpec
-	45,  // 83: v1.ValidateComponentsRequest.filters:type_name -> v1.Filter
-	43,  // 84: v1.ValidateComponentsRequest.pagination:type_name -> v1.Pagination
-	46,  // 85: v1.ValidateComponentsRequest.order_by:type_name -> v1.OrderBy
-	73,  // 86: v1.ValidateComponentsResponse.diffs:type_name -> v1.ComponentDiff
-	11,  // 87: v1.ComponentDiff.type:type_name -> v1.DiffType
-	29,  // 88: v1.ComponentDiff.expected:type_name -> v1.Component
-	29,  // 89: v1.ComponentDiff.actual:type_name -> v1.Component
-	74,  // 90: v1.ComponentDiff.field_diffs:type_name -> v1.FieldDiff
-	22,  // 91: v1.ComponentDiff.id:type_name -> v1.UUID
-	29,  // 92: v1.AddComponentRequest.component:type_name -> v1.Component
-	29,  // 93: v1.AddComponentResponse.component:type_name -> v1.Component
-	22,  // 94: v1.DeleteComponentRequest.id:type_name -> v1.UUID
-	22,  // 95: v1.DeleteRackRequest.id:type_name -> v1.UUID
-	22,  // 96: v1.PurgeRackRequest.id:type_name -> v1.UUID
-	22,  // 97: v1.PurgeComponentRequest.id:type_name -> v1.UUID
-	22,  // 98: v1.PatchComponentRequest.id:type_name -> v1.UUID
-	27,  // 99: v1.PatchComponentRequest.position:type_name -> v1.RackPosition
-	22,  // 100: v1.PatchComponentRequest.rack_id:type_name -> v1.UUID
-	26,  // 101: v1.PatchComponentRequest.bmcs:type_name -> v1.BMCInfo
-	29,  // 102: v1.PatchComponentResponse.component:type_name -> v1.Component
-	22,  // 103: v1.SubmitTaskResponse.task_ids:type_name -> v1.UUID
-	12,  // 104: v1.QueueOptions.conflict_strategy:type_name -> v1.ConflictStrategy
-	32,  // 105: v1.PowerOnRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	88,  // 106: v1.PowerOnRackRequest.queue_options:type_name -> v1.QueueOptions
-	22,  // 107: v1.PowerOnRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 108: v1.PowerOffRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	88,  // 109: v1.PowerOffRackRequest.queue_options:type_name -> v1.QueueOptions
-	22,  // 110: v1.PowerOffRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 111: v1.PowerResetRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	88,  // 112: v1.PowerResetRackRequest.queue_options:type_name -> v1.QueueOptions
-	22,  // 113: v1.PowerResetRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 114: v1.BringUpRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	22,  // 115: v1.BringUpRackRequest.rule_id:type_name -> v1.UUID
-	32,  // 116: v1.IngestRackRequest.target_spec:type_name -> v1.OperationTargetSpec
-	45,  // 117: v1.IngestRackRequest.filters:type_name -> v1.Filter
-	22,  // 118: v1.IngestRackRequest.rule_id:type_name -> v1.UUID
-	22,  // 119: v1.ListTasksRequest.rack_id:type_name -> v1.UUID
-	43,  // 120: v1.ListTasksRequest.pagination:type_name -> v1.Pagination
-	22,  // 121: v1.ListTasksRequest.component_id:type_name -> v1.UUID
-	47,  // 122: v1.ListTasksResponse.tasks:type_name -> v1.Task
-	22,  // 123: v1.GetTasksByIDsRequest.task_ids:type_name -> v1.UUID
-	47,  // 124: v1.GetTasksByIDsResponse.tasks:type_name -> v1.Task
-	22,  // 125: v1.CancelTaskRequest.task_id:type_name -> v1.UUID
-	47,  // 126: v1.CancelTaskResponse.task:type_name -> v1.Task
-	22,  // 127: v1.OperationRule.id:type_name -> v1.UUID
-	13,  // 128: v1.OperationRule.operation_type:type_name -> v1.OperationType
-	187, // 129: v1.OperationRule.created_at:type_name -> google.protobuf.Timestamp
-	187, // 130: v1.OperationRule.updated_at:type_name -> google.protobuf.Timestamp
-	13,  // 131: v1.CreateOperationRuleRequest.operation_type:type_name -> v1.OperationType
-	22,  // 132: v1.CreateOperationRuleResponse.id:type_name -> v1.UUID
-	22,  // 133: v1.UpdateOperationRuleRequest.rule_id:type_name -> v1.UUID
-	22,  // 134: v1.DeleteOperationRuleRequest.rule_id:type_name -> v1.UUID
-	22,  // 135: v1.SetRuleAsDefaultRequest.rule_id:type_name -> v1.UUID
-	22,  // 136: v1.GetOperationRuleRequest.rule_id:type_name -> v1.UUID
-	13,  // 137: v1.ListOperationRulesRequest.operation_type:type_name -> v1.OperationType
-	102, // 138: v1.ListOperationRulesResponse.rules:type_name -> v1.OperationRule
-	22,  // 139: v1.AssociateRuleWithRackRequest.rack_id:type_name -> v1.UUID
-	22,  // 140: v1.AssociateRuleWithRackRequest.rule_id:type_name -> v1.UUID
-	22,  // 141: v1.DisassociateRuleFromRackRequest.rack_id:type_name -> v1.UUID
-	13,  // 142: v1.DisassociateRuleFromRackRequest.operation_type:type_name -> v1.OperationType
-	22,  // 143: v1.GetRackRuleAssociationRequest.rack_id:type_name -> v1.UUID
-	13,  // 144: v1.GetRackRuleAssociationRequest.operation_type:type_name -> v1.OperationType
-	22,  // 145: v1.GetRackRuleAssociationResponse.rule_id:type_name -> v1.UUID
-	22,  // 146: v1.ListRackRuleAssociationsRequest.rack_id:type_name -> v1.UUID
-	22,  // 147: v1.RackRuleAssociation.rack_id:type_name -> v1.UUID
-	13,  // 148: v1.RackRuleAssociation.operation_type:type_name -> v1.OperationType
-	22,  // 149: v1.RackRuleAssociation.rule_id:type_name -> v1.UUID
-	187, // 150: v1.RackRuleAssociation.created_at:type_name -> google.protobuf.Timestamp
-	187, // 151: v1.RackRuleAssociation.updated_at:type_name -> google.protobuf.Timestamp
-	116, // 152: v1.ListRackRuleAssociationsResponse.associations:type_name -> v1.RackRuleAssociation
-	14,  // 153: v1.ScheduleSpec.type:type_name -> v1.ScheduleSpecType
-	118, // 154: v1.ScheduleConfig.spec:type_name -> v1.ScheduleSpec
-	15,  // 155: v1.ScheduleConfig.overlap_policy:type_name -> v1.OverlapPolicy
-	22,  // 156: v1.TaskSchedule.id:type_name -> v1.UUID
-	118, // 157: v1.TaskSchedule.spec:type_name -> v1.ScheduleSpec
-	15,  // 158: v1.TaskSchedule.overlap_policy:type_name -> v1.OverlapPolicy
-	187, // 159: v1.TaskSchedule.next_run_at:type_name -> google.protobuf.Timestamp
-	187, // 160: v1.TaskSchedule.last_run_at:type_name -> google.protobuf.Timestamp
-	187, // 161: v1.TaskSchedule.created_at:type_name -> google.protobuf.Timestamp
-	187, // 162: v1.TaskSchedule.updated_at:type_name -> google.protobuf.Timestamp
-	89,  // 163: v1.ScheduledOperation.power_on:type_name -> v1.PowerOnRackRequest
-	90,  // 164: v1.ScheduledOperation.power_off:type_name -> v1.PowerOffRackRequest
-	91,  // 165: v1.ScheduledOperation.power_reset:type_name -> v1.PowerResetRackRequest
-	92,  // 166: v1.ScheduledOperation.bring_up:type_name -> v1.BringUpRackRequest
-	68,  // 167: v1.ScheduledOperation.upgrade_firmware:type_name -> v1.UpgradeFirmwareRequest
-	93,  // 168: v1.ScheduledOperation.ingest:type_name -> v1.IngestRackRequest
-	119, // 169: v1.CreateTaskScheduleRequest.schedule:type_name -> v1.ScheduleConfig
-	121, // 170: v1.CreateTaskScheduleRequest.operation:type_name -> v1.ScheduledOperation
-	22,  // 171: v1.GetTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 172: v1.ListTaskSchedulesRequest.rack_id:type_name -> v1.UUID
-	43,  // 173: v1.ListTaskSchedulesRequest.pagination:type_name -> v1.Pagination
-	120, // 174: v1.ListTaskSchedulesResponse.task_schedules:type_name -> v1.TaskSchedule
-	22,  // 175: v1.UpdateTaskScheduleRequest.id:type_name -> v1.UUID
-	119, // 176: v1.UpdateTaskScheduleRequest.schedule:type_name -> v1.ScheduleConfig
-	188, // 177: v1.UpdateTaskScheduleRequest.update_mask:type_name -> google.protobuf.FieldMask
-	22,  // 178: v1.PauseTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 179: v1.ResumeTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 180: v1.DeleteTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 181: v1.TriggerTaskScheduleRequest.id:type_name -> v1.UUID
-	22,  // 182: v1.TaskScheduleScope.id:type_name -> v1.UUID
-	22,  // 183: v1.TaskScheduleScope.schedule_id:type_name -> v1.UUID
-	22,  // 184: v1.TaskScheduleScope.rack_id:type_name -> v1.UUID
-	35,  // 185: v1.TaskScheduleScope.types:type_name -> v1.ComponentTypes
-	34,  // 186: v1.TaskScheduleScope.components:type_name -> v1.ComponentTargets
-	22,  // 187: v1.TaskScheduleScope.last_task_id:type_name -> v1.UUID
-	187, // 188: v1.TaskScheduleScope.created_at:type_name -> google.protobuf.Timestamp
-	22,  // 189: v1.AddTaskScheduleScopeRequest.schedule_id:type_name -> v1.UUID
-	32,  // 190: v1.AddTaskScheduleScopeRequest.target_spec:type_name -> v1.OperationTargetSpec
-	131, // 191: v1.AddTaskScheduleScopeResponse.scopes:type_name -> v1.TaskScheduleScope
-	22,  // 192: v1.RemoveTaskScheduleScopeRequest.scope_id:type_name -> v1.UUID
-	22,  // 193: v1.UpdateTaskScheduleScopeRequest.schedule_id:type_name -> v1.UUID
-	32,  // 194: v1.UpdateTaskScheduleScopeRequest.desired_scope:type_name -> v1.OperationTargetSpec
-	131, // 195: v1.UpdateTaskScheduleScopeResponse.scopes:type_name -> v1.TaskScheduleScope
-	22,  // 196: v1.ListTaskScheduleScopesRequest.schedule_id:type_name -> v1.UUID
-	131, // 197: v1.ListTaskScheduleScopesResponse.scopes:type_name -> v1.TaskScheduleScope
-	121, // 198: v1.CheckScheduleConflictsRequest.operation:type_name -> v1.ScheduledOperation
-	22,  // 199: v1.CheckScheduleConflictsRequest.exclude_schedule_id:type_name -> v1.UUID
-	120, // 200: v1.CheckScheduleConflictsResponse.conflicts:type_name -> v1.TaskSchedule
-	143, // 201: v1.CreateOperationRunRequest.configuration:type_name -> v1.OperationRunConfiguration
-	22,  // 202: v1.CreateOperationRunResponse.id:type_name -> v1.UUID
-	156, // 203: v1.OperationRunConfiguration.selector:type_name -> v1.OperationRunSelector
-	158, // 204: v1.OperationRunConfiguration.options:type_name -> v1.OperationRunOptions
-	176, // 205: v1.OperationRunConfiguration.operation:type_name -> v1.OperationRunOperation
-	22,  // 206: v1.GetOperationRunRequest.id:type_name -> v1.UUID
-	179, // 207: v1.GetOperationRunResponse.operation_run:type_name -> v1.OperationRun
-	148, // 208: v1.ListOperationRunsRequest.filter:type_name -> v1.OperationRunFilter
-	43,  // 209: v1.ListOperationRunsRequest.pagination:type_name -> v1.Pagination
-	180, // 210: v1.ListOperationRunsResponse.operation_runs:type_name -> v1.OperationRunSummary
-	44,  // 211: v1.OperationRunFilter.name:type_name -> v1.StringQueryInfo
-	149, // 212: v1.OperationRunFilter.states:type_name -> v1.OperationRunStateFilter
-	178, // 213: v1.OperationRunFilter.operation_kinds:type_name -> v1.OperationKind
-	18,  // 214: v1.OperationRunStateFilter.status:type_name -> v1.OperationRunStatus
-	19,  // 215: v1.OperationRunStateFilter.reason:type_name -> v1.OperationRunStatusReason
-	22,  // 216: v1.ListOperationRunTargetsRequest.operation_run_id:type_name -> v1.UUID
-	20,  // 217: v1.ListOperationRunTargetsRequest.status:type_name -> v1.OperationRunTargetStatus
-	43,  // 218: v1.ListOperationRunTargetsRequest.pagination:type_name -> v1.Pagination
-	16,  // 219: v1.ListOperationRunTargetsRequest.phase_scope:type_name -> v1.OperationRunTargetPhaseScope
-	184, // 220: v1.ListOperationRunTargetsResponse.targets:type_name -> v1.OperationRunTarget
-	22,  // 221: v1.PauseOperationRunRequest.id:type_name -> v1.UUID
-	22,  // 222: v1.ResumeOperationRunRequest.id:type_name -> v1.UUID
-	22,  // 223: v1.AdvanceOperationRunPhaseRequest.id:type_name -> v1.UUID
-	22,  // 224: v1.CancelOperationRunRequest.id:type_name -> v1.UUID
-	157, // 225: v1.OperationRunSelector.percentage:type_name -> v1.PercentageSelector
-	159, // 226: v1.OperationRunOptions.safety_policy:type_name -> v1.OperationRunSafetyPolicy
-	173, // 227: v1.OperationRunOptions.conflict_policy:type_name -> v1.OperationRunConflictPolicy
-	163, // 228: v1.OperationRunOptions.ordering_policy:type_name -> v1.OperationRunOrderingPolicy
-	166, // 229: v1.OperationRunOptions.phase_policy:type_name -> v1.OperationRunPhasePolicy
-	160, // 230: v1.OperationRunSafetyPolicy.gates:type_name -> v1.OperationRunSafetyGate
-	161, // 231: v1.OperationRunSafetyGate.failure_rate:type_name -> v1.OperationRunFailureRateGate
-	162, // 232: v1.OperationRunSafetyGate.failure_count:type_name -> v1.OperationRunFailureCountGate
-	17,  // 233: v1.OperationRunFailureRateGate.scope:type_name -> v1.OperationRunSafetyGateScope
-	17,  // 234: v1.OperationRunFailureCountGate.scope:type_name -> v1.OperationRunSafetyGateScope
-	164, // 235: v1.OperationRunOrderingPolicy.random:type_name -> v1.OperationRunRandomOrdering
-	165, // 236: v1.OperationRunOrderingPolicy.physical_location:type_name -> v1.OperationRunPhysicalLocationOrdering
-	21,  // 237: v1.OperationRunPhysicalLocationOrdering.strategy:type_name -> v1.OperationRunPhysicalLocationOrdering.Strategy
-	167, // 238: v1.OperationRunPhasePolicy.equal:type_name -> v1.EqualOperationRunPhases
-	168, // 239: v1.OperationRunPhasePolicy.percentage:type_name -> v1.PercentageOperationRunPhases
-	170, // 240: v1.OperationRunPhasePolicy.count:type_name -> v1.CountOperationRunPhases
-	172, // 241: v1.OperationRunPhasePolicy.advance_policy:type_name -> v1.OperationRunPhaseAdvancePolicy
-	169, // 242: v1.PercentageOperationRunPhases.phases:type_name -> v1.OperationRunPercentagePhase
-	171, // 243: v1.CountOperationRunPhases.phases:type_name -> v1.OperationRunCountPhase
-	174, // 244: v1.OperationRunConflictPolicy.retry:type_name -> v1.OperationRunConflictRetryPolicy
-	189, // 245: v1.OperationRunConflictRetryPolicy.retry_timeout:type_name -> google.protobuf.Duration
-	189, // 246: v1.OperationRunConflictRetryPolicy.initial_retry_delay:type_name -> google.protobuf.Duration
-	189, // 247: v1.OperationRunConflictRetryPolicy.max_retry_delay:type_name -> google.protobuf.Duration
-	22,  // 248: v1.OperationRunTargetScope.exclude_operation_run_ids:type_name -> v1.UUID
-	36,  // 249: v1.OperationRunTargetScope.default_scope_component_filter:type_name -> v1.ComponentFilter
-	68,  // 250: v1.OperationRunOperation.upgrade_firmware:type_name -> v1.UpgradeFirmwareRequest
-	175, // 251: v1.OperationRunOperation.target_scope:type_name -> v1.OperationRunTargetScope
-	18,  // 252: v1.OperationRunState.status:type_name -> v1.OperationRunStatus
-	19,  // 253: v1.OperationRunState.reason:type_name -> v1.OperationRunStatusReason
-	13,  // 254: v1.OperationKind.type:type_name -> v1.OperationType
-	180, // 255: v1.OperationRun.summary:type_name -> v1.OperationRunSummary
-	143, // 256: v1.OperationRun.configuration:type_name -> v1.OperationRunConfiguration
-	181, // 257: v1.OperationRun.stats:type_name -> v1.OperationRunStats
-	22,  // 258: v1.OperationRunSummary.id:type_name -> v1.UUID
-	178, // 259: v1.OperationRunSummary.operation_kind:type_name -> v1.OperationKind
-	177, // 260: v1.OperationRunSummary.state:type_name -> v1.OperationRunState
-	187, // 261: v1.OperationRunSummary.created_at:type_name -> google.protobuf.Timestamp
-	187, // 262: v1.OperationRunSummary.updated_at:type_name -> google.protobuf.Timestamp
-	187, // 263: v1.OperationRunSummary.started_at:type_name -> google.protobuf.Timestamp
-	187, // 264: v1.OperationRunSummary.finished_at:type_name -> google.protobuf.Timestamp
-	182, // 265: v1.OperationRunStats.current_phase_stats:type_name -> v1.OperationRunPhaseStats
-	182, // 266: v1.OperationRunStats.cumulative_phase_stats:type_name -> v1.OperationRunPhaseStats
-	183, // 267: v1.OperationRunPhaseStats.outcome_counts:type_name -> v1.OperationRunTargetOutcomeCounts
-	22,  // 268: v1.OperationRunTarget.id:type_name -> v1.UUID
-	22,  // 269: v1.OperationRunTarget.operation_run_id:type_name -> v1.UUID
-	22,  // 270: v1.OperationRunTarget.rack_id:type_name -> v1.UUID
-	22,  // 271: v1.OperationRunTarget.task_id:type_name -> v1.UUID
-	20,  // 272: v1.OperationRunTarget.status:type_name -> v1.OperationRunTargetStatus
-	37,  // 273: v1.OperationRunTarget.components_by_type:type_name -> v1.ComponentsByType
-	187, // 274: v1.OperationRunTarget.created_at:type_name -> google.protobuf.Timestamp
-	187, // 275: v1.OperationRunTarget.updated_at:type_name -> google.protobuf.Timestamp
-	186, // 276: v1.NVLDomainTargets.targets:type_name -> v1.NVLDomainTarget
-	22,  // 277: v1.NVLDomainTarget.id:type_name -> v1.UUID
-	1,   // 278: v1.NVLDomainTarget.component_types:type_name -> v1.ComponentType
-	100, // 279: v1.Flow.Version:input_type -> v1.VersionRequest
-	122, // 280: v1.Flow.CreateTaskSchedule:input_type -> v1.CreateTaskScheduleRequest
-	123, // 281: v1.Flow.GetTaskSchedule:input_type -> v1.GetTaskScheduleRequest
-	124, // 282: v1.Flow.ListTaskSchedules:input_type -> v1.ListTaskSchedulesRequest
-	126, // 283: v1.Flow.UpdateTaskSchedule:input_type -> v1.UpdateTaskScheduleRequest
-	127, // 284: v1.Flow.PauseTaskSchedule:input_type -> v1.PauseTaskScheduleRequest
-	128, // 285: v1.Flow.ResumeTaskSchedule:input_type -> v1.ResumeTaskScheduleRequest
-	129, // 286: v1.Flow.DeleteTaskSchedule:input_type -> v1.DeleteTaskScheduleRequest
-	130, // 287: v1.Flow.TriggerTaskSchedule:input_type -> v1.TriggerTaskScheduleRequest
-	132, // 288: v1.Flow.AddTaskScheduleScope:input_type -> v1.AddTaskScheduleScopeRequest
-	134, // 289: v1.Flow.RemoveTaskScheduleScope:input_type -> v1.RemoveTaskScheduleScopeRequest
-	135, // 290: v1.Flow.UpdateTaskScheduleScope:input_type -> v1.UpdateTaskScheduleScopeRequest
-	137, // 291: v1.Flow.ListTaskScheduleScopes:input_type -> v1.ListTaskScheduleScopesRequest
-	139, // 292: v1.Flow.CheckScheduleConflicts:input_type -> v1.CheckScheduleConflictsRequest
-	48,  // 293: v1.Flow.CreateExpectedRack:input_type -> v1.CreateExpectedRackRequest
-	50,  // 294: v1.Flow.GetRackInfoByID:input_type -> v1.GetRackInfoByIDRequest
-	51,  // 295: v1.Flow.GetRackInfoBySerial:input_type -> v1.GetRackInfoBySerialRequest
-	58,  // 296: v1.Flow.GetListOfRacks:input_type -> v1.GetListOfRacksRequest
-	53,  // 297: v1.Flow.PatchRack:input_type -> v1.PatchRackRequest
-	79,  // 298: v1.Flow.DeleteRack:input_type -> v1.DeleteRackRequest
-	81,  // 299: v1.Flow.PurgeRack:input_type -> v1.PurgeRackRequest
-	68,  // 300: v1.Flow.UpgradeFirmware:input_type -> v1.UpgradeFirmwareRequest
-	92,  // 301: v1.Flow.BringUpRack:input_type -> v1.BringUpRackRequest
-	93,  // 302: v1.Flow.IngestRack:input_type -> v1.IngestRackRequest
-	89,  // 303: v1.Flow.PowerOnRack:input_type -> v1.PowerOnRackRequest
-	90,  // 304: v1.Flow.PowerOffRack:input_type -> v1.PowerOffRackRequest
-	91,  // 305: v1.Flow.PowerResetRack:input_type -> v1.PowerResetRackRequest
-	55,  // 306: v1.Flow.GetComponentInfoByID:input_type -> v1.GetComponentInfoByIDRequest
-	56,  // 307: v1.Flow.GetComponentInfoBySerial:input_type -> v1.GetComponentInfoBySerialRequest
-	69,  // 308: v1.Flow.GetComponents:input_type -> v1.GetComponentsRequest
-	71,  // 309: v1.Flow.ValidateComponents:input_type -> v1.ValidateComponentsRequest
-	75,  // 310: v1.Flow.AddComponent:input_type -> v1.AddComponentRequest
-	85,  // 311: v1.Flow.PatchComponent:input_type -> v1.PatchComponentRequest
-	77,  // 312: v1.Flow.DeleteComponent:input_type -> v1.DeleteComponentRequest
-	83,  // 313: v1.Flow.PurgeComponent:input_type -> v1.PurgeComponentRequest
-	60,  // 314: v1.Flow.CreateNVLDomain:input_type -> v1.CreateNVLDomainRequest
-	62,  // 315: v1.Flow.AttachRacksToNVLDomain:input_type -> v1.AttachRacksToNVLDomainRequest
-	63,  // 316: v1.Flow.DetachRacksFromNVLDomain:input_type -> v1.DetachRacksFromNVLDomainRequest
-	64,  // 317: v1.Flow.GetListOfNVLDomains:input_type -> v1.GetListOfNVLDomainsRequest
-	66,  // 318: v1.Flow.GetRacksForNVLDomain:input_type -> v1.GetRacksForNVLDomainRequest
-	94,  // 319: v1.Flow.ListTasks:input_type -> v1.ListTasksRequest
-	96,  // 320: v1.Flow.GetTasksByIDs:input_type -> v1.GetTasksByIDsRequest
-	98,  // 321: v1.Flow.CancelTask:input_type -> v1.CancelTaskRequest
-	103, // 322: v1.Flow.CreateOperationRule:input_type -> v1.CreateOperationRuleRequest
-	105, // 323: v1.Flow.UpdateOperationRule:input_type -> v1.UpdateOperationRuleRequest
-	106, // 324: v1.Flow.DeleteOperationRule:input_type -> v1.DeleteOperationRuleRequest
-	108, // 325: v1.Flow.GetOperationRule:input_type -> v1.GetOperationRuleRequest
-	109, // 326: v1.Flow.ListOperationRules:input_type -> v1.ListOperationRulesRequest
-	107, // 327: v1.Flow.SetRuleAsDefault:input_type -> v1.SetRuleAsDefaultRequest
-	111, // 328: v1.Flow.AssociateRuleWithRack:input_type -> v1.AssociateRuleWithRackRequest
-	112, // 329: v1.Flow.DisassociateRuleFromRack:input_type -> v1.DisassociateRuleFromRackRequest
-	113, // 330: v1.Flow.GetRackRuleAssociation:input_type -> v1.GetRackRuleAssociationRequest
-	115, // 331: v1.Flow.ListRackRuleAssociations:input_type -> v1.ListRackRuleAssociationsRequest
-	141, // 332: v1.Flow.CreateOperationRun:input_type -> v1.CreateOperationRunRequest
-	144, // 333: v1.Flow.GetOperationRun:input_type -> v1.GetOperationRunRequest
-	146, // 334: v1.Flow.ListOperationRuns:input_type -> v1.ListOperationRunsRequest
-	150, // 335: v1.Flow.ListOperationRunTargets:input_type -> v1.ListOperationRunTargetsRequest
-	152, // 336: v1.Flow.PauseOperationRun:input_type -> v1.PauseOperationRunRequest
-	153, // 337: v1.Flow.ResumeOperationRun:input_type -> v1.ResumeOperationRunRequest
-	154, // 338: v1.Flow.AdvanceOperationRunPhase:input_type -> v1.AdvanceOperationRunPhaseRequest
-	155, // 339: v1.Flow.CancelOperationRun:input_type -> v1.CancelOperationRunRequest
-	101, // 340: v1.Flow.Version:output_type -> v1.BuildInfo
-	120, // 341: v1.Flow.CreateTaskSchedule:output_type -> v1.TaskSchedule
-	120, // 342: v1.Flow.GetTaskSchedule:output_type -> v1.TaskSchedule
-	125, // 343: v1.Flow.ListTaskSchedules:output_type -> v1.ListTaskSchedulesResponse
-	120, // 344: v1.Flow.UpdateTaskSchedule:output_type -> v1.TaskSchedule
-	120, // 345: v1.Flow.PauseTaskSchedule:output_type -> v1.TaskSchedule
-	120, // 346: v1.Flow.ResumeTaskSchedule:output_type -> v1.TaskSchedule
-	190, // 347: v1.Flow.DeleteTaskSchedule:output_type -> google.protobuf.Empty
-	87,  // 348: v1.Flow.TriggerTaskSchedule:output_type -> v1.SubmitTaskResponse
-	133, // 349: v1.Flow.AddTaskScheduleScope:output_type -> v1.AddTaskScheduleScopeResponse
-	190, // 350: v1.Flow.RemoveTaskScheduleScope:output_type -> google.protobuf.Empty
-	136, // 351: v1.Flow.UpdateTaskScheduleScope:output_type -> v1.UpdateTaskScheduleScopeResponse
-	138, // 352: v1.Flow.ListTaskScheduleScopes:output_type -> v1.ListTaskScheduleScopesResponse
-	140, // 353: v1.Flow.CheckScheduleConflicts:output_type -> v1.CheckScheduleConflictsResponse
-	49,  // 354: v1.Flow.CreateExpectedRack:output_type -> v1.CreateExpectedRackResponse
-	52,  // 355: v1.Flow.GetRackInfoByID:output_type -> v1.GetRackInfoResponse
-	52,  // 356: v1.Flow.GetRackInfoBySerial:output_type -> v1.GetRackInfoResponse
-	59,  // 357: v1.Flow.GetListOfRacks:output_type -> v1.GetListOfRacksResponse
-	54,  // 358: v1.Flow.PatchRack:output_type -> v1.PatchRackResponse
-	80,  // 359: v1.Flow.DeleteRack:output_type -> v1.DeleteRackResponse
-	82,  // 360: v1.Flow.PurgeRack:output_type -> v1.PurgeRackResponse
-	87,  // 361: v1.Flow.UpgradeFirmware:output_type -> v1.SubmitTaskResponse
-	87,  // 362: v1.Flow.BringUpRack:output_type -> v1.SubmitTaskResponse
-	87,  // 363: v1.Flow.IngestRack:output_type -> v1.SubmitTaskResponse
-	87,  // 364: v1.Flow.PowerOnRack:output_type -> v1.SubmitTaskResponse
-	87,  // 365: v1.Flow.PowerOffRack:output_type -> v1.SubmitTaskResponse
-	87,  // 366: v1.Flow.PowerResetRack:output_type -> v1.SubmitTaskResponse
-	57,  // 367: v1.Flow.GetComponentInfoByID:output_type -> v1.GetComponentInfoResponse
-	57,  // 368: v1.Flow.GetComponentInfoBySerial:output_type -> v1.GetComponentInfoResponse
-	70,  // 369: v1.Flow.GetComponents:output_type -> v1.GetComponentsResponse
-	72,  // 370: v1.Flow.ValidateComponents:output_type -> v1.ValidateComponentsResponse
-	76,  // 371: v1.Flow.AddComponent:output_type -> v1.AddComponentResponse
-	86,  // 372: v1.Flow.PatchComponent:output_type -> v1.PatchComponentResponse
-	78,  // 373: v1.Flow.DeleteComponent:output_type -> v1.DeleteComponentResponse
-	84,  // 374: v1.Flow.PurgeComponent:output_type -> v1.PurgeComponentResponse
-	61,  // 375: v1.Flow.CreateNVLDomain:output_type -> v1.CreateNVLDomainResponse
-	190, // 376: v1.Flow.AttachRacksToNVLDomain:output_type -> google.protobuf.Empty
-	190, // 377: v1.Flow.DetachRacksFromNVLDomain:output_type -> google.protobuf.Empty
-	65,  // 378: v1.Flow.GetListOfNVLDomains:output_type -> v1.GetListOfNVLDomainsResponse
-	67,  // 379: v1.Flow.GetRacksForNVLDomain:output_type -> v1.GetRacksForNVLDomainResponse
-	95,  // 380: v1.Flow.ListTasks:output_type -> v1.ListTasksResponse
-	97,  // 381: v1.Flow.GetTasksByIDs:output_type -> v1.GetTasksByIDsResponse
-	99,  // 382: v1.Flow.CancelTask:output_type -> v1.CancelTaskResponse
-	104, // 383: v1.Flow.CreateOperationRule:output_type -> v1.CreateOperationRuleResponse
-	190, // 384: v1.Flow.UpdateOperationRule:output_type -> google.protobuf.Empty
-	190, // 385: v1.Flow.DeleteOperationRule:output_type -> google.protobuf.Empty
-	102, // 386: v1.Flow.GetOperationRule:output_type -> v1.OperationRule
-	110, // 387: v1.Flow.ListOperationRules:output_type -> v1.ListOperationRulesResponse
-	190, // 388: v1.Flow.SetRuleAsDefault:output_type -> google.protobuf.Empty
-	190, // 389: v1.Flow.AssociateRuleWithRack:output_type -> google.protobuf.Empty
-	190, // 390: v1.Flow.DisassociateRuleFromRack:output_type -> google.protobuf.Empty
-	114, // 391: v1.Flow.GetRackRuleAssociation:output_type -> v1.GetRackRuleAssociationResponse
-	117, // 392: v1.Flow.ListRackRuleAssociations:output_type -> v1.ListRackRuleAssociationsResponse
-	142, // 393: v1.Flow.CreateOperationRun:output_type -> v1.CreateOperationRunResponse
-	145, // 394: v1.Flow.GetOperationRun:output_type -> v1.GetOperationRunResponse
-	147, // 395: v1.Flow.ListOperationRuns:output_type -> v1.ListOperationRunsResponse
-	151, // 396: v1.Flow.ListOperationRunTargets:output_type -> v1.ListOperationRunTargetsResponse
-	179, // 397: v1.Flow.PauseOperationRun:output_type -> v1.OperationRun
-	179, // 398: v1.Flow.ResumeOperationRun:output_type -> v1.OperationRun
-	179, // 399: v1.Flow.AdvanceOperationRunPhase:output_type -> v1.OperationRun
-	179, // 400: v1.Flow.CancelOperationRun:output_type -> v1.OperationRun
-	340, // [340:401] is the sub-list for method output_type
-	279, // [279:340] is the sub-list for method input_type
-	279, // [279:279] is the sub-list for extension type_name
-	279, // [279:279] is the sub-list for extension extendee
-	0,   // [0:279] is the sub-list for field type_name
+	69,  // 77: v1.UpgradeFirmwareRequest.authentication_data:type_name -> v1.FirmwareAuthenticationData
+	70,  // 78: v1.FirmwareAuthenticationData.per_component:type_name -> v1.PerComponentFirmwareAuthenticationData
+	32,  // 79: v1.GetComponentsRequest.target_spec:type_name -> v1.OperationTargetSpec
+	45,  // 80: v1.GetComponentsRequest.filters:type_name -> v1.Filter
+	43,  // 81: v1.GetComponentsRequest.pagination:type_name -> v1.Pagination
+	46,  // 82: v1.GetComponentsRequest.order_by:type_name -> v1.OrderBy
+	29,  // 83: v1.GetComponentsResponse.components:type_name -> v1.Component
+	32,  // 84: v1.ValidateComponentsRequest.target_spec:type_name -> v1.OperationTargetSpec
+	45,  // 85: v1.ValidateComponentsRequest.filters:type_name -> v1.Filter
+	43,  // 86: v1.ValidateComponentsRequest.pagination:type_name -> v1.Pagination
+	46,  // 87: v1.ValidateComponentsRequest.order_by:type_name -> v1.OrderBy
+	75,  // 88: v1.ValidateComponentsResponse.diffs:type_name -> v1.ComponentDiff
+	11,  // 89: v1.ComponentDiff.type:type_name -> v1.DiffType
+	29,  // 90: v1.ComponentDiff.expected:type_name -> v1.Component
+	29,  // 91: v1.ComponentDiff.actual:type_name -> v1.Component
+	76,  // 92: v1.ComponentDiff.field_diffs:type_name -> v1.FieldDiff
+	22,  // 93: v1.ComponentDiff.id:type_name -> v1.UUID
+	29,  // 94: v1.AddComponentRequest.component:type_name -> v1.Component
+	29,  // 95: v1.AddComponentResponse.component:type_name -> v1.Component
+	22,  // 96: v1.DeleteComponentRequest.id:type_name -> v1.UUID
+	22,  // 97: v1.DeleteRackRequest.id:type_name -> v1.UUID
+	22,  // 98: v1.PurgeRackRequest.id:type_name -> v1.UUID
+	22,  // 99: v1.PurgeComponentRequest.id:type_name -> v1.UUID
+	22,  // 100: v1.PatchComponentRequest.id:type_name -> v1.UUID
+	27,  // 101: v1.PatchComponentRequest.position:type_name -> v1.RackPosition
+	22,  // 102: v1.PatchComponentRequest.rack_id:type_name -> v1.UUID
+	26,  // 103: v1.PatchComponentRequest.bmcs:type_name -> v1.BMCInfo
+	29,  // 104: v1.PatchComponentResponse.component:type_name -> v1.Component
+	22,  // 105: v1.SubmitTaskResponse.task_ids:type_name -> v1.UUID
+	12,  // 106: v1.QueueOptions.conflict_strategy:type_name -> v1.ConflictStrategy
+	32,  // 107: v1.PowerOnRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	90,  // 108: v1.PowerOnRackRequest.queue_options:type_name -> v1.QueueOptions
+	22,  // 109: v1.PowerOnRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 110: v1.PowerOffRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	90,  // 111: v1.PowerOffRackRequest.queue_options:type_name -> v1.QueueOptions
+	22,  // 112: v1.PowerOffRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 113: v1.PowerResetRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	90,  // 114: v1.PowerResetRackRequest.queue_options:type_name -> v1.QueueOptions
+	22,  // 115: v1.PowerResetRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 116: v1.BringUpRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	22,  // 117: v1.BringUpRackRequest.rule_id:type_name -> v1.UUID
+	32,  // 118: v1.IngestRackRequest.target_spec:type_name -> v1.OperationTargetSpec
+	45,  // 119: v1.IngestRackRequest.filters:type_name -> v1.Filter
+	22,  // 120: v1.IngestRackRequest.rule_id:type_name -> v1.UUID
+	22,  // 121: v1.ListTasksRequest.rack_id:type_name -> v1.UUID
+	43,  // 122: v1.ListTasksRequest.pagination:type_name -> v1.Pagination
+	22,  // 123: v1.ListTasksRequest.component_id:type_name -> v1.UUID
+	47,  // 124: v1.ListTasksResponse.tasks:type_name -> v1.Task
+	22,  // 125: v1.GetTasksByIDsRequest.task_ids:type_name -> v1.UUID
+	47,  // 126: v1.GetTasksByIDsResponse.tasks:type_name -> v1.Task
+	22,  // 127: v1.CancelTaskRequest.task_id:type_name -> v1.UUID
+	47,  // 128: v1.CancelTaskResponse.task:type_name -> v1.Task
+	22,  // 129: v1.OperationRule.id:type_name -> v1.UUID
+	13,  // 130: v1.OperationRule.operation_type:type_name -> v1.OperationType
+	189, // 131: v1.OperationRule.created_at:type_name -> google.protobuf.Timestamp
+	189, // 132: v1.OperationRule.updated_at:type_name -> google.protobuf.Timestamp
+	13,  // 133: v1.CreateOperationRuleRequest.operation_type:type_name -> v1.OperationType
+	22,  // 134: v1.CreateOperationRuleResponse.id:type_name -> v1.UUID
+	22,  // 135: v1.UpdateOperationRuleRequest.rule_id:type_name -> v1.UUID
+	22,  // 136: v1.DeleteOperationRuleRequest.rule_id:type_name -> v1.UUID
+	22,  // 137: v1.SetRuleAsDefaultRequest.rule_id:type_name -> v1.UUID
+	22,  // 138: v1.GetOperationRuleRequest.rule_id:type_name -> v1.UUID
+	13,  // 139: v1.ListOperationRulesRequest.operation_type:type_name -> v1.OperationType
+	104, // 140: v1.ListOperationRulesResponse.rules:type_name -> v1.OperationRule
+	22,  // 141: v1.AssociateRuleWithRackRequest.rack_id:type_name -> v1.UUID
+	22,  // 142: v1.AssociateRuleWithRackRequest.rule_id:type_name -> v1.UUID
+	22,  // 143: v1.DisassociateRuleFromRackRequest.rack_id:type_name -> v1.UUID
+	13,  // 144: v1.DisassociateRuleFromRackRequest.operation_type:type_name -> v1.OperationType
+	22,  // 145: v1.GetRackRuleAssociationRequest.rack_id:type_name -> v1.UUID
+	13,  // 146: v1.GetRackRuleAssociationRequest.operation_type:type_name -> v1.OperationType
+	22,  // 147: v1.GetRackRuleAssociationResponse.rule_id:type_name -> v1.UUID
+	22,  // 148: v1.ListRackRuleAssociationsRequest.rack_id:type_name -> v1.UUID
+	22,  // 149: v1.RackRuleAssociation.rack_id:type_name -> v1.UUID
+	13,  // 150: v1.RackRuleAssociation.operation_type:type_name -> v1.OperationType
+	22,  // 151: v1.RackRuleAssociation.rule_id:type_name -> v1.UUID
+	189, // 152: v1.RackRuleAssociation.created_at:type_name -> google.protobuf.Timestamp
+	189, // 153: v1.RackRuleAssociation.updated_at:type_name -> google.protobuf.Timestamp
+	118, // 154: v1.ListRackRuleAssociationsResponse.associations:type_name -> v1.RackRuleAssociation
+	14,  // 155: v1.ScheduleSpec.type:type_name -> v1.ScheduleSpecType
+	120, // 156: v1.ScheduleConfig.spec:type_name -> v1.ScheduleSpec
+	15,  // 157: v1.ScheduleConfig.overlap_policy:type_name -> v1.OverlapPolicy
+	22,  // 158: v1.TaskSchedule.id:type_name -> v1.UUID
+	120, // 159: v1.TaskSchedule.spec:type_name -> v1.ScheduleSpec
+	15,  // 160: v1.TaskSchedule.overlap_policy:type_name -> v1.OverlapPolicy
+	189, // 161: v1.TaskSchedule.next_run_at:type_name -> google.protobuf.Timestamp
+	189, // 162: v1.TaskSchedule.last_run_at:type_name -> google.protobuf.Timestamp
+	189, // 163: v1.TaskSchedule.created_at:type_name -> google.protobuf.Timestamp
+	189, // 164: v1.TaskSchedule.updated_at:type_name -> google.protobuf.Timestamp
+	91,  // 165: v1.ScheduledOperation.power_on:type_name -> v1.PowerOnRackRequest
+	92,  // 166: v1.ScheduledOperation.power_off:type_name -> v1.PowerOffRackRequest
+	93,  // 167: v1.ScheduledOperation.power_reset:type_name -> v1.PowerResetRackRequest
+	94,  // 168: v1.ScheduledOperation.bring_up:type_name -> v1.BringUpRackRequest
+	68,  // 169: v1.ScheduledOperation.upgrade_firmware:type_name -> v1.UpgradeFirmwareRequest
+	95,  // 170: v1.ScheduledOperation.ingest:type_name -> v1.IngestRackRequest
+	121, // 171: v1.CreateTaskScheduleRequest.schedule:type_name -> v1.ScheduleConfig
+	123, // 172: v1.CreateTaskScheduleRequest.operation:type_name -> v1.ScheduledOperation
+	22,  // 173: v1.GetTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 174: v1.ListTaskSchedulesRequest.rack_id:type_name -> v1.UUID
+	43,  // 175: v1.ListTaskSchedulesRequest.pagination:type_name -> v1.Pagination
+	122, // 176: v1.ListTaskSchedulesResponse.task_schedules:type_name -> v1.TaskSchedule
+	22,  // 177: v1.UpdateTaskScheduleRequest.id:type_name -> v1.UUID
+	121, // 178: v1.UpdateTaskScheduleRequest.schedule:type_name -> v1.ScheduleConfig
+	190, // 179: v1.UpdateTaskScheduleRequest.update_mask:type_name -> google.protobuf.FieldMask
+	22,  // 180: v1.PauseTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 181: v1.ResumeTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 182: v1.DeleteTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 183: v1.TriggerTaskScheduleRequest.id:type_name -> v1.UUID
+	22,  // 184: v1.TaskScheduleScope.id:type_name -> v1.UUID
+	22,  // 185: v1.TaskScheduleScope.schedule_id:type_name -> v1.UUID
+	22,  // 186: v1.TaskScheduleScope.rack_id:type_name -> v1.UUID
+	35,  // 187: v1.TaskScheduleScope.types:type_name -> v1.ComponentTypes
+	34,  // 188: v1.TaskScheduleScope.components:type_name -> v1.ComponentTargets
+	22,  // 189: v1.TaskScheduleScope.last_task_id:type_name -> v1.UUID
+	189, // 190: v1.TaskScheduleScope.created_at:type_name -> google.protobuf.Timestamp
+	22,  // 191: v1.AddTaskScheduleScopeRequest.schedule_id:type_name -> v1.UUID
+	32,  // 192: v1.AddTaskScheduleScopeRequest.target_spec:type_name -> v1.OperationTargetSpec
+	133, // 193: v1.AddTaskScheduleScopeResponse.scopes:type_name -> v1.TaskScheduleScope
+	22,  // 194: v1.RemoveTaskScheduleScopeRequest.scope_id:type_name -> v1.UUID
+	22,  // 195: v1.UpdateTaskScheduleScopeRequest.schedule_id:type_name -> v1.UUID
+	32,  // 196: v1.UpdateTaskScheduleScopeRequest.desired_scope:type_name -> v1.OperationTargetSpec
+	133, // 197: v1.UpdateTaskScheduleScopeResponse.scopes:type_name -> v1.TaskScheduleScope
+	22,  // 198: v1.ListTaskScheduleScopesRequest.schedule_id:type_name -> v1.UUID
+	133, // 199: v1.ListTaskScheduleScopesResponse.scopes:type_name -> v1.TaskScheduleScope
+	123, // 200: v1.CheckScheduleConflictsRequest.operation:type_name -> v1.ScheduledOperation
+	22,  // 201: v1.CheckScheduleConflictsRequest.exclude_schedule_id:type_name -> v1.UUID
+	122, // 202: v1.CheckScheduleConflictsResponse.conflicts:type_name -> v1.TaskSchedule
+	145, // 203: v1.CreateOperationRunRequest.configuration:type_name -> v1.OperationRunConfiguration
+	22,  // 204: v1.CreateOperationRunResponse.id:type_name -> v1.UUID
+	158, // 205: v1.OperationRunConfiguration.selector:type_name -> v1.OperationRunSelector
+	160, // 206: v1.OperationRunConfiguration.options:type_name -> v1.OperationRunOptions
+	178, // 207: v1.OperationRunConfiguration.operation:type_name -> v1.OperationRunOperation
+	22,  // 208: v1.GetOperationRunRequest.id:type_name -> v1.UUID
+	181, // 209: v1.GetOperationRunResponse.operation_run:type_name -> v1.OperationRun
+	150, // 210: v1.ListOperationRunsRequest.filter:type_name -> v1.OperationRunFilter
+	43,  // 211: v1.ListOperationRunsRequest.pagination:type_name -> v1.Pagination
+	182, // 212: v1.ListOperationRunsResponse.operation_runs:type_name -> v1.OperationRunSummary
+	44,  // 213: v1.OperationRunFilter.name:type_name -> v1.StringQueryInfo
+	151, // 214: v1.OperationRunFilter.states:type_name -> v1.OperationRunStateFilter
+	180, // 215: v1.OperationRunFilter.operation_kinds:type_name -> v1.OperationKind
+	18,  // 216: v1.OperationRunStateFilter.status:type_name -> v1.OperationRunStatus
+	19,  // 217: v1.OperationRunStateFilter.reason:type_name -> v1.OperationRunStatusReason
+	22,  // 218: v1.ListOperationRunTargetsRequest.operation_run_id:type_name -> v1.UUID
+	20,  // 219: v1.ListOperationRunTargetsRequest.status:type_name -> v1.OperationRunTargetStatus
+	43,  // 220: v1.ListOperationRunTargetsRequest.pagination:type_name -> v1.Pagination
+	16,  // 221: v1.ListOperationRunTargetsRequest.phase_scope:type_name -> v1.OperationRunTargetPhaseScope
+	186, // 222: v1.ListOperationRunTargetsResponse.targets:type_name -> v1.OperationRunTarget
+	22,  // 223: v1.PauseOperationRunRequest.id:type_name -> v1.UUID
+	22,  // 224: v1.ResumeOperationRunRequest.id:type_name -> v1.UUID
+	22,  // 225: v1.AdvanceOperationRunPhaseRequest.id:type_name -> v1.UUID
+	22,  // 226: v1.CancelOperationRunRequest.id:type_name -> v1.UUID
+	159, // 227: v1.OperationRunSelector.percentage:type_name -> v1.PercentageSelector
+	161, // 228: v1.OperationRunOptions.safety_policy:type_name -> v1.OperationRunSafetyPolicy
+	175, // 229: v1.OperationRunOptions.conflict_policy:type_name -> v1.OperationRunConflictPolicy
+	165, // 230: v1.OperationRunOptions.ordering_policy:type_name -> v1.OperationRunOrderingPolicy
+	168, // 231: v1.OperationRunOptions.phase_policy:type_name -> v1.OperationRunPhasePolicy
+	162, // 232: v1.OperationRunSafetyPolicy.gates:type_name -> v1.OperationRunSafetyGate
+	163, // 233: v1.OperationRunSafetyGate.failure_rate:type_name -> v1.OperationRunFailureRateGate
+	164, // 234: v1.OperationRunSafetyGate.failure_count:type_name -> v1.OperationRunFailureCountGate
+	17,  // 235: v1.OperationRunFailureRateGate.scope:type_name -> v1.OperationRunSafetyGateScope
+	17,  // 236: v1.OperationRunFailureCountGate.scope:type_name -> v1.OperationRunSafetyGateScope
+	166, // 237: v1.OperationRunOrderingPolicy.random:type_name -> v1.OperationRunRandomOrdering
+	167, // 238: v1.OperationRunOrderingPolicy.physical_location:type_name -> v1.OperationRunPhysicalLocationOrdering
+	21,  // 239: v1.OperationRunPhysicalLocationOrdering.strategy:type_name -> v1.OperationRunPhysicalLocationOrdering.Strategy
+	169, // 240: v1.OperationRunPhasePolicy.equal:type_name -> v1.EqualOperationRunPhases
+	170, // 241: v1.OperationRunPhasePolicy.percentage:type_name -> v1.PercentageOperationRunPhases
+	172, // 242: v1.OperationRunPhasePolicy.count:type_name -> v1.CountOperationRunPhases
+	174, // 243: v1.OperationRunPhasePolicy.advance_policy:type_name -> v1.OperationRunPhaseAdvancePolicy
+	171, // 244: v1.PercentageOperationRunPhases.phases:type_name -> v1.OperationRunPercentagePhase
+	173, // 245: v1.CountOperationRunPhases.phases:type_name -> v1.OperationRunCountPhase
+	176, // 246: v1.OperationRunConflictPolicy.retry:type_name -> v1.OperationRunConflictRetryPolicy
+	191, // 247: v1.OperationRunConflictRetryPolicy.retry_timeout:type_name -> google.protobuf.Duration
+	191, // 248: v1.OperationRunConflictRetryPolicy.initial_retry_delay:type_name -> google.protobuf.Duration
+	191, // 249: v1.OperationRunConflictRetryPolicy.max_retry_delay:type_name -> google.protobuf.Duration
+	22,  // 250: v1.OperationRunTargetScope.exclude_operation_run_ids:type_name -> v1.UUID
+	36,  // 251: v1.OperationRunTargetScope.default_scope_component_filter:type_name -> v1.ComponentFilter
+	68,  // 252: v1.OperationRunOperation.upgrade_firmware:type_name -> v1.UpgradeFirmwareRequest
+	177, // 253: v1.OperationRunOperation.target_scope:type_name -> v1.OperationRunTargetScope
+	18,  // 254: v1.OperationRunState.status:type_name -> v1.OperationRunStatus
+	19,  // 255: v1.OperationRunState.reason:type_name -> v1.OperationRunStatusReason
+	13,  // 256: v1.OperationKind.type:type_name -> v1.OperationType
+	182, // 257: v1.OperationRun.summary:type_name -> v1.OperationRunSummary
+	145, // 258: v1.OperationRun.configuration:type_name -> v1.OperationRunConfiguration
+	183, // 259: v1.OperationRun.stats:type_name -> v1.OperationRunStats
+	22,  // 260: v1.OperationRunSummary.id:type_name -> v1.UUID
+	180, // 261: v1.OperationRunSummary.operation_kind:type_name -> v1.OperationKind
+	179, // 262: v1.OperationRunSummary.state:type_name -> v1.OperationRunState
+	189, // 263: v1.OperationRunSummary.created_at:type_name -> google.protobuf.Timestamp
+	189, // 264: v1.OperationRunSummary.updated_at:type_name -> google.protobuf.Timestamp
+	189, // 265: v1.OperationRunSummary.started_at:type_name -> google.protobuf.Timestamp
+	189, // 266: v1.OperationRunSummary.finished_at:type_name -> google.protobuf.Timestamp
+	184, // 267: v1.OperationRunStats.current_phase_stats:type_name -> v1.OperationRunPhaseStats
+	184, // 268: v1.OperationRunStats.cumulative_phase_stats:type_name -> v1.OperationRunPhaseStats
+	185, // 269: v1.OperationRunPhaseStats.outcome_counts:type_name -> v1.OperationRunTargetOutcomeCounts
+	22,  // 270: v1.OperationRunTarget.id:type_name -> v1.UUID
+	22,  // 271: v1.OperationRunTarget.operation_run_id:type_name -> v1.UUID
+	22,  // 272: v1.OperationRunTarget.rack_id:type_name -> v1.UUID
+	22,  // 273: v1.OperationRunTarget.task_id:type_name -> v1.UUID
+	20,  // 274: v1.OperationRunTarget.status:type_name -> v1.OperationRunTargetStatus
+	37,  // 275: v1.OperationRunTarget.components_by_type:type_name -> v1.ComponentsByType
+	189, // 276: v1.OperationRunTarget.created_at:type_name -> google.protobuf.Timestamp
+	189, // 277: v1.OperationRunTarget.updated_at:type_name -> google.protobuf.Timestamp
+	188, // 278: v1.NVLDomainTargets.targets:type_name -> v1.NVLDomainTarget
+	22,  // 279: v1.NVLDomainTarget.id:type_name -> v1.UUID
+	1,   // 280: v1.NVLDomainTarget.component_types:type_name -> v1.ComponentType
+	102, // 281: v1.Flow.Version:input_type -> v1.VersionRequest
+	124, // 282: v1.Flow.CreateTaskSchedule:input_type -> v1.CreateTaskScheduleRequest
+	125, // 283: v1.Flow.GetTaskSchedule:input_type -> v1.GetTaskScheduleRequest
+	126, // 284: v1.Flow.ListTaskSchedules:input_type -> v1.ListTaskSchedulesRequest
+	128, // 285: v1.Flow.UpdateTaskSchedule:input_type -> v1.UpdateTaskScheduleRequest
+	129, // 286: v1.Flow.PauseTaskSchedule:input_type -> v1.PauseTaskScheduleRequest
+	130, // 287: v1.Flow.ResumeTaskSchedule:input_type -> v1.ResumeTaskScheduleRequest
+	131, // 288: v1.Flow.DeleteTaskSchedule:input_type -> v1.DeleteTaskScheduleRequest
+	132, // 289: v1.Flow.TriggerTaskSchedule:input_type -> v1.TriggerTaskScheduleRequest
+	134, // 290: v1.Flow.AddTaskScheduleScope:input_type -> v1.AddTaskScheduleScopeRequest
+	136, // 291: v1.Flow.RemoveTaskScheduleScope:input_type -> v1.RemoveTaskScheduleScopeRequest
+	137, // 292: v1.Flow.UpdateTaskScheduleScope:input_type -> v1.UpdateTaskScheduleScopeRequest
+	139, // 293: v1.Flow.ListTaskScheduleScopes:input_type -> v1.ListTaskScheduleScopesRequest
+	141, // 294: v1.Flow.CheckScheduleConflicts:input_type -> v1.CheckScheduleConflictsRequest
+	48,  // 295: v1.Flow.CreateExpectedRack:input_type -> v1.CreateExpectedRackRequest
+	50,  // 296: v1.Flow.GetRackInfoByID:input_type -> v1.GetRackInfoByIDRequest
+	51,  // 297: v1.Flow.GetRackInfoBySerial:input_type -> v1.GetRackInfoBySerialRequest
+	58,  // 298: v1.Flow.GetListOfRacks:input_type -> v1.GetListOfRacksRequest
+	53,  // 299: v1.Flow.PatchRack:input_type -> v1.PatchRackRequest
+	81,  // 300: v1.Flow.DeleteRack:input_type -> v1.DeleteRackRequest
+	83,  // 301: v1.Flow.PurgeRack:input_type -> v1.PurgeRackRequest
+	68,  // 302: v1.Flow.UpgradeFirmware:input_type -> v1.UpgradeFirmwareRequest
+	94,  // 303: v1.Flow.BringUpRack:input_type -> v1.BringUpRackRequest
+	95,  // 304: v1.Flow.IngestRack:input_type -> v1.IngestRackRequest
+	91,  // 305: v1.Flow.PowerOnRack:input_type -> v1.PowerOnRackRequest
+	92,  // 306: v1.Flow.PowerOffRack:input_type -> v1.PowerOffRackRequest
+	93,  // 307: v1.Flow.PowerResetRack:input_type -> v1.PowerResetRackRequest
+	55,  // 308: v1.Flow.GetComponentInfoByID:input_type -> v1.GetComponentInfoByIDRequest
+	56,  // 309: v1.Flow.GetComponentInfoBySerial:input_type -> v1.GetComponentInfoBySerialRequest
+	71,  // 310: v1.Flow.GetComponents:input_type -> v1.GetComponentsRequest
+	73,  // 311: v1.Flow.ValidateComponents:input_type -> v1.ValidateComponentsRequest
+	77,  // 312: v1.Flow.AddComponent:input_type -> v1.AddComponentRequest
+	87,  // 313: v1.Flow.PatchComponent:input_type -> v1.PatchComponentRequest
+	79,  // 314: v1.Flow.DeleteComponent:input_type -> v1.DeleteComponentRequest
+	85,  // 315: v1.Flow.PurgeComponent:input_type -> v1.PurgeComponentRequest
+	60,  // 316: v1.Flow.CreateNVLDomain:input_type -> v1.CreateNVLDomainRequest
+	62,  // 317: v1.Flow.AttachRacksToNVLDomain:input_type -> v1.AttachRacksToNVLDomainRequest
+	63,  // 318: v1.Flow.DetachRacksFromNVLDomain:input_type -> v1.DetachRacksFromNVLDomainRequest
+	64,  // 319: v1.Flow.GetListOfNVLDomains:input_type -> v1.GetListOfNVLDomainsRequest
+	66,  // 320: v1.Flow.GetRacksForNVLDomain:input_type -> v1.GetRacksForNVLDomainRequest
+	96,  // 321: v1.Flow.ListTasks:input_type -> v1.ListTasksRequest
+	98,  // 322: v1.Flow.GetTasksByIDs:input_type -> v1.GetTasksByIDsRequest
+	100, // 323: v1.Flow.CancelTask:input_type -> v1.CancelTaskRequest
+	105, // 324: v1.Flow.CreateOperationRule:input_type -> v1.CreateOperationRuleRequest
+	107, // 325: v1.Flow.UpdateOperationRule:input_type -> v1.UpdateOperationRuleRequest
+	108, // 326: v1.Flow.DeleteOperationRule:input_type -> v1.DeleteOperationRuleRequest
+	110, // 327: v1.Flow.GetOperationRule:input_type -> v1.GetOperationRuleRequest
+	111, // 328: v1.Flow.ListOperationRules:input_type -> v1.ListOperationRulesRequest
+	109, // 329: v1.Flow.SetRuleAsDefault:input_type -> v1.SetRuleAsDefaultRequest
+	113, // 330: v1.Flow.AssociateRuleWithRack:input_type -> v1.AssociateRuleWithRackRequest
+	114, // 331: v1.Flow.DisassociateRuleFromRack:input_type -> v1.DisassociateRuleFromRackRequest
+	115, // 332: v1.Flow.GetRackRuleAssociation:input_type -> v1.GetRackRuleAssociationRequest
+	117, // 333: v1.Flow.ListRackRuleAssociations:input_type -> v1.ListRackRuleAssociationsRequest
+	143, // 334: v1.Flow.CreateOperationRun:input_type -> v1.CreateOperationRunRequest
+	146, // 335: v1.Flow.GetOperationRun:input_type -> v1.GetOperationRunRequest
+	148, // 336: v1.Flow.ListOperationRuns:input_type -> v1.ListOperationRunsRequest
+	152, // 337: v1.Flow.ListOperationRunTargets:input_type -> v1.ListOperationRunTargetsRequest
+	154, // 338: v1.Flow.PauseOperationRun:input_type -> v1.PauseOperationRunRequest
+	155, // 339: v1.Flow.ResumeOperationRun:input_type -> v1.ResumeOperationRunRequest
+	156, // 340: v1.Flow.AdvanceOperationRunPhase:input_type -> v1.AdvanceOperationRunPhaseRequest
+	157, // 341: v1.Flow.CancelOperationRun:input_type -> v1.CancelOperationRunRequest
+	103, // 342: v1.Flow.Version:output_type -> v1.BuildInfo
+	122, // 343: v1.Flow.CreateTaskSchedule:output_type -> v1.TaskSchedule
+	122, // 344: v1.Flow.GetTaskSchedule:output_type -> v1.TaskSchedule
+	127, // 345: v1.Flow.ListTaskSchedules:output_type -> v1.ListTaskSchedulesResponse
+	122, // 346: v1.Flow.UpdateTaskSchedule:output_type -> v1.TaskSchedule
+	122, // 347: v1.Flow.PauseTaskSchedule:output_type -> v1.TaskSchedule
+	122, // 348: v1.Flow.ResumeTaskSchedule:output_type -> v1.TaskSchedule
+	192, // 349: v1.Flow.DeleteTaskSchedule:output_type -> google.protobuf.Empty
+	89,  // 350: v1.Flow.TriggerTaskSchedule:output_type -> v1.SubmitTaskResponse
+	135, // 351: v1.Flow.AddTaskScheduleScope:output_type -> v1.AddTaskScheduleScopeResponse
+	192, // 352: v1.Flow.RemoveTaskScheduleScope:output_type -> google.protobuf.Empty
+	138, // 353: v1.Flow.UpdateTaskScheduleScope:output_type -> v1.UpdateTaskScheduleScopeResponse
+	140, // 354: v1.Flow.ListTaskScheduleScopes:output_type -> v1.ListTaskScheduleScopesResponse
+	142, // 355: v1.Flow.CheckScheduleConflicts:output_type -> v1.CheckScheduleConflictsResponse
+	49,  // 356: v1.Flow.CreateExpectedRack:output_type -> v1.CreateExpectedRackResponse
+	52,  // 357: v1.Flow.GetRackInfoByID:output_type -> v1.GetRackInfoResponse
+	52,  // 358: v1.Flow.GetRackInfoBySerial:output_type -> v1.GetRackInfoResponse
+	59,  // 359: v1.Flow.GetListOfRacks:output_type -> v1.GetListOfRacksResponse
+	54,  // 360: v1.Flow.PatchRack:output_type -> v1.PatchRackResponse
+	82,  // 361: v1.Flow.DeleteRack:output_type -> v1.DeleteRackResponse
+	84,  // 362: v1.Flow.PurgeRack:output_type -> v1.PurgeRackResponse
+	89,  // 363: v1.Flow.UpgradeFirmware:output_type -> v1.SubmitTaskResponse
+	89,  // 364: v1.Flow.BringUpRack:output_type -> v1.SubmitTaskResponse
+	89,  // 365: v1.Flow.IngestRack:output_type -> v1.SubmitTaskResponse
+	89,  // 366: v1.Flow.PowerOnRack:output_type -> v1.SubmitTaskResponse
+	89,  // 367: v1.Flow.PowerOffRack:output_type -> v1.SubmitTaskResponse
+	89,  // 368: v1.Flow.PowerResetRack:output_type -> v1.SubmitTaskResponse
+	57,  // 369: v1.Flow.GetComponentInfoByID:output_type -> v1.GetComponentInfoResponse
+	57,  // 370: v1.Flow.GetComponentInfoBySerial:output_type -> v1.GetComponentInfoResponse
+	72,  // 371: v1.Flow.GetComponents:output_type -> v1.GetComponentsResponse
+	74,  // 372: v1.Flow.ValidateComponents:output_type -> v1.ValidateComponentsResponse
+	78,  // 373: v1.Flow.AddComponent:output_type -> v1.AddComponentResponse
+	88,  // 374: v1.Flow.PatchComponent:output_type -> v1.PatchComponentResponse
+	80,  // 375: v1.Flow.DeleteComponent:output_type -> v1.DeleteComponentResponse
+	86,  // 376: v1.Flow.PurgeComponent:output_type -> v1.PurgeComponentResponse
+	61,  // 377: v1.Flow.CreateNVLDomain:output_type -> v1.CreateNVLDomainResponse
+	192, // 378: v1.Flow.AttachRacksToNVLDomain:output_type -> google.protobuf.Empty
+	192, // 379: v1.Flow.DetachRacksFromNVLDomain:output_type -> google.protobuf.Empty
+	65,  // 380: v1.Flow.GetListOfNVLDomains:output_type -> v1.GetListOfNVLDomainsResponse
+	67,  // 381: v1.Flow.GetRacksForNVLDomain:output_type -> v1.GetRacksForNVLDomainResponse
+	97,  // 382: v1.Flow.ListTasks:output_type -> v1.ListTasksResponse
+	99,  // 383: v1.Flow.GetTasksByIDs:output_type -> v1.GetTasksByIDsResponse
+	101, // 384: v1.Flow.CancelTask:output_type -> v1.CancelTaskResponse
+	106, // 385: v1.Flow.CreateOperationRule:output_type -> v1.CreateOperationRuleResponse
+	192, // 386: v1.Flow.UpdateOperationRule:output_type -> google.protobuf.Empty
+	192, // 387: v1.Flow.DeleteOperationRule:output_type -> google.protobuf.Empty
+	104, // 388: v1.Flow.GetOperationRule:output_type -> v1.OperationRule
+	112, // 389: v1.Flow.ListOperationRules:output_type -> v1.ListOperationRulesResponse
+	192, // 390: v1.Flow.SetRuleAsDefault:output_type -> google.protobuf.Empty
+	192, // 391: v1.Flow.AssociateRuleWithRack:output_type -> google.protobuf.Empty
+	192, // 392: v1.Flow.DisassociateRuleFromRack:output_type -> google.protobuf.Empty
+	116, // 393: v1.Flow.GetRackRuleAssociation:output_type -> v1.GetRackRuleAssociationResponse
+	119, // 394: v1.Flow.ListRackRuleAssociations:output_type -> v1.ListRackRuleAssociationsResponse
+	144, // 395: v1.Flow.CreateOperationRun:output_type -> v1.CreateOperationRunResponse
+	147, // 396: v1.Flow.GetOperationRun:output_type -> v1.GetOperationRunResponse
+	149, // 397: v1.Flow.ListOperationRuns:output_type -> v1.ListOperationRunsResponse
+	153, // 398: v1.Flow.ListOperationRunTargets:output_type -> v1.ListOperationRunTargetsResponse
+	181, // 399: v1.Flow.PauseOperationRun:output_type -> v1.OperationRun
+	181, // 400: v1.Flow.ResumeOperationRun:output_type -> v1.OperationRun
+	181, // 401: v1.Flow.AdvanceOperationRunPhase:output_type -> v1.OperationRun
+	181, // 402: v1.Flow.CancelOperationRun:output_type -> v1.OperationRun
+	342, // [342:403] is the sub-list for method output_type
+	281, // [281:342] is the sub-list for method input_type
+	281, // [281:281] is the sub-list for extension type_name
+	281, // [281:281] is the sub-list for extension extendee
+	0,   // [0:281] is the sub-list for field type_name
 }
 
 func init() { file_flow_proto_init() }
@@ -12949,19 +13127,24 @@ func file_flow_proto_init() {
 	file_flow_proto_msgTypes[36].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[42].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[46].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[47].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[47].OneofWrappers = []any{
+		(*FirmwareAuthenticationData_Shared)(nil),
+		(*FirmwareAuthenticationData_PerComponent)(nil),
+	}
+	file_flow_proto_msgTypes[48].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[49].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[63].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[67].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[68].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[51].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[65].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[69].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[70].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[71].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[72].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[83].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[87].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[98].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[99].OneofWrappers = []any{
+	file_flow_proto_msgTypes[73].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[74].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[85].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[89].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[100].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[101].OneofWrappers = []any{
 		(*ScheduledOperation_PowerOn)(nil),
 		(*ScheduledOperation_PowerOff)(nil),
 		(*ScheduledOperation_PowerReset)(nil),
@@ -12969,41 +13152,41 @@ func file_flow_proto_init() {
 		(*ScheduledOperation_UpgradeFirmware)(nil),
 		(*ScheduledOperation_Ingest)(nil),
 	}
-	file_flow_proto_msgTypes[102].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[109].OneofWrappers = []any{
+	file_flow_proto_msgTypes[104].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[111].OneofWrappers = []any{
 		(*TaskScheduleScope_Types)(nil),
 		(*TaskScheduleScope_Components)(nil),
 	}
-	file_flow_proto_msgTypes[117].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[124].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[127].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[128].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[132].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[134].OneofWrappers = []any{
+	file_flow_proto_msgTypes[119].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[126].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[129].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[130].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[134].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[136].OneofWrappers = []any{
 		(*OperationRunSelector_Percentage)(nil),
 	}
-	file_flow_proto_msgTypes[138].OneofWrappers = []any{
+	file_flow_proto_msgTypes[140].OneofWrappers = []any{
 		(*OperationRunSafetyGate_FailureRate)(nil),
 		(*OperationRunSafetyGate_FailureCount)(nil),
 	}
-	file_flow_proto_msgTypes[141].OneofWrappers = []any{
+	file_flow_proto_msgTypes[143].OneofWrappers = []any{
 		(*OperationRunOrderingPolicy_Random)(nil),
 		(*OperationRunOrderingPolicy_PhysicalLocation)(nil),
 	}
-	file_flow_proto_msgTypes[144].OneofWrappers = []any{
+	file_flow_proto_msgTypes[146].OneofWrappers = []any{
 		(*OperationRunPhasePolicy_Equal)(nil),
 		(*OperationRunPhasePolicy_Percentage)(nil),
 		(*OperationRunPhasePolicy_Count)(nil),
 	}
-	file_flow_proto_msgTypes[151].OneofWrappers = []any{
+	file_flow_proto_msgTypes[153].OneofWrappers = []any{
 		(*OperationRunConflictPolicy_Retry)(nil),
 	}
-	file_flow_proto_msgTypes[154].OneofWrappers = []any{
+	file_flow_proto_msgTypes[156].OneofWrappers = []any{
 		(*OperationRunOperation_UpgradeFirmware)(nil),
 	}
-	file_flow_proto_msgTypes[156].OneofWrappers = []any{}
 	file_flow_proto_msgTypes[158].OneofWrappers = []any{}
-	file_flow_proto_msgTypes[164].OneofWrappers = []any{
+	file_flow_proto_msgTypes[160].OneofWrappers = []any{}
+	file_flow_proto_msgTypes[166].OneofWrappers = []any{
 		(*NVLDomainTarget_Id)(nil),
 		(*NVLDomainTarget_Name)(nil),
 	}
@@ -13013,7 +13196,7 @@ func file_flow_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_flow_proto_rawDesc), len(file_flow_proto_rawDesc)),
 			NumEnums:      22,
-			NumMessages:   165,
+			NumMessages:   167,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rest-api/proto/flow/src/v1/flow.proto
+++ b/rest-api/proto/flow/src/v1/flow.proto
@@ -522,6 +522,28 @@ message UpgradeFirmwareRequest {
     // that would otherwise block disruptive operations against tenanted
     // hardware. The bypass is recorded in the server log.
     bool override_readiness_check = 9;
+    // Optional, write-only authentication data for firmware downloads. It is
+    // not supported for DPU-only updates or by the legacy NICo compute
+    // firmware controller.
+    FirmwareAuthenticationData authentication_data = 10;
+}
+
+// FirmwareAuthenticationData selects either one value shared by every target
+// or values scoped to supported firmware tray types.
+message FirmwareAuthenticationData {
+    oneof value {
+        string shared = 1;
+        PerComponentFirmwareAuthenticationData per_component = 2;
+    }
+}
+
+// PerComponentFirmwareAuthenticationData carries independent authentication
+// data for each supported firmware tray type. An omitted field means that tray
+// type receives no authentication data.
+message PerComponentFirmwareAuthenticationData {
+    optional string compute = 1;
+    optional string nvswitch = 2;
+    optional string powershelf = 3;
 }
 
 // GetComponents - retrieves components from local database


### PR DESCRIPTION
Flow firmware upgrade requests may contain authentication credentials that must survive scheduled and Temporal execution without persisting plaintext. This change encrypts the credentials at the API boundary, carries only ciphertext through the Flow database and Temporal, and decrypts them only in the final firmware-control activity.

The gRPC request uses a typed `oneof`: either one shared value or explicit per-component values for `compute`, `nvswitch`, and `powershelf`. Missing per-component values mean no authentication for that type. Legacy NICo and DPU-only firmware paths reject authentication data because they cannot safely consume it.

Persisted ciphertext uses a versioned AES-256-GCM envelope with a non-secret key fingerprint. AAD provides firmware-authentication domain separation and authenticates the envelope metadata; it intentionally does not claim database-row or Temporal-execution binding.

## Related issues

Part of #4392

Builds on #4972, which provisions, preserves, and mounts the Flow data-encryption key.

## Type of Change

- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [x] **This PR contains breaking changes**

Flow now fails fast when its data-encryption cipher is not configured. Helm deployments get the key from #4972; direct or custom deployments must provision a persistent base64-encoded 32-byte key and set `FLOW_DATA_ENCRYPTION_KEY_PATH` before upgrading.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Tested at the final rebased commit with:

- `go test ./...` from `rest-api/flow`
- `go test ./proto/flow/...` from `rest-api`
- `git diff --check origin/main`

## Additional Notes

The scope of #4392 uses one preserved Flow key and does not implement rotation. The envelope includes a key ID so mismatches fail explicitly and a future multi-key rotation workflow can distinguish ciphertext generations.

The shared Flow protobuf mirror is updated only for the firmware-authentication schema; unrelated existing source/generated drift remains outside this PR.