### PR TITLE
fix(site-agent): Dynamic inventory paging to maintain gRPC/Temporal payload limit

### DIFF
--- a/rest-api/site-agent/pkg/components/managers/workflow/orchestrator.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/orchestrator.go
@@ -16,11 +16,11 @@ import (
 	"logur.dev/logur"
 
 	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/worker"
 
 	computils "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/utils"
+	swu "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/util"
 )
 
 // Orchestrator - Workflow Orchestrator
@@ -142,17 +142,9 @@ func workflowOrchestrator() error {
 		HostPort:          fmt.Sprintf("%s:%s", ManagerAccess.Conf.EB.Temporal.Host, ManagerAccess.Conf.EB.Temporal.Port),
 		Namespace:         ManagerAccess.Conf.EB.Temporal.TemporalPublishNamespace,
 		ConnectionOptions: publishClientConnOptions,
-		DataConverter: converter.NewCompositeDataConverter(
-			converter.NewNilPayloadConverter(),
-			converter.NewByteSlicePayloadConverter(),
-			converter.NewProtoJSONPayloadConverterWithOptions(converter.ProtoJSONPayloadConverterOptions{
-				AllowUnknownFields: true,
-			}),
-			converter.NewProtoPayloadConverter(),
-			converter.NewJSONPayloadConverter(),
-		),
-		Interceptors: clientInterceptors,
-		Logger:       tLogger,
+		DataConverter:     swu.NewTemporalDataConverter(),
+		Interceptors:      clientInterceptors,
+		Logger:            tLogger,
 	}
 
 	if ManagerAccess.Data.EB.Conf.UtMode {
@@ -171,17 +163,9 @@ func workflowOrchestrator() error {
 		HostPort:          fmt.Sprintf("%s:%s", ManagerAccess.Conf.EB.Temporal.Host, ManagerAccess.Conf.EB.Temporal.Port),
 		Namespace:         ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace,
 		ConnectionOptions: subscribeClientConnOptions,
-		DataConverter: converter.NewCompositeDataConverter(
-			converter.NewNilPayloadConverter(),
-			converter.NewByteSlicePayloadConverter(),
-			converter.NewProtoJSONPayloadConverterWithOptions(converter.ProtoJSONPayloadConverterOptions{
-				AllowUnknownFields: true,
-			}),
-			converter.NewProtoPayloadConverter(),
-			converter.NewJSONPayloadConverter(),
-		),
-		Interceptors: clientInterceptors,
-		Logger:       tLogger,
+		DataConverter:     swu.NewTemporalDataConverter(),
+		Interceptors:      clientInterceptors,
+		Logger:            tLogger,
 	}
 
 	if ManagerAccess.Data.EB.Conf.UtMode {

--- a/rest-api/site-workflow/pkg/activity/instance_test.go
+++ b/rest-api/site-workflow/pkg/activity/instance_test.go
@@ -412,6 +412,15 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 	}
 	type args struct {
 		wantTotalItems int
+		// padBytesPerItem inflates every Instance Core returns, so a published page can outgrow
+		// the Temporal blob budget and force the publish page size down.
+		padBytesPerItem int
+		// maxRequestIDs makes Core answer a FindInstancesByIds request carrying more IDs than
+		// this with ResourceExhausted, forcing the site page size down.
+		maxRequestIDs int
+		// wantPageItems is the Instance count of each published page, in publish order.
+		wantPageItems []int
+		wantErr       bool
 	}
 	tests := []struct {
 		name   string
@@ -429,6 +438,7 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			},
 			args: args{
 				wantTotalItems: 0,
+				wantPageItems:  []int{0},
 			},
 		},
 		{
@@ -442,6 +452,90 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			},
 			args: args{
 				wantTotalItems: 195,
+				wantPageItems:  []int{25, 25, 25, 25, 25, 25, 25, 20},
+			},
+		},
+		{
+			// Core rejects 100, 90, ... down to 40, so the site page settles at 40 and the
+			// publish page stays at 25, splitting each site page into 25 then 15.
+			name: "test collecting and publishing instance inventory, site page steps down",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems: 100,
+				maxRequestIDs:  45,
+				wantPageItems:  []int{25, 15, 25, 15, 20},
+			},
+		},
+		{
+			// At 115 KB an Instance, 25 and 20 to a page both exceed the budget and 15 fits.
+			name: "test collecting and publishing instance inventory, publish page steps down",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:  60,
+				padBytesPerItem: 115 * 1024,
+				wantPageItems:   []int{15, 15, 15, 15},
+			},
+		},
+		{
+			// Both ladders at once: Core caps the fetch at 40 and the budget caps the page at 15.
+			name: "test collecting and publishing instance inventory, both page sizes step down",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:  60,
+				padBytesPerItem: 115 * 1024,
+				maxRequestIDs:   45,
+				wantPageItems:   []int{15, 15, 10, 15, 5},
+			},
+		},
+		{
+			// A 3 MB Instance cannot be paged under the budget, so each one is published alone
+			// rather than dropped.
+			name: "test collecting and publishing instance inventory, single Instance over budget",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:  2,
+				padBytesPerItem: 3 * 1024 * 1024,
+				wantPageItems:   []int{1, 1},
+			},
+		},
+		{
+			// Core still rejects the floor of 10, so nothing is published and the activity fails.
+			name: "test collecting and publishing instance inventory, site page hits its floor",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems: 100,
+				maxRequestIDs:  5,
+				wantErr:        true,
 			},
 		},
 	}
@@ -464,36 +558,52 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 
 			ctx := context.Background()
 			ctx = context.WithValue(ctx, "wantCount", tt.args.wantTotalItems)
-
-			totalPages := tt.args.wantTotalItems / tt.fields.cloudPageSize
-			if tt.args.wantTotalItems%tt.fields.cloudPageSize > 0 {
-				totalPages++
+			if tt.args.padBytesPerItem > 0 {
+				ctx = context.WithValue(ctx, "instancePadBytes", tt.args.padBytesPerItem)
+			}
+			if tt.args.maxRequestIDs > 0 {
+				ctx = context.WithValue(ctx, "maxRequestIDs", tt.args.maxRequestIDs)
 			}
 
 			err := manageInstance.DiscoverInstanceInventory(ctx)
+			if tt.args.wantErr {
+				assert.Error(t, err)
+				tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 0)
+				return
+			}
 			assert.NoError(t, err)
+			tc.AssertNumberOfCalls(t, "ExecuteWorkflow", len(tt.args.wantPageItems))
 
-			if tt.args.wantTotalItems == 0 {
-				tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 1)
-			} else {
-				tc.AssertNumberOfCalls(t, "ExecuteWorkflow", totalPages)
+			finalPages := []int{}
+			for i, wantItems := range tt.args.wantPageItems {
+				inventory, ok := tc.Calls[i].Arguments[4].(*corev1.InstanceInventory)
+				require.True(t, ok)
+
+				assert.Equal(t, corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, inventory.InventoryStatus)
+				assert.Equal(t, wantItems, len(inventory.Instances), "page %d Instance count", i+1)
+				assert.Equal(t, i+1, int(inventory.InventoryPage.CurrentPage))
+				assert.Equal(t, tt.args.wantTotalItems, int(inventory.InventoryPage.TotalItems))
+				assert.Equal(t, tt.args.wantTotalItems, len(inventory.InventoryPage.ItemIds))
+
+				if tt.args.wantTotalItems == 0 {
+					// Nothing to page through, so Cloud receives the configured page size and no
+					// page total, which is how it recognizes an unpaged inventory.
+					assert.Equal(t, tt.fields.cloudPageSize, int(inventory.InventoryPage.PageSize))
+					assert.Equal(t, 0, int(inventory.InventoryPage.TotalPages))
+					continue
+				}
+
+				assert.Equal(t, wantItems, int(inventory.InventoryPage.PageSize), "page %d reported size", i+1)
+				if inventory.InventoryPage.CurrentPage == inventory.InventoryPage.TotalPages {
+					finalPages = append(finalPages, i+1)
+				}
 			}
 
-			inventory, ok := tc.Calls[0].Arguments[4].(*corev1.InstanceInventory)
-			assert.True(t, ok)
-
-			if tt.args.wantTotalItems == 0 {
-				assert.Equal(t, 0, len(inventory.Instances))
-			} else {
-				assert.Equal(t, tt.fields.cloudPageSize, len(inventory.Instances))
+			if tt.args.wantTotalItems > 0 {
+				// Cloud runs its deletion sweep on the page where CurrentPage equals TotalPages,
+				// so the last published page and only the last one has to satisfy it.
+				assert.Equal(t, []int{len(tt.args.wantPageItems)}, finalPages)
 			}
-
-			assert.Equal(t, corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, inventory.InventoryStatus)
-			assert.Equal(t, totalPages, int(inventory.InventoryPage.TotalPages))
-			assert.Equal(t, 1, int(inventory.InventoryPage.CurrentPage))
-			assert.Equal(t, tt.fields.cloudPageSize, int(inventory.InventoryPage.PageSize))
-			assert.Equal(t, tt.args.wantTotalItems, int(inventory.InventoryPage.TotalItems))
-			assert.Equal(t, tt.args.wantTotalItems, len(inventory.InventoryPage.ItemIds))
 		})
 	}
 }

