### PR TITLE
fix(api-core): Component Manager Firmware Update Status/Error Reporting

### DIFF
--- a/crates/admin-cli/src/component_manager/status/cmd.rs
+++ b/crates/admin-cli/src/component_manager/status/cmd.rs
@@ -23,6 +23,22 @@ use crate::component_manager::common;
 use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
+fn ensure_firmware_status_succeeded(
+    statuses: &[::rpc::forge::FirmwareUpdateStatus],
+) -> Result<(), CarbideCliError> {
+    let (failures, failure_summary) = common::component_failure_count_and_summary(
+        statuses.iter().map(|status| status.result.as_ref()),
+    );
+
+    if failures > 0 {
+        return Err(CarbideCliError::GenericError(format!(
+            "{failures} component firmware status result(s) failed{failure_summary}"
+        )));
+    }
+
+    Ok(())
+}
+
 pub(super) async fn get_status(
     opts: Args,
     format: OutputFormat,
@@ -77,18 +93,37 @@ pub(super) async fn get_status(
         table.printstd();
     }
 
-    let (failures, failure_summary) = common::component_failure_count_and_summary(
-        response
-            .statuses
-            .iter()
-            .map(|status| status.result.as_ref()),
-    );
+    ensure_firmware_status_succeeded(&response.statuses)
+}
 
-    if failures > 0 {
-        return Err(CarbideCliError::GenericError(format!(
-            "{failures} component firmware status result(s) failed{failure_summary}"
-        )));
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_firmware_status_returns_a_cli_error_with_the_backend_reason() {
+        let statuses = [::rpc::forge::FirmwareUpdateStatus {
+            result: Some(::rpc::forge::ComponentResult {
+                component_id: Some("rack-1".into()),
+                status: ::rpc::forge::ComponentManagerStatusCode::InternalError as i32,
+                error: "rack firmware failed".into(),
+                mac_address: None,
+            }),
+            state: ::rpc::forge::FirmwareUpdateState::FwStateFailed as i32,
+            target_version: "fw-42".into(),
+            updated_at: None,
+        }];
+
+        let error = ensure_firmware_status_succeeded(&statuses)
+            .expect_err("a failed component result must make the command fail");
+
+        let CarbideCliError::GenericError(message) = error else {
+            panic!("firmware status failures must return GenericError");
+        };
+
+        assert_eq!(
+            message,
+            "1 component firmware status result(s) failed: rack-1=internal-error(2): rack firmware failed"
+        );
     }
-
-    Ok(())
 }

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -2276,9 +2276,10 @@ fn derive_machine_firmware_update_status(
     // results do. Without this a compute tray reports FwStateFailed with an empty
     // error and the backend reason never reaches the operator.
     let result = if state == rpc::FirmwareUpdateState::FwStateFailed {
-        machine_firmware_failure_reason(machine).map_or_else(
-            || success_result(machine_id),
-            |reason| error_result(machine_id, reason),
+        error_result(
+            machine_id,
+            machine_firmware_failure_reason(machine)
+                .unwrap_or_else(|| "firmware upgrade failed without a recorded reason".to_owned()),
         )
     } else {
         success_result(machine_id)

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -292,12 +292,14 @@ fn rack_firmware_failure_summary(rack: &model::rack::Rack, job: &FirmwareUpgrade
         .map(str::trim)
         .filter(|reason| !reason.is_empty())
         .collect();
+    let reported = reasons.len();
     reasons.sort_unstable();
     reasons.dedup();
 
     match reasons.as_slice() {
         [] => summary,
-        [reason] => format!("{summary}: {reason}"),
+        [reason] if reported == failed.len() => format!("{summary}: {reason}"),
+        [_] => format!("{summary}; some devices reported no reason; see backend service logs"),
         reasons => format!(
             "{summary}: {} distinct errors; see backend service logs",
             reasons.len()
@@ -386,20 +388,25 @@ fn persisted_firmware_status(
 
 fn queued_firmware_status(
     switch_id: SwitchId,
-    requested_at: chrono::DateTime<chrono::Utc>,
+    requested_at: Option<chrono::DateTime<chrono::Utc>>,
 ) -> rpc::FirmwareUpdateStatus {
     rpc::FirmwareUpdateStatus {
         result: Some(success_result(&switch_id.to_string())),
         state: rpc::FirmwareUpdateState::FwStateQueued as i32,
         target_version: String::new(),
-        updated_at: Some(requested_at.into()),
+        updated_at: requested_at.map(Into::into),
     }
 }
 
 /// The firmware upgrade request currently in flight for a switch, whether it was
 /// accepted at the rack or already dispatched to the device.
 struct SwitchFirmwareRequest {
-    requested_at: chrono::DateTime<chrono::Utc>,
+    /// When the request was accepted, used as the cycle boundary. `None` for a
+    /// scope persisted before acceptance timestamps existed: the request is
+    /// active but its boundary is unknown. It is never derived from a mutable
+    /// column such as `racks.updated`, which firmware polling advances on every
+    /// write and which would keep moving the boundary past a running update.
+    requested_at: Option<chrono::DateTime<chrono::Utc>>,
     target_version: Option<String>,
 }
 
@@ -424,7 +431,7 @@ fn switch_firmware_request(
         })
         .map(|request| {
             (
-                request.requested_at,
+                Some(request.requested_at),
                 requested_firmware_version(&request.activities),
             )
         });
@@ -438,16 +445,23 @@ fn switch_firmware_request(
             })
             .map(|scope| {
                 (
-                    scope.requested_at.unwrap_or(rack.updated),
+                    scope.requested_at,
                     requested_firmware_version(&scope.activities),
                 )
             })
     });
 
+    if switch_request.is_none() && rack_request.is_none() {
+        return None;
+    }
     let requested_at = switch_request
         .as_ref()
-        .map(|(requested_at, _)| *requested_at)
-        .max(rack_request.as_ref().map(|(requested_at, _)| *requested_at))?;
+        .and_then(|(requested_at, _)| *requested_at)
+        .max(
+            rack_request
+                .as_ref()
+                .and_then(|(requested_at, _)| *requested_at),
+        );
     // The device request is the dispatched form of the rack request and does not
     // have to repeat the version the operator asked for.
     let target_version = switch_request
@@ -471,7 +485,13 @@ fn select_persisted_switch_firmware_status(
     match request {
         Some(request) => {
             let status = persisted_status
-                .filter(|status| status.is_current_for(request.requested_at))
+                // An unknown boundary cannot prove the status belongs to an
+                // earlier cycle, so keep it rather than reporting Queued forever.
+                .filter(|status| {
+                    request
+                        .requested_at
+                        .is_none_or(|requested_at| status.is_current_for(requested_at))
+                })
                 .map_or_else(
                     || queued_firmware_status(switch_id, request.requested_at),
                     |status| persisted_firmware_status(switch_id, status),
@@ -483,6 +503,40 @@ fn select_persisted_switch_firmware_status(
             })
         }
         None => persisted_status.map(|status| persisted_firmware_status(switch_id, status)),
+    }
+}
+
+/// Drops the state-controller's persisted per-device result for switches whose firmware
+/// update was just queued directly, so status polling stops serving the superseded result
+/// and falls through to the backend running the new update.
+///
+/// Best effort on purpose: the backend has already accepted the update, so a bookkeeping
+/// failure must not be reported as a failed dispatch. A switch that fails to clear keeps
+/// serving its previous status until the next write.
+///
+/// This deliberately leaves `switch_reprovisioning_requested` alone. A switch still under an
+/// active state-controller firmware request keeps reporting that request's view; reconciling
+/// a direct dispatch against a pending controller request is a separate concern and is not
+/// resolved here.
+async fn clear_switch_firmware_upgrade_status(api: &Api, switch_ids: &[SwitchId]) {
+    if switch_ids.is_empty() {
+        return;
+    }
+    let mut conn = match api.database_connection.acquire().await {
+        Ok(conn) => conn,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "failed to acquire a connection to clear superseded switch firmware status"
+            );
+            return;
+        }
+    };
+
+    if let Err(error) =
+        db::switch::clear_firmware_upgrade_status_for_switches(conn.as_mut(), switch_ids).await
+    {
+        tracing::warn!(%error, "failed to clear superseded switch firmware status");
     }
 }
 
@@ -558,17 +612,7 @@ async fn switch_firmware_statuses(
 
     let cm = require_component_manager(api)?;
     let endpoints = resolve_switch_endpoints(api, &backend_switch_ids).await?;
-    statuses.extend(
-        endpoints
-            .unresolved
-            .iter()
-            .map(|u| rpc::FirmwareUpdateStatus {
-                result: Some(error_result(&u.id.to_string(), u.reason.clone())),
-                state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
-                target_version: String::new(),
-                updated_at: None,
-            }),
-    );
+    statuses.extend(unresolved_firmware_statuses(&endpoints.unresolved));
 
     if !endpoints.resolved.endpoints.is_empty() {
         let backend_statuses = cm
@@ -1358,6 +1402,20 @@ fn switch_firmware_maintenance_activities(
 struct UnresolvedDevice<Id> {
     id: Id,
     reason: String,
+}
+
+/// Reports each device that couldn't be resolved to a backend endpoint as an errored
+/// `FwStateUnknown` firmware status, so it still surfaces in the response rather than being
+/// silently dropped from the batch.
+fn unresolved_firmware_statuses<Id: std::fmt::Display>(
+    unresolved: &[UnresolvedDevice<Id>],
+) -> impl Iterator<Item = rpc::FirmwareUpdateStatus> + '_ {
+    unresolved.iter().map(|u| rpc::FirmwareUpdateStatus {
+        result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+        state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+        target_version: String::new(),
+        updated_at: None,
+    })
 }
 
 impl<Id: std::fmt::Display> std::fmt::Display for UnresolvedDevice<Id> {
@@ -2414,16 +2472,7 @@ async fn compute_tray_firmware_statuses(
     )
     .await;
 
-    let mut statuses: Vec<_> = resolved
-        .unresolved
-        .iter()
-        .map(|u| rpc::FirmwareUpdateStatus {
-            result: Some(error_result(&u.id.to_string(), u.reason.clone())),
-            state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
-            target_version: String::new(),
-            updated_at: None,
-        })
-        .collect();
+    let mut statuses: Vec<_> = unresolved_firmware_statuses(&resolved.unresolved).collect();
 
     if !resolved.resolved.endpoints.is_empty() {
         let backend_statuses = cm
@@ -4239,7 +4288,6 @@ async fn firmware_status_switch_ids(
             updated_at: None,
         }
     }));
-
     Ok(statuses)
 }
 
@@ -4293,6 +4341,152 @@ async fn pre_ingestion_switch_firmware_statuses(
     );
 
     Ok(statuses)
+}
+
+/// Power shelves are not part of the rack firmware job, so their status always
+/// comes from the backend.
+async fn power_shelf_firmware_statuses(
+    api: &Api,
+    ids: &[PowerShelfId],
+) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
+    // The rack controller currently writes power-shelf Completed only as an
+    // internal reprovisioning-unblock sentinel; the backend does not include
+    // shelves in the rack firmware job. It is therefore not an API firmware result.
+    let cm = require_component_manager(api)?;
+    let endpoints = resolve_power_shelf_endpoints(api, ids).await?;
+
+    let mut statuses: Vec<_> = unresolved_firmware_statuses(&endpoints.unresolved).collect();
+
+    let backend_statuses = cm
+        .power_shelf
+        .get_firmware_status(&endpoints.resolved.endpoints)
+        .await
+        .map_err(component_manager_error_to_status)?;
+    statuses.extend(backend_statuses.into_iter().map(|s| {
+        let id = ps_mac_to_id_str(&s.pmc_mac, &endpoints.resolved.mac_to_id);
+        rpc::FirmwareUpdateStatus {
+            result: Some(if s.error.is_none() {
+                success_result(&id)
+            } else {
+                error_result(&id, s.error.unwrap_or_default())
+            }),
+            state: map_fw_state(s.state),
+            target_version: s.target_version,
+            updated_at: None,
+        }
+    }));
+
+    Ok(statuses)
+}
+
+/// Routes each machine to the backend or to the database, depending on whether a
+/// firmware update was dispatched around the state controller.
+async fn routed_machine_firmware_statuses(
+    api: &Api,
+    machine_ids: &[HostMachineId],
+) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
+    if machine_ids.is_empty() {
+        return Err(Status::invalid_argument("machine_ids must not be empty"));
+    }
+
+    // In direct-dispatch mode all IDs go to the compute-tray backend. In
+    // state-controller mode, IDs with a persisted direct-dispatch job poll the
+    // live backend; the rest use the database-only status path.
+    let Some(cm) = api.component_manager.as_ref() else {
+        return machine_firmware_statuses(api, machine_ids).await;
+    };
+    let machines_by_id = load_machines_by_id(api, machine_ids).await?;
+    let bmc_macs_with_direct_fw_updates = if cm.compute_tray_use_state_controller {
+        let bmc_macs: Vec<MacAddress> = machine_ids
+            .iter()
+            .filter_map(|id| machines_by_id.get(id).and_then(|m| m.status.bmc_info.mac))
+            .collect();
+
+        db::direct_dispatch_firmware_job::find_macs_with_job(api.pg_pool(), &bmc_macs)
+            .await
+            .map_err(|e| Status::internal(format!("db error: {e}")))?
+    } else {
+        HashSet::new()
+    };
+
+    match select_firmware_status_routing(
+        cm.compute_tray_use_state_controller,
+        machine_ids,
+        &machines_by_id,
+        &bmc_macs_with_direct_fw_updates,
+    ) {
+        FirmwareStatusRouting::DirectDispatch => {
+            compute_tray_firmware_statuses(cm, api, &machines_by_id, machine_ids).await
+        }
+        FirmwareStatusRouting::Partitioned {
+            persisted,
+            fallback,
+        } => {
+            // Disjoint ID sets on independent backends (a component-manager RPC vs. a DB
+            // query): run them concurrently instead of paying the sum of their latencies.
+            let persisted_statuses = async {
+                if persisted.is_empty() {
+                    Ok(Vec::new())
+                } else {
+                    compute_tray_firmware_statuses(cm, api, &machines_by_id, &persisted).await
+                }
+            };
+            let fallback_statuses = async {
+                if fallback.is_empty() {
+                    Ok(Vec::new())
+                } else {
+                    machine_firmware_statuses(api, &fallback).await
+                }
+            };
+            let (persisted_statuses, fallback_statuses) =
+                tokio::try_join!(persisted_statuses, fallback_statuses)?;
+
+            let mut statuses = Vec::with_capacity(machine_ids.len());
+            statuses.extend(persisted_statuses);
+            statuses.extend(fallback_statuses);
+            Ok(statuses)
+        }
+    }
+}
+
+/// Rack status is entirely database-derived; a missing rack is reported per ID
+/// rather than failing the batch.
+async fn rack_firmware_statuses(
+    api: &Api,
+    rack_ids: &[RackId],
+) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
+    if rack_ids.is_empty() {
+        return Err(Status::invalid_argument("rack_ids must not be empty"));
+    }
+
+    let racks = db::rack::find_by(
+        api.db_reader().as_mut(),
+        db::ObjectColumnFilter::List(db::rack::IdColumn, rack_ids),
+    )
+    .await
+    .map_err(|e| Status::internal(format!("failed to look up racks: {e}")))?;
+    let rack_by_id: HashMap<_, _> = racks
+        .into_iter()
+        .map(|rack| (rack.id.clone(), rack))
+        .collect();
+
+    Ok(rack_ids
+        .iter()
+        .map(|rack_id| {
+            rack_by_id
+                .get(rack_id)
+                .map(rack_firmware_status)
+                .unwrap_or(rpc::FirmwareUpdateStatus {
+                    result: Some(not_found_component_result(
+                        rack_id.as_ref(),
+                        format!("rack {rack_id} not found"),
+                    )),
+                    state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+                    target_version: String::new(),
+                    updated_at: None,
+                })
+        })
+        .collect())
 }
 
 pub(crate) async fn get_component_firmware_status(
@@ -4350,140 +4544,13 @@ pub(crate) async fn get_component_firmware_status(
             statuses
         }
         rpc::get_component_firmware_status_request::Target::PowerShelfIds(list) => {
-            // The rack controller currently writes power-shelf Completed only as an
-            // internal reprovisioning-unblock sentinel; the backend does not include
-            // shelves in the rack firmware job. It is therefore not an API firmware result.
-            let cm = require_component_manager(api)?;
-            let endpoints = resolve_power_shelf_endpoints(api, &list.ids).await?;
-
-            let mut statuses: Vec<_> = endpoints
-                .unresolved
-                .iter()
-                .map(|u| rpc::FirmwareUpdateStatus {
-                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
-                    state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
-                    target_version: String::new(),
-                    updated_at: None,
-                })
-                .collect();
-
-            let backend_statuses = cm
-                .power_shelf
-                .get_firmware_status(&endpoints.resolved.endpoints)
-                .await
-                .map_err(component_manager_error_to_status)?;
-            statuses.extend(backend_statuses.into_iter().map(|s| {
-                let id = ps_mac_to_id_str(&s.pmc_mac, &endpoints.resolved.mac_to_id);
-                rpc::FirmwareUpdateStatus {
-                    result: Some(if s.error.is_none() {
-                        success_result(&id)
-                    } else {
-                        error_result(&id, s.error.unwrap_or_default())
-                    }),
-                    state: map_fw_state(s.state),
-                    target_version: s.target_version,
-                    updated_at: None,
-                }
-            }));
-            statuses
+            power_shelf_firmware_statuses(api, &list.ids).await?
         }
         rpc::get_component_firmware_status_request::Target::MachineIds(list) => {
-            if list.machine_ids.is_empty() {
-                return Err(Status::invalid_argument("machine_ids must not be empty"));
-            }
-
-            // In direct-dispatch mode all IDs go to the compute-tray backend.
-            // In state-controller mode the batch is partitioned by whether each
-            // tray's BMC MAC has an in-flight direct-dispatch firmware-object job
-            // in compute_firmware_object_jobs (set when a firmware update was
-            // dispatched via --bypass-state-controller, before or after
-            // ingestion): those are polled from the live backend; the rest use
-            // the DB-only machine_firmware_statuses() path.
-            if let Some(cm) = api.component_manager.as_ref() {
-                let machines_by_id = load_machines_by_id(api, &list.machine_ids).await?;
-
-                let bmc_macs_with_direct_fw_updates = if cm.compute_tray_use_state_controller {
-                    let bmc_macs: Vec<MacAddress> = list
-                        .machine_ids
-                        .iter()
-                        .filter_map(|id| machines_by_id.get(id).and_then(|m| m.status.bmc_info.mac))
-                        .collect();
-                    db::direct_dispatch_firmware_job::find_macs_with_job(api.pg_pool(), &bmc_macs)
-                        .await
-                        .map_err(|e| Status::internal(format!("db error: {e}")))?
-                } else {
-                    HashSet::new()
-                };
-
-                match select_firmware_status_routing(
-                    cm.compute_tray_use_state_controller,
-                    &list.machine_ids,
-                    &machines_by_id,
-                    &bmc_macs_with_direct_fw_updates,
-                ) {
-                    FirmwareStatusRouting::DirectDispatch => {
-                        compute_tray_firmware_statuses(cm, api, &machines_by_id, &list.machine_ids)
-                            .await?
-                    }
-                    FirmwareStatusRouting::Partitioned {
-                        persisted,
-                        fallback,
-                    } => {
-                        let mut statuses = Vec::with_capacity(list.machine_ids.len());
-                        if !persisted.is_empty() {
-                            statuses.extend(
-                                compute_tray_firmware_statuses(
-                                    cm,
-                                    api,
-                                    &machines_by_id,
-                                    &persisted,
-                                )
-                                .await?,
-                            );
-                        }
-                        if !fallback.is_empty() {
-                            statuses.extend(machine_firmware_statuses(api, &fallback).await?);
-                        }
-                        statuses
-                    }
-                }
-            } else {
-                machine_firmware_statuses(api, &list.machine_ids).await?
-            }
+            routed_machine_firmware_statuses(api, &list.machine_ids).await?
         }
         rpc::get_component_firmware_status_request::Target::RackIds(list) => {
-            if list.rack_ids.is_empty() {
-                return Err(Status::invalid_argument("rack_ids must not be empty"));
-            }
-
-            let requested_rack_ids = list.rack_ids;
-            let racks = db::rack::find_by(
-                api.db_reader().as_mut(),
-                db::ObjectColumnFilter::List(db::rack::IdColumn, &requested_rack_ids),
-            )
-            .await
-            .map_err(|e| Status::internal(format!("failed to look up racks: {e}")))?;
-            let rack_by_id: HashMap<_, _> = racks
-                .into_iter()
-                .map(|rack| (rack.id.clone(), rack))
-                .collect();
-
-            requested_rack_ids
-                .iter()
-                .map(|rack_id| {
-                    rack_by_id.get(rack_id).map(rack_firmware_status).unwrap_or(
-                        rpc::FirmwareUpdateStatus {
-                            result: Some(not_found_component_result(
-                                rack_id.as_ref(),
-                                format!("rack {rack_id} not found"),
-                            )),
-                            state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
-                            target_version: String::new(),
-                            updated_at: None,
-                        },
-                    )
-                })
-                .collect()
+            rack_firmware_statuses(api, &list.rack_ids).await?
         }
         rpc::get_component_firmware_status_request::Target::ComputeBmcMacs(list) => {
             let resolution = resolve_compute_macs(api, &list.mac_addresses).await?;
@@ -5509,6 +5576,28 @@ mod tests {
                 } => "firmware upgrade failed: 1/1 devices failed".to_string(),
             }
 
+            "one known reason is not attributed to a device that reported none" {
+                FirmwareUpgradeJob {
+                    machines: vec![
+                        failed_firmware_device("download failed"),
+                        firmware_device(FirmwareProgressState::Failed),
+                    ],
+                    ..Default::default()
+                } => "firmware upgrade failed: 2/2 devices failed; some devices \
+                      reported no reason; see backend service logs".to_string(),
+            }
+
+            "one known reason is not attributed to a device that reported a blank one" {
+                FirmwareUpgradeJob {
+                    machines: vec![
+                        failed_firmware_device("download failed"),
+                        failed_firmware_device("   "),
+                    ],
+                    ..Default::default()
+                } => "firmware upgrade failed: 2/2 devices failed; some devices \
+                      reported no reason; see backend service logs".to_string(),
+            }
+
             "blank reasons are treated as absent" {
                 FirmwareUpgradeJob {
                     machines: vec![failed_firmware_device("   ")],
@@ -5798,7 +5887,7 @@ mod tests {
         };
 
         let request = SwitchFirmwareRequest {
-            requested_at,
+            requested_at: Some(requested_at),
             target_version: Some("fw-42".into()),
         };
 
@@ -5865,12 +5954,13 @@ mod tests {
                 components: vec![],
                 force_update: false,
             }],
+            requested_at: Some(rack_requested_at),
             ..Default::default()
         });
 
         let request = switch_firmware_request(&switch, Some(&rack))
             .expect("the accepted rack request gates status before device dispatch");
