### PR TITLE
remove(machine-a-tron): use_single_bmc_mock true mode

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1449,9 +1449,7 @@ where
         log_format: LogFormat::Compact,
         bmc_mock_port: 0, // unused, we're using dynamic ports on localhost
         bmc_mock_certs_dir: None,
-        interface: String::from("UNUSED"), // unused, we're using dynamic ports on localhost
         tui_enabled: false,
-        use_single_bmc_mock: false, // unused, we're constructing machines ourselves
         configure_carbide_bmc_proxy_host: None,
         persist_dir: None,
         cleanup_on_quit: false,
@@ -1472,7 +1470,7 @@ where
         mat_config,
         additional_api_urls,
         &test_env.root_dir,
-        Some(bmc_mock_registry.clone()),
+        bmc_mock_registry.clone(),
         TEST_MAC_POOL.clone(),
     )
     .await

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -172,9 +172,7 @@ async fn run_machine_a_tron_racks_test(
         log_format: LogFormat::Compact,
         bmc_mock_port: 0,
         bmc_mock_certs_dir: None,
-        interface: String::from("UNUSED"),
         tui_enabled: false,
-        use_single_bmc_mock: false,
         configure_carbide_bmc_proxy_host: None,
         persist_dir: None,
         cleanup_on_quit: false,
@@ -195,7 +193,7 @@ async fn run_machine_a_tron_racks_test(
         mat_config,
         additional_api_urls,
         &test_env.root_dir,
-        Some(bmc_mock_registry.clone()),
+        bmc_mock_registry.clone(),
         TEST_MAC_POOL.clone(),
     )
     .await?;

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -22,8 +22,8 @@ use bmc_mock::mac_address_pool::MacAddressPool;
 use forge_tls::client_config::get_root_ca_path;
 use futures::future::try_join_all;
 use machine_a_tron::{
-    BmcMockRegistry, BmcRegistrationMode, DeviceHandle, DhcpClient, MachineATron,
-    MachineATronConfig, MachineATronContext, UdpDhcpService, api_throttler,
+    BmcMockRegistry, DeviceHandle, DhcpClient, MachineATron, MachineATronConfig,
+    MachineATronContext, UdpDhcpService, api_throttler,
 };
 use rpc::forge_api_client::FailOverOn;
 use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig, RetryConfig};
