### PR TITLE
chore(dev): add dhcp server mode for tilt local dev

### DIFF
--- a/dev/deployment/devspace/Dockerfile.core-artifacts
+++ b/dev/deployment/devspace/Dockerfile.core-artifacts
@@ -19,12 +19,14 @@ RUN --mount=type=cache,id=nico-devspace-cargo-home,target=/cargo-home,sharing=lo
     -p carbide-api --bin carbide-api \
     -p nico-admin-cli --bin nico-admin-cli \
     -p carbide-bmc-proxy --bin carbide-bmc-proxy \
+    -p carbide-dhcp --lib \
     -p carbide-machine-a-tron --bin machine-a-tron && \
   mkdir -p /artifacts && \
   cp \
     /cargo-target/debug/carbide-api \
     /cargo-target/debug/nico-admin-cli \
     /cargo-target/debug/carbide-bmc-proxy \
+    /cargo-target/debug/libdhcp.so \
     /cargo-target/debug/machine-a-tron \
     /artifacts/
 

--- a/dev/deployment/devspace/Dockerfile.dhcp
+++ b/dev/deployment/devspace/Dockerfile.dhcp
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.7
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM nico-devspace-core-artifacts AS artifacts
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  kea-dhcp4-server \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/lib/x86_64-linux-gnu/kea/hooks /var/lib/kea /var/run/kea
+
+COPY --from=artifacts /artifacts/libdhcp.so /usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so

--- a/dev/deployment/tilt/README.md
+++ b/dev/deployment/tilt/README.md
@@ -32,7 +32,7 @@ The default stack includes:
 - cert-manager
 - the CloudNativePG operator and one PostgreSQL cluster
 - Vault in local development mode
-- NICo API, BMC proxy, and machine-a-tron
+- NICo API, BMC proxy, DHCP server, and machine-a-tron
 - Temporal and its local namespaces
 - Keycloak and the `nico-dev` realm
 - NICo REST API, database migrations, certificate manager, site manager,

--- a/dev/deployment/tilt/Tiltfile
+++ b/dev/deployment/tilt/Tiltfile
@@ -35,6 +35,35 @@ rest_namespace = local_config['restNamespace']
 temporal_namespace = local_config['temporalNamespace']
 observability_namespace = local_config['observabilityNamespace']
 
+machine_a_tron_dhcp = tilt_values['machineATronDhcp']
+machine_a_tron_dhcp_server_ip = machine_a_tron_dhcp['serverIP']
+machine_a_tron_dhcp_server_port = machine_a_tron_dhcp['serverPort']
+machine_a_tron_dhcp_pod = machine_a_tron_dhcp['podName']
+machine_a_tron_dhcp_service_ip = machine_a_tron_dhcp['serviceIP']
+machine_a_tron_dhcp_listen_port = machine_a_tron_dhcp['listenPort']
+
+nico_dhcp_values = all_values['nico-dhcp']
+nico_dhcp_values['config']['kea']['serverIdentifier'] = machine_a_tron_dhcp_server_ip
+
+machine_a_tron_values = all_values['nico-machine-a-tron']
+machine_a_tron_configs = machine_a_tron_values['configFiles']['matConfigs']
+if machine_a_tron_dhcp_pod not in machine_a_tron_configs:
+    fail('Tilt DHCP relay mode requires a MAT config for pod %s' % machine_a_tron_dhcp_pod)
+machine_a_tron_config = machine_a_tron_configs[machine_a_tron_dhcp_pod]
+machine_a_tron_config = machine_a_tron_config.replace(
+    '__NICO_DHCP_SERVER_ADDRESS__',
+    '%s:%s' % (machine_a_tron_dhcp_server_ip, machine_a_tron_dhcp_server_port),
+)
+machine_a_tron_config = machine_a_tron_config.replace(
+    '__MAT_DHCP_LISTEN_PORT__',
+    str(machine_a_tron_dhcp_listen_port),
+)
+machine_a_tron_config = machine_a_tron_config.replace(
+    '__MAT_DHCP_SERVICE_IP__',
+    machine_a_tron_dhcp_service_ip,
+)
+machine_a_tron_configs[machine_a_tron_dhcp_pod] = machine_a_tron_config
+
 def merged(first, second):
     result = {}
     for key, value in first.items():
