### PR TITLE
refactor(tests): move NVOS polling tests to tested code mod

### DIFF
--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -22,7 +22,6 @@ use carbide_rack_controller::config::ScaleUpFabricManagerApiVersion;
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_rack_controller::firmware_object::FirmwareObjectFetcher;
 use carbide_rack_controller::handler::RackStateHandler;
-use carbide_rack_controller::maintenance::apply_nvos_job_status_response;
 use carbide_rack_controller::metrics::RackMetrics;
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialReader, Credentials,
@@ -40,9 +39,9 @@ use model::expected_rack::ExpectedRack;
 use model::rack::{
     ConfigureNmxClusterCertificateState, ConfigureNmxClusterState, FirmwareUpgradeDeviceStatus,
     FirmwareUpgradeJob, FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope,
-    NvosUpdateState, NvosUpdateSwitchStatus, Rack, RackConfig, RackFirmwareUpgradeState,
-    RackFirmwareUpgradeStatus, RackMaintenanceState, RackPowerState, RackState,
-    RackValidationState, SwitchNvosUpdateState, SwitchNvosUpdateStatus,
+    NvosUpdateState, Rack, RackConfig, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus,
+    RackMaintenanceState, RackPowerState, RackState, RackValidationState, SwitchNvosUpdateState,
+    SwitchNvosUpdateStatus,
 };
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
@@ -856,93 +855,6 @@ async fn test_expected_no_definition_stays_parked(
     );
 
     Ok(())
