### PR TITLE
chore(ci): Use high availability ubuntu-slim runner for PR description job

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   validate:
     name: Validate pull request description
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Publish pr-description status


### PR DESCRIPTION
`ubuntu-latest` GitHub hosted runners use full VM and can be unavailable when capacity is low. `ubuntu-slim` on the other hand runs in virtualized containers and has a `15m` job limit, so their availability should be much higher.

## Type of Change
- [x] **Change** - Changes in existing functionality

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)