### PR TITLE
feat(ci): Switch jobs to Enterprise runners, utilize all runner groups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,10 +41,17 @@ env:
   GIT_SUBMODULE_STRATEGY: recursive
 
 
+# Runner sizes are chosen from measured job durations on a full main run:
+# `cpu4` under `2m`, `cpu8` `2m`-`10m`, `cpu16` `10m`-`20m`, `cpu32` over `20m`.
+#
+# One label per job on purpose. A label already schedules onto any free runner in
+# its scale set, and `runs-on` intersects several labels rather than unioning
+# them, so listing two sizes would demand a runner carrying both and match
+# nothing. Moving a job between sizes is a one-line edit here.
 jobs:
   changes:
     name: Detect Core CI Gate
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     outputs:
       run_core_ci: ${{ steps.gate.outputs.run_core_ci }}
       non_rest_changed: ${{ steps.non-rest-changes.outputs.non_rest }}
@@ -743,7 +750,7 @@ jobs:
       image_tag: ${{ needs.prepare.outputs.version }}
       additional_tags: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/amd64
-      runner: linux-amd64-cpu16
+      runner: linux-amd64-cpu32
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
@@ -779,7 +786,7 @@ jobs:
       image_tag: ${{ needs.prepare.outputs.version }}
       additional_tags: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide-aarch64:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/arm64
-      runner: linux-arm64-cpu16
+      runner: linux-arm64-cpu32
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
       tag_latest: false
@@ -909,7 +916,7 @@ jobs:
       - prepare
       - build-container-x86_64
       - build-runtime-container-x86_64
-    runs-on: linux-amd64-cpu16
+    runs-on: linux-amd64-cpu32
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1029,7 +1036,7 @@ jobs:
       additional_tags: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64:${{ needs.prepare.outputs.major_minor_version }}-latest
       build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.build_artifacts_container_x86_64_ref }}"}'
       platforms: linux/amd64
-      runner: linux-amd64-cpu4
+      runner: linux-amd64-cpu8
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
@@ -1053,7 +1060,7 @@ jobs:
       additional_tags: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64:${{ needs.prepare.outputs.major_minor_version }}-latest
       build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }}"}'
       platforms: linux/arm64
-      runner: linux-arm64-cpu4
+      runner: linux-arm64-cpu8
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
     secrets: inherit
@@ -1119,7 +1126,7 @@ jobs:
       build_type: boot
       cargo_make_task: build-boot-artifacts-x86-host-ci
       build_container: ${{ needs.prepare.outputs.build_artifacts_container_x86_64_ref }}
-      runner: linux-amd64-cpu4
+      runner: linux-amd64-cpu8
       version: ${{ needs.prepare.outputs.version }}
       use_container: true
       inject_extras: true
@@ -1166,7 +1173,7 @@ jobs:
       build_type: package
       cargo_make_task: package-scout-aarch64-ci
       build_container: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }}
-      runner: linux-arm64-cpu16
+      runner: linux-arm64-cpu8
       version: ${{ needs.prepare.outputs.version }}
       use_container: true
       # Not for injection (`inject_extras` stays false, so the extras are
@@ -1197,7 +1204,7 @@ jobs:
       build_type: ephemeral
       cargo_make_task: create-ephemeral-image-x86-host-ci
       version: ${{ needs.prepare.outputs.version }}
-      runner: linux-amd64-cpu8
+      runner: linux-amd64-cpu16
       use_container: false
       sa_enablement: true
       inject_extras: true
