### PR TITLE
fix(flow): reconcile Core DPU inventory

### DIFF
--- a/rest-api/flow/internal/nicoapi/model.go
+++ b/rest-api/flow/internal/nicoapi/model.go
@@ -23,17 +23,18 @@ func stringsToMachineIds(machineIds []string) (ret []*corev1.MachineId) {
 
 // MachineDetail represents detailed machine information from NICo
 type MachineDetail struct {
-	MachineID           string
-	ChassisSerial       *string
-	State               string
-	MachineType         string
-	BmcIP               string
-	BmcMac              string
-	FirmwareVersion     string
-	UpdateComplete      bool
-	HealthStatus        string
-	LastObservationTime *time.Time
-	FirmwareAutoupdate  *bool
+	MachineID               string
+	ChassisSerial           *string
+	State                   string
+	MachineType             string
+	BmcIP                   string
+	BmcMac                  string
+	FirmwareVersion         string
+	AssociatedDpuMachineIDs []string
+	UpdateComplete          bool
+	HealthStatus            string
+	LastObservationTime     *time.Time
+	FirmwareAutoupdate      *bool
 }
 
 // MachinePosition represents machine position information from NICo
@@ -52,6 +53,11 @@ func machineDetailFromPb(machine *corev1.Machine) MachineDetail {
 		State:          machine.State,
 		MachineType:    machine.MachineType.String(),
 		UpdateComplete: status.GetUpdateComplete(),
+	}
+	for _, dpuID := range status.GetAssociatedDpuMachineIds() {
+		if id := dpuID.GetId(); id != "" {
+			detail.AssociatedDpuMachineIDs = append(detail.AssociatedDpuMachineIDs, id)
+		}
 	}
 
 	// Chassis serial

--- a/rest-api/flow/internal/nicoapi/model_machine_test.go
+++ b/rest-api/flow/internal/nicoapi/model_machine_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nicoapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
+)
+
+func TestMachineDetailFromPbIncludesAssociatedDPUs(t *testing.T) {
+	machine := &corev1.Machine{
+		Id:          &corev1.MachineId{Id: "host-1"},
+		MachineType: corev1.MachineType_HOST,
+		Status: &corev1.MachineStatus{
+			AssociatedDpuMachineIds: []*corev1.MachineId{
+				{Id: "dpu-1"},
+				{Id: ""},
+				{Id: "dpu-2"},
+			},
+		},
+	}
+
+	detail := machineDetailFromPb(machine)
+
+	assert.Equal(t, []string{"dpu-1", "dpu-2"}, detail.AssociatedDpuMachineIDs)
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
+	"sort"
 
 	"github.com/rs/zerolog/log"
 	"github.com/uptrace/bun"
@@ -55,6 +56,7 @@ func reconcileDpuBMCs(
 		for i := range plan.deletes {
 			result, err := tx.NewDelete().Model(&plan.deletes[i]).
 				Where("mac_address = ?", plan.deletes[i].MacAddress).
+				Where("type = ?", devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU)).
 				Exec(ctx)
 			if err != nil {
 				return fmt.Errorf("delete DPU BMC %q: %w", plan.deletes[i].MacAddress, err)
@@ -68,6 +70,7 @@ func reconcileDpuBMCs(
 			result, err := tx.NewUpdate().Model(&plan.updates[i]).
 				Column("component_id", "ip_address").
 				Where("mac_address = ?", plan.updates[i].MacAddress).
+				Where("type = ?", devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU)).
 				Exec(ctx)
 			if err != nil {
 				return fmt.Errorf("update DPU BMC %q: %w", plan.updates[i].MacAddress, err)
@@ -146,8 +149,21 @@ func desiredDpuBMCs(
 			continue
 		}
 		component, represented := componentByHostID[host.MachineID]
+		if !represented && len(host.AssociatedDpuMachineIDs) > 0 {
+			log.Warn().
+				Str("core_host_machine_id", host.MachineID).
+				Int("associated_dpu_count", len(host.AssociatedDpuMachineIDs)).
+				Msg("Skipping DPU projection because Core host is not represented by a Flow compute component")
+		}
 		for _, dpuID := range host.AssociatedDpuMachineIDs {
 			if previousHostID, exists := dpuOwnerByID[dpuID]; exists {
+				if previousHostID == host.MachineID {
+					return nil, fmt.Errorf(
+						"core host machine %q contains duplicate association to DPU machine %q",
+						host.MachineID,
+						dpuID,
+					)
+				}
 				return nil, fmt.Errorf(
 					"core DPU machine %q is associated with multiple hosts %q and %q",
 					dpuID,
@@ -173,12 +189,12 @@ func desiredDpuBMCs(
 					dpu.MachineType,
 				)
 			}
+			if !represented {
+				continue
+			}
 			mac, err := normalizedBMCAddress(dpu.BmcMac)
 			if err != nil {
 				return nil, fmt.Errorf("core DPU machine %q: %w", dpuID, err)
-			}
-			if !represented {
-				continue
 			}
 			if existing, exists := desiredByMAC[mac]; exists {
 				return nil, fmt.Errorf(
@@ -267,6 +283,15 @@ func planDpuBMCReconciliation(
 			plan.deletes = append(plan.deletes, current)
 		}
 	}
+	sort.Slice(plan.inserts, func(i, j int) bool {
+		return plan.inserts[i].MacAddress < plan.inserts[j].MacAddress
+	})
+	sort.Slice(plan.updates, func(i, j int) bool {
+		return plan.updates[i].MacAddress < plan.updates[j].MacAddress
+	})
+	sort.Slice(plan.deletes, func(i, j int) bool {
+		return plan.deletes[i].MacAddress < plan.deletes[j].MacAddress
+	})
 	return plan, nil
 }
 

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu.go
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventorysync
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+
+	"github.com/rs/zerolog/log"
+	"github.com/uptrace/bun"
+
+	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
+)
+
+type dpuBMCReconciliationPlan struct {
+	inserts []model.BMC
+	updates []model.BMC
+	deletes []model.BMC
+}
+
+// reconcileDpuBMCs projects the DPUs associated with Core HOST machines onto
+// the type=DPU BMC rows owned by their matched Flow compute components. The BMC
+// MAC is Flow's durable identity; Core DPU machine IDs are used only to resolve
+// and validate this snapshot and are not persisted.
+func reconcileDpuBMCs(
+	ctx context.Context,
+	pool *cdb.Session,
+	machineDetails []nicoapi.MachineDetail,
+	components []model.Component,
+) error {
+	desired, err := desiredDpuBMCs(machineDetails, components)
+	if err != nil {
+		return err
+	}
+
+	var applied dpuBMCReconciliationPlan
+	if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		var existing []model.BMC
+		if err := tx.NewSelect().Model(&existing).Scan(ctx); err != nil {
+			return fmt.Errorf("load existing BMCs: %w", err)
+		}
+
+		plan, err := planDpuBMCReconciliation(desired, existing)
+		if err != nil {
+			return err
+		}
+
+		for i := range plan.deletes {
+			result, err := tx.NewDelete().Model(&plan.deletes[i]).
+				Where("mac_address = ?", plan.deletes[i].MacAddress).
+				Exec(ctx)
+			if err != nil {
+				return fmt.Errorf("delete DPU BMC %q: %w", plan.deletes[i].MacAddress, err)
+			}
+			if err := requireOneBMCRow(result, "delete", plan.deletes[i].MacAddress); err != nil {
+				return err
+			}
+		}
+
+		for i := range plan.updates {
+			result, err := tx.NewUpdate().Model(&plan.updates[i]).
+				Column("component_id", "ip_address").
+				Where("mac_address = ?", plan.updates[i].MacAddress).
+				Exec(ctx)
+			if err != nil {
+				return fmt.Errorf("update DPU BMC %q: %w", plan.updates[i].MacAddress, err)
+			}
+			if err := requireOneBMCRow(result, "update", plan.updates[i].MacAddress); err != nil {
+				return err
+			}
+		}
+
+		for i := range plan.inserts {
+			result, err := tx.NewInsert().Model(&plan.inserts[i]).Exec(ctx)
+			if err != nil {
+				return fmt.Errorf("insert DPU BMC %q: %w", plan.inserts[i].MacAddress, err)
+			}
+			if err := requireOneBMCRow(result, "insert", plan.inserts[i].MacAddress); err != nil {
+				return err
+			}
+		}
+
+		applied = plan
+		return nil
+	}); err != nil {
+		return fmt.Errorf("reconcile DPU BMC snapshot: %w", err)
+	}
+
+	log.Info().
+		Int("inserted", len(applied.inserts)).
+		Int("updated", len(applied.updates)).
+		Int("deleted", len(applied.deletes)).
+		Msg("DPU BMC reconciliation complete")
+	return nil
+}
+
+// desiredDpuBMCs validates the Core machine snapshot before returning any
+// desired DB state. An associated DPU reference must resolve to one DPU detail,
+// and a DPU may have only one host owner. DPUs belonging to Core hosts that are
+// not represented by a matched Flow compute cannot be projected and are left
+// out of the desired set; the existing host missing-in-expected drift remains
+// the actionable finding for that topology.
+func desiredDpuBMCs(
+	machineDetails []nicoapi.MachineDetail,
+	components []model.Component,
+) ([]model.BMC, error) {
+	detailByID := make(map[string]nicoapi.MachineDetail, len(machineDetails))
+	for _, detail := range machineDetails {
+		if detail.MachineID == "" {
+			continue
+		}
+		if _, exists := detailByID[detail.MachineID]; exists {
+			return nil, fmt.Errorf("core machine snapshot contains duplicate machine ID %q", detail.MachineID)
+		}
+		detailByID[detail.MachineID] = detail
+	}
+
+	componentByHostID := make(map[string]model.Component, len(components))
+	for _, component := range components {
+		if component.ComponentID == nil || *component.ComponentID == "" {
+			continue
+		}
+		hostID := *component.ComponentID
+		if existing, exists := componentByHostID[hostID]; exists {
+			return nil, fmt.Errorf(
+				"flow compute components %s and %s share Core host machine ID %q",
+				existing.ID,
+				component.ID,
+				hostID,
+			)
+		}
+		componentByHostID[hostID] = component
+	}
+
+	dpuOwnerByID := make(map[string]string)
+	desiredByMAC := make(map[string]model.BMC)
+	for _, host := range machineDetails {
+		if host.MachineType != corev1.MachineType_HOST.String() {
+			continue
+		}
+		component, represented := componentByHostID[host.MachineID]
+		for _, dpuID := range host.AssociatedDpuMachineIDs {
+			if previousHostID, exists := dpuOwnerByID[dpuID]; exists {
+				return nil, fmt.Errorf(
+					"core DPU machine %q is associated with multiple hosts %q and %q",
+					dpuID,
+					previousHostID,
+					host.MachineID,
+				)
+			}
+			dpuOwnerByID[dpuID] = host.MachineID
+
+			dpu, exists := detailByID[dpuID]
+			if !exists {
+				return nil, fmt.Errorf(
+					"core host machine %q references DPU machine %q missing from the machine snapshot",
+					host.MachineID,
+					dpuID,
+				)
+			}
+			if dpu.MachineType != corev1.MachineType_DPU.String() {
+				return nil, fmt.Errorf(
+					"core host machine %q references machine %q with type %q, expected DPU",
+					host.MachineID,
+					dpuID,
+					dpu.MachineType,
+				)
+			}
+			mac, err := normalizedBMCAddress(dpu.BmcMac)
+			if err != nil {
+				return nil, fmt.Errorf("core DPU machine %q: %w", dpuID, err)
+			}
+			if !represented {
+				continue
+			}
+			if existing, exists := desiredByMAC[mac]; exists {
+				return nil, fmt.Errorf(
+					"core DPU snapshot maps BMC MAC %q to multiple Flow components %s and %s",
+					mac,
+					existing.ComponentID,
+					component.ID,
+				)
+			}
+
+			desiredByMAC[mac] = model.BMC{
+				MacAddress:  mac,
+				Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU),
+				ComponentID: component.ID,
+				IPAddress:   optionalString(dpu.BmcIP),
+			}
+		}
+	}
+
+	desired := make([]model.BMC, 0, len(desiredByMAC))
+	for _, dpu := range desiredByMAC {
+		desired = append(desired, dpu)
+	}
+	return desired, nil
+}
+
+func planDpuBMCReconciliation(
+	desired []model.BMC,
+	existing []model.BMC,
+) (dpuBMCReconciliationPlan, error) {
+	var plan dpuBMCReconciliationPlan
+	existingByMAC := make(map[string]model.BMC, len(existing))
+	for _, bmc := range existing {
+		mac, err := normalizedBMCAddress(bmc.MacAddress)
+		if err != nil {
+			if bmc.Type == devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU) {
+				plan.deletes = append(plan.deletes, bmc)
+			}
+			continue
+		}
+		if previous, exists := existingByMAC[mac]; exists {
+			return dpuBMCReconciliationPlan{}, fmt.Errorf(
+				"flow BMC rows %q and %q normalize to the same MAC %q",
+				previous.MacAddress,
+				bmc.MacAddress,
+				mac,
+			)
+		}
+		existingByMAC[mac] = bmc
+	}
+
+	desiredMACs := make(map[string]struct{}, len(desired))
+	for _, wanted := range desired {
+		mac, err := normalizedBMCAddress(wanted.MacAddress)
+		if err != nil {
+			return dpuBMCReconciliationPlan{}, err
+		}
+		desiredMACs[mac] = struct{}{}
+		current, exists := existingByMAC[mac]
+		if !exists {
+			wanted.MacAddress = mac
+			plan.inserts = append(plan.inserts, wanted)
+			continue
+		}
+		if current.Type != devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU) {
+			return dpuBMCReconciliationPlan{}, fmt.Errorf(
+				"core DPU BMC MAC %q is occupied by Flow BMC type %q on component %s",
+				mac,
+				current.Type,
+				current.ComponentID,
+			)
+		}
+		if current.ComponentID == wanted.ComponentID && optionalStringsEqual(current.IPAddress, wanted.IPAddress) {
+			continue
+		}
+		current.ComponentID = wanted.ComponentID
+		current.IPAddress = wanted.IPAddress
+		plan.updates = append(plan.updates, current)
+	}
+
+	for mac, current := range existingByMAC {
+		if current.Type != devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU) {
+			continue
+		}
+		if _, wanted := desiredMACs[mac]; !wanted {
+			plan.deletes = append(plan.deletes, current)
+		}
+	}
+	return plan, nil
+}
+
+func normalizedBMCAddress(raw string) (string, error) {
+	addr, err := net.ParseMAC(raw)
+	if err != nil || addr == nil {
+		return "", fmt.Errorf("invalid BMC MAC address %q", raw)
+	}
+	return addr.String(), nil
+}
+
+func optionalStringsEqual(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func requireOneBMCRow(result sql.Result, operation, mac string) error {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count rows for %s DPU BMC %q: %w", operation, mac, err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("%s DPU BMC %q affected %d rows, expected 1", operation, mac, rows)
+	}
+	return nil
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu_test.go
@@ -47,7 +47,7 @@ func TestDesiredDpuBMCs(t *testing.T) {
 	t.Run("unrepresented Core host is not projected", func(t *testing.T) {
 		details := []nicoapi.MachineDetail{
 			{MachineID: "host-only-in-core", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"dpu-1"}},
-			{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String(), BmcMac: "aa:bb:cc:dd:ee:01"},
+			{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String(), BmcMac: "invalid"},
 		}
 
 		desired, err := desiredDpuBMCs(details, []model.Component{componentA})
@@ -78,6 +78,15 @@ func TestDesiredDpuBMCs(t *testing.T) {
 			},
 			components: []model.Component{componentA},
 			errorText:  "expected DPU",
+		},
+		{
+			name: "same DPU repeated by one Core host",
+			details: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"dpu-1", "dpu-1"}},
+				{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String(), BmcMac: "aa:bb:cc:dd:ee:01"},
+			},
+			components: []model.Component{componentA},
+			errorText:  "contains duplicate association",
 		},
 		{
 			name: "DPU has two Core hosts",
@@ -153,6 +162,27 @@ func TestPlanDpuBMCReconciliation(t *testing.T) {
 		_, err := planDpuBMCReconciliation(desired, existing)
 
 		require.ErrorContains(t, err, "occupied by Flow BMC type")
+	})
+
+	t.Run("invalid stored DPU MAC is scheduled for deletion", func(t *testing.T) {
+		existing := []model.BMC{{MacAddress: "invalid", Type: dpuType, ComponentID: componentA}}
+
+		plan, err := planDpuBMCReconciliation(nil, existing)
+
+		require.NoError(t, err)
+		require.Len(t, plan.deletes, 1)
+		assert.Equal(t, "invalid", plan.deletes[0].MacAddress)
+	})
+
+	t.Run("duplicate normalized stored MAC fails the complete plan", func(t *testing.T) {
+		existing := []model.BMC{
+			{MacAddress: "AA-BB-CC-DD-EE-01", Type: dpuType, ComponentID: componentA},
+			{MacAddress: "aa:bb:cc:dd:ee:01", Type: dpuType, ComponentID: componentB},
+		}
+
+		_, err := planDpuBMCReconciliation(nil, existing)
+
+		require.ErrorContains(t, err, "normalize to the same MAC")
 	})
 }
 
