### PR TITLE
fix(rest-deploy): Remove RBAC permission for Cert Manager, run services as non-root

### DIFF
--- a/helm/rest/nico-rest/charts/nico-rest-api/templates/deployment.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-api/templates/deployment.yaml
@@ -22,10 +22,23 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # 1000 is the `nvs` user the image declares. The image names it rather
+      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+      # needs the number spelled out here.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: api
           image: "{{ include "nico-rest-api.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.service.port }}
               name: http
@@ -54,6 +67,8 @@ spec:
               mountPath: /var/secrets/db
               readOnly: true
             {{- end }}
+            - name: tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           readinessProbe:
@@ -69,6 +84,10 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
       volumes:
+        # Scratch space for the read-only root filesystem. Go puts temp files
+        # under /tmp, including the spill from oversized multipart requests.
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ include "nico-rest-api.name" . }}-config

--- a/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/deployment.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/deployment.yaml
@@ -22,10 +22,13 @@ spec:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       serviceAccountName: nico-rest-cert-manager
       terminationGracePeriodSeconds: 5
+      # 1000 is the `nvs` user the image declares. The image states it by name,
+      # which the kubelet cannot verify, so runAsNonRoot needs the numeric UID
+      # spelled out here. fsGroup makes the tmp volume below writable.
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
-        fsGroup: 65534
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: cert-manager
           image: "{{ include "nico-rest-cert-manager.image" . }}"

--- a/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/rbac.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-cert-manager/templates/rbac.yaml
@@ -8,36 +8,7 @@ metadata:
   namespace: {{ include "nico-rest-cert-manager.namespace" . }}
   labels:
     {{- include "nico-rest-cert-manager.labels" . | nindent 4 }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: nico-rest-cert-manager
-  namespace: {{ include "nico-rest-cert-manager.namespace" . }}
-  labels:
-    {{- include "nico-rest-cert-manager.labels" . | nindent 4 }}
-rules:
-  # credsmgr reads/writes Kubernetes Secrets to store issued site credentials
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # credsmgr reads ConfigMaps for runtime configuration
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: nico-rest-cert-manager
-  namespace: {{ include "nico-rest-cert-manager.namespace" . }}
-  labels:
-    {{- include "nico-rest-cert-manager.labels" . | nindent 4 }}
-subjects:
-  - kind: ServiceAccount
-    name: nico-rest-cert-manager
-    namespace: {{ include "nico-rest-cert-manager.namespace" . }}
-roleRef:
-  kind: Role
-  name: nico-rest-cert-manager
-  apiGroup: rbac.authorization.k8s.io
+# credsmgr reads the CA signing cert and key from a mounted Secret volume, which
+# the kubelet resolves without pod RBAC, and writes its serving cert to /tmp. It
+# never calls the Kubernetes API, so it holds no Role and needs no mounted token.
+automountServiceAccountToken: false

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -26,9 +26,22 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # 1000 is the `nvs` user the migrations image declares. `pg_isready` in
+      # the init container is a client binary that writes nothing, so it runs
+      # under the same UID without needing anything from its own image.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       initContainers:
         - name: wait-for-postgres
           image: {{ if and .Values.waitForPostgres.repository .Values.waitForPostgres.tag }}{{ .Values.waitForPostgres.repository }}:{{ .Values.waitForPostgres.tag }}{{ else }}{{ .Values.waitForPostgres.image }}{{ end }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           command:
             - pg_isready
             - -h
@@ -41,6 +54,12 @@ spec:
         - name: migrations
           image: "{{ include "nico-rest-db.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: PGHOST
               value: {{ .Values.db.host }}
@@ -55,5 +74,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secrets.dbCreds }}
                   key: password
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        # Scratch space for the read-only root filesystem. Go puts temp files
+        # under /tmp.
+        - name: tmp
+          emptyDir: {}

