### PR TITLE
feat(dpf): let operators hook scripts around BF4 OVS setup

### DIFF
--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -24,8 +24,10 @@ use kube::core::ObjectMeta;
 use sha2::{Digest, Sha256};
 
 use crate::crds::dpuflavors_generated::{
-    DPUFlavor, DpuFlavorConfigFiles, DpuFlavorConfigFilesOperation, DpuFlavorContainerdConfig,
-    DpuFlavorDpuMode, DpuFlavorEwNicConfigurations, DpuFlavorEwNicConfigurationsNetworkBay,
+    DPUFlavor, DpuFlavorConfigFiles, DpuFlavorConfigFilesContentFrom,
+    DpuFlavorConfigFilesContentFromConfigMapKeyRef, DpuFlavorConfigFilesOperation,
+    DpuFlavorConfigFilesType, DpuFlavorContainerdConfig, DpuFlavorDpuMode,
+    DpuFlavorEwNicConfigurations, DpuFlavorEwNicConfigurationsNetworkBay,
     DpuFlavorEwNicConfigurationsRawNvConfig, DpuFlavorEwNicConfigurationsSpectrumXOptimized,
     DpuFlavorEwNicConfigurationsSpectrumXOptimizedMultiplaneMode,
     DpuFlavorEwNicConfigurationsSpectrumXOptimizedOverlay, DpuFlavorGrub, DpuFlavorNvconfig,
@@ -97,6 +99,11 @@ fn get_bf4_ovs_defaults_base() -> String {
         "_ovs-vsctl() {\n",
         "    ovs-vsctl --timeout 15 \"$@\"\n",
         "}\n",
+        // Exported so the operator hook scripts inherit the helper, as on Astra.
+        "export -f _ovs-vsctl\n",
+
+        // Guarded: agent-applied, so absent on the first boot.
+        "if [ -x /opt/dpf/extra-script-pre-ovs.sh ]; then /opt/dpf/extra-script-pre-ovs.sh; fi\n",
 
         "# Remove default OVS configuration on the DPU and ensure no leftovers on the OVS kernel side\n",
         "for i in $(seq 1 99); do\n",
@@ -130,9 +137,12 @@ fn get_bf4_ovs_defaults_base() -> String {
         "_ovs-vsctl set Interface p0 mtu_request=9216\n",
         "_ovs-vsctl set Port p0 external_ids:dpf-type=physical\n",
 
+        // br-hbn is absent on a fresh DPU, so a bare del-br would fail the run.
+        "_ovs-vsctl --if-exists del-br br-hbn\n",
         "_ovs-vsctl --may-exist add-br br-hbn\n",
         "_ovs-vsctl set bridge br-hbn datapath_type=netdev\n",
         "_ovs-vsctl set bridge br-hbn fail_mode=secure\n",
+
         "mst start\n",
     )
     .to_string()
@@ -153,8 +163,10 @@ fn get_default_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging
 
 /// Builds the generic-BF4 OVS bootstrap after preflighting every configured PF.
 fn get_bf4_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging>) -> String {
+    // Explicit bash, as on Astra: the base uses `export -f`, which errors under dash.
+    let mut script = String::from("#!/bin/bash\n");
     // Preflight is prepended so no inherited or configured OVS operation can run first.
-    let mut script = topology.map_or_else(String::new, render_bf4_pf_preflight);
+    script.push_str(&topology.map_or_else(String::new, render_bf4_pf_preflight));
     script.push_str(&get_bf4_ovs_defaults_base());
     if let Some(topology) = topology {
         append_peer_bridge_bootstrap(&mut script, topology, |interface| {
@@ -166,8 +178,18 @@ fn get_bf4_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging>) -
             }
         });
     }
+    // After every bridge and port, but before the encap-IP tail the
+    // `ovs_bootstrap_ends_with_ovn_encap_ip_configuration` contract requires last.
+    append_post_ovs_hook(&mut script);
     append_ovn_encap_ip_bootstrap(&mut script);
     script
+}
+
+/// Appends the operator's post-OVS hook, guarded because it is agent-applied.
+fn append_post_ovs_hook(script: &mut String) {
+    script.push_str(
+        "if [ -x /opt/dpf/extra-script-post-ovs.sh ]; then /opt/dpf/extra-script-post-ovs.sh; fi\n",
+    );
 }
 
 /// Appends the per-DPU OVN address update to provisioning-time OVS configuration.
