### PR TITLE
feat(ssh-console): SSH console port plumbing

### DIFF
--- a/crates/api-core/src/handlers/bmc_metadata.rs
+++ b/crates/api-core/src/handlers/bmc_metadata.rs
@@ -109,6 +109,7 @@ pub(super) async fn get_inner(
         ip: bmc_endpoint_request.ip_address,
         port: None,
         ssh_port: None,
+        serial_console_ssh_port: explored_metadata.serial_console_ssh_port.map(u32::from),
         ipmi_port: explored_metadata.ipmi_port.map(u32::from),
         mac: bmc_mac_address.to_string(),
         user: username,

--- a/crates/api-core/src/tests/common/endpoint.rs
+++ b/crates/api-core/src/tests/common/endpoint.rs
@@ -114,6 +114,7 @@ fn build_exploration_report(
             power_state: PowerState::On,
             sku: None,
             boot_order: None,
+            serial_console_ssh_port: None,
         }],
         chassis: vec![Chassis {
             model: Some(model.to_string()),

--- a/crates/api-core/src/tests/preingestion_dpu_nic_mode.rs
+++ b/crates/api-core/src/tests/preingestion_dpu_nic_mode.rs
@@ -72,6 +72,7 @@ fn host_bmc_report() -> EndpointExplorationReport {
             power_state: PowerState::On,
             sku: None,
             boot_order: None,
+            serial_console_ssh_port: None,
         }],
         chassis: vec![Chassis {
             id: String::new(),

--- a/crates/api-core/tests/integration/machine_bmc_metadata.rs
+++ b/crates/api-core/tests/integration/machine_bmc_metadata.rs
@@ -115,10 +115,93 @@ async fn fetch_bmc_credentials(pool: PgPool) {
 
         assert_eq!(metadata.ip, host_bmc_ip);
         assert_eq!(metadata.port, None);
+        assert_eq!(metadata.serial_console_ssh_port, None);
         assert_eq!(metadata.ipmi_port, None);
         assert_eq!(metadata.mac, host_bmc_mac.to_string());
         assert!(!metadata.password.is_empty());
         assert!(!metadata.user.is_empty());
+    }
+}
+
+#[sqlx_test]
+async fn test_fetch_ssh_serial_console_metadata(pool: PgPool) {
+    let (env, mh) = init(pool).await;
+    let host_machine = mh.host.rpc_machine().await;
+    let host_bmc_ip = host_machine
+        .bmc_info
+        .as_ref()
+        .and_then(|bmc_info| bmc_info.ip.clone())
+        .expect("Host BMC IP must be available");
+
+    let mut txn = env.db_txn().await;
+    sqlx::query(
+        "UPDATE explored_endpoints SET exploration_report = \
+         jsonb_set(exploration_report, '{Systems,0,SerialConsoleSshPort}', '2222'::jsonb, true) \
+         WHERE address = $1",
+    )
+    .bind(IpAddr::from_str(&host_bmc_ip).expect("invalid host IP"))
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let metadata = env
+        .api()
+        .get_bmc_meta_data(tonic::Request::new(rpc::forge::BmcMetaDataGetRequest {
+            machine_id: host_machine.id,
+            request_type: rpc::forge::BmcRequestType::Redfish.into(),
+            role: rpc::forge::UserRoles::Administrator.into(),
+            bmc_endpoint_request: None,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(metadata.ip, host_bmc_ip);
+    assert_eq!(metadata.serial_console_ssh_port, Some(2222));
+}
+
+#[sqlx_test]
+async fn test_fetch_ssh_serial_console_metadata_ignores_invalid_ports(pool: PgPool) {
+    let (env, mh) = init(pool).await;
+    let host_machine = mh.host.rpc_machine().await;
+    let host_bmc_ip = host_machine
+        .bmc_info
+        .as_ref()
+        .and_then(|bmc_info| bmc_info.ip.clone())
+        .expect("Host BMC IP must be available");
+    let host_bmc_ip = IpAddr::from_str(&host_bmc_ip).expect("invalid host IP");
+
+    for invalid_port in [r#""not-a-port""#, "0", "65536", "2147483648"] {
+        let mut txn = env.db_txn().await;
+        sqlx::query(
+            "UPDATE explored_endpoints SET exploration_report = \
+             jsonb_set(exploration_report, '{Systems,0,SerialConsoleSshPort}', $2::jsonb, true) \
+             WHERE address = $1",
+        )
+        .bind(host_bmc_ip)
+        .bind(invalid_port)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+        txn.commit().await.unwrap();
+
+        let metadata = env
+            .api()
+            .get_bmc_meta_data(tonic::Request::new(rpc::forge::BmcMetaDataGetRequest {
+                machine_id: host_machine.id,
+                request_type: rpc::forge::BmcRequestType::Redfish.into(),
+                role: rpc::forge::UserRoles::Administrator.into(),
+                bmc_endpoint_request: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(
+            metadata.serial_console_ssh_port, None,
+            "stored port: {invalid_port}"
+        );
     }
 }
 

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -326,6 +326,7 @@ pub async fn find_all_by_ip(
 pub struct ExploredBmcMetadata {
     pub vendor: Option<String>,
     pub ipmi_port: Option<u16>,
+    pub serial_console_ssh_port: Option<u16>,
 }
 
 pub async fn lookup_bmc_metadata_by_ip(
@@ -333,23 +334,26 @@ pub async fn lookup_bmc_metadata_by_ip(
     db_reader: impl DbReader<'_>,
 ) -> Result<ExploredBmcMetadata, DatabaseError> {
     let query = "SELECT exploration_report ->> 'Vendor' AS vendor, \
-                 exploration_report #>> '{Managers,0,IpmiPort}' AS ipmi_port \
+                 exploration_report #>> '{Managers,0,IpmiPort}' AS ipmi_port, \
+                 exploration_report #>> '{Systems,0,SerialConsoleSshPort}' AS serial_console_ssh_port \
                  FROM explored_endpoints WHERE address = $1";
 
-    let metadata: Option<(Option<String>, Option<String>)> = sqlx::query_as(query)
+    let metadata: Option<(Option<String>, Option<String>, Option<String>)> = sqlx::query_as(query)
         .bind(address)
         .fetch_optional(db_reader)
         .await
         .map_err(|e| DatabaseError::new("explored_endpoints lookup_bmc_metadata_by_ip", e))?;
 
-    Ok(
-        metadata.map_or_else(ExploredBmcMetadata::default, |(vendor, ipmi_port)| {
-            ExploredBmcMetadata {
-                vendor,
-                ipmi_port: ipmi_port.and_then(|port| port.parse().ok()),
-            }
-        }),
-    )
+    Ok(metadata.map_or_else(
+        ExploredBmcMetadata::default,
+        |(vendor, ipmi_port, serial_console_ssh_port)| ExploredBmcMetadata {
+            vendor,
+            ipmi_port: ipmi_port.and_then(|port| port.parse().ok()),
+            serial_console_ssh_port: serial_console_ssh_port
+                .and_then(|port| port.parse().ok())
+                .filter(|port| *port != 0),
+        },
+    ))
 }
 
 /// Updates the explored information about a node

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1494,6 +1494,9 @@ pub struct ComputerSystem {
     pub sku: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub boot_order: Option<BootOrder>,
+    /// SSH port for the system's Redfish serial-console service.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serial_console_ssh_port: Option<u16>,
 }
 
 pub fn base_mac_deserialize<'a, D>(deserializer: D) -> Result<Option<BaseMac>, D::Error>
@@ -3552,6 +3555,7 @@ mod tests {
                 power_state: PowerState::On,
                 sku: None,
                 boot_order: None,
+                serial_console_ssh_port: None,
             }],
             chassis: vec![Chassis {
                 id: "NIC.Slot.1".to_string(),
@@ -3624,6 +3628,7 @@ mod tests {
                 power_state: PowerState::On,
                 sku: None,
                 boot_order: None,
+                serial_console_ssh_port: None,
             }],
             chassis: vec![Chassis {
                 id: "NIC.Slot.1".to_string(),

--- a/crates/api-model/src/test_support/dpu.rs
+++ b/crates/api-model/src/test_support/dpu.rs
@@ -115,6 +115,7 @@ impl From<DpuConfig> for EndpointExplorationReport {
                 power_state: PowerState::On,
                 sku: None,
                 boot_order: None,
+                serial_console_ssh_port: None,
             }],
             chassis: vec![Chassis {
                 id: "Card1".to_string(),

--- a/crates/api-model/src/test_support/managed_host.rs
+++ b/crates/api-model/src/test_support/managed_host.rs
@@ -309,6 +309,7 @@ impl From<ManagedHostConfig> for EndpointExplorationReport {
                 power_state: PowerState::On,
                 sku: None,
                 boot_order: None,
+                serial_console_ssh_port: None,
             }],
             chassis: vec![Chassis {
                 id: "System.Embedded.1".to_string(),

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -97,6 +97,7 @@ pub async fn run_local(
         forge_api_client,
         dhcp_client,
         mac_address_pool,
+        combined_bmc_ssh_port: std::sync::OnceLock::new(),
     });
 
     let mat = MachineATron::new(app_context.clone());

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -34,6 +34,7 @@ use nv_redfish::ethernet_interface::{EthernetInterface, UefiDevicePath as EthUef
 use nv_redfish::oem::nvidia::NvidiaComputerSystem;
 use nv_redfish::pcie_device::PcieDevice;
 use nv_redfish::resource::PowerState;
+use nv_redfish::schema::computer_system::SerialConsoleProtocol;
 use nv_redfish::{Bmc, Resource, ResourceProvidesStatus};
 use regex::Regex;
 
@@ -295,6 +296,24 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     .unwrap_or_default()
             });
 
+        let serial_console_ssh_port = self
+            .system
+            .raw()
+            .serial_console
+            .as_ref()
+            .and_then(|serial_console| serial_console.ssh.as_ref())
+            .map(enabled_serial_console_ssh_port)
+            .transpose()
+            .unwrap_or_else(|invalid_port| {
+                tracing::warn!(
+                    system_id = %self.system.id(),
+                    serial_console_ssh_port = invalid_port,
+                    "Ignoring invalid SSH serial-console port reported by Redfish",
+                );
+                None
+            })
+            .flatten();
+
         Ok(ModelComputerSystem {
             ethernet_interfaces,
             id: self.system.id().to_string(),
@@ -310,6 +329,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             power_state,
             sku: self.system.sku().map(|v| v.to_string()),
             boot_order,
+            serial_console_ssh_port,
         })
     }
 
@@ -694,11 +714,64 @@ fn pcie_device_to_model<B: Bmc>(
     })
 }
 
+fn enabled_serial_console_ssh_port(ssh: &SerialConsoleProtocol) -> Result<Option<u16>, i64> {
+    ssh.service_enabled
+        .filter(|enabled| *enabled)
+        .and_then(|_| ssh.port.flatten())
+        .map(|port| {
+            let converted = u16::try_from(port).map_err(|_| port)?;
+            (converted != 0).then_some(converted).ok_or(port)
+        })
+        .transpose()
+}
+
 #[cfg(test)]
 mod tests {
     use carbide_test_support::value_scenarios;
 
-    use super::is_usable_ethernet_mac_address;
+    use super::{
+        SerialConsoleProtocol, enabled_serial_console_ssh_port, is_usable_ethernet_mac_address,
+    };
+
+    #[test]
+    fn extracts_only_enabled_valid_ssh_serial_console_ports() {
+        let cases = [
+            ("enabled", Some(true), Some(Some(2200)), Ok(Some(2200))),
+            ("disabled", Some(false), Some(Some(2200)), Ok(None)),
+            ("enabled state absent", None, Some(Some(2200)), Ok(None)),
+            ("port absent", Some(true), None, Ok(None)),
+            ("port null", Some(true), Some(None), Ok(None)),
+            ("zero port", Some(true), Some(Some(0)), Err(())),
+            ("negative port", Some(true), Some(Some(-1)), Err(())),
+            (
+                "maximum port",
+                Some(true),
+                Some(Some(i64::from(u16::MAX))),
+                Ok(Some(u16::MAX)),
+            ),
+            (
+                "port above u16 range",
+                Some(true),
+                Some(Some(i64::from(u16::MAX) + 1)),
+                Err(()),
+            ),
+        ];
+
+        for (name, service_enabled, port, expected) in cases {
+            assert_eq!(
+                enabled_serial_console_ssh_port(&SerialConsoleProtocol {
+                    service_enabled,
+                    port,
+                    shared_with_manager_cli: None,
+                    console_entry_command: None,
+                    hot_key_sequence_display: None,
+                })
+                .map_err(drop),
+                expected,
+                "{name}",
+            );
+        }
+    }
 
     #[test]
     fn usable_ethernet_mac_address_cases() {

--- a/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
@@ -31,6 +31,7 @@ async fn explore_bluefield3_baseline() {
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
     assert!(!report.systems.is_empty(), "systems must be present");
+    assert_eq!(report.systems[0].serial_console_ssh_port, Some(2200));
     assert!(!report.chassis.is_empty(), "chassis must be present");
     assert!(
         report
@@ -46,6 +47,32 @@ async fn explore_bluefield3_baseline() {
             .is_some_and(|status| !status.diffs.is_empty() || status.is_done),
         "machine setup status must be present and structurally valid"
     );
+}
+
+#[test]
+async fn explore_bluefield3_uses_dynamic_system_console_port_not_manager_ssh() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+    assert!(h.state.set_serial_console_ssh_port(Some(3222)));
+    h.state.injection.put(vec![bmc_mock::injection::Rule {
+        id: "manager_ssh_port".into(),
+        selector: bmc_mock::injection::Selector::Path {
+            method: Some("GET".into()),
+            glob: "/redfish/v1/Managers/Bluefield_BMC/NetworkProtocol".into(),
+        },
+        action: bmc_mock::injection::Action::JsonMerge(serde_json::json!({
+            "SSH": {
+                "ProtocolEnabled": true,
+                "Port": 22,
+            },
+        })),
+        remaining: None,
+    }]);
+
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .unwrap();
+
+    assert_eq!(report.systems[0].serial_console_ssh_port, Some(3222));
 }
 
 #[test]

--- a/crates/bmc-explorer/tests/integration/bluefield4_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield4_explore.rs
@@ -44,6 +44,7 @@ async fn explore_bluefield4_and_generate_machine_id_from_system_serial() {
     let system = report.systems.first().expect("systems must be present");
     assert_eq!(system.id, "BlueField_0");
     assert_eq!(system.serial_number.as_deref(), Some("MT2610604VN4"));
+    assert_eq!(system.serial_console_ssh_port, Some(2200));
 
     assert_eq!(
         report.managers.first().map(|manager| manager.id.as_str()),

--- a/crates/bmc-explorer/tests/integration/dell_poweredge_r750_explore.rs
+++ b/crates/bmc-explorer/tests/integration/dell_poweredge_r750_explore.rs
@@ -24,6 +24,7 @@ use crate::common;
 #[test]
 async fn explore_dell_poweredge_r750() {
     let h = test_support::dell_poweredge_r750_bmc().await;
+    assert!(!h.state.set_serial_console_ssh_port(Some(3222)));
     let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
@@ -31,6 +32,7 @@ async fn explore_dell_poweredge_r750() {
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Dell));
     assert!(!report.systems.is_empty(), "systems must be present");
+    assert_eq!(report.systems[0].serial_console_ssh_port, None);
     assert!(!report.chassis.is_empty(), "chassis must be present");
     assert!(
         report

--- a/crates/bmc-explorer/tests/integration/powershelf_explore.rs
+++ b/crates/bmc-explorer/tests/integration/powershelf_explore.rs
@@ -31,6 +31,7 @@ async fn explore_liteon_power_shelf() {
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Liteon));
     assert!(!report.systems.is_empty(), "systems must be present");
+    assert_eq!(report.systems[0].serial_console_ssh_port, Some(2200));
     assert!(!report.chassis.is_empty(), "chassis must be present");
     assert!(
         report
@@ -63,6 +64,7 @@ async fn explore_delta_power_shelf() {
 
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Delta));
+    assert_eq!(report.systems[0].serial_console_ssh_port, None);
     assert!(
         !report.systems.is_empty(),
         "a system must be synthesized from the Delta chassis despite no Systems collection"

--- a/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
+++ b/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
@@ -53,6 +53,7 @@ async fn explore_supermicro_gb300() {
         Some(1623)
     );
     assert!(!report.systems.is_empty(), "systems must be present");
+    assert_eq!(report.systems[0].serial_console_ssh_port, Some(2200));
     assert!(!report.chassis.is_empty(), "chassis must be present");
 
     let setup = report

--- a/crates/bmc-explorer/tests/integration/vera_rubin_explore.rs
+++ b/crates/bmc-explorer/tests/integration/vera_rubin_explore.rs
@@ -35,6 +35,7 @@ async fn explore_nvidia_dgx_vr_and_generate_machine_id() {
 
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert!(!report.systems.is_empty(), "systems must be present");
+    assert_eq!(report.systems[0].serial_console_ssh_port, Some(2200));
     assert!(!report.chassis.is_empty(), "chassis must be present");
     assert!(
         report.systems[0].pcie_devices.is_empty(),

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -53,6 +53,11 @@ pub enum BmcEvent {
 }
 
 impl BmcState {
+    /// Overrides the client-reachable SSH serial-console port on supported systems.
+    pub fn set_serial_console_ssh_port(&self, port: Option<u16>) -> bool {
+        self.system_state.set_serial_console_ssh_port(port)
+    }
+
     pub fn on_event(&self, event: &BmcEvent) {
         match event {
             BmcEvent::PowerOn => {

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -186,7 +186,7 @@ impl Bluefield3<'_> {
                 storage: None,
                 processors: None,
                 memory: None,
-                serial_console: None,
+                serial_console: Some(hw::openbmc::enabled_serial_console()),
                 secure_boot_available: true,
             }],
         }

--- a/crates/bmc-mock/src/hw/bluefield4.rs
+++ b/crates/bmc-mock/src/hw/bluefield4.rs
@@ -393,7 +393,7 @@ impl Bluefield4<'_> {
                 storage: Some(vec![]),
                 processors: Some(vec![]),
                 memory: None,
-                serial_console: None,
+                serial_console: Some(hw::openbmc::enabled_serial_console()),
                 secure_boot_available: true,
             }],
         }

--- a/crates/bmc-mock/src/hw/dgx_vr_nvl.rs
+++ b/crates/bmc-mock/src/hw/dgx_vr_nvl.rs
@@ -137,7 +137,7 @@ impl DgxVrNvl<'_> {
                     model: Some("VR NVL72".into()),
                     oem: redfish::computer_system::Oem::Generic,
                     callbacks: Some(callbacks),
-                    serial_console: None,
+                    serial_console: Some(hw::openbmc::enabled_serial_console()),
                     secure_boot_available: true,
                     serial_number: Some(self.system_0_serial_number.to_string().into()),
                     storage: None,

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 
 use mac_address::MacAddress;
 
-use crate::redfish;
+use crate::{hw, redfish};
 
 pub(crate) struct LiteOnPowerShelf<'a> {
     pub(crate) bmc_mac_address: MacAddress,
@@ -86,7 +86,7 @@ impl LiteOnPowerShelf<'_> {
                 base_bios: Some(
                     redfish::bios::builder(&redfish::bios::resource(system_id)).build(),
                 ),
-                serial_console: None,
+                serial_console: Some(hw::openbmc::enabled_serial_console()),
                 secure_boot_available: false,
             }],
         }

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -21,6 +21,9 @@
 /// Description of NIC card.
 pub(super) mod nic;
 
+/// Common OpenBMC bmcweb hardware profiles.
+pub(super) mod openbmc;
+
 /// Support of NVIDIA Bluefield3 DPU.
 pub(super) mod bluefield3;
 

--- a/crates/bmc-mock/src/hw/openbmc.rs
+++ b/crates/bmc-mock/src/hw/openbmc.rs
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::redfish;
+
+/// The serial-console payload exposed by OpenBMC bmcweb when its console
+/// services are enabled. Hardware profiles must opt in only when their
+/// captured Redfish data confirms this support.
+pub(super) fn enabled_serial_console() -> redfish::serial_console::SerialConsole {
+    redfish::serial_console::builder()
+        .max_concurrent_sessions(15)
+        .ssh(
+            &redfish::serial_console::protocol_builder()
+                .service_enabled(true)
+                .port(2200)
+                .hot_key_sequence_display("Press ~. to exit console")
+                .build(),
+        )
+        .ipmi(
+            &redfish::serial_console::protocol_builder()
+                .service_enabled(true)
+                .build(),
+        )
+        .build()
+}

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -198,29 +198,7 @@ impl SupermicroGB300Nvl<'_> {
                     // This firmware exposes the SecureBoot resource but omits
                     // SecureBootEnable, so there is no usable status to report.
                     secure_boot_available: false,
-                    serial_console: Some(
-                        redfish::serial_console::builder()
-                            .max_concurrent_sessions(1)
-                            .ssh(
-                                &redfish::serial_console::protocol_builder()
-                                    .service_enabled(true)
-                                    .port(22)
-                                    .shared_with_manager_cli(true)
-                                    .console_entry_command("cd system1/sol1; start")
-                                    .hot_key_sequence_display(
-                                        "press <Enter>, <Esc>, and then <T> to terminate session",
-                                    )
-                                    .build(),
-                            )
-                            .ipmi(
-                                &redfish::serial_console::protocol_builder()
-                                    .service_enabled(true)
-                                    .port(623)
-                                    .hot_key_sequence_display("Press ~.  - terminate connection")
-                                    .build(),
-                            )
-                            .build(),
-                    ),
+                    serial_console: Some(hw::openbmc::enabled_serial_console()),
                     serial_number: Some(self.system_0_serial_number.to_string().into()),
                     storage: None,
                     processors: None,

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -237,6 +237,7 @@ struct BootSourceOverride {
 
 pub(crate) struct SingleSystemState {
     config: SingleSystemConfig,
+    serial_console_ssh_port_override: Mutex<Option<u16>>,
     virtual_media: Option<redfish::virtual_media::VirtualMediaState>,
     boot_order_override: Mutex<Option<Vec<String>>>,
     // HPE iLO uses OEM structured boot strings here, not the BootOption IDs
@@ -317,6 +318,27 @@ impl SystemState {
     pub(crate) fn on_boot_completed(&self) {
         self.systems.iter().for_each(|s| s.on_boot_completed())
     }
+
+    /// Overrides the advertised SSH serial-console port only for systems whose
+    /// hardware profile already declares an enabled SSH serial console.
+    pub fn set_serial_console_ssh_port(&self, port: Option<u16>) -> bool {
+        let mut updated = false;
+        for system in &self.systems {
+            if system
+                .config
+                .serial_console
+                .as_ref()
+                .is_some_and(redfish::serial_console::SerialConsole::has_enabled_ssh)
+            {
+                *system
+                    .serial_console_ssh_port_override
+                    .lock()
+                    .expect("mutex poisoned") = port;
+                updated = true;
+            }
+        }
+        updated
+    }
 }
 
 impl SingleSystemState {
@@ -327,6 +349,7 @@ impl SingleSystemState {
         Self {
             config,
             virtual_media,
+            serial_console_ssh_port_override: Mutex::new(None),
             boot_order_override: Mutex::new(None),
             hpe_boot_order_override: Mutex::new(None),
             boot_option_overrides: Mutex::new(HashMap::new()),
@@ -593,7 +616,15 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
     };
 
     if let Some(serial_console) = &config.serial_console {
-        b = b.serial_console(serial_console);
+        let serial_console = system_state
+            .serial_console_ssh_port_override
+            .lock()
+            .expect("mutex poisoned")
+            .map_or_else(
+                || serial_console.clone(),
+                |port| serial_console.with_ssh_port(port),
+            );
+        b = b.serial_console(&serial_console);
     }
 
     let pcie_devices = config

--- a/crates/bmc-mock/src/redfish/serial_console.rs
+++ b/crates/bmc-mock/src/redfish/serial_console.rs
@@ -29,6 +29,20 @@ impl SerialConsole {
     pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
+
+    pub(crate) fn has_enabled_ssh(&self) -> bool {
+        self.value
+            .get("SSH")
+            .and_then(|ssh| ssh.get("ServiceEnabled"))
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+    }
+
+    pub(crate) fn with_ssh_port(&self, port: u16) -> Self {
+        Self {
+            value: self.value.clone().patch(json!({ "SSH": { "Port": port } })),
+        }
+    }
 }
 
 pub(crate) fn builder() -> SerialConsoleBuilder {
@@ -99,14 +113,6 @@ impl SerialConsoleProtocolBuilder {
 
     pub(crate) fn port(self, value: u16) -> Self {
         self.apply_patch(json!({ "Port": value }))
-    }
-
-    pub(crate) fn shared_with_manager_cli(self, value: bool) -> Self {
-        self.apply_patch(json!({ "SharedWithManagerCLI": value }))
-    }
-
-    pub(crate) fn console_entry_command(self, value: &str) -> Self {
-        self.add_str_field("ConsoleEntryCommand", value)
     }
 
     pub(crate) fn hot_key_sequence_display(self, value: &str) -> Self {

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -46,6 +46,7 @@ pub(super) struct BmcMockWrapper {
     hostname: Arc<dyn HostnameQuerying>,
     needs_ipmi_console: bool,
     stable_id: String,
+    is_dpu: bool,
 }
 
 impl BmcMockWrapper {
@@ -76,6 +77,7 @@ impl BmcMockWrapper {
             hostname,
             needs_ipmi_console: machine_info.needs_ipmi_console(),
             stable_id: host_id.to_string(),
+            is_dpu: matches!(machine_info, MachineInfo::Dpu(_)),
         }
     }
 
@@ -157,7 +159,14 @@ impl BmcMockWrapper {
         } else {
             None
         };
-        let ipmi_sim_handle = self.start_ipmi_sim(address.ip()).await?;
+        let ipmi_sim_handle = if self.need_ipmi_sim() {
+            Some(self.start_ipmi_sim(address.ip()).await?)
+        } else {
+            None
+        };
+        let ssh_endpoint_port = ssh_handle.as_ref().map(|handle| handle.port);
+        self.bmc_mock_state
+            .set_serial_console_ssh_port(ssh_endpoint_port);
 
         tracing::info!(
             listen_address = ?address,
@@ -177,34 +186,63 @@ impl BmcMockWrapper {
                 tls_server_config,
             )),
             ssh_handle,
+            ssh_endpoint_port,
             _ipmi_sim_handle: ipmi_sim_handle,
         })
     }
 
-    /// Starts only the optional IPMI simulator when Redfish is served by a shared BMC mock.
-    /// Returns `None` when IPMI simulation is disabled or the machine does not need an IPMI console.
-    pub(super) async fn start_ipmi_only(
+    /// Starts per-machine console simulators when Redfish is served by a shared BMC mock.
+    /// Hosts use the shared SSH listener, while DPUs get a direct per-machine SSH listener.
+    /// Returns `None` when the hardware profile advertises neither an SSH nor IPMI console.
+    pub(super) async fn start_shared_mode_consoles(
         &self,
         bind_ip: std::net::IpAddr,
     ) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
-        Ok(self
-            .start_ipmi_sim(bind_ip)
-            .await?
-            .map(|ipmi_sim_handle| BmcMockWrapperHandle {
-                _bmc_mock: None,
-                ssh_handle: None,
-                _ipmi_sim_handle: Some(ipmi_sim_handle),
-            }))
+        let ssh_handle = if self.app_context.app_config.mock_bmc_ssh_server && self.is_dpu {
+            Some(
+                mock_ssh_server::spawn(
+                    bind_ip,
+                    None,
+                    self.hostname.clone(),
+                    None,
+                    PromptBehavior::Dpu,
+                )
+                .await
+                .map_err(|error| MachineStateError::MockSshServer(error.to_string()))?,
+            )
+        } else {
+            None
+        };
+        let ipmi_sim_handle = if self.need_ipmi_sim() {
+            Some(self.start_ipmi_sim(bind_ip).await?)
+        } else {
+            None
+        };
+        let ssh_endpoint_port = ssh_handle.as_ref().map(|handle| handle.port).or_else(|| {
+            (!self.is_dpu)
+                .then(|| self.app_context.combined_bmc_ssh_port.get().copied())
+                .flatten()
+        });
+        let advertises_ssh = self
+            .bmc_mock_state
+            .set_serial_console_ssh_port(ssh_endpoint_port);
+
+        Ok(
+            (ipmi_sim_handle.is_some() || ssh_handle.is_some() || advertises_ssh).then_some(
+                BmcMockWrapperHandle {
+                    _bmc_mock: None,
+                    ssh_handle,
+                    ssh_endpoint_port,
+                    _ipmi_sim_handle: ipmi_sim_handle,
+                },
+            ),
+        )
     }
 
     async fn start_ipmi_sim(
         &self,
         bind_ip: std::net::IpAddr,
-    ) -> Result<Option<IpmiSimHandle>, MachineStateError> {
-        if !self.app_context.app_config.enable_ipmi_simulation || !self.needs_ipmi_console {
-            return Ok(None);
-        }
-
+    ) -> Result<IpmiSimHandle, MachineStateError> {
         // Determine the reachable port advertised through Redfish:
         // - None (unset): Use default port
         // - Some(0): Use dynamic port (same as listen port)
@@ -226,7 +264,6 @@ impl BmcMockWrapper {
             },
         )
         .await
-        .map(Some)
         .map_err(MachineStateError::IpmiSim)
     }
 
@@ -237,18 +274,27 @@ impl BmcMockWrapper {
     pub(super) fn state(&self) -> &BmcState {
         &self.bmc_mock_state
     }
+
+    fn need_ipmi_sim(&self) -> bool {
+        self.app_context.app_config.enable_ipmi_simulation && self.needs_ipmi_console
+    }
 }
 
 #[derive(Debug)]
 pub(super) struct BmcMockWrapperHandle {
     _bmc_mock: Option<CombinedServer>,
     pub(super) ssh_handle: Option<MockSshServerHandle>,
+    ssh_endpoint_port: Option<u16>,
     _ipmi_sim_handle: Option<IpmiSimHandle>,
 }
 
 impl BmcMockWrapperHandle {
     pub(super) fn ipmi_endpoint(&self) -> Option<IpmiEndpoint> {
         self._ipmi_sim_handle.as_ref().map(|handle| handle.endpoint)
+    }
+
+    pub(super) fn ssh_endpoint_port(&self) -> Option<u16> {
+        self.ssh_endpoint_port
     }
 }
 

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -17,7 +17,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use bmc_mock::mac_address_pool::MacAddressPool;
@@ -956,6 +956,8 @@ pub struct MachineATronContext {
     pub forge_api_client: ForgeApiClient,
     pub dhcp_client: crate::dhcp_wrapper::DhcpClient,
     pub mac_address_pool: Arc<Mutex<MacAddressPool>>,
+    /// Client-reachable port of the shared host SSH listener in combined-BMC mode.
+    pub combined_bmc_ssh_port: OnceLock<u16>,
 }
 
 impl MachineATronContext {

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -422,14 +422,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn machines_status_reports_each_bmc_ipmi_endpoint() {
+    async fn machines_status_reports_each_bmc_console_endpoint() {
         let first = DeviceHandle::for_control_test(
             Vec::new(),
             Some(IpmiEndpoint {
                 reachable_port: 623,
                 listen_port: 16_020,
             }),
-        );
+        )
+        .with_control_test_ssh_endpoint(22_020);
         let second = DeviceHandle::for_control_test(
             Vec::new(),
             Some(IpmiEndpoint {
@@ -455,9 +456,13 @@ mod tests {
 
         assert_eq!(machines[0]["bmc"]["ipmi"]["reachable_port"], 623);
         assert_eq!(machines[0]["bmc"]["ipmi"]["listen_port"], 16_020);
+        assert_eq!(machines[0]["bmc"]["ssh"]["reachable_port"], 22_020);
+        assert_eq!(machines[0]["bmc"]["ssh"]["listen_port"], 22_020);
         assert_eq!(machines[1]["bmc"]["ipmi"]["reachable_port"], 623);
         assert_eq!(machines[1]["bmc"]["ipmi"]["listen_port"], 16_021);
+        assert!(machines[1]["bmc"].get("ssh").is_none());
         assert!(machines[2]["bmc"].get("ipmi").is_none());
+        assert!(machines[2]["bmc"].get("ssh").is_none());
     }
 
     #[tokio::test]

--- a/crates/machine-a-tron/src/device_handle.rs
+++ b/crates/machine-a-tron/src/device_handle.rs
@@ -240,6 +240,18 @@ impl DeviceHandle {
     }
 
     #[cfg(test)]
+    pub(crate) fn with_control_test_ssh_endpoint(self, port: u16) -> Self {
+        match self.0 {
+            DeviceHandleInner::Machine(handle) => {
+                Self::machine(handle.with_control_test_ssh_endpoint(port))
+            }
+            DeviceHandleInner::Switch(_) | DeviceHandleInner::PowerShelf(_) => {
+                unreachable!("control-test SSH endpoint is only configured for machines")
+            }
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn for_control_test_in_section(machine_config_section: &str) -> Self {
         Self::machine(MachineHandle::for_control_test_in_section(
             Vec::new(),

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -485,6 +485,7 @@ impl DpuMachineHandle {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
                 ipmi: live_state.ipmi_endpoint.map(Into::into),
+                ssh: live_state.ssh_endpoint_port.map(EndpointStatus::ssh),
             },
             dpus: Vec::new(),
         }

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -663,6 +663,12 @@ impl MachineHandle {
         }))
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_control_test_ssh_endpoint(self, port: u16) -> Self {
+        self.0.live_state.write().unwrap().ssh_endpoint_port = Some(port);
+        self
+    }
+
     pub(super) fn mat_id(&self) -> Uuid {
         self.0.mat_id
     }
@@ -785,6 +791,7 @@ impl MachineHandle {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
                 ipmi: live_state.ipmi_endpoint.map(Into::into),
+                ssh: live_state.ssh_endpoint_port.map(EndpointStatus::ssh),
             },
             dpus: self.0.dpus.iter().map(|dpu| dpu.status(config)).collect(),
         }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -264,6 +264,7 @@ pub(super) struct LiveState {
     pub(super) machine_ip: Option<Ipv4Addr>,
     pub(super) bmc_ip: Option<Ipv4Addr>,
     pub(super) ipmi_endpoint: Option<IpmiEndpoint>,
+    pub(super) ssh_endpoint_port: Option<u16>,
     pub(super) booted_os: MaybeOsImage,
     pub(super) next_boot_kind: Option<BootOptionKind>,
     pub(super) installed_os: OsImage,
@@ -292,6 +293,7 @@ impl Default for LiveState {
             machine_ip: None,
             bmc_ip: None,
             ipmi_endpoint: None,
+            ssh_endpoint_port: None,
             booted_os: Default::default(),
             next_boot_kind: None,
             installed_os: Default::default(),
@@ -1006,6 +1008,10 @@ impl MachineStateMachine {
             .bmc_mock
             .as_ref()
             .and_then(|bmc_mock| bmc_mock.ipmi_endpoint());
+        live_state.ssh_endpoint_port = self
+            .bmc_mock
+            .as_ref()
+            .and_then(|bmc_mock| bmc_mock.ssh_endpoint_port());
         live_state.installed_os = self.installed_os;
         if let Some(machine_id) = self.machine_id()
             && live_state.observed_machine_id != Some(machine_id)
@@ -1302,11 +1308,20 @@ impl MachineStateMachine {
                     .await
                     .insert(ip_address.to_string(), bmc_mock.router().clone());
                 bmc_mock
-                    .start_ipmi_only(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED))
+                    .start_shared_mode_consoles(std::net::IpAddr::V4(
+                        std::net::Ipv4Addr::UNSPECIFIED,
+                    ))
                     .await?
                     .map(Arc::new)
             }
         };
+        if let Some(ssh_host_key) = maybe_bmc_mock_handle
+            .as_ref()
+            .and_then(|handle| handle.ssh_handle.as_ref())
+            .map(|handle| handle.host_pubkey.clone())
+        {
+            self.live_state.write().unwrap().ssh_host_key = Some(ssh_host_key);
+        }
         Ok((maybe_bmc_mock_handle, bmc_mock.state().clone()))
     }
 

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -168,6 +168,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         forge_api_client,
         dhcp_client,
         mac_address_pool: Mutex::new(mac_address_pool).into(),
+        combined_bmc_ssh_port: std::sync::OnceLock::new(),
     });
 
     let info = app_context.forge_api_client.version(false).await?;
@@ -272,6 +273,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 (control_server, None)
             }
         };
+
+    if let Some(ssh_handle) = &server_handles.1 {
+        app_context
+            .combined_bmc_ssh_port
+            .set(ssh_handle.port)
+            .expect("combined BMC SSH port must only be initialized once");
+    }
 
     // Run TUI
     let (app_tx, app_rx) = mpsc::channel(5000);

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -47,6 +47,7 @@ struct PowerShelfLiveState {
     power_state: MockPowerState,
     bmc_ip: Option<Ipv4Addr>,
     ipmi_endpoint: Option<IpmiEndpoint>,
+    ssh_endpoint_port: Option<u16>,
     ssh_host_key: Option<String>,
     state: &'static str,
 }
@@ -57,6 +58,7 @@ impl PowerShelfLiveState {
             power_state: fsm.power_state(),
             bmc_ip: None,
             ipmi_endpoint: None,
+            ssh_endpoint_port: None,
             ssh_host_key: None,
             state: fsm.state_string(),
         }
@@ -362,11 +364,19 @@ impl PowerShelfActor {
                     .await
                     .insert(dhcp_info.ip_address.to_string(), bmc_mock.router().clone());
                 bmc_mock
-                    .start_ipmi_only(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+                    .start_shared_mode_consoles(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
                     .await?
                     .map(Arc::new)
             }
         };
+
+        if let Some(ssh_host_key) = bmc_handle
+            .as_ref()
+            .and_then(|handle| handle.ssh_handle.as_ref())
+            .map(|handle| handle.host_pubkey.clone())
+        {
+            self.live_state.write().unwrap().ssh_host_key = Some(ssh_host_key);
+        }
 
         {
             let mut state = self.live_state.write().unwrap();
@@ -374,6 +384,9 @@ impl PowerShelfActor {
             state.ipmi_endpoint = bmc_handle
                 .as_ref()
                 .and_then(|handle| handle.ipmi_endpoint());
+            state.ssh_endpoint_port = bmc_handle
+                .as_ref()
+                .and_then(|handle| handle.ssh_endpoint_port());
         }
         self._bmc_mock = bmc_handle;
         Ok(())
@@ -518,6 +531,7 @@ impl PowerShelfHandle {
                 ip: state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
                 ipmi: state.ipmi_endpoint.map(Into::into),
+                ssh: state.ssh_endpoint_port.map(EndpointStatus::ssh),
             },
             dpus: Vec::new(),
         }

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -111,6 +111,8 @@ pub struct BmcStatus {
     pub redfish: EndpointStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipmi: Option<EndpointStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssh: Option<EndpointStatus>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -124,6 +126,13 @@ impl EndpointStatus {
         Self {
             reachable_port: config.redfish_reachable_port,
             listen_port: config.redfish_listen_port,
+        }
+    }
+
+    pub fn ssh(port: u16) -> Self {
+        Self {
+            reachable_port: port,
+            listen_port: port,
         }
     }
 }

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -47,6 +47,7 @@ struct SwitchLiveState {
     bmc_ip: Option<Ipv4Addr>,
     nvos_ip: Option<Ipv4Addr>,
     ipmi_endpoint: Option<IpmiEndpoint>,
+    ssh_endpoint_port: Option<u16>,
     ssh_host_key: Option<String>,
     state: &'static str,
 }
@@ -58,6 +59,7 @@ impl SwitchLiveState {
             bmc_ip: None,
             nvos_ip: None,
             ipmi_endpoint: None,
+            ssh_endpoint_port: None,
             ssh_host_key: None,
             state: fsm.state_string(),
         }
@@ -398,11 +400,19 @@ impl SwitchActor {
                     .await
                     .insert(dhcp_info.ip_address.to_string(), bmc_mock.router().clone());
                 bmc_mock
-                    .start_ipmi_only(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+                    .start_shared_mode_consoles(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
                     .await?
                     .map(Arc::new)
             }
         };
+
+        if let Some(ssh_host_key) = bmc_handle
+            .as_ref()
+            .and_then(|handle| handle.ssh_handle.as_ref())
+            .map(|handle| handle.host_pubkey.clone())
+        {
+            self.live_state.write().unwrap().ssh_host_key = Some(ssh_host_key);
+        }
 
         {
             let mut state = self.live_state.write().unwrap();
@@ -410,6 +420,9 @@ impl SwitchActor {
             state.ipmi_endpoint = bmc_handle
                 .as_ref()
                 .and_then(|handle| handle.ipmi_endpoint());
+            state.ssh_endpoint_port = bmc_handle
+                .as_ref()
+                .and_then(|handle| handle.ssh_endpoint_port());
         }
         self._bmc_mock = bmc_handle;
         Ok(())
@@ -554,6 +567,7 @@ impl SwitchHandle {
                 ip: state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
                 ipmi: state.ipmi_endpoint.map(Into::into),
+                ssh: state.ssh_endpoint_port.map(EndpointStatus::ssh),
             },
             dpus: Vec::new(),
         }

--- a/crates/preingestion-manager/tests/integration/common.rs
+++ b/crates/preingestion-manager/tests/integration/common.rs
@@ -109,6 +109,7 @@ fn build_exploration_report(
             power_state: PowerState::On,
             sku: None,
             boot_order: None,
+            serial_console_ssh_port: None,
         }],
         chassis: vec![Chassis {
             model: Some(model.to_string()),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5355,6 +5355,8 @@ message BMCMetaDataGetResponse {
   optional uint32 ssh_port = 6;
   optional uint32 ipmi_port = 7;
   optional string vendor = 8;
+  // SSH port for the managed system's serial console, not the manager CLI.
+  optional uint32 serial_console_ssh_port = 9;
 }
 
 message MachineCredentialsUpdateRequest {

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -946,6 +946,7 @@ async fn fetch_system(client: &dyn Redfish) -> Result<FetchedSystem, EndpointExp
             power_state: system.power_state.into_model(),
             sku: system.sku,
             boot_order,
+            serial_console_ssh_port: None,
         },
         is_dpu,
         is_host: !(is_dpu || is_switch || is_powershelf),

--- a/crates/ssh-console-mock-api-server/src/api.rs
+++ b/crates/ssh-console-mock-api-server/src/api.rs
@@ -132,7 +132,7 @@ impl Forge for MockApiServer {
             ip: mock_host.bmc_ip.to_string(),
             user: mock_host.bmc_user.clone(),
             password: mock_host.bmc_password.clone(),
-            ssh_port: mock_host.bmc_ssh_port.map(Into::into),
+            serial_console_ssh_port: mock_host.serial_console_ssh_port.map(Into::into),
             ipmi_port: mock_host.ipmi_port.map(Into::into),
             vendor: Some(mock_host.sys_vendor.to_string()),
             ..Default::default()

--- a/crates/ssh-console-mock-api-server/src/lib.rs
+++ b/crates/ssh-console-mock-api-server/src/lib.rs
@@ -40,7 +40,7 @@ pub struct MockHost {
     pub tenant_public_key: String,
     pub sys_vendor: &'static str,
     pub bmc_ip: IpAddr,
-    pub bmc_ssh_port: Option<u16>,
+    pub serial_console_ssh_port: Option<u16>,
     pub ipmi_port: Option<u16>,
     pub bmc_user: String,
     pub bmc_password: String,

--- a/crates/ssh-console/src/bmc/connection.rs
+++ b/crates/ssh-console/src/bmc/connection.rs
@@ -158,7 +158,8 @@ pub(super) async fn lookup(
         password,
         mac: _,
         port: _,
-        ssh_port,
+        ssh_port: _,
+        serial_console_ssh_port,
         ipmi_port,
         vendor,
     } = forge_api_client
@@ -183,11 +184,9 @@ pub(super) async fn lookup(
     })?;
 
     let port = match &bmc_vendor {
-        BmcVendor::Ssh(ssh_bmc_vendor) => ssh_port
-            .map(u16::try_from)
-            .transpose()
+        BmcVendor::Ssh(ssh_bmc_vendor) => nonzero_serial_console_ssh_port(serial_console_ssh_port)
             .map_err(|e| LookupError::InvalidBmcMetadata {
-                reason: format!("invalid ssh port: {e:?}"),
+                reason: format!("invalid SSH serial-console port: {e:?}"),
             })?
             .or(config.override_bmc_ssh_port)
             .unwrap_or(match ssh_bmc_vendor {
@@ -235,6 +234,14 @@ pub(super) async fn lookup(
     };
 
     Ok(connection_details)
+}
+
+fn nonzero_serial_console_ssh_port(
+    port: Option<u32>,
+) -> Result<Option<u16>, std::num::TryFromIntError> {
+    port.filter(|port| *port != 0)
+        .map(u16::try_from)
+        .transpose()
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -401,5 +408,22 @@ impl AtomicConnectionState {
 impl Default for AtomicConnectionState {
     fn default() -> Self {
         AtomicConnectionState::new(State::Disconnected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nonzero_serial_console_ssh_port;
+
+    #[test]
+    fn validates_serial_console_ssh_port() {
+        assert_eq!(nonzero_serial_console_ssh_port(None).unwrap(), None);
+        assert_eq!(nonzero_serial_console_ssh_port(Some(0)).unwrap(), None);
+        assert_eq!(nonzero_serial_console_ssh_port(Some(1)).unwrap(), Some(1));
+        assert_eq!(
+            nonzero_serial_console_ssh_port(Some(u16::MAX.into())).unwrap(),
+            Some(u16::MAX)
+        );
+        assert!(nonzero_serial_console_ssh_port(Some(u32::from(u16::MAX) + 1)).is_err());
     }
 }

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -152,7 +152,7 @@ pub(crate) async fn run_baseline_test_environment(
                     MockBmcHandle::Ipmi(_) => "Supermicro",
                 },
                 bmc_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                bmc_ssh_port: match &bmc_handle {
+                serial_console_ssh_port: match &bmc_handle {
                     MockBmcHandle::Ssh(s) => Some(s.port),
                     MockBmcHandle::Ipmi(_) => None,
                 },

--- a/crates/ssh-console/tests/util/ssh_console_test_helper.rs
+++ b/crates/ssh-console/tests/util/ssh_console_test_helper.rs
@@ -58,7 +58,7 @@ pub(crate) async fn spawn(
         override_bmcs: None,
         dpus: false,
         insecure: false,
-        override_bmc_ssh_port: Some(2222),
+        override_bmc_ssh_port: None,
         override_ipmi_port: Some(1623),
         insecure_ipmi_ciphers: true,
         force_deactivate_conflicting_ipmi_sol_sessions: config_overrides

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -28753,17 +28753,19 @@ func (x *BMCMetaDataGetRequest) GetBmcEndpointRequest() *BmcEndpointRequest {
 }
 
 type BMCMetaDataGetResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ip            string                 `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
-	User          string                 `protobuf:"bytes,2,opt,name=user,proto3" json:"user,omitempty"`
-	Password      string                 `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty"`
-	Mac           string                 `protobuf:"bytes,4,opt,name=mac,proto3" json:"mac,omitempty"`
-	Port          *uint32                `protobuf:"varint,5,opt,name=port,proto3,oneof" json:"port,omitempty"`
-	SshPort       *uint32                `protobuf:"varint,6,opt,name=ssh_port,json=sshPort,proto3,oneof" json:"ssh_port,omitempty"`
-	IpmiPort      *uint32                `protobuf:"varint,7,opt,name=ipmi_port,json=ipmiPort,proto3,oneof" json:"ipmi_port,omitempty"`
-	Vendor        *string                `protobuf:"bytes,8,opt,name=vendor,proto3,oneof" json:"vendor,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Ip       string                 `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	User     string                 `protobuf:"bytes,2,opt,name=user,proto3" json:"user,omitempty"`
+	Password string                 `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty"`
+	Mac      string                 `protobuf:"bytes,4,opt,name=mac,proto3" json:"mac,omitempty"`
+	Port     *uint32                `protobuf:"varint,5,opt,name=port,proto3,oneof" json:"port,omitempty"`
+	SshPort  *uint32                `protobuf:"varint,6,opt,name=ssh_port,json=sshPort,proto3,oneof" json:"ssh_port,omitempty"`
+	IpmiPort *uint32                `protobuf:"varint,7,opt,name=ipmi_port,json=ipmiPort,proto3,oneof" json:"ipmi_port,omitempty"`
+	Vendor   *string                `protobuf:"bytes,8,opt,name=vendor,proto3,oneof" json:"vendor,omitempty"`
+	// SSH port for the managed system's serial console, not the manager CLI.
+	SerialConsoleSshPort *uint32 `protobuf:"varint,9,opt,name=serial_console_ssh_port,json=serialConsoleSshPort,proto3,oneof" json:"serial_console_ssh_port,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *BMCMetaDataGetResponse) Reset() {
@@ -28850,6 +28852,13 @@ func (x *BMCMetaDataGetResponse) GetVendor() string {
 		return *x.Vendor
 	}
 	return ""
+}
+
+func (x *BMCMetaDataGetResponse) GetSerialConsoleSshPort() uint32 {
+	if x != nil && x.SerialConsoleSshPort != nil {
+		return *x.SerialConsoleSshPort
+	}
+	return 0
 }
 
 type MachineCredentialsUpdateRequest struct {
@@ -66533,7 +66542,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x04role\x18\x02 \x01(\x0e2\x10.forge.UserRolesR\x04role\x128\n" +
 	"\frequest_type\x18\x03 \x01(\x0e2\x15.forge.BMCRequestTypeR\vrequestType\x12P\n" +
 	"\x14bmc_endpoint_request\x18\x04 \x01(\v2\x19.forge.BmcEndpointRequestH\x00R\x12bmcEndpointRequest\x88\x01\x01B\x17\n" +
-	"\x15_bmc_endpoint_request\"\x91\x02\n" +
+	"\x15_bmc_endpoint_request\"\xe9\x02\n" +
 	"\x16BMCMetaDataGetResponse\x12\x0e\n" +
 	"\x02ip\x18\x01 \x01(\tR\x02ip\x12\x12\n" +
 	"\x04user\x18\x02 \x01(\tR\x04user\x12\x1a\n" +
@@ -66542,12 +66551,14 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x04port\x18\x05 \x01(\rH\x00R\x04port\x88\x01\x01\x12\x1e\n" +
 	"\bssh_port\x18\x06 \x01(\rH\x01R\asshPort\x88\x01\x01\x12 \n" +
 	"\tipmi_port\x18\a \x01(\rH\x02R\bipmiPort\x88\x01\x01\x12\x1b\n" +
-	"\x06vendor\x18\b \x01(\tH\x03R\x06vendor\x88\x01\x01B\a\n" +
+	"\x06vendor\x18\b \x01(\tH\x03R\x06vendor\x88\x01\x01\x12:\n" +
+	"\x17serial_console_ssh_port\x18\t \x01(\rH\x04R\x14serialConsoleSshPort\x88\x01\x01B\a\n" +
 	"\x05_portB\v\n" +
 	"\t_ssh_portB\f\n" +
 	"\n" +
 	"_ipmi_portB\t\n" +
-	"\a_vendor\"\xaf\x03\n" +
+	"\a_vendorB\x1a\n" +
+	"\x18_serial_console_ssh_port\"\xaf\x03\n" +
 	"\x1fMachineCredentialsUpdateRequest\x120\n" +
 	"\n" +
 	"machine_id\x18\x04 \x01(\v2\x11.common.MachineIdR\tmachineId\x12T\n" +

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -5168,6 +5168,8 @@ message BMCMetaDataGetResponse {
   optional uint32 ssh_port = 6;
   optional uint32 ipmi_port = 7;
   optional string vendor = 8;
+  // SSH port for the managed system's serial console, not the manager CLI.
+  optional uint32 serial_console_ssh_port = 9;
 }
 
 message MachineCredentialsUpdateRequest {


### PR DESCRIPTION
Today, ssh-console uses BMC vendor to identify port for SSH console. However, this information is exposed via Redfish (`ComputerSystem#SerialConsole.SSH.Port` path). Taking SSH port from this attribute is more robust way of choosing correct port. In addition, it enables possibility to work with multiple machines simulated by machine-a-tron.

This PR:
- Provides plumbing of SSH serial console port from site explorer to ssh-console
- Adds exposure of SSH port via Redfish from machine-a-tron

## Related issues

Closes: #4887 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

libredfish exploration mode is out of scope.
