### PR TITLE
Allow imaging to smallest disk, re-use existing EFI disk if found.

### DIFF
--- a/pxe/common_files/disk_imaging.sh
+++ b/pxe/common_files/disk_imaging.sh
@@ -65,12 +65,46 @@ function verify_sha() {
 	echo "$sha $file" | $shasum --check 2>&1 | tee $log_output
 }
 
+function find_efi_disk() {
+	for disk in "$@"
+	do
+		if lsblk -nrpo PARTTYPE "$disk" | grep -Eqi '^(c12a7328-f81f-11d2-ba4b-00a0c93ec93b|0xef)$'; then
+			echo "$disk"
+			return 0
+		fi
+	done
+	return 1
+}
+
 function find_bootdisk() {
-	if [ -b /dev/nvme0n1 ]; then
-		image_disk="/dev/nvme0n1"
-	elif [ -b /dev/sda ]; then
-		image_disk="/dev/sda"
+	disks=$(lsblk -bdnpo NAME,SIZE,TYPE | awk '$3 == "disk" { print $1, $2 }' | sort -k2,2n -k1,1V)
+	disk_names=$(echo "$disks" | awk 'NF { print $1 }' | sort -V)
+
+	if [ "$image_disk" == "smallest" ]; then
+		smallest_size=$(echo "$disks" | awk 'NR == 1 { print $2 }')
+		candidate_disks=$(echo "$disks" | awk -v size="$smallest_size" '$2 == size { print $1 }' | sort -V)
+		candidate_count=$(echo "$candidate_disks" | awk 'NF { count++ } END { print count + 0 }')
+
+		selected_disk=
+		if [ "$candidate_count" -gt 1 ]; then
+			selected_disk=$(find_efi_disk $candidate_disks)
+		fi
+		if [ -z "$selected_disk" ]; then
+			selected_disk=$(echo "$candidate_disks" | head -n 1)
+		fi
+		image_disk=$selected_disk
 	else
+		image_disk=$(find_efi_disk $disk_names)
+		if [ -z "$image_disk" ]; then
+			if [ -b /dev/nvme0n1 ]; then
+				image_disk="/dev/nvme0n1"
+			elif [ -b /dev/sda ]; then
+				image_disk="/dev/sda"
+			fi
+		fi
+	fi
+
+	if [ -z "$image_disk" ]; then
 		echo "Boot drive not detected or specified" | tee $log_output
 		exit 1;
 	fi
@@ -694,6 +728,7 @@ function main() {
 	#  image_sha=[sha1/sha256/sha384/sha512]
 	# use the disk the tenant specified optionally
 	#  image_disk=/dev/nvme0n1
+	#  image_disk=smallest
 	for i in `cat /proc/cmdline`
 	do
 		#echo $line
@@ -798,7 +833,7 @@ function main() {
 			return 1;
 		fi
 	fi
-	if [ -z "$image_disk" ]; then
+	if [ -z "$image_disk" -o "$image_disk" == "smallest" ]; then
 		find_bootdisk
 	fi
 


### PR DESCRIPTION
Adds 2 changes to the qcow disk_imaging script.

1. Users can specify image_disk=smallest on the kernel command line, the script will then look for the smallest disk instead of defaulting to /dev/nvme0n1 or /dev/sda.   If more than 1 disk of the smallest size exists, it will pick the lowest numbered one.
2. To handle the case where the system is being reinstalled, and the nvme disk enumeration isn't consistent, the script will look for a disk with an existing EFI partition on it, and pick that disk.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4990

## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