@@ -312,8 +334,11 @@ fn get_bf4_astra_ovs_defaults() -> String {
         "}\n",
         "export -f _ovs-vsctl\n",
         "\n",
+        // Guarded: agent-applied, so absent on the first boot.
+        "if [ -x /opt/dpf/extra-script-pre-ovs.sh ]; then /opt/dpf/extra-script-pre-ovs.sh; fi\n",
         "# 1. Configure OVS bridges and xplane ports\n",
         "/etc/mellanox/ovs-script.sh\n",
+        "if [ -x /opt/dpf/extra-script-post-ovs.sh ]; then /opt/dpf/extra-script-post-ovs.sh; fi\n",
         "\n",
         "# 2. Configure rail bridge addressing (netplan)\n",
         "/etc/mellanox/xplane-bridge.sh\n",
@@ -866,6 +891,40 @@ fn get_config_files(
             raw: Some(raw),
             content_from: None,
             r#type: None,
+        });
+    }
+
+    // ROLLOUT SAFETY: these entries change the flavor hash, so adding them
+    // reprovisions every existing BF4 DPU once. ConfigMap edits do not.
+    if deployment_type == DpuDeploymentType::Bf4Generic {
+        config_files.push(DpuFlavorConfigFiles {
+            content_from: Some(DpuFlavorConfigFilesContentFrom {
+                config_map_key_ref: Some(DpuFlavorConfigFilesContentFromConfigMapKeyRef {
+                    name: Some("extra-script-pre-ovs-bf4-generic".to_string()),
+                    key: "script".to_string(),
+                    optional: None,
+                }),
+            }),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/opt/dpf/extra-script-pre-ovs.sh".to_string(),
+            permissions: Some("0755".to_string()),
+            raw: None,
+            r#type: Some(DpuFlavorConfigFilesType::AgentApplied),
+        });
+        config_files.push(DpuFlavorConfigFiles {
+            // CRD allows exactly one of `raw` and `contentFrom`.
+            content_from: Some(DpuFlavorConfigFilesContentFrom {
+                config_map_key_ref: Some(DpuFlavorConfigFilesContentFromConfigMapKeyRef {
+                    name: Some("extra-script-post-ovs-bf4-generic".to_string()),
+                    key: "script".to_string(),
+                    optional: None,
+                }),
+            }),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/opt/dpf/extra-script-post-ovs.sh".to_string(),
+            permissions: Some("0755".to_string()),
+            raw: None,
+            r#type: Some(DpuFlavorConfigFilesType::AgentApplied),
         });
     }
 
@@ -1480,6 +1539,35 @@ fn get_bf4_astra_config_files(
                 .to_string(),
             ),
             r#type: None,
+        },
+        DpuFlavorConfigFiles {
+            content_from: Some(DpuFlavorConfigFilesContentFrom {
+                config_map_key_ref: Some(DpuFlavorConfigFilesContentFromConfigMapKeyRef {
+                    name: Some("extra-script-pre-ovs-bf4-astra".to_string()),
+                    key: "script".to_string(),
+                    optional: None,
+                }),
+            }),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/opt/dpf/extra-script-pre-ovs.sh".to_string(),
+            permissions: Some("0755".to_string()),
+            raw: None,
+            r#type: Some(DpuFlavorConfigFilesType::AgentApplied),
+        },
+        DpuFlavorConfigFiles {
+            // CRD allows exactly one of `raw` and `contentFrom`.
+            content_from: Some(DpuFlavorConfigFilesContentFrom {
+                config_map_key_ref: Some(DpuFlavorConfigFilesContentFromConfigMapKeyRef {
+                    name: Some("extra-script-post-ovs-bf4-astra".to_string()),
+                    key: "script".to_string(),
+                    optional: None,
+                }),
+            }),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            path: "/opt/dpf/extra-script-post-ovs.sh".to_string(),
+            permissions: Some("0755".to_string()),
+            raw: None,
+            r#type: Some(DpuFlavorConfigFilesType::AgentApplied),
         },
     ];
 
@@ -2402,12 +2490,12 @@ mod tests {
                     .count();
                 (files.len(), proxy_file_count)
             };
-            "no proxy keeps only the six Astra base files" {
-                None => (6, 0),
+            "no proxy keeps only the eight Astra base files" {
+                None => (8, 0),
             }
 
             "configured proxy appends exactly one proxy file" {
-                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => (7, 1),
+                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => (9, 1),
             }
         );
     }

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -99,11 +99,8 @@ fn get_bf4_ovs_defaults_base() -> String {
         "_ovs-vsctl() {\n",
         "    ovs-vsctl --timeout 15 \"$@\"\n",
         "}\n",
-        // Exported so the operator hook scripts inherit the helper, as on Astra.
+        // Exported so the post-OVS hook inherits the helper, as on Astra.
         "export -f _ovs-vsctl\n",
-
-        // Guarded: agent-applied, so absent on the first boot.
-        "if [ -x /opt/dpf/extra-script-pre-ovs.sh ]; then /opt/dpf/extra-script-pre-ovs.sh; fi\n",
 
         "# Remove default OVS configuration on the DPU and ensure no leftovers on the OVS kernel side\n",
         "for i in $(seq 1 99); do\n",
@@ -165,6 +162,7 @@ fn get_default_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging
 fn get_bf4_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging>) -> String {
     // Explicit bash, as on Astra: the base uses `export -f`, which errors under dash.
     let mut script = String::from("#!/bin/bash\n");
+    append_pre_ovs_hook(&mut script);
     // Preflight is prepended so no inherited or configured OVS operation can run first.
     script.push_str(&topology.map_or_else(String::new, render_bf4_pf_preflight));
     script.push_str(&get_bf4_ovs_defaults_base());
@@ -178,14 +176,19 @@ fn get_bf4_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging>) -
             }
         });
     }
-    // After every bridge and port, but before the encap-IP tail the
-    // `ovs_bootstrap_ends_with_ovn_encap_ip_configuration` contract requires last.
-    append_post_ovs_hook(&mut script);
     append_ovn_encap_ip_bootstrap(&mut script);
+    append_post_ovs_hook(&mut script);
     script
 }
 
