### PR TITLE
Update DOCA BFB to 3.2.3

### DIFF
--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -33,14 +33,14 @@ FORGE_CA_PATH = { value = "${REPO_ROOT}/dev/forge_prodroot.pem" }
 # - using flint tool (BlueField-3 only):
 # `flint -d /dev/mst/mt41692_pciconf0 qbfb`
 #
-DOCA_VERSION = "3.2.2"
-BFB_BUILD = "125"
-BFB_RELEASE = "26.02"
+DOCA_VERSION = "3.2.3"
+BFB_BUILD = "33"
+BFB_RELEASE = "26.06"
 # DPU OS Ubuntu 22.04
 BFB_URL = "https://content.mellanox.com/BlueField/BFBs/Ubuntu22.04"
 BFB_NAME = "bf-bundle-${DOCA_VERSION}-${BFB_BUILD}_${BFB_RELEASE}_ubuntu-22.04_prod.bfb"
 # DOCA HBN Version
-DOCA_HBN_VERSION = "3.2.2"
+DOCA_HBN_VERSION = "3.2.3"
 DOCA_HBN_URL = "nvcr.io/nvidia/doca/doca_hbn:${DOCA_HBN_VERSION}-doca${DOCA_VERSION}"
 DOCA_HBN_CONFIG_URL = "https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/doca/doca_hbn/${DOCA_HBN_VERSION}/files"
 


### PR DESCRIPTION
Use 3.2.3 DOCA HBN and BFB to build the images.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

