### PR TITLE
feat(machine-a-tron): DHCP backoff for power shelves and switches

### DIFF
--- a/crates/machine-a-tron/src/dhcp_retry_fsm.rs
+++ b/crates/machine-a-tron/src/dhcp_retry_fsm.rs
@@ -1,0 +1,279 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::time::Duration;
+
+// RFC 2131 section 4.1's Ethernet example starts at four seconds, doubles to a
+// 64-second base, and adds uniform jitter from -1 through +1 second.
+pub(super) const DHCP_RETRY_MAX_JITTER: Milliseconds = Milliseconds::new(1_000);
+const DHCP_RETRY_MIN_JITTER: Milliseconds = Milliseconds::new(-1_000);
+const DHCP_RETRY_INITIAL_DELAY: Duration = Duration::from_secs(4);
+const DHCP_RETRY_MAX_DELAY: Duration = Duration::from_secs(64);
+
+/// Signed millisecond offset used for DHCP retry jitter.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct Milliseconds(i64);
+
+impl Milliseconds {
+    pub(super) const fn new(value: i64) -> Self {
+        Self(value)
+    }
+
+    pub(super) const fn value(self) -> i64 {
+        self.0
+    }
+
+    fn clamp(self, min: Self, max: Self) -> Self {
+        Self(self.0.clamp(min.0, max.0))
+    }
+
+    fn apply_to(self, duration: Duration) -> Duration {
+        let magnitude = Duration::from_millis(self.0.unsigned_abs());
+        if self.0.is_negative() {
+            duration.saturating_sub(magnitude)
+        } else {
+            duration.saturating_add(magnitude)
+        }
+    }
+}
+
+/// Pure single-flight state machine for DHCP retry policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct DhcpRetryFsm {
+    state: State,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum State {
+    Idle,
+    Waiting { attempt: u32 },
+    Retrying { attempt: u32 },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Event {
+    Failed(Milliseconds),
+    TimerExpired,
+    Completed,
+    Abandon,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Action {
+    Schedule { delay: Duration },
+    Run,
+    Cancel,
+}
+
+impl DhcpRetryFsm {
+    pub(super) const fn new() -> Self {
+        Self { state: State::Idle }
+    }
+
+    pub(super) fn event(self, event: Event) -> (Self, Vec<Action>) {
+        match self.state {
+            State::Idle => self.fsm_idle(event),
+            State::Waiting { attempt } => self.fsm_waiting(event, attempt),
+            State::Retrying { attempt } => self.fsm_retrying(event, attempt),
+        }
+    }
+
+    fn fsm_idle(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::Failed(jitter) => self.schedule_retry(0, jitter),
+            Event::TimerExpired | Event::Completed | Event::Abandon => (self, vec![]),
+        }
+    }
+
+    fn fsm_waiting(self, event: Event, attempt: u32) -> (Self, Vec<Action>) {
+        match event {
+            Event::TimerExpired => (
+                Self {
+                    state: State::Retrying { attempt },
+                },
+                vec![Action::Run],
+            ),
+            Event::Completed | Event::Abandon => {
+                (Self { state: State::Idle }, vec![Action::Cancel])
+            }
+            Event::Failed(_) => (self, vec![]),
+        }
+    }
+
+    fn fsm_retrying(self, event: Event, attempt: u32) -> (Self, Vec<Action>) {
+        match event {
+            Event::Failed(jitter) => self.schedule_retry(attempt, jitter),
+            Event::Completed | Event::Abandon => (Self { state: State::Idle }, vec![]),
+            Event::TimerExpired => (self, vec![]),
+        }
+    }
+
+    fn schedule_retry(self, retry_attempt: u32, jitter: Milliseconds) -> (Self, Vec<Action>) {
+        let delay = dhcp_retry_delay(retry_attempt, jitter);
+        let attempt = retry_attempt.saturating_add(1);
+        (
+            Self {
+                state: State::Waiting { attempt },
+            },
+            vec![Action::Schedule { delay }],
+        )
+    }
+}
+
+fn dhcp_retry_delay(retry_attempt: u32, jitter: Milliseconds) -> Duration {
+    let jitter = jitter.clamp(DHCP_RETRY_MIN_JITTER, DHCP_RETRY_MAX_JITTER);
+    let multiplier = 1_u32 << retry_attempt.min(4);
+    let base_delay = DHCP_RETRY_INITIAL_DELAY
+        .saturating_mul(multiplier)
+        .min(DHCP_RETRY_MAX_DELAY);
+    jitter.apply_to(base_delay)
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    fn fsm() -> DhcpRetryFsm {
+        DhcpRetryFsm::new()
+    }
+
+    fn failed() -> Event {
+        Event::Failed(Milliseconds::new(0))
+    }
+
+    #[test]
+    fn delay_uses_rfc_2131_backoff() {
+        check_values(
+            [
+                Check {
+                    scenario: "first retry with minimum jitter",
+                    input: (0, Milliseconds::new(-1_000)),
+                    expect: Duration::from_secs(3),
+                },
+                Check {
+                    scenario: "jitter below the minimum is clamped",
+                    input: (0, Milliseconds::new(i64::MIN)),
+                    expect: Duration::from_secs(3),
+                },
+                Check {
+                    scenario: "first retry without jitter",
+                    input: (0, Milliseconds::new(0)),
+                    expect: Duration::from_secs(4),
+                },
+                Check {
+                    scenario: "first retry with maximum jitter",
+                    input: (0, Milliseconds::new(1_000)),
+                    expect: Duration::from_secs(5),
+                },
+                Check {
+                    scenario: "jitter above the maximum is clamped",
+                    input: (0, Milliseconds::new(i64::MAX)),
+                    expect: Duration::from_secs(5),
+                },
+                Check {
+                    scenario: "second retry doubles the base",
+                    input: (1, Milliseconds::new(0)),
+                    expect: Duration::from_secs(8),
+                },
+                Check {
+                    scenario: "third retry doubles the base",
+                    input: (2, Milliseconds::new(0)),
+                    expect: Duration::from_secs(16),
+                },
+                Check {
+                    scenario: "fourth retry doubles the base",
+                    input: (3, Milliseconds::new(0)),
+                    expect: Duration::from_secs(32),
+                },
+                Check {
+                    scenario: "fifth retry reaches the cap",
+                    input: (4, Milliseconds::new(0)),
+                    expect: Duration::from_secs(64),
+                },
+                Check {
+                    scenario: "later retry remains capped with minimum jitter",
+                    input: (u32::MAX, Milliseconds::new(-1_000)),
+                    expect: Duration::from_secs(63),
+                },
+                Check {
+                    scenario: "later retry remains capped with maximum jitter",
+                    input: (u32::MAX, Milliseconds::new(1_000)),
+                    expect: Duration::from_secs(65),
+                },
+            ],
+            |(attempt, jitter)| dhcp_retry_delay(attempt, jitter),
+        );
+    }
+
+    #[test]
+    fn retry_lifecycle_is_single_flight() {
+        let fsm = fsm();
+        let (fsm, actions) = fsm.event(failed());
+        assert_eq!(
+            actions,
+            vec![Action::Schedule {
+                delay: Duration::from_secs(4),
+            }]
+        );
+
+        let (fsm, actions) = fsm.event(Event::TimerExpired);
+        assert_eq!(actions, vec![Action::Run]);
+        let (fsm, actions) = fsm.event(failed());
+        assert_eq!(
+            actions,
+            vec![Action::Schedule {
+                delay: Duration::from_secs(8),
+            }]
+        );
+
+        let (fsm, actions) = fsm.event(Event::Abandon);
+        assert_eq!(fsm.state, State::Idle);
+        assert_eq!(actions, vec![Action::Cancel]);
+    }
+
+    #[test]
+    fn failure_uses_supplied_jitter() {
+        let (_, actions) = fsm().event(Event::Failed(DHCP_RETRY_MAX_JITTER));
+        assert_eq!(
+            actions,
+            vec![Action::Schedule {
+                delay: Duration::from_secs(5),
+            }]
+        );
+    }
+
+    #[test]
+    fn completion_resets_the_retry_ladder() {
+        let (fsm, _) = fsm().event(failed());
+        let (fsm, _) = fsm.event(Event::TimerExpired);
+        let (fsm, _) = fsm.event(failed());
+        let (fsm, actions) = fsm.event(Event::TimerExpired);
+        assert_eq!(actions, vec![Action::Run]);
+        let (fsm, actions) = fsm.event(Event::Completed);
+        assert_eq!(actions, vec![]);
+
+        let (_, actions) = fsm.event(failed());
+        assert_eq!(
+            actions,
+            vec![Action::Schedule {
+                delay: Duration::from_secs(4),
+            }]
+        );
+    }
+}

--- a/crates/machine-a-tron/src/dhcp_retry_runtime.rs
+++ b/crates/machine-a-tron/src/dhcp_retry_runtime.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rand::RngExt;
+
+use crate::dhcp_retry_fsm::{DHCP_RETRY_MAX_JITTER, Milliseconds};
+use crate::machine_fsm::Event as MachineEvent;
+use crate::power_shelf_fsm::Event as PowerShelfEvent;
+use crate::switch_fsm::Event as SwitchEvent;
+
+pub(super) fn sample_dhcp_retry_jitter() -> Milliseconds {
+    let max_jitter_milliseconds = DHCP_RETRY_MAX_JITTER.value();
+    Milliseconds::new(rand::rng().random_range(-max_jitter_milliseconds..=max_jitter_milliseconds))
+}
+
+impl MachineEvent {
+    pub(super) fn dhcp_failed() -> Self {
+        Self::DhcpFailed(sample_dhcp_retry_jitter())
+    }
+}
+
+impl SwitchEvent {
+    pub(super) fn dhcp_failed() -> Self {
+        Self::DhcpFailed(sample_dhcp_retry_jitter())
+    }
+}
+
+impl PowerShelfEvent {
+    pub(super) fn dhcp_failed() -> Self {
+        Self::DhcpFailed(sample_dhcp_retry_jitter())
+    }
+}

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -22,6 +22,8 @@ mod config;
 mod control_router;
 mod device_handle;
 mod device_simulator;
+mod dhcp_retry_fsm;
+mod dhcp_retry_runtime;
 mod dhcp_wrapper;
 mod dhcp_wrapper_udp;
 mod discovery_info;

--- a/crates/machine-a-tron/src/machine_fsm.rs
+++ b/crates/machine-a-tron/src/machine_fsm.rs
@@ -15,19 +15,37 @@
  * limitations under the License.
  */
 
+use std::time::Duration;
+
 use bmc_mock::{BmcEvent, MockPowerState};
 
+use crate::dhcp_retry_fsm::{
+    Action as RetryAction, DhcpRetryFsm, Event as RetryEvent, Milliseconds,
+};
 use crate::machine_state_machine::OsImage;
 
 type FsmReturn<Fsm> = (Fsm, Vec<Action>);
 
 #[derive(Clone, Copy, Debug)]
-pub(super) enum MachineFsm {
-    BmcInit { power_on: bool, bmc_only: bool },
-    Init,
+pub(super) struct MachineFsm {
+    state: MachineState,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MachineState {
+    BmcInit {
+        power_on: bool,
+        bmc_only: bool,
+        dhcp_retry: DhcpRetryFsm,
+    },
+    Init {
+        dhcp_retry: DhcpRetryFsm,
+    },
     MachineDown,
     DhcpComplete,
-    MachineUp { os_fsm: OsFsm },
+    MachineUp {
+        os_fsm: OsFsm,
+    },
     BmcOnlyMachineUp,
     BmcOnlyMachineDown,
 }
@@ -35,12 +53,52 @@ pub(super) enum MachineFsm {
 impl MachineFsm {
     pub(super) fn init(power_on: bool, bmc_only: bool) -> FsmReturn<Self> {
         (
-            Self::BmcInit { power_on, bmc_only },
+            Self {
+                state: MachineState::BmcInit {
+                    power_on,
+                    bmc_only,
+                    dhcp_retry: DhcpRetryFsm::new(),
+                },
+            },
             vec![Action::Dhcp(DhcpType::Bmc)],
         )
     }
 
-    pub(super) fn event(self, event: Event) -> (Self, Vec<Action>) {
+    pub(super) fn event(self, event: Event) -> FsmReturn<Self> {
+        let (state, actions) = self.state.event(event);
+        (Self { state }, actions)
+    }
+
+    pub(super) fn is_up(&self) -> bool {
+        self.state.is_up()
+    }
+
+    pub(super) fn is_bmc_only(&self) -> bool {
+        matches!(
+            self.state,
+            MachineState::BmcOnlyMachineUp | MachineState::BmcOnlyMachineDown
+        )
+    }
+
+    pub(super) fn is_bmc_initializing(&self) -> bool {
+        matches!(self.state, MachineState::BmcInit { .. })
+    }
+
+    pub(super) fn power_state(&self) -> MockPowerState {
+        self.state.power_state()
+    }
+
+    pub(super) fn state_string(&self) -> &'static str {
+        self.state.state_string()
+    }
+
+    pub(super) fn booted_os(&self) -> Option<OsImage> {
+        self.state.booted_os()
+    }
+}
+
+impl MachineState {
+    fn event(self, event: Event) -> FsmReturn<Self> {
         // A managed DPU that applied a staged NIC-mode flip is now a plain NIC,
         // not a DPU: converge it to the dormant BMC-only track from any active
         // state. Producing this transition here (rather than assigning the state
@@ -50,12 +108,20 @@ impl MachineFsm {
                 Self::BmcOnlyMachineUp | Self::BmcOnlyMachineDown => (self, vec![]),
                 // Clean up as the DPU parks: drop its relay handle and cached
                 // discovery state so the flipped NIC stops serving host DHCP.
-                _ => (Self::BmcOnlyMachineUp, vec![Action::CleanupOnPowerOff]),
+                _ => {
+                    let mut actions = self.abandon_dhcp_retry();
+                    actions.push(Action::CleanupOnPowerOff);
+                    (Self::BmcOnlyMachineUp, actions)
+                }
             };
         }
         match self {
-            Self::BmcInit { power_on, bmc_only } => self.fsm_bmc_init(event, power_on, bmc_only),
-            Self::Init => self.fsm_init(event),
+            Self::BmcInit {
+                power_on,
+                bmc_only,
+                dhcp_retry,
+            } => self.fsm_bmc_init(event, power_on, bmc_only, dhcp_retry),
+            Self::Init { dhcp_retry } => self.fsm_init(event, dhcp_retry),
             Self::MachineDown => self.fsm_machine_down(event),
             Self::DhcpComplete => self.fsm_dhcp_complete(event),
             Self::MachineUp { os_fsm } => self.fsm_machine_up(event, os_fsm),
@@ -65,17 +131,17 @@ impl MachineFsm {
         }
     }
 
-    pub(super) fn is_up(&self) -> bool {
+    fn is_up(&self) -> bool {
         matches!(self, Self::MachineUp { .. } | Self::BmcOnlyMachineUp)
     }
 
-    pub(super) fn power_state(&self) -> MockPowerState {
+    fn power_state(&self) -> MockPowerState {
         match self {
             Self::BmcInit { power_on: true, .. } => MockPowerState::On,
             Self::BmcInit {
                 power_on: false, ..
             } => MockPowerState::Off,
-            Self::Init => MockPowerState::On,
+            Self::Init { .. } => MockPowerState::On,
             Self::MachineDown => MockPowerState::Off,
             Self::DhcpComplete => MockPowerState::On,
             Self::MachineUp { .. } => MockPowerState::On,
@@ -84,10 +150,10 @@ impl MachineFsm {
         }
     }
 
-    pub(super) fn state_string(&self) -> &'static str {
+    fn state_string(&self) -> &'static str {
         match self {
             Self::BmcInit { .. } => "BmcInit",
-            Self::Init => "Init",
+            Self::Init { .. } => "Init",
             Self::MachineDown => "MachineDown",
             Self::DhcpComplete => "DhcpComplete",
             Self::MachineUp { .. } => "MachineUp",
@@ -96,7 +162,7 @@ impl MachineFsm {
         }
     }
 
-    pub(super) fn booted_os(&self) -> Option<OsImage> {
+    fn booted_os(&self) -> Option<OsImage> {
         match self {
             Self::MachineUp {
                 os_fsm: OsFsm::Scout { .. },
@@ -111,9 +177,38 @@ impl MachineFsm {
         }
     }
 
-    fn fsm_bmc_init(self, event: Event, power_on: bool, bmc_only: bool) -> (Self, Vec<Action>) {
+    fn fsm_bmc_init(
+        self,
+        event: Event,
+        power_on: bool,
+        bmc_only: bool,
+        dhcp_retry: DhcpRetryFsm,
+    ) -> (Self, Vec<Action>) {
         match event {
-            Event::DhcpComplete(DhcpType::Bmc) => {
+            Event::DhcpFailed(jitter) => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::Failed(jitter));
+                (
+                    Self::BmcInit {
+                        power_on,
+                        bmc_only,
+                        dhcp_retry,
+                    },
+                    map_retry_actions(actions, DhcpType::Bmc),
+                )
+            }
+            Event::DhcpRetryExpired => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::TimerExpired);
+                (
+                    Self::BmcInit {
+                        power_on,
+                        bmc_only,
+                        dhcp_retry,
+                    },
+                    map_retry_actions(actions, DhcpType::Bmc),
+                )
+            }
+            Event::DhcpComplete => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Completed);
                 let next_state = if bmc_only {
                     if power_on {
                         Self::BmcOnlyMachineUp
@@ -121,21 +216,25 @@ impl MachineFsm {
                         Self::BmcOnlyMachineDown
                     }
                 } else if power_on {
-                    Self::Init
+                    Self::Init {
+                        dhcp_retry: DhcpRetryFsm::new(),
+                    }
                 } else {
                     Self::MachineDown
                 };
-                let actions = if power_on && !bmc_only {
+                let mut actions = map_retry_actions(retry_actions, DhcpType::Bmc);
+                actions.extend(if power_on && !bmc_only {
                     vec![Action::SetupBmc, Action::SetTimer(Timer::MachineOn)]
                 } else {
                     vec![Action::SetupBmc]
-                };
+                });
                 (next_state, actions)
             }
             Event::PowerOn => (
                 Self::BmcInit {
                     bmc_only,
                     power_on: true,
+                    dhcp_retry,
                 },
                 if power_on {
                     vec![]
@@ -147,6 +246,7 @@ impl MachineFsm {
                 Self::BmcInit {
                     bmc_only,
                     power_on: false,
+                    dhcp_retry,
                 },
                 vec![],
             ),
@@ -154,6 +254,7 @@ impl MachineFsm {
                 Self::BmcInit {
                     bmc_only,
                     power_on: false,
+                    dhcp_retry,
                 },
                 vec![Action::SetTimer(Timer::PowerCycle)],
             ),
@@ -161,6 +262,7 @@ impl MachineFsm {
                 Self::BmcInit {
                     bmc_only,
                     power_on: true,
+                    dhcp_retry,
                 },
                 vec![],
             ),
@@ -168,8 +270,22 @@ impl MachineFsm {
         }
     }
 
-    fn fsm_init(self, event: Event) -> (Self, Vec<Action>) {
+    fn fsm_init(self, event: Event, dhcp_retry: DhcpRetryFsm) -> (Self, Vec<Action>) {
         match event {
+            Event::DhcpFailed(jitter) => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::Failed(jitter));
+                (
+                    Self::Init { dhcp_retry },
+                    map_retry_actions(actions, DhcpType::Machine),
+                )
+            }
+            Event::DhcpRetryExpired => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::TimerExpired);
+                (
+                    Self::Init { dhcp_retry },
+                    map_retry_actions(actions, DhcpType::Machine),
+                )
+            }
             Event::TimerAlert(Timer::MachineOn) => (
                 self,
                 vec![
@@ -177,11 +293,27 @@ impl MachineFsm {
                     Action::Dhcp(DhcpType::Machine),
                 ],
             ),
-            Event::DhcpComplete(DhcpType::Machine) => {
-                (Self::DhcpComplete, vec![Action::PxeBootRequest])
+            Event::DhcpComplete => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Completed);
+                let mut actions = map_retry_actions(retry_actions, DhcpType::Machine);
+                actions.push(Action::PxeBootRequest);
+                (Self::DhcpComplete, actions)
             }
-            Event::PowerCycle => self.machine_down_on_power_cycle(),
-            Event::PowerOff => self.machine_down_on_power_off(),
+            Event::PowerCycle => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Abandon);
+                let mut actions = map_retry_actions(retry_actions, DhcpType::Machine);
+                actions.extend([
+                    Action::CleanupOnPowerOff,
+                    Action::SetTimer(Timer::PowerCycle),
+                ]);
+                (Self::MachineDown, actions)
+            }
+            Event::PowerOff => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Abandon);
+                let mut actions = map_retry_actions(retry_actions, DhcpType::Machine);
+                actions.push(Action::CleanupOnPowerOff);
+                (Self::MachineDown, actions)
+            }
             _ => (self, vec![]),
         }
     }
@@ -189,9 +321,12 @@ impl MachineFsm {
     fn fsm_machine_down(self, event: Event) -> (Self, Vec<Action>) {
         match event {
             Event::PowerCycle => (self, vec![Action::SetTimer(Timer::PowerCycle)]),
-            Event::PowerOn | Event::TimerAlert(Timer::PowerCycle) => {
-                (Self::Init, vec![Action::SetTimer(Timer::MachineOn)])
-            }
+            Event::PowerOn | Event::TimerAlert(Timer::PowerCycle) => (
+                Self::Init {
+                    dhcp_retry: DhcpRetryFsm::new(),
+                },
+                vec![Action::SetTimer(Timer::MachineOn)],
+            ),
             _ => (self, vec![]),
         }
     }
@@ -275,11 +410,38 @@ impl MachineFsm {
             ],
         )
     }
+
+    fn abandon_dhcp_retry(self) -> Vec<Action> {
+        let (dhcp_retry, dhcp_type) = match self {
+            Self::BmcInit { dhcp_retry, .. } => (dhcp_retry, DhcpType::Bmc),
+            Self::Init { dhcp_retry } => (dhcp_retry, DhcpType::Machine),
+            _ => return vec![],
+        };
+        let (_, actions) = dhcp_retry.event(RetryEvent::Abandon);
+        map_retry_actions(actions, dhcp_type)
+    }
+}
+
+fn map_retry_actions(actions: Vec<RetryAction>, dhcp_type: DhcpType) -> Vec<Action> {
+    actions
+        .into_iter()
+        .map(|action| map_retry_action(action, dhcp_type))
+        .collect()
+}
+
+fn map_retry_action(action: RetryAction, dhcp_type: DhcpType) -> Action {
+    match action {
+        RetryAction::Schedule { delay } => Action::ScheduleDhcpRetry { delay },
+        RetryAction::Run => Action::Dhcp(dhcp_type),
+        RetryAction::Cancel => Action::CancelDhcpRetry,
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
 pub(super) enum Event {
-    DhcpComplete(DhcpType),
+    DhcpComplete,
+    DhcpFailed(Milliseconds),
+    DhcpRetryExpired,
     PowerOn,
     PowerOff,
     PowerCycle,
@@ -292,11 +454,20 @@ pub(super) enum Event {
     DpuFlippedToNicMode,
 }
 
+#[cfg(test)]
+impl Event {
+    fn dhcp_failed_with_jitter(jitter: Milliseconds) -> Self {
+        Self::DhcpFailed(jitter)
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub(super) enum Action {
     SetupBmc,
     SetTimer(Timer),
     Dhcp(DhcpType),
+    ScheduleDhcpRetry { delay: Duration },
+    CancelDhcpRetry,
     PxeBootRequest,
     InitialDiscoveryRequest(OsImage),
     AgentControlRequest(OsImage),
@@ -313,7 +484,7 @@ pub(super) enum Timer {
     DpuAgentControlPoll,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(super) enum DhcpType {
     Bmc,
     Machine,
@@ -477,17 +648,17 @@ mod tests {
             (false, true, ExpectedState::BmcOnlyMachineDown, false),
         ] {
             let (fsm, _) = MachineFsm::init(power_on, bmc_only);
-            let (fsm, actions) = fsm.event(Event::DhcpComplete(DhcpType::Bmc));
+            let (fsm, actions) = fsm.event(Event::DhcpComplete);
 
             assert!(
                 match expected_state {
-                    ExpectedState::Init => matches!(fsm, MachineFsm::Init),
-                    ExpectedState::MachineDown => matches!(fsm, MachineFsm::MachineDown),
+                    ExpectedState::Init => matches!(fsm.state, MachineState::Init { .. }),
+                    ExpectedState::MachineDown => matches!(fsm.state, MachineState::MachineDown),
                     ExpectedState::BmcOnlyMachineUp => {
-                        matches!(fsm, MachineFsm::BmcOnlyMachineUp)
+                        matches!(fsm.state, MachineState::BmcOnlyMachineUp)
                     }
                     ExpectedState::BmcOnlyMachineDown => {
-                        matches!(fsm, MachineFsm::BmcOnlyMachineDown)
+                        matches!(fsm.state, MachineState::BmcOnlyMachineDown)
                     }
                 },
                 "unexpected state for power_on={power_on}, bmc_only={bmc_only}"
@@ -504,5 +675,37 @@ mod tests {
                 "unexpected actions for power_on={power_on}, bmc_only={bmc_only}"
             );
         }
+    }
+
+    #[test]
+    fn bmc_retry_survives_power_changes() {
+        let (fsm, _) = MachineFsm::init(true, false);
+        let (fsm, actions) = fsm.event(Event::dhcp_failed_with_jitter(Milliseconds::new(0)));
+        assert!(matches!(
+            actions.as_slice(),
+            [Action::ScheduleDhcpRetry { delay }] if *delay == Duration::from_secs(4)
+        ));
+
+        let (fsm, actions) = fsm.event(Event::PowerOff);
+        assert!(actions.is_empty());
+        let (_, actions) = fsm.event(Event::DhcpRetryExpired);
+        assert!(matches!(actions.as_slice(), [Action::Dhcp(DhcpType::Bmc)]));
+    }
+
+    #[test]
+    fn power_off_abandons_machine_dhcp_retry() {
+        let (fsm, _) = MachineFsm::init(true, false);
+        let (fsm, _) = fsm.event(Event::DhcpComplete);
+        let (fsm, _) = fsm.event(Event::dhcp_failed_with_jitter(Milliseconds::new(0)));
+
+        let (fsm, actions) = fsm.event(Event::PowerOff);
+        assert!(matches!(fsm.state, MachineState::MachineDown));
+        assert!(matches!(
+            actions.as_slice(),
+            [Action::CancelDhcpRetry, Action::CleanupOnPowerOff]
+        ));
+
+        let (_, actions) = fsm.event(Event::DhcpRetryExpired);
+        assert!(actions.is_empty());
     }
 }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -30,7 +30,6 @@ use bmc_mock::{
 };
 use carbide_network::virtualization::build_dual_stack_list;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
-use rand::RngExt;
 use rpc::forge::{MachineArchitecture, MachineDiscoveryResult, ManagedHostNetworkConfigResponse};
 use rpc::forge_agent_control_response::Action;
 use serde::{Deserialize, Serialize};
@@ -55,53 +54,6 @@ use crate::{Guid, InfinibandPortState, PersistedDevice, PersistedDpuMachine};
 
 type DpuDhcpRelayHandle = oneshot::Sender<()>;
 
-// RFC 2131 section 4.1's Ethernet example starts at four seconds, doubles to a
-// 64-second base, and adds uniform jitter from -1 through +1 second.
-const DHCP_RETRY_INITIAL_DELAY: Duration = Duration::from_secs(4);
-const DHCP_RETRY_MAX_DELAY: Duration = Duration::from_secs(64);
-const DHCP_RETRY_JITTER_MILLIS: i64 = 1_000;
-
-fn dhcp_retry_delay(retry_attempt: u32, jitter_millis: i64) -> Duration {
-    assert!((-DHCP_RETRY_JITTER_MILLIS..=DHCP_RETRY_JITTER_MILLIS).contains(&jitter_millis));
-
-    let multiplier = 1_u32 << retry_attempt.min(4);
-    let base_delay = DHCP_RETRY_INITIAL_DELAY
-        .saturating_mul(multiplier)
-        .min(DHCP_RETRY_MAX_DELAY);
-    let delay_millis = i64::try_from(base_delay.as_millis()).expect("DHCP retry delay fits in i64")
-        + jitter_millis;
-    Duration::from_millis(u64::try_from(delay_millis).expect("DHCP retry delay is positive"))
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct DhcpRetryState {
-    attempt: u32,
-    deadline: Option<Instant>,
-}
-
-impl DhcpRetryState {
-    fn reset(&mut self) {
-        self.attempt = 0;
-        self.deadline = None;
-    }
-
-    // Determine how long a DHCP action needs to be parked in the queue
-    // without being re-attempted. Actions behind Dhcp(_) are also effectively
-    // blocked till the backoff expires.
-    fn remaining_backoff(&self, now: Instant) -> Option<Duration> {
-        let remaining = self.deadline?.saturating_duration_since(now);
-        (!remaining.is_zero()).then_some(remaining)
-    }
-
-    fn schedule_next(&mut self, now: Instant, jitter_millis: i64) -> Duration {
-        let retry_attempt = self.attempt;
-        self.attempt = self.attempt.saturating_add(1);
-        let retry_delay = dhcp_retry_delay(retry_attempt, jitter_millis);
-        self.deadline = Some(now + retry_delay);
-        retry_delay
-    }
-}
-
 /// Abandon queued work for the current boot when the machine powers off or
 /// cycles. A retrying in-band action would otherwise block the power-change
 /// cleanup and timer queued behind it.
@@ -111,14 +63,11 @@ impl DhcpRetryState {
 /// change arrives before that action runs.
 fn abandon_machine_actions_on_power_change(
     actions: &mut VecDeque<FsmAction>,
-    dhcp_retry: &mut DhcpRetryState,
+    preserve_dhcp_retry: bool,
 ) {
-    let abandoned_machine_dhcp = actions
-        .iter()
-        .any(|action| matches!(action, FsmAction::Dhcp(DhcpType::Machine)));
-
     actions.retain(|action| match action {
         FsmAction::SetupBmc | FsmAction::Dhcp(DhcpType::Bmc) | FsmAction::CleanupOnPowerOff => true,
+        FsmAction::ScheduleDhcpRetry { .. } | FsmAction::CancelDhcpRetry => preserve_dhcp_retry,
         FsmAction::SetTimer(
             Timer::PowerCycle
             | Timer::MachineOn
@@ -132,10 +81,6 @@ fn abandon_machine_actions_on_power_change(
         | FsmAction::DpuAgentNetworkObservation
         | FsmAction::BmcEvent(BmcEvent::PowerOn | BmcEvent::BootCompleted) => false,
     });
-
-    if abandoned_machine_dhcp {
-        dhcp_retry.reset();
-    }
 }
 
 fn direct_dhcp_relay_address(
@@ -185,7 +130,7 @@ pub(super) struct MachineStateMachine {
     bmc_dhcp_info: Option<DhcpResponseInfo>,
     machine_dhcp_info: Option<DhcpResponseInfo>,
     machine_interface_id: Option<MachineInterfaceId>,
-    dhcp_retry: DhcpRetryState,
+    dhcp_retry_deadline: Option<Instant>,
     machine_discovery_result: Option<MachineDiscoveryResult>,
 
     actions: VecDeque<FsmAction>,
@@ -389,7 +334,7 @@ impl MachineStateMachine {
             bmc_dhcp_info: None,
             machine_dhcp_info: None,
             machine_interface_id: None,
-            dhcp_retry: DhcpRetryState::default(),
+            dhcp_retry_deadline: None,
             machine_discovery_result: None,
             installed_os: initial_os_image,
             live_state: Arc::new(RwLock::new(LiveState::for_machine(
@@ -431,7 +376,7 @@ impl MachineStateMachine {
             bmc_injection: Arc::new(InjectionStore::new()),
             machine_dhcp_info: None,
             machine_interface_id: None,
-            dhcp_retry: DhcpRetryState::default(),
+            dhcp_retry_deadline: None,
             machine_discovery_result: None,
             machine_on_deadline: None,
             agent_polling_deadline: None,
@@ -470,6 +415,12 @@ impl MachineStateMachine {
                 self.agent_polling_deadline = None;
                 self.fsm_event(Event::TimerAlert(timer));
             }
+            if let Some(dhcp_retry_deadline) = self.dhcp_retry_deadline
+                && now > dhcp_retry_deadline
+            {
+                self.dhcp_retry_deadline = None;
+                self.fsm_event(Event::DhcpRetryExpired);
+            }
 
             if let Some(duration) = self.process_actions().await {
                 duration
@@ -478,6 +429,7 @@ impl MachineStateMachine {
                     self.machine_on_deadline,
                     self.power_cycle_deadline,
                     self.agent_polling_deadline.map(|v| v.0),
+                    self.dhcp_retry_deadline,
                 ]
                 .iter()
                 .flatten()
@@ -491,11 +443,6 @@ impl MachineStateMachine {
     async fn process_actions(&mut self) -> Option<Duration> {
         while let Some(action) = self.actions.front() {
             self.update_live_state();
-            if matches!(action, FsmAction::Dhcp(_))
-                && let Some(remaining) = self.dhcp_retry.remaining_backoff(Instant::now())
-            {
-                return Some(remaining);
-            }
             match action {
                 FsmAction::SetupBmc => match self.setup_bmc().await {
                     Ok((bmc_mock, bmc_state)) => {
@@ -534,22 +481,38 @@ impl MachineStateMachine {
                 FsmAction::Dhcp(DhcpType::Bmc) => match self.bmc_dhcp_discovery().await {
                     Ok(bmc_dhcp_info) => {
                         self.bmc_dhcp_info = Some(bmc_dhcp_info);
-                        self.dhcp_retry.reset();
                         self.actions.pop_front();
-                        self.fsm_event(Event::DhcpComplete(DhcpType::Bmc))
+                        self.fsm_event(Event::DhcpComplete)
                     }
-                    Err(_) => return Some(self.next_dhcp_retry_delay(DhcpType::Bmc)),
+                    Err(_) => {
+                        self.actions.pop_front();
+                        self.fsm_event(Event::dhcp_failed());
+                    }
                 },
                 FsmAction::Dhcp(DhcpType::Machine) => match self.machine_dhcp_discovery().await {
                     Ok(machine_dhcp_info) => {
                         self.machine_interface_id = None;
                         self.machine_dhcp_info = Some(machine_dhcp_info);
-                        self.dhcp_retry.reset();
                         self.actions.pop_front();
-                        self.fsm_event(Event::DhcpComplete(DhcpType::Machine))
+                        self.fsm_event(Event::DhcpComplete)
                     }
-                    Err(_) => return Some(self.next_dhcp_retry_delay(DhcpType::Machine)),
+                    Err(_) => {
+                        self.actions.pop_front();
+                        self.fsm_event(Event::dhcp_failed());
+                    }
                 },
+                FsmAction::ScheduleDhcpRetry { delay } => {
+                    tracing::debug!(
+                        retry_delay_milliseconds = delay.as_millis(),
+                        "scheduled DHCP retry"
+                    );
+                    self.dhcp_retry_deadline = Some(Instant::now() + *delay);
+                    self.actions.pop_front();
+                }
+                FsmAction::CancelDhcpRetry => {
+                    self.dhcp_retry_deadline = None;
+                    self.actions.pop_front();
+                }
                 FsmAction::PxeBootRequest => match self.pxe_boot_request().await {
                     Ok((os_image, machine_interface_id)) => {
                         self.machine_interface_id = machine_interface_id;
@@ -589,10 +552,7 @@ impl MachineStateMachine {
                             .as_ref()
                             .and_then(|bmc_state| bmc_state.bluefield_nic_mode())
                             .unwrap_or(false);
-                    let already_dormant = matches!(
-                        self.fsm,
-                        MachineFsm::BmcOnlyMachineUp | MachineFsm::BmcOnlyMachineDown
-                    );
+                    let already_dormant = self.fsm.is_bmc_only();
                     if flipped_to_nic && !already_dormant {
                         // Stop the converged DPU completely: drop queued boot actions
                         // and the pending timers, so `advance()` can't re-enqueue work
@@ -601,7 +561,6 @@ impl MachineStateMachine {
                         self.machine_on_deadline = None;
                         self.power_cycle_deadline = None;
                         self.agent_polling_deadline = None;
-                        self.dhcp_retry.reset();
                         // Let the FSM own the transition: it is returned by `event()`,
                         // not assigned here.
                         self.fsm_event(Event::DpuFlippedToNicMode);
@@ -665,23 +624,12 @@ impl MachineStateMachine {
         None
     }
 
-    fn next_dhcp_retry_delay(&mut self, dhcp_type: DhcpType) -> Duration {
-        let retry_attempt = self.dhcp_retry.attempt;
-        let jitter_millis =
-            rand::rng().random_range(-DHCP_RETRY_JITTER_MILLIS..=DHCP_RETRY_JITTER_MILLIS);
-        let retry_delay = self.dhcp_retry.schedule_next(Instant::now(), jitter_millis);
-        tracing::debug!(
-            ?dhcp_type,
-            retry_attempt,
-            retry_delay_milliseconds = retry_delay.as_millis(),
-            "scheduled DHCP retry"
-        );
-        retry_delay
-    }
-
     fn fsm_event(&mut self, event: Event) {
         if matches!(event, Event::PowerCycle | Event::PowerOff) {
-            abandon_machine_actions_on_power_change(&mut self.actions, &mut self.dhcp_retry);
+            abandon_machine_actions_on_power_change(
+                &mut self.actions,
+                self.fsm.is_bmc_initializing(),
+            );
 
             self.machine_on_deadline = None;
             self.power_cycle_deadline = None;
@@ -1540,169 +1488,6 @@ mod tests {
     }
 
     #[test]
-    fn dhcp_retry_delay_uses_rfc_2131_backoff() {
-        check_values(
-            [
-                Check {
-                    scenario: "first retry with minimum jitter",
-                    input: (0, -1_000),
-                    expect: Duration::from_secs(3),
-                },
-                Check {
-                    scenario: "first retry without jitter",
-                    input: (0, 0),
-                    expect: Duration::from_secs(4),
-                },
-                Check {
-                    scenario: "first retry with maximum jitter",
-                    input: (0, 1_000),
-                    expect: Duration::from_secs(5),
-                },
-                Check {
-                    scenario: "second retry doubles the base",
-                    input: (1, 0),
-                    expect: Duration::from_secs(8),
-                },
-                Check {
-                    scenario: "third retry doubles the base",
-                    input: (2, 0),
-                    expect: Duration::from_secs(16),
-                },
-                Check {
-                    scenario: "fourth retry doubles the base",
-                    input: (3, 0),
-                    expect: Duration::from_secs(32),
-                },
-                Check {
-                    scenario: "fifth retry reaches the cap",
-                    input: (4, 0),
-                    expect: Duration::from_secs(64),
-                },
-                Check {
-                    scenario: "later retry remains capped with minimum jitter",
-                    input: (u32::MAX, -1_000),
-                    expect: Duration::from_secs(63),
-                },
-                Check {
-                    scenario: "later retry remains capped with maximum jitter",
-                    input: (u32::MAX, 1_000),
-                    expect: Duration::from_secs(65),
-                },
-            ],
-            |(retry_attempt, jitter_millis)| dhcp_retry_delay(retry_attempt, jitter_millis),
-        );
-    }
-
-    #[test]
-    fn dhcp_retry_state_increments_and_resets() {
-        #[derive(Clone, Copy)]
-        enum Step {
-            Fail,
-            Reset,
-        }
-
-        check_values(
-            [
-                Check {
-                    scenario: "first failure uses attempt 0",
-                    input: &[Step::Fail][..],
-                    expect: (Duration::from_secs(4), 1),
-                },
-                Check {
-                    scenario: "consecutive failures advance the ladder",
-                    input: &[Step::Fail, Step::Fail, Step::Fail][..],
-                    expect: (Duration::from_secs(16), 3),
-                },
-                Check {
-                    scenario: "reset after failures restarts the ladder",
-                    input: &[Step::Fail, Step::Fail, Step::Reset, Step::Fail][..],
-                    expect: (Duration::from_secs(4), 1),
-                },
-                Check {
-                    scenario: "reset after a failure returns attempt to zero",
-                    input: &[Step::Fail, Step::Reset][..],
-                    expect: (Duration::ZERO, 0),
-                },
-            ],
-            |steps| {
-                let now = Instant::now();
-                let mut retry = DhcpRetryState::default();
-                let mut last_delay = Duration::ZERO;
-                for step in steps {
-                    match step {
-                        Step::Fail => last_delay = retry.schedule_next(now, 0),
-                        Step::Reset => {
-                            retry.reset();
-                            last_delay = Duration::ZERO;
-                        }
-                    }
-                }
-                (last_delay, retry.attempt)
-            },
-        );
-    }
-
-    #[test]
-    fn dhcp_retry_backoff_is_held_until_its_deadline() {
-        let scheduled_at = Instant::now();
-
-        check_values(
-            [
-                Check {
-                    scenario: "no retry scheduled yet",
-                    input: (0, Duration::ZERO),
-                    expect: None,
-                },
-                Check {
-                    scenario: "early wake-up while the backoff is pending",
-                    input: (1, Duration::from_secs(1)),
-                    expect: Some(Duration::from_secs(3)),
-                },
-                Check {
-                    scenario: "early wake-up on a later, longer rung",
-                    input: (3, Duration::from_secs(1)),
-                    expect: Some(Duration::from_secs(15)),
-                },
-                Check {
-                    scenario: "wake-up exactly at the deadline",
-                    input: (1, Duration::from_secs(4)),
-                    expect: None,
-                },
-                Check {
-                    scenario: "wake-up after the deadline",
-                    input: (1, Duration::from_secs(9)),
-                    expect: None,
-                },
-            ],
-            |(failures, elapsed)| {
-                let mut retry = DhcpRetryState::default();
-                for _ in 0..failures {
-                    retry.schedule_next(scheduled_at, 0);
-                }
-                retry.remaining_backoff(scheduled_at + elapsed)
-            },
-        );
-    }
-
-    /// What a power change leaves behind: the remaining action queue (rendered
-    /// through `Debug`, since `FsmAction` is not `PartialEq`), the retry ladder
-    /// position, and whether a retry deadline is still parked.
-    #[derive(Debug, Eq, PartialEq)]
-    struct PowerChangeOutcome {
-        remaining_actions: Vec<String>,
-        attempt: u32,
-        backoff_pending: bool,
-    }
-
-    fn outcome(actions: &VecDeque<FsmAction>, retry: &DhcpRetryState) -> PowerChangeOutcome {
-        PowerChangeOutcome {
-            remaining_actions: actions.iter().map(|action| format!("{action:?}")).collect(),
-            attempt: retry.attempt,
-            backoff_pending: retry.deadline.is_some(),
-        }
-    }
-
-    #[test]
     fn power_change_abandons_queued_machine_actions() {
         let queued = |actions: &[FsmAction]| VecDeque::from(actions.to_vec());
 
@@ -1710,12 +1495,8 @@ mod tests {
             [
                 Check {
                     scenario: "failing machine DHCP no longer blocks power-off cleanup",
-                    input: (queued(&[FsmAction::Dhcp(DhcpType::Machine)]), 3),
-                    expect: PowerChangeOutcome {
-                        remaining_actions: vec![],
-                        attempt: 0,
-                        backoff_pending: false,
-                    },
+                    input: (queued(&[FsmAction::Dhcp(DhcpType::Machine)]), false),
+                    expect: vec![],
                 },
                 Check {
                     scenario: "in-band work from the previous boot is abandoned",
@@ -1735,51 +1516,67 @@ mod tests {
                             FsmAction::BmcEvent(BmcEvent::BootCompleted),
                             FsmAction::CleanupOnPowerOff,
                         ]),
-                        1,
+                        false,
                     ),
-                    expect: PowerChangeOutcome {
-                        remaining_actions: vec![
-                            format!("{:?}", FsmAction::SetupBmc),
-                            format!("{:?}", FsmAction::CleanupOnPowerOff),
-                        ],
-                        attempt: 0,
-                        backoff_pending: false,
-                    },
+                    expect: vec![
+                        format!("{:?}", FsmAction::SetupBmc),
+                        format!("{:?}", FsmAction::CleanupOnPowerOff),
+                    ],
                 },
                 Check {
-                    scenario: "out-of-band BMC DHCP keeps its backoff across a power change",
-                    input: (queued(&[FsmAction::Dhcp(DhcpType::Bmc)]), 2),
-                    expect: PowerChangeOutcome {
-                        remaining_actions: vec![format!("{:?}", FsmAction::Dhcp(DhcpType::Bmc))],
-                        attempt: 2,
-                        backoff_pending: true,
-                    },
+                    scenario: "out-of-band BMC DHCP stays queued across a power change",
+                    input: (queued(&[FsmAction::Dhcp(DhcpType::Bmc)]), true),
+                    expect: vec![format!("{:?}", FsmAction::Dhcp(DhcpType::Bmc))],
+                },
+                Check {
+                    scenario: "BMC retry work stays queued during BMC initialization",
+                    input: (
+                        queued(&[
+                            FsmAction::ScheduleDhcpRetry {
+                                delay: Duration::from_secs(4),
+                            },
+                            FsmAction::CancelDhcpRetry,
+                        ]),
+                        true,
+                    ),
+                    expect: vec![
+                        format!(
+                            "{:?}",
+                            FsmAction::ScheduleDhcpRetry {
+                                delay: Duration::from_secs(4),
+                            }
+                        ),
+                        format!("{:?}", FsmAction::CancelDhcpRetry),
+                    ],
+                },
+                Check {
+                    scenario: "machine retry work is abandoned after BMC initialization",
+                    input: (
+                        queued(&[
+                            FsmAction::ScheduleDhcpRetry {
+                                delay: Duration::from_secs(4),
+                            },
+                            FsmAction::CancelDhcpRetry,
+                        ]),
+                        false,
+                    ),
+                    expect: vec![],
                 },
                 Check {
                     scenario: "power change without queued in-band work changes nothing",
                     input: (
                         queued(&[FsmAction::SetupBmc, FsmAction::CleanupOnPowerOff]),
-                        0,
+                        false,
                     ),
-                    expect: PowerChangeOutcome {
-                        remaining_actions: vec![
-                            format!("{:?}", FsmAction::SetupBmc),
-                            format!("{:?}", FsmAction::CleanupOnPowerOff),
-                        ],
-                        attempt: 0,
-                        backoff_pending: false,
-                    },
+                    expect: vec![
+                        format!("{:?}", FsmAction::SetupBmc),
+                        format!("{:?}", FsmAction::CleanupOnPowerOff),
+                    ],
                 },
             ],
-            |(mut actions, failures)| {
-                let now = Instant::now();
-                let mut retry = DhcpRetryState::default();
-                for _ in 0..failures {
-                    retry.schedule_next(now, 0);
-                }
-
-                abandon_machine_actions_on_power_change(&mut actions, &mut retry);
-                outcome(&actions, &retry)
+            |(mut actions, preserve_dhcp_retry)| {
+                abandon_machine_actions_on_power_change(&mut actions, preserve_dhcp_retry);
+                actions.iter().map(|action| format!("{action:?}")).collect()
             },
         );
     }

--- a/crates/machine-a-tron/src/power_shelf_fsm.rs
+++ b/crates/machine-a-tron/src/power_shelf_fsm.rs
@@ -14,16 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::time::Duration;
+
 use bmc_mock::MockPowerState;
 
+use crate::dhcp_retry_fsm::{
+    Action as RetryAction, DhcpRetryFsm, Event as RetryEvent, Milliseconds,
+};
+
 type FsmReturn = (PowerShelfFsm, Vec<Action>);
+type StateReturn = (PowerShelfState, Vec<Action>);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum PowerShelfFsm {
+pub(super) struct PowerShelfFsm {
+    state: PowerShelfState,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PowerShelfState {
     BmcInit {
         power_on: bool,
         power_cycle_pending: bool,
         paused: bool,
+        dhcp_retry: DhcpRetryFsm,
     },
     DeviceUp {
         paused: bool,
@@ -37,16 +50,38 @@ pub(super) enum PowerShelfFsm {
 impl PowerShelfFsm {
     pub(super) fn init(power_on: bool) -> FsmReturn {
         (
-            Self::BmcInit {
-                power_on,
-                power_cycle_pending: false,
-                paused: true,
+            Self {
+                state: PowerShelfState::BmcInit {
+                    power_on,
+                    power_cycle_pending: false,
+                    paused: true,
+                    dhcp_retry: DhcpRetryFsm::new(),
+                },
             },
             vec![Action::Dhcp],
         )
     }
 
     pub(super) fn event(self, event: Event) -> FsmReturn {
+        let (state, actions) = self.state.event(event);
+        (Self { state }, actions)
+    }
+
+    pub(super) fn is_paused(&self) -> bool {
+        self.state.is_paused()
+    }
+
+    pub(super) fn power_state(&self) -> MockPowerState {
+        self.state.power_state()
+    }
+
+    pub(super) fn state_string(&self) -> &'static str {
+        self.state.state_string()
+    }
+}
+
+impl PowerShelfState {
+    fn event(self, event: Event) -> (Self, Vec<Action>) {
         match event {
             Event::Pause => return (self.with_paused(true), vec![]),
             Event::Resume => return (self.with_paused(false), vec![]),
@@ -58,7 +93,8 @@ impl PowerShelfFsm {
                 power_on,
                 power_cycle_pending,
                 paused,
-            } => self.fsm_bmc_init(event, power_on, power_cycle_pending, paused),
+                dhcp_retry,
+            } => self.fsm_bmc_init(event, power_on, power_cycle_pending, paused, dhcp_retry),
             Self::DeviceUp { paused } => self.fsm_device_up(event, paused),
             Self::DeviceDown {
                 power_cycle_pending,
@@ -67,7 +103,7 @@ impl PowerShelfFsm {
         }
     }
 
-    pub(super) fn is_paused(&self) -> bool {
+    fn is_paused(&self) -> bool {
         match self {
             Self::BmcInit { paused, .. }
             | Self::DeviceUp { paused }
@@ -75,7 +111,7 @@ impl PowerShelfFsm {
         }
     }
 
-    pub(super) fn power_state(&self) -> MockPowerState {
+    fn power_state(&self) -> MockPowerState {
         match self {
             Self::BmcInit { power_on: true, .. } | Self::DeviceUp { .. } => MockPowerState::On,
             Self::BmcInit {
@@ -85,7 +121,7 @@ impl PowerShelfFsm {
         }
     }
 
-    pub(super) fn state_string(&self) -> &'static str {
+    fn state_string(&self) -> &'static str {
         match self {
             Self::BmcInit { .. } => "BmcInit",
             Self::DeviceUp { .. } => "BmcOnly/DeviceUp",
@@ -98,11 +134,13 @@ impl PowerShelfFsm {
             Self::BmcInit {
                 power_on,
                 power_cycle_pending,
+                dhcp_retry,
                 ..
             } => Self::BmcInit {
                 power_on,
                 power_cycle_pending,
                 paused,
+                dhcp_retry,
             },
             Self::DeviceUp { .. } => Self::DeviceUp { paused },
             Self::DeviceDown {
@@ -121,24 +159,53 @@ impl PowerShelfFsm {
         power_on: bool,
         power_cycle_pending: bool,
         paused: bool,
-    ) -> FsmReturn {
+        dhcp_retry: DhcpRetryFsm,
+    ) -> StateReturn {
         match event {
-            Event::DhcpComplete => (
-                if power_on {
+            Event::DhcpFailed(jitter) => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::Failed(jitter));
+                (
+                    Self::BmcInit {
+                        power_on,
+                        power_cycle_pending,
+                        paused,
+                        dhcp_retry,
+                    },
+                    actions.into_iter().map(map_retry_action).collect(),
+                )
+            }
+            Event::DhcpRetryExpired => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::TimerExpired);
+                (
+                    Self::BmcInit {
+                        power_on,
+                        power_cycle_pending,
+                        paused,
+                        dhcp_retry,
+                    },
+                    actions.into_iter().map(map_retry_action).collect(),
+                )
+            }
+            Event::DhcpComplete => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Completed);
+                let next_state = if power_on {
                     Self::DeviceUp { paused }
                 } else {
                     Self::DeviceDown {
                         power_cycle_pending,
                         paused,
                     }
-                },
-                vec![Action::SetupBmc],
-            ),
+                };
+                let mut actions: Vec<_> = retry_actions.into_iter().map(map_retry_action).collect();
+                actions.push(Action::SetupBmc);
+                (next_state, actions)
+            }
             Event::PowerOn => (
                 Self::BmcInit {
                     power_on: true,
                     power_cycle_pending: false,
                     paused,
+                    dhcp_retry,
                 },
                 cancel_timer_action(power_cycle_pending),
             ),
@@ -147,6 +214,7 @@ impl PowerShelfFsm {
                     power_on: false,
                     power_cycle_pending: false,
                     paused,
+                    dhcp_retry,
                 },
                 cancel_timer_action(power_cycle_pending),
             ),
@@ -155,6 +223,7 @@ impl PowerShelfFsm {
                     power_on: false,
                     power_cycle_pending: true,
                     paused,
+                    dhcp_retry,
                 },
                 vec![Action::SetTimer(Timer::PowerCycle)],
             ),
@@ -163,6 +232,7 @@ impl PowerShelfFsm {
                     power_on: true,
                     power_cycle_pending: false,
                     paused,
+                    dhcp_retry,
                 },
                 vec![],
             ),
@@ -171,7 +241,7 @@ impl PowerShelfFsm {
         }
     }
 
-    fn fsm_device_up(self, event: Event, paused: bool) -> FsmReturn {
+    fn fsm_device_up(self, event: Event, paused: bool) -> StateReturn {
         match event {
             Event::PowerOff => (
                 Self::DeviceDown {
@@ -191,7 +261,7 @@ impl PowerShelfFsm {
         }
     }
 
-    fn fsm_device_down(self, event: Event, power_cycle_pending: bool, paused: bool) -> FsmReturn {
+    fn fsm_device_down(self, event: Event, power_cycle_pending: bool, paused: bool) -> StateReturn {
         match event {
             Event::PowerOn => (
                 Self::DeviceUp { paused },
@@ -220,6 +290,14 @@ impl PowerShelfFsm {
     }
 }
 
+fn map_retry_action(action: RetryAction) -> Action {
+    match action {
+        RetryAction::Schedule { delay } => Action::ScheduleDhcpRetry { delay },
+        RetryAction::Run => Action::Dhcp,
+        RetryAction::Cancel => Action::CancelDhcpRetry,
+    }
+}
+
 fn cancel_timer_action(power_cycle_pending: bool) -> Vec<Action> {
     if power_cycle_pending {
         vec![Action::CancelTimer(Timer::PowerCycle)]
@@ -231,6 +309,8 @@ fn cancel_timer_action(power_cycle_pending: bool) -> Vec<Action> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum Event {
     DhcpComplete,
+    DhcpFailed(Milliseconds),
+    DhcpRetryExpired,
     PowerOn,
     PowerOff,
     PowerCycle,
@@ -239,9 +319,18 @@ pub(super) enum Event {
     Resume,
 }
 
+#[cfg(test)]
+impl Event {
+    fn dhcp_failed_with_jitter(jitter: Milliseconds) -> Self {
+        Self::DhcpFailed(jitter)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum Action {
     Dhcp,
+    ScheduleDhcpRetry { delay: Duration },
+    CancelDhcpRetry,
     SetupBmc,
     SetTimer(Timer),
     CancelTimer(Timer),
@@ -258,6 +347,21 @@ mod tests {
 
     use super::*;
 
+    type TestFsm = PowerShelfFsm;
+
+    fn with_state(state: PowerShelfState) -> TestFsm {
+        PowerShelfFsm { state }
+    }
+
+    fn bmc_init(power_on: bool, power_cycle_pending: bool, paused: bool) -> PowerShelfState {
+        PowerShelfState::BmcInit {
+            power_on,
+            power_cycle_pending,
+            paused,
+            dhcp_retry: DhcpRetryFsm::new(),
+        }
+    }
+
     #[test]
     fn power_shelf_transitions() {
         check_values(
@@ -265,108 +369,112 @@ mod tests {
                 Check {
                     scenario: "new power shelf completes BMC DHCP powered off",
                     input: (
-                        PowerShelfFsm::BmcInit {
-                            power_on: false,
-                            power_cycle_pending: false,
-                            paused: false,
-                        },
+                        with_state(bmc_init(false, false, false)),
                         Event::DhcpComplete,
                     ),
                     expect: (
-                        PowerShelfFsm::DeviceDown {
+                        with_state(PowerShelfState::DeviceDown {
                             power_cycle_pending: false,
                             paused: false,
-                        },
+                        }),
                         vec![Action::SetupBmc],
                     ),
                 },
                 Check {
                     scenario: "persisted power shelf completes BMC DHCP powered on",
                     input: (
-                        PowerShelfFsm::BmcInit {
-                            power_on: true,
-                            power_cycle_pending: false,
-                            paused: false,
-                        },
+                        with_state(bmc_init(true, false, false)),
                         Event::DhcpComplete,
                     ),
                     expect: (
-                        PowerShelfFsm::DeviceUp { paused: false },
+                        with_state(PowerShelfState::DeviceUp { paused: false }),
                         vec![Action::SetupBmc],
                     ),
                 },
                 Check {
                     scenario: "powered shelf begins a power cycle",
-                    input: (PowerShelfFsm::DeviceUp { paused: false }, Event::PowerCycle),
+                    input: (
+                        with_state(PowerShelfState::DeviceUp { paused: false }),
+                        Event::PowerCycle,
+                    ),
                     expect: (
-                        PowerShelfFsm::DeviceDown {
+                        with_state(PowerShelfState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         vec![Action::SetTimer(Timer::PowerCycle)],
                     ),
                 },
                 Check {
                     scenario: "power-cycle timer restores power",
                     input: (
-                        PowerShelfFsm::DeviceDown {
+                        with_state(PowerShelfState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         Event::TimerAlert(Timer::PowerCycle),
                     ),
-                    expect: (PowerShelfFsm::DeviceUp { paused: false }, vec![]),
+                    expect: (
+                        with_state(PowerShelfState::DeviceUp { paused: false }),
+                        vec![],
+                    ),
                 },
                 Check {
                     scenario: "explicit power-on cancels a pending power cycle",
                     input: (
-                        PowerShelfFsm::DeviceDown {
+                        with_state(PowerShelfState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         Event::PowerOn,
                     ),
                     expect: (
-                        PowerShelfFsm::DeviceUp { paused: false },
+                        with_state(PowerShelfState::DeviceUp { paused: false }),
                         vec![Action::CancelTimer(Timer::PowerCycle)],
                     ),
                 },
                 Check {
                     scenario: "a new power cycle replaces the pending timer",
                     input: (
-                        PowerShelfFsm::DeviceDown {
+                        with_state(PowerShelfState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         Event::PowerCycle,
                     ),
                     expect: (
-                        PowerShelfFsm::DeviceDown {
+                        with_state(PowerShelfState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         vec![Action::SetTimer(Timer::PowerCycle)],
                     ),
                 },
                 Check {
                     scenario: "power-shelf processing can be paused",
-                    input: (PowerShelfFsm::DeviceUp { paused: false }, Event::Pause),
-                    expect: (PowerShelfFsm::DeviceUp { paused: true }, vec![]),
+                    input: (
+                        with_state(PowerShelfState::DeviceUp { paused: false }),
+                        Event::Pause,
+                    ),
+                    expect: (
+                        with_state(PowerShelfState::DeviceUp { paused: true }),
+                        vec![],
+                    ),
                 },
                 Check {
                     scenario: "power-shelf processing can be resumed",
                     input: (
-                        PowerShelfFsm::DeviceDown {
+                        with_state(PowerShelfState::DeviceDown {
                             power_cycle_pending: false,
                             paused: true,
-                        },
+                        }),
                         Event::Resume,
                     ),
                     expect: (
-                        PowerShelfFsm::DeviceDown {
+                        with_state(PowerShelfState::DeviceDown {
                             power_cycle_pending: false,
                             paused: false,
-                        },
+                        }),
                         vec![],
                     ),
                 },
@@ -377,15 +485,16 @@ mod tests {
 
     #[test]
     fn power_off_supersedes_power_cycle() {
-        let (fsm, _) = PowerShelfFsm::DeviceUp { paused: false }.event(Event::PowerCycle);
+        let (fsm, _) =
+            with_state(PowerShelfState::DeviceUp { paused: false }).event(Event::PowerCycle);
         let (fsm, actions) = fsm.event(Event::PowerOff);
         assert_eq!(
             (fsm, actions,),
             (
-                PowerShelfFsm::DeviceDown {
+                with_state(PowerShelfState::DeviceDown {
                     power_cycle_pending: false,
                     paused: false,
-                },
+                }),
                 vec![Action::CancelTimer(Timer::PowerCycle)],
             )
         );
@@ -394,12 +503,31 @@ mod tests {
         assert_eq!(
             (fsm, actions,),
             (
-                PowerShelfFsm::DeviceDown {
+                with_state(PowerShelfState::DeviceDown {
                     power_cycle_pending: false,
                     paused: false,
-                },
+                }),
                 vec![],
             )
         );
+    }
+
+    #[test]
+    fn bmc_retry_survives_pause_and_power_changes() {
+        let fsm = with_state(bmc_init(false, false, false));
+        let (fsm, actions) = fsm.event(Event::dhcp_failed_with_jitter(Milliseconds::new(0)));
+        assert_eq!(
+            actions,
+            vec![Action::ScheduleDhcpRetry {
+                delay: Duration::from_secs(4),
+            }]
+        );
+
+        let (fsm, actions) = fsm.event(Event::Pause);
+        assert!(actions.is_empty());
+        let (fsm, actions) = fsm.event(Event::PowerCycle);
+        assert_eq!(actions, vec![Action::SetTimer(Timer::PowerCycle)]);
+        let (_, actions) = fsm.event(Event::DhcpRetryExpired);
+        assert_eq!(actions, vec![Action::Dhcp]);
     }
 }

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -116,6 +116,7 @@ pub(crate) struct PowerShelfActor {
     actions: VecDeque<Action>,
     run_alarm: Option<AlarmId>,
     power_cycle_alarm: Option<AlarmId>,
+    dhcp_retry_alarm: Option<AlarmId>,
 }
 
 impl PowerShelfActor {
@@ -144,6 +145,7 @@ impl PowerShelfActor {
             actions: actions.into_iter().collect(),
             run_alarm: None,
             power_cycle_alarm: None,
+            dhcp_retry_alarm: None,
         }
     }
 
@@ -183,6 +185,7 @@ impl PowerShelfActor {
             actions: actions.into_iter().collect(),
             run_alarm: None,
             power_cycle_alarm: None,
+            dhcp_retry_alarm: None,
         }
     }
 
@@ -247,9 +250,32 @@ impl PowerShelfActor {
                             error = %error,
                             "Power-shelf BMC DHCP failed",
                         );
-                        return Some(self.config.run_interval_working);
+                        self.actions.pop_front();
+                        self.fsm_event(Event::dhcp_failed());
                     }
                 },
+                Action::ScheduleDhcpRetry { delay } => {
+                    tracing::debug!(
+                        retry_delay_milliseconds = delay.as_millis(),
+                        "scheduled power-shelf DHCP retry"
+                    );
+                    self.dhcp_retry_alarm = Some(
+                        mailbox
+                            .replace_alarm(
+                                self.dhcp_retry_alarm.take(),
+                                saturating_add_duration_to_instant(Instant::now(), delay),
+                                PowerShelfMessage::DhcpRetryExpired,
+                            )
+                            .expect("running actor mailbox must be open"),
+                    );
+                    self.actions.pop_front();
+                }
+                Action::CancelDhcpRetry => {
+                    if let Some(alarm_id) = self.dhcp_retry_alarm.take() {
+                        mailbox.cancel(alarm_id);
+                    }
+                    self.actions.pop_front();
+                }
                 Action::SetupBmc => match self.setup_bmc(mailbox).await {
                     Ok(()) => {
                         self.actions.pop_front();
@@ -421,6 +447,7 @@ impl PowerShelfActor {
 enum PowerShelfMessage {
     Run,
     PowerCycleExpired,
+    DhcpRetryExpired,
     SetPaused(bool),
     Bmc(BmcCommand),
     Stop,
@@ -437,6 +464,10 @@ impl ActorCallbacks<PowerShelfMessage> for PowerShelfActor {
             PowerShelfMessage::PowerCycleExpired => {
                 self.power_cycle_alarm = None;
                 self.fsm_event(Event::TimerAlert(Timer::PowerCycle));
+            }
+            PowerShelfMessage::DhcpRetryExpired => {
+                self.dhcp_retry_alarm = None;
+                self.fsm_event(Event::DhcpRetryExpired);
             }
             PowerShelfMessage::Stop => return ActorResult::Stop,
             PowerShelfMessage::SetPaused(paused) => {

--- a/crates/machine-a-tron/src/switch_fsm.rs
+++ b/crates/machine-a-tron/src/switch_fsm.rs
@@ -14,19 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::time::Duration;
+
 use bmc_mock::MockPowerState;
 
+use crate::dhcp_retry_fsm::{
+    Action as RetryAction, DhcpRetryFsm, Event as RetryEvent, Milliseconds,
+};
+
 type FsmReturn = (SwitchFsm, Vec<Action>);
+type StateReturn = (SwitchState, Vec<Action>);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum SwitchFsm {
+pub(super) struct SwitchFsm {
+    state: SwitchState,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SwitchState {
     BmcInit {
         power_on: bool,
         power_cycle_pending: bool,
         paused: bool,
+        dhcp_retry: DhcpRetryFsm,
     },
     NvosInit {
         paused: bool,
+        dhcp_retry: DhcpRetryFsm,
     },
     DeviceUp {
         paused: bool,
@@ -40,16 +54,38 @@ pub(super) enum SwitchFsm {
 impl SwitchFsm {
     pub(super) fn init(power_on: bool) -> FsmReturn {
         (
-            Self::BmcInit {
-                power_on,
-                power_cycle_pending: false,
-                paused: true,
+            Self {
+                state: SwitchState::BmcInit {
+                    power_on,
+                    power_cycle_pending: false,
+                    paused: true,
+                    dhcp_retry: DhcpRetryFsm::new(),
+                },
             },
             vec![Action::Dhcp(DhcpEndpoint::Bmc)],
         )
     }
 
     pub(super) fn event(self, event: Event) -> FsmReturn {
+        let (state, actions) = self.state.event(event);
+        (Self { state }, actions)
+    }
+
+    pub(super) fn is_paused(&self) -> bool {
+        self.state.is_paused()
+    }
+
+    pub(super) fn power_state(&self) -> MockPowerState {
+        self.state.power_state()
+    }
+
+    pub(super) fn state_string(&self) -> &'static str {
+        self.state.state_string()
+    }
+}
+
+impl SwitchState {
+    fn event(self, event: Event) -> StateReturn {
         match event {
             Event::Pause => return (self.with_paused(true), vec![]),
             Event::Resume => return (self.with_paused(false), vec![]),
@@ -61,8 +97,9 @@ impl SwitchFsm {
                 power_on,
                 power_cycle_pending,
                 paused,
-            } => self.fsm_bmc_init(event, power_on, power_cycle_pending, paused),
-            Self::NvosInit { paused } => self.fsm_nvos_init(event, paused),
+                dhcp_retry,
+            } => self.fsm_bmc_init(event, power_on, power_cycle_pending, paused, dhcp_retry),
+            Self::NvosInit { paused, dhcp_retry } => self.fsm_nvos_init(event, paused, dhcp_retry),
             Self::DeviceUp { paused } => self.fsm_device_up(event, paused),
             Self::DeviceDown {
                 power_cycle_pending,
@@ -71,16 +108,16 @@ impl SwitchFsm {
         }
     }
 
-    pub(super) fn is_paused(&self) -> bool {
+    fn is_paused(&self) -> bool {
         match self {
             Self::BmcInit { paused, .. }
-            | Self::NvosInit { paused }
+            | Self::NvosInit { paused, .. }
             | Self::DeviceUp { paused }
             | Self::DeviceDown { paused, .. } => *paused,
         }
     }
 
-    pub(super) fn power_state(&self) -> MockPowerState {
+    fn power_state(&self) -> MockPowerState {
         match self {
             Self::BmcInit { power_on: true, .. }
             | Self::NvosInit { .. }
@@ -92,7 +129,7 @@ impl SwitchFsm {
         }
     }
 
-    pub(super) fn state_string(&self) -> &'static str {
+    fn state_string(&self) -> &'static str {
         match self {
             Self::BmcInit { .. } => "BmcInit",
             Self::NvosInit { .. } => "NvosInit",
@@ -106,13 +143,15 @@ impl SwitchFsm {
             Self::BmcInit {
                 power_on,
                 power_cycle_pending,
+                dhcp_retry,
                 ..
             } => Self::BmcInit {
                 power_on,
                 power_cycle_pending,
                 paused,
+                dhcp_retry,
             },
-            Self::NvosInit { .. } => Self::NvosInit { paused },
+            Self::NvosInit { dhcp_retry, .. } => Self::NvosInit { paused, dhcp_retry },
             Self::DeviceUp { .. } => Self::DeviceUp { paused },
             Self::DeviceDown {
                 power_cycle_pending,
@@ -130,28 +169,60 @@ impl SwitchFsm {
         power_on: bool,
         power_cycle_pending: bool,
         paused: bool,
-    ) -> FsmReturn {
+        dhcp_retry: DhcpRetryFsm,
+    ) -> StateReturn {
         match event {
-            Event::DhcpComplete(DhcpEndpoint::Bmc) => (
-                if power_on {
-                    Self::NvosInit { paused }
+            Event::DhcpFailed(jitter) => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::Failed(jitter));
+                (
+                    Self::BmcInit {
+                        power_on,
+                        power_cycle_pending,
+                        paused,
+                        dhcp_retry,
+                    },
+                    map_retry_actions(actions, DhcpEndpoint::Bmc),
+                )
+            }
+            Event::DhcpRetryExpired => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::TimerExpired);
+                (
+                    Self::BmcInit {
+                        power_on,
+                        power_cycle_pending,
+                        paused,
+                        dhcp_retry,
+                    },
+                    map_retry_actions(actions, DhcpEndpoint::Bmc),
+                )
+            }
+            Event::DhcpComplete => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Completed);
+                let next_state = if power_on {
+                    Self::NvosInit {
+                        paused,
+                        dhcp_retry: DhcpRetryFsm::new(),
+                    }
                 } else {
                     Self::DeviceDown {
                         power_cycle_pending,
                         paused,
                     }
-                },
-                if power_on {
+                };
+                let mut actions = map_retry_actions(retry_actions, DhcpEndpoint::Bmc);
+                actions.extend(if power_on {
                     vec![Action::SetupBmc, Action::Dhcp(DhcpEndpoint::Nvos)]
                 } else {
                     vec![Action::SetupBmc]
-                },
-            ),
+                });
+                (next_state, actions)
+            }
             Event::PowerOn => (
                 Self::BmcInit {
                     power_on: true,
                     power_cycle_pending: false,
                     paused,
+                    dhcp_retry,
                 },
                 cancel_timer_action(power_cycle_pending),
             ),
@@ -160,6 +231,7 @@ impl SwitchFsm {
                     power_on: false,
                     power_cycle_pending: false,
                     paused,
+                    dhcp_retry,
                 },
                 cancel_timer_action(power_cycle_pending),
             ),
@@ -168,6 +240,7 @@ impl SwitchFsm {
                     power_on: false,
                     power_cycle_pending: true,
                     paused,
+                    dhcp_retry,
                 },
                 vec![Action::SetTimer(Timer::PowerCycle)],
             ),
@@ -176,18 +249,68 @@ impl SwitchFsm {
                     power_on: true,
                     power_cycle_pending: false,
                     paused,
+                    dhcp_retry,
                 },
                 vec![],
             ),
             Event::TimerAlert(Timer::PowerCycle) => (self, vec![]),
-            Event::DhcpComplete(DhcpEndpoint::Nvos) => (self, vec![]),
-            Event::Pause | Event::Resume => unreachable!("handled before state dispatch"),
+            _ => (self, vec![]),
         }
     }
 
-    fn fsm_nvos_init(self, event: Event, paused: bool) -> FsmReturn {
+    fn fsm_nvos_init(self, event: Event, paused: bool, dhcp_retry: DhcpRetryFsm) -> StateReturn {
         match event {
-            Event::DhcpComplete(DhcpEndpoint::Nvos) => (Self::DeviceUp { paused }, vec![]),
+            Event::DhcpFailed(jitter) => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::Failed(jitter));
+                (
+                    Self::NvosInit { paused, dhcp_retry },
+                    map_retry_actions(actions, DhcpEndpoint::Nvos),
+                )
+            }
+            Event::DhcpRetryExpired => {
+                let (dhcp_retry, actions) = dhcp_retry.event(RetryEvent::TimerExpired);
+                (
+                    Self::NvosInit { paused, dhcp_retry },
+                    map_retry_actions(actions, DhcpEndpoint::Nvos),
+                )
+            }
+            Event::DhcpComplete => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Completed);
+                (
+                    Self::DeviceUp { paused },
+                    map_retry_actions(retry_actions, DhcpEndpoint::Nvos),
+                )
+            }
+            Event::PowerOff => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Abandon);
+                let mut actions = map_retry_actions(retry_actions, DhcpEndpoint::Nvos);
+                actions.push(Action::StopNvos);
+                (
+                    Self::DeviceDown {
+                        power_cycle_pending: false,
+                        paused,
+                    },
+                    actions,
+                )
+            }
+            Event::PowerCycle => {
+                let (_, retry_actions) = dhcp_retry.event(RetryEvent::Abandon);
+                let mut actions = map_retry_actions(retry_actions, DhcpEndpoint::Nvos);
+                actions.extend([Action::StopNvos, Action::SetTimer(Timer::PowerCycle)]);
+                (
+                    Self::DeviceDown {
+                        power_cycle_pending: true,
+                        paused,
+                    },
+                    actions,
+                )
+            }
+            _ => (self, vec![]),
+        }
+    }
+
+    fn fsm_device_up(self, event: Event, paused: bool) -> StateReturn {
+        match event {
             Event::PowerOff => (
                 Self::DeviceDown {
                     power_cycle_pending: false,
@@ -206,30 +329,13 @@ impl SwitchFsm {
         }
     }
 
-    fn fsm_device_up(self, event: Event, paused: bool) -> FsmReturn {
-        match event {
-            Event::PowerOff => (
-                Self::DeviceDown {
-                    power_cycle_pending: false,
-                    paused,
-                },
-                vec![Action::StopNvos],
-            ),
-            Event::PowerCycle => (
-                Self::DeviceDown {
-                    power_cycle_pending: true,
-                    paused,
-                },
-                vec![Action::StopNvos, Action::SetTimer(Timer::PowerCycle)],
-            ),
-            _ => (self, vec![]),
-        }
-    }
-
-    fn fsm_device_down(self, event: Event, power_cycle_pending: bool, paused: bool) -> FsmReturn {
+    fn fsm_device_down(self, event: Event, power_cycle_pending: bool, paused: bool) -> StateReturn {
         match event {
             Event::PowerOn => (
-                Self::NvosInit { paused },
+                Self::NvosInit {
+                    paused,
+                    dhcp_retry: DhcpRetryFsm::new(),
+                },
                 cancel_timer_action(power_cycle_pending)
                     .into_iter()
                     .chain([Action::Dhcp(DhcpEndpoint::Nvos)])
@@ -243,7 +349,10 @@ impl SwitchFsm {
                 cancel_timer_action(power_cycle_pending),
             ),
             Event::TimerAlert(Timer::PowerCycle) if power_cycle_pending => (
-                Self::NvosInit { paused },
+                Self::NvosInit {
+                    paused,
+                    dhcp_retry: DhcpRetryFsm::new(),
+                },
                 vec![Action::Dhcp(DhcpEndpoint::Nvos)],
             ),
             Event::TimerAlert(Timer::PowerCycle) => (self, vec![]),
@@ -259,6 +368,21 @@ impl SwitchFsm {
     }
 }
 
+fn map_retry_actions(actions: Vec<RetryAction>, endpoint: DhcpEndpoint) -> Vec<Action> {
+    actions
+        .into_iter()
+        .map(|action| map_retry_action(action, endpoint))
+        .collect()
+}
+
+fn map_retry_action(action: RetryAction, endpoint: DhcpEndpoint) -> Action {
+    match action {
+        RetryAction::Schedule { delay } => Action::ScheduleDhcpRetry { delay },
+        RetryAction::Run => Action::Dhcp(endpoint),
+        RetryAction::Cancel => Action::CancelDhcpRetry,
+    }
+}
+
 fn cancel_timer_action(power_cycle_pending: bool) -> Vec<Action> {
     if power_cycle_pending {
         vec![Action::CancelTimer(Timer::PowerCycle)]
@@ -269,7 +393,9 @@ fn cancel_timer_action(power_cycle_pending: bool) -> Vec<Action> {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum Event {
-    DhcpComplete(DhcpEndpoint),
+    DhcpComplete,
+    DhcpFailed(Milliseconds),
+    DhcpRetryExpired,
     PowerOn,
     PowerOff,
     PowerCycle,
@@ -278,9 +404,18 @@ pub(super) enum Event {
     Resume,
 }
 
+#[cfg(test)]
+impl Event {
+    fn dhcp_failed_with_jitter(jitter: Milliseconds) -> Self {
+        Self::DhcpFailed(jitter)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum Action {
     Dhcp(DhcpEndpoint),
+    ScheduleDhcpRetry { delay: Duration },
+    CancelDhcpRetry,
     SetupBmc,
     StopNvos,
     SetTimer(Timer),
@@ -304,6 +439,28 @@ mod tests {
 
     use super::*;
 
+    type TestFsm = SwitchFsm;
+
+    fn with_state(state: SwitchState) -> TestFsm {
+        SwitchFsm { state }
+    }
+
+    fn bmc_init(power_on: bool, power_cycle_pending: bool, paused: bool) -> SwitchState {
+        SwitchState::BmcInit {
+            power_on,
+            power_cycle_pending,
+            paused,
+            dhcp_retry: DhcpRetryFsm::new(),
+        }
+    }
+
+    fn nvos_init(paused: bool) -> SwitchState {
+        SwitchState::NvosInit {
+            paused,
+            dhcp_retry: DhcpRetryFsm::new(),
+        }
+    }
+
     #[test]
     fn switch_transitions() {
         check_values(
@@ -311,80 +468,72 @@ mod tests {
                 Check {
                     scenario: "new switch completes BMC DHCP powered off",
                     input: (
-                        SwitchFsm::BmcInit {
-                            power_on: false,
-                            power_cycle_pending: false,
-                            paused: false,
-                        },
-                        Event::DhcpComplete(DhcpEndpoint::Bmc),
+                        with_state(bmc_init(false, false, false)),
+                        Event::DhcpComplete,
                     ),
                     expect: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: false,
                             paused: false,
-                        },
+                        }),
                         vec![Action::SetupBmc],
                     ),
                 },
                 Check {
                     scenario: "persisted switch completes BMC DHCP powered on",
                     input: (
-                        SwitchFsm::BmcInit {
-                            power_on: true,
-                            power_cycle_pending: false,
-                            paused: false,
-                        },
-                        Event::DhcpComplete(DhcpEndpoint::Bmc),
+                        with_state(bmc_init(true, false, false)),
+                        Event::DhcpComplete,
                     ),
                     expect: (
-                        SwitchFsm::NvosInit { paused: false },
+                        with_state(nvos_init(false)),
                         vec![Action::SetupBmc, Action::Dhcp(DhcpEndpoint::Nvos)],
                     ),
                 },
                 Check {
                     scenario: "NVOS DHCP completes switch startup",
-                    input: (
-                        SwitchFsm::NvosInit { paused: false },
-                        Event::DhcpComplete(DhcpEndpoint::Nvos),
-                    ),
-                    expect: (SwitchFsm::DeviceUp { paused: false }, vec![]),
+                    input: (with_state(nvos_init(false)), Event::DhcpComplete),
+                    expect: (with_state(SwitchState::DeviceUp { paused: false }), vec![]),
                 },
                 Check {
                     scenario: "powered switch begins a power cycle",
-                    input: (SwitchFsm::DeviceUp { paused: false }, Event::PowerCycle),
+                    input: (
+                        with_state(SwitchState::DeviceUp { paused: false }),
+                        Event::PowerCycle,
+                    ),
                     expect: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         vec![Action::StopNvos, Action::SetTimer(Timer::PowerCycle)],
                     ),
                 },
                 Check {
                     scenario: "power-cycle timer restores power",
                     input: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         Event::TimerAlert(Timer::PowerCycle),
                     ),
                     expect: (
-                        SwitchFsm::NvosInit { paused: false },
+                        with_state(nvos_init(false)),
                         vec![Action::Dhcp(DhcpEndpoint::Nvos)],
                     ),
                 },
                 Check {
                     scenario: "explicit power-on cancels a pending power cycle",
                     input: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         Event::PowerOn,
                     ),
                     expect: (
-                        SwitchFsm::NvosInit { paused: false },
+                        with_state(nvos_init(false)),
                         vec![
                             Action::CancelTimer(Timer::PowerCycle),
                             Action::Dhcp(DhcpEndpoint::Nvos),
@@ -394,50 +543,53 @@ mod tests {
                 Check {
                     scenario: "a new power cycle replaces the pending timer",
                     input: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         Event::PowerCycle,
                     ),
                     expect: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: true,
                             paused: false,
-                        },
+                        }),
                         vec![Action::SetTimer(Timer::PowerCycle)],
                     ),
                 },
                 Check {
                     scenario: "power off while NVOS starts leaves the switch down",
-                    input: (SwitchFsm::NvosInit { paused: false }, Event::PowerOff),
+                    input: (with_state(nvos_init(false)), Event::PowerOff),
                     expect: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: false,
                             paused: false,
-                        },
+                        }),
                         vec![Action::StopNvos],
                     ),
                 },
                 Check {
                     scenario: "switch processing can be paused",
-                    input: (SwitchFsm::DeviceUp { paused: false }, Event::Pause),
-                    expect: (SwitchFsm::DeviceUp { paused: true }, vec![]),
+                    input: (
+                        with_state(SwitchState::DeviceUp { paused: false }),
+                        Event::Pause,
+                    ),
+                    expect: (with_state(SwitchState::DeviceUp { paused: true }), vec![]),
                 },
                 Check {
                     scenario: "switch processing can be resumed",
                     input: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: false,
                             paused: true,
-                        },
+                        }),
                         Event::Resume,
                     ),
                     expect: (
-                        SwitchFsm::DeviceDown {
+                        with_state(SwitchState::DeviceDown {
                             power_cycle_pending: false,
                             paused: false,
-                        },
+                        }),
                         vec![],
                     ),
                 },
@@ -448,15 +600,15 @@ mod tests {
 
     #[test]
     fn power_off_supersedes_power_cycle() {
-        let (fsm, _) = SwitchFsm::DeviceUp { paused: false }.event(Event::PowerCycle);
+        let (fsm, _) = with_state(SwitchState::DeviceUp { paused: false }).event(Event::PowerCycle);
         let (fsm, actions) = fsm.event(Event::PowerOff);
         assert_eq!(
             (fsm, actions),
             (
-                SwitchFsm::DeviceDown {
+                with_state(SwitchState::DeviceDown {
                     power_cycle_pending: false,
                     paused: false,
-                },
+                }),
                 vec![Action::CancelTimer(Timer::PowerCycle)],
             )
         );
@@ -465,12 +617,40 @@ mod tests {
         assert_eq!(
             (fsm, actions),
             (
-                SwitchFsm::DeviceDown {
+                with_state(SwitchState::DeviceDown {
                     power_cycle_pending: false,
                     paused: false,
-                },
+                }),
                 vec![],
             )
         );
+    }
+
+    #[test]
+    fn bmc_retry_survives_power_changes() {
+        let fsm = with_state(bmc_init(true, false, false));
+        let (fsm, actions) = fsm.event(Event::dhcp_failed_with_jitter(Milliseconds::new(0)));
+        assert_eq!(
+            actions,
+            vec![Action::ScheduleDhcpRetry {
+                delay: Duration::from_secs(4),
+            }]
+        );
+
+        let (fsm, actions) = fsm.event(Event::PowerCycle);
+        assert_eq!(actions, vec![Action::SetTimer(Timer::PowerCycle)]);
+        let (_, actions) = fsm.event(Event::DhcpRetryExpired);
+        assert_eq!(actions, vec![Action::Dhcp(DhcpEndpoint::Bmc)]);
+    }
+
+    #[test]
+    fn power_off_abandons_nvos_retry() {
+        let fsm = with_state(nvos_init(false));
+        let (fsm, _) = fsm.event(Event::dhcp_failed_with_jitter(Milliseconds::new(0)));
+        let (fsm, actions) = fsm.event(Event::PowerOff);
+        assert_eq!(actions, vec![Action::CancelDhcpRetry, Action::StopNvos]);
+
+        let (_, actions) = fsm.event(Event::DhcpRetryExpired);
+        assert!(actions.is_empty());
     }
 }

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -41,6 +41,10 @@ use crate::status::{BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, End
 use crate::switch_fsm::{Action, DhcpEndpoint, Event, SwitchFsm, Timer};
 use crate::tui::UiUpdate;
 
+fn abandon_nvos_dhcp_on_power_change(actions: &mut VecDeque<Action>) {
+    actions.retain(|action| !matches!(action, Action::Dhcp(DhcpEndpoint::Nvos)));
+}
+
 #[derive(Debug)]
 struct SwitchLiveState {
     power_state: MockPowerState,
@@ -117,6 +121,7 @@ pub(crate) struct SwitchActor {
     actions: VecDeque<Action>,
     run_alarm: Option<AlarmId>,
     power_cycle_alarm: Option<AlarmId>,
+    dhcp_retry_alarm: Option<AlarmId>,
 }
 
 impl SwitchActor {
@@ -146,6 +151,7 @@ impl SwitchActor {
             actions: actions.into_iter().collect(),
             run_alarm: None,
             power_cycle_alarm: None,
+            dhcp_retry_alarm: None,
         }
     }
 
@@ -185,6 +191,7 @@ impl SwitchActor {
             actions: actions.into_iter().collect(),
             run_alarm: None,
             power_cycle_alarm: None,
+            dhcp_retry_alarm: None,
         }
     }
 
@@ -238,7 +245,7 @@ impl SwitchActor {
                     Ok(dhcp_info) => {
                         self.bmc_dhcp_info = Some(dhcp_info);
                         self.actions.pop_front();
-                        self.fsm_event(Event::DhcpComplete(DhcpEndpoint::Bmc));
+                        self.fsm_event(Event::DhcpComplete);
                     }
                     Err(error) => {
                         tracing::warn!(
@@ -246,14 +253,15 @@ impl SwitchActor {
                             error = %error,
                             "Switch BMC DHCP failed",
                         );
-                        return Some(self.config.run_interval_working);
+                        self.actions.pop_front();
+                        self.fsm_event(Event::dhcp_failed());
                     }
                 },
                 Action::Dhcp(DhcpEndpoint::Nvos) => match self.nvos_dhcp_discovery().await {
                     Ok(dhcp_info) => {
                         self.live_state.write().unwrap().nvos_ip = Some(dhcp_info.ip_address);
                         self.actions.pop_front();
-                        self.fsm_event(Event::DhcpComplete(DhcpEndpoint::Nvos));
+                        self.fsm_event(Event::DhcpComplete);
                     }
                     Err(error) => {
                         tracing::warn!(
@@ -261,9 +269,33 @@ impl SwitchActor {
                             error = %error,
                             "Switch NVOS DHCP failed",
                         );
-                        return Some(self.config.run_interval_working);
+                        self.actions.pop_front();
+                        self.fsm_event(Event::dhcp_failed());
                     }
                 },
+                Action::ScheduleDhcpRetry { delay } => {
+                    tracing::debug!(
+                        device_id = %self.mat_id,
+                        retry_delay_milliseconds = delay.as_millis(),
+                        "scheduled switch DHCP retry"
+                    );
+                    self.dhcp_retry_alarm = Some(
+                        mailbox
+                            .replace_alarm(
+                                self.dhcp_retry_alarm.take(),
+                                saturating_add_duration_to_instant(Instant::now(), delay),
+                                SwitchMessage::DhcpRetryExpired,
+                            )
+                            .expect("running actor mailbox must be open"),
+                    );
+                    self.actions.pop_front();
+                }
+                Action::CancelDhcpRetry => {
+                    if let Some(alarm_id) = self.dhcp_retry_alarm.take() {
+                        mailbox.cancel(alarm_id);
+                    }
+                    self.actions.pop_front();
+                }
                 Action::SetupBmc => match self.setup_bmc(mailbox).await {
                     Ok(()) => {
                         self.actions.pop_front();
@@ -433,6 +465,10 @@ impl SwitchActor {
     }
 
     fn fsm_event(&mut self, event: Event) {
+        if matches!(event, Event::PowerOff | Event::PowerCycle) {
+            abandon_nvos_dhcp_on_power_change(&mut self.actions);
+        }
+
         let previous_state = self.fsm;
         let (next_state, actions) = self.fsm.event(event);
         tracing::info!(
@@ -457,6 +493,7 @@ impl SwitchActor {
 enum SwitchMessage {
     Run,
     PowerCycleExpired,
+    DhcpRetryExpired,
     SetPaused(bool),
     Bmc(BmcCommand),
     Stop,
@@ -473,6 +510,10 @@ impl ActorCallbacks<SwitchMessage> for SwitchActor {
             SwitchMessage::PowerCycleExpired => {
                 self.power_cycle_alarm = None;
                 self.fsm_event(Event::TimerAlert(Timer::PowerCycle));
+            }
+            SwitchMessage::DhcpRetryExpired => {
+                self.dhcp_retry_alarm = None;
+                self.fsm_event(Event::DhcpRetryExpired);
             }
             SwitchMessage::Stop => return ActorResult::Stop,
             SwitchMessage::SetPaused(paused) => {
@@ -610,5 +651,35 @@ impl SwitchHandle {
 
     pub(crate) fn bmc_ip(&self) -> Option<Ipv4Addr> {
         self.0.live_state.read().unwrap().bmc_ip
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[test]
+    fn power_change_abandons_queued_nvos_dhcp() {
+        check_values(
+            [
+                Check {
+                    scenario: "queued NVOS DHCP is abandoned",
+                    input: vec![Action::Dhcp(DhcpEndpoint::Nvos)],
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "unrelated actions remain queued",
+                    input: vec![Action::Dhcp(DhcpEndpoint::Bmc), Action::SetupBmc],
+                    expect: vec![Action::Dhcp(DhcpEndpoint::Bmc), Action::SetupBmc],
+                },
+            ],
+            |actions| {
+                let mut actions = VecDeque::from(actions);
+                abandon_nvos_dhcp_on_power_change(&mut actions);
+                Vec::from(actions)
+            },
+        );
     }
 }


### PR DESCRIPTION
DHCP retry backoff was added at pretty much the same time as the power-shelf and switch FSMs were separated from the machine state machine. These two state machines did not get the DHCP retry backoff mechanism.

This PR unifies the DHCP retry backoff mechanism and uses it in all three FSM types.

## Related issues

#4343
#4316 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