@@ -41,7 +41,7 @@ pub async fn run_local(
     app_config: MachineATronConfig,
     additional_api_urls: Vec<String>,
     repo_root: &Path,
-    bmc_address_registry: Option<BmcMockRegistry>,
+    bmc_address_registry: BmcMockRegistry,
     mac_address_pool: Arc<Mutex<MacAddressPool>>,
 ) -> eyre::Result<(Vec<DeviceHandle>, MachineATronHandle)> {
     app_config.validate()?;
@@ -84,11 +84,7 @@ pub async fn run_local(
         DhcpClient::start(&app_config, forge_api_client.clone().into()).await?;
 
     let app_context = Arc::new(MachineATronContext {
-        bmc_registration_mode: if let Some(bmc_address_registry) = bmc_address_registry.as_ref() {
-            BmcRegistrationMode::BackingInstance(bmc_address_registry.clone())
-        } else {
-            BmcRegistrationMode::None(app_config.bmc_mock_port)
-        },
+        bmc_registry: bmc_address_registry.clone(),
         app_config,
         forge_client_config,
         bmc_mock_certs_dir: Some(repo_root.join("crates/bmc-mock")),

--- a/crates/bmc-mock/src/ipmi_sim.rs
+++ b/crates/bmc-mock/src/ipmi_sim.rs
@@ -46,7 +46,6 @@ const CHASSIS_CONTROL_FIFO: &str = "chassis-control.fifo";
 
 #[derive(Debug, Clone)]
 pub struct IpmiSimConfig {
-    pub bind_ip: IpAddr,
     /// Client-facing port advertised through Redfish. When absent, clients connect directly to
     /// the dynamically allocated simulator port.
     pub reachable_port: Option<u16>,
@@ -147,9 +146,12 @@ struct Reservations {
 }
 
 impl Reservations {
-    fn new(bind_ip: IpAddr) -> Result<Self, std::io::Error> {
+    fn new() -> Result<Self, std::io::Error> {
         Ok(Self {
-            ipmi_sim_lan_socket: UdpSocket::bind(SocketAddr::new(bind_ip, 0))?,
+            ipmi_sim_lan_socket: UdpSocket::bind(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                0,
+            ))?,
             ipmi_sim_serial_listener: TcpListener::bind((
                 IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
                 0,
@@ -187,7 +189,7 @@ pub async fn start(state: &BmcState, config: IpmiSimConfig) -> Result<IpmiSimHan
     let mut last_error = None;
 
     for attempt in 1..=START_ATTEMPTS {
-        let reservations = Reservations::new(config.bind_ip)?;
+        let reservations = Reservations::new()?;
         let ipmi_sim_lan_port = reservations.ipmi_sim_lan_port()?;
         let ipmi_sim_serial_port = reservations.ipmi_sim_serial_port()?;
         let state_dir = temp_dir.path().join(format!("state-{attempt}"));
@@ -219,21 +221,10 @@ pub async fn start(state: &BmcState, config: IpmiSimConfig) -> Result<IpmiSimHan
             .kill_on_drop(true)
             .spawn()?;
 
-        match wait_until_ready(
-            &mut child,
-            config.bind_ip,
-            ipmi_sim_lan_port,
-            ipmi_sim_serial_port,
-        )
-        .await
-        {
+        match wait_until_ready(&mut child, ipmi_sim_lan_port, ipmi_sim_serial_port).await {
             Ok(()) => {
                 let endpoint = IpmiEndpoint::new(ipmi_sim_lan_port, config.reachable_port);
-                let connect_ip = if config.bind_ip.is_unspecified() {
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
-                } else {
-                    config.bind_ip
-                };
+                let connect_ip = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
                 let password_updater: Arc<dyn PasswordUpdater> = Arc::new(IpmiPasswordUpdater {
                     connect_ip,
                     ipmi_sim_lan_port,
@@ -428,7 +419,7 @@ fn write_config(
 set_working_mc 0x20
 
 startlan 1
-  addr {} {ipmi_sim_lan_port}
+  addr 0.0.0.0 {ipmi_sim_lan_port}
   priv_limit admin
   allowed_auths_admin none md2 md5 straight none
   guid {}
@@ -442,7 +433,6 @@ chassis_control "./chassis-control.sh 0x20"
 serial 15 127.0.0.1 {ipmi_sim_serial_port} codec VM ipmb 0x20
 sol "telnet:127.0.0.1:{bmc_mock_console_port}" 115200
 "#,
-        config.bind_ip,
         stable_guid(&config.stable_id),
     );
 
@@ -479,7 +469,6 @@ fn stable_guid(stable_id: &str) -> String {
 
 async fn wait_until_ready(
     child: &mut tokio::process::Child,
-    bind_ip: IpAddr,
     ipmi_sim_lan_port: u16,
     ipmi_sim_serial_port: u16,
 ) -> Result<(), Error> {
@@ -489,9 +478,7 @@ async fn wait_until_ready(
             return Err(Error::EarlyExit(status));
         }
 
-        if udp_port_is_claimed(bind_ip, ipmi_sim_lan_port)?
-            && tcp_port_is_claimed(ipmi_sim_serial_port)?
-        {
+        if udp_port_is_claimed(ipmi_sim_lan_port)? && tcp_port_is_claimed(ipmi_sim_serial_port)? {
             tokio::time::sleep(READY_POLL_INTERVAL).await;
             if let Some(status) = child.try_wait()? {
                 return Err(Error::EarlyExit(status));
@@ -506,8 +493,11 @@ async fn wait_until_ready(
     }
 }
 
-fn udp_port_is_claimed(bind_ip: IpAddr, port: u16) -> Result<bool, std::io::Error> {
-    port_is_claimed(UdpSocket::bind(SocketAddr::new(bind_ip, port)))
+fn udp_port_is_claimed(port: u16) -> Result<bool, std::io::Error> {
+    port_is_claimed(UdpSocket::bind(SocketAddr::new(
+        IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+        port,
+    )))
 }
 
 fn tcp_port_is_claimed(port: u16) -> Result<bool, std::io::Error> {
@@ -574,7 +564,6 @@ async fn serve_console(mut stream: TcpStream, prompt: &str) -> Result<(), std::i
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::net::{IpAddr, Ipv4Addr};
     use std::os::unix::fs::PermissionsExt;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -717,7 +706,6 @@ mod tests {
         let error = start(
             &state,
             IpmiSimConfig {
-                bind_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
                 reachable_port: None,
                 stable_id: "missing-callback".to_string(),
                 console_prompt: "root@bmc-mock # ".to_string(),
@@ -741,7 +729,6 @@ mod tests {
         let simulator = start(
             &state,
             IpmiSimConfig {
-                bind_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
                 reachable_port: None,
                 stable_id: "chassis-reset".to_string(),
                 console_prompt: "root@bmc-mock # ".to_string(),

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -137,7 +137,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             bmc_mock::ipmi_sim::start(
                 state,
                 bmc_mock::ipmi_sim::IpmiSimConfig {
-                    bind_ip: "0.0.0.0".parse().unwrap(),
                     reachable_port: None,
                     stable_id: "standalone-bmc-mock".to_string(),
                     console_prompt: "root@bmc-mock # ".to_string(),

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -15,23 +15,18 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
 use bmc_mock::injection::InjectionStore;
 use bmc_mock::ipmi_sim::{IpmiEndpoint, IpmiSimConfig, IpmiSimHandle};
-use bmc_mock::{
-    BmcState, Callbacks, CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo,
-};
+use bmc_mock::{BmcState, Callbacks, CombinedServer, HostnameQuerying, MachineInfo};
 use carbide_ipmi::DEFAULT_IPMI_PORT;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use crate::config::MachineATronContext;
 use crate::machine_state_machine::MachineStateError;
-use crate::machine_utils::add_address_to_interface;
 use crate::mock_ssh_server;
 use crate::mock_ssh_server::{MockSshServerHandle, PromptBehavior};
 
@@ -39,7 +34,6 @@ use crate::mock_ssh_server::{MockSshServerHandle, PromptBehavior};
 /// either a DPU or a Host. It will rewrite certain responses to customize them for the machines
 /// machine-a-tron is mocking.
 pub(super) struct BmcMockWrapper {
-    ssh_prompt_behavior: PromptBehavior,
     app_context: Arc<MachineATronContext>,
     bmc_mock_router: Router,
     bmc_mock_state: BmcState,
@@ -67,10 +61,6 @@ impl BmcMockWrapper {
         );
 
         BmcMockWrapper {
-            ssh_prompt_behavior: match machine_info {
-                MachineInfo::Host(_) => PromptBehavior::Dell,
-                MachineInfo::Dpu(_) => PromptBehavior::Dpu,
-            },
             app_context,
             bmc_mock_router,
             bmc_mock_state,
@@ -81,140 +71,21 @@ impl BmcMockWrapper {
         }
     }
 
-    /// Starts the per-machine Redfish server and any enabled SSH and IPMI simulators.
-    /// When requested, the BMC address is first added as an alias on the configured interface.
-    pub(super) async fn start(
-        &mut self,
-        address: SocketAddr,
-        add_ip_alias: bool,
-    ) -> Result<BmcMockWrapperHandle, MachineStateError> {
-        let root_ca_path = self.app_context.forge_client_config.root_ca_path.as_str();
-        let certs_dir = self
-            .app_context
-            .bmc_mock_certs_dir
-            .as_ref()
-            .cloned()
-            .or_else(|| {
-                PathBuf::from(root_ca_path.to_owned())
-                    .parent()
-                    .map(Path::to_path_buf)
-            })
-            .ok_or_else(|| MachineStateError::MissingCertificates(root_ca_path.to_owned()))?;
-
-        // Support dynamically assigning address: If configured for a dynamic address, pass the
-        // listener itself to bmc-mock to prevent race conditions. Otherwise, pass the address.
-        if add_ip_alias {
-            add_address_to_interface(
-                &address.ip().to_string(),
-                &self.app_context.app_config.interface,
-            )
-            .await
-            .inspect_err(|e| {
-                tracing::warn!(
-                    error = %e,
-                    "failed to add BMC mock address to interface",
-                )
-            })
-            .map_err(MachineStateError::ListenAddressConfigError)?;
-        }
-
-        let ssh_handle = if self.app_context.app_config.mock_bmc_ssh_server {
-            // Port: Use the configured port, and if none is configured, use (1) a random port, if
-            // we're launching a single BMC mock for all machines (needed for integration tests
-            // where we can't rely on available ports), or (2) a fixed port if we're creating a new
-            // IP address for every machine
-            let port = self
-                .app_context
-                .app_config
-                .mock_bmc_ssh_port
-                .or(if add_ip_alias {
-                    // We have to use a nonstandard port here even if we're using an ip alias, since most
-                    // hosts listen to SSH on port 22 already on *all* interfaces, including any aliases we
-                    // create for the test.
-                    Some(2222)
-                } else {
-                    None
-                });
-
-            Some(
-                mock_ssh_server::spawn(
-                    address.ip(),
-                    port,
-                    self.hostname.clone(),
-                    Some(mock_ssh_server::Credentials {
-                        user: "root".to_string(),
-                        password: "password".to_string(),
-                    }),
-                    self.ssh_prompt_behavior,
-                )
-                .await
-                .map_err(|error| {
-                    MachineStateError::MockSshServer(format!(
-                        "error running mock SSH server on {}:{}: {error:?}",
-                        address.ip(),
-                        port.map(|p| p.to_string()).unwrap_or("<none>".to_string()),
-                    ))
-                })?,
-            )
-        } else {
-            None
-        };
-        let ipmi_sim_handle = if self.need_ipmi_sim() {
-            Some(self.start_ipmi_sim(address.ip()).await?)
-        } else {
-            None
-        };
-        let ssh_endpoint_port = ssh_handle.as_ref().map(|handle| handle.port);
-        self.bmc_mock_state
-            .set_serial_console_ssh_port(ssh_endpoint_port);
-
-        tracing::info!(
-            listen_address = ?address,
-            "Starting BMC mock",
-        );
-
-        let tls_server_config = bmc_mock::tls::server_config(Some(certs_dir))?;
-        let bmc_mock_router = self.bmc_mock_router.clone();
-        Ok(BmcMockWrapperHandle {
-            _bmc_mock: Some(CombinedServer::run(
-                "bmc-mock",
-                Arc::new(RwLock::new(HashMap::from([(
-                    "".to_string(),
-                    bmc_mock_router,
-                )]))),
-                Some(ListenerOrAddress::Address(address)),
-                tls_server_config,
-            )),
-            ssh_handle,
-            ssh_endpoint_port,
-            _ipmi_sim_handle: ipmi_sim_handle,
-        })
-    }
-
     /// Starts per-machine console simulators when Redfish is served by a shared BMC mock.
     /// Hosts use the shared SSH listener, while DPUs get a direct per-machine SSH listener.
     /// Returns `None` when the hardware profile advertises neither an SSH nor IPMI console.
-    pub(super) async fn start_shared_mode_consoles(
-        &self,
-        bind_ip: std::net::IpAddr,
-    ) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
+    pub(super) async fn start(&self) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
         let ssh_handle = if self.app_context.app_config.mock_bmc_ssh_server && self.is_dpu {
             Some(
-                mock_ssh_server::spawn(
-                    bind_ip,
-                    None,
-                    self.hostname.clone(),
-                    None,
-                    PromptBehavior::Dpu,
-                )
-                .await
-                .map_err(|error| MachineStateError::MockSshServer(error.to_string()))?,
+                mock_ssh_server::spawn(None, self.hostname.clone(), None, PromptBehavior::Dpu)
+                    .await
+                    .map_err(|error| MachineStateError::MockSshServer(error.to_string()))?,
             )
         } else {
             None
         };
         let ipmi_sim_handle = if self.need_ipmi_sim() {
-            Some(self.start_ipmi_sim(bind_ip).await?)
+            Some(self.start_ipmi_sim().await?)
         } else {
             None
         };
@@ -239,10 +110,7 @@ impl BmcMockWrapper {
         )
     }
 
-    async fn start_ipmi_sim(
-        &self,
-        bind_ip: std::net::IpAddr,
-    ) -> Result<IpmiSimHandle, MachineStateError> {
+    async fn start_ipmi_sim(&self) -> Result<IpmiSimHandle, MachineStateError> {
         // Determine the reachable port advertised through Redfish:
         // - None (unset): Use default port
         // - Some(0): Use dynamic port (same as listen port)
@@ -257,7 +125,6 @@ impl BmcMockWrapper {
         bmc_mock::ipmi_sim::start(
             &self.bmc_mock_state,
             IpmiSimConfig {
-                bind_ip,
                 reachable_port,
                 stable_id: self.stable_id.clone(),
                 console_prompt,

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ufm_mock::UfmMockConfig;
 use uuid::Uuid;
 
-use crate::BmcRegistrationMode;
+use crate::BmcMockRegistry;
 use crate::api_client::ApiClient;
 use crate::api_throttler::ApiThrottler;
 use crate::machine_state_machine::OsImage;
@@ -469,8 +469,6 @@ pub struct MachineATronConfig {
     /// Format used for logs written to stdout or `log_file`.
     #[serde(default)]
     pub log_format: LogFormat,
-    pub interface: String,
-
     /// How machine-a-tron obtains DHCP leases for BMCs and directly attached hosts.
     #[serde(default)]
     pub dhcp: DhcpType,
@@ -499,18 +497,10 @@ pub struct MachineATronConfig {
     #[serde(default)]
     pub ipmi_reachable_port: Option<u16>,
 
-    /// Set this to configure the port to use when mocking a BMC SSH server. If unset and
-    /// use_single_bmc_mock is true, it will pick a random port. If unset and use_single_bmc_mock
-    /// is false, it will use port 2222 for each IP alias. (Port 22 is problematic because it
-    /// collides with any system SSH server.)
+    /// Set this to configure the port to use when mocking a BMC SSH
+    /// server. If unset it will pick a random port.
     #[serde(default)]
     pub mock_bmc_ssh_port: Option<u16>,
-
-    /// Set this to true if all BMC-mocks should be behind a single address (using HTTP headers to
-    /// proxy to the real mock). This is the case for machine-a-tron running inside kubernetes
-    /// clusters where there is a single k8s Service and we can't dynamically assign IP's.
-    #[serde(default = "default_false")]
-    pub use_single_bmc_mock: bool,
 
     /// Set this to a hostname or IP If you want machine-a-tron to register its BMC-mock as the
     /// bmc_proxy host (this will be combined with bmc_mock_port.)
@@ -948,7 +938,7 @@ pub struct MachineATronContext {
     pub app_config: MachineATronConfig,
     pub forge_client_config: ForgeClientConfig,
     pub bmc_mock_certs_dir: Option<PathBuf>,
-    pub bmc_registration_mode: BmcRegistrationMode,
+    pub bmc_registry: BmcMockRegistry,
     pub api_throttler: ApiThrottler,
     /// These are the firmware versions the server wants us to be on. If not configured for other
     /// firmware, DPU's can mock that they already have this installed.
@@ -1024,7 +1014,6 @@ pxe_server_port = "8080"
 bmc_mock_port = 1266
 mat_api_server_enabled = true
 mat_api_server_listen_port = 2112
-use_single_bmc_mock = true
 configure_carbide_bmc_proxy_host = "192.168.1.20"
 
 [machines.config]

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -61,7 +61,6 @@ pub use device_simulator::{
 pub use dhcp_wrapper::{DhcpClient, UdpDhcpService};
 pub use dpu_machine::DpuMachineHandle;
 pub use machine_a_tron::{AppEvent, MachineATron};
-pub use machine_state_machine::BmcRegistrationMode;
 pub use mock_ssh_server::{
     Credentials as MockSshCredentials, MockSshServerHandle, PromptBehavior,
     spawn as spawn_mock_ssh_server,

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -17,7 +17,7 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::Ipv4Addr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -39,7 +39,7 @@ use tokio::time::Instant;
 use uuid::Uuid;
 
 use crate::api_client::{ClientApiError, DpuNetworkStatusArgs, MockDiscoveryData};
-use crate::bmc_mock_wrapper::{BmcMockRegistry, BmcMockWrapper, BmcMockWrapperHandle};
+use crate::bmc_mock_wrapper::{BmcMockWrapper, BmcMockWrapperHandle};
 use crate::config::{MachineATronContext, MachineConfig};
 use crate::dhcp_wrapper::{
     DhcpRelayError, DhcpRelayResult, DhcpRequestInfo, DhcpRequester, DhcpResponseInfo,
@@ -340,23 +340,6 @@ impl LiveState {
             None => "Unknown",
         }
     }
-}
-
-/// BmcRegistrationMode configures how each mock machine registers its BMC mock so that carbide can find it.
-#[derive(Debug, Clone)]
-pub enum BmcRegistrationMode {
-    /// BackingInstance: Register the axum Router of the mock into a shared registry. This is used
-    /// when running machine-a-tron as a kubernetes service, where we can only listen on a single
-    /// IP/port but need to mock multiple BMC's. A shared BMC mock is expected to be running, and
-    /// will delegate to these Routers for each BMC mock based on the `Forwarded` header in the
-    /// request from carbide-api.
-    BackingInstance(BmcMockRegistry),
-    /// None: Don't register anything, but instead listen on the actual IP address given via DHCP.
-    /// This is the most true-to-production mode, where we configure a real IP alias on a configured
-    /// interface for every BMC mock, and carbide talks to the BMC's real IP address. It requires
-    /// carbide to be able to reach these aliases, so it is only /// suitable for local use where
-    /// carbide and machine-a-tron are on the same host.
-    None(u16),
 }
 
 pub(super) enum PersistedMachine {
@@ -1268,7 +1251,7 @@ impl MachineStateMachine {
         &self,
         ip_address: Ipv4Addr,
     ) -> Result<(Option<Arc<BmcMockWrapperHandle>>, BmcState), MachineStateError> {
-        let mut bmc_mock = BmcMockWrapper::new(
+        let bmc_mock = BmcMockWrapper::new(
             &self.machine_info,
             self.app_context.clone(),
             Arc::new(LiveStateCallbacks::new(
@@ -1291,29 +1274,13 @@ impl MachineStateMachine {
                 .change_factory_default_password(pw);
         }
 
-        let maybe_bmc_mock_handle = match &self.app_context.bmc_registration_mode {
-            BmcRegistrationMode::None(port) => {
-                let address = SocketAddr::new(ip_address.into(), *port);
-                let handle = bmc_mock.start(address, true).await?;
-                self.live_state.write().unwrap().ssh_host_key =
-                    handle.ssh_handle.as_ref().map(|h| h.host_pubkey.clone());
-                Some(Arc::new(handle))
-            }
-            BmcRegistrationMode::BackingInstance(registry) => {
-                // Assume something has already launched a BMC-mock, our job is to just
-                // insert this bmc-mock's router into the registry so it can delegate to it
-                // by looking it up from the `Forwarded` header.
-                registry
-                    .write()
-                    .await
-                    .insert(ip_address.to_string(), bmc_mock.router().clone());
-                bmc_mock
-                    .start_shared_mode_consoles(std::net::IpAddr::V4(
-                        std::net::Ipv4Addr::UNSPECIFIED,
-                    ))
-                    .await?
-                    .map(Arc::new)
-            }
+        let maybe_bmc_mock_handle = {
+            self.app_context
+                .bmc_registry
+                .write()
+                .await
+                .insert(ip_address.to_string(), bmc_mock.router().clone());
+            bmc_mock.start().await?.map(Arc::new)
         };
         if let Some(ssh_host_key) = maybe_bmc_mock_handle
             .as_ref()
@@ -1406,8 +1373,6 @@ pub(super) enum MachineStateError {
     NoMachineDhcpInfo,
     #[error("error configuring listening address: {0}")]
     ListenAddressConfigError(#[from] AddressConfigError),
-    #[error("could not find certificates at {0}")]
-    MissingCertificates(String),
     #[error("error calling forge API: {0}")]
     ClientApi(#[from] ClientApiError),
     #[error("failed to get DHCP address: {0:?}")]
@@ -1436,8 +1401,6 @@ impl From<tonic::Status> for MachineStateError {
 pub(super) enum AddressConfigError {
     #[error("error running ip command: {0}")]
     Io(#[from] std::io::Error),
-    #[error("error running ip command: {0:?}, output: {1:?}")]
-    CommandFailure(Box<tokio::process::Command>, std::process::Output),
 }
 
 #[cfg(test)]

--- a/crates/machine-a-tron/src/machine_utils.rs
+++ b/crates/machine-a-tron/src/machine_utils.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 use std::collections::HashSet;
-use std::path::Path;
 
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use carbide_uuid::machine_validation::MachineValidationId;
@@ -27,7 +26,6 @@ use uuid::Uuid;
 use crate::DeviceHandle;
 use crate::api_client::ClientApiError;
 use crate::config::MachineATronContext;
-use crate::machine_state_machine::AddressConfigError;
 
 lazy_static! {
     static ref BMC_MOCK_SOCKET_TEMP_DIR: TempDir = tempfile::Builder::new()
@@ -195,106 +193,6 @@ pub(super) async fn get_next_free_machine(
         }
     }
     None
-}
-
-pub(super) async fn add_address_to_interface(
-    address: &str,
-    interface: &str,
-) -> Result<(), AddressConfigError> {
-    if interface_has_address(interface, address).await? {
-        tracing::info!(
-            ip_address = %address,
-            interface_name = %interface,
-            "Skipping address addition; already configured",
-        );
-        return Ok(());
-    }
-
-    tracing::info!(
-        ip_address = %address,
-        interface_name = %interface,
-        "Adding address",
-    );
-    let wrapper_cmd = find_sudo_command();
-    let mut cmd = tokio::process::Command::new(wrapper_cmd);
-    #[cfg(not(target_os = "macos"))]
-    let output = cmd
-        .args(["ip", "a", "add", address, "dev", interface])
-        .output()
-        .await?;
-    #[cfg(target_os = "macos")]
-    let output = cmd
-        .args([
-            // Prevent sudo from trying to read password.
-            "--non-interactive",
-            "ifconfig",
-            interface,
-            "add",
-            address,
-            "up",
-        ])
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        return Err(AddressConfigError::CommandFailure(Box::new(cmd), output));
-    }
-
-    Ok(())
-}
-#[cfg(target_os = "macos")]
-async fn interface_has_address(
-    _interface: &str,
-    _address: &str,
-) -> Result<bool, AddressConfigError> {
-    Ok(false)
-}
-
-#[cfg(not(target_os = "macos"))]
-async fn interface_has_address(interface: &str, address: &str) -> Result<bool, AddressConfigError> {
-    let mut cmd = tokio::process::Command::new("/usr/bin/env");
-
-    let output = cmd
-        .args([
-            "ip",
-            "a",
-            "s",
-            "to",
-            &[address, "32"].join("/"),
-            "dev",
-            interface,
-        ])
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        return Err(AddressConfigError::CommandFailure(Box::new(cmd), output));
-    }
-    if output.stdout.is_empty() {
-        Ok(false)
-    } else {
-        Ok(true)
-    }
-}
-
-fn find_sudo_command() -> &'static str {
-    std::env::var("PATH")
-        .ok()
-        .and_then(|path| {
-            path.split(":").find_map(|dir| {
-                if std::fs::exists(Path::new(dir).join("sudo")).unwrap_or(false) {
-                    Some("sudo")
-                } else if std::fs::exists(Path::new(dir).join("doas")).unwrap_or(false) {
-                    Some("doas")
-                } else {
-                    None
-                }
-            })
-        })
-        .unwrap_or_else(|| {
-            tracing::warn!("could not find sudo or doas in PATH, falling back on /usr/bin/env");
-            "/usr/bin/env"
-        })
 }
 
 #[cfg(test)]

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -38,9 +38,9 @@ use forge_tls::client_config::{
 };
 use mac_address::MacAddress;
 use machine_a_tron::{
-    AppEvent, BmcMockRegistry, BmcRegistrationMode, ControlState, DeviceStatusConfig, DhcpClient,
-    MachineATron, MachineATronArgs, MachineATronConfig, MachineATronContext, MockSshServerHandle,
-    PromptBehavior, SimulatorLifecycle, Tui, TuiHostLogs, api_throttler, append_control_routes,
+    AppEvent, BmcMockRegistry, ControlState, DeviceStatusConfig, DhcpClient, MachineATron,
+    MachineATronArgs, MachineATronConfig, MachineATronContext, MockSshServerHandle, PromptBehavior,
+    SimulatorLifecycle, Tui, TuiHostLogs, api_throttler, append_control_routes,
     spawn_mock_ssh_server,
 };
 use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
@@ -95,13 +95,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     forge_client_config.connect_retries_max = Some(60);
     forge_client_config.connect_retries_interval = Some(Duration::from_secs(1));
 
-    let bmc_registration_mode = if app_config.use_single_bmc_mock {
-        // Machines will register their BMC's with the shared registry
-        BmcRegistrationMode::BackingInstance(BmcMockRegistry::default())
-    } else {
-        // Machines will each listen on a real BMC mock address using the configured port
-        BmcRegistrationMode::None(app_config.bmc_mock_port)
-    };
+    let bmc_registry = BmcMockRegistry::default();
 
     let api_config = ApiConfig::new(&app_config.carbide_api_url, &forge_client_config);
 
@@ -162,7 +156,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         app_config,
         forge_client_config,
         bmc_mock_certs_dir,
-        bmc_registration_mode,
+        bmc_registry,
         api_throttler,
         desired_firmware_versions,
         forge_api_client,
@@ -216,63 +210,45 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .parent()
                 .map(Path::to_path_buf)
         });
-    let server_handles: (CombinedServer, Option<MockSshServerHandle>) =
-        match &app_context.bmc_registration_mode {
-            BmcRegistrationMode::BackingInstance(bmc_mock_registry) => {
-                let server_config = bmc_mock::tls::server_config(certs_dir.clone())?;
-                let bmc_router = bmc_mock::combined_router(bmc_mock_registry.clone());
-                let bmc_router = match ufm_router.clone() {
-                    Some(ufm_router) => ufm_router.merge(bmc_router),
-                    None => bmc_router,
-                };
-                let router = append_control_routes(Some(bmc_router), control_state.clone());
-                let bmc_https_mock = bmc_mock::CombinedServer::run_router(
-                    "bmc-mock",
-                    router,
-                    Some(ListenerOrAddress::Address(
-                        format!("0.0.0.0:{bmc_mock_port}").parse().unwrap(),
-                    )),
-                    server_config,
-                );
-
-                let bmc_ssh_mock = if app_context.app_config.mock_bmc_ssh_server {
-                    // Spawn a single mock SSH server too. ssh-console can be configured to talk to
-                    // this instead of the carbide-assigned BMC IP for each host, so that
-                    // machine-a-tron-based dev environments can have a "working" ssh-console too.
-                    Some(
-                        spawn_mock_ssh_server(
-                            "0.0.0.0".parse().unwrap(),
-                            app_context.app_config.mock_bmc_ssh_port,
-                            Arc::new(KnownHostname("shared-bmc-mock".to_string())),
-                            // Accept any credentials. We don't support mocking changing BMC
-                            // credentials, so we can't properly emulate BMC SSH credentials in dev
-                            // environments today. (Only ssh-console integration tests use
-                            // credentials here as of today.)
-                            None,
-                            PromptBehavior::Dell,
-                        )
-                        .await?,
-                    )
-                } else {
-                    None
-                };
-
-                (bmc_https_mock, bmc_ssh_mock)
-            }
-            BmcRegistrationMode::None(_) => {
-                let server_config = bmc_mock::tls::server_config(certs_dir)?;
-                let router = append_control_routes(ufm_router, control_state);
-                let control_server = bmc_mock::CombinedServer::run_router(
-                    "machine-a-tron-control",
-                    router,
-                    Some(ListenerOrAddress::Address(
-                        format!("127.0.0.1:{bmc_mock_port}").parse().unwrap(),
-                    )),
-                    server_config,
-                );
-                (control_server, None)
-            }
+    let server_handles: (CombinedServer, Option<MockSshServerHandle>) = {
+        let server_config = bmc_mock::tls::server_config(certs_dir.clone())?;
+        let bmc_router = bmc_mock::combined_router(app_context.bmc_registry.clone());
+        let bmc_router = match ufm_router.clone() {
+            Some(ufm_router) => ufm_router.merge(bmc_router),
+            None => bmc_router,
         };
+        let router = append_control_routes(Some(bmc_router), control_state.clone());
+        let bmc_https_mock = bmc_mock::CombinedServer::run_router(
+            "bmc-mock",
+            router,
+            Some(ListenerOrAddress::Address(
+                format!("0.0.0.0:{bmc_mock_port}").parse().unwrap(),
+            )),
+            server_config,
+        );
+
+        let bmc_ssh_mock = if app_context.app_config.mock_bmc_ssh_server {
+            // Spawn a single mock SSH server too. ssh-console can be configured to talk to
+            // this instead of the carbide-assigned BMC IP for each host, so that
+            // machine-a-tron-based dev environments can have a "working" ssh-console too.
+            Some(
+                spawn_mock_ssh_server(
+                    app_context.app_config.mock_bmc_ssh_port,
+                    Arc::new(KnownHostname("shared-bmc-mock".to_string())),
+                    // Accept any credentials. We don't support mocking changing BMC
+                    // credentials, so we can't properly emulate BMC SSH credentials in dev
+                    // environments today. (Only ssh-console integration tests use
+                    // credentials here as of today.)
+                    None,
+                    PromptBehavior::Dell,
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
+        (bmc_https_mock, bmc_ssh_mock)
+    };
 
     if let Some(ssh_handle) = &server_handles.1 {
         app_context

--- a/crates/machine-a-tron/src/mock_ssh_server.rs
+++ b/crates/machine-a-tron/src/mock_ssh_server.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::result::Result as StdResult;
 use std::sync::Arc;
 
@@ -49,7 +49,6 @@ pub enum PromptBehavior {
 }
 
 pub async fn spawn(
-    ip: IpAddr,
     port: Option<u16>,
     prompt_hostname: Arc<dyn HostnameQuerying>,
     require_credentials: Option<Credentials>,
@@ -65,7 +64,7 @@ pub async fn spawn(
         require_credentials,
     };
     let listener = if let Some(port) = port {
-        let socket_addr = SocketAddr::new(ip, port);
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
         TcpListener::bind(socket_addr)
             .await
             .context(format!("error listening on {socket_addr}"))?

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -16,7 +16,7 @@
  */
 use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
@@ -322,7 +322,7 @@ impl PowerShelfActor {
             .as_ref()
             .ok_or(MachineStateError::NoBmcDhcpInfo)?;
         let machine_info = MachineInfo::Host(self.host_info.clone());
-        let mut bmc_mock = BmcMockWrapper::new(
+        let bmc_mock = BmcMockWrapper::new(
             &machine_info,
             self.app_context.clone(),
             Arc::new(PowerShelfCallbacks {
@@ -342,32 +342,13 @@ impl PowerShelfActor {
                 .change_factory_default_password(password);
         }
 
-        let bmc_handle = match &self.app_context.bmc_registration_mode {
-            crate::BmcRegistrationMode::None(port) => {
-                let handle = Arc::new(
-                    bmc_mock
-                        .start(
-                            SocketAddr::new(IpAddr::V4(dhcp_info.ip_address), *port),
-                            true,
-                        )
-                        .await?,
-                );
-                self.live_state.write().unwrap().ssh_host_key = handle
-                    .ssh_handle
-                    .as_ref()
-                    .map(|handle| handle.host_pubkey.clone());
-                Some(handle)
-            }
-            crate::BmcRegistrationMode::BackingInstance(registry) => {
-                registry
-                    .write()
-                    .await
-                    .insert(dhcp_info.ip_address.to_string(), bmc_mock.router().clone());
-                bmc_mock
-                    .start_shared_mode_consoles(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-                    .await?
-                    .map(Arc::new)
-            }
+        let bmc_handle = {
+            self.app_context
+                .bmc_registry
+                .write()
+                .await
+                .insert(dhcp_info.ip_address.to_string(), bmc_mock.router().clone());
+            bmc_mock.start().await?.map(Arc::new)
         };
 
         if let Some(ssh_host_key) = bmc_handle

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -16,7 +16,7 @@
  */
 use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
@@ -360,7 +360,7 @@ impl SwitchActor {
             .as_ref()
             .ok_or(MachineStateError::NoBmcDhcpInfo)?;
         let machine_info = MachineInfo::Host(self.host_info.clone());
-        let mut bmc_mock = BmcMockWrapper::new(
+        let bmc_mock = BmcMockWrapper::new(
             &machine_info,
             self.app_context.clone(),
             Arc::new(SwitchCallbacks {
@@ -378,32 +378,13 @@ impl SwitchActor {
                 .change_factory_default_password(password);
         }
 
-        let bmc_handle = match &self.app_context.bmc_registration_mode {
-            crate::BmcRegistrationMode::None(port) => {
-                let handle = Arc::new(
-                    bmc_mock
-                        .start(
-                            SocketAddr::new(IpAddr::V4(dhcp_info.ip_address), *port),
-                            true,
-                        )
-                        .await?,
-                );
-                self.live_state.write().unwrap().ssh_host_key = handle
-                    .ssh_handle
-                    .as_ref()
-                    .map(|handle| handle.host_pubkey.clone());
-                Some(handle)
-            }
-            crate::BmcRegistrationMode::BackingInstance(registry) => {
-                registry
-                    .write()
-                    .await
-                    .insert(dhcp_info.ip_address.to_string(), bmc_mock.router().clone());
-                bmc_mock
-                    .start_shared_mode_consoles(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-                    .await?
-                    .map(Arc::new)
-            }
+        let bmc_handle = {
+            self.app_context
+                .bmc_registry
+                .write()
+                .await
+                .insert(dhcp_info.ip_address.to_string(), bmc_mock.router().clone());
+            bmc_mock.start().await?.map(Arc::new)
         };
 
         if let Some(ssh_host_key) = bmc_handle

--- a/crates/ssh-console/README.md
+++ b/crates/ssh-console/README.md
@@ -63,7 +63,6 @@ You can test this against a running machine-a-tron cluster by configuring the cl
 
 ```
 mock_bmc_ssh_server = true
-use_single_bmc_mock = false
 interface = "lo"
 ```
 

--- a/crates/ssh-console/tests/util/ipmi_sim.rs
+++ b/crates/ssh-console/tests/util/ipmi_sim.rs
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::{IpAddr, Ipv4Addr};
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::time::Duration;
 
@@ -184,7 +183,6 @@ pub(super) async fn run(prompt: String) -> eyre::Result<IpmiSimHandle> {
     bmc_mock::ipmi_sim::start(
         &bmc.state,
         bmc_mock::ipmi_sim::IpmiSimConfig {
-            bind_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
             reachable_port: None,
             stable_id: prompt.clone(),
             console_prompt: prompt,

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -16,7 +16,6 @@
  */
 use std::borrow::Cow;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -107,7 +106,6 @@ pub(crate) async fn run_baseline_test_environment(
                     | ssh_type @ MockBmcType::DpuSsh => {
                         Ok::<MockBmcHandle, eyre::Error>(MockBmcHandle::Ssh(
                             machine_a_tron::spawn_mock_ssh_server(
-                                IpAddr::from_str("127.0.0.1").unwrap(),
                                 None,
                                 Arc::new(KnownHostname(machine_id.to_string())),
                                 Some(machine_a_tron::MockSshCredentials {

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -223,7 +223,6 @@ nico-machine-a-tron:
         tui_enabled = false
         log_format = "logfmt"
         bmc_mock_port = 1266
-        use_single_bmc_mock = true
         mock_bmc_ssh_server = true
         mock_bmc_ssh_port = 2222
         enable_ipmi_simulation = true


### PR DESCRIPTION
We had legacy mode of machine-a-tron when it assigned IP addresses discovered by DHCP to local interface. This mode didn't work properly in kubernetes and required additional caution for linux.

After supporting plumbing of SSH & IPMI ports via Redfish this mode has become obsoleted. NICo can connect to dynamically allocated ports.

This PR removes use_single_bmc_mock set to false mode.

## Related issues

#3724 #5209

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