-        assert_eq!(request.requested_at, rack_requested_at);
+        assert_eq!(request.requested_at, Some(rack_requested_at));
         assert_eq!(
             request.target_version.as_deref(),
             Some("firmware-object-json")
@@ -5889,7 +5979,8 @@ mod tests {
         let request = switch_firmware_request(&switch, Some(&rack))
             .expect("a dispatched device request is still an active request");
         assert_eq!(
-            request.requested_at, switch_requested_at,
+            request.requested_at,
+            Some(switch_requested_at),
             "the dispatched device request is the more precise cycle boundary"
         );
         assert_eq!(
@@ -5912,6 +6003,53 @@ mod tests {
             switch_firmware_request(&switch, Some(&rack)).is_none(),
             "a rack scope that excludes the switch is not its request"
         );
+    }
+
+    #[test]
+    fn switch_firmware_request_has_no_boundary_for_a_legacy_rack_scope() {
+        let mut rack = test_rack_with_job(None);
+        let mut switch = test_switch();
+        switch.rack_id = Some(rack.id.clone());
+        // A scope persisted before acceptance timestamps existed.
+        rack.config.maintenance_requested = Some(model::rack::MaintenanceScope {
+            switch_ids: vec![switch.id],
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: Some("firmware-object-json".into()),
+                components: vec![],
+                force_update: false,
+            }],
+            requested_at: None,
+            ..Default::default()
+        });
+
+        let started_at = chrono::Utc::now();
+        let status = model::rack::RackFirmwareUpgradeStatus {
+            task_id: "backend-task-id".into(),
+            status: model::rack::RackFirmwareUpgradeState::InProgress,
+            started_at: Some(started_at),
+            ended_at: None,
+        };
+
+        // Firmware polling rewrites the rack row, so `updated` keeps advancing
+        // past the running update. It must not become the cycle boundary.
+        for offset in [0, 5, 60] {
+            rack.updated = started_at + chrono::Duration::minutes(offset);
+            let request = switch_firmware_request(&switch, Some(&rack))
+                .expect("a legacy scope is still an active request");
+            assert_eq!(
+                request.requested_at, None,
+                "a legacy scope has no boundary; rack.updated must not supply one"
+            );
+
+            let selected =
+                select_persisted_switch_firmware_status(switch.id, Some(&status), Some(&request))
+                    .expect("an active request always yields a status");
+            assert_eq!(
+                selected.state,
+                rpc::FirmwareUpdateState::FwStateInProgress as i32,
+                "a later rack write must not send a running update back to queued"
+            );
+        }
     }
 
     #[test]
