### PR TITLE
Add socks proxy name resolution

### DIFF
--- a/crates/http-connector/src/connector.rs
+++ b/crates/http-connector/src/connector.rs
@@ -326,9 +326,11 @@ impl ConnectingTcpRemote {
                                 }
                                 Err(e) => {
                                     trace!(
-                                        "Resolved proxy address '{proxy_addr}' unreachable: {}",
-                                        e
-                                    )
+                                        proxy_address = %proxy_addr,
+                                        error = %e,
+                                        "resolved proxy address unreachable"
+                                    );
+                                    err = Some(e);
                                 }
                             }
                         }

--- a/crates/http-connector/src/connector.rs
+++ b/crates/http-connector/src/connector.rs
@@ -17,7 +17,7 @@
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::future::Future;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -280,10 +280,58 @@ struct ConnectingTcpFallback {
     remote: ConnectingTcpRemote,
 }
 
+#[derive(Clone)]
+enum Dial {
+    Direct,
+    Socks5 { targets: Arc<[SocketAddr]> },
+}
+
+impl Dial {
+    async fn connect(
+        &self,
+        addr: SocketAddr,
+        config: &Config,
+        connect_timeout: Option<Duration>,
+    ) -> Result<TcpStream, ConnectError> {
+        match self {
+            Dial::Direct => connect(&addr, config, connect_timeout)?.await,
+            Dial::Socks5 { targets } => {
+                let mut err = None;
+                for &target in targets.iter() {
+                    match connect_with_socks_proxy(addr, target, config.clone(), connect_timeout)?
+                        .await
+                    {
+                        Ok(tcp) => return Ok(tcp),
+                        Err(e) => {
+                            warn!(proxy_addr = %addr, target = %target, error = %e, "connection error");
+                            err = Some(e);
+                        }
+                    }
+                }
+                match err {
+                    Some(_) => Err(ConnectError::new(
+                        "connection via proxy failed",
+                        format!(
+                            "{} endpoint targets via proxy {} failed",
+                            targets.len(),
+                            addr
+                        ),
+                    )),
+                    None => Err(ConnectError::new(
+                        "dial not possible",
+                        "no connection targets were provided",
+                    )),
+                }
+            }
+        }
+    }
+}
+
 struct ConnectingTcpRemote {
     addrs: resolver::SocketAddrs,
     connect_timeout: Option<Duration>,
     metrics: ConnectorMetrics,
+    dial: Dial,
 }
 
 impl ConnectingTcpRemote {
@@ -291,13 +339,21 @@ impl ConnectingTcpRemote {
         addrs: resolver::SocketAddrs,
         connect_timeout: Option<Duration>,
         metrics: ConnectorMetrics,
+        dial: Dial,
     ) -> Self {
-        let connect_timeout = connect_timeout.map(|t| t / addrs.len() as u32);
+        let connect_timeout = match dial {
+            Dial::Direct => connect_timeout.and_then(|t| t.checked_div(addrs.len() as u32)),
+            // for socks case addrs param is the resolved proxy addrs, so slice using targets
+            Dial::Socks5 { ref targets } => {
+                connect_timeout.and_then(|t| t.checked_div(targets.len() as u32))
+            }
+        };
 
         Self {
             addrs,
             connect_timeout,
             metrics,
+            dial,
         }
     }
 }
