### PR TITLE
fix(machine-a-tron): setup IPMI console for hw types that needs it

### DIFF
--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -1018,16 +1018,28 @@ impl HostMachineInfo {
 }
 
 impl MachineInfo {
-    pub fn supports_ipmi_console(&self) -> bool {
-        matches!(
-            self,
-            MachineInfo::Host(host)
-                if matches!(
-                    host.bmc_vendor(),
-                    redfish::oem::BmcVendor::Supermicro
-                        | redfish::oem::BmcVendor::Nvidia(_)
-                )
-        )
+    /// Returns whether machine-a-tron should start an IPMI console simulator for this profile.
+    pub fn needs_ipmi_console(&self) -> bool {
+        match self {
+            MachineInfo::Host(host) => match host.hw_type {
+                HardwareType::WiwynnGB200Nvl
+                | HardwareType::NvidiaDgxGb300
+                | HardwareType::SupermicroGb300Nvl
+                | HardwareType::NvidiaDgxVr
+                | HardwareType::NvidiaSwitchNd5200Ld
+                | HardwareType::NvidiaSwitchN5700Ld
+                | HardwareType::GenericSupermicro => true,
+                HardwareType::DellPowerEdgeR750
+                | HardwareType::DellPowerEdgeR760Bf4
+                | HardwareType::LenovoGB300Nvl
+                | HardwareType::LiteOnPowerShelf
+                | HardwareType::DeltaPowerShelf
+                | HardwareType::NvidiaDgxH100
+                | HardwareType::GenericAmi
+                | HardwareType::HpeProliantDl380aGen11 => false,
+            },
+            MachineInfo::Dpu(_) => false,
+        }
     }
 
     pub(super) fn oem_state(&self) -> redfish::oem::State {

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -44,7 +44,7 @@ pub(super) struct BmcMockWrapper {
     bmc_mock_router: Router,
     bmc_mock_state: BmcState,
     hostname: Arc<dyn HostnameQuerying>,
-    supports_ipmi_console: bool,
+    needs_ipmi_console: bool,
     stable_id: String,
 }
 
@@ -74,7 +74,7 @@ impl BmcMockWrapper {
             bmc_mock_router,
             bmc_mock_state,
             hostname,
-            supports_ipmi_console: machine_info.supports_ipmi_console(),
+            needs_ipmi_console: machine_info.needs_ipmi_console(),
             stable_id: host_id.to_string(),
         }
     }
@@ -182,7 +182,7 @@ impl BmcMockWrapper {
     }
 
     /// Starts only the optional IPMI simulator when Redfish is served by a shared BMC mock.
-    /// Returns `None` when IPMI simulation is disabled or the machine does not support IPMI SOL.
+    /// Returns `None` when IPMI simulation is disabled or the machine does not need an IPMI console.
     pub(super) async fn start_ipmi_only(
         &self,
         bind_ip: std::net::IpAddr,
@@ -201,7 +201,7 @@ impl BmcMockWrapper {
         &self,
         bind_ip: std::net::IpAddr,
     ) -> Result<Option<IpmiSimHandle>, MachineStateError> {
-        if !self.app_context.app_config.enable_ipmi_simulation || !self.supports_ipmi_console {
+        if !self.app_context.app_config.enable_ipmi_simulation || !self.needs_ipmi_console {
             return Ok(None);
         }
 

--- a/dev/deployment/devspace/Dockerfile.api
+++ b/dev/deployment/devspace/Dockerfile.api
@@ -33,6 +33,7 @@ RUN mkdir -p /opt/carbide /opt/carbide/firmware /mnt/persistence /var/run/kea
 
 COPY --from=artifacts /artifacts/carbide-api /opt/carbide/carbide-api
 COPY --from=artifacts /artifacts/nico-admin-cli /opt/carbide/nico-admin-cli
+COPY --from=artifacts /artifacts/ssh-console /opt/carbide/ssh-console
 RUN ln -s /opt/carbide/nico-admin-cli /opt/carbide/carbide-admin-cli
 COPY crates/api/casbin-policy.csv /opt/carbide/casbin-policy.csv
 

--- a/dev/deployment/devspace/Dockerfile.core-artifacts
+++ b/dev/deployment/devspace/Dockerfile.core-artifacts
@@ -20,6 +20,7 @@ RUN --mount=type=cache,id=nico-devspace-cargo-home,target=/cargo-home,sharing=lo
     -p nico-admin-cli --bin nico-admin-cli \
     -p carbide-bmc-proxy --bin carbide-bmc-proxy \
     -p carbide-dhcp --lib \
+    -p carbide-ssh-console --bin ssh-console \
     -p carbide-machine-a-tron --bin machine-a-tron && \
   mkdir -p /artifacts && \
   cp \
@@ -27,6 +28,7 @@ RUN --mount=type=cache,id=nico-devspace-cargo-home,target=/cargo-home,sharing=lo
     /cargo-target/debug/nico-admin-cli \
     /cargo-target/debug/carbide-bmc-proxy \
     /cargo-target/debug/libdhcp.so \
+    /cargo-target/debug/ssh-console \
     /cargo-target/debug/machine-a-tron \
     /artifacts/
 

--- a/dev/deployment/tilt/Tiltfile
+++ b/dev/deployment/tilt/Tiltfile
@@ -267,6 +267,14 @@ local_ca_certificate = str(read_file(
 local_ca_key = str(read_file(
     os.path.join(repo_root, 'dev/certs/localhost/ca.key'),
 ))
+ssh_console_host_key = str(read_file(os.path.join(
+    repo_root,
+    'crates/ssh-console/tests/fixtures/ssh_host_ed25519_key',
+)))
+ssh_console_host_key_public = str(read_file(os.path.join(
+    repo_root,
+    'crates/ssh-console/tests/fixtures/ssh_host_ed25519_key.pub',
+)))
 database_config = local_config['database']
 rest_database = database_config['rest']
 keycloak_database = database_config['keycloak']
@@ -421,6 +429,14 @@ local_objects = [
         secret_type='kubernetes.io/tls',
     ),
     secret('nico-roots', core_namespace, {'ca.crt': local_ca_certificate}),
+    secret(
+        'ssh-host-key',
+        core_namespace,
+        {
+            'ssh_host_ed25519_key': ssh_console_host_key,
+            'ssh_host_ed25519_key_pub': ssh_console_host_key_public,
+        },
+    ),
     {
         'apiVersion': 'cert-manager.io/v1',
         'kind': 'Issuer',
@@ -1005,6 +1021,35 @@ k8s_resource(
     pod_readiness='ignore',
 )
 
+machine_a_tron_ssh_service_name = 'nico-machine-a-tron-%s-ssh' % machine_a_tron_dhcp_pod
+machine_a_tron_ssh_service = {
+    'apiVersion': 'v1',
+    'kind': 'Service',
+    'metadata': object_metadata(machine_a_tron_ssh_service_name, core_namespace),
+    'spec': {
+        'clusterIP': 'None',
+        'selector': {
+            'app.kubernetes.io/name': 'nico-machine-a-tron',
+            'app.kubernetes.io/component': 'machine-a-tron',
+            'nvidia-infra-controller/pod-name': machine_a_tron_dhcp_pod,
+        },
+        'ports': [{
+            'name': 'ssh',
+            'port': 2222,
+            'targetPort': 'ssh',
+            'protocol': 'TCP',
+        }],
+    },
+}
+k8s_yaml(encode_yaml(machine_a_tron_ssh_service))
+k8s_resource(
+    new_name='nico-machine-a-tron-ssh',
+    objects=[object_selector(machine_a_tron_ssh_service)],
+    resource_deps=['nico-machine-a-tron'],
+    labels=['application'],
+    pod_readiness='ignore',
+)
+
 helm_chart(
     name='nico-machine-a-tron',
     chart=os.path.join(core_charts, 'nico-machine-a-tron'),
@@ -1019,6 +1064,27 @@ helm_chart(
     image_keys=[('image.repository', 'image.tag')],
     port_forwards=[port_forward(1266, 1266)],
     links=[link('https://localhost:1266/', 'Machine-A-Tron UI')],
+    manual=True,
+)
+
+ssh_console_values = component_values(core_global, all_values['nico-ssh-console-rs'])
+ssh_console_values['serviceMonitor'] = {'enabled': enable_observability}
+helm_chart(
+    name='nico-ssh-console-rs',
+    chart=os.path.join(core_charts, 'nico-ssh-console-rs'),
+    namespace=core_namespace,
+    values=ssh_console_values,
+    resource_deps=[
+        'nico-api',
+        'nico-machine-a-tron-ssh',
+    ],
+    image_dep='nico-api',
+    image_keys=[('global.image.repository', 'global.image.tag')],
+    port_forwards=[
+        port_forward(3222, 22),
+        port_forward(3223, 9009),
+    ],
+    links=[link('http://localhost:3223/metrics', 'SSH Console Metrics')],
     manual=True,
 )
 
@@ -1166,6 +1232,8 @@ enabled_resources = [
     'nico-dhcp-machine-a-tron',
     'nico-machine-a-tron-dhcp-relay',
     'nico-machine-a-tron',
+    'nico-machine-a-tron-ssh',
+    'nico-ssh-console-rs',
 ]
 if enable_observability:
     enabled_resources.extend([

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -182,6 +182,27 @@ nico-dhcp:
         ntpServer: 127.0.0.1
         provisioningServer: 127.0.0.1
 
+nico-ssh-console-rs:
+  enabled: true
+  configFiles:
+    config: |
+      listen_address = "[::]:22"
+      metrics_address = "[::]:9009"
+      carbide_url = "https://nico-api.nico-system.svc.cluster.local:1079"
+      forge_root_ca_path = "/var/run/secrets/spiffe.io/ca.crt"
+      client_cert_path = "/var/run/secrets/spiffe.io/tls.crt"
+      client_key_path = "/var/run/secrets/spiffe.io/tls.key"
+      host_key = "/etc/ssh/ssh_host_ed25519_key"
+      hosts = true
+      dpus = true
+      insecure = true
+      override_bmc_ssh_host = "nico-machine-a-tron-mat-0-ssh.nico-system.svc.cluster.local"
+      api_poll_interval = "1s"
+      reconnect_interval_base = "1s"
+      reconnect_interval_max = "10s"
+      console_logging_enabled = true
+      console_logs_path = "/var/log/consoles"
+
 nico-machine-a-tron:
   enabled: true
   machineATron:
@@ -205,6 +226,8 @@ nico-machine-a-tron:
         use_single_bmc_mock = true
         mock_bmc_ssh_server = true
         mock_bmc_ssh_port = 2222
+        enable_ipmi_simulation = true
+        ipmi_reachable_port = 0
         persist_dir = "/tmp/machine-a-tron-data"
         cleanup_on_quit = false
         register_expected_machines = true


### PR DESCRIPTION
Enable IPMI console for hardware types that ssh-console want to connect via IPMI.
In addition, add ssh-console deployment to Tilt local development.

## Related issues

#3687 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