@@ -290,4 +320,31 @@ func TestSyncMachinesGetMachinesFailurePreservesDPUInventory(t *testing.T) {
 	require.NoError(t, pool.DB.NewSelect().Model(&got).Scan(ctx))
 	require.Len(t, got, 1)
 	assert.Equal(t, existing.MacAddress, got[0].MacAddress)
+}
+
+func TestSyncMachinesDpuFailureDoesNotBlockHostConvergence(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	component := model.Component{
+		Type:        devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
+		ComponentID: strPtr("host-1"),
+	}
+	require.NoError(t, component.Create(ctx, pool.DB))
+	createTestBMC(ctx, t, pool, component.ID, "aa:bb:cc:dd:ee:10")
+
+	client := nicoapi.NewMockClient()
+	client.AddMachine(nicoapi.MachineDetail{
+		MachineID:               "host-1",
+		MachineType:             corev1.MachineType_HOST.String(),
+		BmcMac:                  "aa:bb:cc:dd:ee:10",
+		AssociatedDpuMachineIDs: []string{"missing-dpu"},
+	})
+	client.AddPowerState("host-1", nicoapi.PowerStateOn)
+
+	_, _, ok := syncMachines(ctx, pool, client)
+
+	assert.False(t, ok, "the cycle remains degraded when DPU reconciliation fails")
+	var persisted model.Component
+	require.NoError(t, pool.DB.NewSelect().Model(&persisted).Where("id = ?", component.ID).Scan(ctx))
+	require.NotNil(t, persisted.PowerState)
+	assert.Equal(t, nicoapi.PowerStateOn, *persisted.PowerState)
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu_test.go
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventorysync
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
+)
+
+func TestDesiredDpuBMCs(t *testing.T) {
+	componentA := model.Component{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), ComponentID: strPtr("host-1")}
+	componentB := model.Component{ID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), ComponentID: strPtr("host-2")}
+
+	t.Run("multiple DPUs are projected by MAC", func(t *testing.T) {
+		details := []nicoapi.MachineDetail{
+			{
+				MachineID:               "host-1",
+				MachineType:             corev1.MachineType_HOST.String(),
+				AssociatedDpuMachineIDs: []string{"dpu-1", "dpu-2"},
+			},
+			{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String(), BmcMac: "AA-BB-CC-DD-EE-01", BmcIP: "10.0.0.1"},
+			{MachineID: "dpu-2", MachineType: corev1.MachineType_DPU.String(), BmcMac: "aa:bb:cc:dd:ee:02"},
+		}
+
+		desired, err := desiredDpuBMCs(details, []model.Component{componentA})
+
+		require.NoError(t, err)
+		require.Len(t, desired, 2)
+		byMAC := make(map[string]model.BMC, len(desired))
+		for _, bmc := range desired {
+			byMAC[bmc.MacAddress] = bmc
+		}
+		assert.Equal(t, componentA.ID, byMAC["aa:bb:cc:dd:ee:01"].ComponentID)
+		assert.Equal(t, "10.0.0.1", *byMAC["aa:bb:cc:dd:ee:01"].IPAddress)
+		assert.Nil(t, byMAC["aa:bb:cc:dd:ee:02"].IPAddress)
+	})
+
+	t.Run("unrepresented Core host is not projected", func(t *testing.T) {
+		details := []nicoapi.MachineDetail{
+			{MachineID: "host-only-in-core", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"dpu-1"}},
+			{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String(), BmcMac: "aa:bb:cc:dd:ee:01"},
+		}
+
+		desired, err := desiredDpuBMCs(details, []model.Component{componentA})
+
+		require.NoError(t, err)
+		assert.Empty(t, desired)
+	})
+
+	testCases := []struct {
+		name       string
+		details    []nicoapi.MachineDetail
+		components []model.Component
+		errorText  string
+	}{
+		{
+			name: "associated DPU missing from snapshot",
+			details: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"missing"}},
+			},
+			components: []model.Component{componentA},
+			errorText:  "missing from the machine snapshot",
+		},
+		{
+			name: "associated machine has wrong type",
+			details: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"not-dpu"}},
+				{MachineID: "not-dpu", MachineType: corev1.MachineType_HOST.String()},
+			},
+			components: []model.Component{componentA},
+			errorText:  "expected DPU",
+		},
+		{
+			name: "DPU has two Core hosts",
+			details: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"dpu-1"}},
+				{MachineID: "host-2", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"dpu-1"}},
+				{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String(), BmcMac: "aa:bb:cc:dd:ee:01"},
+			},
+			components: []model.Component{componentA, componentB},
+			errorText:  "associated with multiple hosts",
+		},
+		{
+			name: "associated DPU has no valid BMC MAC",
+			details: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"dpu-1"}},
+				{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String()},
+			},
+			components: []model.Component{componentA},
+			errorText:  "invalid BMC MAC address",
+		},
+		{
+			name: "duplicate Flow host identity",
+			details: []nicoapi.MachineDetail{
+				{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String()},
+			},
+			components: []model.Component{componentA, {ID: componentB.ID, ComponentID: strPtr("host-1")}},
+			errorText:  "share Core host machine ID",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := desiredDpuBMCs(tc.details, tc.components)
+			require.ErrorContains(t, err, tc.errorText)
+		})
+	}
+}
+
+func TestPlanDpuBMCReconciliation(t *testing.T) {
+	componentA := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	componentB := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	dpuType := devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU)
+	hostType := devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)
+
+	t.Run("creates moves updates and removes by MAC", func(t *testing.T) {
+		desired := []model.BMC{
+			{MacAddress: "aa:bb:cc:dd:ee:01", Type: dpuType, ComponentID: componentB, IPAddress: strPtr("10.0.0.11")},
+			{MacAddress: "aa:bb:cc:dd:ee:02", Type: dpuType, ComponentID: componentA},
+		}
+		existing := []model.BMC{
+			{MacAddress: "AA-BB-CC-DD-EE-01", Type: dpuType, ComponentID: componentA, IPAddress: strPtr("10.0.0.1"), User: strPtr("admin")},
+			{MacAddress: "aa:bb:cc:dd:ee:03", Type: dpuType, ComponentID: componentA},
+		}
+
+		plan, err := planDpuBMCReconciliation(desired, existing)
+
+		require.NoError(t, err)
+		require.Len(t, plan.inserts, 1)
+		assert.Equal(t, "aa:bb:cc:dd:ee:02", plan.inserts[0].MacAddress)
+		require.Len(t, plan.updates, 1)
+		assert.Equal(t, "AA-BB-CC-DD-EE-01", plan.updates[0].MacAddress)
+		assert.Equal(t, componentB, plan.updates[0].ComponentID)
+		assert.Equal(t, "10.0.0.11", *plan.updates[0].IPAddress)
+		assert.Equal(t, "admin", *plan.updates[0].User, "credentials are preserved")
+		require.Len(t, plan.deletes, 1)
+		assert.Equal(t, "aa:bb:cc:dd:ee:03", plan.deletes[0].MacAddress)
+	})
+
+	t.Run("primary BMC MAC collision fails the complete plan", func(t *testing.T) {
+		desired := []model.BMC{{MacAddress: "aa:bb:cc:dd:ee:01", Type: dpuType, ComponentID: componentA}}
+		existing := []model.BMC{{MacAddress: "aa:bb:cc:dd:ee:01", Type: hostType, ComponentID: componentA}}
+
+		_, err := planDpuBMCReconciliation(desired, existing)
+
+		require.ErrorContains(t, err, "occupied by Flow BMC type")
+	})
+}
+
+func TestReconcileDpuBMCs(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	dpuType := devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU)
+
+	componentA := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute), ComponentID: strPtr("host-1")}
+	componentB := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute), ComponentID: strPtr("host-2")}
+	require.NoError(t, componentA.Create(ctx, pool.DB))
+	require.NoError(t, componentB.Create(ctx, pool.DB))
+
+	legacy := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:01",
+		Type:        dpuType,
+		ComponentID: componentA.ID,
+		IPAddress:   strPtr("10.0.0.1"),
+		User:        strPtr("admin"),
+		Password:    strPtr("secret"),
+	}
+	stale := model.BMC{MacAddress: "aa:bb:cc:dd:ee:03", Type: dpuType, ComponentID: componentA.ID}
+	_, err := pool.DB.NewInsert().Model(&[]model.BMC{legacy, stale}).Exec(ctx)
+	require.NoError(t, err)
+
+	details := []nicoapi.MachineDetail{
+		{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"dpu-1"}},
+		{MachineID: "host-2", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"dpu-2"}},
+		{MachineID: "dpu-1", MachineType: corev1.MachineType_DPU.String(), BmcMac: legacy.MacAddress, BmcIP: "10.0.0.11"},
+		{MachineID: "dpu-2", MachineType: corev1.MachineType_DPU.String(), BmcMac: "aa:bb:cc:dd:ee:02", BmcIP: "10.0.0.12"},
+	}
+	components := []model.Component{componentA, componentB}
+
+	require.NoError(t, reconcileDpuBMCs(ctx, pool, details, components))
+	// A second pass proves restart/idempotence relies only on the persisted MAC.
+	require.NoError(t, reconcileDpuBMCs(ctx, pool, details, components))
+
+	var got []model.BMC
+	require.NoError(t, pool.DB.NewSelect().Model(&got).Order("mac_address ASC").Scan(ctx))
+	require.Len(t, got, 2)
+	assert.Equal(t, legacy.MacAddress, got[0].MacAddress)
+	assert.Equal(t, componentA.ID, got[0].ComponentID)
+	assert.Equal(t, "10.0.0.11", *got[0].IPAddress)
+	assert.Equal(t, "admin", *got[0].User)
+	assert.Equal(t, "secret", *got[0].Password)
+	assert.Equal(t, componentB.ID, got[1].ComponentID)
+
+	// Core reassociation moves the same MAC to the new host without any stored
+	// DPU machine ID.
+	details[0].AssociatedDpuMachineIDs = nil
+	details[1].AssociatedDpuMachineIDs = []string{"dpu-1", "dpu-2"}
+	require.NoError(t, reconcileDpuBMCs(ctx, pool, details, components))
+
+	var moved model.BMC
+	require.NoError(t, pool.DB.NewSelect().Model(&moved).Where("mac_address = ?", legacy.MacAddress).Scan(ctx))
+	assert.Equal(t, componentB.ID, moved.ComponentID)
+}
+
+func TestReconcileDpuBMCsInvalidSnapshotPreservesRows(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	component := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute), ComponentID: strPtr("host-1")}
+	require.NoError(t, component.Create(ctx, pool.DB))
+	existing := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:01",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU),
+		ComponentID: component.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&existing).Exec(ctx)
+	require.NoError(t, err)
+
+	err = reconcileDpuBMCs(ctx, pool, []nicoapi.MachineDetail{
+		{MachineID: "host-1", MachineType: corev1.MachineType_HOST.String(), AssociatedDpuMachineIDs: []string{"missing-dpu"}},
+	}, []model.Component{component})
+
+	require.ErrorContains(t, err, "missing from the machine snapshot")
+	var got []model.BMC
+	require.NoError(t, pool.DB.NewSelect().Model(&got).Scan(ctx))
+	require.Len(t, got, 1)
+	assert.Equal(t, existing.MacAddress, got[0].MacAddress)
+}
+
+func TestSyncMachinesLinksHostAndReconcilesAssociatedDPUInOneCycle(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	const hostMAC = "aa:bb:cc:dd:ee:10"
+	const dpuMAC = "aa:bb:cc:dd:ee:11"
+
+	component := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)}
+	require.NoError(t, component.Create(ctx, pool.DB))
+	createTestBMC(ctx, t, pool, component.ID, hostMAC)
+
+	client := nicoapi.NewMockClient()
+	client.AddMachine(nicoapi.MachineDetail{
+		MachineID:               "host-1",
+		MachineType:             corev1.MachineType_HOST.String(),
+		BmcMac:                  hostMAC,
+		AssociatedDpuMachineIDs: []string{"dpu-1"},
+	})
+	client.AddMachine(nicoapi.MachineDetail{
+		MachineID:   "dpu-1",
+		MachineType: corev1.MachineType_DPU.String(),
+		BmcMac:      dpuMAC,
+		BmcIP:       "10.0.0.11",
+	})
+
+	_, drifts, ok := syncMachines(ctx, pool, client)
+
+	require.True(t, ok)
+	assert.Empty(t, drifts)
+	var persistedComponent model.Component
+	require.NoError(t, pool.DB.NewSelect().Model(&persistedComponent).Where("id = ?", component.ID).Scan(ctx))
+	require.NotNil(t, persistedComponent.ComponentID)
+	assert.Equal(t, "host-1", *persistedComponent.ComponentID)
+	var dpu model.BMC
+	require.NoError(t, pool.DB.NewSelect().Model(&dpu).Where("mac_address = ?", dpuMAC).Scan(ctx))
+	assert.Equal(t, devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU), dpu.Type)
+	assert.Equal(t, component.ID, dpu.ComponentID)
+	assert.Equal(t, "10.0.0.11", *dpu.IPAddress)
+}
+
+func TestSyncMachinesGetMachinesFailurePreservesDPUInventory(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	component := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)}
+	require.NoError(t, component.Create(ctx, pool.DB))
+	existing := model.BMC{
+		MacAddress:  "aa:bb:cc:dd:ee:11",
+		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU),
+		ComponentID: component.ID,
+	}
+	_, err := pool.DB.NewInsert().Model(&existing).Exec(ctx)
+	require.NoError(t, err)
+
+	_, _, ok := syncMachines(ctx, pool, &failGetMachinesClient{Client: nicoapi.NewMockClient()})
+
+	assert.False(t, ok)
+	var got []model.BMC
+	require.NoError(t, pool.DB.NewSelect().Model(&got).Scan(ctx))
+	require.Len(t, got, 1)
+	assert.Equal(t, existing.MacAddress, got[0].MacAddress)
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
@@ -118,9 +118,10 @@ func syncMachines(
 	// the DPU BMC MAC as the durable identity. Validation and all DB mutations
 	// happen transactionally, so an incomplete association cannot apply a
 	// partial DPU inventory snapshot.
+	dpuSyncOK := true
 	if err := reconcileDpuBMCs(ctx, pool, allMachineDetails, components); err != nil {
 		log.Error().Err(err).Msg("Unable to reconcile Core DPU inventory")
-		return received, nil, false
+		dpuSyncOK = false
 	}
 
 	// Build lookup maps for matched components
@@ -135,7 +136,7 @@ func syncMachines(
 	}
 
 	if len(machineIDs) == 0 {
-		return received, buildDriftsForUnmatchedComponents(components, hostMachineDetails), true
+		return received, buildDriftsForUnmatchedComponents(components, hostMachineDetails), dpuSyncOK
 	}
 
 	// Step 5: Direct-write power_state (requires separate NICo API)
@@ -224,7 +225,7 @@ func syncMachines(
 	}
 
 	log.Info().Msgf("Machine sync: %d drift(s) out of %d component(s)", len(drifts), len(components))
-	return received, drifts, true
+	return received, drifts, dpuSyncOK
 }
 
 // buildDriftsForUnmatchedComponents returns missing_in_actual drifts for all

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
@@ -54,9 +54,10 @@ func filterHostMachineDetails(machineDetails []nicoapi.MachineDetail) []nicoapi.
 //  2. NICo GetMachines: fetch runtime inventory and keep the HOST details used
 //     for linking, direct writes, and missing_in_expected detection
 //  3. Link by BMC MAC (from step 2 data) → direct-write external_id
