### PR TITLE
fix(rest-api): Block instance create without VPC prefixes

### DIFF
--- a/rest-api/cli/tui/commands.go
+++ b/rest-api/cli/tui/commands.go
@@ -2856,18 +2856,16 @@ func cmdInstanceCreate(s *Session, _ []string) error {
 // create request by walking the operator through one VPC-prefix-backed
 // interface at a time. The OpenAPI schema requires at least one entry, so
 // the first interface is always prompted; subsequent interfaces are opt-in.
-// Returns nil (not error) if no vpc-prefixes exist for the current VPC scope
-// so cmdInstanceCreate can still attempt the API call and surface the
-// server-side validation error instead of silently sending an empty array.
+// Returns an error if vpc-prefixes cannot be listed or none exist for the
+// current VPC scope so cmdInstanceCreate does not send a request without the
+// required interface.
 func promptInstanceInterfaces(s *Session, ctx context.Context) ([]map[string]interface{}, error) {
 	prefixes, err := s.Resolver.Fetch(ctx, "vpc-prefix")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s could not list vpc-prefixes (%v); the API may reject this create if interfaces are required\n", Dim("note:"), err)
-		return nil, nil
+		return nil, fmt.Errorf("listing vpc-prefixes: %w", err)
 	}
 	if len(prefixes) == 0 {
-		fmt.Fprintf(os.Stderr, "%s no vpc-prefixes available for the selected VPC; the API may reject this create if interfaces are required\n", Dim("note:"))
-		return nil, nil
+		return nil, fmt.Errorf("no vpc-prefixes available for the selected VPC")
 	}
 	var ifaces []map[string]interface{}
 	usedPrefixes := make(map[string]bool)

--- a/rest-api/cli/tui/commands_test.go
+++ b/rest-api/cli/tui/commands_test.go
@@ -5,6 +5,7 @@ package tui
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -464,6 +465,46 @@ func TestReadyMachineItemsForSite_FiltersByStatusAndSite(t *testing.T) {
 	// every machine in the list shares an opaque serial-number prefix.
 	assert.Contains(t, got[0].Label, "m1", "label must include display name")
 	assert.Contains(t, got[0].Label, "1", "label must include machine ID")
+}
+
+func TestPromptInstanceInterfaces(t *testing.T) {
+	tests := []struct {
+		name        string
+		fetch       func(context.Context) ([]NamedItem, error)
+		expectError string
+	}{
+		{
+			name: "no VPC prefixes",
+			fetch: func(context.Context) ([]NamedItem, error) {
+				return nil, nil
+			},
+			expectError: "no vpc-prefixes available for the selected VPC",
+		},
+		{
+			name: "VPC prefix listing fails",
+			fetch: func(context.Context) ([]NamedItem, error) {
+				return nil, fmt.Errorf("list failed")
+			},
+			expectError: "listing vpc-prefixes: list failed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := NewResolver(NewCache())
+			resolver.RegisterFetcher("vpc-prefix", test.fetch)
+			session := &Session{Resolver: resolver}
+
+			interfaces, err := promptInstanceInterfaces(session, t.Context())
+
+			assert.Nil(t, interfaces)
+			if test.expectError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, test.expectError)
+		})
+	}
 }
 
 func TestMachineSelectLabel(t *testing.T) {

--- a/rest-api/cli/tui/repl_pty_test.go
+++ b/rest-api/cli/tui/repl_pty_test.go
@@ -129,6 +129,17 @@ func TestCLIRegression_RealTerminalAndNonInteractive(t *testing.T) {
 		terminal.send(t, "\r")
 		terminal.waitFor(t, "VPC prefix created: tenant-prefix")
 
+		// Instance creation must stop before the API request when the selected
+		// VPC has no prefixes to attach as an interface.
+		terminal.send(t, "instance create\r")
+		terminal.waitFor(t, "VPC:")
+		terminal.send(t, "vpc-two\r")
+		terminal.waitFor(t, "Machine")
+		terminal.send(t, "\r")
+		terminal.waitFor(t, "Instance name")
+		terminal.send(t, "no-prefix-instance\r")
+		terminal.waitFor(t, "no vpc-prefixes available for the selected VPC")
+
 		// A lone Escape must cancel a real selector without waiting forever.
 		terminal.send(t, "scope site\r")
 		terminal.waitFor(t, "Site:")
@@ -304,6 +315,12 @@ func TestCLIRegression_RealTerminalAndNonInteractive(t *testing.T) {
 			prefixRequests[0].Body,
 		)
 
+		instanceRequests := recorder.matching(
+			http.MethodPost,
+			"/v2/org/acme/nico/instance",
+		)
+		assert.Empty(t, instanceRequests, "instance create without a VPC prefix must not reach the API")
+
 		bmcRequests := recorder.matching(
 			http.MethodPut,
 			"/v2/org/acme/nico/credential/bmc",
@@ -468,6 +485,9 @@ func newInteractiveRegressionHandler(recorder *cliRegressionRecorder) http.Handl
 			request.URL.Path == "/v2/org/acme/nico/vpc-prefix":
 			w.WriteHeader(http.StatusCreated)
 			_, _ = io.WriteString(w, `{"id":"prefix-1","name":"tenant-prefix","status":"Pending"}`)
+		case request.Method == http.MethodGet &&
+			request.URL.Path == "/v2/org/acme/nico/vpc-prefix":
+			_, _ = io.WriteString(w, `[]`)
 		case request.Method == http.MethodGet &&
 			request.URL.Path == "/v2/org/acme/nico/machine":
 			_, _ = io.WriteString(w, `[


### PR DESCRIPTION
The interactive nicocli instance flow currently submits a create request without interfaces when the selected VPC has no prefixes or the prefix lookup fails. This change stops the flow before the API request and explains why the instance cannot be created.

## Related issues

Follow-up to #5149

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

None.