### PR TITLE
patch(v0.10): Disable Core Docker build CI cache export to reduce churn

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -172,7 +172,12 @@ jobs:
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
           cache-from: type=gha
-          cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
+          # These builds write to the default unscoped gha key, so a single release
+          # build pushes its whole mode=max export into the Actions cache shared with 
+          # main, evicting the sccache objects the Rust builds depend on.
+          # A release branch may read the default branch's entries, so 
+          # cache-from above still starts these builds warm.
+          cache-to: ''
 
       - name: Display build summary
         run: |


### PR DESCRIPTION
Pipelines for this branch has ungated BuildKit cache export, which is evicting caches exported by `main` pipeline.

This PR disables BuildKit caches for `release/v0.10.0`, avoiding future cache evictions from this branch.

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)