### PR TITLE
ci: content-address base and builder container images

### DIFF
--- a/.github/ci/resolve-base-image.sh
+++ b/.github/ci/resolve-base-image.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Tag each base/builder image by a hash of its build inputs so an identical
+# definition maps to a single image that is reused across runs instead of rebuilt.
+# Prints `<image>_{run,version,ref,version_latest}` to stdout for the build gate.
+#
+# Requires TARGET_REGISTRY, SOURCE_REGISTRY and VERSION; a
+# `ci-rebuild-base-containers` mention in COMMIT_MESSAGE forces a rebuild.
+
+major_minor="$(cut -d. -f1,2 <<< "${VERSION}")"
+
+forced_base=false
+if [[ "${COMMIT_MESSAGE:-}" =~ ci-rebuild-base-containers ]]; then
+	forced_base=true
+fi
+
+# image_exists <ref>: is the image present in its registry?
+#   present            -> return 0
+#   definitively absent (registry says the manifest/name is unknown) -> return 1
+#   transient failure (network, 5xx, rate limit) -> retry with backoff, then
+#     fail open and return 1 so a registry blip triggers a rebuild rather than a
+#     hard pipeline failure.
+image_exists() {
+	local ref="$1" attempt out
+	for attempt in 1 2 3; do
+		if out="$(docker manifest inspect "${ref}" 2>&1)"; then
+			return 0
+		fi
+		case "${out}" in
+		*"no such manifest"* | *"manifest unknown"* | *"not found"* | *MANIFEST_UNKNOWN* | *NAME_UNKNOWN*)
+			return 1
+			;;
+		esac
+		echo "image_exists: transient lookup failure for ${ref} (attempt ${attempt}/3): ${out}" >&2
+		if [[ "${attempt}" -lt 3 ]]; then
+			sleep "$((attempt * 2))"
+		fi
+	done
+	return 1
+}
+
+# copy_inputs <dockerfile>: print each file the Dockerfile COPYs from the build
+# context, one per line. Skips flags (`--chown`, ...) and multi-stage
+# `COPY --from=` copies, which come from an earlier build stage, not the context.
+copy_inputs() {
+	awk '/^COPY / && !/--from=/ { for (i = 2; i < NF; i++) if ($i !~ /^--/) print $i }' "$1"
+}
+
+# resolve <output_prefix> <image_short_name> <dockerfile>
+resolve() {
+	local prefix="$1" name="$2" dockerfile="$3"
+	local tag tgt src ref run copied
+	local inputs=("${dockerfile}")
+
+	# Hash the Dockerfile plus every file it COPYs from the context, so any change
+	# to a build input yields a new tag. The COPY list is derived from the
+	# Dockerfile itself, so it can never drift from the actual COPY statements.
+	# TODO: pin all references within the files so this catches all content changes.
+	while IFS= read -r copied; do
+		inputs+=("${copied}")
+	done < <(copy_inputs "${dockerfile}")
+
+	tag="src-$(sha256sum "${inputs[@]}" | sha256sum | cut -c1-16)"
+	tgt="${TARGET_REGISTRY}/${name}:${tag}"
+	src="${SOURCE_REGISTRY}/${name}:${tag}"
+
+	# Default to building and pushing to the target registry; reuse an existing
+	# image instead (from the source, or the target for a fork) unless forced.
+	run=true
+	ref="${tgt}"
+	if [[ "${forced_base}" != "true" ]]; then
+		if image_exists "${src}"; then
+			run=false
+			ref="${src}"
+		elif [[ "${TARGET_REGISTRY}" != "${SOURCE_REGISTRY}" ]] && image_exists "${tgt}"; then
+			run=false
+			ref="${tgt}"
+		fi
+	fi
+
+	echo "${prefix}_run=${run}"
+	echo "${prefix}_version=${tag}"
+	echo "${prefix}_ref=${ref}"
+	# TODO: nothing reads the `<major.minor>-latest` alias now that consumers use
+	# the content-addressed ref. It is kept only for parity with the previous gate
+	# and can be dropped (along with `tag_latest` on the build jobs) once we confirm
+	# no external puller depends on it. It is published only on a build, so it is
+	# empty on reuse.
+	if [[ "${run}" == "true" ]]; then
+		echo "${prefix}_version_latest=${TARGET_REGISTRY}/${name}:${major_minor}-latest"
+	else
+		echo "${prefix}_version_latest="
+	fi
+}
+
+d=dev/docker
+resolve build_container_x86_64            build-container-x86_64            "${d}/Dockerfile.build-container-x86_64"
+resolve build_container_aarch64           build-container-aarch64           "${d}/Dockerfile.build-container-aarch64"
+resolve runtime_container_x86_64          runtime-container-x86_64          "${d}/Dockerfile.runtime-container-x86_64"
+resolve runtime_container_aarch64         runtime-container-aarch64         "${d}/Dockerfile.runtime-container-aarch64"
+resolve build_artifacts_container_x86_64  build-artifacts-container-x86_64  "${d}/Dockerfile.build-artifacts-container-x86_64"
+resolve build_artifacts_container_aarch64 build-artifacts-container-aarch64 "${d}/Dockerfile.build-artifacts-container-aarch64"

