### PR TITLE
fix: bump libredfish to v0.46.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6926,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.7#97be4e1722e94a77d4278522d7664be5ba381d92"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.8#92267da9072fd1ed74326e5f5ca6e9366fe9c4b5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.7" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.8" }
 librms = { git = "https://github.com/dsx-ai-factory/nv-rms-client.git", tag = "v0.10.1" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
Some Lenovo BMCs lazily initialize OEM boot-order child resources only after the parent `BootSettings` collection is read. Directly requesting `BootOrder.BootOrder` could therefore return 404 and incorrectly trigger the BIOS-attribute fallback.

This PR bumps libredfish to `v0.46.8` which brings in the following changes:

- Reads `BootSettings` before requesting `BootOrder.BootOrder`.
- Reuses the parent-priming helper wherever the general boot order is read.
- Prevents hosts from becoming stuck in repeated boot-order remediation.


## Related issues
https://github.com/NVIDIA/infra-controller/issues/5178

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