--- a/rest-api/site-workflow/pkg/activity/instance_test.go
+++ b/rest-api/site-workflow/pkg/activity/instance_test.go
@@ -421,6 +421,12 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 		// dropInstancesPerPage makes Core return fewer Instances than the IDs asked for, which
 		// is what a delete landing between FindInstanceIds and FindInstancesByIds looks like.
 		dropInstancesPerPage int
+		// rejectEveryFetch makes Core reject a request for even one ID, leaving the site page
+		// ladder nothing smaller to fall back to.
+		rejectEveryFetch bool
+		// cancelContext expires the activity context before the run starts, standing in for the
+		// activity deadline passing during collection.
+		cancelContext bool
 		// wantPageItems is the Instance count of each published page, in publish order.
 		wantPageItems []int
 		wantErr       bool
@@ -598,8 +604,9 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			},
 		},
 		{
-			// Core still rejects the floor of 10, so nothing is published and the activity fails.
-			name: "test collecting and publishing instance inventory, site page hits its floor",
+			// Core rejects anything above 5, so the ladder walks all the way to a single item
+			// and the run still completes rather than failing every tick.
+			name: "test collecting and publishing instance inventory, site page ladder reaches one item",
 			fields: fields{
 				siteID:               uuid.New(),
 				coreGrpcAtomicClient: coreGrpcAtomicClient,
@@ -610,16 +617,60 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			args: args{
 				wantTotalItems: 100,
 				maxRequestIDs:  5,
-				wantErr:        true,
+				wantPageItems:  []int{25, 25, 25, 25},
+			},
+		},
+		{
+			// Core rejects even a single item, so there is nothing smaller left to try and the
+			// activity fails with the failure reported to Cloud.
+			name: "test collecting and publishing instance inventory, site page ladder is exhausted",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:   100,
+				rejectEveryFetch: true,
+				wantErr:          true,
+			},
+		},
+		{
+			// The failure is often the activity deadline itself, so reporting it has to survive
+			// a context that is already dead. Publishing on the caller's context would mean the
+			// one case Cloud most needs to hear about is the one it never hears.
+			name: "test collecting and publishing instance inventory, failure reported on a dead context",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:   100,
+				rejectEveryFetch: true,
+				cancelContext:    true,
+				wantErr:          true,
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// The publish context is bounded by a deferred cancel, so its liveness has to be
+			// recorded while the call is happening rather than inspected afterwards.
+			publishCtxErrs := []error{}
 			tc := &tmocks.Client{}
 			tc.Mock.On("ExecuteWorkflow", mock.Anything, mock.AnythingOfType("internal.StartWorkflowOptions"),
-				mock.AnythingOfType("string"), mock.AnythingOfType("uuid.UUID"), mock.Anything).Return(wrun, nil)
+				mock.AnythingOfType("string"), mock.AnythingOfType("uuid.UUID"), mock.Anything).
+				Run(func(args mock.Arguments) {
+					publishCtx, ok := args.Get(0).(context.Context)
+					require.True(t, ok)
+					publishCtxErrs = append(publishCtxErrs, publishCtx.Err())
+				}).Return(wrun, nil)
 			tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 0)
 
 			manageInstance := NewManageInstanceInventory(ManageInventoryConfig{
@@ -639,6 +690,15 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			if tt.args.maxRequestIDs > 0 {
 				ctx = context.WithValue(ctx, "maxRequestIDs", tt.args.maxRequestIDs)
 			}
+			if tt.args.rejectEveryFetch {
+				// A cap of zero rejects any request, however few IDs it carries.
+				ctx = context.WithValue(ctx, "maxRequestIDs", 0)
+			}
+			if tt.args.cancelContext {
+				cancelledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				ctx = cancelledCtx
+			}
 			if tt.args.dropInstancesPerPage > 0 {
 				ctx = context.WithValue(ctx, "dropInstancesPerPage", tt.args.dropInstancesPerPage)
 			}
@@ -654,6 +714,11 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 				require.True(t, ok)
 				assert.Equal(t, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, inventory.InventoryStatus)
 				assert.Nil(t, inventory.InventoryPage, "a failure carries no paging metadata")
+
+				// The report detaches from the caller, so it goes out on a live context even
+				// when the run failed because that context expired.
+				require.Len(t, publishCtxErrs, 1)
+				assert.NoError(t, publishCtxErrs[0], "the failure report must not inherit a dead context")
 				return
 			}
 			assert.NoError(t, err)

--- a/rest-api/site-workflow/pkg/activity/instance_test.go
+++ b/rest-api/site-workflow/pkg/activity/instance_test.go
@@ -459,8 +459,9 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			},
 		},
 		{
-			// Core rejects 100, 90, ... down to 40, so the site page settles at 40 and the
-			// publish page stays at 25, splitting each site page into 25 then 15.
+			// Core rejects 100, 90, ... down to 40, so the site page settles at 40. Buffering
+			// carries the remainder of each site page into the next, so the published pages stay
+			// full instead of flushing a short one at every boundary.
 			name: "test collecting and publishing instance inventory, site page steps down",
 			fields: fields{
 				siteID:               uuid.New(),
@@ -472,7 +473,7 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			args: args{
 				wantTotalItems: 100,
 				maxRequestIDs:  45,
-				wantPageItems:  []int{25, 15, 25, 15, 20},
+				wantPageItems:  []int{25, 25, 25, 25},
 			},
 		},
 		{
@@ -505,7 +506,7 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 				wantTotalItems:  60,
 				padBytesPerItem: 115 * 1024,
 				maxRequestIDs:   45,
-				wantPageItems:   []int{15, 15, 10, 15, 5},
+				wantPageItems:   []int{15, 15, 15, 15},
 			},
 		},
 		{
@@ -544,8 +545,8 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			},
 		},
 		{
-			// Across several site pages the shortfall is only known page by page, so the total
-			// reads high mid-run and settles exactly on the last page.
+			// Across several site pages the shortfall is only known page by page, and the tail
+			// stays buffered until every page has been fetched, so the total settles exactly.
 			name: "test collecting and publishing instance inventory, Instances missing across site pages",
 			fields: fields{
 				siteID:               uuid.New(),
@@ -557,7 +558,43 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			args: args{
 				wantTotalItems:       250,
 				dropInstancesPerPage: 3,
-				wantPageItems:        []int{25, 25, 25, 22, 25, 25, 25, 22, 25, 22},
+				wantPageItems:        []int{25, 25, 25, 25, 25, 25, 25, 25, 25, 16},
+			},
+		},
+		{
+			// The trailing site page holds exactly 10 IDs and Core returns none of them, so no
+			// page is published from it. Holding the tail back is what keeps the page before it
+			// from claiming a total it cannot reach.
+			name: "test collecting and publishing instance inventory, trailing site page returns nothing",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:       110,
+				dropInstancesPerPage: 10,
+				wantPageItems:        []int{25, 25, 25, 15},
+			},
+		},
+		{
+			// Core reported IDs but returned no object for any of them. Cloud still gets one
+			// page carrying the full ID list, so it reconciles against a complete run and
+			// deletes nothing rather than receiving silence.
+			name: "test collecting and publishing instance inventory, Core returns no Instances at all",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:       50,
+				dropInstancesPerPage: 50,
+				wantPageItems:        []int{0},
 			},
 		},
 		{

--- a/rest-api/site-workflow/pkg/activity/instance_test.go
+++ b/rest-api/site-workflow/pkg/activity/instance_test.go
@@ -418,6 +418,9 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 		// maxRequestIDs makes Core answer a FindInstancesByIds request carrying more IDs than
 		// this with ResourceExhausted, forcing the site page size down.
 		maxRequestIDs int
+		// dropInstancesPerPage makes Core return fewer Instances than the IDs asked for, which
+		// is what a delete landing between FindInstanceIds and FindInstancesByIds looks like.
+		dropInstancesPerPage int
 		// wantPageItems is the Instance count of each published page, in publish order.
 		wantPageItems []int
 		wantErr       bool
@@ -523,6 +526,41 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			},
 		},
 		{
+			// Core drops 3 Instances between the two calls, so 97 items cover 100 IDs. The last
+			// page still has to report CurrentPage equal to TotalPages, or Cloud skips its
+			// deletion sweep for the whole run.
+			name: "test collecting and publishing instance inventory, Core returns fewer Instances than IDs",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:       100,
+				dropInstancesPerPage: 3,
+				wantPageItems:        []int{25, 25, 25, 22},
+			},
+		},
+		{
+			// Across several site pages the shortfall is only known page by page, so the total
+			// reads high mid-run and settles exactly on the last page.
+			name: "test collecting and publishing instance inventory, Instances missing across site pages",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems:       250,
+				dropInstancesPerPage: 3,
+				wantPageItems:        []int{25, 25, 25, 22, 25, 25, 25, 22, 25, 22},
+			},
+		},
+		{
 			// Core still rejects the floor of 10, so nothing is published and the activity fails.
 			name: "test collecting and publishing instance inventory, site page hits its floor",
 			fields: fields{
@@ -564,11 +602,21 @@ func TestManageInstanceInventory_DiscoverInstanceInventory(t *testing.T) {
 			if tt.args.maxRequestIDs > 0 {
 				ctx = context.WithValue(ctx, "maxRequestIDs", tt.args.maxRequestIDs)
 			}
+			if tt.args.dropInstancesPerPage > 0 {
+				ctx = context.WithValue(ctx, "dropInstancesPerPage", tt.args.dropInstancesPerPage)
+			}
 
 			err := manageInstance.DiscoverInstanceInventory(ctx)
 			if tt.args.wantErr {
 				assert.Error(t, err)
-				tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 0)
+
+				// Nothing was collected, so Cloud gets one page carrying the failure rather
+				// than silence, which would leave it serving the previous inventory.
+				tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 1)
+				inventory, ok := tc.Calls[0].Arguments[4].(*corev1.InstanceInventory)
+				require.True(t, ok)
+				assert.Equal(t, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, inventory.InventoryStatus)
+				assert.Nil(t, inventory.InventoryPage, "a failure carries no paging metadata")
 				return
 			}
 			assert.NoError(t, err)

--- a/rest-api/site-workflow/pkg/activity/inventory.go
+++ b/rest-api/site-workflow/pkg/activity/inventory.go
@@ -169,13 +169,13 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 			collector.itemsMissing += consumed - len(siteItems)
 		}
 
-		err = collector.publishItems(ctx, logger, siteItems)
+		err = collector.bufferItems(ctx, logger, siteItems)
 		if err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return collector.flush(ctx, logger)
 }
 
 // collectAndPublishFallback collects the whole inventory in one call, for a Core that does not
@@ -211,7 +211,11 @@ func (impl *manageInventoryImpl[K, R, P]) collectAndPublishFallback(ctx context.
 		return nil
 	}
 
-	return collector.publishItems(ctx, logger, siteItems)
+	err = collector.bufferItems(ctx, logger, siteItems)
+	if err != nil {
+		return err
+	}
+	return collector.flush(ctx, logger)
 }
 
 // inventoryCollector fetches inventory from Core and publishes it to Cloud a page at a time.
@@ -233,6 +237,9 @@ type inventoryCollector[K any, R any, P any] struct {
 	// itemsMissing counts IDs that FindIDs reported but FindByIDs did not return, which is what
 	// a delete landing between the two calls looks like.
 	itemsMissing int
+	// pending holds items fetched but not yet published. It never exceeds one page, because the
+	// tail stays here until the caller flushes it.
+	pending []R
 }
 
 // newCollector prepares the per-run state the collector carries across site pages.
@@ -270,25 +277,58 @@ func (col *inventoryCollector[K, R, P]) fetchSitePage(ctx context.Context, logge
 	}
 }
 
