### PR TITLE
fix(flow): converge expected racks with Core

### DIFF
--- a/rest-api/api/pkg/api/model/rack_test.go
+++ b/rest-api/api/pkg/api/model/rack_test.go
@@ -4,11 +4,36 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	flowv1 "github.com/NVIDIA/infra-controller/rest-api/proto/flow/gen/v1"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAPIRackJSONContract(t *testing.T) {
+	description := "Core rack description"
+	modelName := "NICO-QA-RACK"
+	apiRack := NewAPIRack(&flowv1.Rack{
+		Info: &flowv1.DeviceInfo{
+			Model:       &modelName,
+			Description: &description,
+		},
+		Location: &flowv1.Location{Datacenter: "DC1"},
+	}, false)
+
+	got, err := json.Marshal(apiRack)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"id":"",
+		"name":"",
+		"manufacturer":"",
+		"model":"NICO-QA-RACK",
+		"serialNumber":"",
+		"description":"Core rack description",
+		"location":{"region":"","datacenter":"DC1","room":"","position":""}
+	}`, string(got))
+}
 
 func TestNewAPIRack(t *testing.T) {
 	description := "Test rack description"

--- a/rest-api/flow/internal/converter/dao/converter.go
+++ b/rest-api/flow/internal/converter/dao/converter.go
@@ -127,6 +127,7 @@ func RackFrom(dao *model.Rack) *rack.Rack {
 	if dao == nil {
 		return nil
 	}
+	modelName, _ := dao.Description["model"].(string)
 
 	components := make([]component.Component, 0, len(dao.Components))
 	for _, c := range dao.Components {
@@ -138,6 +139,7 @@ func RackFrom(dao *model.Rack) *rack.Rack {
 			ID:           dao.ID,
 			Name:         dao.Name,
 			Manufacturer: dao.Manufacturer,
+			Model:        modelName,
 			SerialNumber: dao.SerialNumber,
 			Description:  utils.MapToJSONString(dao.Description),
 		},

--- a/rest-api/flow/internal/converter/dao/converter.go
+++ b/rest-api/flow/internal/converter/dao/converter.go
@@ -127,7 +127,7 @@ func RackFrom(dao *model.Rack) *rack.Rack {
 	if dao == nil {
 		return nil
 	}
-	modelName, _ := dao.Description["model"].(string)
+	modelName, description := rackMetadataFromDescription(dao.Description)
 
 	components := make([]component.Component, 0, len(dao.Components))
 	for _, c := range dao.Components {
@@ -141,13 +141,41 @@ func RackFrom(dao *model.Rack) *rack.Rack {
 			Manufacturer: dao.Manufacturer,
 			Model:        modelName,
 			SerialNumber: dao.SerialNumber,
-			Description:  utils.MapToJSONString(dao.Description),
+			Description:  description,
 		},
 		Loc: location.New(
 			[]byte(utils.MapToJSONString(dao.Location)),
 		),
 		Components: components,
 	}
+}
+
+// rackMetadataFromDescription separates the rack fields stored in the shared
+// description JSONB column. Model has a dedicated public field, while the
+// standard scalar description keys should be exposed as plain text rather than
+// leaking the database JSON representation. Unknown structured metadata stays
+// JSON so legacy values continue to round-trip.
+func rackMetadataFromDescription(stored map[string]any) (string, string) {
+	modelName, _ := stored["model"].(string)
+	publicDescription := make(map[string]any, len(stored))
+	for key, value := range stored {
+		if key != "model" {
+			publicDescription[key] = value
+		}
+	}
+	if len(publicDescription) == 0 {
+		return modelName, ""
+	}
+
+	if len(publicDescription) == 1 {
+		for _, key := range []string{"text", "description"} {
+			if value, ok := publicDescription[key].(string); ok {
+				return modelName, value
+			}
+		}
+	}
+
+	return modelName, utils.MapToJSONString(publicDescription)
 }
 
 // NVLDomainFrom converts a DAO NVLDomain model to its domain object.
@@ -283,12 +311,20 @@ func RackTo(r *rack.Rack) *model.Rack {
 		components = append(components, *ComponentTo(&c, r.Info.ID))
 	}
 
+	description := utils.JSONStringToMap("description", r.Info.Description)
+	if r.Info.Model != "" {
+		if description == nil {
+			description = make(map[string]any)
+		}
+		description["model"] = r.Info.Model
+	}
+
 	return &model.Rack{
 		ID:           r.Info.ID,
 		Name:         r.Info.Name,
 		Manufacturer: r.Info.Manufacturer,
 		SerialNumber: r.Info.SerialNumber,
-		Description:  utils.JSONStringToMap("description", r.Info.Description),
+		Description:  description,
 		Location:     r.Loc.ToMap(),
 		Components:   components,
 	}

--- a/rest-api/flow/internal/converter/dao/converter_test.go
+++ b/rest-api/flow/internal/converter/dao/converter_test.go
@@ -474,7 +474,7 @@ func TestRackConversion(t *testing.T) {
 			Manufacturer: "NVIDIA",
 			Model:        "NVL72",
 			SerialNumber: "67890",
-			Description:  utils.MapToJSONString(description),
+			Description:  "A rack",
 		},
 		Loc:        location.New([]byte(loc)),
 		Components: []component.Component{},
@@ -482,4 +482,43 @@ func TestRackConversion(t *testing.T) {
 
 	assert.Equal(t, &internalRack, RackFrom(&daoRack))
 	assert.Equal(t, &daoRack, RackTo(&internalRack))
+}
+
+func TestRackMetadataFromDescription(t *testing.T) {
+	tests := []struct {
+		name            string
+		stored          map[string]any
+		wantModel       string
+		wantDescription string
+	}{
+		{
+			name:            "Core model and text",
+			stored:          map[string]any{"model": "NVL72", "text": "Core rack"},
+			wantModel:       "NVL72",
+			wantDescription: "Core rack",
+		},
+		{
+			name:            "Flow description",
+			stored:          map[string]any{"description": "Flow rack"},
+			wantDescription: "Flow rack",
+		},
+		{
+			name:      "model only",
+			stored:    map[string]any{"model": "NVL72"},
+			wantModel: "NVL72",
+		},
+		{
+			name:            "unknown structured metadata remains JSON",
+			stored:          map[string]any{"owner": "ops", "zone": "west"},
+			wantDescription: `{"owner":"ops","zone":"west"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotModel, gotDescription := rackMetadataFromDescription(tc.stored)
+			assert.Equal(t, tc.wantModel, gotModel)
+			assert.Equal(t, tc.wantDescription, gotDescription)
+		})
+	}
 }

