### PR TITLE
fix: preserve IPv6 status from DPU agents

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -1223,19 +1223,16 @@ pub(super) async fn interfaces(
                         version: nsg.version.clone(),
                     });
 
-            // A SLAAC interface retains its desired IPv6 prefix without a
-            // concrete host address. Status keeps address/prefix lists
-            // positionally aligned, so report that family only after an
-            // address is available.
-            let observed_ipv6 = iface
-                .ipv6_interface_config
-                .as_ref()
-                .filter(|ipv6| !ipv6.ip.is_empty());
-            let addresses =
-                build_dual_stack_list(iface.ip.clone(), observed_ipv6.map(|v6| v6.ip.clone()));
+            let addresses = build_dual_stack_list(
+                iface.ip.clone(),
+                iface.ipv6_interface_config.as_ref().map(|v6| v6.ip.clone()),
+            );
             let prefixes = build_dual_stack_list(
                 iface.interface_prefix.clone(),
-                observed_ipv6.map(|v6| v6.interface_prefix.clone()),
+                iface
+                    .ipv6_interface_config
+                    .as_ref()
+                    .map(|v6| v6.interface_prefix.clone()),
             );
             interfaces.push(rpc::InstanceInterfaceStatusObservation {
                 function_type: iface.function_type,
@@ -3748,7 +3745,7 @@ mod tests {
 
     #[tokio::test]
     #[allow(deprecated)]
-    async fn ipv6_status_projects_admin_and_tenant_slaac_differently() {
+    async fn ipv6_status_preserves_slaac_prefix_without_host_address() {
         for (
             scenario,
             use_admin_network,
@@ -3771,7 +3768,7 @@ mod tests {
                 "",
                 "2001:db8::/64",
                 vec![],
-                vec![],
+                vec!["2001:db8::/64"],
             ),
             (
                 "admin SLAAC prefix without a host address",

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -2274,21 +2274,20 @@ pub(in crate::tests) async fn network_configured_with_health_and_ext_services(
     } else {
         let mut interfaces = vec![];
         for iface in network_config.tenant_interfaces.iter() {
-            let observed_ipv6 = iface
-                .ipv6_interface_config
-                .as_ref()
-                .filter(|ipv6| !ipv6.ip.is_empty());
             interfaces.push(rpc::forge::InstanceInterfaceStatusObservation {
                 function_type: iface.function_type,
                 virtual_function_id: iface.virtual_function_id,
                 mac_address: None,
                 addresses: build_dual_stack_list(
                     iface.ip.clone(),
-                    observed_ipv6.map(|v6| v6.ip.clone()),
+                    iface.ipv6_interface_config.as_ref().map(|v6| v6.ip.clone()),
                 ),
                 prefixes: build_dual_stack_list(
                     iface.interface_prefix.clone(),
-                    observed_ipv6.map(|v6| v6.interface_prefix.clone()),
+                    iface
+                        .ipv6_interface_config
+                        .as_ref()
+                        .map(|v6| v6.interface_prefix.clone()),
                 ),
                 gateways: build_dual_stack_list(iface.gateway.clone(), None),
                 network_security_group: None,

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -3517,7 +3517,7 @@ async fn test_slaac_vpc_allocation_preserves_prefix_without_ipv6_address(pool: P
         .unwrap()
         .interfaces[0];
     assert!(status_interface.addresses.is_empty());
-    assert!(status_interface.prefixes.is_empty());
+    assert_eq!(status_interface.prefixes, ["fd42:2403::/64"]);
 
     // Re-read through the public API: the selected parent prefix remains
     // visible even though SLAAC deliberately has no concrete host address.
@@ -3532,7 +3532,7 @@ async fn test_slaac_vpc_allocation_preserves_prefix_without_ipv6_address(pool: P
     );
     let persisted_status_interface = &persisted_rpc.status().network().interfaces[0];
     assert!(persisted_status_interface.addresses.is_empty());
-    assert!(persisted_status_interface.prefixes.is_empty());
+    assert_eq!(persisted_status_interface.prefixes, ["fd42:2403::/64"]);
 
     let vpc_instance_ids = fixture
         .env
@@ -3792,13 +3792,12 @@ async fn test_slaac_vpc_allocation_preserves_prefix_without_ipv6_address(pool: P
             .unwrap()
             .is_ipv4()
     );
-    assert_eq!(dual_status_interface.prefixes.len(), 1);
-    assert!(
-        dual_status_interface.prefixes[0]
-            .parse::<IpNetwork>()
-            .unwrap()
-            .is_ipv4()
+    assert_eq!(dual_status_interface.prefixes.len(), 2);
+    assert_eq!(
+        dual_status_interface.prefixes[0],
+        format!("{}/32", dual_status_interface.addresses[0])
     );
+    assert_eq!(dual_status_interface.prefixes[1], "fd42:2403:0:1::/64");
 
     let dual_stack_instance_id = dual_stack_instance.id.unwrap();
     let mut txn = fixture.env.db_txn().await;

--- a/crates/api-model/src/instance/status/network.rs
+++ b/crates/api-model/src/instance/status/network.rs
@@ -362,17 +362,17 @@ pub struct InstanceInterfaceStatus {
     /// and therefore the address is unknown.
     pub mac_address: Option<MacAddress>,
 
-    /// The list of IP addresses that had been assigned to this interface,
-    /// based on the requested subnet.
-    /// IPv4 precedes IPv6 when both families are assigned.
-    /// The list will be empty if interface configuration hasn't been completed
+    /// The IP addresses reported for this interface, ordered IPv4 before IPv6.
+    /// This list is independent from `prefixes` and is empty when no address
+    /// is available.
     pub addresses: Vec<IpAddr>,
 
-    /// The IP prefixes assigned to this interface, with one prefix for each
-    /// entry in `addresses` in the same IPv4-before-IPv6 order. A prefix may be
-    /// a /30 for FNN or a /32 for ETV.
-    ///
-    /// The list will be empty if interface configuration hasn't been completed
+    /// The prefixes reported for this interface in CIDR notation, ordered IPv4
+    /// before IPv6. Prefix lengths follow the selected network and allocation
+    /// policy. This list is independent from `addresses`: SLAAC reports an IPv6
+    /// prefix without a fixed host address. Consumers must match values by
+    /// address family rather than list position. The list is empty when no
+    /// prefix is available.
     pub prefixes: Vec<IpNetwork>,
 
     /// The explicitly configured gateways, in CIDR notation. There is at most
@@ -516,18 +516,18 @@ pub struct InstanceInterfaceStatusObservation {
     #[serde(default)]
     pub mac_address: Option<SerializableMacAddress>,
 
-    /// The list of IP addresses that had been assigned to this interface,
-    /// based on the requested subnet.
-    /// IPv4 precedes IPv6 when both families are assigned.
-    /// The list will be empty if interface configuration hasn't been completed
+    /// The IP addresses reported for this interface, ordered IPv4 before IPv6.
+    /// This list is independent from `prefixes` and is empty when no address
+    /// is available.
     #[serde(default)]
     pub addresses: Vec<IpAddr>,
 
-    /// The IP prefixes assigned to this interface, with one prefix for each
-    /// entry in `addresses` in the same IPv4-before-IPv6 order. A prefix may be
-    /// a /30 for FNN or a /32 for ETV.
-    ///
-    /// The list will be empty if interface configuration hasn't been completed
+    /// The prefixes reported for this interface in CIDR notation, ordered IPv4
+    /// before IPv6. Prefix lengths follow the selected network and allocation
+    /// policy. This list is independent from `addresses`: SLAAC reports an IPv6
+    /// prefix without a fixed host address. Consumers must match values by
+    /// address family rather than list position. The list is empty when no
+    /// prefix is available.
     #[serde(default)]
     pub prefixes: Vec<IpNetwork>,
 

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -1110,18 +1110,17 @@ impl MachineStateMachine {
             instance_network_config_version =
                 Some(network_config.instance_network_config_version.clone());
 
-            // Tenant status consumers pair addresses and prefixes positionally. A SLAAC
-            // interface has no concrete IPv6 address yet, so omit that family from both.
             for iface in network_config.tenant_interfaces.iter() {
-                let observed_ipv6 = iface
-                    .ipv6_interface_config
-                    .as_ref()
-                    .filter(|ipv6| !ipv6.ip.is_empty());
-                let addresses =
-                    build_dual_stack_list(iface.ip.clone(), observed_ipv6.map(|v6| v6.ip.clone()));
+                let addresses = build_dual_stack_list(
+                    iface.ip.clone(),
+                    iface.ipv6_interface_config.as_ref().map(|v6| v6.ip.clone()),
+                );
                 let prefixes = build_dual_stack_list(
                     iface.interface_prefix.clone(),
-                    observed_ipv6.map(|v6| v6.interface_prefix.clone()),
+                    iface
+                        .ipv6_interface_config
+                        .as_ref()
+                        .map(|v6| v6.interface_prefix.clone()),
                 );
                 interfaces.push(rpc::forge::InstanceInterfaceStatusObservation {
                     function_type: iface.function_type,

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3701,10 +3701,9 @@ message InstanceInterfaceStatus {
   // and therefore the address is unknown.
   optional string mac_address = 2;
 
-  // The list of IP addresses that had been assigned to this interface,
-  // based on the requested subnet.
-  // IPv4 precedes IPv6 when both families are assigned.
-  // The list will be empty if interface configuration hasn't been completed
+  // The IP addresses reported for this interface, ordered IPv4 before IPv6.
+  // This list is independent from `prefixes` and is empty when no address is
+  // available.
   repeated string addresses = 3;
 
   // The explicitly configured gateways, in CIDR notation. There is at most one
@@ -3714,12 +3713,12 @@ message InstanceInterfaceStatus {
   // IPv6 when both gateways are explicitly configured.
   repeated string gateways = 4;
 
-  // The list of IP prefixes that have been assigned to this interface
-  // out of the requested subnet (where the prefix allocated to the interface
-  // may be a /30 in the case of FNN, or just a /32 in the case of ETV).
-  //
-  // There is one prefix for each entry in `addresses`, in the same
-  // IPv4-before-IPv6 order.
+  // The prefixes reported for this interface in CIDR notation, ordered IPv4
+  // before IPv6. Prefix lengths follow the selected network and allocation
+  // policy. This list is independent from `addresses`: SLAAC reports an IPv6
+  // prefix without a fixed host address. Consumers must match values by address
+  // family rather than list position. The list is empty when no prefix is
+  // available.
   repeated string prefixes = 5;
 
   optional string device = 6;
@@ -5878,10 +5877,9 @@ message InstanceInterfaceStatusObservation {
   // and therefore the address is unknown.
   optional string mac_address = 3;
 
-  // The list of IP addresses that had been assigned to this interface,
-  // based on the requested subnet.
-  // IPv4 precedes IPv6 when both families are assigned.
-  // The list will be empty if interface configuration hasn't been completed
+  // The IP addresses reported for this interface, ordered IPv4 before IPv6.
+  // This list is independent from `prefixes` and is empty when no address is
+  // available.
   repeated string addresses = 4;
 
   // The explicitly configured gateways, in CIDR notation. There is at most one
@@ -5891,12 +5889,12 @@ message InstanceInterfaceStatusObservation {
   // IPv6 when both gateways are explicitly configured.
   repeated string gateways = 5;
 
-  // The list of IP prefixes that have been assigned to this interface
-  // out of the requested subnet (where the prefix allocated to the interface
-  // may be a /30 in the case of FNN, or just a /32 in the case of ETV).
-  //
-  // There is one prefix for each entry in `addresses`, in the same
-  // IPv4-before-IPv6 order.
+  // The prefixes reported for this interface in CIDR notation, ordered IPv4
+  // before IPv6. Prefix lengths follow the selected network and allocation
+  // policy. This list is independent from `addresses`: SLAAC reports an IPv6
+  // prefix without a fixed host address. Consumers must match values by address
+  // family rather than list position. The list is empty when no prefix is
+  // available.
   repeated string prefixes = 6;
 
   // The NSG details for the observed NSG of the interface

--- a/crates/test-harness/src/machine_dpu.rs
+++ b/crates/test-harness/src/machine_dpu.rs
@@ -162,28 +162,27 @@ async fn record_dpu_network_status(api: &Api, dpu_machine_id: MachineId) {
         network_config
             .tenant_interfaces
             .iter()
-            .map(|iface| {
-                let observed_ipv6 = iface
-                    .ipv6_interface_config
-                    .as_ref()
-                    .filter(|ipv6| !ipv6.ip.is_empty());
-                crate::rpc::forge::InstanceInterfaceStatusObservation {
+            .map(
+                |iface| crate::rpc::forge::InstanceInterfaceStatusObservation {
                     function_type: iface.function_type,
                     virtual_function_id: iface.virtual_function_id,
                     mac_address: None,
                     addresses: build_dual_stack_list(
                         iface.ip.clone(),
-                        observed_ipv6.map(|v6| v6.ip.clone()),
+                        iface.ipv6_interface_config.as_ref().map(|v6| v6.ip.clone()),
                     ),
                     prefixes: build_dual_stack_list(
                         iface.interface_prefix.clone(),
-                        observed_ipv6.map(|v6| v6.interface_prefix.clone()),
+                        iface
+                            .ipv6_interface_config
+                            .as_ref()
+                            .map(|v6| v6.interface_prefix.clone()),
                     ),
                     gateways: build_dual_stack_list(iface.gateway.clone(), None),
                     network_security_group: None,
                     internal_uuid: iface.internal_uuid.clone(),
-                }
-            })
+                },
+            )
             .collect()
     };
 

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -20110,10 +20110,9 @@ type InstanceInterfaceStatus struct {
 	// The list will be empty if interface configuration hasn't been completed
 	// and therefore the address is unknown.
 	MacAddress *string `protobuf:"bytes,2,opt,name=mac_address,json=macAddress,proto3,oneof" json:"mac_address,omitempty"`
-	// The list of IP addresses that had been assigned to this interface,
-	// based on the requested subnet.
-	// IPv4 precedes IPv6 when both families are assigned.
-	// The list will be empty if interface configuration hasn't been completed
+	// The IP addresses reported for this interface, ordered IPv4 before IPv6.
+	// This list is independent from `prefixes` and is empty when no address is
+	// available.
 	Addresses []string `protobuf:"bytes,3,rep,name=addresses,proto3" json:"addresses,omitempty"`
 	// The explicitly configured gateways, in CIDR notation. There is at most one
 	// gateway per address family, associated with the same-family address and
@@ -20121,12 +20120,12 @@ type InstanceInterfaceStatus struct {
 	// be shorter than `addresses` and is not positionally aligned. IPv4 precedes
 	// IPv6 when both gateways are explicitly configured.
 	Gateways []string `protobuf:"bytes,4,rep,name=gateways,proto3" json:"gateways,omitempty"`
-	// The list of IP prefixes that have been assigned to this interface
-	// out of the requested subnet (where the prefix allocated to the interface
-	// may be a /30 in the case of FNN, or just a /32 in the case of ETV).
-	//
-	// There is one prefix for each entry in `addresses`, in the same
-	// IPv4-before-IPv6 order.
+	// The prefixes reported for this interface in CIDR notation, ordered IPv4
+	// before IPv6. Prefix lengths follow the selected network and allocation
+	// policy. This list is independent from `addresses`: SLAAC reports an IPv6
+	// prefix without a fixed host address. Consumers must match values by address
+	// family rather than list position. The list is empty when no prefix is
+	// available.
 	Prefixes       []string `protobuf:"bytes,5,rep,name=prefixes,proto3" json:"prefixes,omitempty"`
 	Device         *string  `protobuf:"bytes,6,opt,name=device,proto3,oneof" json:"device,omitempty"`
 	DeviceInstance uint32   `protobuf:"varint,7,opt,name=device_instance,json=deviceInstance,proto3" json:"device_instance,omitempty"`
@@ -31542,10 +31541,9 @@ type InstanceInterfaceStatusObservation struct {
 	// The list will be empty if interface configuration hasn't been completed
 	// and therefore the address is unknown.
 	MacAddress *string `protobuf:"bytes,3,opt,name=mac_address,json=macAddress,proto3,oneof" json:"mac_address,omitempty"`
-	// The list of IP addresses that had been assigned to this interface,
-	// based on the requested subnet.
-	// IPv4 precedes IPv6 when both families are assigned.
-	// The list will be empty if interface configuration hasn't been completed
+	// The IP addresses reported for this interface, ordered IPv4 before IPv6.
+	// This list is independent from `prefixes` and is empty when no address is
+	// available.
 	Addresses []string `protobuf:"bytes,4,rep,name=addresses,proto3" json:"addresses,omitempty"`
 	// The explicitly configured gateways, in CIDR notation. There is at most one
 	// gateway per address family, associated with the same-family address and
@@ -31553,12 +31551,12 @@ type InstanceInterfaceStatusObservation struct {
 	// be shorter than `addresses` and is not positionally aligned. IPv4 precedes
 	// IPv6 when both gateways are explicitly configured.
 	Gateways []string `protobuf:"bytes,5,rep,name=gateways,proto3" json:"gateways,omitempty"`
-	// The list of IP prefixes that have been assigned to this interface
-	// out of the requested subnet (where the prefix allocated to the interface
-	// may be a /30 in the case of FNN, or just a /32 in the case of ETV).
-	//
-	// There is one prefix for each entry in `addresses`, in the same
-	// IPv4-before-IPv6 order.
+	// The prefixes reported for this interface in CIDR notation, ordered IPv4
+	// before IPv6. Prefix lengths follow the selected network and allocation
+	// policy. This list is independent from `addresses`: SLAAC reports an IPv6
+	// prefix without a fixed host address. Consumers must match values by address
+	// family rather than list position. The list is empty when no prefix is
+	// available.
 	Prefixes []string `protobuf:"bytes,6,rep,name=prefixes,proto3" json:"prefixes,omitempty"`
 	// The NSG details for the observed NSG of the interface
 	NetworkSecurityGroup *NetworkSecurityGroupStatus `protobuf:"bytes,7,opt,name=network_security_group,json=networkSecurityGroup,proto3" json:"network_security_group,omitempty"`

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -3570,10 +3570,9 @@ message InstanceInterfaceStatus {
   // and therefore the address is unknown.
   optional string mac_address = 2;
 
-  // The list of IP addresses that had been assigned to this interface,
-  // based on the requested subnet.
-  // IPv4 precedes IPv6 when both families are assigned.
-  // The list will be empty if interface configuration hasn't been completed
+  // The IP addresses reported for this interface, ordered IPv4 before IPv6.
+  // This list is independent from `prefixes` and is empty when no address is
+  // available.
   repeated string addresses = 3;
 
   // The explicitly configured gateways, in CIDR notation. There is at most one
@@ -3583,12 +3582,12 @@ message InstanceInterfaceStatus {
   // IPv6 when both gateways are explicitly configured.
   repeated string gateways = 4;
 
-  // The list of IP prefixes that have been assigned to this interface
-  // out of the requested subnet (where the prefix allocated to the interface
-  // may be a /30 in the case of FNN, or just a /32 in the case of ETV).
-  //
-  // There is one prefix for each entry in `addresses`, in the same
-  // IPv4-before-IPv6 order.
+  // The prefixes reported for this interface in CIDR notation, ordered IPv4
+  // before IPv6. Prefix lengths follow the selected network and allocation
+  // policy. This list is independent from `addresses`: SLAAC reports an IPv6
+  // prefix without a fixed host address. Consumers must match values by address
+  // family rather than list position. The list is empty when no prefix is
+  // available.
   repeated string prefixes = 5;
 
   optional string device = 6;
@@ -5682,10 +5681,9 @@ message InstanceInterfaceStatusObservation {
   // and therefore the address is unknown.
   optional string mac_address = 3;
 
-  // The list of IP addresses that had been assigned to this interface,
-  // based on the requested subnet.
-  // IPv4 precedes IPv6 when both families are assigned.
-  // The list will be empty if interface configuration hasn't been completed
+  // The IP addresses reported for this interface, ordered IPv4 before IPv6.
+  // This list is independent from `prefixes` and is empty when no address is
+  // available.
   repeated string addresses = 4;
 
   // The explicitly configured gateways, in CIDR notation. There is at most one
@@ -5695,12 +5693,12 @@ message InstanceInterfaceStatusObservation {
   // IPv6 when both gateways are explicitly configured.
   repeated string gateways = 5;
 
-  // The list of IP prefixes that have been assigned to this interface
-  // out of the requested subnet (where the prefix allocated to the interface
-  // may be a /30 in the case of FNN, or just a /32 in the case of ETV).
-  //
-  // There is one prefix for each entry in `addresses`, in the same
-  // IPv4-before-IPv6 order.
+  // The prefixes reported for this interface in CIDR notation, ordered IPv4
+  // before IPv6. Prefix lengths follow the selected network and allocation
+  // policy. This list is independent from `addresses`: SLAAC reports an IPv6
+  // prefix without a fixed host address. Consumers must match values by address
+  // family rather than list position. The list is empty when no prefix is
+  // available.
   repeated string prefixes = 6;
 
   // The NSG details for the observed NSG of the interface


### PR DESCRIPTION
When an interface uses SLAAC, NICo knows its IPv6 `/64`, but the host chooses its own address. Status treated the address and prefix like a pair, so it dropped the `/64` whenever the address was empty.

```text
Before
addresses: []
prefixes:  []

After
addresses: []
prefixes:  ["fd42:2403::/64"]
```

This PR lets each DPU-status producer report addresses and prefixes independently. The existing list helper still removes empty values and keeps IPv4 first. Machine-a-tron, the shared test harness, and API fixtures use the same behavior so they report what the real DPU agent reports.

This is a status/API fix. It does not change prefix allocation, assign an IPv6 address to the host, or add router advertisements.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5103

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Unit coverage confirms that DPU-reported status retains a SLAAC prefix without a fixed host address.
- API-core coverage confirms that the `/64` appears immediately, survives persistence, and remains visible beside IPv4 in dual-stack status; generated REST protobufs were regenerated from the canonical schema.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

The counts summarize local reviews across the simplification. CodeRabbit's exact nine-file rerun was clean, and a fresh Codex closure audit verified the Claude-driven scope reduction.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| common-nits reviewer | 0 | 0 | 0 |
| CodeRabbit CLI | 1 | 1 | 0 |
| Claude CLI | 8 | 6 | 2 |
| **Total** | **9** | **7** | **2** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### common-nits reviewer

No findings.

### CodeRabbit CLI

1. **Adopted** -- Make the dual-stack integration assertion check the exact IPv4 status prefix. **Resolution:** Compare it with the assigned IPv4 address as a `/32`; the focused test confirmed that status contract while retaining the SLAAC `/64` assertion.

### Claude CLI

1. **Adopted** -- The added HostInband test modeled a configuration that validation rejects. **Resolution:** Remove the extra HostInband behavior and test; SLAAC is FNN-only and this PR now stays on the DPU status path.
2. **Adopted** -- Four `observed_ipv6` bindings repeated empty-value filtering already provided by `build_dual_stack_list`. **Resolution:** Pass the configured IPv6 address directly to the existing helper.
3. **Declined** -- Add another shared helper around all four producers. **Reason:** The existing one-list helper already owns filtering and ordering; another wrapper recreates the abstraction this simplification removed.
4. **Adopted** -- Keep the prefix field's format and length behavior documented. **Resolution:** State that values use CIDR notation and lengths follow the selected network and allocation policy, avoiding the old incomplete fixed-length list.
5. **Adopted** -- Remove the IPv4 type assertion made redundant by the exact `/32` comparison.
6. **Adopted** -- Remove wording attached to the discarded HostInband implementation.
7. **Declined** -- Rewrite the pre-existing agent tuple table. **Reason:** Its scenarios remain readable and the requested rewrite does not cover a new behavior.
8. **Adopted** -- Revert unrelated zero-DPU gateway/prefix assertion wording.

Claude also verified that no in-tree consumer relies on positional address/prefix pairing; that informational note is not counted as a finding.

</details>

Closes #5103
