### PR TITLE
fix(ib): keep retired PKey memberships removed

### DIFF
--- a/crates/api-core/src/tests/common/mod.rs
+++ b/crates/api-core/src/tests/common/mod.rs
@@ -31,5 +31,6 @@ pub(in crate::tests) mod health_crud;
 pub(in crate::tests) mod metadata;
 pub(in crate::tests) mod network_segment;
 pub(in crate::tests) mod overlay_address;
+pub(in crate::tests) mod postgres;
 pub(in crate::tests) mod rpc_builder;
 pub(in crate::tests) mod sqlx_fixtures;

--- a/crates/api-core/src/tests/common/postgres.rs
+++ b/crates/api-core/src/tests/common/postgres.rs
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use sqlx::PgPool;
+
+/// `wait_for_blocked_query` is a test-specific helper that waits for a query
+/// containing `query_fragment` to enter a lock wait behind `blocker_pid`. It
+/// returns the blocked PostgreSQL backend PID. The fragment match is literal so
+/// underscores in SQL identifiers cannot act as `LIKE` wildcards.
+pub(in crate::tests) async fn wait_for_blocked_query(
+    pool: &PgPool,
+    blocker_pid: i32,
+    query_fragment: &str,
+) -> i32 {
+    for _ in 0..300 {
+        let blocked_pid: Option<i32> = sqlx::query_scalar(
+            r#"
+                SELECT activity.pid
+                FROM pg_stat_activity AS activity
+                WHERE activity.datname = current_database()
+                  AND activity.wait_event_type = 'Lock'
+                  AND $1 = ANY(pg_blocking_pids(activity.pid))
+                  AND strpos(lower(activity.query), lower($2)) > 0
+                ORDER BY activity.pid
+                LIMIT 1
+            "#,
+        )
+        .bind(blocker_pid)
+        .bind(query_fragment)
+        .fetch_optional(pool)
+        .await
+        .expect("database lock state should be readable");
+        if let Some(blocked_pid) = blocked_pid {
+            return blocked_pid;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    panic!("query containing {query_fragment:?} never waited for database lock");
+}

--- a/crates/api-core/src/tests/ib_fabric_monitor.rs
+++ b/crates/api-core/src/tests/ib_fabric_monitor.rs
@@ -15,25 +15,201 @@
  * limitations under the License.
  */
 
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use carbide_ib_fabric::IbFabricMonitor;
 use carbide_ib_fabric::config::IBFabricConfig;
+use carbide_ib_fabric::ib::{Filter, IBFabric, IBFabricManager};
 use carbide_instrument::testing::MetricsCapture;
+use carbide_uuid::instance::InstanceId;
+use model::ib::{
+    DEFAULT_IB_FABRIC_NAME, IBMtu, IBNetwork, IBQosConf, IBRateLimit, IBServiceLevel, IbMembership,
+};
+use model::ib_partition::PartitionKey;
+use model::machine::ManagedHostState;
+use rpc::forge::forge_server::Forge;
 
 use crate::tests::common;
-use crate::tests::common::api_fixtures::{TestEnvOverrides, create_managed_host};
+use crate::tests::common::api_fixtures::ib_partition::{DEFAULT_TENANT, create_ib_partition};
+use crate::tests::common::api_fixtures::instance::create_instance_with_ib_config;
+use crate::tests::common::api_fixtures::{
+    TestEnv, TestEnvOverrides, TestManagedHost, create_managed_host,
+};
+use crate::tests::common::postgres::wait_for_blocked_query;
 
-#[crate::sqlx_test]
-async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+const MANAGED_TEST_PKEY: u16 = 50;
+const UNMANAGED_TEST_PKEY: u16 = 0x101;
+// `pg_stat_activity.query` can truncate long statements before their locking
+// clause, so concurrency tests match the visible start of the `Machine` query.
+const MACHINE_LOCK_QUERY_MARKER: &str = "SELECT row_to_json";
+
+/// `enabled_ib_test_config` builds the test-specific enabled IB configuration
+/// shared by monitor fixtures.
+fn enabled_ib_test_config() -> crate::cfg::file::CarbideConfig {
     let mut config = common::api_fixtures::get_config();
     config.ib_config = Some(IBFabricConfig {
         enabled: true,
         ..Default::default()
     });
+    config
+}
 
-    let env = common::api_fixtures::create_test_env_with_overrides(
-        pool.clone(),
-        TestEnvOverrides::with_config(config),
+/// `retired_membership` is a test-specific helper that builds one exact record
+/// for monitor assertions.
+fn retired_membership(fabric: &str, pkey: PartitionKey, guid: &str) -> IbMembership {
+    IbMembership {
+        fabric: fabric.to_string(),
+        pkey,
+        guid: guid.to_string(),
+    }
+}
+
+/// `insert_retired_membership` is a test-specific helper that seeds the
+/// monitor's durable input directly. The production writer is tracked by
+/// https://github.com/NVIDIA/infra-controller/issues/5147.
+async fn insert_retired_membership(pool: &sqlx::PgPool, membership: &IbMembership) {
+    sqlx::query("INSERT INTO retired_ib_memberships (fabric, pkey, guid) VALUES ($1, $2, $3)")
+        .bind(membership.fabric.clone())
+        .bind(i32::from(u16::from(membership.pkey)))
+        .bind(membership.guid.clone())
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+/// `retired_memberships` is a test-specific helper that reads every record in
+/// a stable order for assertions.
+async fn retired_memberships(pool: &sqlx::PgPool) -> Vec<IbMembership> {
+    let rows: Vec<(String, i32, String)> = sqlx::query_as(
+        "SELECT fabric, pkey, guid FROM retired_ib_memberships \
+         ORDER BY fabric, pkey, guid",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap();
+    rows.into_iter()
+        .map(|(fabric, pkey, guid)| {
+            retired_membership(
+                &fabric,
+                PartitionKey::try_from(u16::try_from(pkey).unwrap()).unwrap(),
+                &guid,
+            )
+        })
+        .collect()
+}
+
+/// `retired_membership_exists` is a test-specific helper that checks whether
+/// one exact record survived a monitor pass.
+async fn retired_membership_exists(pool: &sqlx::PgPool, membership: &IbMembership) -> bool {
+    sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM retired_ib_memberships \
+         WHERE fabric = $1 AND pkey = $2 AND guid = $3)",
+    )
+    .bind(&membership.fabric)
+    .bind(i32::from(u16::from(membership.pkey)))
+    .bind(&membership.guid)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+/// `ib_network` is a test-specific helper that builds the minimal UFM
+/// partition used by cleanup tests.
+fn ib_network(pkey: PartitionKey) -> IBNetwork {
+    IBNetwork {
+        name: "retired-membership-test".to_string(),
+        pkey: pkey.into(),
+        ipoib: false,
+        qos_conf: Some(IBQosConf {
+            mtu: IBMtu::default(),
+            service_level: IBServiceLevel::default(),
+            rate_limit: IBRateLimit::default(),
+        }),
+        associated_guids: None,
+        membership: None,
+    }
+}
+
+/// `membership_is_present` is a test-specific helper that reads mock UFM state
+/// for cleanup assertions.
+async fn membership_is_present(fabric: &Arc<dyn IBFabric>, pkey: PartitionKey, guid: &str) -> bool {
+    fabric
+        .find_ib_port(Some(Filter {
+            guids: None,
+            pkey: Some(pkey.into()),
+            state: None,
+        }))
+        .await
+        .unwrap()
+        .iter()
+        .any(|port| port.guid == guid)
+}
+
+/// `new_ib_monitor` is a test-specific helper that builds a fresh monitor over
+/// the environment's persistent database and UFM state.
+fn new_ib_monitor(env: &TestEnv) -> IbFabricMonitor {
+    IbFabricMonitor::new(
+        env.pool.clone(),
+        env.config.ib_fabrics.clone(),
+        env.test_meter.meter(),
+        env.ib_fabric_manager.clone(),
+        env.config.host_health,
+        env.api.work_lock_manager_handle.clone(),
+    )
+}
+
+/// `ib_monitor_test_env` is a test-specific helper that enables the production
+/// IB monitor in an API test environment.
+async fn ib_monitor_test_env(pool: sqlx::PgPool) -> TestEnv {
+    common::api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(enabled_ib_test_config()),
+    )
+    .await
+}
+
+/// `live_ib_instance` is a test-specific helper that builds the exact
+/// membership used by reuse and deletion tests.
+async fn live_ib_instance(
+    pool: sqlx::PgPool,
+) -> (TestEnv, TestManagedHost, InstanceId, PartitionKey, String) {
+    let env = ib_monitor_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let (partition_id, partition) = create_ib_partition(
+        &env,
+        "retired-membership-live-partition".to_string(),
+        DEFAULT_TENANT.to_string(),
     )
     .await;
+    let pkey = partition.status.as_ref().unwrap().pkey().parse().unwrap();
+    let managed_host = create_managed_host(&env).await;
+    let ib_config = rpc::forge::InstanceInfinibandConfig {
+        ib_interfaces: vec![rpc::forge::InstanceIbInterfaceConfig {
+            function_type: rpc::forge::InterfaceFunctionType::Physical as i32,
+            virtual_function_id: None,
+            ib_partition_id: Some(partition_id),
+            device: "MT2910 Family [ConnectX-7]".to_string(),
+            vendor: None,
+            device_instance: 0,
+        }],
+    };
+    let (instance_id, guid) = {
+        let (test_instance, instance) =
+            create_instance_with_ib_config(&env, &managed_host, ib_config, segment_id).await;
+        let guid = instance.status().infiniband().ib_interfaces[0]
+            .guid()
+            .to_string();
+        (test_instance.id, guid)
+    };
+
+    (env, managed_host, instance_id, pkey, guid)
+}
+
+/// `test_ib_fabric_monitor` covers baseline metrics and insecure partition reporting.
+#[crate::sqlx_test]
+async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = ib_monitor_test_env(pool.clone()).await;
 
     let iteration_metrics = MetricsCapture::start();
     env.run_ib_fabric_monitor_iteration().await;
@@ -113,26 +289,693 @@ async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
-/// Test that IB port down detection sets PreventAllocations alert
-/// and clears it when ports recover.
-///
-/// - Machines with down IB ports should have PreventAllocations health alert
-/// - This prevents tenant allocation failures at UFM
+/// `retired_membership_repairs_a_delayed_bind_after_monitor_restart` is a
+/// test-specific regression that simulates a delayed UFM bind and verifies a
+/// restarted monitor removes it again.
 #[crate::sqlx_test]
-async fn test_ib_port_down_sets_prevent_allocations_alert(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = common::api_fixtures::get_config();
-    config.ib_config = Some(IBFabricConfig {
-        enabled: true,
-        ..Default::default()
-    });
+async fn retired_membership_repairs_a_delayed_bind_after_monitor_restart(pool: sqlx::PgPool) {
+    let env = ib_monitor_test_env(pool.clone()).await;
+    let pkey = PartitionKey::try_from(MANAGED_TEST_PKEY).unwrap();
+    let guid = "retired-restart-guid";
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, guid);
+    let mock = env.ib_fabric_manager.get_mock_manager();
+    mock.register_port(guid.to_string());
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.to_string()])
+        .await
+        .unwrap();
+    insert_retired_membership(&pool, &retired).await;
 
+    let first_monitor = new_ib_monitor(&env);
+    assert_eq!(first_monitor.run_single_iteration().await.unwrap(), 1);
+    assert!(!membership_is_present(&fabric, pkey, guid).await);
+
+    // Simulate an older bind finishing after the first monitor's unbind, then
+    // replace the monitor object while retaining its database state.
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.to_string()])
+        .await
+        .unwrap();
+    drop(first_monitor);
+    let second_monitor = new_ib_monitor(&env);
+    assert_eq!(second_monitor.run_single_iteration().await.unwrap(), 1);
+
+    assert!(!membership_is_present(&fabric, pkey, guid).await);
+    assert_eq!(retired_memberships(&pool).await, vec![retired]);
+}
+
+/// `retired_membership_outside_managed_range_is_left_alone` is a test-specific
+/// regression that verifies a durable record cannot make the monitor manage a
+/// PKey outside its configured range.
+#[crate::sqlx_test]
+async fn retired_membership_outside_managed_range_is_left_alone(pool: sqlx::PgPool) {
+    let env = ib_monitor_test_env(pool.clone()).await;
+    let pkey = PartitionKey::try_from(UNMANAGED_TEST_PKEY).unwrap();
+    let guid = "retired-unmanaged-guid";
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, guid);
+    let mock = env.ib_fabric_manager.get_mock_manager();
+    mock.register_port(guid.to_string());
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.to_string()])
+        .await
+        .unwrap();
+    insert_retired_membership(&pool, &retired).await;
+
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        0
+    );
+    assert!(membership_is_present(&fabric, pkey, guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+}
+
+/// `duplicate_fabric_ownership_leaves_retired_membership_alone` is a
+/// test-specific regression that verifies duplicate GUID reports cannot select
+/// one fabric for cleanup.
+#[crate::sqlx_test]
+async fn duplicate_fabric_ownership_leaves_retired_membership_alone(pool: sqlx::PgPool) {
+    let mut config = enabled_ib_test_config();
+    let mut other_fabric = config
+        .ib_fabrics
+        .get(DEFAULT_IB_FABRIC_NAME)
+        .unwrap()
+        .clone();
+    other_fabric.endpoints = vec!["https://other-fabric.example".to_string()];
+    config
+        .ib_fabrics
+        .insert("other-fabric".to_string(), other_fabric);
     let env = common::api_fixtures::create_test_env_with_overrides(
         pool.clone(),
         TestEnvOverrides::with_config(config),
     )
     .await;
+
+    // The test manager returns the same mock for both configured fabrics, so
+    // each fabric reports this GUID and membership.
+    let pkey = PartitionKey::try_from(MANAGED_TEST_PKEY).unwrap();
+    let guid = "retired-duplicate-guid";
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, guid);
+    let mock = env.ib_fabric_manager.get_mock_manager();
+    mock.register_port(guid.to_string());
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.to_string()])
+        .await
+        .unwrap();
+    insert_retired_membership(&pool, &retired).await;
+
+    let duplicate_ownership_metrics = MetricsCapture::start();
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        0
+    );
+    let skipped_reconciliations = duplicate_ownership_metrics.counter_delta(
+        "carbide_ib_monitor_partial_failures_total",
+        &[("failure_stage", "resolve_fabric_ownership")],
+    );
+    assert!(
+        skipped_reconciliations >= 1.0,
+        "expected the duplicate fabric Event, observed {skipped_reconciliations}"
+    );
+    drop(duplicate_ownership_metrics);
+    assert!(membership_is_present(&fabric, pkey, guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+}
+
+/// `duplicate_machine_ownership_leaves_retired_membership_alone` is a
+/// test-specific regression that verifies duplicate hardware GUID claims
+/// cannot select one `Machine` for cleanup.
+#[crate::sqlx_test]
+async fn duplicate_machine_ownership_leaves_retired_membership_alone(pool: sqlx::PgPool) {
+    let env = ib_monitor_test_env(pool.clone()).await;
+    let first = create_managed_host(&env).await;
+    let second = create_managed_host(&env).await;
+    let guid = {
+        let mut topology_update = pool.begin().await.unwrap();
+        let first_machine = first.host().db_machine(&mut topology_update).await;
+        let guid = first_machine
+            .status
+            .hardware_info
+            .expect("fixture machine should have hardware information")
+            .infiniband_interfaces[0]
+            .guid
+            .clone();
+        let second_machine = second.host().db_machine(&mut topology_update).await;
+        let mut hardware_info = second_machine
+            .status
+            .hardware_info
+            .expect("fixture machine should have hardware information");
+        hardware_info.infiniband_interfaces[0].guid = guid.clone();
+        db::machine_topology::set_topology_update_needed(
+            topology_update.as_mut(),
+            &second_machine.id,
+            true,
+        )
+        .await
+        .unwrap();
+        db::machine_topology::create_or_update(
+            topology_update.as_mut(),
+            &second_machine.id,
+            &hardware_info,
+        )
+        .await
+        .unwrap();
+        topology_update.commit().await.unwrap();
+        guid
+    };
+
+    let pkey = PartitionKey::try_from(MANAGED_TEST_PKEY).unwrap();
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.clone()])
+        .await
+        .unwrap();
+    insert_retired_membership(&pool, &retired).await;
+
+    let duplicate_ownership_metrics = MetricsCapture::start();
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        0
+    );
+    let skipped_reconciliations = duplicate_ownership_metrics.counter_delta(
+        "carbide_ib_monitor_partial_failures_total",
+        &[("failure_stage", "resolve_machine_ownership")],
+    );
+    assert!(
+        skipped_reconciliations >= 1.0,
+        "expected the duplicate Machine Event, observed {skipped_reconciliations}"
+    );
+    drop(duplicate_ownership_metrics);
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+}
+
+/// `retired_membership_retries_after_ufm_failure` is a test-specific regression
+/// that verifies a failed unbind keeps its record for the next monitor pass.
+#[crate::sqlx_test]
+async fn retired_membership_retries_after_ufm_failure(pool: sqlx::PgPool) {
+    let env = ib_monitor_test_env(pool.clone()).await;
+    let pkey = PartitionKey::try_from(MANAGED_TEST_PKEY).unwrap();
+    let guid = "retired-retry-guid";
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, guid);
+    let mock = env.ib_fabric_manager.get_mock_manager();
+    mock.register_port(guid.to_string());
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.to_string()])
+        .await
+        .unwrap();
+    insert_retired_membership(&pool, &retired).await;
+    mock.set_unbind_failure(true);
+
+    let failure_metrics = MetricsCapture::start();
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        0
+    );
+    let failed_unbinds = failure_metrics.counter_delta(
+        "carbide_ib_monitor_ufm_changes_applied_total",
+        &[
+            ("fabric", DEFAULT_IB_FABRIC_NAME),
+            ("operation", "unbind_guid_from_pkey"),
+            ("status", "error"),
+        ],
+    );
+    assert!(
+        failed_unbinds >= 1.0,
+        "expected the retired membership failure Event, observed {failed_unbinds}"
+    );
+    drop(failure_metrics);
+    assert!(membership_is_present(&fabric, pkey, guid).await);
+    assert_eq!(retired_memberships(&pool).await, vec![retired.clone()]);
+
+    mock.set_unbind_failure(false);
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        1
+    );
+    assert!(!membership_is_present(&fabric, pkey, guid).await);
+    assert_eq!(retired_memberships(&pool).await, vec![retired]);
+}
+
+/// `membership_state_lookup_failure_defers_only_failed_membership` is a
+/// test-specific regression that cancels the locked `Machine` reread and
+/// verifies that its exact membership stays suppressed while an unrelated UFM
+/// cleanup still finishes.
+#[crate::sqlx_test]
+async fn membership_state_lookup_failure_defers_only_failed_membership(pool: sqlx::PgPool) {
+    let (env, managed_host, _, pkey, guid) = live_ib_instance(pool.clone()).await;
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    insert_retired_membership(&pool, &retired).await;
+
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .unbind_ib_ports(pkey.into(), vec![guid.clone()])
+        .await
+        .unwrap();
+    let unrelated_pkey_value = if u16::from(pkey) == MANAGED_TEST_PKEY {
+        MANAGED_TEST_PKEY + 1
+    } else {
+        MANAGED_TEST_PKEY
+    };
+    let unrelated_pkey = PartitionKey::try_from(unrelated_pkey_value).unwrap();
+    assert_ne!(unrelated_pkey, pkey);
+    fabric
+        .bind_ib_ports(ib_network(unrelated_pkey), vec![guid.clone()])
+        .await
+        .unwrap();
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(membership_is_present(&fabric, unrelated_pkey, &guid).await);
+
+    // Pause after the monitor has written its status observation but before it
+    // reads the retired record, then make only the later `Machine` reread wait.
+    let mut retired_membership_gate = pool.begin().await.unwrap();
+    let retired_membership_gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(retired_membership_gate.as_mut())
+        .await
+        .unwrap();
+    sqlx::query("LOCK TABLE retired_ib_memberships IN ACCESS EXCLUSIVE MODE")
+        .execute(retired_membership_gate.as_mut())
+        .await
+        .unwrap();
+
+    let lookup_failure_metrics = MetricsCapture::start();
+    let monitor = new_ib_monitor(&env);
+    let monitor_iteration = tokio::spawn(async move { monitor.run_single_iteration().await });
+    wait_for_blocked_query(&pool, retired_membership_gate_pid, "retired_ib_memberships").await;
+
+    let mut machine_gate = pool.begin().await.unwrap();
+    let machine_gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(machine_gate.as_mut())
+        .await
+        .unwrap();
+    let _: String = sqlx::query_scalar("SELECT id FROM machines WHERE id = $1 FOR UPDATE")
+        .bind(managed_host.id)
+        .fetch_one(machine_gate.as_mut())
+        .await
+        .unwrap();
+    retired_membership_gate.commit().await.unwrap();
+
+    let monitor_pid =
+        wait_for_blocked_query(&pool, machine_gate_pid, MACHINE_LOCK_QUERY_MARKER).await;
+    let cancelled: bool = sqlx::query_scalar("SELECT pg_cancel_backend($1)")
+        .bind(monitor_pid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(
+        cancelled,
+        "expected the blocked membership reread to be cancelled"
+    );
+
+    assert_eq!(monitor_iteration.await.unwrap().unwrap(), 1);
+    machine_gate.rollback().await.unwrap();
+
+    let lookup_failures = lookup_failure_metrics.counter_delta(
+        "carbide_ib_monitor_partial_failures_total",
+        &[("failure_stage", "resolve_membership_state")],
+    );
+    assert!(
+        lookup_failures >= 1.0,
+        "expected the membership state lookup Event, observed {lookup_failures}"
+    );
+    drop(lookup_failure_metrics);
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(!membership_is_present(&fabric, unrelated_pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+}
+
+/// `live_membership_is_unbound_after_instance_deletion_while_retired_record_remains`
+/// is a test-specific regression that follows exact reuse through `Instance`
+/// deletion and verifies cleanup resumes.
+#[crate::sqlx_test]
+async fn live_membership_is_unbound_after_instance_deletion_while_retired_record_remains(
+    pool: sqlx::PgPool,
+) {
+    let (env, _, instance_id, pkey, guid) = live_ib_instance(pool.clone()).await;
+
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+    fabric
+        .unbind_ib_ports(pkey.into(), vec![guid.clone()])
+        .await
+        .unwrap();
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+
+    let exact = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    let unrelated = [
+        retired_membership("other-fabric", pkey, &guid),
+        retired_membership(
+            DEFAULT_IB_FABRIC_NAME,
+            PartitionKey::try_from(u16::from(pkey) + 1).unwrap(),
+            &guid,
+        ),
+        retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, "other-guid"),
+    ];
+    for membership in std::iter::once(&exact).chain(&unrelated) {
+        insert_retired_membership(&pool, membership).await;
+    }
+    let all_records = std::iter::once(exact.clone())
+        .chain(unrelated)
+        .collect::<HashSet<_>>();
+
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        1
+    );
+
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+    assert_eq!(
+        retired_memberships(&pool)
+            .await
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        all_records
+    );
+
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        0
+    );
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &exact).await);
+
+    let mut deletion = pool.begin().await.unwrap();
+    db::instance::mark_as_deleted(instance_id, deletion.as_mut())
+        .await
+        .unwrap();
+    deletion.commit().await.unwrap();
+
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        1
+    );
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &exact).await);
+}
+
+/// `membership_reused_after_snapshot_is_not_unbound` is a test-specific
+/// regression that restores live configuration after an older snapshot and
+/// verifies the locked reread suppresses its unbind.
+#[crate::sqlx_test]
+async fn membership_reused_after_snapshot_is_not_unbound(pool: sqlx::PgPool) {
+    let (env, _, instance_id, pkey, guid) = live_ib_instance(pool.clone()).await;
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    insert_retired_membership(&pool, &retired).await;
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+
+    let instance = env.one_instance(instance_id).await;
+    let original_config = instance.config().inner().clone();
+    let mut config_without_ib = original_config.clone();
+    config_without_ib.infiniband = Some(rpc::forge::InstanceInfinibandConfig {
+        ib_interfaces: Vec::new(),
+    });
+    env.api
+        .update_instance_config(tonic::Request::new(
+            rpc::forge::InstanceConfigUpdateRequest {
+                instance_id: instance_id.into(),
+                if_version_match: None,
+                config: Some(config_without_ib),
+                metadata: Some(instance.metadata().clone()),
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Hold the retired membership query after the monitor has captured the
+    // empty IB configuration and its pending unbind.
+    let mut query_gate = pool.begin().await.unwrap();
+    let query_gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(query_gate.as_mut())
+        .await
+        .unwrap();
+    sqlx::query("LOCK TABLE retired_ib_memberships IN ACCESS EXCLUSIVE MODE")
+        .execute(query_gate.as_mut())
+        .await
+        .unwrap();
+
+    let monitor = new_ib_monitor(&env);
+    let monitor_iteration = tokio::spawn(async move { monitor.run_single_iteration().await });
+    wait_for_blocked_query(&pool, query_gate_pid, "retired_ib_memberships").await;
+
+    env.api
+        .update_instance_config(tonic::Request::new(
+            rpc::forge::InstanceConfigUpdateRequest {
+                instance_id: instance_id.into(),
+                if_version_match: None,
+                config: Some(original_config),
+                metadata: Some(instance.metadata().clone()),
+            },
+        ))
+        .await
+        .unwrap();
+    query_gate.commit().await.unwrap();
+
+    assert_eq!(monitor_iteration.await.unwrap().unwrap(), 0);
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+}
+
+/// `membership_removed_from_hardware_after_snapshot_stays_retired` is a
+/// test-specific regression that removes the GUID after an older snapshot and
+/// verifies the retired record still controls UFM cleanup.
+#[crate::sqlx_test]
+async fn membership_removed_from_hardware_after_snapshot_stays_retired(pool: sqlx::PgPool) {
+    let (env, managed_host, _, pkey, guid) = live_ib_instance(pool.clone()).await;
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    insert_retired_membership(&pool, &retired).await;
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+
+    // Hold the retired membership query after the monitor has captured the
+    // original hardware information and live `Instance` configuration.
+    let mut query_gate = pool.begin().await.unwrap();
+    let query_gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(query_gate.as_mut())
+        .await
+        .unwrap();
+    sqlx::query("LOCK TABLE retired_ib_memberships IN ACCESS EXCLUSIVE MODE")
+        .execute(query_gate.as_mut())
+        .await
+        .unwrap();
+
+    let monitor = new_ib_monitor(&env);
+    let monitor_iteration = tokio::spawn(async move { monitor.run_single_iteration().await });
+    wait_for_blocked_query(&pool, query_gate_pid, "retired_ib_memberships").await;
+
+    let mut topology_update = pool.begin().await.unwrap();
+    let machine = managed_host.host().db_machine(&mut topology_update).await;
+    let mut hardware_info = machine
+        .status
+        .hardware_info
+        .expect("fixture machine should have hardware information");
+    hardware_info
+        .infiniband_interfaces
+        .retain(|interface| interface.guid != guid);
+    db::machine_topology::set_topology_update_needed(topology_update.as_mut(), &machine.id, true)
+        .await
+        .unwrap();
+    db::machine_topology::create_or_update(topology_update.as_mut(), &machine.id, &hardware_info)
+        .await
+        .unwrap();
+    topology_update.commit().await.unwrap();
+    query_gate.commit().await.unwrap();
+
+    assert_eq!(monitor_iteration.await.unwrap().unwrap(), 1);
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+}
+
+/// `retired_membership_checks_force_deletion_after_machine_wait` is a
+/// test-specific regression that lets `ForceDeletion` finish during the
+/// monitor's `Machine` wait and blocks a stale bind.
+#[crate::sqlx_test]
+async fn retired_membership_checks_force_deletion_after_machine_wait(pool: sqlx::PgPool) {
+    let (env, managed_host, _, pkey, guid) = live_ib_instance(pool.clone()).await;
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .unbind_ib_ports(pkey.into(), vec![guid.clone()])
+        .await
+        .unwrap();
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    insert_retired_membership(&pool, &retired).await;
+
+    // Hold the retired membership table until the monitor has read the live
+    // `Instance` and recorded the missing membership. This fixes the stale
+    // candidate and its ordinary bind action before `ForceDeletion` begins.
+    let mut query_gate = pool.begin().await.unwrap();
+    let query_gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(query_gate.as_mut())
+        .await
+        .unwrap();
+    sqlx::query("LOCK TABLE retired_ib_memberships IN ACCESS EXCLUSIVE MODE")
+        .execute(query_gate.as_mut())
+        .await
+        .unwrap();
+
+    let monitor = new_ib_monitor(&env);
+    let monitor_iteration = tokio::spawn(async move { monitor.run_single_iteration().await });
+    wait_for_blocked_query(&pool, query_gate_pid, "retired_ib_memberships").await;
+
+    let mut force_deletion = pool.begin().await.unwrap();
+    let force_deletion_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(force_deletion.as_mut())
+        .await
+        .unwrap();
+    let machine = managed_host.host().db_machine(&mut force_deletion).await;
+    assert!(
+        db::machine::advance(
+            &machine,
+            force_deletion.as_mut(),
+            &ManagedHostState::ForceDeletion,
+            None,
+        )
+        .await
+        .unwrap()
+    );
+
+    query_gate.commit().await.unwrap();
+    wait_for_blocked_query(&pool, force_deletion_pid, MACHINE_LOCK_QUERY_MARKER).await;
+    force_deletion.commit().await.unwrap();
+
+    assert_eq!(monitor_iteration.await.unwrap().unwrap(), 0);
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        0
+    );
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+}
+
+/// `force_deletion_without_retirement_keeps_the_existing_membership` is a
+/// test-specific regression that verifies `ForceDeletion` alone does not
+/// change the monitor's expected PKeys.
+#[crate::sqlx_test]
+async fn force_deletion_without_retirement_keeps_the_existing_membership(pool: sqlx::PgPool) {
+    let (env, managed_host, _, pkey, guid) = live_ib_instance(pool).await;
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    let mut txn = env.pool.begin().await.unwrap();
+    let machine = managed_host.host().db_machine(&mut txn).await;
+    assert!(
+        db::machine::advance(
+            &machine,
+            txn.as_mut(),
+            &ManagedHostState::ForceDeletion,
+            None,
+        )
+        .await
+        .unwrap()
+    );
+    txn.commit().await.unwrap();
+
+    assert_eq!(
+        new_ib_monitor(&env).run_single_iteration().await.unwrap(),
+        0
+    );
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+}
+
+/// `deleted_instance_keeps_the_retired_membership` is a test-specific
+/// regression that proves stale configuration from a deleted `Instance` cannot
+/// supersede the retired record.
+#[crate::sqlx_test]
+async fn deleted_instance_keeps_the_retired_membership(pool: sqlx::PgPool) {
+    let (env, _, instance_id, pkey, guid) = live_ib_instance(pool.clone()).await;
+    let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+
+    // Normal release first marks the `Instance` deleted. Until the membership
+    // is retired, the existing monitor behavior still treats its IB
+    // configuration as expected.
+    let mut txn = pool.begin().await.unwrap();
+    db::instance::mark_as_deleted(instance_id, txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let monitor = new_ib_monitor(&env);
+    assert_eq!(monitor.run_single_iteration().await.unwrap(), 0);
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+
+    // The durable record, rather than terminal `Instance` state by itself,
+    // makes the monitor remove the membership.
+    insert_retired_membership(&pool, &retired).await;
+    assert_eq!(monitor.run_single_iteration().await.unwrap(), 1);
+
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+
+    assert_eq!(monitor.run_single_iteration().await.unwrap(), 0);
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(retired_membership_exists(&pool, &retired).await);
+}
+
+/// `test_ib_port_down_sets_prevent_allocations_alert` covers the production
+/// allocation guard when a required IB port goes down and recovers. The
+/// `PreventAllocations` alert keeps tenant allocation from reaching UFM while
+/// the port cannot accept its PKey membership.
+#[crate::sqlx_test]
+async fn test_ib_port_down_sets_prevent_allocations_alert(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = ib_monitor_test_env(pool.clone()).await;
 
     // Create a managed host with IB interfaces
     let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
@@ -225,19 +1068,11 @@ async fn test_ib_port_down_sets_prevent_allocations_alert(
     Ok(())
 }
 
+/// `test_ib_multiple_ports_down` covers alert counts and partial recovery when
+/// more than one required IB port goes down.
 #[crate::sqlx_test]
 async fn test_ib_multiple_ports_down(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = common::api_fixtures::get_config();
-    config.ib_config = Some(IBFabricConfig {
-        enabled: true,
-        ..Default::default()
-    });
-
-    let env = common::api_fixtures::create_test_env_with_overrides(
-        pool.clone(),
-        TestEnvOverrides::with_config(config),
-    )
-    .await;
+    let env = ib_monitor_test_env(pool.clone()).await;
 
     let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
 

--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -44,6 +44,7 @@ use crate::tests::common::api_fixtures::{
     self, TEST_SITE_PREFIXES, TestEnv, TestEnvOverrides, create_managed_host, create_test_env,
     create_test_env_with_overrides, get_vpc_fixture_id,
 };
+use crate::tests::common::postgres::wait_for_blocked_query;
 use crate::tests::common::rpc_builder::VpcCreationRequest;
 
 const REFERENCED_VPC_PREFIX: &str = "192.0.4.0/24";
@@ -134,39 +135,6 @@ fn site_prefix_child_request(
         }),
         site_prefix_id,
     }
-}
-
-/// Waits until one database query is blocked by a known transaction.
-async fn wait_until_query_is_blocked_by(
-    pool: &PgPool,
-    blocker_pid: i32,
-    query_fragment: &str,
-) -> i32 {
-    for _ in 0..300 {
-        let blocked_pid: Option<i32> = sqlx::query_scalar(
-            r#"
-                SELECT activity.pid
-                FROM pg_stat_activity AS activity
-                WHERE activity.datname = current_database()
-                  AND activity.wait_event_type = 'Lock'
-                  AND $1 = ANY(pg_blocking_pids(activity.pid))
-                  AND activity.query ILIKE '%' || $2 || '%'
-                ORDER BY activity.pid
-                LIMIT 1
-            "#,
-        )
-        .bind(blocker_pid)
-        .bind(query_fragment)
-        .fetch_optional(pool)
-        .await
-        .expect("database lock state should be readable");
-        if let Some(blocked_pid) = blocked_pid {
-            return blocked_pid;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-
-    panic!("query containing {query_fragment:?} never waited for database lock");
 }
 
 #[derive(serde::Deserialize)]
@@ -1504,7 +1472,7 @@ async fn omitted_site_prefix_id_serializes_with_tenant_root_creation(
     let request = site_prefix_child_request(vpc_prefix_id, vpc_id, None, "10.81.1.0/24");
     let api = env.api.clone();
     let create = tokio::spawn(async move { api.create_vpc_prefix(Request::new(request)).await });
-    wait_until_query_is_blocked_by(&env.pool, blocker_pid, "site_prefixes:tenant:").await;
+    wait_for_blocked_query(&env.pool, blocker_pid, "site_prefixes:tenant:").await;
 
     site_prefix_create.commit().await?;
     let error = create.await?.unwrap_err();
@@ -1547,7 +1515,7 @@ async fn omitted_site_prefix_id_serializes_with_first_operator_root_reconciliati
     let request = site_prefix_child_request(vpc_prefix_id, vpc_id, None, "198.19.1.0/24");
     let api = env.api.clone();
     let create = tokio::spawn(async move { api.create_vpc_prefix(Request::new(request)).await });
-    wait_until_query_is_blocked_by(&env.pool, blocker_pid, "pg_advisory_xact_lock_shared").await;
+    wait_for_blocked_query(&env.pool, blocker_pid, "pg_advisory_xact_lock_shared").await;
 
     reconciliation.commit().await?;
     let created = create.await??.into_inner();
@@ -1595,7 +1563,7 @@ async fn vpc_prefix_create_rechecks_parent_after_concurrent_retirement(
         site_prefix_child_request(vpc_prefix_id, vpc_id, Some(site_prefix_id), "10.60.1.0/24");
     let api = env.api.clone();
     let create = tokio::spawn(async move { api.create_vpc_prefix(Request::new(request)).await });
-    wait_until_query_is_blocked_by(&env.pool, blocker_pid, "site_prefixes").await;
+    wait_for_blocked_query(&env.pool, blocker_pid, "site_prefixes").await;
 
     retirement.commit().await?;
     let error = create.await?.unwrap_err();
@@ -1719,7 +1687,7 @@ async fn tenant_managed_lineage_blocks_virtualization_transition_and_race(
         }))
         .await
     });
-    wait_until_query_is_blocked_by(&env.pool, blocker_pid, "vpcs").await;
+    wait_for_blocked_query(&env.pool, blocker_pid, "vpcs").await;
     child_create.commit().await?;
 
     let error = update.await?.unwrap_err();

--- a/crates/api-db/migrations/20260820165303_retired_ib_memberships.sql
+++ b/crates/api-db/migrations/20260820165303_retired_ib_memberships.sql
@@ -1,0 +1,9 @@
+-- Retired memberships stay recorded after their `Machine` and `Instance` records
+-- are gone and after UFM removes them. A live `Instance` can reuse the exact
+-- membership and remove its record.
+CREATE TABLE retired_ib_memberships (
+    fabric TEXT NOT NULL,
+    pkey INTEGER NOT NULL CHECK (pkey BETWEEN 0 AND 32767),
+    guid TEXT NOT NULL,
+    PRIMARY KEY (fabric, pkey, guid)
+);

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -85,6 +85,7 @@ pub mod rack;
 pub mod redfish_actions;
 pub mod resource_pool;
 pub mod retained_boot_interface;
+pub mod retired_ib_membership;
 pub mod route_servers;
 pub mod secrets;
 pub mod site_exploration_report;

--- a/crates/api-db/src/retired_ib_membership.rs
+++ b/crates/api-db/src/retired_ib_membership.rs
@@ -1,0 +1,315 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Durable records for IB memberships that should stay removed. A record
+//! survives UFM removal and is deleted only when the exact membership is
+//! assigned again.
+
+use model::ib::IbMembership;
+use model::ib_partition::PartitionKey;
+use sqlx::PgConnection;
+
+use crate::db_read::DbReader;
+use crate::{DatabaseError, DatabaseResult};
+
+/// `record` records the exact membership in the transaction that retires it.
+// The first production caller, which retires the membership in the same
+// transaction, is tracked by https://github.com/NVIDIA/infra-controller/issues/5147.
+#[allow(dead_code)]
+async fn record(txn: &mut PgConnection, membership: &IbMembership) -> DatabaseResult<()> {
+    let query = "INSERT INTO retired_ib_memberships (fabric, pkey, guid)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (fabric, pkey, guid) DO NOTHING";
+
+    sqlx::query(query)
+        .bind(&membership.fabric)
+        .bind(i32::from(u16::from(membership.pkey)))
+        .bind(&membership.guid)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// `find_recorded_candidates` returns candidates that have retired membership
+/// records.
+///
+/// An empty candidate list returns without querying the database. Duplicate
+/// candidates appear once in the result. Results are ordered by `fabric`,
+/// PKey, and GUID.
+pub async fn find_recorded_candidates(
+    db: impl DbReader<'_>,
+    candidates: &[IbMembership],
+) -> DatabaseResult<Vec<IbMembership>> {
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let query = "SELECT DISTINCT retired.fabric, retired.pkey, retired.guid
+        FROM retired_ib_memberships AS retired
+        INNER JOIN UNNEST($1::text[], $2::integer[], $3::text[])
+            AS candidate(fabric, pkey, guid)
+            ON candidate.fabric = retired.fabric
+            AND candidate.pkey = retired.pkey
+            AND candidate.guid = retired.guid
+        ORDER BY retired.fabric, retired.pkey, retired.guid";
+
+    let fabrics = candidates
+        .iter()
+        .map(|membership| membership.fabric.clone())
+        .collect::<Vec<_>>();
+    let pkeys = candidates
+        .iter()
+        .map(|membership| i32::from(u16::from(membership.pkey)))
+        .collect::<Vec<_>>();
+    let guids = candidates
+        .iter()
+        .map(|membership| membership.guid.clone())
+        .collect::<Vec<_>>();
+
+    let rows: Vec<(String, i32, String)> = sqlx::query_as(query)
+        .bind(fabrics)
+        .bind(pkeys)
+        .bind(guids)
+        .fetch_all(db)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    rows.into_iter().map(membership_from_row).collect()
+}
+
+fn membership_from_row(
+    (fabric, pkey, guid): (String, i32, String),
+) -> DatabaseResult<IbMembership> {
+    let pkey = u16::try_from(pkey)
+        .ok()
+        .and_then(|pkey| PartitionKey::try_from(pkey).ok())
+        .ok_or_else(|| {
+            DatabaseError::internal(format!(
+                "retired_ib_memberships contains invalid pkey {pkey}"
+            ))
+        })?;
+    Ok(IbMembership { fabric, pkey, guid })
+}
+
+/// `remove_for_reuse` removes the retired record in the transaction that
+/// assigns the exact membership to a live `Instance`.
+///
+/// Callers must hold the lock that serializes membership changes and verify the
+/// current `Instance` after locking its owning `Machine` row `FOR UPDATE` in
+/// this transaction. Removing the membership from UFM is not enough to delete
+/// the record. Returns `true` when the exact record existed and was deleted.
+// The first production caller, which assigns the exact membership in the same
+// transaction, is tracked by https://github.com/NVIDIA/infra-controller/issues/5147.
+#[allow(dead_code)]
+async fn remove_for_reuse(
+    txn: &mut PgConnection,
+    membership: &IbMembership,
+) -> DatabaseResult<bool> {
+    let query = "DELETE FROM retired_ib_memberships
+        WHERE fabric = $1 AND pkey = $2 AND guid = $3";
+
+    sqlx::query(query)
+        .bind(&membership.fabric)
+        .bind(i32::from(u16::from(membership.pkey)))
+        .bind(&membership.guid)
+        .execute(txn)
+        .await
+        .map(|result| result.rows_affected() == 1)
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::{Fails, Yields};
+    use carbide_test_support::{Case, check_cases_async};
+    use model::ib::IbMembership;
+    use model::ib_partition::PartitionKey;
+
+    use super::{find_recorded_candidates, record, remove_for_reuse};
+
+    fn membership(fabric: &str, pkey: u16, guid: &str) -> IbMembership {
+        IbMembership {
+            fabric: fabric.to_string(),
+            pkey: PartitionKey::try_from(pkey).expect("test PKey must be valid"),
+            guid: guid.to_string(),
+        }
+    }
+
+    #[crate::sqlx_test]
+    async fn migration_enforces_the_pkey_range(pool: sqlx::PgPool) {
+        check_cases_async(
+            [
+                Case {
+                    scenario: "minimum PKey",
+                    input: 0,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "maximum PKey",
+                    input: 32767,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "negative PKey",
+                    input: -1,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "PKey above the maximum",
+                    input: 32768,
+                    expect: Fails,
+                },
+            ],
+            |pkey| {
+                let pool = pool.clone();
+                async move {
+                    sqlx::query(
+                        "INSERT INTO retired_ib_memberships (fabric, pkey, guid) \
+                         VALUES ('fabric-a', $1, $1::text)",
+                    )
+                    .bind(pkey)
+                    .execute(&pool)
+                    .await
+                    .map(|_| ())
+                    .map_err(drop)
+                }
+            },
+        )
+        .await;
+    }
+
+    #[crate::sqlx_test]
+    async fn repeated_record_is_idempotent(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        let membership = membership("fabric-a", 0x101, "guid-a");
+
+        record(txn.as_mut(), &membership).await.unwrap();
+        record(txn.as_mut(), &membership).await.unwrap();
+
+        assert_eq!(
+            find_recorded_candidates(txn.as_mut(), &[membership.clone(), membership.clone()])
+                .await
+                .unwrap(),
+            vec![membership]
+        );
+        assert!(
+            find_recorded_candidates(txn.as_mut(), &[])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn find_recorded_candidates_match_exact_memberships(pool: sqlx::PgPool) {
+        let candidates = [
+            membership("fabric-a", 0x101, "guid-a"),
+            membership("fabric-b", 0x102, "guid-b"),
+        ];
+        let false_cross_product_match = membership("fabric-a", 0x102, "guid-b");
+        let mut txn = pool.begin().await.unwrap();
+        for membership in candidates
+            .iter()
+            .chain(std::iter::once(&false_cross_product_match))
+        {
+            record(txn.as_mut(), membership).await.unwrap();
+        }
+
+        assert_eq!(
+            find_recorded_candidates(txn.as_mut(), &candidates)
+                .await
+                .unwrap(),
+            candidates
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn record_remains_after_machine_and_instance_deletion(pool: sqlx::PgPool) {
+        let membership = membership("fabric-a", 0x101, "guid-a");
+        let mut txn = pool.begin().await.unwrap();
+        sqlx::query(
+            "INSERT INTO machines (id, dpf) \
+             VALUES ('retired-membership-machine', '{}'::jsonb)",
+        )
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO instances (machine_id) VALUES ('retired-membership-machine')")
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        record(txn.as_mut(), &membership).await.unwrap();
+        txn.commit().await.unwrap();
+
+        let mut txn = pool.begin().await.unwrap();
+        sqlx::query("DELETE FROM instances WHERE machine_id = 'retired-membership-machine'")
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM machines WHERE id = 'retired-membership-machine'")
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        assert_eq!(
+            find_recorded_candidates(&pool, std::slice::from_ref(&membership))
+                .await
+                .unwrap(),
+            vec![membership]
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn reuse_removes_only_the_matching_record(pool: sqlx::PgPool) {
+        let exact = membership("fabric-a", 0x101, "guid-a");
+        let retained = [
+            membership("fabric-b", 0x101, "guid-a"),
+            membership("fabric-a", 0x102, "guid-a"),
+            membership("fabric-a", 0x101, "guid-b"),
+        ];
+        let mut txn = pool.begin().await.unwrap();
+        for candidate in std::iter::once(&exact).chain(&retained) {
+            record(txn.as_mut(), candidate).await.unwrap();
+        }
+
+        assert!(remove_for_reuse(txn.as_mut(), &exact).await.unwrap());
+        assert!(!remove_for_reuse(txn.as_mut(), &exact).await.unwrap());
+
+        let missing = membership("fabric-a", 0x103, "guid-a");
+        assert_eq!(
+            find_recorded_candidates(
+                txn.as_mut(),
+                &[
+                    exact,
+                    retained[0].clone(),
+                    retained[1].clone(),
+                    retained[2].clone(),
+                    missing,
+                ],
+            )
+            .await
+            .unwrap(),
+            vec![
+                retained[2].clone(),
+                retained[1].clone(),
+                retained[0].clone()
+            ],
+        );
+    }
+}

--- a/crates/api-model/src/ib.rs
+++ b/crates/api-model/src/ib.rs
@@ -20,12 +20,25 @@ use std::collections::HashSet;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::ModelError;
+use crate::ib_partition::PartitionKey;
 
 pub const DEFAULT_IB_FABRIC_NAME: &str = "default";
 
 // Not implemented yet
 // pub const IBNETWORK_DEFAULT_MEMBERSHIP: IBPortMembership = IBPortMembership::Full;
 // pub const IBNETWORK_DEFAULT_INDEX0: bool = true;
+
+/// `IbMembership` identifies one PKey membership through its fabric and port
+/// GUID.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct IbMembership {
+    /// Fabric containing the membership.
+    pub fabric: String,
+    /// Partition key containing the membership.
+    pub pkey: PartitionKey,
+    /// Port GUID associated with the partition key.
+    pub guid: String,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IBNetwork {

--- a/crates/ib-fabric/src/ib/mock.rs
+++ b/crates/ib-fabric/src/ib/mock.rs
@@ -40,6 +40,8 @@ struct State {
     subnets_to_ports: HashMap<u16, HashSet<String>>,
     /// The next LID that will be used
     next_lid: i32,
+    /// Whether unbind requests fail without changing fabric state.
+    fail_unbind: bool,
 }
 
 #[async_trait]
@@ -228,6 +230,12 @@ impl IBFabric for MockIBFabric {
             .lock()
             .map_err(|_| IbError::IBFabricError("state lock".to_string()))?;
 
+        if state.fail_unbind {
+            return Err(IbError::IBFabricError(
+                "simulated UFM unbind failure".to_string(),
+            ));
+        }
+
         for id in &ids {
             if !state.ports.contains_key(id) {
                 return Err(IbError::IBFabricError(format!(
@@ -292,6 +300,7 @@ impl MockIBFabric {
                 ports: HashMap::new(),
                 subnets_to_ports: HashMap::new(),
                 next_lid: 1,
+                fail_unbind: false,
             })),
         }
     }
@@ -338,6 +347,11 @@ impl MockIBFabric {
         let mut state: std::sync::MutexGuard<'_, State> = self.state.lock().unwrap();
         let partition = state.subnets.get_mut(&DEFAULT_PARTITION_KEY).unwrap();
         partition.membership = Some(membership);
+    }
+
+    /// Configures whether unbind requests fail without changing fabric state.
+    pub fn set_unbind_failure(&self, fail: bool) {
+        self.state.lock().unwrap().fail_unbind = fail;
     }
 }
 

--- a/crates/ib-fabric/src/lib.rs
+++ b/crates/ib-fabric/src/lib.rs
@@ -38,13 +38,15 @@ use metrics::{
     IbMonitorMachineStatusObservationFailed, IbMonitorPkeyReconciliationSkipped,
     IbMonitorSkuInactivePreloadFailed, UfmGuidPkeyChangeFinished, UfmOperation,
 };
-use model::ib::{IBNetwork, IBPort, IBPortMembership, IBPortState};
+use model::ib::{IBNetwork, IBPort, IBPortMembership, IBPortState, IbMembership};
 use model::ib_partition::{IBPartition, IbPartitionSearchFilter, PartitionKey};
 use model::machine::infiniband::{
     MachineIbInterfaceStatusObservation, MachineInfinibandStatusObservation,
 };
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostStateSnapshot};
+use model::machine::{
+    HostHealthConfig, LoadSnapshotOptions, ManagedHostState, ManagedHostStateSnapshot,
+};
 use sqlx::{PgConnection, PgPool};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -309,6 +311,9 @@ impl IbFabricMonitor {
                 HashMap::new()
             });
 
+        let machine_ids_by_guid = machine_ids_by_ib_guid(&snapshots);
+        let current_fabrics_by_guid = current_fabrics_by_ib_guid(&fabric_data);
+        let memberships_in_ufm = memberships_in_fabric_data(&fabric_data);
         let mut reports = Vec::new();
         for (machine, snapshot) in &snapshots {
             let mut snapshot_clone = snapshot.clone();
@@ -323,9 +328,7 @@ impl IbFabricMonitor {
             )
             .await
             {
-                Ok(report) => {
-                    reports.push(report);
-                }
+                Ok(report) => reports.push(report),
                 Err(e) => {
                     emit(IbMonitorMachineStatusObservationFailed::new(
                         e.to_string(),
@@ -335,7 +338,34 @@ impl IbFabricMonitor {
             }
         }
 
-        let num_changes = apply_guid_pkey_changes(
+        // Query only retired records that match a membership UFM reports or a
+        // membership this pass may add. Historical rows are not scanned into
+        // the monitor.
+        let memberships_to_check = memberships_in_ufm
+            .iter()
+            .chain(reports.iter().flat_map(|report| &report.needed_memberships))
+            .cloned()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        // Stop this pass if the lookup fails. Continuing without these records
+        // could restore a membership that must remain absent.
+        let retired_memberships = db::retired_ib_membership::find_recorded_candidates(
+            &self.db_pool,
+            &memberships_to_check,
+        )
+        .await?;
+        let retired_membership_changes = self
+            .reconcile_retired_memberships(
+                &mut fabric_clients,
+                &memberships_in_ufm,
+                &machine_ids_by_guid,
+                &current_fabrics_by_guid,
+                retired_memberships,
+                &mut reports,
+            )
+            .await?;
+        let membership_changes = apply_guid_pkey_changes(
             self.fabric_manager.as_ref(),
             &mut fabric_clients,
             &self.fabrics,
@@ -345,7 +375,277 @@ impl IbFabricMonitor {
         )
         .await?;
 
+        Ok(retired_membership_changes + membership_changes)
+    }
+
+    /// `reconcile_retired_memberships` removes memberships that should stay
+    /// retired and suppresses changes from stale `Machine` snapshots. A locked
+    /// reread leaves exact live reuse alone for this pass.
+    async fn reconcile_retired_memberships(
+        &self,
+        fabric_clients: &mut HashMap<String, Arc<dyn IBFabric>>,
+        memberships_in_ufm: &HashSet<IbMembership>,
+        machine_ids_by_guid: &HashMap<String, Option<MachineId>>,
+        current_fabrics_by_guid: &HashMap<String, Option<String>>,
+        retired_memberships: Vec<IbMembership>,
+        reports: &mut [MachineIbStatusEvaluation],
+    ) -> IbResult<usize> {
+        let mut num_changes = 0;
+        let mut memberships_to_suppress = Vec::new();
+        let mut live_memberships = Vec::new();
+
+        for retired_membership in retired_memberships {
+            let Some(fabric_definition) = self.fabrics.get(&retired_membership.fabric) else {
+                tracing::debug!(
+                    fabric = %retired_membership.fabric,
+                    guid = %retired_membership.guid,
+                    pkey = %retired_membership.pkey,
+                    "Skipping retired membership for unconfigured fabric"
+                );
+                memberships_to_suppress.push(retired_membership);
+                continue;
+            };
+            if !is_pkey_in_managed_range(retired_membership.pkey, fabric_definition) {
+                tracing::debug!(
+                    fabric = %retired_membership.fabric,
+                    guid = %retired_membership.guid,
+                    pkey = %retired_membership.pkey,
+                    "Skipping retired membership outside managed PKey range"
+                );
+                memberships_to_suppress.push(retired_membership);
+                continue;
+            }
+
+            if let Some(duplicate_ownership) = suppress_duplicate_ownership_changes(
+                current_fabrics_by_guid,
+                machine_ids_by_guid,
+                &retired_membership,
+                reports,
+            ) {
+                let skipped = match duplicate_ownership {
+                    DuplicateOwnership::Fabric => {
+                        IbMonitorPkeyReconciliationSkipped::DuplicateFabricOwnership {
+                            fabric: retired_membership.fabric.clone(),
+                            guid: retired_membership.guid.clone(),
+                            pkey: retired_membership.pkey.to_string(),
+                        }
+                    }
+                    DuplicateOwnership::Machine => {
+                        IbMonitorPkeyReconciliationSkipped::DuplicateMachineOwnership {
+                            fabric: retired_membership.fabric.clone(),
+                            guid: retired_membership.guid.clone(),
+                            pkey: retired_membership.pkey.to_string(),
+                        }
+                    }
+                };
+                emit(skipped);
+                continue;
+            }
+
+            // A unique report from another fabric proves that the earlier
+            // `Machine` snapshot no longer owns this membership. Missing port
+            // data still gets the locked database reread.
+            let known_current_fabric_mismatch = current_fabrics_by_guid
+                .get(&retired_membership.guid)
+                .and_then(|fabric| fabric.as_deref())
+                .is_some_and(|fabric| fabric != retired_membership.fabric.as_str());
+            let current_state_still_needs_membership = if known_current_fabric_mismatch {
+                false
+            } else if let Some(Some(machine_id)) = machine_ids_by_guid.get(&retired_membership.guid)
+            {
+                match self
+                    .membership_is_still_needed(*machine_id, &retired_membership)
+                    .await
+                {
+                    Ok(still_needed) => still_needed,
+                    Err(error) => {
+                        emit(
+                            IbMonitorPkeyReconciliationSkipped::MembershipStateLookupFailed {
+                                fabric: retired_membership.fabric.clone(),
+                                guid: retired_membership.guid.clone(),
+                                pkey: retired_membership.pkey.to_string(),
+                                machine_id: machine_id.to_string(),
+                                error: error.to_string(),
+                            },
+                        );
+                        // The monitor cannot tell whether the `Instance` still
+                        // needs this membership. Suppress both its pending bind
+                        // and unbind for this pass.
+                        memberships_to_suppress.push(retired_membership);
+                        continue;
+                    }
+                }
+            } else {
+                false
+            };
+            // Check live reuse before UFM presence. A live membership that UFM
+            // has not bound yet must keep its pending bind.
+            if current_state_still_needs_membership {
+                live_memberships.push(retired_membership);
+                continue;
+            }
+
+            // Keep the record after UFM no longer reports the membership. It
+            // may be needed to remove an older bind that finishes later.
+            if !memberships_in_ufm.contains(&retired_membership) {
+                memberships_to_suppress.push(retired_membership);
+                continue;
+            }
+
+            let conn = client_for_fabric(
+                self.fabric_manager.as_ref(),
+                fabric_clients,
+                &retired_membership.fabric,
+            )
+            .await?;
+            let result = conn
+                .unbind_ib_ports(
+                    retired_membership.pkey.into(),
+                    vec![retired_membership.guid.clone()],
+                )
+                .await;
+            UfmGuidPkeyChangeFinished::emit(
+                &retired_membership.fabric,
+                UfmOperation::UnbindGuidFromPkey,
+                &retired_membership.guid,
+                retired_membership.pkey,
+                &result,
+            );
+            if result.is_ok() {
+                num_changes += 1;
+            }
+            memberships_to_suppress.push(retired_membership);
+        }
+
+        let memberships_to_suppress = memberships_to_suppress.into_iter().collect::<HashSet<_>>();
+        let live_memberships = live_memberships.into_iter().collect::<HashSet<_>>();
+
+        // The locked reread is newer than each report's original `Machine`
+        // snapshot. Keep a pending bind when the current `Instance` still needs
+        // that exact membership. Drop unbinds from the older snapshot for live
+        // memberships and for retired memberships already handled above.
+        for report in reports {
+            report.missing_guid_pkeys.retain(|(fabric, guid, pkey)| {
+                !memberships_to_suppress.contains(&IbMembership {
+                    fabric: fabric.clone(),
+                    pkey: *pkey,
+                    guid: guid.clone(),
+                })
+            });
+            report.unexpected_guid_pkeys.retain(|(fabric, guid, pkey)| {
+                let membership = IbMembership {
+                    fabric: fabric.clone(),
+                    pkey: *pkey,
+                    guid: guid.clone(),
+                };
+                !live_memberships.contains(&membership)
+                    && !memberships_to_suppress.contains(&membership)
+            });
+        }
+
         Ok(num_changes)
+    }
+
+    /// `membership_is_still_needed` checks current `Machine` and `Instance`
+    /// state after waiting for the `Machine` update used by allocation and
+    /// `force-delete` operations. UFM work remains outside this transaction. A
+    /// later monitor pass corrects a UFM change that finishes after this check.
+    async fn membership_is_still_needed(
+        &self,
+        machine_id: MachineId,
+        membership: &IbMembership,
+    ) -> IbResult<bool> {
+        let mut txn = self
+            .db_pool
+            .begin()
+            .await
+            .map_err(|e| DatabaseError::new("begin retired IB membership transaction", e))?;
+
+        let machine_exists = db::machine::find_one(
+            txn.as_mut(),
+            &machine_id,
+            MachineSearchConfig {
+                for_update: true,
+                ..Default::default()
+            },
+        )
+        .await?
+        .is_some();
+        if !machine_exists {
+            txn.commit()
+                .await
+                .map_err(|e| DatabaseError::new("commit retired IB membership transaction", e))?;
+            return Ok(false);
+        }
+
+        // After another transaction finishes its `Machine` update, READ
+        // COMMITTED gives this query a new snapshot that includes that change.
+        let snapshot = db::managed_host::load_snapshot(
+            txn.as_mut(),
+            &machine_id,
+            LoadSnapshotOptions::default().with_host_health(self.host_health),
+        )
+        .await?;
+        let membership_may_be_reused = snapshot.as_ref().is_some_and(|snapshot| {
+            // During `ForceDeletion`, the state controller no longer manages
+            // the `Machine`, so later state transitions may never clear a
+            // stale membership. Keep it retired even while the old `Instance`
+            // configuration remains visible. Other states require the current
+            // hardware and fabric observation to identify the exact membership
+            // before it can be reused.
+            !matches!(snapshot.managed_state, ManagedHostState::ForceDeletion)
+                && snapshot
+                    .host_snapshot
+                    .status
+                    .hardware_info
+                    .as_ref()
+                    .is_some_and(|hardware_info| {
+                        hardware_info
+                            .infiniband_interfaces
+                            .iter()
+                            .any(|interface| interface.guid == membership.guid)
+                    })
+                && snapshot
+                    .host_snapshot
+                    .status
+                    .infiniband_status_observation
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|observation| &observation.ib_interfaces)
+                    .any(|interface| {
+                        interface.guid == membership.guid
+                            && interface.fabric_id == membership.fabric
+                    })
+        });
+        let mut still_live = false;
+        if let Some(instance) = snapshot
+            .as_ref()
+            .filter(|snapshot| membership_may_be_reused && !snapshot.use_admin_network())
+            .and_then(|snapshot| snapshot.instance.as_ref())
+            .filter(|instance| instance.deleted.is_none())
+        {
+            for interface in &instance.config.infiniband.ib_interfaces {
+                if interface.guid.as_deref() != Some(membership.guid.as_str()) {
+                    continue;
+                }
+                let pkey = db::ib_partition::find_pkey_by_partition_id(
+                    txn.as_mut(),
+                    interface.ib_partition_id,
+                )
+                .await?
+                .and_then(|pkey| PartitionKey::try_from(pkey).ok());
+                if pkey == Some(membership.pkey) {
+                    still_live = true;
+                    break;
+                }
+            }
+        }
+
+        txn.commit()
+            .await
+            .map_err(|e| DatabaseError::new("commit retired IB membership transaction", e))?;
+
+        Ok(still_live)
     }
 
     async fn get_all_snapshots(
@@ -371,6 +671,55 @@ impl IbFabricMonitor {
         )
         .await
         .map_err(Into::into)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DuplicateOwnership {
+    Fabric,
+    Machine,
+}
+
+/// Suppresses pending bind and unbind changes for a GUID and PKey on every
+/// fabric when more than one fabric or `Machine` claims the GUID. Returns the
+/// duplicate owner kind so the caller can emit the matching Event.
+fn suppress_duplicate_ownership_changes(
+    current_fabrics_by_guid: &HashMap<String, Option<String>>,
+    machine_ids_by_guid: &HashMap<String, Option<MachineId>>,
+    membership: &IbMembership,
+    reports: &mut [MachineIbStatusEvaluation],
+) -> Option<DuplicateOwnership> {
+    let duplicate_ownership = if matches!(current_fabrics_by_guid.get(&membership.guid), Some(None))
+    {
+        DuplicateOwnership::Fabric
+    } else if matches!(machine_ids_by_guid.get(&membership.guid), Some(None)) {
+        DuplicateOwnership::Machine
+    } else {
+        return None;
+    };
+
+    suppress_membership_changes_across_fabrics(reports, &membership.guid, membership.pkey);
+    Some(duplicate_ownership)
+}
+
+/// Removes pending bind and unbind changes for a GUID and PKey on every
+/// fabric.
+fn suppress_membership_changes_across_fabrics(
+    reports: &mut [MachineIbStatusEvaluation],
+    guid: &str,
+    pkey: PartitionKey,
+) {
+    for report in reports {
+        report
+            .missing_guid_pkeys
+            .retain(|(_, candidate_guid, candidate_pkey)| {
+                candidate_guid != guid || *candidate_pkey != pkey
+            });
+        report
+            .unexpected_guid_pkeys
+            .retain(|(_, candidate_guid, candidate_pkey)| {
+                candidate_guid != guid || *candidate_pkey != pkey
+            });
     }
 }
 
@@ -533,6 +882,101 @@ impl FabricData {
 
         self.partition_ids_by_guid = Some(partitions_by_guid);
     }
+}
+
+/// `machine_ids_by_ib_guid` maps hardware GUIDs from the original monitor
+/// snapshot to the `Machine` that can be locked and read again. A `None` value
+/// means that more than one `Machine` claims the GUID.
+fn machine_ids_by_ib_guid(
+    snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+) -> HashMap<String, Option<MachineId>> {
+    unique_machine_ids_by_ib_guid(
+        snapshots
+            .iter()
+            .filter_map(|(machine_id, snapshot)| {
+                snapshot
+                    .host_snapshot
+                    .status
+                    .hardware_info
+                    .as_ref()
+                    .map(|hardware_info| (machine_id, &hardware_info.infiniband_interfaces))
+            })
+            .flat_map(|(machine_id, interfaces)| {
+                interfaces
+                    .iter()
+                    .map(|interface| (interface.guid.clone(), *machine_id))
+            }),
+    )
+}
+
+/// `unique_machine_ids_by_ib_guid` keeps unique GUID owners and marks duplicate
+/// ownership by distinct machines as `None`.
+fn unique_machine_ids_by_ib_guid(
+    guid_owners: impl IntoIterator<Item = (String, MachineId)>,
+) -> HashMap<String, Option<MachineId>> {
+    let mut machine_ids_by_guid = HashMap::new();
+    for (guid, machine_id) in guid_owners {
+        machine_ids_by_guid
+            .entry(guid)
+            .and_modify(|current_machine_id: &mut Option<MachineId>| {
+                if *current_machine_id != Some(machine_id) {
+                    *current_machine_id = None;
+                }
+            })
+            .or_insert(Some(machine_id));
+    }
+    machine_ids_by_guid
+}
+
+/// `current_fabrics_by_ib_guid` maps each GUID in the available UFM port data
+/// to its current fabric. A `None` value means more than one available fabric
+/// reported the same GUID. Fabrics with unavailable port data make no claim.
+fn current_fabrics_by_ib_guid(
+    data_by_fabric: &HashMap<String, FabricData>,
+) -> HashMap<String, Option<String>> {
+    let mut fabrics_by_guid = HashMap::new();
+    for (fabric, data) in data_by_fabric {
+        let Some(ports_by_guid) = data.ports_by_guid.as_ref() else {
+            continue;
+        };
+        for guid in ports_by_guid.keys() {
+            fabrics_by_guid
+                .entry(guid.clone())
+                .and_modify(|current_fabric: &mut Option<String>| {
+                    if current_fabric.as_deref() != Some(fabric) {
+                        *current_fabric = None;
+                    }
+                })
+                .or_insert_with(|| Some(fabric.clone()));
+        }
+    }
+    fabrics_by_guid
+}
+
+/// `memberships_in_fabric_data` builds the exact memberships UFM reported for
+/// this monitor pass.
+fn memberships_in_fabric_data(
+    data_by_fabric: &HashMap<String, FabricData>,
+) -> HashSet<IbMembership> {
+    let mut memberships = HashSet::new();
+    for (fabric, data) in data_by_fabric {
+        let Some(partitions_by_guid) = data.partition_ids_by_guid.as_ref() else {
+            continue;
+        };
+        for (guid, pkeys) in partitions_by_guid {
+            for pkey in pkeys {
+                let Ok(pkey) = PartitionKey::try_from(*pkey) else {
+                    continue;
+                };
+                memberships.insert(IbMembership {
+                    fabric: fabric.clone(),
+                    pkey,
+                    guid: guid.clone(),
+                });
+            }
+        }
+    }
+    memberships
 }
 
 /// Return port information within a single IB fabric
@@ -737,13 +1181,16 @@ async fn get_tenant_partitions(
     Ok(result)
 }
 
-/// These are the GUID/Pkey combinations where changes are required
+/// `MachineIbStatusEvaluation` holds missing and unexpected PKey changes,
+/// unknown PKey observations, down ports, and expected memberships that
+/// retirement reconciliation must protect from stale changes.
 #[derive(Debug, Clone, Default)]
 struct MachineIbStatusEvaluation {
     missing_guid_pkeys: Vec<(String, String, PartitionKey)>,
     unexpected_guid_pkeys: Vec<(String, String, PartitionKey)>,
     unknown_guid_pkeys: Vec<(String, String, PartitionKey)>,
     down_port_guids: Vec<String>,
+    needed_memberships: Vec<IbMembership>,
 }
 
 async fn record_machine_infiniband_status_observation(
@@ -883,9 +1330,17 @@ async fn record_machine_infiniband_status_observation(
 
         let (fabric_id, lid, associated_pkeys, associated_partition_ids) = match found_port_data {
             Some((fabric_id, fabric_data, port_data)) => {
-                // Port was found. Now try to look up associated pkeys
-                // If there's no associated pkeys found, don't return any potentially invalid or empty
-                // pkey list. Instead opt for a safe result and return `None` (we don't know).
+                if let Some(expected_pkey) = expected_pkeys.get(guid) {
+                    result.needed_memberships.push(IbMembership {
+                        fabric: fabric_id.to_string(),
+                        pkey: *expected_pkey,
+                        guid: guid.to_string(),
+                    });
+                }
+
+                // Look up the found port's associated PKeys. If UFM did not
+                // return partition data, preserve that uncertainty as `None`
+                // instead of treating it as an empty membership list.
                 let associated_pkeys = match fabric_data.partition_ids_by_guid.as_ref() {
                     Some(partition_ids_by_guid) => match partition_ids_by_guid.get(guid) {
                         Some(partition_ids) => {
@@ -1339,8 +1794,230 @@ fn is_pkey_in_managed_range(pkey: PartitionKey, fabric_definition: &IbFabricDefi
 #[cfg(test)]
 mod tests {
     use carbide_test_support::value_scenarios;
+    use carbide_uuid::machine::{MachineIdSource, MachineType};
 
     use super::*;
+
+    /// `fabric_data_with_ports` builds a complete UFM port inventory for the
+    /// fabric ownership tests.
+    fn fabric_data_with_ports(guids: &[&str]) -> FabricData {
+        FabricData {
+            ports_by_guid: Some(
+                guids
+                    .iter()
+                    .enumerate()
+                    .map(|(index, guid)| {
+                        (
+                            (*guid).to_string(),
+                            IBPort {
+                                name: (*guid).to_string(),
+                                guid: (*guid).to_string(),
+                                lid: index as i32 + 1,
+                                state: Some(IBPortState::Active),
+                            },
+                        )
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        }
+    }
+
+    /// `current_fabric_mapping_uses_available_unique_port_ownership` verifies
+    /// that unavailable fabric data does not erase a known GUID location.
+    #[test]
+    fn current_fabric_mapping_uses_available_unique_port_ownership() {
+        let guid = "moved-guid";
+        value_scenarios!(
+            run = |data_by_fabric: HashMap<String, FabricData>| {
+                current_fabrics_by_ib_guid(&data_by_fabric)
+                    .get(guid)
+                    .cloned()
+            };
+            "one available fabric claims the GUID" {
+                HashMap::from([
+                    (
+                        "fabric-a".to_string(),
+                        FabricData {
+                            ports_by_guid: Some(HashMap::new()),
+                            ..Default::default()
+                        },
+                    ),
+                    ("fabric-b".to_string(), fabric_data_with_ports(&[guid])),
+                ]) => Some(Some("fabric-b".to_string())),
+            }
+
+            "two available fabrics claim the GUID" {
+                HashMap::from([
+                    ("fabric-a".to_string(), fabric_data_with_ports(&[guid])),
+                    ("fabric-b".to_string(), fabric_data_with_ports(&[guid])),
+                ]) => Some(None),
+            }
+
+            "retired fabric data is unavailable" {
+                HashMap::from([
+                    ("fabric-a".to_string(), FabricData::default()),
+                    ("fabric-b".to_string(), fabric_data_with_ports(&[guid])),
+                ]) => Some(Some("fabric-b".to_string())),
+            }
+
+            "unrelated fabric data is unavailable" {
+                HashMap::from([
+                    ("fabric-a".to_string(), fabric_data_with_ports(&[guid])),
+                    ("fabric-b".to_string(), FabricData::default()),
+                ]) => Some(Some("fabric-a".to_string())),
+            }
+
+            "no available fabric claims the GUID" {
+                HashMap::from([(
+                    "fabric-a".to_string(),
+                    FabricData {
+                        ports_by_guid: None,
+                        partition_ids_by_guid: Some(HashMap::from([(
+                            guid.to_string(),
+                            HashSet::from([50]),
+                        )])),
+                        ..Default::default()
+                    },
+                )]) => None,
+            }
+        );
+    }
+
+    /// `duplicate_ownership_suppression_applies_to_every_reported_fabric`
+    /// verifies that both production duplicate ownership branches suppress
+    /// the same GUID and PKey on a fabric other than the retired membership.
+    #[test]
+    fn duplicate_ownership_suppression_applies_to_every_reported_fabric() {
+        let pkey = PartitionKey::try_from(0x101).expect("valid PKey");
+        let other_pkey = PartitionKey::try_from(0x102).expect("valid PKey");
+        let duplicate_guid = "duplicate-guid";
+        let retained_changes = vec![
+            (
+                "fabric-b".to_string(),
+                duplicate_guid.to_string(),
+                other_pkey,
+            ),
+            ("fabric-b".to_string(), "other-guid".to_string(), pkey),
+        ];
+        let unchanged_missing = [
+            vec![("fabric-b".to_string(), duplicate_guid.to_string(), pkey)],
+            retained_changes.clone(),
+        ]
+        .concat();
+        let unchanged_unexpected = [
+            vec![
+                ("fabric-a".to_string(), duplicate_guid.to_string(), pkey),
+                ("fabric-b".to_string(), duplicate_guid.to_string(), pkey),
+            ],
+            retained_changes.clone(),
+        ]
+        .concat();
+        value_scenarios!(
+            run = |(current_fabrics_by_guid, machine_ids_by_guid): (
+                HashMap<String, Option<String>>,
+                HashMap<String, Option<MachineId>>,
+            )| {
+                let mut reports = vec![MachineIbStatusEvaluation {
+                    missing_guid_pkeys: unchanged_missing.clone(),
+                    unexpected_guid_pkeys: unchanged_unexpected.clone(),
+                    ..Default::default()
+                }];
+                let duplicate_ownership = suppress_duplicate_ownership_changes(
+                    &current_fabrics_by_guid,
+                    &machine_ids_by_guid,
+                    &IbMembership {
+                        fabric: "fabric-a".to_string(),
+                        pkey,
+                        guid: duplicate_guid.to_string(),
+                    },
+                    &mut reports,
+                );
+                (
+                    duplicate_ownership,
+                    reports[0].missing_guid_pkeys.clone(),
+                    reports[0].unexpected_guid_pkeys.clone(),
+                )
+            };
+            "duplicate fabric ownership" {
+                (
+                    HashMap::from([(duplicate_guid.to_string(), None)]),
+                    HashMap::new(),
+                ) => (
+                    Some(DuplicateOwnership::Fabric),
+                    retained_changes.clone(),
+                    retained_changes.clone(),
+                ),
+            }
+            "duplicate Machine ownership" {
+                (
+                    HashMap::from([(
+                        duplicate_guid.to_string(),
+                        Some("fabric-b".to_string()),
+                    )]),
+                    HashMap::from([(duplicate_guid.to_string(), None)]),
+                ) => (
+                    Some(DuplicateOwnership::Machine),
+                    retained_changes.clone(),
+                    retained_changes.clone(),
+                ),
+            }
+            "fabric ownership takes precedence when both are duplicate" {
+                (
+                    HashMap::from([(duplicate_guid.to_string(), None)]),
+                    HashMap::from([(duplicate_guid.to_string(), None)]),
+                ) => (
+                    Some(DuplicateOwnership::Fabric),
+                    retained_changes.clone(),
+                    retained_changes,
+                ),
+            }
+            "unique ownership leaves changes alone" {
+                (
+                    HashMap::from([(
+                        duplicate_guid.to_string(),
+                        Some("fabric-b".to_string()),
+                    )]),
+                    HashMap::new(),
+                ) => (
+                    None,
+                    unchanged_missing.clone(),
+                    unchanged_unexpected.clone(),
+                ),
+            }
+        );
+    }
+
+    /// `machine_guid_mapping_rejects_duplicate_owners` verifies that a repeated
+    /// claim from one `Machine` stays unique while a second owner prevents
+    /// either one from being selected.
+    #[test]
+    fn machine_guid_mapping_rejects_duplicate_owners() {
+        let first = MachineId::new(MachineIdSource::Tpm, [1; 32], MachineType::Host);
+        let second = MachineId::new(MachineIdSource::Tpm, [2; 32], MachineType::Host);
+        value_scenarios!(
+            run = |machine_ids: Vec<MachineId>| {
+                unique_machine_ids_by_ib_guid(
+                    machine_ids
+                        .into_iter()
+                        .map(|machine_id| ("guid".to_string(), machine_id)),
+                )
+                .get("guid")
+                .copied()
+            };
+            "one Machine claims the GUID" {
+                vec![first] => Some(Some(first)),
+            }
+
+            "one Machine repeats its claim" {
+                vec![first, first] => Some(Some(first)),
+            }
+
+            "two Machines claim the GUID" {
+                vec![first, second] => Some(None),
+            }
+        );
+    }
 
     #[test]
     fn parses_numbers() {
@@ -1943,6 +2620,7 @@ mod tests {
                 ],
                 unknown_guid_pkeys: vec![],
                 down_port_guids: vec![],
+                needed_memberships: vec![],
             }]
         }
 

--- a/crates/ib-fabric/src/metrics.rs
+++ b/crates/ib-fabric/src/metrics.rs
@@ -153,6 +153,9 @@ enum IbMonitorPartialFailureStage {
 enum IbMonitorPkeyReconciliationFailureStage {
     ResolvePartitionId,
     ResolvePartition,
+    ResolveFabricOwnership,
+    ResolveMachineOwnership,
+    ResolveMembershipState,
 }
 
 /// `IbFabricDataLoadFailed` records the stage that left one fabric's cached
@@ -319,7 +322,54 @@ pub(crate) enum IbMonitorPkeyReconciliationSkipped {
         #[context]
         pkey: String,
     },
+
+    #[event(
+        labels(failure_stage = IbMonitorPkeyReconciliationFailureStage::ResolveFabricOwnership),
+        log = warn,
+        message = "Skipping retired PKey reconciliation because more than one fabric reports the GUID"
+    )]
+    DuplicateFabricOwnership {
+        #[context]
+        fabric: String,
+        #[context]
+        guid: String,
+        #[context]
+        pkey: String,
+    },
+
+    #[event(
+        labels(failure_stage = IbMonitorPkeyReconciliationFailureStage::ResolveMachineOwnership),
+        log = warn,
+        message = "Skipping retired PKey reconciliation because more than one Machine claims the GUID"
+    )]
+    DuplicateMachineOwnership {
+        #[context]
+        fabric: String,
+        #[context]
+        guid: String,
+        #[context]
+        pkey: String,
+    },
+
+    #[event(
+        labels(failure_stage = IbMonitorPkeyReconciliationFailureStage::ResolveMembershipState),
+        log = error,
+        message = "Skipping retired PKey reconciliation because current membership state could not be verified"
+    )]
+    MembershipStateLookupFailed {
+        #[context]
+        fabric: String,
+        #[context]
+        guid: String,
+        #[context]
+        pkey: String,
+        #[context]
+        machine_id: String,
+        #[context]
+        error: String,
+    },
 }
+
 /// Registers the observable instruments used by `IbFabricMonitor`.
 struct IbFabricMonitorInstruments;
 
@@ -955,6 +1005,9 @@ mod tests {
         UpdateMachineStatusObservation,
         ResolvePartitionId,
         ResolvePartition,
+        DuplicateFabricOwnership,
+        DuplicateMachineOwnership,
+        MembershipStateLookupFailed,
     }
 
     #[derive(Debug, PartialEq)]
@@ -969,6 +1022,7 @@ mod tests {
         endpoints: Option<String>,
         error: Option<String>,
         machine_id: Option<String>,
+        guid: Option<String>,
         pkey: Option<String>,
         counter_delta: f64,
     }
@@ -978,6 +1032,7 @@ mod tests {
         const ENDPOINTS: &str = "https://ufm-1,https://ufm-2";
         const ERROR: &str = "simulated failure";
         const FABRIC: &str = "fabric-1";
+        const GUID: &str = "guid-1";
         const MACHINE_ID: &str = "machine-1";
         const METRIC: &str = "carbide_ib_monitor_partial_failures_total";
         const PKEY: &str = "0x101";
@@ -998,6 +1053,7 @@ mod tests {
                         endpoints: Some(ENDPOINTS.to_string()),
                         error: Some(ERROR.to_string()),
                         machine_id: None,
+                        guid: None,
                         pkey: None,
                         counter_delta: 1.0,
                     },
@@ -1016,6 +1072,7 @@ mod tests {
                         endpoints: Some(ENDPOINTS.to_string()),
                         error: Some(ERROR.to_string()),
                         machine_id: None,
+                        guid: None,
                         pkey: None,
                         counter_delta: 1.0,
                     },
@@ -1034,6 +1091,7 @@ mod tests {
                         endpoints: Some(ENDPOINTS.to_string()),
                         error: Some(ERROR.to_string()),
                         machine_id: None,
+                        guid: None,
                         pkey: None,
                         counter_delta: 1.0,
                     },
@@ -1052,6 +1110,7 @@ mod tests {
                         endpoints: Some(ENDPOINTS.to_string()),
                         error: Some(ERROR.to_string()),
                         machine_id: None,
+                        guid: None,
                         pkey: None,
                         counter_delta: 1.0,
                     },
@@ -1072,6 +1131,7 @@ mod tests {
                         endpoints: None,
                         error: Some(ERROR.to_string()),
                         machine_id: None,
+                        guid: None,
                         pkey: None,
                         counter_delta: 1.0,
                     },
@@ -1094,6 +1154,7 @@ mod tests {
                         endpoints: None,
                         error: Some(ERROR.to_string()),
                         machine_id: Some(MACHINE_ID.to_string()),
+                        guid: None,
                         pkey: None,
                         counter_delta: 1.0,
                     },
@@ -1114,6 +1175,7 @@ mod tests {
                         endpoints: None,
                         error: None,
                         machine_id: None,
+                        guid: None,
                         pkey: Some(PKEY.to_string()),
                         counter_delta: 1.0,
                     },
@@ -1134,6 +1196,70 @@ mod tests {
                         endpoints: None,
                         error: None,
                         machine_id: None,
+                        guid: None,
+                        pkey: Some(PKEY.to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "duplicate fabric ownership",
+                    input: PartialFailureCase::DuplicateFabricOwnership,
+                    expect: PartialFailureObservation {
+                        log_count: 1,
+                        level: tracing::Level::WARN,
+                        message: "Skipping retired PKey reconciliation because more than one fabric reports the GUID".to_string(),
+                        event_name: Some(
+                            "ib_monitor_pkey_reconciliation_skipped".to_string(),
+                        ),
+                        metric_name: Some(METRIC.to_string()),
+                        failure_stage: Some("resolve_fabric_ownership".to_string()),
+                        fabric: Some(FABRIC.to_string()),
+                        endpoints: None,
+                        error: None,
+                        machine_id: None,
+                        guid: Some(GUID.to_string()),
+                        pkey: Some(PKEY.to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "duplicate Machine ownership",
+                    input: PartialFailureCase::DuplicateMachineOwnership,
+                    expect: PartialFailureObservation {
+                        log_count: 1,
+                        level: tracing::Level::WARN,
+                        message: "Skipping retired PKey reconciliation because more than one Machine claims the GUID".to_string(),
+                        event_name: Some(
+                            "ib_monitor_pkey_reconciliation_skipped".to_string(),
+                        ),
+                        metric_name: Some(METRIC.to_string()),
+                        failure_stage: Some("resolve_machine_ownership".to_string()),
+                        fabric: Some(FABRIC.to_string()),
+                        endpoints: None,
+                        error: None,
+                        machine_id: None,
+                        guid: Some(GUID.to_string()),
+                        pkey: Some(PKEY.to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "membership state lookup",
+                    input: PartialFailureCase::MembershipStateLookupFailed,
+                    expect: PartialFailureObservation {
+                        log_count: 1,
+                        level: tracing::Level::ERROR,
+                        message: "Skipping retired PKey reconciliation because current membership state could not be verified".to_string(),
+                        event_name: Some(
+                            "ib_monitor_pkey_reconciliation_skipped".to_string(),
+                        ),
+                        metric_name: Some(METRIC.to_string()),
+                        failure_stage: Some("resolve_membership_state".to_string()),
+                        fabric: Some(FABRIC.to_string()),
+                        endpoints: None,
+                        error: Some(ERROR.to_string()),
+                        machine_id: Some(MACHINE_ID.to_string()),
+                        guid: Some(GUID.to_string()),
                         pkey: Some(PKEY.to_string()),
                         counter_delta: 1.0,
                     },
@@ -1153,6 +1279,15 @@ mod tests {
                     }
                     PartialFailureCase::ResolvePartitionId => "resolve_partition_id",
                     PartialFailureCase::ResolvePartition => "resolve_partition",
+                    PartialFailureCase::DuplicateFabricOwnership => {
+                        "resolve_fabric_ownership"
+                    }
+                    PartialFailureCase::DuplicateMachineOwnership => {
+                        "resolve_machine_ownership"
+                    }
+                    PartialFailureCase::MembershipStateLookupFailed => {
+                        "resolve_membership_state"
+                    }
                 };
                 let metrics = MetricsCapture::start();
                 let endpoints = vec![
@@ -1196,6 +1331,29 @@ mod tests {
                     PartialFailureCase::ResolvePartition => {
                         emit(IbMonitorPkeyReconciliationSkipped::PartitionMissing { pkey: PKEY.to_string() });
                     }
+                    PartialFailureCase::DuplicateFabricOwnership => {
+                        emit(IbMonitorPkeyReconciliationSkipped::DuplicateFabricOwnership {
+                            fabric: FABRIC.to_string(),
+                            guid: GUID.to_string(),
+                            pkey: PKEY.to_string(),
+                        });
+                    }
+                    PartialFailureCase::DuplicateMachineOwnership => {
+                        emit(IbMonitorPkeyReconciliationSkipped::DuplicateMachineOwnership {
+                            fabric: FABRIC.to_string(),
+                            guid: GUID.to_string(),
+                            pkey: PKEY.to_string(),
+                        });
+                    }
+                    PartialFailureCase::MembershipStateLookupFailed => {
+                        emit(IbMonitorPkeyReconciliationSkipped::MembershipStateLookupFailed {
+                            fabric: FABRIC.to_string(),
+                            guid: GUID.to_string(),
+                            pkey: PKEY.to_string(),
+                            machine_id: MACHINE_ID.to_string(),
+                            error: ERROR.to_string(),
+                        });
+                    }
                 });
                 let log = logs.first().expect("partial failure Event logged");
 
@@ -1210,6 +1368,7 @@ mod tests {
                     endpoints: log.field("endpoints").map(str::to_string),
                     error: log.field("error").map(str::to_string),
                     machine_id: log.field("machine_id").map(str::to_string),
+                    guid: log.field("guid").map(str::to_string),
                     pkey: log.field("pkey").map(str::to_string),
                     counter_delta: metrics
                         .counter_delta(METRIC, &[("failure_stage", failure_stage_label)]),


### PR DESCRIPTION
> [!NOTE]
> While this PR seems large at first glance, just FYI that it contains:
>
> - +925/-67 lines of test changes.
>
> Don't let it scare you!

As part of introducing tenant-managed `SitePrefix` resources, Admin `force-delete` must remove everything that belonged to the old `Instance` before its network can be reused. For a host with InfiniBand, that includes keeping its PKey memberships removed after its `Machine` and `Instance` records are deleted.

An `IbFabricMonitor` pass can decide that a membership should exist, then pause before sending the change to UFM. During that pause, Admin `force-delete` can remove the membership and delete the `Machine` and `Instance` records. The earlier monitor pass can still send the add request. UFM sees the fabric, PKey, and GUID, but it does not know which version of the `Instance` requested the change, so it accepts the older request. With the `Machine` and `Instance` records gone, the normal monitor no longer has the information needed to remove the membership again.

So, this change adds `retired_ib_memberships` and teaches `IbFabricMonitor` to enforce it. Each record identifies one retired membership through its `fabric`, `pkey`, and `guid` fields. For memberships that UFM reports, or that the current pass is considering adding, the monitor checks whether an exact retired record exists. It removes a retired membership from UFM when present and keeps the record afterward so a delayed add can be corrected. A failed removal also leaves the record in place for the next pass.

If a new `Instance` needs the same membership, `IbFabricMonitor` waits for any `Machine` update already in progress and then reads the current `Machine` and `Instance` state again. It leaves the membership alone for that pass only when the current hardware still reports the GUID and the current `Instance` has not been deleted and requires the exact same fabric, PKey, and GUID. The retired record remains in place, so a later pass can still remove the membership if the hardware or `Instance` changes after that check. No database transaction remains open while the monitor calls UFM.

The migration adds an empty table and does not read or rewrite existing data. Older binaries ignore it. This PR adds the storage and monitor behavior, but no production path records a retired membership yet. https://github.com/NVIDIA/infra-controller/issues/5147 adds that step to normal IB changes and removes a retired record in the same transaction when an exact membership is assigned again. https://github.com/NVIDIA/infra-controller/issues/5139 records the memberships removed by Admin `force-delete`.

These records do not expire by age. If the exact tuple is never assigned again, its record remains. The monitor checks only memberships UFM reports and memberships the pass may add, so it does not load the historical table into every pass.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5137 and https://github.com/NVIDIA/infra-controller/issues/5138.

This is part of https://github.com/NVIDIA/infra-controller/issues/5131 and https://github.com/NVIDIA/infra-controller/issues/3883. Completing the series is a prerequisite for https://github.com/NVIDIA/infra-controller/issues/5112.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Unit and monitor tests verify that one available fabric can identify a GUID's current location even when another fabric's port inventory is unavailable. When more than one fabric reports the same GUID, or more than one `Machine` claims it, the monitor defers bind and unbind changes for that GUID and PKey across fabrics for the pass because it cannot identify a trustworthy owner.
- PostgreSQL and monitor tests cover the new table's PKey constraint, exact reuse, delayed UFM adds after a restart, failed removal retries, failed current state reads, deleted or changing `Machine` and `Instance` state, and memberships outside the configured PKey range.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

The counts summarize the final local review and cleanup. All adopted findings are included in this revision.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 26 | 11 | 15 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **26** | **11** | **15** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- Made the unrelated PKey in the database failure regression distinct from the randomly allocated live PKey.
2. **Adopted** -- Removed a backlog integration test that could not detect the broad lookup it claimed to cover; the database test directly proves exact tuple matching.
3. **Adopted** -- Converted the migration constraint cases to the repository's labeled table format.
4. **Adopted** -- Renamed the general monitor environment and constructor helpers so their names match every caller.
5. **Declined** -- Remove the explicit test-specific wording from helper and regression comments; that wording is deliberate because this test file otherwise looks like production code.
6. **Adopted** -- Reused the shared IB monitor environment in the two remaining port health tests.
7. **Adopted** -- Documented why failure to read the retired records must stop the pass instead of behaving as if no records exist.
8. **Declined** -- Add expiration, general garbage collection, or timestamp metadata now; retaining the record is the safety contract, and operational metadata should follow an actual writer or consumer policy.
9. **Declined** -- Add a new local database lock timeout; the server timeout already bounds the wait, failures now defer only the affected membership, and the repository has no production Rust policy to copy here.
10. **Declined** -- Change the candidate lookup for a speculative scale concern; its cost follows current UFM and desired memberships rather than the historical table.
11. **Adopted** -- Removed an unused InfiniBand observation from the database fixture.
12. **Declined** -- Rename `IbMembership` to match older neighboring types; `Ib` follows the repository's current Rust naming convention.
13. **Declined** -- Rename `IbMembership` again to distinguish it from `IBPortMembership`; the exact tuple and the port membership enum remain clear at their use sites, and another rename would add churn across crates.
14. **Adopted** -- Documented why live reuse must be checked before UFM presence so a missing live membership keeps its pending bind.
15. **Declined** -- Filter the default partition from candidate lookups without measured pressure; the lookup follows current UFM and desired memberships and can be optimized separately if site data shows a need.
16. **Adopted** -- Removed redundant exact suppression after duplicate ownership already suppresses the GUID and PKey across fabrics.
17. **Declined** -- Remove the defensive unconfigured fabric guard; keeping it makes future changes to the data flow stop safely instead of acting on an unknown fabric.
18. **Declined** -- Group locked membership checks by `Machine`; that changes transaction and lock scope for a speculative contention reduction before the production writer exists.
19. **Declined** -- Convert every similar database waiter in unrelated test modules; the exact duplicate moved here, while the remaining helpers have different return, timeout, or matching behavior.
20. **Declined** -- Remove the lifecycle durability test; it pins the requirement that later `Machine` or `Instance` deletion must not consume a retired record and would catch future cascade or trigger changes.
21. **Declined** -- Remove the database PKey constraint because Rust uses `PartitionKey`; the constraint is deliberate defense in depth for direct database writes and future callers.
22. **Adopted** -- Simplified the retired-membership seed helper to accept the `PgPool` every caller uses.
23. **Declined** -- Reframe the new-monitor regression as two ordinary passes; rebuilding the monitor object while retaining only database and UFM state is the boundary the test exercises.
24. **Declined** -- Lower current membership lookup failures from error to warning; skipping reconciliation that protects tenant isolation because current state cannot be verified is an error visible to operators even though the next pass retries.
25. **Adopted** -- Documented why the blocked-query helper uses literal matching instead of `LIKE` wildcard semantics.
26. **Declined** -- Split the retirement logic into a new module during this fix; that is broad file movement without a behavior or reviewability benefit for this change.

### common-nits-reviewer

No findings.

</details>

Closes #5137
