### PR TITLE
fix: add apt retries and apt cache

### DIFF
--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -13,9 +13,24 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # add apt proxy cache, more details https://github.com/nv-gha-runners/setup-proxy-cache
+    - name: Setup proxy cache
+      uses: nv-gha-runners/setup-proxy-cache@14229018fe157c83e03c008f27d183d8e99bc67c
+      with:
+        enable-apt: true
+
     - name: Update package lists
       shell: bash
       run: |
+        # apt defaults to three tries against a 120s timeout, so one unhealthy
+        # mirror IP stalls for minutes before it gives up on a package. Failing
+        # faster and trying more often lands on a healthy IP sooner.
+        sudo tee /etc/apt/apt.conf.d/99-nico-acquire >/dev/null <<'EOF'
+        Acquire::Retries "10";
+        Acquire::http::Timeout "20";
+        Acquire::https::Timeout "20";
+        EOF
+
         sudo apt-get update
 
     - name: Install system dependencies

--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -26,7 +26,7 @@ runs:
         # mirror IP stalls for minutes before it gives up on a package. Failing
         # faster and trying more often lands on a healthy IP sooner.
         sudo tee /etc/apt/apt.conf.d/99-nico-acquire >/dev/null <<'EOF'
-        Acquire::Retries "10";
+        Acquire::Retries "30";
         Acquire::http::Timeout "20";
         Acquire::https::Timeout "20";
         EOF


### PR DESCRIPTION
`ports.ubunutu` is inconsistent and returns non-200 more than 50% of the time. Adding several retries and apt caching should help fix the stability of this step.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

