### PR TITLE
fix(ci): run PR description check on trusted pushes

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -3,14 +3,12 @@
 
 name: Pull Request Description
 
+# NVIDIA self-hosted runners reject pull_request and pull_request_target events.
+# copy-pr-bot pushes trusted PR commits to pull-request/<PR number> branches.
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
-      - ready_for_review
+  push:
+    branches:
+      - 'pull-request/[0-9]+'
 
 permissions:
   contents: read
@@ -18,7 +16,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: pr-description-${{ github.event.pull_request.number }}
+  group: pr-description-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -29,13 +27,13 @@ jobs:
     steps:
       - name: Publish pr-description status
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+
+          PR_NUMBER="${GITHUB_REF_NAME#pull-request/}"
+          EVENT_HEAD_SHA="${GITHUB_SHA}"
 
           post_status() {
             local sha="$1"
@@ -69,11 +67,12 @@ jobs:
             "Checking the current pull request description"
 
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          base_sha="$(jq -r '.base.sha' <<<"${pr_json}")"
 
           template="$(
             gh api \
               --header "Accept: application/vnd.github.raw+json" \
-              "repos/${GITHUB_REPOSITORY}/contents/.github/PULL_REQUEST_TEMPLATE.md?ref=${BASE_SHA}"
+              "repos/${GITHUB_REPOSITORY}/contents/.github/PULL_REQUEST_TEMPLATE.md?ref=${base_sha}"
           )"
           body="$(jq -r '.body // ""' <<<"${pr_json}")"
 
@@ -107,25 +106,25 @@ jobs:
 
           if [[ "${comparison}" == "empty" ]]; then
             message="Pull request description must not be empty"
-            post_status "${EVENT_HEAD_SHA}" failure "${message}"
+            post_status "${EVENT_HEAD_SHA}" failure "${message}; edit it, then re-run this failed job"
             status_finalized=true
-            echo "::error::${message}"
+            echo "::error::${message}. After updating the PR description, select 'Re-run failed jobs' on this Actions run."
             exit 1
           fi
 
           if [[ "${comparison}" == "template" ]]; then
             message="Fill in the pull request template before submitting"
-            post_status "${EVENT_HEAD_SHA}" failure "${message}"
+            post_status "${EVENT_HEAD_SHA}" failure "${message}; edit it, then re-run this failed job"
             status_finalized=true
-            echo "::error::${message}"
+            echo "::error::${message}. After updating the PR description, select 'Re-run failed jobs' on this Actions run."
             exit 1
           fi
 
           if [[ "${body}" == *"<!--"* ]]; then
             message="Remove all <!-- ... --> comments from the pull request description"
-            post_status "${EVENT_HEAD_SHA}" failure "${message}"
+            post_status "${EVENT_HEAD_SHA}" failure "${message}; edit it, then re-run this failed job"
             status_finalized=true
-            echo "::error::${message}"
+            echo "::error::${message}. After updating the PR description, select 'Re-run failed jobs' on this Actions run."
             exit 1
           fi
 


### PR DESCRIPTION
PR #5144 moved the PR description validator to an NVIDIA self-hosted runner, but those runners reject workflows triggered by `pull_request_target` before the validation job starts.

This changes the workflow to run when `copy-pr-bot` pushes a trusted PR commit to `pull-request/<number>`. It derives the PR number from the branch, reads the current PR body and base template through the GitHub API, and preserves the existing `pr-description` commit status.

Editing a PR description does not create another push. Validation failures therefore tell the author to update the description and select **Re-run failed jobs** on the Actions run so the job reads the latest body.

## Related issues

- Follow-up to #5144

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `actionlint` (ignoring only its unknown-label warning for NVIDIA's `linux-amd64-cpu4` runner)
- `yq` workflow parsing and trigger assertions
- `bash -n` on the embedded validation script
- `git diff --check`

## Additional Notes

Existing PRs need to contain this workflow version before their trusted branch push can use the new trigger. New PRs based on `main` will pick it up normally.
