### PR TITLE
fix(helm): configure PXE file descriptor limit

### DIFF
--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -57,6 +57,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
               if [ -x /opt/nico/nico ]; then BIN=/opt/nico/nico; else BIN=/opt/carbide/carbide; fi
               exec "$BIN" -s {{ .Values.bootArtifacts.servePath }}
           env:

--- a/helm/charts/nico-pxe/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-pxe/tests/file_descriptor_limit_test.yaml
@@ -1,0 +1,16 @@
+suite: pxe file descriptor limit
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: uses the default soft limit
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 65536 \|\| exit 1'
+  - it: allows an override
+    set:
+      fileDescriptorLimit: 32768
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn 32768 \|\| exit 1'

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -45,6 +45,9 @@ legacyAlias:
 
 replicas: 1
 
+## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
+fileDescriptorLimit: 65536
+
 ## Optional init containers (general-purpose pass-through)
 initContainers: []
 


### PR DESCRIPTION
Backport of the PXE file-descriptor limit chart change for the v2.0 release line.