### PR TITLE
fix(agent): Use BGP neighbors endpoint for NVUE uplink health

### DIFF
--- a/crates/agent/src/health/nvue.rs
+++ b/crates/agent/src/health/nvue.rs
@@ -15,10 +15,8 @@
  * limitations under the License.
  */
 
-use std::collections::BTreeMap;
-
 use health_report::{HealthProbeAlert, HealthProbeSuccess, HealthReport};
-use nvue_client::types::bgp::{BgpPeerInfo, BgpPeerState, BgpVrfInfo};
+use nvue_client::types::bgp::{BgpNeighbors, BgpPeerState};
 use nvue_client::{FieldFilter, NvueClient};
 
 use super::{failed, make_alert, probe_ids};
@@ -58,19 +56,19 @@ impl NvueHealthCheck<'_> {
 
     /// Checks BGP uplink session health through the configured NVUE API target.
     async fn check_bgp_uplinks(&self, report: &mut HealthReport) {
-        const BGP_NEIGHBOR_STATE_FIELD: &str = "/neighbor/*/state";
+        const BGP_NEIGHBOR_STATE_FIELD: &str = "/*/state";
 
-        let bgp_vrf_info = self
+        let bgp_neighbors = self
             .nvue_client
-            .get_bgp_vrf_info_filtered(
+            .get_bgp_neighbors_filtered(
                 BGP_VRF_UPLINKS,
                 FieldFilter::with_includes([BGP_NEIGHBOR_STATE_FIELD]),
             )
             .await;
-        match bgp_vrf_info.as_ref() {
-            Ok(bgp_vrf_info) => check_bgp_uplink_sessions(
+        match bgp_neighbors.as_ref() {
+            Ok(bgp_neighbors) => check_bgp_uplink_sessions(
                 report,
-                bgp_vrf_info,
+                bgp_neighbors.as_ref(),
                 self.min_healthy_links,
                 self.hbn_device_names,
             ),
@@ -78,7 +76,7 @@ impl NvueHealthCheck<'_> {
                 report,
                 probe_ids::BgpPeeringTor.clone(),
                 None,
-                format!("Error fetching NVUE BGP data for VRF {BGP_VRF_UPLINKS}: {error}"),
+                format!("Error fetching NVUE BGP neighbor data for VRF {BGP_VRF_UPLINKS}: {error}"),
             ),
         }
     }
@@ -100,7 +98,7 @@ impl NvueHealthCheck<'_> {
     }
 }
 
-/// Checks configured ToR BGP sessions from an already-fetched NVUE BGP VRF response.
+/// Checks configured ToR BGP sessions from an already-fetched NVUE BGP neighbor response.
 ///
 /// All configured HBN uplinks are evaluated, and the check passes when at least
 /// `min_healthy_links` of them are present and established. If too few uplinks
