### PR TITLE
fix: retry stalled instance provisioning boots

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -3965,6 +3965,247 @@ async fn test_assigned_periodic_boot_interface_drift_defers_convergence(pool: sq
     assert_read_only_boot_interface_observation(&redfish_actions);
 }
 
+async fn load_test_host(env: &TestEnv, managed_host: &TestManagedHost) -> model::machine::Machine {
+    let mut txn = env.db_txn().await;
+    managed_host.host().db_machine(&mut txn).await
+}
+
+/// A pending tenant iPXE handoff retries without resetting its Ready retry budget.
+#[crate::sqlx_test]
+async fn test_assigned_ready_retries_pending_provisioning_boot(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh = create_managed_host(&env).await;
+
+    let mut os = default_os_config();
+    os.phone_home_enabled = true;
+    mh.instance_builer(&env)
+        .config(rpc::InstanceConfig {
+            tenant: Some(default_tenant_config()),
+            os: Some(os),
+            network: Some(single_interface_network_config(segment_id)),
+            infiniband: None,
+            nvlink: None,
+            spxconfig: None,
+            network_security_group_id: None,
+            dpu_extension_services: None,
+            power_profile: None,
+        })
+        .build()
+        .await;
+
+    let host = load_test_host(&env, &mh).await;
+    let initial_reboot_request = host
+        .status
+        .last_reboot_requested
+        .as_ref()
+        .expect("instance provisioning should have requested a reboot")
+        .time;
+    // Test retry periods are clamped to one minute. Age Ready five minutes while leaving the last
+    // request two minutes old so this retry lands on the fourth round, where the shared policy
+    // would otherwise start a separate power off and power on sequence.
+    update_time_params(
+        &env.pool,
+        &host,
+        5,
+        Some(initial_reboot_request - Duration::minutes(2)),
+    )
+    .await;
+
+    backdate_boot_interface_observation(&env, &mh).await;
+    env.redfish_sim.set_is_bios_setup(true);
+    env.redfish_sim.set_is_boot_order_setup(true);
+    let redfish_checkpoint = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+    let redfish_actions = env
+        .redfish_sim
+        .actions_since(&redfish_checkpoint)
+        .all_hosts();
+    assert_read_only_boot_interface_observation(&redfish_actions);
+
+    let host_before_retry = load_test_host(&env, &mh).await;
+    let prior_reboot_request = host_before_retry
+        .status
+        .last_reboot_requested
+        .as_ref()
+        .unwrap()
+        .time;
+    let redfish_checkpoint = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+    let redfish_actions = env
+        .redfish_sim
+        .actions_since(&redfish_checkpoint)
+        .all_hosts();
+    assert_eq!(
+        redfish_actions
+            .iter()
+            .filter(|action| matches!(
+                action,
+                RedfishSimAction::Power(libredfish::SystemPowerControl::ForceRestart)
+            ))
+            .count(),
+        1,
+        "expected one provisioning boot retry, got: {redfish_actions:?}"
+    );
+    assert!(
+        redfish_actions.iter().all(|action| !matches!(
+            action,
+            RedfishSimAction::Power(libredfish::SystemPowerControl::ForceOff)
+        )),
+        "provisioning retries must not power the host off: {redfish_actions:?}"
+    );
+
+    let host_after_retry = load_test_host(&env, &mh).await;
+    assert_eq!(
+        host_after_retry.current_state(),
+        &ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        }
+    );
+    assert_eq!(
+        host_after_retry.current_version(),
+        host_before_retry.current_version(),
+        "retrying must not reset the budget derived from Ready entry time"
+    );
+    assert!(
+        host_after_retry
+            .status
+            .last_reboot_requested
+            .as_ref()
+            .unwrap()
+            .time
+            > prior_reboot_request
+    );
+    assert!(
+        host_after_retry
+            .status
+            .last_reboot_requested
+            .as_ref()
+            .unwrap()
+            .restart_verified
+            .is_none(),
+        "the provisioning retry must not arm generic restart verification"
+    );
+    assert!(matches!(
+        host_after_retry.controller_state_outcome.as_ref(),
+        Some(PersistentStateHandlerOutcome::Wait { reason, .. })
+            if reason.starts_with("Waiting for instance provisioning boot.")
+    ));
+
+    let redfish_checkpoint = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+    let redfish_actions = env
+        .redfish_sim
+        .actions_since(&redfish_checkpoint)
+        .all_hosts();
+    assert!(
+        redfish_actions
+            .iter()
+            .all(|action| !matches!(action, RedfishSimAction::Power(_))),
+        "a fresh retry timestamp must prevent another power action, got: {redfish_actions:?}"
+    );
+
+    // Exercise a failure before the lower Redfish helper can queue its reboot timestamp.
+    // Removing the live address makes client creation fail before any power action is attempted.
+    let successful_reboot_request = host_after_retry
+        .status
+        .last_reboot_requested
+        .as_ref()
+        .unwrap()
+        .time;
+    update_time_params(
+        &env.pool,
+        &host_after_retry,
+        7,
+        Some(successful_reboot_request - Duration::minutes(2)),
+    )
+    .await;
+    let bmc_address = host_after_retry
+        .bmc_addr()
+        .expect("fixture host should have a BMC address")
+        .ip();
+    let mut txn = env.db_txn().await;
+    let host_before_failed_attempt = mh.host().db_machine(&mut txn).await;
+    let prior_failed_attempt = host_before_failed_attempt
+        .status
+        .last_reboot_requested
+        .as_ref()
+        .unwrap()
+        .time;
+    let bmc_interface = db::machine_interface_address::find_by_address(txn.as_mut(), bmc_address)
+        .await
+        .unwrap()
+        .expect("fixture BMC address should have an owner");
+    db::machine::update_restart_verification_status(
+        &mh.host().id,
+        *host_before_failed_attempt
+            .status
+            .last_reboot_requested
+            .as_ref()
+            .unwrap(),
+        Some(false),
+        0,
+        txn.as_mut(),
+    )
+    .await
+    .unwrap();
+    assert!(
+        db::machine_interface_address::delete_by_interface_and_address(
+            txn.as_mut(),
+            bmc_interface.id,
+            bmc_address,
+            bmc_interface.allocation_type,
+        )
+        .await
+        .unwrap()
+    );
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    let host_after_failed_attempt = load_test_host(&env, &mh).await;
+    let failed_attempt_recorded_at = host_after_failed_attempt
+        .status
+        .last_reboot_requested
+        .as_ref()
+        .unwrap()
+        .time;
+    assert!(failed_attempt_recorded_at > prior_failed_attempt);
+    assert!(
+        host_after_failed_attempt
+            .status
+            .last_reboot_requested
+            .as_ref()
+            .unwrap()
+            .restart_verified
+            .is_none(),
+        "failed retry backoff must not restore stale restart verification"
+    );
+    assert!(matches!(
+        host_after_failed_attempt.controller_state_outcome.as_ref(),
+        Some(PersistentStateHandlerOutcome::Wait { reason, .. })
+            if reason.starts_with("Failed to retry instance provisioning boot:")
+    ));
+
+    env.run_machine_state_controller_iteration().await;
+    let host_after_backoff = load_test_host(&env, &mh).await;
+    assert_eq!(
+        host_after_backoff
+            .status
+            .last_reboot_requested
+            .as_ref()
+            .unwrap()
+            .time,
+        failed_attempt_recorded_at,
+        "an early Redfish failure must not retry on every controller iteration"
+    );
+    assert!(matches!(
+        host_after_backoff.controller_state_outcome.as_ref(),
+        Some(PersistentStateHandlerOutcome::Wait { reason, .. })
+            if reason.contains("Will attempt next reboot at")
+    ));
+}
+
 /// Locked Supermicro reports a stale boot-order view until an unlock and
 /// reboot. Periodic observation must therefore leave both Ready and its
 /// verified status untouched instead of disrupting the host or publishing a

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -586,6 +586,13 @@ impl InstanceNetworkConfig {
     pub fn is_host_inband(&self) -> bool {
         self.interfaces.iter().all(|i| i.is_host_inband())
     }
+
+    /// `uses_operator_managed_networking` returns true when every configured interface uses the
+    /// operator's HostInband network instead of the NICo DPU data plane. The config must be
+    /// nonempty because `is_host_inband` is vacuously true for an empty interface list.
+    pub fn uses_operator_managed_networking(&self) -> bool {
+        !self.interfaces.is_empty() && self.is_host_inband()
+    }
 }
 
 /// Validates that any container which has elements that have InterfaceFunctionIds
