### PR TITLE
refactor(tests): credential management tests to integration suite

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -3702,7 +3702,6 @@ pub struct DefaultCredential {
     _key: String,
 }
 
-#[cfg(test)]
 impl DefaultCredential {
     pub(crate) fn key(&self) -> &str {
         &self._key

--- a/crates/api-core/src/handlers/credential.rs
+++ b/crates/api-core/src/handlers/credential.rs
@@ -46,10 +46,7 @@ const DEFAULT_FORGE_ADMIN_BMC_USERNAME: &str = "root";
 /// on the DPU.  This was directly verified by checking the maximum accepted
 /// by FRR on the DPU.  NVUE will silently accept seemingly any length,
 /// but FRR reloads fail above this length.
-const MAX_BGP_PASSWORD_LENGTH: usize = 80;
-
-#[cfg(test)]
-pub(crate) const TEST_MAX_BGP_PASSWORD_LENGTH: usize = MAX_BGP_PASSWORD_LENGTH;
+pub(crate) const MAX_BGP_PASSWORD_LENGTH: usize = 80;
 
 pub(crate) async fn create_credential(
     api: &Api,

--- a/crates/api-core/src/test_support/mod.rs
+++ b/crates/api-core/src/test_support/mod.rs
@@ -34,6 +34,12 @@ pub use rpc;
 pub use crate::api::Api;
 pub use crate::api::metrics::ApiMetricsEmitter;
 
+pub const MAX_BGP_PASSWORD_LENGTH: usize = crate::handlers::credential::MAX_BGP_PASSWORD_LENGTH;
+
+pub fn default_credential_key(credential: &crate::api::DefaultCredential) -> &str {
+    credential.key()
+}
+
 impl Api {
     pub fn work_lock_manager_handle(&self) -> WorkLockManagerHandle {
         self.work_lock_manager_handle.clone()

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -18,7 +18,6 @@
 mod boot_interface_resolution;
 mod client_resolution;
 pub(in crate::tests) mod common;
-mod credential;
 mod dns;
 mod dpa_interfaces;
 mod dpf;

--- a/crates/api-core/tests/integration/credential_management.rs
+++ b/crates/api-core/tests/integration/credential_management.rs
@@ -15,27 +15,39 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
+use carbide_api_core::AuthContext;
+use carbide_api_core::test_support::{MAX_BGP_PASSWORD_LENGTH, default_credential_key};
 use carbide_secrets::credentials::{
     BgpCredentialType, BmcCredentialType, CredentialKey, CredentialReader, CredentialType,
     CredentialWriter, Credentials,
 };
-use rpc::forge::forge_server::Forge;
+use carbide_secrets::test_support::credentials::TestCredentialManager;
+use carbide_test_harness::prelude::*;
+use mac_address::MacAddress;
 use rpc::forge::{
     CredentialCreationRequest, CredentialDeletionRequest, CredentialType as RpcCredentialType,
     GetBmcCredentialsRequest,
 };
 use tonic::Code;
 
-use crate::handlers::credential::TEST_MAX_BGP_PASSWORD_LENGTH;
-use crate::tests::common::api_fixtures::create_test_env;
-use crate::tests::common::api_fixtures::site_explorer::new_switch;
+async fn init(pool: PgPool) -> (TestHarness, Arc<TestCredentialManager>) {
+    let credential_manager = Arc::new(TestCredentialManager::default());
+    let api_credential_manager = credential_manager.clone();
+    let env = TestHarness::builder(pool)
+        .with_api_builder_fn(move |builder| builder.with_credential_manager(api_credential_manager))
+        .build()
+        .await;
+    (env, credential_manager)
+}
 
-#[crate::sqlx_test]
-async fn test_create_host_uefi_credential_when_missing(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
+#[sqlx_test]
+async fn test_create_host_uefi_credential_when_missing(pool: PgPool) {
+    let (env, credential_manager) = init(pool).await;
 
     let response = env
-        .api
+        .api()
         .create_credential(tonic::Request::new(CredentialCreationRequest {
             credential_type: RpcCredentialType::HostUefi.into(),
             username: None,
@@ -46,8 +58,7 @@ async fn test_create_host_uefi_credential_when_missing(pool: sqlx::PgPool) {
         .await;
     assert!(response.is_ok());
 
-    let stored = env
-        .test_credential_manager
+    let stored = credential_manager
         .get_credentials(&CredentialKey::HostUefi {
             credential_type: CredentialType::SiteDefault,
         })
@@ -63,7 +74,7 @@ async fn test_create_host_uefi_credential_when_missing(pool: sqlx::PgPool) {
 
     // A second create should fail because the credential now exists.
     let second = env
-        .api
+        .api()
         .create_credential(tonic::Request::new(CredentialCreationRequest {
             credential_type: RpcCredentialType::HostUefi.into(),
             username: None,
@@ -76,12 +87,12 @@ async fn test_create_host_uefi_credential_when_missing(pool: sqlx::PgPool) {
     assert_eq!(second.unwrap_err().code(), Code::AlreadyExists);
 }
 
-#[crate::sqlx_test]
-async fn test_create_dpu_uefi_credential_when_missing(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
+#[sqlx_test]
+async fn test_create_dpu_uefi_credential_when_missing(pool: PgPool) {
+    let (env, credential_manager) = init(pool).await;
 
     let response = env
-        .api
+        .api()
         .create_credential(tonic::Request::new(CredentialCreationRequest {
             credential_type: RpcCredentialType::DpuUefi.into(),
             username: None,
@@ -92,8 +103,7 @@ async fn test_create_dpu_uefi_credential_when_missing(pool: sqlx::PgPool) {
         .await;
     assert!(response.is_ok());
 
-    let stored = env
-        .test_credential_manager
+    let stored = credential_manager
         .get_credentials(&CredentialKey::DpuUefi {
             credential_type: CredentialType::SiteDefault,
         })
@@ -109,7 +119,7 @@ async fn test_create_dpu_uefi_credential_when_missing(pool: sqlx::PgPool) {
 
     // A second create should fail because the credential now exists.
     let second = env
-        .api
+        .api()
         .create_credential(tonic::Request::new(CredentialCreationRequest {
             credential_type: RpcCredentialType::DpuUefi.into(),
             username: None,
@@ -122,13 +132,13 @@ async fn test_create_dpu_uefi_credential_when_missing(pool: sqlx::PgPool) {
     assert_eq!(second.unwrap_err().code(), Code::AlreadyExists);
 }
 
-#[crate::sqlx_test]
-async fn test_create_and_delete_bgp_credential(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
+#[sqlx_test]
+async fn test_create_and_delete_bgp_credential(pool: PgPool) {
+    let (env, credential_manager) = init(pool).await;
 
     // Create the site-wide DPU BGP credential.
     let response = env
-        .api
+        .api()
         .create_credential(tonic::Request::new(CredentialCreationRequest {
             credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
             username: None,
@@ -140,8 +150,7 @@ async fn test_create_and_delete_bgp_credential(pool: sqlx::PgPool) {
     assert!(response.is_ok());
 
     // Verify the credential was stored in the credential manager.
-    let stored = env
-        .test_credential_manager
+    let stored = credential_manager
         .get_credentials(&CredentialKey::Bgp {
             credential_type: BgpCredentialType::SiteWideLeafPassword,
         })
@@ -157,7 +166,7 @@ async fn test_create_and_delete_bgp_credential(pool: sqlx::PgPool) {
 
     // Delete the site-wide DPU BGP credential.
     let delete_response = env
-        .api
+        .api()
         .delete_credential(tonic::Request::new(CredentialDeletionRequest {
             credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
             username: None,
@@ -167,8 +176,7 @@ async fn test_create_and_delete_bgp_credential(pool: sqlx::PgPool) {
     assert!(delete_response.is_ok());
 
     // Verify the credential was removed from the credential manager.
-    let deleted = env
-        .test_credential_manager
+    let deleted = credential_manager
         .get_credentials(&CredentialKey::Bgp {
             credential_type: BgpCredentialType::SiteWideLeafPassword,
         })
@@ -177,9 +185,9 @@ async fn test_create_and_delete_bgp_credential(pool: sqlx::PgPool) {
     assert_eq!(deleted, None);
 }
 
-#[crate::sqlx_test]
-async fn test_get_bmc_credentials_rejects_caller_without_spiffe_service_id(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
+#[sqlx_test]
+async fn test_get_bmc_credentials_rejects_caller_without_spiffe_service_id(pool: PgPool) {
+    let (env, _credential_manager) = init(pool).await;
 
     // No `AuthContext` extension attached -> no SPIFFE service identity ->
     // PermissionDenied. We do not need a real BMC, machine record, or
@@ -188,26 +196,24 @@ async fn test_get_bmc_credentials_rejects_caller_without_spiffe_service_id(pool:
     let mut request = tonic::Request::new(GetBmcCredentialsRequest {
         mac_addr: "11:22:33:44:55:66".to_string(),
     });
-    request
-        .extensions_mut()
-        .insert(crate::auth::AuthContext::default());
+    request.extensions_mut().insert(AuthContext::default());
 
     let err = env
-        .api
+        .api()
         .get_bmc_credentials(request)
         .await
         .expect_err("caller without SPIFFE service id should be rejected");
     assert_eq!(err.code(), Code::PermissionDenied);
 }
 
-#[crate::sqlx_test]
-async fn test_create_bgp_credential_validates_max_password_length(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
+#[sqlx_test]
+async fn test_create_bgp_credential_validates_max_password_length(pool: PgPool) {
+    let (env, credential_manager) = init(pool).await;
 
     // Create a site-wide DPU BGP credential using the maximum supported length.
-    let max_password = "a".repeat(TEST_MAX_BGP_PASSWORD_LENGTH);
+    let max_password = "a".repeat(MAX_BGP_PASSWORD_LENGTH);
     let ok_response = env
-        .api
+        .api()
         .create_credential(tonic::Request::new(CredentialCreationRequest {
             credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
             username: None,
@@ -219,8 +225,7 @@ async fn test_create_bgp_credential_validates_max_password_length(pool: sqlx::Pg
     assert!(ok_response.is_ok());
 
     // Verify the credential was stored unchanged.
-    let stored = env
-        .test_credential_manager
+    let stored = credential_manager
         .get_credentials(&CredentialKey::Bgp {
             credential_type: BgpCredentialType::SiteWideLeafPassword,
         })
@@ -236,11 +241,11 @@ async fn test_create_bgp_credential_validates_max_password_length(pool: sqlx::Pg
 
     // Try to create a site-wide DPU BGP credential longer than the supported maximum.
     let response = env
-        .api
+        .api()
         .create_credential(tonic::Request::new(CredentialCreationRequest {
             credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
             username: None,
-            password: "a".repeat(TEST_MAX_BGP_PASSWORD_LENGTH + 1),
+            password: "a".repeat(MAX_BGP_PASSWORD_LENGTH + 1),
             vendor: None,
             mac_address: None,
         }))
@@ -250,12 +255,11 @@ async fn test_create_bgp_credential_validates_max_password_length(pool: sqlx::Pg
     // Verify the handler returns a validation error.
     assert_eq!(err.code(), Code::InvalidArgument);
     assert!(err.message().contains(&format!(
-        "BGP password length exceeds {TEST_MAX_BGP_PASSWORD_LENGTH} characters"
+        "BGP password length exceeds {MAX_BGP_PASSWORD_LENGTH} characters"
     )));
 
     // Verify the previously stored credential was left unchanged.
-    let stored = env
-        .test_credential_manager
+    let stored = credential_manager
         .get_credentials(&CredentialKey::Bgp {
             credential_type: BgpCredentialType::SiteWideLeafPassword,
         })
@@ -265,22 +269,33 @@ async fn test_create_bgp_credential_validates_max_password_length(pool: sqlx::Pg
         stored,
         Some(Credentials::UsernamePassword {
             username: "".to_string(),
-            password: "a".repeat(TEST_MAX_BGP_PASSWORD_LENGTH),
+            password: "a".repeat(MAX_BGP_PASSWORD_LENGTH),
         })
     );
 }
 
-#[crate::sqlx_test]
-async fn test_get_switch_nvos_credentials(pool: sqlx::PgPool) -> eyre::Result<()> {
-    let env = create_test_env(pool).await;
-    let switch_id = new_switch(&env, Some("Switch1".to_string()), None).await?;
-    let bmc_mac_address = db::switch::find_switch_endpoints_by_ids(&env.pool, &[switch_id])
-        .await?
-        .first()
-        .expect("switch endpoint row")
-        .bmc_mac;
+#[sqlx_test]
+async fn test_get_switch_nvos_credentials(pool: PgPool) -> eyre::Result<()> {
+    let (env, credential_manager) = init(pool).await;
+    let bmc_mac_address: MacAddress = "6A:6B:6C:6D:6E:A1".parse()?;
+    let switch = env
+        .create_expected_switch(rpc::forge::ExpectedSwitch {
+            bmc_mac_address: bmc_mac_address.to_string(),
+            nvos_mac_addresses: vec!["7A:7B:7C:7D:7E:A1".to_string()],
+            bmc_username: "ADMIN".to_string(),
+            bmc_password: "PASS".to_string(),
+            switch_serial_number: "CREDENTIAL-SWITCH-001".to_string(),
+            metadata: Some(rpc::forge::Metadata {
+                name: "Switch1".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .create_switch(0, 0)
+        .await;
 
-    env.test_credential_manager
+    credential_manager
         .set_credentials(
             &CredentialKey::SwitchNvosAdmin { bmc_mac_address },
             &Credentials::UsernamePassword {
@@ -291,10 +306,10 @@ async fn test_get_switch_nvos_credentials(pool: sqlx::PgPool) -> eyre::Result<()
         .await?;
 
     let response = env
-        .api
+        .api()
         .get_switch_nvos_credentials(tonic::Request::new(
             rpc::forge::GetSwitchNvosCredentialsRequest {
-                switch_id: Some(switch_id),
+                switch_id: Some(switch.id),
             },
         ))
         .await?
@@ -313,9 +328,9 @@ async fn test_get_switch_nvos_credentials(pool: sqlx::PgPool) -> eyre::Result<()
     Ok(())
 }
 
-#[crate::sqlx_test]
-async fn test_missing_default_credentials(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
+#[sqlx_test]
+async fn test_missing_default_credentials(pool: PgPool) {
+    let (env, credential_manager) = init(pool).await;
 
     let bmc_root = CredentialKey::BmcCredentials {
         credential_type: BmcCredentialType::SiteWideRoot,
@@ -337,11 +352,11 @@ async fn test_missing_default_credentials(pool: sqlx::PgPool) {
 
     // A fresh environment has none of the site-wide defaults configured.
     let keys: Vec<String> = env
-        .api
+        .api()
         .missing_default_credentials()
         .await
         .into_iter()
-        .map(|c| c.key().to_owned())
+        .map(|c| default_credential_key(&c).to_owned())
         .collect();
     assert_eq!(keys.len(), 3, "expected all defaults missing, got {keys:?}");
     assert!(keys.contains(&bmc_root_key));
@@ -349,31 +364,31 @@ async fn test_missing_default_credentials(pool: sqlx::PgPool) {
     assert!(keys.contains(&dpu_uefi_key));
 
     // Configuring one credential removes it from the missing set.
-    env.test_credential_manager
+    credential_manager
         .set_credentials(&bmc_root, &creds("bmc-root-pw"))
         .await
         .unwrap();
     let keys: Vec<String> = env
-        .api
+        .api()
         .missing_default_credentials()
         .await
         .into_iter()
-        .map(|c| c.key().to_owned())
+        .map(|c| default_credential_key(&c).to_owned())
         .collect();
     assert_eq!(keys.len(), 2, "got {keys:?}");
     assert!(!keys.contains(&bmc_root_key));
 
     // An empty password still counts as "not configured".
-    env.test_credential_manager
+    credential_manager
         .set_credentials(&host_uefi, &creds(""))
         .await
         .unwrap();
     let keys: Vec<String> = env
-        .api
+        .api()
         .missing_default_credentials()
         .await
         .into_iter()
-        .map(|c| c.key().to_owned())
+        .map(|c| default_credential_key(&c).to_owned())
         .collect();
     assert!(
         keys.contains(&host_uefi_key),
@@ -381,15 +396,15 @@ async fn test_missing_default_credentials(pool: sqlx::PgPool) {
     );
 
     // Configuring the remaining two with real passwords clears the warning.
-    env.test_credential_manager
+    credential_manager
         .set_credentials(&host_uefi, &creds("host-uefi-pw"))
         .await
         .unwrap();
-    env.test_credential_manager
+    credential_manager
         .set_credentials(&dpu_uefi, &creds("dpu-uefi-pw"))
         .await
         .unwrap();
-    let missing = env.api.missing_default_credentials().await;
+    let missing = env.api().missing_default_credentials().await;
     assert!(
         missing.is_empty(),
         "expected no missing defaults, got {missing:?}"

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -16,6 +16,7 @@
  */
 
 mod compute_allocation;
+mod credential_management;
 mod credential_rotation;
 mod dhcp_lease_expiration;
 mod dpu_machine_inventory;

--- a/crates/test-harness/src/asset.rs
+++ b/crates/test-harness/src/asset.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use carbide_uuid::power_shelf::{PowerShelfId, PowerShelfIdSource, PowerShelfType};
 use carbide_uuid::rack::{RackId, RackProfileId};
 use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
@@ -22,7 +24,8 @@ use model::power_shelf::{NewPowerShelf, PowerShelfConfig, power_shelf_id};
 use model::rack::RackConfig;
 use model::switch::{NewSwitch, SwitchConfig, switch_id};
 
-use crate::TestHarness;
+use crate::rpc::forge::forge_server::Forge as _;
+use crate::{Api, TestHarness, rpc};
 
 pub struct TestRack {
     pub id: RackId,
@@ -90,6 +93,101 @@ impl TestSwitch {
             .await
             .expect("database transaction should commit");
         Self { id }
+    }
+}
+
+/// An expected-switch fixture identified by its Forge API record.
+pub struct TestExpectedSwitch {
+    api: Arc<Api>,
+    id: rpc::common::Uuid,
+}
+
+impl TestExpectedSwitch {
+    pub(crate) async fn create(
+        test_harness: &TestHarness,
+        expected_switch: rpc::forge::ExpectedSwitch,
+    ) -> Self {
+        let bmc_mac_address = expected_switch.bmc_mac_address.clone();
+        let api = test_harness.api_arc();
+        api.add_expected_switch(tonic::Request::new(expected_switch))
+            .await
+            .expect("expected switch should be created");
+
+        let expected_switch = api
+            .get_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitchRequest {
+                bmc_mac_address,
+                expected_switch_id: None,
+            }))
+            .await
+            .expect("created expected switch should be found")
+            .into_inner();
+        let id = expected_switch
+            .expected_switch_id
+            .expect("created expected switch should have an id");
+
+        Self { api, id }
+    }
+
+    async fn load(&self) -> rpc::forge::ExpectedSwitch {
+        self.api
+            .get_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitchRequest {
+                bmc_mac_address: String::new(),
+                expected_switch_id: Some(self.id.clone()),
+            }))
+            .await
+            .expect("expected switch should be found")
+            .into_inner()
+    }
+
+    /// Creates a switch record from the current expected-switch state.
+    pub async fn create_switch(&self, slot_number: i32, tray_index: i32) -> TestSwitch {
+        let expected_switch = self.load().await;
+        let bmc_mac_address: mac_address::MacAddress = expected_switch
+            .bmc_mac_address
+            .parse()
+            .expect("expected switch BMC MAC address should be valid");
+        let name = expected_switch
+            .metadata
+            .as_ref()
+            .map(|metadata| metadata.name.as_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or(&expected_switch.switch_serial_number)
+            .to_string();
+        let id = switch_id::from_hardware_info(
+            &expected_switch.switch_serial_number,
+            "NVIDIA",
+            "Switch",
+            SwitchIdSource::ProductBoardChassisSerial,
+            SwitchType::NvLink,
+        )
+        .expect("switch id should be derived from expected switch hardware info");
+        let new_switch = NewSwitch {
+            id,
+            config: SwitchConfig {
+                name,
+                enable_nmxc: false,
+                fabric_manager_config: None,
+            },
+            bmc_mac_address: Some(bmc_mac_address),
+            metadata: None,
+            rack_id: expected_switch.rack_id,
+            slot_number: Some(slot_number),
+            tray_index: Some(tray_index),
+        };
+
+        let mut txn = self
+            .api
+            .database_connection
+            .begin()
+            .await
+            .expect("database transaction should start");
+        db::switch::create(&mut txn, &new_switch)
+            .await
+            .expect("switch should be created");
+        txn.commit()
+            .await
+            .expect("database transaction should commit");
+        TestSwitch { id }
     }
 }
 

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -31,7 +31,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::{CancellationToken, DropGuard};
 use tonic::Request;
 
-use crate::asset::{TestPowerShelf, TestRack, TestSwitch};
+use crate::asset::{TestExpectedSwitch, TestPowerShelf, TestRack, TestSwitch};
 use crate::builder::TestHarnessBuilder;
 use crate::dns::TestDomain;
 use crate::network::controller::TestNetworkController;
@@ -164,6 +164,14 @@ impl TestHarness {
 
     pub async fn create_switch(&self, slot_number: i32, tray_index: i32) -> TestSwitch {
         TestSwitch::create(self, slot_number, tray_index).await
+    }
+
+    /// Creates an expected-switch fixture through the Forge API.
+    pub async fn create_expected_switch(
+        &self,
+        expected_switch: rpc::forge::ExpectedSwitch,
+    ) -> TestExpectedSwitch {
+        TestExpectedSwitch::create(self, expected_switch).await
     }
 
     pub async fn create_power_shelf(&self) -> TestPowerShelf {

--- a/crates/test-harness/src/prelude.rs
+++ b/crates/test-harness/src/prelude.rs
@@ -20,7 +20,7 @@ pub use rpc::forge::forge_server::Forge;
 pub use sqlx::PgPool;
 pub use sqlx_testing;
 
-pub use crate::asset::{TestPowerShelf, TestRack, TestSwitch};
+pub use crate::asset::{TestExpectedSwitch, TestPowerShelf, TestRack, TestSwitch};
 pub use crate::resource_pool::ResourcePoolBuilder;
 pub use crate::{
     Api, DbMachineExt, TestDpuMachine, TestHarness, TestHostMachine, TestMachine, TestManagedHost,


### PR DESCRIPTION
Move credential CRUD, validation, lookup, and default-warning coverage onto the shared integration harness.

Add a reusable `TestExpectedSwitch` fixture that creates an expected switch through the Forge API and materializes a matching `TestSwitch` from current API state.

## Related issues

#2001 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