-// publishItems cuts one site page of items into published pages and sends each to Cloud.
-func (col *inventoryCollector[K, R, P]) publishItems(ctx context.Context, logger *zerolog.Logger, items []R) error {
-	for len(items) > 0 {
-		page, pageItems, err := col.buildPageWithinBudget(ctx, logger, items)
+// bufferItems takes one site page of items and publishes whole pages from everything buffered
+// so far, always holding at least one item back. Retaining the tail is what lets flush know the
+// page carrying it is the last one, which is how Cloud recognizes a complete run. It also fills
+// pages across site page boundaries instead of flushing a short page at each one.
+func (col *inventoryCollector[K, R, P]) bufferItems(ctx context.Context, logger *zerolog.Logger, items []R) error {
+	col.pending = append(col.pending, items...)
+	// Strictly greater, so a full buffer still leaves something for flush to carry.
+	for len(col.pending) > col.cloudPageSize {
+		err := col.publishNextPage(ctx, logger)
 		if err != nil {
 			return err
 		}
-
-		logger.Info().Msgf("Publishing inventory page %d to Cloud", col.pagesPublished+1)
-		err = col.execute(ctx, page)
-		if err != nil {
-			logger.Error().Err(err).Int("Cloud Page", col.pagesPublished+1).Msg("Failed to publish inventory to Cloud")
-			return err
-		}
-
-		col.pagesPublished++
-		col.itemsPublished += pageItems
-		items = items[pageItems:]
 	}
+	return nil
+}
+
+// flush publishes whatever is still buffered once every site page has been fetched, so the last
+// page it sends reports itself as the final page.
+func (col *inventoryCollector[K, R, P]) flush(ctx context.Context, logger *zerolog.Logger) error {
+	for len(col.pending) > 0 {
+		err := col.publishNextPage(ctx, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Core reported IDs but returned no object for any of them. Publishing the ID list with no
+	// items lets Cloud reconcile against a complete run instead of receiving nothing and holding
+	// the previous inventory. Every reported ID is present, so nothing gets deleted.
+	if col.pagesPublished == 0 {
+		return col.publishNextPage(ctx, logger)
+	}
+	return nil
+}
+
+// publishNextPage builds one page from the front of the buffer and sends it to Cloud.
+func (col *inventoryCollector[K, R, P]) publishNextPage(ctx context.Context, logger *zerolog.Logger) error {
+	page, pageItems, err := col.buildPageWithinBudget(ctx, logger, col.pending)
+	if err != nil {
+		return err
+	}
+
+	logger.Info().Msgf("Publishing inventory page %d to Cloud", col.pagesPublished+1)
+	err = col.execute(ctx, page)
+	if err != nil {
+		logger.Error().Err(err).Int("Cloud Page", col.pagesPublished+1).Msg("Failed to publish inventory to Cloud")
+		return err
+	}
+
+	col.pagesPublished++
+	col.itemsPublished += pageItems
+	col.pending = col.pending[pageItems:]
 	return nil
 }
 
@@ -311,9 +351,12 @@ func (col *inventoryCollector[K, R, P]) buildPageWithinBudget(ctx context.Contex
 		if size <= maxPublishPayloadBytes {
 			return page, pageItems, nil
 		}
-		if pageItems == 1 {
+		// At one item there is nothing left to split, and at zero the page is carrying only the
+		// ID list, which no page size can shrink. Publishing either anyway beats dropping
+		// inventory or looping on a size that cannot come down.
+		if pageItems <= 1 {
 			logger.Error().Int("Payload Bytes", size).Int("Budget Bytes", maxPublishPayloadBytes).
-				Msg("A single inventory item exceeds the publish budget, publishing it anyway")
+				Int("Page Items", pageItems).Msg("An inventory page exceeds the publish budget, publishing it anyway")
 			return page, pageItems, nil
 		}
 
@@ -337,8 +380,9 @@ func (col *inventoryCollector[K, R, P]) buildInventoryPage(ctx context.Context, 
 	}
 	// The Cloud worker runs its deletion sweep on the page where CurrentPage equals TotalPages, so
 	// the total is derived from what is left rather than fixed up front, which the publish page
-	// size stepping down would invalidate. Discounting itemsMissing keeps the last page exact, and
-	// because it only grows as site pages arrive a mid-run total can read high but never low.
+	// size stepping down would invalidate. This reduces to unfetched IDs plus buffered items, so
+	// it reaches zero only on the page that carries the last of both. Discounting itemsMissing is
+	// what keeps an item Core never returned from holding the total above the page number.
 	remainingItems := input.totalItems - col.itemsMissing - col.itemsPublished - pageItems
 	input.totalPages = input.pageNumber + ceilDiv(remainingItems, col.cloudPageSize)
 

--- a/rest-api/site-workflow/pkg/activity/inventory.go
+++ b/rest-api/site-workflow/pkg/activity/inventory.go
@@ -11,12 +11,36 @@ import (
 
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	cClient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
+	"github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/util"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	tClient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// sitePageSizeStep is how much the Core fetch page shrinks after a response that exceeds
+	// the gRPC client receive limit.
+	sitePageSizeStep = 10
+	// minSitePageSize floors the Core fetch ladder. A response of this many items that still
+	// does not fit means a single item is enormous, so the activity fails rather than keep
+	// stepping down.
+	minSitePageSize = 10
+
+	// cloudPageSizeStep is how much the published page shrinks when a page exceeds the budget.
+	cloudPageSizeStep = 5
+
+	// maxPublishPayloadBytes budgets one published inventory page at 1.9 MiB, under the 2 MiB
+	// blob Temporal rejects (limit.blobSize.error). The remaining margin is not accounting for
+	// anything: payloadSize already measures the Site ID argument and the payload framing. It
+	// covers a deployment that configures a lower limit than the Site Agent can see, and the
+	// cost of guessing wrong, since a rejected page fails the activity and leaves inventory
+	// stale until the next cron tick.
+	maxPublishPayloadBytes = 1945 * 1024
 )
 
 type ManageInventoryConfig struct {
@@ -68,32 +92,14 @@ func (pii *pagedInventoryInput) buildPage() *corev1.InventoryPage {
 	}
 }
 
-func buildPagedInventoryInput(totalCount int, pageSize int) *pagedInventoryInput {
-	input := &pagedInventoryInput{
-		totalItems: totalCount,
-		pageSize:   pageSize,
-	}
-	input.totalPages = totalCount / pageSize
-	if totalCount%pageSize > 0 {
-		input.totalPages++
-	}
-	return input
-}
-
 func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context.Context, logger *zerolog.Logger) error {
-	// Define workflow options
-	workflowOptions := tClient.StartWorkflowOptions{
-		ID:        fmt.Sprintf("update-%s-inventory-%s", strings.ToLower(impl.itemType), impl.config.SiteID.String()),
-		TaskQueue: impl.config.TemporalPublishQueue,
-	}
-
-	// define workflow name
-	workflowName := fmt.Sprintf("Update%sInventory", impl.itemType)
 	// get Core gRPC client
 	grpcClient := impl.config.CoreGrpcAtomicClient.GetClient()
 	if grpcClient == nil {
 		return cClient.ErrCoreGrpcClientNotConnected
 	}
+
+	collector := impl.newCollector(grpcClient)
 
 	// find IDs
 	allIDs, err := impl.internalFindIDs(ctx, grpcClient)
@@ -101,87 +107,50 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 		if grpcStatus, ok := status.FromError(err); ok {
 			if grpcStatus.Code() == codes.Unimplemented {
 				log.Info().Msg("Using fallback API to get inventory")
-				if err = impl.collectAndPublishFallback(ctx, logger, grpcClient, workflowName, workflowOptions); err == nil {
+				if err = impl.collectAndPublishFallback(ctx, logger, grpcClient); err == nil {
 					return err
 				}
 			}
 		}
 		logger.Warn().Err(err).Msg("Failed to retrieve IDs using Core gRPC API")
 		// Error encountered before we've published anything, report inventory collection error to Cloud
-		pagedInput := buildPagedInventoryInput(0, impl.config.CloudPageSize)
-		pagedInput.status = corev1.InventoryStatus_INVENTORY_STATUS_FAILED
-		pagedInput.statusMessage = err.Error()
-		inventory := impl.internalPagedInventory([]K{}, []R{}, pagedInput)
-		if _, execErr := impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), workflowOptions, workflowName, impl.config.SiteID, inventory); execErr != nil {
+		if execErr := collector.publishStatusOnly(corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error()); execErr != nil {
 			logger.Error().Err(execErr).Msg("Failed to publish inventory error to Cloud")
 			return execErr
 		}
 		return err
 	}
 
-	// build paged inventory input with common values
-	pagedInput := buildPagedInventoryInput(len(allIDs), impl.config.CloudPageSize)
-	if pagedInput.totalItems == 0 {
-		pagedInput.pageNumber = 1
-		pagedInput.status = corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS
-		pagedInput.statusMessage = "No items reported by Site Controller"
-		inventoryPage := impl.internalPagedInventory([]K{}, []R{}, pagedInput)
-
+	collector.allIDs = allIDs
+	if len(allIDs) == 0 {
 		logger.Info().Msg("Publishing empty inventory page to Cloud")
-
-		if _, err := impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), workflowOptions, workflowName, impl.config.SiteID, inventoryPage); err != nil {
+		if err = collector.publishStatusOnly(corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, "No items reported by Site Controller"); err != nil {
 			logger.Error().Err(err).Msg("Failed to publish inventory to Cloud")
 			return err
 		}
+		return nil
 	}
 
-	// Iterate through all pages and publish inventory
-	cloudEffectivePage := 1
-	sitePagedIDs := cClient.SliceToChunks(allIDs, impl.config.SitePageSize)
-	for sitePage, siteItemIDs := range sitePagedIDs {
-		// find items by IDs
-		siteItems, err := impl.internalFindByIDs(ctx, grpcClient, siteItemIDs)
+	// Fetch the inventory a site page at a time and publish each site page onwards to Cloud, so
+	// only one site page is held in memory at a time.
+	for remainingIDs := allIDs; len(remainingIDs) > 0; {
+		siteItems, consumed, err := collector.fetchSitePage(ctx, logger, remainingIDs)
 		if err != nil {
-			logger.Warn().Err(err).Int("Site Page", sitePage+1).Msg("Failed to retrieve using Core gRPC API")
+			logger.Warn().Err(err).Int("Site Page", collector.sitePagesFetched+1).Msg("Failed to retrieve using Core gRPC API")
 			return err
 		}
+		remainingIDs = remainingIDs[consumed:]
 
 		// We could return an error, but that might get us caught in
 		// a scenerio where deletes on site between FindIDs and FindByIDs
 		// calls creates a mismatch that fails.  If we log the error, we could
 		// alert on it without letting it break inventory entirely.
-		if len(siteItems) != len(siteItemIDs) {
+		if len(siteItems) != consumed {
 			logger.Error().Msg("size of FindByIDs set does not match size of FindIDs set")
 		}
 
-		// publish inventory to Cloud in separate chunks
-		cloudItems := cClient.SliceToChunks(siteItems, impl.config.CloudPageSize)
-		for _, items := range cloudItems {
-			workflowOptions := tClient.StartWorkflowOptions{
-				ID:        fmt.Sprintf("%v-%v", workflowOptions.ID, cloudEffectivePage),
-				TaskQueue: workflowOptions.TaskQueue,
-			}
-			// Create an inventory page
-			pagedInput.pageNumber = cloudEffectivePage
-			pagedInput.status = corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS
-			pagedInput.statusMessage = "Successfully retrieved from Site Controller"
-			inventoryPage := impl.internalPagedInventory(allIDs, items, pagedInput)
-
-			// Handle any requested post processing
-			if impl.internalPagedInventoryPostProcess != nil {
-				inventoryPage, err = impl.internalPagedInventoryPostProcess(ctx, grpcClient, inventoryPage)
-				if err != nil {
-					return err
-				}
-			}
-
-			// publish
-			logger.Info().Msgf("Publishing inventory page %d to Cloud", cloudEffectivePage)
-			if _, err = impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), workflowOptions, workflowName, impl.config.SiteID, inventoryPage); err != nil {
-				logger.Error().Err(err).Int("Cloud Page", cloudEffectivePage).Msg("Failed to publish inventory to Cloud")
-				return err
-			}
-			cloudEffectivePage++
+		if err = collector.publishItems(ctx, logger, siteItems); err != nil {
+			return err
 		}
 	}
 
@@ -189,68 +158,206 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 }
 
 func (impl *manageInventoryImpl[K, R, P]) collectAndPublishFallback(ctx context.Context, logger *zerolog.Logger,
-	grpcClient *cClient.CoreGrpcClient, workflowName string, workflowOptions tClient.StartWorkflowOptions) error {
+	grpcClient *cClient.CoreGrpcClient) error {
 	if impl.internalFindFallback == nil {
 		return errors.New("no fallback find function defined")
 	}
+	collector := impl.newCollector(grpcClient)
+
 	allIDs, siteItems, err := impl.internalFindFallback(ctx, grpcClient)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to retrieve using Site Controller fallback API")
 		// Error encountered before we've published anything, report inventory collection error to Cloud
-		pagedInput := buildPagedInventoryInput(0, impl.config.CloudPageSize)
-		pagedInput.status = corev1.InventoryStatus_INVENTORY_STATUS_FAILED
-		pagedInput.statusMessage = err.Error()
-		inventory := impl.internalPagedInventory([]K{}, []R{}, pagedInput)
-		if _, execErr := impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), workflowOptions, workflowName, impl.config.SiteID, inventory); execErr != nil {
+		if execErr := collector.publishStatusOnly(corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error()); execErr != nil {
 			logger.Error().Err(execErr).Msg("Failed to publish inventory error to Cloud")
 			return execErr
 		}
 		return err
 	}
 
-	// build paged inventory input with common values
-	pagedInput := buildPagedInventoryInput(len(allIDs), impl.config.CloudPageSize)
-	if pagedInput.totalItems == 0 {
-		pagedInput.pageNumber = 1
-		pagedInput.status = corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS
-		pagedInput.statusMessage = "No items reported by Site Controller"
-		inventoryPage := impl.internalPagedInventory([]K{}, []R{}, pagedInput)
-
+	collector.allIDs = allIDs
+	if len(allIDs) == 0 {
 		logger.Info().Msg("Publishing empty inventory page to Cloud")
-
-		if _, err := impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), workflowOptions, workflowName, impl.config.SiteID, inventoryPage); err != nil {
+		if err = collector.publishStatusOnly(corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, "No items reported by Site Controller"); err != nil {
 			logger.Error().Err(err).Msg("Failed to publish inventory to Cloud")
 			return err
 		}
+		return nil
 	}
 
-	// publish inventory to Cloud in separate chunks
-	cloudItems := cClient.SliceToChunks(siteItems, impl.config.CloudPageSize)
-	for page, items := range cloudItems {
-		workflowOptions := tClient.StartWorkflowOptions{
-			ID:        fmt.Sprintf("%v-%v", workflowOptions.ID, page),
-			TaskQueue: workflowOptions.TaskQueue,
-		}
-		// Create an inventory page
-		pagedInput.pageNumber = page + 1
-		pagedInput.status = corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS
-		pagedInput.statusMessage = "Successfully retrieved from Site Controller"
-		inventoryPage := impl.internalPagedInventory(allIDs, items, pagedInput)
+	return collector.publishItems(ctx, logger, siteItems)
+}
 
-		// Handle any requested post processing
-		if impl.internalPagedInventoryPostProcess != nil {
-			inventoryPage, err = impl.internalPagedInventoryPostProcess(ctx, grpcClient, inventoryPage)
-			if err != nil {
-				return err
-			}
-		}
+// inventoryCollector fetches inventory from Core and publishes it to Cloud a page at a time.
+// Both page sizes only ever decrease, so each ladder is walked once per run rather than on
+// every page.
+type inventoryCollector[K any, R any, P any] struct {
+	impl          *manageInventoryImpl[K, R, P]
+	grpcClient    *cClient.CoreGrpcClient
+	workflowName  string
+	workflowID    string
+	dataConverter converter.DataConverter
+	allIDs        []K
 
-		// publish
-		logger.Info().Msgf("Publishing inventory page %d to Cloud", page+1)
-		if _, err = impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), workflowOptions, workflowName, impl.config.SiteID, inventoryPage); err != nil {
-			logger.Error().Err(err).Int("Cloud Page", page+1).Msg("Failed to publish inventory to Cloud")
+	sitePageSize     int
+	cloudPageSize    int
+	sitePagesFetched int
+	pagesPublished   int
+	itemsPublished   int
+}
+
+func (impl *manageInventoryImpl[K, R, P]) newCollector(grpcClient *cClient.CoreGrpcClient) *inventoryCollector[K, R, P] {
+	return &inventoryCollector[K, R, P]{
+		impl:          impl,
+		grpcClient:    grpcClient,
+		workflowName:  fmt.Sprintf("Update%sInventory", impl.itemType),
+		workflowID:    fmt.Sprintf("update-%s-inventory-%s", strings.ToLower(impl.itemType), impl.config.SiteID.String()),
+		dataConverter: util.NewTemporalDataConverter(),
+		// Both loops advance by the page size, so a caller that left either unset would spin
+		// forever on empty pages instead of failing.
+		sitePageSize:  max(1, impl.config.SitePageSize),
+		cloudPageSize: max(1, impl.config.CloudPageSize),
+	}
+}
+
+// fetchSitePage retrieves one page of items from Core and reports how many IDs it consumed. A
+// response larger than the client receive limit comes back as ResourceExhausted, so the page
+// size steps down and the same IDs are requested again.
+func (col *inventoryCollector[K, R, P]) fetchSitePage(ctx context.Context, logger *zerolog.Logger, ids []K) ([]R, int, error) {
+	for {
+		pageIDs := ids[:min(col.sitePageSize, len(ids))]
+		items, err := col.impl.internalFindByIDs(ctx, col.grpcClient, pageIDs)
+		if err == nil {
+			col.sitePagesFetched++
+			return items, len(pageIDs), nil
+		}
+		if status.Code(err) != codes.ResourceExhausted || len(pageIDs) <= minSitePageSize {
+			return nil, 0, err
+		}
+		col.sitePageSize = max(minSitePageSize, len(pageIDs)-sitePageSizeStep)
+		logger.Warn().Err(err).Int("Site Page Size", col.sitePageSize).
+			Msg("Core response exceeded the gRPC receive limit, retrying with a smaller site page")
+	}
+}
+
+// publishItems cuts one site page of items into published pages and sends each to Cloud.
+func (col *inventoryCollector[K, R, P]) publishItems(ctx context.Context, logger *zerolog.Logger, items []R) error {
+	for len(items) > 0 {
+		page, pageItems, err := col.buildPageWithinBudget(ctx, logger, items)
+		if err != nil {
 			return err
 		}
+
+		logger.Info().Msgf("Publishing inventory page %d to Cloud", col.pagesPublished+1)
+		if err = col.execute(page); err != nil {
+			logger.Error().Err(err).Int("Cloud Page", col.pagesPublished+1).Msg("Failed to publish inventory to Cloud")
+			return err
+		}
+
+		col.pagesPublished++
+		col.itemsPublished += pageItems
+		items = items[pageItems:]
 	}
 	return nil
+}
+
+// buildPageWithinBudget builds the next page from the front of items, stepping the publish page
+// size down until the serialized page fits the budget. A single item over the budget is
+// published anyway, because dropping it would silently lose inventory.
+func (col *inventoryCollector[K, R, P]) buildPageWithinBudget(ctx context.Context, logger *zerolog.Logger, items []R) (P, int, error) {
+	for {
+		pageItems := min(col.cloudPageSize, len(items))
+		page, err := col.buildInventoryPage(ctx, items[:pageItems], pageItems)
+		if err != nil {
+			return page, 0, err
+		}
+
+		size, err := col.payloadSize(page)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to measure the size of an inventory page")
+			return page, 0, err
+		}
+		if size <= maxPublishPayloadBytes {
+			return page, pageItems, nil
+		}
+		if pageItems == 1 {
+			logger.Error().Int("Payload Bytes", size).Int("Budget Bytes", maxPublishPayloadBytes).
+				Msg("A single inventory item exceeds the publish budget, publishing it anyway")
+			return page, pageItems, nil
+		}
+
+		// Step down from what this page actually held rather than from the configured size, so a
+		// short trailing page reaches a fitting size in one step instead of several.
+		col.cloudPageSize = max(1, pageItems-cloudPageSizeStep)
+		logger.Warn().Int("Payload Bytes", size).Int("Cloud Page Size", col.cloudPageSize).
+			Msg("Inventory page exceeded the publish budget, rebuilding with fewer items")
+	}
+}
+
+func (col *inventoryCollector[K, R, P]) buildInventoryPage(ctx context.Context, items []R, pageItems int) (P, error) {
+	input := &pagedInventoryInput{
+		totalItems:    len(col.allIDs),
+		pageSize:      pageItems,
+		pageNumber:    col.pagesPublished + 1,
+		status:        corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
+		statusMessage: "Successfully retrieved from Site Controller",
+	}
+	// The Cloud worker treats a page whose CurrentPage equals TotalPages as the last one and runs
+	// its deletion sweep there, so the total is derived from what is left rather than fixed up
+	// front, which the publish page size stepping down would invalidate. With nothing left this
+	// is exactly pageNumber; with items left it is always greater, so no earlier page can be
+	// mistaken for the last one.
+	remainingItems := input.totalItems - col.itemsPublished - pageItems
+	input.totalPages = input.pageNumber + ceilDiv(remainingItems, col.cloudPageSize)
+
+	page := col.impl.internalPagedInventory(col.allIDs, items, input)
+
+	// Handle any requested post processing
+	if col.impl.internalPagedInventoryPostProcess != nil {
+		return col.impl.internalPagedInventoryPostProcess(ctx, col.grpcClient, page)
+	}
+	return page, nil
+}
+
+// payloadSize reports how many bytes the workflow arguments occupy once serialized, measured
+// with the converter the publish client uses so it matches what Temporal receives.
+func (col *inventoryCollector[K, R, P]) payloadSize(page P) (int, error) {
+	payloads, err := col.dataConverter.ToPayloads(col.impl.config.SiteID, page)
+	if err != nil {
+		return 0, err
+	}
+	return proto.Size(payloads), nil
+}
+
+// publishStatusOnly publishes a single page carrying a status and no items, used when the Site
+// reported nothing and when collection failed before any page went out. It keeps the unpaged
+// workflow ID and reports the configured page size, which is what Cloud has always received for
+// these two cases.
+func (col *inventoryCollector[K, R, P]) publishStatusOnly(inventoryStatus corev1.InventoryStatus, statusMessage string) error {
+	page := col.impl.internalPagedInventory([]K{}, []R{}, &pagedInventoryInput{
+		pageSize:      col.cloudPageSize,
+		pageNumber:    1,
+		status:        inventoryStatus,
+		statusMessage: statusMessage,
+	})
+	_, err := col.impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), tClient.StartWorkflowOptions{
+		ID:        col.workflowID,
+		TaskQueue: col.impl.config.TemporalPublishQueue,
+	}, col.workflowName, col.impl.config.SiteID, page)
+	return err
+}
+
+func (col *inventoryCollector[K, R, P]) execute(page P) error {
+	_, err := col.impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), tClient.StartWorkflowOptions{
+		ID:        fmt.Sprintf("%v-%v", col.workflowID, col.pagesPublished+1),
+		TaskQueue: col.impl.config.TemporalPublishQueue,
+	}, col.workflowName, col.impl.config.SiteID, page)
+	return err
+}
+
+func ceilDiv(dividend, divisor int) int {
+	if divisor <= 0 || dividend <= 0 {
+		return 0
+	}
+	return (dividend + divisor - 1) / divisor
 }

