### PR TITLE
fix(instance): include concurrent allocations in force-delete

### DIFF
--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -603,11 +603,6 @@ pub(crate) async fn admin_force_delete_machine(
         host_machine = Some(machine);
     }
 
-    let mut instance_id = None;
-    if let Some(host_machine) = &host_machine {
-        instance_id = db::instance::find_id_by_machine_id(&mut txn, &host_machine.id).await?;
-    }
-
     if let Some(host_machine) = &host_machine {
         response.managed_host_machine_id = host_machine.id.to_string();
         if let Some(iface) = host_machine.status.interfaces.first() {
@@ -636,9 +631,6 @@ pub(crate) async fn admin_force_delete_machine(
             response.dpu_bmc_ip = ip.to_string();
         }
     }
-    if let Some(instance_id) = &instance_id {
-        response.instance_id = instance_id.to_string();
-    }
 
     if let Some(machine) = &host_machine
         && machine.config.dpf.used_for_ingestion
@@ -657,7 +649,9 @@ pub(crate) async fn admin_force_delete_machine(
 
     // So far we only inspected state - now we start the deletion process
     // TODO: In the new model we might just need to move one Machine to this state
-    if let Some(host_machine) = &host_machine {
+    let instance_id = if let Some(host_machine) = &host_machine {
+        // Write to the machine row before fetching the instance, to lock it in case
+        // allocate_instance is running at the same time.
         db::machine::advance(
             host_machine,
             &mut txn,
@@ -665,7 +659,14 @@ pub(crate) async fn admin_force_delete_machine(
             None,
         )
         .await?;
-    }
+        let instance_id = db::instance::find_id_by_machine_id(&mut txn, &host_machine.id).await?;
+        if let Some(instance_id) = &instance_id {
+            response.instance_id = instance_id.to_string();
+        }
+        instance_id
+    } else {
+        None
+    };
     for dpu_machine in dpu_machines.iter() {
         db::machine::advance(
             dpu_machine,

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -29,6 +29,7 @@ use carbide_ib_fabric::config::IBFabricConfig;
 use carbide_ib_fabric::ib::{self, IBFabricManager};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::infiniband::IBPartitionId;
+use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineType};
 use common::api_fixtures::dpu::create_dpu_machine;
 use common::api_fixtures::host::host_discover_dhcp;
@@ -40,12 +41,24 @@ use common::api_fixtures::{
     create_managed_host_with_dpf, create_test_env, create_test_env_with_overrides, get_config,
     get_instance_type_fixture_id,
 };
+use config_version::ConfigVersion;
 use model::hardware_info::TpmEkCertificate;
 use model::ib::DEFAULT_IB_FABRIC_NAME;
+use model::instance::NewInstance;
+use model::instance::config::InstanceConfig;
+use model::instance::config::extension_services::InstanceExtensionServicesConfig;
+use model::instance::config::infiniband::InstanceInfinibandConfig;
+use model::instance::config::network::InstanceNetworkConfig;
+use model::instance::config::nvlink::InstanceNvLinkConfig;
+use model::instance::config::spx::InstanceSpxConfig;
+use model::instance::config::tenant_config::TenantConfig;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{InstanceState, ManagedHostState};
+use model::metadata::Metadata;
+use model::os::{InlineIpxe, OperatingSystem, OperatingSystemVariant};
 use model::resource_pool::{ResourcePoolDef, ResourcePoolType};
 use model::site_explorer::ExploredManagedHost;
+use model::tenant::TenantOrganizationId;
 use sqlx::{PgConnection, Row};
 use tonic::Request;
 
@@ -721,7 +734,124 @@ async fn validate_machine_deletion(
     txn.rollback().await.unwrap();
 }
 
-// TODO: Test deletion for machines with active instances on them
+/// Allocation locks the host Machine before inserting its Instance. If
+/// force-delete waits behind that lock, it must read membership after the wait
+/// and clean the Instance in the same request.
+#[crate::sqlx_test]
+async fn test_admin_force_delete_reads_instance_after_machine_lock(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let managed_host = create_managed_host(&env).await;
+    let instance_id = InstanceId::new();
+
+    // Model allocation's Machine -> Instance lock/write order. This
+    // transaction owns the host `machines` row while no `instances` row is
+    // visible, then persists the Instance before releasing the Machine.
+    let mut allocation_txn = env.pool.begin().await.unwrap();
+    let locked_machine = db::machine::find_one(
+        allocation_txn.as_mut(),
+        &managed_host.id,
+        MachineSearchConfig {
+            for_update: true,
+            ..MachineSearchConfig::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        locked_machine.is_some(),
+        "fixture host must exist to be locked",
+    );
+    assert!(
+        db::instance::find_id_by_machine_id(allocation_txn.as_mut(), &managed_host.id)
+            .await
+            .unwrap()
+            .is_none(),
+        "fixture host must not have an Instance before concurrent allocation",
+    );
+
+    // Force-delete waits for allocation's host Machine lock when it advances
+    // the Machine to ForceDeletion. It cannot read authoritative Instance
+    // membership until it owns that row.
+    let api = managed_host.api.clone();
+    let host_id = managed_host.id;
+    let force_delete_task = tokio::spawn(async move {
+        api.admin_force_delete_machine(tonic::Request::new(AdminForceDeleteMachineRequest {
+            host_query: host_id.to_string(),
+            delete_interfaces: false,
+            delete_bmc_interfaces: false,
+            delete_bmc_credentials: false,
+            allow_delete_with_orphaned_dpf_crds: false,
+        }))
+        .await
+    });
+    wait_until_blocked_on(&env.pool, "UPDATE machines SET controller_state_version").await;
+
+    let config = InstanceConfig {
+        tenant: TenantConfig {
+            tenant_organization_id: TenantOrganizationId::try_from("force-delete-race".to_string())
+                .unwrap(),
+            tenant_keyset_ids: Vec::new(),
+            hostname: None,
+        },
+        os: OperatingSystem {
+            user_data: None,
+            variant: OperatingSystemVariant::Ipxe(InlineIpxe {
+                ipxe_script: "#!ipxe".to_string(),
+            }),
+            phone_home_enabled: false,
+            run_provisioning_instructions_on_every_boot: false,
+        },
+        network: InstanceNetworkConfig::default(),
+        infiniband: InstanceInfinibandConfig::default(),
+        network_security_group_id: None,
+        extension_services: InstanceExtensionServicesConfig::default(),
+        nvlink: InstanceNvLinkConfig::default(),
+        spxconfig: InstanceSpxConfig::default(),
+        power_profile: None,
+    };
+    let version = ConfigVersion::initial();
+    db::instance::batch_persist(
+        vec![NewInstance {
+            instance_id,
+            machine_id: managed_host.id,
+            instance_type_id: None,
+            config: &config,
+            metadata: Metadata::default(),
+            config_version: version,
+            network_config_version: version,
+            ib_config_version: version,
+            extension_services_config_version: version,
+            nvlink_config_version: version,
+            spx_config_version: version,
+        }],
+        allocation_txn.as_mut(),
+    )
+    .await
+    .unwrap();
+    allocation_txn.commit().await.unwrap();
+
+    let response = force_delete_task
+        .await
+        .unwrap()
+        .expect("force-delete completes after allocation commits")
+        .into_inner();
+    assert!(response.all_done);
+    assert_eq!(response.instance_id, instance_id.to_string());
+    assert!(
+        db::instance::find_by_id(&env.pool, instance_id)
+            .await
+            .unwrap()
+            .is_none(),
+        "the same force-delete request must remove the concurrent Instance"
+    );
+    for machine_id in managed_host
+        .dpu_ids
+        .iter()
+        .chain(std::iter::once(&managed_host.id))
+    {
+        validate_machine_deletion(&env, machine_id, None).await;
+    }
+}
 
 #[crate::sqlx_test]
 async fn test_admin_force_delete_host_with_ib_instance(pool: sqlx::PgPool) {


### PR DESCRIPTION
As part of introducing tenant-managed `SitePrefix` resources, we need Admin force-delete to find every Instance whose network state must be cleaned before those resources can be reused. However, force-delete used to look up a host's Instance before changing the Machine state. If allocation already held the Machine row, force-delete could see no Instance, wait for allocation to commit one, and then continue with that stale answer. The final foreign key stopped Machine deletion, but the RPC failed and left the new Instance for another request to clean up.

So, this change moves the Instance lookup immediately after `db::machine::advance` returns. Allocation and force-delete already serialize on the same Machine row, and the post-wait lookup sees an Instance committed by the writer that held the lock first. That one value now feeds both the response and the existing Instance cleanup path.

The change keeps the existing Machine-to-Instance lock order and final foreign-key safeguard, and it does not add another lock, retry loop, cleanup path, or `SitePrefix` behavior.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5132

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`test_admin_force_delete_reads_instance_after_machine_lock` holds the Machine row, starts force-delete and waits for it to block, commits a new Instance from the transaction that held the lock first, and verifies that the same RPC reports and removes that Instance before deleting the host and its DPUs.

## Additional Notes

This is a focused prerequisite for https://github.com/NVIDIA/infra-controller/issues/5112 and part of https://github.com/NVIDIA/infra-controller/issues/3883. Terminal Instance-write protection and durable IB cleanup remain in their own changes.
