### PR TITLE
patch(v2.1): wait for primary DPU BGP before PXE reboot

### DIFF
--- a/crates/agent/src/hbn_bgp_ipv6_unicast_summary_no_failed_peers.json
+++ b/crates/agent/src/hbn_bgp_ipv6_unicast_summary_no_failed_peers.json
@@ -1,0 +1,5 @@
+{
+  "failedPeersCount": 0,
+  "dynamicPeers": 0,
+  "totalPeers": 2
+}

--- a/crates/agent/src/health.rs
+++ b/crates/agent/src/health.rs
@@ -121,6 +121,8 @@ pub struct HealthCheckParams<'a> {
     pub has_changed_configs: bool,
     pub min_healthy_links: u32,
     pub route_servers: &'a [String],
+    /// Whether this check should require the FNN IPv6-unicast underlay.
+    pub should_check_ipv6_unicast: bool,
     pub hbn_device_names: HBNDeviceNames,
     pub include_dhcp_server: bool,
     pub run_restricted_mode_check: bool,
@@ -167,10 +169,13 @@ pub async fn health_check(params: HealthCheckParams<'_>) -> health_report::Healt
     bgp::check_bgp_stats(
         &mut hr,
         &container_id,
-        params.host_routes,
-        params.min_healthy_links,
-        params.route_servers,
-        params.hbn_device_names,
+        bgp::BgpHealthCheckParams {
+            host_routes: params.host_routes,
+            min_healthy_links: params.min_healthy_links,
+            route_servers: params.route_servers,
+            should_check_ipv6_unicast: params.should_check_ipv6_unicast,
+            hbn_device_names: &params.hbn_device_names,
+        },
     )
     .await;
     check_files(&mut hr, params.hbn_root, &EXPECTED_FILES);

--- a/crates/agent/src/health.rs
+++ b/crates/agent/src/health.rs
@@ -63,20 +63,29 @@ fn make_alert(
     message: String,
     is_critical: bool,
 ) -> health_report::HealthProbeAlert {
-    let classifications = match is_critical {
+    let health_classifications = match is_critical {
         true => vec![
             health_report::HealthAlertClassification::prevent_allocations(),
             health_report::HealthAlertClassification::prevent_host_state_changes(),
         ],
         false => vec![],
     };
+    make_classified_alert(probe_id, probe_target, message, health_classifications)
+}
+
+fn make_classified_alert(
+    probe_id: impl Into<HealthProbeId>,
+    probe_target: Option<String>,
+    message: String,
+    health_classifications: Vec<health_report::HealthAlertClassification>,
+) -> health_report::HealthProbeAlert {
     health_report::HealthProbeAlert {
         id: probe_id.into(),
         target: probe_target,
         in_alert_since: None,
         message,
         tenant_message: None,
-        classifications,
+        classifications: health_classifications,
     }
 }
 
@@ -91,6 +100,25 @@ fn passed(
             id: probe_id.into(),
             target: probe_target,
         })
+}
+
+/// Makes the controller wait for one more health sample after a network update.
+///
+/// The config version and health report are published together. This critical
+/// alert makes the controller wait for the next health sample instead of acting
+/// on neighbor state collected before HBN applied the update.
+fn add_post_config_wait_alert(
+    health_report: &mut health_report::HealthReport,
+    should_wait_for_post_config_check: bool,
+) {
+    if should_wait_for_post_config_check {
+        failed(
+            health_report,
+            probe_ids::PostConfigCheckWait.clone(),
+            None,
+            "Post-config waiting period".to_string(),
+        );
+    }
 }
 
 /// Is enough of HBN ready so that we can configure it?
@@ -119,7 +147,7 @@ pub struct HealthCheckParams<'a> {
     pub hbn_root: &'a Path,
     pub host_routes: &'a [&'a str],
     pub has_changed_configs: bool,
-    pub min_healthy_links: u32,
+    pub min_healthy_links: usize,
     pub route_servers: &'a [String],
     /// Whether this check should require the FNN IPv6-unicast underlay.
     pub should_check_ipv6_unicast: bool,
@@ -180,16 +208,7 @@ pub async fn health_check(params: HealthCheckParams<'_>) -> health_report::Healt
     .await;
     check_files(&mut hr, params.hbn_root, &EXPECTED_FILES);
 
-    // If we just applied a new network config report network as unhealthy.
-    // This gives HBN / BGP time to act on the config.
-    if params.has_changed_configs {
-        failed(
-            &mut hr,
-            probe_ids::PostConfigCheckWait.clone(),
-            None,
-            "Post-config waiting period".to_string(),
-        );
-    }
+    add_post_config_wait_alert(&mut hr, params.has_changed_configs);
 
     hr
 }
@@ -776,6 +795,39 @@ shm              68M  8.2k   68M   1% /run/containerd/io.containerd.grpc.v1.cri/
 overlay          41G   12G   27G  31% /run/containerd/io.containerd.runtime.v2.task/k8s.io/5e38cefc8507fcf3b872fa12f21bdbcc09244832c24a34871ef9d8d519fa37b9/rootfs
 tmpfs           3.4G     0  3.4G   0% /run/user/1002
 "#;
+
+    #[test]
+    fn post_config_wait_alert_tracks_wait_signal() {
+        check_values(
+            [
+                Check {
+                    scenario: "wait signal is clear",
+                    input: false,
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "wait signal adds one critical alert",
+                    input: true,
+                    expect: vec![health_report::HealthProbeAlert {
+                        id: probe_ids::PostConfigCheckWait.clone(),
+                        target: None,
+                        in_alert_since: None,
+                        message: "Post-config waiting period".to_string(),
+                        tenant_message: None,
+                        classifications: vec![
+                            health_report::HealthAlertClassification::prevent_allocations(),
+                            health_report::HealthAlertClassification::prevent_host_state_changes(),
+                        ],
+                    }],
+                },
+            ],
+            |should_wait_for_post_config_check| {
+                let mut report = health_report::HealthReport::empty("forge-dpu-agent".to_string());
+                add_post_config_wait_alert(&mut report, should_wait_for_post_config_check);
+                report.alerts
+            },
+        );
+    }
 
     /// Builds the expected `DiskUtilization` for one `df -HP` row, in the column
     /// order the output lists them: device, size, used, available, then the

--- a/crates/agent/src/health/bgp.rs
+++ b/crates/agent/src/health/bgp.rs
@@ -22,14 +22,21 @@ use serde::Deserialize;
 use super::{failed, make_alert, passed, probe_ids};
 use crate::{HBNDeviceNames, hbn};
 
+/// `BgpHealthCheckParams` contains the configured peers, uplinks, and address
+/// families that the BGP health check should require.
+pub(super) struct BgpHealthCheckParams<'a> {
+    pub(super) host_routes: &'a [&'a str],
+    pub(super) min_healthy_links: u32,
+    pub(super) route_servers: &'a [String],
+    pub(super) should_check_ipv6_unicast: bool,
+    pub(super) hbn_device_names: &'a HBNDeviceNames,
+}
+
 /// Check HBN BGP stats