-}
-
-#[test]
-fn test_nvos_polling_updates_node_id_and_maps_running_to_in_progress() {
-    let mut switch = NvosUpdateSwitchStatus {
-        node_id: "old-node-id".into(),
-        mac: "00:11:22:33:44:55".into(),
-        bmc_ip: "10.0.0.10".into(),
-        nvos_ip: "192.168.10.10".into(),
-        status: "pending".into(),
-        job_id: Some("job-1".into()),
-        error_message: Some("stale error".into()),
-    };
-
-    apply_nvos_job_status_response(
-        &mut switch,
-        "job-1",
-        Ok(rms::GetSwitchSystemImageJobStatusResponse {
-            status: rms::ReturnCode::Success as i32,
-            state: "RUNNING".into(),
-            node_id: "new-node-id".into(),
-            ..Default::default()
-        }),
-    );
-
-    assert_eq!(switch.node_id, "new-node-id");
-    assert_eq!(switch.status, "in_progress");
-    assert_eq!(switch.error_message, None);
-}
-
-#[test]
-fn test_nvos_polling_maps_failed_state_and_uses_error_message() {
-    let mut switch = NvosUpdateSwitchStatus {
-        node_id: "node-id".into(),
-        mac: "00:11:22:33:44:55".into(),
-        bmc_ip: "10.0.0.10".into(),
-        nvos_ip: "192.168.10.10".into(),
-        status: "in_progress".into(),
-        job_id: Some("job-2".into()),
-        error_message: None,
-    };
-
-    apply_nvos_job_status_response(
-        &mut switch,
-        "job-2",
-        Ok(rms::GetSwitchSystemImageJobStatusResponse {
-            status: rms::ReturnCode::Success as i32,
-            state: "failed".into(),
-            error_message: "image install failed".into(),
-            ..Default::default()
-        }),
-    );
-
-    assert_eq!(switch.status, "failed");
-    assert_eq!(
-        switch.error_message.as_deref(),
-        Some("image install failed")
-    );
-}
-
-#[test]
-fn test_nvos_polling_unknown_state_preserves_status_and_sets_error() {
-    let mut switch = NvosUpdateSwitchStatus {
-        node_id: "node-id".into(),
-        mac: "00:11:22:33:44:55".into(),
-        bmc_ip: "10.0.0.10".into(),
-        nvos_ip: "192.168.10.10".into(),
-        status: "pending".into(),
-        job_id: Some("job-3".into()),
-        error_message: None,
-    };
-
-    apply_nvos_job_status_response(
-        &mut switch,
-        "job-3",
-        Ok(rms::GetSwitchSystemImageJobStatusResponse {
-            status: rms::ReturnCode::Success as i32,
-            state: "mystery".into(),
-            ..Default::default()
-        }),
-    );
-
-    assert_eq!(switch.status, "pending");
-    assert_eq!(
-        switch.error_message.as_deref(),
-        Some("Unknown RMS switch image job state mystery")
-    );
 }
 
 /// test_expected_incomplete_device_counts_stays verifies that a rack with a

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -3774,20 +3774,109 @@ mod tests {
     use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
     use carbide_uuid::rack::RackId;
     use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
+    use librms::protos::rack_manager as rms;
     use model::rack::{
         ConfigureNmxClusterState, FirmwareUpgradeDeviceInfo, FirmwareUpgradeState,
-        MaintenanceActivity, MaintenanceScope, NvosUpdateState, RackMaintenanceState,
-        RackPowerState,
+        MaintenanceActivity, MaintenanceScope, NvosUpdateState, NvosUpdateSwitchStatus,
+        RackMaintenanceState, RackPowerState,
     };
     use model::rack_type::{RackHardwareType, RackProductFamily, RackProfile};
 
     use super::{
-        DeviceFirmwareOutcome, DeviceFirmwareProgress, build_switch_device_info_request,
-        delete_rack_maintenance_access_token, filter_inventory_by_scope, firmware_device_status,
-        first_maintenance_state, next_state_after_configure, next_state_after_firmware,
-        next_state_after_nvos, next_state_if_activity_not_requested, profile_hardware_type_or_any,
+        DeviceFirmwareOutcome, DeviceFirmwareProgress, apply_nvos_job_status_response,
+        build_switch_device_info_request, delete_rack_maintenance_access_token,
+        filter_inventory_by_scope, firmware_device_status, first_maintenance_state,
+        next_state_after_configure, next_state_after_firmware, next_state_after_nvos,
+        next_state_if_activity_not_requested, profile_hardware_type_or_any,
         summarize_firmware_outcomes, validate_complete_nmx_fabric_inventory,
     };
+
+    #[test]
+    fn test_nvos_polling_updates_node_id_and_maps_running_to_in_progress() {
+        let mut switch = NvosUpdateSwitchStatus {
+            node_id: "old-node-id".into(),
+            mac: "00:11:22:33:44:55".into(),
+            bmc_ip: "10.0.0.10".into(),
+            nvos_ip: "192.168.10.10".into(),
+            status: "pending".into(),
+            job_id: Some("job-1".into()),
+            error_message: Some("stale error".into()),
+        };
+
+        apply_nvos_job_status_response(
+            &mut switch,
+            "job-1",
+            Ok(rms::GetSwitchSystemImageJobStatusResponse {
+                status: rms::ReturnCode::Success as i32,
+                state: "RUNNING".into(),
+                node_id: "new-node-id".into(),
+                ..Default::default()
+            }),
+        );
+
+        assert_eq!(switch.node_id, "new-node-id");
+        assert_eq!(switch.status, "in_progress");
+        assert_eq!(switch.error_message, None);
+    }
+
+    #[test]
+    fn test_nvos_polling_maps_failed_state_and_uses_error_message() {
+        let mut switch = NvosUpdateSwitchStatus {
+            node_id: "node-id".into(),
+            mac: "00:11:22:33:44:55".into(),
+            bmc_ip: "10.0.0.10".into(),
+            nvos_ip: "192.168.10.10".into(),
+            status: "in_progress".into(),
+            job_id: Some("job-2".into()),
+            error_message: None,
+        };
+
+        apply_nvos_job_status_response(
+            &mut switch,
+            "job-2",
+            Ok(rms::GetSwitchSystemImageJobStatusResponse {
+                status: rms::ReturnCode::Success as i32,
+                state: "failed".into(),
+                error_message: "image install failed".into(),
+                ..Default::default()
+            }),
+        );
+
+        assert_eq!(switch.status, "failed");
+        assert_eq!(
+            switch.error_message.as_deref(),
+            Some("image install failed")
+        );
+    }
+
+    #[test]
+    fn test_nvos_polling_unknown_state_preserves_status_and_sets_error() {
+        let mut switch = NvosUpdateSwitchStatus {
+            node_id: "node-id".into(),
+            mac: "00:11:22:33:44:55".into(),
+            bmc_ip: "10.0.0.10".into(),
+            nvos_ip: "192.168.10.10".into(),
+            status: "pending".into(),
+            job_id: Some("job-3".into()),
+            error_message: None,
+        };
+
+        apply_nvos_job_status_response(
+            &mut switch,
+            "job-3",
+            Ok(rms::GetSwitchSystemImageJobStatusResponse {
+                status: rms::ReturnCode::Success as i32,
+                state: "mystery".into(),
+                ..Default::default()
+            }),
+        );
+
+        assert_eq!(switch.status, "pending");
+        assert_eq!(
+            switch.error_message.as_deref(),
+            Some("Unknown RMS switch image job state mystery")
+        );
+    }
 
     fn test_machine_id(seed: u8) -> MachineId {
         let mut hash = [0u8; 32];


### PR DESCRIPTION
Move the focused NVOS job status response tests out of the legacy `api-core` test module and next to the implementation in `rack-controller`.

## Related issues

#2001 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