-//  4. NICo GetPowerStates: direct-write power_state
-//  5. Direct-write firmware_version (from step 2 data)
-//  6. NICo GetMachinePositionInfo: compare validation fields, return drifts
+//  4. Reconcile associated DPU BMC children by MAC from the same snapshot
+//  5. NICo GetPowerStates: direct-write power_state
+//  6. Direct-write firmware_version (from step 2 data)
+//  7. NICo GetMachinePositionInfo: compare validation fields, return drifts
 //
 // Correlation/identity key: BMC MAC address (serial number is not used).
 // Validation fields (compared for drift): slot_id, tray_index, host_id
@@ -112,6 +113,16 @@ func syncMachines(
 		}
 	}
 
+	// Project the DPU children from the same complete Core machine snapshot.
+	// DPU machine IDs resolve host associations only for this pass; Flow keeps
+	// the DPU BMC MAC as the durable identity. Validation and all DB mutations
+	// happen transactionally, so an incomplete association cannot apply a
+	// partial DPU inventory snapshot.
+	if err := reconcileDpuBMCs(ctx, pool, allMachineDetails, components); err != nil {
+		log.Error().Err(err).Msg("Unable to reconcile Core DPU inventory")
+		return received, nil, false
+	}
+
 	// Build lookup maps for matched components
 	var machineIDs []string
 	componentsByExternalID := make(map[string]*model.Component)