@@ -785,6 +814,12 @@ docker_build(
     ignore=['dev/deployment/tilt'],
 )
 docker_build(
+    'nico-dhcp',
+    repo_root,
+    dockerfile=os.path.join(devspace_dir, 'Dockerfile.dhcp'),
+    ignore=['dev/deployment/tilt'],
+)
+docker_build(
     'machine-a-tron',
     repo_root,
     dockerfile=os.path.join(devspace_dir, 'Dockerfile.machine-a-tron'),
@@ -902,11 +937,84 @@ helm_chart(
     manual=True,
 )
 helm_chart(
+    name='nico-dhcp',
+    chart=os.path.join(core_charts, 'nico-dhcp'),
+    namespace=core_namespace,
+    values=component_values(core_global, nico_dhcp_values),
+    resource_deps=['nico-api'],
+    image_dep='nico-dhcp',
+    image_keys=[('global.image.repository', 'global.image.tag')],
+    manual=True,
+)
+
+nico_dhcp_machine_a_tron_service = {
+    'apiVersion': 'v1',
+    'kind': 'Service',
+    'metadata': object_metadata('nico-dhcp-machine-a-tron', core_namespace),
+    'spec': {
+        'type': 'ClusterIP',
+        'clusterIP': machine_a_tron_dhcp_server_ip,
+        'selector': {
+            'app.kubernetes.io/name': 'nico-dhcp',
+            'app.kubernetes.io/component': 'dhcp',
+        },
+        'ports': [{
+            'name': 'dhcp',
+            'port': machine_a_tron_dhcp_server_port,
+            'targetPort': machine_a_tron_dhcp_server_port,
+            'protocol': 'UDP',
+        }],
+    },
+}
+k8s_yaml(encode_yaml(nico_dhcp_machine_a_tron_service))
+k8s_resource(
+    new_name='nico-dhcp-machine-a-tron',
+    objects=[object_selector(nico_dhcp_machine_a_tron_service)],
+    resource_deps=['nico-dhcp'],
+    labels=['application'],
+    pod_readiness='ignore',
+)
+
+machine_a_tron_dhcp_service_name = 'nico-machine-a-tron-%s-dhcp-relay' % machine_a_tron_dhcp_pod
+machine_a_tron_dhcp_service = {
+    'apiVersion': 'v1',
+    'kind': 'Service',
+    'metadata': object_metadata(machine_a_tron_dhcp_service_name, core_namespace),
+    'spec': {
+        'type': 'ClusterIP',
+        'clusterIP': machine_a_tron_dhcp_service_ip,
+        'selector': {
+            'app.kubernetes.io/name': 'nico-machine-a-tron',
+            'app.kubernetes.io/component': 'machine-a-tron',
+            'nvidia-infra-controller/pod-name': machine_a_tron_dhcp_pod,
+        },
+        'ports': [{
+            'name': 'dhcp-relay',
+            'port': machine_a_tron_dhcp_listen_port,
+            'targetPort': machine_a_tron_dhcp_listen_port,
+            'protocol': 'UDP',
+        }],
+    },
+}
+k8s_yaml(encode_yaml(machine_a_tron_dhcp_service))
+k8s_resource(
+    new_name='nico-machine-a-tron-dhcp-relay',
+    objects=[object_selector(machine_a_tron_dhcp_service)],
+    resource_deps=['nico-dhcp'],
+    labels=['application'],
+    pod_readiness='ignore',
+)
+
+helm_chart(
     name='nico-machine-a-tron',
     chart=os.path.join(core_charts, 'nico-machine-a-tron'),
     namespace=core_namespace,
-    values=component_values(core_global, all_values['nico-machine-a-tron']),
-    resource_deps=['nico-api'],
+    values=component_values(core_global, machine_a_tron_values),
+    resource_deps=[
+        'nico-api',
+        'nico-dhcp-machine-a-tron',
+        'nico-machine-a-tron-dhcp-relay',
+    ],
     image_dep='machine-a-tron',
     image_keys=[('image.repository', 'image.tag')],
     port_forwards=[port_forward(1266, 1266)],
@@ -1054,6 +1162,9 @@ enabled_resources = [
     'nico-postgres',
     'nico-api',
     'nico-bmc-proxy',
+    'nico-dhcp',
+    'nico-dhcp-machine-a-tron',
+    'nico-machine-a-tron-dhcp-relay',
     'nico-machine-a-tron',
 ]
 if enable_observability:

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -173,6 +173,15 @@ nico-bmc-proxy:
       client_cert = "/var/run/secrets/spiffe.io/tls.crt"
       client_key = "/var/run/secrets/spiffe.io/tls.key"
 
+nico-dhcp:
+  enabled: true
+  config:
+    kea:
+      hookParameters:
+        nameservers: 127.0.0.1
+        ntpServer: 127.0.0.1
+        provisioningServer: 127.0.0.1
+
 nico-machine-a-tron:
   enabled: true
   machineATron:
@@ -184,6 +193,54 @@ nico-machine-a-tron:
   certificate:
     uris:
       - spiffe://nico.local/nico-system/sa/machine-a-tron
+  configFiles:
+    matConfigs:
+      mat-0: |
+        carbide_api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
+        interface = "NOTUSED"
+        dhcp = { type = "udp_relay", server_address = "__NICO_DHCP_SERVER_ADDRESS__", listen_address = "0.0.0.0:__MAT_DHCP_LISTEN_PORT__", advertise_address = "__MAT_DHCP_SERVICE_IP__" }
+        tui_enabled = false
+        log_format = "logfmt"
+        bmc_mock_port = 1266
+        use_single_bmc_mock = true
+        mock_bmc_ssh_server = true
+        mock_bmc_ssh_port = 2222
+        persist_dir = "/tmp/machine-a-tron-data"
+        cleanup_on_quit = false
+        register_expected_machines = true
+        api_refresh_interval = "2s"
+
+        [ufm_mock]
+        enabled = true
+        include_local_inventory = true
+        metrics_address = "[::]:9090"
+
+        [racks.gb200]
+        type = "wiwynn_gb200_nvl72"
+        rack_profile_id = "NVL72"
+        ids = ["rack-001"]
+        dpu_reboot_delay = 20
+        host_reboot_delay = 10
+        discovery_retry_interval = "5s"
+        oob_dhcp_relay_address = "192.168.192.1"
+        admin_dhcp_relay_address = "192.168.176.1"
+
+        [machines.rack-machines]
+        hw_type = "wiwynn_gb200_nvl"
+        host_count = 2
+        vpc_count = 0
+        subnets_per_vpc = 0
+        dpu_per_host_count = 2
+        dpu_reboot_delay = 1
+        host_reboot_delay = 1
+        scout_run_interval = "60s"
+        discovery_retry_interval = "5s"
+        run_interval_working = "1s"
+        run_interval_idle = "10s"
+        network_status_run_interval = "20s"
+        oob_dhcp_relay_address = "192.168.192.1"
+        admin_dhcp_relay_address = "192.168.176.1"
+        dpus_in_nic_mode = false
   pods:
     mat-0:
       racks:
@@ -205,6 +262,13 @@ nico-machine-a-tron:
           adminDhcpRelayAddress: 192.168.176.1
 
 tilt:
+  machineATronDhcp:
+    serverIP: 10.96.0.20
+    serverPort: 67
+    podName: mat-0
+    serviceIP: 10.96.0.21
+    listenPort: 67
+
   profiles: # Toggle optional stacks; required dependencies follow automatically.
     rest: false
     mcp: false


### PR DESCRIPTION
Currently, machine-a-tron calls the DiscoverDhcp RPC directly to obtain IP addresses and advance simulated machines through provisioning.

This change deploys nico-dhcp in Tilt and configures machine-a-tron to use UDP relay mode. In this mode, machine-a-tron sends DHCP relay packets to the DHCP server and obtains addresses through the same DHCP flow used by real machines.

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

