### PR TITLE
chore(CODEOWNERS): Update default CODEOWNERS to approver-only group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # Rules are evaluated from top to bottom, with later rules taking precedence.
 
 # Default owners for everything in the repo
-* @NVIDIA/carbide-sw-contributors
+* @NVIDIA/carbide-sw-approvers
 
 # CODEOWNERS file itself - requires admin approval
 /.github/CODEOWNERS @NVIDIA/carbide-sw-admins
@@ -18,8 +18,6 @@
 /helm-prereqs/ @NVIDIA/dsx-sw-helm
 
 # Documentation (To be re-enabled once as have a doc reviewer)
-#/docs/ @CoCo-Ben
-#/fern/ @CoCo-Ben
 /docs/ @polarweasel
 /fern/ @polarweasel
 
@@ -27,6 +25,3 @@
 # `/metrics` scrape; `cargo xtask check-metric-docs --fix` adds the rest), not
 # authored prose -- exclude it so metric-only changes don't wait on docs review.
 /docs/observability/core_metrics.md
-
-# Network IP module
-/common/network/src/ip/ @DrewBloechl


### PR DESCRIPTION
Update CODEOWNERS to use a new group that includes a smaller, approver-only group.  We want to create a situation where people can generally merge their own PRs as long as an "approver" has approved it.  This is less than "maintainer" that can change a bunch of settings we want even a smaller group of people to be maintainers.

## Type of Change
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] No testing required (docs, internal refactor, etc.)