@@ -1261,7 +1268,7 @@ jobs:
       # steps (FROM alpine + COPY only), so no QEMU is needed. Single-arch on PR
       # so the image can load to the daemon.
       platforms: ${{ needs.prepare.outputs.publish_images == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-      runner: linux-amd64-cpu4
+      runner: linux-amd64-cpu8
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
@@ -1301,7 +1308,7 @@ jobs:
       # Dockerfile has no RUN steps (FROM alpine + COPY only), so no QEMU is
       # needed. Single-arch on PR so the image can load to the daemon.
       platforms: ${{ needs.prepare.outputs.publish_images == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-      runner: linux-amd64-cpu4
+      runner: linux-amd64-cpu16
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
@@ -1529,7 +1536,7 @@ jobs:
     needs:
       - changes
     if: ${{ contains(github.ref, 'pull-request/') }}
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1548,7 +1555,7 @@ jobs:
     needs:
       - changes
     if: ${{ needs.changes.outputs.run_core_ci == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1614,7 +1621,7 @@ jobs:
       - prepare
       - build-container-x86_64
     if: ${{ !failure() && !cancelled() && needs.prepare.outputs.source_files_changed == 'true' && contains(github.ref, 'pull-request/') }}
-    runs-on: linux-amd64-cpu16
+    runs-on: linux-amd64-cpu32
     container:
       image: ${{ needs.prepare.outputs.lint_container_ref }}
       credentials:
@@ -2250,7 +2257,7 @@ jobs:
   # Branch protection should require only this gate and `rest-ci-pass`.
   core-ci-pass:
     name: core-ci-pass
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     if: always()
     needs:
       # Detection and preparation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     steps:
       - name: Create redirect site
         run: |
@@ -58,7 +58,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -43,7 +43,7 @@ jobs:
     if: >-
       (github.event_name == 'push' && contains(github.ref, 'refs/heads/pull-request/'))
       || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -48,7 +48,7 @@ jobs:
     if: >-
       (github.event_name == 'push' && contains(github.ref, 'refs/heads/pull-request/'))
       || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   # Build workflow can "succeed" with collect skipped (fork PR); then no artifact.
   artifact-present:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     if: github.event.workflow_run.conclusion == 'success'
     outputs:
       exists: ${{ steps.check.outputs.exists }}
@@ -58,7 +58,7 @@ jobs:
 
   preview:
     needs: artifact-present
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     if: needs.artifact-present.outputs.exists == 'true'
     steps:
       - name: Download fern sources and metadata

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -50,7 +50,7 @@ jobs:
     # and those record no targets. Checked here so the common case costs one
     # skipped job rather than an artifact listing.
     if: ${{ github.event.workflow_run.head_branch == 'main' }}
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     outputs:
       targets: ${{ steps.matrix.outputs.targets }}
     steps:

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   validate:
     name: Validate pull request description
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 5
     steps:
       - name: Publish pr-description status

--- a/.github/workflows/rest-build-binaries.yml
+++ b/.github/workflows/rest-build-binaries.yml
@@ -126,7 +126,7 @@ jobs:
       ${{ !cancelled() &&
           (needs.resolve-manual-identity.result == 'success' ||
            needs.resolve-manual-identity.result == 'skipped') }}
-    runs-on: ${{ inputs.runner || 'linux-amd64-cpu4' }}
+    runs-on: ${{ inputs.runner || 'linux-amd64-cpu8' }}
     timeout-minutes: 30
     env:
       TARGET: ${{ matrix.target }}

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -323,13 +323,12 @@ jobs:
       NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
       NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
-  # GitHub-hosted on purpose. This job only writes markdown to the step summary,
-  # but as the last thing in the run it was spending 75 seconds waiting for a
-  # self-hosted runner to do three seconds of work. The service builds above
-  # still use `inputs.runner`.
+  # Was GitHub-hosted because this markdown-only job spent `75s` waiting for an
+  # enterprise runner to do `3s` of work. Hosted waits now reach `~8m`, and being
+  # last in the run means a hosted queue holds the whole run open.
   build-summary:
     name: Build Summary
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     needs:
       - build-nico-rest-api
       - build-nico-rest-db

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -18,10 +18,13 @@ concurrency:
   group: ${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') && format('rest-pr-{0}', github.ref_name) || format('rest-run-{0}-{1}', github.run_id, github.run_attempt) }}
   cancel-in-progress: ${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') }}
 
+# Runner sizes are chosen from measured job durations on a full REST run:
+# `cpu4` under `2m`, `cpu8` `2m`-`10m`. Nothing in this lane reaches `cpu16`.
+# See the note in `ci.yaml` for why each job names exactly one label.
 jobs:
   changes:
     name: Detect REST CI Gate
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     outputs:
       run_rest_ci: ${{ steps.gate.outputs.run_rest_ci }}
       rest_api_changed: ${{ steps.filter.outputs.rest_api }}
@@ -87,12 +90,11 @@ jobs:
     if: ${{ needs.changes.outputs.run_rest_ci == 'true' }}
     uses: ./.github/workflows/rest-prepare-build-info.yml
     with:
-      # GitHub-hosted: the job is a checkout and a `git describe`, but on the
-      # self-hosted pool it waited 91 seconds for a runner to do 24 seconds of
-      # work — and everything downstream waits on it. `changes` above already
-      # does a full-depth checkout of this repo on a hosted runner in ten
-      # seconds.
-      runner: ubuntu-latest
+      # Was GitHub-hosted to dodge a measured `91s` enterprise queue wait for
+      # `24s` of work. That trade has inverted: hosted `ubuntu-latest` waits now
+      # reach `~8m` while the enterprise pool stays clear, and everything
+      # downstream waits on this job.
+      runner: linux-amd64-cpu4
 
   lint-and-test:
     name: Lint and Test
@@ -251,7 +253,7 @@ jobs:
   # this required check.
   rest-ci-pass:
     name: rest-ci-pass
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     if: always()
     needs:
       - changes

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -62,7 +62,7 @@ jobs:
 
   lint-go:
     name: Lint Go
-    runs-on: linux-amd64-cpu4
+    runs-on: linux-amd64-cpu8
     continue-on-error: false
     steps:
       - name: Checkout code
@@ -113,7 +113,7 @@ jobs:
 
   openapi-breaking-changes:
     name: OpenAPI Breaking Changes Check
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -248,7 +248,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.module }})
-    runs-on: linux-amd64-cpu4
+    runs-on: linux-amd64-cpu8
     continue-on-error: false
     strategy:
       fail-fast: false


### PR DESCRIPTION
Every job on `ubuntu-latest` compete for GitHub's shared hosted pool. These are turning out to be unpredictable and can hold CI pipelines in queue for arbitrary length of time (averaging `~8m` today) while the Enterprise pool ran clear.
Enterprise runners groups are also not properly utilized. `test-release-container-services` takes `29.2m` on `cpu16` while `build-release-artifacts-arm-host` did `12.9m` of work on `cpu4`.

This PR moves the last 17 GitHub share hosted pool jobs onto Enterprise runners. It also sizes every job from measured durations on a full `main` run, so the four longest builds get `cpu32` and the under-provisioned ones move up a tier.

> [!NOTE]
> The hosted jobs relied on tooling preinstalled in the `ubuntu-latest` image. The Enterprise runners have `python3`, `jq`, `gh`, and Docker on their image, so none of them needed an extra setup step.

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

## Additional Notes
* Fern, Pages, and `pr-description` now reach npm and external APIs from inside the
  NVIDIA network for the first time, so we need to check those runs after merge
* `cpu32` has the tightest instance ceiling of the four sizes, so we need to watch the
  heavy builds for queueing