@@ -306,50 +362,15 @@ impl ConnectingTcpRemote {
     async fn connect(&mut self, config: &Config) -> Result<TcpStream, ConnectError> {
         let mut err = None;
         for addr in &mut self.addrs {
-            if let Some(proxy) = config.socks5_proxy.as_deref() {
-                match proxy.to_socket_addrs() {
-                    Ok(proxy_addrs) => {
-                        // try all resolved ips
-                        for proxy_addr in proxy_addrs {
-                            let connect_start = Instant::now();
-                            match connect_with_socks_proxy(
-                                proxy_addr,
-                                addr,
-                                config.clone(),
-                                self.connect_timeout,
-                            )?
-                            .await
-                            {
-                                Ok(tcp) => {
-                                    self.metrics.connect_success(proxy_addr, connect_start);
-                                    return Ok(tcp);
-                                }
-                                Err(e) => {
-                                    trace!(
-                                        proxy_address = %proxy_addr,
-                                        error = %e,
-                                        "resolved proxy address unreachable"
-                                    );
-                                    err = Some(e);
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        return Err(ConnectError::new("Invalid proxy setting", e));
-                    }
+            let connect_start = Instant::now();
+            match self.dial.connect(addr, config, self.connect_timeout).await {
+                Ok(tcp) => {
+                    self.metrics.connect_success(addr, connect_start);
+                    return Ok(tcp);
                 }
-            } else {
-                let connect_start = Instant::now();
-                match connect(&addr, config, self.connect_timeout)?.await {
-                    Ok(tcp) => {
-                        self.metrics.connect_success(addr, connect_start);
-                        return Ok(tcp);
-                    }
-                    Err(e) => {
-                        self.metrics.connect_error(addr, connect_start, &e);
-                        err = Some(e);
-                    }
+                Err(e) => {
+                    self.metrics.connect_error(addr, connect_start, &e);
+                    err = Some(e);
                 }
             }
         }
@@ -493,12 +514,15 @@ async fn proxy_connect(
     target: SocketAddr,
     config: &Config,
 ) -> Result<TcpStream, ConnectError> {
-    let proxy_stream = connect(&proxy_addr, config, None)?.await?;
-
-    Ok(Socks5Stream::connect_with_socket(proxy_stream, target)
-        .await
-        .map_err(|e| ConnectError::new("proxy connect error: {}", e))?
-        .into_inner())
+    match connect(&proxy_addr, config, None)?.await {
+        Err(e) => Err(ConnectError::new("proxy is unreachable", e)),
+        Ok(stream) => Ok(Socks5Stream::connect_with_socket(stream, target)
+            .await
+            .map_err(|e| {
+                ConnectError::new("proxy stream established but target is unreachable: ", e)
+            })?
+            .into_inner()),
+    }
 }
 
 fn connect_with_socks_proxy(
@@ -529,6 +553,7 @@ impl<'a> ConnectingTcp<'a> {
         remote_addrs: resolver::SocketAddrs,
         config: &'a Config,
         metrics: ConnectorMetrics,
+        dial: Dial,
     ) -> Self {
         trace!(?config, "ConnectingTcp config");
 
@@ -541,6 +566,7 @@ impl<'a> ConnectingTcp<'a> {
                         preferred_addrs,
                         config.connect_timeout,
                         metrics,
+                        dial,
                     ),
                     fallback: None,
                     config,
@@ -552,6 +578,7 @@ impl<'a> ConnectingTcp<'a> {
                     preferred_addrs,
                     config.connect_timeout,
                     metrics.clone(),
+                    dial.clone(),
                 ),
                 fallback: Some(ConnectingTcpFallback {
                     delay: tokio::time::sleep(fallback_timeout),
@@ -559,13 +586,19 @@ impl<'a> ConnectingTcp<'a> {
                         fallback_addrs,
                         config.connect_timeout,
                         metrics,
+                        dial,
                     ),
                 }),
                 config,
             }
         } else {
             ConnectingTcp {
-                preferred: ConnectingTcpRemote::new(remote_addrs, config.connect_timeout, metrics),
+                preferred: ConnectingTcpRemote::new(
+                    remote_addrs,
+                    config.connect_timeout,
+                    metrics,
+                    dial,
+                ),
                 fallback: None,
                 config,
             }
@@ -983,12 +1016,23 @@ impl From<Vec<std::net::SocketAddr>> for resolver::SocketAddrs {
     }
 }
 
-impl ForgeHttpConnector {
-    async fn call_async(&mut self, dst: Uri) -> Result<TcpStream, ConnectError> {
-        let config = &self.config;
-        let (host, port) = get_host_port(config, &dst)?;
-        let host = host.trim_start_matches('[').trim_end_matches(']');
+fn get_proxy_host_port(proxy: &str) -> Result<(&str, u16), ConnectError> {
+    let (host, port) = proxy.rsplit_once(':').ok_or_else(|| ConnectError {
+        msg: "Invalid proxy setting".into(),
+        cause: None,
+    })?;
+    let port: u16 = port
+        .parse()
+        .map_err(|e| ConnectError::new("Invalid proxy setting", e))?;
+    Ok((host, port))
+}
 
+impl ForgeHttpConnector {
+    async fn resolve_host(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> Result<resolver::SocketAddrs, ConnectError> {
         let addrs = if let Some(addrs) = resolver::SocketAddrs::try_parse(host, port) {
             addrs
         } else {
@@ -1005,7 +1049,30 @@ impl ForgeHttpConnector {
                     addr
                 })
                 .collect();
+            if addrs.is_empty() {
+                return Err(ConnectError::dns(format!(
+                    "no addresses resolved for {host}:{port}"
+                )));
+            }
             resolver::SocketAddrs::new(addrs)
+        };
+        Ok(addrs)
+    }
+    async fn call_async(&mut self, dst: Uri) -> Result<TcpStream, ConnectError> {
+        let config = &self.config;
+        let (host, port) = get_host_port(config, &dst)?;
+        let host = host.trim_start_matches('[').trim_end_matches(']');
+
+        let (addrs, dial) = match config.socks5_proxy.as_deref() {
+            None => (self.resolve_host(host, port).await?, Dial::Direct),
+            Some(proxy) => {
+                trace!(%proxy, "connecting via proxy");
+                let (proxy_host, proxy_port) = get_proxy_host_port(proxy)?;
+                let proxy_host = proxy_host.trim_start_matches('[').trim_end_matches(']');
+                let targets: Arc<[SocketAddr]> = self.resolve_host(host, port).await?.collect();
+                let proxy_addrs = self.resolve_host(proxy_host, proxy_port).await?;
+                (proxy_addrs, Dial::Socks5 { targets })
+            }
         };
 
         let retry_config = RetryFutureConfig::new(self.config.connect_retries_max.unwrap_or(0))
@@ -1017,7 +1084,7 @@ impl ForgeHttpConnector {
 
         tryhard::retry_fn(|| {
             trace!(destination_address = %dst, "establishing new tcp connection");
-            let c = ConnectingTcp::new(addrs.clone(), config, self.metrics.clone());
+            let c = ConnectingTcp::new(addrs.clone(), config, self.metrics.clone(), dial.clone());
             c.connect()
         })
         .with_config(retry_config)

--- a/crates/http-connector/src/connector.rs
+++ b/crates/http-connector/src/connector.rs
@@ -17,9 +17,8 @@
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::future::Future;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 use std::pin::Pin;
-use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
@@ -308,24 +307,34 @@ impl ConnectingTcpRemote {
         let mut err = None;
         for addr in &mut self.addrs {
             if let Some(proxy) = config.socks5_proxy.as_deref() {
-                let proxy_addr = SocketAddr::from_str(proxy)
-                    .map_err(|e| ConnectError::new("Invalid proxy setting", e))?;
-                let connect_start = Instant::now();
-                match connect_with_socks_proxy(
-                    proxy_addr,
-                    addr,
-                    config.clone(),
-                    self.connect_timeout,
-                )?
-                .await
-                {
-                    Ok(tcp) => {
-                        self.metrics.connect_success(proxy_addr, connect_start);
-                        return Ok(tcp);
+                match proxy.to_socket_addrs() {
+                    Ok(proxy_addrs) => {
+                        // try all resolved ips
+                        for proxy_addr in proxy_addrs {
+                            let connect_start = Instant::now();
+                            match connect_with_socks_proxy(
+                                proxy_addr,
+                                addr,
+                                config.clone(),
+                                self.connect_timeout,
+                            )?
+                            .await
+                            {
+                                Ok(tcp) => {
+                                    self.metrics.connect_success(proxy_addr, connect_start);
+                                    return Ok(tcp);
+                                }
+                                Err(e) => {
+                                    trace!(
+                                        "Resolved proxy address '{proxy_addr}' unreachable: {}",
+                                        e
+                                    )
+                                }
+                            }
+                        }
                     }
                     Err(e) => {
-                        self.metrics.connect_error(proxy_addr, connect_start, &e);
-                        err = Some(e);
+                        return Err(ConnectError::new("Invalid proxy setting", e));
                     }
                 }
             } else {

--- a/crates/http-connector/src/connector.rs
+++ b/crates/http-connector/src/connector.rs
@@ -539,7 +539,7 @@ fn connect_with_socks_proxy(
                 Ok(Ok(s)) => Ok(s),
                 Ok(Err(e)) => Err(e),
                 Err(e) => Err(ConnectError::new(
-                    "Proxy connect timed out",
+                    "proxy connect timed out",
                     io::Error::new(io::ErrorKind::TimedOut, e),
                 )),
             },
@@ -1018,12 +1018,12 @@ impl From<Vec<std::net::SocketAddr>> for resolver::SocketAddrs {
 
 fn get_proxy_host_port(proxy: &str) -> Result<(&str, u16), ConnectError> {
     let (host, port) = proxy.rsplit_once(':').ok_or_else(|| ConnectError {
-        msg: "Invalid proxy setting".into(),
+        msg: "invalid proxy setting".into(),
         cause: None,
     })?;
     let port: u16 = port
         .parse()
-        .map_err(|e| ConnectError::new("Invalid proxy setting", e))?;
+        .map_err(|e| ConnectError::new("invalid proxy setting", e))?;
     Ok((host, port))
 }
 


### PR DESCRIPTION
Adds proxy name resolution using std lib. When proxy is configured using a name such as 'localhost' instead of ip connection attempts are made against all resolved addresses.

Description:
Currently a proxy setting (via env var https_proxy etc) is not resolving when this is set to 'localhost', it is expecting an ip address:
```
                let proxy_addr = SocketAddr::from_str(proxy)
```
When a name is supplied, the log does not provide any info as to why it is hanging. You can see a proxy is configured, and nothing happens and the connector goes into sleep and tries again it's next cycle.
```
2026-08-20T03:36:32.025627Z TRACE forge_http_connector::connector: ConnectingTcp config config=Config { connect_timeout: Some(5s), enforce_http: false, happy_eyeballs_timeout: None, keep_alive_timeout: Some(20s), keep_alive_interval: Some(4s), keep_alive_retries: Some(3), tcp_user_timeout: Some(30s), local_address_ipv4: None, local_address_ipv6: None, nodelay: false, reuse_address: false, send_buffer_size: None, recv_buffer_size: None, socks5_proxy: Some("localhost:9001"), connect_retries_max: Some(3), connect_retries_interval: Some(20s) }
2026-08-20T03:36:32.025669Z TRACE runtime.resource: runtime::resource::state_update: duration=20001 duration.unit="ms" duration.op="override" concrete_type="Sleep" kind="timer" loc.file="/Users/rafaell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tryhard-0.5.2/src/lib.rs" loc.line=626 loc.col=41
```

Using IP addresses only is in contradiction to documentation (eg. https://docs.nvidia.com/infra-controller/documentation/reference/development/nico-admin-cli#socks5-proxy) which documents 'localhost' and doesn't mention requiring an IP address specifically. In addition, many people use the 'localhost' convention when configuring a socks proxys rather than a pure IP address. 

This change implements proxy name resolution so that names like 'localhost' will work. 

## Type of Change
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
The change has added a resolve_host fn with the code previously used for resolving endpoint addresses (making use of ForgeResolver), so it can be used for both endpoint and proxy resolution. It has also added a new enum "Dial" (and subsequent member for struct ConnectingTcpRemote) to distinguish direct vs proxy connections.