### PR TITLE
fix(ib): keep removed memberships from coming back in UFM

### DIFF
--- a/crates/api-core/src/tests/ib_fabric_monitor.rs
+++ b/crates/api-core/src/tests/ib_fabric_monitor.rs
@@ -15,11 +15,205 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
+use carbide_ib_fabric::IbFabricMonitor;
 use carbide_ib_fabric::config::IBFabricConfig;
+use carbide_ib_fabric::ib::{Filter, IBFabric, IBFabricManager};
 use carbide_instrument::testing::MetricsCapture;
+use carbide_uuid::instance::InstanceId;
+use db::ib_membership_cleanup_intent::IbMembershipCleanupIntent;
+use model::ib::{DEFAULT_IB_FABRIC_NAME, IBMtu, IBNetwork, IBQosConf, IBRateLimit, IBServiceLevel};
+use model::ib_partition::PartitionKey;
+use model::machine::ManagedHostState;
 
 use crate::tests::common;
-use crate::tests::common::api_fixtures::{TestEnvOverrides, create_managed_host};
+use crate::tests::common::api_fixtures::ib_partition::{DEFAULT_TENANT, create_ib_partition};
+use crate::tests::common::api_fixtures::instance::create_instance_with_ib_config;
+use crate::tests::common::api_fixtures::{
+    TestEnv, TestEnvOverrides, TestManagedHost, create_managed_host,
+};
+
+fn cleanup_intent(fabric: &str, pkey: PartitionKey, guid: &str) -> IbMembershipCleanupIntent {
+    IbMembershipCleanupIntent {
+        fabric: fabric.to_string(),
+        pkey,
+        guid: guid.to_string(),
+    }
+}
+
+async fn insert_cleanup_intent<'e>(
+    db: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
+    intent: &IbMembershipCleanupIntent,
+) {
+    sqlx::query(
+        "INSERT INTO ib_membership_cleanup_intents (fabric, pkey, guid) VALUES ($1, $2, $3)",
+    )
+    .bind(intent.fabric.clone())
+    .bind(i32::from(u16::from(intent.pkey)))
+    .bind(intent.guid.clone())
+    .execute(db)
+    .await
+    .unwrap();
+}
+
+async fn insert_cleanup_intent_range(
+    pool: &sqlx::PgPool,
+    pkey: PartitionKey,
+    range: std::ops::RangeInclusive<usize>,
+) {
+    let mut txn = pool.begin().await.unwrap();
+    for index in range {
+        insert_cleanup_intent(
+            txn.as_mut(),
+            &cleanup_intent(
+                DEFAULT_IB_FABRIC_NAME,
+                pkey,
+                &format!("cleanup-page-guid-{index:03}"),
+            ),
+        )
+        .await;
+    }
+    txn.commit().await.unwrap();
+}
+
+async fn cleanup_intents(pool: &sqlx::PgPool) -> Vec<IbMembershipCleanupIntent> {
+    db::ib_membership_cleanup_intent::list_batch(pool, None, None)
+        .await
+        .unwrap()
+}
+
+async fn cleanup_intent_exists(pool: &sqlx::PgPool, intent: &IbMembershipCleanupIntent) -> bool {
+    sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM ib_membership_cleanup_intents \
+         WHERE fabric = $1 AND pkey = $2 AND guid = $3)",
+    )
+    .bind(&intent.fabric)
+    .bind(i32::from(u16::from(intent.pkey)))
+    .bind(&intent.guid)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn wait_until_query_is_blocked_by(
+    pool: &sqlx::PgPool,
+    blocker_pid: i32,
+    query_fragment: &str,
+) {
+    for _ in 0..300 {
+        let blocked: bool = sqlx::query_scalar(
+            r#"
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_stat_activity AS activity
+                    WHERE activity.datname = current_database()
+                      AND activity.wait_event_type = 'Lock'
+                      AND $1 = ANY(pg_blocking_pids(activity.pid))
+                      AND activity.query ILIKE '%' || $2 || '%'
+                )
+            "#,
+        )
+        .bind(blocker_pid)
+        .bind(query_fragment)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        if blocked {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    panic!("query containing {query_fragment:?} never waited for database lock");
+}
+
+fn ib_network(pkey: PartitionKey) -> IBNetwork {
+    IBNetwork {
+        name: "cleanup-test".to_string(),
+        pkey: pkey.into(),
+        ipoib: false,
+        qos_conf: Some(IBQosConf {
+            mtu: IBMtu::default(),
+            service_level: IBServiceLevel::default(),
+            rate_limit: IBRateLimit::default(),
+        }),
+        associated_guids: None,
+        membership: None,
+    }
+}
+
+async fn membership_is_present(fabric: &Arc<dyn IBFabric>, pkey: PartitionKey, guid: &str) -> bool {
+    fabric
+        .find_ib_port(Some(Filter {
+            guids: None,
+            pkey: Some(pkey.into()),
+            state: None,
+        }))
+        .await
+        .unwrap()
+        .iter()
+        .any(|port| port.guid == guid)
+}
+
+fn restarted_monitor(env: &TestEnv) -> IbFabricMonitor {
+    IbFabricMonitor::new(
+        env.pool.clone(),
+        env.config.ib_fabrics.clone(),
+        env.test_meter.meter(),
+        env.ib_fabric_manager.clone(),
+        env.config.host_health,
+        env.api.work_lock_manager_handle.clone(),
+    )
+}
+
+async fn cleanup_test_env(pool: sqlx::PgPool) -> TestEnv {
+    let mut config = common::api_fixtures::get_config();
+    config.ib_config = Some(IBFabricConfig {
+        enabled: true,
+        ..Default::default()
+    });
+    common::api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config),
+    )
+    .await
+}
+
+async fn live_ib_instance(
+    pool: sqlx::PgPool,
+) -> (TestEnv, TestManagedHost, InstanceId, PartitionKey, String) {
+    let env = cleanup_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let (partition_id, partition) = create_ib_partition(
+        &env,
+        "cleanup-live-partition".to_string(),
+        DEFAULT_TENANT.to_string(),
+    )
+    .await;
+    let pkey = partition.status.as_ref().unwrap().pkey().parse().unwrap();
+    let managed_host = create_managed_host(&env).await;
+    let ib_config = rpc::forge::InstanceInfinibandConfig {
+        ib_interfaces: vec![rpc::forge::InstanceIbInterfaceConfig {
+            function_type: rpc::forge::InterfaceFunctionType::Physical as i32,
+            virtual_function_id: None,
+            ib_partition_id: Some(partition_id),
+            device: "MT2910 Family [ConnectX-7]".to_string(),
+            vendor: None,
+            device_instance: 0,
+        }],
+    };
+    let (instance_id, guid) = {
+        let (test_instance, instance) =
+            create_instance_with_ib_config(&env, &managed_host, ib_config, segment_id).await;
+        let guid = instance.status().infiniband().ib_interfaces[0]
+            .guid()
+            .to_string();
+        (test_instance.id, guid)
+    };
+
+    (env, managed_host, instance_id, pkey, guid)
+}
 
 #[crate::sqlx_test]
 async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