--- a/.github/ci/test-resolve-base-image.sh
+++ b/.github/ci/test-resolve-base-image.sh
@@ -102,11 +102,16 @@ for dfname in "${dockerfiles[@]}"; do
 done
 rm -rf "${work}"
 
-# 5. A transient registry error is retried (3 attempts) and then fails open.
+# 5. A transient registry error is retried (3 attempts) and then fails open. The
+#    503 below is simulated by the docker stub; the resolver's real retry
+#    diagnostics are left visible and framed so a log reader knows they are
+#    expected. The retry itself is verified via the call counter.
+echo "[test] simulating a transient registry failure; the following 503 errors are EXPECTED and not a real outage:" >&2
 call_log="$(mktemp)"
 export TRANSIENT_REF="reg/build-container-x86_64:${tag}" CALL_LOG="${call_log}"
 retry_out="$(run_gate "${repo_root}" "" reg reg 2.1.0 "")"
 unset TRANSIENT_REF CALL_LOG
+echo "[test] end of expected 503 errors" >&2
 grep -q '^build_container_x86_64_run=true$' <<< "${retry_out}" || fail "transient error should fail open to a build"
 attempts="$(grep -c . "${call_log}")"
 [[ "${attempts}" -eq 3 ]] || fail "expected 3 inspect attempts on transient error, got ${attempts}"

