### PR TITLE
[scout] Add ibverbs-providers for RDMA debugging

### DIFF
--- a/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.conf
@@ -35,6 +35,7 @@ Packages=
      erofs-utils
      file
      freeipmi-tools
+     ibverbs-providers
      ibverbs-utils
      iperf3
      ipmitool

--- a/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.conf
@@ -34,6 +34,7 @@ Packages=
      erofs-utils
      file
      freeipmi-tools
+     ibverbs-providers
      ibverbs-utils
      iperf3
      ipmitool


### PR DESCRIPTION
ibverbs-utils and rdma-core were already present, but neither pulls in the vendor libibverbs plugins (mlx4/mlx5/etc.) that ibv_devinfo actually dispatches to. Without them ibv_devinfo reports no devices even when the hardware is present:

  root@scout:~# ibv_devinfo
  libibverbs: Warning: couldn't open config directory '/etc/libibverbs.d'.
  No IB devices found

Needed to debug RDMA/InfiniBand hardware from the scout environment.