--- a/helm/rest/nico-rest/charts/nico-rest-site-manager/templates/deployment.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-site-manager/templates/deployment.yaml
@@ -23,10 +23,23 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "nico-rest-site-manager.name" . }}
+      # 1000 is the `nvs` user the image declares. The image names it rather
+      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+      # needs the number spelled out here.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: site-manager
           image: "{{ include "nico-rest-site-manager.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           args:
             - --listen-port={{ .Values.args.listenPort }}
             - --creds-manager-url={{ .Values.args.credsManagerUrl }}
@@ -43,6 +56,8 @@ spec:
             - name: tls-certs
               mountPath: /etc/tls
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           readinessProbe:
@@ -63,3 +78,9 @@ spec:
         - name: tls-certs
           secret:
             secretName: {{ .Values.certificate.secretName }}
+        # sitemgr skips its own cert issuance while `args.tlsCertPath` and
+        # `args.tlsKeyPath` are set. Clearing either one sends it back to
+        # writing /tmp/mgr.cert, so keep this writable alongside the read-only
+        # root filesystem.
+        - name: tmp
+          emptyDir: {}

--- a/helm/rest/nico-rest/charts/nico-rest-workflow/templates/deployment-cloud-worker.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-workflow/templates/deployment-cloud-worker.yaml
@@ -57,6 +57,8 @@ spec:
               mountPath: /var/secrets/temporal/certs
               readOnly: true
             {{- include "nico-rest-workflow.dbCredsVolumeMount" . | nindent 12 }}
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /healthz
@@ -72,13 +74,23 @@ spec:
           resources:
             {{- toYaml .Values.cloudWorker.resources | nindent 12 }}
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - NET_RAW
+                - ALL
+      # 1000 is the `nvs` user the image declares. The image names it rather
+      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+      # needs the number spelled out here.
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       volumes:
+        # Scratch space for the read-only root filesystem. Go puts temp files
+        # under /tmp.
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ include "nico-rest-workflow.name" . }}-config

--- a/helm/rest/nico-rest/charts/nico-rest-workflow/templates/deployment-site-worker.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-workflow/templates/deployment-site-worker.yaml
@@ -57,6 +57,8 @@ spec:
               mountPath: /var/secrets/temporal/certs
               readOnly: true
             {{- include "nico-rest-workflow.dbCredsVolumeMount" . | nindent 12 }}
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /healthz
@@ -72,13 +74,23 @@ spec:
           resources:
             {{- toYaml .Values.siteWorker.resources | nindent 12 }}
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - NET_RAW
+                - ALL
+      # 1000 is the `nvs` user the image declares. The image names it rather
+      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+      # needs the number spelled out here.
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       volumes:
+        # Scratch space for the read-only root filesystem. Go puts temp files
+        # under /tmp.
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ include "nico-rest-workflow.name" . }}-config

--- a/rest-api/deploy/INSTALLATION.md
+++ b/rest-api/deploy/INSTALLATION.md
@@ -256,7 +256,7 @@ kubectl apply -k deploy/kustomize/base/keycloak -n nico-rest
 |---|---|
 | `base/cert-manager/deployment.yaml` | Deployment `nico-rest-cert-manager` — mounts `ca-signing-secret` |
 | `base/cert-manager/service.yaml` | ClusterIP Service — ports 8000 (https) and 8001 (http) |
-| `base/cert-manager/rbac.yaml` | ServiceAccount + Role/RoleBinding — needs read/write access to Secrets and ConfigMaps |
+| `base/cert-manager/rbac.yaml` | ServiceAccount only — `credsmgr` never calls the Kubernetes API, so it carries no Role and disables token automount |
 
 ### CLI flags (set in `deployment.yaml`)
 
@@ -868,7 +868,7 @@ kubectl kustomize --load-restrictor LoadRestrictionsNone \
 
 | Overlay | What it deploys |
 |---|---|
-| `overlays/cert-manager` | `nico-rest-cert-manager` Deployment + Service + RBAC |
+| `overlays/cert-manager` | `nico-rest-cert-manager` Deployment + Service + ServiceAccount |
 | `overlays/api` | `nico-rest-api` Deployment + Services + ConfigMap |
 | `overlays/workflow` | `nico-rest-cloud-worker` + `nico-rest-site-worker` Deployments + ConfigMap |
 | `overlays/site-manager` | `nico-rest-site-manager` Deployment + Service + Certificate + RBAC |

--- a/rest-api/deploy/kustomize/base/api/deployment.yaml
+++ b/rest-api/deploy/kustomize/base/api/deployment.yaml
@@ -20,10 +20,23 @@ spec:
     spec:
       imagePullSecrets:
         - name: image-pull-secret
+      # 1000 is the `nvs` user the image declares. The image names it rather
+      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+      # needs the number spelled out here.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: api
           image: nico-rest-api
           imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 8388
               name: http
@@ -45,6 +58,8 @@ spec:
             - name: temporal-tls-certs
               mountPath: /var/secrets/temporal/certs
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               memory: "128Mi"
@@ -65,6 +80,10 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
       volumes:
+        # Scratch space for the read-only root filesystem. Go puts temp files
+        # under /tmp, including the spill from oversized multipart requests.
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: nico-rest-api-config

--- a/rest-api/deploy/kustomize/base/cert-manager/deployment.yaml
+++ b/rest-api/deploy/kustomize/base/cert-manager/deployment.yaml
@@ -23,10 +23,13 @@ spec:
         - name: image-pull-secret
       serviceAccountName: nico-rest-cert-manager
       terminationGracePeriodSeconds: 5
+      # 1000 is the `nvs` user the image declares. The image states it by name,
+      # which the kubelet cannot verify, so runAsNonRoot needs the numeric UID
+      # spelled out here. fsGroup makes the tmp volume below writable.
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
-        fsGroup: 65534
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: cert-manager
           image: nico-rest-cert-manager

--- a/rest-api/deploy/kustomize/base/cert-manager/rbac.yaml
+++ b/rest-api/deploy/kustomize/base/cert-manager/rbac.yaml
@@ -8,32 +8,7 @@ metadata:
   name: nico-rest-cert-manager
   labels:
     app: nico-rest-cert-manager
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: nico-rest-cert-manager
-  labels:
-    app: nico-rest-cert-manager
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: nico-rest-cert-manager
-  labels:
-    app: nico-rest-cert-manager
-subjects:
-  - kind: ServiceAccount
-    name: nico-rest-cert-manager
-roleRef:
-  kind: Role
-  name: nico-rest-cert-manager
-  apiGroup: rbac.authorization.k8s.io
-
+# credsmgr reads the CA signing cert and key from a mounted Secret volume, which
+# the kubelet resolves without pod RBAC, and writes its serving cert to /tmp. It
+# never calls the Kubernetes API, so it holds no Role and needs no mounted token.
+automountServiceAccountToken: false

--- a/rest-api/deploy/kustomize/base/db/job.yaml
+++ b/rest-api/deploy/kustomize/base/db/job.yaml
@@ -20,10 +20,23 @@ spec:
       imagePullSecrets:
         - name: image-pull-secret
       restartPolicy: OnFailure
+      # 1000 is the `nvs` user the migrations image declares. `pg_isready` in
+      # the init container is a client binary that writes nothing, so it runs
+      # under the same UID without needing anything from its own image.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       initContainers:
         # Wait for PostgreSQL to be ready using a single pg_isready check (relying on Job retries)
         - name: wait-for-postgres
           image: postgres:14.4-alpine
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           command:
             - pg_isready
             - -h
@@ -36,6 +49,12 @@ spec:
         - name: migrations
           image: nico-rest-db
           imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: PGHOST
               value: postgres.postgres
@@ -50,6 +69,9 @@ spec:
                 secretKeyRef:
                   name: db-creds
                   key: password
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               memory: "64Mi"
@@ -57,3 +79,8 @@ spec:
             limits:
               memory: "128Mi"
               cpu: "100m"
+      volumes:
+        # Scratch space for the read-only root filesystem. Go puts temp files
+        # under /tmp.
+        - name: tmp
+          emptyDir: {}

--- a/rest-api/deploy/kustomize/base/site-manager/deployment.yaml
+++ b/rest-api/deploy/kustomize/base/site-manager/deployment.yaml
@@ -21,10 +21,23 @@ spec:
       imagePullSecrets:
         - name: image-pull-secret
       serviceAccountName: carbide-rest-site-manager
+      # 1000 is the `nvs` user the image declares. The image names it rather
+      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+      # needs the number spelled out here.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: site-manager
           image: carbide-rest-site-manager
           imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           args:
             - --listen-port=8100
             - --creds-manager-url=https://carbide-rest-cert-manager.carbide-rest:8000
@@ -39,6 +52,8 @@ spec:
             - name: tls-certs
               mountPath: /etc/tls
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               memory: "64Mi"
@@ -64,3 +79,9 @@ spec:
         - name: tls-certs
           secret:
             secretName: site-manager-tls
+        # sitemgr skips its own cert issuance while --tls-cert-path and
+        # --tls-key-path are set. Dropping either flag sends it back to writing
+        # /tmp/mgr.cert, so keep this writable alongside the read-only root
+        # filesystem.
+        - name: tmp
+          emptyDir: {}

--- a/rest-api/deploy/kustomize/base/workflow/deployment.yaml
+++ b/rest-api/deploy/kustomize/base/workflow/deployment.yaml
@@ -49,6 +49,8 @@ spec:
             - name: temporal-tls-certs
               mountPath: /var/secrets/temporal/certs
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /healthz
@@ -69,13 +71,23 @@ spec:
               memory: "512Mi"
               cpu: "500m"
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - NET_RAW
+                - ALL
+      # 1000 is the `nvs` user the image declares. The image names it rather
+      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+      # needs the number spelled out here.
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       volumes:
+        # Scratch space for the read-only root filesystem. Go puts temp files
+        # under /tmp.
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: nico-rest-workflow-config
@@ -137,6 +149,8 @@ spec:
             - name: temporal-tls-certs
               mountPath: /var/secrets/temporal/certs
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /healthz
@@ -157,13 +171,23 @@ spec:
               memory: "512Mi"
               cpu: "500m"
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - NET_RAW
+                - ALL
+      # 1000 is the `nvs` user the image declares. The image names it rather
+      # than giving a UID, which the kubelet cannot verify, so runAsNonRoot
+      # needs the number spelled out here.
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       volumes:
+        # Scratch space for the read-only root filesystem. Go puts temp files
+        # under /tmp.
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: nico-rest-workflow-config

--- a/rest-api/deploy/kustomize/overlays/cert-manager/kustomization.yaml
+++ b/rest-api/deploy/kustomize/overlays/cert-manager/kustomization.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Overlay for cert-manager only: nico-rest-cert-manager (deployment, service, rbac).
+# Overlay for cert-manager only: nico-rest-cert-manager (deployment, service, service account).
 # Deploys only this component; namespace, image-pull-secret, ca-signing-secret, etc. are assumed to exist.
 # Apply with: kubectl kustomize --load-restrictor LoadRestrictionsNone . | kubectl apply -f -
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
The `nico-rest-cert-manager` Role granted broad Secrets and ConfigMaps, but it no longer calls the Kubernetes API. This PR removes the permissions.

Also pinned `runAsUser` and `fsGroup` to `1000` (the actual user of the base image) instead of the arbitrary `65534`), the `nvs` user both the local and production images declare, replacing `65534`.

> [!IMPORTANT]
> `kubectl apply -k` does not prune, so Kustomize-deployed clusters keep the live `Role` and `RoleBinding`. The following command should be run to clean up stale permissions after deploying this version: `kubectl -n nico-rest delete role,rolebinding nico-rest-cert-manager`.
> Helm upgrades remove them on their own.

## Related issues

## Type of Change
- [x] **Change** - Changes in existing functionality

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed