### PR TITLE
fix(machine-a-tron): machine interface id from PXE instead of DHCP

### DIFF
--- a/crates/machine-a-tron/src/dhcp_wrapper.rs
+++ b/crates/machine-a-tron/src/dhcp_wrapper.rs
@@ -19,7 +19,6 @@ use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 use bmc_mock::{HardwareType, MachineInfo};
-use carbide_uuid::machine::MachineInterfaceId;
 use dhcproto::v4::MessageType;
 use mac_address::MacAddress;
 use rpc::forge::ManagedHostNetworkConfigResponse;
@@ -122,7 +121,6 @@ fn vendor_class_for(machine: DhcpMachine, requester: DhcpRequester) -> Option<&'
 
 #[derive(Clone, Debug)]
 pub(super) struct DhcpResponseInfo {
-    pub(super) interface_id: Option<MachineInterfaceId>,
     pub(super) ip_address: Ipv4Addr,
 }
 
@@ -194,12 +192,7 @@ async fn request_ip_from_api(
         "DHCP request received an address",
     );
 
-    let interface_uuid = dhcp_record.machine_interface_id.ok_or_else(|| {
-        DhcpRelayError::InvalidDhcpRecord("missing machine_interface_id".to_string())
-    })?;
-
     let response_info = DhcpResponseInfo {
-        interface_id: Some(interface_uuid),
         ip_address: dhcp_record.address.parse::<Ipv4Addr>().map_err(|e| {
             DhcpRelayError::InvalidDhcpRecord(format!(
                 "{} is not an IPv4 address: {}",
@@ -308,8 +301,7 @@ impl DpuDhcpRelayServer {
     }
 }
 
-// Synthesize a DHCP response given the provided ManagedHostNetworkConfigResponse
-// Machine-a-tron receives the compatibility fields from the agent-facing response.
+// Synthesize a DHCP response given the provided ManagedHostNetworkConfigResponse.
 #[allow(deprecated)]
 fn synthesize_dhcp_response_for_host(
     managed_host_config: &ManagedHostNetworkConfigResponse,
@@ -329,13 +321,7 @@ fn synthesize_dhcp_response_for_host(
         .parse::<Ipv4Addr>()
         .map_err(|x| DhcpRelayError::InvalidDhcpRecord(x.to_string()))?;
 
-    Ok(DhcpResponseInfo {
-        interface_id: managed_host_config
-            .host_interface_id
-            .as_ref()
-            .and_then(|x| x.parse().ok()),
-        ip_address: ip,
-    })
+    Ok(DhcpResponseInfo { ip_address: ip })
 }
 
 #[cfg(test)]

--- a/crates/machine-a-tron/src/dhcp_wrapper_udp.rs
+++ b/crates/machine-a-tron/src/dhcp_wrapper_udp.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use carbide_uuid::machine::MachineInterfaceId;
 use dhcproto::v4::relay::{RelayAgentInformation, RelayInfo};
 use dhcproto::v4::{
     Decodable, Decoder, DhcpOption, HType, Message, MessageType, Opcode, OptionCode,
@@ -36,7 +35,6 @@ use crate::dhcp_wrapper::{DhcpRelayError, DhcpRelayResult, DhcpRequestInfo, Dhcp
 
 const DHCP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 const DHCP_PACKET_BUFFER_SIZE: usize = 4096;
-const MACHINE_INTERFACE_ID_SUBOPTION: u8 = 70;
 
 #[derive(Clone, Debug)]
 pub struct UdpDhcpClient {
@@ -117,7 +115,6 @@ impl UdpDhcpClient {
         let task = tokio::spawn(receive_responses(
             socket.clone(),
             pending.clone(),
-            server_address,
             advertise_address,
             cancellation.clone(),
         ));
@@ -201,16 +198,13 @@ impl UdpDhcpClient {
             )));
         }
 
-        let interface_id = machine_interface_id(&ack)?;
         tracing::info!(
             mac_address = %request_info.mac_address,
             relay_address = %request_info.relay_address,
             assigned_address = %ack.yiaddr(),
-            %interface_id,
             "DHCP relay request received an address",
         );
         Ok(DhcpResponseInfo {
-            interface_id: Some(interface_id),
             ip_address: ack.yiaddr(),
         })
     }
@@ -299,7 +293,6 @@ impl UdpDhcpClient {
 async fn receive_responses(
     socket: Arc<UdpSocket>,
     pending: PendingResponses,
-    server_address: SocketAddrV4,
     advertise_address: Ipv4Addr,
     cancellation: CancellationToken,
 ) -> std::io::Result<()> {
@@ -329,7 +322,6 @@ async fn receive_responses(
             advertise_address,
             transaction.expected_type,
             source,
-            server_address,
         );
         let terminal_result = match result {
             Ok(()) => Ok(response),
@@ -353,10 +345,11 @@ fn validate_response(
     advertise_address: Ipv4Addr,
     expected_type: MessageType,
     source: SocketAddr,
-    server_address: SocketAddrV4,
 ) -> DhcpRelayResult<()> {
-    if source != SocketAddr::V4(server_address)
-        || response.opcode() != Opcode::BootReply
+    // A DHCP server sends replies to giaddr as a new UDP flow, so neither the
+    // source IP nor source port has to match the configured request destination.
+    // Correlate replies using the DHCP transaction fields instead.
+    if response.opcode() != Opcode::BootReply
         || response.xid() != xid
         || response.chaddr() != mac_address.bytes()
         || response.giaddr() != advertise_address
@@ -368,6 +361,7 @@ fn validate_response(
     let actual_type = response.opts().msg_type().ok_or_else(|| {
         DhcpRelayError::InvalidDhcpPacket("response is missing DHCP message type".to_string())
     })?;
+    server_identifier(response)?;
     if actual_type == MessageType::Nak {
         return Err(DhcpRelayError::NegativeAcknowledgement(xid));
     }
@@ -388,44 +382,6 @@ fn server_identifier(message: &Message) -> DhcpRelayResult<Ipv4Addr> {
     }
 }
 
-fn machine_interface_id(message: &Message) -> DhcpRelayResult<MachineInterfaceId> {
-    let Some(DhcpOption::VendorExtensions(value)) =
-        message.opts().get(OptionCode::VendorExtensions)
-    else {
-        return Err(DhcpRelayError::InvalidDhcpRecord(
-            "ACK is missing Carbide vendor extensions".to_string(),
-        ));
-    };
-    let mut remaining = value.as_slice();
-    while !remaining.is_empty() {
-        let Some((&code, suboption)) = remaining.split_first() else {
-            break;
-        };
-        let Some((&length, suboption)) = suboption.split_first() else {
-            return Err(DhcpRelayError::InvalidDhcpRecord(
-                "ACK has a truncated Carbide vendor suboption".to_string(),
-            ));
-        };
-        let length = usize::from(length);
-        if suboption.len() < length {
-            return Err(DhcpRelayError::InvalidDhcpRecord(
-                "ACK has a truncated Carbide vendor suboption value".to_string(),
-            ));
-        }
-        let (suboption, rest) = suboption.split_at(length);
-        remaining = rest;
-        if code == MACHINE_INTERFACE_ID_SUBOPTION {
-            return std::str::from_utf8(suboption)
-                .map_err(|error| DhcpRelayError::InvalidDhcpRecord(error.to_string()))?
-                .parse()
-                .map_err(|error| DhcpRelayError::InvalidDhcpRecord(format!("{error}")));
-        }
-    }
-    Err(DhcpRelayError::InvalidDhcpRecord(
-        "ACK is missing the machine interface ID suboption".to_string(),
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
@@ -436,13 +392,14 @@ mod tests {
 
     const ASSIGNED_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 21, 0, 42);
     const SERVER_IDENTIFIER: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
-    const LEGACY_VENDOR_SUBOPTION: u8 = 6;
-    const LEGACY_VENDOR_VALUE: u32 = 8;
 
     #[derive(Clone, Copy, Debug)]
     enum ResponseVariation {
         Valid,
-        WrongSource,
+        DifferentSourceIp,
+        DifferentSourcePort,
+        MissingServerIdentifier,
+        DifferentServerIdentifier,
         WrongOpcode,
         WrongTransactionId,
         WrongMacAddress,
@@ -467,9 +424,24 @@ mod tests {
                     expect: Yields(()),
                 },
                 Case {
-                    scenario: "wrong source",
-                    input: ResponseVariation::WrongSource,
+                    scenario: "DHCP pod source behind a Kubernetes Service",
+                    input: ResponseVariation::DifferentSourceIp,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "different source port",
+                    input: ResponseVariation::DifferentSourcePort,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "missing server identifier",
+                    input: ResponseVariation::MissingServerIdentifier,
                     expect: Fails,
+                },
+                Case {
+                    scenario: "server identifier differs from request destination",
+                    input: ResponseVariation::DifferentServerIdentifier,
+                    expect: Yields(()),
                 },
                 Case {
                     scenario: "wrong opcode",
@@ -517,12 +489,26 @@ mod tests {
                 response
                     .opts_mut()
                     .insert(DhcpOption::MessageType(MessageType::Offer));
+                response
+                    .opts_mut()
+                    .insert(DhcpOption::ServerIdentifier(*server_address.ip()));
                 let mut source = SocketAddr::V4(server_address);
 
                 match variation {
                     ResponseVariation::Valid => {}
-                    ResponseVariation::WrongSource => {
+                    ResponseVariation::DifferentSourceIp => {
+                        source = "127.0.0.2:6767".parse().unwrap();
+                    }
+                    ResponseVariation::DifferentSourcePort => {
                         source = "127.0.0.1:6768".parse().unwrap();
+                    }
+                    ResponseVariation::MissingServerIdentifier => {
+                        response.opts_mut().remove(OptionCode::ServerIdentifier);
+                    }
+                    ResponseVariation::DifferentServerIdentifier => {
+                        response
+                            .opts_mut()
+                            .insert(DhcpOption::ServerIdentifier(Ipv4Addr::new(127, 0, 0, 2)));
                     }
                     ResponseVariation::WrongOpcode => {
                         response.set_opcode(Opcode::BootRequest);
@@ -558,26 +544,10 @@ mod tests {
                     advertise_address,
                     MessageType::Offer,
                     source,
-                    server_address,
                 )
                 .map_err(drop)
             },
         );
-    }
-
-    fn append_vendor_suboption(
-        vendor_extensions: &mut Vec<u8>,
-        code: u8,
-        value: &[u8],
-    ) -> DhcpRelayResult<()> {
-        let length = value.len().try_into().map_err(|_| {
-            DhcpRelayError::InvalidDhcpPacket(format!(
-                "DHCP vendor suboption {code} exceeds 255 bytes"
-            ))
-        })?;
-        vendor_extensions.extend_from_slice(&[code, length]);
-        vendor_extensions.extend_from_slice(value);
-        Ok(())
     }
 
     #[tokio::test]
@@ -635,15 +605,8 @@ mod tests {
         .await
         .unwrap();
         let client_address = client.socket.local_addr().unwrap();
-        let interface_id: MachineInterfaceId =
-            "0fd6e9a3-06fc-4a22-ad29-aca299677b00".parse().unwrap();
-        let server_task = tokio::spawn(run_fake_server(
-            server,
-            client_address,
-            interface_id,
-            2,
-            ASSIGNED_ADDRESS,
-        ));
+        let server_task =
+            tokio::spawn(run_fake_server(server, client_address, 2, ASSIGNED_ADDRESS));
 
         let request = |last_mac_byte| DhcpRequestInfo {
             mac_address: MacAddress::new([2, 0, 0, 0, 0, last_mac_byte]),
@@ -655,7 +618,6 @@ mod tests {
 
         for response in [first.unwrap(), second.unwrap()] {
             assert_eq!(response.ip_address, ASSIGNED_ADDRESS);
-            assert_eq!(response.interface_id, Some(interface_id));
         }
         server_task.await.unwrap();
         service.shutdown().await.unwrap();
@@ -676,12 +638,9 @@ mod tests {
         .await
         .unwrap();
         let client_address = client.socket.local_addr().unwrap();
-        let interface_id: MachineInterfaceId =
-            "0fd6e9a3-06fc-4a22-ad29-aca299677b00".parse().unwrap();
         let server_task = tokio::spawn(run_fake_server(
             server,
             client_address,
-            interface_id,
             1,
             Ipv4Addr::new(172, 21, 0, 43),
         ));
@@ -702,7 +661,6 @@ mod tests {
     async fn run_fake_server(
         server: UdpSocket,
         client_address: SocketAddr,
-        interface_id: MachineInterfaceId,
         exchange_count: usize,
         ack_address: Ipv4Addr,
     ) {
@@ -737,8 +695,7 @@ mod tests {
                 message_type => panic!("unexpected DHCP request: {message_type:?}"),
             };
             if request_type == MessageType::Request {
-                let delayed_offer =
-                    fake_response(&request, MessageType::Offer, interface_id, ASSIGNED_ADDRESS);
+                let delayed_offer = fake_response(&request, MessageType::Offer, ASSIGNED_ADDRESS);
                 let mut encoded = Vec::new();
                 delayed_offer
                     .encode(&mut Encoder::new(&mut encoded))
@@ -750,7 +707,7 @@ mod tests {
             } else {
                 ASSIGNED_ADDRESS
             };
-            let response = fake_response(&request, response_type, interface_id, assigned_address);
+            let response = fake_response(&request, response_type, assigned_address);
             let mut encoded = Vec::new();
             response.encode(&mut Encoder::new(&mut encoded)).unwrap();
             server.send_to(&encoded, client_address).await.unwrap();
@@ -760,7 +717,6 @@ mod tests {
     fn fake_response(
         request: &Message,
         message_type: MessageType,
-        interface_id: MachineInterfaceId,
         assigned_address: Ipv4Addr,
     ) -> Message {
         let mut response = Message::default();
@@ -777,88 +733,6 @@ mod tests {
         response
             .opts_mut()
             .insert(DhcpOption::ServerIdentifier(SERVER_IDENTIFIER));
-        if message_type == MessageType::Ack {
-            let interface_id = interface_id.to_string();
-            let mut vendor_extension = Vec::new();
-            append_vendor_suboption(
-                &mut vendor_extension,
-                LEGACY_VENDOR_SUBOPTION,
-                &LEGACY_VENDOR_VALUE.to_be_bytes(),
-            )
-            .unwrap();
-            append_vendor_suboption(
-                &mut vendor_extension,
-                MACHINE_INTERFACE_ID_SUBOPTION,
-                interface_id.as_bytes(),
-            )
-            .unwrap();
-            response
-                .opts_mut()
-                .insert(DhcpOption::VendorExtensions(vendor_extension));
-        }
         response
-    }
-
-    #[test]
-    fn vendor_extension_is_built_as_suboptions() {
-        let interface_id: MachineInterfaceId =
-            "0fd6e9a3-06fc-4a22-ad29-aca299677b00".parse().unwrap();
-        let response = fake_response(
-            &Message::default(),
-            MessageType::Ack,
-            interface_id,
-            ASSIGNED_ADDRESS,
-        );
-        let Some(DhcpOption::VendorExtensions(value)) =
-            response.opts().get(OptionCode::VendorExtensions)
-        else {
-            panic!("fake ACK is missing vendor extensions");
-        };
-        assert_eq!(value[0], LEGACY_VENDOR_SUBOPTION);
-        assert_eq!(value[1], LEGACY_VENDOR_VALUE.to_be_bytes().len() as u8);
-        assert_eq!(&value[2..6], &LEGACY_VENDOR_VALUE.to_be_bytes());
-        assert_eq!(value[6], MACHINE_INTERFACE_ID_SUBOPTION);
-        assert_eq!(usize::from(value[7]), interface_id.to_string().len());
-        assert_eq!(&value[8..], interface_id.to_string().as_bytes());
-    }
-
-    #[test]
-    fn machine_interface_suboption_does_not_require_a_fixed_prefix() {
-        let interface_id: MachineInterfaceId =
-            "0fd6e9a3-06fc-4a22-ad29-aca299677b00".parse().unwrap();
-        let mut vendor_extensions = Vec::new();
-        append_vendor_suboption(&mut vendor_extensions, 99, &[1, 2]).unwrap();
-        append_vendor_suboption(
-            &mut vendor_extensions,
-            MACHINE_INTERFACE_ID_SUBOPTION,
-            interface_id.to_string().as_bytes(),
-        )
-        .unwrap();
-
-        let mut message = Message::default();
-        message
-            .opts_mut()
-            .insert(DhcpOption::VendorExtensions(vendor_extensions));
-        assert_eq!(machine_interface_id(&message).unwrap(), interface_id);
-    }
-
-    #[test]
-    fn malformed_machine_interface_vendor_extensions_are_rejected() {
-        for vendor_extensions in [
-            vec![LEGACY_VENDOR_SUBOPTION],
-            vec![LEGACY_VENDOR_SUBOPTION, 4, 0],
-            vec![LEGACY_VENDOR_SUBOPTION, 4, 0, 0, 0, 8],
-        ] {
-            let mut message = Message::default();
-            message
-                .opts_mut()
-                .insert(DhcpOption::VendorExtensions(vendor_extensions));
-            assert!(machine_interface_id(&message).is_err());
-        }
-    }
-
-    #[test]
-    fn oversized_vendor_suboption_is_rejected() {
-        assert!(append_vendor_suboption(&mut Vec::new(), 1, &[0; 256]).is_err());
     }
 }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -29,7 +29,7 @@ use bmc_mock::{
     SystemPowerControl,
 };
 use carbide_network::virtualization::build_dual_stack_list;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use rand::RngExt;
 use rpc::forge::{MachineArchitecture, MachineDiscoveryResult, ManagedHostNetworkConfigResponse};
 use rpc::forge_agent_control_response::Action;
@@ -48,7 +48,8 @@ use crate::dhcp_wrapper::{
 use crate::machine_fsm::{Action as FsmAction, DhcpType, Event, MachineFsm, Timer};
 use crate::machine_state_machine::MachineStateError::MissingMachineId;
 use crate::machine_utils::{
-    PxeError, PxeResponse, forge_agent_control, get_validation_id, send_pxe_boot_request,
+    PxeBootTarget, PxeError, PxeResponse, forge_agent_control, get_validation_id,
+    send_pxe_boot_request,
 };
 use crate::{Guid, InfinibandPortState, PersistedDevice, PersistedDpuMachine};
 
@@ -149,6 +150,22 @@ fn direct_dhcp_relay_address(
     }
 }
 
+fn resolve_pxe_boot(
+    pxe_response: PxeResponse,
+    installed_os: OsImage,
+) -> Result<(OsImage, Option<MachineInterfaceId>), MachineStateError> {
+    let os_image = match pxe_response.boot_target {
+        PxeBootTarget::Exit => installed_os,
+        PxeBootTarget::Scout => OsImage::Scout,
+        PxeBootTarget::DpuAgent => OsImage::DpuAgent,
+    };
+
+    match pxe_response.machine_interface_id {
+        None if os_image != OsImage::None => Err(MachineStateError::MissingInterfaceId),
+        machine_interface_id => Ok((os_image, machine_interface_id)),
+    }
+}
+
 /// MachineStateMachine (yo dawg) models the state machine of a machine endpoint
 ///
 /// This code is in common between DPUs and Hosts.(ie. anything that has a BMC, boots via DHCP, can
@@ -167,6 +184,7 @@ pub(super) struct MachineStateMachine {
     agent_polling_deadline: Option<(Instant, Timer)>,
     bmc_dhcp_info: Option<DhcpResponseInfo>,
     machine_dhcp_info: Option<DhcpResponseInfo>,
+    machine_interface_id: Option<MachineInterfaceId>,
     dhcp_retry: DhcpRetryState,
     machine_discovery_result: Option<MachineDiscoveryResult>,
 
@@ -370,6 +388,7 @@ impl MachineStateMachine {
             agent_polling_deadline: None,
             bmc_dhcp_info: None,
             machine_dhcp_info: None,
+            machine_interface_id: None,
             dhcp_retry: DhcpRetryState::default(),
             machine_discovery_result: None,
             installed_os: initial_os_image,
@@ -411,6 +430,7 @@ impl MachineStateMachine {
             bmc_state: None,
             bmc_injection: Arc::new(InjectionStore::new()),
             machine_dhcp_info: None,
+            machine_interface_id: None,
             dhcp_retry: DhcpRetryState::default(),
             machine_discovery_result: None,
             machine_on_deadline: None,
@@ -522,6 +542,7 @@ impl MachineStateMachine {
                 },
                 FsmAction::Dhcp(DhcpType::Machine) => match self.machine_dhcp_discovery().await {
                     Ok(machine_dhcp_info) => {
+                        self.machine_interface_id = None;
                         self.machine_dhcp_info = Some(machine_dhcp_info);
                         self.dhcp_retry.reset();
                         self.actions.pop_front();
@@ -530,7 +551,8 @@ impl MachineStateMachine {
                     Err(_) => return Some(self.next_dhcp_retry_delay(DhcpType::Machine)),
                 },
                 FsmAction::PxeBootRequest => match self.pxe_boot_request().await {
-                    Ok(os_image) => {
+                    Ok((os_image, machine_interface_id)) => {
+                        self.machine_interface_id = machine_interface_id;
                         // A netbooted DPU-agent image is this simulation's stand-in
                         // for the DPF BFB install writing the OS to the DPU's disk,
                         // so record it as installed at boot. NICo's PXE serves a DPU
@@ -633,6 +655,7 @@ impl MachineStateMachine {
                 }
                 FsmAction::CleanupOnPowerOff => {
                     self.actions.pop_front();
+                    self.machine_interface_id = None;
                     self.machine_discovery_result = None;
                     self.dpu_dhcp_relay_handle = None;
                 }
@@ -790,9 +813,11 @@ impl MachineStateMachine {
             })
     }
 
-    async fn pxe_boot_request(&self) -> Result<OsImage, MachineStateError> {
+    async fn pxe_boot_request(
+        &self,
+    ) -> Result<(OsImage, Option<MachineInterfaceId>), MachineStateError> {
         let Some(dhcp_info) = self.machine_dhcp_info.as_ref() else {
-            return Err(MachineStateError::MissingInterfaceId);
+            return Err(MachineStateError::NoMachineDhcpInfo);
         };
 
         let (architecture, product) = match self.machine_info {
@@ -814,36 +839,19 @@ impl MachineStateMachine {
         )
         .await?;
 
-        let os = match pxe_response {
-            PxeResponse::Exit => self.installed_os,
-            PxeResponse::Scout => OsImage::Scout,
-            PxeResponse::DpuAgent => OsImage::DpuAgent,
-        };
-        match os {
-            OsImage::None => Ok(os),
-            OsImage::DpuAgent => {
-                if matches!(self.machine_info, MachineInfo::Host(_)) {
-                    Err(MachineStateError::WrongOsForMachine(
-                        "ERROR: Running DpuAgent OS on a host machine, this should not happen."
-                            .to_string(),
-                    ))
-                } else {
-                    Ok(os)
-                }
+        let (os, machine_interface_id) = resolve_pxe_boot(pxe_response, self.installed_os)?;
+
+        match (&self.machine_info, os) {
+            (MachineInfo::Host(_), OsImage::DpuAgent) => Err(MachineStateError::WrongOsForMachine(
+                "ERROR: Running DpuAgent OS on a host machine, this should not happen.".to_string(),
+            )),
+            (MachineInfo::Dpu(_), OsImage::Scout) => {
+                tracing::warn!("ERROR: Running Scout OS on a DPU machine, this should not happen.");
+                Err(MachineStateError::WrongOsForMachine(
+                    "ERROR: Running Scout OS on a DPU machine, this should not happen.".to_string(),
+                ))
             }
-            OsImage::Scout => {
-                if matches!(self.machine_info, MachineInfo::Dpu(_)) {
-                    tracing::warn!(
-                        "ERROR: Running Scout OS on a DPU machine, this should not happen."
-                    );
-                    Err(MachineStateError::WrongOsForMachine(
-                        "ERROR: Running Scout OS on a DPU machine, this should not happen."
-                            .to_string(),
-                    ))
-                } else {
-                    Ok(os)
-                }
-            }
+            _ => Ok((os, machine_interface_id)),
         }
     }
 
@@ -851,12 +859,12 @@ impl MachineStateMachine {
         &self,
         os_image: OsImage,
     ) -> Result<Option<MachineDiscoveryResult>, MachineStateError> {
-        let Some(machine_dhcp_info) = self.machine_dhcp_info.as_ref() else {
+        if self.machine_dhcp_info.is_none() {
             return Err(MachineStateError::NoMachineDhcpInfo);
-        };
+        }
         // No machine_discovery_result means we just booted. Run discovery now.
         tracing::trace!("Running initial discovery after boot");
-        match self.run_machine_discovery(machine_dhcp_info).await {
+        match self.run_machine_discovery().await {
             Ok(result) => {
                 if os_image == OsImage::Scout {
                     let machine_id = result.machine_id.as_ref().ok_or(MissingMachineId)?;
@@ -1098,11 +1106,8 @@ impl MachineStateMachine {
         }
     }
 
-    async fn run_machine_discovery(
-        &self,
-        machine_dhcp_info: &DhcpResponseInfo,
-    ) -> Result<MachineDiscoveryResult, MachineStateError> {
-        let Some(machine_interface_id) = machine_dhcp_info.interface_id else {
+    async fn run_machine_discovery(&self) -> Result<MachineDiscoveryResult, MachineStateError> {
+        let Some(machine_interface_id) = self.machine_interface_id else {
             return Err(MachineStateError::MissingInterfaceId);
         };
 
@@ -1421,9 +1426,90 @@ pub(super) enum AddressConfigError {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
+
+    #[test]
+    fn resolves_pxe_boot_identity_requirements() {
+        let machine_interface_id: MachineInterfaceId =
+            "0fd6e9a3-06fc-4a22-ad29-aca299677b00".parse().unwrap();
+
+        check_cases(
+            [
+                Case {
+                    scenario: "Scout netboot",
+                    input: (
+                        PxeResponse {
+                            boot_target: PxeBootTarget::Scout,
+                            machine_interface_id: Some(machine_interface_id),
+                        },
+                        OsImage::None,
+                    ),
+                    expect: Yields((OsImage::Scout, Some(machine_interface_id))),
+                },
+                Case {
+                    scenario: "DPU agent netboot",
+                    input: (
+                        PxeResponse {
+                            boot_target: PxeBootTarget::DpuAgent,
+                            machine_interface_id: Some(machine_interface_id),
+                        },
+                        OsImage::None,
+                    ),
+                    expect: Yields((OsImage::DpuAgent, Some(machine_interface_id))),
+                },
+                Case {
+                    scenario: "exit to installed Scout",
+                    input: (
+                        PxeResponse {
+                            boot_target: PxeBootTarget::Exit,
+                            machine_interface_id: Some(machine_interface_id),
+                        },
+                        OsImage::Scout,
+                    ),
+                    expect: Yields((OsImage::Scout, Some(machine_interface_id))),
+                },
+                Case {
+                    scenario: "unknown machine exits without an installed OS",
+                    input: (
+                        PxeResponse {
+                            boot_target: PxeBootTarget::Exit,
+                            machine_interface_id: None,
+                        },
+                        OsImage::None,
+                    ),
+                    expect: Yields((OsImage::None, None)),
+                },
+                Case {
+                    scenario: "Scout netboot without an interface ID",
+                    input: (
+                        PxeResponse {
+                            boot_target: PxeBootTarget::Scout,
+                            machine_interface_id: None,
+                        },
+                        OsImage::None,
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "exit to installed Scout without an interface ID",
+                    input: (
+                        PxeResponse {
+                            boot_target: PxeBootTarget::Exit,
+                            machine_interface_id: None,
+                        },
+                        OsImage::Scout,
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |(pxe_response, installed_os)| {
+                resolve_pxe_boot(pxe_response, installed_os).map_err(drop)
+            },
+        );
+    }
 
     #[test]
     fn direct_dhcp_relay_selection() {

--- a/crates/machine-a-tron/src/machine_utils.rs
+++ b/crates/machine-a-tron/src/machine_utils.rs
@@ -17,7 +17,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use carbide_uuid::machine_validation::MachineValidationId;
 use lazy_static::lazy_static;
 use rpc::forge::{ForgeAgentControlResponse, MachineArchitecture};
@@ -36,11 +36,17 @@ lazy_static! {
         .unwrap();
 }
 
-#[derive(Debug, Clone)]
-pub(super) enum PxeResponse {
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum PxeBootTarget {
     Exit,
     Scout,    // PXE script is booting scout.efi
     DpuAgent, // PXE script is booting carbide.efi
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) struct PxeResponse {
+    pub(super) boot_target: PxeBootTarget,
+    pub(super) machine_interface_id: Option<MachineInterfaceId>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -51,6 +57,8 @@ pub(super) enum PxeError {
     PxeRequest(#[from] tonic::Status),
     #[error("error sending PXE request: {0}")]
     Reqwest(#[from] reqwest::Error),
+    #[error("PXE script contains an invalid machine interface ID '{0}'")]
+    InvalidMachineInterfaceId(String),
 }
 
 pub(super) async fn forge_agent_control(
@@ -107,34 +115,70 @@ pub(super) async fn send_pxe_boot_request(
         .pxe_script;
     tracing::info!("PXE Request successful");
 
-    let response = if pxe_script.contains("exit") {
-        tracing::info!("PXE Request is EXIT");
-        PxeResponse::Exit
+    let response = parse_pxe_response(&pxe_script)?;
+    match response.boot_target {
+        PxeBootTarget::Exit => {
+            tracing::info!("PXE Request is EXIT");
+        }
+        PxeBootTarget::Scout => {
+            tracing::info!("PXE Request boots Scout");
+        }
+        PxeBootTarget::DpuAgent => {
+            tracing::info!("PXE Request boots DPU agent");
+        }
+    }
+
+    Ok(response)
+}
+
+fn parse_pxe_response(pxe_script: &str) -> Result<PxeResponse, PxeError> {
+    let machine_interface_id = pxe_script
+        .split_ascii_whitespace()
+        .find_map(|token| token.strip_prefix("machine_id="))
+        .or_else(|| {
+            pxe_script.lines().find_map(|line| {
+                line.trim()
+                    .strip_prefix("echo Interface ID:")
+                    .map(str::trim)
+            })
+        })
+        .map(|value| {
+            value
+                .parse()
+                .map_err(|_| PxeError::InvalidMachineInterfaceId(value.to_string()))
+        })
+        .transpose()?;
+
+    let boot_target = if pxe_script.contains("exit") {
+        PxeBootTarget::Exit
     } else if let Some(kernel_url) = pxe_script
         .lines()
         .find(|l| l.starts_with("kernel"))
-        .and_then(|l| l.split(" ").nth(1))
+        .and_then(|l| l.split_ascii_whitespace().nth(1))
     {
         if kernel_url.ends_with("/carbide.efi") {
-            PxeResponse::DpuAgent
+            PxeBootTarget::DpuAgent
         } else if kernel_url.ends_with("/scout.efi") {
-            PxeResponse::Scout
+            PxeBootTarget::Scout
         } else {
             tracing::error!(
                 pxe_script = %pxe_script,
                 "Could not determine what to do with kernel URL returned by PXE script, will treat as 'exit'",
             );
-            PxeResponse::Exit
+            PxeBootTarget::Exit
         }
     } else {
         tracing::error!(
             pxe_script = %pxe_script,
             "Could not determine what to do with PXE script (no kernel line, no exit line), will treat as 'exit'",
         );
-        PxeResponse::Exit
+        PxeBootTarget::Exit
     };
 
-    Ok(response)
+    Ok(PxeResponse {
+        boot_target,
+        machine_interface_id,
+    })
 }
 
 pub(super) async fn get_next_free_machine(
@@ -251,4 +295,65 @@ fn find_sudo_command() -> &'static str {
             tracing::warn!("could not find sudo or doas in PATH, falling back on /usr/bin/env");
             "/usr/bin/env"
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
+    use super::*;
+
+    #[test]
+    fn parses_pxe_boot_target_and_machine_interface_id() {
+        let machine_interface_id: MachineInterfaceId =
+            "0fd6e9a3-06fc-4a22-ad29-aca299677b00".parse().unwrap();
+
+        check_cases(
+            [
+                Case {
+                    scenario: "Scout kernel command line",
+                    input: format!(
+                        "kernel http://carbide-pxe/scout.efi console=tty0 machine_id={machine_interface_id}"
+                    ),
+                    expect: Yields(PxeResponse {
+                        boot_target: PxeBootTarget::Scout,
+                        machine_interface_id: Some(machine_interface_id),
+                    }),
+                },
+                Case {
+                    scenario: "DPU agent kernel command line",
+                    input: format!(
+                        "kernel http://carbide-pxe/carbide.efi machine_id={machine_interface_id}"
+                    ),
+                    expect: Yields(PxeResponse {
+                        boot_target: PxeBootTarget::DpuAgent,
+                        machine_interface_id: Some(machine_interface_id),
+                    }),
+                },
+                Case {
+                    scenario: "known interface exiting to installed OS",
+                    input: format!("echo Interface ID: {machine_interface_id}\nexit ||"),
+                    expect: Yields(PxeResponse {
+                        boot_target: PxeBootTarget::Exit,
+                        machine_interface_id: Some(machine_interface_id),
+                    }),
+                },
+                Case {
+                    scenario: "unknown interface exits without identity",
+                    input: "echo this is an unknown host interface\nexit ||".to_string(),
+                    expect: Yields(PxeResponse {
+                        boot_target: PxeBootTarget::Exit,
+                        machine_interface_id: None,
+                    }),
+                },
+                Case {
+                    scenario: "malformed machine interface ID",
+                    input: "kernel http://carbide-pxe/scout.efi machine_id=not-a-uuid".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |pxe_script| parse_pxe_response(&pxe_script).map_err(drop),
+        );
+    }
 }


### PR DESCRIPTION
Machine-a-tron has two issues in its DHCP implementation:

1. It expects the source IP address of a DHCP response to match the configured DHCP server address. This assumption does not hold for Kubernetes deployments, where responses may originate from a different address due to Service networking.
2. It expects a DHCP response for Scout to contain `machine_interface_id`. In production, this information is provided by the PXE boot response instead.

This PR addresses both issues and enables machine-a-tron to run in DHCP relay mode when deployed in Kubernetes.

## Related issues

#3366 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

