### PR TITLE
fix(admin-ui): properly display network segment state

### DIFF
--- a/crates/api-web/src/network_segment.rs
+++ b/crates/api-web/src/network_segment.rs
@@ -34,6 +34,7 @@ use super::{Base, filters};
 #[template(path = "network_segment_show.html")]
 struct NetworkSegmentShow {
     admin: Vec<NetworkSegmentRowDisplay>,
+    host_inband: Vec<NetworkSegmentRowDisplay>,
     tenant: Vec<NetworkSegmentRowDisplay>,
     underlay: Vec<NetworkSegmentRowDisplay>,
 }
@@ -43,8 +44,7 @@ struct NetworkSegmentRowDisplay {
     id: String,
     vpc_id: String,
     created: String,
-    state: String,
-    time_in_state_above_sla: bool,
+    state_display: super::StateDisplay,
     sub_domain: String,
     mtu: i32,
     prefixes: String,
@@ -70,11 +70,7 @@ impl TryFrom<forgerpc::NetworkSegment> for NetworkSegmentRowDisplay {
             name,
             vpc_id: config.vpc_id.map(|id| id.to_string()).unwrap_or_default(),
             created: segment.created.unwrap_or_default().to_string(),
-            state: lifecycle.map(|lc| lc.state.clone()).unwrap_or_default(),
-            time_in_state_above_sla: lifecycle
-                .and_then(|lc| lc.sla.as_ref())
-                .map(|sla| sla.time_in_state_above_sla)
-                .unwrap_or_default(),
+            state_display: super::StateDisplay::from_lifecycle(lifecycle),
             sub_domain: String::new(), // filled in later
             mtu: config.mtu.unwrap_or(-1),
             prefixes: config
@@ -103,6 +99,7 @@ pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response
     };
 
     let mut admin = Vec::new();
+    let mut host_inband = Vec::new();
     let mut underlay = Vec::new();
     let mut tenant = Vec::new();
     for n in networks.into_iter() {
@@ -129,6 +126,7 @@ pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response
         display.sub_domain = domain_name;
         match forgerpc::NetworkSegmentType::try_from(segment_type) {
             Ok(forgerpc::NetworkSegmentType::Admin) => admin.push(display),
+            Ok(forgerpc::NetworkSegmentType::HostInband) => host_inband.push(display),
             Ok(forgerpc::NetworkSegmentType::Underlay) => underlay.push(display),
             Ok(forgerpc::NetworkSegmentType::Tenant) => tenant.push(display),
             _ => {
@@ -139,6 +137,7 @@ pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response
 
     let tmpl = NetworkSegmentShow {
         admin,
+        host_inband,
         underlay,
         tenant,
     };

--- a/crates/api-web/src/tests/mod.rs
+++ b/crates/api-web/src/tests/mod.rs
@@ -27,6 +27,7 @@ mod explored_endpoint;
 mod firmware;
 mod health;
 mod managed_host;
+mod network_segment;
 mod vpc;
 
 fn make_test_app(test_harness: &TestHarness) -> Router {

--- a/crates/api-web/src/tests/network_segment.rs
+++ b/crates/api-web/src/tests/network_segment.rs
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use axum::body::Body;
+use http_body_util::BodyExt;
+use hyper::http::StatusCode;
+use tower::ServiceExt;
+
+use crate::tests::env::TestEnv;
+use crate::tests::{make_test_app, web_request_builder};
+
+#[crate::sqlx_test]
+async fn overview_shows_host_inband_with_formatted_state(pool: sqlx::PgPool) {
+    let env = TestEnv::new(pool).await;
+    let segment = env
+        .test_harness
+        .network_controller()
+        .create_host_inband_segment(env.domain())
+        .await;
+    let app = make_test_app(&env.test_harness);
+
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri("/admin/network-segment")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("empty response body")
+        .to_bytes();
+    let body = String::from_utf8(body.to_vec()).expect("invalid UTF-8 in response body");
+    let host_inband = body
+        .split_once("<h2>Host Inband</h2>")
+        .expect("missing Host Inband section")
+        .1
+        .split_once("<h2>Underlay</h2>")
+        .expect("missing Underlay section after Host Inband")
+        .0;
+
+    assert!(host_inband.contains(&format!(
+        "href=\"/admin/network-segment/{}\">HOST_INBAND</a>",
+        segment.id
+    )));
+    assert!(host_inband.contains("<span class=\"bubble success\">Ready</span>"));
+    assert!(!host_inband.contains(r#"{&quot;state&quot;:&quot;ready&quot;}"#));
+}

--- a/crates/api-web/templates/network_segment_show.html
+++ b/crates/api-web/templates/network_segment_show.html
@@ -24,17 +24,37 @@
 			<td><a href="/admin/network-segment/{{ ns.id }}">{{ ns.name }}</a></td>
 			<td>{{ ns.id }}</td>
 			<td>{{ ns.created }}</td>
-			<td>
-				{% if ns.state.to_lowercase().contains("failed") %}
-					<span class="bubble error">{{ ns.state }}{% if ns.time_in_state_above_sla %} ⏱️{% endif %}</span>
-				{% else if ns.time_in_state_above_sla %}
-					<span class="bubble warning">{{ ns.state }} ⏱️</span>
-				{% else if ns.state == "Ready" || ns.state == "Assigned/Ready" %}
-					<span class="bubble success">{{ ns.state }}</span>
-				{% else %}
-					<span class="bubble">{{ ns.state }}</span>
-				{% endif %}
-			</td>
+			<td>{{ ns.state_display|safe }}</td>
+			<td>{{ ns.sub_domain }}</td>
+			<td>{{ ns.mtu }}</td>
+			<td>{{ ns.prefixes }}</td>
+			<td>{{ ns.version|config_version|safe }}</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+</table>
+
+<h2>Host Inband</h2>
+<table class="sortable overview">
+	<thead>
+		<th>Name</th>
+		<th>Id</th>
+		<th>VPC ID</th>
+		<th>Created</th>
+		<th>State</th>
+		<th>Sub Domain</th>
+		<th>MTU</th>
+		<th>Prefixes</th>
+		<th>Version</th>
+	</thead>
+	<tbody>
+		{% for ns in host_inband %}
+		<tr>
+			<td><a href="/admin/network-segment/{{ ns.id }}">{{ ns.name }}</a></td>
+			<td>{{ ns.id }}</td>
+			<td><a href="/admin/vpc/{{ ns.vpc_id }}">{{ ns.vpc_id }}</a></td>
+			<td>{{ ns.created }}</td>
+			<td>{{ ns.state_display|safe }}</td>
 			<td>{{ ns.sub_domain }}</td>
 			<td>{{ ns.mtu }}</td>
 			<td>{{ ns.prefixes }}</td>
@@ -62,17 +82,7 @@
 			<td><a href="/admin/network-segment/{{ ns.id }}">{{ ns.name }}</a></td>
 			<td>{{ ns.id }}</td>
 			<td>{{ ns.created }}</td>
-			<td>
-				{% if ns.state.to_lowercase().contains("failed") %}
-					<span class="bubble error">{{ ns.state }}{% if ns.time_in_state_above_sla %} ⏱️{% endif %}</span>
-				{% else if ns.time_in_state_above_sla %}
-					<span class="bubble warning">{{ ns.state }} ⏱️</span>
-				{% else if ns.state == "Ready" || ns.state == "Assigned/Ready" %}
-					<span class="bubble success">{{ ns.state }}</span>
-				{% else %}
-					<span class="bubble">{{ ns.state }}</span>
-				{% endif %}
-			</td>
+			<td>{{ ns.state_display|safe }}</td>
 			<td>{{ ns.sub_domain }}</td>
 			<td>{{ ns.mtu }}</td>
 			<td>{{ ns.prefixes }}</td>
@@ -102,17 +112,7 @@
 			<td>{{ ns.id }}</td>
 			<td><a href="/admin/vpc/{{ ns.vpc_id }}">{{ ns.vpc_id }}</a></td>
 			<td>{{ ns.created }}</td>
-			<td>
-				{% if ns.state.to_lowercase().contains("failed") %}
-					<span class="bubble error">{{ ns.state }}{% if ns.time_in_state_above_sla %} ⏱️{% endif %}</span>
-				{% else if ns.time_in_state_above_sla %}
-					<span class="bubble warning">{{ ns.state }} ⏱️</span>
-				{% else if ns.state == "Ready" || ns.state == "Assigned/Ready" %}
-					<span class="bubble success">{{ ns.state }}</span>
-				{% else %}
-					<span class="bubble">{{ ns.state }}</span>
-				{% endif %}
-			</td>
+			<td>{{ ns.state_display|safe }}</td>
 			<td>{{ ns.sub_domain }}</td>
 			<td>{{ ns.mtu }}</td>
 			<td>{{ ns.prefixes }}</td>

--- a/crates/api-web/templates/network_segment_show.html
+++ b/crates/api-web/templates/network_segment_show.html
@@ -2,124 +2,56 @@
 
 {% block title %}Network Segments{% endblock %}
 
+{% macro network_segment_table(network_segments, show_vpc=false) %}
+<table class="sortable overview">
+	<thead>
+		<th>Name</th>
+		<th>Id</th>
+		{% if show_vpc %}
+			<th>VPC ID</th>
+		{% endif %}
+		<th>Created</th>
+		<th>State</th>
+		<th>Sub Domain</th>
+		<th>MTU</th>
+		<th>Prefixes</th>
+		<th>Version</th>
+	</thead>
+	<tbody>
+		{% for ns in network_segments %}
+		<tr>
+			<td><a href="/admin/network-segment/{{ ns.id }}">{{ ns.name }}</a></td>
+			<td>{{ ns.id }}</td>
+			{% if show_vpc %}
+				<td><a href="/admin/vpc/{{ ns.vpc_id }}">{{ ns.vpc_id }}</a></td>
+			{% endif %}
+			<td>{{ ns.created }}</td>
+			<td>{{ ns.state_display|safe }}</td>
+			<td>{{ ns.sub_domain }}</td>
+			<td>{{ ns.mtu }}</td>
+			<td>{{ ns.prefixes }}</td>
+			<td>{{ ns.version|config_version|safe }}</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+</table>
+{% endmacro %}
+
 {% block content %}
 <div id="json"><a id="json-link" href="">JSON</a></div>
 <h1>Network Segments</h1>
 
 <h2>Admin</h2>
-<table class="sortable overview">
-	<thead>
-		<th>Name</th>
-		<th>Id</th>
-		<th>Created</th>
-		<th>State</th>
-		<th>Sub Domain</th>
-		<th>MTU</th>
-		<th>Prefixes</th>
-		<th>Version</th>
-	</thead>
-	<tbody>
-		{% for ns in admin %}
-		<tr>
-			<td><a href="/admin/network-segment/{{ ns.id }}">{{ ns.name }}</a></td>
-			<td>{{ ns.id }}</td>
-			<td>{{ ns.created }}</td>
-			<td>{{ ns.state_display|safe }}</td>
-			<td>{{ ns.sub_domain }}</td>
-			<td>{{ ns.mtu }}</td>
-			<td>{{ ns.prefixes }}</td>
-			<td>{{ ns.version|config_version|safe }}</td>
-		</tr>
-		{% endfor %}
-	</tbody>
-</table>
+{% call network_segment_table(admin) %}{% endcall %}
 
 <h2>Host Inband</h2>
-<table class="sortable overview">
-	<thead>
-		<th>Name</th>
-		<th>Id</th>
-		<th>VPC ID</th>
-		<th>Created</th>
-		<th>State</th>
-		<th>Sub Domain</th>
-		<th>MTU</th>
-		<th>Prefixes</th>
-		<th>Version</th>
-	</thead>
-	<tbody>
-		{% for ns in host_inband %}
-		<tr>
-			<td><a href="/admin/network-segment/{{ ns.id }}">{{ ns.name }}</a></td>
-			<td>{{ ns.id }}</td>
-			<td><a href="/admin/vpc/{{ ns.vpc_id }}">{{ ns.vpc_id }}</a></td>
-			<td>{{ ns.created }}</td>
-			<td>{{ ns.state_display|safe }}</td>
-			<td>{{ ns.sub_domain }}</td>
-			<td>{{ ns.mtu }}</td>
-			<td>{{ ns.prefixes }}</td>
-			<td>{{ ns.version|config_version|safe }}</td>
-		</tr>
-		{% endfor %}
-	</tbody>
-</table>
+{% call network_segment_table(host_inband, true) %}{% endcall %}
 
 <h2>Underlay</h2>
-<table class="sortable overview">
-	<thead>
-		<th>Name</th>
-		<th>Id</th>
-		<th>Created</th>
-		<th>State</th>
-		<th>Sub Domain</th>
-		<th>MTU</th>
-		<th>Prefixes</th>
-		<th>Version</th>
-	</thead>
-	<tbody>
-		{% for ns in underlay %}
-		<tr>
-			<td><a href="/admin/network-segment/{{ ns.id }}">{{ ns.name }}</a></td>
-			<td>{{ ns.id }}</td>
-			<td>{{ ns.created }}</td>
-			<td>{{ ns.state_display|safe }}</td>
-			<td>{{ ns.sub_domain }}</td>
-			<td>{{ ns.mtu }}</td>
-			<td>{{ ns.prefixes }}</td>
-			<td>{{ ns.version|config_version|safe }}</td>
-		</tr>
-		{% endfor %}
-	</tbody>
-</table>
+{% call network_segment_table(underlay) %}{% endcall %}
 
 <h2>Tenant</h2>
-<table class="sortable overview">
-	<thead>
-		<th>Name</th>
-		<th>Id</th>
-		<th>VPC ID</th>
-		<th>Created</th>
-		<th>State</th>
-		<th>Sub Domain</th>
-		<th>MTU</th>
-		<th>Prefixes</th>
-		<th>Version</th>
-	</thead>
-	<tbody>
-		{% for ns in tenant %}
-		<tr>
-			<td><a href="/admin/network-segment/{{ ns.id }}">{{ ns.name }}</a></td>
-			<td>{{ ns.id }}</td>
-			<td><a href="/admin/vpc/{{ ns.vpc_id }}">{{ ns.vpc_id }}</a></td>
-			<td>{{ ns.created }}</td>
-			<td>{{ ns.state_display|safe }}</td>
-			<td>{{ ns.sub_domain }}</td>
-			<td>{{ ns.mtu }}</td>
-			<td>{{ ns.prefixes }}</td>
-			<td>{{ ns.version|config_version|safe }}</td>
-		</tr>
-		{% endfor %}
-	</tbody>
-</table>
+{% call network_segment_table(tenant, true) %}{% endcall %}
+
 
 {% endblock %}


### PR DESCRIPTION
The admin UI page summarizing network segments now includes a list of those categorized as 'Host Inband' as well as Admin, Tenant, and Underlay.

The state column now shows a single string to represent the lifecycle state rather than a JSON object.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/5165

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


