### PR TITLE
fix(helm/nico-rest): give the site worker headroom for large sites

### DIFF
--- a/helm/rest/nico-rest/charts/nico-rest-workflow/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-workflow/values.yaml
@@ -19,12 +19,23 @@ cloudWorker:
 
 siteWorker:
   replicaCount: 1
+  ## The site worker's footprint scales with the size of the site it is
+  ## reconciling, which the original 128Mi/512Mi did not account for -- it was
+  ## sized before large-fleet testing. On a 4,500-host site the steady state is
+  ## roughly 165MiB with a 195MiB peak, so 512Mi leaves under 3x headroom on a
+  ## workload whose demand grows with the inventory.
+  ##
+  ## Raise the limit to 1Gi and the request to 256Mi. The request now sits above
+  ## observed steady state so scheduling reflects real usage, and the limit
+  ## gives ~5x headroom over the measured peak without reserving memory the
+  ## worker has never been shown to need. Deliberately modest: this is
+  ## headroom for a known growth trend, not a fix for a diagnosed leak.
   resources:
     requests:
-      memory: "128Mi"
+      memory: "256Mi"
       cpu: "100m"
     limits:
-      memory: "512Mi"
+      memory: "1Gi"
       cpu: "500m"
 
 secrets:


### PR DESCRIPTION
The site worker's memory footprint scales with the size of the site it reconciles, and `128Mi`/`512Mi` was set before large-fleet testing.

| | before | after |
|---|---|---|
| requests.memory | 128Mi | **256Mi** |
| limits.memory | 512Mi | **1Gi** |

On a 4,500-host site the worker settles around **165 MiB with a 195 MiB peak**, so the old limit left under 3x headroom on a workload whose demand grows with the inventory. The request now sits above observed steady state so scheduling reflects real usage, and the limit gives roughly 5x headroom over the measured peak.

**Deliberately modest, and I want to be straight about why.** This was originally filed as a perpetual OOM crash-loop (#5001, ~54 restarts). That was observed while our test harness was silently rendering a **double-sized fleet** — 9,000 hosts where 4,500 were configured — which we have since found and fixed. Re-checking on a correctly-sized fleet, the worker does not OOM at all:

- three replicas showing 0–1 restarts
- the single restart exited `code 2`, not `OOMKilled`
- no `OOMKilled` events in the namespace

So this is headroom for a known growth trend, not a fix for a diagnosed leak, and it is sized accordingly rather than defensively. If you would rather close #5001 as not-reproducible and leave the limits alone, that is a reasonable call too — happy to drop this.

`cloudWorker` is deliberately left untouched: only the site worker's footprint tracks site size.

## Related issues

Fixes #5001.

## Type of Change

- [ ] **Add**
- [x] **Change**
- [ ] **Fix**
- [ ] **Remove**
- [ ] **Internal**

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed — memory measured from the container cgroup on a 4,500-host site.
- [ ] No testing required