### PR TITLE
fix(build): rerun protobuf codegen when proto files change

### DIFF
--- a/crates/machine-controller/build.rs
+++ b/crates/machine-controller/build.rs
@@ -19,6 +19,8 @@ use std::path::PathBuf;
 use carbide_proto_compiler::{CompilerConfig, TonicBuilderCodegenExt, compile};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=../rpc/proto");
+
     let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
     let schema = compile(&CompilerConfig {
         proto_files: vec![PathBuf::from("../rpc/proto/scout_firmware_upgrade.proto")],

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -36,6 +36,9 @@ const PROTO_FILES: &[&str] = &[
 const INCLUDE_PATHS: &[&str] = &["proto"];
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=proto");
+    println!("cargo:rerun-if-changed=../agent/proto");
+
     let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
     // Write generated code to OUT_DIR rather than back into the source tree.
     // Consumers pull these in via:


### PR DESCRIPTION
Protobuf generation uses descriptor sets, so Cargo does not automatically track source files outside the consuming crate.

Add explicit rebuild triggers for RPC and machine-controller protobuf inputs to prevent stale generated code.

## Related issues

#4594 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