@@ -110,7 +108,7 @@ impl NvueHealthCheck<'_> {
 /// device names provide. The helper does not emit success entries.
 pub(super) fn check_bgp_uplink_sessions(
     report: &mut HealthReport,
-    bgp: &BgpVrfInfo,
+    neighbors: Option<&BgpNeighbors>,
     min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
@@ -119,7 +117,7 @@ pub(super) fn check_bgp_uplink_sessions(
     let expected_hbn_uplinks = hbn_device_names.uplinks.iter().copied();
 
     for expected_uplink in expected_hbn_uplinks {
-        match check_expected_peer_established(bgp.neighbor.as_ref(), expected_uplink) {
+        match check_expected_peer_established(neighbors, expected_uplink) {
             Ok(()) => healthy_uplink_count += 1,
             Err(message) => unhealthy_uplink_names.push((expected_uplink.to_string(), message)),
         }
@@ -177,7 +175,7 @@ pub(super) fn check_bgp_uplink_sessions(
 /// missing state, or non-established state returns a descriptive error message
 /// for conversion to a health alert by the caller.
 fn check_expected_peer_established(
-    neighbors: Option<&BTreeMap<String, BgpPeerInfo>>,
+    neighbors: Option<&BgpNeighbors>,
     peer_name: &str,
 ) -> Result<(), String> {
     let Some(neighbors) = neighbors else {
@@ -216,9 +214,9 @@ mod tests {
         expected_alerts: Vec<health_report::HealthProbeAlert>,
     }
 
-    /// Builds a NVUE BGP VRF response from a compact scenario JSON fixture.
-    fn bgp_vrf_info(bgp_json: &str) -> BgpVrfInfo {
-        serde_json::from_str(bgp_json).expect("BGP VRF info should deserialize")
+    /// Builds NVUE BGP neighbors from a compact scenario JSON fixture.
+    fn bgp_neighbors(bgp_json: &str) -> Option<BgpNeighbors> {
+        serde_json::from_str(bgp_json).expect("BGP neighbors should deserialize")
     }
 
     /// Builds a ToR peering alert with the same target and criticality rules as production.
@@ -256,18 +254,16 @@ mod tests {
                     scenario: "all configured uplinks established",
                     bgp_json: r#"
                     {
-                        "neighbor": {
-                            "p0_if": { "state": "established" },
-                            "p1_if": { "state": "established" }
-                        }
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "established" }
                     }
                     "#,
                     min_healthy_links: 2,
                     expected_alerts: vec![],
                 },
                 Row {
-                    scenario: "missing neighbor map alerts for each configured uplink",
-                    bgp_json: r#"{}"#,
+                    scenario: "null neighbor response alerts for each configured uplink",
+                    bgp_json: r#"null"#,
                     min_healthy_links: 2,
                     expected_alerts: vec![
                         tor_alert(
@@ -286,9 +282,7 @@ mod tests {
                     scenario: "missing configured uplink targets that uplink",
                     bgp_json: r#"
                     {
-                        "neighbor": {
-                            "p0_if": { "state": "established" }
-                        }
+                        "p0_if": { "state": "established" }
                     }
                     "#,
                     min_healthy_links: 2,
@@ -302,10 +296,8 @@ mod tests {
                     scenario: "idle configured uplink alerts when below threshold",
                     bgp_json: r#"
                     {
-                        "neighbor": {
-                            "p0_if": { "state": "idle" },
-                            "p1_if": { "state": "established" }
-                        }
+                        "p0_if": { "state": "idle" },
+                        "p1_if": { "state": "established" }
                     }
                     "#,
                     min_healthy_links: 2,
@@ -319,10 +311,8 @@ mod tests {
                     scenario: "another non-established state alerts",
                     bgp_json: r#"
                     {
-                        "neighbor": {
-                            "p0_if": { "state": "active" },
-                            "p1_if": { "state": "established" }
-                        }
+                        "p0_if": { "state": "active" },
+                        "p1_if": { "state": "established" }
                     }
                     "#,
                     min_healthy_links: 2,
@@ -336,10 +326,8 @@ mod tests {
                     scenario: "missing state alerts",
                     bgp_json: r#"
                     {
-                        "neighbor": {
-                            "p0_if": {},
-                            "p1_if": { "state": "established" }
-                        }
+                        "p0_if": {},
+                        "p1_if": { "state": "established" }
                     }
                     "#,
                     min_healthy_links: 2,
@@ -353,12 +341,10 @@ mod tests {
                     scenario: "extra non-ToR and route-server neighbors ignored",
                     bgp_json: r#"
                     {
-                        "neighbor": {
-                            "p0_if": { "state": "established" },
-                            "p1_if": { "state": "established" },
-                            "tenant-vrf-peer": { "state": "idle" },
-                            "10.217.126.67": { "state": "active" }
-                        }
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "established" },
+                        "tenant-vrf-peer": { "state": "idle" },
+                        "10.217.126.67": { "state": "active" }
                     }
                     "#,
                     min_healthy_links: 2,
@@ -368,10 +354,8 @@ mod tests {
                     scenario: "one healthy uplink may be the second configured uplink",
                     bgp_json: r#"
                     {
-                        "neighbor": {
-                            "p0_if": { "state": "idle" },
-                            "p1_if": { "state": "established" }
-                        }
+                        "p0_if": { "state": "idle" },
+                        "p1_if": { "state": "established" }
                     }
                     "#,
                     min_healthy_links: 1,
@@ -381,10 +365,8 @@ mod tests {
                     scenario: "min healthy links greater than configured uplinks alerts",
                     bgp_json: r#"
                     {
-                        "neighbor": {
-                            "p0_if": { "state": "established" },
-                            "p1_if": { "state": "established" }
-                        }
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "established" }
                     }
                     "#,
                     min_healthy_links: 3,
@@ -402,9 +384,10 @@ mod tests {
             }),
             |row| {
                 let mut hr = HealthReport::empty("forge-dpu-agent".to_string());
+                let bgp_neighbors = bgp_neighbors(row.bgp_json);
                 check_bgp_uplink_sessions(
                     &mut hr,
-                    &bgp_vrf_info(row.bgp_json),
+                    bgp_neighbors.as_ref(),
                     row.min_healthy_links,
                     &HBNDeviceNames::hbn_23(),
                 );

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -25,7 +25,7 @@ use reqwest::{Client, ClientBuilder, Method, Response, Url};
 pub use serde_json::Value as JsonValue;
 
 use crate::config::{NvueConfig, NvueConfigWithHeader, NvueRevision};
-use crate::types::bgp::BgpVrfInfo;
+use crate::types::bgp::{BgpNeighbors, BgpVrfInfo};
 use crate::types::revision::{RevisionApplyStatus, RevisionData, RevisionIssueSummary};
 
 /// Repeated NVUE field-selection query parameters.
@@ -223,16 +223,46 @@ impl NvueClient {
         );
         let mut request = self.request(Method::GET, &path)?.build()?;
 
-        if !filter.is_empty() {
-            let mut query_pairs = request.url_mut().query_pairs_mut();
-            for (key, value) in filter.query_pairs() {
-                query_pairs.append_pair(key, value);
-            }
-        }
+        append_filter_query_pairs(&mut request, &filter);
 
         let response = self.execute("get_bgp_vrf_info", request).await?;
         let bgp_vrf_info = response.json().await?;
         Ok(bgp_vrf_info)
+    }
+
+    /// Return BGP neighbor data for a VRF.
+    ///
+    /// This calls `GET /nvue_v1/vrf/{vrf-id}/router/bgp/neighbor` without field filters.
+    /// The `vrf_id` path segment is URL-encoded before the request is built.
+    pub async fn get_bgp_neighbors(
+        &self,
+        vrf_id: &str,
+    ) -> Result<Option<BgpNeighbors>, NvueClientError> {
+        self.get_bgp_neighbors_filtered(vrf_id, FieldFilter::new())
+            .await
+    }
+
+    /// Return BGP neighbor data for a VRF, applying NVUE field-selection filters.
+    ///
+    /// This calls `GET /nvue_v1/vrf/{vrf-id}/router/bgp/neighbor`. Non-empty
+    /// filters are encoded as repeated `include` and `omit` query parameters.
+    /// The `vrf_id` path segment is URL-encoded before the request is built.
+    pub async fn get_bgp_neighbors_filtered(
+        &self,
+        vrf_id: &str,
+        filter: FieldFilter,
+    ) -> Result<Option<BgpNeighbors>, NvueClientError> {
+        let path = format!(
+            "/nvue_v1/vrf/{encoded_vrf_id}/router/bgp/neighbor",
+            encoded_vrf_id = urlencoding::encode(vrf_id),
+        );
+        let mut request = self.request(Method::GET, &path)?.build()?;
+
+        append_filter_query_pairs(&mut request, &filter);
+
+        let response = self.execute("get_bgp_neighbors_filtered", request).await?;
+        let bgp_neighbors = response.json().await?;
+        Ok(bgp_neighbors)
     }
 
     /// Create a new NVUE config revision, returning the revision ID.
@@ -390,6 +420,17 @@ impl NvueClient {
         let resonse_body: BTreeMap<String, _> = response.json().await?;
         let response = resonse_body.into_values().collect();
         Ok(response)
+    }
+}
+
+fn append_filter_query_pairs(request: &mut reqwest::Request, filter: &FieldFilter) {
+    if filter.is_empty() {
+        return;
+    }
+
+    let mut query_pairs = request.url_mut().query_pairs_mut();
+    for (key, value) in filter.query_pairs() {
+        query_pairs.append_pair(key, value);
     }
 }
 

--- a/crates/nvue-client/src/types/bgp.rs
+++ b/crates/nvue-client/src/types/bgp.rs
@@ -20,6 +20,9 @@ use std::collections::BTreeMap;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
+/// BGP neighbor collection response data, keyed by peer name.
+pub type BgpNeighbors = BTreeMap<String, BgpPeerInfo>;
+
 /// BGP VRF response data.
 /// Corresponds to `#/x-defs/cue-show-schema-bgp-vrf-bgp`.
 #[derive(Debug, Deserialize)]
@@ -35,7 +38,7 @@ pub struct BgpVrfInfo {
 
     // #/x-defs/cue-show-schema-bgp-vrf-bgp-config-children
     pub address_family: Option<JsonValue>,
-    pub neighbor: Option<BTreeMap<String, BgpPeerInfo>>,
+    pub neighbor: Option<BgpNeighbors>,
     pub peer_group: Option<JsonValue>,
     pub path_selection: Option<JsonValue>,
     pub route_reflection: Option<JsonValue>,


### PR DESCRIPTION
During testing of #5075, it emerged that NVUE (at least this specific flavor of it) does not in fact provide neighbor data when per-VRF BGP data is fetched from the `/nvue_v1/vrf/{vrf-id}/router/bgp` endpoint, and instead we should be using `/nvue_v1/vrf/{vrf-id}/router/bgp/neighbor`. This updates the health check to use that instead.

## Related issues
- #5075
- NVBugs ID 6600607

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