--- a/.github/ci/test-resolve-base-image.sh
+++ b/.github/ci/test-resolve-base-image.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Tests for resolve-base-image.sh:
+#   1. the $GITHUB_OUTPUT contract (only key=value, four keys per image);
+#   2. the build / reuse / forced-rebuild decision;
+#   3. that changing any file a base Dockerfile COPYs changes that image's tag,
+#      i.e. the auto-derived hash inputs really include the COPYd files;
+#   4. that a transient registry error is retried and then fails open to a build.
+#
+# `docker` and `sleep` are stubbed so there is no network and no real backoff.
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${here}/../.." && pwd)"
+script="${here}/resolve-base-image.sh"
+
+fail() {
+	printf '::error::resolve-base-image test failed: %s\n' "$1" >&2
+	exit 1
+}
+
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "${stub_dir}"' EXIT
+
+# docker stub for `manifest inspect <ref>`:
+#   - present if <ref> is listed in $EXISTING;
+#   - a retryable 503 if <ref> == $TRANSIENT_REF (logging each attempt to $CALL_LOG);
+#   - otherwise a genuine "no such manifest" (absent, must not be retried).
+cat > "${stub_dir}/docker" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "manifest inspect" ]]; then
+	if [[ -n "${TRANSIENT_REF:-}" && "$3" == "${TRANSIENT_REF}" ]]; then
+		[[ -n "${CALL_LOG:-}" ]] && echo "$3" >> "${CALL_LOG}"
+		echo "received unexpected HTTP status: 503 Service Unavailable" >&2
+		exit 1
+	fi
+	for e in ${EXISTING:-}; do [[ "$e" == "$3" ]] && exit 0; done
+	echo "no such manifest: $3" >&2
+	exit 1
+fi
+exit 0
+STUB
+# no-op sleep so retry backoff does not slow the test down
+printf '#!/usr/bin/env bash\nexit 0\n' > "${stub_dir}/sleep"
+chmod +x "${stub_dir}/docker" "${stub_dir}/sleep"
+
+run_gate() { # <dir> <existing> <target> <source> <version> <commit>
+	(
+		cd "$1" \
+			&& EXISTING="$2" TARGET_REGISTRY="$3" SOURCE_REGISTRY="$4" VERSION="$5" COMMIT_MESSAGE="$6" \
+				PATH="${stub_dir}:${PATH}" bash "${script}"
+	)
+}
+
+# 1. Nothing exists -> every image builds; output is only key=value, 4 per image.
+absent="$(run_gate "${repo_root}" "" reg reg 2.1.0 "")"
+while IFS= read -r line; do
+	[[ "${line}" =~ ^[a-z0-9_]+= ]] || fail "output line is not key=value: '${line}'"
+done <<< "${absent}"
+count="$(grep -c '=' <<< "${absent}")"
+[[ "${count}" -eq 24 ]] || fail "expected 24 output lines (6 images x 4), got ${count}"
+grep -q '^build_container_x86_64_run=true$' <<< "${absent}" || fail "expected build when tag absent"
+
+# 2. Present in the source registry -> reuse in place (run=false, ref=source).
+tag="$(sed -n 's/^build_container_x86_64_version=//p' <<< "${absent}")"
+reuse="$(run_gate "${repo_root}" "reg/build-container-x86_64:${tag}" reg reg 2.1.0 "")"
+grep -q '^build_container_x86_64_run=false$' <<< "${reuse}" || fail "expected reuse when tag exists"
+grep -q "^build_container_x86_64_ref=reg/build-container-x86_64:${tag}$" <<< "${reuse}" \
+	|| fail "expected reuse ref to be the existing content tag"
+
+# 3. `ci-rebuild-base-containers` forces a rebuild even if the image exists.
+forced="$(run_gate "${repo_root}" "reg/build-container-x86_64:${tag}" reg reg 2.1.0 "chore: ci-rebuild-base-containers")"
+grep -q '^build_container_x86_64_run=true$' <<< "${forced}" || fail "expected forced rebuild"
+
+# 4. Auto-derived inputs: changing any file a base Dockerfile COPYs must change
+#    that image's tag. Runs against a throwaway copy of the build context.
+work="$(mktemp -d)"
+mkdir -p "${work}/dev"
+cp -R "${repo_root}/dev/docker" "${work}/dev/docker"
+baseline="$(run_gate "${work}" "" reg reg 2.1.0 "")"
+dockerfiles=(
+	Dockerfile.build-container-x86_64
+	Dockerfile.build-container-aarch64
+	Dockerfile.runtime-container-x86_64
+	Dockerfile.runtime-container-aarch64
+	Dockerfile.build-artifacts-container-x86_64
+	Dockerfile.build-artifacts-container-aarch64
+)
+for dfname in "${dockerfiles[@]}"; do
+	prefix="$(sed 's/^Dockerfile\.//; s/-/_/g' <<< "${dfname}")"
+	base_ver="$(sed -n "s/^${prefix}_version=//p" <<< "${baseline}")"
+	while IFS= read -r copied; do
+		printf '\n# resolve-base-image test mutation\n' >> "${work}/${copied}"
+		new_ver="$(run_gate "${work}" "" reg reg 2.1.0 "" | sed -n "s/^${prefix}_version=//p")"
+		[[ "${base_ver}" != "${new_ver}" ]] \
+			|| fail "${prefix}: changing COPYd '${copied}' did not change the tag; it is not a hash input"
+		cp "${repo_root}/${copied}" "${work}/${copied}"
+	done < <(awk '/^COPY / && !/--from=/ { for (i = 2; i < NF; i++) if ($i !~ /^--/) print $i }' "${work}/dev/docker/${dfname}")
+done
+rm -rf "${work}"
+
+# 5. A transient registry error is retried (3 attempts) and then fails open.
+call_log="$(mktemp)"
+export TRANSIENT_REF="reg/build-container-x86_64:${tag}" CALL_LOG="${call_log}"
+retry_out="$(run_gate "${repo_root}" "" reg reg 2.1.0 "")"
+unset TRANSIENT_REF CALL_LOG
+grep -q '^build_container_x86_64_run=true$' <<< "${retry_out}" || fail "transient error should fail open to a build"
+attempts="$(grep -c . "${call_log}")"
+[[ "${attempts}" -eq 3 ]] || fail "expected 3 inspect attempts on transient error, got ${attempts}"
+rm -f "${call_log}"
+
+echo "resolve-base-image test: OK (contract, decision, COPY-derivation, retry)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,9 @@ jobs:
       - name: Test PR secret-scan range resolver
         run: bash .github/ci/test-resolve-pr-scan-range.sh
 
+      - name: Test base image resolver
+        run: bash .github/ci/test-resolve-base-image.sh
+
       - name: Detect non-rest changes
         id: non-rest-changes
         if: startsWith(github.ref, 'refs/heads/pull-request/')
@@ -147,23 +150,11 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Detect build-container-x86_64 changes
+      - name: Detect proto and source changes
         id: build-container-changes
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            build_container:
-              - 'dev/docker/Dockerfile.build-container-x86_64'
-            runtime_container:
-              - 'dev/docker/Dockerfile.runtime-container-x86_64'
-            runtime_container_aarch64:
-              - 'dev/docker/Dockerfile.runtime-container-aarch64'
-            build_container_aarch64:
-              - 'dev/docker/Dockerfile.build-container-aarch64'
-            build_artifacts_x86_64:
-              - 'dev/docker/Dockerfile.build-artifacts-container-x86_64'
-            build_artifacts_aarch64:
-              - 'dev/docker/Dockerfile.build-artifacts-container-aarch64'
             proto_files:
               - '**/*.proto'
             core_rpc_proto_files:
@@ -346,44 +337,20 @@ jobs:
           echo "|-----------|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| \`${EXTRAS_IMAGE}\` | \`${EXTRAS_REF}\` |" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Decide if build-container-x86_64 must run
+      - name: Resolve base and builder container tags
         id: base-container-gate
         env:
           TARGET_REGISTRY: ${{ steps.registry.outputs.registry }}
           SOURCE_REGISTRY: ${{ steps.registry.outputs.source_registry }}
-          EVENT_NAME: ${{ github.event_name }}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
           VERSION: ${{ steps.version.outputs.version }}
-          BUILD_CONTAINER_X86_64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.build_container }}
-          RUNTIME_CONTAINER_X86_64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.runtime_container }}
-          RUNTIME_CONTAINER_AARCH64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.runtime_container_aarch64 }}
-          BUILD_CONTAINER_AARCH64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.build_container_aarch64 }}
-          BUILD_ARTIFACTS_X86_64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.build_artifacts_x86_64 }}
-          BUILD_ARTIFACTS_AARCH64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.build_artifacts_aarch64 }}
           PROTO_FILES_CHANGED: ${{ steps.build-container-changes.outputs.proto_files }}
           CORE_RPC_PROTO_FILES_CHANGED: ${{ steps.build-container-changes.outputs.core_rpc_proto_files }}
           SOURCE_FILES_CHANGED: ${{ steps.build-container-changes.outputs.source_files }}
         run: |
-          build_container_x86_64_run=false
-          runtime_container_x86_64_run=false
-          build_container_aarch64_run=false
-          runtime_container_aarch64_run=false
-          build_artifacts_container_x86_64_run=false
-          build_artifacts_container_aarch64_run=false
           proto_files_changed=false
           core_rpc_proto_files_changed=false
           source_files_changed=false
-
-          if [[ "${COMMIT_MESSAGE}" =~ ci-rebuild-base-containers ]]; then
-            build_container_x86_64_run=true
-            runtime_container_x86_64_run=true
-            build_container_aarch64_run=true
-            runtime_container_aarch64_run=true
-            build_artifacts_container_x86_64_run=true
-            build_artifacts_container_aarch64_run=true
-          elif [[ "${BUILD_CONTAINER_X86_64_DOCKERFILE_CHANGED}" == "true" ]]; then
-            build_container_x86_64_run=true
-          fi
 
           if [[ "${PROTO_FILES_CHANGED}" == "true" ]]; then
              proto_files_changed=true
@@ -397,32 +364,6 @@ jobs:
              source_files_changed=true
           fi
 