@@ -127,16 +138,16 @@ func syncMachines(
 		return received, buildDriftsForUnmatchedComponents(components, hostMachineDetails), true
 	}
 
-	// Step 4: Direct-write power_state (requires separate NICo API)
+	// Step 5: Direct-write power_state (requires separate NICo API)
 	syncPowerStates(ctx, pool, nicoClient, machineIDs, componentsByExternalID)
 
-	// Step 5: Direct-write firmware_version (from pre-fetched details, no extra API call)
+	// Step 6: Direct-write firmware_version (from pre-fetched details, no extra API call)
 	syncFirmwareVersions(ctx, pool, detailByID, componentsByExternalID)
 
-	// Step 5b: Direct-write derived ComponentOperationStatus (from pre-fetched detail.State).
+	// Step 6b: Direct-write derived ComponentOperationStatus (from pre-fetched detail.State).
 	syncMachineStatuses(ctx, pool, detailByID, componentsByExternalID)
 
-	// Step 6: Fetch positions and build drift records (requires separate NICo API)
+	// Step 7: Fetch positions and build drift records (requires separate NICo API)
 	machinePositions, err := nicoClient.GetMachinePositionInfo(ctx, machineIDs)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve machine positions from NICo: %v", err)


### PR DESCRIPTION
Flow already reads Core's complete machine inventory, but it only projects HOST records. Core-associated DPUs are deliberately excluded from host linking and host drift so their machine IDs cannot replace the parent Compute external ID; however, no second path creates or refreshes the corresponding type=DPU BMC children. Flow DPU inventory can therefore be missing, stale, or attached to the wrong Compute component even while DPU operations continue to work by querying Core directly.

This change retains each HOST machine's associated DPU IDs in the in-memory Core snapshot, validates that every association resolves to exactly one DPU MachineDetail with one host owner, and transactionally reconciles Flow's type=DPU BMC rows. The normalized DPU BMC MAC remains Flow's durable identity; Core DPU machine IDs are used only to resolve the current snapshot and are not persisted. A successful snapshot creates or adopts DPU rows, converges their parent Compute and BMC IP, preserves Flow credentials, and removes stale rows. An RPC failure, incomplete reference, conflicting owner, invalid MAC, or persistence failure applies no partial DPU snapshot.

DPUs associated with an unmatched Core host are not projected as unattached Flow resources. The existing HOST missing-in-expected drift remains the actionable finding, and DPU records continue to stay out of HOST drift.

## Related issues

Fixes #5133

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified with `go test ./flow/...` against a disposable PostgreSQL instance, focused DB-backed DPU reconciliation tests, focused `go vet`, changed-line `golangci-lint`, and `revive` on every changed Go file.

## Additional Notes

This requires no database migration or REST/OpenAPI change. The existing `bmc.mac_address` primary key is the DPU identity, and existing BMC credentials are preserved when Core moves or refreshes a DPU.
