### PR TITLE
feat(site-explorer): order DPUs using Redfish chassis IDs

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -519,6 +519,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         dpus: vec![ExploredDpu {
             bmc_ip: dpu_bmc_ip,
             host_pf_mac_address: Some(mock_dpu.host_mac_address),
+            host_chassis_id: None,
             report: dpu_report.clone(),
         }],
     };

--- a/crates/api-core/tests/integration/explored_managed_host_find.rs
+++ b/crates/api-core/tests/integration/explored_managed_host_find.rs
@@ -38,6 +38,7 @@ async fn test_find_explored_managed_host_ids(
             dpus: vec![ExploredDpu {
                 bmc_ip,
                 host_pf_mac_address: Some(mac_address),
+                host_chassis_id: None,
                 report: EndpointExplorationReport::default().into(),
             }],
         });
@@ -75,6 +76,7 @@ async fn test_find_explored_managed_hosts_by_ids(
             dpus: vec![ExploredDpu {
                 bmc_ip,
                 host_pf_mac_address: Some(mac_address),
+                host_chassis_id: None,
                 report: EndpointExplorationReport::default().into(),
             }],
         });

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -36,6 +36,7 @@ use eyre::ContextCompat;
 use futures::FutureExt;
 use futures::future::join_all;
 use itertools::Itertools;
+use mac_address::MacAddress;
 use model::machine_boot_interface::BootInterfaceSelectionSource;
 use sqlx::{Postgres, Row};
 use tokio::time::sleep;
@@ -266,6 +267,11 @@ async fn test_integration() -> eyre::Result<()> {
         }
     }
 