-pub async fn check_bgp_stats(
+pub(super) async fn check_bgp_stats(
     hr: &mut health_report::HealthReport,
     container_id: &str,
-    host_routes: &[&str],
-    min_healthy_links: u32,
-    route_servers: &[String],
-    hbn_device_names: HBNDeviceNames,
+    params: BgpHealthCheckParams<'_>,
 ) {
     // If BGP daemon is not enabled, we will get a bunch of bogus alerts shown
     // that are not helpful to anyone. Since showing `BgpDaemonEnabled` already
@@ -45,26 +52,43 @@ pub async fn check_bgp_stats(
     let mut health_data = BgpHealthData::default();
 
     // `vtysh` is the Free Range Routing (FRR) shell.
-    match hbn::run_in_container(
+    let bgp_summary_parsed = match hbn::run_in_container(
         container_id,
         &["vtysh", "-c", "show bgp summary json"],
         true,
     )
     .await
     {
-        Ok(bgp_json) => verify_bgp_summary(
-            &mut health_data,
-            &bgp_json,
-            host_routes,
-            min_healthy_links,
-            route_servers,
-            hbn_device_names,
-        ),
+        Ok(bgp_json) => verify_bgp_summary(&mut health_data, &bgp_json, &params),
         Err(err) => {
             tracing::warn!(error = %err, "Failed to fetch BGP summary");
             health_data.other_errors.push(err.to_string());
+            false
         }
     };
+
+    if params.should_check_ipv6_unicast && bgp_summary_parsed {
+        match hbn::run_in_container(
+            container_id,
+            &["vtysh", "-c", "show bgp ipv6 unicast summary failed json"],
+            true,
+        )
+        .await
+        {
+            Ok(failed_peers_json) => verify_failed_ipv6_unicast_peers(
+                &mut health_data,
+                &failed_peers_json,
+                params.min_healthy_links,
+                params.hbn_device_names,
+            ),
+            Err(err) => {
+                tracing::warn!(error = %err, "Failed to fetch failed IPv6-unicast BGP peers");
+                health_data.other_errors.push(format!(
+                    "failed to fetch failed IPv6-unicast BGP peers: {err}"
+                ));
+            }
+        }
+    }
 
     health_data.into_health_report(hr);
 }
@@ -106,21 +130,22 @@ pub fn check_daemon_enabled(hr: &mut health_report::HealthReport, hbn_daemons_fi
     passed(hr, probe_ids::BgpDaemonEnabled.clone(), None);
 }
 
+/// `verify_bgp_summary` records health failures from a parsed FRR summary.
+///
+/// The return value only says whether deserialization succeeded. Individual
+/// BGP failures stay in `health_data` and still return `true`.
 fn verify_bgp_summary(
     health_data: &mut BgpHealthData,
     bgp_json: &str,
-    host_routes: &[&str],
-    min_healthy_links: u32,
-    route_servers: &[String],
-    hbn_device_names: HBNDeviceNames,
-) {
+    params: &BgpHealthCheckParams<'_>,
+) -> bool {
     let networks: BgpNetworks = match serde_json::from_str(bgp_json) {
         Ok(networks) => networks,
-        Err(e) => {
-            health_data.other_errors.push(format!(
-                "failed to deserialize bgp_json: {bgp_json} with error: {e}"
-            ));
-            return;
+        Err(error) => {
+            health_data
+                .other_errors
+                .push(format!("failed to deserialize BGP summary: {error}"));
+            return false;
         }
     };
 
@@ -128,25 +153,40 @@ fn verify_bgp_summary(
         "ipv4_unicast",
         &networks.ipv4_unicast,
         health_data,
-        host_routes,
-        min_healthy_links,
-        hbn_device_names.clone(),
+        params.host_routes,
+        params.min_healthy_links,
+        params.hbn_device_names,
     );
+    if params.should_check_ipv6_unicast {
+        match &networks.ipv6_unicast {
+            Some(ipv6_unicast) => check_bgp_stats_ipv6_unicast(
+                "ipv6_unicast",
+                ipv6_unicast,
+                health_data,
+                params.min_healthy_links,
+                params.hbn_device_names,
+            ),
+            None => health_data
+                .other_errors
+                .push("ipv6_unicast BGP summary was not reported".to_string()),
+        }
+    }
     check_bgp_stats_l2_vpn_evpn(
         "l2_vpn_evpn",
         &networks.l2_vpn_evpn,
         health_data,
-        route_servers,
-        min_healthy_links,
-        hbn_device_names,
+        params.route_servers,
+        params.min_healthy_links,
+        params.hbn_device_names,
     );
+    true
 }
 
 fn check_bgp_tor_routes(
     s: &BgpStats,
     health_data: &mut BgpHealthData,
     min_healthy_links: u32,
-    hbn_device_names: HBNDeviceNames,
+    hbn_device_names: &HBNDeviceNames,
 ) {
     for port_id in 0..min_healthy_links {
         let mut message = None;
@@ -158,11 +198,14 @@ fn check_bgp_tor_routes(
         else {
             // This case should not happen, and will only happen if a configuration error at runtime is applied
             // such as having 7 min_healthy_links but we only have 2 ports
-            health_data.other_errors.push(format!(
+            let error = format!(
                 "The number of min healthy links: {min_healthy_links} \
                 was bigger than the number of uplinks defined by the hbn device names: {}",
                 hbn_device_names.uplinks.len()
-            ));
+            );
+            if !health_data.other_errors.contains(&error) {
+                health_data.other_errors.push(error);
+            }
             return;
         };
 
@@ -189,26 +232,16 @@ fn check_bgp_tor_routes(
     }
 }
 
-fn check_bgp_stats_ipv4_unicast(
+/// Applies the ToR-session and dynamic-peer invariants shared by both underlay
+/// unicast address families.
+fn check_bgp_stats_unicast(
     name: &str,
     s: &BgpStats,
     health_data: &mut BgpHealthData,
-    host_routes: &[&str],
     min_healthy_links: u32,
-    hbn_device_names: HBNDeviceNames,
+    hbn_device_names: &HBNDeviceNames,
 ) {
     check_bgp_tor_routes(s, health_data, min_healthy_links, hbn_device_names);
-
-    // We ignore the BPG sessions pointing towards tenant Machines
-    // Tenants can choose to use or not use them.
-    // However no other sessions are expected
-    for (peer_name, _peer) in s.other_peers() {
-        if !host_routes.contains(&peer_name.as_str()) {
-            health_data
-                .unexpected_peers
-                .push((name.to_string(), peer_name.clone()));
-        }
-    }
 
     if s.dynamic_peers != 0 {
         health_data.other_errors.push(format!(
@@ -218,13 +251,93 @@ fn check_bgp_stats_ipv4_unicast(
     }
 }
 
+/// Checks the default-VRF IPv6 underlay, where every non-ToR peer is
+/// unexpected.
+///
+/// Tenant peers live in per-VPC VRFs, and route-server IPv6 is disabled. That
+/// leaves the configured HBN uplinks as the only expected peers here.
+fn check_bgp_stats_ipv6_unicast(
+    name: &str,
+    s: &BgpStats,
+    health_data: &mut BgpHealthData,
+    min_healthy_links: u32,
+    hbn_device_names: &HBNDeviceNames,
+) {
+    check_bgp_stats_unicast(name, s, health_data, min_healthy_links, hbn_device_names);
+
+    for peer_name in s.peers.keys() {
+        if !hbn_device_names.uplinks.contains(&peer_name.as_str()) {
+            health_data
+                .unexpected_peers
+                .push((name.to_string(), peer_name.clone()));
+        }
+    }
+}
+
+/// Maps FRR's address-family-specific failed-peer view back to the required
+/// physical uplinks.
+///
+/// The regular summary's peer state describes the shared BGP transport. The
+/// filtered view also includes established peers whose remote did not
+/// negotiate IPv6-unicast.
+fn verify_failed_ipv6_unicast_peers(
+    health_data: &mut BgpHealthData,
+    failed_peers_json: &str,
+    min_healthy_links: u32,
+    hbn_device_names: &HBNDeviceNames,
+) {
+    let failed_summary: BgpFailedSummary = match serde_json::from_str(failed_peers_json) {
+        Ok(summary) => summary,
+        Err(error) => {
+            health_data.other_errors.push(format!(
+                "failed to deserialize failed IPv6-unicast BGP summary: {error}"
+            ));
+            return;
+        }
+    };
+
+    for &port_name in hbn_device_names
+        .uplinks
+        .iter()
+        .take(min_healthy_links as usize)
+    {
+        if failed_summary.peers.contains_key(port_name) {
+            health_data
+                .unhealthy_tor_peers
+                .entry(port_name.to_string())
+                .or_insert_with(|| format!("Session {port_name} did not negotiate IPv6-unicast"));
+        }
+    }
+}
+
+fn check_bgp_stats_ipv4_unicast(
+    name: &str,
+    s: &BgpStats,
+    health_data: &mut BgpHealthData,
+    host_routes: &[&str],
+    min_healthy_links: u32,
+    hbn_device_names: &HBNDeviceNames,
+) {
+    check_bgp_stats_unicast(name, s, health_data, min_healthy_links, hbn_device_names);
+
+    // Tenant sessions are optional because tenants choose whether to use them.
+    // No other non-ToR sessions belong in the IPv4-unicast summary.
+    for (peer_name, _peer) in s.other_peers() {
+        if !host_routes.contains(&peer_name.as_str()) {
+            health_data
+                .unexpected_peers
+                .push((name.to_string(), peer_name.clone()));
+        }
+    }
+}
+
 fn check_bgp_stats_l2_vpn_evpn(
     name: &str,
     s: &BgpStats,
     health_data: &mut BgpHealthData,
     route_servers: &[String],
     min_healthy_links: u32,
-    hbn_device_names: HBNDeviceNames,
+    hbn_device_names: &HBNDeviceNames,
 ) {
     // In case Route servers are not specified, the peer list should contain only
     // TORs. Otherwise we expect it to contain the route servers.
@@ -279,10 +392,10 @@ fn check_bgp_stats_l2_vpn_evpn(
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct BgpHealthData {
-    // Note that these are HashMaps because we check TOR connections in 2 places
-    // and dedup the messages using the HashMap
+    // ToR state appears in multiple address-family summaries. Keying by port
+    // emits one alert for each physical link.
     pub unhealthy_tor_peers: HashMap<String, String>,
     pub unhealthy_route_server_peers: Vec<(String, String)>,
     pub unexpected_peers: Vec<(String, String)>,
@@ -336,7 +449,40 @@ impl BgpHealthData {
 #[serde(rename_all = "camelCase")]
 struct BgpNetworks {
     ipv4_unicast: BgpStats,
+    /// FRR can omit or null inactive address families; the configuration gate
+    /// decides when this summary becomes required.
+    ipv6_unicast: Option<BgpStats>,
     l2_vpn_evpn: BgpStats,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(try_from = "BgpFailedSummaryWire")]
+struct BgpFailedSummary {
+    /// FRR omits this map when no peers fail the address-family filter.
+    peers: HashMap<String, serde::de::IgnoredAny>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BgpFailedSummaryWire {
+    #[serde(default)]
+    peers: HashMap<String, serde::de::IgnoredAny>,
+    failed_peers: Option<u32>,
+    failed_peers_count: Option<u32>,
+}
+
+impl TryFrom<BgpFailedSummaryWire> for BgpFailedSummary {
+    type Error = &'static str;
+
+    fn try_from(summary: BgpFailedSummaryWire) -> Result<Self, Self::Error> {
+        if summary.failed_peers.is_none() && summary.failed_peers_count.is_none() {
+            return Err("missing failedPeers or failedPeersCount");
+        }
+
+        Ok(Self {
+            peers: summary.peers,
+        })
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -387,6 +533,8 @@ mod tests {
         include_str!("../hbn_bgp_summary_with_route_server_and_tenant_routes.json");
     const BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_FAILED_ALL_PEERS: &str =
         include_str!("../hbn_bgp_summary_with_route_server_failed_all_peers.json");
+    const BGP_IPV6_UNICAST_SUMMARY_JSON_NO_FAILED_PEERS: &str =
+        include_str!("../hbn_bgp_ipv6_unicast_summary_no_failed_peers.json");
 
     /// One `verify_bgp_summary` scenario: a BGP summary JSON plus the host routes
     /// and route servers that frame what's expected, and the exact alerts the
@@ -547,15 +695,361 @@ mod tests {
                 verify_bgp_summary(
                     &mut health_data,
                     row.json,
-                    row.host_routes,
-                    2,
-                    &route_servers,
-                    HBNDeviceNames::hbn_23(),
+                    &BgpHealthCheckParams {
+                        host_routes: row.host_routes,
+                        min_healthy_links: 2,
+                        route_servers: &route_servers,
+                        should_check_ipv6_unicast: false,
+                        hbn_device_names: &HBNDeviceNames::hbn_23(),
+                    },
                 );
                 health_data.into_health_report(&mut hr);
                 let mut alerts = hr.alerts;
                 sort_alerts(&mut alerts);
                 alerts
+            },
+        );
+    }
+
+    #[test]
+    fn malformed_bgp_summary_is_not_verified() {
+        let mut health_data = BgpHealthData::default();
+
+        let verified = verify_bgp_summary(
+            &mut health_data,
+            r#"{"ipv4Unicast":"#,
+            &BgpHealthCheckParams {
+                host_routes: &[],
+                min_healthy_links: 2,
+                route_servers: &[],
+                should_check_ipv6_unicast: true,
+                hbn_device_names: &HBNDeviceNames::hbn_23(),
+            },
+        );
+
+        assert!(!verified);
+        assert_eq!(health_data.other_errors.len(), 1);
+        assert!(
+            health_data.other_errors[0].starts_with("failed to deserialize BGP summary"),
+            "unexpected error: {}",
+            health_data.other_errors[0]
+        );
+    }
+
+    enum Ipv6UnicastSummary {
+        Missing,
+        Null,
+        Healthy,
+        P0Idle,
+        DynamicPeer,
+        UnexpectedPeer,
+        UnexpectedTorLikePeer,
+        Unhealthy,
+    }
+
+    struct Ipv6UnicastInput {
+        should_check_ipv6_unicast: bool,
+        summary: Ipv6UnicastSummary,
+    }
+
+    #[test]
+    fn ipv6_unicast_summary_checks_enabled_underlay_sessions() {
+        check_values(
+            [
+                Check {
+                    scenario: "disabled health ignores an unhealthy IPv6 summary",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: false,
+                        summary: Ipv6UnicastSummary::Unhealthy,
+                    },
+                    expect: BgpHealthData::default(),
+                },
+                Check {
+                    scenario: "missing enabled address family is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::Missing,
+                    },
+                    expect: BgpHealthData {
+                        other_errors: vec!["ipv6_unicast BGP summary was not reported".to_string()],
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "null enabled address family is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::Null,
+                    },
+                    expect: BgpHealthData {
+                        other_errors: vec!["ipv6_unicast BGP summary was not reported".to_string()],
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "established underlay sessions are healthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::Healthy,
+                    },
+                    expect: BgpHealthData::default(),
+                },
+                Check {
+                    scenario: "idle underlay session is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::P0Idle,
+                    },
+                    expect: BgpHealthData {
+                        unhealthy_tor_peers: HashMap::from([(
+                            "p0_if".to_string(),
+                            "Session p0_if is not Established, but in state Idle".to_string(),
+                        )]),
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "dynamic peers are unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::DynamicPeer,
+                    },
+                    expect: BgpHealthData {
+                        other_errors: vec![
+                            "ipv6_unicast.dynamic_peers is 1 should be 0".to_string(),
+                        ],
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "unexpected default-VRF peer is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::UnexpectedPeer,
+                    },
+                    expect: BgpHealthData {
+                        unexpected_peers: vec![(
+                            "ipv6_unicast".to_string(),
+                            "2001:db8::2".to_string(),
+                        )],
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "unconfigured ToR-like peer is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::UnexpectedTorLikePeer,
+                    },
+                    expect: BgpHealthData {
+                        unexpected_peers: vec![("ipv6_unicast".to_string(), "p2_if".to_string())],
+                        ..Default::default()
+                    },
+                },
+            ],
+            |input: Ipv6UnicastInput| {
+                let mut summary: serde_json::Value =
+                    serde_json::from_str(BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SUCCESS)
+                        .expect("parse known-good BGP summary fixture");
+                match input.summary {
+                    Ipv6UnicastSummary::Missing => {}
+                    Ipv6UnicastSummary::Null => {
+                        summary["ipv6Unicast"] = serde_json::Value::Null;
+                    }
+                    Ipv6UnicastSummary::Healthy => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                    }
+                    Ipv6UnicastSummary::P0Idle => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["peers"]["p0_if"]["state"] = "Idle".into();
+                    }
+                    Ipv6UnicastSummary::DynamicPeer => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["dynamicPeers"] = 1.into();
+                    }
+                    Ipv6UnicastSummary::UnexpectedPeer => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["peers"]["2001:db8::2"] =
+                            summary["ipv4Unicast"]["peers"]["p0_if"].clone();
+                    }
+                    Ipv6UnicastSummary::UnexpectedTorLikePeer => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["peers"]["p2_if"] =
+                            summary["ipv4Unicast"]["peers"]["p0_if"].clone();
+                    }
+                    Ipv6UnicastSummary::Unhealthy => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["peers"]["p0_if"]["state"] = "Idle".into();
+                        summary["ipv6Unicast"]["dynamicPeers"] = 1.into();
+                        summary["ipv6Unicast"]["peers"]["2001:db8::2"] =
+                            summary["ipv4Unicast"]["peers"]["p0_if"].clone();
+                    }
+                }
+
+                let mut health_data = BgpHealthData::default();
+                verify_bgp_summary(
+                    &mut health_data,
+                    &summary.to_string(),
+                    &BgpHealthCheckParams {
+                        host_routes: &[],
+                        min_healthy_links: 2,
+                        route_servers: &[],
+                        should_check_ipv6_unicast: input.should_check_ipv6_unicast,
+                        hbn_device_names: &HBNDeviceNames::hbn_23(),
+                    },
+                );
+                health_data
+            },
+        );
+    }
+
+    struct FailedIpv6SummaryInput {
+        json: &'static str,
+        min_healthy_links: u32,
+        existing_p0_error: Option<&'static str>,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct FailedIpv6SummaryOutcome {
+        unhealthy_tor_peers: HashMap<String, String>,
+        other_error_count: usize,
+        has_deserialization_error: bool,
+    }
+
+    #[test]
+    fn failed_ipv6_unicast_summary_checks_only_required_uplinks() {
+        check_values(
+            [
+                Check {
+                    scenario: "no failed peers is healthy",
+                    input: FailedIpv6SummaryInput {
+                        json: BGP_IPV6_UNICAST_SUMMARY_JSON_NO_FAILED_PEERS,
+                        min_healthy_links: 2,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::new(),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "required p0 negotiation failure is unhealthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":{"p0_if":{}},"failedPeers":1}"#,
+                        min_healthy_links: 1,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::from([(
+                            "p0_if".to_string(),
+                            "Session p0_if did not negotiate IPv6-unicast".to_string(),
+                        )]),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "optional p1 negotiation failure is healthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":{"p1_if":{}},"failedPeers":1}"#,
+                        min_healthy_links: 1,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::new(),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "both required negotiation failures are unhealthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":{"p0_if":{},"p1_if":{}},"failedPeers":2}"#,
+                        min_healthy_links: 2,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::from([
+                            (
+                                "p0_if".to_string(),
+                                "Session p0_if did not negotiate IPv6-unicast".to_string(),
+                            ),
+                            (
+                                "p1_if".to_string(),
+                                "Session p1_if did not negotiate IPv6-unicast".to_string(),
+                            ),
+                        ]),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "transport failure remains the primary diagnosis",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":{"p0_if":{}},"failedPeers":1}"#,
+                        min_healthy_links: 1,
+                        existing_p0_error: Some("Session p0_if is in state Idle"),
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::from([(
+                            "p0_if".to_string(),
+                            "Session p0_if is in state Idle".to_string(),
+                        )]),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "unrelated JSON payload is unhealthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"error":"BGP instance unavailable"}"#,
+                        min_healthy_links: 2,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::new(),
+                        other_error_count: 1,
+                        has_deserialization_error: true,
+                    },
+                },
+                Check {
+                    scenario: "malformed failed-peer summary is unhealthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":"#,
+                        min_healthy_links: 2,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::new(),
+                        other_error_count: 1,
+                        has_deserialization_error: true,
+                    },
+                },
+            ],
+            |input: FailedIpv6SummaryInput| {
+                let mut health_data = BgpHealthData::default();
+                if let Some(error) = input.existing_p0_error {
+                    health_data
+                        .unhealthy_tor_peers
+                        .insert("p0_if".to_string(), error.to_string());
+                }
+
+                verify_failed_ipv6_unicast_peers(
+                    &mut health_data,
+                    input.json,
+                    input.min_healthy_links,
+                    &HBNDeviceNames::hbn_23(),
+                );
+
+                let has_deserialization_error = health_data.other_errors.iter().any(|error| {
+                    error.starts_with("failed to deserialize failed IPv6-unicast BGP summary")
+                });
+                FailedIpv6SummaryOutcome {
+                    unhealthy_tor_peers: health_data.unhealthy_tor_peers,
+                    other_error_count: health_data.other_errors.len(),
+                    has_deserialization_error,
+                }
             },
         );
     }

--- a/crates/agent/src/health/bgp.rs
+++ b/crates/agent/src/health/bgp.rs
@@ -15,18 +15,19 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use health_report::HealthAlertClassification;
 use serde::Deserialize;
 
-use super::{failed, make_alert, passed, probe_ids};
+use super::{failed, make_alert, make_classified_alert, passed, probe_ids};
 use crate::{HBNDeviceNames, hbn};
 
 /// `BgpHealthCheckParams` contains the configured peers, uplinks, and address
 /// families that the BGP health check should require.
 pub(super) struct BgpHealthCheckParams<'a> {
     pub(super) host_routes: &'a [&'a str],
-    pub(super) min_healthy_links: u32,
+    pub(super) min_healthy_links: usize,
     pub(super) route_servers: &'a [String],
     pub(super) should_check_ipv6_unicast: bool,
     pub(super) hbn_device_names: &'a HBNDeviceNames,
@@ -67,7 +68,7 @@ pub(super) async fn check_bgp_stats(
         }
     };
 
-    if params.should_check_ipv6_unicast && bgp_summary_parsed {
+    if params.should_check_ipv6_unicast && bgp_summary_parsed && params.min_healthy_links > 0 {
         match hbn::run_in_container(
             container_id,
             &["vtysh", "-c", "show bgp ipv6 unicast summary failed json"],
@@ -90,7 +91,7 @@ pub(super) async fn check_bgp_stats(
         }
     }
 
-    health_data.into_health_report(hr);
+    health_data.into_health_report(hr, params.min_healthy_links, params.hbn_device_names);
 }
 
 pub fn check_daemon_enabled(hr: &mut health_report::HealthReport, hbn_daemons_file: &str) {
@@ -185,31 +186,30 @@ fn verify_bgp_summary(
 fn check_bgp_tor_routes(
     s: &BgpStats,
     health_data: &mut BgpHealthData,
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
-    for port_id in 0..min_healthy_links {
-        let mut message = None;
-        // The number of healthy links should never be above the total number of avail links
-        let Some(port_name) = hbn_device_names
-            .uplinks
-            .get(port_id as usize)
-            .map(|s| s.to_string())
-        else {
-            // This case should not happen, and will only happen if a configuration error at runtime is applied
-            // such as having 7 min_healthy_links but we only have 2 ports
-            let error = format!(
-                "The number of min healthy links: {min_healthy_links} \
-                was bigger than the number of uplinks defined by the hbn device names: {}",
-                hbn_device_names.uplinks.len()
-            );
-            if !health_data.other_errors.contains(&error) {
-                health_data.other_errors.push(error);
-            }
-            return;
-        };
+    if min_healthy_links > hbn_device_names.uplinks.len() {
+        let error = format!(
+            "The number of min healthy links: {min_healthy_links} \
+            was bigger than the number of uplinks defined by the hbn device names: {}",
+            hbn_device_names.uplinks.len()
+        );
+        if !health_data.other_errors.contains(&error) {
+            health_data.other_errors.push(error);
+        }
+    }
 
-        let session_data = s.peers.get(&port_name);
+    if min_healthy_links == 0 {
+        return;
+    }
+
+    // A positive minimum is a health threshold, not a positional limit on
+    // which physical sessions should be inspected.
+    for &port_name in &hbn_device_names.uplinks {
+        let mut message = None;
+
+        let session_data = s.peers.get(port_name);
         match session_data {
             Some(session) => {
                 if session.state != "Established" {
@@ -227,7 +227,12 @@ fn check_bgp_tor_routes(
         }
 
         if let Some(message) = message {
-            health_data.unhealthy_tor_peers.insert(port_name, message);
+            health_data
+                .tor_session_failures
+                .insert(port_name.to_string());
+            health_data
+                .unhealthy_tor_peers
+                .insert(port_name.to_string(), message);
         }
     }
 }
@@ -238,7 +243,7 @@ fn check_bgp_stats_unicast(
     name: &str,
     s: &BgpStats,
     health_data: &mut BgpHealthData,
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     check_bgp_tor_routes(s, health_data, min_healthy_links, hbn_device_names);
@@ -260,7 +265,7 @@ fn check_bgp_stats_ipv6_unicast(
     name: &str,
     s: &BgpStats,
     health_data: &mut BgpHealthData,
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     check_bgp_stats_unicast(name, s, health_data, min_healthy_links, hbn_device_names);
@@ -274,16 +279,18 @@ fn check_bgp_stats_ipv6_unicast(
     }
 }
 
-/// Maps FRR's address-family-specific failed-peer view back to the required
-/// physical uplinks.
+/// Maps FRR's failed peer view for one address family back to the required uplinks.
 ///
 /// The regular summary's peer state describes the shared BGP transport. The
 /// filtered view also includes established peers whose remote did not
-/// negotiate IPv6-unicast.
+/// negotiate IPv6 unicast. The configured minimum limits this check to the
+/// required uplinks, so a minimum of one requires only the primary uplink to
+/// negotiate IPv6 unicast. Transport health is evaluated separately for both
+/// sessions, so this limit does not hide a total uplink outage.
 fn verify_failed_ipv6_unicast_peers(
     health_data: &mut BgpHealthData,
     failed_peers_json: &str,
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     let failed_summary: BgpFailedSummary = match serde_json::from_str(failed_peers_json) {
@@ -296,11 +303,7 @@ fn verify_failed_ipv6_unicast_peers(
         }
     };
 
-    for &port_name in hbn_device_names
-        .uplinks
-        .iter()
-        .take(min_healthy_links as usize)
-    {
+    for &port_name in hbn_device_names.uplinks.iter().take(min_healthy_links) {
         if failed_summary.peers.contains_key(port_name) {
             health_data
                 .unhealthy_tor_peers
@@ -315,7 +318,7 @@ fn check_bgp_stats_ipv4_unicast(
     s: &BgpStats,
     health_data: &mut BgpHealthData,
     host_routes: &[&str],
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     check_bgp_stats_unicast(name, s, health_data, min_healthy_links, hbn_device_names);
@@ -336,7 +339,7 @@ fn check_bgp_stats_l2_vpn_evpn(
     s: &BgpStats,
     health_data: &mut BgpHealthData,
     route_servers: &[String],
-    min_healthy_links: u32,
+    min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
     // In case Route servers are not specified, the peer list should contain only
@@ -394,16 +397,25 @@ fn check_bgp_stats_l2_vpn_evpn(
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct BgpHealthData {
-    // ToR state appears in multiple address-family summaries. Keying by port
+    // ToR state appears in summaries for multiple address families. Keying by port
     // emits one alert for each physical link.
     pub unhealthy_tor_peers: HashMap<String, String>,
+    // Only transport/session failures should affect allocation policy for the
+    // primary uplink. Failures to negotiate an address family reuse the same
+    // probe ID but do not mean the ToR session itself is unavailable.
+    pub tor_session_failures: HashSet<String>,
     pub unhealthy_route_server_peers: Vec<(String, String)>,
     pub unexpected_peers: Vec<(String, String)>,
     pub other_errors: Vec<String>,
 }
 
 impl BgpHealthData {
-    pub fn into_health_report(mut self, hr: &mut health_report::HealthReport) {
+    pub fn into_health_report(
+        mut self,
+        hr: &mut health_report::HealthReport,
+        min_healthy_links: usize,
+        hbn_device_names: &HBNDeviceNames,
+    ) {
         if self.other_errors.is_empty() {
             passed(hr, probe_ids::BgpStats.clone(), None);
         } else {
@@ -413,15 +425,50 @@ impl BgpHealthData {
             failed(hr, probe_ids::BgpStats.clone(), None, err_msg);
         }
 
-        let num_unhealthy_tors = self.unhealthy_tor_peers.len();
-        // TODO: This is correct for environments with both DPU ports connected
-        let unhealthy_tors_critical = num_unhealthy_tors > 1;
-        for (port_name, message) in self.unhealthy_tor_peers.into_iter() {
-            hr.alerts.push(make_alert(
+        let healthy_uplink_count = hbn_device_names
+            .uplinks
+            .len()
+            .saturating_sub(self.tor_session_failures.len());
+        let minimum_satisfied = healthy_uplink_count >= min_healthy_links;
+        let [primary_uplink, _] = hbn_device_names.uplinks;
+
+        // Apply the configured redundancy suppression before preserving the
+        // legacy policy that two unhealthy physical uplinks are blocking. The
+        // effective set includes address family negotiation warnings as well as
+        // transport failures.
+        let mut effective_unhealthy_tors = self.unhealthy_tor_peers;
+        if min_healthy_links == 0 {
+            effective_unhealthy_tors.clear();
+        } else if minimum_satisfied {
+            for secondary_uplink in hbn_device_names.uplinks.iter().skip(1) {
+                if self.tor_session_failures.contains(*secondary_uplink) {
+                    effective_unhealthy_tors.remove(*secondary_uplink);
+                }
+            }
+        }
+        let multiple_unhealthy_tors = effective_unhealthy_tors.len() > 1;
+
+        // Emit the unhealthy uplinks that remain after applying the configured
+        // redundancy policy, with classifications based on their role and count.
+        for (port_name, message) in effective_unhealthy_tors {
+            let is_primary_session_failure =
+                port_name == primary_uplink && self.tor_session_failures.contains(&port_name);
+
+            let health_classifications = if multiple_unhealthy_tors {
+                vec![
+                    HealthAlertClassification::prevent_allocations(),
+                    HealthAlertClassification::prevent_host_state_changes(),
+                ]
+            } else if is_primary_session_failure {
+                vec![HealthAlertClassification::prevent_allocations()]
+            } else {
+                vec![]
+            };
+            hr.alerts.push(make_classified_alert(
                 probe_ids::BgpPeeringTor.clone(),
                 Some(port_name),
                 message,
-                unhealthy_tors_critical,
+                health_classifications,
             ));
         }
 
@@ -547,15 +594,50 @@ mod tests {
         expected_alerts: Vec<health_report::HealthProbeAlert>,
     }
 
-    /// Builds a TOR-peering alert for `port`, the most common alert these
+    /// Test-only names for the exact classification sets expected by table rows.
+    ///
+    /// This builds the vectors without production classification helpers, so
+    /// the tests can catch policy regressions.
+    #[derive(Clone, Copy)]
+    enum ExpectedClassifications {
+        /// Contains no classifications; the alert remains visible.
+        Unclassified,
+        /// Contains only `PreventAllocations`.
+        PreventAllocations,
+        /// Contains `PreventAllocations` and `PreventHostStateChanges`.
+        PreventAllocationsAndHostStateChanges,
+    }
+
+    impl ExpectedClassifications {
+        fn health_classifications(self) -> Vec<HealthAlertClassification> {
+            match self {
+                Self::Unclassified => vec![],
+                Self::PreventAllocations => {
+                    vec![HealthAlertClassification::prevent_allocations()]
+                }
+                Self::PreventAllocationsAndHostStateChanges => vec![
+                    HealthAlertClassification::prevent_allocations(),
+                    HealthAlertClassification::prevent_host_state_changes(),
+                ],
+            }
+        }
+    }
+
+    /// Builds a ToR BGP peering alert for `port`, the most common alert these
     /// scenarios produce.
-    fn tor_alert(port: &str, message: &str, critical: bool) -> health_report::HealthProbeAlert {
-        make_alert(
-            probe_ids::BgpPeeringTor.clone(),
-            Some(port.to_string()),
-            message.to_string(),
-            critical,
-        )
+    fn tor_alert(
+        port: &str,
+        message: &str,
+        expected_classifications: ExpectedClassifications,
+    ) -> health_report::HealthProbeAlert {
+        health_report::HealthProbeAlert {
+            id: health_report::HealthProbeId::bgp_peering_tor(),
+            target: Some(port.to_string()),
+            in_alert_since: None,
+            message: message.to_string(),
+            tenant_message: None,
+            classifications: expected_classifications.health_classifications(),
+        }
     }
 
     #[test]
@@ -570,7 +652,7 @@ mod tests {
                     expected_alerts: vec![],
                 },
                 Row {
-                    scenario: "both TOR peers down is critical",
+                    scenario: "both ToR peers block allocations and state changes",
                     json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_FAILED_TOR_PEERS,
                     host_routes: &[],
                     route_servers: &[],
@@ -578,24 +660,24 @@ mod tests {
                         tor_alert(
                             "p0_if",
                             "Session p0_if is not Established, but in state Idle",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         tor_alert(
                             "p1_if",
                             "Session p1_if is not Established, but in state Idle",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                     ],
                 },
                 Row {
-                    scenario: "single TOR peer down is not critical",
+                    scenario: "failed primary prevents allocations but not state changes",
                     json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SINGLE_FAILED_TOR_PEER,
                     host_routes: &[],
                     route_servers: &[],
                     expected_alerts: vec![tor_alert(
                         "p0_if",
                         "Session p0_if is not Established, but in state Idle",
-                        false,
+                        ExpectedClassifications::PreventAllocations,
                     )],
                 },
                 Row {
@@ -627,12 +709,12 @@ mod tests {
                         tor_alert(
                             "p0_if",
                             "Expected session for p0_if was not found in BGP peer data",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         tor_alert(
                             "p1_if",
                             "Expected session for p1_if was not found in BGP peer data",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         make_alert(
                             probe_ids::UnexpectedBgpPeer.clone(),
@@ -666,12 +748,12 @@ mod tests {
                         tor_alert(
                             "p0_if",
                             "Session p0_if is not Established, but in state Idle",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         tor_alert(
                             "p1_if",
                             "Session p1_if is not Established, but in state Idle",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                     ],
                 },
@@ -688,9 +770,13 @@ mod tests {
                 }
             }),
             |row: Row| {
+                // Exercise the full ContainerExec/FRR path by collecting
+                // failures, then converting them into the public health alerts.
                 let route_servers: Vec<String> =
                     row.route_servers.iter().map(|s| s.to_string()).collect();
-                let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
+                let hbn_device_names = HBNDeviceNames::hbn_23();
+                let mut report =
+                    health_report::HealthReport::empty("forge-dpu-agent".to_string());
                 let mut health_data = BgpHealthData::default();
                 verify_bgp_summary(
                     &mut health_data,
@@ -700,13 +786,392 @@ mod tests {
                         min_healthy_links: 2,
                         route_servers: &route_servers,
                         should_check_ipv6_unicast: false,
-                        hbn_device_names: &HBNDeviceNames::hbn_23(),
+                        hbn_device_names: &hbn_device_names,
                     },
                 );
-                health_data.into_health_report(&mut hr);
-                let mut alerts = hr.alerts;
+                health_data.into_health_report(&mut report, 2, &hbn_device_names);
+                let mut alerts = report.alerts;
                 sort_alerts(&mut alerts);
                 alerts
+            },
+        );
+    }
+
+    /// Inputs for one ContainerExec/FRR ToR health policy scenario.
+    struct TorHealthInput {
+        /// Configured minimum passed to failure collection and alert classification.
+        min_healthy_links: usize,
+        /// FRR BGP transport state reported for the primary uplink.
+        p0_state: &'static str,
+        /// Compact test encoding for the secondary uplink state.
+        ///
+        /// Real FRR transport states pass through unchanged.
+        /// `ESTABLISHED_WITHOUT_IPV6_UNICAST` instead represents an established
+        /// session that appears in FRR's separate failed IPv6 unicast summary.
+        p1_state: &'static str,
+        /// Whether the primary appears in FRR's failed IPv6 unicast summary.
+        p0_ipv6_unicast_failed: bool,
+    }
+
+    /// Marks an established p1 session whose IPv6 unicast negotiation failed.
+    const ESTABLISHED_WITHOUT_IPV6_UNICAST: &str = "EstablishedWithoutIpv6Unicast";
+
+    #[test]
+    fn bgp_health_data_classifies_redundant_uplink_failures() {
+        check_values(
+            [
+                Check {
+                    scenario: "minimum zero ignores two established sessions",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum zero ignores a failed primary session",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Idle",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum zero ignores a failed secondary session",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum zero ignores two failed sessions",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Idle",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum zero ignores session and negotiation failures",
+                    input: TorHealthInput {
+                        min_healthy_links: 0,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum one accepts two established sessions",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum one keeps a failed primary as an allocation blocker",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Idle",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if is not Established, but in state Idle",
+                        ExpectedClassifications::PreventAllocations,
+                    )],
+                },
+                Check {
+                    scenario: "minimum one suppresses a failed redundant secondary",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum one blocks when both sessions fail",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Idle",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum two accepts two established sessions",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "minimum two keeps a failed primary as an allocation blocker",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Idle",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if is not Established, but in state Idle",
+                        ExpectedClassifications::PreventAllocations,
+                    )],
+                },
+                Check {
+                    scenario: "minimum two keeps a failed secondary visible",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![tor_alert(
+                        "p1_if",
+                        "Session p1_if is not Established, but in state Idle",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Check {
+                    scenario: "minimum two blocks when both sessions fail",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Idle",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum one retains a primary negotiation warning",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if did not negotiate IPv6-unicast",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Check {
+                    scenario: "minimum one retains primary negotiation warning and suppresses failed secondary",
+                    input: TorHealthInput {
+                        min_healthy_links: 1,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if did not negotiate IPv6-unicast",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Check {
+                    scenario: "minimum two keeps a lone primary negotiation warning unclassified",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if did not negotiate IPv6-unicast",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Check {
+                    scenario: "minimum two blocks a failed primary session with a secondary negotiation warning",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Idle",
+                        p1_state: ESTABLISHED_WITHOUT_IPV6_UNICAST,
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if did not negotiate IPv6-unicast",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum two blocks a primary negotiation warning with a failed secondary session",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: "Idle",
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if did not negotiate IPv6-unicast",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if is not Established, but in state Idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum two blocks negotiation warnings on both uplinks",
+                    input: TorHealthInput {
+                        min_healthy_links: 2,
+                        p0_state: "Established",
+                        p1_state: ESTABLISHED_WITHOUT_IPV6_UNICAST,
+                        p0_ipv6_unicast_failed: true,
+                    },
+                    expect: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if did not negotiate IPv6-unicast",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if did not negotiate IPv6-unicast",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Check {
+                    scenario: "minimum above configured uplink count remains a configuration error",
+                    input: TorHealthInput {
+                        min_healthy_links: 3,
+                        p0_state: "Established",
+                        p1_state: "Established",
+                        p0_ipv6_unicast_failed: false,
+                    },
+                    expect: vec![make_alert(
+                        probe_ids::BgpStats.clone(),
+                        None,
+                        "Failures while gathering BGP health data:\nThe number of min healthy links: 3 was bigger than the number of uplinks defined by the hbn device names: 2".to_string(),
+                        true,
+                    )],
+                },
+            ],
+            |input| {
+                // FRR reports transport state and IPv6 unicast negotiation
+                // failures separately. Build both inputs before combining them.
+                let hbn_device_names = HBNDeviceNames::hbn_23();
+                let (p1_session_state, p1_ipv6_unicast_failed) = match input.p1_state {
+                    ESTABLISHED_WITHOUT_IPV6_UNICAST => ("Established", true),
+                    state => (state, false),
+                };
+                let stats = BgpStats {
+                    dynamic_peers: 0,
+                    peers: HashMap::from([
+                        (
+                            "p0_if".to_string(),
+                            BgpPeer {
+                                state: input.p0_state.to_string(),
+                            },
+                        ),
+                        (
+                            "p1_if".to_string(),
+                            BgpPeer {
+                                state: p1_session_state.to_string(),
+                            },
+                        ),
+                    ]),
+                };
+                let mut health_data = BgpHealthData::default();
+                check_bgp_tor_routes(
+                    &stats,
+                    &mut health_data,
+                    input.min_healthy_links,
+                    &hbn_device_names,
+                );
+
+                // Model the separate FRR summary only when an uplink failed
+                // IPv6 unicast negotiation.
+                let failed_ipv6_unicast_json =
+                    match (input.p0_ipv6_unicast_failed, p1_ipv6_unicast_failed) {
+                        (false, false) => None,
+                        (true, false) => {
+                            Some(r#"{"peers":{"p0_if":{}},"failedPeers":1}"#)
+                        }
+                        (false, true) => {
+                            Some(r#"{"peers":{"p1_if":{}},"failedPeers":1}"#)
+                        }
+                        (true, true) => Some(
+                            r#"{"peers":{"p0_if":{},"p1_if":{}},"failedPeers":2}"#,
+                        ),
+                    };
+                if let Some(failed_ipv6_unicast_json) = failed_ipv6_unicast_json {
+                    verify_failed_ipv6_unicast_peers(
+                        &mut health_data,
+                        failed_ipv6_unicast_json,
+                        input.min_healthy_links,
+                        &hbn_device_names,
+                    );
+                }
+
+                // Convert the combined FRR results into the exact public alert
+                // set asserted by each row.
+                let mut report = health_report::HealthReport::empty("forge-dpu-agent".to_string());
+                health_data.into_health_report(
+                    &mut report,
+                    input.min_healthy_links,
+                    &hbn_device_names,
+                );
+                sort_alerts(&mut report.alerts);
+                report.alerts
             },
         );
     }
@@ -805,6 +1270,7 @@ mod tests {
                             "p0_if".to_string(),
                             "Session p0_if is not Established, but in state Idle".to_string(),
                         )]),
+                        tor_session_failures: HashSet::from(["p0_if".to_string()]),
                         ..Default::default()
                     },
                 },
@@ -905,13 +1371,14 @@ mod tests {
 
     struct FailedIpv6SummaryInput {
         json: &'static str,
-        min_healthy_links: u32,
+        min_healthy_links: usize,
         existing_p0_error: Option<&'static str>,
     }
 
     #[derive(Debug, PartialEq, Eq)]
     struct FailedIpv6SummaryOutcome {
         unhealthy_tor_peers: HashMap<String, String>,
+        tor_session_failures: HashSet<String>,
         other_error_count: usize,
         has_deserialization_error: bool,
     }
@@ -929,6 +1396,7 @@ mod tests {
                     },
                     expect: FailedIpv6SummaryOutcome {
                         unhealthy_tor_peers: HashMap::new(),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -945,6 +1413,7 @@ mod tests {
                             "p0_if".to_string(),
                             "Session p0_if did not negotiate IPv6-unicast".to_string(),
                         )]),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -958,6 +1427,7 @@ mod tests {
                     },
                     expect: FailedIpv6SummaryOutcome {
                         unhealthy_tor_peers: HashMap::new(),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -980,6 +1450,7 @@ mod tests {
                                 "Session p1_if did not negotiate IPv6-unicast".to_string(),
                             ),
                         ]),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -996,6 +1467,7 @@ mod tests {
                             "p0_if".to_string(),
                             "Session p0_if is in state Idle".to_string(),
                         )]),
+                        tor_session_failures: HashSet::from(["p0_if".to_string()]),
                         other_error_count: 0,
                         has_deserialization_error: false,
                     },
@@ -1009,6 +1481,7 @@ mod tests {
                     },
                     expect: FailedIpv6SummaryOutcome {
                         unhealthy_tor_peers: HashMap::new(),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 1,
                         has_deserialization_error: true,
                     },
@@ -1022,6 +1495,7 @@ mod tests {
                     },
                     expect: FailedIpv6SummaryOutcome {
                         unhealthy_tor_peers: HashMap::new(),
+                        tor_session_failures: HashSet::new(),
                         other_error_count: 1,
                         has_deserialization_error: true,
                     },
@@ -1033,6 +1507,7 @@ mod tests {
                     health_data
                         .unhealthy_tor_peers
                         .insert("p0_if".to_string(), error.to_string());
+                    health_data.tor_session_failures.insert("p0_if".to_string());
                 }
 
                 verify_failed_ipv6_unicast_peers(
@@ -1047,6 +1522,7 @@ mod tests {
                 });
                 FailedIpv6SummaryOutcome {
                     unhealthy_tor_peers: health_data.unhealthy_tor_peers,
+                    tor_session_failures: health_data.tor_session_failures,
                     other_error_count: health_data.other_errors.len(),
                     has_deserialization_error,
                 }

--- a/crates/agent/src/health/nvue.rs
+++ b/crates/agent/src/health/nvue.rs
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-use health_report::{HealthProbeAlert, HealthProbeSuccess, HealthReport};
+use health_report::{
+    HealthAlertClassification, HealthProbeAlert, HealthProbeSuccess, HealthReport,
+};
 use nvue_client::types::bgp::{BgpNeighbors, BgpPeerState};
 use nvue_client::{FieldFilter, NvueClient};
 
-use super::{failed, make_alert, probe_ids};
+use super::{add_post_config_wait_alert, failed, make_alert, make_classified_alert, probe_ids};
 use crate::HBNDeviceNames;
 
 /// The VRF we'll look for our BGP uplinks in.
@@ -33,6 +35,8 @@ pub(crate) struct NvueHealthCheck<'a> {
     pub(crate) min_healthy_links: usize,
     /// HBN interface names used to identify expected ToR uplink sessions.
     pub(crate) hbn_device_names: &'a HBNDeviceNames,
+    /// Whether this iteration applied a changed HBN configuration through NVUE.
+    pub(crate) has_changed_hbn_config: bool,
 }
 
 impl NvueHealthCheck<'_> {
@@ -51,12 +55,17 @@ impl NvueHealthCheck<'_> {
         }
 
         self.check_bgp_uplinks(&mut report).await;
+        add_post_config_wait_alert(&mut report, self.has_changed_hbn_config);
         report
     }
 
     /// Checks BGP uplink session health through the configured NVUE API target.
     async fn check_bgp_uplinks(&self, report: &mut HealthReport) {
         const BGP_NEIGHBOR_STATE_FIELD: &str = "/*/state";
+
+        if self.min_healthy_links == 0 {
+            return;
+        }
 
         let bgp_neighbors = self
             .nvue_client
@@ -98,32 +107,71 @@ impl NvueHealthCheck<'_> {
     }
 }
 
-/// Checks configured ToR BGP sessions from an already-fetched NVUE BGP neighbor response.
+/// One configured NVUE uplink whose BGP session is not established.
+struct UnhealthyUplink {
+    /// Whether this is the first configured uplink, which PXE boot requires.
+    is_primary: bool,
+    /// HBN interface name used as the health alert target.
+    uplink_name: String,
+    /// Diagnostic reason that the session check failed.
+    message: String,
+}
+
+/// Checks configured ToR BGP sessions using an NVUE response fetched by the caller.
 ///
 /// All configured HBN uplinks are evaluated, and the check passes when at least
 /// `min_healthy_links` of them are present and established. If too few uplinks
 /// are healthy, each missing peer, missing state, or non-established state emits
-/// a `BgpPeeringTor` alert targeted at that uplink. A `BgpPeeringTor` alert is
-/// emitted when `min_healthy_links` asks for more uplinks than the configured
-/// device names provide. The helper does not emit success entries.
-pub(super) fn check_bgp_uplink_sessions(
+/// a `BgpPeeringTor` alert targeted at that uplink. While a redundant session
+/// remains established, an unavailable primary (the first configured uplink)
+/// prevents allocations but not host state changes; an unavailable secondary
+/// has no classifications. With a minimum of one, either established session
+/// satisfies the configured minimum, so only a failed primary remains visible
+/// for the PXE readiness gate. A minimum of zero disables the NVUE neighbor
+/// request and all uplink alerts, including the primary readiness signal. If no
+/// expected uplink is established, each alert prevents allocations and host
+/// state changes. A `BgpPeeringTor` alert is emitted when `min_healthy_links`
+/// asks for more uplinks than the configured device names provide. The helper
+/// does not emit success entries.
+fn check_bgp_uplink_sessions(
     report: &mut HealthReport,
     neighbors: Option<&BgpNeighbors>,
     min_healthy_links: usize,
     hbn_device_names: &HBNDeviceNames,
 ) {
-    let mut unhealthy_uplink_names = Vec::new();
+    let mut unhealthy_uplinks = Vec::new();
     let mut healthy_uplink_count = 0;
-    let expected_hbn_uplinks = hbn_device_names.uplinks.iter().copied();
+    let expected_hbn_uplinks = hbn_device_names.uplinks.iter().copied().enumerate();
 
-    for expected_uplink in expected_hbn_uplinks {
+    for (uplink_index, expected_uplink) in expected_hbn_uplinks {
         match check_expected_peer_established(neighbors, expected_uplink) {
             Ok(()) => healthy_uplink_count += 1,
-            Err(message) => unhealthy_uplink_names.push((expected_uplink.to_string(), message)),
+            Err(message) => unhealthy_uplinks.push(UnhealthyUplink {
+                is_primary: uplink_index == 0,
+                uplink_name: expected_uplink.to_string(),
+                message,
+            }),
         }
     }
 
+    if min_healthy_links == 0 {
+        return;
+    }
+
     if healthy_uplink_count >= min_healthy_links {
+        // A healthy p1 can satisfy the configured minimum, but PXE still
+        // depends on p0, so preserve a failed primary as an allocation blocker.
+        let failed_primary_uplink = unhealthy_uplinks
+            .into_iter()
+            .find(|unhealthy_uplink| unhealthy_uplink.is_primary);
+        if let Some(failed_primary_uplink) = failed_primary_uplink {
+            report.alerts.push(make_classified_alert(
+                probe_ids::BgpPeeringTor.clone(),
+                Some(failed_primary_uplink.uplink_name),
+                failed_primary_uplink.message,
+                bgp_uplink_classifications(true, false),
+            ));
+        }
         return;
     }
 
@@ -141,30 +189,31 @@ pub(super) fn check_bgp_uplink_sessions(
         );
     }
 
-    // This behavior differs from what the non-NVUE code path does (in
-    // BgpHealthData::into_health_report()), in that we always treat this
-    // case as critical. I couldn't make sense of why the other path computes
-    // criticality like this:
-    //
-    // let num_unhealthy_tors = self.unhealthy_tor_peers.len();
-    // // TODO: This is correct for environments with both DPU ports connected
-    // let unhealthy_tors_critical = num_unhealthy_tors > 1;
-    //
-    // This looks like a duplication of what I think min_healthy_links is
-    // concerned with, and also seems to hardcode an assumption about uplink
-    // count.
-    //
-    // It was all added before The Big Squash so I couldn't learn anything from
-    // the git history of the file.
-    // - drew
-    let is_critical = true;
-    for (uplink, message) in unhealthy_uplink_names {
-        report.alerts.push(make_alert(
+    let no_established_uplinks = healthy_uplink_count == 0;
+    for unhealthy_uplink in unhealthy_uplinks {
+        report.alerts.push(make_classified_alert(
             probe_ids::BgpPeeringTor.clone(),
-            Some(uplink),
-            message,
-            is_critical,
+            Some(unhealthy_uplink.uplink_name),
+            unhealthy_uplink.message,
+            bgp_uplink_classifications(unhealthy_uplink.is_primary, no_established_uplinks),
         ));
+    }
+}
+
+/// Selects the classifications for one unavailable ToR uplink.
+fn bgp_uplink_classifications(
+    is_primary: bool,
+    no_established_uplinks: bool,
+) -> Vec<HealthAlertClassification> {
+    if no_established_uplinks {
+        vec![
+            HealthAlertClassification::prevent_allocations(),
+            HealthAlertClassification::prevent_host_state_changes(),
+        ]
+    } else if is_primary {
+        vec![HealthAlertClassification::prevent_allocations()]
+    } else {
+        vec![]
     }
 }
 
@@ -214,31 +263,69 @@ mod tests {
         expected_alerts: Vec<health_report::HealthProbeAlert>,
     }
 
+    /// Test-only names for the exact classification sets expected by table rows.
+    ///
+    /// This builds the vectors without production classification helpers, so
+    /// the tests can catch policy regressions.
+    #[derive(Clone, Copy)]
+    enum ExpectedClassifications {
+        /// Contains no classifications; the alert remains visible.
+        Unclassified,
+        /// Contains only `PreventAllocations`.
+        PreventAllocations,
+        /// Contains `PreventAllocations` and `PreventHostStateChanges`.
+        PreventAllocationsAndHostStateChanges,
+    }
+
+    impl ExpectedClassifications {
+        fn health_classifications(self) -> Vec<HealthAlertClassification> {
+            match self {
+                Self::Unclassified => vec![],
+                Self::PreventAllocations => {
+                    vec![HealthAlertClassification::prevent_allocations()]
+                }
+                Self::PreventAllocationsAndHostStateChanges => vec![
+                    HealthAlertClassification::prevent_allocations(),
+                    HealthAlertClassification::prevent_host_state_changes(),
+                ],
+            }
+        }
+    }
+
     /// Builds NVUE BGP neighbors from a compact scenario JSON fixture.
     fn bgp_neighbors(bgp_json: &str) -> Option<BgpNeighbors> {
         serde_json::from_str(bgp_json).expect("BGP neighbors should deserialize")
     }
 
-    /// Builds a ToR peering alert with the same target and criticality rules as production.
-    fn tor_alert(port: &str, message: &str, critical: bool) -> health_report::HealthProbeAlert {
-        make_alert(
-            probe_ids::BgpPeeringTor.clone(),
-            Some(port.to_string()),
-            message.to_string(),
-            critical,
-        )
+    /// Builds an expected ToR peering alert independently of the production helper.
+    fn tor_alert(
+        port: &str,
+        message: &str,
+        expected_classifications: ExpectedClassifications,
+    ) -> health_report::HealthProbeAlert {
+        health_report::HealthProbeAlert {
+            id: health_report::HealthProbeId::bgp_peering_tor(),
+            target: Some(port.to_string()),
+            in_alert_since: None,
+            message: message.to_string(),
+            tenant_message: None,
+            classifications: expected_classifications.health_classifications(),
+        }
     }
 
     /// Builds the site-configuration alert for impossible uplink thresholds.
     fn config_mismatch_alert(min_healthy_links: usize) -> health_report::HealthProbeAlert {
-        make_alert(
-            probe_ids::BgpPeeringTor.clone(),
-            None,
-            format!(
+        health_report::HealthProbeAlert {
+            id: health_report::HealthProbeId::bgp_peering_tor(),
+            target: None,
+            in_alert_since: None,
+            message: format!(
                 "Site configuration requires a minimum of {min_healthy_links} healthy uplinks, but this is greater than the number of expected uplink interface names (p0_if,p1_if)"
             ),
-            true,
-        )
+            tenant_message: None,
+            classifications: ExpectedClassifications::PreventAllocationsAndHostStateChanges
+                .health_classifications(),
+        }
     }
 
     /// Orders alerts by `(id, target, message)` so table rows can stay readable.
@@ -262,24 +349,24 @@ mod tests {
                     expected_alerts: vec![],
                 },
                 Row {
-                    scenario: "null neighbor response alerts for each configured uplink",
+                    scenario: "missing neighbor data blocks allocations and host state changes",
                     bgp_json: r#"null"#,
                     min_healthy_links: 2,
                     expected_alerts: vec![
                         tor_alert(
                             "p0_if",
                             "BGP neighbor data was not reported; expected session for p0_if",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                         tor_alert(
                             "p1_if",
                             "BGP neighbor data was not reported; expected session for p1_if",
-                            true,
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
                         ),
                     ],
                 },
                 Row {
-                    scenario: "missing configured uplink targets that uplink",
+                    scenario: "missing secondary stays visible without classifications",
                     bgp_json: r#"
                     {
                         "p0_if": { "state": "established" }
@@ -289,11 +376,11 @@ mod tests {
                     expected_alerts: vec![tor_alert(
                         "p1_if",
                         "expected session for p1_if was not found in BGP peer data",
-                        true,
+                        ExpectedClassifications::Unclassified,
                     )],
                 },
                 Row {
-                    scenario: "idle configured uplink alerts when below threshold",
+                    scenario: "failed primary prevents allocations but not state changes",
                     bgp_json: r#"
                     {
                         "p0_if": { "state": "idle" },
@@ -304,11 +391,48 @@ mod tests {
                     expected_alerts: vec![tor_alert(
                         "p0_if",
                         "BGP session p0_if is not established, but in state idle",
-                        true,
+                        ExpectedClassifications::PreventAllocations,
                     )],
                 },
                 Row {
-                    scenario: "another non-established state alerts",
+                    scenario: "failed secondary stays visible without classifications",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 2,
+                    expected_alerts: vec![tor_alert(
+                        "p1_if",
+                        "BGP session p1_if is not established, but in state idle",
+                        ExpectedClassifications::Unclassified,
+                    )],
+                },
+                Row {
+                    scenario: "two failed sessions block allocations and state changes",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "idle" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 2,
+                    expected_alerts: vec![
+                        tor_alert(
+                            "p0_if",
+                            "BGP session p0_if is not established, but in state idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "BGP session p1_if is not established, but in state idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Row {
+                    scenario: "active primary session prevents allocations",
                     bgp_json: r#"
                     {
                         "p0_if": { "state": "active" },
@@ -319,11 +443,11 @@ mod tests {
                     expected_alerts: vec![tor_alert(
                         "p0_if",
                         "BGP session p0_if is not established, but in state active",
-                        true,
+                        ExpectedClassifications::PreventAllocations,
                     )],
                 },
                 Row {
-                    scenario: "missing state alerts",
+                    scenario: "primary with missing state prevents allocations",
                     bgp_json: r#"
                     {
                         "p0_if": {},
@@ -334,7 +458,7 @@ mod tests {
                     expected_alerts: vec![tor_alert(
                         "p0_if",
                         "state field for p0_if peer is not present",
-                        true,
+                        ExpectedClassifications::PreventAllocations,
                     )],
                 },
                 Row {
@@ -351,7 +475,7 @@ mod tests {
                     expected_alerts: vec![],
                 },
                 Row {
-                    scenario: "one healthy uplink may be the second configured uplink",
+                    scenario: "minimum one keeps failed primary as allocation blocker",
                     bgp_json: r#"
                     {
                         "p0_if": { "state": "idle" },
@@ -359,6 +483,65 @@ mod tests {
                     }
                     "#,
                     min_healthy_links: 1,
+                    expected_alerts: vec![tor_alert(
+                        "p0_if",
+                        "BGP session p0_if is not established, but in state idle",
+                        ExpectedClassifications::PreventAllocations,
+                    )],
+                },
+                Row {
+                    scenario: "minimum one accepts two established sessions",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "established" }
+                    }
+                    "#,
+                    min_healthy_links: 1,
+                    expected_alerts: vec![],
+                },
+                Row {
+                    scenario: "minimum one suppresses failed secondary after p0 is established",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "established" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 1,
+                    expected_alerts: vec![],
+                },
+                Row {
+                    scenario: "minimum one still blocks when both sessions fail",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "idle" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 1,
+                    expected_alerts: vec![
+                        tor_alert(
+                            "p0_if",
+                            "BGP session p0_if is not established, but in state idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "BGP session p1_if is not established, but in state idle",
+                            ExpectedClassifications::PreventAllocationsAndHostStateChanges,
+                        ),
+                    ],
+                },
+                Row {
+                    scenario: "minimum zero disables every uplink alert",
+                    bgp_json: r#"
+                    {
+                        "p0_if": { "state": "idle" },
+                        "p1_if": { "state": "idle" }
+                    }
+                    "#,
+                    min_healthy_links: 0,
                     expected_alerts: vec![],
                 },
                 Row {
@@ -374,6 +557,8 @@ mod tests {
                 },
             ]
             .map(|mut row| {
+                // Alert emission order is not part of the policy under test, so
+                // normalize each expected row before moving it into `Check`.
                 sort_alerts(&mut row.expected_alerts);
                 let expect = row.expected_alerts.clone();
                 Check {
@@ -383,16 +568,18 @@ mod tests {
                 }
             }),
             |row| {
-                let mut hr = HealthReport::empty("forge-dpu-agent".to_string());
+                // Parse the NVUE response, apply the uplink policy, and compare
+                // the complete alert set independent of emission order.
+                let mut report = HealthReport::empty("forge-dpu-agent".to_string());
                 let bgp_neighbors = bgp_neighbors(row.bgp_json);
                 check_bgp_uplink_sessions(
-                    &mut hr,
+                    &mut report,
                     bgp_neighbors.as_ref(),
                     row.min_healthy_links,
                     &HBNDeviceNames::hbn_23(),
                 );
-                sort_alerts(&mut hr.alerts);
-                hr.alerts
+                sort_alerts(&mut report.alerts);
+                report.alerts
             },
         );
     }

--- a/crates/agent/src/health/probe_ids.rs
+++ b/crates/agent/src/health/probe_ids.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
     pub static ref DhcpRelay: HealthProbeId = "DhcpRelay".parse().unwrap();
     pub static ref DhcpServer: HealthProbeId = "DhcpServer".parse().unwrap();
     pub static ref BgpStats: HealthProbeId = "BgpStats".parse().unwrap();
-    pub static ref BgpPeeringTor: HealthProbeId = "BgpPeeringTor".parse().unwrap();
+    pub static ref BgpPeeringTor: HealthProbeId = HealthProbeId::bgp_peering_tor();
     pub static ref BgpPeeringRouteServer: HealthProbeId = "BgpPeeringRouteServer".parse().unwrap();
     pub static ref UnexpectedBgpPeer: HealthProbeId = "UnexpectedBgpPeer".parse().unwrap();
     pub static ref Ifreload: HealthProbeId = "Ifreload".parse().unwrap();

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -391,6 +391,9 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                 has_changed_configs: false,
                 min_healthy_links: 2,
                 route_servers: &[],
+                // Standalone checks lack managed-host config to establish that
+                // the FNN IPv6 underlay is active.
+                should_check_ipv6_unicast: false,
                 hbn_device_names: HBNDeviceNames::hbn_23(),
                 include_dhcp_server: false,
                 run_restricted_mode_check: true,

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -823,6 +823,7 @@ impl MainLoop {
                     .collect();
 
                 let tenant_peers = ethernet_virtualization::tenant_peers(&conf);
+                let mut should_check_ipv6_unicast = false;
                 if self.is_hbn_up {
                     // First thing is to read the existing HBN version and properly set the hbn device names
                     // associated with that version.
@@ -875,10 +876,12 @@ impl MainLoop {
                     }
 
                     tracing::trace!(network_config = ?conf, "Desired network config");
-                    // Get the actual virtualization type to use for configuring
-                    // an interface, where we'll default to reading the one provided
-                    // by the Carbide API, with the ability to override via RunOptions.
+                    // Resolve the virtualization type used to generate HBN
+                    // configuration, including any RunOptions override. The IPv6
+                    // health gate follows that same effective value.
                     let virtualization_type = effective_virtualization_type(&conf, &self.options)?;
+                    should_check_ipv6_unicast =
+                        ipv6_unicast_health_enabled(&conf, virtualization_type);
 
                     let dhcp_result = ethernet_virtualization::update_dhcp(
                         &self.agent_config.hbn.root_dir,
@@ -1085,6 +1088,7 @@ impl MainLoop {
                             has_changed_configs,
                             min_healthy_links: conf.min_dpu_functioning_links.unwrap_or(2),
                             route_servers: &conf.route_servers,
+                            should_check_ipv6_unicast,
                             hbn_device_names: self.hbn_device_names.clone(),
                             include_dhcp_server: !conf.use_admin_network || conf.is_primary_dpu,
                             run_restricted_mode_check: false,
@@ -1298,6 +1302,23 @@ impl MainLoop {
             loop_period: Default::default(),
         }
     }
+}
+
+/// Enables IPv6-unicast health only after the effective FNN configuration has
+/// the dedicated IPv6 loopback used by that underlay.
+///
+/// FNN templates activate the address family before the loopback pool is
+/// available, so FRR summary-key presence cannot serve as the activation
+/// signal.
+fn ipv6_unicast_health_enabled(
+    conf: &ManagedHostNetworkConfigResponse,
+    virtualization_type: VpcVirtualizationType,
+) -> bool {
+    virtualization_type == VpcVirtualizationType::Fnn
+        && conf
+            .managed_host_config
+            .as_ref()
+            .is_some_and(|config| config.loopback_ip_v6.is_some())
 }
 
 /// effective_virtualization_type returns the virtualization type
@@ -1648,6 +1669,77 @@ ATF: v2.2(release):4.9.3-")
 #[cfg(test)]
 mod test {
     use super::*;
+
+    enum ManagedHostConfigInput {
+        Missing,
+        WithoutIpv6Loopback,
+        WithIpv6Loopback(&'static str),
+    }
+
+    struct Ipv6UnicastHealthRow {
+        virtualization_type: VpcVirtualizationType,
+        managed_host_config: ManagedHostConfigInput,
+    }
+
+    #[test]
+    fn ipv6_unicast_health_requires_fnn_with_an_ipv6_loopback() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(run = |row: Ipv6UnicastHealthRow| {
+            let managed_host_config = match row.managed_host_config {
+                ManagedHostConfigInput::Missing => None,
+                ManagedHostConfigInput::WithoutIpv6Loopback => {
+                    Some(rpc::ManagedHostNetworkConfig {
+                        loopback_ip: "10.0.0.1".to_string(),
+                        loopback_ip_v6: None,
+                        quarantine_state: None,
+                    })
+                }
+                ManagedHostConfigInput::WithIpv6Loopback(loopback_ip_v6) => {
+                    Some(rpc::ManagedHostNetworkConfig {
+                        loopback_ip: "10.0.0.1".to_string(),
+                        loopback_ip_v6: Some(loopback_ip_v6.to_string()),
+                        quarantine_state: None,
+                    })
+                }
+            };
+            let conf = ManagedHostNetworkConfigResponse {
+                managed_host_config,
+                ..Default::default()
+            };
+            ipv6_unicast_health_enabled(&conf, row.virtualization_type)
+        };
+            "FNN with a reserved IPv6 loopback" {
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::Fnn,
+                    managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
+                } => true,
+            }
+
+            "inactive IPv6 underlay" {
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::Fnn,
+                    managed_host_config: ManagedHostConfigInput::Missing,
+                } => false,
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::Fnn,
+                    managed_host_config: ManagedHostConfigInput::WithoutIpv6Loopback,
+                } => false,
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::EthernetVirtualizer,
+                    managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
+                } => false,
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
+                } => false,
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::Flat,
+                    managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
+                } => false,
+            }
+        );
+    }
 
     #[test]
     fn test_current_network_version_hashes_nested_managed_host_config() {

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -769,6 +769,7 @@ impl MainLoop {
         let mut current_config_error = None;
         let mut is_healthy = false;
         let mut has_changed_configs = false;
+        let mut has_changed_hbn_config = false;
         let mut current_host_network_config_version = None;
         let mut current_instance_network_config_version = None;
         let mut current_instance_config_version = None;
@@ -986,7 +987,9 @@ impl MainLoop {
                             .await;
 
                     let joined_result = match (update_result, dhcp_result, astra_config_status) {
-                        (Ok(a), Ok(b), Ok(spx_net_status)) => Ok((a | b, spx_net_status)),
+                        (Ok(hbn_changed), Ok(dhcp_changed), Ok(spx_net_status)) => {
+                            Ok((hbn_changed, dhcp_changed, spx_net_status))
+                        }
                         (update_result, dhcp_result, astra_config_status) => {
                             let mut errors = Vec::new();
 
@@ -1004,9 +1007,10 @@ impl MainLoop {
                         }
                     };
                     match joined_result {
-                        Ok((has_changed, astra_config_status)) => {
+                        Ok((hbn_changed, dhcp_changed, astra_config_status)) => {
                             self.current_network_version.update_from(&conf);
-                            has_changed_configs = has_changed;
+                            has_changed_hbn_config = hbn_changed;
+                            has_changed_configs = hbn_changed || dhcp_changed;
                             if conf.astra_config.is_some() {
                                 status_out.astra_config_status = Some(astra_config_status);
                             }
@@ -1080,13 +1084,16 @@ impl MainLoop {
                 current_instance_config_version = status_out.instance_config_version.clone();
                 current_instance_id = status_out.instance_id.as_ref().map(|id| id.to_string());
 
+                let min_healthy_links = conf.min_dpu_functioning_links.unwrap_or(2) as usize;
                 let health_report = match self.nvue_context.as_ref() {
                     None => {
+                        // In `ContainerExec` mode, the DHCP flag represents a real local
+                        // reload, so keep the existing wait while that service restarts.
                         health::health_check(HealthCheckParams {
                             hbn_root: &self.agent_config.hbn.root_dir,
                             host_routes: &tenant_peers,
                             has_changed_configs,
-                            min_healthy_links: conf.min_dpu_functioning_links.unwrap_or(2),
+                            min_healthy_links,
                             route_servers: &conf.route_servers,
                             should_check_ipv6_unicast,
                             hbn_device_names: self.hbn_device_names.clone(),
@@ -1096,10 +1103,13 @@ impl MainLoop {
                         .await
                     }
                     Some(nvue_context) => {
+                        // DHCP gRPC reports every accepted request as changed, so only an
+                        // actual HBN update may trigger the NVUE wait after a config update.
                         health::nvue::NvueHealthCheck {
                             nvue_client: &nvue_context.nvue_client,
-                            min_healthy_links: conf.min_dpu_functioning_links.unwrap_or(2) as usize,
+                            min_healthy_links,
                             hbn_device_names: &self.hbn_device_names,
+                            has_changed_hbn_config,
                         }
                         .health_check()
                         .await

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -442,9 +442,11 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub network_security_group: NetworkSecurityGroupConfig,
 
-    /// Minimum functioning DPU links required for the DPU
-    /// to be considered healthy. If unset, all links must
-    /// be functional.
+    /// Controls the DPU ToR BGP health checks. If unset, both uplinks are
+    /// checked; zero disables the checks, and values above two produce a
+    /// configuration health alert. With one, either established link satisfies
+    /// the minimum, but a failed p0 is still reported because PXE boot depends
+    /// on the primary session.
     #[serde(default)]
     pub min_dpu_functioning_links: Option<u32>,
 

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -51,6 +51,7 @@ use futures_util::future::join_all;
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 use mac_address::MacAddress;
+use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::dpu_machine_update::DpuMachineUpdate;
 use model::instance::config::extension_services::InstanceExtensionServicesConfig;
 use model::instance::config::infiniband::InstanceInfinibandConfig;
@@ -1348,6 +1349,216 @@ async fn test_instance_deletion_before_provisioning_finishes(
 
     // Now go through regular deletion
     mh.delete_instance(&env, instance_id).await;
+}
+
+#[crate::sqlx_test]
+async fn test_instance_waits_for_primary_dpu_bgp_before_pxe_reboot(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    const PRIMARY_DPU_BGP_WAIT_REASON: &str =
+        "Waiting for the primary DPU p0 BGP session to be established";
+    const HOST_HEALTH_WAIT_REASON: &str =
+        "Waiting for lifecycle-blocking host health alerts to clear before PXE reboot";
+
+    fn dpu_health_alert(
+        id: &str,
+        target: Option<&str>,
+        classifications: Vec<health_report::HealthAlertClassification>,
+    ) -> rpc::health::HealthReport {
+        rpc::health::HealthReport {
+            source: "forge-dpu-agent".to_string(),
+            triggered_by: None,
+            observed_at: None,
+            successes: vec![],
+            alerts: vec![rpc::health::HealthProbeAlert {
+                id: id.to_string(),
+                target: target.map(str::to_string),
+                in_alert_since: None,
+                message: "test lifecycle gate".to_string(),
+                tenant_message: None,
+                classifications: classifications
+                    .into_iter()
+                    .map(|classification| classification.to_string())
+                    .collect(),
+            }],
+        }
+    }
+
+    fn post_config_wait_health() -> rpc::health::HealthReport {
+        dpu_health_alert(
+            "PostConfigCheckWait",
+            None,
+            vec![
+                health_report::HealthAlertClassification::prevent_allocations(),
+                health_report::HealthAlertClassification::prevent_host_state_changes(),
+            ],
+        )
+    }
+
+    fn bgp_tor_health(target: &str, prevent_allocations: bool) -> rpc::health::HealthReport {
+        let classifications = prevent_allocations
+            .then(health_report::HealthAlertClassification::prevent_allocations)
+            .into_iter()
+            .collect();
+        dpu_health_alert(
+            health_report::HealthProbeId::bgp_peering_tor().as_str(),
+            Some(target),
+            classifications,
+        )
+    }
+
+    fn pxe_blocking_bgp_merge(source: &str) -> health_report::HealthReport {
+        health_report::HealthReport {
+            source: source.to_string(),
+            triggered_by: None,
+            observed_at: None,
+            successes: vec![],
+            alerts: vec![health_report::HealthProbeAlert {
+                id: health_report::HealthProbeId::bgp_peering_tor(),
+                target: Some("p0_if".to_string()),
+                in_alert_since: None,
+                message: "test additive PXE gate".to_string(),
+                tenant_message: None,
+                classifications: vec![
+                    health_report::HealthAlertClassification::prevent_allocations(),
+                ],
+            }],
+        }
+    }
+
+    async fn assert_instance_state(env: &TestEnv, mh: &TestManagedHost, expected: InstanceState) {
+        let mut txn = env.db_txn().await;
+        assert_eq!(
+            mh.host().db_machine(&mut txn).await.current_state(),
+            &ManagedHostState::Assigned {
+                instance_state: expected,
+            }
+        );
+        txn.commit().await.unwrap();
+    }
+
+    async fn assert_pxe_reboot_wait_outcome(
+        env: &TestEnv,
+        mh: &TestManagedHost,
+        expected_reason: &str,
+    ) {
+        let mut txn = env.db_txn().await;
+        let host_machine = mh.host().db_machine(&mut txn).await;
+        let Some(PersistentStateHandlerOutcome::Wait {
+            reason,
+            source_ref: Some(source_ref),
+        }) = &host_machine.controller_state_outcome
+        else {
+            panic!("The PXE reboot gate should persist a Wait outcome with a source reference");
+        };
+        assert_eq!(reason, expected_reason);
+        assert!(source_ref.file.ends_with("/handler.rs"));
+        txn.commit().await.unwrap();
+    }
+
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh = create_managed_host(&env).await;
+    let dpu_id = mh.dpu().id;
+
+    let config = InstanceConfig::default_tenant_and_os()
+        .network(single_interface_network_config(segment_id));
+    env.api
+        .allocate_instance(
+            InstanceAllocationRequest::builder(false)
+                .machine_id(mh.host().id)
+                .config(config)
+                .metadata(rpc::Metadata {
+                    name: "test_instance".to_string(),
+                    description: "tests/instance".to_string(),
+                    labels: Vec::new(),
+                })
+                .tonic_request(),
+        )
+        .await
+        .expect("Create instance failed.");
+
+    env.run_network_segment_controller_iteration().await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        10,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::WaitingForNetworkConfig,
+        },
+    )
+    .await;
+
+    // Both the configuration settle period and a failed p0 session hold the
+    // initial network configuration gate.
+    network_configured_with_health(&env, &dpu_id, Some(post_config_wait_health())).await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForNetworkConfig).await;
+
+    network_configured_with_health(&env, &dpu_id, Some(bgp_tor_health("p0_if", true))).await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForNetworkConfig).await;
+
+    // An empty DPU Replace report masks the agent Merge report and allows
+    // provisioning to advance to the reboot gate.
+    send_health_report_entry(
+        &env,
+        &dpu_id,
+        (
+            health_report::HealthReport::empty("test-pxe-bgp-override".to_string()),
+            health_report::HealthReportApplyMode::Replace,
+        ),
+    )
+    .await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::WaitingForRebootToReady,
+        },
+    )
+    .await;
+
+    // Removing the Replace report exposes the agent p0 alert again, so the
+    // reboot gate must recheck it before restarting the host.
+    remove_health_report_entry(&env, &dpu_id, "test-pxe-bgp-override".to_string()).await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForRebootToReady).await;
+    assert_pxe_reboot_wait_outcome(&env, &mh, PRIMARY_DPU_BGP_WAIT_REASON).await;
+
+    // The reboot gate also rechecks health alerts that block host state
+    // changes and persists a diagnosable wait reason.
+    network_configured_with_health(&env, &dpu_id, Some(post_config_wait_health())).await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForRebootToReady).await;
+    assert_pxe_reboot_wait_outcome(&env, &mh, HOST_HEALTH_WAIT_REASON).await;
+
+    // A visible p1 alert permits reboot, but an additional primary DPU Merge
+    // report that carries the p0 classification still blocks it.
+    network_configured_with_health(&env, &dpu_id, Some(bgp_tor_health("p1_if", false))).await;
+    send_health_report_entry(
+        &env,
+        &dpu_id,
+        (
+            pxe_blocking_bgp_merge("test-pxe-bgp-merge"),
+            health_report::HealthReportApplyMode::Merge,
+        ),
+    )
+    .await;
+    env.run_machine_state_controller_iteration().await;
+    assert_instance_state(&env, &mh, InstanceState::WaitingForRebootToReady).await;
+
+    // Clearing the last PXE blocking Merge report lets provisioning reach Ready.
+    remove_health_report_entry(&env, &dpu_id, "test-pxe-bgp-merge".to_string()).await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        },
+    )
+    .await;
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -42,9 +42,9 @@ use common::api_fixtures::network_segment::{
 use common::api_fixtures::tpm_attestation::{CA_CERT_SERIALIZED, EK_CERT_SERIALIZED};
 use common::api_fixtures::{
     TestEnv, TestManagedHost, create_managed_host, create_managed_host_with_config,
-    create_test_env, create_test_env_with_overrides, get_config,
+    create_test_env, create_test_env_with_overrides, get_config, simulate_hardware_health_report,
 };
-use health_report::HealthReport;
+use health_report::{HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthReport};
 use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
 use measured_boot::bundle::MeasurementBundle;
@@ -5513,6 +5513,62 @@ async fn load_host_state(env: &TestEnv, host_id: &MachineId) -> ManagedHostState
     .expect("host should exist")
     .current_state()
     .clone()
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_reboot_checks_health_for_zero_dpu(pool: sqlx::PgPool) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    let host_id = mh.host().id;
+    set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
+
+    let health_source = "test-reboot-health-gate";
+    let mut blocking_health = HealthReport::empty(health_source.to_string());
+    blocking_health.alerts.push(HealthProbeAlert {
+        id: HealthProbeId::sku_validation(),
+        target: None,
+        in_alert_since: None,
+        message: "test host health alert".to_string(),
+        tenant_message: None,
+        classifications: vec![HealthAlertClassification::prevent_host_state_changes()],
+    });
+    simulate_hardware_health_report(&env, &host_id, blocking_health).await;
+
+    // The aggregate health gate applies even when the host has no managed DPU.
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &host_id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::WaitingForRebootToReady,
+        }
+    );
+
+    let mut txn = env.db_txn().await;
+    let host_machine = mh.host().db_machine(&mut txn).await;
+    let Some(PersistentStateHandlerOutcome::Wait { reason, .. }) =
+        &host_machine.controller_state_outcome
+    else {
+        panic!("host health alert should persist a Wait outcome");
+    };
+    assert_eq!(
+        reason,
+        "Waiting for lifecycle-blocking host health alerts to clear before PXE reboot"
+    );
+    txn.commit().await.unwrap();
+
+    // Clearing the alert preserves the normal zero DPU reboot path.
+    simulate_hardware_health_report(
+        &env,
+        &host_id,
+        HealthReport::empty(health_source.to_string()),
+    )
+    .await;
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &host_id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        }
+    );
 }
 
 #[crate::sqlx_test]

--- a/crates/health-report/src/lib.rs
+++ b/crates/health-report/src/lib.rs
@@ -608,6 +608,11 @@ impl HealthProbeId {
     pub fn ib_port_down() -> Self {
         HealthProbeId("IbPortDown".to_string())
     }
+
+    /// The ID used when an expected DPU-to-ToR BGP session is unavailable.
+    pub fn bgp_peering_tor() -> Self {
+        HealthProbeId("BgpPeeringTor".to_string())
+    }
 }
 
 impl std::fmt::Debug for HealthProbeId {
@@ -746,6 +751,11 @@ mod tests {
             format!("{classification:?} {classification}").as_str(),
             "\"Network\" Network"
         );
+    }
+
+    #[test]
+    fn bgp_peering_tor_probe_id_string() {
+        assert_eq!(HealthProbeId::bgp_peering_tor().as_str(), "BgpPeeringTor");
     }
 
     #[test]

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -5671,6 +5671,59 @@ fn check_host_health_for_alerts(state: &ManagedHostStateSnapshot) -> Result<(), 
     }
 }
 
+const PRIMARY_DPU_BGP_WAIT_REASON: &str =
+    "Waiting for the primary DPU p0 BGP session to be established";
+const HOST_HEALTH_WAIT_REASON: &str =
+    "Waiting for lifecycle-blocking host health alerts to clear before PXE reboot";
+
+/// Returns whether the DPU agent marked a ToR BGP alert as unsafe for PXE allocation.
+fn is_pxe_blocking_bgp_alert(alert: &HealthProbeAlert) -> bool {
+    alert.id == HealthProbeId::bgp_peering_tor()
+        && alert
+            .classifications
+            .contains(&HealthAlertClassification::prevent_allocations())
+}
+
+/// Checks whether a health report contains a BGP alert that should block PXE.
+fn report_has_pxe_blocking_bgp_alert(report: &HealthReport) -> bool {
+    report.alerts.iter().any(is_pxe_blocking_bgp_alert)
+}
+
+/// Checks whether effective health data contains the p0 BGP condition that blocks PXE.
+///
+/// The agent marks a failed p0 session with `PreventAllocations` because PXE
+/// boot depends on p0. A host Replace report overrides all DPU reports.
+/// Otherwise, only the primary attached DPU is checked: its Replace report
+/// overrides its Merge reports, and any Merge report may contain the blocking
+/// BGP alert when there is no Replace report.
+fn primary_dpu_has_pxe_blocking_bgp_alert(state: &ManagedHostStateSnapshot) -> bool {
+    if let Some(host_replace_report) = state.host_snapshot.health_reports.replace.as_ref() {
+        return report_has_pxe_blocking_bgp_alert(host_replace_report);
+    }
+
+    let Some(primary_dpu_id) = state.host_snapshot.primary_attached_dpu_machine_id() else {
+        return false;
+    };
+
+    let Some(primary_dpu) = state
+        .dpu_snapshots
+        .iter()
+        .find(|dpu| dpu.id == primary_dpu_id)
+    else {
+        return false;
+    };
+
+    if let Some(dpu_replace_report) = primary_dpu.health_reports.replace.as_ref() {
+        return report_has_pxe_blocking_bgp_alert(dpu_replace_report);
+    }
+
+    primary_dpu
+        .health_reports
+        .merges
+        .values()
+        .any(report_has_pxe_blocking_bgp_alert)
+}
+
 /// Whether a captured desired target can be replaced before this substate runs.
 ///
 /// Pure checks and pre-write states can adopt newer intent. Vendor jobs,
@@ -7737,6 +7790,12 @@ impl StateHandler for InstanceStateHandler {
                         }
                     };
 
+                    if primary_dpu_has_pxe_blocking_bgp_alert(mh_snapshot) {
+                        return Ok(StateHandlerOutcome::wait(
+                            PRIMARY_DPU_BGP_WAIT_REASON.to_string(),
+                        ));
+                    }
+
                     // Check whether the IB config is synced
                     if let Err(not_synced_reason) = ib_config_synced(
                         mh_snapshot
@@ -7851,6 +7910,29 @@ impl StateHandler for InstanceStateHandler {
                     })
                 }
                 InstanceState::WaitingForRebootToReady => {
+                    // Deletion and custom iPXE requests intentionally bypass these readiness
+                    // checks. During normal provisioning, recheck aggregate health for every host.
+                    // Hosts with managed DPUs also recheck the primary DPU p0 BGP alert. This
+                    // closes the gap between the network configuration check and the restart.
+                    if instance.deleted.is_none() && !instance.custom_pxe_reboot_requested {
+                        match check_host_health_for_alerts(mh_snapshot) {
+                            Ok(()) => {}
+                            Err(StateHandlerError::HealthProbeAlert) => {
+                                return Ok(StateHandlerOutcome::wait(
+                                    HOST_HEALTH_WAIT_REASON.to_string(),
+                                ));
+                            }
+                            Err(error) => return Err(error),
+                        }
+                        if mh_snapshot.has_managed_dpus()
+                            && primary_dpu_has_pxe_blocking_bgp_alert(mh_snapshot)
+                        {
+                            return Ok(StateHandlerOutcome::wait(
+                                PRIMARY_DPU_BGP_WAIT_REASON.to_string(),
+                            ));
+                        }
+                    }
+
                     // If custom_pxe_reboot_requested is set, this reboot was triggered by
                     // the tenant requested a boot with custom iPXE. Clear the request flag.
                     // The use_custom_pxe_on_boot flag was already set by the API handler.
@@ -13360,6 +13442,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
     use model::firmware::FirmwareComponent;
     use model::site_explorer::{
         EndpointExplorationReport, EndpointType, Inventory, PreingestionState, Service,
@@ -13367,6 +13450,65 @@ mod tests {
     use regex::Regex;
 
     use super::*;
+
+    #[test]
+    fn pxe_blocking_bgp_alert_requires_probe_and_allocation_classification() {
+        check_values(
+            [
+                Check {
+                    scenario: "allocation-blocking ToR alert",
+                    input: (
+                        HealthProbeId::bgp_peering_tor(),
+                        vec![HealthAlertClassification::prevent_allocations()],
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "critical ToR alert also blocks PXE",
+                    input: (
+                        HealthProbeId::bgp_peering_tor(),
+                        vec![
+                            HealthAlertClassification::prevent_allocations(),
+                            HealthAlertClassification::prevent_host_state_changes(),
+                        ],
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "visible ToR alert does not block PXE",
+                    input: (HealthProbeId::bgp_peering_tor(), vec![]),
+                    expect: false,
+                },
+                Check {
+                    scenario: "host-state classification alone is not the p0 signal",
+                    input: (
+                        HealthProbeId::bgp_peering_tor(),
+                        vec![HealthAlertClassification::prevent_host_state_changes()],
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "different allocation-blocking probe",
+                    input: (
+                        HealthProbeId::from_str("BgpPeeringRouteServer")
+                            .expect("valid test probe id"),
+                        vec![HealthAlertClassification::prevent_allocations()],
+                    ),
+                    expect: false,
+                },
+            ],
+            |(id, classifications)| {
+                is_pxe_blocking_bgp_alert(&HealthProbeAlert {
+                    id,
+                    target: None,
+                    in_alert_since: None,
+                    message: "test alert".to_string(),
+                    tenant_message: None,
+                    classifications,
+                })
+            },
+        );
+    }
 
     #[test]
     fn terminal_ready_boot_config_failure_is_deferred_until_lockdown_restoration() {


### PR DESCRIPTION
> [!IMPORTANT]
> This PR cherry-picks two commits into `release/v2.1`:
> - 628b50bf938e9262f838d53ceb2047dec423336e (#4314) -- check IPv6-unicast BGP health *(required prerequisite, see below)*
> - c34504ec0df5a21b36e5bbd1ecac70829e3a304e (#5218) -- wait for primary DPU BGP before PXE reboot

Note that no config changes are needed here, e.g. for our existing `min_dpu_functioning_links = 1` workaround:

  - It can remain set; p1 failure stays suppressed.
  - It can ALSO be removed, restoring the default of `2`. The p1 failure will remain visible as `BgpPeeringTor`, but will no longer block allocation or host state transitions.
  - A p0 failure still blocks PXE provisioning.
  - Both links failing remains lifecycle-blocking.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5210 and https://github.com/NVIDIA/infra-controller/issues/2392

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated