### PR TITLE
fix(rest-api): honor local build target platform

### DIFF
--- a/rest-api/docker/local/Dockerfile.nico-flow
+++ b/rest-api/docker/local/Dockerfile.nico-flow
@@ -5,8 +5,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-mcp
+++ b/rest-api/docker/local/Dockerfile.nico-mcp
@@ -7,8 +7,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-nsm
+++ b/rest-api/docker/local/Dockerfile.nico-nsm
@@ -5,8 +5,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-psm
+++ b/rest-api/docker/local/Dockerfile.nico-psm
@@ -5,8 +5,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-rest-api
+++ b/rest-api/docker/local/Dockerfile.nico-rest-api
@@ -7,8 +7,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-rest-cert-manager
+++ b/rest-api/docker/local/Dockerfile.nico-rest-cert-manager
@@ -7,8 +7,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-rest-db
+++ b/rest-api/docker/local/Dockerfile.nico-rest-db
@@ -7,8 +7,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-rest-mock-core
+++ b/rest-api/docker/local/Dockerfile.nico-rest-mock-core
@@ -7,8 +7,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-rest-site-agent
+++ b/rest-api/docker/local/Dockerfile.nico-rest-site-agent
@@ -7,8 +7,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-rest-site-manager
+++ b/rest-api/docker/local/Dockerfile.nico-rest-site-manager
@@ -7,8 +7,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation

--- a/rest-api/docker/local/Dockerfile.nico-rest-workflow
+++ b/rest-api/docker/local/Dockerfile.nico-rest-workflow
@@ -7,8 +7,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 # Set environment variables for cross-compilation


### PR DESCRIPTION
The local REST Dockerfiles currently provide `linux` and `amd64` defaults when
redeclaring BuildKit's automatic target-platform arguments. Those defaults can
produce AMD64 Go binaries during native ARM64 local builds. This change removes
the defaults so each local image uses the `TARGETOS` and `TARGETARCH` selected
by BuildKit.

## Related issues

- #4999 depends on this PR.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Manual validation included:

- full local stack setup on native AMD64 and ARM64 Linux VMs as part of #4999
- reported successful `make tilt-up` use on an Apple Silicon Mac with
  [local-carbide-build](https://gitlab-master.nvidia.com/dporokh/local-carbide-build)
- consistency checks across all 11 local Go Dockerfiles and `git diff --check`

## Additional Notes

- Only Dockerfiles under `rest-api/docker/local` are changed.
- BuildKit supplies the target platform; release image definitions are
  unaffected.