-          if [[ "${RUNTIME_CONTAINER_X86_64_DOCKERFILE_CHANGED}" == "true" ]]; then
-            runtime_container_x86_64_run=true
-          fi
-
-          if [[ "${RUNTIME_CONTAINER_AARCH64_DOCKERFILE_CHANGED}" == "true" ]]; then
-            runtime_container_aarch64_run=true
-          fi
-
-          if [[ "${BUILD_CONTAINER_AARCH64_DOCKERFILE_CHANGED}" == "true" ]]; then
-            build_container_aarch64_run=true
-          fi
-
-          if [[ "${BUILD_ARTIFACTS_X86_64_DOCKERFILE_CHANGED}" == "true" ]]; then
-            build_artifacts_container_x86_64_run=true
-          fi
-
-          if [[ "${BUILD_ARTIFACTS_AARCH64_DOCKERFILE_CHANGED}" == "true" ]]; then
-            build_artifacts_container_aarch64_run=true
-          fi
-
-          echo "build_container_x86_64_run=${build_container_x86_64_run}" >> "$GITHUB_OUTPUT"
-          echo "runtime_container_x86_64_run=${runtime_container_x86_64_run}" >> "$GITHUB_OUTPUT"
-          echo "build_container_aarch64_run=${build_container_aarch64_run}" >> "$GITHUB_OUTPUT"
-          echo "runtime_container_aarch64_run=${runtime_container_aarch64_run}" >> "$GITHUB_OUTPUT"
-          echo "build_artifacts_container_x86_64_run=${build_artifacts_container_x86_64_run}" >> "$GITHUB_OUTPUT"
-          echo "build_artifacts_container_aarch64_run=${build_artifacts_container_aarch64_run}" >> "$GITHUB_OUTPUT"
           echo "proto_files_changed=${proto_files_changed}" >> "$GITHUB_OUTPUT"
           echo "core_rpc_proto_files_changed=${core_rpc_proto_files_changed}" >> "$GITHUB_OUTPUT"
           echo "source_files_changed=${source_files_changed}" >> "$GITHUB_OUTPUT"
@@ -430,65 +371,9 @@ jobs:
           MAJOR_MINOR=$(echo "${VERSION}" | cut -d. -f1,2)
           echo "major_minor_version=${MAJOR_MINOR}" >> "$GITHUB_OUTPUT"
 
-          if [[ "$build_container_x86_64_run" == "true" ]]; then
-            echo "build_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_container_x86_64_ref=${TARGET_REGISTRY}/build-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_container_x86_64_version_latest=${TARGET_REGISTRY}/build-container-x86_64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "build_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
-            echo "build_container_x86_64_ref=${SOURCE_REGISTRY}/build-container-x86_64:latest" >> "$GITHUB_OUTPUT"
-            echo "build_container_x86_64_version_latest=" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [[ "$runtime_container_x86_64_run" == "true" ]]; then
-            echo "runtime_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_x86_64_ref=${TARGET_REGISTRY}/runtime-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_x86_64_version_latest=${TARGET_REGISTRY}/runtime-container-x86_64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "runtime_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_x86_64_ref=${SOURCE_REGISTRY}/runtime-container-x86_64:latest" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_x86_64_version_latest=" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [[ "$build_container_aarch64_run" == "true" ]]; then
-            echo "build_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_container_aarch64_ref=${TARGET_REGISTRY}/build-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_container_aarch64_version_latest=${TARGET_REGISTRY}/build-container-aarch64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "build_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
-            echo "build_container_aarch64_ref=${SOURCE_REGISTRY}/build-container-aarch64:latest" >> "$GITHUB_OUTPUT"
-            echo "build_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [[ "$runtime_container_aarch64_run" == "true" ]]; then
-            echo "runtime_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_aarch64_ref=${TARGET_REGISTRY}/runtime-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_aarch64_version_latest=${TARGET_REGISTRY}/runtime-container-aarch64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "runtime_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_aarch64_ref=${SOURCE_REGISTRY}/runtime-container-aarch64:latest" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [[ "$build_artifacts_container_x86_64_run" == "true" ]]; then
-            echo "build_artifacts_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_x86_64_ref=${TARGET_REGISTRY}/build-artifacts-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_x86_64_version_latest=${TARGET_REGISTRY}/build-artifacts-container-x86_64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "build_artifacts_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_x86_64_ref=${SOURCE_REGISTRY}/build-artifacts-container-x86_64:latest" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_x86_64_version_latest=" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [[ "$build_artifacts_container_aarch64_run" == "true" ]]; then
-            echo "build_artifacts_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_aarch64_ref=${TARGET_REGISTRY}/build-artifacts-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_aarch64_version_latest=${TARGET_REGISTRY}/build-artifacts-container-aarch64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "build_artifacts_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_aarch64_ref=${SOURCE_REGISTRY}/build-artifacts-container-aarch64:latest" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
-          fi
+          # Lookup the container image to determine if it has already been built.
+          # Sets `[build|build_artifacts|runtime]_container_[x86_64|aarch64]_run=true` for any image that needs to be built.
+          bash .github/ci/resolve-base-image.sh >> "$GITHUB_OUTPUT"
 
       - name: Decide release container publish strategy
         id: release-gate

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -233,6 +233,12 @@ jobs:
           # provenance would embed private downstream repo refs into artifacts
           provenance: ${{ github.repository == 'NVIDIA/infra-controller' && 'mode=min' || 'false' }}
           tags: ${{ steps.tag_list.outputs.tags }}
