### PR TITLE
docs: explain DPU ToR readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,7 +372,7 @@ check before requesting review.
     `fern docs md check` and `fern check` from the repository root. Neither
     command needs a Fern token, but without one, `fern check` skips the
     published-state `missing-redirects` check.
-  - `docs/release-notes.md` owns current unified releases;
+  - `fern/changelog/` owns current unified releases;
     do not modify `rest-api/CHANGELOG.md`, as it is legacy history whose
     published entry order must be preserved.
 

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -689,7 +689,7 @@ These don't fit any sub-section but show up in production tuning:
 | `max_find_by_ids` | `100` | Increase if scripts paginate batch lookups; raise the API-side limit to match the client. |
 | `compute_allocation_enforcement` | `WarnOnly` | Switch to `Enforce` once tenant compute pools are sized correctly — flips over-allocation from a warning to a refusal. |
 | `bmc_session_lockout_threshold` | `3` | Number of consecutive 401/403s from a BMC before NICo stops session-token logins for that BMC. Raise on environments with flaky BMC firmware. |
-| `min_dpu_functioning_links` | unset | Minimum healthy DPU links for a machine to report `Healthy`. Unset = all links required. |
+| `min_dpu_functioning_links` | unset (effective value `2`) | Controls DPU ToR BGP health checks. See [DPU ToR Uplink Health](../../../docs/dpu-management/dpu_configuration.md#dpu-tor-uplink-health) for values and lifecycle effects. |
 | `set_http_boot_uri_for_vendors` | `[]` | Vendors for which the state controller pins UEFI HTTP Boot URL on the BMC via Redfish. Empty = rely on DHCP option 67. |
 | `x86_pxe_boot_url_override` / `arm_pxe_boot_url_override` | unset | Override the default `nico-pxe` boot URL by architecture. Useful when chaining through an external HTTP boot artifact server. |
 | `anycast_site_prefixes` | `[]` | **Deprecated** — use `[fnn.routing_profiles.<name>].allowed_anycast_prefixes` instead. |
@@ -775,7 +775,7 @@ advertised. Both are documented field-by-field in
 defines a specific UFM-managed fabric. Currently exactly one fabric is
 supported. Required fields: UFM endpoint, credentials (username + password,
 or token), MGMT IB subnet, GUID prefix. See
-[`crates/api-core/src/cfg/README.md` → IbFabricDefinition](../../../crates/api-core/src/cfg/README.md#ibfabricdefinition).
+[`crates/api-core/src/cfg/README.md` → NicoConfig](../../../crates/api-core/src/cfg/README.md#nicoconfig-top-level).
 
 ### Operator dev / debug knobs
 
@@ -1016,7 +1016,7 @@ for the full field list.
 Maps a host model identifier to a Firmware definition (BMC, UEFI, NIC
 images plus version constraints). The state controller picks the right
 images when a machine in the model joins. See
-[`crates/api-core/src/cfg/README.md` → host_models](../../../crates/api-core/src/cfg/README.md#hostmodelsfirmware).
+[`crates/api-core/src/cfg/README.md` → NicoConfig](../../../crates/api-core/src/cfg/README.md#nicoconfig-top-level).
 
 ### Rack profile firmware object: `[rack_profiles.<name>]`
 

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -689,7 +689,7 @@ These don't fit any sub-section but show up in production tuning:
 | `max_find_by_ids` | `100` | Increase if scripts paginate batch lookups; raise the API-side limit to match the client. |
 | `compute_allocation_enforcement` | `WarnOnly` | Switch to `Enforce` once tenant compute pools are sized correctly — flips over-allocation from a warning to a refusal. |
 | `bmc_session_lockout_threshold` | `3` | Number of consecutive 401/403s from a BMC before NICo stops session-token logins for that BMC. Raise on environments with flaky BMC firmware. |
-| `min_dpu_functioning_links` | unset (effective value `2`) | Controls DPU ToR BGP health checks. See [DPU ToR Uplink Health](../../../docs/dpu-management/dpu_configuration.md#dpu-tor-uplink-health) for values and lifecycle effects. |
+| `min_dpu_functioning_links` | unset (effective value `2`) | Controls DPU ToR BGP health checks. Refer to [DPU ToR Uplink Health](../../../docs/dpu-management/dpu_configuration.md#dpu-tor-uplink-health) for values and lifecycle effects. |
 | `set_http_boot_uri_for_vendors` | `[]` | Vendors for which the state controller pins UEFI HTTP Boot URL on the BMC via Redfish. Empty = rely on DHCP option 67. |
 | `x86_pxe_boot_url_override` / `arm_pxe_boot_url_override` | unset | Override the default `nico-pxe` boot URL by architecture. Useful when chaining through an external HTTP boot artifact server. |
 | `anycast_site_prefixes` | `[]` | **Deprecated** — use `[fnn.routing_profiles.<name>].allowed_anycast_prefixes` instead. |

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -85,7 +85,7 @@ Use `site_explorer.dpu_policy` instead.
 | `machine_updater` | `MachineUpdater` | *(see below)* | `machines` | Machine update policies (see [MachineUpdater](#machineupdater)). |
 | `max_find_by_ids` | `u32` | `100` | `server` | Max IDs accepted by `find_*_by_ids` APIs. |
 | `network_security_group` | `NetworkSecurityGroupConfig` | *(see below)* | `networking` | NSG settings (see [NetworkSecurityGroupConfig](#networksecuritygroupconfig)). |
-| `min_dpu_functioning_links` | `Option<u32>` | unset (effective value `2`) | `machines` | Controls DPU ToR BGP health checks. See [DPU ToR Uplink Health](../../../../docs/dpu-management/dpu_configuration.md#dpu-tor-uplink-health) for values and lifecycle effects. |
+| `min_dpu_functioning_links` | `Option<u32>` | unset (effective value `2`) | `machines` | Controls DPU ToR BGP health checks. Refer to [DPU ToR Uplink Health](../../../../docs/dpu-management/dpu_configuration.md#dpu-tor-uplink-health) for values and lifecycle effects. |
 | `host_health` | `HostHealthConfig` | *(default)* | `machines` | Host health monitoring thresholds for hardware health and DPU agent compliance. |
 | `observability` | `ObservabilityConfig` | *(default)* | `integrations` | Observability settings shared across all state controllers (see [ObservabilityConfig](#observabilityconfig)). |
 | `internet_l3_vni` | `u32` | `100001` | `networking` | Network infrastructure-provided L3 VNI for FNN VPC Internet connectivity. Combined with `datacenter_asn` for route-target. |

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -85,7 +85,7 @@ Use `site_explorer.dpu_policy` instead.
 | `machine_updater` | `MachineUpdater` | *(see below)* | `machines` | Machine update policies (see [MachineUpdater](#machineupdater)). |
 | `max_find_by_ids` | `u32` | `100` | `server` | Max IDs accepted by `find_*_by_ids` APIs. |
 | `network_security_group` | `NetworkSecurityGroupConfig` | *(see below)* | `networking` | NSG settings (see [NetworkSecurityGroupConfig](#networksecuritygroupconfig)). |
-| `min_dpu_functioning_links` | `Option<u32>` | — | `machines` | Minimum functioning DPU links for healthy status. If unset, all must work. |
+| `min_dpu_functioning_links` | `Option<u32>` | unset (effective value `2`) | `machines` | Controls DPU ToR BGP health checks. See [DPU ToR Uplink Health](../../../../docs/dpu-management/dpu_configuration.md#dpu-tor-uplink-health) for values and lifecycle effects. |
 | `host_health` | `HostHealthConfig` | *(default)* | `machines` | Host health monitoring thresholds for hardware health and DPU agent compliance. |
 | `observability` | `ObservabilityConfig` | *(default)* | `integrations` | Observability settings shared across all state controllers (see [ObservabilityConfig](#observabilityconfig)). |
 | `internet_l3_vni` | `u32` | `100001` | `networking` | Network infrastructure-provided L3 VNI for FNN VPC Internet connectivity. Combined with `datacenter_asn` for route-target. |

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4843,8 +4843,11 @@ message ManagedHostNetworkConfigResponse {
   // Host primary interface id
   optional string host_interface_id = 102;
 
-  // temporary flag for telling a DPU how many links it needs to have up to be considered healthy.
-  // if not set, all links must be up.
+  // Minimum number of functioning DPU ToR links. The default is two. Zero
+  // disables ToR uplink health checks, one allows either link to satisfy the
+  // minimum, and values above two produce a configuration health alert. When
+  // checks are enabled, a failed primary link is still reported because PXE
+  // boot depends on it.
   optional uint32 min_dpu_functioning_links = 103;
 
   // Is it a primary DPU

--- a/docs/architecture/health/health_probe_ids.md
+++ b/docs/architecture/health/health_probe_ids.md
@@ -60,6 +60,7 @@ Indicates that an already-ingested Managed Host's BMC MAC is no longer listed in
 Indicates that a BMC sensor reported a warning/critical/failure condition.
 
 Details:
+
 - `target` is set to the BMC sensor ID (for example, a fan/temperature/power sensor name).
 - The alert `message` contains the entity type, reading, unit, and threshold ranges used for evaluation.
 - Classifications are documented in [Health alert classifications](health_alert_classifications.md), including `Hardware`, `SensorWarning`, `SensorCritical`, and `SensorFailure`.
@@ -80,7 +81,23 @@ power_supply 'PSU0_OutputPower': Critical - reading 1320.00W (power), valid rang
 
 ### `BgpPeeringTor`
 
-Indicates that a BGP session with a top-of-rack (TOR) switch could not be established by a host/DPU.
+Reports a DPU top-of-rack (ToR) uplink problem. For a finding on one expected
+uplink, the `target` identifies p0 or p1 and the message identifies the failed
+condition. On the NVUE path, a request failure or a minimum greater than two
+uses an untargeted critical alert.
+
+Both NVUE and FRR use this ID when a BGP transport session is unavailable. A p0
+transport alert includes `PreventAllocations` because normal PXE boot requires
+p0. A lone p1 transport failure is unclassified or suppressed, depending on
+`min_dpu_functioning_links`. With a positive minimum, both unavailable sessions
+produce alerts with `PreventAllocations` and `PreventHostStateChanges`.
+
+For FNN configurations with an IPv6 loopback, the FRR path also uses this ID
+when an established transport session did not negotiate IPv6 unicast. A single
+address family warning is unclassified and does not indicate a transport
+failure. Refer to
+[DPU ToR Uplink Health](../../dpu-management/dpu_configuration.md#dpu-tor-uplink-health)
+for the complete policy and transport state matrix.
 
 ### `BgpPeeringRouteServer`
 
@@ -88,7 +105,9 @@ Indicates that a BGP session with the route server that is part of the NICo cont
 
 ### `BgpStats`
 
-Indicates that BGP statistics could not be extacted by `dpu-agent`
+Indicates that `dpu-agent` could not collect or validate FRR BGP statistics.
+The FRR path also uses this critical alert when
+`min_dpu_functioning_links` is greater than the two expected uplinks.
 
 ### `BgpDaemonEnabled`
 
@@ -121,12 +140,20 @@ Indicates an issue with retrieving the list of running services
 
 ### `ServiceRunning`
 
-Indicates that an expected service on the DPU is not runnning
+Indicates that an expected service on the DPU is not running
 
 ### `PostConfigCheckWait`
 
-The alert is placed on a host for a few seconds after a configuration change by dpu-agent in order to allow the configuration changes to "settle" before doing the health assessment.
-That avoids the host to move between states even though the new configuration might be  problematic.
+`dpu-agent` adds this critical alert to one health report after it changes HBN
+or reloads local DHCP in ContainerExec mode. The alert includes
+`PreventAllocations` and `PreventHostStateChanges`. NICo waits for the next
+health report before it uses the newly acknowledged configuration version.
+
+This is not a fixed timer. The alert clears from the next report when the agent
+does not apply another configuration change. If it continues across multiple
+reports, check whether the agent repeatedly applies the configuration. Refer to
+[Health Sampling After Configuration Changes](../../dpu-management/dpu_configuration.md#health-sampling-after-configuration-changes)
+for behavior on each path.
 
 ### `RestrictedMode`
 
@@ -146,6 +173,7 @@ Indicates that the dpu-agent disk utilization on the DPU is above a critical thr
 
 The alert indicates that no health report was received, where health report
 was expected. It is different from `HeartbeatTimeout` in the following sense
+
 - `HeartbeatTimeout` alerts can be emitted if data is available, but stale.
   `MissingReport` is only emitted if data has never been received.
 - `MissingReport` is mainly used on the NICo client side. It has no impact on

--- a/docs/architecture/health/health_probe_ids.md
+++ b/docs/architecture/health/health_probe_ids.md
@@ -140,7 +140,7 @@ Indicates an issue with retrieving the list of running services
 
 ### `ServiceRunning`
 
-Indicates that an expected service on the DPU is not running
+Indicates that an expected service on the DPU is not running.
 
 ### `PostConfigCheckWait`
 

--- a/docs/architecture/health_aggregation.md
+++ b/docs/architecture/health_aggregation.md
@@ -1,11 +1,10 @@
 # Health Checks and Health Aggregation
 
-[summary]: #summary
-
 NVIDIA Infra Controller (NICo) integrates a variety of tools to continuously assess and report the health of any host under its management. It also allows site operators to configure and extend the set of health checks via runtime configurations and extension APIs.
 
 The health information that is obtained by these tools is rolled up within NICo Core into an "aggregated host health".
 The aggregated host health information is used for multiple purposes:
+
 1. For NICo internal decision making - e.g. "is this host usable as a bare metal instance by a tenant" and "is the host allowed to transition between 2 states".
 2. The aggregated host health information is made available to NICo API users. Site administrators can use the information to assess host health and external fleet health automation systems can use it to trigger remediation workflows.
 3. A filtered subset of the aggregated health status is made available to tenants in order to inform them whether their host is subject to known problems and whether they should release it.
@@ -13,6 +12,7 @@ The aggregated host health information is used for multiple purposes:
 ## Health check types
 
 Health checks roughly fall into 3 categories:
+
 1. Out of band health checks: These continuous health checks are able to continuously assess the health of a host - independent of whether the host is used as a bare metal instance or not. Within this category, NICo provides the following types of health checks
     1. [BMC health metric based health monitoring](#bmc-health-monitoring)
     2. [BMC inventory based health monitoring](#bmc-inventory-monitoring)
@@ -27,7 +27,7 @@ reports. If any component reports that a subsystem is not healthy, then the
 overall system is not healthy. This combination of health-reports is performed
 inside `nico-core` at any time the health status of a host is queried.
 
-A more detailed list of health probes can be found in [Health Probe IDs](health/health_probe_ids.md).  
+A more detailed list of health probes can be found in [Health Probe IDs](health/health_probe_ids.md).
 A list of health alert classifications can be found in [Health Alert Classifications](health/health_alert_classifications.md).
 
 ## Overview diagram
@@ -190,9 +190,18 @@ message HealthProbeSuccess {
 
 For failed health checks, the `HealthProbeAlert` can carry an optional set of `classifications` that describe how the system will react on the failed health check.
 
-The core idea here is that not all types of alerts have the same significance, and that different alerts will require a different response by NICo and site administrators: E.g. a BGP peering failure with a BGP peering issue on just one of the 2 redundant links will not render a host automatically unusable, while a fully unreachable DPU implies that the host can't be used.
+Not all alerts have the same effect. An unavailable secondary p1 session can
+remain visible without preventing allocation or host state changes. When uplink
+checks are enabled, an unavailable primary p0 session prevents allocation
+because normal PXE depends on p0. Losing both sessions also prevents host state
+changes. Refer to
+[DPU ToR Uplink Health](../dpu-management/dpu_configuration.md#dpu-tor-uplink-health)
+for the complete policy.
 
-Health alert classifications decouple the NICo logic from the actual alert IDs. E.g. NICo logic does not have to encode an exhaustive check over all possible health probe IDs:
+Most NICo decisions use classifications without matching specific alert IDs.
+For example, allocation logic does not need an exhaustive check over every
+health probe ID:
+
 ```rust
 if alert.id == "BgpPeeringFailure" || alert.id === BmcUnreachable || lots_of_other_conditions {
     host_is_fit_for_instance_creation = false;
@@ -200,11 +209,25 @@ if alert.id == "BgpPeeringFailure" || alert.id === BmcUnreachable || lots_of_oth
 ```
 
 Instead of this, it can just scan whether any of the health alerts in the aggregate host health carries a certain condition:
+
 ```rust
 if alert.classifications.contains("PreventAllocations") {
   host_is_fit_for_instance_creation = false;
 }
 ```
+
+The normal PXE readiness check is a narrow exception. It matches the
+`BgpPeeringTor` probe ID together with `PreventAllocations`; it does not inspect
+the alert target. The DPU agent uses that combination for a p0 transport
+failure. A host `Replace` report takes precedence for this check. Without one,
+NICo checks the primary DPU's `Replace` report, or each of its `Merge` reports
+when no DPU `Replace` report exists.
+
+During `WaitingForNetworkConfig`, a host `Replace` report can therefore supply
+the PXE blocking signal even when the host has no managed DPU. During
+`WaitingForRebootToReady`, NICo evaluates this special signal only for hosts
+with managed DPUs. Every host still receives the separate aggregate
+`PreventHostStateChanges` check immediately before the normal PXE restart.
 
 This mechanism also allows site-administrator provided health checks via [Health report override APIs](#health-report-overrides) to trigger the same behavior as integrated health checks.
 
@@ -216,6 +239,7 @@ The set of classifications that are currently interpreted by NICo is described i
 
 NICo will schedule the execution of validation tests via the `scout` tool on the actual host at various points
 in the lifecycle of a managed host:
+
 1. When the host is ingested into NICo
 2. After an instance is released by tenant and got cleaned up
 3. On demand while the host is not assigned to any tenant
@@ -236,6 +260,7 @@ SKU validation is a feature in NICo which validates that a host contains all the
 The SKU is the definition of hardware components within the host. And the SKU validation workflow compares it to the set of hardware components that have been detected via NICo hardware discovery workflows - which utilize inband data as well as out of band data.
 
 SKU validation can thereby e.g. detect
+
 - whether a host has the right type of CPU installed
 - whether a host has the right amount of memory installed
 - whether a host has the right type and amount of GPUS installed
@@ -255,6 +280,7 @@ Details can be found in the [SKU Validation guide](../provisioning/sku-validatio
 The [`nico-hw-health`](https://github.com/NVIDIA/infra-controller/blob/main/crates/health) service periodically queries all Host and DPU BMCs in the system for health information. It emits the captured health datapoints as metrics on a metrics endpoint that can be scraped by a standard telemetry system (prometheus/otel).
 
 Health metrics fetched from BMCs include:
+
 - Fan speeds
 - Temperatures
 - Power supply utilization, outputs and voltages
@@ -294,7 +320,7 @@ the existing opt-in JSON representation controlled by the target's
 `health_report.alerts` and `health_report.alerts.dropped` are absent unless
 details are enabled. If the schema version is missing or unsupported, consumers
 retain the human-readable summary body, ignore the structured `health_report.*`
-attributes, and do not reject the record. This fallback emits no warning. 
+attributes, and do not reject the record. This fallback emits no warning.
 Additional fields may be present besides the minimum ones listed below.
 
 | Attribute | OTLP type | Presence | Value |
@@ -339,12 +365,14 @@ The two record timestamps are set by different clocks. `time_unix_nano` is never
 The Site Explorer process within NICo Core periodically queries all Host and DPU BMCs in order to record certain BMC properties (e.g. components within a host and firmware versions).
 
 In certain conditions the scraping process will place a health alert on the host:
+
 - If the host BMC is not reachable
 - If any of the host properties indicates the host is not fit for instance creation.
 
 ### dpu-agent based health monitoring
 
 [`dpu-agent`](https://github.com/NVIDIA/infra-controller/blob/main/crates/agent) collects health information directly on the DPU and sends a health-**rollup** towards `nico-core`. The agent monitors a variety of health conditions, including
+
 - whether BGP sessions are established to peers according to the current configuration of the DPU
 - whether all required services on the DPU are running
 - whether the DPU is configured in restricted mode
@@ -376,6 +404,7 @@ This allows you to integrate health information from multiple external systems a
 If a ManagedHost's health is overridden, the remaining behavior is exactly the same
 as if the overridden Health report would have been directly derived from monitoring
 hardware health:
+
 - The host will be allocatable depending on whether any `PreventAllocations` classification is present in the aggregate host health
 - State transitions behave as if NICo integrated monitoring would have detected
   the same health status:

--- a/docs/architecture/health_aggregation.md
+++ b/docs/architecture/health_aggregation.md
@@ -259,12 +259,12 @@ Details can be found in the [Machine Validation guide](../provisioning/machine-v
 SKU validation is a feature in NICo which validates that a host contains all the hardware it is expected to contain by validating it to "conform to a certain SKU".
 The SKU is the definition of hardware components within the host. And the SKU validation workflow compares it to the set of hardware components that have been detected via NICo hardware discovery workflows - which utilize inband data as well as out of band data.
 
-SKU validation can thereby e.g. detect
+SKU validation can thereby detect whether a host has, for example:
 
-- whether a host has the right type of CPU installed
-- whether a host has the right amount of memory installed
-- whether a host has the right type and amount of GPUS installed
-- whether a host has the right type and amount of InfiniBand NICs installed, and whether they are connected to switches
+- The right type of CPU installed
+- The right amount of memory installed
+- The right type and amount of GPUS installed
+- The right type and amount of InfiniBand NICs installed, and whether they are connected to switches
 
 SKU validation runs at the same points in the host lifecycle as machine validation tests, and can also be run on-demand while the host is not assigned to any tenant.
 

--- a/docs/architecture/networking_integrations.md
+++ b/docs/architecture/networking_integrations.md
@@ -31,8 +31,8 @@ Networking integrations in NICo achieve this through the following patterns:
 - Tenants need to know how they can actually configure their instances. Valid configurations depend on the hardware. E.g. in an instance with 4 connected InfiniBand ports, tenants can associate each of these ports with a separate partition. However tenants are not able to configure instances without InfiniBand ports for IB.
 - Tenants learn about the support configurations via "Instance Types", which hold a list of capabilities. Each type of networking capability informs a tenant on how the respective interface can be configured. This means for each configurable interface, the instance type should list a respective capability.
 - The set of capabilities encoded in instance types must match or be a subset of the capabilities associated with a `Machine`. Machine capabilities are detected during the hardware discovery and ingestion phases. They are viewable by site administrators via debug tools.
-    - During Machine ingestion, data about all network interfaces is collected both in-band (using scout) and out-of-band (using site-explorer). The data is stored within `machine` and `machine_topologies` tables
-    - Based on the raw discovery data, "machine capabilities" (type `MachineCapabilitiesSet`) are computed by the core service and presented to site administrators. These capabilities inform users about the amount of interfaces which are configurable. For each network integration, a new type of machine capability is required. E.g. InfiniBand uses the `MachineCapabilityAttributesInfiniband` capability, while nvlink uses the `MachineCapabilityAttributesGpu` capability.
+  - During Machine ingestion, data about all network interfaces is collected both in-band (using scout) and out-of-band (using site-explorer). The data is stored within `machine` and `machine_topologies` tables
+  - Based on the raw discovery data, "machine capabilities" (type `MachineCapabilitiesSet`) are computed by the core service and presented to site administrators. These capabilities inform users about the amount of interfaces which are configurable. For each network integration, a new type of machine capability is required. For example, InfiniBand uses the `MachineCapabilityAttributesInfiniband` capability, while nvlink uses the `MachineCapabilityAttributesGpu` capability.
 - The SKU validation feature can include checks whether any newly ingested host includes the expected amount of network interfaces - where each network interface is typically described as a machine capability.
 
 ## Implementation requirements and considerations
@@ -45,14 +45,14 @@ To implement these workflows, the following patterns had been developed and prov
 - The desired state is a combination of the "tenant requested state" as well as a set of configurations internally managed by NICo.
   - The tenant requested state is stored fully in the `InstanceConfig` object
   - The internal requested state is stored in the `ManagedHostNetworkConfig` that is part of the `machine` table in the database. The most important field here is the `use_admin_network` field which controls whether tenant configurations are overridden and that the machine should indeed be placed onto an isolated/admin network.
-- The actual state is stored as part of the `Machine` database object. The integration between NICo and the respective networking subsystem is responsible for updating it there. All other workflows within NICo will use this observed state for decision making instead of reaching out to any external services. This internal caching of observed state keeps workflows deterministic and reliable, since they act on the same source of truth. It also helps with reactivity and scaling, since all other code path won't need to reach out to an external service anymore to learn about network state.  
-  
-  2 integration patterns had been developed here over time:
+- The actual state is stored as part of the `Machine` database object. The integration between NICo and the respective networking subsystem is responsible for updating it there. All other workflows within NICo will use this observed state for decision making instead of reaching out to any external services. This internal caching of observed state keeps workflows deterministic and reliable, since they act on the same source of truth. It also helps with reactivity and scaling, since all other code paths do not need to reach out to an external service to learn about network state.
+
+  Two integration patterns have been developed over time:
     1. The actual observed state is updated by a "monitoring and reconciliation task" specific to the networking technology. Examples of this integration are the `IbFabricMonitor` services (for InfiniBand) and `NvlPartitionMonitor` (for NVLink). This kind of monitoring and integration is favorable if the external networking is controlled via an external service, since the integration is able to fetch the actual networking state for more than one device and host at the same time and can update all affected machine objects at once.
-    2. The actual observed state is updated for each interface or host by a service associated with this interface by making an API call into NICo. An examples of this integration is `dpu-agent` sending the observed DPU configuration via a gRPC call (`RecordDpuNetworkStatus`).
+    2. The actual observed state is updated for each interface or host by a service associated with this interface by making an API call into NICo. An example of this integration is `dpu-agent` sending the observed DPU configuration via a gRPC call (`RecordDpuNetworkStatus`).
 - Site admins need to be able to view both the desired configuration for any interface as well as the actual configuration.
 
-### State reconciliation
+### State Reconciliation
 
 There needs to be a mechanism that periodically compares the expected networking configuration with the desired networking configuration. If they are not in-sync, the respective components needs to take all the required actions to bring the configurations in sync.
 
@@ -69,7 +69,19 @@ There needs to be a mechanism that periodically compares the expected networking
     - If the instance ever had been `Ready`, and the actual network configuration deviates from the intended configuration, the status should show `Configuring`.
     - If instance termination has been requested, the instances status should show `Terminating` independent of network configurations.
 3. The instance state machine should have guards in certain states that wait until the desired network configurations are applied:
-    - During initial instance provisioning (before `Ready` state), one state in the state machine should wait until the desired network configuration is applied. For DPU configurations, this happens in the `WaitingForNetworkConfig` state. The guards in this state should use the same logic that derive the `configs_synced` value for tenants.
+    - During initial provisioning, `WaitingForNetworkConfig` waits for current
+      DPU observations and matching configuration versions. It also waits for
+      health alerts that prevent host state changes and the primary p0 PXE gate.
+      Refer to
+      [DPU ToR Uplink Health](../dpu-management/dpu_configuration.md#dpu-tor-uplink-health)
+      for the BGP policy.
+    - Immediately before a normal PXE restart, `WaitingForRebootToReady`
+      repeats the aggregate health and primary p0 checks. Instance deletion and
+      explicit custom iPXE requests bypass these checks.
+    - A live `UpdateInstanceConfig` request uses
+      `NetworkConfigUpdate/WaitingForConfigSynced`. This state waits for current
+      DPU observations and health alerts that prevent host state changes. It does
+      not apply the primary p0 PXE gate or restart the host.
     - During instance termination, one state in the state machine should wait until the machine is isolated from any other machine in the network. If this step is omitted (to let the machine proceed termination in the case of an unhealthy network fabric), the respective machine must at least be tagged with a health alert that would prevent a different tenant from using the host. Both options guarantee that no other tenant will get access to the tenants network partition.
 
 ### Machine Capabilities and Instance types
@@ -95,4 +107,3 @@ There needs to be a mechanism that periodically compares the expected networking
 
 - If an external fabric manager is used to observe interface state and set configuration, a client library in Rust is required.
 - Interactions with external fabric managers will require credentials. These should be read from the file system, and get injected via an external service (e.g. K8S secrets).
-

--- a/docs/architecture/state_machines/managedhost.md
+++ b/docs/architecture/state_machines/managedhost.md
@@ -441,7 +441,8 @@ stateDiagram-v2
 
     state "WaitingForNetworkSegmentToBeReady" as A_WaitingForNetworkSegmentToBeReady
     state "WaitingForNetworkConfig" as A_WaitingForNetworkConfig
-    state "WaitingForStorageConfig" as A_WaitingForStorageConfig
+    state "WaitingForStorageConfig (legacy recovery)" as A_WaitingForStorageConfig
+    state "WaitingForExtensionServicesConfig (legacy recovery)" as A_WaitingForExtensionServicesConfig
     state "WaitingForRebootToReady" as A_WaitingForRebootToReady
     state "Assigned/Ready" as A_Ready
     state "WaitingForDpusToUp" as A_WaitingForDpusToUp
@@ -456,6 +457,7 @@ stateDiagram-v2
         state "ReleaseOldResources" as A_NCU_ReleaseOldResources
     }
     state "HostPlatformConfiguration" as A_HostPlatformConfiguration {
+        state "FactoryResetBmc" as A_HPC_FactoryResetBmc
         state "PowerCycle" as A_HPC_PowerCycle
         state "UnlockHost" as A_HPC_UnlockHost {
             state "DisableLockdown" as A_HPC_UH_DisableLockdown
@@ -486,19 +488,23 @@ stateDiagram-v2
     A_WaitingForNetworkSegmentToBeReady --> A_WaitingForNetworkSegmentToBeReady : segments not ready
     A_WaitingForNetworkSegmentToBeReady --> A_WaitingForNetworkConfig : No segment OR segments ready
 
-    A_WaitingForNetworkConfig --> A_WaitingForNetworkConfig : Host network not synced on DPU
-    A_WaitingForNetworkConfig --> A_WaitingForStorageConfig : No DPU OR Host network synced on DPU
+    A_WaitingForNetworkConfig --> A_WaitingForNetworkConfig : An assigned provisioning gate is not ready
+    A_WaitingForNetworkConfig --> A_WaitingForRebootToReady : Deletion requested OR all assigned provisioning gates clear
 
-    A_WaitingForStorageConfig --> A_WaitingForRebootToReady : Attach storage volumes
-    A_WaitingForRebootToReady --> A_Ready : Reboot machine
+    A_WaitingForStorageConfig --> A_WaitingForExtensionServicesConfig : Recover a persisted legacy state
+    A_WaitingForExtensionServicesConfig --> A_WaitingForExtensionServicesConfig : Extension services not ready
+    A_WaitingForExtensionServicesConfig --> A_WaitingForRebootToReady : No managed DPU OR no configured services OR services ready
+    A_WaitingForRebootToReady --> A_WaitingForRebootToReady : Aggregate PreventHostStateChanges OR managed DPU PXE signal
+    A_WaitingForRebootToReady --> A_Ready : Readiness checks pass OR deletion or custom iPXE bypass; ForceRestart
 
     A_Ready --> A_NCU_WaitingForNetworkSegmentToBeReady : Update network request
-    A_Ready --> A_HPC_PowerCycle : (Instance deleted OR Host/DPU reporvisioning requested) AND need config bootorder
-    A_Ready --> A_WaitingForDpusToUp : (Instance deleted OR Host/DPU reporvisioning requested) AND not need config bootorder AND Power is Off
-    A_Ready --> A_BootingWithDiscoveryImage : (Instance deleted OR Host/DPU reporvisioning requested) AND not need config bootorder AND Power is On
+    A_Ready --> A_HPC_FactoryResetBmc : Instance deleted
+    A_Ready --> A_HPC_UH_DisableLockdown : Host or DPU reprovisioning, firmware update, or custom iPXE requested
+    A_HPC_FactoryResetBmc --> A_HPC_PowerCycle : Factory reset completes or is disabled
 
-    A_WaitingForDpusToUp --> A_BootingWithDiscoveryImage : DPUs UP-triggered
-    A_WaitingForDpusToUp --> A_WaitingForDpusToUp : Not DPUs UP-triggered
+    A_WaitingForDpusToUp --> A_WaitingForRebootToReady : DPUs ready or absent AND custom iPXE requested
+    A_WaitingForDpusToUp --> A_BootingWithDiscoveryImage : DPUs ready or absent AND no custom iPXE request
+    A_WaitingForDpusToUp --> A_WaitingForDpusToUp : Managed DPUs not ready
 
     A_BootingWithDiscoveryImage --> A_BootingWithDiscoveryImage : Retry reboot if needed
     A_BootingWithDiscoveryImage --> A_SwitchToAdminNetwork : If instance deleted
@@ -520,8 +526,8 @@ stateDiagram-v2
     A_NCU_WaitingForNetworkSegmentToBeReady --> A_NCU_WaitingForConfigSynced : No segments OR All ready
     A_NCU_WaitingForNetworkSegmentToBeReady --> A_NCU_WaitingForNetworkSegmentToBeReady : Not all segments ready
 
-    A_NCU_WaitingForConfigSynced --> A_NCU_ReleaseOldResources : No DPU OR DPU synced
-    A_NCU_WaitingForConfigSynced --> A_NCU_WaitingForConfigSynced : Wait for DPU synced
+    A_NCU_WaitingForConfigSynced --> A_NCU_ReleaseOldResources : No associated DPU OR observations synced with no aggregate PreventHostStateChanges
+    A_NCU_WaitingForConfigSynced --> A_NCU_WaitingForConfigSynced : Managed DPU observation not synced OR aggregate PreventHostStateChanges
     A_NCU_ReleaseOldResources --> A_Ready
 
     A_HPC_PowerCycle --> A_HPC_PowerCycle : Wait Power Off
@@ -555,6 +561,46 @@ stateDiagram-v2
     A_Failed --> A_HPC_SBO_SetBootOrder : BiosSetupFailed AND is_bios_setup ok
 ```
 
+### Network Readiness Gates
+
+During initial provisioning, `WaitingForNetworkConfig` waits for all required
+network configuration observations to match their desired versions. For a host
+with associated DPUs, it also waits for aggregate health alerts that prevent
+host state changes to clear. A host without associated DPUs skips both the DPU
+observation and aggregate health checks in this state.
+
+The normal agent report gives a p0 transport failure the combination of
+`BgpPeeringTor` and `PreventAllocations`. The PXE gate matches that probe ID and
+classification; it does not inspect the alert target. A host `Replace` report
+takes precedence for this check. Without one, the primary DPU `Replace` report
+takes precedence over that DPU's `Merge` reports. Refer to
+[DPU ToR Uplink Health](../../dpu-management/dpu_configuration.md#dpu-tor-uplink-health)
+for the uplink policy and classifications.
+
+`WaitingForRebootToReady` repeats the aggregate health and primary p0 checks
+immediately before the normal PXE `ForceRestart`. This closes the interval in
+which health can change after the configuration check. Hosts without managed
+DPUs skip this PXE signal check, including one supplied by a host `Replace`
+report, but still receive the aggregate health check. In
+`WaitingForNetworkConfig`, a host `Replace` report can supply the matching
+signal before NICo looks for a primary DPU, including on a host without managed
+DPUs.
+
+Normal success proceeds directly from `WaitingForNetworkConfig` to
+`WaitingForRebootToReady`. `WaitingForStorageConfig` and
+`WaitingForExtensionServicesConfig` remain only so NICo can recover hosts that
+persisted those states on an older release.
+
+The following requests bypass these readiness checks:
+
+- Instance deletion proceeds through its required restart without waiting for
+  network health.
+- An explicit custom iPXE request proceeds through its requested restart.
+
+A live network update uses `NetworkConfigUpdate/WaitingForConfigSynced`. A host
+with associated DPUs waits for current observations and aggregate health alerts
+that prevent host state changes. A host without associated DPUs skips both
+checks. This path does not apply the primary p0 PXE gate or restart the host.
 
 ## Host Reprovision State Details (HostReprovisionState)
 
@@ -672,7 +718,6 @@ stateDiagram-v2
     DR_RebootHost --> HostReprovision_HR_CheckingFirmware : if entered from Assigned AND host reprovision requested
     DR_RebootHost --> Assigned_A_Ready : if entered from Assigned AND host reprovision not requested
 ```
-
 
 ## WaitingForCleanup State Details
 

--- a/docs/dpu-management/dpu-lifecycle-management.md
+++ b/docs/dpu-management/dpu-lifecycle-management.md
@@ -19,7 +19,10 @@ NICo treats each managed host as a host server paired with one or more BlueField
 
 ### `dpu-agent`
 
-The DPU agent runs as a daemon on the DPU. In service names and logs it appears as `nico-dpu-agent`; in the documentation it is usually referred to as `dpu-agent`.
+The DPU agent runs as a daemon on the DPU. A systemd deployment uses
+`forge-dpu-agent.service`. A DPF deployment runs the `nico-dpu-agent` container,
+and centralized logs identify it as `nico-dpu-agent`. This documentation uses
+`dpu-agent` when the distinction does not matter.
 
 The agent periodically calls `GetManagedHostNetworkConfig` to fetch the desired configuration from NICo Core. It applies the configuration locally, runs health checks, and reports status back with `RecordDpuNetworkStatus`. The report includes applied configuration versions and DPU health.
 
@@ -125,9 +128,9 @@ Most DPU OS installation failures are diagnosed from the managed host state, `ni
 | Task exception or unknown state | Redfish | Unexpected Redfish task status. | Inspect the Redfish task messages in `nico-api` logs and confirm the BFB URL served by `nico-pxe`. |
 | rshim ownership conflict | rshim (SCP) | Host holds rshim and the DPU BMC cannot initiate the copy. | Use `--pre-copy-powercycle` when installing a fresh BFB via rshim to release host control first. |
 | DPU never becomes reachable after reboot | UEFI HTTP | DPU failed to PXE boot or kickstart failed. | Check `nico-pxe` logs for the DPU's PXE request. Verify the DPU boot order is set to UEFI HTTP. Check `nico-api` logs for the DPU BMC IP. |
-| Stuck in `WaitingForNetworkInstall` | UEFI HTTP | DPU booted but did not install the OS or `dpu-agent` did not start. | SSH to the DPU via its BMC/rshim and check `journalctl -fu nico-dpu-agent`. NICo reboots the DPU automatically if it does not appear within the reboot timeout. |
+| Stuck in `WaitingForNetworkInstall` | UEFI HTTP | DPU booted but did not install the OS or `dpu-agent` did not start. | SSH to a systemd DPU via its BMC or rshim and check `journalctl -fu forge-dpu-agent.service`. For DPF, inspect the `nico-dpu-agent` container logs. NICo reboots the DPU automatically if it does not appear within the reboot timeout. |
 
-For the manual rshim recovery command (which installs the preingestion BFB, not the NICo BFB) and additional pairing troubleshooting, see [DPU-Related Issues: Installing a Fresh DPU OS](../provisioning/ingesting-hosts.md#dpu-related-issues-installing-a-fresh-dpu-os). For the full DPU troubleshooting workflow, see [`WaitingForNetworkConfig` and DPU health](../playbooks/stuck_objects/waiting_for_network_config.md).
+For the manual rshim recovery command (which installs the preingestion BFB, not the NICo BFB) and additional pairing troubleshooting, see [DPU-Related Issues: Installing a Fresh DPU OS](../provisioning/ingesting-hosts.md#dpu-related-issues-installing-a-fresh-dpu-os). For the full DPU troubleshooting workflow, see [Waiting for Network Configuration and DPU Health](../playbooks/stuck_objects/waiting_for_network_config.md).
 
 ## Firmware Upgrades
 
@@ -194,9 +197,14 @@ After the DPU OS is installed, the `dpu-agent` keeps HBN configured by applying 
 
 ### Configuration Versioning
 
-Configuration is versioned. NICo maintains separate version numbers for `managedhost_network_config` (site controller lifecycle changes) and `instance_network_config` (tenant-driven changes). NICo only considers the DPU synchronized when the DPU reports the expected versions for both and reports itself healthy.
+Configuration is versioned. NICo maintains separate version numbers for `managedhost_network_config` (site controller lifecycle changes) and `instance_network_config` (tenant-driven changes). NICo considers the network configuration synchronized when the DPU reports the expected versions for both. Health classifications and primary p0 readiness determine whether normal instance provisioning can advance.
 
-After any configuration change, the `dpu-agent` raises a `PostConfigCheckWait` alert for approximately 30 seconds. This brief hold gives the DPU time to verify that the new configuration is stable (BGP sessions re-establish, services restart) before NICo treats it as applied.
+After an agent iteration changes HBN or reloads local DHCP in ContainerExec
+mode, `dpu-agent` adds a `PostConfigCheckWait` alert to one health report. NICo
+waits for the next health sample before it acts on the new configuration
+version. This is not a fixed timer. Refer to
+[DPU ToR Uplink Health](dpu_configuration.md#dpu-tor-uplink-health) for the
+complete behavior.
 
 ### Isolation Behavior
 
@@ -212,7 +220,7 @@ The `dpu-agent` runs periodic health checks and includes the results in every `R
 
 | Health probe | What it checks |
 |---|---|
-| BGP peering | Sessions established to all configured TOR and route server peers. |
+| BGP peering | p0 and p1 ToR transport sessions, route server peers, and FRR IPv6 unicast address families when required for FNN. |
 | Required services | Mandatory DPU services (HBN container, DHCP, etc.) are running. |
 | Restricted mode | DPU is not in an unexpected restricted mode. |
 | Disk utilization | DPU filesystem usage is below the configured threshold. |
@@ -223,9 +231,22 @@ The `dpu-agent` runs periodic health checks and includes the results in every `R
 
 NICo uses DPU health to gate state transitions and allocation:
 
-- If the DPU has not recently reported that it is up, healthy, and synchronized to the desired configuration, the managed host state does not advance.
+- If a required DPU has not reported a current observation, or its reported
+  versions do not match the desired configuration, the managed host state does
+  not advance.
 - If the health report contains alerts with the `PreventAllocations` classification, the host is not available for new tenant allocation.
+- Alerts with `PreventHostStateChanges` block the host transitions that enforce
+  that classification.
+- During normal instance provisioning, a p0 `BgpPeeringTor` transport alert also blocks
+  PXE readiness. A lone p1 failure does not prevent allocation or block host
+  state transitions.
 - If the `dpu-agent` stops sending reports entirely, NICo records a `HeartbeatTimeout` health alert against `nico-dpu-agent`.
+
+The ToR transport policy applies to both DPF agents that use NVUE and non-DPF
+agents that use FRR. The FRR path also checks IPv6 unicast negotiation when it
+is required for an FNN configuration with an IPv6 loopback. Refer to
+[DPU ToR Uplink Health](dpu_configuration.md#dpu-tor-uplink-health) for the
+configuration values, classifications, and transport state matrix.
 
 ### Investigating Unhealthy DPUs
 
@@ -233,7 +254,9 @@ When a DPU becomes unhealthy, inspect the managed host state and DPU health repo
 
 ```bash
 nico-admin-cli -a <api-url> managed-host show <machine-id>
-nico-admin-cli -a <api-url> machine network status
+nico-admin-cli -a <api-url> dpu network status
+nico-admin-cli -a <api-url> dpu network config --machine-id <dpu-machine-id>
+nico-admin-cli -a <api-url> dpu health-report show <dpu-machine-id>
 ```
 
 Key fields to check in the output:
@@ -242,7 +265,7 @@ Key fields to check in the output:
 - **Last seen**: when the DPU last reported to NICo. A stale timestamp suggests the DPU agent has crashed or the DPU is offline.
 - **State SLA**: if the host has been in its current state longer than the SLA, the output shows `In State > SLA: true` with the breach reason.
 
-For the full troubleshooting workflow, including how to check logs via Grafana/Loki, verify DPU liveliness, restart the agent, and diagnose specific health probe alerts, see [`WaitingForNetworkConfig` and DPU health](../playbooks/stuck_objects/waiting_for_network_config.md).
+For the full troubleshooting workflow, including how to check logs via Grafana/Loki, verify DPU liveliness, restart the agent, and diagnose specific health probe alerts, see [Waiting for Network Configuration and DPU Health](../playbooks/stuck_objects/waiting_for_network_config.md).
 
 ## DPU Reprovisioning
 

--- a/docs/dpu-management/dpu-lifecycle-management.md
+++ b/docs/dpu-management/dpu-lifecycle-management.md
@@ -128,9 +128,9 @@ Most DPU OS installation failures are diagnosed from the managed host state, `ni
 | Task exception or unknown state | Redfish | Unexpected Redfish task status. | Inspect the Redfish task messages in `nico-api` logs and confirm the BFB URL served by `nico-pxe`. |
 | rshim ownership conflict | rshim (SCP) | Host holds rshim and the DPU BMC cannot initiate the copy. | Use `--pre-copy-powercycle` when installing a fresh BFB via rshim to release host control first. |
 | DPU never becomes reachable after reboot | UEFI HTTP | DPU failed to PXE boot or kickstart failed. | Check `nico-pxe` logs for the DPU's PXE request. Verify the DPU boot order is set to UEFI HTTP. Check `nico-api` logs for the DPU BMC IP. |
-| Stuck in `WaitingForNetworkInstall` | UEFI HTTP | DPU booted but did not install the OS or `dpu-agent` did not start. | SSH to a systemd DPU via its BMC or rshim and check `journalctl -fu forge-dpu-agent.service`. For DPF, inspect the `nico-dpu-agent` container logs. NICo reboots the DPU automatically if it does not appear within the reboot timeout. |
+| Stuck in `WaitingForNetworkInstall` | UEFI HTTP | DPU booted but did not install the OS or `dpu-agent` did not start. | SSH to a systemd DPU through its BMC or rshim and check `journalctl -fu forge-dpu-agent.service`. For DPF, inspect the `nico-dpu-agent` container logs. NICo reboots the DPU automatically if it does not appear within the reboot timeout. |
 
-For the manual rshim recovery command (which installs the preingestion BFB, not the NICo BFB) and additional pairing troubleshooting, see [DPU-Related Issues: Installing a Fresh DPU OS](../provisioning/ingesting-hosts.md#dpu-related-issues-installing-a-fresh-dpu-os). For the full DPU troubleshooting workflow, see [Waiting for Network Configuration and DPU Health](../playbooks/stuck_objects/waiting_for_network_config.md).
+[DPU-Related Issues: Installing a Fresh DPU OS](../provisioning/ingesting-hosts.md#dpu-related-issues-installing-a-fresh-dpu-os) documents the manual rshim recovery command (which installs the preingestion BFB, not the NICo BFB) and additional pairing troubleshooting. For the full DPU troubleshooting workflow, refer to [Waiting for Network Configuration and DPU Health](../playbooks/stuck_objects/waiting_for_network_config.md).
 
 ## Firmware Upgrades
 
@@ -265,7 +265,7 @@ Key fields to check in the output:
 - **Last seen**: when the DPU last reported to NICo. A stale timestamp suggests the DPU agent has crashed or the DPU is offline.
 - **State SLA**: if the host has been in its current state longer than the SLA, the output shows `In State > SLA: true` with the breach reason.
 
-For the full troubleshooting workflow, including how to check logs via Grafana/Loki, verify DPU liveliness, restart the agent, and diagnose specific health probe alerts, see [Waiting for Network Configuration and DPU Health](../playbooks/stuck_objects/waiting_for_network_config.md).
+[Waiting for Network Configuration and DPU Health](../playbooks/stuck_objects/waiting_for_network_config.md) documents the full troubleshooting workflow. This workflow includes how to check logs using Grafana or Loki, verify DPU liveliness, restart the agent, and diagnose specific health probe alerts.
 
 ## DPU Reprovisioning
 

--- a/docs/dpu-management/dpu_configuration.md
+++ b/docs/dpu-management/dpu_configuration.md
@@ -16,14 +16,15 @@ The following guiding principles are for DPU configuration:
 
 ## Core Configuration Flow
 
-DPUs are configured by the NICo site controller via a **declarative** and **stateless** mechanism:
+The NICo site controller configures DPUs using a **declarative** and
+**stateless** mechanism:
 
-- The agent running on DPUs (`dpu-agent`) requests the current desired configuration via the `GetManagedHostNetworkConfig` gRPC API call. Example data of the returned configuration is provided in the [Appendix](#dpu-configuration-example) below.
-- Every configuration that is received from the site controller is converted into a [NVUE](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux/System-Configuration/NVIDIA-User-Experience-NVUE/) configuration file, which is then used to reconfigure HBN via the nvue CLI tool (`nv config apply`).
+- The agent running on DPUs (`dpu-agent`) requests the current desired configuration using the `GetManagedHostNetworkConfig` gRPC API call. Example response data is provided in the [Appendix](#dpu-configuration-example).
+- The agent converts each configuration from the site controller into an [NVUE](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux/System-Configuration/NVIDIA-User-Experience-NVUE/) configuration file. It then reconfigures HBN with the NVUE CLI tool (`nv config apply`).
 - The `dpu-agent` also reconfigures a DHCP server running on the DPU, which responds to DHCP requests from the attached host.
-- After HBN and the DHCP server are reconfigured, `dpu-agent` implements health-checks that supervise whether the desired configurations are in-place and check whether the DPU is healthy (e.g. the agent continuously checks whether the DPU has established BGP peering with TORs and route servers according to the desired configuration).
+- After HBN and the DHCP server are reconfigured, `dpu-agent` checks whether the desired configuration is in place and the DPU is healthy. The checks include BGP peering with top-of-rack (ToR) switches and route servers.
 - The `dpu-agent` uses the `RecordDpuNetworkStatus` gRPC API call to report back to the site control plane whether the desired configurations are applied, and whether all health checks are succeeding.
-- For the first 30s after any configuration change, the DPU reports itself as unhealthy with a `PostConfigCheckWait` alert. This gives the DPU some time to monitor the stability and health of the new configuration before the site controller assumes that the new configuration is fully applied and operational.
+- After an agent iteration changes HBN or reloads local DHCP in ContainerExec mode, the agent adds a `PostConfigCheckWait` alert to one health report. The controller waits for a fresh health sample before it advances the host lifecycle.
 
 ```mermaid
 sequenceDiagram
@@ -37,7 +38,7 @@ sequenceDiagram
         participant Dhcp as DHCP Server
     end
 
-    loop Every 30s
+    loop At each polling interval
         Agent->>NICo: GetManagedHostNetworkConfig()<br>Returns desired configs and versions
         Agent->>Nvue: Apply requested configuration
         Agent->>Dhcp: Reconfigure DHCP Server
@@ -45,6 +46,103 @@ sequenceDiagram
         Agent->>NICo: RecordDpuNetworkStatus()<br>Report applied config versions<br>Report DPU health
     end
 ```
+
+## DPU ToR Uplink Health
+
+The DPU agent expects two ordered HBN uplinks. The first uplink is the primary
+p0 interface, and the second is the redundant p1 interface. Health alert
+targets use the configured HBN interface names. Normal PXE boot depends on p0.
+
+Agents deployed with DOCA Platform Framework (DPF) query NVUE. Agents without
+DPF query FRR. Both paths apply the same policy to BGP transport sessions. The
+optional `min_dpu_functioning_links` field sets the minimum number of
+established transport sessions. Add it as a top-level key in the `nico-api`
+site configuration.
+
+`nico-api` reads this field when the process starts. Restart the `nico-api`
+Deployment after you change its site configuration ConfigMap. The chart adds a
+ConfigMap reloader annotation by default, so installations with that reloader
+restart the Deployment automatically.
+
+The field accepts an unsigned 32-bit integer. The following table describes
+each supported setting and the invalid configuration range:
+
+| Value | ToR Uplink Behavior |
+|---|---|
+| Unset | Uses the default value of `2`. |
+| `0` | Disables the p0 and p1 transport checks and their FRR IPv6 unicast negotiation checks. NVUE does not request BGP neighbor data. The agent emits no p0 PXE readiness signal. Other BGP and DPU health checks continue. |
+| `1` | Either established transport session satisfies the minimum. A p0 failure remains visible because PXE requires p0. A p1 transport failure is suppressed when p0 is established. |
+| `2` | Requires both sessions for a clean report. A lone p1 failure remains visible but does not block lifecycle progress. This value is the default. |
+| Greater than `2` | Produces a critical configuration health alert because the agent expects exactly two uplinks. The NVUE path uses `BgpPeeringTor`; the FRR path uses `BgpStats`. |
+
+No configuration change is required for this policy. A site using `1` can keep
+it to suppress a lone p1 transport alert. Remove the setting to restore the
+default p1 visibility. A lone p1 failure does not prevent allocation or block
+host state transitions with either setting.
+
+### Transport Session Policy
+
+Both paths treat a missing neighbor or a state other than `Established` as an
+unavailable uplink. NVUE also treats a missing state as an uplink finding. The
+FRR summary requires a state string, so missing or malformed summary data
+produces a critical `BgpStats` alert instead. The following table shows the
+resulting `BgpPeeringTor` alerts for valid transport data:
+
+| p0 Transport | p1 Transport | Minimum `1` | Minimum `2` |
+|---|---|---|---|
+| Established | Established | No alert | No alert |
+| Unavailable | Established | p0 alert with `PreventAllocations` | p0 alert with `PreventAllocations` |
+| Established | Unavailable | No alert | Unclassified p1 alert |
+| Unavailable | Unavailable | Both alerts with `PreventAllocations` and `PreventHostStateChanges` | Both alerts with `PreventAllocations` and `PreventHostStateChanges` |
+
+`PreventAllocations` keeps the host out of the allocation pool. On a p0
+transport alert, it also supplies the PXE readiness signal used during normal
+instance provisioning. The controller checks this signal before it leaves
+`WaitingForNetworkConfig` and immediately before the normal PXE restart in
+`WaitingForRebootToReady`.
+
+The final restart check also evaluates general
+`PreventHostStateChanges` alerts. Hosts without managed DPUs receive this
+general check but have no p0 check. Instance deletion and custom iPXE reboot
+paths bypass the final readiness check.
+
+The p0 check applies to the initial normal PXE flow. Live network updates do not
+use this PXE readiness gate.
+
+### FRR IPv6 Unicast Warnings
+
+For an FNN configuration with an IPv6 loopback, the non-DPF FRR path also checks
+whether required uplinks negotiated the IPv6 unicast address family. Other FRR
+configurations do not run this address family check. The DPF NVUE path checks
+transport state only.
+
+FRR reports an address family failure as a `BgpPeeringTor` alert whose message
+states that the session did not negotiate IPv6 unicast. This warning does not
+mean that the BGP transport session is unavailable. One address family warning
+is unclassified and does not supply the p0 PXE readiness signal.
+
+With a minimum of `1`, only p0 must negotiate IPv6 unicast. With a minimum of
+`2`, both uplinks must negotiate it. At `2`, if both uplinks have findings,
+including a mix of a transport failure and an address family warning, both
+alerts include `PreventAllocations` and `PreventHostStateChanges`.
+
+### Health Sampling After Configuration Changes
+
+When an agent iteration applies an actual HBN configuration change, it adds a
+critical `PostConfigCheckWait` alert to that iteration's health report. The
+alert includes `PreventAllocations` and `PreventHostStateChanges`. The
+controller therefore cannot accept the newly acknowledged network version from
+that same report. It waits for a later health report.
+
+This behavior is a report boundary, not a fixed timer. If the next iteration
+does not apply another configuration change, the agent removes the alert. When
+the uplink check is enabled and completes, the later report contains its current
+BGP result. With default agent settings, the active polling interval is 10
+seconds.
+
+On the NVUE path, only an actual HBN update triggers this alert. An accepted
+DHCP gRPC request does not trigger it by itself. On the ContainerExec path, an
+actual local HBN update or DHCP reload triggers the alert.
 
 ## Bootstrap CA Trust
 
@@ -114,8 +212,13 @@ NICo uses versioned immutable configuration data in order to detect whether any 
 
 The DPU configuration that is applied can be understood as coming from two different sources:
 
-* **Tenant configurations**: While the host is under control of a tenant, the tenant can change the desired overlay network configuration. The tenant can e.g. control from which VPC prefix an IP address should be allocated for a given network interface. They can also decide how many Virtual Function interfaces (VFs) are utilized, and what their configuration is.
-* **Site controller and host lifecycle**: During the lifecycle of a host, certain parts of the network configuration need to be updated. For example, when the host is provisioned for a tenant, the host networking gets reconfigured from using the admin overlay network towards the tenant overlay network. When the host is released by the tenant, it is moved back onto the admin network.
+- **Tenant configurations**: While a tenant controls the host, the tenant can
+  change the desired overlay network configuration. For example, the tenant can
+  select the VPC prefix and configure the virtual function (VF) interfaces.
+- **Site controller and host lifecycle**: The site controller updates parts of
+  the network configuration during the host lifecycle. Provisioning moves host
+  networking from the admin overlay to the tenant overlay. Release moves it
+  back to the admin overlay.
 
 In order to separate these concerns, NICo internally uses two different configuration data structs and associated version numbers (`instance_network_config` versus `managedhost_network_config`). It can thereby distinguish whether a setting that is required by the tenant has not been applied, compared to whether a setting that is required by the control plane has not been applied.
 

--- a/docs/operations/monitoring-health.md
+++ b/docs/operations/monitoring-health.md
@@ -273,21 +273,22 @@ Health report records exported over OTLP carry versioned routing fields, counts,
 
 Keep the following in mind when configuring health report records:
 
-* The per-target `include_alert_details` setting defaults to `false`. This omits `health_report.alerts` and `health_report.alerts.dropped`. Set `include_alert_details` to `true` on a `[[sinks.otlp.targets]]` entry to add `health_report.alerts` when the report has alerts.
+- The per-target `include_alert_details` setting defaults to `false`. This omits `health_report.alerts` and `health_report.alerts.dropped`. Set `include_alert_details` to `true` on a `[[sinks.otlp.targets]]` entry to add `health_report.alerts` when the report has alerts.
 
-* _The setting is per-target_. This means that, for example, a debugging destination can receive detail, while a long-term store receives the routing, count, and success evidence without needing to store free-form alert messages.
+- *The setting is per-target*. This means that, for example, a debugging destination can receive detail, while a long-term store receives the routing, count, and success evidence without needing to store free-form alert messages.
 
-* The JSON array in `health_report.alerts` contains the first 64 alerts in report order, each with `probe_id`, `message`, `classifications`, and `target` if the alert names one.
+- The JSON array in `health_report.alerts` contains the first 64 alerts in report order, each with `probe_id`, `message`, `classifications`, and `target` if the alert names one.
 
-* `health_report.alerts.dropped` appears only when details are enabled _and_ the report has more than 64 alerts. It contains the number of omitted alerts beyond those first 64.
+- `health_report.alerts.dropped` appears only when details are enabled *and* the report has more than 64 alerts. It contains the number of omitted alerts beyond those first 64.
 
-* Probe IDs use health API names: for example, OOB GPU inventory alerts appear as `SkuValidation` to deduplicate with the in-band SKU alerts.
+- Probe IDs use health API names: for example, OOB GPU inventory alerts appear as `SkuValidation` to deduplicate with the in-band SKU alerts.
 
 ## DPU Health Checks
 
 `dpu-agent` runs on managed DPUs and reports DPU health to NICo. The BlueField
-chart is named `nico-dpu-agent`. In service names and logs, the DPU agent
-currently appears as `forge-dpu-agent.service`.
+chart is named `nico-dpu-agent`. A systemd deployment uses
+`forge-dpu-agent.service`. A DPF deployment runs the `nico-dpu-agent` container,
+and centralized logs identify it as `nico-dpu-agent`.
 
 The agent checks DPU service health, networking state, HBN/NVUE configuration,
 DHCP behavior, BGP status, and heartbeat. DPU health is part of aggregate host
@@ -365,27 +366,45 @@ Common DPU alert IDs include:
 from the DPU agent. Check whether the DPU is powered, the agent is running, DPU
 time is correct, and the DPU can reach NICo.
 
+For `BgpPeeringTor`, start with the alert target and message. A p0 transport
+failure includes `PreventAllocations` and blocks normal PXE readiness. A lone
+p1 transport failure does not prevent allocation or block host state
+transitions. An FRR message that states the session did not negotiate IPv6
+unicast is an address family warning, not evidence that the transport session
+is down.
+
+`PostConfigCheckWait` is expected in one report after the agent changes HBN or
+reloads local DHCP in ContainerExec mode. It includes `PreventAllocations` and
+`PreventHostStateChanges`, then clears when the agent sends a fresh sample. If
+it appears in consecutive reports, check the DPU agent logs for repeated
+configuration applications.
+
+Refer to [DPU ToR Uplink Health](../dpu-management/dpu_configuration.md#dpu-tor-uplink-health)
+for the configuration values, classifications, and complete transport matrix.
+
 ### DPU Logs
 
-Use Loki to inspect DPU-agent logs:
+Use Loki to inspect DPU agent logs. Select the query for the deployment path:
 
 ```logql
 {systemd_unit="forge-dpu-agent.service", machine_id="<machine-id>"}
+{systemd_unit="nico-dpu-agent", machine_id="<machine-id>"}
 ```
 
-Alternative labels can be used when available:
+The hostname label can be used when the DPU has not learned its machine ID:
 
 ```logql
 {systemd_unit="forge-dpu-agent.service", host_name="<host-name>"}
+{systemd_unit="nico-dpu-agent", host_name="<host-name>"}
 ```
 
-On the DPU, use `journalctl` for direct service logs:
+On a systemd DPU, use `journalctl` for direct service logs:
 
 ```bash
 journalctl -u forge-dpu-agent.service -e --no-pager
 ```
 
-Restart the agent when required:
+Restart the systemd agent when required:
 
 ```bash
 systemctl restart forge-dpu-agent.service
@@ -742,6 +761,7 @@ Common Loki patterns:
 
 ```logql
 {systemd_unit="forge-dpu-agent.service", machine_id="<machine-id>"}
+{systemd_unit="nico-dpu-agent", machine_id="<machine-id>"}
 ```
 
 ```logql
@@ -800,6 +820,7 @@ For example:
 ```bash
 logcli query --since=1h '{k8s_container_name="nico-hardware-health"} |= "<machine-id>"'
 logcli query --since=1h '{systemd_unit="forge-dpu-agent.service"} |= "<machine-id>"'
+logcli query --since=1h '{systemd_unit="nico-dpu-agent"} |= "<machine-id>"'
 ```
 
 ### Dashboard Starting Points
@@ -824,7 +845,7 @@ Classifications.
 | Symptom | Check | Next action |
 |---|---|---|
 | Host is unhealthy with `PoweredOff` | Admin Web UI health page and hardware-health logs around `inAlertSince`. | Confirm BMC power state and whether the alert target is the expected BMC IP. |
-| Host is unhealthy with `HeartbeatTimeout` for `forge-dpu-agent` | `journalctl -u forge-dpu-agent.service -e --no-pager` and Loki query for the DPU agent. | Confirm the DPU is powered, time-synced, and able to reach NICo. Restart `forge-dpu-agent.service` only when service-level remediation requires it. |
+| Host is unhealthy with `HeartbeatTimeout` for the DPU agent | For systemd, use `journalctl -u forge-dpu-agent.service -e --no-pager`. For DPF, query the `nico-dpu-agent` logs in Loki. | Confirm the DPU is powered, its time is synchronized, and it can reach NICo. Restart the systemd service or DPF pod only when service remediation requires it. |
 | Host has active overrides | `nico-admin-cli machine health-override show <machine-id>` and the Health Overrides dashboard panel. | Verify the override reason is still valid. Remove temporary overrides after the condition ends. |
 | Health metrics are missing | `kubectl get servicemonitor -n nico-system` and the component-specific ServiceMonitor. | Enable the chart `serviceMonitor` block or fix the Prometheus selector/namespace match. |
 | Hardware-health logs do not show reports for a host | Loki query for `k8s_container_name="nico-hardware-health"` and the machine ID. | Confirm hardware-health is running, BMC discovery found the endpoint, and the collector is enabled for the source. |

--- a/docs/operations/monitoring-health.md
+++ b/docs/operations/monitoring-health.md
@@ -391,7 +391,7 @@ Use Loki to inspect DPU agent logs. Select the query for the deployment path:
 {systemd_unit="nico-dpu-agent", machine_id="<machine-id>"}
 ```
 
-The hostname label can be used when the DPU has not learned its machine ID:
+Use the hostname label when the DPU has not learned its machine ID:
 
 ```logql
 {systemd_unit="forge-dpu-agent.service", host_name="<host-name>"}

--- a/docs/playbooks/stuck_objects/dpu_provisioning_failures.md
+++ b/docs/playbooks/stuck_objects/dpu_provisioning_failures.md
@@ -56,24 +56,39 @@ Check:
 
 ### `WaitingForNetworkConfig`
 
-NICo blocks state advancement until the DPU agent reports:
+The parent state determines what this repeated substate name means:
 
-1. It is alive.
-2. It applied the latest desired network config version.
-3. Its DPU network health is acceptable.
+| State | Conditions that must clear |
+|---|---|
+| `DPUInit/WaitingForNetworkConfig` | Every DPU agent reports the current managed host network configuration version, and its own report has no `PreventHostStateChanges` alert. NICo can retry a reboot of the DPU being handled while it waits. |
+| `DPUReprovision/WaitingForNetworkConfig` | All reprovision targets reach this stage, all DPUs are up, and every DPU reports the current managed host network configuration version without `PreventHostStateChanges`. NICo can retry a reboot of the DPU being handled while it waits. |
+| `Assigned/WaitingForNetworkConfig` | Instance observations and versions, DPA acknowledgements, aggregate health, the normal PXE signal, InfiniBand, and NVLink satisfy the assigned host readiness policy. |
+
+The `DPUInit` and `DPUReprovision` forms inspect each DPU agent report directly.
+They do not use the assigned instance observation, primary p0 PXE, DPA,
+InfiniBand, or NVLink gates. For the assigned form and its final
+`WaitingForRebootToReady` check, use
+[Waiting for Network Configuration and DPU Health](waiting_for_network_config.md).
 
 ```bash
 nico-admin-cli managed-host show <host-machine-id>
-nico-admin-cli machine network status
-nico-admin-cli machine health-report show <dpu-machine-id>
+nico-admin-cli dpu network status
+nico-admin-cli dpu network config --machine-id <dpu-machine-id>
+nico-admin-cli dpu health-report show <dpu-machine-id>
 ```
 
-If `Last seen` is stale or `HeartbeatTimeout` is present, inspect the DPU
-directly:
+If `Last seen` is stale or `HeartbeatTimeout` is present, inspect the agent.
+On a systemd deployment, inspect the DPU directly:
 
 ```bash
-journalctl -u nico-dpu-agent.service -e --no-pager
+journalctl -u forge-dpu-agent.service -e --no-pager
 ```
+
+On a DPF deployment, use the `nico-dpu-agent` Loki selectors in
+[Inspect DPU Logs](waiting_for_network_config.md#inspect-dpu-logs).
+
+Refer to [DPU ToR Uplink Health](../../dpu-management/dpu_configuration.md#dpu-tor-uplink-health)
+for the uplink threshold, classifications, and primary p0 behavior.
 
 ### `DPUReprovision`
 
@@ -94,28 +109,40 @@ Common DPU probe alerts:
 | Probe | Meaning | First checks |
 |---|---|---|
 | `HeartbeatTimeout` | NICo has not received recent DPU agent health. | DPU booted, agent running, DPU can reach `nico-api`. |
-| `BgpStats` | BGP peering is not healthy. | HBN container, FRR/BGP status, TOR or route-server reachability. |
+| `BgpPeeringTor` | A targeted alert reports an unavailable or unusable ToR uplink. An untargeted NVUE alert reports neighbor retrieval or minimum link configuration failure. | For a target, check the p0 or p1 role, HBN session state, and physical link. Without a target, check the message, NVUE access, and `min_dpu_functioning_links`. |
+| `BgpPeeringRouteServer` | A route server session is not established. | Route server reachability, address, and HBN session state. |
+| `BgpStats` | The FRR health path found a collection, parsing, configuration, or summary validation error. | Alert message, HBN container, FRR output, and `min_dpu_functioning_links`. |
+| `PostConfigCheckWait` | NICo is waiting for the first fresh health sample after an HBN change or ContainerExec DHCP reload. | Recent local configuration change and the following agent report. |
 | `ServiceRunning` | Required DPU service is down. | `crictl ps`, systemd status, HBN logs. |
 | `DhcpRelay` / `DhcpServer` | Host-facing DHCP path is broken. | DPU agent logs, HBN, DHCP relay/server config. |
 
+The agent adds `PostConfigCheckWait` to one health report when it applies a
+changed HBN configuration. The alert makes NICo wait for the following health
+report. It is not a timer with a fixed duration. With the default agent polling
+interval, the fresh report usually arrives on the next 10-second loop. If the
+alert appears in consecutive reports, check whether the agent repeatedly
+applies the same HBN configuration or, in ContainerExec mode, reloads local
+DHCP. The ContainerExec path adds this alert after an actual local HBN change
+or DHCP reload.
+
 ## DPU Console and Logs
 
-If SSH to the DPU works:
+On a systemd deployment, if SSH to the DPU works:
 
 ```bash
 ssh <dpu-oob-ip>
-journalctl -u nico-dpu-agent.service -e --no-pager
+journalctl -u forge-dpu-agent.service -e --no-pager
 ```
 
 If SSH fails, use DPU BMC or rshim access and check whether the DPU OS booted.
 
-Useful on-DPU checks:
+Useful on-DPU checks for a systemd deployment:
 
 ```bash
-systemctl status nico-dpu-agent.service
-journalctl -u nico-dpu-agent.service -e --no-pager
+systemctl status forge-dpu-agent.service
+journalctl -u forge-dpu-agent.service -e --no-pager
 sudo crictl ps
-sudo crictl exec -ti $(sudo crictl ps | grep doca-hbn | awk '{print $1}') vtysh -c 'show bgp summary'
+sudo crictl exec -ti <doca-hbn-container-id> vtysh -c 'show bgp summary'
 ```
 
 ## Mitigations
@@ -124,8 +151,9 @@ Use the least disruptive mitigation that addresses the root cause.
 
 | Situation | Mitigation |
 |---|---|
-| DPU agent is stopped | `systemctl restart nico-dpu-agent.service` |
-| Unit files changed | `systemctl daemon-reload && systemctl restart nico-dpu-agent.service` |
+| DPU agent is stopped and disabled | `sudo systemctl enable --now forge-dpu-agent.service` |
+| DPU agent is unresponsive | `sudo systemctl restart forge-dpu-agent.service` |
+| Unit files changed | Run `sudo systemctl daemon-reload`, then `sudo systemctl restart forge-dpu-agent.service`. |
 | DPU is unresponsive | Power cycle host only after confirming tenant or operator impact. |
 | Reprovision stuck | `nico-admin-cli dpu reprovision restart --id <host-machine-id>` |
 | False health blocker | Add a temporary override only with incident context and remove it after recovery. |

--- a/docs/playbooks/stuck_objects/dpu_provisioning_failures.md
+++ b/docs/playbooks/stuck_objects/dpu_provisioning_failures.md
@@ -58,8 +58,8 @@ Check:
 
 The parent state determines what this repeated substate name means:
 
-| State | Conditions that must clear |
-|---|---|
+| Parent state | Conditions that must clear |
+| ------------ | -------------------------- |
 | `DPUInit/WaitingForNetworkConfig` | Every DPU agent reports the current managed host network configuration version, and its own report has no `PreventHostStateChanges` alert. NICo can retry a reboot of the DPU being handled while it waits. |
 | `DPUReprovision/WaitingForNetworkConfig` | All reprovision targets reach this stage, all DPUs are up, and every DPU reports the current managed host network configuration version without `PreventHostStateChanges`. NICo can retry a reboot of the DPU being handled while it waits. |
 | `Assigned/WaitingForNetworkConfig` | Instance observations and versions, DPA acknowledgements, aggregate health, the normal PXE signal, InfiniBand, and NVLink satisfy the assigned host readiness policy. |

--- a/docs/playbooks/stuck_objects/waiting_for_network_config.md
+++ b/docs/playbooks/stuck_objects/waiting_for_network_config.md
@@ -10,14 +10,14 @@ normal PXE boot path during initial instance provisioning.
 continue:
 
 1. The DPU agents acknowledge the current managed host network configuration.
-2. Enabled DPA interfaces acknowledge their current configuration.
-3. Each required DPU reports an instance network observation with the desired
+1. Enabled DPA interfaces acknowledge their current configuration.
+1. Each required DPU reports an instance network observation with the desired
    version.
-4. For a host with associated DPUs, the aggregate health report has no alert
+1. For a host with associated DPUs, the aggregate health report has no alert
    that prevents host state changes.
-5. The primary p0 ToR session has no `BgpPeeringTor` alert with
+1. The primary p0 ToR session has no `BgpPeeringTor` alert with
    `PreventAllocations`.
-6. The required InfiniBand and NVLink configurations are synchronized.
+1. The required InfiniBand and NVLink configurations are synchronized.
 
 `WaitingForRebootToReady` repeats the aggregate health and primary p0 checks
 immediately before the normal PXE `ForceRestart`. This second check catches a

--- a/docs/playbooks/stuck_objects/waiting_for_network_config.md
+++ b/docs/playbooks/stuck_objects/waiting_for_network_config.md
@@ -1,236 +1,243 @@
-# `WaitingForNetworkConfig` and DPU health
+# Waiting for Network Configuration and DPU Health
 
-Whenever the configuration of a ManagedHost changes (Instance gets created,
-Instance gets deleted, Provisioning), NICo requires the `nico-dpu-agent` to
-acknowledge that the desired DPU configuration is applied and that the DPU and
-services running on it (like `HBN`) are in a healthy state.
+Use this playbook when an assigned managed host waits in
+`WaitingForNetworkConfig` or `WaitingForRebootToReady`. These states protect the
+normal PXE boot path during initial instance provisioning.
 
-This feedback mechanism works in the following fashion:
-1. `nico-dpu-agent` periodically calls `GetManagedHostNetworkConfig`. It thereby
-   obtains the latest configuration for all interfaces, including the configuration
-   which states whether the Host should get attached to an admin or tenant network.
-   The configuration includes Version numbers, which increase whenever the
-   configuration changes.
-2. `nico-dpu-agent` reports the version numbers of the currently applied
-   configurations back to NICo using the `RecordDpuNetworkStatus` API.
-   This report also includes the DPUs health in the form of a `HealthReport`.
+## Readiness Checks
 
-If the DPU has not recently reported that it is up, healthy and that the latest
-desired configuration is applied, the state will not be advanced.
+`WaitingForNetworkConfig` evaluates these conditions before provisioning can
+continue:
 
-If a ManagedHost is stuck due to this check, you can inspect which condition is
-not met by inspecting the last report from the Host and DPUs
-- via nico-admin-cli:
-  - ```
-    nico-admin-cli managed-host show fm100psa0aqpqvll7vi4jfrvtqv058mo8ifb0vtg761j06sqhq466b0slmg
-    ```
-  - ```
-    nico-admin-cli machine show fm100psa0aqpqvll7vi4jfrvtqv058mo8ifb0vtg761j06sqhq466b0slmg
-    ```
-  - ```
-    nico-admin-cli machine show fm100dsa0aqpqvll7vi4jfrvtqv058mo8ifb0vtg761j06sqhq466b0slmg
-    ```
-  - ```
-    nico-admin-cli machine network status
-    ```
+1. The DPU agents acknowledge the current managed host network configuration.
+2. Enabled DPA interfaces acknowledge their current configuration.
+3. Each required DPU reports an instance network observation with the desired
+   version.
+4. For a host with associated DPUs, the aggregate health report has no alert
+   that prevents host state changes.
+5. The primary p0 ToR session has no `BgpPeeringTor` alert with
+   `PreventAllocations`.
+6. The required InfiniBand and NVLink configurations are synchronized.
 
-E.g. in the following report
-```
-/opt/nico/nico-admin-cli managed-host show fm100psa0aqpqvll7vi4jfrvtqv058mo8ifb0vtg761j06sqhq466b0slmg
-Hostname    : 192-168-18-95
-State       : DPUInitializing/WaitingForNetworkConfig
-    Time in State : 296 days and 29 minutes
-    State SLA     : 30 minutes
-    In State > SLA: true
-    Reason        : The object is in the state for longer than defined by the SLA. Handler outcome: Wait("Waiting for DPU agent to apply network config and report healthy network for DPU fm100dsa0aqpqvll7vi4jfrvtqv058mo8ifb0vtg761j06sqhq466b0slmg")
+`WaitingForRebootToReady` repeats the aggregate health and primary p0 checks
+immediately before the normal PXE `ForceRestart`. This second check catches a
+health change that occurs after the network configuration check.
 
-Host:
-----------------------------------------
-  ID                    : fm100psa0aqpqvll7vi4jfrvtqv058mo8ifb0vtg761j06sqhq466b0slmg
-  Memory                : Unknown
-  Admin IP              : 192.168.18.95
-  Admin MAC             : B8:3F:D2:B7:70:64
-  Health
-    Probe Alerts        : HeartbeatTimeout [Target: nico-dpu-agent]:
-    Overrides
-  BMC
-    Version             : Unknown
-    Firmware Version    : Unknown
-    IP                  : Unknown
-    MAC                 : Unknown
+The following paths have different behavior:
 
-DPU0:
-----------------------------------------
-  ID                    : fm100dsa0aqpqvll7vi4jfrvtqv058mo8ifb0vtg761j06sqhq466b0slmg
-  State                 : DPUInitializing/WaitingForNetworkConfig
-  Primary               : true
-  Failure details       : Unknown
-  Last reboot           : 2023-12-13 16:38:08.180734 UTC
-  Last reboot requested : Unknown/
-  Last seen             : 2023-12-13 17:24:15.454965 UTC
-  Serial Number         : MT2244XZ022R
-  BIOS Version          : BlueField:3.9.3-7-g8f2d8ca
-  Admin IP              : 192.168.134.233
-  Admin MAC             : B8:3F:D2:B7:70:72
-  BMC
-    Version             : 1
-    Firmware Version    : 2.08
-    IP                  : 192.168.134.234
-    MAC                 : B8:3F:D2:B7:70:66
-  Health
-    Probe Alerts        : HeartbeatTimeout [Target: nico-dpu-agent]: No health data was received from DPU
+- A host without associated DPUs skips DPU observations and aggregate health in
+  `WaitingForNetworkConfig`. It still receives the aggregate health check before
+  the normal restart.
+- Instance deletion bypasses the network wait and both final readiness checks.
+- An explicit custom iPXE request bypasses both final readiness checks.
+- A live network update uses `NetworkConfigUpdate/WaitingForConfigSynced`. A
+  host with associated DPUs waits for current observations and aggregate
+  health. A host without associated DPUs skips both checks. This path does not
+  apply the p0 PXE gate or restart the host.
+
+Refer to
+[DPU ToR Uplink Health](../../dpu-management/dpu_configuration.md#dpu-tor-uplink-health)
+for the uplink threshold, alert visibility, and classifications.
+
+## Inspect the Wait Condition
+
+Collect the managed host state, network observations, and effective health
+reports:
+
+```bash
+nico-admin-cli managed-host show <host-machine-id>
+nico-admin-cli dpu network status
+nico-admin-cli dpu network config --machine-id <dpu-machine-id>
+nico-admin-cli dpu health-report show <dpu-machine-id>
+nico-admin-cli machine health-report show <host-machine-id>
 ```
 
-- The `Health` field indicates whether any of the health checks failed. In this case we can see an alert of the `HeartbeatTimeout` probe - with target `nico-dpu-agent`. That indicates no
-  `HealthReport` had been received from `nico-dpu-agent` via a `RecordDpuNetworkStatus`
-  API call for a certain amount of time.
-- The aggregate `Health` of a Host is the aggregation of Health states from
-  monitoring by `nico-dpu-agent`, out of band BMC monitoring (`hardware-health`),
-  and the results of validation tests. If the health check failure also shows up
-  in the `Health` field of the DPU, then the failure is related to the DPU,
-  and/or has been reported by `nico-dpu-agent`.
-  If a health-check has failed, then the root-caused for the failed health-check
-  needs to be remediated.
-- "Last seen" indicates whether the DPU (and `nico-dpu-agent`) is up and running.
-  If the timestamp is too old, it might indicate the DPU agent has crashed or the
-  whole DPU is no longer online. In such a case a `HeartbeatTimeout` alert on the
-  DPU and Host would be raised too.
+The DPU network configuration shows the desired managed host and instance
+versions. The status view shows the last observed versions and DPU agent health.
+The health report commands show the sources and whether each uses `Merge` or
+`Replace`.
 
-The network status details show:
-```
-/opt/nico/nico-admin-cli machine network status
-+-------------------------+-------------------------------------------------------------+------------------------+----------+--------------------------------------------+---------------------------------+
-| Observed at             | DPU machine ID                                              | Network config version | Healthy? | Health Probe Alerts                        | Agent version                   |
-+=========================+=============================================================+========================+==========+============================================+=================================+
-| 2023-12-13 17:24:15.454 | fm100dsa0aqpqvll7vi4jfrvtqv058mo8ifb0vtg761j06sqhq466b0slmg | V2-T1702485344893918   | false    | HeartbeatTimeout [Target: nico-dpu-agent] | v2023.12-rc1-43-g3322d125f      |
-+-------------------------+-------------------------------------------------------------+------------------------+----------+--------------------------------------------+---------------------------------+
-```
+The persisted handler reason identifies the active gate:
 
-In this case we learn that the DPU was alive before, and acknowledged network config version `V2-T1702485344893918`. This is still the desired network configuration version for
-this DPU. The target configuration for a DPU can be found on the `Network Config` block the DPU page in the admin Web UI.
+| Wait Reason | Interpretation |
+|---|---|
+| `Waiting for DPU agent(s) to apply network config and report healthy network` | A managed host configuration version has not synchronized. |
+| `Waiting for DPU agents to apply initial network config for DPUs: <comma-separated DPU IDs>` | One or more required DPU observations are missing. |
+| `Waiting for DPU agent to apply most recent network config for DPUs: <comma-separated DPU IDs>` | A DPU observation reports an older version. |
+| `Waiting for lifecycle-blocking host health alerts to clear before PXE reboot` | An effective alert has `PreventHostStateChanges`. |
+| `Waiting for the primary DPU p0 BGP session to be established` | The effective primary p0 alert has `PreventAllocations`. |
 
-The summary for this example is that the Machine is stuck because the DPU
-- is either not healthy at all (e.g. not booted)
-- is not running `nico-dpu-agent`
-- `nico-dpu-agent` is not reporting back to NICo
+Check these fields together:
 
-## Follow-up investigation steps
+- `Last seen` shows when NICo last received a DPU agent report.
+- The desired and observed configuration versions show whether the agent has
+  acknowledged current intent.
+- The alert ID, target, message, and classifications show whether health blocks
+  the current transition.
+- Health report sources and apply modes show which report is effective.
 
-### Checking DPU liveliness
+The PXE gate matches the `BgpPeeringTor` probe ID together with
+`PreventAllocations`; it does not inspect the target. The agent uses that
+combination for a p0 transport failure. A host `Replace` report overrides all
+DPU reports for this check. Without a host `Replace` report, the primary DPU
+`Replace` report overrides its `Merge` reports. If no `Replace` report exists,
+any primary DPU `Merge` report can add the signal. In
+`WaitingForNetworkConfig`, a host `Replace` report can supply it even on a host
+without managed DPUs. `WaitingForRebootToReady` skips this special check on a
+host without managed DPUs, but still checks aggregate `PreventHostStateChanges`.
+Refer to
+[Health Report Overrides](../../architecture/health_aggregation.md#health-report-overrides)
+before changing an override.
 
-Operators can try SSHing to the DPU, using the DPU OOB address that is shown
-on ManagedHost pages and DPU details pages.
-If SSH fails, the DPU might not be up and running.
+## Diagnose Health Alerts
 
-If directly SSHing to the DPU does not work, it can be accessed via its BMC
-and rshim to investigate its state.
+### `BgpPeeringTor`
 
-{/* TODO: Document the BMC path */}
+A targeted `BgpPeeringTor` alert identifies an unavailable or unusable physical
+ToR uplink. The target identifies p0 or p1. Depending on the HBN version, the
+target uses `p0_if` and `p1_if` or the legacy `p0_sf` and `p1_sf` names. An
+untargeted alert on the NVUE path indicates a neighbor retrieval failure or a
+minimum link configuration greater than the two expected uplinks. Follow its
+message before investigating a physical link.
 
-### Checking DPU agent logs
+When uplink checking is enabled, a primary p0 transport failure with
+`PreventAllocations` blocks normal PXE even when p1 is established. When p0
+remains established, a secondary p1 alert can remain visible without blocking
+provisioning. If both transport sessions are unavailable, the alerts also
+prevent host state changes.
 
-In case the DPU is running, `nico-dpu-agent` logs can be inspected in order to
-learn why it can not communicate with nico, or why the configuration application
-might have failed. There are various options for this.
+For an FNN configuration with an IPv6 loopback, the FRR health path can use the
+same probe for an IPv6 unicast negotiation warning. This warning is distinct
+from a transport session failure. Inspect the message and classifications
+instead of relying on the probe ID alone.
 
-#### Checking logs via Grafana & Loki
+Inspect HBN session state on the DPU:
 
-nico-dpu-agent logs are forwarded via OpenTelemetry to the site controller logging
-infrastructure. They can be queried from there via Loki.
-
-Search strings for DPU can be:
-```
-{systemd_unit="nico-dpu-agent.service", machine_id="fm100ds006eliqt3u4h65ou9ebrqfq9th2jf39qqki68k9ueu2amearv47g"}
-{systemd_unit="nico-dpu-agent.service", host_name="192-168-155-135.nico.example.org"}
-```
-
-**Note that the query using the MachineId will only work if the DPU once had been fully ingested
-and is aware of its Machine ID. Otherwise only searches by `host_name` will work.**
-
-In case the DPU problem affects log forwarding, DPU logs need to be checked directly on the DPU.
-
-#### Checking logs on the DPU:
-
-The dpu agent logs are stored in the systemd journal on the DPU.
-They can be queried using
-```
-journalctl -u nico-dpu-agent.service -e --no-pager
+```bash
+sudo crictl ps
+sudo crictl exec -ti <doca-hbn-container-id> vtysh -c 'show bgp summary'
 ```
 
-### Checking additional logs
+Restore the p0 session before retrying normal PXE provisioning. Setting the
+minimum healthy link count to `1` does not remove the p0 dependency.
 
-Depending on the problems that are found in dpu-agent logs, it can be useful
-to check other logs that are available on the DPU. Examples are
-- `nl2doca` logs: `{machine_id="fm100ds02e5g65099ov37rmho1gnge0c99ihdisvluo4fls1ba3br9bksg0", log_file_path="/var/log/doca/hbn/nl2docad.log"}`
-- `syslog`: `{machine_id="fm100ds02e5g65099ov37rmho1gnge0c99ihdisvluo4fls1ba3br9bksg0", log_file_path="/var/log/doca/hbn/syslog"}`
-- `nvue` logs
-- `frr` logs
+### `BgpPeeringRouteServer` and `BgpStats`
 
-## Potential Mitigations
+`BgpPeeringRouteServer` identifies a route server session that is not
+established. Check route server reachability, peer configuration, and the HBN
+session state.
 
-### Power Cycling the Host
-
-**⚠️ Note that while a tenant uses a Machine as an instance, powercycling the Host will interrupt
-their workloads. Only perform these step if its clear that the Tenant no longer requires the Machine (is stuck in termination), or if the Tenant agrees with this action.**
-
-If the DPU is unresponsive, powering off the Host and back on can help. This will
-restart the DPU.
-
-The Host can be powercycled using the Explored-Endpoint view in the Admin Web UI, The DPU Machine details page will link to the explored endpoint by clicking on the DPU BMC IP.
-
-### Restarting nico-dpu-agent
-
-If nico-dpu-agent is not even started, then it needs to be started (`systemctl enable nico-dpu-agent.service`).
-This should however never be necessary, since the agent gets restarted on all
-crashes.
-
-If `nico-dpu-agent` should just be restarted, use
-```
-systemctl restart nico-dpu-agent.service
-```
-
-### Reloading nico-dpu-agent configurations
-
-In rare situations, it might be useful to restart nico-dpu-agent using latest
-dpu-agent systemd config files. To do so:
-```
-systemctl daemon-reload
-systemctl restart nico-dpu-agent.service
-```
-
-## Mitigations for specific Health Probe Alerts
-
-### `BgpStats`
-
-The BgpStats health probe indicates that BGP peering with the TOR or route server
-is not successful. This might either indicate a link issue or a configuration issue.
-The BGP details can be checked on the DPU using
-```
-sudo crictl exec -ti $(sudo crictl ps |grep doca-hbn |awk '{print $1}') vtysh -c 'show bgp summary'
-```
-
-{/* TODO: Provide more details on the next steps here */}
-
-### `ServiceRunning`
-
-Indicates that mandatory DPU services are not running. Next steps in the investigation
-can be to check whether the HBN container is running on the DPU (`crictl ps` should
-show `doca-hbn` container), and to search for associated logs.
-
-### `DhcpRelay`/`DhcpServer`
-
-Indicates that the DHCP Relay or Server that NICo deploys on the DPU in order
-to respond to the DHCP requests from the Host are not running as intended.
-In these conditions, the Host would not be able to boot since nothing would respond
-to the DHCP request.
-
-Next steps in the investigation would be to check `nico-dpu-agent` logs for details.
+`BgpStats` means the FRR health path found a collection, parsing, configuration,
+or summary validation error that is not represented by a targeted peer alert.
+It does not identify a specific ToR session failure. Check the alert message,
+HBN container, FRR command output, and `min_dpu_functioning_links` value.
 
 ### `PostConfigCheckWait`
 
-This alert is only raised for a brief time after each configuration change in order
-to wait for the configuration to settle on the DPU. The alert should always settle
-down after less than a minute. In case the alert keeps raised, it can indicate
-that new configurations are applied in every dpu-agent eventloop iteration. In this
-case it would need to be debugged what in the configurations changed, and the
-source of the unnecessary configuration changes would need to be fixed.
+The DPU agent adds `PostConfigCheckWait` to one health report when it applies a
+changed HBN configuration. The agent publishes the acknowledged configuration
+version with that report. The immediate BGP sample can still reflect the state
+from before the HBN change has converged.
+
+The alert has `PreventAllocations` and `PreventHostStateChanges`, which makes
+NICo wait for the next health report. It is not a timer with a fixed duration.
+
+The default active agent loop is 10 seconds, so the fresh report usually arrives
+on the following loop. The DPF path uses NVUE and triggers this alert only for
+an actual HBN change. The ContainerExec path also triggers it after an actual
+local HBN change or DHCP reload.
+
+If the alert appears in consecutive reports, check whether the agent repeatedly
+applies HBN configuration or, in ContainerExec mode, reloads local DHCP.
+Compare desired and observed versions, then inspect the DPU agent log around
+each configuration operation.
+
+### `HeartbeatTimeout`
+
+`HeartbeatTimeout` means NICo has not received recent DPU agent health. Compare
+`Last seen` with the current time. Then check DPU power, agent status, and
+connectivity to `nico-api`.
+
+### `ServiceRunning`, `DhcpRelay`, and `DhcpServer`
+
+`ServiceRunning` identifies a required DPU service that is not running. Inspect
+systemd and the HBN container. `DhcpRelay` and `DhcpServer` identify failures on
+the host DHCP path, which can prevent PXE from receiving boot instructions.
+
+## Inspect DPU Logs
+
+Search the DPU agent logs in Loki with the DPU machine ID or hostname. The
+systemd deployment uses `forge-dpu-agent.service`; the DPF container uses
+`nico-dpu-agent`:
+
+```logql
+{systemd_unit="forge-dpu-agent.service", machine_id="<dpu-machine-id>"}
+{systemd_unit="nico-dpu-agent", machine_id="<dpu-machine-id>"}
+{systemd_unit="forge-dpu-agent.service", host_name="<dpu-hostname>"}
+{systemd_unit="nico-dpu-agent", host_name="<dpu-hostname>"}
+```
+
+The machine ID query works only after the DPU has completed enough ingestion to
+learn its ID. Use the hostname query earlier in ingestion.
+
+Use the HBN log that matches the failed path:
+
+| Path | DPU log | What to inspect |
+|---|---|---|
+| DPF and NVUE | `/var/log/doca/hbn/nvued.log` | NVUE requests, revisions, and neighbor data. |
+| FRR | `/var/log/doca/hbn/frr/frr.log` | Session transitions and peer errors. |
+| Netlink to DOCA | `/var/log/doca/hbn/nl2docad.log` | Interface and route programming failures. |
+| HBN system log | `/var/log/doca/hbn/syslog` | Service startup and shared HBN errors. |
+
+These files are also available in Loki. Filter the DPU stream by its
+`log_file_path` label, or use `{component="hbn"}` and search for the subsystem
+name. For example:
+
+```logql
+{component="hbn", log_file_path="/var/log/doca/hbn/nl2docad.log"}
+```
+
+If log forwarding is unavailable, connect to the DPU using SSH, its BMC, or
+rshim. On a systemd deployment, inspect the local service and container state:
+
+```bash
+systemctl status forge-dpu-agent.service
+journalctl -u forge-dpu-agent.service -e --no-pager
+sudo crictl ps
+```
+
+## Apply a Mitigation
+
+Use the least disruptive action that corrects the observed failure. On a
+systemd deployment, enable a stopped and disabled agent, restart an unresponsive
+agent, or reload changed unit files:
+
+```bash
+# Start the agent now and on subsequent boots.
+sudo systemctl enable --now forge-dpu-agent.service
+
+# Restart an agent that is running but unresponsive.
+sudo systemctl restart forge-dpu-agent.service
+
+# Load changed unit files before restarting the agent.
+sudo systemctl daemon-reload
+sudo systemctl restart forge-dpu-agent.service
+```
+
+For other failures:
+
+- Restore the failed p0 link or BGP session before normal PXE provisioning.
+- Power cycle the host only after confirming the workload impact with the
+  tenant or operator. Use the host BMC UI or the following command:
+
+  ```bash
+  nico-admin-cli redfish --address <host-bmc-ip> ac-power-cycle
+  ```
+
+- Use a health `Replace` override only with incident context. Remove it after
+  recovery because it masks the reports that it replaces.
+
+Do not change `min_dpu_functioning_links` as a substitute for repairing p0. A
+value of `1` changes redundant p1 reporting, but p0 remains required for normal
+PXE. A value of `0` disables ToR uplink health checks, including the p0 readiness
+signal.

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -25920,8 +25920,11 @@ type ManagedHostNetworkConfigResponse struct {
 	EnableDhcp bool `protobuf:"varint,100,opt,name=enable_dhcp,json=enableDhcp,proto3" json:"enable_dhcp,omitempty"`
 	// Host primary interface id
 	HostInterfaceId *string `protobuf:"bytes,102,opt,name=host_interface_id,json=hostInterfaceId,proto3,oneof" json:"host_interface_id,omitempty"`
-	// temporary flag for telling a DPU how many links it needs to have up to be considered healthy.
-	// if not set, all links must be up.
+	// Minimum number of functioning DPU ToR links. The default is two. Zero
+	// disables ToR uplink health checks, one allows either link to satisfy the
+	// minimum, and values above two produce a configuration health alert. When
+	// checks are enabled, a failed primary link is still reported because PXE
+	// boot depends on it.
 	MinDpuFunctioningLinks *uint32 `protobuf:"varint,103,opt,name=min_dpu_functioning_links,json=minDpuFunctioningLinks,proto3,oneof" json:"min_dpu_functioning_links,omitempty"`
 	// Is it a primary DPU
 	IsPrimaryDpu bool `protobuf:"varint,104,opt,name=is_primary_dpu,json=isPrimaryDpu,proto3" json:"is_primary_dpu,omitempty"`

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -4671,8 +4671,11 @@ message ManagedHostNetworkConfigResponse {
   // Host primary interface id
   optional string host_interface_id = 102;
 
-  // temporary flag for telling a DPU how many links it needs to have up to be considered healthy.
-  // if not set, all links must be up.
+  // Minimum number of functioning DPU ToR links. The default is two. Zero
+  // disables ToR uplink health checks, one allows either link to satisfy the
+  // minimum, and values above two produce a configuration health alert. When
+  // checks are enabled, a failed primary link is still reported because PXE
+  // boot depends on it.
   optional uint32 min_dpu_functioning_links = 103;
 
   // Is it a primary DPU


### PR DESCRIPTION
## Summary

PR #5218 corrected DPU ToR health policy and closed two gaps before normal PXE provisioning: NICo now waits for a later health report after HBN changes and checks the primary p0 BGP signal again immediately before restart. Existing documentation still described the old binary health behavior, a fixed settling delay, and stale lifecycle transitions.

This change makes DPU configuration the canonical policy reference and reconciles the configuration tables, health probe descriptions, lifecycle diagrams, monitoring guidance, and troubleshooting playbooks. It also updates the protobuf source comment and regenerates its REST API mirrors.

No operator configuration change is required. Sites that set `min_dpu_functioning_links = 1` can keep it to suppress a redundant p1 alert, or remove it to restore the default value of `2`, where a p1 failure remains visible without blocking allocation or host state changes.

## Related issues

- Related to #5252
- Documents the behavior introduced by #5218 and its v2.1 backport #5248
- Companion v2.1 release note: https://github.com/polarweasel/infra-controller/pull/3

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

### Verification

- Regenerated the Core protobuf REST mirrors with `make -C rest-api core-proto`.
- Ran `rumdl check` on `AGENTS.md` and every changed Markdown file.
- Ran Fern 5.94.0 `docs md check` and `check --warnings`; both passed, with only the expected unauthenticated published-redirect warning.
- Exercised every changed `nico-admin-cli` example against the current binary's `--help` output.
- Ran `git diff --check` and final cross-surface searches for `min_dpu_functioning_links`, `BgpPeeringTor`, and `PostConfigCheckWait`.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the complete documentation and generated contract change. The active model then completed a bounded closure review of the final diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 5 | 5 | 0 |
| CodeRabbit CLI | 6 | 3 | 3 |
| CodeRabbit cloud | 6 | 5 | 1 |
| Claude CLI | 8 | 6 | 2 |
| common-nits-reviewer | 2 | 2 | 0 |
| **Total** | **27** | **21** | **6** |

</details>

Closes #5252

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** - Replaced a deprecated lifecycle status command with the DPU status, desired configuration, and health report commands.
2. **Adopted** - Distinguished targeted uplink alerts from untargeted NVUE retrieval and configuration failures.
3. **Adopted** - Reworded the post-configuration sample explanation around HBN convergence.
4. **Adopted (post-fix closure)** - Replaced a Latin abbreviation exposed by the rewritten architecture list.
5. **Adopted (post-fix closure)** - Replaced an unnecessary compound in the final troubleshooting wording.

### CodeRabbit CLI

1. **Adopted** - Corrected `reporvisioning` in the updated state diagram.
2. **Adopted** - Corrected capitalization and singular grammar in the integration pattern list.
3. **Adopted** - Replaced an ambiguous container ID substitution with an explicit placeholder.
4. **Declined** - Hyphenating “address family” conflicts with the project prose preference and adds no clarity.
5. **Declined** - Hyphenating “decision making” was unnecessary; the surrounding grammar was corrected without it.
6. **Declined** - The suggested replacement CLI commands were based on an outdated premise; all three DPU commands exist and were verified from current `--help` output.

### CodeRabbit cloud

1. **Adopted** - Qualified direct `journalctl` guidance as systemd-specific and linked DPF deployments to the existing `nico-dpu-agent` Loki procedure.
2. **Adopted** - Documented the dynamic, comma-separated DPU ID suffixes in the two persisted network wait reasons.
3. **Adopted** - Made both ContainerExec triggers explicit: an actual local HBN change or an actual local DHCP reload.
4. **Adopted** - Added `sudo` to mutating systemd recovery commands so the documented procedures work outside a root shell.
5. **Adopted** - Expanded consecutive `PostConfigCheckWait` troubleshooting to cover repeated HBN application and repeated ContainerExec DHCP reloads.
6. **Declined** - Read-only `journalctl` commands intentionally follow the repository-wide convention of working for root or users granted journal access; adding `sudo` only on these pages would create privilege-guidance drift.

### Claude CLI

1. **Adopted** - Scoped FRR IPv6 unicast warnings to FNN configurations with an IPv6 loopback.
2. **Adopted** - Removed `--extended` because the DPU status handler does not consume it.
3. **Adopted** - Restored the Loki `log_file_path` label and an executable example.
4. **Adopted** - Aligned troubleshooting link text with the target page title.
5. **Adopted** - Corrected stale neighboring transitions in the managed-host diagram.
6. **Adopted** - Distinguished an unset configuration key from its effective default value of `2`.
7. **Declined** - The DPF selector is reachable: the collector transform explicitly assigns `systemd.unit = nico-dpu-agent`; the final docs use exact selectors for both deployment paths.
8. **Declined** - Updating an unrelated manually written Go field comment is a separate cleanup and does not affect this documented or generated contract.

### common-nits-reviewer

1. **Adopted** - Added operator guidance for untargeted NVUE `BgpPeeringTor` alerts.
2. **Adopted** - Reconciled the systemd service and DPF container log identities across lifecycle and monitoring pages.

</details>
