### PR TITLE
fix(flow): preserve event rule operation payload

### DIFF
--- a/rest-api/flow/internal/eventrule/action.go
+++ b/rest-api/flow/internal/eventrule/action.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"slices"
 
-	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 )
 
@@ -120,7 +120,8 @@ type ActionSpec interface {
 	validate() error
 }
 
-// Action describes one independently selected and deduplicated response.
+// Action describes one independently selected and deduplicated response. Name
+// is its stable identity within the owning rule (it is not a database key).
 type Action struct {
 	Name      string
 	Condition ActionCondition
@@ -219,8 +220,7 @@ func (s TargetStrategy) RequiresResolution() bool {
 
 // SubmitTask describes a task submission requested by an event rule.
 type SubmitTask struct {
-	OperationType    taskcommon.TaskType
-	OperationCode    taskcommon.OperationCode
+	Operation        operations.Operation
 	TargetStrategy   TargetStrategy
 	ConflictStrategy ConflictStrategy
 	Description      string
@@ -243,34 +243,36 @@ func (s *SubmitTask) clone() ActionSpec {
 	if s == nil {
 		return nil
 	}
-	cloned := *s
-	return &cloned
+	cloned := &SubmitTask{
+		TargetStrategy:   s.TargetStrategy,
+		ConflictStrategy: s.ConflictStrategy,
+		Description:      s.Description,
+	}
+	if s.Operation != nil {
+		cloned.Operation = s.Operation.Clone()
+	}
+	return cloned
 }
 
 func (s *SubmitTask) validate() error {
 	if s == nil {
 		return fmt.Errorf("action spec is required")
 	}
-
-	if !s.OperationType.IsValid() {
-		return fmt.Errorf("operation_type %q is invalid", s.OperationType)
+	if s.Operation == nil {
+		return fmt.Errorf("operation is required")
 	}
-
-	if err := s.OperationCode.ValidateFor(s.OperationType); err != nil {
-		return err
+	if err := s.Operation.Validate(); err != nil {
+		return fmt.Errorf("operation: %w", err)
 	}
-
 	if err := s.TargetStrategy.Validate(); err != nil {
 		return err
 	}
 	if !s.TargetStrategy.RequiresResolution() {
 		return fmt.Errorf("submit task target strategy must require resolution")
 	}
-
 	if err := s.ConflictStrategy.validate(); err != nil {
 		return err
 	}
-
 	return validateOptionalString("description", s.Description)
 }
 

--- a/rest-api/flow/internal/eventrule/action_test.go
+++ b/rest-api/flow/internal/eventrule/action_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -37,8 +37,9 @@ func TestActionsValidate(t *testing.T) {
 			Name:      []string{"component", "rack", "affected"}[i],
 			Condition: conditions[i],
 			Spec: &SubmitTask{
-				OperationType:    taskcommon.TaskTypePowerControl,
-				OperationCode:    taskcommon.OpCodePowerControlForcePowerOff,
+				Operation: &operations.PowerControlTaskInfo{
+					Operation: operations.PowerOperationForcePowerOff,
+				},
 				TargetStrategy:   strategy,
 				ConflictStrategy: ConflictStrategyQueue,
 			},
@@ -103,18 +104,6 @@ func TestValidateActions(t *testing.T) {
 }
 
 func TestActionRejectsInvalidDomainValues(t *testing.T) {
-	validTaskSpec := SubmitTask{
-		OperationType:    taskcommon.TaskTypePowerControl,
-		OperationCode:    taskcommon.OpCodePowerControlForcePowerOff,
-		TargetStrategy:   TargetStrategyComponent,
-		ConflictStrategy: ConflictStrategyQueue,
-	}
-	unknownStrategySpec := validTaskSpec
-	unknownStrategySpec.TargetStrategy = "unknown"
-	noneStrategySpec := validTaskSpec
-	noneStrategySpec.TargetStrategy = TargetStrategyNone
-	mismatchedOperationSpec := validTaskSpec
-	mismatchedOperationSpec.OperationCode = taskcommon.OpCodeFirmwareControlUpgrade
 	tests := map[string]Action{
 		"empty condition list": {
 			Name:      "noop",
@@ -132,10 +121,50 @@ func TestActionRejectsInvalidDomainValues(t *testing.T) {
 			Name: "alert",
 			Spec: &SendAlert{Severity: SeverityUnspecified},
 		},
-		"unknown strategy":               {Name: "task", Spec: &unknownStrategySpec},
-		"task without target resolution": {Name: "task", Spec: &noneStrategySpec},
-		"mismatched operation":           {Name: "task", Spec: &mismatchedOperationSpec},
-		"missing spec":                   {Name: "task"},
+		"unknown strategy": {
+			Name: "task",
+			Spec: &SubmitTask{
+				Operation: &operations.PowerControlTaskInfo{
+					Operation: operations.PowerOperationForcePowerOff,
+				},
+				TargetStrategy:   "unknown",
+				ConflictStrategy: ConflictStrategyQueue,
+			},
+		},
+		"task without target resolution": {
+			Name: "task",
+			Spec: &SubmitTask{
+				Operation: &operations.PowerControlTaskInfo{
+					Operation: operations.PowerOperationForcePowerOff,
+				},
+				TargetStrategy:   TargetStrategyNone,
+				ConflictStrategy: ConflictStrategyQueue,
+			},
+		},
+		"invalid operation": {
+			Name: "task",
+			Spec: &SubmitTask{
+				Operation:        &operations.PowerControlTaskInfo{},
+				TargetStrategy:   TargetStrategyComponent,
+				ConflictStrategy: ConflictStrategyQueue,
+			},
+		},
+		"missing operation": {
+			Name: "task",
+			Spec: &SubmitTask{
+				TargetStrategy:   TargetStrategyComponent,
+				ConflictStrategy: ConflictStrategyQueue,
+			},
+		},
+		"typed nil operation": {
+			Name: "task",
+			Spec: &SubmitTask{
+				Operation:        (*operations.PowerControlTaskInfo)(nil),
+				TargetStrategy:   TargetStrategyComponent,
+				ConflictStrategy: ConflictStrategyQueue,
+			},
+		},
+		"missing spec": {Name: "task"},
 	}
 
 	for name, action := range tests {
@@ -159,9 +188,15 @@ func TestActionRejectsInvalidDomainValues(t *testing.T) {
 
 func TestAction_Clone(t *testing.T) {
 	tests := map[string]ActionSpec{
-		"submit task": &SubmitTask{Description: "submit"},
-		"send alert":  &SendAlert{Message: "alert"},
-		"noop":        &Noop{Reason: "noop"},
+		"submit task": &SubmitTask{
+			Operation: &operations.FirmwareControlTaskInfo{
+				Operation:  operations.FirmwareOperationUpgrade,
+				SubTargets: []string{"bmc"},
+			},
+			Description: "submit",
+		},
+		"send alert": &SendAlert{Message: "alert"},
+		"noop":       &Noop{Reason: "noop"},
 	}
 
 	for name, spec := range tests {
@@ -182,6 +217,29 @@ func TestAction_Clone(t *testing.T) {
 			require.Equal(t, SeverityWarning, action.Condition.Severities[0])
 		})
 	}
+
+	t.Run("submit task operation", func(t *testing.T) {
+		action := Action{
+			Spec: &SubmitTask{
+				Operation: &operations.FirmwareControlTaskInfo{
+					Operation:  operations.FirmwareOperationUpgrade,
+					SubTargets: []string{"bmc"},
+				},
+			},
+		}
+
+		cloned := action.Clone()
+		originalSpec := action.Spec.(*SubmitTask)
+		clonedSpec := cloned.Spec.(*SubmitTask)
+		require.NotSame(t, originalSpec.Operation, clonedSpec.Operation)
+		clonedOperation := clonedSpec.Operation.(*operations.FirmwareControlTaskInfo)
+		clonedOperation.SubTargets[0] = "bios"
+		require.Equal(
+			t,
+			[]string{"bmc"},
+			originalSpec.Operation.(*operations.FirmwareControlTaskInfo).SubTargets,
+		)
+	})
 
 	t.Run("nil specs", func(t *testing.T) {
 		require.Nil(t, (Action{}).Clone().Spec)

--- a/rest-api/flow/internal/eventrule/codec/action/action_v1.go
+++ b/rest-api/flow/internal/eventrule/codec/action/action_v1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/codec"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 )
 
@@ -29,11 +30,15 @@ type actionConditionV1 struct {
 }
 
 type submitTaskSpecV1 struct {
-	OperationType    string `json:"operationType"`
-	OperationCode    string `json:"operationCode"`
-	TargetStrategy   string `json:"targetStrategy"`
-	ConflictStrategy string `json:"conflictStrategy"`
-	Description      string `json:"description,omitempty"`
+	Operation        operationV1 `json:"operation"`
+	TargetStrategy   string      `json:"targetStrategy"`
+	ConflictStrategy string      `json:"conflictStrategy"`
+	Description      string      `json:"description,omitempty"`
+}
+
+type operationV1 struct {
+	Type string          `json:"type"`
+	Info json.RawMessage `json:"info"`
 }
 
 type sendAlertSpecV1 struct {
@@ -142,9 +147,16 @@ func unmarshalActionV1(data json.RawMessage) (eventrule.Action, error) {
 func marshalActionSpecV1(spec eventrule.ActionSpec) (json.RawMessage, error) {
 	switch typed := spec.(type) {
 	case *eventrule.SubmitTask:
+		operationInfo, err := typed.Operation.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("encode submit_task operation v1: %w", err)
+		}
+
 		return json.Marshal(submitTaskSpecV1{
-			OperationType:    string(typed.OperationType),
-			OperationCode:    string(typed.OperationCode),
+			Operation: operationV1{
+				Type: string(typed.Operation.Type()),
+				Info: operationInfo,
+			},
 			TargetStrategy:   string(typed.TargetStrategy),
 			ConflictStrategy: string(typed.ConflictStrategy),
 			Description:      typed.Description,
@@ -171,10 +183,16 @@ func unmarshalActionSpecV1(
 		if err := codec.DecodeStrict(data, &persisted); err != nil {
 			return nil, fmt.Errorf("decode submit_task action spec v1: %w", err)
 		}
+		operation, err := operations.New(
+			taskcommon.TaskType(persisted.Operation.Type),
+			persisted.Operation.Info,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("decode submit_task operation v1: %w", err)
+		}
 
 		return &eventrule.SubmitTask{
-			OperationType:    taskcommon.TaskType(persisted.OperationType),
-			OperationCode:    taskcommon.OperationCode(persisted.OperationCode),
+			Operation:        operation,
 			TargetStrategy:   eventrule.TargetStrategy(persisted.TargetStrategy),
 			ConflictStrategy: eventrule.ConflictStrategy(persisted.ConflictStrategy),
 			Description:      persisted.Description,

--- a/rest-api/flow/internal/eventrule/codec/action/codec_test.go
+++ b/rest-api/flow/internal/eventrule/codec/action/codec_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
 	actioncodec "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/codec/action"
-	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -22,8 +22,14 @@ func TestMarshal(t *testing.T) {
 				ComponentTypes: []flowtypes.ComponentType{flowtypes.ComponentTypeCompute},
 			},
 			Spec: &eventrule.SubmitTask{
-				OperationType:    taskcommon.TaskTypePowerControl,
-				OperationCode:    taskcommon.OpCodePowerControlForcePowerOff,
+				Operation: &operations.FirmwareControlTaskInfo{
+					Operation:              operations.FirmwareOperationUpgrade,
+					TargetVersion:          "1.2.3",
+					StartTime:              123,
+					EndTime:                456,
+					SubTargets:             []string{"bmc", "bios"},
+					OverrideReadinessCheck: true,
+				},
 				TargetStrategy:   eventrule.TargetStrategyComponent,
 				ConflictStrategy: eventrule.ConflictStrategyQueue,
 				Description:      "power off",

--- a/rest-api/flow/internal/eventrule/codec/policy/codec_test.go
+++ b/rest-api/flow/internal/eventrule/codec/policy/codec_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
 	policycodec "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/codec/policy"
-	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -80,8 +80,9 @@ func fullPolicy() eventrule.Policy {
 					ComponentTypes: []flowtypes.ComponentType{flowtypes.ComponentTypeCompute},
 				},
 				Spec: &eventrule.SubmitTask{
-					OperationType:    taskcommon.TaskTypePowerControl,
-					OperationCode:    taskcommon.OpCodePowerControlForcePowerOff,
+					Operation: &operations.PowerControlTaskInfo{
+						Operation: operations.PowerOperationForcePowerOff,
+					},
 					TargetStrategy:   eventrule.TargetStrategyComponent,
 					ConflictStrategy: eventrule.ConflictStrategyQueue,
 					Description:      "power off",

--- a/rest-api/flow/internal/eventrule/codec/policy/testdata/policy_v1_all_actions.json
+++ b/rest-api/flow/internal/eventrule/codec/policy/testdata/policy_v1_all_actions.json
@@ -14,8 +14,13 @@
         "componentTypes": ["COMPUTE"]
       },
       "spec": {
-        "operationType": "power_control",
-        "operationCode": "force_power_off",
+        "operation": {
+          "type": "power_control",
+          "info": {
+            "operation": 4,
+            "forced": false
+          }
+        },
         "targetStrategy": "component",
         "conflictStrategy": "queue",
         "description": "power off"

--- a/rest-api/flow/internal/eventrule/leakage/leakage.go
+++ b/rest-api/flow/internal/eventrule/leakage/leakage.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/target"
-	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
 	"github.com/google/uuid"
 )
@@ -154,8 +154,9 @@ func DefaultRule() eventrule.Rule {
 				{
 					Name: "power_off_affected_components",
 					Spec: &eventrule.SubmitTask{
-						OperationType:    taskcommon.TaskTypePowerControl,
-						OperationCode:    taskcommon.OpCodePowerControlForcePowerOff,
+						Operation: &operations.PowerControlTaskInfo{
+							Operation: operations.PowerOperationForcePowerOff,
+						},
 						TargetStrategy:   eventrule.TargetStrategyAffectedComponents,
 						ConflictStrategy: eventrule.ConflictStrategyQueue,
 						Description:      "Leakage response",

--- a/rest-api/flow/internal/eventrule/leakage/leakage_test.go
+++ b/rest-api/flow/internal/eventrule/leakage/leakage_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/target"
 	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
-	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/deviceinfo"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/component"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
@@ -32,8 +32,9 @@ func TestDefaultRuleValidates(t *testing.T) {
 	require.Len(t, rule.Actions, 1)
 	spec, ok := rule.Actions[0].Spec.(*eventrule.SubmitTask)
 	require.True(t, ok)
-	assert.Equal(t, taskcommon.TaskTypePowerControl, spec.OperationType)
-	assert.Equal(t, taskcommon.OperationCode(taskcommon.OpCodePowerControlForcePowerOff), spec.OperationCode)
+	operation, ok := spec.Operation.(*operations.PowerControlTaskInfo)
+	require.True(t, ok)
+	assert.Equal(t, operations.PowerOperationForcePowerOff, operation.Operation)
 	assert.Equal(t, eventrule.TargetStrategyAffectedComponents, spec.TargetStrategy)
 }
 

--- a/rest-api/flow/internal/eventrule/processor/process_test.go
+++ b/rest-api/flow/internal/eventrule/processor/process_test.go
@@ -17,7 +17,7 @@ import (
 	memorystore "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/store/memory"
 	eventtarget "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/target"
 	inventoryresolver "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
-	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/deviceinfo"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/location"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
@@ -553,8 +553,9 @@ func submitAction(name string) eventrule.Action {
 	return eventrule.Action{
 		Name: name,
 		Spec: &eventrule.SubmitTask{
-			OperationType:    taskcommon.TaskTypePowerControl,
-			OperationCode:    taskcommon.OpCodePowerControlForcePowerOff,
+			Operation: &operations.PowerControlTaskInfo{
+				Operation: operations.PowerOperationForcePowerOff,
+			},
 			TargetStrategy:   eventrule.TargetStrategyRack,
 			ConflictStrategy: eventrule.ConflictStrategyQueue,
 		},

--- a/rest-api/flow/internal/eventrule/target/registry_test.go
+++ b/rest-api/flow/internal/eventrule/target/registry_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
-	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -298,8 +298,9 @@ func targetRule(strategy eventrule.TargetStrategy) *eventrule.Rule {
 			{
 				Name: "task",
 				Spec: &eventrule.SubmitTask{
-					OperationType:    taskcommon.TaskTypePowerControl,
-					OperationCode:    taskcommon.OpCodePowerControlForcePowerOff,
+					Operation: &operations.PowerControlTaskInfo{
+						Operation: operations.PowerOperationForcePowerOff,
+					},
 					TargetStrategy:   strategy,
 					ConflictStrategy: eventrule.ConflictStrategyQueue,
 				},

--- a/rest-api/flow/internal/task/operations/operations.go
+++ b/rest-api/flow/internal/task/operations/operations.go
@@ -6,6 +6,7 @@ package operations
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,6 +31,7 @@ func ExtractRuleID(info json.RawMessage) *uuid.UUID {
 }
 
 type Operation interface {
+	Clone() Operation
 	Validate() error
 	Marshal() (json.RawMessage, error)
 	Unmarshal(data json.RawMessage) error
@@ -89,11 +91,24 @@ type PowerControlTaskInfo struct {
 }
 
 func (t *PowerControlTaskInfo) Validate() error {
+	if t == nil {
+		return fmt.Errorf("operation is required")
+	}
+
 	if t.Operation == PowerOperationUnknown {
 		return fmt.Errorf("invalid power control operation")
 	}
 
 	return nil
+}
+
+// Clone returns an independent copy of the operation.
+func (t *PowerControlTaskInfo) Clone() Operation {
+	if t == nil {
+		return nil
+	}
+	cloned := *t
+	return &cloned
 }
 
 func (t *PowerControlTaskInfo) Marshal() (json.RawMessage, error) {
@@ -128,7 +143,21 @@ type InjectExpectationTaskInfo struct {
 }
 
 func (t *InjectExpectationTaskInfo) Validate() error {
+	if t == nil {
+		return fmt.Errorf("operation is required")
+	}
+
 	return nil
+}
+
+// Clone returns an independent copy of the operation.
+func (t *InjectExpectationTaskInfo) Clone() Operation {
+	if t == nil {
+		return nil
+	}
+	cloned := *t
+	cloned.Info = slices.Clone(t.Info)
+	return &cloned
 }
 
 func (t *InjectExpectationTaskInfo) Marshal() (json.RawMessage, error) {
@@ -171,7 +200,20 @@ type BringUpTaskInfo struct {
 }
 
 func (t *BringUpTaskInfo) Validate() error {
+	if t == nil {
+		return fmt.Errorf("operation is required")
+	}
+
 	return nil
+}
+
+// Clone returns an independent copy of the operation.
+func (t *BringUpTaskInfo) Clone() Operation {
+	if t == nil {
+		return nil
+	}
+	cloned := *t
+	return &cloned
 }
 
 func (t *BringUpTaskInfo) Marshal() (json.RawMessage, error) {
@@ -243,11 +285,25 @@ type FirmwareControlTaskInfo struct {
 }
 
 func (t *FirmwareControlTaskInfo) Validate() error {
+	if t == nil {
+		return fmt.Errorf("operation is required")
+	}
+
 	if t.Operation == FirmwareOperationUnknown {
 		return fmt.Errorf("invalid firmware control operation")
 	}
 
 	return nil
+}
+
+// Clone returns an independent copy of the operation.
+func (t *FirmwareControlTaskInfo) Clone() Operation {
+	if t == nil {
+		return nil
+	}
+	cloned := *t
+	cloned.SubTargets = slices.Clone(t.SubTargets)
+	return &cloned
 }
 
 func (t *FirmwareControlTaskInfo) Marshal() (json.RawMessage, error) {
@@ -283,7 +339,20 @@ type DecommissionTaskInfo struct {
 }
 
 func (t *DecommissionTaskInfo) Validate() error {
+	if t == nil {
+		return fmt.Errorf("operation is required")
+	}
+
 	return nil
+}
+
+// Clone returns an independent copy of the operation.
+func (t *DecommissionTaskInfo) Clone() Operation {
+	if t == nil {
+		return nil
+	}
+	cloned := *t
+	return &cloned
 }
 
 func (t *DecommissionTaskInfo) Marshal() (json.RawMessage, error) {

--- a/rest-api/flow/internal/task/operations/operations_test.go
+++ b/rest-api/flow/internal/task/operations/operations_test.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package operations
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperation_Clone(t *testing.T) {
+	tests := map[string]Operation{
+		"power control": &PowerControlTaskInfo{
+			Operation:              PowerOperationForcePowerOff,
+			Forced:                 true,
+			RuleID:                 "power-rule",
+			OverrideReadinessCheck: true,
+		},
+		"inject expectation": &InjectExpectationTaskInfo{
+			Info: json.RawMessage(`{"expected":"value"}`),
+		},
+		"bring up": &BringUpTaskInfo{
+			RuleID:                 "bring-up-rule",
+			OpCode:                 "ingest",
+			OverrideReadinessCheck: true,
+		},
+		"firmware control": &FirmwareControlTaskInfo{
+			Operation:              FirmwareOperationUpgrade,
+			TargetVersion:          "1.2.3",
+			StartTime:              123,
+			EndTime:                456,
+			RuleID:                 "firmware-rule",
+			SubTargets:             []string{"bmc", "bios"},
+			OverrideReadinessCheck: true,
+		},
+		"decommission": &DecommissionTaskInfo{RuleID: "decommission-rule"},
+	}
+
+	for name, operation := range tests {
+		t.Run(name, func(t *testing.T) {
+			cloned := operation.Clone()
+			require.Equal(t, operation, cloned)
+			require.NotSame(t, operation, cloned)
+		})
+	}
+}
+
+func TestOperation_CloneMutablePayload(t *testing.T) {
+	tests := map[string]struct {
+		operation Operation
+		mutate    func(Operation)
+	}{
+		"inject expectation": {
+			operation: &InjectExpectationTaskInfo{
+				Info: json.RawMessage(`{"expected":"value"}`),
+			},
+			mutate: func(operation Operation) {
+				operation.(*InjectExpectationTaskInfo).Info[0] = '['
+			},
+		},
+		"firmware subtargets": {
+			operation: &FirmwareControlTaskInfo{
+				Operation:  FirmwareOperationUpgrade,
+				SubTargets: []string{"bmc"},
+			},
+			mutate: func(operation Operation) {
+				operation.(*FirmwareControlTaskInfo).SubTargets[0] = "bios"
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cloned := test.operation.Clone()
+			test.mutate(cloned)
+			require.NotEqual(t, test.operation, cloned)
+		})
+	}
+}
+
+func TestOperation_CloneNilReceiver(t *testing.T) {
+	tests := map[string]Operation{
+		"power control":      (*PowerControlTaskInfo)(nil),
+		"inject expectation": (*InjectExpectationTaskInfo)(nil),
+		"bring up":           (*BringUpTaskInfo)(nil),
+		"firmware control":   (*FirmwareControlTaskInfo)(nil),
+		"decommission":       (*DecommissionTaskInfo)(nil),
+	}
+
+	for name, operation := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Nil(t, operation.Clone())
+		})
+	}
+}


### PR DESCRIPTION
The action spec of SubmitTask must retain the complete Operation, not
only its type and code, because executors and retry workers need the
operation-specific payload to submit the task correctly. Persisting the
full operation also makes deferred executions self-contained and
reproducible without reconstructing parameters from unavailable event
or rule state.
- Replace SubmitTask's derived operation type and code fields with the
   complete task operation so executors and future retries retain every
   parameter required to submit the task. 
- Persist the operation discriminator and payload in the V1 action codec,
   reconstruct concrete operations during decode, and deep-clone mutable
   operation data when cloning actions. 
- Update the built-in leakage action, codec fixtures, processor and resolver
   tests, and add regression coverage for validation, round trips, typed nils,
   and independent operation clones.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