+          # Stamp the source commit so a content-addressed tag (e.g. base images
+          # tagged src-<hash>) can be traced back to the commit that built it via
+          # `docker buildx imagetools inspect`.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
           cache-from: ${{ inputs.cache && 'type=gha' || '' }}
           # Never exported from this branch. The Actions cache is a single 50 GB

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@ cargo make build-and-test-release-container-services
 cargo make build-cli
 ```
 
+CI content-addresses the base and builder container images, building each only when its
+definition changes and reusing it otherwise. Force a rebuild of all of them by putting
+`ci-rebuild-base-containers` in a commit message. See
+[Continuous Integration](CONTRIBUTING.md#continuous-integration).
+
 ### Testing
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,6 +276,18 @@ for the requested behavior.
 - Be responsive to feedback and code review comments.
 - Ensure all CI checks pass before requesting review.
 
+## Continuous Integration
+
+CI content-addresses the base and builder container images (`build-container-*`,
+`runtime-container-*`, `build-artifacts-container-*`): each is tagged by a hash of its
+Dockerfile plus any files it `COPY`s, built only when that definition changes and reused
+otherwise (see `.github/ci/resolve-base-image.sh`).
+
+To force a rebuild of all of them, include `ci-rebuild-base-containers` in a commit message.
+It is a case-sensitive substring match on the pushed tip commit, so add it to the latest
+commit of a push to `main`, a `pull-request/*` branch or a tag. Use it to refresh a
+re-published base image or the unpinned installs in those Dockerfiles.
+
 ## Build Guide
 
 For pinned dependency updates, image testing, and build optimization trade-offs, see the


### PR DESCRIPTION
CI rebuilt every base and builder container image on each release and tag build. The gate compared non-main refs against `main` with `dorny/paths-filter`, so once `release/v2.1` diverged from `main` (a different pinned rust) the base Dockerfiles always looked changed and were rebuilt and re-pushed, re-running their apt installs against the flaky `ports.ubuntu` mirror each time.

This content-addresses those images: each is tagged by a hash of its build inputs (its Dockerfile plus any files it `COPY`s) and built only when that tag is absent from the registry, reused otherwise. A `ci-rebuild-base-containers` mention in a commit message still forces a rebuild.

- new `.github/ci/resolve-base-image.sh` gate resolving all six base and builder images through one helper, plus `test-resolve-base-image.sh`
- transient registry lookups are retried, genuine 404s are reused or built without retry
- OCI `revision`/`source` labels so a content tag traces back to the commit that built it
- directive documented in `CONTRIBUTING.md` and `AGENTS.md`

## Related issues

Complements the `ports.ubuntu` mirror hardening in #5249: reusing base images instead of rebuilding them every release removes most of the apt traffic to that mirror.

## Type of Change

- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

`.github/ci/test-resolve-base-image.sh` runs in the `changes` job and covers the output contract, the build/reuse/forced decision, that changing a `COPY`d file changes the image tag, and the transient-error retry. `shellcheck` passes on both scripts and the workflows parse.

## Additional Notes

Follow-ups in separate PRs: pin the base images' unpinned installs for byte-for-byte reproducibility, and document `ci-run-complete-pipeline`.