### PR TITLE
feat(health): add gNMI leak sensor telemetry collection

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -461,6 +461,9 @@ interfaces_enabled = true
 # Switch-level memory, disk utilization, and ambient temperature from
 # `/platform-general/state` (a singleton, not keyed by interface or component name).
 platform_general_enabled = true
+# Per-sensor leakage state from `/platform-general/leak-sensors/leak-sensor[id]/state/state`.
+# Enable only on NVOS releases that support this path. Default: false.
+leak_sensors_enabled = false
 
 # ==============================================================================
 # Processors

--- a/crates/health/src/collectors/nvue/gnmi/client.rs
+++ b/crates/health/src/collectors/nvue/gnmi/client.rs
@@ -32,7 +32,8 @@ use crate::HealthError;
 use crate::config::{MtlsProfileConfig, NvueGnmiPaths};
 
 pub(super) fn nvue_subscribe_paths(paths_config: &NvueGnmiPaths) -> Vec<Path> {
-    let mut paths = Vec::with_capacity(4);
+    let mut paths = Vec::with_capacity(5);
+
     if paths_config.components_enabled {
         paths.push(Path {
             elem: vec![
@@ -96,6 +97,35 @@ pub(super) fn nvue_subscribe_paths(paths_config: &NvueGnmiPaths) -> Vec<Path> {
             ..Default::default()
         });
     }
+
+    if paths_config.leak_sensors_enabled {
+        paths.push(Path {
+            elem: vec![
+                PathElem {
+                    name: "platform-general".into(),
+                    key: Default::default(),
+                },
+                PathElem {
+                    name: "leak-sensors".into(),
+                    key: Default::default(),
+                },
+                PathElem {
+                    name: "leak-sensor".into(),
+                    key: Default::default(),
+                },
+                PathElem {
+                    name: "state".into(),
+                    key: Default::default(),
+                },
+                PathElem {
+                    name: "state".into(),
+                    key: Default::default(),
+                },
+            ],
+            ..Default::default()
+        });
+    }
+
     paths
 }
 
@@ -749,64 +779,73 @@ mod tests {
 
     #[test]
     fn nvue_subscribe_path_cases() {
-        check_values(
-            [
-                Check {
-                    scenario: "all path groups",
-                    input: NvueGnmiPaths::default(),
-                    expect: "components/component,interfaces/interface,platform-general/state,platform-general/versions".to_string(),
-                },
-                Check {
-                    scenario: "components only",
-                    input: NvueGnmiPaths {
-                        components_enabled: true,
-                        interfaces_enabled: false,
-                        platform_general_enabled: false,
-                    },
-                    expect: "components/component".to_string(),
-                },
-                Check {
-                    scenario: "interfaces only",
-                    input: NvueGnmiPaths {
-                        components_enabled: false,
-                        interfaces_enabled: true,
-                        platform_general_enabled: false,
-                    },
-                    expect: "interfaces/interface".to_string(),
-                },
-                Check {
-                    scenario: "platform general only",
-                    input: NvueGnmiPaths {
-                        components_enabled: false,
-                        interfaces_enabled: false,
-                        platform_general_enabled: true,
-                    },
-                    expect: "platform-general/state,platform-general/versions".to_string(),
-                },
-                Check {
-                    scenario: "no path groups",
-                    input: NvueGnmiPaths {
-                        components_enabled: false,
-                        interfaces_enabled: false,
-                        platform_general_enabled: false,
-                    },
-                    expect: String::new(),
-                },
-            ],
-            |config| {
-                nvue_subscribe_paths(&config)
-                    .into_iter()
-                    .map(|path| {
-                        path.elem
-                            .into_iter()
-                            .map(|elem| elem.name)
-                            .collect::<Vec<_>>()
-                            .join("/")
-                    })
-                    .collect::<Vec<_>>()
-                    .join(",")
-            },
-        );
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum Group {
+            Components,
+            Interfaces,
+            PlatformGeneral,
+            LeakSensors,
+        }
+
+        use Group::{Components, Interfaces, LeakSensors, PlatformGeneral};
+
+        const COMPONENTS: &str = "components/component";
+        const INTERFACES: &str = "interfaces/interface";
+        const PLATFORM_STATE: &str = "platform-general/state";
+        const PLATFORM_VERSIONS: &str = "platform-general/versions";
+        const LEAKS: &str = "platform-general/leak-sensors/leak-sensor/state/state";
+
+        let cases = [
+            &[][..],
+            &[Components][..],
+            &[Interfaces][..],
+            &[Components, Interfaces][..],
+            &[PlatformGeneral][..],
+            &[Components, PlatformGeneral][..],
+            &[Interfaces, PlatformGeneral][..],
+            &[Components, Interfaces, PlatformGeneral][..],
+            &[LeakSensors][..],
+            &[Components, LeakSensors][..],
+            &[Interfaces, LeakSensors][..],
+            &[Components, Interfaces, LeakSensors][..],
+            &[PlatformGeneral, LeakSensors][..],
+            &[Components, PlatformGeneral, LeakSensors][..],
+            &[Interfaces, PlatformGeneral, LeakSensors][..],
+            &[Components, Interfaces, PlatformGeneral, LeakSensors][..],
+        ];
+
+        for groups in cases {
+            let config = NvueGnmiPaths {
+                components_enabled: groups.contains(&Components),
+                interfaces_enabled: groups.contains(&Interfaces),
+                platform_general_enabled: groups.contains(&PlatformGeneral),
+                leak_sensors_enabled: groups.contains(&LeakSensors),
+            };
+
+            let actual = nvue_subscribe_paths(&config)
+                .into_iter()
+                .map(|path| {
+                    path.elem
+                        .into_iter()
+                        .map(|elem| elem.name)
+                        .collect::<Vec<_>>()
+                        .join("/")
+                })
+                .collect::<Vec<_>>();
+
+            let expected = groups
+                .iter()
+                .flat_map(|group| match group {
+                    Components => &[COMPONENTS][..],
+                    Interfaces => &[INTERFACES][..],
+                    PlatformGeneral => &[PLATFORM_STATE, PLATFORM_VERSIONS][..],
+                    LeakSensors => &[LEAKS][..],
+                })
+                .copied()
+                .collect::<Vec<_>>();
+
+            assert_eq!(actual, expected, "enabled groups: {groups:?}");
+        }
     }
 
     #[test]

--- a/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
@@ -99,6 +99,14 @@ impl GnmiSampleProcessor {
             } else if let Some(comp) = find_elem_key_ref(&combined, "component", "name") {
                 entities.insert(("component", comp));
                 self.process_component_metric(&combined, comp, val);
+            } else if let Some(sensor) = find_elem_key_ref(&combined, "leak-sensor", "id") {
+                entities.insert(("leak-sensor", sensor));
+
+                if leaf_matches(&combined, &["leak-sensor", "state", "state"]) {
+                    let current = leakage_state_to_state(typed_value_to_string(val).as_deref());
+
+                    self.emit_state_set("leakage_state", "sensor", sensor, current, LEAKAGE_STATES);
+                }
             } else if combined.iter().any(|e| e.name == "platform-general") {
                 // switch-level singleton: no name key, counted as one entity.
                 entities.insert(("platform-general", ""));
@@ -889,6 +897,18 @@ const FEC_HIST_NAMES: [&str; 16] = [
     "interface_fec_hist_15",
 ];
 
+const LEAKAGE_STATES: &[&str] = &["ok", "leak", "unknown"];
+
+/// Maps NVUE leakage sensor strings to the emitted StateSet domain.
+/// Missing or unrecognized values are emitted as `unknown`.
+fn leakage_state_to_state(state: Option<&str>) -> &'static str {
+    match state.map(str::trim) {
+        Some(s) if s.eq_ignore_ascii_case("ok") => "ok",
+        Some(s) if s.eq_ignore_ascii_case("leak") => "leak",
+        _ => "unknown",
+    }
+}
+
 const OPER_STATUS_STATES: &[&str] = &["up", "down"];
 
 /// oper-status string -> current StateSet state. "up" when the source reads
@@ -1312,6 +1332,76 @@ mod tests {
 
         let count = proc.process_notification(&notification);
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn leak_sensor_states_emit_distinct_state_sets() {
+        let sink = Arc::new(CapturingSink::default());
+        let mut proc = test_processor();
+        proc.data_sink = Some(sink.clone());
+
+        let cases = [("LEAK0", "ok"), ("LEAK1", "leak"), ("LEAK2", "unknown")];
+
+        let notification = proto::Notification {
+            timestamp: 0,
+            prefix: None,
+            update: cases
+                .iter()
+                .map(|(sensor, state)| proto::Update {
+                    path: Some(proto::Path {
+                        elem: vec![
+                            make_path_elem("platform-general", &[]),
+                            make_path_elem("leak-sensors", &[]),
+                            make_path_elem("leak-sensor", &[("id", sensor)]),
+                            make_path_elem("state", &[]),
+                            make_path_elem("state", &[]),
+                        ],
+                        ..Default::default()
+                    }),
+                    val: Some(make_typed_value_string(state)),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(proc.process_notification(&notification), cases.len());
+
+        let events = sink.events.lock().expect("lock poisoned");
+
+        let samples = events
+            .iter()
+            .map(|(_, event)| {
+                let CollectorEvent::Metric(sample) = event else {
+                    panic!("expected a Metric event");
+                };
+
+                sample.as_ref()
+            })
+            .collect::<Vec<_>>();
+
+        for (sensor, state) in cases {
+            let sensor_samples = samples
+                .iter()
+                .copied()
+                .filter(|sample| {
+                    sample
+                        .labels
+                        .iter()
+                        .any(|(key, value)| key == "sensor" && value == sensor)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+
+            assert_state_set(
+                &sensor_samples,
+                "leakage_state",
+                "sensor",
+                sensor,
+                LEAKAGE_STATES,
+                state,
+            );
+        }
     }
 
     #[test]

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1767,6 +1767,10 @@ pub struct NvueGnmiPaths {
     pub components_enabled: bool,
     pub interfaces_enabled: bool,
     pub platform_general_enabled: bool,
+
+    /// Collect leak sensor state from the NVOS platform-general gNMI tree.
+    /// Disabled by default because path support depends on the NVOS release.
+    pub leak_sensors_enabled: bool,
 }
 
 impl Default for NvueGnmiPaths {
@@ -1775,6 +1779,7 @@ impl Default for NvueGnmiPaths {
             components_enabled: true,
             interfaces_enabled: true,
             platform_general_enabled: true,
+            leak_sensors_enabled: false,
         }
     }
 }
@@ -3951,6 +3956,7 @@ platform_environment_leakage_enabled = false
                 components_enabled: bool,
                 interfaces_enabled: bool,
                 platform_general_enabled: bool,
+                leak_sensors_enabled: bool,
             },
         }
 
@@ -3978,6 +3984,7 @@ platform_environment_leakage_enabled = false
                         components_enabled: true,
                         interfaces_enabled: true,
                         platform_general_enabled: true,
+                        leak_sensors_enabled: false,
                     },
                 },
                 Check {
@@ -3994,6 +4001,7 @@ system_events_enabled = false
 components_enabled = false
 interfaces_enabled = true
 platform_general_enabled = false
+leak_sensors_enabled = true
 "#,
                     expect: Projection::Enabled {
                         port: 19339,
@@ -4004,6 +4012,7 @@ platform_general_enabled = false
                         components_enabled: false,
                         interfaces_enabled: true,
                         platform_general_enabled: false,
+                        leak_sensors_enabled: true,
                     },
                 },
                 Check {
@@ -4021,6 +4030,7 @@ system_events_subscription_enabled = false
                         components_enabled: true,
                         interfaces_enabled: true,
                         platform_general_enabled: true,
+                        leak_sensors_enabled: false,
                     },
                 },
                 Check {
@@ -4038,6 +4048,7 @@ events_enabled = false
                         components_enabled: true,
                         interfaces_enabled: true,
                         platform_general_enabled: true,
+                        leak_sensors_enabled: false,
                     },
                 },
             ],
@@ -4063,6 +4074,7 @@ events_enabled = false
                     components_enabled: gnmi.paths.components_enabled,
                     interfaces_enabled: gnmi.paths.interfaces_enabled,
                     platform_general_enabled: gnmi.paths.platform_general_enabled,
+                    leak_sensors_enabled: gnmi.paths.leak_sensors_enabled,
                 }
             },
         );


### PR DESCRIPTION
Collect per-sensor leak state from the NVUE gNMI path: `/platform-general/leak-sensors/leak-sensor[id]/state/state`

Support may vary by NVOS version. The subscription must therefore be explicitly enabled so unsupported paths do not interrupt existing gNMI telemetry.

## Related issues

Resolves #5188

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)