@@ -111,6 +305,286 @@ async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     );
 
     Ok(())
+}
+
+#[crate::sqlx_test]
+async fn cleanup_intent_repairs_a_delayed_bind_after_monitor_restart(pool: sqlx::PgPool) {
+    let env = cleanup_test_env(pool.clone()).await;
+    let pkey = PartitionKey::try_from(0x101).unwrap();
+    let guid = "cleanup-restart-guid";
+    let intent = cleanup_intent(DEFAULT_IB_FABRIC_NAME, pkey, guid);
+    let mock = env.ib_fabric_manager.get_mock_manager();
+    mock.register_port(guid.to_string());
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.to_string()])
+        .await
+        .unwrap();
+    insert_cleanup_intent(&pool, &intent).await;
+
+    let first_monitor = restarted_monitor(&env);
+    assert_eq!(first_monitor.run_single_iteration().await.unwrap(), 1);
+    assert!(!membership_is_present(&fabric, pkey, guid).await);
+
+    // Simulate an older bind finishing after the first monitor's unbind, then
+    // replace the monitor object while retaining its database state.
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.to_string()])
+        .await
+        .unwrap();
+    drop(first_monitor);
+    let restarted_monitor = restarted_monitor(&env);
+    assert_eq!(restarted_monitor.run_single_iteration().await.unwrap(), 1);
+
+    assert!(!membership_is_present(&fabric, pkey, guid).await);
+    assert_eq!(cleanup_intents(&pool).await, vec![intent]);
+}
+
+#[crate::sqlx_test]
+async fn cleanup_intent_cursor_revisits_low_keys_despite_higher_arrivals(pool: sqlx::PgPool) {
+    let env = cleanup_test_env(pool.clone()).await;
+    let pkey = PartitionKey::try_from(0x101).unwrap();
+    let low = cleanup_intent(DEFAULT_IB_FABRIC_NAME, pkey, "cleanup-page-guid-000");
+    let boundary = cleanup_intent(DEFAULT_IB_FABRIC_NAME, pkey, "cleanup-page-guid-100");
+    insert_cleanup_intent_range(&pool, pkey, 0..=100).await;
+
+    let mock = env.ib_fabric_manager.get_mock_manager();
+    mock.register_port(low.guid.clone());
+    mock.register_port(boundary.guid.clone());
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .bind_ib_ports(
+            ib_network(pkey),
+            vec![low.guid.clone(), boundary.guid.clone()],
+        )
+        .await
+        .unwrap();
+    let monitor = restarted_monitor(&env);
+
+    assert_eq!(monitor.run_single_iteration().await.unwrap(), 1);
+    assert!(!membership_is_present(&fabric, pkey, &low.guid).await);
+    assert!(membership_is_present(&fabric, pkey, &boundary.guid).await);
+
+    // Rebind the low tuple, then keep adding at least a full page above the
+    // first cycle's fixed high-water mark. The second pass finishes that
+    // finite cycle; the third must wrap and revisit the low tuple rather than
+    // chase the growing tail.
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![low.guid.clone()])
+        .await
+        .unwrap();
+    insert_cleanup_intent_range(&pool, pkey, 101..=200).await;
+    assert_eq!(monitor.run_single_iteration().await.unwrap(), 1);
+    assert!(membership_is_present(&fabric, pkey, &low.guid).await);
+    assert!(!membership_is_present(&fabric, pkey, &boundary.guid).await);
+
+    insert_cleanup_intent_range(&pool, pkey, 201..=300).await;
+    assert_eq!(monitor.run_single_iteration().await.unwrap(), 1);
+    assert!(!membership_is_present(&fabric, pkey, &low.guid).await);
+    assert!(cleanup_intent_exists(&pool, &low).await);
+    assert!(cleanup_intent_exists(&pool, &boundary).await);
+}
+
+#[crate::sqlx_test]
+async fn cleanup_intent_retries_after_ufm_failure(pool: sqlx::PgPool) {
+    let env = cleanup_test_env(pool.clone()).await;
+    let pkey = PartitionKey::try_from(0x101).unwrap();
+    let guid = "cleanup-retry-guid";
+    let intent = cleanup_intent(DEFAULT_IB_FABRIC_NAME, pkey, guid);
+    let mock = env.ib_fabric_manager.get_mock_manager();
+    mock.register_port(guid.to_string());
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .bind_ib_ports(ib_network(pkey), vec![guid.to_string()])
+        .await
+        .unwrap();
+    insert_cleanup_intent(&pool, &intent).await;
+    mock.set_unbind_failure(true);
+
+    let failure_metrics = MetricsCapture::start();
+    assert_eq!(
+        restarted_monitor(&env)
+            .run_single_iteration()
+            .await
+            .unwrap(),
+        0
+    );
+    let failed_unbinds = failure_metrics.counter_delta(
+        "carbide_ib_monitor_ufm_changes_applied_total",
+        &[
+            ("fabric", DEFAULT_IB_FABRIC_NAME),
+            ("operation", "unbind_guid_from_pkey"),
+            ("status", "error"),
+        ],
+    );
+    assert!(
+        failed_unbinds >= 1.0,
+        "expected the cleanup failure Event, observed {failed_unbinds}"
+    );
+    drop(failure_metrics);
+    assert!(membership_is_present(&fabric, pkey, guid).await);
+    assert_eq!(cleanup_intents(&pool).await, vec![intent.clone()]);
+
+    mock.set_unbind_failure(false);
+    assert_eq!(
+        restarted_monitor(&env)
+            .run_single_iteration()
+            .await
+            .unwrap(),
+        1
+    );
+    assert!(!membership_is_present(&fabric, pkey, guid).await);
+    assert_eq!(cleanup_intents(&pool).await, vec![intent]);
+}
+
+#[crate::sqlx_test]
+async fn cleanup_intent_live_presence_supersedes_only_the_exact_tuple(pool: sqlx::PgPool) {
+    let (env, _, _, pkey, guid) = live_ib_instance(pool.clone()).await;
+
+    let exact = cleanup_intent(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    let retained = [
+        cleanup_intent("other-fabric", pkey, &guid),
+        cleanup_intent(
+            DEFAULT_IB_FABRIC_NAME,
+            PartitionKey::try_from(u16::from(pkey) + 1).unwrap(),
+            &guid,
+        ),
+        cleanup_intent(DEFAULT_IB_FABRIC_NAME, pkey, "other-guid"),
+    ];
+    for intent in std::iter::once(&exact).chain(&retained) {
+        insert_cleanup_intent(&pool, intent).await;
+    }
+
+    restarted_monitor(&env)
+        .run_single_iteration()
+        .await
+        .unwrap();
+
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+    assert_eq!(
+        cleanup_intents(&pool).await,
+        vec![
+            retained[2].clone(),
+            retained[1].clone(),
+            retained[0].clone(),
+        ]
+    );
+}
+
+#[crate::sqlx_test]
+async fn cleanup_intent_rechecks_force_deletion_after_machine_lock_wait(pool: sqlx::PgPool) {
+    let (env, managed_host, _, pkey, guid) = live_ib_instance(pool.clone()).await;
+    let intent = cleanup_intent(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    fabric
+        .unbind_ib_ports(pkey.into(), vec![guid.clone()])
+        .await
+        .unwrap();
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    insert_cleanup_intent(&pool, &intent).await;
+
+    // Hold the intent table until the monitor has read the live Instance and
+    // recorded the now-missing membership. This fixes the stale candidate and
+    // its ordinary bind action before ForceDeletion begins.
+    let mut scan_gate = pool.begin().await.unwrap();
+    let scan_gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(scan_gate.as_mut())
+        .await
+        .unwrap();
+    sqlx::query("LOCK TABLE ib_membership_cleanup_intents IN ACCESS EXCLUSIVE MODE")
+        .execute(scan_gate.as_mut())
+        .await
+        .unwrap();
+
+    let monitor = restarted_monitor(&env);
+    let monitor_iteration = tokio::spawn(async move { monitor.run_single_iteration().await });
+    wait_until_query_is_blocked_by(&pool, scan_gate_pid, "ib_membership_cleanup_intents").await;
+
+    let mut force_deletion = pool.begin().await.unwrap();
+    let force_deletion_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(force_deletion.as_mut())
+        .await
+        .unwrap();
+    let machine = managed_host.host().db_machine(&mut force_deletion).await;
+    db::machine::advance(
+        &machine,
+        force_deletion.as_mut(),
+        &ManagedHostState::ForceDeletion,
+        None,
+    )
+    .await
+    .unwrap();
+
+    scan_gate.commit().await.unwrap();
+    wait_until_query_is_blocked_by(&pool, force_deletion_pid, "SELECT row_to_json").await;
+    force_deletion.commit().await.unwrap();
+
+    assert_eq!(monitor_iteration.await.unwrap().unwrap(), 0);
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(cleanup_intent_exists(&pool, &intent).await);
+
+    assert_eq!(
+        restarted_monitor(&env)
+            .run_single_iteration()
+            .await
+            .unwrap(),
+        0
+    );
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(cleanup_intent_exists(&pool, &intent).await);
+}
+
+#[crate::sqlx_test]
+async fn cleanup_intent_deleted_instance_cannot_supersede_desired_absence(pool: sqlx::PgPool) {
+    let (env, _, instance_id, pkey, guid) = live_ib_instance(pool.clone()).await;
+    let intent = cleanup_intent(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
+    let fabric = env
+        .ib_fabric_manager
+        .new_client(DEFAULT_IB_FABRIC_NAME)
+        .await
+        .unwrap();
+    assert!(membership_is_present(&fabric, pkey, &guid).await);
+
+    // Normal release first marks the Instance deleted. Its Machine can remain
+    // Assigned on the tenant network with the old IB config while termination
+    // proceeds, but that stale config must not supersede desired absence.
+    let mut txn = pool.begin().await.unwrap();
+    db::instance::mark_as_deleted(instance_id, txn.as_mut())
+        .await
+        .unwrap();
+    insert_cleanup_intent(txn.as_mut(), &intent).await;
+    txn.commit().await.unwrap();
+
+    let monitor = restarted_monitor(&env);
+    monitor.run_single_iteration().await.unwrap();
+
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(cleanup_intent_exists(&pool, &intent).await);
+
+    assert_eq!(monitor.run_single_iteration().await.unwrap(), 0);
+    assert!(!membership_is_present(&fabric, pkey, &guid).await);
+    assert!(cleanup_intent_exists(&pool, &intent).await);
 }
 
 /// Test that IB port down detection sets PreventAllocations alert

--- a/crates/api-db/migrations/20260819000315_ib_membership_cleanup_intents.sql
+++ b/crates/api-db/migrations/20260819000315_ib_membership_cleanup_intents.sql
@@ -1,0 +1,8 @@
+-- Keep exact desired-absence memberships after their Machine and Instance are
+-- gone and after successful unbinds. Only later live presence supersedes them.
+CREATE TABLE ib_membership_cleanup_intents (
+    fabric TEXT NOT NULL,
+    pkey INTEGER NOT NULL CHECK (pkey BETWEEN 0 AND 32767),
+    guid TEXT NOT NULL,
+    PRIMARY KEY (fabric, pkey, guid)
+);

--- a/crates/api-db/src/ib_membership_cleanup_intent.rs
+++ b/crates/api-db/src/ib_membership_cleanup_intent.rs
@@ -23,16 +23,25 @@ use sqlx::PgConnection;
 use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct IbMembershipCleanupIntent {
-    fabric: String,
-    pkey: PartitionKey,
-    guid: String,
+/// One exact IB membership that must remain absent until matching live state
+/// supersedes it.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct IbMembershipCleanupIntent {
+    /// Fabric containing the membership.
+    pub fabric: String,
+    /// Partition key containing the membership.
+    pub pkey: PartitionKey,
+    /// Port GUID associated with the partition key.
+    pub guid: String,
 }
 
 const LIST_BATCH_SIZE: i64 = 100;
 
 /// Ensures that an exact desired-absence membership is durable.
+// Persistence intentionally landed one PR before its force-delete publisher.
+// Remove this exception when https://github.com/NVIDIA/infra-controller/issues/5139
+// calls the helper.
+#[allow(dead_code)]
 async fn create(txn: &mut PgConnection, intent: &IbMembershipCleanupIntent) -> DatabaseResult<()> {
     const QUERY: &str = "INSERT INTO ib_membership_cleanup_intents (fabric, pkey, guid)
         VALUES ($1, $2, $3)
@@ -48,50 +57,82 @@ async fn create(txn: &mut PgConnection, intent: &IbMembershipCleanupIntent) -> D
         .map_err(|e| DatabaseError::query(QUERY, e))
 }
 
-/// Returns the next bounded batch in deterministic tuple order.
-async fn list_batch(
+/// Returns at most 100 rows in deterministic tuple order, after the exclusive
+/// `after` tuple and at or below the inclusive `through` tuple. `None` starts
+/// before the first tuple for `after` and leaves the upper bound open for
+/// `through`.
+pub async fn list_batch(
     db: impl DbReader<'_>,
     after: Option<&IbMembershipCleanupIntent>,
+    through: Option<&IbMembershipCleanupIntent>,
 ) -> DatabaseResult<Vec<IbMembershipCleanupIntent>> {
     const QUERY: &str = "SELECT fabric, pkey, guid
         FROM ib_membership_cleanup_intents
-        WHERE $1::text IS NULL
-           OR (fabric, pkey, guid) > ($1::text, $2::integer, $3::text)
+        WHERE ($1::text IS NULL
+               OR (fabric, pkey, guid) > ($1::text, $2::integer, $3::text))
+          AND ($4::text IS NULL
+               OR (fabric, pkey, guid) <= ($4::text, $5::integer, $6::text))
         ORDER BY fabric, pkey, guid
-        LIMIT $4";
+        LIMIT $7";
 
     let after_fabric = after.map(|intent| intent.fabric.as_str());
     let after_pkey = after.map(|intent| i32::from(u16::from(intent.pkey)));
     let after_guid = after.map(|intent| intent.guid.as_str());
+    let through_fabric = through.map(|intent| intent.fabric.as_str());
+    let through_pkey = through.map(|intent| i32::from(u16::from(intent.pkey)));
+    let through_guid = through.map(|intent| intent.guid.as_str());
 
     let rows: Vec<(String, i32, String)> = sqlx::query_as(QUERY)
         .bind(after_fabric)
         .bind(after_pkey)
         .bind(after_guid)
+        .bind(through_fabric)
+        .bind(through_pkey)
+        .bind(through_guid)
         .bind(LIST_BATCH_SIZE)
         .fetch_all(db)
         .await
         .map_err(|e| DatabaseError::query(QUERY, e))?;
 
-    rows.into_iter()
-        .map(|(fabric, pkey, guid)| {
-            let pkey = u16::try_from(pkey)
-                .ok()
-                .and_then(|pkey| PartitionKey::try_from(pkey).ok())
-                .ok_or_else(|| {
-                    DatabaseError::internal(format!(
-                        "ib_membership_cleanup_intents contains invalid pkey {pkey}"
-                    ))
-                })?;
-            Ok(IbMembershipCleanupIntent { fabric, pkey, guid })
-        })
-        .collect()
+    rows.into_iter().map(intent_from_row).collect()
+}
+
+/// Returns the greatest tuple stored when the query runs, for a finite keyset
+/// scan. `None` means the table is empty.
+pub async fn high_water_mark(
+    db: impl DbReader<'_>,
+) -> DatabaseResult<Option<IbMembershipCleanupIntent>> {
+    const QUERY: &str = "SELECT fabric, pkey, guid
+        FROM ib_membership_cleanup_intents
+        ORDER BY fabric DESC, pkey DESC, guid DESC
+        LIMIT 1";
+
+    sqlx::query_as(QUERY)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))?
+        .map(intent_from_row)
+        .transpose()
+}
+
+fn intent_from_row(
+    (fabric, pkey, guid): (String, i32, String),
+) -> DatabaseResult<IbMembershipCleanupIntent> {
+    let pkey = u16::try_from(pkey)
+        .ok()
+        .and_then(|pkey| PartitionKey::try_from(pkey).ok())
+        .ok_or_else(|| {
+            DatabaseError::internal(format!(
+                "ib_membership_cleanup_intents contains invalid pkey {pkey}"
+            ))
+        })?;
+    Ok(IbMembershipCleanupIntent { fabric, pkey, guid })
 }
 
 /// Supersedes exactly one intent when the same membership becomes desired live
 /// state. Callers must establish that live presence in the same serialized
 /// transition; a successful cleanup alone must never remove the intent.
-async fn supersede_for_live_presence(
+pub async fn supersede_for_live_presence(
     txn: &mut PgConnection,
     intent: &IbMembershipCleanupIntent,
 ) -> DatabaseResult<bool> {
@@ -113,7 +154,8 @@ mod tests {
     use model::ib_partition::PartitionKey;
 
     use super::{
-        IbMembershipCleanupIntent, LIST_BATCH_SIZE, create, list_batch, supersede_for_live_presence,
+        IbMembershipCleanupIntent, LIST_BATCH_SIZE, create, high_water_mark, list_batch,
+        supersede_for_live_presence,
     };
 
     fn intent(fabric: &str, pkey: u16, guid: &str) -> IbMembershipCleanupIntent {
@@ -146,7 +188,10 @@ mod tests {
         create(txn.as_mut(), &intent).await.unwrap();
         create(txn.as_mut(), &intent).await.unwrap();
 
-        assert_eq!(list_batch(txn.as_mut(), None).await.unwrap(), vec![intent]);
+        assert_eq!(
+            list_batch(txn.as_mut(), None, None).await.unwrap(),
+            vec![intent]
+        );
     }
 
     #[crate::sqlx_test]
@@ -182,7 +227,7 @@ mod tests {
             .unwrap();
         txn.commit().await.unwrap();
 
-        assert_eq!(list_batch(&pool, None).await.unwrap(), vec![intent]);
+        assert_eq!(list_batch(&pool, None, None).await.unwrap(), vec![intent]);
     }
 
     #[crate::sqlx_test]
@@ -210,7 +255,7 @@ mod tests {
         );
 
         assert_eq!(
-            list_batch(txn.as_mut(), None).await.unwrap(),
+            list_batch(txn.as_mut(), None, None).await.unwrap(),
             vec![
                 retained[2].clone(),
                 retained[1].clone(),
@@ -231,9 +276,25 @@ mod tests {
             .unwrap();
         }
 
-        let first = list_batch(txn.as_mut(), None).await.unwrap();
+        let high_water = high_water_mark(txn.as_mut()).await.unwrap().unwrap();
+        assert_eq!(high_water, intent("fabric-a", 0x101, "guid-100"));
+        let first = list_batch(txn.as_mut(), None, Some(&high_water))
+            .await
+            .unwrap();
         assert_eq!(first.len(), LIST_BATCH_SIZE as usize);
-        let second = list_batch(txn.as_mut(), first.last()).await.unwrap();
+        let second = list_batch(txn.as_mut(), first.last(), Some(&high_water))
+            .await
+            .unwrap();
         assert_eq!(second, vec![intent("fabric-a", 0x101, "guid-100")]);
+
+        create(txn.as_mut(), &intent("fabric-a", 0x101, "guid-101"))
+            .await
+            .unwrap();
+        assert!(
+            list_batch(txn.as_mut(), second.last(), Some(&high_water))
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/crates/api-db/src/ib_membership_cleanup_intent.rs
+++ b/crates/api-db/src/ib_membership_cleanup_intent.rs
@@ -1,0 +1,239 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Durable requests to remove exact GUID memberships from an IB fabric.
+
+use model::ib_partition::PartitionKey;
+use sqlx::PgConnection;
+
+use crate::db_read::DbReader;
+use crate::{DatabaseError, DatabaseResult};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct IbMembershipCleanupIntent {
+    fabric: String,
+    pkey: PartitionKey,
+    guid: String,
+}
+
+const LIST_BATCH_SIZE: i64 = 100;
+
+/// Ensures that an exact desired-absence membership is durable.
+async fn create(txn: &mut PgConnection, intent: &IbMembershipCleanupIntent) -> DatabaseResult<()> {
+    const QUERY: &str = "INSERT INTO ib_membership_cleanup_intents (fabric, pkey, guid)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (fabric, pkey, guid) DO NOTHING";
+
+    sqlx::query(QUERY)
+        .bind(&intent.fabric)
+        .bind(i32::from(u16::from(intent.pkey)))
+        .bind(&intent.guid)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+/// Returns the next bounded batch in deterministic tuple order.
+async fn list_batch(
+    db: impl DbReader<'_>,
+    after: Option<&IbMembershipCleanupIntent>,
+) -> DatabaseResult<Vec<IbMembershipCleanupIntent>> {
+    const QUERY: &str = "SELECT fabric, pkey, guid
+        FROM ib_membership_cleanup_intents
+        WHERE $1::text IS NULL
+           OR (fabric, pkey, guid) > ($1::text, $2::integer, $3::text)
+        ORDER BY fabric, pkey, guid
+        LIMIT $4";
+
+    let after_fabric = after.map(|intent| intent.fabric.as_str());
+    let after_pkey = after.map(|intent| i32::from(u16::from(intent.pkey)));
+    let after_guid = after.map(|intent| intent.guid.as_str());
+
+    let rows: Vec<(String, i32, String)> = sqlx::query_as(QUERY)
+        .bind(after_fabric)
+        .bind(after_pkey)
+        .bind(after_guid)
+        .bind(LIST_BATCH_SIZE)
+        .fetch_all(db)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))?;
+
+    rows.into_iter()
+        .map(|(fabric, pkey, guid)| {
+            let pkey = u16::try_from(pkey)
+                .ok()
+                .and_then(|pkey| PartitionKey::try_from(pkey).ok())
+                .ok_or_else(|| {
+                    DatabaseError::internal(format!(
+                        "ib_membership_cleanup_intents contains invalid pkey {pkey}"
+                    ))
+                })?;
+            Ok(IbMembershipCleanupIntent { fabric, pkey, guid })
+        })
+        .collect()
+}
+
+/// Supersedes exactly one intent when the same membership becomes desired live
+/// state. Callers must establish that live presence in the same serialized
+/// transition; a successful cleanup alone must never remove the intent.
+async fn supersede_for_live_presence(
+    txn: &mut PgConnection,
+    intent: &IbMembershipCleanupIntent,
+) -> DatabaseResult<bool> {
+    const QUERY: &str = "DELETE FROM ib_membership_cleanup_intents
+        WHERE fabric = $1 AND pkey = $2 AND guid = $3";
+
+    sqlx::query(QUERY)
+        .bind(&intent.fabric)
+        .bind(i32::from(u16::from(intent.pkey)))
+        .bind(&intent.guid)
+        .execute(txn)
+        .await
+        .map(|result| result.rows_affected() == 1)
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use model::ib_partition::PartitionKey;
+
+    use super::{
+        IbMembershipCleanupIntent, LIST_BATCH_SIZE, create, list_batch, supersede_for_live_presence,
+    };
+
+    fn intent(fabric: &str, pkey: u16, guid: &str) -> IbMembershipCleanupIntent {
+        IbMembershipCleanupIntent {
+            fabric: fabric.to_string(),
+            pkey: PartitionKey::try_from(pkey).expect("test PKey must be valid"),
+            guid: guid.to_string(),
+        }
+    }
+
+    #[crate::sqlx_test]
+    async fn migration_enforces_the_pkey_range(pool: sqlx::PgPool) {
+        for (pkey, should_succeed) in [(0, true), (32767, true), (-1, false), (32768, false)] {
+            let result = sqlx::query(
+                "INSERT INTO ib_membership_cleanup_intents (fabric, pkey, guid) \
+                 VALUES ('fabric-a', $1, $1::text)",
+            )
+            .bind(pkey)
+            .execute(&pool)
+            .await;
+            assert_eq!(result.is_ok(), should_succeed, "PKey: {pkey}");
+        }
+    }
+
+    #[crate::sqlx_test]
+    async fn repeated_create_is_idempotent(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        let intent = intent("fabric-a", 0x101, "guid-a");
+
+        create(txn.as_mut(), &intent).await.unwrap();
+        create(txn.as_mut(), &intent).await.unwrap();
+
+        assert_eq!(list_batch(txn.as_mut(), None).await.unwrap(), vec![intent]);
+    }
+
+    #[crate::sqlx_test]
+    async fn intent_outlives_its_machine_and_instance(pool: sqlx::PgPool) {
+        let intent = intent("fabric-a", 0x101, "guid-a");
+        let mut txn = pool.begin().await.unwrap();
+        sqlx::query(
+            "INSERT INTO machines (id, dpf, infiniband_status_observation) \
+             VALUES ( \
+                 'cleanup-intent-machine', \
+                 '{}'::jsonb, \
+                 '{\"observed_at\":\"2026-08-19T00:00:00Z\",\"ib_interfaces\":[{\"guid\":\"guid-a\",\"lid\":1,\"fabric_id\":\"fabric-a\",\"associated_pkeys\":[\"0x101\"],\"associated_partition_ids\":[]}]}'::jsonb \
+             )",
+        )
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO instances (machine_id) VALUES ('cleanup-intent-machine')")
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        create(txn.as_mut(), &intent).await.unwrap();
+        txn.commit().await.unwrap();
+
+        let mut txn = pool.begin().await.unwrap();
+        sqlx::query("DELETE FROM instances WHERE machine_id = 'cleanup-intent-machine'")
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM machines WHERE id = 'cleanup-intent-machine'")
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        assert_eq!(list_batch(&pool, None).await.unwrap(), vec![intent]);
+    }
+
+    #[crate::sqlx_test]
+    async fn live_presence_supersedes_only_the_exact_tuple(pool: sqlx::PgPool) {
+        let exact = intent("fabric-a", 0x101, "guid-a");
+        let retained = [
+            intent("fabric-b", 0x101, "guid-a"),
+            intent("fabric-a", 0x102, "guid-a"),
+            intent("fabric-a", 0x101, "guid-b"),
+        ];
+        let mut txn = pool.begin().await.unwrap();
+        for candidate in std::iter::once(&exact).chain(&retained) {
+            create(txn.as_mut(), candidate).await.unwrap();
+        }
+
+        assert!(
+            supersede_for_live_presence(txn.as_mut(), &exact)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !supersede_for_live_presence(txn.as_mut(), &exact)
+                .await
+                .unwrap()
+        );
+
+        assert_eq!(
+            list_batch(txn.as_mut(), None).await.unwrap(),
+            vec![
+                retained[2].clone(),
+                retained[1].clone(),
+                retained[0].clone()
+            ],
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn list_uses_bounded_keyset_batches(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        for index in 0..=LIST_BATCH_SIZE {
+            create(
+                txn.as_mut(),
+                &intent("fabric-a", 0x101, &format!("guid-{index:03}")),
+            )
+            .await
+            .unwrap();
+        }
+
+        let first = list_batch(txn.as_mut(), None).await.unwrap();
+        assert_eq!(first.len(), LIST_BATCH_SIZE as usize);
+        let second = list_batch(txn.as_mut(), first.last()).await.unwrap();
+        assert_eq!(second, vec![intent("fabric-a", 0x101, "guid-100")]);
+    }
+}

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -46,6 +46,10 @@ pub mod health_report;
 pub mod host_firmware_config;
 pub mod host_machine_update;
 pub mod host_naming;
+// Persistence lands before its IB reconciliation callers as the small first
+// slice of https://github.com/NVIDIA/infra-controller/issues/5138.
+#[allow(dead_code)]
+mod ib_membership_cleanup_intent;
 pub mod ib_partition;
 pub mod instance;
 pub mod instance_address;

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -46,10 +46,7 @@ pub mod health_report;
 pub mod host_firmware_config;
 pub mod host_machine_update;
 pub mod host_naming;
-// Persistence lands before its IB reconciliation callers as the small first
-// slice of https://github.com/NVIDIA/infra-controller/issues/5138.
-#[allow(dead_code)]
-mod ib_membership_cleanup_intent;
+pub mod ib_membership_cleanup_intent;
 pub mod ib_partition;
 pub mod instance;
 pub mod instance_address;

--- a/crates/ib-fabric/src/ib/mock.rs
+++ b/crates/ib-fabric/src/ib/mock.rs
@@ -40,6 +40,8 @@ struct State {
     subnets_to_ports: HashMap<u16, HashSet<String>>,
     /// The next LID that will be used
     next_lid: i32,
+    /// Whether unbind requests fail without changing fabric state.
+    fail_unbind: bool,
 }
 
 #[async_trait]
@@ -228,6 +230,12 @@ impl IBFabric for MockIBFabric {
             .lock()
             .map_err(|_| IbError::IBFabricError("state lock".to_string()))?;
 
+        if state.fail_unbind {
+            return Err(IbError::IBFabricError(
+                "simulated UFM unbind failure".to_string(),
+            ));
+        }
+
         for id in &ids {
             if !state.ports.contains_key(id) {
                 return Err(IbError::IBFabricError(format!(
@@ -292,6 +300,7 @@ impl MockIBFabric {
                 ports: HashMap::new(),
                 subnets_to_ports: HashMap::new(),
                 next_lid: 1,
+                fail_unbind: false,
             })),
         }
     }
@@ -338,6 +347,11 @@ impl MockIBFabric {
         let mut state: std::sync::MutexGuard<'_, State> = self.state.lock().unwrap();
         let partition = state.subnets.get_mut(&DEFAULT_PARTITION_KEY).unwrap();
         partition.membership = Some(membership);
+    }
+
+    /// Configures whether unbind requests fail without changing fabric state.
+    pub fn set_unbind_failure(&self, fail: bool) {
+        self.state.lock().unwrap().fail_unbind = fail;
     }
 }
 

--- a/crates/ib-fabric/src/lib.rs
+++ b/crates/ib-fabric/src/lib.rs
@@ -22,7 +22,7 @@ mod metrics;
 
 use std::collections::{HashMap, HashSet};
 use std::io;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
 
 use carbide_instrument::emit;
@@ -30,6 +30,7 @@ use carbide_utils::periodic_timer::PeriodicTimer;
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::machine::MachineId;
 use chrono::Utc;
+use db::ib_membership_cleanup_intent::IbMembershipCleanupIntent;
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{self, DatabaseError};
 use health_report::HealthReportApplyMode;
@@ -44,7 +45,9 @@ use model::machine::infiniband::{
     MachineIbInterfaceStatusObservation, MachineInfinibandStatusObservation,
 };
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostStateSnapshot};
+use model::machine::{
+    HostHealthConfig, LoadSnapshotOptions, ManagedHostState, ManagedHostStateSnapshot,
+};
 use sqlx::{PgConnection, PgPool};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -55,6 +58,12 @@ use crate::errors::{IbError, IbResult};
 use crate::ib::{GetPartitionOptions, IBFabric, IBFabricManager, IBFabricManagerType};
 
 type SkuInactiveDevicesCache = HashMap<String, Option<HashSet<u32>>>;
+
+#[derive(Clone, Debug, Default)]
+struct CleanupIntentScan {
+    after: Option<IbMembershipCleanupIntent>,
+    high_water: Option<IbMembershipCleanupIntent>,
+}
 
 /// `IbFabricMonitor` monitors the health of all connected InfiniBand fabrics in periodic intervals
 pub struct IbFabricMonitor {
@@ -67,6 +76,7 @@ pub struct IbFabricMonitor {
 
     host_health: HostHealthConfig,
     work_lock_manager_handle: WorkLockManagerHandle,
+    cleanup_intent_scan: Mutex<CleanupIntentScan>,
 }
 
 impl IbFabricMonitor {
@@ -105,6 +115,7 @@ impl IbFabricMonitor {
             fabric_manager,
             host_health,
             work_lock_manager_handle,
+            cleanup_intent_scan: Mutex::new(CleanupIntentScan::default()),
         }
     }
 
@@ -310,6 +321,7 @@ impl IbFabricMonitor {
             });
 
         let mut reports = Vec::new();
+        let mut live_desired_memberships = HashMap::new();
         for (machine, snapshot) in &snapshots {
             let mut snapshot_clone = snapshot.clone();
             match record_machine_infiniband_status_observation(
@@ -324,6 +336,9 @@ impl IbFabricMonitor {
             .await
             {
                 Ok(report) => {
+                    for membership in &report.live_desired_memberships {
+                        live_desired_memberships.insert(membership.clone(), *machine);
+                    }
                     reports.push(report);
                 }
                 Err(e) => {
@@ -335,7 +350,15 @@ impl IbFabricMonitor {
             }
         }
 
-        let num_changes = apply_guid_pkey_changes(
+        let cleanup_changes = self
+            .reconcile_cleanup_intents(
+                &mut fabric_clients,
+                &fabric_data,
+                &live_desired_memberships,
+                &mut reports,
+            )
+            .await?;
+        let membership_changes = apply_guid_pkey_changes(
             self.fabric_manager.as_ref(),
             &mut fabric_clients,
             &self.fabrics,
@@ -345,7 +368,210 @@ impl IbFabricMonitor {
         )
         .await?;
 
+        Ok(cleanup_changes + membership_changes)
+    }
+
+    /// Reconciles one keyset page per iteration. Each finite scan fixes its
+    /// high-water tuple before the first page, so continuous higher-key
+    /// arrivals wait for the next scan instead of postponing its wrap.
+    async fn reconcile_cleanup_intents(
+        &self,
+        fabric_clients: &mut HashMap<String, Arc<dyn IBFabric>>,
+        data_by_fabric: &HashMap<String, FabricData>,
+        live_desired_memberships: &HashMap<IbMembershipCleanupIntent, MachineId>,
+        reports: &mut [MachineIbStatusEvaluation],
+    ) -> IbResult<usize> {
+        let scan = self
+            .cleanup_intent_scan
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+        let high_water = match scan.high_water {
+            Some(high_water) => high_water,
+            None => {
+                let Some(high_water) =
+                    db::ib_membership_cleanup_intent::high_water_mark(&self.db_pool).await?
+                else {
+                    *self
+                        .cleanup_intent_scan
+                        .lock()
+                        .unwrap_or_else(PoisonError::into_inner) = CleanupIntentScan::default();
+                    return Ok(0);
+                };
+                high_water
+            }
+        };
+        let batch = db::ib_membership_cleanup_intent::list_batch(
+            &self.db_pool,
+            scan.after.as_ref(),
+            Some(&high_water),
+        )
+        .await?;
+        let Some(last) = batch.last().cloned() else {
+            *self
+                .cleanup_intent_scan
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = CleanupIntentScan::default();
+            return Ok(0);
+        };
+        let mut num_changes = 0;
+
+        for intent in batch {
+            if let Some(machine_id) = live_desired_memberships.get(&intent)
+                && self
+                    .supersede_cleanup_intent_if_still_live(*machine_id, &intent)
+                    .await?
+            {
+                continue;
+            }
+
+            // A processed intent wins over this iteration's Machine-derived
+            // bind and unbind actions. Intents beyond the bounded page are
+            // suppressed when the rotating cursor reaches them, so this is an
+            // eventual convergence guarantee rather than a global per-pass
+            // snapshot of the table.
+            for report in reports.iter_mut() {
+                report.missing_guid_pkeys.retain(|(fabric, guid, pkey)| {
+                    fabric != &intent.fabric || guid != &intent.guid || *pkey != intent.pkey
+                });
+                report.unexpected_guid_pkeys.retain(|(fabric, guid, pkey)| {
+                    fabric != &intent.fabric || guid != &intent.guid || *pkey != intent.pkey
+                });
+            }
+
+            // A retained intent is a standing desired-absence policy, not
+            // work that must issue a no-op UFM call every iteration. Fresh
+            // fabric data will expose any delayed stale bind on a later pass.
+            if !fabric_contains_membership(data_by_fabric, &intent) {
+                continue;
+            }
+
+            let conn =
+                client_for_fabric(self.fabric_manager.as_ref(), fabric_clients, &intent.fabric)
+                    .await?;
+            let result = conn
+                .unbind_ib_ports(intent.pkey.into(), vec![intent.guid.clone()])
+                .await;
+            UfmGuidPkeyChangeFinished::emit(
+                &intent.fabric,
+                UfmOperation::UnbindGuidFromPkey,
+                &intent.guid,
+                intent.pkey,
+                &result,
+            );
+            if result.is_ok() {
+                num_changes += 1;
+            }
+        }
+
+        let next_scan = if last == high_water {
+            CleanupIntentScan::default()
+        } else {
+            CleanupIntentScan {
+                after: Some(last),
+                high_water: Some(high_water),
+            }
+        };
+        *self
+            .cleanup_intent_scan
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = next_scan;
+
         Ok(num_changes)
+    }
+
+    /// Rechecks desired presence while holding the Machine row lock used by
+    /// allocation and force-delete transitions. The UFM observation that found
+    /// the fabric stays outside this transaction; overlapping UFM calls remain
+    /// subject to repair by later monitor iterations.
+    async fn supersede_cleanup_intent_if_still_live(
+        &self,
+        machine_id: MachineId,
+        intent: &IbMembershipCleanupIntent,
+    ) -> IbResult<bool> {
+        let mut txn = self
+            .db_pool
+            .begin()
+            .await
+            .map_err(|e| DatabaseError::new("begin IB cleanup supersession transaction", e))?;
+
+        let machine_exists = db::machine::find_one(
+            txn.as_mut(),
+            &machine_id,
+            MachineSearchConfig {
+                for_update: true,
+                ..Default::default()
+            },
+        )
+        .await?
+        .is_some();
+        if !machine_exists {
+            txn.commit()
+                .await
+                .map_err(|e| DatabaseError::new("commit IB cleanup supersession transaction", e))?;
+            return Ok(false);
+        }
+
+        // READ COMMITTED takes a new statement snapshot after the row-lock
+        // wait, so this reload sees the Instance transition that held the lock
+        // before us rather than the monitor's earlier iteration snapshot.
+        let snapshot = db::managed_host::load_snapshot(
+            txn.as_mut(),
+            &machine_id,
+            LoadSnapshotOptions::default().with_host_health(self.host_health),
+        )
+        .await?;
+        let fabric_matches = snapshot.as_ref().is_some_and(|snapshot| {
+            // The force-delete publisher creates the absence intent while
+            // holding this same Machine lock. Its old Instance config can
+            // still look live until deletion finishes, so ForceDeletion wins
+            // at that exact publication boundary. Other lifecycle states keep
+            // using the monitor's existing tenant/admin-network policy below.
+            !matches!(snapshot.managed_state, ManagedHostState::ForceDeletion)
+                && snapshot
+                    .host_snapshot
+                    .status
+                    .infiniband_status_observation
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|observation| &observation.ib_interfaces)
+                    .any(|interface| {
+                        interface.guid == intent.guid && interface.fabric_id == intent.fabric
+                    })
+        });
+        let mut still_live = false;
+        if let Some(instance) = snapshot
+            .as_ref()
+            .filter(|snapshot| fabric_matches && !snapshot.use_admin_network())
+            .and_then(|snapshot| snapshot.instance.as_ref())
+            .filter(|instance| instance.deleted.is_none())
+        {
+            for interface in &instance.config.infiniband.ib_interfaces {
+                if interface.guid.as_deref() != Some(intent.guid.as_str()) {
+                    continue;
+                }
+                let pkey = db::ib_partition::find_pkey_by_partition_id(
+                    txn.as_mut(),
+                    interface.ib_partition_id,
+                )
+                .await?
+                .and_then(|pkey| PartitionKey::try_from(pkey).ok());
+                if pkey == Some(intent.pkey) {
+                    still_live = true;
+                    break;
+                }
+            }
+        }
+
+        if still_live {
+            db::ib_membership_cleanup_intent::supersede_for_live_presence(txn.as_mut(), intent)
+                .await?;
+        }
+        txn.commit()
+            .await
+            .map_err(|e| DatabaseError::new("commit IB cleanup supersession transaction", e))?;
+
+        Ok(still_live)
     }
 
     async fn get_all_snapshots(
@@ -617,6 +843,21 @@ async fn client_for_fabric(
     Ok(conn)
 }
 
+/// Returns whether the iteration's complete UFM partition data contains an
+/// exact cleanup tuple. Missing or incomplete data is treated as unknown and
+/// deferred to a later iteration.
+fn fabric_contains_membership(
+    data_by_fabric: &HashMap<String, FabricData>,
+    intent: &IbMembershipCleanupIntent,
+) -> bool {
+    data_by_fabric
+        .get(&intent.fabric)
+        .and_then(|fabric| fabric.partitions.as_ref())
+        .and_then(|partitions| partitions.get(&u16::from(intent.pkey)))
+        .and_then(|partition| partition.associated_guids.as_ref())
+        .is_some_and(|guids| guids.contains(&intent.guid))
+}
+
 /// Applies the GUID<->pkey binding changes that the per-machine status
 /// evaluations found to be required. Each fabric is served by a single client
 /// from `fabric_clients` for the whole batch, and every UFM call emits its
@@ -744,6 +985,7 @@ struct MachineIbStatusEvaluation {
     unexpected_guid_pkeys: Vec<(String, String, PartitionKey)>,
     unknown_guid_pkeys: Vec<(String, String, PartitionKey)>,
     down_port_guids: Vec<String>,
+    live_desired_memberships: Vec<IbMembershipCleanupIntent>,
 }
 
 async fn record_machine_infiniband_status_observation(
@@ -883,6 +1125,16 @@ async fn record_machine_infiniband_status_observation(
 
         let (fabric_id, lid, associated_pkeys, associated_partition_ids) = match found_port_data {
             Some((fabric_id, fabric_data, port_data)) => {
+                if let Some(expected_pkey) = expected_pkeys.get(guid) {
+                    result
+                        .live_desired_memberships
+                        .push(IbMembershipCleanupIntent {
+                            fabric: fabric_id.to_string(),
+                            pkey: *expected_pkey,
+                            guid: guid.to_string(),
+                        });
+                }
+
                 // Port was found. Now try to look up associated pkeys
                 // If there's no associated pkeys found, don't return any potentially invalid or empty
                 // pkey list. Instead opt for a safe result and return `None` (we don't know).
@@ -1943,6 +2195,7 @@ mod tests {
                 ],
                 unknown_guid_pkeys: vec![],
                 down_port_guids: vec![],
+                live_desired_memberships: vec![],
             }]
         }
 


### PR DESCRIPTION
> [!NOTE]
> While this PR seems large at first glance, just FYI that it contains:
>
> - +475/-1 lines of test changes.
>
> Don't let it scare you!

As part of introducing tenant-managed `SitePrefix` resources, Admin `force-delete` must remove everything that belongs to the old `Instance` before its address space can be reused. That includes more than IP state: the `Instance`'s InfiniBand PKey memberships must stay removed even after its `Machine` and `Instance` records are deleted.

An IB monitor pass can read that a membership should exist. Before it reaches UFM, `force-delete` can remove that membership and delete the `Machine` and `Instance` records. The older monitor pass can then ask UFM to add the membership again. UFM does not receive a NICo version with the request, so it cannot know that the request is based on an `Instance` that has since been deleted. With the `Machine` and `Instance` records gone, the normal monitor has no remaining instruction to remove the membership again.

So, this change teaches `IbFabricMonitor` to process the cleanup records introduced by https://github.com/NVIDIA/infra-controller/pull/5142. Each record identifies one membership through its `fabric`, `pkey`, and `guid` fields. The monitor checks UFM for that membership, removes it when present, and keeps the cleanup record afterward so another delayed add can be repaired. Failed removals remain recorded and are retried. This PR processes cleanup records but does not create them; https://github.com/NVIDIA/infra-controller/issues/5147 and https://github.com/NVIDIA/infra-controller/issues/5139 add the production paths that record normal IB transitions and Admin `force-delete`.

When another `Instance` later needs the same membership, the monitor waits for any `Machine` update already in progress and then checks the current `Machine` and `Instance` state before removing the cleanup record. It does so only when an `Instance` that has not been deleted still requires the exact same `fabric`, `pkey`, and `guid`. The cleanup record remains in place if the `Machine` is in `ForceDeletion`, the `Instance` has already been deleted, the fabric, PKey, or GUID differs, or an error occurs. No database transaction is held open while the monitor calls UFM.

The `nico-api` chart defaults to one replica. With additional replicas, a different process may perform the next monitor pass, which can repeat some cleanup work or delay when a retained record is checked again. Repeating cleanup is safe.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5138.

This is part of https://github.com/NVIDIA/infra-controller/issues/5131 and https://github.com/NVIDIA/infra-controller/issues/3883. Completing the series is a prerequisite for https://github.com/NVIDIA/infra-controller/issues/5112.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Integration tests against PostgreSQL verify that delayed memberships are removed after restart, failed UFM removals are retried, cleanup records continue to be revisited while new ones are added, and only an `Instance` that still requires the exact membership can remove its cleanup record. They also cover `ForceDeletion` and deleted `Instance` state so stale configuration cannot restore an old membership.