--- a/rest-api/flow/internal/converter/dao/converter_test.go
+++ b/rest-api/flow/internal/converter/dao/converter_test.go
@@ -454,7 +454,7 @@ func TestComponentConversionWithComponentID(t *testing.T) {
 func TestRackConversion(t *testing.T) {
 	// Test RackFrom and RackTo
 	rackID := uuid.New()
-	description := map[string]any{"description": "A rack"}
+	description := map[string]any{"description": "A rack", "model": "NVL72"}
 	loc := `{"region":"US-West","data_center":"Santa Clara","room":"Mars","position":"Row 5"}`
 
 	daoRack := model.Rack{
@@ -472,6 +472,7 @@ func TestRackConversion(t *testing.T) {
 			ID:           rackID,
 			Name:         "Rack1",
 			Manufacturer: "NVIDIA",
+			Model:        "NVL72",
 			SerialNumber: "67890",
 			Description:  utils.MapToJSONString(description),
 		},

--- a/rest-api/flow/internal/db/migrations/20260819120000_allow_duplicate_rack_names.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260819120000_allow_duplicate_rack_names.down.sql
@@ -1,0 +1,20 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM rack
+        GROUP BY name
+        HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'rack rows have duplicate names and cannot restore rack_name_idx uniqueness';
+    END IF;
+END
+$$;
+
+DROP INDEX rack_name_idx;
+
+ALTER TABLE rack
+    ADD CONSTRAINT rack_name_idx UNIQUE (name);

--- a/rest-api/flow/internal/db/migrations/20260819120000_allow_duplicate_rack_names.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260819120000_allow_duplicate_rack_names.up.sql
@@ -1,0 +1,20 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Core treats an expected rack's name as optional metadata and does not
+-- require it to be unique. Flow identifies mirrored racks by external_id, so
+-- retain an index for name filters without rejecting duplicate Core names.
+ALTER TABLE rack
+    DROP CONSTRAINT rack_name_idx;
+
+CREATE INDEX rack_name_idx ON rack (name);
+
+-- Older expected-rack reconciliation wrote the shared Location field under
+-- "datacenter". Move existing values to the canonical JSON key immediately so
+-- reads remain correct before the next successful authoritative sync.
+UPDATE rack
+SET location = CASE
+    WHEN location ? 'data_center' THEN location - 'datacenter'
+    ELSE (location - 'datacenter') || jsonb_build_object('data_center', location->'datacenter')
+END
+WHERE location ? 'datacenter';

--- a/rest-api/flow/internal/db/model/rack.go
+++ b/rest-api/flow/internal/db/model/rack.go
@@ -25,7 +25,7 @@ type Rack struct {
 	bun.BaseModel `bun:"table:rack,alias:r"`
 
 	ID   uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	Name string    `bun:"name,notnull,unique:rack_name_idx"`
+	Name string    `bun:"name,notnull"`
 	// Manufacturer and SerialNumber are descriptive chassis labels, not
 	// identity: a mirrored rack is identified by ExternalID. nullzero maps the
 	// empty string to SQL NULL, so a rack missing either half occupies no slot

--- a/rest-api/flow/internal/inventory/store/postgres.go
+++ b/rest-api/flow/internal/inventory/store/postgres.go
@@ -213,7 +213,7 @@ func (s *PostgresStore) GetRackByIdentifier(
 		},
 		nil,
 		nil,
-		nil,
+		&dbquery.Pagination{Limit: 2},
 		nil,
 		withComponents,
 	)
@@ -222,13 +222,24 @@ func (s *PostgresStore) GetRackByIdentifier(
 		return nil, errors.GRPCErrorInternal(err.Error())
 	}
 
-	if len(rackDaos) == 0 {
-		return nil, errors.GRPCErrorNotFound(
-			fmt.Sprintf("rack %s", identifier.Name),
+	rackDao, err := uniqueRackByName(rackDaos, identifier.Name)
+	if err != nil {
+		return nil, err
+	}
+	return dao.RackFrom(rackDao), nil
+}
+
+func uniqueRackByName(racks []model.Rack, name string) (*model.Rack, error) {
+	switch len(racks) {
+	case 0:
+		return nil, errors.GRPCErrorNotFound(fmt.Sprintf("rack %s", name))
+	case 1:
+		return &racks[0], nil
+	default:
+		return nil, errors.GRPCErrorInvalidArgument(
+			fmt.Sprintf("rack name %q matches multiple racks; use rack id", name),
 		)
 	}
-
-	return dao.RackFrom(&rackDaos[0]), nil
 }
 
 // PatchRack updates an existing rack.

--- a/rest-api/flow/internal/inventory/store/postgres_test.go
+++ b/rest-api/flow/internal/inventory/store/postgres_test.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+)
+
+func TestUniqueRackByName(t *testing.T) {
+	tests := []struct {
+		name      string
+		racks     []model.Rack
+		wantName  string
+		wantCode  codes.Code
+		wantError string
+	}{
+		{
+			name:      "no match",
+			wantCode:  codes.NotFound,
+			wantError: "rack shared",
+		},
+		{
+			name:     "one match",
+			racks:    []model.Rack{{Name: "shared"}},
+			wantName: "shared",
+		},
+		{
+			name:      "ambiguous match",
+			racks:     []model.Rack{{Name: "shared"}, {Name: "shared"}},
+			wantCode:  codes.InvalidArgument,
+			wantError: `rack name "shared" matches multiple racks; use rack id`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := uniqueRackByName(tc.racks, "shared")
+			if tc.wantCode != codes.OK {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantCode, status.Code(err))
+				assert.ErrorContains(t, err, tc.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantName, got.Name)
+		})
+	}
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror.go
@@ -28,9 +28,7 @@ type mirrorResult struct {
 	adopted          int
 	resurrected      int
 	softDeleted      int
-	legacyExempt     int
 	skippedNoIDOrKey int
-	skippedNameTaken int
 }
 
 func (r mirrorResult) log() {
@@ -42,9 +40,7 @@ func (r mirrorResult) log() {
 		Int("adopted", r.adopted).
 		Int("resurrected", r.resurrected).
 		Int("soft_deleted", r.softDeleted).
-		Int("legacy_exempt", r.legacyExempt).
 		Int("skipped_invalid", r.skippedNoIDOrKey).
-		Int("skipped_name_taken", r.skippedNameTaken).
 		Msgf("Expected-inventory mirror: %s", r.resource)
 }
 

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_db_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -52,8 +53,8 @@ func coreRack(rackID, mfr, serial string) nicoapi.ExpectedRackDetail {
 	}
 }
 
-// coreRackNamed is coreRack with an explicit name, for cases that contend on
-// the chassis pair and so must not also contend on rack_name_idx.
+// coreRackNamed is coreRack with an explicit name for tests that need stable
+// display metadata independent of the chassis pair.
 func coreRackNamed(rackID, name, mfr, serial string) nicoapi.ExpectedRackDetail {
 	r := coreRack(rackID, mfr, serial)
 	r.Name = name
@@ -72,10 +73,9 @@ func computeSpec(mfr, serial, mac string) expectedComponentSpec {
 
 // --- rack mirror ----------------------------------------------------------
 
-// A successful but empty Core response soft-deletes both mirror-adopted racks
-// and identity-less legacy rows. An identifiable legacy row remains available
-// for later natural-key adoption.
-func TestMirrorRacks_EmptyCoreDeletesAbsentAndIdentitylessRows(t *testing.T) {
+// A successful but empty Core response soft-deletes both mirror-adopted and
+// legacy racks because no remaining row can be adopted from this snapshot.
+func TestMirrorRacks_EmptyCoreDeletesAllRows(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
 	adopted := model.Rack{Name: "adopted", Manufacturer: "Mfg", SerialNumber: "AD-1", ExternalID: strPtr("a12")}
@@ -92,7 +92,7 @@ func TestMirrorRacks_EmptyCoreDeletesAbsentAndIdentitylessRows(t *testing.T) {
 	}
 
 	result := mirrorExpectedRacks(ctx, pool, nil)
-	assert.Equal(t, 4, result.softDeleted, "summary count must reflect the four rows actually soft-deleted")
+	assert.Equal(t, 5, result.softDeleted, "summary count must reflect every row actually soft-deleted")
 
 	gotAdopted, err := (&model.Rack{ID: adopted.ID}).GetIncludingDeleted(ctx, pool.DB)
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestMirrorRacks_EmptyCoreDeletesAbsentAndIdentitylessRows(t *testing.T) {
 
 	gotIdentifiableLegacy, err := (&model.Rack{ID: identifiableLegacy.ID}).GetIncludingDeleted(ctx, pool.DB)
 	require.NoError(t, err)
-	assert.Nil(t, gotIdentifiableLegacy.DeletedAt, "legacy rack with a complete natural key must remain available for later adoption")
+	assert.NotNil(t, gotIdentifiableLegacy.DeletedAt, "unmatched legacy rack must be soft-deleted")
 
 	for _, legacy := range identitylessLegacy {
 		gotIdentitylessLegacy, err := (&model.Rack{ID: legacy.ID}).GetIncludingDeleted(ctx, pool.DB)
@@ -109,26 +109,25 @@ func TestMirrorRacks_EmptyCoreDeletesAbsentAndIdentitylessRows(t *testing.T) {
 	}
 }
 
-// An identity-less legacy rack can reserve a globally unique name needed by a
-// Core rack. The first authoritative pass removes the orphan; the next pass can
-// collect that tombstone and mirror the Core rack under the released name.
-func TestMirrorRacks_IdentitylessRowCleanupReleasesNameForCoreRack(t *testing.T) {
+// An identity-less legacy rack and a Core rack may share a non-unique name. The
+// authoritative pass removes the orphan and mirrors the Core rack immediately.
+func TestMirrorRacks_IdentitylessRowCleanupDoesNotBlockDuplicateName(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
 	orphan := model.Rack{Name: "reserved-name"}
 	require.NoError(t, orphan.Create(ctx, pool.DB))
 	core := coreRackNamed("a12", "reserved-name", "Mfg", "CORE-1")
 
-	first := mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{core})
-	assert.Equal(t, 1, first.skippedNameTaken)
-	assert.Equal(t, 1, first.softDeleted)
-
-	second := mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{core})
-	assert.Equal(t, 1, second.inserted)
+	result := mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{core})
+	assert.Equal(t, 1, result.softDeleted)
+	assert.Equal(t, 1, result.inserted)
 
 	var mirrored model.Rack
 	require.NoError(t, pool.DB.NewSelect().Model(&mirrored).Where("external_id = ?", "a12").Scan(ctx))
 	assert.Equal(t, "reserved-name", mirrored.Name)
+	gotOrphan, err := (&model.Rack{ID: orphan.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.NotNil(t, gotOrphan.DeletedAt, "legacy rack must remain recoverable as a tombstone")
 }
 
 // #1: a soft-deleted rack is resurrected (deleted_at cleared) when Core
@@ -165,8 +164,8 @@ func TestMirrorRacks_RenameKeepsRow(t *testing.T) {
 	assert.Equal(t, "new", *got.ExternalID, "external_id must be updated to Core's new rack_id")
 }
 
-// #3: a Core row missing a chassis label is mirrored, not skipped, and the
-// existing Flow rack survives with its own label intact.
+// #3: a Core row missing a chassis label is authoritative and clears the
+// existing Flow value without deleting the rack.
 func TestMirrorRacks_MissingChassisLabelStillMirrored(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
@@ -184,7 +183,8 @@ func TestMirrorRacks_MissingChassisLabelStillMirrored(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, got.DeletedAt, "rack still listed by Core must survive")
 	assert.Equal(t, "still-here", got.Name, "the row must be updated, proving Core's row was not skipped")
-	assert.Equal(t, "Mfg", got.Manufacturer, "Core omitting a label must not erase Flow's copy")
+	assert.Empty(t, got.Manufacturer, "Core omitting a label must clear Flow's stale copy")
+	assert.Equal(t, "MF-1", got.SerialNumber)
 }
 
 // A Core rack carrying no chassis labels at all is mirrored under its rack_id.
@@ -303,9 +303,9 @@ func TestMirrorRacks_DuplicateChassisNoAbort(t *testing.T) {
 	assert.Equal(t, 1, withSerial, "only one rack may hold the contested chassis pair")
 }
 
-// Two Core racks resolving to the same name must not abort the cycle on
-// rack_name_idx: the second write is skipped and the first still lands.
-func TestMirrorRacks_DuplicateNameNoAbort(t *testing.T) {
+// Names are Core metadata, not identity. Two Core racks with the same name are
+// both mirrored under their distinct external IDs.
+func TestMirrorRacks_DuplicateNamesBothConverge(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
 	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
@@ -315,15 +315,17 @@ func TestMirrorRacks_DuplicateNameNoAbort(t *testing.T) {
 
 	total, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Count(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 1, total, "the first rack must land; the second is skipped, not left to abort the cycle")
+	assert.Equal(t, 2, total)
 
-	var got model.Rack
-	require.NoError(t, pool.DB.NewSelect().Model(&got).Where("name = ?", "same-name").Scan(ctx))
-	assert.Equal(t, "NM-1", got.SerialNumber)
+	var got []model.Rack
+	require.NoError(t, pool.DB.NewSelect().Model(&got).Where("name = ?", "same-name").Order("external_id").Scan(ctx))
+	require.Len(t, got, 2)
+	assert.Equal(t, "a12", *got[0].ExternalID)
+	assert.Equal(t, "b34", *got[1].ExternalID)
 }
 
-// #8: an empty Core description must not wipe operator-set rack metadata.
-func TestMirrorRacks_EmptyDescriptionPreserved(t *testing.T) {
+// #8: an empty Core description clears stale Flow metadata.
+func TestMirrorRacks_EmptyDescriptionCleared(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
 	r := model.Rack{
@@ -339,13 +341,111 @@ func TestMirrorRacks_EmptyDescriptionPreserved(t *testing.T) {
 
 	got, err := (&model.Rack{ID: r.ID}).GetIncludingDeleted(ctx, pool.DB)
 	require.NoError(t, err)
-	require.NotNil(t, got.Description)
-	assert.Equal(t, "operator note", got.Description["text"], "empty Core description must not wipe operator metadata")
+	assert.Nil(t, got.Description, "empty Core description must clear stale Flow metadata")
 }
 
-// #6: a Core rack whose name collides with a different live Flow rack must be
-// skipped, not abort the cycle on the unique name index.
-func TestMirrorRacks_NameCollisionWithLiveRackSkips(t *testing.T) {
+func TestMirrorRacks_CoreMetadataCorrectionConvergesExistingExternalID(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	domain := model.NVLDomain{Name: "domain-a"}
+	require.NoError(t, domain.Create(ctx, pool.DB))
+	ingestedAt := time.Now().UTC().Truncate(time.Microsecond)
+
+	r := model.Rack{
+		Name:         "rack-a12",
+		Manufacturer: "OldMfg",
+		SerialNumber: "OLD-1",
+		ExternalID:   strPtr("a12"),
+		Description:  map[string]any{"model": "old-model", "text": "old description"},
+		Location:     map[string]any{"region": "old-region", "room": "old-room"},
+		NVLDomainID:  domain.ID,
+		Status:       model.RackStatusIngested,
+		IngestedAt:   &ingestedAt,
+	}
+	require.NoError(t, r.Create(ctx, pool.DB))
+
+	core := nicoapi.ExpectedRackDetail{
+		RackID:      "a12",
+		Name:        "rack-a12",
+		Description: "new description",
+		Labels: map[string]string{
+			labelChassisManufacturer: "NewMfg",
+			labelChassisSerialNumber: "NEW-1",
+			labelChassisModel:        "new-model",
+			labelLocationRegion:      "new-region",
+			labelLocationDatacenter:  "new-dc",
+			labelLocationPosition:    "new-position",
+		},
+	}
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{core})
+
+	got, err := (&model.Rack{ID: r.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Equal(t, r.ID, got.ID)
+	assert.Equal(t, "NewMfg", got.Manufacturer)
+	assert.Equal(t, "NEW-1", got.SerialNumber)
+	assert.Equal(t, map[string]any{"model": "new-model", "text": "new description"}, got.Description)
+	assert.Equal(t, map[string]any{
+		"region":      "new-region",
+		"data_center": "new-dc",
+		"position":    "new-position",
+	}, got.Location)
+	assert.Equal(t, domain.ID, got.NVLDomainID)
+	assert.Equal(t, model.RackStatusIngested, got.Status)
+	require.NotNil(t, got.IngestedAt)
+	assert.Equal(t, ingestedAt, got.IngestedAt.UTC())
+}
+
+func TestMirrorRacks_ExternalIDCorrectionReclaimsLegacyChassisSlot(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	authoritative := model.Rack{
+		Name:         "rack-a12",
+		Manufacturer: "Mfg",
+		SerialNumber: "OLD-1",
+		ExternalID:   strPtr("a12"),
+	}
+	require.NoError(t, authoritative.Create(ctx, pool.DB))
+	legacy := model.Rack{Name: "legacy-holder", Manufacturer: "Mfg", SerialNumber: "NEW-1"}
+	require.NoError(t, legacy.Create(ctx, pool.DB))
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		coreRackNamed("a12", "rack-a12", "Mfg", "NEW-1"),
+	})
+
+	gotAuthoritative, err := (&model.Rack{ID: authoritative.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Equal(t, "NEW-1", gotAuthoritative.SerialNumber)
+	gotLegacy, err := (&model.Rack{ID: legacy.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.NotNil(t, gotLegacy.DeletedAt)
+	assert.Empty(t, gotLegacy.Manufacturer)
+	assert.Empty(t, gotLegacy.SerialNumber)
+}
+
+func TestMirrorRacks_ExternalIDRowsCanSwapChassisSlots(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+
+	a := model.Rack{Name: "rack-a", Manufacturer: "Mfg", SerialNumber: "A", ExternalID: strPtr("a")}
+	b := model.Rack{Name: "rack-b", Manufacturer: "Mfg", SerialNumber: "B", ExternalID: strPtr("b")}
+	require.NoError(t, a.Create(ctx, pool.DB))
+	require.NoError(t, b.Create(ctx, pool.DB))
+
+	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
+		coreRackNamed("a", "rack-a", "Mfg", "B"),
+		coreRackNamed("b", "rack-b", "Mfg", "A"),
+	})
+
+	gotA, err := (&model.Rack{ID: a.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	gotB, err := (&model.Rack{ID: b.ID}).GetIncludingDeleted(ctx, pool.DB)
+	require.NoError(t, err)
+	assert.Equal(t, "B", gotA.SerialNumber)
+	assert.Equal(t, "A", gotB.SerialNumber)
+}
+
+// #6: a Core rack may share a name with a different live Flow rack.
+func TestMirrorRacks_NameCollisionWithLiveRackConverges(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 
 	live := model.Rack{Name: "collide", Manufacturer: "Mfg", SerialNumber: "LIVE-1", ExternalID: strPtr("x")}
@@ -361,7 +461,7 @@ func TestMirrorRacks_NameCollisionWithLiveRackSkips(t *testing.T) {
 	}
 	// Include the live rack's own Core row so it isn't soft-deleted for absence.
 	mirrorExpectedRacks(ctx, pool, []nicoapi.ExpectedRackDetail{
-		coreRack("x", "Mfg", "LIVE-1"),
+		coreRackNamed("x", "collide", "Mfg", "LIVE-1"),
 		collidingCore,
 	})
 
@@ -369,9 +469,9 @@ func TestMirrorRacks_NameCollisionWithLiveRackSkips(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, gotLive.DeletedAt, "the live rack holding the name must survive")
 
-	n, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Where("serial_number = ?", "NEW-1").Count(ctx)
+	n, err := pool.DB.NewSelect().Model((*model.Rack)(nil)).Where("name = ?", "collide").Count(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 0, n, "the colliding-name insert must be skipped, not committed or aborting the cycle")
+	assert.Equal(t, 2, n)
 }
 
 // --- component mirror -----------------------------------------------------

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack.go
@@ -77,9 +77,10 @@ func pullExpectedRacks(
 //     the caller only invokes this after a successful RPC, so empty is
 //     authoritative). A legacy row with neither external_id nor a complete
 //     (manufacturer, serial_number) identity is also soft-deleted because no
-//     future snapshot can correlate it. An unmatched legacy row with a
-//     complete natural key remains exempt and is warn-logged for migration.
-//     Soft-deleted rows Core doesn't report are left alone (already gone).
+//     future snapshot can correlate it. A legacy row with a complete natural
+//     key is adopted during step 2 when Core still reports that chassis;
+//     otherwise it is stale and is deleted too. Soft-deleted rows Core doesn't
+//     report are left alone (already gone).
 //
 // All writes for one pass happen in a single transaction so partial failures
 // can't leave the table half-mirrored.
@@ -115,56 +116,24 @@ func mirrorExpectedRacks(
 	}
 	var p plan
 
-	// Tombstones (soft-deleted rows) indexed by name. Used to GC stale rows
-	// that occupy the full unique rack_name_idx index before INSERT/UPDATE
-	// statements that would otherwise collide. Same row can be matched at
-	// most once: gcTombstoneForNameReuse deletes the entry after firing so
-	// we don't attempt to GC the same tombstone twice in the same cycle.
-	tombstonesByName := make(map[string]*model.Rack)
-	// liveByName: name -> id of every live (non-deleted) rack. rack_name_idx
-	// is a full unique index, so an INSERT or UPDATE that writes a name a
-	// different live rack already holds would roll back the whole cycle.
-	// The mirror skips the colliding write and logs instead. A soft-deleted
-	// row holding the name is handled separately by gcTombstoneForNameReuse.
-	liveByName := make(map[string]uuid.UUID)
-	for i := range flowRacks {
-		r := &flowRacks[i]
-		if r.DeletedAt != nil {
-			tombstonesByName[r.Name] = r
-			continue
-		}
-		liveByName[r.Name] = r.ID
-	}
-
 	// seenExtID: every Core rack_id still reported this cycle, recorded
 	// BEFORE any skip so the delete phase never drops a Flow rack Core is
 	// still listing (even one whose labels are momentarily incomplete).
 	// touchedIDs: Flow rack UUIDs the match path adopted / updated this
 	// cycle; the delete phase skips them so a rack_id rename (update to the
 	// new external_id) isn't immediately undone by a soft-delete keyed off
-	// the stale in-memory external_id. plannedNaturalKeys: complete natural
-	// keys already queued, to drop Core duplicates before they collide on the
-	// (manufacturer, serial) unique constraint.
+	// the stale in-memory external_id.
 	seenExtID := make(map[string]struct{}, len(coreRacks))
 	touchedIDs := make(map[uuid.UUID]struct{}, len(coreRacks))
-	plannedNaturalKeys := make(map[string]struct{}, len(coreRacks))
-	// plannedNames: names claimed by a write already queued this cycle, which
-	// liveByName cannot know about since it is built from the state at cycle
-	// start. See nameUnavailable.
-	plannedNames := make(map[string]struct{}, len(coreRacks))
-
-	// coreExtIDs / coreNaturalKeys: every rack_id and every complete chassis
-	// pair in this response. Both are precomputed because the guards reading
-	// them ask about Core rows the loops below have not reached yet, whereas
-	// seenExtID only fills in as it goes.
+	naturalKeyWinners := planRackNaturalKeyWinners(coreRacks, flowByNaturalKey)
+	// coreExtIDs contains every rack_id in this response. It is precomputed
+	// because natural-key adoption needs to know whether an external_id on a
+	// candidate row is still authoritative even when that Core row appears
+	// later in the response.
 	coreExtIDs := make(map[string]struct{}, len(coreRacks))
-	coreNaturalKeys := make(map[string]struct{}, len(coreRacks))
 	for _, cr := range coreRacks {
 		if cr.RackID != "" {
 			coreExtIDs[cr.RackID] = struct{}{}
-		}
-		if key := naturalKeyOrEmpty(cr.Labels[labelChassisManufacturer], cr.Labels[labelChassisSerialNumber]); key != "" {
-			coreNaturalKeys[key] = struct{}{}
 		}
 	}
 
@@ -191,18 +160,16 @@ func mirrorExpectedRacks(
 		// collides with nothing, so it needs no such check.
 		naturalKey := naturalKeyOrEmpty(built.Manufacturer, built.SerialNumber)
 		if naturalKey != "" {
-			_, planned := plannedNaturalKeys[naturalKey]
-			if planned {
+			if winner := naturalKeyWinners[naturalKey]; winner != cr.RackID {
 				log.Warn().
 					Str("rack_id", cr.RackID).
+					Str("winning_rack_id", winner).
 					Str("manufacturer", built.Manufacturer).
 					Str("serial", built.SerialNumber).
-					Msg("Expected-inventory mirror: Core reported this chassis on more than one expected rack; mirroring the later rack without chassis labels")
+					Msg("Expected-inventory mirror: Core reported this chassis on more than one expected rack; mirroring the non-owner without chassis labels")
 				built.Manufacturer = ""
 				built.SerialNumber = ""
 				naturalKey = ""
-			} else {
-				plannedNaturalKeys[naturalKey] = struct{}{}
 			}
 		}
 
@@ -215,23 +182,11 @@ func mirrorExpectedRacks(
 				needUpdate = true
 				result.resurrected++
 			}
-			clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, existing.ID, cr.RackID)
 			if patched := rackUpdatedFromCore(&candidate, &built); patched != nil {
 				candidate = *patched
 				needUpdate = true
 			}
-			if needUpdate && nameUnavailable(liveByName, plannedNames, candidate.Name, existing.ID) {
-				log.Warn().
-					Str("rack_id", cr.RackID).
-					Str("name", candidate.Name).
-					Str("rack_serial", candidate.SerialNumber).
-					Msg("Expected-inventory mirror: Core rack name already held by a different live Flow rack; skipping this update to avoid a unique-name abort (operator must resolve the duplicate name)")
-				result.skippedNameTaken++
-				touchedIDs[existing.ID] = struct{}{}
-				continue
-			}
 			if needUpdate {
-				plannedNames[candidate.Name] = struct{}{}
 				p.toUpdate = append(p.toUpdate, candidate)
 			}
 			touchedIDs[existing.ID] = struct{}{}
@@ -251,48 +206,25 @@ func mirrorExpectedRacks(
 				candidate.DeletedAt = nil
 				result.resurrected++
 			}
-			clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, existing.ID, cr.RackID)
 			if patched := rackUpdatedFromCore(&candidate, &built); patched != nil {
 				candidate = *patched
 			}
-			if nameUnavailable(liveByName, plannedNames, candidate.Name, existing.ID) {
-				log.Warn().
-					Str("rack_id", cr.RackID).
-					Str("name", candidate.Name).
-					Str("rack_serial", candidate.SerialNumber).
-					Msg("Expected-inventory mirror: Core rack name already held by a different live Flow rack; skipping this adoption to avoid a unique-name abort (operator must resolve the duplicate name)")
-				result.skippedNameTaken++
-				touchedIDs[existing.ID] = struct{}{}
-				continue
-			}
-			plannedNames[candidate.Name] = struct{}{}
 			p.toUpdate = append(p.toUpdate, candidate)
 			touchedIDs[existing.ID] = struct{}{}
 			result.adopted++
 			continue
 		}
 
-		if nameUnavailable(liveByName, plannedNames, built.Name, uuid.Nil) {
-			log.Warn().
-				Str("rack_id", cr.RackID).
-				Str("name", built.Name).
-				Str("rack_serial", built.SerialNumber).
-				Msg("Expected-inventory mirror: Core rack name already held by a different live Flow rack; skipping this insert to avoid a unique-name abort (operator must resolve the duplicate name)")
-			result.skippedNameTaken++
-			continue
-		}
-
-		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.Nil, cr.RackID)
-		plannedNames[built.Name] = struct{}{}
 		p.toInsert = append(p.toInsert, built)
 	}
 
 	// Reconcile the delete side. Already soft-deleted rows are skipped: if
 	// Core still lists them, the match path above resurrected them; if not,
 	// they're correctly gone already. Live Flow rows whose external_id is set
-	// but absent from Core get soft-deleted. Legacy rows without any complete
-	// identity are also deleted; identifiable legacy rows remain eligible for
-	// later natural-key adoption.
+	// but absent from Core get soft-deleted. Every remaining live legacy row
+	// without external_id is also deleted: a complete natural-key match would
+	// already have been adopted above, so the rest are absent from the
+	// authoritative snapshot.
 	for i := range flowRacks {
 		r := &flowRacks[i]
 		if r.DeletedAt != nil {
@@ -313,25 +245,7 @@ func mirrorExpectedRacks(
 			p.toDelete = append(p.toDelete, *r)
 			continue
 		}
-		// External_id is NULL — never adopted. Without a complete natural key,
-		// this row cannot join the successful authoritative Core snapshot. Keeping
-		// it live also reserves its globally unique rack name, which can prevent a
-		// real Core rack from being mirrored. A complete but currently unmatched
-		// natural key remains a migration-compatible legacy row and may still be
-		// adopted by a later snapshot.
-		key := naturalKeyOrEmpty(r.Manufacturer, r.SerialNumber)
-		if key == "" {
-			p.toDelete = append(p.toDelete, *r)
-			continue
-		}
-		if _, adoptable := coreNaturalKeys[key]; !adoptable {
-			result.legacyExempt++
-			log.Warn().
-				Str("rack_name", r.Name).
-				Str("rack_serial", r.SerialNumber).
-				Str("rack_manufacturer", r.Manufacturer).
-				Msg("Expected-inventory mirror: identifiable legacy Flow rack not present in Core's expected inventory; left in place for possible later adoption")
-		}
+		p.toDelete = append(p.toDelete, *r)
 	}
 
 	if len(p.toInsert) == 0 && len(p.toUpdate) == 0 && len(p.toDelete) == 0 {
@@ -342,16 +256,28 @@ func mirrorExpectedRacks(
 	softDeleted := 0
 	if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		for i := range p.toInsert {
-			if err := gcTombstoneForNameReuse(ctx, tx, tombstonesByName, p.toInsert[i].Name, uuid.Nil); err != nil {
-				return err
+			if chassisSlotOwnedByOther(flowByNaturalKey, &p.toInsert[i]) {
+				if err := releaseChassisSlot(ctx, tx, &p.toInsert[i], now); err != nil {
+					return err
+				}
 			}
-			if _, err := tx.NewInsert().Model(&p.toInsert[i]).Exec(ctx); err != nil {
+			insertResult, err := tx.NewInsert().Model(&p.toInsert[i]).Exec(ctx)
+			if err != nil {
 				return fmt.Errorf("insert rack %q: %w", p.toInsert[i].Name, err)
+			}
+			rowsAffected, err := insertResult.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("count inserted rack %q: %w", p.toInsert[i].Name, err)
+			}
+			if rowsAffected != 1 {
+				return fmt.Errorf("insert rack %q affected %d rows, expected 1", p.toInsert[i].Name, rowsAffected)
 			}
 		}
 		for i := range p.toUpdate {
-			if err := gcTombstoneForNameReuse(ctx, tx, tombstonesByName, p.toUpdate[i].Name, p.toUpdate[i].ID); err != nil {
-				return err
+			if chassisSlotOwnedByOther(flowByNaturalKey, &p.toUpdate[i]) {
+				if err := releaseChassisSlot(ctx, tx, &p.toUpdate[i], now); err != nil {
+					return err
+				}
 			}
 			// Mirror-managed columns only; status / ingested_at / nvldomain_id
 			// belong to other paths. WhereAllWithDeleted is required so a
@@ -359,14 +285,22 @@ func mirrorExpectedRacks(
 			// bun otherwise appends "deleted_at IS NULL" to the UPDATE and the
 			// resurrect silently matches zero rows.
 			p.toUpdate[i].UpdatedAt = now
-			if _, err := tx.NewUpdate().
+			updateResult, err := tx.NewUpdate().
 				Model(&p.toUpdate[i]).
 				Column("name", "manufacturer", "serial_number", "description",
 					"location", "external_id", "deleted_at", "updated_at").
 				WhereAllWithDeleted().
 				Where("id = ?", p.toUpdate[i].ID).
-				Exec(ctx); err != nil {
+				Exec(ctx)
+			if err != nil {
 				return fmt.Errorf("update rack %q: %w", p.toUpdate[i].Name, err)
+			}
+			rowsAffected, err := updateResult.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("count updated rack %q: %w", p.toUpdate[i].Name, err)
+			}
+			if rowsAffected != 1 {
+				return fmt.Errorf("update rack %q affected %d rows, expected 1", p.toUpdate[i].Name, rowsAffected)
 			}
 		}
 		for i := range p.toDelete {
@@ -389,8 +323,8 @@ func mirrorExpectedRacks(
 		// Tx rolled back: per-spec decisions logged above describe intent,
 		// not committed state. Strip success-side counters so the summary
 		// log reflects what actually landed (nothing). pulled,
-		// skippedNoIDOrKey and legacyExempt survive: they're decided
-		// before the tx opened and aren't invalidated by the rollback.
+		// skippedNoIDOrKey survives: it is decided before the tx opened and
+		// isn't invalidated by the rollback.
 		result.resurrected = 0
 		result.adopted = 0
 		return result
@@ -402,58 +336,21 @@ func mirrorExpectedRacks(
 	return result
 }
 
-// nameUnavailable reports whether writing name would collide on rack_name_idx:
-// either a live Flow rack other than selfID already holds it, or a write queued
-// earlier in this cycle has claimed it. selfID is uuid.Nil for an INSERT.
-//
-// The index is a full unique constraint and every write lands in one
-// transaction, so a collision rolls back the entire cycle rather than the one
-// offending write. That is why queued claims count: two Core racks can resolve
-// to the same name, and the second must be skipped rather than left to abort
-// everything.
-func nameUnavailable(
-	liveByName map[string]uuid.UUID,
-	plannedNames map[string]struct{},
-	name string,
-	selfID uuid.UUID,
+// chassisSlotOwnedByOther reports whether the initial Flow snapshot contains
+// another row holding the desired chassis pair. The transaction only needs a
+// release UPDATE in that case. This remains correct for swaps: both desired
+// pairs are occupied by another row in the initial snapshot, so both release
+// operations are planned before their corresponding authoritative updates.
+func chassisSlotOwnedByOther(
+	flowByNaturalKey map[string]*model.Rack,
+	desired *model.Rack,
 ) bool {
-	if _, planned := plannedNames[name]; planned {
-		return true
+	key := naturalKeyOrEmpty(desired.Manufacturer, desired.SerialNumber)
+	if key == "" {
+		return false
 	}
-	id, ok := liveByName[name]
-	return ok && id != selfID
-}
-
-// gcTombstoneForNameReuse hard-deletes a soft-deleted rack that's occupying
-// the supplied name so the caller's INSERT or UPDATE doesn't collide on
-// rack_name_idx (which is a full unique constraint and so applies to
-// tombstones too). excludeID lets the UPDATE path skip the row that's
-// itself being resurrected (the tombstone IS that row; deleting it would
-// erase what we're about to write). uuid.Nil for INSERT — no exclusion
-// needed. The map entry is removed on hit so a later op against the same
-// name doesn't replay the same delete.
-func gcTombstoneForNameReuse(
-	ctx context.Context,
-	tx bun.Tx,
-	tombstonesByName map[string]*model.Rack,
-	name string,
-	excludeID uuid.UUID,
-) error {
-	tomb, ok := tombstonesByName[name]
-	if !ok || tomb.ID == excludeID {
-		return nil
-	}
-	if _, err := tx.NewDelete().Model(tomb).Where("id = ?", tomb.ID).ForceDelete().Exec(ctx); err != nil {
-		return fmt.Errorf("GC stale rack tombstone occupying name %q: %w", name, err)
-	}
-	delete(tombstonesByName, name)
-	log.Info().
-		Str("rack_name", name).
-		Str("tombstone_id", tomb.ID.String()).
-		Str("tombstone_manufacturer", tomb.Manufacturer).
-		Str("tombstone_serial", tomb.SerialNumber).
-		Msg("Expected-inventory mirror: GC'd stale rack tombstone to free up name for reuse")
-	return nil
+	owner := flowByNaturalKey[key]
+	return owner != nil && owner.ID != desired.ID
 }
 
 // getAllRacksIncludingDeleted returns every rack in the Flow DB, soft-deleted
@@ -476,8 +373,9 @@ func getAllRacksIncludingDeleted(ctx context.Context, idb bun.IDB) ([]model.Rack
 // rack_id, so this is a Core-side data fault rather than an expected input.
 //
 // The chassis labels are copied through as-is, empty included. They are
-// descriptive metadata here, not identity, and the caller vets them against
-// rack_manufacturer_serial_idx before writing.
+// descriptive metadata here, not identity. The planner degrades duplicate
+// pairs within one Core response, and the transaction releases any stale Flow
+// holder before the external-id row claims its desired pair.
 func buildRackFromCore(cr nicoapi.ExpectedRackDetail) (model.Rack, bool) {
 	if cr.RackID == "" {
 		return model.Rack{}, false
@@ -485,9 +383,8 @@ func buildRackFromCore(cr nicoapi.ExpectedRackDetail) (model.Rack, bool) {
 
 	name := cr.Name
 	if name == "" {
-		// Flow's rack.name is NOT NULL with a unique index. Core's rack_id is
-		// operator-meaningful and unique, so it stands in until someone
-		// renames the rack through the PATCH path.
+		// Flow's rack.name is NOT NULL. Core's rack_id is operator-meaningful,
+		// so use it as the display name when Core has no name metadata.
 		name = cr.RackID
 	}
 
@@ -532,7 +429,7 @@ func rackLocationFromLabels(labels map[string]string) map[string]any {
 		out["region"] = v
 	}
 	if v := labels[labelLocationDatacenter]; v != "" {
-		out["datacenter"] = v
+		out["data_center"] = v
 	}
 	if v := labels[labelLocationRoom]; v != "" {
 		out["room"] = v
@@ -547,10 +444,10 @@ func rackLocationFromLabels(labels map[string]string) map[string]any {
 // overwritten from `fromCore`. Lifecycle (status / ingested_at) and
 // nvldomain_id belong to other paths and are left alone.
 //
-// A chassis label is filled in only when Flow's copy is empty: Core dropping a
-// label it used to send is a data gap, not an instruction to erase what Flow
-// already recorded. The caller has already blanked any pair that would collide
-// on rack_manufacturer_serial_idx.
+// A successful expected-inventory response is authoritative for all fields
+// copied by buildRackFromCore. Missing labels and metadata therefore clear the
+// corresponding Flow values. Runtime-owned fields are not part of fromCore and
+// remain untouched.
 //
 // Returns nil when no patchable field changed so the caller can skip a no-op
 // UPDATE.
@@ -562,15 +459,11 @@ func rackUpdatedFromCore(existing, fromCore *model.Rack) *model.Rack {
 		patched.Name = fromCore.Name
 		changed = true
 	}
-	// Only overwrite Description / Location when Core actually carries a
-	// value. buildRackFromCore leaves these nil when the labels are absent;
-	// overwriting with an empty/nil map would wipe operator-set rack metadata
-	// every cycle (and DeepEqual(nil, map{}) would also churn a no-op UPDATE).
-	if len(fromCore.Description) > 0 && !reflect.DeepEqual(existing.Description, fromCore.Description) {
+	if !reflect.DeepEqual(existing.Description, fromCore.Description) {
 		patched.Description = fromCore.Description
 		changed = true
 	}
-	if len(fromCore.Location) > 0 && !reflect.DeepEqual(existing.Location, fromCore.Location) {
+	if !reflect.DeepEqual(existing.Location, fromCore.Location) {
 		patched.Location = fromCore.Location
 		changed = true
 	}
@@ -579,11 +472,11 @@ func rackUpdatedFromCore(existing, fromCore *model.Rack) *model.Rack {
 		patched.ExternalID = fromCore.ExternalID
 		changed = true
 	}
-	if existing.Manufacturer == "" && fromCore.Manufacturer != "" {
+	if existing.Manufacturer != fromCore.Manufacturer {
 		patched.Manufacturer = fromCore.Manufacturer
 		changed = true
 	}
-	if existing.SerialNumber == "" && fromCore.SerialNumber != "" {
+	if existing.SerialNumber != fromCore.SerialNumber {
 		patched.SerialNumber = fromCore.SerialNumber
 		changed = true
 	}
@@ -610,31 +503,100 @@ func adoptableByNaturalKey(r *model.Rack, coreExtIDs map[string]struct{}) bool {
 	return !stillReported
 }
 
-// clearChassisLabelsIfSlotTaken blanks built's chassis labels when a Flow rack
-// other than selfID already holds that complete pair. selfID is uuid.Nil for an
-// INSERT. rack_manufacturer_serial_idx covers soft-deleted rows too, so writing
-// an occupied pair would abort the whole cycle; the rack is still mirrored under
-// its external_id, just without the labels.
-func clearChassisLabelsIfSlotTaken(
-	built *model.Rack,
+// planRackNaturalKeyWinners chooses one Core rack for each duplicated chassis
+// pair that Flow's unique index can represent only once. An external-id row
+// already holding the pair keeps it when that rack still claims it; otherwise
+// the lexicographically smallest rack_id wins so Core response order cannot
+// change ownership between reconciliation cycles.
+func planRackNaturalKeyWinners(
+	coreRacks []nicoapi.ExpectedRackDetail,
 	flowByNaturalKey map[string]*model.Rack,
-	selfID uuid.UUID,
-	rackID string,
-) {
-	key := naturalKeyOrEmpty(built.Manufacturer, built.SerialNumber)
-	if key == "" {
-		return
+) map[string]string {
+	claimants := make(map[string]map[string]struct{}, len(coreRacks))
+	for _, coreRack := range coreRacks {
+		if coreRack.RackID == "" {
+			continue
+		}
+		key := naturalKeyOrEmpty(
+			coreRack.Labels[labelChassisManufacturer],
+			coreRack.Labels[labelChassisSerialNumber],
+		)
+		if key == "" {
+			continue
+		}
+		if claimants[key] == nil {
+			claimants[key] = make(map[string]struct{})
+		}
+		claimants[key][coreRack.RackID] = struct{}{}
 	}
-	owner, ok := flowByNaturalKey[key]
-	if !ok || owner.ID == selfID {
-		return
+
+	winners := make(map[string]string, len(claimants))
+	for key, rackIDs := range claimants {
+		winner := ""
+		for rackID := range rackIDs {
+			if winner == "" || rackID < winner {
+				winner = rackID
+			}
+		}
+		if owner := flowByNaturalKey[key]; owner != nil && owner.ExternalID != nil {
+			if _, stillClaimsPair := rackIDs[*owner.ExternalID]; stillClaimsPair {
+				winner = *owner.ExternalID
+			}
+		}
+		winners[key] = winner
 	}
-	log.Warn().
-		Str("rack_id", rackID).
-		Str("manufacturer", built.Manufacturer).
-		Str("serial", built.SerialNumber).
-		Str("held_by_rack", owner.Name).
-		Msg("Expected-inventory mirror: another Flow rack already holds this chassis manufacturer and serial number; mirroring this rack without chassis labels")
-	built.Manufacturer = ""
-	built.SerialNumber = ""
+	return winners
+}
+
+// releaseChassisSlot clears a desired chassis pair from any other Flow row
+// before an INSERT or UPDATE claims it. external_id is the authoritative rack
+// identity, so a stale natural-key holder must not prevent Core from correcting
+// the external-id row. Clearing first also permits two racks to swap chassis
+// pairs within one transaction. The unique index guarantees at most one other
+// row can be changed.
+func releaseChassisSlot(
+	ctx context.Context,
+	tx bun.Tx,
+	desired *model.Rack,
+	now time.Time,
+) error {
+	if naturalKeyOrEmpty(desired.Manufacturer, desired.SerialNumber) == "" {
+		return nil
+	}
+
+	query := tx.NewUpdate().
+		Model(&model.Rack{}).
+		Set("manufacturer = NULL").
+		Set("serial_number = NULL").
+		Set("updated_at = ?", now).
+		Where("manufacturer = ?", desired.Manufacturer).
+		Where("serial_number = ?", desired.SerialNumber).
+		WhereAllWithDeleted()
+	if desired.ID != uuid.Nil {
+		query = query.Where("id <> ?", desired.ID)
+	}
+
+	updateResult, err := query.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("release chassis slot for rack %q: %w", desired.Name, err)
+	}
+	rowsAffected, err := updateResult.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count released chassis slots for rack %q: %w", desired.Name, err)
+	}
+	if rowsAffected > 1 {
+		return fmt.Errorf("release chassis slot for rack %q affected %d rows, expected at most 1", desired.Name, rowsAffected)
+	}
+	if rowsAffected == 1 {
+		rackID := ""
+		if desired.ExternalID != nil {
+			rackID = *desired.ExternalID
+		}
+		log.Info().
+			Str("rack_id", rackID).
+			Str("manufacturer", desired.Manufacturer).
+			Str("serial", desired.SerialNumber).
+			Msg("Expected-inventory mirror: released occupied chassis slot for authoritative rack update")
+	}
+	return nil
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	daoconverter "github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/dao"
+	pbconverter "github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/protobuf"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 )
@@ -49,6 +51,75 @@ func TestNaturalKeyOrEmpty(t *testing.T) {
 	}
 }
 
+func TestChassisSlotOwnedByOther(t *testing.T) {
+	ownerID := uuid.New()
+	otherID := uuid.New()
+	owner := &model.Rack{
+		ID:           ownerID,
+		Manufacturer: "NVIDIA",
+		SerialNumber: "SN-1",
+	}
+	flowByNaturalKey := map[string]*model.Rack{
+		naturalKey("NVIDIA", "SN-1"): owner,
+	}
+
+	tests := []struct {
+		name    string
+		desired model.Rack
+		want    bool
+	}{
+		{
+			name:    "same rack already owns slot",
+			desired: model.Rack{ID: ownerID, Manufacturer: "NVIDIA", SerialNumber: "SN-1"},
+		},
+		{
+			name:    "another rack owns slot",
+			desired: model.Rack{ID: otherID, Manufacturer: "NVIDIA", SerialNumber: "SN-1"},
+			want:    true,
+		},
+		{
+			name:    "new rack claims occupied slot",
+			desired: model.Rack{Manufacturer: "NVIDIA", SerialNumber: "SN-1"},
+			want:    true,
+		},
+		{
+			name:    "slot is free",
+			desired: model.Rack{ID: otherID, Manufacturer: "NVIDIA", SerialNumber: "SN-2"},
+		},
+		{
+			name:    "incomplete pair occupies no slot",
+			desired: model.Rack{ID: otherID, Manufacturer: "NVIDIA"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, chassisSlotOwnedByOther(flowByNaturalKey, &tc.desired))
+		})
+	}
+}
+
+func TestPlanRackNaturalKeyWinners(t *testing.T) {
+	coreRacks := []nicoapi.ExpectedRackDetail{
+		coreRackNamed("b34", "rack-b", "Mfg", "SHARED"),
+		coreRackNamed("a12", "rack-a", "Mfg", "SHARED"),
+	}
+	key := naturalKey("Mfg", "SHARED")
+
+	t.Run("rack id order is deterministic without an existing owner", func(t *testing.T) {
+		winners := planRackNaturalKeyWinners(coreRacks, nil)
+		assert.Equal(t, "a12", winners[key])
+	})
+
+	t.Run("the external id already holding the pair retains it", func(t *testing.T) {
+		ownerID := "b34"
+		winners := planRackNaturalKeyWinners(coreRacks, map[string]*model.Rack{
+			key: {ExternalID: &ownerID},
+		})
+		assert.Equal(t, "b34", winners[key])
+	})
+}
+
 func TestBuildRackFromCore(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -80,13 +151,14 @@ func TestBuildRackFromCore(t *testing.T) {
 				assert.Equal(t, "MGX-Rack-Gen2", r.Description["model"])
 				assert.Equal(t, "Building 1, Row 3", r.Description["text"])
 				assert.Equal(t, "us-east", r.Location["region"])
-				assert.Equal(t, "DC1", r.Location["datacenter"])
+				assert.Equal(t, "DC1", r.Location["data_center"])
+				assert.NotContains(t, r.Location, "datacenter")
 				assert.NotContains(t, r.Location, "room")
 				assert.NotContains(t, r.Location, "position")
 			},
 		},
 		{
-			name: "empty name falls back to rack_id so the NOT NULL/unique name constraint holds",
+			name: "empty name falls back to rack_id so the NOT NULL name constraint holds",
 			in: nicoapi.ExpectedRackDetail{
 				RackID: "b07",
 				Labels: map[string]string{
@@ -182,6 +254,37 @@ func TestBuildRackFromCore(t *testing.T) {
 	}
 }
 
+func TestRackFromCoreRoundTripsThroughPublicFlowModel(t *testing.T) {
+	built, ok := buildRackFromCore(nicoapi.ExpectedRackDetail{
+		RackID:      "a12",
+		Name:        "Rack A12",
+		Description: "Building 1, Row 3",
+		Labels: map[string]string{
+			labelChassisManufacturer: "Foxconn",
+			labelChassisSerialNumber: "SN-A12",
+			labelChassisModel:        "MGX-Rack-Gen2",
+			labelLocationRegion:      "us-east",
+			labelLocationDatacenter:  "DC1",
+			labelLocationRoom:        "room-3",
+			labelLocationPosition:    "row-3",
+		},
+	})
+	require.True(t, ok)
+
+	public := pbconverter.RackTo(daoconverter.RackFrom(&built))
+	require.NotNil(t, public)
+	require.NotNil(t, public.GetInfo())
+	assert.Equal(t, "Foxconn", public.GetInfo().GetManufacturer())
+	assert.Equal(t, "SN-A12", public.GetInfo().GetSerialNumber())
+	assert.Equal(t, "MGX-Rack-Gen2", public.GetInfo().GetModel())
+	assert.JSONEq(t, `{"model":"MGX-Rack-Gen2","text":"Building 1, Row 3"}`, public.GetInfo().GetDescription())
+	require.NotNil(t, public.GetLocation())
+	assert.Equal(t, "us-east", public.GetLocation().GetRegion())
+	assert.Equal(t, "DC1", public.GetLocation().GetDatacenter())
+	assert.Equal(t, "room-3", public.GetLocation().GetRoom())
+	assert.Equal(t, "row-3", public.GetLocation().GetPosition())
+}
+
 func TestRackUpdatedFromCore(t *testing.T) {
 	id := uuid.New()
 	base := func() *model.Rack {
@@ -258,88 +361,37 @@ func TestRackUpdatedFromCore(t *testing.T) {
 		assert.Equal(t, "SN-1", got.SerialNumber)
 	})
 
-	t.Run("Core dropping a chassis label does not erase Flow's copy", func(t *testing.T) {
+	t.Run("Core dropping chassis labels clears Flow's copy", func(t *testing.T) {
 		existing := base()
 		fromCore := *base()
 		fromCore.Manufacturer = ""
 		fromCore.SerialNumber = ""
-		assert.Nil(t, rackUpdatedFromCore(existing, &fromCore))
+		got := rackUpdatedFromCore(existing, &fromCore)
+		require.NotNil(t, got)
+		assert.Empty(t, got.Manufacturer)
+		assert.Empty(t, got.SerialNumber)
 	})
 
-	t.Run("a populated chassis label is not overwritten with a different one", func(t *testing.T) {
+	t.Run("Core corrections overwrite populated chassis labels", func(t *testing.T) {
 		existing := base()
 		fromCore := *base()
 		fromCore.Manufacturer = "Wistron"
 		fromCore.SerialNumber = "SN-2"
-		assert.Nil(t, rackUpdatedFromCore(existing, &fromCore))
-	})
-}
-
-func TestNameUnavailable(t *testing.T) {
-	holder := uuid.New()
-	liveByName := map[string]uuid.UUID{"held": holder}
-
-	tests := []struct {
-		name         string
-		plannedNames map[string]struct{}
-		rackName     string
-		selfID       uuid.UUID
-		want         bool
-	}{
-		{name: "free name", rackName: "free", selfID: uuid.Nil},
-		{name: "name held by another live rack", rackName: "held", selfID: uuid.New(), want: true},
-		{name: "name held by the rack being updated", rackName: "held", selfID: holder},
-		{
-			name:         "name claimed by a write queued earlier this cycle",
-			plannedNames: map[string]struct{}{"free": {}},
-			rackName:     "free",
-			selfID:       uuid.Nil,
-			want:         true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			planned := tc.plannedNames
-			if planned == nil {
-				planned = map[string]struct{}{}
-			}
-			assert.Equal(t, tc.want, nameUnavailable(liveByName, planned, tc.rackName, tc.selfID))
-		})
-	}
-}
-
-func TestClearChassisLabelsIfSlotTaken(t *testing.T) {
-	owner := &model.Rack{ID: uuid.New(), Name: "owner", Manufacturer: "Foxconn", SerialNumber: "SN-1"}
-	flowByNaturalKey := map[string]*model.Rack{
-		naturalKey("Foxconn", "SN-1"): owner,
-	}
-
-	t.Run("labels held by another rack are dropped", func(t *testing.T) {
-		built := model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-1"}
-		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.New(), "b34")
-		assert.Empty(t, built.Manufacturer)
-		assert.Empty(t, built.SerialNumber)
+		got := rackUpdatedFromCore(existing, &fromCore)
+		require.NotNil(t, got)
+		assert.Equal(t, "Wistron", got.Manufacturer)
+		assert.Equal(t, "SN-2", got.SerialNumber)
 	})
 
-	t.Run("the rack already holding the pair keeps it", func(t *testing.T) {
-		built := model.Rack{Manufacturer: "Foxconn", SerialNumber: "SN-1"}
-		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, owner.ID, "a12")
-		assert.Equal(t, "Foxconn", built.Manufacturer)
-		assert.Equal(t, "SN-1", built.SerialNumber)
-	})
-
-	t.Run("an unclaimed pair is kept", func(t *testing.T) {
-		built := model.Rack{Manufacturer: "Wistron", SerialNumber: "SN-9"}
-		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.Nil, "c01")
-		assert.Equal(t, "Wistron", built.Manufacturer)
-		assert.Equal(t, "SN-9", built.SerialNumber)
-	})
-
-	t.Run("a half-populated pair occupies no slot and is left alone", func(t *testing.T) {
-		built := model.Rack{SerialNumber: "SN-1"}
-		clearChassisLabelsIfSlotTaken(&built, flowByNaturalKey, uuid.Nil, "c02")
-		assert.Equal(t, "SN-1", built.SerialNumber)
+	t.Run("missing Core description and location clear Flow's copy", func(t *testing.T) {
+		existing := base()
+		fromCore := *base()
+		fromCore.Description = nil
+		fromCore.Location = nil
+		got := rackUpdatedFromCore(existing, &fromCore)
+		require.NotNil(t, got)
+		assert.Nil(t, got.Description)
+		assert.Nil(t, got.Location)
 	})
 }
 

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_rack_test.go
@@ -277,7 +277,7 @@ func TestRackFromCoreRoundTripsThroughPublicFlowModel(t *testing.T) {
 	assert.Equal(t, "Foxconn", public.GetInfo().GetManufacturer())
 	assert.Equal(t, "SN-A12", public.GetInfo().GetSerialNumber())
 	assert.Equal(t, "MGX-Rack-Gen2", public.GetInfo().GetModel())
-	assert.JSONEq(t, `{"model":"MGX-Rack-Gen2","text":"Building 1, Row 3"}`, public.GetInfo().GetDescription())
+	assert.Equal(t, "Building 1, Row 3", public.GetInfo().GetDescription())
 	require.NotNil(t, public.GetLocation())
 	assert.Equal(t, "us-east", public.GetLocation().GetRegion())
 	assert.Equal(t, "DC1", public.GetLocation().GetDatacenter())

--- a/rest-api/flow/internal/task/manager/resolver.go
+++ b/rest-api/flow/internal/task/manager/resolver.go
@@ -101,12 +101,12 @@ func resolveRackTarget(
 	rt *operation.RackTarget,
 ) (*rack.Rack, error) {
 	rackObj, err := fetcher.GetRackByIdentifier(ctx, rt.Identifier, true)
-	if rackObj == nil {
-		return nil, fmt.Errorf("rack not found for identifier %+v", rt.Identifier)
-	}
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rack by identifier %+v: %w", rt.Identifier, err)
+	}
+
+	if rackObj == nil {
+		return nil, fmt.Errorf("rack not found for identifier %+v", rt.Identifier)
 	}
 
 	var components []component.Component

--- a/rest-api/flow/internal/task/manager/resolver_test.go
+++ b/rest-api/flow/internal/task/manager/resolver_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	identifier "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/Identifier"
@@ -380,6 +382,26 @@ func TestResolveTargetSpecToRacks_RackFetchError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
+}
+
+func TestResolveTargetSpecToRacks_RackFetchErrorTakesPrecedenceOverNilRack(t *testing.T) {
+	ctx := context.Background()
+	fetcher := newMockTargetFetcher()
+	fetcher.getRackErr = status.Error(codes.InvalidArgument, "rack name matches multiple racks; use rack id")
+
+	targetSpec := &operation.TargetSpec{
+		Racks: []operation.RackTarget{
+			{Identifier: identifier.Identifier{Name: "shared"}},
+		},
+	}
+
+	result, err := resolveTargetSpecToRacks(ctx, fetcher, targetSpec)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.ErrorContains(t, err, "rack name matches multiple racks; use rack id")
+	assert.NotContains(t, err.Error(), "rack not found")
 }
 
 func TestResolveTargetSpecToRacks_NVLinkDomainTargets(t *testing.T) {


### PR DESCRIPTION
Core is the source of truth for expected rack inventory, but Flow preserved stale rack metadata, skipped racks whose names collided with existing rows, and retained unmatched legacy racks indefinitely. Flow also stored `location.datacenter` under a JSON key that the shared location model did not read.

This change makes expected-rack reconciliation converge on each complete successful Core snapshot. It matches racks by Core `rack_id` through `external_id`, overwrites or clears Core-owned metadata, preserves Flow runtime fields, adopts legacy rows by chassis identity, and soft-deletes every unmatched legacy row after adoption. Chassis slot changes release stale database ownership before the authoritative external-ID row is updated, including rack-to-rack swaps; duplicate Core chassis claims use the current external-ID owner or a deterministic rack-ID fallback.

Rack names are now non-unique metadata, matching the Core contract. The migration replaces the unique name constraint with a normal lookup index, so distinct Core rack IDs with the same name are all mirrored. List and filter operations may return all matching racks, while singular name lookup rejects ambiguous matches and directs callers to use the rack UUID.

The DAO and public Flow conversion now expose the mirrored chassis model and use the shared `data_center` location key.

## Related issues

Fixes #4349
Fixes #4350
Fixes #4354
Bug 6593367

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The down migration refuses to restore rack-name uniqueness while duplicate names remain.

Verified with `go test ./flow/...`, DB-backed rack reconciliation tests against a disposable PostgreSQL instance, focused `go vet`, the REST lint target, and changed-line `golangci-lint`.