### PR TITLE
refactor(tests): move the empty batch allocation request

### DIFF
--- a/crates/api-core/src/tests/instance_batch_allocate.rs
+++ b/crates/api-core/src/tests/instance_batch_allocate.rs
@@ -182,31 +182,6 @@ async fn test_batch_allocate_instances_rollback_on_failure(
     );
 }
 
-/// Send an empty batch request with no instances.
-/// Expect an error indicating at least one instance is required.
-#[crate::sqlx_test]
-async fn test_batch_allocate_instances_empty_request(_: PgPoolOptions, options: PgConnectOptions) {
-    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
-    let env = create_test_env(pool).await;
-
-    let batch_request = rpc::forge::BatchInstanceAllocationRequest {
-        instance_requests: vec![],
-    };
-
-    let result = env
-        .api
-        .allocate_instances(tonic::Request::new(batch_request))
-        .await;
-
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.message().contains("at least one instance"),
-        "Expected error about empty request, got: {}",
-        err.message()
-    );
-}
-
 /// Allocate 2 instances sharing the same NSG in one batch.
 /// Expect both instances to be created successfully with the shared NSG.
 #[crate::sqlx_test]

--- a/crates/api-core/tests/integration/batch_instance_allocation_validation.rs
+++ b/crates/api-core/tests/integration/batch_instance_allocation_validation.rs
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_test_harness::prelude::*;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+
+/// Send an empty batch request with no instances.
+/// Expect an error indicating at least one instance is required.
+#[sqlx_test]
+async fn test_batch_allocate_instances_empty_request(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = TestHarness::builder(pool).build().await;
+
+    let batch_request = rpc::forge::BatchInstanceAllocationRequest {
+        instance_requests: vec![],
+    };
+
+    let result = env
+        .api()
+        .allocate_instances(tonic::Request::new(batch_request))
+        .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.message().contains("at least one instance"),
+        "Expected error about empty request, got: {}",
+        err.message()
+    );
+}

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+mod batch_instance_allocation_validation;
 mod compute_allocation;
 mod connected_device;
 mod credential_rotation;


### PR DESCRIPTION
Move the empty batch allocation request check from the legacy `api-core` test module into the integration suite. This keeps request validation covered through the public API.

## Related issues

#2001 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
