### PR TITLE
fix(ci): Add Ubuntu mirrors for mkosi environment job, minimize package list

### DIFF
--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -52,10 +52,17 @@ runs:
         # apt defaults to three tries against a 120s timeout, so one unhealthy
         # mirror IP stalls for minutes before it gives up on a package. Failing
         # faster and trying more often lands on a healthy IP sooner.
+        #
+        # DEP-11 and Translation indexes are the ones the mirror most often 503s
+        # on, and nothing here resolves an AppStream id or reads a localised
+        # description. Not asking for them drops about fifteen requests per
+        # update, and with them their chance of failing.
         sudo tee /etc/apt/apt.conf.d/99-nico-acquire >/dev/null <<'EOF'
         Acquire::Retries "5";
         Acquire::http::Timeout "20";
         Acquire::https::Timeout "20";
+        Acquire::Languages "none";
+        Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";
         Binary::apt-get::APT::Keep-Downloaded-Packages "true";
         EOF
 
@@ -64,7 +71,38 @@ runs:
         mkdir -p ~/.cache/nico-apt-archives
         sudo cp -n ~/.cache/nico-apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
 
-        sudo apt-get update
+        # Acquire::Retries only re-asks the same host, so the cloud regional
+        # mirror these runners point at returns 503 on every try while it is
+        # down. Walk independent origins instead, Canonical's own first and then
+        # two university mirrors. security.ubuntu.com is deliberately left
+        # alone, it is a separate origin and is not the one that fails.
+        if grep -qs ubuntu-ports /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null; then
+          repo_path=ubuntu-ports
+          fallbacks="http://ports.ubuntu.com/ubuntu-ports/
+                     https://mirrors.ocf.berkeley.edu/ubuntu-ports/
+                     https://mirrors.mit.edu/ubuntu-ports/"
+        else
+          repo_path=ubuntu
+          fallbacks="http://archive.ubuntu.com/ubuntu/
+                     https://mirrors.ocf.berkeley.edu/ubuntu/
+                     https://mirrors.mit.edu/ubuntu/"
+        fi
+
+        updated=0
+        if sudo apt-get update; then
+          updated=1
+        else
+          for base in ${fallbacks}; do
+            echo "::warning::apt-get update failed, retrying against ${base}"
+            sudo sed -i -E "\#security\.ubuntu\.com#! s#https?://[A-Za-z0-9._-]+/${repo_path}/?#${base}#g" \
+              /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list 2>/dev/null || true
+            if sudo apt-get update; then
+              updated=1
+              break
+            fi
+          done
+        fi
+        [ "${updated}" = 1 ]
 
     - name: Install system dependencies
       shell: bash

--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -78,12 +78,12 @@ runs:
         # alone, it is a separate origin and is not the one that fails.
         if grep -qs ubuntu-ports /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null; then
           repo_path=ubuntu-ports
-          fallbacks="http://ports.ubuntu.com/ubuntu-ports/
+          fallbacks="https://ports.ubuntu.com/ubuntu-ports/
                      https://mirrors.ocf.berkeley.edu/ubuntu-ports/
                      https://mirrors.mit.edu/ubuntu-ports/"
         else
           repo_path=ubuntu
-          fallbacks="http://archive.ubuntu.com/ubuntu/
+          fallbacks="https://archive.ubuntu.com/ubuntu/
                      https://mirrors.ocf.berkeley.edu/ubuntu/
                      https://mirrors.mit.edu/ubuntu/"
         fi


### PR DESCRIPTION
The arm64 boot-artifact builds fail whenever the runner's regional Ubuntu mirror
returns `503`, which it has been doing since yesterday. `Acquire::Retries "5"`
only re-asks the same host, so all five tries hit the same dead mirror, and three
of the four failed requests were `dep11` and `Translation` metadata that nothing
here installs from. This PR stops asking for that metadata, which drops about
`15` requests per `apt-get update`, and falls through to `ports.ubuntu.com` and
two other mirrors when the regional one is down.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed