### PR TITLE
fix: wait for primary DPU BGP before PXE reboot

### DIFF
--- a/crates/agent/src/health.rs
+++ b/crates/agent/src/health.rs
@@ -63,20 +63,29 @@ fn make_alert(
     message: String,
     is_critical: bool,
 ) -> health_report::HealthProbeAlert {
-    let classifications = match is_critical {
+    let health_classifications = match is_critical {
         true => vec![
             health_report::HealthAlertClassification::prevent_allocations(),
             health_report::HealthAlertClassification::prevent_host_state_changes(),
         ],
         false => vec![],
     };
+    make_classified_alert(probe_id, probe_target, message, health_classifications)
+}
+
+fn make_classified_alert(
+    probe_id: impl Into<HealthProbeId>,
+    probe_target: Option<String>,
+    message: String,
+    health_classifications: Vec<health_report::HealthAlertClassification>,
+) -> health_report::HealthProbeAlert {
     health_report::HealthProbeAlert {
         id: probe_id.into(),
         target: probe_target,
         in_alert_since: None,
         message,
         tenant_message: None,
-        classifications,
+        classifications: health_classifications,
     }
 }
 
@@ -91,6 +100,25 @@ fn passed(
             id: probe_id.into(),
             target: probe_target,
         })
+}
+
+/// Makes the controller wait for one more health sample after a network update.
+///
+/// The config version and health report are published together. This critical
+/// alert makes the controller wait for the next health sample instead of acting
+/// on neighbor state collected before HBN applied the update.
+fn add_post_config_wait_alert(
+    health_report: &mut health_report::HealthReport,
+    should_wait_for_post_config_check: bool,
+) {
+    if should_wait_for_post_config_check {
+        failed(
+            health_report,
+            probe_ids::PostConfigCheckWait.clone(),
+            None,
+            "Post-config waiting period".to_string(),
+        );
+    }
 }
 
 /// Is enough of HBN ready so that we can configure it?
@@ -119,7 +147,7 @@ pub(super) struct HealthCheckParams<'a> {
     pub(super) hbn_root: &'a Path,
     pub(super) host_routes: &'a [&'a str],
     pub(super) has_changed_configs: bool,
-    pub(super) min_healthy_links: u32,
+    pub(super) min_healthy_links: usize,
     pub(super) route_servers: &'a [String],
     /// Whether this check should require the FNN IPv6-unicast underlay.
     pub(super) should_check_ipv6_unicast: bool,
@@ -180,16 +208,7 @@ pub(super) async fn health_check(params: HealthCheckParams<'_>) -> health_report
     .await;
     check_files(&mut hr, params.hbn_root, &EXPECTED_FILES);
 
-    // If we just applied a new network config report network as unhealthy.
-    // This gives HBN / BGP time to act on the config.
-    if params.has_changed_configs {
-        failed(
-            &mut hr,
-            probe_ids::PostConfigCheckWait.clone(),
-            None,
-            "Post-config waiting period".to_string(),
-        );
-    }
+    add_post_config_wait_alert(&mut hr, params.has_changed_configs);
 
     hr
 }
@@ -776,6 +795,39 @@ shm              68M  8.2k   68M   1% /run/containerd/io.containerd.grpc.v1.cri/
 overlay          41G   12G   27G  31% /run/containerd/io.containerd.runtime.v2.task/k8s.io/5e38cefc8507fcf3b872fa12f21bdbcc09244832c24a34871ef9d8d519fa37b9/rootfs
 tmpfs           3.4G     0  3.4G   0% /run/user/1002
 "#;
+
+    #[test]
+    fn post_config_wait_alert_tracks_wait_signal() {
+        check_values(
+            [
+                Check {
+                    scenario: "wait signal is clear",
+                    input: false,
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "wait signal adds one critical alert",
+                    input: true,
+                    expect: vec![health_report::HealthProbeAlert {
+                        id: probe_ids::PostConfigCheckWait.clone(),
+                        target: None,
+                        in_alert_since: None,
+                        message: "Post-config waiting period".to_string(),
+                        tenant_message: None,
+                        classifications: vec![
+                            health_report::HealthAlertClassification::prevent_allocations(),
+                            health_report::HealthAlertClassification::prevent_host_state_changes(),
+                        ],
+                    }],
+                },
+            ],
+            |should_wait_for_post_config_check| {
+                let mut report = health_report::HealthReport::empty("forge-dpu-agent".to_string());
+                add_post_config_wait_alert(&mut report, should_wait_for_post_config_check);
+                report.alerts
+            },
+        );
+    }
 
     /// Builds the expected `DiskUtilization` for one `df -HP` row, in the column
     /// order the output lists them: device, size, used, available, then the

--- a/crates/agent/src/health/bgp.rs
+++ b/crates/agent/src/health/bgp.rs
@@ -15,18 +15,19 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use health_report::HealthAlertClassification;
 use serde::Deserialize;
 
-use super::{failed, make_alert, passed, probe_ids};
+use super::{failed, make_alert, make_classified_alert, passed, probe_ids};
 use crate::{HBNDeviceNames, hbn};
 
 /// `BgpHealthCheckParams` contains the configured peers, uplinks, and address
 /// families that the BGP health check should require.
 pub(super) struct BgpHealthCheckParams<'a> {
     pub(super) host_routes: &'a [&'a str],
-    pub(super) min_healthy_links: u32,
+    pub(super) min_healthy_links: usize,
     pub(super) route_servers: &'a [String],
     pub(super) should_check_ipv6_unicast: bool,
     pub(super) hbn_device_names: &'a HBNDeviceNames,
@@ -67,7 +68,7 @@ pub(super) async fn check_bgp_stats(
         }
     };
 
