### PR TITLE
fix(ci): restore hosted PR description runner

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   validate:
     name: Validate pull request description
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Publish pr-description status


### PR DESCRIPTION
PR #5144 moved the PR description validator from GitHub's hosted pool to an NVIDIA self-hosted runner. NVIDIA's runner policy rejects `pull_request_target` workflows during runner setup, so the validator now fails before any validation step runs.

This is the minimal hotfix: move only this lightweight job back to `ubuntu-latest`. It preserves the existing `pull_request_target` events, immediate revalidation after description edits, and the custom `pr-description` status. The remaining runner changes from #5144 are unaffected.

This is an alternative to #5150; only one of the two approaches should be merged.

## Related issues

- Follow-up to #5144
- Alternative implementation: #5150

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `actionlint .github/workflows/pr-description.yml`
- `yq` assertions for the runner and `edited` event
- `bash -n` on the embedded validation script
- `git diff --check`

## Additional Notes

This intentionally keeps one lightweight workflow on the GitHub-hosted runner because NVIDIA self-hosted runners do not accept `pull_request_target` events.

This PR's own validator still uses the workflow from the base branch, so it will hit the currently broken self-hosted configuration. The hosted-runner change takes effect for subsequent PR events after merge.
