### PR TITLE
feat(helm/nico-api): prefer co-locating nico-api with the PostgreSQL primary

### DIFF
--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -24,6 +24,50 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       serviceAccountName: {{ include "nico-api.name" . }}
+      {{- /*
+        Scheduling. `affinity` is a plain pass-through for operators who want
+        full control. `databaseAffinity` is a convenience on top of it: a SOFT
+        preference to land on the same node as the PostgreSQL primary.
+
+        Soft is deliberate. nico-api holds the admin-segment advisory lock
+        across application round trips, so much of that lock's hold time is
+        network latency to the database rather than query time. Co-located and
+        cross-node runs of the same 4,500-host ingestion measured a 1.32x
+        throughput difference (local RTT 0.073ms vs 0.473ms). Worth preferring;
+        never worth blocking on -- `preferred...` lets the scheduler place
+        nico-api anywhere if the primary's node is full, cordoned or gone.
+
+        Also `...IgnoredDuringExecution`: a Patroni failover moves the
+        `spilo-role=master` label to another pod, and nico-api deliberately does
+        NOT get evicted to chase it. Staying up beats the 1.32x.
+      */}}
+      {{- if and .Values.databaseAffinity.enabled (not .Values.affinity) }}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.databaseAffinity.weight }}
+              podAffinityTerm:
+                topologyKey: {{ .Values.databaseAffinity.topologyKey }}
+                {{- with .Values.databaseAffinity.namespaces }}
+                namespaces:
+                  {{- toYaml . | nindent 18 }}
+                {{- end }}
+                labelSelector:
+                  matchLabels:
+                    {{- toYaml .Values.databaseAffinity.matchLabels | nindent 20 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -71,6 +71,44 @@ automountServiceAccountToken: true
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-api.name" . }}-config-files,{{ include "nico-api.name" . }}-site-config-files'
 
+## Scheduling
+##
+## `affinity`, `nodeSelector` and `tolerations` are plain pass-throughs. Setting
+## `affinity` disables the `databaseAffinity` convenience below.
+affinity: {}
+nodeSelector: {}
+tolerations: []
+
+## Prefer -- never require -- scheduling nico-api onto the PostgreSQL primary's
+## node.
+##
+## nico-api holds the admin-segment advisory lock across application round trips
+## to the database, so a large share of that lock's hold time is network latency
+## rather than query time. The same 4,500-host ingestion measured a 1.32x
+## throughput difference between co-located and cross-node placement (local RTT
+## 0.073ms vs 0.473ms), with no other variable changed.
+##
+## Expressed as a soft preference on purpose:
+##   * `preferredDuringScheduling...` -- if the primary's node is full, cordoned
+##     or unreachable, nico-api still schedules normally. It never blocks a
+##     deployment or a node failover.
+##   * `...IgnoredDuringExecution` -- when Patroni promotes a new primary the
+##     `spilo-role=master` label moves, and nico-api is deliberately NOT evicted
+##     to follow it. Staying up beats chasing the 1.32x.
+##
+## The selector targets the Zalando/Spilo operator's convention. If your
+## PostgreSQL is deployed differently, point `matchLabels` at whatever marks
+## your primary, or set `enabled: false`. An unmatched preference is simply
+## ignored by the scheduler, so a wrong label costs nothing but the benefit.
+databaseAffinity:
+  enabled: true
+  weight: 100
+  topologyKey: kubernetes.io/hostname
+  namespaces:
+    - postgres
+  matchLabels:
+    spilo-role: master
+
 resources:
   limits:
     cpu: 3


### PR DESCRIPTION
nico-api holds the admin-segment advisory lock across application round trips to the database, so a large share of that lock's hold time is network latency rather than query time. Two 4,500-host ingestion runs that differed **only** in pod placement measured a **1.32x throughput difference** — local RTT 0.073ms against 0.473ms cross-node, with roughly 450GiB of nico-api↔Postgres traffic moving from loopback onto the overlay. Nothing else varied between the runs.

This expresses that as a **preference, never a requirement**. Scheduling should not become more fragile in exchange for throughput:

- **`preferredDuringScheduling...`** — if the primary's node is full, cordoned or unreachable, nico-api schedules normally. It can never block a deployment or a node failover.
- **`...IgnoredDuringExecution`** — when Patroni promotes a new primary the `spilo-role=master` label moves to another pod. nico-api is deliberately **not** evicted to follow it. Staying up beats chasing the 1.32x, and a controller that reshuffles itself on every failover is worse than a slightly slower one.

Rendering was checked for the cases that matter:

| case | result |
|---|---|
| defaults | soft `podAffinity` emitted |
| `databaseAffinity.enabled=false` | no affinity block |
| operator sets `affinity` explicitly | theirs wins, convenience block suppressed |
| anywhere in the chart | **zero** `requiredDuringScheduling` |

The selector targets the Zalando/Spilo operator convention (`spilo-role: master` in the `postgres` namespace), which is what this deployment uses. Anyone marking their primary differently can repoint `matchLabels` or disable it — an unmatched preference is simply ignored by the scheduler, so a wrong label costs the benefit and nothing else.

The chart had no `affinity`, `nodeSelector` or `tolerations` support at all, so those are added as plain pass-throughs alongside.

## Related issues

Fixes #5002.

## Type of Change

- [ ] **Add**
- [x] **Change**
- [ ] **Fix**
- [ ] **Remove**
- [ ] **Internal**

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed — `helm template` across the four cases above; the placement effect itself measured across paired 4,500-host runs.
- [ ] No testing required