### PR TITLE
fix(scripts): preserve DEBIAN_FRONTEND when make bootstrap runs as root

### DIFF
--- a/scripts/setup-build-host.sh
+++ b/scripts/setup-build-host.sh
@@ -36,7 +36,7 @@ DOCKER_USER="${SUDO_USER:-$(id -un)}"
 # --- 1. System packages -------------------------------------------------------
 echo "=== [1/9] Installing system packages via apt ==="
 ${SUDO} apt-get update
-${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y \
+${SUDO} env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential cpio direnv mkosi uidmap curl file fakeroot git \
     docker.io docker-buildx sccache protobuf-compiler libopenipmi-dev \
     libudev-dev libboost-dev libgrpc-dev libprotobuf-dev libssl-dev \


### PR DESCRIPTION
`./scripts/setup-build-host.sh` (`make bootstrap`) fails as root:

    ./scripts/setup-build-host.sh: line 39: DEBIAN_FRONTEND=noninteractive: command not found
    make: *** [Makefile:69: bootstrap] Error 127

Cause:

    ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y ...

Bash only treats a leading `NAME=value` word as an assignment if it's literally first. `${SUDO}` isn't that syntax, so it's parsed as the command word, leaving `DEBIAN_FRONTEND=noninteractive` as an argument. As a normal user `SUDO="sudo"` absorbs it fine (sudo recognizes a leading `VAR=value` on its own command line and passes it through regardless of `env_reset`). As root `SUDO=""` vanishes on expansion, so `DEBIAN_FRONTEND=noninteractive` becomes the command bash tries to run, giving "command not found".

Fix: set the variable via `env` inside the privileged command instead of as a plain leading shell assignment:

    ${SUDO} env DEBIAN_FRONTEND=noninteractive apt-get install -y ...

This works identically whether `${SUDO}` is empty or `sudo`: `env` sets the variable explicitly for the `apt-get` child process either directly (root) or after sudo has already elevated privilege (non-root) — so it isn't at the mercy of sudoers `env_reset`/`env_keep`, unlike a plain leading assignment placed before `${SUDO}`.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Manual testing performed

Verified directly on an Ubuntu 24.04 VM, both as root and as a regular
`sudo`-group user, using `apt-get install --dry-run` to confirm the resulting
command line without installing packages:

| Context | Before this fix | After this fix |
|---|---|---|
| root (`EUID=0`, `SUDO=""`) | fails, exit 127: `DEBIAN_FRONTEND=noninteractive: command not found` | works, apt-get runs |
| non-root, `sudo`-group user (`SUDO="sudo"`) | works | works (no regression) |

Reproduced on a VM (`root@e2e-147-162`, Ubuntu 24.04) before this fix:

```bash
root@e2e-147-162:~/infra-controller# make bootstrap
./scripts/setup-build-host.sh
=== [1/9] Installing system packages via apt ===
...
Fetched 11.1 MB in 4s (2,751 kB/s)
Reading package lists... Done
./scripts/setup-build-host.sh: line 39: DEBIAN_FRONTEND=noninteractive: command not found
make: *** [Makefile:69: bootstrap] Error 127
```

Now it works fine after the change

## Additional Notes

Single-line change, no other behavior affected. No documentation update
needed.