### PR TITLE
refactor(machine-a-tron): align DHCP relay configuration names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,6 +1466,7 @@ dependencies = [
  "ctor",
  "eyre",
  "futures",
+ "ipnet",
  "itertools 0.14.0",
  "lazy_static",
  "librms",

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -25,6 +25,7 @@ use ::carbide_utils::HostPortPair;
 use ::machine_a_tron::{
     BmcMockRegistry, DeviceHandle, DhcpType, LogFormat, MachineATronConfig, MachineConfig,
 };
+use api_test_helper::api_server::{TEST_BMC_DHCP_RELAY_ADDRESS, TEST_BMC_NETWORK_PREFIX};
 use api_test_helper::utils::TestApiServerArgs;
 use api_test_helper::{
     IntegrationTestEnvironment, domain, instance, machine, metrics, subnet, tenant, utils, vpc,
@@ -41,7 +42,7 @@ use sqlx::{Postgres, Row};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-const DPU_UNDERLAY_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 20, 1, 1);
+const UNDERLAY_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 20, 1, 1);
 
 #[ctor::ctor(unsafe)]
 fn setup() {
@@ -152,7 +153,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -160,7 +161,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -168,7 +169,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -176,7 +177,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -184,7 +185,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -192,7 +193,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_zerodpu(
@@ -246,7 +247,7 @@ async fn test_integration() -> eyre::Result<()> {
             tenant_org_id,
             &v4_vpc_prefix_id,
             &v6_vpc_prefix_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_dual_stack_l2(
@@ -254,7 +255,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &dual_stack_l2_segment_id,
-            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+            UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
     ]);
@@ -481,7 +482,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
         false,
         &test_env,
         &bmc_address_registry,
-        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+        UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let db_pool = db_pool.clone();
             let carbide_api_addrs = carbide_api_addrs.to_vec();
@@ -619,7 +620,7 @@ async fn test_machine_a_tron_multidpu(
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     segment_id: &str,
-    admin_dhcp_relay_address: Ipv4Addr,
+    underlay_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     run_machine_a_tron_machine_test(
         hw_type,
@@ -628,7 +629,7 @@ async fn test_machine_a_tron_multidpu(
         false,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        underlay_dhcp_relay_address,
         |machine_handle| {
             let segment_id = segment_id.to_string();
             let carbide_api_addrs = &test_env.carbide_api_addrs;
@@ -734,7 +735,7 @@ async fn test_machine_a_tron_zerodpu(
         false,
         test_env,
         bmc_mock_registry,
-        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+        UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             let flat_vpc_id = flat_vpc_id.to_string();
@@ -796,7 +797,7 @@ async fn test_machine_a_tron_nic_mode(
         true,
         test_env,
         bmc_mock_registry,
-        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
+        UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             let flat_vpc_id = flat_vpc_id.to_string();
@@ -967,7 +968,7 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
     hw_type: HardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
-    admin_dhcp_relay_address: Ipv4Addr,
+    underlay_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     run_machine_a_tron_machine_test(
         hw_type,
@@ -978,7 +979,7 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
         false,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        underlay_dhcp_relay_address,
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             async move {
@@ -1196,7 +1197,7 @@ async fn test_machine_a_tron_dual_stack(
     tenant_organization_id: &str,
     v4_vpc_prefix_id: &str,
     v6_vpc_prefix_id: &str,
-    admin_dhcp_relay_address: Ipv4Addr,
+    underlay_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     run_machine_a_tron_machine_test(
         hw_type,
@@ -1205,7 +1206,7 @@ async fn test_machine_a_tron_dual_stack(
         false,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        underlay_dhcp_relay_address,
         |machine_handle| {
             let v4_prefix_id = v4_vpc_prefix_id.to_string();
             let v6_prefix_id = v6_vpc_prefix_id.to_string();
@@ -1309,7 +1310,7 @@ async fn test_machine_a_tron_dual_stack_l2(
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     dual_stack_segment_id: &str,
-    admin_dhcp_relay_address: Ipv4Addr,
+    underlay_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     run_machine_a_tron_machine_test(
         hw_type,
@@ -1318,7 +1319,7 @@ async fn test_machine_a_tron_dual_stack_l2(
         false,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        underlay_dhcp_relay_address,
         |machine_handle| {
             let segment_id = dual_stack_segment_id.to_string();
             let carbide_api_addrs = &test_env.carbide_api_addrs;
@@ -1380,7 +1381,7 @@ async fn run_machine_a_tron_machine_test<F, O>(
     dpus_in_nic_mode: bool,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
-    admin_dhcp_relay_address: Ipv4Addr,
+    underlay_dhcp_relay_address: Ipv4Addr,
     run_assertions: F,
 ) -> eyre::Result<()>
 where
@@ -1408,13 +1409,11 @@ where
                 dpu_per_host_count,
                 dpu_reboot_delay: 1,
                 host_reboot_delay: 1,
-                // MAT currently uses this legacy-named field for DPU OS DHCP. Route that
-                // request through Underlay so it matches the predicted DPU interface.
-                admin_dhcp_relay_address,
+                underlay_dhcp_relay_address,
                 // Keep this distinct from the DPU Underlay relay so NIC-mode tests fail if
                 // machine-a-tron sends direct host DHCP through the DPU network.
                 host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
-                oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
+                bmc_dhcp_relay_address: TEST_BMC_DHCP_RELAY_ADDRESS,
                 vpc_count: 0,
                 subnets_per_vpc: 0,
                 run_interval_idle: Duration::from_secs(1),
@@ -1464,7 +1463,19 @@ where
     .await
     .unwrap();
 
-    let results = join_all(provisionable_handles.into_iter().map(run_assertions)).await;
+    let results = join_all(provisionable_handles.into_iter().map(|machine_handle| {
+        let relay_assertion_handle = machine_handle.clone();
+        let assertions = run_assertions(machine_handle);
+        async move {
+            assertions.await?;
+            assert_relay_selection(
+                &relay_assertion_handle,
+                dpus_in_nic_mode,
+                underlay_dhcp_relay_address,
+            )
+        }
+    }))
+    .await;
     let result_count = results.len();
     let assertion_result: eyre::Result<()> = results.into_iter().try_collect();
     let shutdown_result = mat_handle.shutdown().await;
@@ -1472,6 +1483,39 @@ where
     assert_eq!(result_count, host_count as usize);
     assertion_result?;
     shutdown_result
+}
+
+fn assert_relay_selection(
+    machine_handle: &DeviceHandle,
+    dpus_in_nic_mode: bool,
+    underlay_dhcp_relay_address: Ipv4Addr,
+) -> eyre::Result<()> {
+    let host_bmc_ip = machine_handle
+        .bmc_ip()
+        .context("host BMC DHCP did not return an address")?;
+    eyre::ensure!(
+        TEST_BMC_NETWORK_PREFIX.contains(&host_bmc_ip),
+        "host BMC DHCP used the underlay relay: {host_bmc_ip}"
+    );
+
+    for dpu in machine_handle.dpus() {
+        let details = dpu.host_details();
+        let dpu_bmc_ip: Ipv4Addr = details.oob_ip.parse()?;
+        eyre::ensure!(
+            TEST_BMC_NETWORK_PREFIX.contains(&dpu_bmc_ip),
+            "DPU BMC DHCP used the underlay relay: {dpu_bmc_ip}"
+        );
+
+        if !dpus_in_nic_mode {
+            let dpu_underlay_ip: Ipv4Addr = details.machine_ip.parse()?;
+            eyre::ensure!(
+                dpu_underlay_ip.octets()[..3] == underlay_dhcp_relay_address.octets()[..3],
+                "DPU OOB boot DHCP used the BMC relay: {dpu_underlay_ip}"
+            );
+        }
+    }
+
+    Ok(())
 }
 
 // Get the current number of rows in the dns_records view,

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -19,6 +19,7 @@ use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, TcpListener};
 use std::time::Duration;
 
+use api_test_helper::api_server::{TEST_BMC_DHCP_RELAY_ADDRESS, TEST_BMC_NETWORK_PREFIX};
 use api_test_helper::utils::TestApiServerArgs;
 use api_test_helper::{IntegrationTestEnvironment, utils};
 use bmc_mock::ListenerOrAddress;
@@ -32,6 +33,8 @@ use machine_a_tron::{
     RackModelConfig, WiwynnGb200RackConfig,
 };
 use tokio_util::sync::CancellationToken;
+
+const UNDERLAY_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 20, 1, 1);
 
 #[ctor::ctor(unsafe)]
 fn setup() {
@@ -81,8 +84,8 @@ async fn test_machine_a_tron_racks_integration() -> eyre::Result<()> {
     run_machine_a_tron_racks_test(
         &test_env,
         &bmc_address_registry,
-        // MAT currently uses admin_dhcp_relay_address for DPU OS DHCP.
-        Ipv4Addr::new(172, 20, 1, 1),
+        // DPU OOB boot and switch NVOS DHCP use the shared Underlay network.
+        UNDERLAY_DHCP_RELAY_ADDRESS,
     )
     .await?;
 
@@ -96,7 +99,7 @@ async fn test_machine_a_tron_racks_integration() -> eyre::Result<()> {
 async fn run_machine_a_tron_racks_test(
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
-    admin_dhcp_relay_address: Ipv4Addr,
+    underlay_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
     let gb200_rack_id = RackId::new("machine-a-tron-gb200-nvl72");
     let gb300_rack_id = RackId::new("machine-a-tron-gb300-nvl72");
@@ -122,8 +125,8 @@ async fn run_machine_a_tron_racks_test(
                             host_reboot_delay: 1,
                             scout_run_interval: Duration::from_secs(1),
                             discovery_retry_interval: Duration::from_millis(100),
-                            oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
-                            admin_dhcp_relay_address,
+                            bmc_dhcp_relay_address: TEST_BMC_DHCP_RELAY_ADDRESS,
+                            underlay_dhcp_relay_address,
                             host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
                             run_interval_working: Duration::from_millis(100),
                             run_interval_idle: Duration::from_secs(1),
@@ -147,8 +150,8 @@ async fn run_machine_a_tron_racks_test(
                             host_reboot_delay: 1,
                             scout_run_interval: Duration::from_secs(1),
                             discovery_retry_interval: Duration::from_millis(100),
-                            oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
-                            admin_dhcp_relay_address,
+                            bmc_dhcp_relay_address: TEST_BMC_DHCP_RELAY_ADDRESS,
+                            underlay_dhcp_relay_address,
                             host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
                             run_interval_working: Duration::from_millis(100),
                             run_interval_idle: Duration::from_secs(1),
@@ -243,6 +246,50 @@ async fn run_machine_a_tron_racks_test(
                     .fetch_one(&test_env.db_pool)
                     .await?;
             assert_eq!(expected_switch_count, 9, "rack {rack_id}");
+
+            let switch_bmc_ips: Vec<String> = sqlx::query_scalar(
+                "SELECT host(mia.address) \
+                 FROM expected_switches es \
+                 JOIN machine_interfaces mi ON mi.mac_address = es.bmc_mac_address \
+                 JOIN machine_interface_addresses mia ON mia.interface_id = mi.id \
+                 WHERE es.rack_id = $1",
+            )
+            .bind(rack_id.as_str())
+            .fetch_all(&test_env.db_pool)
+            .await?;
+            let switch_bmc_ips: Vec<Ipv4Addr> = switch_bmc_ips
+                .into_iter()
+                .map(|address| address.parse())
+                .collect::<Result<_, _>>()?;
+            assert_eq!(switch_bmc_ips.len(), 9, "rack {rack_id}");
+            assert!(
+                switch_bmc_ips
+                    .iter()
+                    .all(|address| TEST_BMC_NETWORK_PREFIX.contains(address)),
+                "rack {rack_id} switch BMC DHCP used the Underlay relay: {switch_bmc_ips:?}"
+            );
+
+            let switch_nvos_ips: Vec<String> = sqlx::query_scalar(
+                "SELECT host(mia.address) \
+                 FROM expected_switches es \
+                 JOIN machine_interfaces mi ON mi.mac_address = ANY(es.nvos_mac_addresses) \
+                 JOIN machine_interface_addresses mia ON mia.interface_id = mi.id \
+                 WHERE es.rack_id = $1",
+            )
+            .bind(rack_id.as_str())
+            .fetch_all(&test_env.db_pool)
+            .await?;
+            let switch_nvos_ips: Vec<Ipv4Addr> = switch_nvos_ips
+                .into_iter()
+                .map(|address| address.parse())
+                .collect::<Result<_, _>>()?;
+            assert_eq!(switch_nvos_ips.len(), 9, "rack {rack_id}");
+            assert!(
+                switch_nvos_ips.iter().all(|address| {
+                    address.octets()[..3] == UNDERLAY_DHCP_RELAY_ADDRESS.octets()[..3]
+                }),
+                "rack {rack_id} switch NVOS DHCP used the BMC relay: {switch_nvos_ips:?}"
+            );
 
             let actual_power_shelf_count: i64 = sqlx::query_scalar(
                 "SELECT COUNT(*) FROM expected_power_shelves WHERE rack_id = $1",

--- a/crates/api-test-helper/Cargo.toml
+++ b/crates/api-test-helper/Cargo.toml
@@ -73,6 +73,7 @@ tracing-subscriber = { features = [
 futures = { workspace = true }
 librms = { workspace = true }
 itertools = { workspace = true }
+ipnet = { workspace = true }
 ctor = { workspace = true }
 temp-dir = { workspace = true }
 rand = { workspace = true }

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -14,17 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use carbide_secrets::CredentialConfig;
 use carbide_utils::HostPortPair;
+use ipnet::Ipv4Net;
 use tokio::sync::oneshot::Sender;
 use tokio_util::sync::CancellationToken;
 
 use crate::utils::LOCALHOST_CERTS;
 
 const DOMAIN_NAME: &str = "forge.integrationtest";
+
+/// BMC network used by API integration tests. The `/23` accommodates both 71-BMC rack fixtures
+/// while keeping the SQL allocator's candidate scan bounded.
+pub const TEST_BMC_NETWORK_PREFIX: Ipv4Net = Ipv4Net::new_assert(Ipv4Addr::new(127, 0, 0, 0), 23);
+
+/// DHCP relay address for [`TEST_BMC_NETWORK_PREFIX`].
+pub const TEST_BMC_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 10);
 
 // Use a struct for the args to start() so that callers can see argument names
 pub struct StartArgs {
@@ -185,8 +193,8 @@ pub async fn start(
 
         [networks.DEV1-C09-IPMI-01]
         type = "underlay"
-        prefix = "127.0.0.0/8"
-        gateway = "127.0.0.10"
+        prefix = "{TEST_BMC_NETWORK_PREFIX}"
+        gateway = "{TEST_BMC_DHCP_RELAY_ADDRESS}"
         mtu = 1490
         reserve_first = 0
 

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -101,10 +101,14 @@ pub struct MachineConfig {
         serialize_with = "as_std_duration"
     )]
     pub discovery_retry_interval: Duration,
-    pub oob_dhcp_relay_address: Ipv4Addr,
-    pub admin_dhcp_relay_address: Ipv4Addr,
+    /// Relay address for BMC DHCP traffic.
+    #[serde(alias = "oob_dhcp_relay_address")]
+    pub bmc_dhcp_relay_address: Ipv4Addr,
+    /// Shared Underlay relay for DPU OOB boot and switch NVOS DHCP traffic.
+    #[serde(alias = "admin_dhcp_relay_address")]
+    pub underlay_dhcp_relay_address: Ipv4Addr,
     /// Relay address used when a host DHCPs directly through a plain NIC rather than a managed DPU.
-    /// If omitted, direct host DHCP falls back to `admin_dhcp_relay_address` for compatibility.
+    /// If omitted, direct host DHCP falls back to `underlay_dhcp_relay_address` for compatibility.
     #[serde(default)]
     pub host_inband_dhcp_relay_address: Option<Ipv4Addr>,
 
@@ -177,8 +181,14 @@ pub struct WiwynnGb200RackConfig {
         serialize_with = "as_std_duration"
     )]
     pub discovery_retry_interval: Duration,
-    pub oob_dhcp_relay_address: Ipv4Addr,
-    pub admin_dhcp_relay_address: Ipv4Addr,
+    /// Relay address for BMC DHCP traffic.
+    #[serde(alias = "oob_dhcp_relay_address")]
+    pub bmc_dhcp_relay_address: Ipv4Addr,
+    /// Shared Underlay relay for DPU OOB boot and switch NVOS DHCP traffic.
+    #[serde(alias = "admin_dhcp_relay_address")]
+    pub underlay_dhcp_relay_address: Ipv4Addr,
+    /// Relay address used when a rack host DHCPs directly through a plain NIC.
+    /// If omitted, direct host DHCP falls back to `underlay_dhcp_relay_address` for compatibility.
     #[serde(default)]
     pub host_inband_dhcp_relay_address: Option<Ipv4Addr>,
     #[serde(
@@ -229,8 +239,8 @@ impl WiwynnGb200RackConfig {
             host_reboot_delay: self.host_reboot_delay,
             scout_run_interval: self.scout_run_interval,
             discovery_retry_interval: self.discovery_retry_interval,
-            oob_dhcp_relay_address: self.oob_dhcp_relay_address,
-            admin_dhcp_relay_address: self.admin_dhcp_relay_address,
+            bmc_dhcp_relay_address: self.bmc_dhcp_relay_address,
+            underlay_dhcp_relay_address: self.underlay_dhcp_relay_address,
             host_inband_dhcp_relay_address: self.host_inband_dhcp_relay_address,
             run_interval_working: self.run_interval_working,
             run_interval_idle: self.run_interval_idle,
@@ -260,8 +270,14 @@ pub struct LenovoGb300RackConfig {
         serialize_with = "as_std_duration"
     )]
     pub discovery_retry_interval: Duration,
-    pub oob_dhcp_relay_address: Ipv4Addr,
-    pub admin_dhcp_relay_address: Ipv4Addr,
+    /// Relay address for BMC DHCP traffic.
+    #[serde(alias = "oob_dhcp_relay_address")]
+    pub bmc_dhcp_relay_address: Ipv4Addr,
+    /// Shared Underlay relay for DPU OOB boot and switch NVOS DHCP traffic.
+    #[serde(alias = "admin_dhcp_relay_address")]
+    pub underlay_dhcp_relay_address: Ipv4Addr,
+    /// Relay address used when a rack host DHCPs directly through a plain NIC.
+    /// If omitted, direct host DHCP falls back to `underlay_dhcp_relay_address` for compatibility.
     #[serde(default)]
     pub host_inband_dhcp_relay_address: Option<Ipv4Addr>,
     #[serde(
@@ -312,8 +328,8 @@ impl LenovoGb300RackConfig {
             host_reboot_delay: self.host_reboot_delay,
             scout_run_interval: self.scout_run_interval,
             discovery_retry_interval: self.discovery_retry_interval,
-            oob_dhcp_relay_address: self.oob_dhcp_relay_address,
-            admin_dhcp_relay_address: self.admin_dhcp_relay_address,
+            bmc_dhcp_relay_address: self.bmc_dhcp_relay_address,
+            underlay_dhcp_relay_address: self.underlay_dhcp_relay_address,
             host_inband_dhcp_relay_address: self.host_inband_dhcp_relay_address,
             run_interval_working: self.run_interval_working,
             run_interval_idle: self.run_interval_idle,
@@ -986,9 +1002,11 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::fmt::Debug;
 
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, Check, check_cases, check_values};
+    use serde::de::DeserializeOwned;
 
     use super::*;
 
@@ -1014,9 +1032,9 @@ dpu_per_host_count = 2
 dpu_reboot_delay = 1 # in units of seconds
 host_reboot_delay = 1 # in units of seconds
 vpc_count = 0
-admin_dhcp_relay_address = "192.168.176.1"
+underlay_dhcp_relay_address = "192.168.176.1"
 host_inband_dhcp_relay_address = "192.168.177.1"
-oob_dhcp_relay_address = "192.168.192.1"
+bmc_dhcp_relay_address = "192.168.192.1"
 subnets_per_vpc = 0
 run_interval_working = "100ms"
 run_interval_idle = "1s"
@@ -1033,8 +1051,8 @@ scout_run_interval = "5s"
             host_reboot_delay: machine.host_reboot_delay,
             scout_run_interval: machine.scout_run_interval,
             discovery_retry_interval: machine.discovery_retry_interval,
-            oob_dhcp_relay_address: machine.oob_dhcp_relay_address,
-            admin_dhcp_relay_address: machine.admin_dhcp_relay_address,
+            bmc_dhcp_relay_address: machine.bmc_dhcp_relay_address,
+            underlay_dhcp_relay_address: machine.underlay_dhcp_relay_address,
             host_inband_dhcp_relay_address: machine.host_inband_dhcp_relay_address,
             run_interval_working: machine.run_interval_working,
             run_interval_idle: machine.run_interval_idle,
@@ -1052,8 +1070,8 @@ scout_run_interval = "5s"
             host_reboot_delay: machine.host_reboot_delay,
             scout_run_interval: machine.scout_run_interval,
             discovery_retry_interval: machine.discovery_retry_interval,
-            oob_dhcp_relay_address: machine.oob_dhcp_relay_address,
-            admin_dhcp_relay_address: machine.admin_dhcp_relay_address,
+            bmc_dhcp_relay_address: machine.bmc_dhcp_relay_address,
+            underlay_dhcp_relay_address: machine.underlay_dhcp_relay_address,
             host_inband_dhcp_relay_address: machine.host_inband_dhcp_relay_address,
             run_interval_working: machine.run_interval_working,
             run_interval_idle: machine.run_interval_idle,
@@ -1536,6 +1554,72 @@ server_address = "127.0.0.1:6767""#,
             .try_into()
             .expect("legacy config without host_inband_dhcp_relay_address should deserialize");
         assert_eq!(cfg.machines["config"].host_inband_dhcp_relay_address, None);
+    }
+
+    fn assert_relay_name_compatibility<T>(config: T)
+    where
+        T: Clone + Debug + DeserializeOwned + PartialEq + Serialize,
+    {
+        let canonical = toml::Value::try_from(config.clone())
+            .expect("relay configuration should serialize to TOML");
+        let canonical_table = canonical
+            .as_table()
+            .expect("relay configuration should serialize as a TOML table");
+        assert!(canonical_table.contains_key("bmc_dhcp_relay_address"));
+        assert!(canonical_table.contains_key("underlay_dhcp_relay_address"));
+        assert!(!canonical_table.contains_key("oob_dhcp_relay_address"));
+        assert!(!canonical_table.contains_key("admin_dhcp_relay_address"));
+
+        let mut legacy = canonical.clone();
+        let legacy_table = legacy
+            .as_table_mut()
+            .expect("relay configuration should serialize as a TOML table");
+        let bmc_relay = legacy_table
+            .remove("bmc_dhcp_relay_address")
+            .expect("canonical BMC relay should be present");
+        legacy_table.insert("oob_dhcp_relay_address".to_string(), bmc_relay);
+        let underlay_relay = legacy_table
+            .remove("underlay_dhcp_relay_address")
+            .expect("canonical Underlay relay should be present");
+        legacy_table.insert("admin_dhcp_relay_address".to_string(), underlay_relay);
+        let deserialized: T = legacy
+            .try_into()
+            .expect("legacy relay names should deserialize");
+        assert_eq!(deserialized, config);
+
+        let mut duplicate = canonical.clone();
+        let duplicate_table = duplicate
+            .as_table_mut()
+            .expect("relay configuration should serialize as a TOML table");
+        let bmc_relay = duplicate_table["bmc_dhcp_relay_address"].clone();
+        duplicate_table.insert("oob_dhcp_relay_address".to_string(), bmc_relay);
+        let underlay_relay = duplicate_table["underlay_dhcp_relay_address"].clone();
+        duplicate_table.insert("admin_dhcp_relay_address".to_string(), underlay_relay);
+        assert!(
+            duplicate.try_into::<T>().is_err(),
+            "canonical and legacy relay names must not be accepted together"
+        );
+
+        for missing_key in ["bmc_dhcp_relay_address", "underlay_dhcp_relay_address"] {
+            let mut missing = canonical.clone();
+            missing
+                .as_table_mut()
+                .expect("relay configuration should serialize as a TOML table")
+                .remove(missing_key);
+            assert!(
+                missing.try_into::<T>().is_err(),
+                "{missing_key} or its legacy alias must be configured"
+            );
+        }
+    }
+
+    #[test]
+    fn relay_names_are_backward_compatible() {
+        let machine = rack_config().machines["config"].as_ref().clone();
+
+        assert_relay_name_compatibility(machine.clone());
+        assert_relay_name_compatibility(wiwynn_gb200_rack_from_machine(&machine));
+        assert_relay_name_compatibility(lenovo_gb300_rack_from_machine(&machine));
     }
 
     #[test]

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -94,8 +94,8 @@ impl MachineATron {
                     machine_group,
                     dpu_per_host_count = machine.dpu_per_host_count,
                     dpus_in_nic_mode = machine.dpus_in_nic_mode,
-                    admin_dhcp_relay_address = %machine.admin_dhcp_relay_address,
-                    "host_inband_dhcp_relay_address is not configured for a zero-DPU or NIC-mode host; direct host DHCP will fall back to admin_dhcp_relay_address"
+                    underlay_dhcp_relay_address = %machine.underlay_dhcp_relay_address,
+                    "host_inband_dhcp_relay_address is not configured for a zero-DPU or NIC-mode host; direct host DHCP will fall back to underlay_dhcp_relay_address"
                 );
             }
         }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -140,13 +140,13 @@ fn abandon_machine_actions_on_power_change(
 
 fn direct_dhcp_relay_address(
     is_host: bool,
-    admin_relay_address: Ipv4Addr,
+    underlay_relay_address: Ipv4Addr,
     host_inband_relay_address: Option<Ipv4Addr>,
 ) -> Ipv4Addr {
     if is_host {
-        host_inband_relay_address.unwrap_or(admin_relay_address)
+        host_inband_relay_address.unwrap_or(underlay_relay_address)
     } else {
-        admin_relay_address
+        underlay_relay_address
     }
 }
 
@@ -712,7 +712,7 @@ impl MachineStateMachine {
             .dhcp_client
             .request_ip(DhcpRequestInfo {
                 mac_address: self.machine_info.bmc_mac_address(),
-                relay_address: self.config.oob_dhcp_relay_address,
+                relay_address: self.config.bmc_dhcp_relay_address,
                 vendor_class: vendor_class(&self.machine_info, DhcpRequester::Bmc),
             })
             .await
@@ -777,7 +777,7 @@ impl MachineStateMachine {
         } else {
             let direct_relay_address = direct_dhcp_relay_address(
                 matches!(&self.machine_info, MachineInfo::Host(_)),
-                self.config.admin_dhcp_relay_address,
+                self.config.underlay_dhcp_relay_address,
                 self.config.host_inband_dhcp_relay_address,
             );
             tracing::debug!(
@@ -1514,7 +1514,7 @@ mod tests {
 
     #[test]
     fn direct_dhcp_relay_selection() {
-        let admin = Ipv4Addr::new(172, 21, 0, 1);
+        let underlay = Ipv4Addr::new(172, 21, 0, 1);
         let host_inband = Ipv4Addr::new(172, 22, 0, 1);
 
         check_values(
@@ -1527,15 +1527,15 @@ mod tests {
                 Check {
                     scenario: "legacy host without HostInband configuration",
                     input: (true, None),
-                    expect: admin,
+                    expect: underlay,
                 },
                 Check {
                     scenario: "DPU ignores HostInband configuration",
                     input: (false, Some(host_inband)),
-                    expect: admin,
+                    expect: underlay,
                 },
             ],
-            |(is_host, host_inband)| direct_dhcp_relay_address(is_host, admin, host_inband),
+            |(is_host, host_inband)| direct_dhcp_relay_address(is_host, underlay, host_inband),
         );
     }
 

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -305,7 +305,7 @@ impl PowerShelfActor {
             .dhcp_client
             .request_ip(DhcpRequestInfo {
                 mac_address: self.host_info.bmc_mac_address,
-                relay_address: self.config.oob_dhcp_relay_address,
+                relay_address: self.config.bmc_dhcp_relay_address,
                 vendor_class: vendor_class(&machine_info, DhcpRequester::Bmc),
             })
             .await

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -323,7 +323,7 @@ impl SwitchActor {
             .dhcp_client
             .request_ip(DhcpRequestInfo {
                 mac_address: self.host_info.bmc_mac_address,
-                relay_address: self.config.oob_dhcp_relay_address,
+                relay_address: self.config.bmc_dhcp_relay_address,
                 vendor_class: vendor_class(&machine_info, DhcpRequester::Bmc),
             })
             .await
@@ -342,7 +342,7 @@ impl SwitchActor {
             .dhcp_client
             .request_ip(DhcpRequestInfo {
                 mac_address: *nvos_mac_address,
-                relay_address: self.config.admin_dhcp_relay_address,
+                relay_address: self.config.underlay_dhcp_relay_address,
                 // No DHCP option 60 value has been verified for NVOS.
                 vendor_class: None,
             })


### PR DESCRIPTION
Historically, machine-a-tron used admin_dhcp_relay_address for the shared Underlay DHCP relay used by DPU OOB boot and switch NVOS DHCP traffic. The name was confusing because the relay does not belong to the Admin network segment.
 
Similarly, oob_dhcp_relay_address is used for BMC DHCP traffic, which made it easy to confuse with the DPU OOB boot relay.

This PR renames these configuration parameters to underlay_dhcp_relay_address and bmc_dhcp_relay_address, respectively. It retains the old names as deserialization aliases for backward compatibility. The aliases can be removed once all configuration references have migrated to the new names.

The integration tests also verify that BMC and Underlay DHCP traffic use their respective relays.

## Related issues

#5084 

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

