### PR TITLE
docs(machine-a-tron): bmc_proxy hostname needs the pod key

### DIFF
--- a/docs/development/machine-a-tron-deployment.md
+++ b/docs/development/machine-a-tron-deployment.md
@@ -274,7 +274,7 @@ Add this to the nico-core site config under `[site_explorer]`:
 
 ```toml
 [site_explorer]
-bmc_proxy = "nico-machine-a-tron-bmc-mock.nico-mat.svc.cluster.local:1266"
+bmc_proxy = "nico-machine-a-tron-default-bmc-mock.nico-mat.svc.cluster.local:1266"
 ```
 
 **Use the cross-namespace FQDN.** site-explorer runs inside nico-api in
@@ -298,7 +298,7 @@ to work: when set, machine-a-tron calls nico-api's `set_dynamic_config` to set
 `bmc_proxy` at runtime, but that call is rejected with `PermissionDenied` unless
 `allow_changing_bmc_proxy` is true. The two mechanisms are complementary — the
 values file ships `configureBmcProxyHost:
-"nico-machine-a-tron-bmc-mock.nico-mat.svc.cluster.local"` (FQDN, same
+"nico-machine-a-tron-default-bmc-mock.nico-mat.svc.cluster.local"` (FQDN, same
 cross-namespace requirement), and the nico-core `bmc_proxy` setting both
 enables that path and covers the case where the runtime call has not happened
 yet.
@@ -469,7 +469,7 @@ The `machine_dhcp_records` view inner-joins the singleton control row `machine_i
 | Machine creation fails `No IP addresses left in prefix <admin-cidr>` | Admin pool too small: creation needs one host-PF IP per DPU | Fit `hostCount×dpuPerHostCount` ≤ usable admin-pool IPs (the script auto-fits) |
 | `No IP addresses left in prefix ...`; machines stuck in `BmcInit` | OOB DHCP pool too small for host×DPU count | Sizing: `hostCount + hostCount×dpuPerHostCount` ≤ usable pool IPs; use ≥ /27 or reduce counts |
 | Redfish `connection refused` on every endpoint despite bmc_proxy set | Bare service name resolves against nico-system, not nico-mat | Use the cross-namespace FQDN in `bmc_proxy` |
-| Redfish redirect ignored; `endpoint_explorations=0` | Wrong config field (`override_target_host` is not real) | Use `bmc_proxy = "nico-machine-a-tron-bmc-mock.nico-mat.svc.cluster.local:1266"` under `[site_explorer]` |
+| Redfish redirect ignored; `endpoint_explorations=0` | Wrong config field (`override_target_host` is not real) | Use `bmc_proxy = "nico-machine-a-tron-default-bmc-mock.nico-mat.svc.cluster.local:1266"` under `[site_explorer]` |
 | `Refusing to create managed host, expected machines entry not found` | No `expected_machines` row for the discovered BMC MAC | Set `machineATron.registerExpectedMachines: true` (default) so machine-a-tron auto-registers them |
 | `Refusing to create managed host`; machine-a-tron logs `PermissionDenied` on registration | nico-api build lacks the `Machineatron` → `AddExpectedMachine` RBAC grant | Rebuild nico-api with the grant (internal_rbac_rules.rs); the setup script also has a DB fallback |
 | `SIGSEGV` compiling `aws-lc-sys` | QEMU emulates the `.S` assembler, which crashes | True cross-compilation (native arm64 host → x86_64 target) instead of QEMU |

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -91,7 +91,7 @@ helm upgrade --install nico ./helm \
 
 ```toml
 [site_explorer]
-bmc_proxy = "nico-machine-a-tron-default-bmc-mock.nico-mat.svc.cluster.local:1266"
+bmc_proxy = "nico-machine-a-tron-default-bmc-mock.nico-system.svc.cluster.local:1266"
 ```
 
 The port defaults to 1266 and must match the `service.bmcMock.port` value if

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -91,7 +91,7 @@ helm upgrade --install nico ./helm \
 
 ```toml
 [site_explorer]
-bmc_proxy = "nico-machine-a-tron-bmc-mock.nico-system.svc.cluster.local:1266"
+bmc_proxy = "nico-machine-a-tron-default-bmc-mock.nico-mat.svc.cluster.local:1266"
 ```
 
 The port defaults to 1266 and must match the `service.bmcMock.port` value if


### PR DESCRIPTION
The chart names the BMC mock Service `<release>-<pod key>-bmc-mock` (`templates/service.yaml`), but the docs give it without the pod key. That hostname resolves to nothing, so every Redfish endpoint fails with ConnectionRefused and exploration reports zero endpoints — with no obvious cause.

It appears in the troubleshooting table too, which is exactly where someone looks when exploration is finding nothing, so the doc was handing back the same broken value that caused the problem.

The chart README additionally pointed at the `nico-system` namespace rather than `nico-mat`; corrected to match the deployment guide.

Split out of #4985 on review feedback, so the functional fixes there are not held up by a docs review. The corresponding values-file fixes are in that PR.

## Related issues

Follow-up to review feedback on #4985.

## Type of Change

- [ ] **Add**
- [ ] **Change**
- [x] **Fix**
- [ ] **Remove**
- [ ] **Internal**

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed — the corrected name is the Service that actually exists on a running deployment (`nico-machine-a-tron-default-bmc-mock`).
- [ ] No testing required (docs)