+    metrics::wait_for_metric_line(
+        &test_env.carbide_metrics_addrs,
+        r#"carbide_site_explorer_boot_interface_selections_total{mechanism="redfish_chassis_id"}"#,
+    )
+    .await?;
     metrics::wait_for_metric_line(
         &test_env.carbide_metrics_addrs,
         r#"carbide_site_explorer_boot_interface_selections_total{mechanism="redfish_serial_number"}"#,
@@ -633,8 +639,17 @@ async fn test_machine_a_tron_multidpu(
             let segment_id = segment_id.to_string();
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             let db_pool = test_env.db_pool.clone();
-            let expected_selection_source = (hw_type == HardwareType::WiwynnGB200Nvl)
-                .then_some(BootInterfaceSelectionSource::RedfishSerialNumber);
+            let expected_selection = (hw_type == HardwareType::WiwynnGB200Nvl).then(|| {
+                let dpu = machine_handle
+                    .host_info()
+                    .dpus
+                    .first()
+                    .expect("Wiwynn GB200 host should contain its Slot1 DPU");
+                (
+                    dpu.host_mac_address,
+                    BootInterfaceSelectionSource::RedfishChassisId,
+                )
+            });
             async move {
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
@@ -642,9 +657,9 @@ async fn test_machine_a_tron_multidpu(
                 let machine_id = machine_handle
                     .observed_machine_id()
                     .expect("Machine ID should be set if host is ready");
-                if let Some(expected_selection_source) = expected_selection_source {
-                    let selection_source: BootInterfaceSelectionSource = sqlx::query_scalar(
-                        "SELECT selection_source
+                if let Some(expected_selection) = expected_selection {
+                    let selection: (MacAddress, BootInterfaceSelectionSource) = sqlx::query_as(
+                        "SELECT desired_mac_address, selection_source
                          FROM machine_boot_interfaces
                          WHERE machine_id = $1",
                     )
@@ -652,8 +667,8 @@ async fn test_machine_a_tron_multidpu(
                     .fetch_one(&db_pool)
                     .await?;
                     assert_eq!(
-                        selection_source, expected_selection_source,
-                        "GB200's Redfish serial fallback must survive the full ingestion handoff",
+                        selection, expected_selection,
+                        "GB200's Slot1 chassis selection must survive the full ingestion handoff",
                     );
                 }
                 tracing::info!(

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -608,6 +608,11 @@ pub struct ExploredDpu {
     /// The MAC address that is visible to the host (provided by the DPU)
     #[serde(with = "serialize_option_display", default)]
     pub host_pf_mac_address: Option<MacAddress>,
+    /// The trimmed, nonblank host BMC `Chassis.id` associated with this DPU's
+    /// serial number. Conflicting IDs leave this unset so Site Explorer can
+    /// fall back to ordering by DPU serial number.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_chassis_id: Option<String>,
 
     #[serde(skip)]
     pub report: Arc<EndpointExplorationReport>,
@@ -3479,13 +3484,14 @@ mod tests {
             dpus: vec![ExploredDpu {
                 bmc_ip: "1.2.3.5".parse().unwrap(),
                 host_pf_mac_address: Some("11:22:33:44:55:66".parse().unwrap()),
+                host_chassis_id: Some("Riser_Slot2_BlueField_3_Card".to_string()),
                 report: Default::default(),
             }],
         };
         let serialized = serde_json::to_string(&host).unwrap();
         assert_eq!(
             serialized,
-            r#"{"HostBmcIp":"1.2.3.4","Dpus":[{"BmcIp":"1.2.3.5","HostPfMacAddress":"11:22:33:44:55:66"}]}"#
+            r#"{"HostBmcIp":"1.2.3.4","Dpus":[{"BmcIp":"1.2.3.5","HostPfMacAddress":"11:22:33:44:55:66","HostChassisId":"Riser_Slot2_BlueField_3_Card"}]}"#
         );
         assert_eq!(
             serde_json::from_str::<ExploredManagedHost>(&serialized).unwrap(),
@@ -3497,6 +3503,7 @@ mod tests {
             dpus: vec![ExploredDpu {
                 bmc_ip: "1.2.3.5".parse().unwrap(),
                 host_pf_mac_address: None,
+                host_chassis_id: None,
                 report: Default::default(),
             }],
         };

--- a/crates/rpc/src/model/site_explorer.rs
+++ b/crates/rpc/src/model/site_explorer.rs
@@ -486,6 +486,7 @@ mod tests {
         ExploredDpu {
             bmc_ip: address.parse().expect("valid DPU BMC IP"),
             host_pf_mac_address: mac_address.map(|mac| mac.parse().expect("valid test MAC")),
+            host_chassis_id: None,
             report: Arc::new(EndpointExplorationReport::default()),
         }
     }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -53,8 +53,8 @@ use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
 use model::rack_type::RackProfileConfig;
 use model::resource_pool::common::CommonPools;
 use model::site_explorer::{
-    BlueFieldOperatingMode, EndpointExplorationError, EndpointExplorationReport, EndpointType,
-    ExploredDpu, ExploredEndpoint, ExploredManagedHost, ExploredManagedSwitch,
+    BlueFieldOperatingMode, Chassis, EndpointExplorationError, EndpointExplorationReport,
+    EndpointType, ExploredDpu, ExploredEndpoint, ExploredManagedHost, ExploredManagedSwitch,
     HostPrimaryInterfaceSelection, MachineExpectation, PowerState, PreingestionState, Service,
     SiteExplorerLastRun, is_bf3_dpu_part_number, is_bf3_supernic_part_number,
     is_bluefield_part_number, is_bluefield_system,
@@ -352,6 +352,62 @@ enum ReportSelectionOrdering {
     NoDpus,
     /// DPU records exist, but none has the selected host PF MAC.
     Mismatch,
+}
+
+/// Natural sorting key for an entire Redfish `Chassis.id`.
+///
+/// Text is converted to lowercase and ASCII decimal runs are compared
+/// numerically, so values such as `Slot2` sort before `Slot10`.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct ChassisIdSortKey {
+    /// Alternating text and number parts, beginning and ending with text.
+    parts: Vec<ChassisIdSortPart>,
+}
+
+/// One text or numeric component of a [`ChassisIdSortKey`].
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum ChassisIdSortPart {
+    /// Lowercase text between decimal runs.
+    Text(String),
+    /// An ASCII decimal run. Comparing the normalized length before the digits
+    /// provides numeric order without imposing a numeric size limit.
+    Number {
+        /// Number of normalized decimal digits.
+        significant_digit_count: usize,
+        /// Decimal digits without leading zeros, or `0` for zero.
+        digits: String,
+    },
+}
+
+/// Why all DPUs could not be ordered by Redfish `Chassis.id`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ChassisIdOrderingFailure {
+    /// At least one DPU has no unambiguous, nonblank host chassis identity.
+    MissingChassisId,
+    /// Two chassis identities become equal after lowercase and decimal normalization.
+    DuplicateChassisId,
+    /// The selected DPU has no host PF MAC address to use as the boot interface.
+    MissingHostPfMac,
+}
+
+impl Display for ChassisIdOrderingFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::MissingChassisId => "missing or ambiguous host chassis ID",
+            Self::DuplicateChassisId => "duplicate normalized host chassis ID",
+            Self::MissingHostPfMac => "selected DPU has no host PF MAC address",
+        };
+        f.write_str(message)
+    }
+}
+
+/// Host inventory fields that can identify one DPU by serial number.
+#[derive(Clone, Copy)]
+struct HostDpuInventoryCandidate<'a> {
+    /// Part number used by the existing BlueField detection and mode checks.
+    part_number: Option<&'a str>,
+    /// Serial number joined to the DPU endpoint report.
+    serial_number: Option<&'a str>,
 }
 
 /// When Site Explorer last physically reset a BMC, tracked per reset method.
@@ -1559,28 +1615,10 @@ impl SiteExplorer {
             // found none.
             if dpu_exploration.expected_managed_total() == 0 {
                 for chassis in ep.report.chassis.iter() {
-                    // Some BMCs (e.g. the AMI/Lenovo GB300 host BMC) report the
-                    // BlueField as the chassis object itself -- model, part_number
-                    // and serial_number live on the chassis, while its nested
-                    // network adapter carries an empty serial. Match on the
-                    // chassis identity in that case; otherwise fall back to the
-                    // chassis's network adapters (other vendors put the DPU
-                    // serial there). Matching only one of the two per chassis
-                    // keeps a single DPU from being counted twice.
-                    let chassis_is_bluefield = chassis
-                        .part_number
-                        .as_deref()
-                        .map(str::trim)
-                        .is_some_and(is_bluefield_part_number);
-                    let chassis_has_serial = chassis
-                        .serial_number
-                        .as_deref()
-                        .map(str::trim)
-                        .is_some_and(|serial| !serial.is_empty());
-                    if chassis_is_bluefield && chassis_has_serial {
+                    for record in host_dpu_inventory_records(chassis) {
                         self.record_host_dpu_device(
-                            chassis.part_number.as_deref(),
-                            chassis.serial_number.as_deref(),
+                            record.part_number,
+                            record.serial_number,
                             &dpu_sn_to_endpoint,
                             host_dpu_policy,
                             &ep,
@@ -1588,19 +1626,6 @@ impl SiteExplorer {
                             metrics,
                         )
                         .await;
-                    } else {
-                        for network_adapter in chassis.network_adapters.iter() {
-                            self.record_host_dpu_device(
-                                network_adapter.part_number.as_deref(),
-                                network_adapter.serial_number.as_deref(),
-                                &dpu_sn_to_endpoint,
-                                host_dpu_policy,
-                                &ep,
-                                &mut dpu_exploration,
-                                metrics,
-                            )
-                            .await;
-                        }
                     }
                 }
             }
@@ -1788,9 +1813,15 @@ impl SiteExplorer {
                 }
             }
 
-            // If we know the booting interface of the host, we should use this for deciding
-            // primary interface.
-            let mut is_sorted = false;
+            // The host report owns the physical chassis identity, while each
+            // `ExploredDpu` owns the DPU endpoint report. Join those views by
+            // the same serial number used for DPU pairing before we choose a
+            // fallback order.
+            Self::assign_host_chassis_ids(&ep.report, &mut dpus_explored_for_host);
+
+            // ExpectedMachine and complete UEFI PCI evidence resolve the order
+            // before either provisional Redfish fallback is considered.
+            let mut dpu_order_resolved = false;
             let mut primary_interface_selection = ep
                 .report
                 .select_host_primary_interface(&dpus_explored_for_host, declared_primary);
@@ -1807,7 +1838,7 @@ impl SiteExplorer {
                     &mut dpus_explored_for_host,
                     selection.mac_address,
                 ) {
-                    ReportSelectionOrdering::Applied => is_sorted = true,
+                    ReportSelectionOrdering::Applied => dpu_order_resolved = true,
                     ReportSelectionOrdering::NoDpus => {}
                     ReportSelectionOrdering::Mismatch => {
                         let all_mac = dpus_explored_for_host
@@ -1834,7 +1865,27 @@ impl SiteExplorer {
                 }
             }
 
-            if !is_sorted {
+            if !dpu_order_resolved && dpus_explored_for_host.len() > 1 {
+                match Self::sort_dpus_by_redfish_chassis_id(&mut dpus_explored_for_host) {
+                    Ok(selection) => {
+                        primary_interface_selection = Some(selection);
+                        dpu_order_resolved = true;
+                    }
+                    Err(error) => {
+                        tracing::debug!(
+                            host_bmc_ip_address = %ep.address,
+                            host_chassis_ids = ?dpus_explored_for_host
+                                .iter()
+                                .map(|dpu| dpu.host_chassis_id.as_deref())
+                                .collect_vec(),
+                            %error,
+                            "Cannot order DPUs using Redfish chassis IDs; falling back to Redfish serial numbers",
+                        );
+                    }
+                }
+            }
+
+            if !dpu_order_resolved {
                 // Serial ordering is the existing deterministic fallback. Keep
                 // its result beside the selected MAC so machine creation can
                 // persist the exact reason only when that same MAC becomes the
@@ -1948,6 +1999,68 @@ impl SiteExplorer {
         txn.commit().await?;
 
         Ok(managed_hosts)
+    }
+
+    /// `assign_host_chassis_ids` joins each explored DPU to one host BMC
+    /// `Chassis.id` through the serial number used for DPU pairing. A missing,
+    /// blank, or ambiguous chassis identity remains `None`, which prevents a
+    /// partial chassis ordering later in this pass.
+    fn assign_host_chassis_ids(host_report: &EndpointExplorationReport, dpus: &mut [ExploredDpu]) {
+        let chassis_ids = host_chassis_ids_by_dpu_serial(host_report);
+        for dpu in dpus {
+            dpu.host_chassis_id = dpu
+                .report
+                .dpu_pairing_serial_number()
+                .and_then(|serial| chassis_ids.get(serial))
+                .cloned()
+                .flatten();
+        }
+    }
+
+    /// Orders all DPUs by each full host `Chassis.id` after lowercasing text and
+    /// comparing ASCII decimal runs numerically. The caller first assigns the
+    /// trimmed, unambiguous identities through [`Self::assign_host_chassis_ids`].
+    /// Validation precedes mutation so every failure leaves discovery order
+    /// intact for the fallback that orders by serial number.
+    fn sort_dpus_by_redfish_chassis_id(
+        dpus: &mut [ExploredDpu],
+    ) -> Result<HostPrimaryInterfaceSelection, ChassisIdOrderingFailure> {
+        debug_assert!(
+            dpus.len() > 1,
+            "chassis ordering is only needed for hosts with multiple DPUs"
+        );
+
+        let keys = dpus
+            .iter()
+            .map(|dpu| {
+                let id = dpu
+                    .host_chassis_id
+                    .as_deref()
+                    .filter(|id| !id.is_empty())
+                    .ok_or(ChassisIdOrderingFailure::MissingChassisId)?;
+                Ok(chassis_id_sort_key(id))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut unique = HashSet::with_capacity(keys.len());
+        if keys.iter().any(|key| !unique.insert(key)) {
+            return Err(ChassisIdOrderingFailure::DuplicateChassisId);
+        }
+
+        let mut ordered = dpus.iter().cloned().zip(keys).collect_vec();
+        ordered.sort_by(|(_, left), (_, right)| left.cmp(right));
+        let mac_address = ordered
+            .first()
+            .and_then(|(dpu, _)| dpu.host_pf_mac_address)
+            .ok_or(ChassisIdOrderingFailure::MissingHostPfMac)?;
+        for (target, (dpu, _)) in dpus.iter_mut().zip(ordered) {
+            *target = dpu;
+        }
+
+        Ok(HostPrimaryInterfaceSelection {
+            mac_address,
+            source: BootInterfaceSelectionSource::RedfishChassisId,
+        })
     }
 
     /// Applies the existing case-insensitive Redfish serial number fallback and
@@ -4352,6 +4465,101 @@ fn duplicate_bluefield_serial<'a>(
     (!seen.insert(serial_number)).then_some(serial_number)
 }
 
+/// `host_dpu_inventory_records` applies the existing chassis inventory rule in
+/// one place. Some BMCs put the BlueField identity on the chassis itself;
+/// others put it on a nested network adapter. Reading only one form prevents a
+/// single DPU from being counted twice.
+fn host_dpu_inventory_records(chassis: &Chassis) -> Vec<HostDpuInventoryCandidate<'_>> {
+    let chassis_is_bluefield = chassis
+        .part_number
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(is_bluefield_part_number);
+    let chassis_has_serial = chassis
+        .serial_number
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|serial| !serial.is_empty());
+
+    if chassis_is_bluefield && chassis_has_serial {
+        return vec![HostDpuInventoryCandidate {
+            part_number: chassis.part_number.as_deref(),
+            serial_number: chassis.serial_number.as_deref(),
+        }];
+    }
+
+    chassis
+        .network_adapters
+        .iter()
+        .map(|adapter| HostDpuInventoryCandidate {
+            part_number: adapter.part_number.as_deref(),
+            serial_number: adapter.serial_number.as_deref(),
+        })
+        .collect()
+}
+
+/// `host_chassis_ids_by_dpu_serial` keeps one usable parent `Chassis.id` for
+/// each host reported DPU serial. A blank identity or conflicting IDs for one
+/// serial become `None`, which makes the whole host use the safer serial
+/// fallback.
+fn host_chassis_ids_by_dpu_serial(
+    report: &EndpointExplorationReport,
+) -> HashMap<String, Option<String>> {
+    let mut chassis_ids = HashMap::<String, Option<String>>::new();
+    for chassis in &report.chassis {
+        for record in host_dpu_inventory_records(chassis) {
+            let Some(serial_number) = record.serial_number.map(str::trim).none_if_empty() else {
+                continue;
+            };
+            let candidate = chassis.id.trim().none_if_empty().map(str::to_string);
+            chassis_ids
+                .entry(serial_number.to_string())
+                .and_modify(|existing| {
+                    if existing.as_deref() != candidate.as_deref() {
+                        *existing = None;
+                    }
+                })
+                .or_insert(candidate);
+        }
+    }
+    chassis_ids
+}
+
+/// Builds a natural sorting key from the full chassis ID.
+///
+/// Lowercase text stays in place and ASCII decimal runs are normalized without
+/// a numeric size limit.
+fn chassis_id_sort_key(id: &str) -> ChassisIdSortKey {
+    let bytes = id.as_bytes();
+    let mut parts = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(relative_start) = bytes[cursor..]
+        .iter()
+        .position(|byte| byte.is_ascii_digit())
+    {
+        let number_start = cursor + relative_start;
+        parts.push(ChassisIdSortPart::Text(
+            id[cursor..number_start].to_lowercase(),
+        ));
+
+        let number_end = bytes[number_start..]
+            .iter()
+            .position(|byte| !byte.is_ascii_digit())
+            .map_or(bytes.len(), |relative_end| number_start + relative_end);
+        let digits = id[number_start..number_end].trim_start_matches('0');
+        let digits = if digits.is_empty() { "0" } else { digits };
+        parts.push(ChassisIdSortPart::Number {
+            significant_digit_count: digits.len(),
+            digits: digits.to_string(),
+        });
+        cursor = number_end;
+    }
+    parts.push(ChassisIdSortPart::Text(id[cursor..].to_lowercase()));
+
+    ChassisIdSortKey { parts }
+}
+
 /// Queues a complete host boot-interface pair for endpoint persistence.
 ///
 /// A report that resolves only the MAC must not overwrite the last-known-good
@@ -4454,6 +4662,7 @@ fn classify_matched_dpu(
     DiscoveredDpu::RunningAsDpu(ExploredDpu {
         bmc_ip: dpu_ep.address,
         host_pf_mac_address: get_host_pf_mac_address(dpu_ep),
+        host_chassis_id: None,
         report: dpu_ep.report.clone().into(),
     })
 }
@@ -4539,7 +4748,7 @@ mod tests {
     use carbide_test_support::{Case, Check, check_cases, check_values, value_scenarios};
     use config_version::ConfigVersion;
     use model::expected_machine::ExpectedInterfaceRole;
-    use model::site_explorer::{ComputerSystem, PreingestionState};
+    use model::site_explorer::{ComputerSystem, NetworkAdapter, PreingestionState};
 
     use super::*;
 
@@ -5349,6 +5558,85 @@ mod tests {
     }
 
     #[test]
+    fn host_chassis_id_correlation_requires_one_nonblank_parent_identity() {
+        let nested = |id: &str, serials: &[&str]| Chassis {
+            id: id.to_string(),
+            network_adapters: serials
+                .iter()
+                .enumerate()
+                .map(|(index, serial)| NetworkAdapter {
+                    id: format!("adapter-{index}"),
+                    serial_number: Some((*serial).to_string()),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let direct = |id: &str, serial: &str| Chassis {
+            id: id.to_string(),
+            part_number: Some("900-9D3B6-00CV-AA0".to_string()),
+            serial_number: Some(serial.to_string()),
+            ..Default::default()
+        };
+        let expected = |entries: &[(&str, Option<&str>)]| {
+            entries
+                .iter()
+                .map(|(serial, id)| ((*serial).to_string(), id.map(|id| id.to_string())))
+                .collect::<HashMap<_, _>>()
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "chassis and nested adapter serials both correlate",
+                    input: vec![
+                        direct("Riser_Slot1", " DPU-1 "),
+                        nested("Riser_Slot2", &["DPU-2"]),
+                    ],
+                    expect: expected(&[
+                        ("DPU-1", Some("Riser_Slot1")),
+                        ("DPU-2", Some("Riser_Slot2")),
+                    ]),
+                },
+                Check {
+                    scenario: "repeated serial under the same chassis retains one identity",
+                    input: vec![nested("Riser_Slot1", &["DPU-1", "DPU-1"])],
+                    expect: expected(&[("DPU-1", Some("Riser_Slot1"))]),
+                },
+                Check {
+                    scenario: "surrounding chassis identity whitespace is removed",
+                    input: vec![nested("  Riser_Slot1 Card  ", &["DPU-1"])],
+                    expect: expected(&[("DPU-1", Some("Riser_Slot1 Card"))]),
+                },
+                Check {
+                    scenario: "serial under different chassis objects is ambiguous",
+                    input: vec![
+                        nested("Riser_Slot1", &["DPU-1"]),
+                        nested("Riser_Slot2", &["DPU-1"]),
+                    ],
+                    expect: expected(&[("DPU-1", None)]),
+                },
+                Check {
+                    scenario: "empty chassis identity is unusable",
+                    input: vec![nested("", &["DPU-1"])],
+                    expect: expected(&[("DPU-1", None)]),
+                },
+                Check {
+                    scenario: "whitespace-only chassis identity is unusable",
+                    input: vec![nested("   ", &["DPU-1"])],
+                    expect: expected(&[("DPU-1", None)]),
+                },
+            ],
+            |chassis| {
+                host_chassis_ids_by_dpu_serial(&EndpointExplorationReport {
+                    chassis,
+                    ..Default::default()
+                })
+            },
+        );
+    }
+
+    #[test]
     fn test_find_host_pf_mac_address() {
         // A freshly-loaded BF2 endpoint; each case starts from one of these and
         // perturbs the firmware inventory the legacy MAC lookup reads from.
@@ -5464,11 +5752,188 @@ mod tests {
         );
     }
 
+    /// Builds one explored DPU for chassis ordering tests. The final MAC byte
+    /// keeps expected orders compact and readable.
+    fn chassis_ordering_dpu(chassis_id: Option<&str>, mac_last_byte: Option<u8>) -> ExploredDpu {
+        ExploredDpu {
+            bmc_ip: "192.0.2.1".parse().unwrap(),
+            host_pf_mac_address: mac_last_byte.map(fallback_ordering_mac),
+            host_chassis_id: chassis_id.map(str::to_string),
+            report: Arc::new(EndpointExplorationReport {
+                systems: vec![ComputerSystem {
+                    serial_number: Some("DPU-SERIAL".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// Returns the locally administered MAC used by fallback ordering tests.
+    fn fallback_ordering_mac(last_byte: u8) -> MacAddress {
+        MacAddress::new([0x02, 0, 0, 0, 0, last_byte])
+    }
+
+    #[test]
+    fn redfish_chassis_ordering_uses_a_lowercase_natural_key_for_the_full_id() {
+        value_scenarios!(run = |mut dpus| {
+                let selection = SiteExplorer::sort_dpus_by_redfish_chassis_id(&mut dpus)
+                    .expect("full unique chassis IDs should resolve an order");
+                (
+                    dpus.iter()
+                        .filter_map(|dpu| dpu.host_pf_mac_address)
+                        .collect_vec(),
+                    selection,
+                )
+            };
+            "slot numbers order naturally after lowercasing" {
+                vec![
+                    chassis_ordering_dpu(Some("Slot10"), Some(10)),
+                    chassis_ordering_dpu(Some("slot2"), Some(2)),
+                    chassis_ordering_dpu(Some("SLOT11"), Some(11)),
+                    chassis_ordering_dpu(Some("sLoT1"), Some(1)),
+                ] => (
+                    vec![
+                        fallback_ordering_mac(1),
+                        fallback_ordering_mac(2),
+                        fallback_ordering_mac(10),
+                        fallback_ordering_mac(11),
+                    ],
+                    HostPrimaryInterfaceSelection {
+                        mac_address: fallback_ordering_mac(1),
+                        source: BootInterfaceSelectionSource::RedfishChassisId,
+                    },
+                ),
+            }
+            "multiple numeric runs participate in full ID ordering" {
+                vec![
+                    chassis_ordering_dpu(Some("Riser2_Slot1"), Some(3)),
+                    chassis_ordering_dpu(Some("Riser1_Slot11"), Some(2)),
+                    chassis_ordering_dpu(Some("Riser1_Slot2"), Some(1)),
+                ] => (
+                    vec![
+                        fallback_ordering_mac(1),
+                        fallback_ordering_mac(2),
+                        fallback_ordering_mac(3),
+                    ],
+                    HostPrimaryInterfaceSelection {
+                        mac_address: fallback_ordering_mac(1),
+                        source: BootInterfaceSelectionSource::RedfishChassisId,
+                    },
+                ),
+            }
+            "digitless identities order by lowercase text" {
+                vec![
+                    chassis_ordering_dpu(Some("secondaryDpu"), Some(2)),
+                    chassis_ordering_dpu(Some("PrimaryDPU"), Some(1)),
+                ] => (
+                    vec![fallback_ordering_mac(1), fallback_ordering_mac(2)],
+                    HostPrimaryInterfaceSelection {
+                        mac_address: fallback_ordering_mac(1),
+                        source: BootInterfaceSelectionSource::RedfishChassisId,
+                    },
+                ),
+            }
+            "different ID structures use full natural order" {
+                vec![
+                    chassis_ordering_dpu(Some("Riser_Slot2"), Some(2)),
+                    chassis_ordering_dpu(Some("Bay11/DPU"), Some(1)),
+                ] => (
+                    vec![fallback_ordering_mac(1), fallback_ordering_mac(2)],
+                    HostPrimaryInterfaceSelection {
+                        mac_address: fallback_ordering_mac(1),
+                        source: BootInterfaceSelectionSource::RedfishChassisId,
+                    },
+                ),
+            }
+            "large decimal runs have no numeric size limit" {
+                vec![
+                    chassis_ordering_dpu(Some("Slot18446744073709551617"), Some(2)),
+                    chassis_ordering_dpu(Some("Slot18446744073709551616"), Some(1)),
+                ] => (
+                    vec![fallback_ordering_mac(1), fallback_ordering_mac(2)],
+                    HostPrimaryInterfaceSelection {
+                        mac_address: fallback_ordering_mac(1),
+                        source: BootInterfaceSelectionSource::RedfishChassisId,
+                    },
+                ),
+            }
+            "text and numeric prefixes remain ordered" {
+                vec![
+                    chassis_ordering_dpu(Some("Slot1A2"), Some(4)),
+                    chassis_ordering_dpu(Some("Slot1A"), Some(3)),
+                    chassis_ordering_dpu(Some("Slot1"), Some(2)),
+                    chassis_ordering_dpu(Some("Slot"), Some(1)),
+                ] => (
+                    vec![
+                        fallback_ordering_mac(1),
+                        fallback_ordering_mac(2),
+                        fallback_ordering_mac(3),
+                        fallback_ordering_mac(4),
+                    ],
+                    HostPrimaryInterfaceSelection {
+                        mac_address: fallback_ordering_mac(1),
+                        source: BootInterfaceSelectionSource::RedfishChassisId,
+                    },
+                ),
+            }
+            "Unicode text is lowercased around ASCII decimal runs" {
+                vec![
+                    chassis_ordering_dpu(Some("Ä10"), Some(2)),
+                    chassis_ordering_dpu(Some("ä2"), Some(1)),
+                ] => (
+                    vec![fallback_ordering_mac(1), fallback_ordering_mac(2)],
+                    HostPrimaryInterfaceSelection {
+                        mac_address: fallback_ordering_mac(1),
+                        source: BootInterfaceSelectionSource::RedfishChassisId,
+                    },
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn redfish_chassis_ordering_failures_leave_discovery_order_intact() {
+        value_scenarios!(run = |mut dpus| {
+                let discovery_order = dpus.clone();
+                let failure = SiteExplorer::sort_dpus_by_redfish_chassis_id(&mut dpus)
+                    .expect_err("invalid chassis evidence must not resolve an order");
+                assert_eq!(dpus, discovery_order);
+                failure
+            };
+            "missing identity" {
+                vec![
+                    chassis_ordering_dpu(None, Some(1)),
+                    chassis_ordering_dpu(Some("Riser_Slot2"), Some(2)),
+                ] => ChassisIdOrderingFailure::MissingChassisId,
+            }
+            "empty identity" {
+                vec![
+                    chassis_ordering_dpu(Some(""), Some(1)),
+                    chassis_ordering_dpu(Some("Riser_Slot2"), Some(2)),
+                ] => ChassisIdOrderingFailure::MissingChassisId,
+            }
+            "equal normalized identities" {
+                vec![
+                    chassis_ordering_dpu(Some("Slot01"), Some(1)),
+                    chassis_ordering_dpu(Some("slot1"), Some(2)),
+                ] => ChassisIdOrderingFailure::DuplicateChassisId,
+            }
+            "selected DPU has no host PF MAC address" {
+                vec![
+                    chassis_ordering_dpu(Some("Riser_Slot2"), Some(2)),
+                    chassis_ordering_dpu(Some("Riser_Slot1"), None),
+                ] => ChassisIdOrderingFailure::MissingHostPfMac,
+            }
+        );
+    }
+
     #[test]
     fn redfish_serial_fallback_preserves_existing_winner_semantics() {
         let dpu = |serial_number: Option<&str>, mac_last_byte| ExploredDpu {
             bmc_ip: "192.0.2.1".parse().unwrap(),
-            host_pf_mac_address: Some(MacAddress::new([0x02, 0, 0, 0, 0, mac_last_byte])),
+            host_pf_mac_address: Some(fallback_ordering_mac(mac_last_byte)),
+            host_chassis_id: None,
             report: Arc::new(EndpointExplorationReport {
                 systems: vec![ComputerSystem {
                     serial_number: serial_number.map(str::to_string),
@@ -5477,17 +5942,15 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let mac = |last| MacAddress::new([0x02, 0, 0, 0, 0, last]);
-
         check_values(
             [
                 Check {
                     scenario: "lower serial wins case-insensitively",
                     input: vec![dpu(Some("ZETA"), 1), dpu(Some("alpha"), 2)],
                     expect: (
-                        vec![mac(2), mac(1)],
+                        vec![fallback_ordering_mac(2), fallback_ordering_mac(1)],
                         Some(HostPrimaryInterfaceSelection {
-                            mac_address: mac(2),
+                            mac_address: fallback_ordering_mac(2),
                             source: BootInterfaceSelectionSource::RedfishSerialNumber,
                         }),
                     ),
@@ -5496,9 +5959,9 @@ mod tests {
                     scenario: "equal serials retain discovery order",
                     input: vec![dpu(Some("ALPHA"), 1), dpu(Some("alpha"), 2)],
                     expect: (
-                        vec![mac(1), mac(2)],
+                        vec![fallback_ordering_mac(1), fallback_ordering_mac(2)],
                         Some(HostPrimaryInterfaceSelection {
-                            mac_address: mac(1),
+                            mac_address: fallback_ordering_mac(1),
                             source: BootInterfaceSelectionSource::RedfishSerialNumber,
                         }),
                     ),
@@ -5507,9 +5970,9 @@ mod tests {
                     scenario: "missing and empty serials retain discovery order",
                     input: vec![dpu(None, 1), dpu(Some(""), 2)],
                     expect: (
-                        vec![mac(1), mac(2)],
+                        vec![fallback_ordering_mac(1), fallback_ordering_mac(2)],
                         Some(HostPrimaryInterfaceSelection {
-                            mac_address: mac(1),
+                            mac_address: fallback_ordering_mac(1),
                             source: BootInterfaceSelectionSource::RedfishSerialNumber,
                         }),
                     ),
@@ -5518,9 +5981,9 @@ mod tests {
                     scenario: "missing serial keeps the established empty-key priority",
                     input: vec![dpu(Some("alpha"), 1), dpu(None, 2)],
                     expect: (
-                        vec![mac(2), mac(1)],
+                        vec![fallback_ordering_mac(2), fallback_ordering_mac(1)],
                         Some(HostPrimaryInterfaceSelection {
-                            mac_address: mac(2),
+                            mac_address: fallback_ordering_mac(2),
                             source: BootInterfaceSelectionSource::RedfishSerialNumber,
                         }),
                     ),
@@ -5536,6 +5999,7 @@ mod tests {
             },
         );
 
+        let mac = fallback_ordering_mac;
         check_values(
             [
                 Check {

--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -390,6 +390,8 @@ pub(crate) enum SiteExplorerIterationFinished {
 enum BootInterfaceSelectionMechanism {
     ExpectedMachine,
     RedfishUefiPci,
+    /// Natural ordering of the host BMC `Chassis.id` values selected the first DPU.
+    RedfishChassisId,
     RedfishSerialNumber,
 }
 
@@ -411,6 +413,9 @@ pub(crate) enum BootInterfaceSelected {
 
     #[event(labels(mechanism = RedfishUefiPci))]
     RedfishUefiPci {},
+
+    #[event(labels(mechanism = RedfishChassisId))]
+    RedfishChassisId {},
 
     #[event(
         labels(mechanism = RedfishSerialNumber),
@@ -441,6 +446,7 @@ impl BootInterfaceSelected {
         match source {
             BootInterfaceSelectionSource::ExpectedMachine => Some(Self::ExpectedMachine {}),
             BootInterfaceSelectionSource::RedfishUefiPci => Some(Self::RedfishUefiPci {}),
+            BootInterfaceSelectionSource::RedfishChassisId => Some(Self::RedfishChassisId {}),
             BootInterfaceSelectionSource::RedfishSerialNumber => Some(Self::RedfishSerialNumber {
                 host_bmc_ip_address,
                 dpu_count,
@@ -449,7 +455,6 @@ impl BootInterfaceSelected {
             }),
             BootInterfaceSelectionSource::Operator
             | BootInterfaceSelectionSource::LegacyUnknown
-            | BootInterfaceSelectionSource::RedfishChassisId
             | BootInterfaceSelectionSource::ScoutReportPci => None,
         }
     }
@@ -1445,6 +1450,23 @@ mod tests {
                     counter_delta: 1.0,
                 },
             }
+            "RedfishChassisId selection is metric-only" {
+                BootInterfaceSelectionCase {
+                    source: BootInterfaceSelectionSource::RedfishChassisId,
+                    mechanism: "redfish_chassis_id",
+                } => BootInterfaceSelectionObservation {
+                    log_count: 0,
+                    level: None,
+                    message: None,
+                    event_name: None,
+                    metric_name: None,
+                    host_bmc_ip_address: None,
+                    dpu_count: None,
+                    selected_mac_address: None,
+                    selected_dpu_serial_number: None,
+                    counter_delta: 1.0,
+                },
+            }
             "RedfishSerialNumber selection retains its DEBUG diagnostic" {
                 BootInterfaceSelectionCase {
                     source: BootInterfaceSelectionSource::RedfishSerialNumber,
@@ -1483,9 +1505,6 @@ mod tests {
             }
             "legacy unknown selection" {
                 BootInterfaceSelectionSource::LegacyUnknown => true,
-            }
-            "Redfish chassis-id selection" {
-                BootInterfaceSelectionSource::RedfishChassisId => true,
             }
             "Scout report PCI selection" {
                 BootInterfaceSelectionSource::ScoutReportPci => true,

--- a/crates/site-explorer/tests/integration/machine_creator.rs
+++ b/crates/site-explorer/tests/integration/machine_creator.rs
@@ -460,6 +460,7 @@ async fn explored_host_fixture(env: &Env, managed_host: &ManagedHostConfig) -> E
                 .dpus
                 .get(dpu.dpu_index as usize)
                 .map(|config| config.host_mac_address),
+            host_chassis_id: None,
             report: Arc::new(dpu.report),
         })
         .collect();

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -2983,6 +2983,7 @@ async fn test_select_host_primary_interface(
         explored_dpus.push(ExploredDpu {
             bmc_ip: IpAddr::from_str(format!("192.168.1.{i}").as_str())?,
             host_pf_mac_address: Some(mock_dpu.host_mac_address),
+            host_chassis_id: None,
             report: dpu_report,
         });
     }
@@ -3001,7 +3002,7 @@ async fn test_select_host_primary_interface(
 
     // Preserve the all-or-nothing PCI rule: one matching DPU interface without
     // a UEFI path disables PCI selection for the whole host, allowing the
-    // existing stable fallback that orders by serial number to run.
+    // provisional chassis or serial ordering to run.
     let mut incomplete_pci_report = host_report.clone();
     let missing_path_mac = mock_dpus[0].host_mac_address;
     incomplete_pci_report.systems[0]


### PR DESCRIPTION
Site Explorer already chooses a host's primary interface deterministically: `ExpectedMachine` comes first, followed by complete Redfish UEFI PCI paths, with DPU serial ordering as the final fallback. Some host inventory also associates each DPU with a Redfish `Chassis.id`, so going directly to serial ordering can ignore a useful physical ordering hint when firmware does not provide complete PCI paths.

This adds provisional chassis ordering between PCI and serial ordering. Site Explorer joins each DPU to its host `Chassis.id` through the serial number already used for DPU pairing, retains that ID on `ExploredDpu`, and compares the full IDs using lowercase text and numeric comparison of ASCII decimal runs. That puts `Slot1`, `Slot2`, and `Slot10` in the expected order without assuming one vendor's ID format. A winning choice is persisted as `RedfishChassisId` and counted through the existing selection metric.

Redfish does not define ordering semantics for `Chassis.id`, so this remains a conservative, best effort hint. Every DPU being ordered must have one nonblank, unambiguous ID, and the normalized values must be unique. Any missing, ambiguous, or duplicate evidence leaves discovery order unchanged and sends the whole host to the existing serial fallback. This does not change Scout or controller behavior.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5080

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Table-driven unit coverage exercises IDs without digits, different formats, several and arbitrarily large numeric runs, prefixes, lowercase and Unicode text, missing or duplicate evidence, and unchanged discovery order on fallback.
- Full integration coverage verifies that the Wiwynn GB200 fixture persists Slot1's MAC with `RedfishChassisId` and exposes both chassis and serial selection metric labels.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable natural ordering change. Codex then completed a bounded closure review after the accepted fixes.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 3 | 3 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 7 | 3 | 4 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **10** | **6** | **4** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- Removed the `u64` limit from decimal comparison so an otherwise usable vendor ID cannot force serial fallback only because one digit run is large.
2. **Adopted** -- Scoped numeric comparison explicitly to ASCII decimal runs and added coverage for Unicode text around those runs.
3. **Adopted** -- Updated comments that still described the earlier structural parser and documented how normalized digit length and text provide natural order.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Declined** -- Keep `host_chassis_id` on `ExploredDpu`; retaining this selection evidence for later Scout comparison is an explicit #5080 requirement, and the optional field is compatible with stored reports from older versions.
2. **Adopted** -- Trim the chassis ID once while associating it with the DPU serial number so ambiguity detection and ordering share one normalized value.
3. **Declined** -- Replace the inventory helper's small `Vec` with a mixed iterator and rename the candidate type; the existing helper keeps the established direct or nested inventory rule readable, and the allocation is bounded by host inventory size.
4. **Adopted** -- Document that normalized digit length is compared before the digits, which provides numeric order without a fixed integer width.
5. **Declined** -- Rename the shared test MAC helper to save a local alias; the existing name explains its role across both fallback ordering tables.
6. **Adopted** -- Replace overloaded uses of “complete” with “all,” “whole,” or “full” where those meanings are intended.
7. **Declined** -- Add another unit test around the assignment from serial number to chassis ID; the correlation and ordering tables cover both halves, and the full integration test exercises the join and persisted selection.

### common-nits-reviewer

No findings.

</details>
