### PR TITLE
feat(site-explorer): raise the ingestion knob defaults to measured values

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -408,10 +408,10 @@ shipped configuration selects a plaintext mode.
 | ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `true` | Enables hardware discovery. |
 | `run_interval` | `Duration` | `120s` | Interval between exploration runs. |
-| `concurrent_explorations` | `u64` | `30` | Max nodes explored in parallel. |
-| `explorations_per_run` | `u64` | `90` | Max nodes explored per run. |
+| `concurrent_explorations` | `u64` | `100` | Max nodes explored in parallel. |
+| `explorations_per_run` | `u64` | `360` | Max nodes explored per run. |
 | `create_machines` | `bool` | `true` | When false, SiteExplorer skips creating ManagedHost state machines; the DPU agent (scout) must self-register via DiscoverMachine gRPC endpoint with create_machine=true. Dynamically toggleable. |
-| `machines_created_per_run` | `u64` | `4` | Max ManagedHosts created per run. |
+| `machines_created_per_run` | `u64` | `100` | Max ManagedHosts created per run. |
 | `rotate_switch_nvos_credentials` | `bool` | `false` | Auto-rotate switch NVOS admin credentials. |
 | `override_target_ip` | `Option<String>` | — | **Deprecated.** Use `bmc_proxy`. Debug BMC IP override. |
 | `override_target_port` | `Option<u16>` | — | **Deprecated.** Use `bmc_proxy`. Debug BMC port override. |

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -290,16 +290,23 @@ impl SiteExplorerConfig {
         Arc::new(true.into())
     }
 
+    /// Redfish endpoints probed in parallel per exploration cycle. Bounds the
+    /// concurrent load placed on BMCs.
     pub const fn default_concurrent_explorations() -> u64 {
-        30
+        100
     }
 
+    /// Endpoints selected for exploration per cycle. Identification and machine
+    /// creation run only at the end of a completed cycle, so this trades sweep
+    /// breadth against how frequently creation runs.
     pub const fn default_explorations_per_run() -> u64 {
-        90
+        360
     }
 
+    /// Machines created per completed exploration cycle. Caps ingestion rate
+    /// independently of how many hosts exploration has identified.
     pub const fn default_machines_created_per_run() -> u64 {
-        4
+        100
     }
 
     pub fn default_rotate_switch_nvos_credentials() -> Arc<AtomicBool> {

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -56,11 +56,9 @@ pub struct SiteExplorerConfig {
     )]
     pub run_interval: std::time::Duration,
     /// The maximum amount of nodes that are explored concurrently.
-    /// Default is 5.
     #[serde(default = "SiteExplorerConfig::default_concurrent_explorations")]
     pub concurrent_explorations: u64,
     /// How many routine (non-requested) endpoints should be explored in a single run.
-    /// Default is 90.
     /// This bounds only the background refresh work: previously unseen endpoints
     /// and stale endpoints whose reports we want to update. Endpoints with the
     /// `exploration_requested` flag set are always attempted, regardless of this
@@ -82,7 +80,7 @@ pub struct SiteExplorerConfig {
     )]
     pub create_machines: Arc<AtomicBool>,
 
-    /// How many ManagedHosts should be created in a single run. Default is 4.
+    /// How many ManagedHosts should be created in a single run.
     #[serde(default = "SiteExplorerConfig::default_machines_created_per_run")]
     pub machines_created_per_run: u64,
 

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -48,7 +48,6 @@ pub struct SiteExplorerConfig {
     #[serde(skip)]
     pub retained_boot_interface_window: Option<chrono::Duration>,
     /// The interval at which site explorer runs.
-    /// Defaults to 5 Minutes if not specified.
     #[serde(
         default = "SiteExplorerConfig::default_run_interval",
         deserialize_with = "deserialize_duration",


### PR DESCRIPTION
These three site-explorer defaults limit how quickly NICo can ingest a site. The most restrictive is `machines_created_per_run: 4` - however many hosts have been discovered, only four machines get created per run.

On a 4,500-host fleet, raising all three took a full ingestion from roughly 50 hours to 3h22m, with every machine reaching `ready`.

`concurrent_explorations` is 100 rather than higher because throughput is flat above 100 — no reason to add parallel Redfish load for no gain.

## Related issues

- #3764
- #4299

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Defaults only — any site setting these explicitly is unaffected.