-    if params.should_check_ipv6_unicast && bgp_summary_parsed {
+    if params.should_check_ipv6_unicast && bgp_summary_parsed && params.min_healthy_links > 0 {
         match hbn::run_in_container(
             container_id,
             &["vtysh", "-c", "show bgp ipv6 unicast summary failed json"],
@@ -90,7 +91,7 @@ pub(super) async fn check_bgp_stats(
         }
     }
 
-    health_data.into_health_report(hr);
+    health_data.into_health_report(hr, params.min_healthy_links, params.hbn_device_names);
 }
 
 pub(super) fn check_daemon_enabled(hr: &mut health_report::HealthReport, hbn_daemons_file: &str) {
@@ -185,31 +186,30 @@ fn verify_bgp_summary(
 fn check_bgp_tor_routes(
     s: &BgpStats,
     health_data: &mut BgpHealthData,
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
-    for port_id in 0..min_healthy_links {
-        let mut message = None;
-        // The number of healthy links should never be above the total number of avail links
-        let Some(port_name) = hbn_device_names
-            .uplinks
-            .get(port_id as usize)
-            .map(|s| s.to_string())
-        else {
-            // This case should not happen, and will only happen if a configuration error at runtime is applied
-            // such as having 7 min_healthy_links but we only have 2 ports
-            let error = format!(
-                "The number of min healthy links: {min_healthy_links} \
-                was bigger than the number of uplinks defined by the hbn device names: {}",
-                hbn_device_names.uplinks.len()
-            );
-            if !health_data.other_errors.contains(&error) {
-                health_data.other_errors.push(error);
-            }
-            return;
-        };
+    if min_healthy_links > hbn_device_names.uplinks.len() {
+        let error = format!(
+            "The number of min healthy links: {min_healthy_links} \
+            was bigger than the number of uplinks defined by the hbn device names: {}",
+            hbn_device_names.uplinks.len()
+        );
+        if !health_data.other_errors.contains(&error) {
+            health_data.other_errors.push(error);
+        }
+    }
 
-        let session_data = s.peers.get(&port_name);
+    if min_healthy_links == 0 {
+        return;
+    }
+
+    // A positive minimum is a health threshold, not a positional limit on
+    // which physical sessions should be inspected.
+    for &port_name in &hbn_device_names.uplinks {
+        let mut message = None;
+
+        let session_data = s.peers.get(port_name);
         match session_data {
             Some(session) => {
                 if session.state != "Established" {
@@ -227,7 +227,12 @@ fn check_bgp_tor_routes(
         }
 
         if let Some(message) = message {
-            health_data.unhealthy_tor_peers.insert(port_name, message);
+            health_data
+                .tor_session_failures
+                .insert(port_name.to_string());
+            health_data
+                .unhealthy_tor_peers
+                .insert(port_name.to_string(), message);
         }
     }
 }
@@ -238,7 +243,7 @@ fn check_bgp_stats_unicast(
     name: &str,
     s: &BgpStats,
     health_data: &mut BgpHealthData,
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     check_bgp_tor_routes(s, health_data, min_healthy_links, hbn_device_names);
@@ -260,7 +265,7 @@ fn check_bgp_stats_ipv6_unicast(
     name: &str,
     s: &BgpStats,
     health_data: &mut BgpHealthData,
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     check_bgp_stats_unicast(name, s, health_data, min_healthy_links, hbn_device_names);
@@ -274,16 +279,18 @@ fn check_bgp_stats_ipv6_unicast(
     }
 }
 
-/// Maps FRR's address-family-specific failed-peer view back to the required
-/// physical uplinks.
+/// Maps FRR's failed peer view for one address family back to the required uplinks.
 ///
 /// The regular summary's peer state describes the shared BGP transport. The
 /// filtered view also includes established peers whose remote did not
-/// negotiate IPv6-unicast.
+/// negotiate IPv6 unicast. The configured minimum limits this check to the
+/// required uplinks, so a minimum of one requires only the primary uplink to
+/// negotiate IPv6 unicast. Transport health is evaluated separately for both
+/// sessions, so this limit does not hide a total uplink outage.
 fn verify_failed_ipv6_unicast_peers(
     health_data: &mut BgpHealthData,
     failed_peers_json: &str,
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     let failed_summary: BgpFailedSummary = match serde_json::from_str(failed_peers_json) {
@@ -296,11 +303,7 @@ fn verify_failed_ipv6_unicast_peers(
         }
     };
 
-    for &port_name in hbn_device_names
-        .uplinks
-        .iter()
-        .take(min_healthy_links as usize)
-    {
+    for &port_name in hbn_device_names.uplinks.iter().take(min_healthy_links) {
         if failed_summary.peers.contains_key(port_name) {
             health_data
                 .unhealthy_tor_peers
@@ -315,7 +318,7 @@ fn check_bgp_stats_ipv4_unicast(
     s: &BgpStats,
     health_data: &mut BgpHealthData,
     host_routes: &[&str],
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     check_bgp_stats_unicast(name, s, health_data, min_healthy_links, hbn_device_names);
@@ -336,7 +339,7 @@ fn check_bgp_stats_l2_vpn_evpn(
     s: &BgpStats,
     health_data: &mut BgpHealthData,
     route_servers: &[String],
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     // In case Route servers are not specified, the peer list should contain only
@@ -394,16 +397,25 @@ fn check_bgp_stats_l2_vpn_evpn(
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct BgpHealthData {
-    // ToR state appears in multiple address-family summaries. Keying by port
+    // ToR state appears in summaries for multiple address families. Keying by port
     // emits one alert for each physical link.
     pub unhealthy_tor_peers: HashMap<String, String>,
+    // Only transport/session failures should affect allocation policy for the
+    // primary uplink. Failures to negotiate an address family reuse the same
+    // probe ID but do not mean the ToR session itself is unavailable.
+    pub tor_session_failures: HashSet<String>,
     pub unhealthy_route_server_peers: Vec<(String, String)>,
     pub unexpected_peers: Vec<(String, String)>,
     pub other_errors: Vec<String>,
 }
 
 impl BgpHealthData {
-    fn into_health_report(mut self, hr: &mut health_report::HealthReport) {
+    fn into_health_report(
+        mut self,
+        hr: &mut health_report::HealthReport,
+        min_healthy_links: usize,
+        hbn_device_names: &HBNDeviceNames,
+    ) {
         if self.other_errors.is_empty() {
             passed(hr, probe_ids::BgpStats.clone(), None);
         } else {
@@ -413,15 +425,50 @@ impl BgpHealthData {
             failed(hr, probe_ids::BgpStats.clone(), None, err_msg);
         }
 
-        let num_unhealthy_tors = self.unhealthy_tor_peers.len();
-        // TODO: This is correct for environments with both DPU ports connected
-        let unhealthy_tors_critical = num_unhealthy_tors > 1;
-        for (port_name, message) in self.unhealthy_tor_peers.into_iter() {
-            hr.alerts.push(make_alert(
+        let healthy_uplink_count = hbn_device_names
+            .uplinks
+            .len()
+            .saturating_sub(self.tor_session_failures.len());
+        let minimum_satisfied = healthy_uplink_count >= min_healthy_links;
+        let [primary_uplink, _] = hbn_device_names.uplinks;
+
+        // Apply the configured redundancy suppression before preserving the
+        // legacy policy that two unhealthy physical uplinks are blocking. The
+        // effective set includes address family negotiation warnings as well as
+        // transport failures.
+        let mut effective_unhealthy_tors = self.unhealthy_tor_peers;
+        if min_healthy_links == 0 {
+            effective_unhealthy_tors.clear();
+        } else if minimum_satisfied {
+            for secondary_uplink in hbn_device_names.uplinks.iter().skip(1) {
+                if self.tor_session_failures.contains(*secondary_uplink) {
+                    effective_unhealthy_tors.remove(*secondary_uplink);
+                }
+            }
+        }
+        let multiple_unhealthy_tors = effective_unhealthy_tors.len() > 1;
+
+        // Emit the unhealthy uplinks that remain after applying the configured
+        // redundancy policy, with classifications based on their role and count.
+        for (port_name, message) in effective_unhealthy_tors {
+            let is_primary_session_failure =
+                port_name == primary_uplink && self.tor_session_failures.contains(&port_name);
+
+            let health_classifications = if multiple_unhealthy_tors {
+                vec![
+                    HealthAlertClassification::prevent_allocations(),
+                    HealthAlertClassification::prevent_host_state_changes(),
+                ]
+            } else if is_primary_session_failure {
+                vec![HealthAlertClassification::prevent_allocations()]
+            } else {
+                vec![]
+            };
+            hr.alerts.push(make_classified_alert(
                 probe_ids::BgpPeeringTor.clone(),
                 Some(port_name),
                 message,
-                unhealthy_tors_critical,
+                health_classifications,
             ));
         }
 
@@ -547,15 +594,50 @@ mod tests {
         expected_alerts: Vec<health_report::HealthProbeAlert>,
     }
 
-    /// Builds a TOR-peering alert for `port`, the most common alert these
+    /// Test-only names for the exact classification sets expected by table rows.
+    ///
+    /// This builds the vectors without production classification helpers, so
+    /// the tests can catch policy regressions.
+    #[derive(Clone, Copy)]
+    enum ExpectedClassifications {
+        /// Contains no classifications; the alert remains visible.
+        Unclassified,
+        /// Contains only `PreventAllocations`.
+        PreventAllocations,
+        /// Contains `PreventAllocations` and `PreventHostStateChanges`.
+        PreventAllocationsAndHostStateChanges,
+    }
+
+    impl ExpectedClassifications {
+        fn health_classifications(self) -> Vec<HealthAlertClassification> {
+            match self {
+                Self::Unclassified => vec![],
+                Self::PreventAllocations => {
+                    vec![HealthAlertClassification::prevent_allocations()]
+                }
+                Self::PreventAllocationsAndHostStateChanges => vec![
+                    HealthAlertClassification::prevent_allocations(),
+                    HealthAlertClassification::prevent_host_state_changes(),
+                ],
+            }
+        }
+    }
+
+    /// Builds a ToR BGP peering alert for `port`, the most common alert these
     /// scenarios produce.
-    fn tor_alert(port: &str, message: &str, critical: bool) -> health_report::HealthProbeAlert {
-        make_alert(
-            probe_ids::BgpPeeringTor.clone(),
-            Some(port.to_string()),
-            message.to_string(),
-            critical,
-        )
+    fn tor_alert(
+        port: &str,
+        message: &str,
+        expected_classifications: ExpectedClassifications,
+    ) -> health_report::HealthProbeAlert {
+        health_report::HealthProbeAlert {
+            id: health_report::HealthProbeId::bgp_peering_tor(),
+            target: Some(port.to_string()),
+            in_alert_since: None,
+            message: message.to_string(),
+            tenant_message: None,
+            classifications: expected_classifications.health_classifications(),
+        }
     }
 
     #[test]
@@ -570,7 +652,7 @@ mod tests {
                     expected_alerts: vec![],
                 },
                 Row {
-                    scenario: "both TOR peers down is critical",
+                    scenario: "both ToR peers block allocations and state changes",
                     json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_FAILED_TOR_PEERS,
                     host_routes: &[],
                     route_servers: &[],
@@ -578,24 +660,24 @@ mod tests {
                         tor_alert(
                             "p0_if",
                             "Session p0_if is not Established, but in state Idle",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         tor_alert(
                             "p1_if",
                             "Session p1_if is not Established, but in state Idle",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                     ],
                 },
                 Row {
-                    scenario: "single TOR peer down is not critical",
+                    scenario: "failed primary prevents allocations but not state changes",
                     json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SINGLE_FAILED_TOR_PEER,
                     host_routes: &[],
                     route_servers: &[],
                     expected_alerts: vec![tor_alert(
                         "p0_if",
                         "Session p0_if is not Established, but in state Idle",
-                        false,
+                        ExpectedClassifications::PreventAllocations,
                     )],
                 },
                 Row {
@@ -627,12 +709,12 @@ mod tests {
                         tor_alert(
                             "p0_if",
                             "Expected session for p0_if was not found in BGP peer data",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         tor_alert(
                             "p1_if",
                             "Expected session for p1_if was not found in BGP peer data",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         make_alert(
                             probe_ids::UnexpectedBgpPeer.clone(),
@@ -666,12 +748,12 @@ mod tests {
                         tor_alert(
                             "p0_if",
                             "Session p0_if is not Established, but in state Idle",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         tor_alert(
                             "p1_if",
                             "Session p1_if is not Established, but in state Idle",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                     ],
                 },
@@ -688,9 +770,13 @@ mod tests {
                 }
             }),
             |row: Row| {
+                // Exercise the full ContainerExec/FRR path by collecting
+                // failures, then converting them into the public health alerts.
                 let route_servers: Vec<String> =
                     row.route_servers.iter().map(|s| s.to_string()).collect();
-                let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
+                let hbn_device_names = HBNDeviceNames::hbn_23();
+                let mut report =
+                    health_report::HealthReport::empty("forge-dpu-agent".to_string());
                 let mut health_data = BgpHealthData::default();
                 verify_bgp_summary(
                     &mut health_data,
@@ -700,13 +786,392 @@ mod tests {
                         min_healthy_links: 2,
                         route_servers: &route_servers,
                         should_check_ipv6_unicast: false,
-                        hbn_device_names: &HBNDeviceNames::hbn_23(),
+                        hbn_device_names: &hbn_device_names,
                     },
                 );
-                health_data.into_health_report(&mut hr);
-                let mut alerts = hr.alerts;
+                health_data.into_health_report(&mut report, 2, &hbn_device_names);
+                let mut alerts = report.alerts;
                 sort_alerts(&mut alerts);
                 alerts
+            },
+        );
+    }
+
+    /// Inputs for one ContainerExec/FRR ToR health policy scenario.
+    struct TorHealthInput {
+        /// Configured minimum passed to failure collection and alert classification.
+        min_healthy_links: usize,
+        /// FRR BGP transport state reported for the primary uplink.
+        p0_state: &'static str,
+        /// Compact test encoding for the secondary uplink state.
+        ///
+        /// Real FRR transport states pass through unchanged.
+        /// `ESTABLISHED_WITHOUT_IPV6_UNICAST` instead represents an established
+        /// session that appears in FRR's separate failed IPv6 unicast summary.
+        p1_state: &'static str,
+        /// Whether the primary appears in FRR's failed IPv6 unicast summary.
+        p0_ipv6_unicast_failed: bool,
+    }
+
+    /// Marks an established p1 session whose IPv6 unicast negotiation failed.
+    const ESTABLISHED_WITHOUT_IPV6_UNICAST: &str = "EstablishedWithoutIpv6Unicast";
+
+    #[test]
+    fn bgp_health_data_classifies_redundant_uplink_failures() {
+        check_values(
+            [
+                Check {
+                    scenario: "minimum zero ignores two established sessions",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum zero ignores a failed primary session",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Idle",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum zero ignores a failed secondary session",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum zero ignores two failed sessions",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Idle",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum zero ignores session and negotiation failures",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum one accepts two established sessions",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum one keeps a failed primary as an allocation blocker",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Idle",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if is not Established, but in state Idle",
+                        ExpectedClassifications::PreventAllocations,
+                    )],
+                },
+                Check {
+                    scenario: "minimum one suppresses a failed redundant secondary",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum one blocks when both sessions fail",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Idle",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum two accepts two established sessions",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum two keeps a failed primary as an allocation blocker",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Idle",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if is not Established, but in state Idle",
+                        ExpectedClassifications::PreventAllocations,
+                    )],
+                },
+                Check {
+                    scenario: "minimum two keeps a failed secondary visible",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![tor_alert(
+                        "p1_if",
+                        "Session p1_if is not Established, but in state Idle",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Check {
+                    scenario: "minimum two blocks when both sessions fail",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Idle",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum one retains a primary negotiation warning",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if did not negotiate IPv6-unicast",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Check {
+                    scenario: "minimum one retains primary negotiation warning and suppresses failed secondary",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if did not negotiate IPv6-unicast",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Check {
+                    scenario: "minimum two keeps a lone primary negotiation warning unclassified",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if did not negotiate IPv6-unicast",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Check {
+                    scenario: "minimum two blocks a failed primary session with a secondary negotiation warning",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Idle",
+                        p1_state: ESTABLISHED_WITHOUT_IPV6_UNICAST,
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if did not negotiate IPv6-unicast",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum two blocks a primary negotiation warning with a failed secondary session",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if did not negotiate IPv6-unicast",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum two blocks negotiation warnings on both uplinks",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: ESTABLISHED_WITHOUT_IPV6_UNICAST,
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if did not negotiate IPv6-unicast",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if did not negotiate IPv6-unicast",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum above configured uplink count remains a configuration error",
+                    input: TorHealthInput {
+                        min_healthy_links: 3,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![make_alert(
+                        probe_ids::BgpStats.clone(),
+                        None,
+                        "Failures while gathering BGP health data:\nThe number of min healthy links: 3 was bigger than the number of uplinks defined by the hbn device names: 2".to_string(),
+                        true,
+                    )],
+                },
+            ],
+            |input| {
+                // FRR reports transport state and IPv6 unicast negotiation
+                // failures separately. Build both inputs before combining them.
+                let hbn_device_names = HBNDeviceNames::hbn_23();
+                let (p1_session_state, p1_ipv6_unicast_failed) = match input.p1_state {
+                    ESTABLISHED_WITHOUT_IPV6_UNICAST => ("Established", true),
+                    state => (state, false),
+                };
+                let stats = BgpStats {
+                    dynamic_peers: 0,
+                    peers: HashMap::from([
+                        (
+                            "p0_if".to_string(),
+                            BgpPeer {
+                                state: input.p0_state.to_string(),
+                            },
+                        ),
+                        (
+                            "p1_if".to_string(),
+                            BgpPeer {
+                                state: p1_session_state.to_string(),
+                            },
+                        ),
+                    ]),
+                };
+                let mut health_data = BgpHealthData::default();
+                check_bgp_tor_routes(
+                    &stats,
+                    &mut health_data,
+                    input.min_healthy_links,
+                    &hbn_device_names,
+                );
+
+                // Model the separate FRR summary only when an uplink failed
+                // IPv6 unicast negotiation.
+                let failed_ipv6_unicast_json =
+                    match (input.p0_ipv6_unicast_failed, p1_ipv6_unicast_failed) {
+                        (false, false) => None,
+                        (true, false) => {
+                            Some(r#"{"peers":{"p0_if":{}},"failedPeers":1}"#)
+                        }
+                        (false, true) => {
+                            Some(r#"{"peers":{"p1_if":{}},"failedPeers":1}"#)
+                        }
+                        (true, true) => Some(
+                            r#"{"peers":{"p0_if":{},"p1_if":{}},"failedPeers":2}"#,
+                        ),
+                    };
+                if let Some(failed_ipv6_unicast_json) = failed_ipv6_unicast_json {
+                    verify_failed_ipv6_unicast_peers(
+                        &mut health_data,
+                        failed_ipv6_unicast_json,
+                        input.min_healthy_links,
+                        &hbn_device_names,
+                    );
+                }
+
+                // Convert the combined FRR results into the exact public alert
+                // set asserted by each row.
+                let mut report = health_report::HealthReport::empty("forge-dpu-agent".to_string());
+                health_data.into_health_report(
+                    &mut report,
+                    input.min_healthy_links,
+                    &hbn_device_names,
+                );
+                sort_alerts(&mut report.alerts);
+                report.alerts
             },
         );
     }
@@ -805,6 +1270,7 @@ mod tests {
                             "p0_if".to_string(),
                             "Session p0_if is not Established, but in state Idle".to_string(),
                         )]),
+                        tor_session_failures: HashSet::from(["p0_if".to_string()]),
                         ..Default::default()
                     },
                 },
@@ -905,13 +1371,14 @@ mod tests {
 
     struct FailedIpv6SummaryInput {
         json: &'static str,
-        min_healthy_links: u32,
+        min_healthy_links: usize,
         existing_p0_error: Option<&'static str>,
     }
 
     #[derive(Debug, PartialEq, Eq)]
     struct FailedIpv6SummaryOutcome {
         unhealthy_tor_peers: HashMap<String, String>,
+        tor_session_failures: HashSet<String>,
         other_error_count: usize,
         has_deserialization_error: bool,
     }
@@ -929,6 +1396,7 @@ mod tests {
                     },
                     expect: FailedIpv6SummaryOutcome {
                         unhealthy_tor_peers: HashMap::new(),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -945,6 +1413,7 @@ mod tests {
                             "p0_if".to_string(),
                             "Session p0_if did not negotiate IPv6-unicast".to_string(),
                         )]),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -958,6 +1427,7 @@ mod tests {
                     },
                     expect: FailedIpv6SummaryOutcome {
                         unhealthy_tor_peers: HashMap::new(),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -980,6 +1450,7 @@ mod tests {
                                 "Session p1_if did not negotiate IPv6-unicast".to_string(),
                             ),
                         ]),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -996,6 +1467,7 @@ mod tests {
                             "p0_if".to_string(),
                             "Session p0_if is in state Idle".to_string(),
                         )]),
+                        tor_session_failures: HashSet::from(["p0_if".to_string()]),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -1009,6 +1481,7 @@ mod tests {
                     },
                     expect: FailedIpv6SummaryOutcome {
                         unhealthy_tor_peers: HashMap::new(),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 1,
                         has_deserialization_error: true,
                     },
@@ -1022,6 +1495,7 @@ mod tests {
                     },
                     expect: FailedIpv6SummaryOutcome {
                         unhealthy_tor_peers: HashMap::new(),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 1,
                         has_deserialization_error: true,
                     },
@@ -1033,6 +1507,7 @@ mod tests {
                     health_data
                         .unhealthy_tor_peers
                         .insert("p0_if".to_string(), error.to_string());
+                    health_data.tor_session_failures.insert("p0_if".to_string());
                 }
 
                 verify_failed_ipv6_unicast_peers(
@@ -1047,6 +1522,7 @@ mod tests {
                 });
                 FailedIpv6SummaryOutcome {
                     unhealthy_tor_peers: health_data.unhealthy_tor_peers,
+                    tor_session_failures: health_data.tor_session_failures,
                     other_error_count: health_data.other_errors.len(),
                     has_deserialization_error,
                 }

--- a/crates/agent/src/health/nvue.rs
+++ b/crates/agent/src/health/nvue.rs
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-use health_report::{HealthProbeAlert, HealthProbeSuccess, HealthReport};
+use health_report::{
+    HealthAlertClassification, HealthProbeAlert, HealthProbeSuccess, HealthReport,
+};
 use nvue_client::types::bgp::{BgpNeighbors, BgpPeerState};
 use nvue_client::{FieldFilter, NvueClient};
 
-use super::{failed, make_alert, probe_ids};
+use super::{add_post_config_wait_alert, failed, make_alert, make_classified_alert, probe_ids};
 use crate::HBNDeviceNames;
 
 /// The VRF we'll look for our BGP uplinks in.
@@ -33,6 +35,8 @@ pub(crate) struct NvueHealthCheck<'a> {
     pub(crate) min_healthy_links: usize,
     /// HBN interface names used to identify expected ToR uplink sessions.
     pub(crate) hbn_device_names: &'a HBNDeviceNames,
+    /// Whether this iteration applied a changed HBN configuration through NVUE.
+    pub(crate) has_changed_hbn_config: bool,
 }
 
 impl NvueHealthCheck<'_> {
@@ -51,12 +55,17 @@ impl NvueHealthCheck<'_> {
         }
 
         self.check_bgp_uplinks(&mut report).await;
+        add_post_config_wait_alert(&mut report, self.has_changed_hbn_config);
         report
     }
 
     /// Checks BGP uplink session health through the configured NVUE API target.
     async fn check_bgp_uplinks(&self, report: &mut HealthReport) {
         const BGP_NEIGHBOR_STATE_FIELD: &str = "/*/state";
+
+        if self.min_healthy_links == 0 {
+            return;
+        }
 
         let bgp_neighbors = self
             .nvue_client
@@ -98,32 +107,71 @@ impl NvueHealthCheck<'_> {
     }
 }
 
-/// Checks configured ToR BGP sessions from an already-fetched NVUE BGP neighbor response.
+/// One configured NVUE uplink whose BGP session is not established.
+struct UnhealthyUplink {
+    /// Whether this is the first configured uplink, which PXE boot requires.
+    is_primary: bool,
+    /// HBN interface name used as the health alert target.
+    uplink_name: String,
+    /// Diagnostic reason that the session check failed.
+    message: String,
+}
+
+/// Checks configured ToR BGP sessions using an NVUE response fetched by the caller.
 ///
 /// All configured HBN uplinks are evaluated, and the check passes when at least
 /// `min_healthy_links` of them are present and established. If too few uplinks
 /// are healthy, each missing peer, missing state, or non-established state emits
-/// a `BgpPeeringTor` alert targeted at that uplink. A `BgpPeeringTor` alert is
-/// emitted when `min_healthy_links` asks for more uplinks than the configured
-/// device names provide. The helper does not emit success entries.
-pub(super) fn check_bgp_uplink_sessions(
+/// a `BgpPeeringTor` alert targeted at that uplink. While a redundant session
+/// remains established, an unavailable primary (the first configured uplink)
+/// prevents allocations but not host state changes; an unavailable secondary
+/// has no classifications. With a minimum of one, either established session
+/// satisfies the configured minimum, so only a failed primary remains visible
+/// for the PXE readiness gate. A minimum of zero disables the NVUE neighbor
+/// request and all uplink alerts, including the primary readiness signal. If no
+/// expected uplink is established, each alert prevents allocations and host
+/// state changes. A `BgpPeeringTor` alert is emitted when `min_healthy_links`
+/// asks for more uplinks than the configured device names provide. The helper
+/// does not emit success entries.
+fn check_bgp_uplink_sessions(
     report: &mut HealthReport,
     neighbors: Option<&BgpNeighbors>,
     min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
-    let mut unhealthy_uplink_names = Vec::new();
+    let mut unhealthy_uplinks = Vec::new();
     let mut healthy_uplink_count = 0;
-    let expected_hbn_uplinks = hbn_device_names.uplinks.iter().copied();
+    let expected_hbn_uplinks = hbn_device_names.uplinks.iter().copied().enumerate();
 
-    for expected_uplink in expected_hbn_uplinks {
+    for (uplink_index, expected_uplink) in expected_hbn_uplinks {
         match check_expected_peer_established(neighbors, expected_uplink) {
             Ok(()) => healthy_uplink_count += 1,
-            Err(message) => unhealthy_uplink_names.push((expected_uplink.to_string(), message)),
+            Err(message) => unhealthy_uplinks.push(UnhealthyUplink {
+                is_primary: uplink_index == 0,
+                uplink_name: expected_uplink.to_string(),
+                message,
+            }),
         }
     }
 
+    if min_healthy_links == 0 {
+        return;
+    }
+
     if healthy_uplink_count >= min_healthy_links {
+        // A healthy p1 can satisfy the configured minimum, but PXE still
+        // depends on p0, so preserve a failed primary as an allocation blocker.
+        let failed_primary_uplink = unhealthy_uplinks
+            .into_iter()
+            .find(|unhealthy_uplink| unhealthy_uplink.is_primary);
+        if let Some(failed_primary_uplink) = failed_primary_uplink {
+            report.alerts.push(make_classified_alert(
+                probe_ids::BgpPeeringTor.clone(),
+                Some(failed_primary_uplink.uplink_name),
+                failed_primary_uplink.message,
+                bgp_uplink_classifications(true, false),
+            ));
+        }
         return;
     }
 
@@ -141,30 +189,31 @@ pub(super) fn check_bgp_uplink_sessions(
         );
     }
 
-    // This behavior differs from what the non-NVUE code path does (in
-    // BgpHealthData::into_health_report()), in that we always treat this
-    // case as critical. I couldn't make sense of why the other path computes
-    // criticality like this:
-    //
-    // let num_unhealthy_tors = self.unhealthy_tor_peers.len();
-    // // TODO: This is correct for environments with both DPU ports connected
-    // let unhealthy_tors_critical = num_unhealthy_tors > 1;
-    //
-    // This looks like a duplication of what I think min_healthy_links is
-    // concerned with, and also seems to hardcode an assumption about uplink
-    // count.
-    //
-    // It was all added before The Big Squash so I couldn't learn anything from
-    // the git history of the file.
-    // - drew
-    let is_critical = true;
-    for (uplink, message) in unhealthy_uplink_names {
-        report.alerts.push(make_alert(
+    let no_established_uplinks = healthy_uplink_count == 0;
+    for unhealthy_uplink in unhealthy_uplinks {
+        report.alerts.push(make_classified_alert(
             probe_ids::BgpPeeringTor.clone(),
-            Some(uplink),
-            message,
-            is_critical,
+            Some(unhealthy_uplink.uplink_name),
+            unhealthy_uplink.message,
+            bgp_uplink_classifications(unhealthy_uplink.is_primary, no_established_uplinks),
         ));
+    }
+}
+
+/// Selects the classifications for one unavailable ToR uplink.
+fn bgp_uplink_classifications(
+    is_primary: bool,
+    no_established_uplinks: bool,
+) -> Vec<HealthAlertClassification> {
+    if no_established_uplinks {
+        vec![
+            HealthAlertClassification::prevent_allocations(),
+            HealthAlertClassification::prevent_host_state_changes(),
+        ]
+    } else if is_primary {
+        vec![HealthAlertClassification::prevent_allocations()]
+    } else {
+        vec![]
     }
 }
 
@@ -214,31 +263,69 @@ mod tests {
         expected_alerts: Vec<health_report::HealthProbeAlert>,
     }
 
+    /// Test-only names for the exact classification sets expected by table rows.
+    ///
+    /// This builds the vectors without production classification helpers, so
+    /// the tests can catch policy regressions.
+    #[derive(Clone, Copy)]
+    enum ExpectedClassifications {
+        /// Contains no classifications; the alert remains visible.
+        Unclassified,
+        /// Contains only `PreventAllocations`.
+        PreventAllocations,
+        /// Contains `PreventAllocations` and `PreventHostStateChanges`.
+        PreventAllocationsAndHostStateChanges,
+    }
+
+    impl ExpectedClassifications {
+        fn health_classifications(self) -> Vec<HealthAlertClassification> {
+            match self {
+                Self::Unclassified => vec![],
+                Self::PreventAllocations => {
+                    vec![HealthAlertClassification::prevent_allocations()]
+                }
+                Self::PreventAllocationsAndHostStateChanges => vec![
+                    HealthAlertClassification::prevent_allocations(),
+                    HealthAlertClassification::prevent_host_state_changes(),
+                ],
+            }
+        }
+    }
+
     /// Builds NVUE BGP neighbors from a compact scenario JSON fixture.
     fn bgp_neighbors(bgp_json: &str) -> Option<BgpNeighbors> {
         serde_json::from_str(bgp_json).expect("BGP neighbors should deserialize")
     }
 
-    /// Builds a ToR peering alert with the same target and criticality rules as production.
-    fn tor_alert(port: &str, message: &str, critical: bool) -> health_report::HealthProbeAlert {
-        make_alert(
-            probe_ids::BgpPeeringTor.clone(),
-            Some(port.to_string()),
-            message.to_string(),
-            critical,
-        )
+    /// Builds an expected ToR peering alert independently of the production helper.
+    fn tor_alert(
+        port: &str,
+        message: &str,
+        expected_classifications: ExpectedClassifications,
+    ) -> health_report::HealthProbeAlert {
+        health_report::HealthProbeAlert {
+            id: health_report::HealthProbeId::bgp_peering_tor(),
+            target: Some(port.to_string()),
+            in_alert_since: None,
+            message: message.to_string(),
+            tenant_message: None,
+            classifications: expected_classifications.health_classifications(),
+        }
     }
 
     /// Builds the site-configuration alert for impossible uplink thresholds.
     fn config_mismatch_alert(min_healthy_links: usize) -> health_report::HealthProbeAlert {
-        make_alert(
-            probe_ids::BgpPeeringTor.clone(),
-            None,
-            format!(
+        health_report::HealthProbeAlert {
+            id: health_report::HealthProbeId::bgp_peering_tor(),
+            target: None,
+            in_alert_since: None,
+            message: format!(
                 "Site configuration requires a minimum of {min_healthy_links} healthy uplinks, but this is greater than the number of expected uplink interface names (p0_if,p1_if)"
             ),
-            true,
-        )
+            tenant_message: None,
+            classifications: ExpectedClassifications::PreventAllocationsAndHostStateChanges
+                .health_classifications(),
+        }
     }
 
     /// Orders alerts by `(id, target, message)` so table rows can stay readable.
@@ -262,24 +349,24 @@ mod tests {
                     expected_alerts: vec![],
                 },
                 Row {
-                    scenario: "null neighbor response alerts for each configured uplink",
+                    scenario: "missing neighbor data blocks allocations and host state changes",
                     bgp_json: r#"null"#,
                     min_healthy_links: 2,
                     expected_alerts: vec![
                         tor_alert(
                             "p0_if",
                             "BGP neighbor data was not reported; expected session for p0_if",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         tor_alert(
                             "p1_if",
                             "BGP neighbor data was not reported; expected session for p1_if",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                     ],
                 },
                 Row {
-                    scenario: "missing configured uplink targets that uplink",
+                    scenario: "missing secondary stays visible without classifications",
                     bgp_json: r#"
                     {
                         "p0_if": { "state": "established" }
@@ -289,11 +376,11 @@ mod tests {
                     expected_alerts: vec![tor_alert(
                         "p1_if",
                         "expected session for p1_if was not found in BGP peer data",
-                        true,
+                        ExpectedClassifications::Unclassified,
                     )],
                 },
                 Row {
-                    scenario: "idle configured uplink alerts when below threshold",
+                    scenario: "failed primary prevents allocations but not state changes",
                     bgp_json: r#"
                     {
                         "p0_if": { "state": "idle" },
@@ -304,11 +391,48 @@ mod tests {
                     expected_alerts: vec![tor_alert(
                         "p0_if",
                         "BGP session p0_if is not established, but in state idle",
-                        true,
+                        ExpectedClassifications::PreventAllocations,
                     )],
                 },
                 Row {
-                    scenario: "another non-established state alerts",
+                    scenario: "failed secondary stays visible without classifications",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 2,
+                    expected_alerts: vec![tor_alert(
+                        "p1_if",
+                        "BGP session p1_if is not established, but in state idle",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Row {
+                    scenario: "two failed sessions block allocations and state changes",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "idle" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 2,
+                    expected_alerts: vec![
+                        tor_alert(
+                            "p0_if",
+                            "BGP session p0_if is not established, but in state idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "BGP session p1_if is not established, but in state idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Row {
+                    scenario: "active primary session prevents allocations",
                     bgp_json: r#"
                     {
                         "p0_if": { "state": "active" },
@@ -319,11 +443,11 @@ mod tests {
                     expected_alerts: vec![tor_alert(
                         "p0_if",
                         "BGP session p0_if is not established, but in state active",
-                        true,
+                        ExpectedClassifications::PreventAllocations,
                     )],
                 },
                 Row {
-                    scenario: "missing state alerts",
+                    scenario: "primary with missing state prevents allocations",
                     bgp_json: r#"
                     {
                         "p0_if": {},
@@ -334,7 +458,7 @@ mod tests {
                     expected_alerts: vec![tor_alert(
                         "p0_if",
                         "state field for p0_if peer is not present",
-                        true,
+                        ExpectedClassifications::PreventAllocations,
                     )],
                 },
                 Row {
@@ -351,7 +475,7 @@ mod tests {
                     expected_alerts: vec![],
                 },
                 Row {
-                    scenario: "one healthy uplink may be the second configured uplink",
+                    scenario: "minimum one keeps failed primary as allocation blocker",
                     bgp_json: r#"
                     {
                         "p0_if": { "state": "idle" },
@@ -359,6 +483,65 @@ mod tests {
                     }
                     "#,
                     min_healthy_links: 1,
+                    expected_alerts: vec![tor_alert(
+                        "p0_if",
+                        "BGP session p0_if is not established, but in state idle",
+                        ExpectedClassifications::PreventAllocations,
+                    )],
+                },
+                Row {
+                    scenario: "minimum one accepts two established sessions",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "established" }
+                    }
+                    "#,
+                    min_healthy_links: 1,
+                    expected_alerts: vec![],
+                },
+                Row {
+                    scenario: "minimum one suppresses failed secondary after p0 is established",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 1,
+                    expected_alerts: vec![],
+                },
+                Row {
+                    scenario: "minimum one still blocks when both sessions fail",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "idle" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 1,
+                    expected_alerts: vec![
+                        tor_alert(
+                            "p0_if",
+                            "BGP session p0_if is not established, but in state idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "BGP session p1_if is not established, but in state idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Row {
+                    scenario: "minimum zero disables every uplink alert",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "idle" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 0,
                     expected_alerts: vec![],
                 },
                 Row {
@@ -374,6 +557,8 @@ mod tests {
                 },
             ]
             .map(|mut row| {
+                // Alert emission order is not part of the policy under test, so
+                // normalize each expected row before moving it into `Check`.
                 sort_alerts(&mut row.expected_alerts);
                 let expect = row.expected_alerts.clone();
                 Check {
@@ -383,16 +568,18 @@ mod tests {
                 }
             }),
             |row| {
-                let mut hr = HealthReport::empty("forge-dpu-agent".to_string());
+                // Parse the NVUE response, apply the uplink policy, and compare
+                // the complete alert set independent of emission order.
+                let mut report = HealthReport::empty("forge-dpu-agent".to_string());
                 let bgp_neighbors = bgp_neighbors(row.bgp_json);
                 check_bgp_uplink_sessions(
-                    &mut hr,
+                    &mut report,
                     bgp_neighbors.as_ref(),
                     row.min_healthy_links,
                     &HBNDeviceNames::hbn_23(),
                 );
-                sort_alerts(&mut hr.alerts);
-                hr.alerts
+                sort_alerts(&mut report.alerts);
+                report.alerts
             },
         );
     }

--- a/crates/agent/src/health/probe_ids.rs
+++ b/crates/agent/src/health/probe_ids.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
     pub static ref DhcpRelay: HealthProbeId = "DhcpRelay".parse().unwrap();
     pub static ref DhcpServer: HealthProbeId = "DhcpServer".parse().unwrap();
     pub static ref BgpStats: HealthProbeId = "BgpStats".parse().unwrap();
-    pub static ref BgpPeeringTor: HealthProbeId = "BgpPeeringTor".parse().unwrap();
+    pub static ref BgpPeeringTor: HealthProbeId = HealthProbeId::bgp_peering_tor();
     pub static ref BgpPeeringRouteServer: HealthProbeId = "BgpPeeringRouteServer".parse().unwrap();
     pub static ref UnexpectedBgpPeer: HealthProbeId = "UnexpectedBgpPeer".parse().unwrap();
     pub static ref Ifreload: HealthProbeId = "Ifreload".parse().unwrap();

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -851,6 +851,7 @@ impl MainLoop {
         let mut current_config_error = None;
         let mut is_healthy = false;
         let mut has_changed_configs = false;
+        let mut has_changed_hbn_config = false;
         let mut current_host_network_config_version = None;
         let mut current_instance_network_config_version = None;
         let mut current_instance_config_version = None;
@@ -1036,7 +1037,9 @@ impl MainLoop {
                             .await;
 
                     let joined_result = match (update_result, dhcp_result, astra_config_status) {
-                        (Ok(a), Ok(b), Ok(spx_net_status)) => Ok((a | b, spx_net_status)),
+                        (Ok(hbn_changed), Ok(dhcp_changed), Ok(spx_net_status)) => {
+                            Ok((hbn_changed, dhcp_changed, spx_net_status))
+                        }
                         (update_result, dhcp_result, astra_config_status) => {
                             let mut errors = Vec::new();
 
@@ -1054,9 +1057,10 @@ impl MainLoop {
                         }
                     };
                     match joined_result {
-                        Ok((has_changed, astra_config_status)) => {
+                        Ok((hbn_changed, dhcp_changed, astra_config_status)) => {
                             self.current_network_version.update_from(&conf);
-                            has_changed_configs = has_changed;
+                            has_changed_hbn_config = hbn_changed;
+                            has_changed_configs = hbn_changed || dhcp_changed;
                             if conf.astra_config.is_some() {
                                 status_out.astra_config_status = Some(astra_config_status);
                             }
@@ -1130,13 +1134,16 @@ impl MainLoop {
                 current_instance_config_version = status_out.instance_config_version.clone();
                 current_instance_id = status_out.instance_id.as_ref().map(|id| id.to_string());
 
+                let min_healthy_links = conf.min_dpu_functioning_links.unwrap_or(2) as usize;
                 let health_report = match self.nvue_context.as_ref() {
                     None => {
+                        // In `ContainerExec` mode, the DHCP flag represents a real local
+                        // reload, so keep the existing wait while that service restarts.
                         health::health_check(HealthCheckParams {
                             hbn_root: &self.agent_config.hbn.root_dir,
                             host_routes: &tenant_peers,
                             has_changed_configs,
-                            min_healthy_links: conf.min_dpu_functioning_links.unwrap_or(2),
+                            min_healthy_links,
                             route_servers: &conf.route_servers,
                             should_check_ipv6_unicast,
                             hbn_device_names: self.hbn_device_names.clone(),
@@ -1146,10 +1153,13 @@ impl MainLoop {
                         .await
                     }
                     Some(nvue_context) => {
+                        // DHCP gRPC reports every accepted request as changed, so only an
+                        // actual HBN update may trigger the NVUE wait after a config update.
                         health::nvue::NvueHealthCheck {
                             nvue_client: &nvue_context.nvue_client,
-                            min_healthy_links: conf.min_dpu_functioning_links.unwrap_or(2) as usize,
+                            min_healthy_links,
                             hbn_device_names: &self.hbn_device_names,
+                            has_changed_hbn_config,
                         }
                         .health_check()
                         .await

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -493,9 +493,11 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub network_security_group: NetworkSecurityGroupConfig,
 
-    /// Minimum functioning DPU links required for the DPU
-    /// to be considered healthy. If unset, all links must
-    /// be functional.
+    /// Controls the DPU ToR BGP health checks. If unset, both uplinks are
+    /// checked; zero disables the checks, and values above two produce a
+    /// configuration health alert. With one, either established link satisfies
+    /// the minimum, but a failed p0 is still reported because PXE boot depends
+    /// on the primary session.
     #[serde(default)]
     pub min_dpu_functioning_links: Option<u32>,
 

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -51,6 +51,7 @@ use futures_util::future::join_all;
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 use mac_address::MacAddress;
+use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::dpu_machine_update::DpuMachineUpdate;
 use model::instance::config::extension_services::InstanceExtensionServicesConfig;
 use model::instance::config::infiniband::InstanceInfinibandConfig;
@@ -1357,6 +1358,216 @@ async fn test_instance_deletion_before_provisioning_finishes(
 
     // Now go through regular deletion
     mh.delete_instance(&env, instance_id).await;
+}
+
+#[crate::sqlx_test]
+async fn test_instance_waits_for_primary_dpu_bgp_before_pxe_reboot(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    const PRIMARY_DPU_BGP_WAIT_REASON: &str =
+        "Waiting for the primary DPU p0 BGP session to be established";
+    const HOST_HEALTH_WAIT_REASON: &str =
+        "Waiting for lifecycle-blocking host health alerts to clear before PXE reboot";
+
+    fn dpu_health_alert(
+        id: &str,
+        target: Option<&str>,
+        classifications: Vec<health_report::HealthAlertClassification>,
+    ) -> rpc::health::HealthReport {
+        rpc::health::HealthReport {
+            source: "forge-dpu-agent".to_string(),
+            triggered_by: None,
+            observed_at: None,
+            successes: vec![],
+            alerts: vec![rpc::health::HealthProbeAlert {
+                id: id.to_string(),
+                target: target.map(str::to_string),
+                in_alert_since: None,
+                message: "test lifecycle gate".to_string(),
+                tenant_message: None,
+                classifications: classifications
+                    .into_iter()
+                    .map(|classification| classification.to_string())
+                    .collect(),
+            }],
+        }
+    }
+
+    fn post_config_wait_health() -> rpc::health::HealthReport {
+        dpu_health_alert(
+            "PostConfigCheckWait",
+            None,
+            vec![
+                health_report::HealthAlertClassification::prevent_allocations(),
+                health_report::HealthAlertClassification::prevent_host_state_changes(),
+            ],
+        )
+    }
+
+    fn bgp_tor_health(target: &str, prevent_allocations: bool) -> rpc::health::HealthReport {
+        let classifications = prevent_allocations
+            .then(health_report::HealthAlertClassification::prevent_allocations)
+            .into_iter()
+            .collect();
+        dpu_health_alert(
+            health_report::HealthProbeId::bgp_peering_tor().as_str(),
+            Some(target),
+            classifications,
+        )
+    }
+
+    fn pxe_blocking_bgp_merge(source: &str) -> health_report::HealthReport {
+        health_report::HealthReport {
+            source: source.to_string(),
+            triggered_by: None,
+            observed_at: None,
+            successes: vec![],
+            alerts: vec![health_report::HealthProbeAlert {
+                id: health_report::HealthProbeId::bgp_peering_tor(),
+                target: Some("p0_if".to_string()),
+                in_alert_since: None,
+                message: "test additive PXE gate".to_string(),
+                tenant_message: None,
+                classifications: vec![
+                    health_report::HealthAlertClassification::prevent_allocations(),
+                ],
+            }],
+        }
+    }
+
+    async fn assert_instance_state(env: &TestEnv, mh: &TestManagedHost, expected: InstanceState) {
+        let mut txn = env.db_txn().await;
+        assert_eq!(
+            mh.host().db_machine(&mut txn).await.current_state(),
+            &ManagedHostState::Assigned {
+                instance_state: expected,
+            }
+        );
+        txn.commit().await.unwrap();
+    }
+
+    async fn assert_pxe_reboot_wait_outcome(
+        env: &TestEnv,
+        mh: &TestManagedHost,
+        expected_reason: &str,
+    ) {
+        let mut txn = env.db_txn().await;
+        let host_machine = mh.host().db_machine(&mut txn).await;
+        let Some(PersistentStateHandlerOutcome::Wait {
+            reason,
+            source_ref: Some(source_ref),
+        }) = &host_machine.controller_state_outcome
+        else {
+            panic!("The PXE reboot gate should persist a Wait outcome with a source reference");
+        };
+        assert_eq!(reason, expected_reason);
+        assert!(source_ref.file.ends_with("/handler.rs"));
+        txn.commit().await.unwrap();
+    }
+
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh = create_managed_host(&env).await;
+    let dpu_id = mh.dpu().id;
+
+    let config = InstanceConfig::default_tenant_and_os()
+        .network(single_interface_network_config(segment_id));
+    env.api
+        .allocate_instance(
+            InstanceAllocationRequest::builder(false)
+                .machine_id(mh.host().id)
+                .config(config)
+                .metadata(rpc::Metadata {
+                    name: "test_instance".to_string(),
+                    description: "tests/instance".to_string(),
+                    labels: Vec::new(),
+                })
+                .tonic_request(),
+        )
+        .await
+        .expect("Create instance failed.");
+
+    env.run_network_segment_controller_iteration().await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        10,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::WaitingForNetworkConfig,
+        },
+    )
+    .await;
+
+    // Both the configuration settle period and a failed p0 session hold the
+    // initial network configuration gate.
+    network_configured_with_health(&env, &dpu_id, Some(post_config_wait_health())).await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForNetworkConfig).await;
+
+    network_configured_with_health(&env, &dpu_id, Some(bgp_tor_health("p0_if", true))).await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForNetworkConfig).await;
+
+    // An empty DPU Replace report masks the agent Merge report and allows
+    // provisioning to advance to the reboot gate.
+    send_health_report_entry(
+        &env,
+        &dpu_id,
+        (
+            health_report::HealthReport::empty("test-pxe-bgp-override".to_string()),
+            health_report::HealthReportApplyMode::Replace,
+        ),
+    )
+    .await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::WaitingForRebootToReady,
+        },
+    )
+    .await;
+
+    // Removing the Replace report exposes the agent p0 alert again, so the
+    // reboot gate must recheck it before restarting the host.
+    remove_health_report_entry(&env, &dpu_id, "test-pxe-bgp-override".to_string()).await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForRebootToReady).await;
+    assert_pxe_reboot_wait_outcome(&env, &mh, PRIMARY_DPU_BGP_WAIT_REASON).await;
+
+    // The reboot gate also rechecks health alerts that block host state
+    // changes and persists a diagnosable wait reason.
+    network_configured_with_health(&env, &dpu_id, Some(post_config_wait_health())).await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForRebootToReady).await;
+    assert_pxe_reboot_wait_outcome(&env, &mh, HOST_HEALTH_WAIT_REASON).await;
+
+    // A visible p1 alert permits reboot, but an additional primary DPU Merge
+    // report that carries the p0 classification still blocks it.
+    network_configured_with_health(&env, &dpu_id, Some(bgp_tor_health("p1_if", false))).await;
+    send_health_report_entry(
+        &env,
+        &dpu_id,
+        (
+            pxe_blocking_bgp_merge("test-pxe-bgp-merge"),
+            health_report::HealthReportApplyMode::Merge,
+        ),
+    )
+    .await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForRebootToReady).await;
+
+    // Clearing the last PXE blocking Merge report lets provisioning reach Ready.
+    remove_health_report_entry(&env, &dpu_id, "test-pxe-bgp-merge".to_string()).await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        },
+    )
+    .await;
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -42,9 +42,9 @@ use common::api_fixtures::network_segment::{
 use common::api_fixtures::tpm_attestation::{CA_CERT_SERIALIZED, EK_CERT_SERIALIZED};
 use common::api_fixtures::{
     TestEnv, TestManagedHost, create_managed_host, create_managed_host_with_config,
-    create_test_env, create_test_env_with_overrides, get_config,
+    create_test_env, create_test_env_with_overrides, get_config, simulate_hardware_health_report,
 };
-use health_report::HealthReport;
+use health_report::{HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthReport};
 use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
 use measured_boot::bundle::MeasurementBundle;
@@ -5931,6 +5931,62 @@ async fn load_host_state(env: &TestEnv, host_id: &MachineId) -> ManagedHostState
     .expect("host should exist")
     .current_state()
     .clone()
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_reboot_checks_health_for_zero_dpu(pool: sqlx::PgPool) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    let host_id = mh.host().id;
+    set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
+
+    let health_source = "test-reboot-health-gate";
+    let mut blocking_health = HealthReport::empty(health_source.to_string());
+    blocking_health.alerts.push(HealthProbeAlert {
+        id: HealthProbeId::sku_validation(),
+        target: None,
+        in_alert_since: None,
+        message: "test host health alert".to_string(),
+        tenant_message: None,
+        classifications: vec![HealthAlertClassification::prevent_host_state_changes()],
+    });
+    simulate_hardware_health_report(&env, &host_id, blocking_health).await;
+
+    // The aggregate health gate applies even when the host has no managed DPU.
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &host_id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::WaitingForRebootToReady,
+        }
+    );
+
+    let mut txn = env.db_txn().await;
+    let host_machine = mh.host().db_machine(&mut txn).await;
+    let Some(PersistentStateHandlerOutcome::Wait { reason, .. }) =
+        &host_machine.controller_state_outcome
+    else {
+        panic!("host health alert should persist a Wait outcome");
+    };
+    assert_eq!(
+        reason,
+        "Waiting for lifecycle-blocking host health alerts to clear before PXE reboot"
+    );
+    txn.commit().await.unwrap();
+
+    // Clearing the alert preserves the normal zero DPU reboot path.
+    simulate_hardware_health_report(
+        &env,
+        &host_id,
+        HealthReport::empty(health_source.to_string()),
+    )
+    .await;
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &host_id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        }
+    );
 }
 
 #[crate::sqlx_test]

--- a/crates/health-report/src/lib.rs
+++ b/crates/health-report/src/lib.rs
@@ -608,6 +608,11 @@ impl HealthProbeId {
     pub fn ib_port_down() -> Self {
         HealthProbeId("IbPortDown".to_string())
     }
+
+    /// The ID used when an expected DPU-to-ToR BGP session is unavailable.
+    pub fn bgp_peering_tor() -> Self {
+        HealthProbeId("BgpPeeringTor".to_string())
+    }
 }
 
 impl std::fmt::Debug for HealthProbeId {
@@ -746,6 +751,11 @@ mod tests {
             format!("{classification:?} {classification}").as_str(),
             "\"Network\" Network"
         );
+    }
+
+    #[test]
+    fn bgp_peering_tor_probe_id_string() {
+        assert_eq!(HealthProbeId::bgp_peering_tor().as_str(), "BgpPeeringTor");
     }
 
     #[test]

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -5683,6 +5683,59 @@ fn check_host_health_for_alerts(state: &ManagedHostStateSnapshot) -> Result<(), 
     }
 }
 
+const PRIMARY_DPU_BGP_WAIT_REASON: &str =
+    "Waiting for the primary DPU p0 BGP session to be established";
+const HOST_HEALTH_WAIT_REASON: &str =
+    "Waiting for lifecycle-blocking host health alerts to clear before PXE reboot";
+
+/// Returns whether the DPU agent marked a ToR BGP alert as unsafe for PXE allocation.
+fn is_pxe_blocking_bgp_alert(alert: &HealthProbeAlert) -> bool {
+    alert.id == HealthProbeId::bgp_peering_tor()
+        && alert
+            .classifications
+            .contains(&HealthAlertClassification::prevent_allocations())
+}
+
+/// Checks whether a health report contains a BGP alert that should block PXE.
+fn report_has_pxe_blocking_bgp_alert(report: &HealthReport) -> bool {
+    report.alerts.iter().any(is_pxe_blocking_bgp_alert)
+}
+
+/// Checks whether effective health data contains the p0 BGP condition that blocks PXE.
+///
+/// The agent marks a failed p0 session with `PreventAllocations` because PXE
+/// boot depends on p0. A host Replace report overrides all DPU reports.
+/// Otherwise, only the primary attached DPU is checked: its Replace report
+/// overrides its Merge reports, and any Merge report may contain the blocking
+/// BGP alert when there is no Replace report.
+fn primary_dpu_has_pxe_blocking_bgp_alert(state: &ManagedHostStateSnapshot) -> bool {
+    if let Some(host_replace_report) = state.host_snapshot.health_reports.replace.as_ref() {
+        return report_has_pxe_blocking_bgp_alert(host_replace_report);
+    }
+
+    let Some(primary_dpu_id) = state.host_snapshot.primary_attached_dpu_machine_id() else {
+        return false;
+    };
+
+    let Some(primary_dpu) = state
+        .dpu_snapshots
+        .iter()
+        .find(|dpu| dpu.id == primary_dpu_id)
+    else {
+        return false;
+    };
+
+    if let Some(dpu_replace_report) = primary_dpu.health_reports.replace.as_ref() {
+        return report_has_pxe_blocking_bgp_alert(dpu_replace_report);
+    }
+
+    primary_dpu
+        .health_reports
+        .merges
+        .values()
+        .any(report_has_pxe_blocking_bgp_alert)
+}
+
 /// Whether a captured desired target can be replaced before this substate runs.
 ///
 /// Pure checks and pre-write states can adopt newer intent. Vendor jobs,
@@ -7758,6 +7811,12 @@ impl StateHandler for InstanceStateHandler {
                         }
                     };
 
+                    if primary_dpu_has_pxe_blocking_bgp_alert(mh_snapshot) {
+                        return Ok(StateHandlerOutcome::wait(
+                            PRIMARY_DPU_BGP_WAIT_REASON.to_string(),
+                        ));
+                    }
+
                     // Check whether the IB config is synced
                     if let Err(not_synced_reason) = ib_config_synced(
                         mh_snapshot
@@ -7872,6 +7931,29 @@ impl StateHandler for InstanceStateHandler {
                     })
                 }
                 InstanceState::WaitingForRebootToReady => {
+                    // Deletion and custom iPXE requests intentionally bypass these readiness
+                    // checks. During normal provisioning, recheck aggregate health for every host.
+                    // Hosts with managed DPUs also recheck the primary DPU p0 BGP alert. This
+                    // closes the gap between the network configuration check and the restart.
+                    if instance.deleted.is_none() && !instance.custom_pxe_reboot_requested {
+                        match check_host_health_for_alerts(mh_snapshot) {
+                            Ok(()) => {}
+                            Err(StateHandlerError::HealthProbeAlert) => {
+                                return Ok(StateHandlerOutcome::wait(
+                                    HOST_HEALTH_WAIT_REASON.to_string(),
+                                ));
+                            }
+                            Err(error) => return Err(error),
+                        }
+                        if mh_snapshot.has_managed_dpus()
+                            && primary_dpu_has_pxe_blocking_bgp_alert(mh_snapshot)
+                        {
+                            return Ok(StateHandlerOutcome::wait(
+                                PRIMARY_DPU_BGP_WAIT_REASON.to_string(),
+                            ));
+                        }
+                    }
+
                     // If custom_pxe_reboot_requested is set, this reboot was triggered by
                     // the tenant requested a boot with custom iPXE. Clear the request flag.
                     // The use_custom_pxe_on_boot flag was already set by the API handler.
@@ -13442,6 +13524,65 @@ mod tests {
     use regex::Regex;
 
     use super::*;
+
+    #[test]
+    fn pxe_blocking_bgp_alert_requires_probe_and_allocation_classification() {
+        check_values(
+            [
+                Check {
+                    scenario: "allocation-blocking ToR alert",
+                    input: (
+                        HealthProbeId::bgp_peering_tor(),
+                        vec![HealthAlertClassification::prevent_allocations()],
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "critical ToR alert also blocks PXE",
+                    input: (
+                        HealthProbeId::bgp_peering_tor(),
+                        vec![
+                            HealthAlertClassification::prevent_allocations(),
+                            HealthAlertClassification::prevent_host_state_changes(),
+                        ],
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "visible ToR alert does not block PXE",
+                    input: (HealthProbeId::bgp_peering_tor(), vec![]),
+                    expect: false,
+                },
+                Check {
+                    scenario: "host-state classification alone is not the p0 signal",
+                    input: (
+                        HealthProbeId::bgp_peering_tor(),
+                        vec![HealthAlertClassification::prevent_host_state_changes()],
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "different allocation-blocking probe",
+                    input: (
+                        HealthProbeId::from_str("BgpPeeringRouteServer")
+                            .expect("valid test probe id"),
+                        vec![HealthAlertClassification::prevent_allocations()],
+                    ),
+                    expect: false,
+                },
+            ],
+            |(id, classifications)| {
+                is_pxe_blocking_bgp_alert(&HealthProbeAlert {
+                    id,
+                    target: None,
+                    in_alert_since: None,
+                    message: "test alert".to_string(),
+                    tenant_message: None,
+                    classifications,
+                })
+            },
+        );
+    }
 
     #[test]
     fn dpu_restart_requires_a_stable_power_state() {


### PR DESCRIPTION
> [!NOTE]
> While this PR seems large at first glance, just FYI that it contains:
>
> - +985 test lines and +317 production lines (+1,302/-157 overall), so 75.7% of the additions are tests. Most of those tests are the BGP/NVUE policy matrices and lifecycle regressions.
>
> Don't let it scare you!

NVUE can report a new HBN configuration as applied before HBN has finished reprogramming the dataplane. During that gap, NICo's most recent health report can still show the old p0 session as `Established`. HBN can then drop p0 while applying the configuration, but NICo can leave `WaitingForNetworkConfig` and reboot before the next health report records the failure. UEFI then tries PXE while p0 is unavailable and times out. The NVUE health path also blocked host state changes for a failure on p1 alone, even when p0 was usable.

The agent now keeps the NVUE HBN change result separate from the DHCP gRPC result, which returns true for every accepted request. It emits `PostConfigCheckWait` after an NVUE HBN change, while container mode keeps its existing wait for one more health report after a local HBN or DHCP reload. NVUE and FRR now classify each BGP session failure according to the affected link: a failed p0 BGP session prevents allocations and PXE readiness without blocking unrelated state changes, a failure on p1 alone does not prevent allocations or state changes, and losing both uplinks prevents allocations and host state changes. The controller checks health again immediately before the provisioning reboot.

`min_dpu_functioning_links` still defaults to two. When set to one, the agent hides a failure on p1 alone, but it still inspects both sessions so it detects a complete outage. Deleted instances and custom iPXE reboots bypass the new reboot check. Hosts without managed DPUs still use the aggregate health check, but the p0 check does not apply. A host Replace report overrides all DPU reports; for the primary DPU, its Replace report overrides its Merge reports.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5210

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Unit tables cover `min_dpu_functioning_links` values zero, one, and two on NVUE and FRR. The complete agent suite (230 tests), `carbide-health-report` suite (13 tests), and the SQLx lifecycle regressions pass. Targeted Clippy, nightly formatting, and custom lints also pass.

<details>
<summary>Review findings (56 received; 44 adopted; 12 declined)</summary>

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Author review | 15 | 15 | 0 |
| Codex review | 6 | 4 | 2 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 10 | 8 | 2 |
| Common infra-controller review | 6 | 6 | 0 |
| CodeRabbit Cloud | 15 | 8 | 7 |
| Simplicity audit | 4 | 3 | 1 |

Codex review:

1. Adopted: skip the NVUE request at minimum zero.
2. Adopted: distinguish primary session loss from a warning that IPv6 unicast negotiation failed.
3. Adopted: inspect both legacy sessions at minimum one; losing both sessions stays critical.
4. Adopted: skip the legacy query for IPv6 failures at minimum zero.
5. Declined here: public docs are tracked by NVBug 6642111 and a separate PR.
6. Declined here: broader fixtures with several DPUs; the focused primary path is covered.

Author review:

1. Adopted: convert the configured link count to `usize` once at the health boundary.
2. Adopted: visually separate selection of the primary uplink from policy application.
3. Adopted: replace the nested suppression predicate with direct map updates.
4. Adopted: use `health_classifications` where the value is constructed.
5. Adopted: explain the loop that emits unhealthy uplink alerts at a glance.
6. Adopted: document the classification shorthand used only by tests.
7. Adopted: replace positional NVUE tuples and nested matching with named data.
8. Adopted: show exact test and production line counts in the PR summary.
9. Adopted: name and document every expected classification set explicitly.
10. Adopted: document the FRR ToR test input, its fields, and its fixture marker.
11. Adopted: explain the meaningful phases in the table and lifecycle tests.
12. Adopted: document the unhealthy NVUE uplink record and each field.
13. Adopted: remove awkward compound modifiers from new comments.
14. Adopted: name the BGP alert that blocks PXE instead of calling it a signal.
15. Adopted: make the lookup of health for the primary DPU linear and separate its guards.

Claude CLI:

1. Adopted: make primary session failure prevent allocation.
2. Adopted: honor host and DPU Replace reports in the PXE gate.
3. Adopted: specify behavior for minimum values of zero, one, two, and values above the number of uplinks in Rust.
4. Adopted: use a shared probe ID and semantic classification.
5. Adopted: exclude deletion and custom iPXE from the reboot recheck; apply the p0 check only to hosts with managed DPUs.
6. Adopted: align how legacy and NVUE handle the minimum link setting.
7. Adopted: preserve minimum zero as the way to disable ToR uplink alerts.
8. Declined here: expanding the fixtures to cover several DPUs is additional coverage.
9. Declined: flattening HBN/DHCP signals would make DHCP permanently trigger the wait.
10. Adopted: tighten names, comments, and table cases.

Common infra-controller review:

1. Adopted: assert the `PostConfigCheckWait` alert through the lifecycle test.
2. Adopted: document that minimum zero disables every uplink alert.
3. Adopted: avoid the NVUE call at minimum zero.
4. Adopted: honor Merge and Replace reports for the primary DPU.
5. Adopted: keep mixed failures from falsely tagging a healthy primary session.
6. Adopted: retain blocking for two effective AF or mixed failures.

CodeRabbit Cloud:

1. Declined: legacy combines real local HBN/DHCP reloads intentionally; NVUE must exclude the DHCP gRPC result because it is true for every accepted request.
2. Declined: IPv6 checks with a minimum of one intentionally inspect the required uplink; transport checks still inspect both.
3. Adopted: replace the NVUE uplink tuple with a named record.
4. Declined here: keep independently constructed test helpers that are specific to each path.
5. Declined here: broader fixtures with several DPUs remain additional coverage.
6. Adopted: persist an expected final health hold as Wait instead of Error.
7. Adopted: use the typed `BgpPeeringTor` ID in the lifecycle fixture.
8. Adopted: apply aggregate health checks to normal provisioning without managed DPUs.
9. Adopted: assert the exact persisted primary BGP wait reason.
10. Declined here: a larger primary DPU precedence table is additional coverage.
11. Adopted: make the NVUE session helper private.
12. Adopted: document why IPv6 validation with a minimum of one checks the required uplink and preserve the existing behavior.
13. Declined: keep FRR and NVUE severity logic separate because FRR also includes address family warnings.
14. Adopted: replace indexed access to the fixed uplink pair with irrefutable array destructuring.
15. Declined: retain host state blocking when both required uplinks lack a usable transport or address family; counting only transport failures would relax the existing IPv6 underlay health contract from #4314.

Simplicity audit:

1. Adopted: remove the network change wrapper used once and its Boolean OR test.
2. Adopted: inline the NVUE guard for a minimum of zero and remove its disconnected test.
3. Adopted: use logical OR for the combined HBN/DHCP change signal.
4. Declined: retain the explicit matrix combinations for a minimum of zero required by repository test guidance.

</details>

Closes #5210
