### PR TITLE
chore: Change mlnx_bf_conf to include SNAP_DMA_SF=no in Bf4Astra depl…

### DIFF
--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -760,7 +760,10 @@ fn get_config_files(
         "ENABLE_ESWITCH_MULTIPORT=\"yes\"\n"
     )
     .to_string();
-    if matches!(deployment_type, DpuDeploymentType::Bf4Generic) {
+    if matches!(
+        deployment_type,
+        DpuDeploymentType::Bf4Generic | DpuDeploymentType::Bf4Astra
+    ) {
         mlnx_bf_conf.push_str("SNAP_DMA_SF=\"no\"\n");
     }
 

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -760,10 +760,7 @@ fn get_config_files(
         "ENABLE_ESWITCH_MULTIPORT=\"yes\"\n"
     )
     .to_string();
-    if matches!(
-        deployment_type,
-        DpuDeploymentType::Bf4Generic | DpuDeploymentType::Bf4Astra
-    ) {
+    if matches!(deployment_type, DpuDeploymentType::Bf4Generic) {
         mlnx_bf_conf.push_str("SNAP_DMA_SF=\"no\"\n");
     }
 
@@ -981,6 +978,7 @@ fn get_bf4_astra_config_files(
                     "ALLOW_SHARED_RQ=\"no\"\n",
                     "IPSEC_FULL_OFFLOAD=\"no\"\n",
                     "ENABLE_ESWITCH_MULTIPORT=\"yes\"\n",
+                    "SNAP_DMA_SF=\"no\"\n"
                 )
                 .to_string(),
             ),


### PR DESCRIPTION
…oymenta also.


Description: Change mlnx_bf_conf to include SNAP_DMA_Sf=no in case deployment
type is Bf4Astra also.

## Related issues


## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This is being tested on the VR minipod



Closes https://github.com/NVIDIA/infra-controller/issues/5498
