### PR TITLE
Update PXE DOCA BFB to 3.2.3

### DIFF
--- a/crates/firmware/src/defaults.rs
+++ b/crates/firmware/src/defaults.rs
@@ -16,10 +16,10 @@
  */
 
 /// Default BlueField-2 NIC firmware version.
-pub const BF2_NIC_VERSION: &str = "24.47.2682";
+pub const BF2_NIC_VERSION: &str = "24.47.3576";
 
 /// Default BlueField-2 BMC firmware version.
-pub const BF2_BMC_VERSION: &str = "BF-25.10-20";
+pub const BF2_BMC_VERSION: &str = "BF-25.10-24";
 
 /// Default BlueField-2 CEC firmware version.
 pub const BF2_CEC_VERSION: &str = "4-15";
@@ -28,10 +28,10 @@ pub const BF2_CEC_VERSION: &str = "4-15";
 pub const BF2_UEFI_VERSION: &str = "4.13.2-12-g943a91640d";
 
 /// Default BlueField-3 NIC firmware version.
-pub const BF3_NIC_VERSION: &str = "32.47.2682";
+pub const BF3_NIC_VERSION: &str = "32.47.3576";
 
 /// Default BlueField-3 BMC firmware version.
-pub const BF3_BMC_VERSION: &str = "BF-25.10-20";
+pub const BF3_BMC_VERSION: &str = "BF-25.10-24";
 
 /// Default BlueField-3 CEC firmware version.
 pub const BF3_CEC_VERSION: &str = "00.02.0195.0000_n02";
@@ -75,15 +75,15 @@ mod tests {
         // BF2 and BF3 currently share BMC and UEFI payload versions.
         value_scenarios!(default_version:
             "bluefield 2" {
-                BlueFieldVersion::Bf2Nic => "24.47.2682",
-                BlueFieldVersion::Bf2Bmc => "BF-25.10-20",
+                BlueFieldVersion::Bf2Nic => "24.47.3576",
+                BlueFieldVersion::Bf2Bmc => "BF-25.10-24",
                 BlueFieldVersion::Bf2Cec => "4-15",
                 BlueFieldVersion::Bf2Uefi => "4.13.2-12-g943a91640d",
             }
 
             "bluefield 3" {
-                BlueFieldVersion::Bf3Nic => "32.47.2682",
-                BlueFieldVersion::Bf3Bmc => "BF-25.10-20",
+                BlueFieldVersion::Bf3Nic => "32.47.3576",
+                BlueFieldVersion::Bf3Bmc => "BF-25.10-24",
                 BlueFieldVersion::Bf3Cec => "00.02.0195.0000_n02",
                 BlueFieldVersion::Bf3Uefi => "4.13.2-12-g943a91640d",
             }

--- a/deploy/nico-base/api/config-files/carbide-api-config.toml
+++ b/deploy/nico-base/api/config-files/carbide-api-config.toml
@@ -34,7 +34,7 @@ bypass_rbac = true
 [dpu_config]
 dpu_nic_firmware_initial_update_enabled = false
 dpu_nic_firmware_reprovision_update_enabled = true
-dpu_nic_firmware_update_versions = ["24.47.2682", "32.47.2682"]
+dpu_nic_firmware_update_versions = ["24.47.3576", "32.47.3576"]
 
 [host_health]
 hardware_health_reports = "MonitorOnly"

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -29,7 +29,7 @@ anycast_site_prefixes = ["0.0.0.0/0"]
 # DPU NIC firmware settings.
 dpu_nic_firmware_initial_update_enabled = false
 dpu_nic_firmware_reprovision_update_enabled = true
-dpu_nic_firmware_update_versions = ["24.47.2682", "32.47.2682"]
+dpu_nic_firmware_update_versions = ["24.47.3576", "32.47.3576"]
 # Number of VFs configured per DPU PF during BlueField provisioning.
 num_of_vfs = 16
 

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -40,14 +40,14 @@ MKOSI_PACKAGE_CACHE_DIR = { value = "${REPO_ROOT}/pxe/.mkosi-package-cache", con
 # - using flint tool (BlueField-3 only):
 # `flint -d /dev/mst/mt41692_pciconf0 qbfb`
 #
-DOCA_VERSION = "3.2.2"
-BFB_BUILD = "125"
-BFB_RELEASE = "26.02"
+DOCA_VERSION = "3.2.3"
+BFB_BUILD = "33"
+BFB_RELEASE = "26.06"
 # DPU OS Ubuntu 22.04
 BFB_URL = "https://content.mellanox.com/BlueField/BFBs/Ubuntu22.04"
 BFB_NAME = "bf-bundle-${DOCA_VERSION}-${BFB_BUILD}_${BFB_RELEASE}_ubuntu-22.04_prod.bfb"
 # DOCA HBN Version
-DOCA_HBN_VERSION = "3.2.2"
+DOCA_HBN_VERSION = "3.2.3"
 DOCA_HBN_URL = "nvcr.io/nvidia/doca/doca_hbn:${DOCA_HBN_VERSION}-doca${DOCA_VERSION}"
 DOCA_HBN_CONFIG_URL = "https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/doca/doca_hbn/${DOCA_HBN_VERSION}/files"
 


### PR DESCRIPTION
Upgrade to use DOCA HBN and BFB 3.2.3

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