@@ -5942,7 +6080,7 @@ mod tests {
 
         let request = switch_firmware_request(&switch, Some(&rack))
             .expect("the dispatched device request is active on its own");
-        assert_eq!(request.requested_at, requested_at);
+        assert_eq!(request.requested_at, Some(requested_at));
         assert_eq!(
             request.target_version, None,
             "a scope that does not cover this switch must not supply its target version"
@@ -5971,7 +6109,8 @@ mod tests {
         let request = switch_firmware_request(&switch, Some(&rack))
             .expect("a pending rack request is an active request");
         assert_eq!(
-            request.requested_at, requested_at,
+            request.requested_at,
+            Some(requested_at),
             "the cycle boundary is when the request was accepted"
         );
 

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -5378,7 +5378,9 @@ mod tests {
     #[test]
     fn firmware_job_state_unknown_device_status_is_unknown() {
         let job = FirmwareUpgradeJob {
-            machines: vec![firmware_device(FirmwareProgressState::Unknown("mystery".into()))],
+            machines: vec![firmware_device(FirmwareProgressState::Unknown(
+                "mystery".into(),
+            ))],
             ..Default::default()
         };
 
@@ -5831,7 +5833,8 @@ mod tests {
             let actual = select_persisted_switch_firmware_status(switch_id, persisted, request)
                 .expect("a request or a persisted status yields a status");
             assert_eq!(
-                actual.state, expected as i32,
+                actual.state,
+                expected as i32,
                 "persisted: {persisted:?}, requested_at: {:?}",
                 request.map(|request| request.requested_at)
             );
@@ -5868,7 +5871,10 @@ mod tests {
         let request = switch_firmware_request(&switch, Some(&rack))
             .expect("the accepted rack request gates status before device dispatch");
         assert_eq!(request.requested_at, rack_requested_at);
-        assert_eq!(request.target_version.as_deref(), Some("firmware-object-json"));
+        assert_eq!(
+            request.target_version.as_deref(),
+            Some("firmware-object-json")
+        );
 
         switch.switch_reprovisioning_requested = Some(model::switch::SwitchReprovisionRequest {
             requested_at: switch_requested_at,

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -47,9 +47,11 @@ use model::component_manager::{
 };
 use model::firmware::FirmwareComponentType;
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{HostMachine, MachineMaintenanceOperation};
+use model::machine::{
+    HostMachine, HostReprovisionState, MachineMaintenanceOperation, ManagedHostState,
+};
 use model::power_shelf::PowerShelfMaintenanceOperation;
-use model::rack::{FirmwareUpgradeJob, MaintenanceActivity};
+use model::rack::{FirmwareProgressState, FirmwareUpgradeJob, MaintenanceActivity};
 use model::switch::SwitchMaintenanceOperation;
 use tonic::{Code, Request, Response, Status};
 
@@ -165,21 +167,18 @@ fn safe_firmware_target_display(firmware_version: &str) -> String {
         )
 }
 
+fn requested_firmware_version(activities: &[MaintenanceActivity]) -> Option<String> {
+    activities.iter().find_map(|activity| match activity {
+        MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: Some(firmware_version),
+            ..
+        } if !firmware_version.is_empty() => Some(safe_firmware_target_display(firmware_version)),
+        _ => None,
+    })
+}
+
 fn rack_requested_firmware_version(rack: &model::rack::Rack) -> Option<String> {
-    rack.config
-        .maintenance_requested
-        .as_ref()?
-        .activities
-        .iter()
-        .find_map(|activity| match activity {
-            MaintenanceActivity::FirmwareUpgrade {
-                firmware_version: Some(firmware_version),
-                ..
-            } if !firmware_version.is_empty() => {
-                Some(safe_firmware_target_display(firmware_version))
-            }
-            _ => None,
-        })
+    requested_firmware_version(&rack.config.maintenance_requested.as_ref()?.activities)
 }
 
 fn rack_firmware_upgrade_requested(rack: &model::rack::Rack) -> bool {
@@ -195,56 +194,52 @@ fn rack_firmware_upgrade_requested(rack: &model::rack::Rack) -> bool {
         })
 }
 
-fn firmware_job_state(job: &FirmwareUpgradeJob) -> i32 {
-    if let Some(status) = job.status.as_deref() {
-        match status.to_ascii_lowercase().as_str() {
-            "queued" | "pending" => return rpc::FirmwareUpdateState::FwStateQueued as i32,
-            "running" | "in_progress" | "active" => {
-                return rpc::FirmwareUpdateState::FwStateInProgress as i32;
-            }
-            "verifying" => return rpc::FirmwareUpdateState::FwStateVerifying as i32,
-            "completed" | "success" | "done" => {
-                return rpc::FirmwareUpdateState::FwStateCompleted as i32;
-            }
-            "failed" | "error" => return rpc::FirmwareUpdateState::FwStateFailed as i32,
-            "cancelled" | "canceled" => return rpc::FirmwareUpdateState::FwStateCancelled as i32,
-            _ => {}
+fn firmware_job_state(job: &FirmwareUpgradeJob) -> rpc::FirmwareUpdateState {
+    match job.status.as_ref() {
+        Some(FirmwareProgressState::Pending) => return rpc::FirmwareUpdateState::FwStateQueued,
+        Some(FirmwareProgressState::InProgress) => {
+            return rpc::FirmwareUpdateState::FwStateInProgress;
         }
+        Some(FirmwareProgressState::Completed) => {
+            return rpc::FirmwareUpdateState::FwStateCompleted;
+        }
+        Some(FirmwareProgressState::Failed) => return rpc::FirmwareUpdateState::FwStateFailed,
+        Some(FirmwareProgressState::Unknown(_)) | None => {}
     }
 
     let devices: Vec<_> = job.all_devices().collect();
     let total = devices.len();
 
     if total == 0 {
-        return rpc::FirmwareUpdateState::FwStateUnknown as i32;
+        return rpc::FirmwareUpdateState::FwStateUnknown;
     }
 
     let completed = devices
         .iter()
-        .filter(|device| device.status == "completed")
+        .filter(|device| device.status == FirmwareProgressState::Completed)
         .count();
     let failed = devices
         .iter()
-        .filter(|device| device.status == "failed")
+        .filter(|device| device.status == FirmwareProgressState::Failed)
         .count();
     let terminal = completed + failed;
     let has_in_progress = devices
         .iter()
-        .any(|device| matches!(device.status.as_str(), "in_progress" | "running" | "active"));
+        .any(|device| device.status == FirmwareProgressState::InProgress);
     let all_queued = devices
         .iter()
-        .all(|device| matches!(device.status.as_str(), "pending" | "queued" | "started"));
+        .all(|device| device.status == FirmwareProgressState::Pending);
 
     if failed > 0 && terminal == total {
-        rpc::FirmwareUpdateState::FwStateFailed as i32
+        rpc::FirmwareUpdateState::FwStateFailed
     } else if completed == total {
-        rpc::FirmwareUpdateState::FwStateCompleted as i32
+        rpc::FirmwareUpdateState::FwStateCompleted
     } else if terminal > 0 || has_in_progress || job.started_at.is_some() {
-        rpc::FirmwareUpdateState::FwStateInProgress as i32
+        rpc::FirmwareUpdateState::FwStateInProgress
     } else if all_queued {
-        rpc::FirmwareUpdateState::FwStateQueued as i32
+        rpc::FirmwareUpdateState::FwStateQueued
     } else {
-        rpc::FirmwareUpdateState::FwStateUnknown as i32
+        rpc::FirmwareUpdateState::FwStateUnknown
     }
 }
 
@@ -252,22 +247,30 @@ fn firmware_job_state(job: &FirmwareUpgradeJob) -> i32 {
 ///
 /// A rack upgrade fans out to every device in the rack, so the one rack-level
 /// `ComponentResult` can only carry a summary of the per-device outcomes the rack
-/// controller recorded. A common RMS reason is useful inline; divergent failures are
-/// summarized by count because their details belong in the RMS logs. If the job failed
-/// without any failed device result, preserve the rack controller's actual failure cause
-/// instead of reporting the contradictory "0/N devices failed".
+/// controller recorded. A common backend reason is useful inline; divergent failures
+/// are summarized by count because their details belong in the backend service logs.
+///
+/// A job-level failure carries no per-device reason, so the rack's error state is the
+/// only detail left. It is reported as context rather than as the cause: see the note
+/// on the `RackState::Error` branch below.
 fn rack_firmware_failure_summary(rack: &model::rack::Rack, job: &FirmwareUpgradeJob) -> String {
     let total = job.all_devices().count();
     let failed: Vec<_> = job
         .all_devices()
-        .filter(|device| device.status == "failed")
+        .filter(|device| device.status == FirmwareProgressState::Failed)
         .collect();
 
     if failed.is_empty() {
+        // `firmware_upgrade_job` is only cleared when the next firmware maintenance
+        // request is accepted, never when a job fails, while `controller_state` moves
+        // on with any later rack operation — NVOS, NMX cluster, ingestion. A failed
+        // job can therefore outlive its own error and sit next to an unrelated one, so
+        // quote the rack error as context instead of claiming it caused this upgrade
+        // to fail.
         if let model::rack::RackState::Error { cause } = &rack.controller_state.value {
             let cause = cause.trim();
             if !cause.is_empty() {
-                return format!("firmware upgrade failed: {cause}");
+                return format!("firmware upgrade failed; rack is in error state: {cause}");
             }
         }
 
@@ -295,7 +298,10 @@ fn rack_firmware_failure_summary(rack: &model::rack::Rack, job: &FirmwareUpgrade
     match reasons.as_slice() {
         [] => summary,
         [reason] => format!("{summary}: {reason}"),
-        reasons => format!("{summary}: {} distinct errors; see RMS logs", reasons.len()),
+        reasons => format!(
+            "{summary}: {} distinct errors; see backend service logs",
+            reasons.len()
+        ),
     }
 }
 
@@ -306,9 +312,9 @@ fn rack_firmware_status(rack: &model::rack::Rack) -> rpc::FirmwareUpdateStatus {
     let state = if let Some(job) = job {
         firmware_job_state(job)
     } else if firmware_upgrade_requested {
-        rpc::FirmwareUpdateState::FwStateQueued as i32
+        rpc::FirmwareUpdateState::FwStateQueued
     } else {
-        rpc::FirmwareUpdateState::FwStateUnknown as i32
+        rpc::FirmwareUpdateState::FwStateUnknown
     };
     let target_version = requested_version
         .or_else(|| job.and_then(|job| job.firmware_id.clone()))
@@ -319,9 +325,9 @@ fn rack_firmware_status(rack: &model::rack::Rack) -> rpc::FirmwareUpdateStatus {
         .map(Into::into);
 
     // A failed upgrade must carry why it failed: the rack controller already
-    // persisted each device's reason from RMS, and this is the only place an
+    // persisted each device's reason from the backend, and this is the only place an
     // operator can see it.
-    let result = if state == rpc::FirmwareUpdateState::FwStateFailed as i32 {
+    let result = if state == rpc::FirmwareUpdateState::FwStateFailed {
         let summary = job.map_or_else(
             || "firmware upgrade failed".to_owned(),
             |job| rack_firmware_failure_summary(rack, job),
@@ -333,7 +339,7 @@ fn rack_firmware_status(rack: &model::rack::Rack) -> rpc::FirmwareUpdateStatus {
 
     rpc::FirmwareUpdateStatus {
         result: Some(result),
-        state,
+        state: state as i32,
         target_version,
         updated_at,
     }
@@ -366,7 +372,7 @@ fn persisted_firmware_status(
     rpc::FirmwareUpdateStatus {
         result: Some(result),
         state: state as i32,
-        // The per-device status currently persists the RMS task ID and state,
+        // The per-device status currently persists the backend task ID and state,
         // but not the firmware object ID.
         target_version: String::new(),
         updated_at: status
@@ -379,28 +385,34 @@ fn persisted_firmware_status(
 }
 
 fn queued_firmware_status(
-    component_id: impl std::fmt::Display,
+    switch_id: SwitchId,
     requested_at: chrono::DateTime<chrono::Utc>,
 ) -> rpc::FirmwareUpdateStatus {
-    let component_id = component_id.to_string();
     rpc::FirmwareUpdateStatus {
-        result: Some(success_result(&component_id)),
+        result: Some(success_result(&switch_id.to_string())),
         state: rpc::FirmwareUpdateState::FwStateQueued as i32,
         target_version: String::new(),
         updated_at: Some(requested_at.into()),
     }
 }
 
-fn switch_firmware_request_time(
+/// The firmware upgrade request currently in flight for a switch, whether it was
+/// accepted at the rack or already dispatched to the device.
+struct SwitchFirmwareRequest {
+    requested_at: chrono::DateTime<chrono::Utc>,
+    target_version: Option<String>,
+}
+
+fn switch_firmware_request(
     switch: &model::switch::Switch,
     rack: Option<&model::rack::Rack>,
-) -> Option<chrono::DateTime<chrono::Utc>> {
+) -> Option<SwitchFirmwareRequest> {
     let firmware_activity = MaintenanceActivity::FirmwareUpgrade {
         firmware_version: None,
         components: vec![],
         force_update: false,
     };
-    let switch_request_time = switch
+    let switch_request = switch
         .switch_reprovisioning_requested
         .as_ref()
         .filter(|request| {
@@ -410,8 +422,13 @@ fn switch_firmware_request_time(
                     .iter()
                     .any(|activity| activity.same_kind(&firmware_activity))
         })
-        .map(|request| request.requested_at);
-    let rack_request_time = rack.and_then(|rack| {
+        .map(|request| {
+            (
+                request.requested_at,
+                requested_firmware_version(&request.activities),
+            )
+        });
+    let rack_request = rack.and_then(|rack| {
         rack.config
             .maintenance_requested
             .as_ref()
@@ -419,10 +436,28 @@ fn switch_firmware_request_time(
                 scope.should_run(&firmware_activity)
                     && (scope.is_full_rack() || scope.switch_ids.contains(&switch.id))
             })
-            .map(|scope| scope.requested_at.unwrap_or(rack.updated))
+            .map(|scope| {
+                (
+                    scope.requested_at.unwrap_or(rack.updated),
+                    requested_firmware_version(&scope.activities),
+                )
+            })
     });
 
-    switch_request_time.max(rack_request_time)
+    let requested_at = switch_request
+        .as_ref()
+        .map(|(requested_at, _)| *requested_at)
+        .max(rack_request.as_ref().map(|(requested_at, _)| *requested_at))?;
+    // The device request is the dispatched form of the rack request and does not
+    // have to repeat the version the operator asked for.
+    let target_version = switch_request
+        .and_then(|(_, version)| version)
+        .or_else(|| rack_request.and_then(|(_, version)| version));
+
+    Some(SwitchFirmwareRequest {
+        requested_at,
+        target_version,
+    })
 }
 
 /// Selects the persisted result only when it belongs to the active request.
@@ -431,17 +466,22 @@ fn switch_firmware_request_time(
 fn select_persisted_switch_firmware_status(
     switch_id: SwitchId,
     persisted_status: Option<&model::rack::RackFirmwareUpgradeStatus>,
-    requested_at: Option<chrono::DateTime<chrono::Utc>>,
+    request: Option<&SwitchFirmwareRequest>,
 ) -> Option<rpc::FirmwareUpdateStatus> {
-    match requested_at {
-        Some(requested_at) => Some(
-            persisted_status
-                .filter(|status| status.is_current_for(requested_at))
+    match request {
+        Some(request) => {
+            let status = persisted_status
+                .filter(|status| status.is_current_for(request.requested_at))
                 .map_or_else(
-                    || queued_firmware_status(switch_id, requested_at),
+                    || queued_firmware_status(switch_id, request.requested_at),
                     |status| persisted_firmware_status(switch_id, status),
-                ),
-        ),
+                );
+            // The per-device backend status never persists the firmware object ID.
+            Some(rpc::FirmwareUpdateStatus {
+                target_version: request.target_version.clone().unwrap_or_default(),
+                ..status
+            })
+        }
         None => persisted_status.map(|status| persisted_firmware_status(switch_id, status)),
     }
 }
@@ -504,7 +544,7 @@ async fn switch_firmware_statuses(
         if let Some(status) = select_persisted_switch_firmware_status(
             switch.id,
             switch.firmware_upgrade_status.as_ref(),
-            switch_firmware_request_time(switch, rack),
+            switch_firmware_request(switch, rack).as_ref(),
         ) {
             statuses.push(status);
         } else {
@@ -2154,6 +2194,31 @@ fn exploration_report_firmware_versions(
         .collect()
 }
 
+/// The reason reprovisioning recorded for this machine's firmware failure, if any.
+///
+/// For a rack-driven upgrade the machine controller copies this out of the rack
+/// controller's `rack_fw_details` — which carries the per-device backend
+/// `error_message` — on the same transition that clears the reprovisioning
+/// request. Reading the state rather than `rack_fw_details` therefore keeps the
+/// reason tied to the cycle that produced this failure: once the request is gone
+/// there is no timestamp left to gate a persisted status against. Host-driven
+/// upgrades fill the same field in from the scout report.
+fn machine_firmware_failure_reason(machine: &HostMachine) -> Option<String> {
+    let ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::FailedFirmwareUpgrade { reason, .. },
+        ..
+    } = &machine.state.value
+    else {
+        return None;
+    };
+
+    reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+        .map(str::to_owned)
+}
+
 /// When explored firmware satisfies a desired entry, the update is complete
 /// (or still verifying while the host reprovisions). Otherwise status is
 /// inferred from `update_complete` and the machine's reprovision state.
@@ -2207,8 +2272,20 @@ fn derive_machine_firmware_update_status(
         rpc::FirmwareUpdateState::FwStateQueued
     };
 
+    // A failed upgrade must carry why it failed, the same way the rack and switch
+    // results do. Without this a compute tray reports FwStateFailed with an empty
+    // error and the backend reason never reaches the operator.
+    let result = if state == rpc::FirmwareUpdateState::FwStateFailed {
+        machine_firmware_failure_reason(machine).map_or_else(
+            || success_result(machine_id),
+            |reason| error_result(machine_id, reason),
+        )
+    } else {
+        success_result(machine_id)
+    };
+
     rpc::FirmwareUpdateStatus {
-        result: Some(success_result(machine_id)),
+        result: Some(result),
         state: state as i32,
         target_version: String::new(),
         updated_at: None,
@@ -2429,9 +2506,9 @@ async fn pre_ingestion_compute_tray_firmware_statuses(
 ///
 /// Divide the requested machines the same way compute firmware updates do:
 /// rack-scale (MNNVL) systems vs standalone servers. Only rack-scale systems
-/// have a compute-tray backend (RMS) and a state-controller maintenance flow;
+/// have a compute-tray backend and a state-controller maintenance flow;
 /// standalone servers are always driven synchronously through NICo-core's
-/// Redfish stack, because RMS cannot power-control them.
+/// Redfish stack, because the backend service cannot power-control them.
 ///
 /// Classify each machine and persist its power-manager desired state in a
 /// single pass. A machine joins `rack_scale_ids`/`standalone_ids` only after
@@ -2526,7 +2603,7 @@ async fn power_control_ingested_machine_ids(
 
     // Rack-scale systems: the state-controller maintenance flow when
     // enabled, otherwise a synchronous dispatch through the configured
-    // backend (RMS).
+    // backend.
     if !rack_scale_ids.is_empty() {
         if cm.compute_tray_use_state_controller && !bypass_state_controller {
             match queue_machine_power_control_via_state_controller(api, cm, &rack_scale_ids, action)
@@ -3916,7 +3993,7 @@ async fn update_pre_ingestion_compute_tray_firmware(
 /// Standalone (non-rack-scale) servers have no compute-tray backend that can
 /// take a direct firmware dispatch, so they always go through the host
 /// reprovisioning firmware flow. Only rack-scale systems (currently GB200 NVL,
-/// backed by RMS via the ComputeTrayManager interface) can choose between the
+/// driven through the ComputeTrayManager interface) can choose between the
 /// rack-level state controller maintenance flow and a direct backend dispatch.
 async fn update_compute_tray_firmware_by_machine_ids(
     api: &Api,
@@ -4273,8 +4350,8 @@ pub(crate) async fn get_component_firmware_status(
         }
         rpc::get_component_firmware_status_request::Target::PowerShelfIds(list) => {
             // The rack controller currently writes power-shelf Completed only as an
-            // internal reprovisioning-unblock sentinel; RMS does not include shelves
-            // in the rack firmware job. It is therefore not an API firmware result.
+            // internal reprovisioning-unblock sentinel; the backend does not include
+            // shelves in the rack firmware job. It is therefore not an API firmware result.
             let cm = require_component_manager(api)?;
             let endpoints = resolve_power_shelf_endpoints(api, &list.ids).await?;
 
@@ -4846,12 +4923,12 @@ mod tests {
 
     use super::*;
 
-    fn firmware_device(status: &str) -> model::rack::FirmwareUpgradeDeviceStatus {
+    fn firmware_device(status: FirmwareProgressState) -> model::rack::FirmwareUpgradeDeviceStatus {
         model::rack::FirmwareUpgradeDeviceStatus {
             node_id: String::new(),
             mac: "00:00:00:00:00:00".to_string(),
             bmc_ip: String::new(),
-            status: status.to_string(),
+            status,
             job_id: None,
             parent_job_id: None,
             error_message: None,
@@ -4889,6 +4966,7 @@ mod tests {
             bmc_mac_address: None,
             bmc_info: None,
             bmc_credential_rotation_requested: false,
+            decommission_requested: false,
             controller_state: Versioned::new(
                 model::switch::SwitchControllerState::Created,
                 ConfigVersion::initial(),
@@ -5222,13 +5300,13 @@ mod tests {
     #[test]
     fn firmware_job_state_explicit_status_wins_for_empty_job() {
         let job = FirmwareUpgradeJob {
-            status: Some("queued".to_string()),
+            status: Some(FirmwareProgressState::Pending),
             ..Default::default()
         };
 
         assert_eq!(
             firmware_job_state(&job),
-            rpc::FirmwareUpdateState::FwStateQueued as i32
+            rpc::FirmwareUpdateState::FwStateQueued
         );
     }
 
@@ -5236,76 +5314,76 @@ mod tests {
     fn firmware_job_state_empty_job_without_status_is_unknown() {
         assert_eq!(
             firmware_job_state(&FirmwareUpgradeJob::default()),
-            rpc::FirmwareUpdateState::FwStateUnknown as i32
+            rpc::FirmwareUpdateState::FwStateUnknown
         );
     }
 
     #[test]
     fn firmware_job_state_all_completed_is_completed() {
         let job = FirmwareUpgradeJob {
-            machines: vec![firmware_device("completed")],
-            switches: vec![firmware_device("completed")],
+            machines: vec![firmware_device(FirmwareProgressState::Completed)],
+            switches: vec![firmware_device(FirmwareProgressState::Completed)],
             ..Default::default()
         };
 
         assert_eq!(
             firmware_job_state(&job),
-            rpc::FirmwareUpdateState::FwStateCompleted as i32
+            rpc::FirmwareUpdateState::FwStateCompleted
         );
     }
 
     #[test]
     fn firmware_job_state_mixed_terminal_with_failure_is_failed() {
         let job = FirmwareUpgradeJob {
-            machines: vec![firmware_device("completed")],
-            switches: vec![firmware_device("failed")],
+            machines: vec![firmware_device(FirmwareProgressState::Completed)],
+            switches: vec![firmware_device(FirmwareProgressState::Failed)],
             ..Default::default()
         };
 
         assert_eq!(
             firmware_job_state(&job),
-            rpc::FirmwareUpdateState::FwStateFailed as i32
+            rpc::FirmwareUpdateState::FwStateFailed
         );
     }
 
     #[test]
     fn firmware_job_state_partial_terminal_is_in_progress() {
         let job = FirmwareUpgradeJob {
-            machines: vec![firmware_device("completed")],
-            switches: vec![firmware_device("pending")],
+            machines: vec![firmware_device(FirmwareProgressState::Completed)],
+            switches: vec![firmware_device(FirmwareProgressState::Pending)],
             ..Default::default()
         };
 
         assert_eq!(
             firmware_job_state(&job),
-            rpc::FirmwareUpdateState::FwStateInProgress as i32
+            rpc::FirmwareUpdateState::FwStateInProgress
         );
     }
 
     #[test]
     fn firmware_job_state_all_pending_without_start_is_queued() {
         let job = FirmwareUpgradeJob {
-            machines: vec![firmware_device("pending")],
-            switches: vec![firmware_device("queued")],
+            machines: vec![firmware_device(FirmwareProgressState::Pending)],
+            switches: vec![firmware_device(FirmwareProgressState::Pending)],
             ..Default::default()
         };
 
         assert_eq!(
             firmware_job_state(&job),
-            rpc::FirmwareUpdateState::FwStateQueued as i32
+            rpc::FirmwareUpdateState::FwStateQueued
         );
     }
 
     #[test]
     fn firmware_job_state_unknown_device_status_is_unknown() {
         let job = FirmwareUpgradeJob {
-            machines: vec![firmware_device("mystery")],
+            machines: vec![firmware_device(FirmwareProgressState::Unknown("mystery".into()))],
             ..Default::default()
         };
 
         assert_eq!(
             firmware_job_state(&job),
-            rpc::FirmwareUpdateState::FwStateUnknown as i32
+            rpc::FirmwareUpdateState::FwStateUnknown
         );
     }
 
@@ -5313,7 +5391,7 @@ mod tests {
     fn rack_firmware_status_reports_retained_completed_job() {
         let job = FirmwareUpgradeJob {
             firmware_id: Some("fw-1".to_string()),
-            status: Some("completed".to_string()),
+            status: Some(FirmwareProgressState::Completed),
             started_at: Some(chrono::Utc::now() - chrono::Duration::hours(1)),
             completed_at: Some(chrono::Utc::now()),
             ..Default::default()
@@ -5334,7 +5412,7 @@ mod tests {
     fn rack_firmware_status_default_request_uses_job_firmware_id() {
         let job = FirmwareUpgradeJob {
             firmware_id: Some("fw-default".to_string()),
-            status: Some("in_progress".to_string()),
+            status: Some(FirmwareProgressState::InProgress),
             started_at: Some(chrono::Utc::now()),
             ..Default::default()
         };
@@ -5377,11 +5455,11 @@ mod tests {
         assert!(status.updated_at.is_some());
     }
 
-    /// Builds a failed device carrying the reason RMS reported for it.
+    /// Builds a failed device carrying the reason backend service reported for it.
     fn failed_firmware_device(error_message: &str) -> model::rack::FirmwareUpgradeDeviceStatus {
         model::rack::FirmwareUpgradeDeviceStatus {
             error_message: Some(error_message.to_string()),
-            ..firmware_device("failed")
+            ..firmware_device(FirmwareProgressState::Failed)
         }
     }
 
@@ -5402,20 +5480,20 @@ mod tests {
                       config_json.ProductName is required".to_string(),
             }
 
-            "divergent reasons direct operators to RMS logs" {
+            "divergent reasons direct operators to backend service logs" {
                 FirmwareUpgradeJob {
                     machines: vec![failed_firmware_device("download failed")],
                     switches: vec![failed_firmware_device("target not found")],
                     ..Default::default()
                 } => "firmware upgrade failed: 2/2 devices failed: 2 distinct errors; \
-                      see RMS logs".to_string(),
+                      see backend service logs".to_string(),
             }
 
             "a partial failure reports the failed subset" {
                 FirmwareUpgradeJob {
                     machines: vec![
                         failed_firmware_device("task failed"),
-                        firmware_device("completed"),
+                        firmware_device(FirmwareProgressState::Completed),
                     ],
                     ..Default::default()
                 } => "firmware upgrade failed: 1/2 devices failed: task failed".to_string(),
@@ -5423,7 +5501,7 @@ mod tests {
 
             "devices without a recorded reason still report the count" {
                 FirmwareUpgradeJob {
-                    machines: vec![firmware_device("failed")],
+                    machines: vec![firmware_device(FirmwareProgressState::Failed)],
                     ..Default::default()
                 } => "firmware upgrade failed: 1/1 devices failed".to_string(),
             }
@@ -5446,10 +5524,10 @@ mod tests {
     fn rack_firmware_status_job_level_failure_reports_controller_cause() {
         let cause = "rack firmware upgrade cannot progress because target machines are Ready with desired power state Off";
         let job = FirmwareUpgradeJob {
-            status: Some("failed".to_string()),
+            status: Some(FirmwareProgressState::Failed),
             started_at: Some(chrono::Utc::now()),
             completed_at: Some(chrono::Utc::now()),
-            machines: vec![firmware_device("in_progress")],
+            machines: vec![firmware_device(FirmwareProgressState::InProgress)],
             ..Default::default()
         };
         let mut rack = test_rack_with_job(Some(job));
@@ -5464,17 +5542,58 @@ mod tests {
         let result = status.result.expect("a rack status carries a result");
 
         assert_eq!(status.state, rpc::FirmwareUpdateState::FwStateFailed as i32);
-        assert_eq!(result.error, format!("firmware upgrade failed: {cause}"));
+        assert_eq!(
+            result.error,
+            format!("firmware upgrade failed; rack is in error state: {cause}")
+        );
         assert!(!result.error.contains("0/1 devices failed"));
     }
 
-    /// The reported regression: every device failed with the RMS SOT parse error, but
+    /// A failed job outlives its own error: it is only cleared when the next firmware
+    /// maintenance request is accepted, so an unrelated later failure can leave a stale
+    /// "failed" job sitting next to a rack error that has nothing to do with firmware.
+    /// The summary must not present that error as the reason the upgrade failed.
+    #[test]
+    fn rack_firmware_status_does_not_attribute_an_unrelated_rack_error() {
+        let unrelated = "rack profile is missing or unknown; cannot build switch node descriptor";
+        let job = FirmwareUpgradeJob {
+            status: Some(FirmwareProgressState::Failed),
+            started_at: Some(chrono::Utc::now()),
+            completed_at: Some(chrono::Utc::now()),
+            machines: vec![firmware_device(FirmwareProgressState::InProgress)],
+            ..Default::default()
+        };
+        let mut rack = test_rack_with_job(Some(job));
+        rack.controller_state = Versioned::new(
+            RackState::Error {
+                cause: unrelated.to_string(),
+            },
+            ConfigVersion::initial(),
+        );
+
+        let status = rack_firmware_status(&rack);
+        let result = status.result.expect("a rack status carries a result");
+
+        assert!(
+            result
+                .error
+                .starts_with("firmware upgrade failed; rack is in error state:"),
+            "the rack error must be quoted as context, not as the cause: {}",
+            result.error
+        );
+        assert!(
+            result.error.contains(unrelated),
+            "the rack error is still worth showing an operator"
+        );
+    }
+
+    /// The reported regression: every device failed with the backend SOT parse error, but
     /// the rack-level result claimed success and carried no error at all.
     #[test]
     fn rack_firmware_status_failed_job_reports_the_device_error() {
         let job = FirmwareUpgradeJob {
             firmware_id: Some(String::new()),
-            status: Some("failed".to_string()),
+            status: Some(FirmwareProgressState::Failed),
             started_at: Some(chrono::Utc::now()),
             completed_at: Some(chrono::Utc::now()),
             machines: vec![failed_firmware_device(
@@ -5503,9 +5622,9 @@ mod tests {
     #[test]
     fn rack_firmware_status_unfinished_job_stays_successful() {
         let job = FirmwareUpgradeJob {
-            status: Some("in_progress".to_string()),
+            status: Some(FirmwareProgressState::InProgress),
             started_at: Some(chrono::Utc::now()),
-            machines: vec![firmware_device("in_progress")],
+            machines: vec![firmware_device(FirmwareProgressState::InProgress)],
             ..Default::default()
         };
         let rack = test_rack_with_job(Some(job));
@@ -5639,7 +5758,7 @@ mod tests {
 
         for (input, expected_state, expected_result, expected_error) in cases {
             let status = model::rack::RackFirmwareUpgradeStatus {
-                task_id: "rms-task-id".into(),
+                task_id: "backend-task-id".into(),
                 status: input,
                 started_at: Some(started_at),
                 ended_at: None,
@@ -5661,7 +5780,7 @@ mod tests {
         let switch_id = test_switch_id();
         let requested_at = chrono::Utc::now();
         let stale_status = model::rack::RackFirmwareUpgradeStatus {
-            task_id: "old-rms-task".into(),
+            task_id: "old-backend-task".into(),
             status: model::rack::RackFirmwareUpgradeState::Failed {
                 cause: "old failure".into(),
             },
@@ -5669,41 +5788,55 @@ mod tests {
             ended_at: Some(requested_at - chrono::Duration::minutes(1)),
         };
         let current_status = model::rack::RackFirmwareUpgradeStatus {
-            task_id: "current-rms-task".into(),
+            task_id: "current-backend-task".into(),
             status: model::rack::RackFirmwareUpgradeState::Completed,
             started_at: Some(requested_at + chrono::Duration::seconds(1)),
             ended_at: Some(requested_at + chrono::Duration::seconds(2)),
         };
 
+        let request = SwitchFirmwareRequest {
+            requested_at,
+            target_version: Some("fw-42".into()),
+        };
+
         let cases = [
             (
                 Some(&stale_status),
-                Some(requested_at),
+                Some(&request),
                 rpc::FirmwareUpdateState::FwStateQueued,
+                "fw-42",
             ),
             (
                 None,
-                Some(requested_at),
+                Some(&request),
                 rpc::FirmwareUpdateState::FwStateQueued,
+                "fw-42",
             ),
             (
                 Some(&current_status),
-                Some(requested_at),
+                Some(&request),
                 rpc::FirmwareUpdateState::FwStateCompleted,
+                "fw-42",
             ),
             (
                 Some(&stale_status),
                 None,
                 rpc::FirmwareUpdateState::FwStateFailed,
+                "",
             ),
         ];
 
-        for (persisted, requested_at, expected) in cases {
-            let actual = select_persisted_switch_firmware_status(switch_id, persisted, requested_at)
+        for (persisted, request, expected, expected_version) in cases {
+            let actual = select_persisted_switch_firmware_status(switch_id, persisted, request)
                 .expect("a request or a persisted status yields a status");
             assert_eq!(
                 actual.state, expected as i32,
-                "persisted: {persisted:?}, requested_at: {requested_at:?}"
+                "persisted: {persisted:?}, requested_at: {:?}",
+                request.map(|request| request.requested_at)
+            );
+            assert_eq!(
+                actual.target_version, expected_version,
+                "the active request carries the target version for its whole cycle"
             );
         }
 
@@ -5714,7 +5847,7 @@ mod tests {
     }
 
     #[test]
-    fn switch_firmware_request_time_covers_pending_rack_and_dispatched_requests() {
+    fn switch_firmware_request_covers_pending_rack_and_dispatched_requests() {
         let rack_requested_at = chrono::Utc::now();
         let switch_requested_at = rack_requested_at + chrono::Duration::seconds(1);
         let mut rack = test_rack_with_job(None);
@@ -5731,11 +5864,10 @@ mod tests {
             ..Default::default()
         });
 
-        assert_eq!(
-            switch_firmware_request_time(&switch, Some(&rack)),
-            Some(rack_requested_at),
-            "the accepted rack request gates status before device dispatch"
-        );
+        let request = switch_firmware_request(&switch, Some(&rack))
+            .expect("the accepted rack request gates status before device dispatch");
+        assert_eq!(request.requested_at, rack_requested_at);
+        assert_eq!(request.target_version.as_deref(), Some("firmware-object-json"));
 
         switch.switch_reprovisioning_requested = Some(model::switch::SwitchReprovisionRequest {
             requested_at: switch_requested_at,
@@ -5747,10 +5879,16 @@ mod tests {
             }],
         });
 
+        let request = switch_firmware_request(&switch, Some(&rack))
+            .expect("a dispatched device request is still an active request");
         assert_eq!(
-            switch_firmware_request_time(&switch, Some(&rack)),
-            Some(switch_requested_at),
+            request.requested_at, switch_requested_at,
             "the dispatched device request is the more precise cycle boundary"
+        );
+        assert_eq!(
+            request.target_version.as_deref(),
+            Some("firmware-object-json"),
+            "the rack scope still supplies the version the operator asked for"
         );
 
         rack.config.maintenance_requested = Some(model::rack::MaintenanceScope {
@@ -5763,11 +5901,49 @@ mod tests {
             ..Default::default()
         });
         switch.switch_reprovisioning_requested = None;
-        assert_eq!(switch_firmware_request_time(&switch, Some(&rack)), None);
+        assert!(
+            switch_firmware_request(&switch, Some(&rack)).is_none(),
+            "a rack scope that excludes the switch is not its request"
+        );
     }
 
     #[test]
-    fn switch_firmware_request_time_ignores_later_rack_writes() {
+    fn switch_firmware_request_ignores_version_from_an_unrelated_rack_scope() {
+        let requested_at = chrono::Utc::now();
+        let mut rack = test_rack_with_job(None);
+        let mut switch = test_switch();
+        switch.rack_id = Some(rack.id.clone());
+        rack.config.maintenance_requested = Some(model::rack::MaintenanceScope {
+            power_shelf_ids: vec![test_power_shelf_id()],
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: Some("other-firmware-object-json".into()),
+                components: vec![],
+                force_update: false,
+            }],
+            requested_at: Some(requested_at),
+            ..Default::default()
+        });
+        switch.switch_reprovisioning_requested = Some(model::switch::SwitchReprovisionRequest {
+            requested_at,
+            initiator: "test".into(),
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: None,
+                components: vec![],
+                force_update: false,
+            }],
+        });
+
+        let request = switch_firmware_request(&switch, Some(&rack))
+            .expect("the dispatched device request is active on its own");
+        assert_eq!(request.requested_at, requested_at);
+        assert_eq!(
+            request.target_version, None,
+            "a scope that does not cover this switch must not supply its target version"
+        );
+    }
+
+    #[test]
+    fn switch_firmware_request_ignores_later_rack_writes() {
         let requested_at = chrono::Utc::now();
         let mut rack = test_rack_with_job(None);
         let mut switch = test_switch();
@@ -5785,24 +5961,22 @@ mod tests {
             ..Default::default()
         });
 
+        let request = switch_firmware_request(&switch, Some(&rack))
+            .expect("a pending rack request is an active request");
         assert_eq!(
-            switch_firmware_request_time(&switch, Some(&rack)),
-            Some(requested_at),
+            request.requested_at, requested_at,
             "the cycle boundary is when the request was accepted"
         );
 
         let status = model::rack::RackFirmwareUpgradeStatus {
-            task_id: "rms-task-id".into(),
+            task_id: "backend-task-id".into(),
             status: model::rack::RackFirmwareUpgradeState::InProgress,
             started_at: Some(requested_at + chrono::Duration::seconds(30)),
             ended_at: None,
         };
-        let selected = select_persisted_switch_firmware_status(
-            switch.id,
-            Some(&status),
-            switch_firmware_request_time(&switch, Some(&rack)),
-        )
-        .expect("a pending request always yields a status");
+        let selected =
+            select_persisted_switch_firmware_status(switch.id, Some(&status), Some(&request))
+                .expect("a pending request always yields a status");
 
         assert_eq!(
             selected.state,
@@ -6119,6 +6293,86 @@ mod tests {
                 .as_ref()
                 .is_some_and(|result| result.error.contains("machine not found"))
         );
+    }
+
+    /// A failed rack firmware upgrade must reach the operator with the reason the
+    /// backend gave. The rack controller records it on `rack_fw_details`, the machine
+    /// controller copies it into `FailedFirmwareUpgrade` while clearing the
+    /// reprovisioning request, and this is the only place the API can surface it.
+    #[test]
+    fn derive_machine_firmware_update_status_failed_reports_the_reprovision_reason() {
+        use super::derive_machine_firmware_update_status;
+
+        fn failed_machine(reason: Option<&str>) -> HostMachine {
+            let mut machine = machine_with_id(standalone_machine(), host_machine_id());
+            machine.status.update_complete = false;
+            machine.state = Versioned::new(
+                ManagedHostState::HostReprovision {
+                    reprovision_state: HostReprovisionState::FailedFirmwareUpgrade {
+                        firmware_type: FirmwareComponentType::Unknown,
+                        report_time: Some(chrono::Utc::now()),
+                        reason: reason.map(str::to_owned),
+                    },
+                    retry_count: 0,
+                },
+                ConfigVersion::initial(),
+            );
+            machine
+        }
+
+        let machine_id = host_machine_id().to_string();
+        let cases = [
+            (
+                "the backend reason is reported verbatim",
+                Some("config_json.ProductName is required"),
+                "config_json.ProductName is required",
+            ),
+            ("no recorded reason stays silent", None, ""),
+            ("a blank reason is treated as absent", Some("   "), ""),
+        ];
+
+        for (label, reason, expected_error) in cases {
+            let machine = failed_machine(reason);
+            let status =
+                derive_machine_firmware_update_status(&machine_id, Some(&machine), None, &[]);
+            let result = status.result.expect("a machine status carries a result");
+
+            assert_eq!(
+                status.state,
+                rpc::FirmwareUpdateState::FwStateFailed as i32,
+                "[{label}] state"
+            );
+            assert_eq!(result.error, expected_error, "[{label}] error");
+            assert_eq!(
+                result.status,
+                if expected_error.is_empty() {
+                    rpc::ComponentManagerStatusCode::Success as i32
+                } else {
+                    rpc::ComponentManagerStatusCode::InternalError as i32
+                },
+                "[{label}] status code"
+            );
+        }
+    }
+
+    /// A machine that is not in a firmware failure keeps the plain success result,
+    /// so the reason lookup cannot leak into healthy states.
+    #[test]
+    fn derive_machine_firmware_update_status_non_failed_states_stay_successful() {
+        use super::derive_machine_firmware_update_status;
+
+        let mut machine = machine_with_id(standalone_machine(), host_machine_id());
+        machine.status.update_complete = true;
+        let machine_id = host_machine_id().to_string();
+
+        let status = derive_machine_firmware_update_status(&machine_id, Some(&machine), None, &[]);
+        let result = status.result.expect("a machine status carries a result");
+
+        assert_eq!(
+            status.state,
+            rpc::FirmwareUpdateState::FwStateCompleted as i32
+        );
+        assert!(result.error.is_empty());
     }
 
     // ---- compute power-control (MachineIds) decision logic ----

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -2308,12 +2308,18 @@ fn exploration_report_firmware_versions(
 /// there is no timestamp left to gate a persisted status against. Host-driven
 /// upgrades fill the same field in from the scout report.
 fn machine_firmware_failure_reason(machine: &HostMachine) -> Option<String> {
-    let ManagedHostState::HostReprovision {
-        reprovision_state: HostReprovisionState::FailedFirmwareUpgrade { reason, .. },
-        ..
-    } = &machine.state.value
-    else {
-        return None;
+    let reason = match &machine.state.value {
+        ManagedHostState::HostReprovision {
+            reprovision_state: HostReprovisionState::FailedFirmwareUpgrade { reason, .. },
+            ..
+        }
+        | ManagedHostState::Assigned {
+            instance_state:
+                model::machine::InstanceState::HostReprovision {
+                    reprovision_state: HostReprovisionState::FailedFirmwareUpgrade { reason, .. },
+                },
+        } => reason,
+        _ => return None,
     };
 
     reason
@@ -6492,20 +6498,30 @@ mod tests {
     fn derive_machine_firmware_update_status_failed_reports_the_reprovision_reason() {
         use super::derive_machine_firmware_update_status;
 
-        fn failed_machine(reason: Option<&str>) -> HostMachine {
-            let mut machine = machine_with_id(standalone_machine(), host_machine_id());
+        fn failed_machine(reason: Option<&str>, assigned: bool) -> HostMachine {
+            let mut machine = machine_with_id(standalone_machine(), *host_machine_id());
             machine.status.update_complete = false;
-            machine.state = Versioned::new(
-                ManagedHostState::HostReprovision {
-                    reprovision_state: HostReprovisionState::FailedFirmwareUpgrade {
-                        firmware_type: FirmwareComponentType::Unknown,
-                        report_time: Some(chrono::Utc::now()),
-                        reason: reason.map(str::to_owned),
+
+            let reprovision_state = HostReprovisionState::FailedFirmwareUpgrade {
+                firmware_type: FirmwareComponentType::Unknown,
+                report_time: Some(chrono::Utc::now()),
+                reason: reason.map(str::to_owned),
+            };
+
+            let state = if assigned {
+                ManagedHostState::Assigned {
+                    instance_state: model::machine::InstanceState::HostReprovision {
+                        reprovision_state,
                     },
+                }
+            } else {
+                ManagedHostState::HostReprovision {
+                    reprovision_state,
                     retry_count: 0,
-                },
-                ConfigVersion::initial(),
-            );
+                }
+            };
+
+            machine.state = Versioned::new(state, ConfigVersion::initial());
             machine
         }
 
@@ -6514,22 +6530,32 @@ mod tests {
             (
                 "the backend reason is reported verbatim",
                 Some("config_json.ProductName is required"),
+                false,
+                "config_json.ProductName is required",
+            ),
+            (
+                "an assigned machine reports the backend reason verbatim",
+                Some("config_json.ProductName is required"),
+                true,
                 "config_json.ProductName is required",
             ),
             (
                 "no recorded reason is reported as such",
                 None,
+                false,
                 "firmware upgrade failed without a recorded reason",
             ),
             (
                 "a blank reason is treated as absent",
                 Some("   "),
+                false,
                 "firmware upgrade failed without a recorded reason",
             ),
         ];
 
-        for (label, reason, expected_error) in cases {
-            let machine = failed_machine(reason);
+        for (label, reason, assigned, expected_error) in cases {
+            let machine = failed_machine(reason, assigned);
+
             let status =
                 derive_machine_firmware_update_status(&machine_id, Some(&machine), None, &[]);
             let result = status.result.expect("a machine status carries a result");
@@ -6558,7 +6584,7 @@ mod tests {
     fn derive_machine_firmware_update_status_non_failed_states_stay_successful() {
         use super::derive_machine_firmware_update_status;
 
-        let mut machine = machine_with_id(standalone_machine(), host_machine_id());
+        let mut machine = machine_with_id(standalone_machine(), *host_machine_id());
         machine.status.update_complete = true;
         let machine_id = host_machine_id().to_string();
 

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -469,17 +469,18 @@ async fn switch_firmware_statuses(
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
+    drop(txn);
+
     let racks = if rack_ids.is_empty() {
         vec![]
     } else {
         db::rack::find_by(
-            &mut txn,
+            api.db_reader().as_mut(),
             db::ObjectColumnFilter::List(db::rack::IdColumn, &rack_ids),
         )
         .await
         .map_err(|e| Status::internal(format!("failed to look up switch racks: {e}")))?
     };
-    drop(txn);
 
     let switch_by_id: HashMap<_, _> = switches
         .into_iter()

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -326,6 +326,211 @@ fn rack_firmware_status(rack: &model::rack::Rack) -> rpc::FirmwareUpdateStatus {
     }
 }
 
+fn persisted_firmware_status(
+    component_id: impl std::fmt::Display,
+    status: &model::rack::RackFirmwareUpgradeStatus,
+) -> rpc::FirmwareUpdateStatus {
+    let component_id = component_id.to_string();
+    let (state, result) = match &status.status {
+        model::rack::RackFirmwareUpgradeState::Started => (
+            rpc::FirmwareUpdateState::FwStateQueued,
+            success_result(&component_id),
+        ),
+        model::rack::RackFirmwareUpgradeState::InProgress => (
+            rpc::FirmwareUpdateState::FwStateInProgress,
+            success_result(&component_id),
+        ),
+        model::rack::RackFirmwareUpgradeState::Completed => (
+            rpc::FirmwareUpdateState::FwStateCompleted,
+            success_result(&component_id),
+        ),
+        model::rack::RackFirmwareUpgradeState::Failed { cause } => (
+            rpc::FirmwareUpdateState::FwStateFailed,
+            error_result(&component_id, cause.clone()),
+        ),
+    };
+
+    rpc::FirmwareUpdateStatus {
+        result: Some(result),
+        state: state as i32,
+        // The per-device status currently persists the RMS task ID and state,
+        // but not the firmware object ID.
+        target_version: String::new(),
+        updated_at: status
+            .ended_at
+            .as_ref()
+            .or(status.started_at.as_ref())
+            .cloned()
+            .map(Into::into),
+    }
+}
+
+async fn switch_firmware_statuses(
+    api: &Api,
+    switch_ids: &[SwitchId],
+) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
+    let mut txn = api
+        .database_connection
+        .begin()
+        .await
+        .map_err(|e| Status::internal(format!("failed to begin transaction: {e}")))?;
+
+    let switches = db::switch::find_by(
+        &mut txn,
+        db::ObjectColumnFilter::List(db::switch::IdColumn, switch_ids),
+    )
+    .await
+    .map_err(|e| Status::internal(format!("failed to look up switches: {e}")))?;
+    drop(txn);
+
+    let persisted_status_by_id: HashMap<_, _> = switches
+        .into_iter()
+        .filter_map(|switch| {
+            switch
+                .firmware_upgrade_status
+                .map(|status| (switch.id, status))
+        })
+        .collect();
+
+    let mut statuses: Vec<_> = switch_ids
+        .iter()
+        .filter_map(|switch_id| {
+            persisted_status_by_id
+                .get(switch_id)
+                .map(|status| persisted_firmware_status(switch_id, status))
+        })
+        .collect();
+    let backend_switch_ids: Vec<_> = switch_ids
+        .iter()
+        .filter(|switch_id| !persisted_status_by_id.contains_key(switch_id))
+        .copied()
+        .collect();
+
+    if backend_switch_ids.is_empty() {
+        return Ok(statuses);
+    }
+
+    let cm = require_component_manager(api)?;
+    let endpoints = resolve_switch_endpoints(api, &backend_switch_ids).await?;
+    statuses.extend(
+        endpoints
+            .unresolved
+            .iter()
+            .map(|u| rpc::FirmwareUpdateStatus {
+                result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+                state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+                target_version: String::new(),
+                updated_at: None,
+            }),
+    );
+
+    if !endpoints.resolved.endpoints.is_empty() {
+        let backend_statuses = cm
+            .nv_switch
+            .get_firmware_status(&endpoints.resolved.endpoints)
+            .await
+            .map_err(component_manager_error_to_status)?;
+        statuses.extend(backend_statuses.into_iter().map(|s| {
+            let id = switch_mac_to_id_str(&s.bmc_mac, &endpoints.resolved.mac_to_id);
+            rpc::FirmwareUpdateStatus {
+                result: Some(if s.error.is_none() {
+                    success_result(&id)
+                } else {
+                    error_result(&id, s.error.unwrap_or_default())
+                }),
+                state: map_fw_state(s.state),
+                target_version: s.target_version,
+                updated_at: None,
+            }
+        }));
+    }
+
+    Ok(statuses)
+}
+
+async fn power_shelf_firmware_statuses(
+    api: &Api,
+    power_shelf_ids: &[PowerShelfId],
+) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
+    let mut txn = api
+        .database_connection
+        .begin()
+        .await
+        .map_err(|e| Status::internal(format!("failed to begin transaction: {e}")))?;
+
+    let power_shelves = db::power_shelf::find_by(
+        &mut txn,
+        db::ObjectColumnFilter::List(db::power_shelf::IdColumn, power_shelf_ids),
+    )
+    .await
+    .map_err(|e| Status::internal(format!("failed to look up power shelves: {e}")))?;
+    drop(txn);
+
+    let persisted_status_by_id: HashMap<_, _> = power_shelves
+        .into_iter()
+        .filter_map(|power_shelf| {
+            power_shelf
+                .firmware_upgrade_status
+                .map(|status| (power_shelf.id, status))
+        })
+        .collect();
+
+    let mut statuses: Vec<_> = power_shelf_ids
+        .iter()
+        .filter_map(|power_shelf_id| {
+            persisted_status_by_id
+                .get(power_shelf_id)
+                .map(|status| persisted_firmware_status(power_shelf_id, status))
+        })
+        .collect();
+    let backend_power_shelf_ids: Vec<_> = power_shelf_ids
+        .iter()
+        .filter(|power_shelf_id| !persisted_status_by_id.contains_key(power_shelf_id))
+        .copied()
+        .collect();
+
+    if backend_power_shelf_ids.is_empty() {
+        return Ok(statuses);
+    }
+
+    let cm = require_component_manager(api)?;
+    let endpoints = resolve_power_shelf_endpoints(api, &backend_power_shelf_ids).await?;
+    statuses.extend(
+        endpoints
+            .unresolved
+            .iter()
+            .map(|u| rpc::FirmwareUpdateStatus {
+                result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+                state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+                target_version: String::new(),
+                updated_at: None,
+            }),
+    );
+
+    if !endpoints.resolved.endpoints.is_empty() {
+        let backend_statuses = cm
+            .power_shelf
+            .get_firmware_status(&endpoints.resolved.endpoints)
+            .await
+            .map_err(component_manager_error_to_status)?;
+        statuses.extend(backend_statuses.into_iter().map(|s| {
+            let id = ps_mac_to_id_str(&s.pmc_mac, &endpoints.resolved.mac_to_id);
+            rpc::FirmwareUpdateStatus {
+                result: Some(if s.error.is_none() {
+                    success_result(&id)
+                } else {
+                    error_result(&id, s.error.unwrap_or_default())
+                }),
+                state: map_fw_state(s.state),
+                target_version: s.target_version,
+                updated_at: None,
+            }
+        }));
+    }
+
+    Ok(statuses)
+}
+
 fn build_inventory_entries(
     id_strings: &[String],
     report_by_id: &HashMap<String, model::site_explorer::EndpointExplorationReport>,
@@ -4002,8 +4207,7 @@ pub(crate) async fn get_component_firmware_status(
 
     let statuses = match target {
         rpc::get_component_firmware_status_request::Target::SwitchIds(list) => {
-            let cm = require_component_manager(api)?;
-            firmware_status_switch_ids(api, cm, &list.ids).await?
+            switch_firmware_statuses(api, &list.ids).await?
         }
         rpc::get_component_firmware_status_request::Target::SwitchBmcMacs(list) => {
             let cm = require_component_manager(api)?;
@@ -4045,39 +4249,7 @@ pub(crate) async fn get_component_firmware_status(
             statuses
         }
         rpc::get_component_firmware_status_request::Target::PowerShelfIds(list) => {
-            let cm = require_component_manager(api)?;
-            let endpoints = resolve_power_shelf_endpoints(api, &list.ids).await?;
-
-            let mut statuses: Vec<_> = endpoints
-                .unresolved
-                .iter()
-                .map(|u| rpc::FirmwareUpdateStatus {
-                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
-                    state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
-                    target_version: String::new(),
-                    updated_at: None,
-                })
-                .collect();
-
-            let backend_statuses = cm
-                .power_shelf
-                .get_firmware_status(&endpoints.resolved.endpoints)
-                .await
-                .map_err(component_manager_error_to_status)?;
-            statuses.extend(backend_statuses.into_iter().map(|s| {
-                let id = ps_mac_to_id_str(&s.pmc_mac, &endpoints.resolved.mac_to_id);
-                rpc::FirmwareUpdateStatus {
-                    result: Some(if s.error.is_none() {
-                        success_result(&id)
-                    } else {
-                        error_result(&id, s.error.unwrap_or_default())
-                    }),
-                    state: map_fw_state(s.state),
-                    target_version: s.target_version,
-                    updated_at: None,
-                }
-            }));
-            statuses
+            power_shelf_firmware_statuses(api, &list.ids).await?
         }
         rpc::get_component_firmware_status_request::Target::MachineIds(list) => {
             if list.machine_ids.is_empty() {
@@ -5310,6 +5482,58 @@ mod tests {
         ];
         for (input, expected) in cases {
             assert_eq!(map_fw_state(input), expected, "mismatch for {input:?}");
+        }
+    }
+
+    #[test]
+    fn persisted_firmware_status_maps_all_states() {
+        let component_id = "component-id";
+        let started_at = chrono::Utc::now();
+        let cases = [
+            (
+                model::rack::RackFirmwareUpgradeState::Started,
+                rpc::FirmwareUpdateState::FwStateQueued,
+                rpc::ComponentManagerStatusCode::Success,
+                "",
+            ),
+            (
+                model::rack::RackFirmwareUpgradeState::InProgress,
+                rpc::FirmwareUpdateState::FwStateInProgress,
+                rpc::ComponentManagerStatusCode::Success,
+                "",
+            ),
+            (
+                model::rack::RackFirmwareUpgradeState::Completed,
+                rpc::FirmwareUpdateState::FwStateCompleted,
+                rpc::ComponentManagerStatusCode::Success,
+                "",
+            ),
+            (
+                model::rack::RackFirmwareUpgradeState::Failed {
+                    cause: "config_json.ProductName is required".into(),
+                },
+                rpc::FirmwareUpdateState::FwStateFailed,
+                rpc::ComponentManagerStatusCode::InternalError,
+                "config_json.ProductName is required",
+            ),
+        ];
+
+        for (input, expected_state, expected_result, expected_error) in cases {
+            let status = model::rack::RackFirmwareUpgradeStatus {
+                task_id: "rms-task-id".into(),
+                status: input,
+                started_at: Some(started_at),
+                ended_at: None,
+            };
+
+            let actual = persisted_firmware_status(component_id, &status);
+            let result = actual.result.expect("component result must be present");
+
+            assert_eq!(result.component_id.as_deref(), Some(component_id));
+            assert_eq!(actual.state, expected_state as i32);
+            assert_eq!(result.status, expected_result as i32);
+            assert_eq!(result.error, expected_error);
+            assert_eq!(actual.updated_at, Some(started_at.into()));
         }
     }
 

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -6334,8 +6334,8 @@ mod tests {
                 Some("config_json.ProductName is required"),
                 "config_json.ProductName is required",
             ),
-            ("no recorded reason stays silent", None, ""),
-            ("a blank reason is treated as absent", Some("   "), ""),
+            ("no recorded reason is reported as such", None, "firmware upgrade failed without a recorded reason"),
+            ("a blank reason is treated as absent", Some("   "), "firmware upgrade failed without a recorded reason"),
         ];
 
         for (label, reason, expected_error) in cases {

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -475,8 +475,10 @@ fn switch_firmware_request(
 }
 
 /// Selects the persisted result only when it belongs to the active request.
-/// A pending request with no current result is queued; no request and no persisted
-/// result means the caller must query the component-manager backend.
+/// A pending request with no current result is queued. Once the request is gone the
+/// persisted result is not served at all, it records a cycle that has already ended and
+/// would otherwise shadow the backend for as long as the row survives, so the caller
+/// queries the component-manager backend instead.
 fn select_persisted_switch_firmware_status(
     switch_id: SwitchId,
     persisted_status: Option<&model::rack::RackFirmwareUpgradeStatus>,
@@ -502,41 +504,7 @@ fn select_persisted_switch_firmware_status(
                 ..status
             })
         }
-        None => persisted_status.map(|status| persisted_firmware_status(switch_id, status)),
-    }
-}
-
-/// Drops the state-controller's persisted per-device result for switches whose firmware
-/// update was just queued directly, so status polling stops serving the superseded result
-/// and falls through to the backend running the new update.
-///
-/// Best effort on purpose: the backend has already accepted the update, so a bookkeeping
-/// failure must not be reported as a failed dispatch. A switch that fails to clear keeps
-/// serving its previous status until the next write.
-///
-/// This deliberately leaves `switch_reprovisioning_requested` alone. A switch still under an
-/// active state-controller firmware request keeps reporting that request's view; reconciling
-/// a direct dispatch against a pending controller request is a separate concern and is not
-/// resolved here.
-async fn clear_switch_firmware_upgrade_status(api: &Api, switch_ids: &[SwitchId]) {
-    if switch_ids.is_empty() {
-        return;
-    }
-    let mut conn = match api.database_connection.acquire().await {
-        Ok(conn) => conn,
-        Err(error) => {
-            tracing::warn!(
-                %error,
-                "failed to acquire a connection to clear superseded switch firmware status"
-            );
-            return;
-        }
-    };
-
-    if let Err(error) =
-        db::switch::clear_firmware_upgrade_status_for_switches(conn.as_mut(), switch_ids).await
-    {
-        tracing::warn!(%error, "failed to clear superseded switch firmware status");
+        None => None,
     }
 }
 
@@ -5910,17 +5878,11 @@ mod tests {
                 rpc::FirmwareUpdateState::FwStateCompleted,
                 "fw-42",
             ),
-            (
-                Some(&stale_status),
-                None,
-                rpc::FirmwareUpdateState::FwStateFailed,
-                "",
-            ),
         ];
 
         for (persisted, request, expected, expected_version) in cases {
             let actual = select_persisted_switch_firmware_status(switch_id, persisted, request)
-                .expect("a request or a persisted status yields a status");
+                .expect("an active request always yields a status");
             assert_eq!(
                 actual.state,
                 expected as i32,
@@ -5933,10 +5895,13 @@ mod tests {
             );
         }
 
-        assert!(
-            select_persisted_switch_firmware_status(switch_id, None, None).is_none(),
-            "the backend is required when neither request nor persisted status exists"
-        );
+        for persisted in [None, Some(&stale_status), Some(&current_status)] {
+            assert!(
+                select_persisted_switch_firmware_status(switch_id, persisted, None).is_none(),
+                "with no active request the backend answers; a finished cycle's result must \
+                 not shadow it: {persisted:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -61,6 +61,7 @@ use crate::handlers::firmware::load_desired_firmware_version_entries;
 
 const MACHINE_POWER_OVERRIDE_SOURCE: &str = "component_power_control";
 const MACHINE_POWER_OVERRIDE_MESSAGE: &str = "Compute-Tray component power control in progress";
+const UNTRACKED_SWITCH_FIRMWARE_ERROR: &str = "no firmware job tracked for this switch";
 
 fn require_component_manager(api: &Api) -> Result<&ComponentManager, Status> {
     api.component_manager
@@ -548,7 +549,7 @@ fn untracked_switch_firmware_status(switch_id: SwitchId) -> rpc::FirmwareUpdateS
     rpc::FirmwareUpdateStatus {
         result: Some(error_result(
             &switch_id.to_string(),
-            "no firmware job tracked for this switch".into(),
+            UNTRACKED_SWITCH_FIRMWARE_ERROR.into(),
         )),
         state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
         target_version: String::new(),
@@ -634,7 +635,24 @@ async fn switch_firmware_statuses(
 
     let cm = require_component_manager(api)?;
     let endpoints = resolve_switch_endpoints(api, &backend_switch_ids).await?;
-    statuses.extend(unresolved_firmware_statuses(&endpoints.unresolved));
+
+    for unresolved in &endpoints.unresolved {
+        // Endpoint resolution did not produce a newer backend observation, so
+        // preserve a terminal result retained from the rack firmware job.
+        statuses.push(
+            persisted_fallbacks
+                .remove(&unresolved.id)
+                .unwrap_or_else(|| rpc::FirmwareUpdateStatus {
+                    result: Some(error_result(
+                        &unresolved.id.to_string(),
+                        unresolved.reason.clone(),
+                    )),
+                    state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+                    target_version: String::new(),
+                    updated_at: None,
+                }),
+        );
+    }
 
     if !endpoints.resolved.endpoints.is_empty() {
         let backend_statuses = cm
@@ -4301,52 +4319,11 @@ fn select_firmware_status_routing(
     }
 }
 
-/// Firmware status for a set of ingested switches by id, via the configured
-/// backend. Shared by the `switch_ids` target and the ingested branch of the
-/// `switch_bmc_macs` target.
-async fn firmware_status_switch_ids(
-    api: &Api,
-    cm: &ComponentManager,
-    switch_ids: &[SwitchId],
-) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
-    let endpoints = resolve_switch_endpoints(api, switch_ids).await?;
-
-    let mut statuses: Vec<_> = endpoints
-        .unresolved
-        .iter()
-        .map(|u| rpc::FirmwareUpdateStatus {
-            result: Some(error_result(&u.id.to_string(), u.reason.clone())),
-            state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
-            target_version: String::new(),
-            updated_at: None,
-        })
-        .collect();
-
-    let backend_statuses = cm
-        .nv_switch
-        .get_firmware_status(&endpoints.resolved.endpoints)
-        .await
-        .map_err(component_manager_error_to_status)?;
-    statuses.extend(backend_statuses.into_iter().map(|s| {
-        let id = switch_mac_to_id_str(&s.bmc_mac, &endpoints.resolved.mac_to_id);
-        rpc::FirmwareUpdateStatus {
-            result: Some(if s.error.is_none() {
-                success_result(&id)
-            } else {
-                error_result(&id, s.error.unwrap_or_default())
-            }),
-            state: map_fw_state(s.state),
-            target_version: s.target_version,
-            updated_at: None,
-        }
-    }));
-    Ok(statuses)
-}
-
 /// Firmware status for pre-ingestion switches, dispatched to the configured
 /// backend via direct endpoints and correlated by BMC MAC. Endpoints that
 /// cannot be resolved (missing NVOS info, credentials, or expected inventory)
-/// are reported per-MAC.
+/// and resolved endpoints omitted from the backend response are reported
+/// per-MAC as unknown errors.
 async fn pre_ingestion_switch_firmware_statuses(
     api: &Api,
     cm: &ComponentManager,
@@ -4373,24 +4350,43 @@ async fn pre_ingestion_switch_firmware_statuses(
         .get_firmware_status(&endpoints)
         .await
         .map_err(component_manager_error_to_status)?;
-    statuses.extend(
-        backend_statuses
-            .into_iter()
-            .map(|s| rpc::FirmwareUpdateStatus {
-                result: Some(if s.error.is_none() {
-                    mac_result(&s.bmc_mac, rpc::ComponentManagerStatusCode::Success, None)
-                } else {
-                    mac_result(
-                        &s.bmc_mac,
-                        rpc::ComponentManagerStatusCode::InternalError,
-                        s.error,
-                    )
-                }),
-                state: map_fw_state(s.state),
-                target_version: s.target_version,
-                updated_at: None,
+
+    let mut observed_bmc_macs = HashSet::new();
+
+    statuses.extend(backend_statuses.into_iter().map(|s| {
+        observed_bmc_macs.insert(s.bmc_mac);
+        rpc::FirmwareUpdateStatus {
+            result: Some(if s.error.is_none() {
+                mac_result(&s.bmc_mac, rpc::ComponentManagerStatusCode::Success, None)
+            } else {
+                mac_result(
+                    &s.bmc_mac,
+                    rpc::ComponentManagerStatusCode::InternalError,
+                    s.error,
+                )
             }),
-    );
+            state: map_fw_state(s.state),
+            target_version: s.target_version,
+            updated_at: None,
+        }
+    }));
+
+    for endpoint in endpoints {
+        if observed_bmc_macs.contains(&endpoint.bmc_mac) {
+            continue;
+        }
+
+        statuses.push(rpc::FirmwareUpdateStatus {
+            result: Some(mac_result(
+                &endpoint.bmc_mac,
+                rpc::ComponentManagerStatusCode::InternalError,
+                Some(UNTRACKED_SWITCH_FIRMWARE_ERROR.to_owned()),
+            )),
+            state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+            target_version: String::new(),
+            updated_at: None,
+        });
+    }
 
     Ok(statuses)
 }
@@ -4580,8 +4576,8 @@ pub(crate) async fn get_component_firmware_status(
 
             // Ingested MACs: reuse the switch-id path, then echo the MAC.
             if !resolution.ingested.is_empty() {
-                let ingested =
-                    firmware_status_switch_ids(api, cm, &resolution.ingested_ids()).await?;
+                let ingested = switch_firmware_statuses(api, &resolution.ingested_ids()).await?;
+
                 statuses.extend(ingested.into_iter().map(|mut status| {
                     if let Some(result) = status.result.as_mut()
                         && let Some(mac) =

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -6334,8 +6334,16 @@ mod tests {
                 Some("config_json.ProductName is required"),
                 "config_json.ProductName is required",
             ),
-            ("no recorded reason is reported as such", None, "firmware upgrade failed without a recorded reason"),
-            ("a blank reason is treated as absent", Some("   "), "firmware upgrade failed without a recorded reason"),
+            (
+                "no recorded reason is reported as such",
+                None,
+                "firmware upgrade failed without a recorded reason",
+            ),
+            (
+                "a blank reason is treated as absent",
+                Some("   "),
+                "firmware upgrade failed without a recorded reason",
+            ),
         ];
 
         for (label, reason, expected_error) in cases {

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -508,6 +508,54 @@ fn select_persisted_switch_firmware_status(
     }
 }
 
+/// Retains the terminal per-switch result of the latest rack job as a fallback.
+/// A component-manager backend result takes precedence over this status.
+fn retained_rack_switch_firmware_status(
+    switch: &model::switch::Switch,
+    rack: Option<&model::rack::Rack>,
+) -> Option<rpc::FirmwareUpdateStatus> {
+    let job = rack?.firmware_upgrade_job.as_ref()?;
+    if !matches!(
+        firmware_job_state(job),
+        rpc::FirmwareUpdateState::FwStateCompleted | rpc::FirmwareUpdateState::FwStateFailed
+    ) {
+        return None;
+    }
+
+    let persisted_status = switch
+        .firmware_upgrade_status
+        .as_ref()
+        .filter(|status| status.is_terminal())?;
+
+    if job
+        .started_at
+        .is_some_and(|started_at| !persisted_status.is_current_for(started_at))
+    {
+        return None;
+    }
+
+    let mut status = persisted_firmware_status(switch.id, persisted_status);
+    status.target_version = job
+        .firmware_id
+        .as_deref()
+        .map(safe_firmware_target_display)
+        .unwrap_or_default();
+
+    Some(status)
+}
+
+fn untracked_switch_firmware_status(switch_id: SwitchId) -> rpc::FirmwareUpdateStatus {
+    rpc::FirmwareUpdateStatus {
+        result: Some(error_result(
+            &switch_id.to_string(),
+            "no firmware job tracked for this switch".into(),
+        )),
+        state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+        target_version: String::new(),
+        updated_at: None,
+    }
+}
+
 async fn switch_firmware_statuses(
     api: &Api,
     switch_ids: &[SwitchId],
@@ -554,6 +602,8 @@ async fn switch_firmware_statuses(
 
     let mut statuses = Vec::new();
     let mut backend_switch_ids = Vec::new();
+    let mut persisted_fallbacks = HashMap::new();
+
     for switch_id in switch_ids {
         let Some(switch) = switch_by_id.get(switch_id) else {
             backend_switch_ids.push(*switch_id);
@@ -570,6 +620,10 @@ async fn switch_firmware_statuses(
         ) {
             statuses.push(status);
         } else {
+            if let Some(fallback) = retained_rack_switch_firmware_status(switch, rack) {
+                persisted_fallbacks.insert(switch.id, fallback);
+            }
+
             backend_switch_ids.push(*switch_id);
         }
     }
@@ -588,7 +642,15 @@ async fn switch_firmware_statuses(
             .get_firmware_status(&endpoints.resolved.endpoints)
             .await
             .map_err(component_manager_error_to_status)?;
+
+        let mut observed_switch_ids = HashSet::new();
+
         statuses.extend(backend_statuses.into_iter().map(|s| {
+            if let Some(switch_id) = endpoints.resolved.mac_to_id.get(&s.bmc_mac) {
+                observed_switch_ids.insert(*switch_id);
+                persisted_fallbacks.remove(switch_id);
+            }
+
             let id = switch_mac_to_id_str(&s.bmc_mac, &endpoints.resolved.mac_to_id);
             rpc::FirmwareUpdateStatus {
                 result: Some(if s.error.is_none() {
@@ -601,6 +663,22 @@ async fn switch_firmware_statuses(
                 updated_at: None,
             }
         }));
+
+        for endpoint in &endpoints.resolved.endpoints {
+            let Some(switch_id) = endpoints.resolved.mac_to_id.get(&endpoint.bmc_mac) else {
+                continue;
+            };
+
+            if observed_switch_ids.contains(switch_id) {
+                continue;
+            }
+
+            statuses.push(
+                persisted_fallbacks
+                    .remove(switch_id)
+                    .unwrap_or_else(|| untracked_switch_firmware_status(*switch_id)),
+            );
+        }
     }
 
     Ok(statuses)

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -373,7 +373,7 @@ fn persisted_firmware_status(
             .ended_at
             .as_ref()
             .or(status.started_at.as_ref())
-            .cloned()
+            .copied()
             .map(Into::into),
     }
 }
@@ -411,17 +411,16 @@ fn switch_firmware_request_time(
                     .any(|activity| activity.same_kind(&firmware_activity))
         })
         .map(|request| request.requested_at);
-    let rack_request_time = rack
-        .filter(|rack| {
-            rack.config
-                .maintenance_requested
-                .as_ref()
-                .is_some_and(|scope| {
-                    scope.should_run(&firmware_activity)
-                        && (scope.is_full_rack() || scope.switch_ids.contains(&switch.id))
-                })
-        })
-        .map(|rack| rack.updated);
+    let rack_request_time = rack.and_then(|rack| {
+        rack.config
+            .maintenance_requested
+            .as_ref()
+            .filter(|scope| {
+                scope.should_run(&firmware_activity)
+                    && (scope.is_full_rack() || scope.switch_ids.contains(&switch.id))
+            })
+            .map(|scope| scope.requested_at.unwrap_or(rack.updated))
+    });
 
     switch_request_time.max(rack_request_time)
 }
@@ -5764,6 +5763,51 @@ mod tests {
         });
         switch.switch_reprovisioning_requested = None;
         assert_eq!(switch_firmware_request_time(&switch, Some(&rack)), None);
+    }
+
+    #[test]
+    fn switch_firmware_request_time_ignores_later_rack_writes() {
+        let requested_at = chrono::Utc::now();
+        let mut rack = test_rack_with_job(None);
+        let mut switch = test_switch();
+        switch.rack_id = Some(rack.id.clone());
+        // The rack row is written repeatedly while the request is pending
+        // (state transitions, job updates), long after the upgrade started.
+        rack.updated = requested_at + chrono::Duration::minutes(5);
+        rack.config.maintenance_requested = Some(model::rack::MaintenanceScope {
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: Some("firmware-object-json".into()),
+                components: vec![],
+                force_update: false,
+            }],
+            requested_at: Some(requested_at),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            switch_firmware_request_time(&switch, Some(&rack)),
+            Some(requested_at),
+            "the cycle boundary is when the request was accepted"
+        );
+
+        let status = model::rack::RackFirmwareUpgradeStatus {
+            task_id: "rms-task-id".into(),
+            status: model::rack::RackFirmwareUpgradeState::InProgress,
+            started_at: Some(requested_at + chrono::Duration::seconds(30)),
+            ended_at: None,
+        };
+        let selected = select_persisted_switch_firmware_status(
+            switch.id,
+            Some(&status),
+            switch_firmware_request_time(&switch, Some(&rack)),
+        )
+        .expect("a pending request always yields a status");
+
+        assert_eq!(
+            selected.state,
+            rpc::FirmwareUpdateState::FwStateInProgress as i32,
+            "a later rack write must not send the upgrade back to queued"
+        );
     }
 
     #[test]

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -248,23 +248,36 @@ fn firmware_job_state(job: &FirmwareUpgradeJob) -> i32 {
     }
 }
 
-/// Summarizes a failed rack firmware upgrade into a single operator-facing message.
+/// Summarizes a failed rack firmware upgrade into an operator-facing message.
 ///
 /// A rack upgrade fans out to every device in the rack, so the one rack-level
 /// `ComponentResult` can only carry a summary of the per-device outcomes the rack
-/// controller recorded. A rejected firmware bundle fails every device with an
-/// identical reason, which is worth reporting verbatim; divergent reasons collapse to
-/// a count so a large rack cannot produce an unbounded message.
-fn rack_firmware_failure_summary(job: &FirmwareUpgradeJob) -> String {
+/// controller recorded. A common RMS reason is useful inline; divergent failures are
+/// summarized by count because their details belong in the RMS logs. If the job failed
+/// without any failed device result, preserve the rack controller's actual failure cause
+/// instead of reporting the contradictory "0/N devices failed".
+fn rack_firmware_failure_summary(rack: &model::rack::Rack, job: &FirmwareUpgradeJob) -> String {
     let total = job.all_devices().count();
-    if total == 0 {
-        return "firmware upgrade failed before any device update was submitted".to_owned();
-    }
-
     let failed: Vec<_> = job
         .all_devices()
         .filter(|device| device.status == "failed")
         .collect();
+
+    if failed.is_empty() {
+        if let model::rack::RackState::Error { cause } = &rack.controller_state.value {
+            let cause = cause.trim();
+            if !cause.is_empty() {
+                return format!("firmware upgrade failed: {cause}");
+            }
+        }
+
+        return if total == 0 {
+            "firmware upgrade failed before any device update was submitted".to_owned()
+        } else {
+            "firmware upgrade failed without a failed per-device result".to_owned()
+        };
+    }
+
     let summary = format!(
         "firmware upgrade failed: {}/{total} devices failed",
         failed.len()
@@ -282,7 +295,7 @@ fn rack_firmware_failure_summary(job: &FirmwareUpgradeJob) -> String {
     match reasons.as_slice() {
         [] => summary,
         [reason] => format!("{summary}: {reason}"),
-        reasons => format!("{summary}: {} distinct errors", reasons.len()),
+        reasons => format!("{summary}: {} distinct errors; see RMS logs", reasons.len()),
     }
 }
 
@@ -311,7 +324,7 @@ fn rack_firmware_status(rack: &model::rack::Rack) -> rpc::FirmwareUpdateStatus {
     let result = if state == rpc::FirmwareUpdateState::FwStateFailed as i32 {
         let summary = job.map_or_else(
             || "firmware upgrade failed".to_owned(),
-            rack_firmware_failure_summary,
+            |job| rack_firmware_failure_summary(rack, job),
         );
         error_result(rack.id.as_ref(), summary)
     } else {
@@ -365,6 +378,75 @@ fn persisted_firmware_status(
     }
 }
 
+fn queued_firmware_status(
+    component_id: impl std::fmt::Display,
+    requested_at: chrono::DateTime<chrono::Utc>,
+) -> rpc::FirmwareUpdateStatus {
+    let component_id = component_id.to_string();
+    rpc::FirmwareUpdateStatus {
+        result: Some(success_result(&component_id)),
+        state: rpc::FirmwareUpdateState::FwStateQueued as i32,
+        target_version: String::new(),
+        updated_at: Some(requested_at.into()),
+    }
+}
+
+fn switch_firmware_request_time(
+    switch: &model::switch::Switch,
+    rack: Option<&model::rack::Rack>,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    let firmware_activity = MaintenanceActivity::FirmwareUpgrade {
+        firmware_version: None,
+        components: vec![],
+        force_update: false,
+    };
+    let switch_request_time = switch
+        .switch_reprovisioning_requested
+        .as_ref()
+        .filter(|request| {
+            request.activities.is_empty()
+                || request
+                    .activities
+                    .iter()
+                    .any(|activity| activity.same_kind(&firmware_activity))
+        })
+        .map(|request| request.requested_at);
+    let rack_request_time = rack
+        .filter(|rack| {
+            rack.config
+                .maintenance_requested
+                .as_ref()
+                .is_some_and(|scope| {
+                    scope.should_run(&firmware_activity)
+                        && (scope.is_full_rack() || scope.switch_ids.contains(&switch.id))
+                })
+        })
+        .map(|rack| rack.updated);
+
+    switch_request_time.max(rack_request_time)
+}
+
+/// Selects the persisted result only when it belongs to the active request.
+/// A pending request with no current result is queued; no request and no persisted
+/// result means the caller must query the component-manager backend.
+fn select_persisted_switch_firmware_status(
+    switch_id: SwitchId,
+    persisted_status: Option<&model::rack::RackFirmwareUpgradeStatus>,
+    requested_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> Option<rpc::FirmwareUpdateStatus> {
+    match requested_at {
+        Some(requested_at) => Some(
+            persisted_status
+                .filter(|status| status.is_current_for(requested_at))
+                .map_or_else(
+                    || queued_firmware_status(switch_id, requested_at),
+                    |status| persisted_firmware_status(switch_id, status),
+                ),
+        ),
+        None => persisted_status.map(|status| persisted_firmware_status(switch_id, status)),
+    }
+}
+
 async fn switch_firmware_statuses(
     api: &Api,
     switch_ids: &[SwitchId],
@@ -381,30 +463,54 @@ async fn switch_firmware_statuses(
     )
     .await
     .map_err(|e| Status::internal(format!("failed to look up switches: {e}")))?;
+    let rack_ids: Vec<_> = switches
+        .iter()
+        .filter_map(|switch| switch.rack_id.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let racks = if rack_ids.is_empty() {
+        vec![]
+    } else {
+        db::rack::find_by(
+            &mut txn,
+            db::ObjectColumnFilter::List(db::rack::IdColumn, &rack_ids),
+        )
+        .await
+        .map_err(|e| Status::internal(format!("failed to look up switch racks: {e}")))?
+    };
     drop(txn);
 
-    let persisted_status_by_id: HashMap<_, _> = switches
+    let switch_by_id: HashMap<_, _> = switches
         .into_iter()
-        .filter_map(|switch| {
-            switch
-                .firmware_upgrade_status
-                .map(|status| (switch.id, status))
-        })
+        .map(|switch| (switch.id, switch))
+        .collect();
+    let rack_by_id: HashMap<_, _> = racks
+        .into_iter()
+        .map(|rack| (rack.id.clone(), rack))
         .collect();
 
-    let mut statuses: Vec<_> = switch_ids
-        .iter()
-        .filter_map(|switch_id| {
-            persisted_status_by_id
-                .get(switch_id)
-                .map(|status| persisted_firmware_status(switch_id, status))
-        })
-        .collect();
-    let backend_switch_ids: Vec<_> = switch_ids
-        .iter()
-        .filter(|switch_id| !persisted_status_by_id.contains_key(switch_id))
-        .copied()
-        .collect();
+    let mut statuses = Vec::new();
+    let mut backend_switch_ids = Vec::new();
+    for switch_id in switch_ids {
+        let Some(switch) = switch_by_id.get(switch_id) else {
+            backend_switch_ids.push(*switch_id);
+            continue;
+        };
+        let rack = switch
+            .rack_id
+            .as_ref()
+            .and_then(|rack_id| rack_by_id.get(rack_id));
+        if let Some(status) = select_persisted_switch_firmware_status(
+            switch.id,
+            switch.firmware_upgrade_status.as_ref(),
+            switch_firmware_request_time(switch, rack),
+        ) {
+            statuses.push(status);
+        } else {
+            backend_switch_ids.push(*switch_id);
+        }
+    }
 
     if backend_switch_ids.is_empty() {
         return Ok(statuses);
@@ -432,89 +538,6 @@ async fn switch_firmware_statuses(
             .map_err(component_manager_error_to_status)?;
         statuses.extend(backend_statuses.into_iter().map(|s| {
             let id = switch_mac_to_id_str(&s.bmc_mac, &endpoints.resolved.mac_to_id);
-            rpc::FirmwareUpdateStatus {
-                result: Some(if s.error.is_none() {
-                    success_result(&id)
-                } else {
-                    error_result(&id, s.error.unwrap_or_default())
-                }),
-                state: map_fw_state(s.state),
-                target_version: s.target_version,
-                updated_at: None,
-            }
-        }));
-    }
-
-    Ok(statuses)
-}
-
-async fn power_shelf_firmware_statuses(
-    api: &Api,
-    power_shelf_ids: &[PowerShelfId],
-) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
-    let mut txn = api
-        .database_connection
-        .begin()
-        .await
-        .map_err(|e| Status::internal(format!("failed to begin transaction: {e}")))?;
-
-    let power_shelves = db::power_shelf::find_by(
-        &mut txn,
-        db::ObjectColumnFilter::List(db::power_shelf::IdColumn, power_shelf_ids),
-    )
-    .await
-    .map_err(|e| Status::internal(format!("failed to look up power shelves: {e}")))?;
-    drop(txn);
-
-    let persisted_status_by_id: HashMap<_, _> = power_shelves
-        .into_iter()
-        .filter_map(|power_shelf| {
-            power_shelf
-                .firmware_upgrade_status
-                .map(|status| (power_shelf.id, status))
-        })
-        .collect();
-
-    let mut statuses: Vec<_> = power_shelf_ids
-        .iter()
-        .filter_map(|power_shelf_id| {
-            persisted_status_by_id
-                .get(power_shelf_id)
-                .map(|status| persisted_firmware_status(power_shelf_id, status))
-        })
-        .collect();
-    let backend_power_shelf_ids: Vec<_> = power_shelf_ids
-        .iter()
-        .filter(|power_shelf_id| !persisted_status_by_id.contains_key(power_shelf_id))
-        .copied()
-        .collect();
-
-    if backend_power_shelf_ids.is_empty() {
-        return Ok(statuses);
-    }
-
-    let cm = require_component_manager(api)?;
-    let endpoints = resolve_power_shelf_endpoints(api, &backend_power_shelf_ids).await?;
-    statuses.extend(
-        endpoints
-            .unresolved
-            .iter()
-            .map(|u| rpc::FirmwareUpdateStatus {
-                result: Some(error_result(&u.id.to_string(), u.reason.clone())),
-                state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
-                target_version: String::new(),
-                updated_at: None,
-            }),
-    );
-
-    if !endpoints.resolved.endpoints.is_empty() {
-        let backend_statuses = cm
-            .power_shelf
-            .get_firmware_status(&endpoints.resolved.endpoints)
-            .await
-            .map_err(component_manager_error_to_status)?;
-        statuses.extend(backend_statuses.into_iter().map(|s| {
-            let id = ps_mac_to_id_str(&s.pmc_mac, &endpoints.resolved.mac_to_id);
             rpc::FirmwareUpdateStatus {
                 result: Some(if s.error.is_none() {
                     success_result(&id)
@@ -4249,7 +4272,42 @@ pub(crate) async fn get_component_firmware_status(
             statuses
         }
         rpc::get_component_firmware_status_request::Target::PowerShelfIds(list) => {
-            power_shelf_firmware_statuses(api, &list.ids).await?
+            // The rack controller currently writes power-shelf Completed only as an
+            // internal reprovisioning-unblock sentinel; RMS does not include shelves
+            // in the rack firmware job. It is therefore not an API firmware result.
+            let cm = require_component_manager(api)?;
+            let endpoints = resolve_power_shelf_endpoints(api, &list.ids).await?;
+
+            let mut statuses: Vec<_> = endpoints
+                .unresolved
+                .iter()
+                .map(|u| rpc::FirmwareUpdateStatus {
+                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+                    state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+                    target_version: String::new(),
+                    updated_at: None,
+                })
+                .collect();
+
+            let backend_statuses = cm
+                .power_shelf
+                .get_firmware_status(&endpoints.resolved.endpoints)
+                .await
+                .map_err(component_manager_error_to_status)?;
+            statuses.extend(backend_statuses.into_iter().map(|s| {
+                let id = ps_mac_to_id_str(&s.pmc_mac, &endpoints.resolved.mac_to_id);
+                rpc::FirmwareUpdateStatus {
+                    result: Some(if s.error.is_none() {
+                        success_result(&id)
+                    } else {
+                        error_result(&id, s.error.unwrap_or_default())
+                    }),
+                    state: map_fw_state(s.state),
+                    target_version: s.target_version,
+                    updated_at: None,
+                }
+            }));
+            statuses
         }
         rpc::get_component_firmware_status_request::Target::MachineIds(list) => {
             if list.machine_ids.is_empty() {
@@ -4818,6 +4876,40 @@ mod tests {
         }
     }
 
+    fn test_switch() -> model::switch::Switch {
+        model::switch::Switch {
+            id: test_switch_id(),
+            config: model::switch::SwitchConfig {
+                name: "test-switch".into(),
+                enable_nmxc: false,
+                fabric_manager_config: None,
+            },
+            status: None,
+            deleted: None,
+            bmc_mac_address: None,
+            bmc_info: None,
+            bmc_credential_rotation_requested: false,
+            controller_state: Versioned::new(
+                model::switch::SwitchControllerState::Created,
+                ConfigVersion::initial(),
+            ),
+            controller_state_outcome: None,
+            switch_maintenance_requested: None,
+            switch_reprovisioning_requested: None,
+            firmware_upgrade_status: None,
+            nvos_update_status: None,
+            fabric_manager_status: None,
+            nvlink_domain_uuid: None,
+            rack_id: None,
+            metadata: Metadata::default(),
+            version: ConfigVersion::initial(),
+            is_primary: false,
+            slot_number: None,
+            tray_index: None,
+            health_reports: Default::default(),
+        }
+    }
+
     /// Yields a real `tonic::transport::Error` so the `Transport` arm can be
     /// exercised without a live connection: an invalid endpoint URI fails to parse
     /// synchronously into exactly that error type.
@@ -5298,7 +5390,7 @@ mod tests {
         use carbide_test_support::value_scenarios;
 
         value_scenarios!(
-            run = |job| rack_firmware_failure_summary(&job);
+            run = |job| rack_firmware_failure_summary(&test_rack_with_job(None), &job);
             "a shared reason is reported verbatim so the SOT rejection is visible" {
                 FirmwareUpgradeJob {
                     machines: vec![
@@ -5310,12 +5402,13 @@ mod tests {
                       config_json.ProductName is required".to_string(),
             }
 
-            "divergent reasons collapse to a count" {
+            "divergent reasons direct operators to RMS logs" {
                 FirmwareUpgradeJob {
                     machines: vec![failed_firmware_device("download failed")],
                     switches: vec![failed_firmware_device("target not found")],
                     ..Default::default()
-                } => "firmware upgrade failed: 2/2 devices failed: 2 distinct errors".to_string(),
+                } => "firmware upgrade failed: 2/2 devices failed: 2 distinct errors; \
+                      see RMS logs".to_string(),
             }
 
             "a partial failure reports the failed subset" {
@@ -5347,6 +5440,32 @@ mod tests {
                     "firmware upgrade failed before any device update was submitted".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn rack_firmware_status_job_level_failure_reports_controller_cause() {
+        let cause = "rack firmware upgrade cannot progress because target machines are Ready with desired power state Off";
+        let job = FirmwareUpgradeJob {
+            status: Some("failed".to_string()),
+            started_at: Some(chrono::Utc::now()),
+            completed_at: Some(chrono::Utc::now()),
+            machines: vec![firmware_device("in_progress")],
+            ..Default::default()
+        };
+        let mut rack = test_rack_with_job(Some(job));
+        rack.controller_state = Versioned::new(
+            RackState::Error {
+                cause: cause.to_string(),
+            },
+            ConfigVersion::initial(),
+        );
+
+        let status = rack_firmware_status(&rack);
+        let result = status.result.expect("a rack status carries a result");
+
+        assert_eq!(status.state, rpc::FirmwareUpdateState::FwStateFailed as i32);
+        assert_eq!(result.error, format!("firmware upgrade failed: {cause}"));
+        assert!(!result.error.contains("0/1 devices failed"));
     }
 
     /// The reported regression: every device failed with the RMS SOT parse error, but
@@ -5535,6 +5654,115 @@ mod tests {
             assert_eq!(result.error, expected_error);
             assert_eq!(actual.updated_at, Some(started_at.into()));
         }
+    }
+
+    #[test]
+    fn switch_persisted_status_is_gated_to_the_current_request() {
+        let switch_id = test_switch_id();
+        let requested_at = chrono::Utc::now();
+        let stale_status = model::rack::RackFirmwareUpgradeStatus {
+            task_id: "old-rms-task".into(),
+            status: model::rack::RackFirmwareUpgradeState::Failed {
+                cause: "old failure".into(),
+            },
+            started_at: Some(requested_at - chrono::Duration::minutes(2)),
+            ended_at: Some(requested_at - chrono::Duration::minutes(1)),
+        };
+        let current_status = model::rack::RackFirmwareUpgradeStatus {
+            task_id: "current-rms-task".into(),
+            status: model::rack::RackFirmwareUpgradeState::Completed,
+            started_at: Some(requested_at + chrono::Duration::seconds(1)),
+            ended_at: Some(requested_at + chrono::Duration::seconds(2)),
+        };
+
+        let stale = select_persisted_switch_firmware_status(
+            switch_id,
+            Some(&stale_status),
+            Some(requested_at),
+        )
+        .expect("a pending request reports queued");
+        let missing = select_persisted_switch_firmware_status(switch_id, None, Some(requested_at))
+            .expect("a pending request without status reports queued");
+        let current = select_persisted_switch_firmware_status(
+            switch_id,
+            Some(&current_status),
+            Some(requested_at),
+        )
+        .expect("a current persisted status is reported");
+        let historical =
+            select_persisted_switch_firmware_status(switch_id, Some(&stale_status), None)
+                .expect("the last persisted result is reported without an active request");
+
+        assert_eq!(stale.state, rpc::FirmwareUpdateState::FwStateQueued as i32);
+        assert_eq!(
+            missing.state,
+            rpc::FirmwareUpdateState::FwStateQueued as i32
+        );
+        assert_eq!(
+            current.state,
+            rpc::FirmwareUpdateState::FwStateCompleted as i32
+        );
+        assert_eq!(
+            historical.state,
+            rpc::FirmwareUpdateState::FwStateFailed as i32
+        );
+        assert!(
+            select_persisted_switch_firmware_status(switch_id, None, None).is_none(),
+            "the backend is required when neither request nor persisted status exists"
+        );
+    }
+
+    #[test]
+    fn switch_firmware_request_time_covers_pending_rack_and_dispatched_requests() {
+        let rack_requested_at = chrono::Utc::now();
+        let switch_requested_at = rack_requested_at + chrono::Duration::seconds(1);
+        let mut rack = test_rack_with_job(None);
+        let mut switch = test_switch();
+        switch.rack_id = Some(rack.id.clone());
+        rack.updated = rack_requested_at;
+        rack.config.maintenance_requested = Some(model::rack::MaintenanceScope {
+            switch_ids: vec![switch.id],
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: Some("firmware-object-json".into()),
+                components: vec![],
+                force_update: false,
+            }],
+            ..Default::default()
+        });
+
+        assert_eq!(
+            switch_firmware_request_time(&switch, Some(&rack)),
+            Some(rack_requested_at),
+            "the accepted rack request gates status before device dispatch"
+        );
+
+        switch.switch_reprovisioning_requested = Some(model::switch::SwitchReprovisionRequest {
+            requested_at: switch_requested_at,
+            initiator: "test".into(),
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: None,
+                components: vec![],
+                force_update: false,
+            }],
+        });
+
+        assert_eq!(
+            switch_firmware_request_time(&switch, Some(&rack)),
+            Some(switch_requested_at),
+            "the dispatched device request is the more precise cycle boundary"
+        );
+
+        rack.config.maintenance_requested = Some(model::rack::MaintenanceScope {
+            power_shelf_ids: vec![test_power_shelf_id()],
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: None,
+                components: vec![],
+                force_update: false,
+            }],
+            ..Default::default()
+        });
+        switch.switch_reprovisioning_requested = None;
+        assert_eq!(switch_firmware_request_time(&switch, Some(&rack)), None);
     }
 
     #[test]

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -248,6 +248,44 @@ fn firmware_job_state(job: &FirmwareUpgradeJob) -> i32 {
     }
 }
 
+/// Summarizes a failed rack firmware upgrade into a single operator-facing message.
+///
+/// A rack upgrade fans out to every device in the rack, so the one rack-level
+/// `ComponentResult` can only carry a summary of the per-device outcomes the rack
+/// controller recorded. A rejected firmware bundle fails every device with an
+/// identical reason, which is worth reporting verbatim; divergent reasons collapse to
+/// a count so a large rack cannot produce an unbounded message.
+fn rack_firmware_failure_summary(job: &FirmwareUpgradeJob) -> String {
+    let total = job.all_devices().count();
+    if total == 0 {
+        return "firmware upgrade failed before any device update was submitted".to_owned();
+    }
+
+    let failed: Vec<_> = job
+        .all_devices()
+        .filter(|device| device.status == "failed")
+        .collect();
+    let summary = format!(
+        "firmware upgrade failed: {}/{total} devices failed",
+        failed.len()
+    );
+
+    let mut reasons: Vec<&str> = failed
+        .iter()
+        .filter_map(|device| device.error_message.as_deref())
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+        .collect();
+    reasons.sort_unstable();
+    reasons.dedup();
+
+    match reasons.as_slice() {
+        [] => summary,
+        [reason] => format!("{summary}: {reason}"),
+        reasons => format!("{summary}: {} distinct errors", reasons.len()),
+    }
+}
+
 fn rack_firmware_status(rack: &model::rack::Rack) -> rpc::FirmwareUpdateStatus {
     let requested_version = rack_requested_firmware_version(rack);
     let firmware_upgrade_requested = rack_firmware_upgrade_requested(rack);
@@ -267,8 +305,21 @@ fn rack_firmware_status(rack: &model::rack::Rack) -> rpc::FirmwareUpdateStatus {
         .or_else(|| firmware_upgrade_requested.then_some(rack.updated))
         .map(Into::into);
 
+    // A failed upgrade must carry why it failed: the rack controller already
+    // persisted each device's reason from RMS, and this is the only place an
+    // operator can see it.
+    let result = if state == rpc::FirmwareUpdateState::FwStateFailed as i32 {
+        let summary = job.map_or_else(
+            || "firmware upgrade failed".to_owned(),
+            rack_firmware_failure_summary,
+        );
+        error_result(rack.id.as_ref(), summary)
+    } else {
+        success_result(rack.id.as_ref())
+    };
+
     rpc::FirmwareUpdateStatus {
-        result: Some(success_result(rack.id.as_ref())),
+        result: Some(result),
         state,
         target_version,
         updated_at,
@@ -5060,6 +5111,128 @@ mod tests {
         assert_eq!(status.state, rpc::FirmwareUpdateState::FwStateQueued as i32);
         assert!(status.target_version.is_empty());
         assert!(status.updated_at.is_some());
+    }
+
+    /// Builds a failed device carrying the reason RMS reported for it.
+    fn failed_firmware_device(error_message: &str) -> model::rack::FirmwareUpgradeDeviceStatus {
+        model::rack::FirmwareUpgradeDeviceStatus {
+            error_message: Some(error_message.to_string()),
+            ..firmware_device("failed")
+        }
+    }
+
+    #[test]
+    fn rack_firmware_failure_summary_reports_counts_and_reasons() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |job| rack_firmware_failure_summary(&job);
+            "a shared reason is reported verbatim so the SOT rejection is visible" {
+                FirmwareUpgradeJob {
+                    machines: vec![
+                        failed_firmware_device("config_json.ProductName is required"),
+                        failed_firmware_device("config_json.ProductName is required"),
+                    ],
+                    ..Default::default()
+                } => "firmware upgrade failed: 2/2 devices failed: \
+                      config_json.ProductName is required".to_string(),
+            }
+
+            "divergent reasons collapse to a count" {
+                FirmwareUpgradeJob {
+                    machines: vec![failed_firmware_device("download failed")],
+                    switches: vec![failed_firmware_device("target not found")],
+                    ..Default::default()
+                } => "firmware upgrade failed: 2/2 devices failed: 2 distinct errors".to_string(),
+            }
+
+            "a partial failure reports the failed subset" {
+                FirmwareUpgradeJob {
+                    machines: vec![
+                        failed_firmware_device("task failed"),
+                        firmware_device("completed"),
+                    ],
+                    ..Default::default()
+                } => "firmware upgrade failed: 1/2 devices failed: task failed".to_string(),
+            }
+
+            "devices without a recorded reason still report the count" {
+                FirmwareUpgradeJob {
+                    machines: vec![firmware_device("failed")],
+                    ..Default::default()
+                } => "firmware upgrade failed: 1/1 devices failed".to_string(),
+            }
+
+            "blank reasons are treated as absent" {
+                FirmwareUpgradeJob {
+                    machines: vec![failed_firmware_device("   ")],
+                    ..Default::default()
+                } => "firmware upgrade failed: 1/1 devices failed".to_string(),
+            }
+
+            "a job that never reached its devices says so" {
+                FirmwareUpgradeJob::default() =>
+                    "firmware upgrade failed before any device update was submitted".to_string(),
+            }
+        );
+    }
+
+    /// The reported regression: every device failed with the RMS SOT parse error, but
+    /// the rack-level result claimed success and carried no error at all.
+    #[test]
+    fn rack_firmware_status_failed_job_reports_the_device_error() {
+        let job = FirmwareUpgradeJob {
+            firmware_id: Some(String::new()),
+            status: Some("failed".to_string()),
+            started_at: Some(chrono::Utc::now()),
+            completed_at: Some(chrono::Utc::now()),
+            machines: vec![failed_firmware_device(
+                "config_json.ProductName is required",
+            )],
+            ..Default::default()
+        };
+        let rack = test_rack_with_job(Some(job));
+
+        let status = rack_firmware_status(&rack);
+        let result = status
+            .result
+            .expect("a rack status always carries a result");
+
+        assert_eq!(status.state, rpc::FirmwareUpdateState::FwStateFailed as i32);
+        assert_eq!(
+            result.status,
+            rpc::ComponentManagerStatusCode::InternalError as i32
+        );
+        assert_eq!(
+            result.error,
+            "firmware upgrade failed: 1/1 devices failed: config_json.ProductName is required"
+        );
+    }
+
+    #[test]
+    fn rack_firmware_status_unfinished_job_stays_successful() {
+        let job = FirmwareUpgradeJob {
+            status: Some("in_progress".to_string()),
+            started_at: Some(chrono::Utc::now()),
+            machines: vec![firmware_device("in_progress")],
+            ..Default::default()
+        };
+        let rack = test_rack_with_job(Some(job));
+
+        let status = rack_firmware_status(&rack);
+        let result = status
+            .result
+            .expect("a rack status always carries a result");
+
+        assert_eq!(
+            status.state,
+            rpc::FirmwareUpdateState::FwStateInProgress as i32
+        );
+        assert_eq!(
+            result.status,
+            rpc::ComponentManagerStatusCode::Success as i32
+        );
+        assert!(result.error.is_empty());
     }
 
     #[test]

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -450,14 +450,14 @@ async fn switch_firmware_statuses(
     api: &Api,
     switch_ids: &[SwitchId],
 ) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
-    let mut txn = api
+    let mut conn = api
         .database_connection
-        .begin()
+        .acquire()
         .await
-        .map_err(|e| Status::internal(format!("failed to begin transaction: {e}")))?;
+        .map_err(|e| Status::internal(format!("failed to acquire database connection: {e}")))?;
 
     let switches = db::switch::find_by(
-        &mut txn,
+        &mut conn,
         db::ObjectColumnFilter::List(db::switch::IdColumn, switch_ids),
     )
     .await
@@ -468,7 +468,7 @@ async fn switch_firmware_statuses(
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
-    drop(txn);
+    drop(conn);
 
     let racks = if rack_ids.is_empty() {
         vec![]

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -5675,37 +5675,38 @@ mod tests {
             ended_at: Some(requested_at + chrono::Duration::seconds(2)),
         };
 
-        let stale = select_persisted_switch_firmware_status(
-            switch_id,
-            Some(&stale_status),
-            Some(requested_at),
-        )
-        .expect("a pending request reports queued");
-        let missing = select_persisted_switch_firmware_status(switch_id, None, Some(requested_at))
-            .expect("a pending request without status reports queued");
-        let current = select_persisted_switch_firmware_status(
-            switch_id,
-            Some(&current_status),
-            Some(requested_at),
-        )
-        .expect("a current persisted status is reported");
-        let historical =
-            select_persisted_switch_firmware_status(switch_id, Some(&stale_status), None)
-                .expect("the last persisted result is reported without an active request");
+        let cases = [
+            (
+                Some(&stale_status),
+                Some(requested_at),
+                rpc::FirmwareUpdateState::FwStateQueued,
+            ),
+            (
+                None,
+                Some(requested_at),
+                rpc::FirmwareUpdateState::FwStateQueued,
+            ),
+            (
+                Some(&current_status),
+                Some(requested_at),
+                rpc::FirmwareUpdateState::FwStateCompleted,
+            ),
+            (
+                Some(&stale_status),
+                None,
+                rpc::FirmwareUpdateState::FwStateFailed,
+            ),
+        ];
 
-        assert_eq!(stale.state, rpc::FirmwareUpdateState::FwStateQueued as i32);
-        assert_eq!(
-            missing.state,
-            rpc::FirmwareUpdateState::FwStateQueued as i32
-        );
-        assert_eq!(
-            current.state,
-            rpc::FirmwareUpdateState::FwStateCompleted as i32
-        );
-        assert_eq!(
-            historical.state,
-            rpc::FirmwareUpdateState::FwStateFailed as i32
-        );
+        for (persisted, requested_at, expected) in cases {
+            let actual = select_persisted_switch_firmware_status(switch_id, persisted, requested_at)
+                .expect("a request or a persisted status yields a status");
+            assert_eq!(
+                actual.state, expected as i32,
+                "persisted: {persisted:?}, requested_at: {requested_at:?}"
+            );
+        }
+
         assert!(
             select_persisted_switch_firmware_status(switch_id, None, None).is_none(),
             "the backend is required when neither request nor persisted status exists"

--- a/crates/api-core/src/handlers/rack.rs
+++ b/crates/api-core/src/handlers/rack.rs
@@ -833,6 +833,7 @@ pub(crate) async fn on_demand_rack_maintenance(
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| CarbideError::InvalidArgument(format!("invalid power_shelf_id: {e}")))?,
         activities,
+        requested_at: None,
     };
 
     if !scope.is_full_rack() {

--- a/crates/api-core/src/tests/component_manager.rs
+++ b/crates/api-core/src/tests/component_manager.rs
@@ -16,15 +16,23 @@
  */
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
+use carbide_uuid::rack::{RackId, RackProfileId};
 use carbide_uuid::switch::SwitchId;
-use model::rack::{MaintenanceActivity, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus};
+use component_manager::mock::MockNvSwitchManager;
+use model::rack::{
+    FirmwareProgressState, FirmwareUpgradeDeviceStatus, FirmwareUpgradeJob, MaintenanceActivity,
+    RackConfig, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus,
+};
 use model::switch::{NewSwitch, SwitchConfig};
 use rpc::forge as rpc;
 use tonic::Request;
 
 use crate::test_support::builder::TestApiBuilder;
-use crate::tests::common::api_fixtures::create_test_env;
+use crate::tests::common::api_fixtures::site_explorer::create_expected_switch;
+use crate::tests::common::api_fixtures::{TestEnv, create_test_env};
 
 #[crate::sqlx_test]
 async fn switch_firmware_status_uses_only_current_cycle_persistence(
@@ -179,6 +187,253 @@ async fn switch_firmware_status_uses_only_current_cycle_persistence(
             "the active request supplies the target version the backend never persists"
         );
     }
+
+    Ok(())
+}
+
+async fn create_terminal_rack_switch_firmware_failure(
+    pool: sqlx::PgPool,
+) -> Result<(TestEnv, RackId, SwitchId), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+    let started_at = chrono::Utc::now() - chrono::Duration::minutes(2);
+    let completed_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+    let mut txn = pool.begin().await?;
+
+    db::rack::create(
+        txn.as_mut(),
+        &rack_id,
+        Some(&RackProfileId::new("NVL72")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+
+    let expected_switch = create_expected_switch(txn.as_mut(), 20).await;
+
+    let switch_id = model::switch::switch_id::from_hardware_info(
+        &expected_switch.serial_number,
+        "NVIDIA",
+        "Switch",
+        carbide_uuid::switch::SwitchIdSource::ProductBoardChassisSerial,
+        carbide_uuid::switch::SwitchType::NvLink,
+    )?;
+
+    db::switch::create(
+        txn.as_mut(),
+        &NewSwitch {
+            id: switch_id,
+            config: SwitchConfig {
+                name: expected_switch.metadata.name.clone(),
+                enable_nmxc: false,
+                fabric_manager_config: None,
+            },
+            bmc_mac_address: Some(expected_switch.bmc_mac_address),
+            metadata: None,
+            rack_id: Some(rack_id.clone()),
+            slot_number: Some(0),
+            tray_index: Some(0),
+        },
+    )
+    .await?;
+
+    db::rack::update_firmware_upgrade_job(
+        txn.as_mut(),
+        &rack_id,
+        Some(&FirmwareUpgradeJob {
+            job_id: Some("rack-job".into()),
+            firmware_id: Some("fw-42".into()),
+            status: Some(FirmwareProgressState::Failed),
+            started_at: Some(started_at),
+            completed_at: Some(completed_at),
+            switches: vec![FirmwareUpgradeDeviceStatus {
+                node_id: "switch-node".into(),
+                mac: expected_switch.bmc_mac_address.to_string(),
+                bmc_ip: String::new(),
+                status: FirmwareProgressState::Failed,
+                job_id: Some("switch-job".into()),
+                parent_job_id: Some("rack-job".into()),
+                error_message: Some("rack firmware failed".into()),
+            }],
+            ..Default::default()
+        }),
+    )
+    .await?;
+
+    db::switch::update_firmware_upgrade_status(
+        txn.as_mut(),
+        switch_id,
+        Some(&RackFirmwareUpgradeStatus {
+            task_id: "switch-job".into(),
+            status: RackFirmwareUpgradeState::Failed {
+                cause: "rack firmware failed".into(),
+            },
+            started_at: Some(started_at),
+            ended_at: Some(completed_at),
+        }),
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    env.api
+        .credential_manager
+        .set_credentials(
+            &CredentialKey::BmcCredentials {
+                credential_type: BmcCredentialType::BmcRoot {
+                    bmc_mac_address: expected_switch.bmc_mac_address,
+                },
+            },
+            &Credentials::UsernamePassword {
+                username: "root".into(),
+                password: "notforprod".into(),
+            },
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    env.api
+        .credential_manager
+        .set_credentials(
+            &CredentialKey::SwitchNvosAdmin {
+                bmc_mac_address: expected_switch.bmc_mac_address,
+            },
+            &Credentials::UsernamePassword {
+                username: "nvos-admin".into(),
+                password: "nvos-pass".into(),
+            },
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok((env, rack_id, switch_id))
+}
+
+async fn get_switch_firmware_status(
+    api: &crate::api::Api,
+    switch_id: SwitchId,
+) -> Result<rpc::FirmwareUpdateStatus, Box<dyn std::error::Error>> {
+    let status = crate::handlers::component_manager::get_component_firmware_status(
+        api,
+        Request::new(rpc::GetComponentFirmwareStatusRequest {
+            target: Some(
+                rpc::get_component_firmware_status_request::Target::SwitchIds(rpc::SwitchIdList {
+                    ids: vec![switch_id],
+                }),
+            ),
+        }),
+    )
+    .await?
+    .into_inner()
+    .statuses
+    .into_iter()
+    .next()
+    .ok_or_else(|| eyre::eyre!("the switch status response must not be empty"))?;
+
+    Ok(status)
+}
+
+#[crate::sqlx_test]
+async fn terminal_rack_switch_status_survives_request_cleanup(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, _, switch_id) = create_terminal_rack_switch_firmware_failure(pool).await?;
+    let retained = get_switch_firmware_status(&env.api, switch_id).await?;
+
+    assert_eq!(
+        retained.state,
+        rpc::FirmwareUpdateState::FwStateFailed as i32
+    );
+
+    assert_eq!(retained.target_version, "fw-42");
+
+    let retained_result = retained
+        .result
+        .as_ref()
+        .ok_or_else(|| eyre::eyre!("the retained status must include a component result"))?;
+
+    assert_eq!(
+        retained_result.status,
+        rpc::ComponentManagerStatusCode::InternalError as i32
+    );
+
+    assert_eq!(retained_result.error, "rack firmware failed");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn tracked_backend_switch_job_supersedes_terminal_rack_status(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, _, switch_id) = create_terminal_rack_switch_firmware_failure(pool.clone()).await?;
+
+    let mut component_manager = env
+        .test_component_manager
+        .as_deref()
+        .ok_or_else(|| eyre::eyre!("the test environment must include a component manager"))?
+        .clone();
+
+    component_manager.nv_switch = Arc::new(MockNvSwitchManager::default());
+
+    let direct_api = TestApiBuilder::new(
+        pool,
+        env.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+    )
+    .with_credential_manager(env.api.credential_manager.clone())
+    .with_component_manager(Arc::new(component_manager))
+    .build();
+
+    let superseding = get_switch_firmware_status(&direct_api, switch_id).await?;
+
+    assert_eq!(
+        superseding.state,
+        rpc::FirmwareUpdateState::FwStateCompleted as i32
+    );
+
+    assert_eq!(superseding.target_version, "mock-1.0.0");
+
+    assert_eq!(
+        superseding
+            .result
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("the backend status must include a component result"))?
+            .status,
+        rpc::ComponentManagerStatusCode::Success as i32
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn untracked_backend_switch_job_remains_an_unknown_api_status(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, rack_id, switch_id) =
+        create_terminal_rack_switch_firmware_failure(pool.clone()).await?;
+    let mut txn = pool.begin().await?;
+
+    db::rack::update_firmware_upgrade_job(txn.as_mut(), &rack_id, None).await?;
+    db::switch::update_firmware_upgrade_status(txn.as_mut(), switch_id, None).await?;
+    txn.commit().await?;
+
+    let untracked = get_switch_firmware_status(&env.api, switch_id).await?;
+
+    assert_eq!(
+        untracked.state,
+        rpc::FirmwareUpdateState::FwStateUnknown as i32
+    );
+    let result = untracked
+        .result
+        .as_ref()
+        .ok_or_else(|| eyre::eyre!("the untracked status must include a component result"))?;
+
+    assert_eq!(
+        result.status,
+        rpc::ComponentManagerStatusCode::InternalError as i32
+    );
+    assert_eq!(result.error, "no firmware job tracked for this switch");
 
     Ok(())
 }

--- a/crates/api-core/src/tests/component_manager.rs
+++ b/crates/api-core/src/tests/component_manager.rs
@@ -1,0 +1,176 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+
+use carbide_uuid::switch::SwitchId;
+use model::rack::{MaintenanceActivity, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus};
+use model::switch::{NewSwitch, SwitchConfig};
+use rpc::forge as rpc;
+use tonic::Request;
+
+use crate::test_support::builder::TestApiBuilder;
+use crate::tests::common::api_fixtures::create_test_env;
+
+#[crate::sqlx_test]
+async fn switch_firmware_status_uses_only_current_cycle_persistence(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let switch_ids = (0..3)
+        .map(|_| SwitchId::from(uuid::Uuid::new_v4()))
+        .collect::<Vec<_>>();
+    let firmware_activity = MaintenanceActivity::FirmwareUpgrade {
+        firmware_version: Some("firmware-object-json".into()),
+        components: vec![],
+        force_update: false,
+    };
+
+    let mut txn = pool.begin().await?;
+    for (index, switch_id) in switch_ids.iter().enumerate() {
+        db::switch::create(
+            txn.as_mut(),
+            &NewSwitch {
+                id: *switch_id,
+                config: SwitchConfig {
+                    name: format!("firmware-status-switch-{index}"),
+                    enable_nmxc: false,
+                    fabric_manager_config: None,
+                },
+                bmc_mac_address: None,
+                metadata: None,
+                rack_id: None,
+                slot_number: None,
+                tray_index: None,
+            },
+        )
+        .await?;
+        db::switch::set_switch_reprovisioning_requested(
+            txn.as_mut(),
+            *switch_id,
+            "rack-test",
+            vec![firmware_activity.clone()],
+        )
+        .await?;
+    }
+
+    let switches = db::switch::find_by(
+        txn.as_mut(),
+        db::ObjectColumnFilter::List(db::switch::IdColumn, &switch_ids),
+    )
+    .await?;
+    let requested_at_by_id = switches
+        .into_iter()
+        .map(|switch| {
+            let requested_at = switch
+                .switch_reprovisioning_requested
+                .expect("test request must be persisted")
+                .requested_at;
+            (switch.id, requested_at)
+        })
+        .collect::<HashMap<_, _>>();
+
+    let stale_requested_at = requested_at_by_id[&switch_ids[0]];
+    db::switch::update_firmware_upgrade_status(
+        txn.as_mut(),
+        switch_ids[0],
+        Some(&RackFirmwareUpgradeStatus {
+            task_id: "stale-task".into(),
+            status: RackFirmwareUpgradeState::Completed,
+            started_at: Some(stale_requested_at - chrono::Duration::minutes(2)),
+            ended_at: Some(stale_requested_at - chrono::Duration::minutes(1)),
+        }),
+    )
+    .await?;
+
+    let current_requested_at = requested_at_by_id[&switch_ids[1]];
+    db::switch::update_firmware_upgrade_status(
+        txn.as_mut(),
+        switch_ids[1],
+        Some(&RackFirmwareUpgradeStatus {
+            task_id: "current-task".into(),
+            status: RackFirmwareUpgradeState::Failed {
+                cause: "current RMS failure".into(),
+            },
+            started_at: Some(current_requested_at),
+            ended_at: Some(current_requested_at),
+        }),
+    )
+    .await?;
+    txn.commit().await?;
+
+    // Deliberately omit Component Manager: every switch has an active persisted
+    // request, so status selection must be fully answerable from the database.
+    let api = TestApiBuilder::new(
+        pool,
+        env.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+    )
+    .build();
+    let response = crate::handlers::component_manager::get_component_firmware_status(
+        &api,
+        Request::new(rpc::GetComponentFirmwareStatusRequest {
+            target: Some(
+                rpc::get_component_firmware_status_request::Target::SwitchIds(rpc::SwitchIdList {
+                    ids: switch_ids.clone(),
+                }),
+            ),
+        }),
+    )
+    .await?
+    .into_inner();
+    let status_by_id = response
+        .statuses
+        .into_iter()
+        .map(|status| {
+            let component_id = status
+                .result
+                .as_ref()
+                .expect("every firmware status must carry a result")
+                .component_id
+                .clone()
+                .expect("a switch-id target always reports the component id");
+            (component_id, status)
+        })
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(
+        status_by_id[&switch_ids[0].to_string()].state,
+        rpc::FirmwareUpdateState::FwStateQueued as i32,
+        "a stale terminal result must not complete the new request"
+    );
+    let current = &status_by_id[&switch_ids[1].to_string()];
+    assert_eq!(
+        current.state,
+        rpc::FirmwareUpdateState::FwStateFailed as i32
+    );
+    assert_eq!(
+        current
+            .result
+            .as_ref()
+            .expect("current status must carry a result")
+            .error,
+        "current RMS failure"
+    );
+    assert_eq!(
+        status_by_id[&switch_ids[2].to_string()].state,
+        rpc::FirmwareUpdateState::FwStateQueued as i32,
+        "an accepted request without a persisted device result is still queued"
+    );
+
+    Ok(())
+}

--- a/crates/api-core/src/tests/component_manager.rs
+++ b/crates/api-core/src/tests/component_manager.rs
@@ -174,7 +174,8 @@ async fn switch_firmware_status_uses_only_current_cycle_persistence(
 
     for switch_id in &switch_ids {
         assert_eq!(
-            status_by_id[&switch_id.to_string()].target_version, "firmware-object-json",
+            status_by_id[&switch_id.to_string()].target_version,
+            "firmware-object-json",
             "the active request supplies the target version the backend never persists"
         );
     }

--- a/crates/api-core/src/tests/component_manager.rs
+++ b/crates/api-core/src/tests/component_manager.rs
@@ -104,7 +104,7 @@ async fn switch_firmware_status_uses_only_current_cycle_persistence(
         Some(&RackFirmwareUpgradeStatus {
             task_id: "current-task".into(),
             status: RackFirmwareUpgradeState::Failed {
-                cause: "current RMS failure".into(),
+                cause: "current backend failure".into(),
             },
             started_at: Some(current_requested_at),
             ended_at: Some(current_requested_at),
@@ -164,13 +164,20 @@ async fn switch_firmware_status_uses_only_current_cycle_persistence(
             .as_ref()
             .expect("current status must carry a result")
             .error,
-        "current RMS failure"
+        "current backend failure"
     );
     assert_eq!(
         status_by_id[&switch_ids[2].to_string()].state,
         rpc::FirmwareUpdateState::FwStateQueued as i32,
         "an accepted request without a persisted device result is still queued"
     );
+
+    for switch_id in &switch_ids {
+        assert_eq!(
+            status_by_id[&switch_id.to_string()].target_version, "firmware-object-json",
+            "the active request supplies the target version the backend never persists"
+        );
+    }
 
     Ok(())
 }

--- a/crates/api-core/src/tests/component_manager.rs
+++ b/crates/api-core/src/tests/component_manager.rs
@@ -22,6 +22,7 @@ use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials
 use carbide_uuid::rack::{RackId, RackProfileId};
 use carbide_uuid::switch::SwitchId;
 use component_manager::mock::MockNvSwitchManager;
+use mac_address::MacAddress;
 use model::rack::{
     FirmwareProgressState, FirmwareUpgradeDeviceStatus, FirmwareUpgradeJob, MaintenanceActivity,
     RackConfig, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus,
@@ -193,7 +194,7 @@ async fn switch_firmware_status_uses_only_current_cycle_persistence(
 
 async fn create_terminal_rack_switch_firmware_failure(
     pool: sqlx::PgPool,
-) -> Result<(TestEnv, RackId, SwitchId), Box<dyn std::error::Error>> {
+) -> Result<(TestEnv, RackId, SwitchId, MacAddress), Box<dyn std::error::Error>> {
     let env = create_test_env(pool.clone()).await;
     let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let started_at = chrono::Utc::now() - chrono::Duration::minutes(2);
@@ -306,7 +307,7 @@ async fn create_terminal_rack_switch_firmware_failure(
         .await
         .map_err(|e| e.to_string())?;
 
-    Ok((env, rack_id, switch_id))
+    Ok((env, rack_id, switch_id, expected_switch.bmc_mac_address))
 }
 
 async fn get_switch_firmware_status(
@@ -333,11 +334,37 @@ async fn get_switch_firmware_status(
     Ok(status)
 }
 
+async fn get_switch_firmware_status_by_bmc_mac(
+    api: &crate::api::Api,
+    bmc_mac: MacAddress,
+) -> Result<rpc::FirmwareUpdateStatus, Box<dyn std::error::Error>> {
+    let status = crate::handlers::component_manager::get_component_firmware_status(
+        api,
+        Request::new(rpc::GetComponentFirmwareStatusRequest {
+            target: Some(
+                rpc::get_component_firmware_status_request::Target::SwitchBmcMacs(
+                    rpc::MacAddressList {
+                        mac_addresses: vec![bmc_mac.to_string()],
+                    },
+                ),
+            ),
+        }),
+    )
+    .await?
+    .into_inner()
+    .statuses
+    .into_iter()
+    .next()
+    .ok_or_else(|| eyre::eyre!("the switch status response must not be empty"))?;
+
+    Ok(status)
+}
+
 #[crate::sqlx_test]
 async fn terminal_rack_switch_status_survives_request_cleanup(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (env, _, switch_id) = create_terminal_rack_switch_firmware_failure(pool).await?;
+    let (env, _, switch_id, _) = create_terminal_rack_switch_firmware_failure(pool).await?;
     let retained = get_switch_firmware_status(&env.api, switch_id).await?;
 
     assert_eq!(
@@ -363,10 +390,47 @@ async fn terminal_rack_switch_status_survives_request_cleanup(
 }
 
 #[crate::sqlx_test]
+async fn terminal_rack_switch_status_survives_endpoint_resolution_failure(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, _, switch_id, _) = create_terminal_rack_switch_firmware_failure(pool.clone()).await?;
+
+    let component_manager = env
+        .test_component_manager
+        .clone()
+        .ok_or_else(|| eyre::eyre!("the test environment must include a component manager"))?;
+
+    let api_without_credentials = TestApiBuilder::new(
+        pool,
+        env.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+    )
+    .with_component_manager(component_manager)
+    .build();
+
+    let retained = get_switch_firmware_status(&api_without_credentials, switch_id).await?;
+
+    let result = retained
+        .result
+        .as_ref()
+        .ok_or_else(|| eyre::eyre!("the retained status must include a component result"))?;
+
+    assert_eq!(
+        retained.state,
+        rpc::FirmwareUpdateState::FwStateFailed as i32
+    );
+
+    assert_eq!(retained.target_version, "fw-42");
+    assert_eq!(result.error, "rack firmware failed");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn tracked_backend_switch_job_supersedes_terminal_rack_status(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (env, _, switch_id) = create_terminal_rack_switch_firmware_failure(pool.clone()).await?;
+    let (env, _, switch_id, _) = create_terminal_rack_switch_firmware_failure(pool.clone()).await?;
 
     let mut component_manager = env
         .test_component_manager
@@ -407,10 +471,10 @@ async fn tracked_backend_switch_job_supersedes_terminal_rack_status(
 }
 
 #[crate::sqlx_test]
-async fn untracked_backend_switch_job_remains_an_unknown_api_status(
+async fn untracked_backend_switch_job_is_unknown_for_every_switch_target(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (env, rack_id, switch_id) =
+    let (env, rack_id, switch_id, bmc_mac) =
         create_terminal_rack_switch_firmware_failure(pool.clone()).await?;
     let mut txn = pool.begin().await?;
 
@@ -418,22 +482,42 @@ async fn untracked_backend_switch_job_remains_an_unknown_api_status(
     db::switch::update_firmware_upgrade_status(txn.as_mut(), switch_id, None).await?;
     txn.commit().await?;
 
-    let untracked = get_switch_firmware_status(&env.api, switch_id).await?;
+    let by_switch_id = get_switch_firmware_status(&env.api, switch_id).await?;
+    let by_ingested_bmc_mac = get_switch_firmware_status_by_bmc_mac(&env.api, bmc_mac).await?;
 
-    assert_eq!(
-        untracked.state,
-        rpc::FirmwareUpdateState::FwStateUnknown as i32
-    );
-    let result = untracked
-        .result
-        .as_ref()
-        .ok_or_else(|| eyre::eyre!("the untracked status must include a component result"))?;
+    let mut txn = pool.begin().await?;
+    db::switch::final_delete(switch_id, txn.as_mut()).await?;
+    txn.commit().await?;
 
-    assert_eq!(
-        result.status,
-        rpc::ComponentManagerStatusCode::InternalError as i32
-    );
-    assert_eq!(result.error, "no firmware job tracked for this switch");
+    let by_pre_ingestion_bmc_mac = get_switch_firmware_status_by_bmc_mac(&env.api, bmc_mac).await?;
+
+    for (target, status) in [
+        ("switch ID", by_switch_id),
+        ("ingested BMC MAC", by_ingested_bmc_mac),
+        ("pre-ingestion BMC MAC", by_pre_ingestion_bmc_mac),
+    ] {
+        assert_eq!(
+            status.state,
+            rpc::FirmwareUpdateState::FwStateUnknown as i32,
+            "{target}"
+        );
+
+        let result = status
+            .result
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("the {target} status must include a component result"))?;
+
+        assert_eq!(
+            result.status,
+            rpc::ComponentManagerStatusCode::InternalError as i32,
+            "{target}"
+        );
+
+        assert_eq!(
+            result.error, "no firmware job tracked for this switch",
+            "{target}"
+        );
+    }
 
     Ok(())
 }

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -18,6 +18,9 @@
 mod boot_interface_resolution;
 mod client_resolution;
 pub(in crate::tests) mod common;
+mod component_manager;
+mod credential;
+mod dns;
 mod dpf;
 mod dpu_machine_update;
 mod dpu_nic_firmware;

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -19,8 +19,6 @@ mod boot_interface_resolution;
 mod client_resolution;
 pub(in crate::tests) mod common;
 mod component_manager;
-mod credential;
-mod dns;
 mod dpf;
 mod dpu_machine_update;
 mod dpu_nic_firmware;

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -37,11 +37,11 @@ use librms::protos::{rack_manager as rms, rack_manager_v2 as rms_v2};
 use model::expected_machine::ExpectedMachineData;
 use model::expected_rack::ExpectedRack;
 use model::rack::{
-    ConfigureNmxClusterState, FirmwareUpgradeDeviceStatus, FirmwareUpgradeJob,
-    FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, NvosUpdateJob, NvosUpdateState,
-    NvosUpdateSwitchStatus, Rack, RackConfig, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus,
-    RackMaintenanceState, RackPowerState, RackState, RackValidationState, SwitchNvosUpdateState,
-    SwitchNvosUpdateStatus,
+    ConfigureNmxClusterState, FirmwareProgressState, FirmwareUpgradeDeviceStatus,
+    FirmwareUpgradeJob, FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, NvosUpdateJob,
+    NvosUpdateState, NvosUpdateSwitchStatus, Rack, RackConfig, RackFirmwareUpgradeState,
+    RackFirmwareUpgradeStatus, RackMaintenanceState, RackPowerState, RackState,
+    RackValidationState, SwitchNvosUpdateState, SwitchNvosUpdateStatus,
 };
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
@@ -2039,7 +2039,7 @@ async fn test_firmware_upgrade_wait_for_complete_recovers_power_blocked_machine(
     };
     let job = FirmwareUpgradeJob {
         job_id: Some("parent-job".to_string()),
-        status: Some("in_progress".to_string()),
+        status: Some(FirmwareProgressState::InProgress),
         started_at: Some(chrono::Utc::now()),
         ..Default::default()
     };
@@ -2130,7 +2130,7 @@ async fn test_firmware_upgrade_wait_for_complete_recovers_power_blocked_machine(
     let job = rack
         .firmware_upgrade_job
         .expect("failed firmware job should be retained");
-    assert_eq!(job.status.as_deref(), Some("failed"));
+    assert_eq!(job.status, Some(FirmwareProgressState::Failed));
     assert!(job.completed_at.is_some());
 
     let blocked_machine = db::machine::find_one(
@@ -2214,7 +2214,7 @@ async fn test_rack_maintenance_termination_unwinds_all_scoped_device_state(
         txn.as_mut(),
         &rack_id,
         Some(&FirmwareUpgradeJob {
-            status: Some("in_progress".to_string()),
+            status: Some(FirmwareProgressState::InProgress),
             started_at: Some(now),
             ..Default::default()
         }),
@@ -2320,8 +2320,8 @@ async fn test_rack_maintenance_termination_unwinds_all_scoped_device_state(
     assert!(rack.config.maintenance_requested.is_none());
     assert!(!rack.config.maintenance_termination_requested);
     assert_eq!(
-        rack.firmware_upgrade_job.unwrap().status.as_deref(),
-        Some("failed")
+        rack.firmware_upgrade_job.unwrap().status,
+        Some(FirmwareProgressState::Failed)
     );
     assert_eq!(
         rack.nvos_update_job.unwrap().status.as_deref(),
@@ -2513,14 +2513,14 @@ async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     rack.firmware_upgrade_job = Some(FirmwareUpgradeJob {
         job_id: Some("batch-job-1".to_string()),
-        status: Some("in_progress".to_string()),
+        status: Some(FirmwareProgressState::InProgress),
         started_at: Some(chrono::Utc::now()),
         batch_job_ids: vec!["batch-job-1".to_string()],
         machines: vec![FirmwareUpgradeDeviceStatus {
             node_id: host.host_snapshot.id.to_string(),
             mac: "00:11:22:33:44:55".to_string(),
             bmc_ip: "192.0.2.10".to_string(),
-            status: "in_progress".to_string(),
+            status: FirmwareProgressState::InProgress,
             job_id: Some("child-job-1".to_string()),
             parent_job_id: Some("batch-job-1".to_string()),
             error_message: None,
@@ -2617,14 +2617,14 @@ async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_fai
     };
     let job = FirmwareUpgradeJob {
         job_id: Some("batch-job-1".to_string()),
-        status: Some("in_progress".to_string()),
+        status: Some(FirmwareProgressState::InProgress),
         started_at: Some(chrono::Utc::now()),
         batch_job_ids: vec!["batch-job-1".to_string()],
         machines: vec![FirmwareUpgradeDeviceStatus {
             node_id: host.host_snapshot.id.to_string(),
             mac: "00:11:22:33:44:55".to_string(),
             bmc_ip: "192.0.2.10".to_string(),
-            status: "in_progress".to_string(),
+            status: FirmwareProgressState::InProgress,
             job_id: Some("child-job-1".to_string()),
             parent_job_id: Some("batch-job-1".to_string()),
             error_message: None,
@@ -2692,8 +2692,8 @@ async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_fai
     let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(rack.config.maintenance_requested.is_none());
     assert_eq!(
-        rack.firmware_upgrade_job.unwrap().status.as_deref(),
-        Some("failed")
+        rack.firmware_upgrade_job.unwrap().status,
+        Some(FirmwareProgressState::Failed)
     );
 
     let machine = db::machine::find_one(
@@ -2770,7 +2770,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     rack.firmware_upgrade_job = Some(FirmwareUpgradeJob {
         job_id: Some("batch-job-1".to_string()),
-        status: Some("in_progress".to_string()),
+        status: Some(FirmwareProgressState::InProgress),
         started_at: Some(chrono::Utc::now()),
         batch_job_ids: vec!["batch-job-1".to_string()],
         machines: vec![
@@ -2778,7 +2778,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
                 node_id: host_a.host_snapshot.id.to_string(),
                 mac: "00:11:22:33:44:55".to_string(),
                 bmc_ip: "192.0.2.10".to_string(),
-                status: "in_progress".to_string(),
+                status: FirmwareProgressState::InProgress,
                 job_id: Some("child-job-1".to_string()),
                 parent_job_id: Some("batch-job-1".to_string()),
                 error_message: None,
@@ -2787,7 +2787,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
                 node_id: host_b.host_snapshot.id.to_string(),
                 mac: "00:11:22:33:44:66".to_string(),
                 bmc_ip: "192.0.2.11".to_string(),
-                status: "in_progress".to_string(),
+                status: FirmwareProgressState::InProgress,
                 job_id: Some("child-job-2".to_string()),
                 parent_job_id: Some("batch-job-1".to_string()),
                 error_message: None,
@@ -2975,14 +2975,14 @@ async fn test_firmware_upgrade_wait_for_complete_retries_when_job_lookup_fails(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     rack.firmware_upgrade_job = Some(FirmwareUpgradeJob {
         job_id: Some("batch-job-1".to_string()),
-        status: Some("in_progress".to_string()),
+        status: Some(FirmwareProgressState::InProgress),
         started_at: Some(chrono::Utc::now()),
         batch_job_ids: vec!["batch-job-1".to_string()],
         machines: vec![FirmwareUpgradeDeviceStatus {
             node_id: host.host_snapshot.id.to_string(),
             mac: "00:11:22:33:44:55".to_string(),
             bmc_ip: "192.0.2.10".to_string(),
-            status: "in_progress".to_string(),
+            status: FirmwareProgressState::InProgress,
             job_id: Some("child-job-1".to_string()),
             parent_job_id: Some("batch-job-1".to_string()),
             error_message: None,
@@ -3021,8 +3021,8 @@ async fn test_firmware_upgrade_wait_for_complete_retries_when_job_lookup_fails(
     let job = persisted_rack
         .firmware_upgrade_job
         .expect("rack firmware job should still be persisted");
-    assert_eq!(job.status.as_deref(), Some("in_progress"));
-    assert_eq!(job.machines[0].status, "in_progress");
+    assert_eq!(job.status, Some(FirmwareProgressState::InProgress));
+    assert_eq!(job.machines[0].status, FirmwareProgressState::InProgress);
     assert_eq!(
         job.machines[0].error_message.as_deref(),
         Some("Job not found: child-job-1")
@@ -3060,14 +3060,14 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     rack.firmware_upgrade_job = Some(FirmwareUpgradeJob {
         job_id: Some("batch-job-1".to_string()),
-        status: Some("in_progress".to_string()),
+        status: Some(FirmwareProgressState::InProgress),
         started_at: Some(chrono::Utc::now()),
         batch_job_ids: vec!["batch-job-1".to_string()],
         machines: vec![FirmwareUpgradeDeviceStatus {
             node_id: host.host_snapshot.id.to_string(),
             mac: "00:11:22:33:44:55".to_string(),
             bmc_ip: "192.0.2.10".to_string(),
-            status: "in_progress".to_string(),
+            status: FirmwareProgressState::InProgress,
             job_id: Some("child-job-1".to_string()),
             parent_job_id: Some("batch-job-1".to_string()),
             error_message: None,
@@ -3106,8 +3106,8 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
     let job = persisted_rack
         .firmware_upgrade_job
         .expect("rack firmware job should still be persisted");
-    assert_eq!(job.status.as_deref(), Some("in_progress"));
-    assert_eq!(job.machines[0].status, "in_progress");
+    assert_eq!(job.status, Some(FirmwareProgressState::InProgress));
+    assert_eq!(job.machines[0].status, FirmwareProgressState::InProgress);
     assert!(
         job.machines[0]
             .error_message

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -520,6 +520,24 @@ pub async fn update_firmware_upgrade_status(
     Ok(())
 }
 
+/// Clears firmware_upgrade_status for every switch in `switch_ids` in one statement. Used when a
+/// direct dispatch supersedes whatever the state controller last recorded.
+pub async fn clear_firmware_upgrade_status_for_switches(
+    txn: &mut PgConnection,
+    switch_ids: &[SwitchId],
+) -> DatabaseResult<()> {
+    if switch_ids.is_empty() {
+        return Ok(());
+    }
+    let query = "UPDATE switches SET firmware_upgrade_status = NULL WHERE id = ANY($1)";
+    sqlx::query(query)
+        .bind(switch_ids)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::new("clear_firmware_upgrade_status_for_switches", e))?;
+    Ok(())
+}
+
 pub async fn update_nvos_update_status(
     txn: &mut PgConnection,
     switch_id: SwitchId,

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -520,24 +520,6 @@ pub async fn update_firmware_upgrade_status(
     Ok(())
 }
 
-/// Clears firmware_upgrade_status for every switch in `switch_ids` in one statement. Used when a
-/// direct dispatch supersedes whatever the state controller last recorded.
-pub async fn clear_firmware_upgrade_status_for_switches(
-    txn: &mut PgConnection,
-    switch_ids: &[SwitchId],
-) -> DatabaseResult<()> {
-    if switch_ids.is_empty() {
-        return Ok(());
-    }
-    let query = "UPDATE switches SET firmware_upgrade_status = NULL WHERE id = ANY($1)";
-    sqlx::query(query)
-        .bind(switch_ids)
-        .execute(txn)
-        .await
-        .map_err(|e| DatabaseError::new("clear_firmware_upgrade_status_for_switches", e))?;
-    Ok(())
-}
-
 pub async fn update_nvos_update_status(
     txn: &mut PgConnection,
     switch_id: SwitchId,

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -191,6 +191,11 @@ pub enum FirmwareProgressState {
 }
 
 impl FirmwareProgressState {
+    /// Returns `true` once the upgrade has settled and will not advance again
+    /// without a new request, so callers can stop polling the backend for this
+    /// device and treat its `ended_at` as final. `Unknown` is not terminal: an
+    /// unrecognized value is treated as still in flight rather than silently
+    /// completed.
     pub fn is_terminal(&self) -> bool {
         matches!(self, Self::Completed | Self::Failed)
     }
@@ -763,6 +768,10 @@ pub struct MaintenanceScope {
     /// Which maintenance activities to perform. Empty means all activities.
     #[serde(default)]
     pub activities: Vec<MaintenanceActivity>,
+    /// When this request was accepted, stamped by the server rather than
+    /// supplied by the caller. It marks the boundary of the current maintenance
+    /// cycle, so a persisted per-device status can be tested against it to tell
+    /// this request's result from a leftover of the previous one.
     #[serde(default)]
     pub requested_at: Option<DateTime<Utc>>,
 }
@@ -778,6 +787,15 @@ impl MaintenanceScope {
         self.activities.is_empty() || self.activities.iter().any(|a| a.same_kind(activity))
     }
 
+    /// Returns `true` when `other` selects the same devices and activities as
+    /// this scope, used to tell a resubmission of the pending request
+    /// (`AlreadyPending`) from a different one arriving while it is still in
+    /// flight (`Busy`).
+    ///
+    /// This deliberately ignores [`Self::requested_at`]. That field is stamped
+    /// on acceptance, so the pending scope always carries one and an incoming
+    /// scope never does; comparing it would make every resubmission look like a
+    /// different request and turn an idempotent retry into a spurious `Busy`.
     pub fn same_request(&self, other: &Self) -> bool {
         self.machine_ids == other.machine_ids
             && self.switch_ids == other.switch_ids

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -1263,7 +1263,10 @@ mod tests {
             (FirmwareProgressState::InProgress, "\"in_progress\""),
             (FirmwareProgressState::Completed, "\"completed\""),
             (FirmwareProgressState::Failed, "\"failed\""),
-            (FirmwareProgressState::Unknown("verifying".into()), "\"verifying\""),
+            (
+                FirmwareProgressState::Unknown("verifying".into()),
+                "\"verifying\"",
+            ),
         ];
 
         for (state, wire) in cases {

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -742,6 +742,8 @@ pub struct MaintenanceScope {
     /// Which maintenance activities to perform. Empty means all activities.
     #[serde(default)]
     pub activities: Vec<MaintenanceActivity>,
+    #[serde(default)]
+    pub requested_at: Option<DateTime<Utc>>,
 }
 
 impl MaintenanceScope {
@@ -753,6 +755,13 @@ impl MaintenanceScope {
 
     pub fn should_run(&self, activity: &MaintenanceActivity) -> bool {
         self.activities.is_empty() || self.activities.iter().any(|a| a.same_kind(activity))
+    }
+
+    pub fn same_request(&self, other: &Self) -> bool {
+        self.machine_ids == other.machine_ids
+            && self.switch_ids == other.switch_ids
+            && self.power_shelf_ids == other.power_shelf_ids
+            && self.activities == other.activities
     }
 }
 

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -84,7 +84,7 @@ pub struct FirmwareUpgradeJob {
     pub job_id: Option<String>,
     #[serde(default)]
     pub firmware_id: Option<String>,
-    pub status: Option<String>,
+    pub status: Option<FirmwareProgressState>,
     pub started_at: Option<DateTime<Utc>>,
     pub completed_at: Option<DateTime<Utc>>,
     #[serde(default)]
@@ -175,6 +175,27 @@ pub struct FirmwareUpgradeDeviceInfo {
     pub os_hostname: Option<String>,
 }
 
+/// Progress of a firmware upgrade, per device and for the job as a whole.
+///
+/// `Unknown` keeps a value written by an older revision from failing the whole
+/// rack row: `FirmwareUpgradeJob` is persisted as `jsonb`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FirmwareProgressState {
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+impl FirmwareProgressState {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed)
+    }
+}
+
 /// Per-device status tracked inside `FirmwareUpgradeJob`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FirmwareUpgradeDeviceStatus {
@@ -182,7 +203,7 @@ pub struct FirmwareUpgradeDeviceStatus {
     pub node_id: String,
     pub mac: String,
     pub bmc_ip: String,
-    pub status: String,
+    pub status: FirmwareProgressState,
     #[serde(default)]
     pub job_id: Option<String>,
     #[serde(default)]
@@ -1213,5 +1234,62 @@ mod tests {
         let rejection = RackMaintenanceRejection::AlreadyPending;
         let msg = rejection.to_string();
         assert!(msg.contains("already has a pending maintenance request"));
+    }
+
+    // ── FirmwareProgressState ───────────────────────────────────────────
+
+    #[test]
+    fn firmware_progress_state_round_trips_persisted_wire_values() {
+        let cases = [
+            (FirmwareProgressState::Pending, "\"pending\""),
+            (FirmwareProgressState::InProgress, "\"in_progress\""),
+            (FirmwareProgressState::Completed, "\"completed\""),
+            (FirmwareProgressState::Failed, "\"failed\""),
+            (FirmwareProgressState::Unknown("verifying".into()), "\"verifying\""),
+        ];
+
+        for (state, wire) in cases {
+            assert_eq!(serde_json::to_string(&state).unwrap(), wire);
+            assert_eq!(
+                serde_json::from_str::<FirmwareProgressState>(wire).unwrap(),
+                state
+            );
+        }
+    }
+
+    #[test]
+    fn firmware_upgrade_job_tolerates_an_unrecognized_device_status() {
+        let job: FirmwareUpgradeJob = serde_json::from_str(
+            r#"{
+                "job_id": "parent-job",
+                "firmware_id": "fw-1",
+                "status": "in_progress",
+                "started_at": null,
+                "completed_at": null,
+                "machines": [
+                    {
+                        "node_id": "node-1",
+                        "mac": "00:11:22:33:44:55",
+                        "bmc_ip": "192.0.2.10",
+                        "status": "in_progress"
+                    },
+                    {
+                        "node_id": "node-2",
+                        "mac": "00:11:22:33:44:56",
+                        "bmc_ip": "192.0.2.11",
+                        "status": "sideways"
+                    }
+                ]
+            }"#,
+        )
+        .expect("one unrecognized device status must not fail the whole rack row");
+
+        assert_eq!(job.status, Some(FirmwareProgressState::InProgress));
+        assert_eq!(job.machines[0].status, FirmwareProgressState::InProgress);
+        assert_eq!(
+            job.machines[1].status,
+            FirmwareProgressState::Unknown("sideways".into())
+        );
+        assert!(!job.machines[1].status.is_terminal());
     }
 }

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -797,10 +797,17 @@ impl MaintenanceScope {
     /// scope never does; comparing it would make every resubmission look like a
     /// different request and turn an idempotent retry into a spurious `Busy`.
     pub fn same_request(&self, other: &Self) -> bool {
-        self.machine_ids == other.machine_ids
-            && self.switch_ids == other.switch_ids
-            && self.power_shelf_ids == other.power_shelf_ids
-            && self.activities == other.activities
+        let Self {
+            machine_ids,
+            switch_ids,
+            power_shelf_ids,
+            activities,
+            requested_at: _,
+        } = self;
+        *machine_ids == other.machine_ids
+            && *switch_ids == other.switch_ids
+            && *power_shelf_ids == other.power_shelf_ids
+            && *activities == other.activities
     }
 }
 

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -182,20 +182,27 @@ pub struct FirmwareUpgradeDeviceInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FirmwareProgressState {
+    /// The backend accepted the upgrade but has not started it.
     Pending,
+
+    /// The backend is applying the upgrade.
     InProgress,
+
+    /// The upgrade completed successfully.
     Completed,
+
+    /// The upgrade completed unsuccessfully.
     Failed,
+
+    /// A state written by a newer producer that this revision does not recognize.
     #[serde(untagged)]
     Unknown(String),
 }
 
 impl FirmwareProgressState {
     /// Returns `true` once the upgrade has settled and will not advance again
-    /// without a new request, so callers can stop polling the backend for this
-    /// device and treat its `ended_at` as final. `Unknown` is not terminal: an
-    /// unrecognized value is treated as still in flight rather than silently
-    /// completed.
+    /// without a new request. `Unknown` is not terminal: an unrecognized value
+    /// is treated as still in flight rather than silently completed.
     pub fn is_terminal(&self) -> bool {
         matches!(self, Self::Completed | Self::Failed)
     }

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -189,7 +189,10 @@ pub async fn request_rack_maintenance_via_state_controller(
                         .map_err(|error| ComponentManagerError::Internal(error.to_string()))?;
                 }
 
-                Ok((RackMaintenanceRequestOutcome::Scheduled, Some(accepted_scope)))
+                Ok((
+                    RackMaintenanceRequestOutcome::Scheduled,
+                    Some(accepted_scope),
+                ))
             })
         })
         .await;

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -147,7 +147,7 @@ pub async fn request_rack_maintenance_via_state_controller(
                 })?;
 
                 if let Some(existing_scope) = rack.config.maintenance_requested.as_ref() {
-                    return Ok(if existing_scope == &scope {
+                    return Ok(if existing_scope.same_request(&scope) {
                         RackMaintenanceRequestOutcome::AlreadyPending
                     } else {
                         RackMaintenanceRequestOutcome::Busy
@@ -171,8 +171,10 @@ pub async fn request_rack_maintenance_via_state_controller(
                         components: vec![],
                         force_update: false,
                     });
+                let mut accepted_scope = scope;
+                accepted_scope.requested_at = Some(chrono::Utc::now());
                 let mut config = rack.config;
-                config.maintenance_requested = Some(scope);
+                config.maintenance_requested = Some(accepted_scope);
                 db::rack::update(txn.as_mut(), &transaction_rack_id, &config)
                     .await
                     .map_err(|error| ComponentManagerError::Internal(error.to_string()))?;

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -120,7 +120,6 @@ pub async fn request_rack_maintenance_via_state_controller(
     maintenance_access_token: Option<RackMaintenanceAccessToken<'_>>,
 ) -> Result<RackMaintenanceRequestOutcome, ComponentManagerError> {
     let rack_id = rack_id.clone();
-    let scheduled_scope = scope.clone();
     let transaction_rack_id = rack_id.clone();
 
     let result = db_pool
@@ -147,11 +146,14 @@ pub async fn request_rack_maintenance_via_state_controller(
                 })?;
 
                 if let Some(existing_scope) = rack.config.maintenance_requested.as_ref() {
-                    return Ok(if existing_scope.same_request(&scope) {
-                        RackMaintenanceRequestOutcome::AlreadyPending
-                    } else {
-                        RackMaintenanceRequestOutcome::Busy
-                    });
+                    return Ok((
+                        if existing_scope.same_request(&scope) {
+                            RackMaintenanceRequestOutcome::AlreadyPending
+                        } else {
+                            RackMaintenanceRequestOutcome::Busy
+                        },
+                        None,
+                    ));
                 }
 
                 let state = rack.controller_state.value.clone();
@@ -162,7 +164,7 @@ pub async fn request_rack_maintenance_via_state_controller(
                     }
                 };
                 if !eligible {
-                    return Ok(RackMaintenanceRequestOutcome::Deferred { state });
+                    return Ok((RackMaintenanceRequestOutcome::Deferred { state }, None));
                 }
 
                 let reset_firmware_upgrade_job =
@@ -174,7 +176,7 @@ pub async fn request_rack_maintenance_via_state_controller(
                 let mut accepted_scope = scope;
                 accepted_scope.requested_at = Some(chrono::Utc::now());
                 let mut config = rack.config;
-                config.maintenance_requested = Some(accepted_scope);
+                config.maintenance_requested = Some(accepted_scope.clone());
                 db::rack::update(txn.as_mut(), &transaction_rack_id, &config)
                     .await
                     .map_err(|error| ComponentManagerError::Internal(error.to_string()))?;
@@ -187,18 +189,19 @@ pub async fn request_rack_maintenance_via_state_controller(
                         .map_err(|error| ComponentManagerError::Internal(error.to_string()))?;
                 }
 
-                Ok(RackMaintenanceRequestOutcome::Scheduled)
+                Ok((RackMaintenanceRequestOutcome::Scheduled, Some(accepted_scope)))
             })
         })
         .await;
 
-    let outcome = match result {
-        Ok(Ok(outcome)) => outcome,
+    let (outcome, accepted_scope) = match result {
+        Ok(Ok(accepted)) => accepted,
         Ok(Err(error)) => return Err(error),
         Err(error) => return Err(ComponentManagerError::Internal(error.to_string())),
     };
 
     if outcome == RackMaintenanceRequestOutcome::Scheduled
+        && let Some(accepted_scope) = accepted_scope.as_ref()
         && let Some(RackMaintenanceAccessToken {
             credential_manager,
             token,
@@ -214,7 +217,7 @@ pub async fn request_rack_maintenance_via_state_controller(
             .await
     {
         let recovery =
-            recover_rack_maintenance_after_credential_failure(db_pool, &rack_id, &scheduled_scope)
+            recover_rack_maintenance_after_credential_failure(db_pool, &rack_id, accepted_scope)
                 .await;
         return Err(ComponentManagerError::Internal(match recovery {
             Ok(recovery) => format!(
@@ -1096,12 +1099,20 @@ mod tests {
             .unwrap(),
             RackMaintenanceRequestOutcome::Scheduled,
         );
+        let scheduled = load_rack(&pool, &ready_rack)
+            .await
+            .config
+            .maintenance_requested
+            .expect("the accepted request is persisted");
+        let requested_at = scheduled
+            .requested_at
+            .expect("acceptance stamps the request time");
         assert_eq!(
-            load_rack(&pool, &ready_rack)
-                .await
-                .config
-                .maintenance_requested,
-            Some(scope.clone()),
+            scheduled,
+            MaintenanceScope {
+                requested_at: Some(requested_at),
+                ..scope.clone()
+            },
         );
 
         // Exact retries are idempotent, including after the rack state has
@@ -1154,7 +1165,11 @@ mod tests {
                 .await
                 .config
                 .maintenance_requested,
-            Some(scope),
+            Some(MaintenanceScope {
+                requested_at: Some(requested_at),
+                ..scope
+            }),
+            "the pending request, timestamp included, survives both retries",
         );
 
         // Automatic callers defer non-Ready racks; operator callers may

--- a/crates/component-manager/src/nv_switch_manager.rs
+++ b/crates/component-manager/src/nv_switch_manager.rs
@@ -254,6 +254,9 @@ pub trait NvSwitchManager: Send + Sync + Debug + 'static {
         options: &FirmwareUpdateOptions,
     ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError>;
 
+    /// Returns status for firmware jobs known to the backend.
+    ///
+    /// An endpoint may be omitted when the backend does not track a firmware job for it.
     async fn get_firmware_status(
         &self,
         endpoints: &[SwitchEndpoint],

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -2387,12 +2387,6 @@ impl NvSwitchManager for RmsBackend {
             };
 
             if jobs.is_empty() {
-                statuses.push(SwitchFirmwareUpdateStatus {
-                    bmc_mac: *bmc_mac,
-                    state: FirmwareState::Unknown,
-                    target_version: String::new(),
-                    error: Some("no firmware job tracked for this switch".into()),
-                });
                 continue;
             }
 
@@ -6875,14 +6869,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(statuses[0].state, FirmwareState::Unknown);
-        assert!(
-            statuses[0]
-                .error
-                .as_ref()
-                .unwrap()
-                .contains("no firmware job")
-        );
+        assert!(statuses.is_empty());
     }
 
     #[carbide_macros::sqlx_test]

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -2290,7 +2290,13 @@ pub async fn handle_maintenance(
                         let state = match device.status.as_str() {
                             "completed" => RackFirmwareUpgradeState::Completed,
                             "failed" => RackFirmwareUpgradeState::Failed {
-                                cause: format!("RMS reported failure for {}", device.mac),
+                                cause: device
+                                    .error_message
+                                    .clone()
+                                    .filter(|message| !message.trim().is_empty())
+                                    .unwrap_or_else(|| {
+                                        format!("RMS reported failure for {}", device.mac)
+                                    }),
                             },
                             "in_progress" => RackFirmwareUpgradeState::InProgress,
                             _ => RackFirmwareUpgradeState::Started,

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -52,11 +52,11 @@ use db::{
 use librms::protos::rack_manager as rms;
 use model::machine::HostMachine;
 use model::rack::{
-    ConfigureNmxClusterState, FirmwareUpgradeDeviceInfo, FirmwareUpgradeDeviceStatus,
-    FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, NvosUpdateState,
-    NvosUpdateSwitchStatus, Rack, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus,
-    RackMaintenanceState, RackPowerState, RackState, RackValidationState, SwitchNvosUpdateState,
-    SwitchNvosUpdateStatus,
+    ConfigureNmxClusterState, FirmwareProgressState, FirmwareUpgradeDeviceInfo,
+    FirmwareUpgradeDeviceStatus, FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope,
+    NvosUpdateState, NvosUpdateSwitchStatus, Rack, RackFirmwareUpgradeState,
+    RackFirmwareUpgradeStatus, RackMaintenanceState, RackPowerState, RackState,
+    RackValidationState, SwitchNvosUpdateState, SwitchNvosUpdateStatus,
 };
 use model::rack_type::RackProfile;
 use state_controller::state_handler::{
@@ -271,7 +271,7 @@ async fn terminate_active_rack_maintenance(
             if matches!(rack_firmware_upgrade, FirmwareUpgradeState::WaitForComplete)
                 && let Some(mut job) = state.firmware_upgrade_job.clone()
             {
-                job.status = Some("failed".into());
+                job.status = Some(FirmwareProgressState::Failed);
                 job.completed_at.get_or_insert(now);
                 db_rack::update_firmware_upgrade_job(txn.as_mut(), rack_id, Some(&job)).await?;
                 state.firmware_upgrade_job = Some(job);
@@ -759,7 +759,7 @@ async fn transition_to_rack_error_with_firmware_job(
     let now = chrono::Utc::now();
     let job = model::rack::FirmwareUpgradeJob {
         firmware_id: Some(firmware_id.into()),
-        status: Some("failed".into()),
+        status: Some(FirmwareProgressState::Failed),
         started_at: Some(now),
         completed_at: Some(now),
         ..Default::default()
@@ -1097,19 +1097,19 @@ fn firmware_device_status(
         node_id: device.node_id.clone(),
         mac: device.mac,
         bmc_ip: device.bmc_ip,
-        status: "in_progress".into(),
+        status: FirmwareProgressState::InProgress,
         job_id: None,
         parent_job_id,
         error_message: None,
     };
 
     if let Some(error_message) = node_errors.get(&device.node_id) {
-        status.status = "failed".into();
+        status.status = FirmwareProgressState::Failed;
         status.error_message = Some(error_message.clone());
     } else if let Some(job_id) = child_jobs.get(&device.node_id) {
         status.job_id = Some(job_id.clone());
     } else {
-        status.status = "failed".into();
+        status.status = FirmwareProgressState::Failed;
         status.error_message = Some(
             batch_error
                 .unwrap_or("RMS did not return a child firmware job for this device")
@@ -1313,25 +1313,22 @@ async fn rms_start_firmware_upgrade_from_json(
     let all_devices: Vec<_> = job.all_devices().collect();
     let failed = all_devices
         .iter()
-        .filter(|device| device.status == "failed")
+        .filter(|device| device.status == FirmwareProgressState::Failed)
         .count();
     let completed = all_devices
         .iter()
-        .filter(|device| device.status == "completed")
+        .filter(|device| device.status == FirmwareProgressState::Completed)
         .count();
     let total = all_devices.len();
     let terminal = completed + failed;
 
-    job.status = Some(
-        if total > 0 && terminal < total {
-            "in_progress"
-        } else if failed > 0 {
-            "failed"
-        } else {
-            "completed"
-        }
-        .into(),
-    );
+    job.status = Some(if total > 0 && terminal < total {
+        FirmwareProgressState::InProgress
+    } else if failed > 0 {
+        FirmwareProgressState::Failed
+    } else {
+        FirmwareProgressState::Completed
+    });
     if total > 0 && terminal == total {
         job.completed_at = Some(chrono::Utc::now());
     }
@@ -1347,12 +1344,12 @@ async fn rms_get_firmware_upgrade_status(
 ) -> Result<model::rack::FirmwareUpgradeJob, StateHandlerError> {
     let mut updated = job.clone();
     for device in updated.all_devices_mut() {
-        if matches!(device.status.as_str(), "completed" | "failed") {
+        if device.status.is_terminal() {
             continue;
         }
 
         let Some(job_id) = device.job_id.clone() else {
-            device.status = "failed".into();
+            device.status = FirmwareProgressState::Failed;
             if device.error_message.is_none() {
                 device.error_message = Some("Device has no firmware job ID to poll".into());
             }
@@ -1374,19 +1371,19 @@ async fn rms_get_firmware_upgrade_status(
                 }
                 match rms::FirmwareJobState::try_from(response.job_state) {
                     Ok(rms::FirmwareJobState::Queued) => {
-                        device.status = "pending".into();
+                        device.status = FirmwareProgressState::Pending;
                         device.error_message = None;
                     }
                     Ok(rms::FirmwareJobState::Running) => {
-                        device.status = "in_progress".into();
+                        device.status = FirmwareProgressState::InProgress;
                         device.error_message = None;
                     }
                     Ok(rms::FirmwareJobState::Completed) => {
-                        device.status = "completed".into();
+                        device.status = FirmwareProgressState::Completed;
                         device.error_message = None;
                     }
                     Ok(rms::FirmwareJobState::Failed) => {
-                        device.status = "failed".into();
+                        device.status = FirmwareProgressState::Failed;
                         device.error_message = Some(if response.error_message.is_empty() {
                             response.state_description
                         } else {
@@ -1439,25 +1436,22 @@ async fn rms_get_firmware_upgrade_status(
     let all_devices: Vec<_> = updated.all_devices().collect();
     let failed = all_devices
         .iter()
-        .filter(|device| device.status == "failed")
+        .filter(|device| device.status == FirmwareProgressState::Failed)
         .count();
     let completed = all_devices
         .iter()
-        .filter(|device| device.status == "completed")
+        .filter(|device| device.status == FirmwareProgressState::Completed)
         .count();
     let total = all_devices.len();
     let terminal = completed + failed;
 
-    updated.status = Some(
-        if total > 0 && terminal < total {
-            "in_progress"
-        } else if failed > 0 {
-            "failed"
-        } else {
-            "completed"
-        }
-        .into(),
-    );
+    updated.status = Some(if total > 0 && terminal < total {
+        FirmwareProgressState::InProgress
+    } else if failed > 0 {
+        FirmwareProgressState::Failed
+    } else {
+        FirmwareProgressState::Completed
+    });
     updated.completed_at = if total > 0 && terminal == total {
         Some(chrono::Utc::now())
     } else {
@@ -2227,7 +2221,7 @@ pub async fn handle_maintenance(
                 if !power_blocked_machine_ids.is_empty() {
                     let now = chrono::Utc::now();
                     let mut job = state.firmware_upgrade_job.clone().unwrap();
-                    job.status = Some("failed".into());
+                    job.status = Some(FirmwareProgressState::Failed);
                     if job.completed_at.is_none() {
                         job.completed_at = Some(now);
                     }
@@ -2287,9 +2281,9 @@ pub async fn handle_maintenance(
 
                 let build_status =
                     |device: &FirmwareUpgradeDeviceStatus| -> RackFirmwareUpgradeStatus {
-                        let state = match device.status.as_str() {
-                            "completed" => RackFirmwareUpgradeState::Completed,
-                            "failed" => RackFirmwareUpgradeState::Failed {
+                        let state = match &device.status {
+                            FirmwareProgressState::Completed => RackFirmwareUpgradeState::Completed,
+                            FirmwareProgressState::Failed => RackFirmwareUpgradeState::Failed {
                                 cause: device
                                     .error_message
                                     .clone()
@@ -2298,8 +2292,12 @@ pub async fn handle_maintenance(
                                         format!("RMS reported failure for {}", device.mac)
                                     }),
                             },
-                            "in_progress" => RackFirmwareUpgradeState::InProgress,
-                            _ => RackFirmwareUpgradeState::Started,
+                            FirmwareProgressState::InProgress => {
+                                RackFirmwareUpgradeState::InProgress
+                            }
+                            FirmwareProgressState::Pending | FirmwareProgressState::Unknown(_) => {
+                                RackFirmwareUpgradeState::Started
+                            }
                         };
                         RackFirmwareUpgradeStatus {
                             task_id: device
@@ -2310,7 +2308,7 @@ pub async fn handle_maintenance(
                                 .unwrap_or_else(|| "unknown".to_string()),
                             status: state,
                             started_at: job.started_at,
-                            ended_at: if device.status == "completed" || device.status == "failed" {
+                            ended_at: if device.status.is_terminal() {
                                 job.completed_at.or(Some(chrono::Utc::now()))
                             } else {
                                 None
@@ -2420,7 +2418,7 @@ pub async fn handle_maintenance(
                     DeviceFirmwareProgress::Failed { failed, total } => {
                         let should_cleanup_token = requested_nvos_config_json(scope).is_some();
                         let now = chrono::Utc::now();
-                        job.status = Some("failed".into());
+                        job.status = Some(FirmwareProgressState::Failed);
                         if job.completed_at.is_none() {
                             job.completed_at = Some(now);
                         }
@@ -2454,7 +2452,7 @@ pub async fn handle_maintenance(
                     }
                     DeviceFirmwareProgress::Completed { completed, total } => {
                         let now = chrono::Utc::now();
-                        job.status = Some("completed".into());
+                        job.status = Some(FirmwareProgressState::Completed);
                         if job.completed_at.is_none() {
                             job.completed_at = Some(now);
                         }
@@ -2894,9 +2892,9 @@ mod tests {
     use carbide_uuid::rack::RackId;
     use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
     use model::rack::{
-        ConfigureNmxClusterState, FirmwareUpgradeDeviceInfo, FirmwareUpgradeState,
-        MaintenanceActivity, MaintenanceScope, NvosUpdateState, RackMaintenanceState,
-        RackPowerState,
+        ConfigureNmxClusterState, FirmwareProgressState, FirmwareUpgradeDeviceInfo,
+        FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, NvosUpdateState,
+        RackMaintenanceState, RackPowerState,
     };
     use model::rack_type::{RackHardwareType, RackProfile};
 
@@ -3204,7 +3202,7 @@ mod tests {
             Some("invalid SOT JSON"),
         );
 
-        assert_eq!(status.status, "failed");
+        assert_eq!(status.status, FirmwareProgressState::Failed);
         assert_eq!(status.error_message.as_deref(), Some("invalid SOT JSON"));
     }
 


### PR DESCRIPTION
This PR addresses the fact that rack and switch firmware update status reporting lost RMS errors, returned misleading success, and reported results from an older upgrade cycle.

This PR addresses by adding the following behaviors:

- Preserve RMS per-device failure messages
- Return failed rack jobs as failed API results with device counts and the shared RMS error where available.
- Fall back to the rack controller’s error cause when a job fails without any failed per-device result, avoiding contradictory messages
- Report error count and direct operators to RMS logs when devices have divergent failure reasons
- Read persisted switch status for state-controller updates while ensuring it belongs to the current request

## Related issues

- https://github.com/NVIDIA/infra-controller/issues/3424
- https://github.com/NVIDIA/infra-controller/issues/3422

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
- Power-shelf firmware update status persistence is pending because its current Completed status is a placeholder at the moment
- Concurrent direct switch firmware dispatch (bypass_state_controller=true) during an active state-controller request is not reconciled by this PR. Status continues to report the active state-controller cycle until that request clears; explicit concurrent job ownership and correlation remain follow-up work

#### Rack Update Error Reporting
component manager get rack firmware update status:
<img width="2120" height="110" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/1f673fca-e5be-4769-ad99-6287868e3bbc" />

#### Switch Update Error Reporting
component manager get switch firmware update status:
<img width="1920" height="160" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/66caaae1-2a26-4ae9-ab0c-a53de0171951" />
