### PR TITLE
docs: document shared HostInband BMC networking

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -50,14 +50,20 @@ DPU agent performs the following tasks:
 
 ### DHCP Server
 
-NICo runs a [custom DHCP server](https://github.com/NVIDIA/infra-controller/blob/main/crates/dhcp-server) on the DPU, which handles all DHCP requests of the actual host. This means DHCP requests on the host's primary networking interfaces will never leave the DPU and show up on the underlay network, which provides enhanced security and reliability. The DHCP server is configured by dpu-agent.
+For a host with a NICo-managed DPU operating in DPU mode, NICo runs a
+[custom DHCP server](https://github.com/NVIDIA/infra-controller/blob/main/crates/dhcp-server)
+on the DPU. It handles that host's DHCP requests locally, so they do not reach
+the physical underlay. The DHCP server is configured by dpu-agent. A zero-DPU
+or DPU-NIC-mode host instead uses the central `nico-dhcp` service through its
+physical `HostInband` segment; see
+[IP and Network Configuration](../provisioning/ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 ## NICo Control plane services
 
 The NICo control plane consists of a number of services which work together to orchestrate the lifecycle of a managed host:
 
 - [nico-core](https://github.com/NVIDIA/infra-controller/blob/main/crates/api): The NICo core service is the entrypoint into the control plane. It provides a [gRPC](https://grpc.io) API that all other components as well as users (site providers/tenants/site administrators) interact with, as well as implements the lifecycle management of all NICo-managed resources (VPCs, prefixes, InfiniBand and NVLink partitions and bare-metal instances). The [NICo Core](#nico-core) section describes it further in detail.
-- [nico-dhcp (DHCP)](https://github.com/NVIDIA/infra-controller/blob/main/crates/dhcp): The DHCP server responds to DHCP requests for all devices on underlay networks. This includes Host BMCs, DPU BMCs and DPU OOB addresses. nico-dhcp can be thought of as a stateless proxy: It does not actually perform any IP address management - it just converts DHCP requests into gRPC format and forwards the gRPC-based DHCP requests to nico core.
+- [nico-dhcp (DHCP)](https://github.com/NVIDIA/infra-controller/blob/main/crates/dhcp): The central DHCP service responds to relay-selected physical-network requests: conventional `Underlay` endpoints such as host BMCs, DPU BMCs, and DPU OOB interfaces, plus zero-DPU host OS interfaces and optionally their host BMCs on `HostInband`. It does not serve a managed-DPU host's DPU-local overlay DHCP. `nico-dhcp` is a stateless proxy: it converts DHCP requests into gRPC and forwards them to NICo Core, which performs IP address management.
 - [nico-pxe (iPXE)](https://github.com/NVIDIA/infra-controller/blob/main/crates/pxe): The PXE server provides boot artifacts like iPXE scripts, iPXE user-data and OS images to managed hosts at boot time over HTTP. It determines which OS data to provide for a specific host by requesting the respective data from nico core - therefore the PXE server is also stateless.
 
   Managed hosts are configured to always boot from PXE. If a local bootable device is found, the host will boot it. Hosts can also be configured to always boot from a particular image for stateless configurations.
@@ -111,9 +117,19 @@ Read more about the NICo [state handling implementation](state_handling.md).
 
 ### Site Explorer
 
-Site Explorer is a background module within the `nico-api` binary that continuously monitors the state of all BMCs detected on the underlay network. Its implementation lives in the separate `crates/site-explorer` crate to keep the `crates/api` crate smaller, but it is still started and run as part of NICo Core.
+Site Explorer is a background module within the `nico-api` binary that
+continuously monitors the state of BMCs detected on conventional `Underlay`
+segments and BMC-typed interfaces on the supported shared `HostInband`
+topology. It does not treat ordinary host data interfaces on HostInband as
+Redfish endpoints. Its implementation lives in the separate
+`crates/site-explorer` crate to keep the `crates/api` crate smaller, but it is
+still started and run as part of NICo Core. See
+[Shared HostInband for a Host BMC and Host OS](../provisioning/ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
-The process acts as a "crawler". It continuously tries to perform Redfish requests against all IPs on the underlay network that were provided by NICo Core and records information that NICo needs to manage hosts later. The information collected by NICo includes:
+The process acts as a "crawler". It continuously tries to perform Redfish
+requests against eligible BMC interface addresses provided by NICo Core and
+records information that NICo needs to manage hosts later. The information
+collected by NICo includes:
 
 - Serial numbers
 - Certain inventory data, such as the amount, type and serial numbers of DPUs

--- a/docs/architecture/redfish_workflow.md
+++ b/docs/architecture/redfish_workflow.md
@@ -6,7 +6,7 @@ For the overall NICo architecture and component responsibilities, see [Overview 
 
 ## Workflow Summary
 
-```
+```text
 DHCP Request (BMC)
   → NICo DHCP (Kea hook)
     → NICo Core (gRPC discover_dhcp)
@@ -28,7 +28,12 @@ DHCP Request (BMC)
 
 ## 1. DHCP Discovery
 
-When a BMC on the underlay network sends a DHCP request, the NICo DHCP server (a Kea hook plugin) captures it and forwards the discovery information to NICo Core.
+When a BMC on a NICo-managed physical network sends a DHCP request, the NICo
+DHCP server (a Kea hook plugin) captures it and forwards the discovery
+information to NICo Core. Site Explorer scans conventional `Underlay` BMC
+interfaces and BMC-typed interfaces on the supported shared `HostInband`
+topology; ordinary host data interfaces on HostInband are not Redfish targets.
+See [Shared HostInband for a Host BMC and Host OS](../provisioning/ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 The Kea hook is implemented as a Rust library with C FFI bindings. When a DHCP packet arrives, the hook:
 
@@ -40,6 +45,7 @@ The Kea hook is implemented as a Rust library with C FFI bindings. When a DHCP p
 The vendor class string is parsed to identify the BMC type and capabilities. DHCP entries are tracked in the database by MAC address and associated with machine interfaces.
 
 **Key files:**
+
 - `crates/dhcp/src/discovery.rs` — `Discovery` struct and FFI entry points (`discovery_fetch_machine`)
 - `crates/dhcp/src/machine.rs` — `Machine::try_fetch()` sends gRPC discovery request
 - `crates/dhcp/src/vendor_class.rs` — Vendor class parsing and BMC type identification
@@ -80,6 +86,7 @@ With an authenticated session, Site Explorer queries a comprehensive set of Redf
 Serial numbers are trimmed of whitespace. If `system.serial_number` is missing, the chassis serial number is used as a fallback.
 
 **Key files:**
+
 - `crates/site-explorer/src/redfish.rs` — `RedfishClient`: `get_redfish_vendor()`, `create_redfish_client()`, inventory queries
 - `crates/site-explorer/src/bmc_endpoint_explorer.rs` — `BmcEndpointExplorer` orchestrates credential lookup and exploration
 - `crates/api-model/src/bmc_info.rs` — `BmcInfo` model (IP, port, MAC, firmware version)
@@ -107,6 +114,7 @@ If the explored matches are incomplete, check `expected_machine.fallback_dpu_ser
 ### Validation
 
 Before accepting a pairing, NICo validates:
+
 - **DPU mode**: The DPU must be in DPU mode, not NIC mode. BlueFields in NIC mode are excluded from pairing.
 - **DPU model configuration**: `check_and_configure_dpu_mode()` verifies the DPU is correctly configured for its model. Hosts with misconfigured DPUs are not ingested.
 - **Completeness**: The number of explored DPUs must match the number of BlueField devices the host reports. Incomplete pairings are deferred.
@@ -116,6 +124,7 @@ Before accepting a pairing, NICo validates:
 Once all DPUs are matched and validated, the host enters an "ingestable" state and Site Explorer kickstarts the ingestion process via the ManagedHost state machine.
 
 **Key file:**
+
 - `crates/site-explorer/src/lib.rs`: `identify_managed_hosts()` with the complete pairing algorithm
 
 ## 4. DPU Provisioning
@@ -133,7 +142,7 @@ The DPU is configured to boot from HTTP IPv4 UEFI, which directs it to the NICo 
 
 The DPU is power-cycled via Redfish to trigger the network boot:
 
-```
+```http
 POST /redfish/v1/Systems/{system_id}/Actions/ComputerSystem.Reset
 Body: {"ResetType": "GracefulRestart"}
 ```
@@ -143,11 +152,13 @@ The power control operation supports multiple reset types: `On`, `ForceOff`, `Gr
 ### Installation
 
 After PXE boot, the DPU:
+
 1. Fetches `nico.efi` from the NICo PXE server over HTTP
 2. Receives cloud-init configuration with its `machine_id` and NICo API endpoint
 3. Installs and starts the DPU agent (`dpu-agent`), which connects back to NICo Core via gRPC
 
 **Key files:**
+
 - `crates/api/src/ipxe.rs` — iPXE instruction generation per architecture
 - `pxe/ipxe/local/embed.ipxe` — iPXE boot script template
 - `nico-rest/workflow/pkg/workflow/instance/reboot.go` — `RebootInstance` Temporal workflow
@@ -167,7 +178,8 @@ NICo sets BIOS attributes required for bare-metal infrastructure operation. This
 - `is_bios_setup()` / `machine_setup_status()` — Check configuration state
 
 These translate to Redfish calls:
-```
+
+```http
 GET  /redfish/v1/Systems/{id}/Bios           — Read attributes
 PATCH /redfish/v1/Systems/{id}/Bios/Settings — Write attributes (pending next reboot)
 ```
@@ -186,7 +198,7 @@ This configures the UEFI boot order to prioritize the DPU's PF MAC address, ensu
 
 After BIOS and boot order changes, the host is power-cycled via Redfish to apply the configuration:
 
-```
+```http
 POST /redfish/v1/Systems/{system_id}/Actions/ComputerSystem.Reset
 Body: {"ResetType": "GracefulRestart"}
 ```
@@ -194,6 +206,7 @@ Body: {"ResetType": "GracefulRestart"}
 Power cycles are rate-limited to avoid excessive reboots (checked via `time_since_redfish_powercycle` against `config.reset_rate_limit`).
 
 **Key files:**
+
 - `crates/site-explorer/src/redfish.rs` — `set_boot_order_dpu_first()`, `redfish_powercycle()`
 - `crates/site-explorer/src/bmc_endpoint_explorer.rs` — Orchestrates boot order with credential lookup
 
@@ -218,7 +231,8 @@ let firmware_inventories = update_service.firmware_inventories().await?;
 ```
 
 This translates to:
-```
+
+```http
 GET /redfish/v1
 GET /redfish/v1/UpdateService
 GET /redfish/v1/UpdateService/FirmwareInventory
@@ -226,6 +240,7 @@ GET /redfish/v1/UpdateService/FirmwareInventory/{id}  (for each item)
 ```
 
 Each firmware item's name and version is exported as a Prometheus gauge metric with labels:
+
 - `serial_number` — Machine chassis serial
 - `machine_id` — NICo machine UUID
 - `bmc_mac` — BMC MAC address
@@ -246,7 +261,8 @@ global `bmc_request_concurrency` limit. It defaults to four concurrent Redfish
 operations per BMC.
 
 Sensor data is read from:
-```
+
+```http
 GET /redfish/v1/Chassis/{id}/Sensors
 GET /redfish/v1/Chassis/{id}/Sensors/{sensor_id}
 ```
@@ -256,6 +272,7 @@ Sensor types include: Temperature (Cel), Rotational/Fan (RPM), Power (W), and Cu
 All sensor data is exported as Prometheus metrics on the `/metrics` endpoint (port 9009) and fed into NICo Core via `RecordHardwareHealthReport` for health aggregation.
 
 **Key files:**
+
 - `crates/health/src/firmware_collector.rs` — `FirmwareCollector` using nv-redfish
 - `crates/health/src/discovery.rs` — Creates and manages collectors per endpoint
 - `crates/health/src/config.rs` — Polling intervals and concurrency configuration

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ This document contains frequently asked questions about NVIDIA Infra Controller 
 
 NICo commonly runs on a Kubernetes cluster (with 3 or 5 control plane nodes recommended), though there is no requirement to do so. NICo runs as a set of microservices for API, DNS, DHCP, Hardware Monitoring, BMC Console, Rack Management, etc.
 
-NICo can be deployed with Helm charts (located in  the `/helm`) directory or with Kubernetes Kustomize manifests.
+NICo can be deployed with Helm charts (located in the `/helm`) directory or with Kubernetes Kustomize manifests.
 
 **Does NICo install Cumulus Linux onto Ethernet switches?**
 
@@ -20,7 +20,7 @@ Yes, NICo installs the DPU operating system, including all DPU firmware (BMC, NI
 
 **Does NICo install NVIDIA Unified Fabric Manager (UFM)?**
 
-No, NICo does not install UFM; it is a dependency. NICo leverages existing UFM deployments for InfiniBand partition management via the UFM API using partition keys (P_Keys). 
+No, NICo does not install UFM; it is a dependency. NICo leverages existing UFM deployments for InfiniBand partition management via the UFM API using partition keys (P_Keys).
 
 **Does NICo manage InfiniBand switches in standalone mode?**
 
@@ -36,9 +36,14 @@ Yes, NICo supports DGX as well as OEM/ODM nodes that are CPU-only, for storage, 
 
 Yes, NICo supports both PXE and image-based installation of operating systems onto servers. Any operating system supported by [iPXE](http://ipxe.org) can be installed. Operating system management (patching, configuration, image generation) is the user’s responsibility.
 
-**Do I need to change the OOB management TOR to configure a separate VLAN for the NICo managed hosts and DPU (DPU OOB, Host OOB), with DHCP relay pointing to NICo DHCP?**
+**Must every host BMC use a separate OOB VLAN with DHCP relay to NICo?**
 
-Yes, this is the most common way to configure NICo. Each VLAN (sometimes the whole switch is a VLAN) or SVI port needs to have its DHCP relay for the machines and DPUs you wish to manage, with NICo pointing to the DHCP server address you have set up.
+No. A dedicated OOB VLAN is the conventional and recommended topology. For a
+zero-DPU or DPU-NIC-mode host, however, the host BMC and host OS NIC may use
+distinct addresses on one `HostInband` subnet/VLAN. Model it as one HostInband
+segment and relay that network to NICo DHCP. The exception does not apply to a
+DPU BMC or DPU OOB interface, and it gives up dedicated OOB network isolation.
+See [Shared HostInband for a Host BMC and Host OS](provisioning/ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 **Do I need to change existing infrastructure if separate VLANs are used?**
 
@@ -46,13 +51,21 @@ No, there is no need to change existing infrastructure if separate VLANs are use
 
 **With only one RJ45 on BF3, the DPU in-band IP addresses allocation is part of DPU loopback allocated by NICo. Does it assume that the same management switch also supports DPU SSH access and that the DPU SSH IP is allocated by NICo and only accessible inside the data center?**
 
-The IP addresses issued to the DPU RJ45 port are from the "network segments" (which is different than a DPU loopback)--the API in NICo is used to create a Network Segment of type underlay on whatever the underlying network configuration is. NICo issues two IPs to the RJ45: One IP is the DPU OOB used to SSH to the ARM OS and NICo management traffic; the other IP is for the DPU BMC, which is used for Redfish and DPU configuration.  
+The IP addresses issued to the DPU RJ45 port are from the "network segments" (which is different than a DPU loopback)--the API in NICo is used to create a Network Segment of type underlay on whatever the underlying network configuration is. NICo issues two IPs to the RJ45: One IP is the DPU OOB used to SSH to the ARM OS and NICo management traffic; the other IP is for the DPU BMC, which is used for Redfish and DPU configuration.
 
-Also note that the host BMC needs to be on a VLAN that is forwarded to the NICo DHCP relay.
+The host BMC must be on a network relayed to NICo DHCP. That network can be the
+conventional OOB Underlay or, for the supported zero-DPU topology, the shared
+HostInband segment described above.
 
 **The host overlay interfaces addresses on top of vxlan and DPU is allocated via NICo through the control NIC on NICo through overlay networking. Is DHCP relay configuration needed on any switches? Does this overlay need to be manually configured on the NICo control host NIC?**
 
-The DHCP relay is required only on the switches connected to the DPU OOBs/BMCs and Host BMCs. The in-band ToRs only need to be configured for BGP Unnumbered as "routed port". The "overlay" networks that NICo will assign IPs to are defined as "network segments" with the "overlay" type, then the overlay network is referenced when creating an instance.
+For a managed-DPU host, DHCP relay is required only on the switches connected
+to DPU OOB/BMC and host-BMC networks; the DPU serves the host overlay itself,
+and the in-band ToRs use BGP unnumbered routed ports. For a zero-DPU or
+DPU-NIC-mode host, the host OS uses central NICo DHCP on HostInband, so the
+HostInband L2/SVI must also relay to `nico-dhcp`. The host BMC can use that same
+relay-selected segment as described above. The DPU-served overlay itself does
+not require a physical-switch DHCP relay.
 
 **Do I need to separate the NICo PXE to isolate the PXE installation process from site PXE server?**
 
@@ -84,10 +97,10 @@ Yes, NICo supports NVLink partitioning.
 
 **How does NICo maintain tenancy enforcement between Ethernet (N/S), Infiniband (E/W), NVLink (GPU-to-GPU) networks?**
 
-* **Ethernet**: VXLAN with EVPN for VPC creation on DPUs
-* **E/W Ethernet (Spectrum-X)**: A CX-based firmware, named "DPA", which uses VXLAN on CX switches (as part of a future release)
-* **Infiniband**: UFM-based partition key (P_Key) assignment
-* **NVLink**: NMX-C-based partition management
+- **Ethernet**: VXLAN with EVPN for VPC creation on DPUs
+- **E/W Ethernet (Spectrum-X)**: A CX-based firmware, named "DPA", which uses VXLAN on CX switches (as part of a future release)
+- **Infiniband**: UFM-based partition key (P_Key) assignment
+- **NVLink**: NMX-C-based partition management
 
 DPUs enforce Ethernet isolation in hardware, UFM enforces InfiniBand isolation, and NMX-C enforces NVLink isolation--all coordinated by NICo.
 
@@ -103,7 +116,15 @@ NICo stores the owner of each instance in the form of a `tenant_organization_id`
 
 **When NICo is used to maintain tenancy enforcement for Ethernet and hosts are presented to customers as bare metal, is OOB isolation of GPU/CPU host BMC managed as well, or only the N/S overlay running on DPU?**
 
-NICo configures the host BMC to disable connectivity from within the host to the BMC (e.g. Dell iDrac Lockdown, disabling KCS, etc), and also prevents access from the host (via network) to the BMC of the host. Effectively, the user cannot access the BMC of the bare metal hosts. The BMC console (serial console) is accessed by a user through a NICo service called "SSH Console", which performs authentication and authorization to ensure that the user accessing the console is the current owner of the machine.
+NICo hardens host-local BMC access where the platform supports controls such as
+Dell iDRAC Lockdown or disabling KCS. Network isolation is topology-dependent:
+a dedicated OOB network can keep the tenant-facing host network from reaching
+the BMC, but the supported shared HostInband topology does not provide that
+separation by itself. Operators using shared HostInband must enforce the
+required BMC isolation in the fabric with ACLs, VRFs, private VLANs, or an
+equivalent control. The BMC console (serial console) is accessed through NICo's
+SSH Console service, which authenticates and authorizes the current instance
+owner.
 
 **Can NICo be used to manage a portion of a cluster?**
 

--- a/docs/getting-started/prerequisites/bmc-oob-setup.md
+++ b/docs/getting-started/prerequisites/bmc-oob-setup.md
@@ -4,14 +4,26 @@ This page covers the out-of-band (OOB) network configuration and BMC preparation
 
 ## OOB Network and DHCP Relay
 
-NICo discovers hosts when their BMCs send DHCP requests over the OOB network. The OOB network must be configured to forward these requests to the NICo DHCP service.
+NICo discovers hosts when their BMCs send DHCP requests through a
+NICo-managed physical network. A dedicated OOB network is the conventional and
+recommended topology, and it must forward these requests to the NICo DHCP
+service.
 
 **Requirements:**
-- A dedicated OOB management network connecting all host BMCs and DPU BMCs to the site controller
-- A DHCP relay configured on OOB switches, pointing to the NICo DHCP service IP (`NICo_DHCP_EXTERNAL`)
-- Separate OOB management connectivity for DPU BMCs
+
+- Network connectivity from every BMC to the site controller; normally this is
+  a dedicated OOB management network
+- A DHCP relay on every BMC-facing network, pointing to the NICo DHCP service
+  IP (`NICo_DHCP_EXTERNAL`)
+- `Underlay` connectivity for DPU BMC and DPU OOB interfaces
 
 NICo manages IP allocation for the management network—the OOB switches only need to relay DHCP traffic, not assign addresses. For the full switch configuration requirements, refer to the [Network Prerequisites](network.md) page.
+
+For a zero-DPU host, including a host whose DPU policy is `nic`, the **host
+BMC** may instead share one `HostInband` subnet/VLAN with the host OS NIC. This
+exception does not apply to a DPU BMC or DPU OOB interface. See
+[Shared HostInband for a Host BMC and Host OS](../../provisioning/ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os)
+for the allocation, relay, DNS-subdomain, and isolation requirements.
 
 ## BMC Credentials
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,7 +6,6 @@ Terms are grouped by domain rather than by repository. A reader looking up "Site
 
 This glossary focuses on NICo-specific concepts: terms that only make sense in the context of the NICo platform. Where a term has a general industry definition but carries additional NICo-specific meaning, this glossary explains the NICo-specific part.
 
-
 ## Platform Architecture
 
 ### NICo
@@ -148,11 +147,26 @@ VXLAN solves this by wrapping an Ethernet frame in a VXLAN packet identified by 
 
 ### Network Segments
 
-A NICo concept for defining IP address pools. Underlay segments are used for management traffic on the underlying physical network, such as DPU OOB and BMC addresses. Overlay segments are used for tenant-facing networks built on top of VXLAN. NICo assigns IPs from overlay segments to Hosts when creating instances.
+A NICo concept for defining IP address pools. Underlay segments are normally
+used for management traffic on the underlying physical network, such as DPU OOB
+and BMC addresses. A supported zero-DPU exception places the host BMC on
+HostInband instead. Overlay segments are used for tenant-facing networks built
+on top of VXLAN. NICo assigns IPs from overlay segments to Hosts when creating
+instances.
 
 ### HostInband Network Segment
 
-A network segment type for the underlay network that a zero-DPU host's NIC attaches to directly. Unlike overlay (tenant) segments, a HostInband segment describes a real underlay subnet, exists before any VPC, and may remain unassociated with a VPC. It is the only segment type a Flat VPC accepts. Operators declare HostInband segments in the API server configuration (or create them through the segment API); tenant instances on zero-DPU hosts attach to them automatically rather than drawing a link-net from a VpcPrefix.
+A network segment type for the underlay network that a zero-DPU host's NIC
+attaches to directly. Unlike overlay (tenant) segments, a HostInband segment
+describes a real underlay subnet, exists before any VPC, and may remain
+unassociated with a VPC. It is the only segment type a Flat VPC accepts. A
+zero-DPU host BMC may share the same physical subnet/VLAN and segment with the
+host OS, using a distinct address; this does not extend to DPU BMC or DPU OOB
+interfaces. Operators declare HostInband segments in the API server
+configuration (or create them through the segment API); tenant instances on
+zero-DPU hosts attach to them automatically rather than drawing a link-net from
+a VpcPrefix. See
+[Shared HostInband for a Host BMC and Host OS](provisioning/ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 ### Flat VPC
 
@@ -275,7 +289,12 @@ General reference: [Redfish](https://en.wikipedia.org/wiki/Redfish_(specificatio
 
 ### OOB
 
-Out of band. OOB management uses a path independent from the Host operating system, usually through BMC and DPU management networks, so NICo can discover, power-cycle, and repair machines even when the tenant OS is unavailable.
+Out of band. OOB management uses an endpoint independent from the Host operating
+system, usually through dedicated BMC and DPU management networks, so NICo can
+discover, power-cycle, and repair machines even when the tenant OS is
+unavailable. A host BMC can remain operationally out of band while sharing a
+HostInband L2 network with a zero-DPU host OS, but that topology lacks dedicated
+network isolation.
 
 ### IPMI
 

--- a/docs/manuals/vpc/flat_vpcs_zero_dpu.md
+++ b/docs/manuals/vpc/flat_vpcs_zero_dpu.md
@@ -197,8 +197,20 @@ prefix = "10.40.9.0/24"      # CIDR of the underlay subnet
 gateway = "10.40.9.1"        # usually the first usable address
 mtu = 1500
 reserve_first = 2            # addresses to skip before allocating
-# allocation_strategy = "dynamic"   # or "static" for reservation-only DHCP
+# allocation_strategy = "dynamic"   # or "reserved" for reservation-only DHCP
 ```
+
+<Note>
+A zero-DPU host's BMC and host OS NIC may share this physical subnet/VLAN. Give
+the two interfaces distinct addresses from **one** `HostInband` segment; do not
+declare an overlapping `Underlay` segment for the same prefix.
+`bmc_ip_address` is optional: the default allocation retains the BMC's first
+DHCP address for the machine-interface row's lifetime. This is also supported
+when `dpu_policy = "nic"`, but it does not place the DPU BMC or DPU OOB
+interface on HostInband. See
+[Shared HostInband for a Host BMC and Host OS](../../provisioning/ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os)
+for relay selection, DNS-subdomain, allocation, and isolation requirements.
+</Note>
 
 The same `[networks.<name>]` mechanism is used for `admin` and `underlay`
 segments; `hostinband` is the third config-declarable type. (Tenant segments are

--- a/docs/overview/what-is-nico.md
+++ b/docs/overview/what-is-nico.md
@@ -46,7 +46,12 @@ The green boxes in the architecture diagram are the services that NICo provides.
 **Site Controller services:**
 
 - **API Service (NICo Core)** — the central control plane and single source of truth. All other NICo services communicate with it over mTLS/gRPC. It is the only service that reads from and writes to PostgreSQL. Implements state machines for all managed resources (hosts, network segments, InfiniBand and NVLink partitions). Exposes a debug web UI on `/admin` for operators via HTTPS with OIDC authentication.
-- **DHCP Server** — responds to DHCP requests from all underlay devices (host BMCs, DPU BMCs, DPU OOB interfaces). Stateless — converts DHCP requests into gRPC calls to the API Service, which performs the actual IP address management.
+- **DHCP Server** — the central `nico-dhcp` service responds to relayed
+  requests from physical networks: conventional `Underlay` endpoints such as
+  host BMCs, DPU BMCs, and DPU OOB interfaces, plus zero-DPU host OS interfaces
+  and optionally their host BMCs on `HostInband`. It does not serve the local
+  overlay DHCP of a host with a managed DPU. The service is stateless and
+  forwards requests to the API Service for IP address management.
 - **PXE Service** — serves boot artifacts (iPXE scripts, cloud-init user-data, OS images) to managed hosts and DPUs over HTTP. Fetches the correct artifact for each host from the API Service via mTLS/gRPC.
 - **Hardware Health** — scrapes host and DPU BMCs via Redfish HTTPS for sensor data (temperature, fan speed, power, current) and firmware inventory. Exports metrics on a Prometheus `/metrics` endpoint and reports health alerts to the API Service via mTLS/gRPC.
 - **SSH Console Service** — maintains persistent SSH/IPMI connections to all host BMCs for serial console access. Streams console output to Loki for logging and provides live console access to tenants and administrators. Connects to the API Service via mTLS/gRPC.
@@ -61,7 +66,11 @@ The green boxes in the architecture diagram are the services that NICo provides.
 - **Scout** — a temporary agent that runs on the x86 host during discovery (before a tenant is assigned). Collects hardware inventory that cannot be determined out-of-band, runs machine validation tests, and reports to the API Service via mTLS/gRPC.
 - **DPU Agent** — a persistent daemon on the DPU (ARM OS). Polls the API Service every 30 seconds for desired network configuration, applies it via HBN (Host-Based Networking with Containerized Cumulus), and reports observed state back. Also manages DPU health checks, the Metadata Service, auto-updates, and hotfix deployment.
 - **Metadata Service (FMDS)** — runs on the DPU. Provides tenant workloads with instance metadata (machine ID, boot info) via a local HTTP API on the host-facing interface.
-- **DHCP (DPU)** — a per-host DHCP server running on the DPU. Handles all host DHCP requests locally so host DHCP traffic never reaches the underlay network. Configured by the DPU Agent.
+- **DHCP (DPU)** — a per-host DHCP server used when the host's DPU is managed
+  in DPU mode. It handles that host's requests locally so they do not reach the
+  physical underlay. A zero-DPU or DPU-NIC-mode host instead uses central
+  `nico-dhcp` on HostInband. See
+  [IP and Network Configuration](../provisioning/ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 ### Prerequisite Components
 

--- a/docs/provisioning/boot-interfaces-and-dpu-modes.md
+++ b/docs/provisioning/boot-interfaces-and-dpu-modes.md
@@ -32,11 +32,11 @@ A host's management network lives on one of a few segment types. Which one depen
 | Segment type | What it is | Used when |
 |---|---|---|
 | **Admin** | A **DPU-served overlay**. A DPU in DPU mode runs an on-board DHCP server and hands the host OS its admin IP over the overlay; the physical fabric never sees it (the DPU is a VTEP). | The host boots **through a DPU**. |
-| **HostInband** | An ordinary NIC straight to the physical fabric. The host gets its IP from central NICo DHCP (`nico-dhcp`), and the switch port is configured differently. This is also the segment Flat-VPC allocation keys off. | The host boots through a **plain NIC** — an integrated NIC, or a DPU in NIC mode. |
-| **Underlay** | The DPU's *own* IP (its loopback/VTEP) and the OOB/BMC management network. | Always, for DPU self-addressing and BMCs. |
+| **HostInband** | An ordinary NIC straight to the physical fabric. The host gets its IP from central NICo DHCP (`nico-dhcp`), and the switch port is configured differently. This is also the segment Flat-VPC allocation keys off. | The host boots through a **plain NIC** — an integrated NIC, or a DPU in NIC mode. A zero-DPU host BMC may share this segment with the host OS. |
+| **Underlay** | The DPU's *own* IP (its loopback/VTEP) and the conventional OOB/BMC management network. | For DPU self-addressing, DPU BMC/OOB, and the usual isolated host-BMC topology. |
 | **Tenant** | Tenant workload networks. | After a host is assigned to a tenant. |
 
-**Rule of thumb:** the host-OS segment follows the boot interface's mode — boot via DPU ⇒ **Admin**; boot via a plain NIC ⇒ **HostInband**. A non-DPU NIC is never on the Admin segment, because Admin *is* the DPU overlay.
+**Rule of thumb:** the host-OS segment follows the boot interface's mode — boot via DPU ⇒ **Admin**; boot via a plain NIC ⇒ **HostInband**. A non-DPU NIC is never on the Admin segment, because Admin *is* the DPU overlay. The supported shared host-BMC topology is documented in [IP and Network Configuration](ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 ### The boot (primary) interface
 
@@ -94,11 +94,17 @@ The optional `host_nics` array declares specifics for individual host NICs. Each
 |---|---|---|---|
 | `mac_address` | string (required) | The NIC's MAC address. | — |
 | `primary` | bool | Declare **this NIC** as the host's boot/primary interface. **At most one per host.** | For hosts whose effective DPU policy is `manage`, Site Explorer chooses among discovered DPU host PFs: it selects the lowest UEFI PCI path when every matching Redfish interface has one; otherwise it orders the DPUs by Redfish serial number and uses the first DPU's host PF. Hosts using `nic` or `ignore` do not get this fallback and must declare a primary HostInband NIC. |
-| `network_segment_type` | enum: `admin` / `underlay` / `host_inband` / `tenant` | The segment type this NIC's first DHCP lease should come from. Only needed to **disambiguate** when the NIC's DHCP relay matches more than one segment (nested/overlapping prefixes — see note below); otherwise the relay decides. | The relay's matching segment(s) stand. |
-| `fixed_ip` / `fixed_mask` / `fixed_gateway` | string | Static IP assignment for the NIC, pre-allocated at upload time. | Dynamic allocation. |
+| `network_segment_type` | enum: `admin` / `underlay` / `host_inband` / `tenant` | The expected segment type for this NIC's DHCP selection. It narrows candidates when a request carries multiple relay addresses and prevents a declaration from silently using the wrong segment type. | The relay's matching segment(s) stand. |
+| `fixed_ip` / `fixed_mask` / `fixed_gateway` | string | Static IP assignment for the NIC, materialized during expected-interface reconciliation. | Dynamic allocation. |
 | `nic_type` | string (legacy) | A free-form segment hint, **superseded by `network_segment_type`**. Kept for backward compatibility only. | — |
 
-> **What `network_segment_type` actually does.** A NIC's segment is normally determined by its DHCP relay: NICo picks the segment whose prefix *contains* the relay address. Where segment prefixes **nest or overlap** — for example a `/27` HostInband segment inside a `/24` underlay — one relay matches several segments. `network_segment_type` narrows that to the segment of the named type. If a relay maps unambiguously to one segment (the common case), this field is unnecessary.
+> **What `network_segment_type` actually does.** A NIC's segment is normally
+> determined by relay metadata: NICo finds the segment whose prefix contains
+> an IPv4 relay address; an exact configured DHCPv6 link-address takes
+> precedence. `network_segment_type` narrows multiple relay candidates to the
+> named type and acts as an expected-type check for explicit interface
+> policies. Network-segment prefixes cannot nest or overlap, so do not create
+> an Underlay and HostInband alias for one physical prefix.
 
 **Admin JSON** (an Expected Machine entry):
 
@@ -155,7 +161,9 @@ A plain server with one or more host NICs and no DPU. Declare `ignore` and mark 
 }
 ```
 
-The host boots from that NIC on HostInband and gets its IP from central NICo DHCP.
+The host boots from that NIC on HostInband and gets its IP from central NICo
+DHCP. Its host BMC may use the same physical subnet/VLAN and HostInband segment;
+see [Shared HostInband for a Host BMC and Host OS](ip-and-network-configuration.md#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 ### 3.3 DPU in NIC mode
 

--- a/docs/provisioning/ingesting-hosts.md
+++ b/docs/provisioning/ingesting-hosts.md
@@ -220,7 +220,17 @@ Some per-host settings are not exposed through the REST API or `nicocli`. To set
 - **`dpf_enabled`** (bool, default `true`): Enable or disable DPF provisioning for this host. When omitted or `true`, DPF is the provisioning path (requires `[dpf].enabled = true` in the site config — see [DPF setup](../manuals/dpf.md)). Set to `false` to keep a host on the deprecated iPXE path.
 - **`bmc_retain_credentials`** (bool): Skip BMC password rotation.
 - **`default_pause_ingestion_and_poweron`** (bool): Pause ingestion and power-on for this host.
-- **`bmc_ip_address`** (string): Static BMC IP, which pre-allocates a machine interface.
+- **`bmc_ip_address`** (string, optional): Fixed host-BMC address. When omitted,
+  the default allocation obtains an address through DHCP and retains it for the
+  machine-interface row's lifetime.
+- **`bmc_ip_allocation`** (`"Unspecified"` | `"Auto"` | `"Dynamic"` |
+  `"Fixed"` | `"Retained"`, default `"Auto"`): Allocation policy for the host
+  BMC in the whole-table JSON consumed by `em replace-all`. `Auto` resolves to
+  `Fixed` when `bmc_ip_address` is present and `Retained` otherwise;
+  `Unspecified` resets to `Auto`. The corresponding `em add` and `em patch`
+  flag values are lowercase. See
+  [OOB/BMC IP Addresses](ip-and-network-configuration.md#13-oobbmc-ip-addresses-static-vs-dynamic)
+  for field interactions and the supported shared HostInband topology.
 - **`host_lifecycle_profile.disable_lockdown`** (bool, default `false`): When `true`, the state machine does not lock down the host during lifecycle management, which suits automation workflows that keep lockdown disabled.
 
 Each manifest entry combines the required BMC credentials with any of these fields:

--- a/docs/provisioning/ip-and-network-configuration.md
+++ b/docs/provisioning/ip-and-network-configuration.md
@@ -12,7 +12,7 @@ Before configuring the items on this page, complete:
 
 - [Hardware](../getting-started/prerequisites/hardware.md) — server, DPU, and BMC inventory.
 - [Network Prerequisites](../getting-started/prerequisites/network.md) — VNI/ASN allocation, BGP/EVPN, route targets, and switch configuration.
-- [BMC and Out-of-Band Setup](../getting-started/prerequisites/bmc-oob-setup.md) — physical OOB connectivity and BMC credentials.
+- [BMC and Out-of-Band Setup](../getting-started/prerequisites/bmc-oob-setup.md) — physical BMC connectivity, DHCP relay, and credentials.
 
 This page assumes the underlay and overlay routing decisions described in those pages have already been made.
 
@@ -84,23 +84,57 @@ mtu = 1500
 
 ### 1.3 OOB/BMC IP Addresses (Static vs. Dynamic)
 
-Every host BMC, DPU BMC, and DPU OOB interface needs an IP on the OOB management network. NICo supports two modes for each BMC interface:
+Every host BMC, DPU BMC, and DPU OOB interface needs an address on a
+NICo-managed physical network. The usual deployment places these interfaces on
+an OOB network represented by an `Underlay` segment. A zero-DPU host's BMC can
+instead share one `HostInband` subnet/VLAN with the host OS; see
+[Shared HostInband for a Host BMC and Host OS](#15-shared-hostinband-for-a-host-bmc-and-host-os).
+That exception applies only to the host BMC. DPU BMC and DPU OOB interfaces
+remain on `Underlay` segments.
 
-| Mode | When IP is fixed | Configured by |
+The top-level Expected Machine fields `bmc_ip_address` and
+`bmc_ip_allocation` control host-BMC allocation.
+
+The `nico-admin-cli em add` and `em patch` flags accept policy values
+`unspecified`, `auto`, `dynamic`, `fixed`, and `retained`. The
+`bmc_ip_allocation` enum in the whole-table JSON consumed by `em replace-all`
+uses `Unspecified`, `Auto`, `Dynamic`, `Fixed`, and `Retained`. Direct gRPC
+clients use the corresponding `BMC_IP_ALLOCATION_TYPE_*` enum values.
+
+The table describes a newly created entry. On patch/update, omitting the policy
+preserves the stored effective policy rather than resetting it to Auto.
+Explicit `unspecified`/`Unspecified` resets the policy to Auto.
+
+| Expected Machine configuration | Effective policy | Behavior |
 |---|---|---|
-| **Dynamic** (default) | At first DHCP discovery, NICo allocates from the management network pool | `nico-dhcp` + the relevant `[networks.<name>]` block in `siteConfig` |
-| **Static** (predefined) | Set in `expected_machines.json` per host; `nico-dhcp` serves that exact address on first contact | `bmc_ip_address` field per machine |
+| Omit both fields, or select Auto without an address | **Retained** (default) | DHCP selects an address; Site Explorer makes it static for that machine-interface row's lifetime. |
+| Set `bmc_ip_address`; omit `bmc_ip_allocation` or select Auto | **Fixed** | NICo reserves and serves the configured address. |
+| Select Dynamic without an address | **Dynamic** | DHCP allocates a normal lease that can expire and change. |
+| Select Retained without an address | **Retained** | Same retained behavior as the default. |
+| Select Fixed with `bmc_ip_address` | **Fixed** | Same fixed behavior as inferred Auto. |
 
-Mixing modes within the same site is supported — each host can use whichever mode is convenient.
+Fixed requires `bmc_ip_address`. Dynamic and Retained reject a configured
+address. A retained address is not written back to the Expected Machine, so
+deleting the machine-interface row and re-ingesting the host can select a new
+address. Use a fixed address when it must survive interface recreation. Mixing
+policies within one site is supported.
 
 **Per node**, expect to allocate:
 
 - 1 IP for the host BMC.
 - For hosts with DPUs: 1 IP for the DPU ARM OS + 1 IP for the DPU BMC, per DPU.
 
-So a host with one DPU consumes three OOB addresses; a host without DPUs consumes one.
+In the conventional topology, a host with one DPU therefore consumes three OOB
+addresses. When a zero-DPU host BMC shares HostInband, its one BMC address is
+capacity on that HostInband segment rather than on a dedicated OOB segment.
 
-The OOB management network is declared as one or more NICo-managed network segments in `siteConfig` `[networks.<name>]` (block names are operator-chosen). Each segment carries its own prefix, gateway, and MTU. The OOB switches **must run a DHCP relay** pointed at the `nico-dhcp` LoadBalancer VIP — they must not assign addresses themselves. See [BMC and Out-of-Band Setup](../getting-started/prerequisites/bmc-oob-setup.md) for switch-side relay configuration.
+The conventional OOB management network is declared as one or more
+NICo-managed `Underlay` network segments in `siteConfig`
+`[networks.<name>]` blocks. Each segment carries its own prefix, gateway, and
+MTU. The switches **must run a DHCP relay** pointed at the `nico-dhcp`
+LoadBalancer VIP; they must not assign addresses themselves. See
+[BMC and Out-of-Band Setup](../getting-started/prerequisites/bmc-oob-setup.md)
+for switch-side relay configuration.
 
 ### 1.4 Predefined BMC IP Allocation for Expected Machines
 
@@ -122,11 +156,78 @@ For sites that require a stable, pre-known BMC IP per host (for example, to wire
 
 When `bmc_ip_address` is present:
 
-- The address pre-allocates a machine interface in `nico-api` at manifest upload time.
-- The first DHCP DISCOVER from that BMC's MAC is answered with the pre-allocated address — `nico-dhcp` does not draw from the dynamic OOB pool for that host.
-- The pre-allocated address must fall within a network segment prefix declared in `siteConfig` `[networks.<name>]`, and it must not overlap any range used by the dynamic pool for that segment.
+- NICo records the fixed intent with the Expected Machine. The API update path
+  and Site Explorer reconciliation materialize the machine-interface
+  reservation; the DHCP path also restores it if the interface was deleted.
+- The first DHCP DISCOVER from that BMC's MAC is answered with the reserved
+  address; `nico-dhcp` does not draw another address for that host.
+- For a BMC on a managed segment, the address must fall within that segment's
+  prefix. It can be inside the segment's otherwise-dynamic pool: once the
+  reservation exists, NICo's address-uniqueness constraint prevents the
+  dynamic allocator from assigning it to another interface.
+
+Changing `bmc_ip_address` does not replace an address already present on a live
+machine-interface row. Plan fixed addresses before ingestion, or use the
+machine-interface address workflow to replace existing state deliberately.
 
 For the full `expected_machines.json` schema and upload command, see [Ingesting Hosts](ingesting-hosts.md).
+
+### 1.5 Shared HostInband for a Host BMC and Host OS
+
+NICo supports connecting a zero-DPU host's BMC and host OS NIC to the same
+physical subnet/VLAN. This applies when the effective DPU policy is `ignore`
+(no managed DPU) or `nic` (an installed DPU operates as a plain NIC). Each
+interface receives its own address from one `HostInband` segment.
+
+Model the prefix **once**, as `HostInband`. Do not also declare an `Underlay`
+segment for the same prefix. NICo enforces globally non-overlapping network
+prefixes, so duplicate, nested, or partially overlapping segment definitions
+are rejected. Machine-interface addresses are also globally unique.
+
+The shared topology has these requirements:
+
+- Configure the `HostInband` segment with `allocation_strategy = "dynamic"`
+  (the default) whenever either interface needs an unreserved DHCP allocation.
+  A `reserved` segment answers only clients whose fixed reservation already
+  exists.
+- Associate the segment with a valid DNS subdomain. Config-seeded network
+  creation requires one selected initial forward domain and associates the
+  segment with it automatically; startup skips segment creation if no forward
+  domain can be selected unambiguously. A segment created at runtime with
+  `nico-admin-cli network-segment create` requires `--subdomain-id`.
+- Size the prefix for distinct host-BMC and host-OS addresses and set
+  `reserve_first` high enough to protect gateway or infrastructure addresses.
+- Declare every zero-DPU host data-NIC MAC on its Expected Machine in
+  `host_nics` (`interfaces` on newer admin-CLI surfaces). Mark one data NIC
+  `primary: true`; that NIC is the host's boot interface, and declarations with
+  more than one primary are rejected. Setting
+  `network_segment_type: "host_inband"` is recommended so DHCP fails on a
+  segment-type mismatch instead of using a relay candidate of another type.
+  See the [zero-DPU site setup](../manuals/vpc/flat_vpcs_zero_dpu.md#site-operations-operator).
+- Register the BMC MAC and credentials on the Expected Machine. Omit
+  `bmc_ip_address` to use the default Auto → Retained behavior, or set it
+  to an address in the HostInband prefix when the address must remain stable
+  after interface deletion and re-ingestion.
+- Configure the BMC-facing and host-NIC-facing switch ports so DHCP reaches
+  `nico-dhcp` with relay/link metadata that identifies the HostInband prefix.
+
+For IPv4, NICo selects candidate segments whose prefix contains the relay's
+`giaddr`; `giaddr` does not need to equal the configured gateway. For DHCPv6,
+an exact configured link-address match is authoritative, with prefix
+containment used as a fallback. VLAN ID, circuit ID, remote ID, and physical
+cabling do not themselves select a NICo segment, although the switch
+configuration determines which relay/link address NICo receives.
+
+This is a host-BMC exception only. Do not place a DPU BMC or DPU OOB interface
+on HostInband; those endpoints retain the conventional `Underlay` model.
+
+<Warning>
+Sharing the host-facing L2 network removes the network-level OOB isolation that
+a dedicated management VLAN provides. The BMC still operates independently of
+the host OS, but it can be reachable from the same physical network unless the
+fabric supplies ACL, VRF, private-VLAN, or equivalent isolation. Treat that as
+an explicit site security decision.
+</Warning>
 
 ---
 
@@ -136,8 +237,11 @@ For the full `expected_machines.json` schema and upload command, see [Ingesting 
 
 `nico-dhcp` is **not** a standalone DHCP daemon. It is a [Kea DHCP](https://www.isc.org/kea/) hooks library (`cdylib`) loaded into the upstream Kea v4 server inside the `nico-dhcp` container. Every DHCPDISCOVER/REQUEST is intercepted by the hooks library and forwarded to `nico-api` over mTLS gRPC (the `discover_dhcp` RPC). `nico-api` decides what address to lease based on:
 
-- Whether the source MAC matches an entry in `expected_machines` with a `bmc_ip_address` (predefined allocation).
-- Otherwise, whether the source MAC is a known host/DPU BMC or DPU OOB interface — `nico-api` consults the corresponding network segment pool and allocates the next free address.
+- Whether the source MAC has a fixed reservation, including an Expected Machine
+  `bmc_ip_address`.
+- Otherwise, whether the source MAC is a known host/DPU BMC, DPU OOB interface,
+  or declared host NIC. `nico-api` uses relay metadata to select a network
+  segment and applies that interface's allocation policy.
 - Vendor class (option 60) determines whether the client is a PXE/iPXE/BlueField boot client, which influences the boot options returned.
 
 The hook callouts (`lease4_select` and `lease4_renew`) overwrite the lease that Kea would have selected — `yiaddr`, valid lifetime, and DHCP options are replaced with the values `nico-api` produced, and the hook can return `SKIP` to cancel Kea's own lease assignment and database write. The result is written to Kea's memfile (`kea-leases4.csv`), but the authoritative record lives in `nico-api`. From an operator perspective this means:
@@ -148,31 +252,51 @@ The hook callouts (`lease4_select` and `lease4_renew`) overwrite the lease that 
 
 ### 2.2 DHCP Configuration for Host BMCs, DPU BMCs, and DPU OOB Addresses
 
-All three interface types are served by the same `nico-dhcp` instance. What distinguishes them at the wire level is which network segment the relayed request lands in — `nico-api` selects the segment by matching the relay's `giaddr` against the `gateway` field of each `[networks.<name>]` block in `siteConfig`:
+All physical interface types are served by the same `nico-dhcp` instance. For
+IPv4, `nico-api` selects candidate segments by finding the configured prefix
+that contains the relay's `giaddr`. The configured `gateway` is not the segment
+selector. DHCPv6 uses an exact configured link-address match when present and
+otherwise falls back to prefix containment.
 
 | Interface | DHCP request originates on | Served from |
 |---|---|---|
-| Host BMC | OOB management network | The `[networks.<name>]` segment whose `gateway` matches the OOB relay's `giaddr` |
-| DPU BMC | OOB management network | Same as host BMC — both attach to whichever management segment matches `giaddr` |
-| DPU OOB (ARM OS) | OOB management network | A management segment matched the same way; may share the BMC segment or be a distinct segment, depending on how `[networks.<name>]` blocks are declared |
+| Host BMC | Usually the OOB management network; optionally the shared zero-DPU host network | The relay-selected `Underlay`, or the supported shared `HostInband` segment |
+| DPU BMC | OOB management network | The relay-selected `Underlay` segment |
+| DPU OOB (ARM OS) | OOB management network | The relay-selected `Underlay` segment; it can share the DPU BMC segment or use another Underlay prefix |
+| Zero-DPU host OS NIC | Host-facing physical network | The relay-selected `HostInband` segment |
 
 Each `[networks.<name>]` block declares:
 
 | Field | Purpose |
 |---|---|
-| `type` | Segment classification: `admin` for the admin segment, `underlay` for routed/per-TOR segments. NICo uses this to decide which segment is eligible for which interface role. |
+| `type` | Segment classification: `admin`, `underlay`, or `hostinband`. Tenant segments are not config-declarable. |
 | `prefix` | The IPv4 CIDR for the segment. |
-| `gateway` | The address the OOB DHCP relay sets as `giaddr`; `nico-api` matches the inbound request to this segment by comparing `giaddr` against this field. |
+| `gateway` | The IPv4 gateway associated with the prefix and returned in network configuration. It does not have to equal `giaddr`. |
 | `mtu` | MTU advertised to clients on this segment. |
 | `reserve_first` | Number of leading addresses in the prefix to hold back from the dynamic pool (typically 5 — covers the network address, gateway, broadcast, plus headroom). |
+| `allocation_strategy` | `dynamic` (default) permits pool allocation and fixed reservations; `reserved` serves only pre-existing reservations. |
 
-A real site declares one `admin` segment and one `underlay` segment per OOB-facing TOR; the OOB management network is fragmented across as many `underlay` blocks as there are TORs.
+A conventional DPU site declares an `admin` segment and one or more `underlay`
+segments covering its OOB relay scopes. A zero-DPU or DPU-NIC-mode site also
+declares the required `hostinband` segments. The host BMC can use one of those
+HostInband segments as described in [section 1.5](#15-shared-hostinband-for-a-host-bmc-and-host-os).
 
 To configure these flows:
 
-1. **Declare the management network segments in `siteConfig`.** Use the schema above. The admin segment is not a singleton — a site may declare multiple admin/management segments, and the host's IP is sourced from whichever segment's `gateway` matches the relay's `giaddr` on the inbound DHCP request.
-2. **Configure the DHCP relay on every OOB switch** to forward DHCP traffic to the `nico-dhcp` LoadBalancer VIP (the IP assigned to the `nico-dhcp` service by MetalLB in [Quick Start Step 3h](../getting-started/quick-start.md#3h-assign-service-vips)). The relay must be on the same L2 broadcast domain as the BMCs and DPUs it serves.
-3. **For predefined IPs**, upload `expected_machines.json` with `bmc_ip_address` populated **before** the host first powers on. Uploading after the BMC has already received a dynamic lease will not retroactively change its IP — release the lease (`nico-admin-cli ... em ...`) and power-cycle the BMC.
+1. **Declare the physical network segments in `siteConfig`.** Use the schema
+   above. Each relay/link address must fall within the intended segment prefix,
+   except a separately configured DHCPv6 link-address can select its segment by
+   exact match.
+2. **Configure the DHCP relay on every applicable switch** to forward DHCP
+   traffic to the `nico-dhcp` LoadBalancer VIP (the IP assigned to the
+   `nico-dhcp` service by MetalLB in
+   [Quick Start Step 3h](../getting-started/quick-start.md#3h-assign-service-vips)).
+   The relay-facing interface must cover the L2 broadcast domain whose clients
+   it serves. In the shared HostInband topology, both the host BMC and host OS
+   paths must produce relay metadata for that HostInband prefix.
+3. **For predefined IPs**, upload `expected_machines.json` with
+   `bmc_ip_address` populated before ingestion. Adding it after the BMC has an
+   address does not overwrite the live machine-interface row.
 4. **Set `dhcp_servers`** in `siteConfig` to the list of DHCP server IPs reachable from bare-metal hosts. This list is informational and is passed through to agents; it does not change how `nico-dhcp` itself serves leases. May be left as `[]`.
 5. **Set `ntp_servers`** in `siteConfig` to your NTP server IPs. NICo uses this list to configure BMC NTP through Redfish during pre-ingestion, includes it in `DiscoverDhcp` responses, and passes it to DPU agents so their DHCP server advertises the same NTP servers to managed hosts.
 
@@ -215,7 +339,10 @@ kubectl exec -n nico-system deploy/nico-dhcp -- \
 
 The lease IP and MAC should match what `nico-api` allocated. The lease file is authoritative for Kea only — `nico-api` is the system of record.
 
-**From the OOB relay's vantage point**, verify packets are being forwarded by checking the switch's relay statistics (`show ip dhcp relay statistics` on Cumulus / SONiC). DISCOVER packets sent should match OFFER packets received.
+**On the switch relaying the tested BMC or HostInband client**, verify packets
+are being forwarded by checking its relay statistics (`show ip dhcp relay
+statistics` on Cumulus / SONiC). DISCOVER packets sent should match OFFER
+packets received.
 
 For DHCP-related stuck states during ingestion, see the [WaitingForNetworkConfig playbook](../playbooks/stuck_objects/waiting_for_network_config.md).
 
@@ -295,7 +422,11 @@ The required A records (shown for `.nico`; substitute `.nico` if your binaries u
 
 One additional `.nico` hostname, `socks.nico`, is hardcoded into the DPU agent as the SOCKS5 outbound proxy for DPU extension-service pods. Add a corresponding A record only if your environment runs a SOCKS5 proxy for that purpose; it is not part of every NICo deployment. For per-endpoint detail (consumers, in-cluster addresses, hardcode locations, and the `unbound`-vs-other-resolver guidance), see [`deploy/DNS.md`](https://github.com/NVIDIA/infra-controller/blob/main/deploy/DNS.md). That file is the canonical endpoint reference; the table above is the operator-facing summary.
 
-> **Note:** Neither `.nico` nor `.nico` is a publicly registered TLD. Both are used exclusively on the isolated OOB management network. Configure the recursive resolver to treat the chosen TLD as locally authoritative and **not** forward queries to upstream public resolvers.
+> **Note:** The `.nico` service zone is private and is not a publicly
+> registered TLD. It can be served on the conventional isolated OOB network or
+> on a supported shared HostInband network. Configure the recursive resolver to
+> treat it as locally authoritative and **not** forward it to upstream public
+> resolvers.
 
 #### Bootstrap CA Selection and Network Trust
 
@@ -373,7 +504,9 @@ kubectl get svc nico-dns -n nico-system
 dig +short @<nico-dns-vip> <initial_domain_name>
 ```
 
-**From an OOB-network vantage point** (a host BMC console, a managed host's BMC web UI shell, or any client on the OOB network), confirm the service zone resolves:
+**From a managed physical-network vantage point** (a host BMC console, a
+managed host's BMC web UI shell, or another client on its network), confirm the
+service zone resolves:
 
 ```bash
 for name in nico-api.nico nico-pxe.nico nico-static-pxe.nico \
@@ -405,17 +538,20 @@ A successful external recursion via `unbound.nico` confirms both DHCP option 6 (
 
 Use this checklist across the Day 0 rollout. Complete the configuration and
 infrastructure prerequisites before powering on the first host BMC. Complete
-the runtime checks as the first DPUs come online and before expanding the
-rollout to the rest of the fleet:
+the runtime checks as the first managed endpoints come online and before
+expanding the rollout to the rest of the fleet:
 
 - [ ] `siteConfig` `[pools.lo-ip]` and `[pools.vpc-dpu-lo]` populated with non-empty ranges.
 - [ ] `siteConfig` `[networks.admin]` has non-empty `prefix` and `gateway`.
-- [ ] One or more OOB network segments declared in `[networks.<name>]`, sized for `1 + 2 × DPU_count` IPs per host.
+- [ ] Each required physical segment declared in `[networks.<name>]`:
+      `underlay` capacity for every DPU BMC/OOB pair and isolated host BMC, and
+      `hostinband` capacity for every shared zero-DPU host BMC and host OS NIC.
 - [ ] `initial_domain_name` set in `siteConfig`.
 - [ ] `dhcp_servers` set in `siteConfig` (or left as `[]`).
 - [ ] `ntp_servers` set in `siteConfig`, or the legacy `nico-ntp` DNS / `nico-dhcp` `nico-ntpserver` fallback is intentionally configured.
 - [ ] `expected_machines.json` uploaded for every host; `bmc_ip_address` populated for any host that needs a predefined BMC IP.
-- [ ] OOB switches configured with a DHCP relay pointing to the `nico-dhcp` LoadBalancer VIP.
+- [ ] Every BMC- or zero-DPU-host-facing network configured with a DHCP relay
+      pointing to the `nico-dhcp` LoadBalancer VIP.
 - [ ] LoadBalancer VIPs assigned for `nico-api`, `nico-dhcp`, `nico-pxe`, `nico-dns` (one per replica), `nico-ssh-console-rs`, and `unbound`.
 - [ ] `unbound`'s `local_data.conf` ConfigMap contains A records for `nico-api`, `nico-pxe`, `nico-static-pxe`, `unbound`, and `otel-receiver` in the `.nico` zone; include `nico-ntp` pointing at your operator-supplied NTP server if you use the legacy fallback.
 - [ ] `nico-dns` zone for `initial_domain_name` is delegated from upstream DNS, or `unbound` forwards the zone to the `nico-dns` VIPs.
@@ -434,7 +570,7 @@ When every item is checked, proceed to [Ingesting Hosts](ingesting-hosts.md).
 ## Related Pages
 
 - [Network Prerequisites](../getting-started/prerequisites/network.md) — VNI/ASN/IPv4 sizing, BGP/EVPN, route targets, switch configuration.
-- [BMC and Out-of-Band Setup](../getting-started/prerequisites/bmc-oob-setup.md) — OOB physical network, DHCP relay setup, BMC credentials.
+- [BMC and Out-of-Band Setup](../getting-started/prerequisites/bmc-oob-setup.md) — physical management networks, DHCP relay setup, BMC credentials.
 - [IP Resource Pools](../manuals/networking/ip_resource_pools.md) — `lo-ip` / `vpc-dpu-lo` semantics, sizing, `admin-cli resource-pool grow`.
 - [Quick Start Guide](../getting-started/quick-start.md) — the install flow that consumes the configuration described here.
 - [Reference Installation](../getting-started/installation-options/reference-install.md) — pointers to the manual, manifest-level install and troubleshooting references.


### PR DESCRIPTION
Documents the intentional zero-DPU/NIC-mode topology in which the host BMC and host OS NIC use distinct addresses on one physical subnet/VLAN represented by a single `HostInband` segment.

The current implementation explicitly supports this path, but the documentation described dedicated Underlay/OOB networking as universal. That made a valid small-site configuration look unsupported and left several related contracts—relay selection, default BMC retention, prefix overlap, and isolation ownership—unclear or contradictory.

This change adds one canonical operator contract and reconciles the zero-DPU, boot-mode, ingestion, OOB prerequisite, FAQ, glossary, and architecture pages. It also makes clear that DPU BMC/OOB interfaces remain on Underlay and that a shared HostInband topology gives up dedicated network-level OOB isolation.

## Related issues

- Follow-up documentation for #1978
- Complements the broader ExpectedMachine interface reference in #4418

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)
