### PR TITLE
fix: bump libredfish to v0.44.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6306,7 +6306,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.3.1#797f4c0c4970c64f6c8c70d1650b0cb24262f089"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.3.2#f31f1eb3d202e56a553ec41f52db9228279c7909"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.3.1" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.3.2" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.12-rc3" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
Some Lenovo BMCs lazily initialize OEM boot-order child resources only after the parent `BootSettings` collection is read. Directly requesting `BootOrder.BootOrder` could therefore return 404 and incorrectly trigger the BIOS-attribute fallback.

This PR bumps libredfish to `v0.44.3.2` which brings in the following changes:

- Reads `BootSettings` before requesting `BootOrder.BootOrder`.
- Reuses the parent-priming helper wherever the general boot order is read.
- Prevents hosts from becoming stuck in repeated boot-order remediation.


## Related issues
https://github.com/NVIDIA/infra-controller/issues/5178

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