--- a/rest-api/site-workflow/pkg/activity/inventory.go
+++ b/rest-api/site-workflow/pkg/activity/inventory.go
@@ -92,6 +92,11 @@ func (pii *pagedInventoryInput) buildPage() *corev1.InventoryPage {
 	}
 }
 
+// CollectAndPublishInventory fetches the inventory from Core a site page at a time and publishes
+// each page onwards to Cloud, so only one site page is held in memory. Both page sizes adapt: the
+// Core fetch shrinks when a response outgrows the gRPC receive limit, and a published page shrinks
+// until it fits Temporal's blob limit. A failure before any page goes out is reported to Cloud as
+// a FAILED status page.
 func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context.Context, logger *zerolog.Logger) error {
 	// get Core gRPC client
 	grpcClient := impl.config.CoreGrpcAtomicClient.GetClient()
@@ -104,17 +109,16 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 	// find IDs
 	allIDs, err := impl.internalFindIDs(ctx, grpcClient)
 	if err != nil {
-		if grpcStatus, ok := status.FromError(err); ok {
-			if grpcStatus.Code() == codes.Unimplemented {
-				log.Info().Msg("Using fallback API to get inventory")
-				if err = impl.collectAndPublishFallback(ctx, logger, grpcClient); err == nil {
-					return err
-				}
-			}
+		// The fallback reports its own failures, so returning here keeps a failed fallback from
+		// publishing a second FAILED page under the same workflow ID.
+		if status.Code(err) == codes.Unimplemented && impl.internalFindFallback != nil {
+			log.Info().Msg("Using fallback API to get inventory")
+			return impl.collectAndPublishFallback(ctx, logger, grpcClient)
 		}
 		logger.Warn().Err(err).Msg("Failed to retrieve IDs using Core gRPC API")
 		// Error encountered before we've published anything, report inventory collection error to Cloud
-		if execErr := collector.publishStatusOnly(corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error()); execErr != nil {
+		execErr := collector.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error())
+		if execErr != nil {
 			logger.Error().Err(execErr).Msg("Failed to publish inventory error to Cloud")
 			return execErr
 		}
@@ -124,7 +128,8 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 	collector.allIDs = allIDs
 	if len(allIDs) == 0 {
 		logger.Info().Msg("Publishing empty inventory page to Cloud")
-		if err = collector.publishStatusOnly(corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, "No items reported by Site Controller"); err != nil {
+		err = collector.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, "No items reported by Site Controller")
+		if err != nil {
 			logger.Error().Err(err).Msg("Failed to publish inventory to Cloud")
 			return err
 		}
@@ -132,11 +137,22 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 	}
 
 	// Fetch the inventory a site page at a time and publish each site page onwards to Cloud, so
-	// only one site page is held in memory at a time.
-	for remainingIDs := allIDs; len(remainingIDs) > 0; {
+	// only one site page is held in memory at a time. The cursor advances by however many IDs the
+	// fetch consumed, which shrinks when the site page ladder steps down.
+	remainingIDs := allIDs
+	for len(remainingIDs) > 0 {
 		siteItems, consumed, err := collector.fetchSitePage(ctx, logger, remainingIDs)
 		if err != nil {
 			logger.Warn().Err(err).Int("Site Page", collector.sitePagesFetched+1).Msg("Failed to retrieve using Core gRPC API")
+			// Nothing reached Cloud yet, so report the failure the way the find path does.
+			// After a partial publish the pages already sent carry the run, and the unpaged
+			// workflow ID a status page uses would say nothing about where it stopped.
+			if collector.pagesPublished == 0 {
+				execErr := collector.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error())
+				if execErr != nil {
+					logger.Error().Err(execErr).Msg("Failed to publish inventory error to Cloud")
+				}
+			}
 			return err
 		}
 		remainingIDs = remainingIDs[consumed:]
@@ -147,9 +163,14 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 		// alert on it without letting it break inventory entirely.
 		if len(siteItems) != consumed {
 			logger.Error().Msg("size of FindByIDs set does not match size of FindIDs set")
+			// The page total is derived from the ID count, so an item Core did not return would
+			// leave the last page short of its total and skip the Cloud deletion sweep for the
+			// whole run. Discount what is missing to keep the last page recognizable.
+			collector.itemsMissing += consumed - len(siteItems)
 		}
 
-		if err = collector.publishItems(ctx, logger, siteItems); err != nil {
+		err = collector.publishItems(ctx, logger, siteItems)
+		if err != nil {
 			return err
 		}
 	}
@@ -157,6 +178,9 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 	return nil
 }
 
+// collectAndPublishFallback collects the whole inventory in one call, for a Core that does not
+// implement the paged find API. It owns reporting its own failures to Cloud, so callers return its
+// result rather than publishing a status page of their own.
 func (impl *manageInventoryImpl[K, R, P]) collectAndPublishFallback(ctx context.Context, logger *zerolog.Logger,
 	grpcClient *cClient.CoreGrpcClient) error {
 	if impl.internalFindFallback == nil {
@@ -168,7 +192,8 @@ func (impl *manageInventoryImpl[K, R, P]) collectAndPublishFallback(ctx context.
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to retrieve using Site Controller fallback API")
 		// Error encountered before we've published anything, report inventory collection error to Cloud
-		if execErr := collector.publishStatusOnly(corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error()); execErr != nil {
+		execErr := collector.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error())
+		if execErr != nil {
 			logger.Error().Err(execErr).Msg("Failed to publish inventory error to Cloud")
 			return execErr
 		}
@@ -178,7 +203,8 @@ func (impl *manageInventoryImpl[K, R, P]) collectAndPublishFallback(ctx context.
 	collector.allIDs = allIDs
 	if len(allIDs) == 0 {
 		logger.Info().Msg("Publishing empty inventory page to Cloud")
-		if err = collector.publishStatusOnly(corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, "No items reported by Site Controller"); err != nil {
+		err = collector.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, "No items reported by Site Controller")
+		if err != nil {
 			logger.Error().Err(err).Msg("Failed to publish inventory to Cloud")
 			return err
 		}
@@ -204,8 +230,12 @@ type inventoryCollector[K any, R any, P any] struct {
 	sitePagesFetched int
 	pagesPublished   int
 	itemsPublished   int
+	// itemsMissing counts IDs that FindIDs reported but FindByIDs did not return, which is what
+	// a delete landing between the two calls looks like.
+	itemsMissing int
 }
 
+// newCollector prepares the per-run state the collector carries across site pages.
 func (impl *manageInventoryImpl[K, R, P]) newCollector(grpcClient *cClient.CoreGrpcClient) *inventoryCollector[K, R, P] {
 	return &inventoryCollector[K, R, P]{
 		impl:          impl,
@@ -249,7 +279,8 @@ func (col *inventoryCollector[K, R, P]) publishItems(ctx context.Context, logger
 		}
 
 		logger.Info().Msgf("Publishing inventory page %d to Cloud", col.pagesPublished+1)
-		if err = col.execute(page); err != nil {
+		err = col.execute(ctx, page)
+		if err != nil {
 			logger.Error().Err(err).Int("Cloud Page", col.pagesPublished+1).Msg("Failed to publish inventory to Cloud")
 			return err
 		}
@@ -294,6 +325,8 @@ func (col *inventoryCollector[K, R, P]) buildPageWithinBudget(ctx context.Contex
 	}
 }
 
+// buildInventoryPage assembles one page and its paging metadata, then applies whatever post
+// processing the resource type asked for.
 func (col *inventoryCollector[K, R, P]) buildInventoryPage(ctx context.Context, items []R, pageItems int) (P, error) {
 	input := &pagedInventoryInput{
 		totalItems:    len(col.allIDs),
@@ -302,12 +335,11 @@ func (col *inventoryCollector[K, R, P]) buildInventoryPage(ctx context.Context, 
 		status:        corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
 		statusMessage: "Successfully retrieved from Site Controller",
 	}
-	// The Cloud worker treats a page whose CurrentPage equals TotalPages as the last one and runs
-	// its deletion sweep there, so the total is derived from what is left rather than fixed up
-	// front, which the publish page size stepping down would invalidate. With nothing left this
-	// is exactly pageNumber; with items left it is always greater, so no earlier page can be
-	// mistaken for the last one.
-	remainingItems := input.totalItems - col.itemsPublished - pageItems
+	// The Cloud worker runs its deletion sweep on the page where CurrentPage equals TotalPages, so
+	// the total is derived from what is left rather than fixed up front, which the publish page
+	// size stepping down would invalidate. Discounting itemsMissing keeps the last page exact, and
+	// because it only grows as site pages arrive a mid-run total can read high but never low.
+	remainingItems := input.totalItems - col.itemsMissing - col.itemsPublished - pageItems
 	input.totalPages = input.pageNumber + ceilDiv(remainingItems, col.cloudPageSize)
 
 	page := col.impl.internalPagedInventory(col.allIDs, items, input)
@@ -333,28 +365,31 @@ func (col *inventoryCollector[K, R, P]) payloadSize(page P) (int, error) {
 // reported nothing and when collection failed before any page went out. It keeps the unpaged
 // workflow ID and reports the configured page size, which is what Cloud has always received for
 // these two cases.
-func (col *inventoryCollector[K, R, P]) publishStatusOnly(inventoryStatus corev1.InventoryStatus, statusMessage string) error {
+func (col *inventoryCollector[K, R, P]) publishStatusOnly(ctx context.Context, inventoryStatus corev1.InventoryStatus,
+	statusMessage string) error {
 	page := col.impl.internalPagedInventory([]K{}, []R{}, &pagedInventoryInput{
 		pageSize:      col.cloudPageSize,
 		pageNumber:    1,
 		status:        inventoryStatus,
 		statusMessage: statusMessage,
 	})
-	_, err := col.impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), tClient.StartWorkflowOptions{
+	_, err := col.impl.config.TemporalPublishClient.ExecuteWorkflow(ctx, tClient.StartWorkflowOptions{
 		ID:        col.workflowID,
 		TaskQueue: col.impl.config.TemporalPublishQueue,
 	}, col.workflowName, col.impl.config.SiteID, page)
 	return err
 }
 
-func (col *inventoryCollector[K, R, P]) execute(page P) error {
-	_, err := col.impl.config.TemporalPublishClient.ExecuteWorkflow(context.Background(), tClient.StartWorkflowOptions{
+// execute starts the Cloud workflow for one published page.
+func (col *inventoryCollector[K, R, P]) execute(ctx context.Context, page P) error {
+	_, err := col.impl.config.TemporalPublishClient.ExecuteWorkflow(ctx, tClient.StartWorkflowOptions{
 		ID:        fmt.Sprintf("%v-%v", col.workflowID, col.pagesPublished+1),
 		TaskQueue: col.impl.config.TemporalPublishQueue,
 	}, col.workflowName, col.impl.config.SiteID, page)
 	return err
 }
 
+// ceilDiv divides and rounds up, reporting zero for a non-positive dividend or divisor.
 func ceilDiv(dividend, divisor int) int {
 	if divisor <= 0 || dividend <= 0 {
 		return 0

--- a/rest-api/site-workflow/pkg/activity/inventory.go
+++ b/rest-api/site-workflow/pkg/activity/inventory.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	cClient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
@@ -26,13 +27,18 @@ const (
 	// sitePageSizeStep is how much the Core fetch page shrinks after a response that exceeds
 	// the gRPC client receive limit.
 	sitePageSizeStep = 10
-	// minSitePageSize floors the Core fetch ladder. A response of this many items that still
-	// does not fit means a single item is enormous, so the activity fails rather than keep
-	// stepping down.
-	minSitePageSize = 10
+	// minSitePageSize floors the Core fetch ladder at a single item, mirroring the publish
+	// ladder. Stopping any higher would give up while a smaller page would still have fit, and
+	// that failure repeats every run, so inventory for the type stays down until the ceiling is
+	// raised and redeployed. Only one item that does not fit leaves nothing left to try.
+	minSitePageSize = 1
 
 	// cloudPageSizeStep is how much the published page shrinks when a page exceeds the budget.
 	cloudPageSizeStep = 5
+
+	// statusPublishTimeout bounds the detached publish that reports a collection failure, so
+	// telling Cloud the run failed cannot outlive the run by much.
+	statusPublishTimeout = 30 * time.Second
 
 	// maxPublishPayloadBytes budgets one published inventory page at 1.9 MiB, under the 2 MiB
 	// blob Temporal rejects (limit.blobSize.error). The remaining margin is not accounting for
@@ -116,12 +122,7 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 			return impl.collectAndPublishFallback(ctx, logger, grpcClient)
 		}
 		logger.Warn().Err(err).Msg("Failed to retrieve IDs using Core gRPC API")
-		// Error encountered before we've published anything, report inventory collection error to Cloud
-		execErr := collector.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error())
-		if execErr != nil {
-			logger.Error().Err(execErr).Msg("Failed to publish inventory error to Cloud")
-			return execErr
-		}
+		collector.reportFailure(ctx, logger, err)
 		return err
 	}
 
@@ -144,15 +145,7 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 		siteItems, consumed, err := collector.fetchSitePage(ctx, logger, remainingIDs)
 		if err != nil {
 			logger.Warn().Err(err).Int("Site Page", collector.sitePagesFetched+1).Msg("Failed to retrieve using Core gRPC API")
-			// Nothing reached Cloud yet, so report the failure the way the find path does.
-			// After a partial publish the pages already sent carry the run, and the unpaged
-			// workflow ID a status page uses would say nothing about where it stopped.
-			if collector.pagesPublished == 0 {
-				execErr := collector.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error())
-				if execErr != nil {
-					logger.Error().Err(execErr).Msg("Failed to publish inventory error to Cloud")
-				}
-			}
+			collector.reportFailure(ctx, logger, err)
 			return err
 		}
 		remainingIDs = remainingIDs[consumed:]
@@ -169,13 +162,21 @@ func (impl *manageInventoryImpl[K, R, P]) CollectAndPublishInventory(ctx context
 			collector.itemsMissing += consumed - len(siteItems)
 		}
 
+		// A post-processing or publish failure aborts the run just as a fetch failure does, and
+		// leaves Cloud with the same partial picture, so it is reported the same way.
 		err = collector.bufferItems(ctx, logger, siteItems)
 		if err != nil {
+			collector.reportFailure(ctx, logger, err)
 			return err
 		}
 	}
 
-	return collector.flush(ctx, logger)
+	err = collector.flush(ctx, logger)
+	if err != nil {
+		collector.reportFailure(ctx, logger, err)
+		return err
+	}
+	return nil
 }
 
 // collectAndPublishFallback collects the whole inventory in one call, for a Core that does not
@@ -191,12 +192,7 @@ func (impl *manageInventoryImpl[K, R, P]) collectAndPublishFallback(ctx context.
 	allIDs, siteItems, err := impl.internalFindFallback(ctx, grpcClient)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to retrieve using Site Controller fallback API")
-		// Error encountered before we've published anything, report inventory collection error to Cloud
-		execErr := collector.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, err.Error())
-		if execErr != nil {
-			logger.Error().Err(execErr).Msg("Failed to publish inventory error to Cloud")
-			return execErr
-		}
+		collector.reportFailure(ctx, logger, err)
 		return err
 	}
 
@@ -212,10 +208,28 @@ func (impl *manageInventoryImpl[K, R, P]) collectAndPublishFallback(ctx context.
 	}
 
 	err = collector.bufferItems(ctx, logger, siteItems)
+	if err == nil {
+		err = collector.flush(ctx, logger)
+	}
 	if err != nil {
+		collector.reportFailure(ctx, logger, err)
 		return err
 	}
-	return collector.flush(ctx, logger)
+	return nil
+}
+
+// reportFailure tells Cloud the run failed, but only when no page has gone out yet. After a
+// partial publish the pages already sent carry the run, and the unpaged workflow ID a status
+// page uses would say nothing about where it stopped. A failure to report is logged rather
+// than returned, so the caller still surfaces the underlying cause.
+func (col *inventoryCollector[K, R, P]) reportFailure(ctx context.Context, logger *zerolog.Logger, cause error) {
+	if col.pagesPublished > 0 {
+		return
+	}
+	err := col.publishStatusOnly(ctx, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, cause.Error())
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to publish inventory error to Cloud")
+	}
 }
 
 // inventoryCollector fetches inventory from Core and publishes it to Cloud a page at a time.
@@ -336,8 +350,9 @@ func (col *inventoryCollector[K, R, P]) publishNextPage(ctx context.Context, log
 // size down until the serialized page fits the budget. A single item over the budget is
 // published anyway, because dropping it would silently lose inventory.
 func (col *inventoryCollector[K, R, P]) buildPageWithinBudget(ctx context.Context, logger *zerolog.Logger, items []R) (P, int, error) {
+	pageSize := col.cloudPageSize
 	for {
-		pageItems := min(col.cloudPageSize, len(items))
+		pageItems := min(pageSize, len(items))
 		page, err := col.buildInventoryPage(ctx, items[:pageItems], pageItems)
 		if err != nil {
 			return page, 0, err
@@ -362,8 +377,15 @@ func (col *inventoryCollector[K, R, P]) buildPageWithinBudget(ctx context.Contex
 
 		// Step down from what this page actually held rather than from the configured size, so a
 		// short trailing page reaches a fitting size in one step instead of several.
-		col.cloudPageSize = max(1, pageItems-cloudPageSizeStep)
-		logger.Warn().Int("Payload Bytes", size).Int("Cloud Page Size", col.cloudPageSize).
+		pageSize = max(1, pageItems-cloudPageSizeStep)
+		// Carry the reduction into the rest of the run only when the page that failed was full.
+		// A short tail fragment that does not fit says nothing about whether a full page of
+		// typical items would, and lowering the run's size on its account would split every
+		// page that follows.
+		if pageItems == col.cloudPageSize {
+			col.cloudPageSize = pageSize
+		}
+		logger.Warn().Int("Payload Bytes", size).Int("Page Size", pageSize).
 			Msg("Inventory page exceeded the publish budget, rebuilding with fewer items")
 	}
 }
@@ -409,6 +431,11 @@ func (col *inventoryCollector[K, R, P]) payloadSize(page P) (int, error) {
 // reported nothing and when collection failed before any page went out. It keeps the unpaged
 // workflow ID and reports the configured page size, which is what Cloud has always received for
 // these two cases.
+//
+// The failure it reports is often the activity deadline expiring, which would leave the caller's
+// context already dead, so this detaches from cancellation and takes its own deadline. Otherwise
+// the one case where Cloud most needs to hear that collection failed is the case where the
+// message could never be sent.
 func (col *inventoryCollector[K, R, P]) publishStatusOnly(ctx context.Context, inventoryStatus corev1.InventoryStatus,
 	statusMessage string) error {
 	page := col.impl.internalPagedInventory([]K{}, []R{}, &pagedInventoryInput{
@@ -417,6 +444,10 @@ func (col *inventoryCollector[K, R, P]) publishStatusOnly(ctx context.Context, i
 		status:        inventoryStatus,
 		statusMessage: statusMessage,
 	})
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), statusPublishTimeout)
+	defer cancel()
+
 	_, err := col.impl.config.TemporalPublishClient.ExecuteWorkflow(ctx, tClient.StartWorkflowOptions{
 		ID:        col.workflowID,
 		TaskQueue: col.impl.config.TemporalPublishQueue,

--- a/rest-api/site-workflow/pkg/activity/operatingsystem_test.go
+++ b/rest-api/site-workflow/pkg/activity/operatingsystem_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	tmocks "go.temporal.io/sdk/mocks"
+	gcodes "google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
 )
 
 func TestManageOsImage_CreateOsImageOnSite(t *testing.T) {
@@ -312,6 +315,9 @@ func TestManageOsImageInventory_DiscoverOsImageInventory(t *testing.T) {
 	type args struct {
 		wantTotalItems int
 		findIDsError   error
+		// fallbackError makes the fallback's own Core call fail, which is the path that used to
+		// publish the FAILED page twice under one workflow ID.
+		fallbackError error
 	}
 	tests := []struct {
 		name   string
@@ -344,6 +350,23 @@ func TestManageOsImageInventory_DiscoverOsImageInventory(t *testing.T) {
 				wantTotalItems: 195,
 			},
 		},
+		{
+			// osImageFindIDs always reports Unimplemented, so this exercises the fallback
+			// failing. The fallback owns its own failure reporting, so Cloud has to receive
+			// exactly one FAILED page rather than a second one under the same workflow ID.
+			name: "test collecting and publishing os image inventory fallback, collection fails",
+			fields: fields{
+				siteID:               uuid.New(),
+				coreGrpcAtomicClient: coreGrpcAtomicClient,
+				temporalPublishQueue: "test-queue",
+				sitePageSize:         100,
+				cloudPageSize:        25,
+			},
+			args: args{
+				wantTotalItems: 195,
+				fallbackError:  gstatus.Error(gcodes.Internal, "Core is unavailable"),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -367,6 +390,9 @@ func TestManageOsImageInventory_DiscoverOsImageInventory(t *testing.T) {
 			if tt.args.findIDsError != nil {
 				ctx = context.WithValue(ctx, "wantError", tt.args.findIDsError)
 			}
+			if tt.args.fallbackError != nil {
+				ctx = context.WithValue(ctx, "wantError", tt.args.fallbackError)
+			}
 
 			totalPages := tt.args.wantTotalItems / tt.fields.cloudPageSize
 			if tt.args.wantTotalItems%tt.fields.cloudPageSize > 0 {
@@ -374,6 +400,16 @@ func TestManageOsImageInventory_DiscoverOsImageInventory(t *testing.T) {
 			}
 
 			err := manageOsImage.DiscoverOsImageInventory(ctx)
+			if tt.args.fallbackError != nil {
+				assert.Error(t, err)
+
+				tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 1)
+				inventory, ok := tc.Calls[0].Arguments[4].(*corev1.OsImageInventory)
+				require.True(t, ok)
+				assert.Equal(t, corev1.InventoryStatus_INVENTORY_STATUS_FAILED, inventory.InventoryStatus)
+				assert.Nil(t, inventory.InventoryPage, "a failure carries no paging metadata")
+				return
+			}
 			assert.NoError(t, err)
 
 			if tt.args.wantTotalItems == 0 {

--- a/rest-api/site-workflow/pkg/grpc/client/core_client.go
+++ b/rest-api/site-workflow/pkg/grpc/client/core_client.go
@@ -57,6 +57,13 @@ const (
 	// gRPC client default dial timeout
 	defaultCoreGrpcDialTimeoutSeconds = 5 // 5 seconds
 
+	// coreGrpcMaxRecvMsgSize raises the Go gRPC 4 MiB default. Instance inventory already
+	// returns ~7.8 MB for a page of 100, and a ceiling near that size leaves the inventory
+	// pager's site page ladder in permanent use, where every rejected response still costs Core
+	// a full query and serialization. This is a limit rather than a reservation, so the headroom
+	// only consumes memory once a response arrives to fill it.
+	coreGrpcMaxRecvMsgSize = 32 * 1024 * 1024
+
 	// CoreGrpcConnectionRetryTimeout is the maximum time to retry establishing a Core gRPC connection.
 	CoreGrpcConnectionRetryTimeout = 15 * time.Minute
 	// CoreGrpcConnectionBackoffInitial is the initial delay between connection retries.
@@ -171,6 +178,8 @@ func NewCoreGrpcClient(config *CoreGrpcClientConfig) (client *CoreGrpcClient, er
 		log.Error().Err(ErrCoreGrpcClientInvalidSecureOpts).Msg("CoreGrpcClient: Invalid dial options")
 		return nil, ErrCoreGrpcClientInvalidSecureOpts
 	}
+
+	client.dialOpts = append(client.dialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(coreGrpcMaxRecvMsgSize)))
 
 	// configure interceptors
 	var unaryInterceptors []grpc.UnaryClientInterceptor

--- a/rest-api/site-workflow/pkg/grpc/client/testing.go
+++ b/rest-api/site-workflow/pkg/grpc/client/testing.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/gogo/status"
@@ -310,11 +311,27 @@ func (mcgsc *MockCoreGrpcServiceClient) FindInstancesByIds(ctx context.Context, 
 		return nil, status.Error(status.Code(err), "failed to retrieve instances")
 	}
 
+	// Stands in for a response that outgrows the gRPC client receive limit, which is what makes
+	// the inventory pager step its site page size down and ask for fewer Instances.
+	maxRequestIDs, ok := ctx.Value("maxRequestIDs").(int)
+	if ok && in != nil && len(in.InstanceIds) > maxRequestIDs {
+		return nil, status.Errorf(codes.ResourceExhausted,
+			"grpc: received message larger than max (%v IDs requested, mock accepts %v)", len(in.InstanceIds), maxRequestIDs)
+	}
+
+	// Inflates every Instance so a published inventory page can outgrow the Temporal blob budget.
+	var padding *string
+	if padBytes, _ := ctx.Value("instancePadBytes").(int); padBytes > 0 {
+		pad := strings.Repeat("a", padBytes)
+		padding = &pad
+	}
+
 	out := &corev1.InstanceList{}
 	if in != nil {
 		for _, id := range in.InstanceIds {
 			out.Instances = append(out.Instances, &corev1.Instance{
-				Id: id,
+				Id:               id,
+				TpmEkCertificate: padding,
 			})
 		}
 	}

--- a/rest-api/site-workflow/pkg/grpc/client/testing.go
+++ b/rest-api/site-workflow/pkg/grpc/client/testing.go
@@ -334,7 +334,7 @@ func (mcgsc *MockCoreGrpcServiceClient) FindInstancesByIds(ctx context.Context, 
 	out := &corev1.InstanceList{}
 	if in != nil {
 		ids := in.InstanceIds
-		if dropPerPage > 0 && len(ids) > dropPerPage {
+		if dropPerPage > 0 && len(ids) >= dropPerPage {
 			ids = ids[:len(ids)-dropPerPage]
 		}
 		for _, id := range ids {

--- a/rest-api/site-workflow/pkg/grpc/client/testing.go
+++ b/rest-api/site-workflow/pkg/grpc/client/testing.go
@@ -321,14 +321,23 @@ func (mcgsc *MockCoreGrpcServiceClient) FindInstancesByIds(ctx context.Context, 
 
 	// Inflates every Instance so a published inventory page can outgrow the Temporal blob budget.
 	var padding *string
-	if padBytes, _ := ctx.Value("instancePadBytes").(int); padBytes > 0 {
+	padBytes, _ := ctx.Value("instancePadBytes").(int)
+	if padBytes > 0 {
 		pad := strings.Repeat("a", padBytes)
 		padding = &pad
 	}
 
+	// Stands in for Instances deleted between FindInstanceIds and FindInstancesByIds, which is
+	// how Core comes to return fewer Instances than the IDs asked for.
+	dropPerPage, _ := ctx.Value("dropInstancesPerPage").(int)
+
 	out := &corev1.InstanceList{}
 	if in != nil {
-		for _, id := range in.InstanceIds {
+		ids := in.InstanceIds
+		if dropPerPage > 0 && len(ids) > dropPerPage {
+			ids = ids[:len(ids)-dropPerPage]
+		}
+		for _, id := range ids {
 			out.Instances = append(out.Instances, &corev1.Instance{
 				Id:               id,
 				TpmEkCertificate: padding,

--- a/rest-api/site-workflow/pkg/util/temporal.go
+++ b/rest-api/site-workflow/pkg/util/temporal.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"go.temporal.io/sdk/converter"
+)
+
+// NewTemporalDataConverter returns the data converter every Site Agent Temporal client uses.
+// The inventory pager measures a page against Temporal's blob size limit with this same
+// converter, so the two cannot disagree on how large a page is on the wire. ProtoJSON
+// precedes the binary proto converter, so protos travel as JSON and measure larger.
+func NewTemporalDataConverter() converter.DataConverter {
+	return converter.NewCompositeDataConverter(
+		converter.NewNilPayloadConverter(),
+		converter.NewByteSlicePayloadConverter(),
+		converter.NewProtoJSONPayloadConverterWithOptions(converter.ProtoJSONPayloadConverterOptions{
+			AllowUnknownFields: true,
+		}),
+		converter.NewProtoPayloadConverter(),
+		converter.NewJSONPayloadConverter(),
+	)
+}


### PR DESCRIPTION
Site Agent's Instance inventory stops processing when a Core gRPC response outgrows Go's
default `4 MiB` receive limit. In an internal deployment, `FindInstancesByIds` returns `7767972`
bytes for a page of `100` Instances, so `DiscoverInstanceInventory` fails with 
`ResourceExhausted`. Raising the receive limit alone only moves the failure, since at `~78 KB`
an Instance a `25`-Instance page already sits near Temporal's `2 MiB` blob limit. Raising
Temporal's limit destabilizes Temporal, so the paging has to adapt instead.

This PR lifts the receive limit to `32 MiB` and makes both paging steps adapt. The Core fetch
steps `100` down by `10` and on to a single item, so a Site whose responses stay too large
keeps collecting rather than failing every tick. The published page steps `25` down by `5`
until the serialized page measures under `1.9 MiB`. Pages fill across Site page boundaries
and the tail is held back until every fetch completes, which is what lets Cloud recognize the
last page of a run.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