-/// Appends the operator's post-OVS hook, guarded because it is agent-applied.
+/// Appends the operator's pre-OVS hook, which runs before anything else.
+fn append_pre_ovs_hook(script: &mut String) {
+    script.push_str(
+        "if [ -x /opt/dpf/extra-script-pre-ovs.sh ]; then /opt/dpf/extra-script-pre-ovs.sh; fi\n",
+    );
+}
+
+/// Appends the operator's post-OVS hook, which runs last.
 fn append_post_ovs_hook(script: &mut String) {
     script.push_str(
         "if [ -x /opt/dpf/extra-script-post-ovs.sh ]; then /opt/dpf/extra-script-post-ovs.sh; fi\n",
@@ -324,6 +327,7 @@ fn bf4_pf_variable(controller_id: u8, pf_id: u8) -> String {
 fn get_bf4_astra_ovs_defaults() -> String {
     concat!(
         "#!/bin/bash\n",
+        "if [ -x /opt/dpf/extra-script-pre-ovs.sh ]; then /opt/dpf/extra-script-pre-ovs.sh; fi\n",
         "# Shared helper used by the called scripts; exported so they inherit it\n",
         "\n",
         "# create an entry in /etc/hosts to allow self hostname resolution: (bug fix)\n",
@@ -334,14 +338,12 @@ fn get_bf4_astra_ovs_defaults() -> String {
         "}\n",
         "export -f _ovs-vsctl\n",
         "\n",
-        // Guarded: agent-applied, so absent on the first boot.
-        "if [ -x /opt/dpf/extra-script-pre-ovs.sh ]; then /opt/dpf/extra-script-pre-ovs.sh; fi\n",
         "# 1. Configure OVS bridges and xplane ports\n",
         "/etc/mellanox/ovs-script.sh\n",
-        "if [ -x /opt/dpf/extra-script-post-ovs.sh ]; then /opt/dpf/extra-script-post-ovs.sh; fi\n",
         "\n",
         "# 2. Configure rail bridge addressing (netplan)\n",
         "/etc/mellanox/xplane-bridge.sh\n",
+        "if [ -x /opt/dpf/extra-script-post-ovs.sh ]; then /opt/dpf/extra-script-post-ovs.sh; fi\n",
     )
     .to_string()
 }
@@ -2030,27 +2032,81 @@ mod tests {
                 get_default_ovs_defaults_with_topology(None) => true,
             }
 
+            // BF4 runs the operator's post-OVS hook last, so the encap-IP block is
+            // the final NICo-authored step rather than the final line.
             "generic BF4 provisioning" {
-                get_bf4_ovs_defaults_with_topology(None) => true,
+                get_bf4_ovs_defaults_with_topology(None) => false,
             }
         );
+        assert!(get_bf4_ovs_defaults_with_topology(None).contains(&expected));
     }
 
-    /// Both BF4 scripts must invoke both operator hooks; the post-ovs one is
-    /// appended separately from the base and is easy to drop.
+    /// Every BF4 script must run the pre hook before any OVS work and the post
+    /// hook after all of it. The post hook is appended separately and is easy to
+    /// drop or misplace.
     #[test]
-    fn bf4_scripts_invoke_both_operator_hooks() {
+    fn bf4_scripts_run_pre_hook_first_and_post_hook_last() {
         for script in [
             get_bf4_ovs_defaults_with_topology(None),
             get_bf4_ovs_defaults_with_topology(Some(&intercept_bridging())),
             get_bf4_astra_ovs_defaults(),
         ] {
+            let guard = |hook: &str| {
+                let path = format!("/opt/dpf/extra-script-{hook}.sh");
+                let line = format!("if [ -x {path} ]; then {path}; fi");
+                script
+                    .find(&line)
+                    .unwrap_or_else(|| panic!("missing guarded {hook} hook"))
+            };
+            let (pre, post) = (guard("pre-ovs"), guard("post-ovs"));
+
+            let first_ovs = script
+                .find("ovs")
+                .expect("script must contain OVS configuration");
+            assert!(pre < first_ovs, "pre-ovs hook must precede all OVS work");
+            assert_eq!(
+                post + script[post..].len(),
+                script.len(),
+                "post-ovs hook must be the last line"
+            );
+            assert!(script[post..].lines().count() == 1, "nothing may follow it");
+        }
+    }
+
+    /// The hook files must keep referencing the ConfigMaps the SDK seeds, under
+    /// the key it writes, and stay executable agent-applied files.
+    #[test]
+    fn bf4_hook_config_files_reference_their_configmaps() {
+        for (files, suffix) in [
+            (
+                get_config_files(&None, DpuDeploymentType::Bf4Generic, None).unwrap(),
+                "bf4-generic",
+            ),
+            (get_bf4_astra_config_files(&None).unwrap(), "bf4-astra"),
+        ] {
             for hook in ["pre-ovs", "post-ovs"] {
                 let path = format!("/opt/dpf/extra-script-{hook}.sh");
-                assert!(
-                    script.contains(&format!("if [ -x {path} ]; then {path}; fi")),
-                    "missing guarded {hook} hook"
+                let file = files
+                    .iter()
+                    .find(|f| f.path == path)
+                    .unwrap_or_else(|| panic!("{suffix}: no config file for {path}"));
+                let key_ref = file
+                    .content_from
+                    .as_ref()
+                    .and_then(|c| c.config_map_key_ref.as_ref())
+                    .unwrap_or_else(|| panic!("{suffix}: {path} must use configMapKeyRef"));
+
+                assert_eq!(
+                    key_ref.name.as_deref(),
+                    Some(&*format!("extra-script-{hook}-{suffix}"))
                 );
+                assert_eq!(key_ref.key, "script");
+                assert_eq!(file.permissions.as_deref(), Some("0755"));
+                assert!(matches!(
+                    file.r#type,
+                    Some(DpuFlavorConfigFilesType::AgentApplied)
+                ));
+                assert!(file.raw.is_none(), "{suffix}: raw and contentFrom conflict");
             }
         }
     }

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -2046,30 +2046,39 @@ mod tests {
     /// drop or misplace.
     #[test]
     fn bf4_scripts_run_pre_hook_first_and_post_hook_last() {
-        for script in [
-            get_bf4_ovs_defaults_with_topology(None),
-            get_bf4_ovs_defaults_with_topology(Some(&intercept_bridging())),
-            get_bf4_astra_ovs_defaults(),
+        // Matched against a real OVS operation, not the substring "ovs", which
+        // also occurs inside the pre-hook's own filename.
+        for (script, first_ovs_operation) in [
+            (
+                get_bf4_ovs_defaults_with_topology(None),
+                "ovs-vsctl --if-exists del-br",
+            ),
+            (
+                get_bf4_ovs_defaults_with_topology(Some(&intercept_bridging())),
+                "ovs-vsctl --if-exists del-br",
+            ),
+            (get_bf4_astra_ovs_defaults(), "/etc/mellanox/ovs-script.sh"),
         ] {
             let guard = |hook: &str| {
                 let path = format!("/opt/dpf/extra-script-{hook}.sh");
                 let line = format!("if [ -x {path} ]; then {path}; fi");
-                script
+                let at = script
                     .find(&line)
-                    .unwrap_or_else(|| panic!("missing guarded {hook} hook"))
+                    .unwrap_or_else(|| panic!("missing guarded {hook} hook"));
+                (at, line)
             };
-            let (pre, post) = (guard("pre-ovs"), guard("post-ovs"));
+            let (pre, _) = guard("pre-ovs");
+            let (_, post_line) = guard("post-ovs");
 
             let first_ovs = script
-                .find("ovs")
-                .expect("script must contain OVS configuration");
+                .find(first_ovs_operation)
+                .expect("script must contain an OVS operation");
             assert!(pre < first_ovs, "pre-ovs hook must precede all OVS work");
             assert_eq!(
-                post + script[post..].len(),
-                script.len(),
-                "post-ovs hook must be the last line"
+                script.trim_end().lines().last(),
+                Some(post_line.as_str()),
+                "post-ovs hook must be the final line"
             );
-            assert!(script[post..].lines().count() == 1, "nothing may follow it");
         }
     }
 

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -2036,6 +2036,25 @@ mod tests {
         );
     }
 
+    /// Both BF4 scripts must invoke both operator hooks; the post-ovs one is
+    /// appended separately from the base and is easy to drop.
+    #[test]
+    fn bf4_scripts_invoke_both_operator_hooks() {
+        for script in [
+            get_bf4_ovs_defaults_with_topology(None),
+            get_bf4_ovs_defaults_with_topology(Some(&intercept_bridging())),
+            get_bf4_astra_ovs_defaults(),
+        ] {
+            for hook in ["pre-ovs", "post-ovs"] {
+                let path = format!("/opt/dpf/extra-script-{hook}.sh");
+                assert!(
+                    script.contains(&format!("if [ -x {path} ]; then {path}; fi")),
+                    "missing guarded {hook} hook"
+                );
+            }
+        }
+    }
+
     /// Verifies the retained OVN oneshot is installed after network readiness and either OVS unit.
     #[test]
     fn ovn_encap_oneshot_has_required_systemd_ordering() {

--- a/crates/dpf/src/repository/kube.rs
+++ b/crates/dpf/src/repository/kube.rs
@@ -608,6 +608,29 @@ impl K8sConfigRepository for KubeRepository {
         }
     }
 
+    async fn create_configmap(
+        &self,
+        name: &str,
+        namespace: &str,
+        data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        let api: Api<ConfigMap> = Api::namespaced(self.client.clone(), namespace);
+        let cm = ConfigMap {
+            metadata: kube::core::ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(namespace.to_string()),
+                ..Default::default()
+            },
+            data: Some(data),
+            ..Default::default()
+        };
+        match api.create(&PostParams::default(), &cm).await {
+            Ok(_) => Ok(true),
+            Err(kube::Error::Api(err)) if err.is_already_exists() => Ok(false),
+            Err(err) => Err(err.into()),
+        }
+    }
+
     async fn apply_configmap(
         &self,
         name: &str,

--- a/crates/dpf/src/repository/traits.rs
+++ b/crates/dpf/src/repository/traits.rs
@@ -259,6 +259,17 @@ pub trait K8sConfigRepository: Send + Sync {
         name: &str,
         namespace: &str,
     ) -> Result<Option<BTreeMap<String, String>>, DpfError>;
+    /// Create a ConfigMap, reporting `false` when one already exists.
+    ///
+    /// Distinct from `apply_configmap`, which force-applies and would overwrite
+    /// content the object already holds.
+    async fn create_configmap(
+        &self,
+        name: &str,
+        namespace: &str,
+        data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError>;
+
     async fn apply_configmap(
         &self,
         name: &str,

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -519,40 +519,32 @@ fn extra_script_configmap_names(deployment_type: DpuDeploymentType) -> &'static 
 
 /// Seed the extra-script ConfigMaps a BF4 DPUFlavor sources via `contentFrom`.
 ///
-/// Create-if-absent, not apply: `apply_configmap` is a force server-side apply and
-/// would overwrite the operator's script on every carbide-api restart.
+/// Create-only. NICo never updates these: the content belongs to the operator, so
+/// an existing ConfigMap is left exactly as found. A plain create is also atomic,
+/// so an edit racing this cannot be clobbered.
 async fn create_extra_script_configmaps<R: K8sConfigRepository>(
     repo: &R,
     namespace: &str,
     deployment_type: DpuDeploymentType,
 ) -> Result<(), DpfError> {
     for name in extra_script_configmap_names(deployment_type) {
-        // Keyed on the script key, not mere existence: `get_configmap` returns
-        // `data`, so a ConfigMap without this key must still be seeded.
-        let has_script = repo
-            .get_configmap(name, namespace)
-            .await?
-            .is_some_and(|data| data.contains_key(EXTRA_SCRIPT_CONFIGMAP_KEY));
-        if has_script {
-            tracing::debug!(
-                configmap = %name,
-                %namespace,
-                key = EXTRA_SCRIPT_CONFIGMAP_KEY,
-                "Extra-script ConfigMap already carries its script; leaving it alone"
-            );
-            continue;
-        }
-
         let data = BTreeMap::from([(
             EXTRA_SCRIPT_CONFIGMAP_KEY.to_string(),
             EXTRA_SCRIPT_PLACEHOLDER.to_string(),
         )]);
-        repo.apply_configmap(name, namespace, data).await?;
-        tracing::info!(
-            configmap = %name,
-            %namespace,
-            "Created extra-script ConfigMap with a no-op placeholder script"
-        );
+        if repo.create_configmap(name, namespace, data).await? {
+            tracing::info!(
+                configmap = %name,
+                %namespace,
+                "Created extra-script ConfigMap with a no-op placeholder script"
+            );
+        } else {
+            tracing::debug!(
+                configmap = %name,
+                %namespace,
+                "Extra-script ConfigMap already exists; leaving it untouched"
+            );
+        }
     }
     Ok(())
 }
@@ -3780,6 +3772,15 @@ mod tests {
 
     #[async_trait]
     impl crate::repository::K8sConfigRepository for SdkMock {
+        async fn create_configmap(
+            &self,
+            _name: &str,
+            _ns: &str,
+            _data: BTreeMap<String, String>,
+        ) -> Result<bool, DpfError> {
+            Ok(true)
+        }
+
         async fn get_configmap(
             &self,
             _name: &str,
@@ -4463,6 +4464,15 @@ mod tests {
 
     #[async_trait]
     impl crate::repository::K8sConfigRepository for SecretTrackingMock {
+        async fn create_configmap(
+            &self,
+            _name: &str,
+            _ns: &str,
+            _data: BTreeMap<String, String>,
+        ) -> Result<bool, DpfError> {
+            Ok(true)
+        }
+
         async fn get_configmap(
             &self,
             _: &str,
@@ -5536,18 +5546,31 @@ mod extra_script_configmap_tests {
         ) -> Result<Option<BTreeMap<String, String>>, DpfError> {
             Ok(self.existing.lock().unwrap().get(name).cloned())
         }
-        async fn apply_configmap(
+        async fn create_configmap(
             &self,
             name: &str,
             _ns: &str,
             data: BTreeMap<String, String>,
-        ) -> Result<(), DpfError> {
+        ) -> Result<bool, DpfError> {
+            let mut existing = self.existing.lock().unwrap();
+            if existing.contains_key(name) {
+                return Ok(false);
+            }
             self.applied
                 .lock()
                 .unwrap()
                 .push((name.to_string(), data.clone()));
-            self.existing.lock().unwrap().insert(name.to_string(), data);
-            Ok(())
+            existing.insert(name.to_string(), data);
+            Ok(true)
+        }
+
+        async fn apply_configmap(
+            &self,
+            _name: &str,
+            _ns: &str,
+            _data: BTreeMap<String, String>,
+        ) -> Result<(), DpfError> {
+            unreachable!("seeding must never apply; it is create-only")
         }
         async fn get_secret(
             &self,
@@ -5641,20 +5664,28 @@ mod extra_script_configmap_tests {
         );
     }
 
-    /// A ConfigMap lacking the script key must still be seeded.
+    /// Seeding is create-only, so an existing ConfigMap is never written to,
+    /// whatever it holds. NICo has no `update` on these at the RBAC layer either.
     #[tokio::test]
-    async fn a_configmap_without_the_script_key_is_still_seeded() {
+    async fn an_existing_configmap_is_never_written_to() {
         for seeded in [
             BTreeMap::new(),
             BTreeMap::from([("other".into(), "x".into())]),
         ] {
-            let mock = ConfigMapMock::seeded("extra-script-pre-ovs-bf4-astra", seeded);
+            let mock = ConfigMapMock::seeded("extra-script-pre-ovs-bf4-astra", seeded.clone());
             create_extra_script_configmaps(&mock, NS, DpuDeploymentType::Bf4Astra)
                 .await
                 .expect("seeding succeeds");
-            assert!(
-                mock.applied_names()
-                    .contains(&"extra-script-pre-ovs-bf4-astra".to_string())
+
+            assert_eq!(
+                mock.applied_names(),
+                vec!["extra-script-post-ovs-bf4-astra"],
+                "only the absent ConfigMap is created"
+            );
+            assert_eq!(
+                mock.existing.lock().unwrap()["extra-script-pre-ovs-bf4-astra"],
+                seeded,
+                "the existing ConfigMap is left byte-for-byte alone"
             );
         }
     }

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -494,6 +494,69 @@ impl<R, L: ResourceLabeler> DpfSdk<R, L> {
     }
 }
 
+/// Must match the `configMapKeyRef.key` the BF4 flavors declare in `flavor.rs`.
+const EXTRA_SCRIPT_CONFIGMAP_KEY: &str = "script";
+
+/// No-op body seeded into a new extra-script ConfigMap; the flavor runs it by path.
+const EXTRA_SCRIPT_PLACEHOLDER: &str =
+    "#!/usr/bin/env bash\necho \"NICo extra script: nothing to run\"\n";
+
+/// ConfigMaps the deployment's flavor references, in run order. Empty for BF3,
+/// which inlines its scripts instead of using `contentFrom`.
+fn extra_script_configmap_names(deployment_type: DpuDeploymentType) -> &'static [&'static str] {
+    match deployment_type {
+        DpuDeploymentType::Bf3 => &[],
+        DpuDeploymentType::Bf4Generic => &[
+            "extra-script-pre-ovs-bf4-generic",
+            "extra-script-post-ovs-bf4-generic",
+        ],
+        DpuDeploymentType::Bf4Astra => &[
+            "extra-script-pre-ovs-bf4-astra",
+            "extra-script-post-ovs-bf4-astra",
+        ],
+    }
+}
+
+/// Seed the extra-script ConfigMaps a BF4 DPUFlavor sources via `contentFrom`.
+///
+/// Create-if-absent, not apply: `apply_configmap` is a force server-side apply and
+/// would overwrite the operator's script on every carbide-api restart.
+async fn create_extra_script_configmaps<R: K8sConfigRepository>(
+    repo: &R,
+    namespace: &str,
+    deployment_type: DpuDeploymentType,
+) -> Result<(), DpfError> {
+    for name in extra_script_configmap_names(deployment_type) {
+        // Keyed on the script key, not mere existence: `get_configmap` returns
+        // `data`, so a ConfigMap without this key must still be seeded.
+        let has_script = repo
+            .get_configmap(name, namespace)
+            .await?
+            .is_some_and(|data| data.contains_key(EXTRA_SCRIPT_CONFIGMAP_KEY));
+        if has_script {
+            tracing::debug!(
+                configmap = %name,
+                %namespace,
+                key = EXTRA_SCRIPT_CONFIGMAP_KEY,
+                "Extra-script ConfigMap already carries its script; leaving it alone"
+            );
+            continue;
+        }
+
+        let data = BTreeMap::from([(
+            EXTRA_SCRIPT_CONFIGMAP_KEY.to_string(),
+            EXTRA_SCRIPT_PLACEHOLDER.to_string(),
+        )]);
+        repo.apply_configmap(name, namespace, data).await?;
+        tracing::info!(
+            configmap = %name,
+            %namespace,
+            "Created extra-script ConfigMap with a no-op placeholder script"
+        );
+    }
+    Ok(())
+}
+
 async fn create_bfb<R: BfbRepository>(
     repo: &R,
     namespace: &str,
@@ -1728,6 +1791,11 @@ impl<
         } else {
             config.services.clone()
         };
+        // Before the flavor: it references these with `optional` unset, so a DPU
+        // instantiated in between would point at a ConfigMap that does not exist.
+        create_extra_script_configmaps(&*self.repo, &self.namespace, config.deployment_type)
+            .await?;
+
         create_flavor_services_and_deployment(
             &*self.repo,
             &self.namespace,
@@ -5420,5 +5488,174 @@ mod tests {
         neither.spec.dpus.bfb = None;
         neither.spec.dpus.blue_field_software = None;
         assert!(dpu_mismatch(TEST_NAMESPACE, &dpu, &neither).is_none());
+    }
+}
+
+#[cfg(test)]
+mod extra_script_configmap_tests {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::repository::K8sConfigRepository;
+
+    const NS: &str = "dpf-operator-system";
+
+    /// Records applies and lets a test seed already-existing ConfigMaps.
+    #[derive(Default)]
+    struct ConfigMapMock {
+        existing: Mutex<BTreeMap<String, BTreeMap<String, String>>>,
+        applied: Mutex<Vec<(String, BTreeMap<String, String>)>>,
+    }
+
+    impl ConfigMapMock {
+        fn seeded(name: &str, data: BTreeMap<String, String>) -> Self {
+            let mock = Self::default();
+            mock.existing.lock().unwrap().insert(name.to_string(), data);
+            mock
+        }
+
+        fn applied_names(&self) -> Vec<String> {
+            self.applied
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(name, _)| name.clone())
+                .collect()
+        }
+    }
+
+    #[async_trait]
+    impl K8sConfigRepository for ConfigMapMock {
+        async fn get_configmap(
+            &self,
+            name: &str,
+            _ns: &str,
+        ) -> Result<Option<BTreeMap<String, String>>, DpfError> {
+            Ok(self.existing.lock().unwrap().get(name).cloned())
+        }
+        async fn apply_configmap(
+            &self,
+            name: &str,
+            _ns: &str,
+            data: BTreeMap<String, String>,
+        ) -> Result<(), DpfError> {
+            self.applied
+                .lock()
+                .unwrap()
+                .push((name.to_string(), data.clone()));
+            self.existing.lock().unwrap().insert(name.to_string(), data);
+            Ok(())
+        }
+        async fn get_secret(
+            &self,
+            _name: &str,
+            _ns: &str,
+        ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
+            Ok(None)
+        }
+        async fn apply_secret(
+            &self,
+            _name: &str,
+            _ns: &str,
+            _data: BTreeMap<String, Vec<u8>>,
+        ) -> Result<(), DpfError> {
+            Ok(())
+        }
+    }
+
+    /// BF3 inlines its scripts, so it must not create unreferenced ConfigMaps.
+    #[tokio::test]
+    async fn bf3_creates_no_configmaps() {
+        let mock = ConfigMapMock::default();
+        create_extra_script_configmaps(&mock, NS, DpuDeploymentType::Bf3)
+            .await
+            .expect("seeding succeeds");
+        assert!(mock.applied_names().is_empty());
+    }
+
+    /// Names and key must stay in lockstep with the flavors' `configMapKeyRef`.
+    #[tokio::test]
+    async fn bf4_seeds_both_hooks_under_the_referenced_key() {
+        for (deployment_type, expected) in [
+            (
+                DpuDeploymentType::Bf4Generic,
+                [
+                    "extra-script-pre-ovs-bf4-generic",
+                    "extra-script-post-ovs-bf4-generic",
+                ],
+            ),
+            (
+                DpuDeploymentType::Bf4Astra,
+                [
+                    "extra-script-pre-ovs-bf4-astra",
+                    "extra-script-post-ovs-bf4-astra",
+                ],
+            ),
+        ] {
+            let mock = ConfigMapMock::default();
+            create_extra_script_configmaps(&mock, NS, deployment_type)
+                .await
+                .expect("seeding succeeds");
+
+            assert_eq!(mock.applied_names(), expected, "{deployment_type:?}");
+            for (_, data) in mock.applied.lock().unwrap().iter() {
+                let script = data
+                    .get(EXTRA_SCRIPT_CONFIGMAP_KEY)
+                    .expect("script key is present");
+                assert!(
+                    script.starts_with("#!"),
+                    "placeholder needs a shebang, the flavor runs it by path: {script:?}"
+                );
+            }
+        }
+    }
+
+    /// Re-running initialization must not put the placeholder back over an edit.
+    #[tokio::test]
+    async fn an_operator_edited_script_is_left_alone() {
+        let operator_script = "#!/usr/bin/env bash\necho site-specific\n";
+        let mock = ConfigMapMock::seeded(
+            "extra-script-pre-ovs-bf4-generic",
+            BTreeMap::from([(
+                EXTRA_SCRIPT_CONFIGMAP_KEY.to_string(),
+                operator_script.to_string(),
+            )]),
+        );
+
+        create_extra_script_configmaps(&mock, NS, DpuDeploymentType::Bf4Generic)
+            .await
+            .expect("seeding succeeds");
+
+        assert_eq!(
+            mock.applied_names(),
+            vec!["extra-script-post-ovs-bf4-generic"],
+            "only the absent hook is created"
+        );
+        assert_eq!(
+            mock.existing.lock().unwrap()["extra-script-pre-ovs-bf4-generic"]
+                [EXTRA_SCRIPT_CONFIGMAP_KEY],
+            operator_script
+        );
+    }
+
+    /// A ConfigMap lacking the script key must still be seeded.
+    #[tokio::test]
+    async fn a_configmap_without_the_script_key_is_still_seeded() {
+        for seeded in [
+            BTreeMap::new(),
+            BTreeMap::from([("other".into(), "x".into())]),
+        ] {
+            let mock = ConfigMapMock::seeded("extra-script-pre-ovs-bf4-astra", seeded);
+            create_extra_script_configmaps(&mock, NS, DpuDeploymentType::Bf4Astra)
+                .await
+                .expect("seeding succeeds");
+            assert!(
+                mock.applied_names()
+                    .contains(&"extra-script-pre-ovs-bf4-astra".to_string())
+            );
+        }
     }
 }

--- a/crates/dpf/src/test/helpers.rs
+++ b/crates/dpf/src/test/helpers.rs
@@ -285,6 +285,15 @@ pub(super) struct ConfigMock;
 
 #[async_trait]
 impl K8sConfigRepository for ConfigMock {
+    async fn create_configmap(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        Ok(true)
+    }
+
     async fn get_configmap(
         &self,
         _: &str,

--- a/crates/dpf/src/test/maintenance_flow.rs
+++ b/crates/dpf/src/test/maintenance_flow.rs
@@ -212,6 +212,15 @@ impl DpuNodeMaintenanceRepository for MaintenanceFlowMock {
 
 #[async_trait]
 impl K8sConfigRepository for MaintenanceFlowMock {
+    async fn create_configmap(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        Ok(true)
+    }
+
     async fn get_configmap(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -173,6 +173,15 @@ impl DpuRepository for DeviceRegistrationMock {
 
 #[async_trait]
 impl K8sConfigRepository for DeviceRegistrationMock {
+    async fn create_configmap(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        Ok(true)
+    }
+
     async fn get_configmap(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -399,13 +399,21 @@ impl DpuServiceInterfaceRepository for InitializationMock {
 
 #[async_trait]
 impl K8sConfigRepository for InitializationMock {
+    /// Create-only, like the real repository: an existing ConfigMap is reported
+    /// back rather than overwritten.
     async fn create_configmap(
         &self,
-        _name: &str,
-        _ns: &str,
-        _data: BTreeMap<String, String>,
+        name: &str,
+        ns: &str,
+        data: BTreeMap<String, String>,
     ) -> Result<bool, DpfError> {
-        Ok(true)
+        match self.configs.entry(ns_key(ns, name)) {
+            dashmap::mapref::entry::Entry::Occupied(_) => Ok(false),
+            dashmap::mapref::entry::Entry::Vacant(slot) => {
+                slot.insert(data);
+                Ok(true)
+            }
+        }
     }
 
     async fn get_configmap(
@@ -1120,4 +1128,64 @@ async fn service_versions_fail_when_referenced_template_is_missing() {
     assert!(message.contains(
         "DPUServiceTemplate z-missing not found for service z-missing in DPUDeployment deployment"
     ));
+}
+
+/// Re-initialization must not overwrite an operator's extra-script content.
+///
+/// carbide-api seeds these ConfigMaps on every startup, so the create-only path
+/// is the only thing standing between a restart and a clobbered site script.
+#[tokio::test]
+async fn reinitialization_preserves_operator_extra_scripts() {
+    let mock = InitializationMock::default();
+    let sdk = crate::sdk::DpfSdkBuilder::new(mock.clone(), TEST_NS, "test-password".to_string())
+        .with_labeler(InitializationLabeler)
+        .build_without_resources()
+        .await
+        .unwrap();
+
+    let services = [
+        DTS_SERVICE_NAME,
+        DOCA_HBN_SERVICE_NAME,
+        DPU_AGENT_SERVICE_NAME,
+        DHCP_SERVER_SERVICE_NAME,
+        FMDS_SERVICE_NAME,
+        OTEL_COLLECTOR_SERVICE_NAME,
+    ]
+    .into_iter()
+    .map(|name| ServiceDefinition::new(name, "repo", "chart", "1.0.0"))
+    .collect::<Vec<_>>();
+    let config = InitDpfResourcesConfig {
+        bluefield_software: Some(BlueFieldSoftwareParams {
+            os_iso: "http://example.com/bf4.iso".to_string(),
+            pldm_fw_bundle: Some("http://example.com/bf4.pldm".to_string()),
+        }),
+        deployment_name: "bf4-deployment".to_string(),
+        flavor_name: "bf4-flavor".to_string(),
+        services,
+        deployment_type: DpuDeploymentType::Bf4Generic,
+        ..Default::default()
+    };
+
+    sdk.create_initialization_objects(&config).await.unwrap();
+
+    let key = ns_key(TEST_NS, "extra-script-pre-ovs-bf4-generic");
+    assert!(
+        mock.configs.contains_key(&key),
+        "first initialization seeds the hook ConfigMap"
+    );
+
+    // Stand in for an operator replacing the placeholder with a site script.
+    let operator_script = "#!/usr/bin/env bash\necho site-specific\n";
+    mock.configs.insert(
+        key.clone(),
+        BTreeMap::from([("script".to_string(), operator_script.to_string())]),
+    );
+
+    sdk.create_initialization_objects(&config).await.unwrap();
+
+    assert_eq!(
+        mock.configs.get(&key).unwrap().get("script").unwrap(),
+        operator_script,
+        "a restart must leave the operator's script alone"
+    );
 }

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -399,6 +399,15 @@ impl DpuServiceInterfaceRepository for InitializationMock {
 
 #[async_trait]
 impl K8sConfigRepository for InitializationMock {
+    async fn create_configmap(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        Ok(true)
+    }
+
     async fn get_configmap(
         &self,
         name: &str,

--- a/crates/dpf/src/test/sdk_maintenance_hold.rs
+++ b/crates/dpf/src/test/sdk_maintenance_hold.rs
@@ -80,6 +80,15 @@ impl DpuNodeMaintenanceRepository for MaintenanceHoldMock {
 
 #[async_trait]
 impl K8sConfigRepository for MaintenanceHoldMock {
+    async fn create_configmap(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        Ok(true)
+    }
+
     async fn get_configmap(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_outdated_dpu.rs
+++ b/crates/dpf/src/test/sdk_outdated_dpu.rs
@@ -119,6 +119,15 @@ impl DpuDeploymentRepository for OutdatedDpuMock {
 /// Required by `build_without_resources`; nothing here reads config or secrets.
 #[async_trait]
 impl K8sConfigRepository for OutdatedDpuMock {
+    async fn create_configmap(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        Ok(true)
+    }
+
     async fn get_configmap(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_provisioning_flow.rs
+++ b/crates/dpf/src/test/sdk_provisioning_flow.rs
@@ -173,6 +173,15 @@ impl DpuNodeRepository for ProvisioningFlowMock {
 
 #[async_trait]
 impl K8sConfigRepository for ProvisioningFlowMock {
+    async fn create_configmap(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        Ok(true)
+    }
+
     async fn get_configmap(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_reboot_annotation.rs
+++ b/crates/dpf/src/test/sdk_reboot_annotation.rs
@@ -95,6 +95,15 @@ impl DpuNodeRepository for RebootAnnotationMock {
 
 #[async_trait]
 impl K8sConfigRepository for RebootAnnotationMock {
+    async fn create_configmap(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _data: BTreeMap<String, String>,
+    ) -> Result<bool, DpfError> {
+        Ok(true)
+    }
+
     async fn get_configmap(
         &self,
         _: &str,

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -476,7 +476,7 @@ rules:
     verbs: ["get", "create", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -474,6 +474,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "create", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/charts/nico-api/templates/dpf-rbac.yaml
+++ b/helm/charts/nico-api/templates/dpf-rbac.yaml
@@ -56,9 +56,11 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "create", "patch"]
   # Extra-script ConfigMaps the BF4 DPUFlavors source via contentFrom.
+  # Create only: their content belongs to the operator, so NICo must not be able
+  # to update or overwrite them.
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["create"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/charts/nico-api/templates/dpf-rbac.yaml
+++ b/helm/charts/nico-api/templates/dpf-rbac.yaml
@@ -55,6 +55,10 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "create", "patch"]
+  # Extra-script ConfigMaps the BF4 DPUFlavors source via contentFrom.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "patch"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
BF4 OVS bootstrap is fixed at provisioning time, so a site needing its own step
around it had to fork the DPUFlavor.

Adds `/opt/dpf/extra-script-{pre,post}-ovs.sh` for BF4 and Astra, sourced from
per-deployment ConfigMaps via `configFiles[].contentFrom`. carbide-api seeds each
with a no-op script; operators edit the ConfigMap, which is not part of the flavor
hash. Seeding is create-if-absent (a force apply would overwrite operator edits on
every restart) and runs before the flavor. Hooks are guarded with `[ -x ]` because
they are `agent-applied` and absent on first boot.

RBAC is required, not incidental: these are carbide-api's first ConfigMap operations
in the DPF namespace and the Role granted `secrets` only.

Also fixed, BF4-only: `--if-exists` on `del-br br-hbn`; post-ovs hook moved after the
intercept bridges rather than midway; `export -f _ovs-vsctl` and `#!/bin/bash` for
parity with Astra. BF3 untouched.

## Related issues

None filed.

## Type of Change

- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


## Additional Notes