@@ -1108,6 +1115,32 @@ mod tests {
             interfaces,
             auto_config: None,
         }
+    }
+
+    #[test]
+    fn operator_managed_networking_requires_nonempty_host_inband_interfaces() {
+        let empty = InstanceNetworkConfig::default();
+        let dpu_networked = create_valid_network_config();
+
+        let mut host_inband = create_valid_network_config();
+        for interface in &mut host_inband.interfaces {
+            interface.host_inband_mac_address = Some(MacAddress::new([1, 2, 3, 4, 5, 6]));
+        }
+
+        let mut mixed = host_inband.clone();
+        mixed.interfaces[0].host_inband_mac_address = None;
+
+        value_scenarios!(
+            run = |config: InstanceNetworkConfig| config.uses_operator_managed_networking();
+            "operator-managed" {
+                host_inband => true,
+            }
+            "not operator-managed" {
+                empty => false,
+                dpu_networked => false,
+                mixed => false,
+            }
+        );
     }
 
     /// Builds one resolved automatic interface while retaining the usual

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -5328,13 +5328,10 @@ mod require_boot_interface_tests {
     }
 }
 
-/// In case machine does not come up until a specified duration, this function tries to reboot
-/// it again. The reboot continues till 6 hours only. After that this function gives up.
-/// WARNING:
-/// If using this function in handler, never return Error, return wait/donothing.
-/// In case a error is returned, last_reboot_requested won't be updated in db by state handler.
-/// This will cause continuous reboot of machine after first failure_retry_time is
-/// passed.
+/// `trigger_reboot_if_needed` retries a machine that does not come up within the configured period,
+/// for at most 15 periods. Callers that handle a recoverable error should ensure an attempt
+/// timestamp is queued and return `Wait` or `DoNothing` so it is committed; returning an error can
+/// cause another reboot on the next retry pass.
 #[track_caller]
 pub fn trigger_reboot_if_needed(
     target: &Machine,
@@ -5344,23 +5341,64 @@ pub fn trigger_reboot_if_needed(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> impl Future<Output = Result<RebootStatus, StateHandlerError>> {
     let trigger_location = std::panic::Location::caller();
-    trigger_reboot_if_needed_with_location(
+    trigger_reboot_if_needed_with_policy(
         target,
         state,
         retry_count,
         reachability_params,
         ctx,
         trigger_location,
+        true,
     )
 }
 
-pub async fn trigger_reboot_if_needed_with_location(
+#[track_caller]
+fn trigger_reboot_if_needed_without_power_cycle(
+    target: &Machine,
+    state: &ManagedHostStateSnapshot,
+    retry_count: Option<i64>,
+    reachability_params: &ReachabilityParams,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> impl Future<Output = Result<RebootStatus, StateHandlerError>> {
+    let trigger_location = std::panic::Location::caller();
+    trigger_reboot_if_needed_with_policy(
+        target,
+        state,
+        retry_count,
+        reachability_params,
+        ctx,
+        trigger_location,
+        false,
+    )
+}
+
+/// Queues a fresh retry timestamp after earlier writes and disables generic restart verification.
+/// The verification write stores the supplied reboot record in full, so the next retry is
+/// calculated from the updated time.
+fn record_provisioning_retry_attempt(
+    target: &Machine,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) {
+    let mut current_reboot = target.status.last_reboot_requested.unwrap_or_default();
+    current_reboot.time = Utc::now();
+
+    ctx.pending_db_writes
+        .push(MachineWriteOp::UpdateRestartVerificationStatus {
+            machine_id: target.id,
+            current_reboot,
+            verified: None,
+            attempts: 0,
+        });
+}
+
+async fn trigger_reboot_if_needed_with_policy(
     target: &Machine,
     state: &ManagedHostStateSnapshot,
     retry_count: Option<i64>,
     reachability_params: &ReachabilityParams,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     trigger_location: &std::panic::Location<'_>,
+    allow_power_cycle: bool,
 ) -> Result<RebootStatus, StateHandlerError> {
     let host = &state.host_snapshot;
     // Its highly unlikely that the host has never been rebooted (and the last_reboot_reqeusted
@@ -5491,7 +5529,7 @@ pub async fn trigger_reboot_if_needed_with_location(
             };
 
             // Dont power down the host on the first cycle
-            let power_down_host = cycle != 0 && cycle % 4 == 0;
+            let power_down_host = allow_power_cycle && cycle != 0 && cycle % 4 == 0;
 
             let status = if power_down_host {
                 // PowerDown (or ACPowercycle for Lenovo)
@@ -5687,6 +5725,26 @@ const PRIMARY_DPU_BGP_WAIT_REASON: &str =
     "Waiting for the primary DPU p0 BGP session to be established";
 const HOST_HEALTH_WAIT_REASON: &str =
     "Waiting for lifecycle-blocking host health alerts to clear before PXE reboot";
+
+/// `provisioning_pxe_reboot_wait_reason` returns the safety condition blocking a provisioning PXE
+/// reboot.
+fn provisioning_pxe_reboot_wait_reason(
+    state: &ManagedHostStateSnapshot,
+) -> Result<Option<&'static str>, StateHandlerError> {
+    match check_host_health_for_alerts(state) {
+        Ok(()) => {}
+        Err(StateHandlerError::HealthProbeAlert) => {
+            return Ok(Some(HOST_HEALTH_WAIT_REASON));
+        }
+        Err(error) => return Err(error),
+    }
+
+    if state.has_managed_dpus() && primary_dpu_has_pxe_blocking_bgp_alert(state) {
+        return Ok(Some(PRIMARY_DPU_BGP_WAIT_REASON));
+    }
+
+    Ok(None)
+}
 
 /// Returns whether the DPU agent marked a ToR BGP alert as unsafe for PXE allocation.
 fn is_pxe_blocking_bgp_alert(alert: &HealthProbeAlert) -> bool {
@@ -7935,23 +7993,11 @@ impl StateHandler for InstanceStateHandler {
                     // checks. During normal provisioning, recheck aggregate health for every host.
                     // Hosts with managed DPUs also recheck the primary DPU p0 BGP alert. This
                     // closes the gap between the network configuration check and the restart.
-                    if instance.deleted.is_none() && !instance.custom_pxe_reboot_requested {
-                        match check_host_health_for_alerts(mh_snapshot) {
-                            Ok(()) => {}
-                            Err(StateHandlerError::HealthProbeAlert) => {
-                                return Ok(StateHandlerOutcome::wait(
-                                    HOST_HEALTH_WAIT_REASON.to_string(),
-                                ));
-                            }
-                            Err(error) => return Err(error),
-                        }
-                        if mh_snapshot.has_managed_dpus()
-                            && primary_dpu_has_pxe_blocking_bgp_alert(mh_snapshot)
-                        {
-                            return Ok(StateHandlerOutcome::wait(
-                                PRIMARY_DPU_BGP_WAIT_REASON.to_string(),
-                            ));
-                        }
+                    if instance.deleted.is_none()
+                        && !instance.custom_pxe_reboot_requested
+                        && let Some(reason) = provisioning_pxe_reboot_wait_reason(mh_snapshot)?
+                    {
+                        return Ok(StateHandlerOutcome::wait(reason.to_string()));
                     }
 
                     // If custom_pxe_reboot_requested is set, this reboot was triggered by
@@ -8160,11 +8206,99 @@ impl StateHandler for InstanceStateHandler {
                         // Redfish I/O in a separate attempt.
                         Ok(StateHandlerOutcome::do_nothing().with_txn(txn))
                     } else {
-                        boot_interface_observation::observe_verified_boot_interface(
-                            ctx,
-                            mh_snapshot,
-                        )
-                        .await
+                        let observation_outcome =
+                            boot_interface_observation::observe_verified_boot_interface(
+                                ctx,
+                                mh_snapshot,
+                            )
+                            .await?;
+                        if matches!(
+                            &observation_outcome,
+                            StateHandlerOutcome::DoNothing { txn: Some(_), .. }
+                        ) {
+                            // Commit the observation transaction before doing any other Ready work.
+                            // The provisioning retry can run during the next controller iteration.
+                            return Ok(observation_outcome);
+                        }
+
+                        // `use_custom_pxe_on_boot` remains set until Core serves the tenant boot
+                        // instructions. Together with missing phone home, it identifies
+                        // provisioning that has not reached the tenant iPXE handler.
+                        // Operator-managed networks do not use phone home to determine tenant
+                        // readiness, so skip this retry.
+                        if instance.use_custom_pxe_on_boot
+                            && instance.config.os.phone_home_enabled
+                            && instance.observations.phone_home_last_contact.is_none()
+                            && !instance.config.network.uses_operator_managed_networking()
+                        {
+                            // Apply the same PXE safety checks as the initial provisioning reboot.
+                            // An explicit custom PXE request bypasses them only for its original
+                            // reboot, not for an automatic retry.
+                            if let Some(reason) = provisioning_pxe_reboot_wait_reason(mh_snapshot)?
+                            {
+                                return Ok(StateHandlerOutcome::wait(reason.to_string()));
+                            }
+
+                            return match trigger_reboot_if_needed_without_power_cycle(
+                                &mh_snapshot.host_snapshot,
+                                mh_snapshot,
+                                None,
+                                &self.reachability_params,
+                                ctx,
+                            )
+                            .await
+                            {
+                                Ok(status) => {
+                                    if status.increase_retry_count {
+                                        record_provisioning_retry_attempt(
+                                            &mh_snapshot.host_snapshot,
+                                            ctx,
+                                        );
+                                    }
+                                    Ok(StateHandlerOutcome::wait(format!(
+                                        "Waiting for instance provisioning boot. {}",
+                                        status.status
+                                    )))
+                                }
+                                Err(error @ StateHandlerError::ManualInterventionRequired(_)) => {
+                                    // Intermediate verification attempts return before Ready. If an
+                                    // unverified restart reaches this arm, a final verification
+                                    // update is queued and must commit before reporting the error.
+                                    let restart_verification_must_commit = mh_snapshot
+                                        .host_snapshot
+                                        .status
+                                        .last_reboot_requested
+                                        .is_some_and(|reboot| {
+                                            reboot.restart_verified == Some(false)
+                                        });
+                                    if restart_verification_must_commit {
+                                        Ok(StateHandlerOutcome::wait(error.to_string()))
+                                    } else {
+                                        Err(error)
+                                    }
+                                }
+                                Err(error) => {
+                                    // Redfish client setup can fail before the power path records an
+                                    // attempt. Record the next retry time and clear verification so
+                                    // Ready does not retry every controller iteration or verify a
+                                    // restart that was never issued.
+                                    record_provisioning_retry_attempt(
+                                        &mh_snapshot.host_snapshot,
+                                        ctx,
+                                    );
+                                    tracing::warn!(
+                                        machine_id = %host_machine_id,
+                                        error = %error,
+                                        "Failed to retry instance provisioning boot; will retry",
+                                    );
+                                    Ok(StateHandlerOutcome::wait(format!(
+                                        "Failed to retry instance provisioning boot: {error}. Will retry."
+                                    )))
+                                }
+                            };
+                        }
+
+                        Ok(observation_outcome)
                     }
                 }
                 InstanceState::HostPlatformConfiguration {
@@ -8262,9 +8396,8 @@ impl StateHandler for InstanceStateHandler {
                         return Ok(st);
                     }
 
-                    // Now retry_count won't exceed a limit. Function trigger_reboot_if_needed does
-                    // not reboot a machine after 6 hrs, so this counter won't increase at all
-                    // after 6 hours.
+                    // `trigger_reboot_if_needed` stops rebooting after 15 attempts, so this counter
+                    // stops increasing at the same limit.
                     ctx.metrics
                         .machine_reboot_attempts_in_booting_with_discovery_image =
                         Some(retry.count + 1);

--- a/crates/rpc/src/model/instance/status.rs
+++ b/crates/rpc/src/model/instance/status.rs
@@ -90,8 +90,7 @@ pub fn instance_status_from_config_and_observation(
 ) -> Result<InstanceStatus, RpcDataConversionError> {
     let mut instance_config_synced = SyncState::Synced;
 
-    let operator_managed_networking =
-        !network_config.interfaces.is_empty() && network_config.is_host_inband();
+    let operator_managed_networking = network_config.uses_operator_managed_networking();
 
     for network_obs in observations.network.values() {
         if let Some(version_obs) = network_obs.instance_config_version


### PR DESCRIPTION
An instance can remain in `Provisioning` indefinitely when firmware fails before reaching tenant iPXE. Core has already moved the machine to `Assigned { Ready }`, but tenant instructions remain pending and the operating system never phones home.

The `Ready` handler now retries that boot (on the existing 90-minute schedule) when NICo manages the network. Deletion, network updates, reprovisioning, and explicit PXE requests still run first, and the existing host health and primary DPU BGP checks still apply. Attempts use `ForceRestart` and preserve retry backoff without generic restart verification. After 15 intervals, the API still reports `ManualInterventionRequired` and leaves tenant status in `Provisioning`; changing that terminal policy is outside this PR.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5225

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Coverage:

- The network model table covers the HostInband classification used by tenant status and retry eligibility.
- The focused SQLx test verifies observer ordering, one `ForceRestart` without `ForceOff`, an unchanged Ready retry budget, and persisted backoff after success or an early Redfish error.
- Nightly formatting, workspace Clippy, and the Carbide custom lints pass.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the complete change. Codex and common-nits-reviewer then reviewed the final simplification; the local CodeRabbit and Claude passes found no additional issues. Hosted CodeRabbit suggested broader coverage for a compound compatibility state after publication.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 3 | 3 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 14 | 8 | 6 |
| common-nits-reviewer | 2 | 2 | 0 |
| Hosted CodeRabbit | 1 | 0 | 1 |
| **Total** | **20** | **13** | **7** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- The instance reread only narrowed a race that it could not close. **Resolution:** Removed the reread and its intent table; request serialization remains outside this PR.
2. **Adopted** -- The integration test covered unrelated health and recovery sequences. **Resolution:** Kept only observer ordering, successful retry, and early Redfish failure behavior.
3. **Adopted** -- A comment said retry accounting restored restart verification. **Resolution:** It now states that the final write clears verification and records backoff.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- Reporting exhausted retries could discard a queued verification update and repeat on every controller iteration. **Resolution:** Ready returns `Wait` once so that update commits.
2. **Adopted** -- Retry accounting did not explain that its verification update stores the full reboot record. **Resolution:** The comment now states the write and backoff behavior.
3. **Adopted** -- The reason for applying the provisioning safety checks to later retries was unclear. **Resolution:** The comment ties them to the initial provisioning reboot.
4. **Adopted** -- The retry decision test used positional booleans. **Resolution:** The decision now reads fields directly at its only call site.
5. **Adopted** -- Reduce the exhaustive retry decision table. **Resolution:** Removed the table after deleting the standalone decision helper; the SQLx test still covers the resulting restart and backoff behavior.
6. **Declined** -- Return `Option` from the health wait helper. **Reason:** Its existing `Result` contract preserves error propagation.
7. **Adopted** -- Inline or move the retry predicate. **Resolution:** Inlined the direct field checks and removed the four positional boolean parameters.
8. **Declined** -- Handle hypothetical new observer results. **Reason:** The current return variants are exhaustively understood; future behavior is not part of this fix.
9. **Declined** -- Add a longer retry exhaustion integration sequence. **Reason:** Unit coverage and the focused persistence test cover the changed contract.
10. **Adopted** -- The observer transaction branch lacked direct coverage. **Resolution:** The integration test verifies that it commits before the restart attempt.
11. **Adopted** -- A nearby comment still described a six-hour retry limit. **Resolution:** It now states the limit of 15 attempts.
12. **Declined** -- Broaden this change to rename power policy or alter adjacent metrics and reboot fields. **Reason:** The Ready path cannot enter the inherited `PowerOff` branch, and the other behavior predates this fix.
13. **Declined** -- Treat later routine always PXE boots as missing coverage. **Reason:** The initial allocation marker is set; later routine boots are not the initial provisioning flow fixed here.
14. **Declined** -- Rename test helpers and further rewrite typed address deletion setup. **Reason:** The current names and existing database helpers state the focused test setup directly.

### common-nits-reviewer

1. **Adopted** -- Generic restart verification could issue another restart outside this retry's schedule and safety checks. **Resolution:** Every provisioning attempt finishes with verification disabled and a fresh retry time.
2. **Adopted** -- A new Rustdoc comment used temporary wording without a support boundary. **Resolution:** It now names the blocking safety condition directly.

### Hosted CodeRabbit

1. **Declined** -- Add an integration case for an exhausted Ready budget and stale restart verification. **Reason:** This retry clears verification after each attempt; reproducing the compound state requires separate stale data and new BMC event log simulator support, while the focused test covers the changed retry behavior.

</details>
