### PR TITLE
refactor(flow): separate target resolver lookup from execution

### DIFF
--- a/rest-api/flow/internal/eventrule/leakage/leakage.go
+++ b/rest-api/flow/internal/eventrule/leakage/leakage.go
@@ -47,11 +47,11 @@ func RegisterTargetResolvers(
 	return registry.Register(
 		TypeHardwareLeakDetected,
 		eventrule.TargetStrategyAffectedComponents,
-		resolver.resolveAffectedComponents,
+		resolver,
 	)
 }
 
-func (r *targetResolver) resolveAffectedComponents(
+func (r *targetResolver) Resolve(
 	ctx context.Context,
 	request target.ResolveRequest,
 ) ([]target.Target, error) {

--- a/rest-api/flow/internal/eventrule/leakage/leakage_test.go
+++ b/rest-api/flow/internal/eventrule/leakage/leakage_test.go
@@ -59,7 +59,7 @@ func testResolveAffectedComponentsRack(t *testing.T) {
 	registry := target.New()
 	require.NoError(t, RegisterTargetResolvers(registry, inventory))
 
-	targets, err := registry.Resolve(context.Background(), target.ResolveRequest{
+	request := target.ResolveRequest{
 		Envelope: eventrule.Envelope{Type: TypeHardwareLeakDetected},
 		Resource: eventrule.ResolvedResource{
 			Kind:   eventrule.ResourceKindRack,
@@ -67,7 +67,10 @@ func testResolveAffectedComponentsRack(t *testing.T) {
 			RackID: rackID,
 		},
 		Strategy: eventrule.TargetStrategyAffectedComponents,
-	})
+	}
+	resolver, err := registry.Lookup(request.Envelope.Type, request.Strategy)
+	require.NoError(t, err)
+	targets, err := resolver.Resolve(context.Background(), request)
 	require.NoError(t, err)
 	require.Equal(t, []target.Target{{
 		Kind: eventrule.ResourceKindRack,
@@ -158,7 +161,7 @@ func testResolveAffectedComponents(t *testing.T) {
 	registry := target.New()
 	require.NoError(t, RegisterTargetResolvers(registry, inventory))
 
-	targets, err := registry.Resolve(context.Background(), target.ResolveRequest{
+	request := target.ResolveRequest{
 		Envelope: eventrule.Envelope{Type: TypeHardwareLeakDetected},
 		Resource: eventrule.ResolvedResource{
 			Kind:          eventrule.ResourceKindComponent,
@@ -167,7 +170,10 @@ func testResolveAffectedComponents(t *testing.T) {
 			ComponentType: flowtypes.ComponentTypeCompute,
 		},
 		Strategy: eventrule.TargetStrategyAffectedComponents,
-	})
+	}
+	resolver, err := registry.Lookup(request.Envelope.Type, request.Strategy)
+	require.NoError(t, err)
+	targets, err := resolver.Resolve(context.Background(), request)
 	require.NoError(t, err)
 	require.Equal(t, []target.Target{
 		{Kind: eventrule.ResourceKindComponent, ID: firstBelowID},
@@ -189,7 +195,7 @@ func testResolveAffectedComponentsSourceOnly(t *testing.T) {
 	registry := target.New()
 	require.NoError(t, RegisterTargetResolvers(registry, inventory))
 
-	targets, err := registry.Resolve(context.Background(), target.ResolveRequest{
+	request := target.ResolveRequest{
 		Envelope: eventrule.Envelope{Type: TypeHardwareLeakDetected},
 		Resource: eventrule.ResolvedResource{
 			Kind:          eventrule.ResourceKindComponent,
@@ -198,7 +204,10 @@ func testResolveAffectedComponentsSourceOnly(t *testing.T) {
 			ComponentType: flowtypes.ComponentTypeCompute,
 		},
 		Strategy: eventrule.TargetStrategyAffectedComponents,
-	})
+	}
+	resolver, err := registry.Lookup(request.Envelope.Type, request.Strategy)
+	require.NoError(t, err)
+	targets, err := resolver.Resolve(context.Background(), request)
 	require.NoError(t, err)
 	require.Equal(t, []target.Target{{
 		Kind: eventrule.ResourceKindComponent,
@@ -211,7 +220,7 @@ func testResolveAffectedComponentsError(t *testing.T) {
 	require.NoError(t, RegisterTargetResolvers(registry, &targetInventory{
 		rackErr: errors.New("inventory unavailable"),
 	}))
-	targets, err := registry.Resolve(context.Background(), target.ResolveRequest{
+	request := target.ResolveRequest{
 		Envelope: eventrule.Envelope{Type: TypeHardwareLeakDetected},
 		Resource: eventrule.ResolvedResource{
 			Kind:          eventrule.ResourceKindComponent,
@@ -220,7 +229,10 @@ func testResolveAffectedComponentsError(t *testing.T) {
 			ComponentType: flowtypes.ComponentTypeCompute,
 		},
 		Strategy: eventrule.TargetStrategyAffectedComponents,
-	})
+	}
+	resolver, err := registry.Lookup(request.Envelope.Type, request.Strategy)
+	require.NoError(t, err)
+	targets, err := resolver.Resolve(context.Background(), request)
 	require.ErrorContains(t, err, "inventory unavailable")
 	require.Nil(t, targets)
 }
@@ -238,7 +250,7 @@ func testResolveAffectedComponentsMalformedTopology(t *testing.T) {
 		},
 	}))
 
-	targets, err := registry.Resolve(context.Background(), target.ResolveRequest{
+	request := target.ResolveRequest{
 		Envelope: eventrule.Envelope{Type: TypeHardwareLeakDetected},
 		Resource: eventrule.ResolvedResource{
 			Kind:          eventrule.ResourceKindComponent,
@@ -247,7 +259,10 @@ func testResolveAffectedComponentsMalformedTopology(t *testing.T) {
 			ComponentType: flowtypes.ComponentTypeCompute,
 		},
 		Strategy: eventrule.TargetStrategyAffectedComponents,
-	})
+	}
+	resolver, err := registry.Lookup(request.Envelope.Type, request.Strategy)
+	require.NoError(t, err)
+	targets, err := resolver.Resolve(context.Background(), request)
 	require.ErrorContains(t, err, "has no valid position")
 	require.ErrorIs(t, err, target.ErrUnresolvable)
 	require.Nil(t, targets)

--- a/rest-api/flow/internal/eventrule/processor/config.go
+++ b/rest-api/flow/internal/eventrule/processor/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	Inventory  inventoryresolver.InventoryReader
 	Rules      RuleResolver
 	Executions eventrule.ExecutionStore
-	Targets    target.Resolver
+	Targets    *target.Registry
 	Executor   executor.Executor
 }
 
@@ -33,7 +33,7 @@ func (c Config) Validate() error {
 		return fmt.Errorf("execution store is required")
 	}
 	if c.Targets == nil {
-		return fmt.Errorf("target resolver is required")
+		return fmt.Errorf("target resolver registry is required")
 	}
 	if c.Executor == nil {
 		return fmt.Errorf("action executor is required")

--- a/rest-api/flow/internal/eventrule/processor/config_test.go
+++ b/rest-api/flow/internal/eventrule/processor/config_test.go
@@ -29,7 +29,7 @@ func TestConfigValidate(t *testing.T) {
 		},
 		"missing target resolver": {
 			mutate:  func(config *Config) { config.Targets = nil },
-			wantErr: "target resolver is required",
+			wantErr: "target resolver registry is required",
 		},
 		"missing action executor": {
 			mutate:  func(config *Config) { config.Executor = nil },

--- a/rest-api/flow/internal/eventrule/processor/execution.go
+++ b/rest-api/flow/internal/eventrule/processor/execution.go
@@ -71,14 +71,11 @@ func (p *Processor) resolveTargets(
 		return nil, nil
 	}
 
-	targets, err := p.targets.Resolve(
-		ctx,
-		target.ResolveRequest{
-			Envelope: prepared.Envelope,
-			Resource: prepared.Resource,
-			Strategy: strategy,
-		},
-	)
+	targets, err := p.resolveTargetRequest(ctx, target.ResolveRequest{
+		Envelope: prepared.Envelope,
+		Resource: prepared.Resource,
+		Strategy: strategy,
+	})
 	if err != nil {
 		if isTerminalTargetError(err) {
 			result := eventrule.FailedExecutionResult(err.Error())
@@ -98,6 +95,33 @@ func (p *Processor) resolveTargets(
 			eventrule.ExecutionReasonNoTargets,
 		)
 		return nil, &result
+	}
+
+	return targets, nil
+}
+
+func (p *Processor) resolveTargetRequest(
+	ctx context.Context,
+	request target.ResolveRequest,
+) ([]target.Target, error) {
+	resolver, err := p.targets.Lookup(request.Envelope.Type, request.Strategy)
+	if err != nil {
+		return nil, err
+	}
+
+	targets, err := resolver.Resolve(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	for i, resolved := range targets {
+		if err := resolved.Validate(); err != nil {
+			return nil, fmt.Errorf(
+				"%w: resolver target %d: %v",
+				target.ErrUnresolvable,
+				i,
+				err,
+			)
+		}
 	}
 
 	return targets, nil

--- a/rest-api/flow/internal/eventrule/processor/process_test.go
+++ b/rest-api/flow/internal/eventrule/processor/process_test.go
@@ -34,6 +34,7 @@ func TestProcessor_Process(t *testing.T) {
 		ruleErr          error
 		invalidEnvelope  bool
 		noTargets        bool
+		invalidTarget    bool
 		targetErr        error
 		executorErr      error
 		cancelContext    bool
@@ -99,6 +100,13 @@ func TestProcessor_Process(t *testing.T) {
 			targetErr:      fmt.Errorf("%w: invalid topology", eventtarget.ErrUnresolvable),
 			wantStatus:     eventrule.ExecutionStatusFailed,
 			wantMessage:    "event target cannot be resolved: invalid topology",
+			wantExecutions: 1,
+		},
+		"invalid resolved target fails": {
+			rule:           processorRuntimeRule(submitAction("submit")),
+			invalidTarget:  true,
+			wantStatus:     eventrule.ExecutionStatusFailed,
+			wantMessage:    "event target cannot be resolved: resolver target 0: target id is required",
 			wantExecutions: 1,
 		},
 		"unresolvable inventory target fails": {
@@ -182,13 +190,13 @@ func TestProcessor_Process(t *testing.T) {
 
 			var executorRuns int
 			targets := defaultTargetResolver(rackID)
-			if test.noTargets || test.targetErr != nil {
-				targets = targetResolverFunc(func(
-					context.Context,
-					eventtarget.ResolveRequest,
-				) ([]eventtarget.Target, error) {
-					return nil, test.targetErr
-				})
+			if test.noTargets || test.invalidTarget || test.targetErr != nil {
+				targets = &testTargetResolver{err: test.targetErr}
+				if test.invalidTarget {
+					targets = &testTargetResolver{targets: []eventtarget.Target{{
+						Kind: eventrule.ResourceKindRack,
+					}}}
+				}
 			}
 			execute := executorFunc(func(
 				_ context.Context,
@@ -349,13 +357,10 @@ func testProcessDeferredRedelivery(t *testing.T) {
 		processorRuntimeRule(submitAction("submit")),
 		nil,
 		store,
-		targetResolverFunc(func(
-			context.Context,
-			eventtarget.ResolveRequest,
-		) ([]eventtarget.Target, error) {
-			resolverRuns++
-			return nil, errors.New("inventory unavailable")
-		}),
+		&testTargetResolver{
+			err:  errors.New("inventory unavailable"),
+			runs: &resolverRuns,
+		},
 		executorFunc(func(
 			context.Context,
 			eventexecutor.ExecutionRequest,
@@ -491,7 +496,7 @@ func runtimeProcessor(
 		},
 		Rules:      resolver,
 		Executions: store,
-		Targets:    targets,
+		Targets:    targetRegistry(t, targets),
 		Executor:   execute,
 	})
 	require.NoError(t, err)
@@ -517,7 +522,7 @@ func newTestProcessor(
 		Inventory:  inventory,
 		Rules:      rules,
 		Executions: memorystore.New(),
-		Targets:    defaultTargetResolver(uuid.New()),
+		Targets:    eventtarget.New(),
 		Executor: executorFunc(func(
 			_ context.Context,
 			request eventexecutor.ExecutionRequest,
@@ -569,25 +574,41 @@ func successResult(request eventexecutor.ExecutionRequest) eventrule.ExecutionRe
 	return eventrule.CompletedExecutionResult()
 }
 
-type targetResolverFunc func(
-	context.Context,
-	eventtarget.ResolveRequest,
-) ([]eventtarget.Target, error)
-
-func (f targetResolverFunc) Resolve(
-	ctx context.Context,
-	request eventtarget.ResolveRequest,
-) ([]eventtarget.Target, error) {
-	return f(ctx, request)
+func targetRegistry(
+	t *testing.T,
+	resolver eventtarget.Resolver,
+) *eventtarget.Registry {
+	t.Helper()
+	registry := eventtarget.New()
+	require.NoError(t, registry.Register(
+		"test.event",
+		eventrule.TargetStrategyRack,
+		resolver,
+	))
+	return registry
 }
 
 func defaultTargetResolver(rackID uuid.UUID) eventtarget.Resolver {
-	return targetResolverFunc(func(
-		context.Context,
-		eventtarget.ResolveRequest,
-	) ([]eventtarget.Target, error) {
-		return []eventtarget.Target{{Kind: eventrule.ResourceKindRack, ID: rackID}}, nil
-	})
+	return &testTargetResolver{targets: []eventtarget.Target{{
+		Kind: eventrule.ResourceKindRack,
+		ID:   rackID,
+	}}}
+}
+
+type testTargetResolver struct {
+	targets []eventtarget.Target
+	err     error
+	runs    *int
+}
+
+func (r *testTargetResolver) Resolve(
+	context.Context,
+	eventtarget.ResolveRequest,
+) ([]eventtarget.Target, error) {
+	if r.runs != nil {
+		(*r.runs)++
+	}
+	return r.targets, r.err
 }
 
 type executorFunc func(
@@ -613,7 +634,7 @@ func validProcessorConfig() Config {
 			return nil, nil
 		}),
 		Executions: memorystore.New(),
-		Targets:    defaultTargetResolver(uuid.New()),
+		Targets:    eventtarget.New(),
 		Executor: executorFunc(func(
 			_ context.Context,
 			request eventexecutor.ExecutionRequest,

--- a/rest-api/flow/internal/eventrule/processor/processor.go
+++ b/rest-api/flow/internal/eventrule/processor/processor.go
@@ -19,7 +19,7 @@ type Processor struct {
 	inventory  *inventoryresolver.Resolver
 	rules      RuleResolver
 	executions eventrule.ExecutionStore
-	targets    target.Resolver
+	targets    *target.Registry
 	executor   executor.Executor
 }
 

--- a/rest-api/flow/internal/eventrule/target/generic.go
+++ b/rest-api/flow/internal/eventrule/target/generic.go
@@ -10,7 +10,9 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
 )
 
-func resolveComponent(
+type componentResolver struct{}
+
+func (componentResolver) Resolve(
 	_ context.Context,
 	request ResolveRequest,
 ) ([]Target, error) {
@@ -29,7 +31,9 @@ func resolveComponent(
 	}}, nil
 }
 
-func resolveRack(
+type rackResolver struct{}
+
+func (rackResolver) Resolve(
 	_ context.Context,
 	request ResolveRequest,
 ) ([]Target, error) {
@@ -39,15 +43,17 @@ func resolveRack(
 	}}, nil
 }
 
-func resolveAffectedComponents(
+type affectedComponentsResolver struct{}
+
+func (affectedComponentsResolver) Resolve(
 	ctx context.Context,
 	request ResolveRequest,
 ) ([]Target, error) {
 	switch request.Resource.Kind {
 	case eventrule.ResourceKindComponent:
-		return resolveComponent(ctx, request)
+		return (componentResolver{}).Resolve(ctx, request)
 	case eventrule.ResourceKindRack:
-		return resolveRack(ctx, request)
+		return (rackResolver{}).Resolve(ctx, request)
 	default:
 		return nil, fmt.Errorf(
 			"%w: "+

--- a/rest-api/flow/internal/eventrule/target/registry.go
+++ b/rest-api/flow/internal/eventrule/target/registry.go
@@ -4,7 +4,6 @@
 package target
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
@@ -16,32 +15,33 @@ type resolverKey struct {
 	strategy  eventrule.TargetStrategy
 }
 
-// Registry dispatches generic and event-specific target strategies.
+// Registry stores generic and event-specific target resolvers.
 type Registry struct {
 	mu            sync.RWMutex
-	generic       map[eventrule.TargetStrategy]ResolverFunc
-	eventSpecific map[resolverKey]ResolverFunc
+	generic       map[eventrule.TargetStrategy]Resolver
+	eventSpecific map[resolverKey]Resolver
 }
 
 // New constructs a registry containing the generic component, rack, and
 // affected-components strategies.
 func New() *Registry {
 	return &Registry{
-		generic: map[eventrule.TargetStrategy]ResolverFunc{
-			eventrule.TargetStrategyComponent:          resolveComponent,
-			eventrule.TargetStrategyRack:               resolveRack,
-			eventrule.TargetStrategyAffectedComponents: resolveAffectedComponents,
+		generic: map[eventrule.TargetStrategy]Resolver{
+			eventrule.TargetStrategyComponent:          componentResolver{},
+			eventrule.TargetStrategyRack:               rackResolver{},
+			eventrule.TargetStrategyAffectedComponents: affectedComponentsResolver{},
 		},
-		eventSpecific: make(map[resolverKey]ResolverFunc),
+		eventSpecific: make(map[resolverKey]Resolver),
 	}
 }
 
-// Register associates an event-specific strategy with its resolver. An
-// event-specific resolver takes precedence over the generic strategy resolver.
+// Register associates an event-specific strategy with a Resolver
+// implementation. An event-specific resolver takes precedence over the generic
+// strategy resolver.
 func (r *Registry) Register(
 	eventType eventrule.Type,
 	strategy eventrule.TargetStrategy,
-	resolver ResolverFunc,
+	resolver Resolver,
 ) error {
 	if r == nil {
 		return fmt.Errorf("target resolver registry is nil")
@@ -55,10 +55,12 @@ func (r *Registry) Register(
 	if !strategy.RequiresResolution() {
 		return fmt.Errorf("target strategy %q does not require resolution", strategy)
 	}
+	// Check the interface itself only. Registrations are controlled by this
+	// service, so a typed-nil implementation is a programming bug and does not
+	// justify reflection-based validation here.
 	if resolver == nil {
 		return fmt.Errorf("target resolver is required")
 	}
-
 	key := resolverKey{eventType: eventType, strategy: strategy}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -73,47 +75,36 @@ func (r *Registry) Register(
 	return nil
 }
 
-// Resolve dispatches a request to its generic or event-specific target
-// resolver.
-func (r *Registry) Resolve(
-	ctx context.Context,
-	request ResolveRequest,
-) ([]Target, error) {
+// Lookup returns the event-specific resolver when registered, otherwise the
+// generic resolver for the strategy. It returns either a non-nil resolver and
+// a nil error, or a nil resolver and a non-nil error; it never returns
+// (nil, nil).
+func (r *Registry) Lookup(
+	eventType eventrule.Type,
+	strategy eventrule.TargetStrategy,
+) (Resolver, error) {
 	if r == nil {
-		return nil, fmt.Errorf("target resolver registry is nil")
+		return nil, fmt.Errorf("%w: target resolver registry is nil", ErrUnresolvable)
+	}
+	if err := eventType.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: event type: %v", ErrUnresolvable, err)
+	}
+	if err := strategy.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: target strategy: %v", ErrUnresolvable, err)
 	}
 
-	if err := request.Resource.Validate(); err != nil {
-		return nil, fmt.Errorf("%w: target resource: %v", ErrUnresolvable, err)
-	}
-
-	resolver := r.resolver(request.Envelope.Type, request.Strategy)
+	resolver := r.lookup(eventType, strategy)
 	if resolver == nil {
 		return nil, fmt.Errorf(
 			"%w: "+
 				"no target resolver for event type %q and strategy %q",
 			ErrUnresolvable,
-			request.Envelope.Type,
-			request.Strategy,
+			eventType,
+			strategy,
 		)
 	}
 
-	targets, err := resolver(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-	for i, resolved := range targets {
-		if err := resolved.Validate(); err != nil {
-			return nil, fmt.Errorf(
-				"%w: resolver target %d: %v",
-				ErrUnresolvable,
-				i,
-				err,
-			)
-		}
-	}
-
-	return targets, nil
+	return resolver, nil
 }
 
 // ValidateRule checks that every task action in a valid rule has a registered
@@ -132,7 +123,7 @@ func (r *Registry) ValidateRule(rule *eventrule.Rule) error {
 		if !strategy.RequiresResolution() {
 			continue
 		}
-		if r.resolver(rule.EventType, strategy) == nil {
+		if _, err := r.Lookup(rule.EventType, strategy); err != nil {
 			return fmt.Errorf(
 				"event rule %s action %q has no target resolver for strategy %q",
 				rule.ID,
@@ -145,10 +136,10 @@ func (r *Registry) ValidateRule(rule *eventrule.Rule) error {
 	return nil
 }
 
-func (r *Registry) resolver(
+func (r *Registry) lookup(
 	eventType eventrule.Type,
 	strategy eventrule.TargetStrategy,
-) ResolverFunc {
+) Resolver {
 	key := resolverKey{eventType: eventType, strategy: strategy}
 
 	r.mu.RLock()
@@ -160,5 +151,3 @@ func (r *Registry) resolver(
 
 	return r.generic[strategy]
 }
-
-var _ Resolver = (*Registry)(nil)

--- a/rest-api/flow/internal/eventrule/target/registry_test.go
+++ b/rest-api/flow/internal/eventrule/target/registry_test.go
@@ -14,14 +14,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegistry_Resolve(t *testing.T) {
+func TestRegistry_Lookup(t *testing.T) {
 	componentID := uuid.New()
 	rackID := uuid.New()
 	tests := []struct {
-		name    string
-		request ResolveRequest
-		want    []Target
-		wantErr string
+		name          string
+		request       ResolveRequest
+		want          []Target
+		wantErr       string
+		wantLookupErr string
 	}{
 		{
 			name: "component",
@@ -52,14 +53,6 @@ func TestRegistry_Resolve(t *testing.T) {
 			wantErr: "requires a component resource",
 		},
 		{
-			name: "component requires identity",
-			request: targetRequest(
-				eventrule.TargetStrategyComponent,
-				eventrule.ResolvedResource{Kind: eventrule.ResourceKindComponent},
-			),
-			wantErr: "resolved resource id is required",
-		},
-		{
 			name: "rack from component",
 			request: targetRequest(
 				eventrule.TargetStrategyRack,
@@ -71,14 +64,6 @@ func TestRegistry_Resolve(t *testing.T) {
 				},
 			),
 			want: []Target{{Kind: eventrule.ResourceKindRack, ID: rackID}},
-		},
-		{
-			name: "rack requires identity",
-			request: targetRequest(
-				eventrule.TargetStrategyRack,
-				eventrule.ResolvedResource{Kind: eventrule.ResourceKindRack},
-			),
-			wantErr: "resolved resource id is required",
 		},
 		{
 			name: "affected components from component",
@@ -106,7 +91,7 @@ func TestRegistry_Resolve(t *testing.T) {
 			want: []Target{{Kind: eventrule.ResourceKindRack, ID: rackID}},
 		},
 		{
-			name: "unregistered event-specific strategy",
+			name: "invalid strategy",
 			request: targetRequest(
 				eventrule.TargetStrategy("unknown"),
 				eventrule.ResolvedResource{
@@ -116,14 +101,38 @@ func TestRegistry_Resolve(t *testing.T) {
 					ComponentType: flowtypes.ComponentTypeCompute,
 				},
 			),
-			wantErr: "no target resolver",
+			wantLookupErr: "unknown target strategy",
+		},
+		{
+			name: "strategy without resolver",
+			request: targetRequest(
+				eventrule.TargetStrategyNone,
+				eventrule.ResolvedResource{
+					Kind:          eventrule.ResourceKindComponent,
+					ID:            componentID,
+					RackID:        rackID,
+					ComponentType: flowtypes.ComponentTypeCompute,
+				},
+			),
+			wantLookupErr: "no target resolver",
 		},
 	}
 
 	registry := New()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			resolved, err := registry.Resolve(context.Background(), test.request)
+			resolver, err := registry.Lookup(
+				test.request.Envelope.Type,
+				test.request.Strategy,
+			)
+			if test.wantLookupErr != "" {
+				require.ErrorContains(t, err, test.wantLookupErr)
+				require.Nil(t, resolver)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, resolver)
+			resolved, err := resolver.Resolve(context.Background(), test.request)
 			if test.wantErr != "" {
 				require.ErrorContains(t, err, test.wantErr)
 				require.Nil(t, resolved)
@@ -140,12 +149,10 @@ func TestRegistry_Resolve(t *testing.T) {
 		require.NoError(t, registry.Register(
 			"hardware.leak.detected",
 			eventrule.TargetStrategyComponent,
-			func(context.Context, ResolveRequest) ([]Target, error) {
-				return want, nil
-			},
+			&staticResolver{targets: want},
 		))
 
-		resolved, err := registry.Resolve(context.Background(), targetRequest(
+		request := targetRequest(
 			eventrule.TargetStrategyComponent,
 			eventrule.ResolvedResource{
 				Kind:          eventrule.ResourceKindComponent,
@@ -153,42 +160,18 @@ func TestRegistry_Resolve(t *testing.T) {
 				RackID:        rackID,
 				ComponentType: flowtypes.ComponentTypeCompute,
 			},
-		))
+		)
+		resolver, err := registry.Lookup(request.Envelope.Type, request.Strategy)
+		require.NoError(t, err)
+		require.NotNil(t, resolver)
+		resolved, err := resolver.Resolve(context.Background(), request)
 		require.NoError(t, err)
 		require.Equal(t, want, resolved)
-	})
-
-	t.Run("invalid resolver result is unresolvable", func(t *testing.T) {
-		registry := New()
-		require.NoError(t, registry.Register(
-			"hardware.leak.detected",
-			eventrule.TargetStrategyComponent,
-			func(context.Context, ResolveRequest) ([]Target, error) {
-				return []Target{{Kind: eventrule.ResourceKindComponent}}, nil
-			},
-		))
-
-		resolved, err := registry.Resolve(context.Background(), targetRequest(
-			eventrule.TargetStrategyComponent,
-			eventrule.ResolvedResource{
-				Kind:          eventrule.ResourceKindComponent,
-				ID:            componentID,
-				RackID:        rackID,
-				ComponentType: flowtypes.ComponentTypeCompute,
-			},
-		))
-		require.ErrorIs(t, err, ErrUnresolvable)
-		require.Nil(t, resolved)
 	})
 }
 
 func TestRegistry_Register(t *testing.T) {
-	resolver := ResolverFunc(func(
-		context.Context,
-		ResolveRequest,
-	) ([]Target, error) {
-		return nil, nil
-	})
+	resolver := &staticResolver{}
 
 	t.Run("event-specific strategy", func(t *testing.T) {
 		require.NoError(t, New().Register(
@@ -217,6 +200,22 @@ func TestRegistry_Register(t *testing.T) {
 			resolver,
 		))
 	})
+	t.Run("struct resolver", func(t *testing.T) {
+		registered := &staticResolver{}
+		registry := New()
+		require.NoError(t, registry.Register(
+			"hardware.leak.detected",
+			eventrule.TargetStrategyAffectedComponents,
+			registered,
+		))
+
+		resolved, err := registry.Lookup(
+			"hardware.leak.detected",
+			eventrule.TargetStrategyAffectedComponents,
+		)
+		require.NoError(t, err)
+		require.Same(t, registered, resolved)
+	})
 	t.Run("nil resolver", func(t *testing.T) {
 		require.Error(t, New().Register(
 			"hardware.leak.detected",
@@ -240,9 +239,7 @@ func TestRegistry_ValidateRule(t *testing.T) {
 		require.NoError(t, registry.Register(
 			rule.EventType,
 			eventrule.TargetStrategyAffectedComponents,
-			func(context.Context, ResolveRequest) ([]Target, error) {
-				return nil, nil
-			},
+			&staticResolver{},
 		))
 		require.NoError(t, registry.ValidateRule(rule))
 	})
@@ -274,6 +271,17 @@ func TestRegistry_ValidateRule(t *testing.T) {
 			})
 		}
 	})
+}
+
+type staticResolver struct {
+	targets []Target
+}
+
+func (r *staticResolver) Resolve(
+	context.Context,
+	ResolveRequest,
+) ([]Target, error) {
+	return r.targets, nil
 }
 
 func targetRequest(

--- a/rest-api/flow/internal/eventrule/target/target.go
+++ b/rest-api/flow/internal/eventrule/target/target.go
@@ -38,9 +38,6 @@ type Resolver interface {
 	Resolve(context.Context, ResolveRequest) ([]Target, error)
 }
 
-// ResolverFunc resolves one target request.
-type ResolverFunc func(context.Context, ResolveRequest) ([]Target, error)
-
 // Validate checks that the target has a supported kind and canonical identity.
 func (t Target) Validate() error {
 	if err := t.Kind.Validate(); err != nil {


### PR DESCRIPTION
Limit the target registry to selecting the event-specific or generic resolver
for an event type and strategy. Move resolver invocation and the validation
of the returned targets into the event processor.

This keeps registry responsibilities focused on dispatch while the processor
owns the complete action-processing boundary and terminal target-resolution
failures.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

