### PR TITLE
feat: leverage Scout reporting for boot interface candidates

### DIFF
--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::Ordering;
 
 use ::rpc::forge as rpc;
 use carbide_utils::none_if_empty::NoneIfEmpty;
-use carbide_uuid::machine::MachineIdSource;
+use carbide_uuid::machine::{MachineId, MachineIdSource};
 use carbide_uuid::nvlink::NvLinkDomainId;
 use db::WithTransaction;
 use futures_util::FutureExt;
@@ -37,6 +37,37 @@ use crate::handlers::client_resolution::{
 };
 use crate::handlers::utils::convert_and_log_machine_id;
 use crate::{CarbideError, attestation as attest};
+
+mod scout_pci;
+
+/// Loads the state needed for optional Scout PCI diagnostics after discovery commits.
+///
+/// The caller has released the discovery locks, and failures here are ignored so
+/// this diagnostic cannot reject an otherwise successful machine registration.
+async fn load_scout_pci_evaluation(
+    api: &Api,
+    hardware_info: &HardwareInfo,
+    machine_id: &MachineId,
+) -> Option<scout_pci::Evaluation> {
+    match db::machine::find_one(api.pg_pool(), machine_id, MachineSearchConfig::default()).await {
+        Ok(Some(machine)) => scout_pci::evaluate(hardware_info, &machine),
+        Ok(None) => {
+            tracing::warn!(
+                %machine_id,
+                "Skipping Scout PCI evaluation because the discovered machine was not found"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::warn!(
+                %machine_id,
+                error = %error,
+                "Skipping Scout PCI evaluation after discovery"
+            );
+            None
+        }
+    }
+}
 
 pub(crate) async fn discover_machine(
     api: &Api,
@@ -565,6 +596,18 @@ pub(crate) async fn discover_machine(
 
     txn.commit().await?;
     drop(admin_admission);
+
+    // Authentication and stable ID resolution are complete. Use this request's
+    // HardwareInfo so an older stored topology cannot stand in for the Scout report.
+    let scout_pci_evaluation =
+        if discovery_reporter == rpc::MachineDiscoveryReporter::Scout && !hardware_info.is_dpu() {
+            load_scout_pci_evaluation(api, &hardware_info, &stable_machine_id).await
+        } else {
+            None
+        };
+    if let Some(evaluation) = scout_pci_evaluation {
+        evaluation.emit(&stable_machine_id);
+    }
 
     let machine_certificate = if attest_key_challenge.is_none() {
         if std::env::var("UNSUPPORTED_CERTIFICATE_PROVIDER").is_ok() {

--- a/crates/api-core/src/handlers/machine_discovery/scout_pci.rs
+++ b/crates/api-core/src/handlers/machine_discovery/scout_pci.rs
@@ -1,0 +1,760 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashSet;
+
+use carbide_instrument::{DynamicLog, Event, LabelValue, LogAt};
+use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use mac_address::MacAddress;
+use model::hardware_info::HardwareInfo;
+use model::machine::Machine;
+use model::machine_boot_interface::BootInterfaceSelectionSource;
+use model::network_segment::NetworkSegmentType;
+use rpc::forge::BootInterfaceSelectionSource as RpcBootInterfaceSelectionSource;
+
+/// Bounded outcomes recorded for each Scout PCI evaluation.
+#[derive(Clone, Copy, Debug, Eq, LabelValue, PartialEq)]
+enum EvaluationResult {
+    /// The Scout candidate matches the stored boot interface.
+    Agreement,
+    /// The Scout candidate differs from the stored boot interface.
+    Disagreement,
+    /// The report or stored selection is missing required information.
+    Incomplete,
+    /// The stored interfaces or report do not identify one candidate.
+    Ambiguous,
+}
+
+/// The stored identity fields needed to match and describe one candidate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct EligibleInterface {
+    machine_interface_id: MachineInterfaceId,
+    mac_address: MacAddress,
+    dpu_machine_id: MachineId,
+}
+
+/// One eligible interface paired with its normalized Scout PCI slot.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Candidate {
+    interface: EligibleInterface,
+    pci_slot: String,
+}
+
+impl Candidate {
+    /// Converts this candidate to the context attached to an evaluation.
+    fn subject(&self) -> EvaluationSubject {
+        EvaluationSubject {
+            mac_address: self.interface.mac_address,
+            pci_slot: Some(self.pci_slot.clone()),
+        }
+    }
+}
+
+/// Interface and slot details that explain which evidence produced a result.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct EvaluationSubject {
+    mac_address: MacAddress,
+    pci_slot: Option<String>,
+}
+
+impl EvaluationSubject {
+    /// Builds context for an interface before its PCI slot is available.
+    fn for_interface(interface: EligibleInterface) -> Self {
+        Self {
+            mac_address: interface.mac_address,
+            pci_slot: None,
+        }
+    }
+}
+
+/// A Scout PCI result with no side effects that is emitted after discovery commits.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct Evaluation {
+    result: EvaluationResult,
+    subject: Option<EvaluationSubject>,
+    desired_mac_address: Option<MacAddress>,
+    selection_source: Option<BootInterfaceSelectionSource>,
+    reason: &'static str,
+}
+
+impl Evaluation {
+    /// Captures a result and its stored machine context without emitting it.
+    fn from_machine(
+        machine: &Machine,
+        result: EvaluationResult,
+        subject: Option<EvaluationSubject>,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            result,
+            subject,
+            desired_mac_address: machine
+                .config
+                .desired_boot_interface
+                .as_ref()
+                .map(|target| target.value.mac_address()),
+            selection_source: machine
+                .config
+                .boot_interface_selection
+                .map(|selection| selection.source),
+            reason,
+        }
+    }
+
+    /// Emits the evaluation metric and its diagnostic log.
+    pub(super) fn emit(self, machine_id: &MachineId) {
+        let (interface_mac_address, pci_slot) = self.subject.map_or_else(
+            || (None, None),
+            |subject| (Some(subject.mac_address.to_string()), subject.pci_slot),
+        );
+
+        carbide_instrument::emit(ScoutPciEvaluated {
+            result: self.result,
+            machine_id: machine_id.to_string(),
+            interface_mac_address,
+            desired_mac_address: self
+                .desired_mac_address
+                .map(|mac_address| mac_address.to_string()),
+            pci_slot,
+            selection_source: self
+                .selection_source
+                .map(RpcBootInterfaceSelectionSource::from)
+                .map(|selection_source| selection_source.as_str().to_owned()),
+            reason: self.reason,
+        });
+    }
+}
+
+/// Metric and diagnostic record for one completed Scout PCI evaluation.
+#[derive(Event)]
+#[event(
+    event_name = "scout_pci_evaluated",
+    metric_name = "carbide_scout_pci_evaluations_total",
+    component = "nico-api",
+    log = dynamic,
+    metric = counter,
+    message = "Evaluated Scout PCI boot interface evidence",
+    describe = "Number of comparisons between PCI slots reported by Scout and the stored boot interface, by result."
+)]
+struct ScoutPciEvaluated {
+    #[label]
+    result: EvaluationResult,
+    #[context]
+    machine_id: String,
+    #[context]
+    interface_mac_address: Option<String>,
+    #[context]
+    desired_mac_address: Option<String>,
+    #[context]
+    pci_slot: Option<String>,
+    #[context]
+    selection_source: Option<String>,
+    #[context]
+    reason: &'static str,
+}
+
+impl DynamicLog for ScoutPciEvaluated {
+    /// Uses warning for results that need attention and debug for agreement.
+    fn log_at(&self) -> LogAt {
+        match self.result {
+            EvaluationResult::Agreement => LogAt::Level(tracing::Level::DEBUG),
+            EvaluationResult::Disagreement
+            | EvaluationResult::Incomplete
+            | EvaluationResult::Ambiguous => LogAt::Level(tracing::Level::WARN),
+        }
+    }
+}
+
+/// Compares PCI slots reported by Scout with the machine's stored boot interface.
+pub(super) fn evaluate(hardware_info: &HardwareInfo, machine: &Machine) -> Option<Evaluation> {
+    let eligible_interfaces = eligible_interfaces(machine);
+    if eligible_interfaces.len() < 2 {
+        return None;
+    }
+
+    let desired_mac_address = machine
+        .config
+        .desired_boot_interface
+        .as_ref()
+        .map(|target| target.value.mac_address());
+    if desired_mac_address.is_some_and(|desired_mac_address| {
+        !eligible_interfaces
+            .iter()
+            .any(|interface| interface.mac_address == desired_mac_address)
+            && machine.status.interfaces.iter().any(|interface| {
+                interface.machine_id == Some(machine.id)
+                    && interface.mac_address == desired_mac_address
+            })
+    }) {
+        return None;
+    }
+
+    if let Some(interface) = first_duplicate_mac(&eligible_interfaces) {
+        return Some(Evaluation::from_machine(
+            machine,
+            EvaluationResult::Ambiguous,
+            Some(EvaluationSubject::for_interface(interface)),
+            "eligible interface MAC is not unique",
+        ));
+    }
+    if let Some(interface) = first_duplicate_dpu(&eligible_interfaces) {
+        return Some(Evaluation::from_machine(
+            machine,
+            EvaluationResult::Ambiguous,
+            Some(EvaluationSubject::for_interface(interface)),
+            "eligible interface DPU ID is not unique",
+        ));
+    }
+
+    let candidates = match candidates_from_report(hardware_info, machine, &eligible_interfaces) {
+        Ok(candidates) => candidates,
+        Err(evaluation) => return Some(evaluation),
+    };
+    let candidate = candidates
+        .into_iter()
+        .min_by(|left, right| left.pci_slot.cmp(&right.pci_slot))?;
+
+    let Some(desired_mac_address) = desired_mac_address else {
+        return Some(Evaluation::from_machine(
+            machine,
+            EvaluationResult::Incomplete,
+            Some(candidate.subject()),
+            "stored boot interface is missing",
+        ));
+    };
+
+    if !eligible_interfaces
+        .iter()
+        .any(|interface| interface.mac_address == desired_mac_address)
+    {
+        return Some(Evaluation::from_machine(
+            machine,
+            EvaluationResult::Incomplete,
+            Some(candidate.subject()),
+            "stored boot interface is not present on this host",
+        ));
+    }
+
+    Some(compare_candidate(machine, candidate, desired_mac_address))
+}
+
+/// Collects this host's Admin interfaces that are attached to DPU machines.
+fn eligible_interfaces(machine: &Machine) -> Vec<EligibleInterface> {
+    let mut interfaces = machine
+        .status
+        .interfaces
+        .iter()
+        .filter_map(|interface| {
+            let dpu_machine_id = interface.attached_dpu_machine_id?;
+            (interface.machine_id == Some(machine.id)
+                && interface.network_segment_type == Some(NetworkSegmentType::Admin)
+                && dpu_machine_id.machine_type().is_dpu())
+            .then_some(EligibleInterface {
+                machine_interface_id: interface.id,
+                mac_address: interface.mac_address,
+                dpu_machine_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    interfaces.sort_by_key(|interface| interface.machine_interface_id);
+    interfaces
+}
+
+/// Returns the second interface carrying a repeated eligible MAC address.
+fn first_duplicate_mac(interfaces: &[EligibleInterface]) -> Option<EligibleInterface> {
+    let mut seen = HashSet::with_capacity(interfaces.len());
+    interfaces
+        .iter()
+        .copied()
+        .find(|interface| !seen.insert(interface.mac_address))
+}
+
+/// Returns the second interface carrying a repeated eligible DPU ID.
+fn first_duplicate_dpu(interfaces: &[EligibleInterface]) -> Option<EligibleInterface> {
+    let mut seen = HashSet::with_capacity(interfaces.len());
+    interfaces
+        .iter()
+        .copied()
+        .find(|interface| !seen.insert(interface.dpu_machine_id))
+}
+
+/// Matches every eligible MAC to one report row and one nonblank PCI slot.
+fn candidates_from_report(
+    hardware_info: &HardwareInfo,
+    machine: &Machine,
+    eligible_interfaces: &[EligibleInterface],
+) -> Result<Vec<Candidate>, Evaluation> {
+    let mut candidates = Vec::with_capacity(eligible_interfaces.len());
+
+    for interface in eligible_interfaces {
+        let mut matches = hardware_info
+            .network_interfaces
+            .iter()
+            .filter(|reported| reported.mac_address == interface.mac_address);
+        let Some(reported) = matches.next() else {
+            return Err(Evaluation::from_machine(
+                machine,
+                EvaluationResult::Incomplete,
+                Some(EvaluationSubject::for_interface(*interface)),
+                "eligible interface has no Scout report row",
+            ));
+        };
+        if matches.next().is_some() {
+            return Err(Evaluation::from_machine(
+                machine,
+                EvaluationResult::Ambiguous,
+                Some(EvaluationSubject::for_interface(*interface)),
+                "eligible interface has multiple Scout report rows",
+            ));
+        }
+
+        let Some(pci_slot) = reported
+            .pci_properties
+            .as_ref()
+            .and_then(|properties| properties.slot.as_deref())
+            .map(str::trim)
+            .filter(|slot| !slot.is_empty())
+        else {
+            return Err(Evaluation::from_machine(
+                machine,
+                EvaluationResult::Incomplete,
+                Some(EvaluationSubject::for_interface(*interface)),
+                "eligible interface report has no PCI slot",
+            ));
+        };
+
+        candidates.push(Candidate {
+            interface: *interface,
+            pci_slot: pci_slot.to_ascii_lowercase(),
+        });
+    }
+
+    let mut slots = HashSet::with_capacity(candidates.len());
+    if let Some(candidate) = candidates
+        .iter()
+        .find(|candidate| !slots.insert(candidate.pci_slot.as_str()))
+    {
+        return Err(Evaluation::from_machine(
+            machine,
+            EvaluationResult::Ambiguous,
+            Some(candidate.subject()),
+            "eligible interfaces share a reported PCI slot",
+        ));
+    }
+
+    Ok(candidates)
+}
+
+/// Compares the Scout candidate with the stored desired boot interface MAC.
+fn compare_candidate(
+    machine: &Machine,
+    candidate: Candidate,
+    desired_mac_address: MacAddress,
+) -> Evaluation {
+    if candidate.interface.mac_address == desired_mac_address {
+        Evaluation::from_machine(
+            machine,
+            EvaluationResult::Agreement,
+            Some(candidate.subject()),
+            "candidate matches the stored boot interface",
+        )
+    } else {
+        Evaluation::from_machine(
+            machine,
+            EvaluationResult::Disagreement,
+            Some(candidate.subject()),
+            "candidate differs from the stored boot interface",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
+    use config_version::Versioned;
+    use model::hardware_info::{NetworkInterface, PciDeviceProperties};
+    use model::machine::MachineInterfaceSnapshot;
+    use model::machine_boot_interface::MachineBootInterfaceTarget;
+    use model::test_support::machine_snapshot::{
+        config_version, dpu_machine_id, host_machine, host_machine_id,
+    };
+
+    use super::*;
+
+    /// One variation from the complete, agreeing evaluator fixture.
+    #[derive(Clone, Copy)]
+    enum EvaluationCase {
+        NotEnoughInterfaces,
+        BdfOrdering,
+        ReversedRows,
+        Disagreement,
+        SecondAgreement,
+        DomainOrdering,
+        NormalizedOrdering,
+        StringOrdering,
+        MissingRow,
+        MissingPci,
+        MissingSlot,
+        BlankSlot,
+        DuplicateRow,
+        DuplicateSlot,
+        DuplicateMac,
+        DuplicateDpu,
+        MissingDesired,
+        UnknownDesired,
+        IntegratedInterface,
+        IntegratedDesired,
+        IntegratedDesiredWithMissingSlot,
+        ExtraReportRow,
+    }
+
+    /// Returns a deterministic MAC address for test interface identities.
+    fn mac(index: u8) -> MacAddress {
+        MacAddress::new([0x02, 0, 0, 0, 0, index])
+    }
+
+    /// Builds one Admin interface owned by the fixture host and attached to a DPU.
+    fn eligible_interface(
+        mac_address: MacAddress,
+        dpu_machine_id: MachineId,
+    ) -> MachineInterfaceSnapshot {
+        let mut interface = MachineInterfaceSnapshot::mock_with_mac(mac_address);
+        interface.id =
+            MachineInterfaceId::from(uuid::Uuid::from_u128(u128::from(mac_address.bytes()[5])));
+        interface.machine_id = Some(host_machine_id());
+        interface.attached_dpu_machine_id = Some(dpu_machine_id);
+        interface.network_segment_type = Some(NetworkSegmentType::Admin);
+        interface
+    }
+
+    /// Builds an Admin interface owned by the host and not attached to a DPU.
+    fn integrated_interface() -> MachineInterfaceSnapshot {
+        let mut interface = MachineInterfaceSnapshot::mock_with_mac(mac(9));
+        interface.id = MachineInterfaceId::from(uuid::Uuid::from_u128(9));
+        interface.machine_id = Some(host_machine_id());
+        interface.network_segment_type = Some(NetworkSegmentType::Admin);
+        interface.attached_dpu_machine_id = None;
+        interface
+    }
+
+    /// Builds one Scout network row with the supplied PCI slot.
+    fn reported_interface(mac_address: MacAddress, slot: Option<&str>) -> NetworkInterface {
+        NetworkInterface {
+            mac_address,
+            pci_properties: Some(PciDeviceProperties {
+                vendor: String::new(),
+                device: String::new(),
+                path: String::new(),
+                numa_node: 0,
+                description: None,
+                slot: slot.map(str::to_string),
+            }),
+        }
+    }
+
+    /// Builds a machine and returns the evaluator's bounded result.
+    fn run_evaluation(case: EvaluationCase) -> Option<EvaluationResult> {
+        let mut machine = host_machine();
+        machine.status.interfaces = vec![
+            eligible_interface(mac(1), dpu_machine_id(0)),
+            eligible_interface(mac(2), dpu_machine_id(1)),
+        ];
+        let mut reports = vec![
+            reported_interface(mac(1), Some("0000:02:00.0")),
+            reported_interface(mac(2), Some("0000:0a:00.0")),
+        ];
+        let mut desired_mac_address = Some(mac(1));
+
+        match case {
+            EvaluationCase::NotEnoughInterfaces => machine.status.interfaces.truncate(1),
+            EvaluationCase::BdfOrdering => {}
+            EvaluationCase::ReversedRows => {
+                machine.status.interfaces.reverse();
+                reports.reverse();
+            }
+            EvaluationCase::Disagreement => {
+                reports = vec![
+                    reported_interface(mac(1), Some("0000:0a:00.0")),
+                    reported_interface(mac(2), Some("0000:02:00.0")),
+                ];
+            }
+            EvaluationCase::SecondAgreement => {
+                reports = vec![
+                    reported_interface(mac(1), Some("0000:0a:00.0")),
+                    reported_interface(mac(2), Some("0000:02:00.0")),
+                ];
+                desired_mac_address = Some(mac(2));
+            }
+            EvaluationCase::DomainOrdering => {
+                reports = vec![
+                    reported_interface(mac(1), Some("0001:00:00.0")),
+                    reported_interface(mac(2), Some("0000:ff:00.0")),
+                ];
+                desired_mac_address = Some(mac(2));
+            }
+            EvaluationCase::NormalizedOrdering => {
+                reports = vec![
+                    reported_interface(mac(1), Some(" 0000:0A:00.0 ")),
+                    reported_interface(mac(2), Some("0000:0b:00.0")),
+                ];
+            }
+            EvaluationCase::StringOrdering => {
+                reports = vec![
+                    reported_interface(mac(1), Some("Riser_Slot1")),
+                    reported_interface(mac(2), Some("riser_slot2")),
+                ];
+            }
+            EvaluationCase::MissingRow => {
+                reports.remove(0);
+            }
+            EvaluationCase::MissingPci => reports[0].pci_properties = None,
+            EvaluationCase::MissingSlot => {
+                reports[0].pci_properties.as_mut().unwrap().slot = None;
+            }
+            EvaluationCase::BlankSlot => {
+                reports[0].pci_properties.as_mut().unwrap().slot = Some(" \t".to_string());
+            }
+            EvaluationCase::DuplicateRow => reports.insert(0, reports[0].clone()),
+            EvaluationCase::DuplicateSlot => {
+                reports[1].pci_properties.as_mut().unwrap().slot =
+                    Some(" 0000:02:00.0 ".to_string());
+            }
+            EvaluationCase::DuplicateMac => {
+                machine.status.interfaces[1] = eligible_interface(mac(1), dpu_machine_id(1));
+            }
+            EvaluationCase::DuplicateDpu => {
+                machine.status.interfaces[1] = eligible_interface(mac(2), dpu_machine_id(0));
+            }
+            EvaluationCase::MissingDesired => desired_mac_address = None,
+            EvaluationCase::UnknownDesired => desired_mac_address = Some(mac(9)),
+            EvaluationCase::IntegratedInterface => {
+                machine.status.interfaces.push(integrated_interface());
+                reports.push(reported_interface(mac(9), Some("0000:01:00.0")));
+            }
+            EvaluationCase::IntegratedDesired => {
+                machine.status.interfaces.push(integrated_interface());
+                reports.push(reported_interface(mac(9), Some("0000:01:00.0")));
+                desired_mac_address = Some(mac(9));
+            }
+            EvaluationCase::IntegratedDesiredWithMissingSlot => {
+                machine.status.interfaces.push(integrated_interface());
+                reports[0].pci_properties.as_mut().unwrap().slot = None;
+                desired_mac_address = Some(mac(9));
+            }
+            EvaluationCase::ExtraReportRow => {
+                reports.push(reported_interface(mac(9), None));
+            }
+        }
+
+        machine.config.desired_boot_interface = desired_mac_address.map(|address| {
+            Versioned::new(
+                MachineBootInterfaceTarget::MacOnly(address),
+                config_version(20),
+            )
+        });
+
+        let hardware_info = HardwareInfo {
+            network_interfaces: reports,
+            ..HardwareInfo::default()
+        };
+        evaluate(&hardware_info, &machine).map(|evaluation| evaluation.result)
+    }
+
+    /// Builds one compact evaluator table row.
+    macro_rules! evaluation_case {
+        ($scenario:literal, $input:ident, $expect:ident) => {
+            Check {
+                scenario: $scenario,
+                input: EvaluationCase::$input,
+                expect: Some(EvaluationResult::$expect),
+            }
+        };
+        ($scenario:literal, $input:ident) => {
+            Check {
+                scenario: $scenario,
+                input: EvaluationCase::$input,
+                expect: None,
+            }
+        };
+    }
+
+    /// The evaluator covers ordering, completeness, ambiguity, and comparison as one table.
+    #[test]
+    fn evaluator_uses_complete_unambiguous_scout_slot_mappings() {
+        check_values(
+            [
+                evaluation_case!(
+                    "fewer than two eligible interfaces are ignored",
+                    NotEnoughInterfaces
+                ),
+                evaluation_case!("slot 02 sorts before slot 0a", BdfOrdering, Agreement),
+                evaluation_case!(
+                    "stored and report row order do not affect selection",
+                    ReversedRows,
+                    Agreement
+                ),
+                evaluation_case!(
+                    "lower second slot disagrees with the stored first interface",
+                    Disagreement,
+                    Disagreement
+                ),
+                evaluation_case!(
+                    "lower second slot agrees with the stored second interface",
+                    SecondAgreement,
+                    Agreement
+                ),
+                evaluation_case!("lower domain sorts first", DomainOrdering, Agreement),
+                evaluation_case!(
+                    "slot comparison ignores case and surrounding whitespace",
+                    NormalizedOrdering,
+                    Agreement
+                ),
+                evaluation_case!(
+                    "arbitrary slot values are compared as strings",
+                    StringOrdering,
+                    Agreement
+                ),
+                evaluation_case!("missing report row is incomplete", MissingRow, Incomplete),
+                evaluation_case!(
+                    "missing PCI properties are incomplete",
+                    MissingPci,
+                    Incomplete
+                ),
+                evaluation_case!("missing PCI slot is incomplete", MissingSlot, Incomplete),
+                evaluation_case!("blank PCI slot is incomplete", BlankSlot, Incomplete),
+                evaluation_case!("duplicate report row is ambiguous", DuplicateRow, Ambiguous),
+                evaluation_case!(
+                    "duplicate normalized PCI slot is ambiguous",
+                    DuplicateSlot,
+                    Ambiguous
+                ),
+                evaluation_case!(
+                    "duplicate eligible MAC is ambiguous",
+                    DuplicateMac,
+                    Ambiguous
+                ),
+                evaluation_case!(
+                    "duplicate eligible DPU identity is ambiguous",
+                    DuplicateDpu,
+                    Ambiguous
+                ),
+                evaluation_case!(
+                    "missing stored target is incomplete",
+                    MissingDesired,
+                    Incomplete
+                ),
+                evaluation_case!(
+                    "unknown stored target is incomplete",
+                    UnknownDesired,
+                    Incomplete
+                ),
+                evaluation_case!(
+                    "integrated interface is excluded from DPU ordering",
+                    IntegratedInterface,
+                    Agreement
+                ),
+                evaluation_case!(
+                    "integrated boot interface needs no DPU comparison",
+                    IntegratedDesired
+                ),
+                evaluation_case!(
+                    "integrated boot interface is ignored before DPU evidence is checked",
+                    IntegratedDesiredWithMissingSlot
+                ),
+                evaluation_case!("unrelated Scout row is ignored", ExtraReportRow, Agreement),
+            ],
+            run_evaluation,
+        );
+    }
+
+    /// One table covers every result's metric label and diagnostic level.
+    #[test]
+    fn event_emits_every_result_with_candidate_context() {
+        /// Expected observable values for one bounded evaluation result.
+        struct EventCase {
+            result: EvaluationResult,
+            label: &'static str,
+            level: tracing::Level,
+        }
+
+        let cases = [
+            EventCase {
+                result: EvaluationResult::Agreement,
+                label: "agreement",
+                level: tracing::Level::DEBUG,
+            },
+            EventCase {
+                result: EvaluationResult::Disagreement,
+                label: "disagreement",
+                level: tracing::Level::WARN,
+            },
+            EventCase {
+                result: EvaluationResult::Incomplete,
+                label: "incomplete",
+                level: tracing::Level::WARN,
+            },
+            EventCase {
+                result: EvaluationResult::Ambiguous,
+                label: "ambiguous",
+                level: tracing::Level::WARN,
+            },
+        ];
+        let metrics = MetricsCapture::start();
+        let machine_id = host_machine_id();
+        let logs = capture_logs(|| {
+            for case in &cases {
+                Evaluation {
+                    result: case.result,
+                    subject: Some(EvaluationSubject {
+                        mac_address: mac(1),
+                        pci_slot: Some("0000:02:00.0".to_string()),
+                    }),
+                    desired_mac_address: Some(mac(1)),
+                    selection_source: Some(BootInterfaceSelectionSource::RedfishUefiPci),
+                    reason: "test reason",
+                }
+                .emit(&machine_id);
+            }
+        });
+
+        assert_eq!(logs.len(), cases.len());
+        for (index, case) in cases.iter().enumerate() {
+            assert!(
+                metrics.counter_delta(
+                    "carbide_scout_pci_evaluations_total",
+                    &[("result", case.label)],
+                ) >= 1.0,
+                "missing result series {}",
+                case.label,
+            );
+            assert_eq!(
+                logs[index].level, case.level,
+                "wrong log level for {}",
+                case.label,
+            );
+        }
+
+        let machine_id = machine_id.to_string();
+        assert_eq!(logs[0].field("machine_id"), Some(machine_id.as_str()));
+        assert_eq!(
+            logs[0].field("interface_mac_address"),
+            Some("02:00:00:00:00:01")
+        );
+        assert_eq!(logs[0].field("pci_slot"), Some("0000:02:00.0"));
+    }
+}

--- a/crates/api-core/src/tests/machine_discovery.rs
+++ b/crates/api-core/src/tests/machine_discovery.rs
@@ -20,18 +20,22 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use carbide_authn::middleware::ConnectionAttributes;
-use carbide_uuid::machine::MachineInterfaceId;
+use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use chrono::{DateTime, Utc};
 use common::api_fixtures::dpu::create_dpu_machine;
 use common::api_fixtures::host::{host_discover_dhcp, host_discover_machine_with_reporter};
 use common::api_fixtures::{
     FIXTURE_DHCP_RELAY_ADDRESS, create_managed_host, create_managed_host_with_config,
     create_test_env,
 };
+use config_version::ConfigVersion;
 use itertools::Itertools;
 use mac_address::MacAddress;
-use model::hardware_info::{HardwareInfo, TpmEkCertificate};
+use model::hardware_info::{HardwareInfo, PciDeviceProperties, TpmEkCertificate};
 use model::machine::machine_id::from_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
+use model::machine_boot_interface::BootInterfaceSelectionSource;
+use model::network_segment::NetworkSegmentType;
 use model::resource_pool::{ResourcePoolDef, ResourcePoolType};
 use rpc::forge::forge_server::Forge;
 use tonic::{Code, Request};
@@ -41,6 +45,9 @@ use crate::test_support::fixture_config::{FixtureDefault, ManagedHostConfigExt a
 use crate::tests::common;
 use crate::tests::common::api_fixtures::instance::{
     default_os_config, default_tenant_config, single_interface_network_config,
+};
+use crate::tests::common::api_fixtures::tpm_attestation::{
+    AK_NAME_SERIALIZED, AK_PUB_SERIALIZED, EK_PUB_SERIALIZED,
 };
 use crate::tests::common::api_fixtures::{TestEnvOverrides, create_test_env_with_overrides};
 
@@ -80,6 +87,48 @@ fn discovery_request_from(
             peer_certificates: vec![],
         }));
     request
+}
+
+/// Snapshot of the selection fields that the Scout PCI test must not rewrite.
+#[derive(Debug, PartialEq, sqlx::FromRow)]
+struct ScoutPciSelectionState {
+    current_primary_mac_address: Option<MacAddress>,
+    desired_mac_address: Option<MacAddress>,
+    desired_interface_id: Option<String>,
+    desired_version: Option<ConfigVersion>,
+    selection_source: Option<BootInterfaceSelectionSource>,
+    selection_updated_at: Option<DateTime<Utc>>,
+}
+
+/// Loads the selection fields that the Scout PCI observer must leave unchanged.
+///
+/// This query keeps the handler test focused on the current primary interface
+/// and the stored boot interface decision.
+async fn load_scout_pci_selection_state(
+    pool: &sqlx::PgPool,
+    host_machine_id: MachineId,
+) -> Result<ScoutPciSelectionState, Box<dyn std::error::Error>> {
+    let state = sqlx::query_as::<_, ScoutPciSelectionState>(
+        "SELECT (
+                    SELECT mac_address
+                    FROM machine_interfaces
+                    WHERE machine_id = machine.id
+                      AND primary_interface
+                ) AS current_primary_mac_address,
+                boot_interface.desired_mac_address,
+                boot_interface.desired_interface_id,
+                boot_interface.desired_version,
+                boot_interface.selection_source,
+                boot_interface.selection_updated_at
+         FROM machines machine
+         LEFT JOIN machine_boot_interfaces boot_interface
+           ON boot_interface.machine_id = machine.id
+         WHERE machine.id = $1",
+    )
+    .bind(host_machine_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(state)
 }
 
 async fn allocated_host_for_secure_discovery(
@@ -1101,6 +1150,156 @@ async fn test_discovery_rejects_interface_owned_by_different_stable_identity(
             .fetch_one(&env.pool)
             .await?;
     assert_eq!(topology_count.0, 0);
+    Ok(())
+}
+
+/// A valid Scout PCI report may disagree with the selected Redfish interface.
+/// The handler records that fact without treating the report as a command.
+#[crate::sqlx_test]
+async fn test_scout_pci_disagreement_does_not_reconfigure_host(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let host_config = env.managed_host_config().with_dpu_count(2);
+    let managed_host = create_managed_host_with_config(&env, host_config.clone()).await;
+    let host_machine_id = managed_host.host().id;
+
+    let stored_machine =
+        db::machine::find_one(&env.pool, &host_machine_id, MachineSearchConfig::default())
+            .await?
+            .expect("managed host must exist");
+    let selected_interface = stored_machine
+        .status
+        .interfaces
+        .iter()
+        .find(|interface| {
+            interface.network_segment_type == Some(NetworkSegmentType::Admin)
+                && interface.attached_dpu_machine_id.is_some()
+                && interface.primary_interface
+        })
+        .expect("host with two DPUs must have one selected DPU interface");
+    assert_eq!(
+        selected_interface.mac_address, host_config.dpus[0].host_mac_address,
+        "the Redfish fixture must select the first reported DPU",
+    );
+    let caller_interface_id = selected_interface.id;
+
+    let before = load_scout_pci_selection_state(&env.pool, host_machine_id).await?;
+    assert_eq!(
+        before.current_primary_mac_address,
+        Some(host_config.dpus[0].host_mac_address),
+        "the fixture must start with the first DPU as its current primary interface",
+    );
+    assert_eq!(
+        before.desired_mac_address,
+        Some(host_config.dpus[0].host_mac_address),
+        "the stored Redfish target must match the selected first DPU",
+    );
+    assert_eq!(
+        before.selection_source,
+        Some(BootInterfaceSelectionSource::RedfishUefiPci),
+        "the fixture target must retain the complete Redfish UEFI selection source",
+    );
+    assert!(
+        before.desired_interface_id.is_some(),
+        "the stored Redfish target must include its interface id",
+    );
+    assert!(
+        before.desired_version.is_some(),
+        "the stored Redfish target must have a configuration version",
+    );
+    assert!(
+        before.selection_updated_at.is_some(),
+        "the stored Redfish target must have a selection time",
+    );
+    let mut hardware_info = HardwareInfo::from(&host_config);
+    let [first_reported_dpu, second_reported_dpu, ..] =
+        hardware_info.network_interfaces.as_mut_slice()
+    else {
+        panic!("discovery report for two DPUs must include both DPU interfaces")
+    };
+    assert_eq!(
+        first_reported_dpu.mac_address,
+        host_config.dpus[0].host_mac_address
+    );
+    assert_eq!(
+        second_reported_dpu.mac_address,
+        host_config.dpus[1].host_mac_address
+    );
+    first_reported_dpu.pci_properties = Some(PciDeviceProperties {
+        vendor: "0x15b3".to_string(),
+        device: "0xa2dc".to_string(),
+        path: "/devices/pci0000:00/0000:0a:00.0/net/enp10s0f0".to_string(),
+        numa_node: 0,
+        description: Some("selected DPU".to_string()),
+        slot: Some("0000:0a:00.0".to_string()),
+    });
+    second_reported_dpu.pci_properties = Some(PciDeviceProperties {
+        vendor: "0x15b3".to_string(),
+        device: "0xa2dc".to_string(),
+        path: "/devices/pci0000:00/0000:02:00.0/net/enp2s0f0".to_string(),
+        numa_node: 0,
+        description: Some("lower PCI slot".to_string()),
+        slot: Some("0000:02:00.0".to_string()),
+    });
+
+    let mut discovery_info = rpc::DiscoveryInfo::try_from(hardware_info)?;
+    discovery_info.attest_key_info = Some(rpc::machine_discovery::AttestKeyInfo {
+        ek_pub: EK_PUB_SERIALIZED.to_vec(),
+        ak_pub: AK_PUB_SERIALIZED.to_vec(),
+        ak_name: AK_NAME_SERIALIZED.to_vec(),
+    });
+
+    let metrics = carbide_instrument::testing::MetricsCapture::start();
+    let (response, logs) = carbide_instrument::testing::capture_logs_async(
+        env.api
+            .discover_machine(Request::new(rpc::MachineDiscoveryInfo {
+                machine_interface_id: Some(caller_interface_id),
+                discovery_data: Some(rpc::DiscoveryData::Info(discovery_info)),
+                create_machine: true,
+                discovery_reporter: rpc::MachineDiscoveryReporter::Scout as i32,
+                discovery_reporter_version: None,
+            })),
+    )
+    .await;
+    let response = response?.into_inner();
+    let disagreement_count = metrics.counter_delta(
+        "carbide_scout_pci_evaluations_total",
+        &[("result", "disagreement")],
+    );
+    drop(metrics);
+
+    let host_machine_id_string = host_machine_id.to_string();
+    let evaluation_logs = logs
+        .iter()
+        .filter(|log| {
+            log.field("event_name") == Some("scout_pci_evaluated")
+                && log.field("machine_id") == Some(host_machine_id_string.as_str())
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(response.machine_id, Some(host_machine_id));
+    assert_eq!(response.machine_interface_id, Some(caller_interface_id));
+    assert_eq!(evaluation_logs.len(), 1);
+    assert_eq!(
+        evaluation_logs[0].field("metric_name"),
+        Some("carbide_scout_pci_evaluations_total")
+    );
+    assert_eq!(evaluation_logs[0].field("result"), Some("disagreement"));
+    // MetricsCapture serializes metric assertions, but a future discovery test
+    // could emit the same process global series without capturing it. The scoped
+    // log above proves this request emitted exactly once.
+    assert!(
+        disagreement_count >= 1.0,
+        "the incoming PCI winner must emit a disagreement metric",
+    );
+
+    let after = load_scout_pci_selection_state(&env.pool, host_machine_id).await?;
+    assert_eq!(
+        after, before,
+        "Scout PCI comparison must not change the current primary interface or the stored target, version, source, and time",
+    );
+
     Ok(())
 }
 

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -278,6 +278,13 @@ async fn test_integration() -> eyre::Result<()> {
         r#"carbide_site_explorer_boot_interface_selections_total{mechanism="redfish_serial_number"}"#,
     )
     .await?;
+    // MaT exercises a host with multiple DPUs whose lowest Scout PCI slot
+    // matches its stored boot interface.
+    metrics::wait_for_metric_line(
+        &test_env.carbide_metrics_addrs,
+        r#"carbide_scout_pci_evaluations_total{result="agreement"}"#,
+    )
+    .await?;
 
     let metric_infos = metrics::collect_metric_infos(&test_env.carbide_metrics_addrs)?;
     assert!(
@@ -285,6 +292,12 @@ async fn test_integration() -> eyre::Result<()> {
             metric.name == "carbide_site_explorer_boot_interface_selections_total"
         }),
         "the multi-DPU integration paths must exercise boot-interface selection observability",
+    );
+    assert!(
+        metric_infos
+            .iter()
+            .any(|metric| metric.name == "carbide_scout_pci_evaluations_total"),
+        "the MaT Scout path must exercise PCI evaluation observability",
     );
     generate_core_metric_docs(&test_env.carbide_metrics_addrs);
 

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -143,10 +143,15 @@ impl ApiClient {
                     ClientApiError::ConfigError("No TPM EK certificate waa supplied".to_string()),
                 )?))
         }
+        let discovery_reporter = match machine_info {
+            MachineInfo::Host(_) => rpc::MachineDiscoveryReporter::Scout,
+            MachineInfo::Dpu(_) => rpc::MachineDiscoveryReporter::DpuAgent,
+        };
         let mdi = rpc::forge::MachineDiscoveryInfo {
             machine_interface_id: Some(machine_interface_id),
             discovery_data: Some(rpc::DiscoveryData::Info(machine_discovery_info)),
             create_machine: true,
+            discovery_reporter: discovery_reporter as i32,
             ..Default::default()
         };
 

--- a/crates/machine-a-tron/src/discovery_info.rs
+++ b/crates/machine-a-tron/src/discovery_info.rs
@@ -63,7 +63,7 @@ fn for_host(host: &HostMachineInfo) -> DiscoveryInfo {
         HardwareType::NvidiaDgxGb300 => DiscoveryInfo {
             network_interfaces: vec![generic_nic(
                 required_dpu(host).host_mac_address,
-                0x0603,
+                0x0006_0003,
                 "Mellanox Technologies",
                 "BlueField-3 SmartNIC Main Card",
                 Some("MT43244 BlueField-3 integrated ConnectX-7 network controller"),
@@ -298,14 +298,14 @@ fn wiwynn_gb200(host: &HostMachineInfo) -> DiscoveryInfo {
         network_interfaces: vec![
             generic_nic(
                 dpus[0].host_mac_address,
-                0x0603,
+                0x0006_0003,
                 "Mellanox Technologies",
                 "BlueField-3 SmartNIC Main Card",
                 Some("MT43244 BlueField-3 integrated ConnectX-7 network controller"),
             ),
             generic_nic(
                 dpus[1].host_mac_address,
-                0x1603,
+                0x0016_0003,
                 "Mellanox Technologies",
                 "BlueField-3 SmartNIC Main Card",
                 Some("MT43244 BlueField-3 integrated ConnectX-7 network controller"),
@@ -626,14 +626,18 @@ fn generic_nic(
     device: &str,
     description: Option<&str>,
 ) -> NetworkInterface {
-    let device_name = format!("enp{}s{}np0", slot >> 16, slot & 0xff);
-    let slot = format!("{:04x}:{:02x}:00.0", slot >> 16, slot & 0xff);
+    let domain = slot >> 16;
+    let bus = slot & 0xff;
+    let device_name = format!("enp{domain}s{bus}np0");
+    let slot = format!("{domain:04x}:{bus:02x}:00.0");
     NetworkInterface {
         mac_address: mac_address.to_string(),
         pci_properties: Some(PciDeviceProperties {
             vendor: vendor.into(),
             device: device.into(),
-            path: format!("/devices/pci0000:00/0000:00:00.0/{slot}/net/{device_name}"),
+            path: format!(
+                "/devices/pci{domain:04x}:00/{domain:04x}:00:00.0/{slot}/net/{device_name}"
+            ),
             numa_node: 0,
             description: description.map(Into::into),
             slot: Some(slot),
@@ -875,7 +879,8 @@ mod tests {
 
     use super::*;
 
-    fn lenovo_host() -> MachineInfo {
+    /// Builds a mock host with the platform's fixed number of DPUs.
+    fn host_for_platform(platform: HardwareType) -> MachineInfo {
         let pool_config =
             PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
         let hardware_pool_config =
@@ -884,17 +889,20 @@ mod tests {
             ranges: None,
             pool: Some(pool_config),
         });
-        let dpu = DpuMachineInfo::new(
-            HardwareType::LenovoGB300Nvl,
-            &mut pool,
-            DpuSettings::default(),
-        );
+        let dpu_count = platform.fixed_number_of_dpu().unwrap_or(1);
+        let dpus = (0..dpu_count)
+            .map(|_| DpuMachineInfo::new(platform, &mut pool, DpuSettings::default()))
+            .collect();
         MachineInfo::Host(HostMachineInfo::new(
-            HardwareType::LenovoGB300Nvl,
-            vec![dpu],
+            platform,
+            dpus,
             &mut pool,
             hardware_pool_config,
         ))
+    }
+
+    fn lenovo_host() -> MachineInfo {
+        host_for_platform(HardwareType::LenovoGB300Nvl)
     }
 
     #[test]
@@ -996,22 +1004,38 @@ mod tests {
         ];
 
         for platform in platforms {
-            let pool_config =
-                PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid pool");
-            let hardware_pool_config =
-                PoolConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 16).expect("valid pool");
-            let mut pool = MacAddressPool::new(Config {
-                ranges: None,
-                pool: Some(pool_config),
-            });
-            let dpu_count = platform.fixed_number_of_dpu().unwrap_or(1);
-            let dpus = (0..dpu_count)
-                .map(|_| DpuMachineInfo::new(platform, &mut pool, DpuSettings::default()))
-                .collect();
-            let host = HostMachineInfo::new(platform, dpus, &mut pool, hardware_pool_config);
-
-            let _ = for_machine(&MachineInfo::Host(host));
+            for_machine(&host_for_platform(platform));
         }
+    }
+
+    #[test]
+    fn wiwynn_gb200_reports_distinct_pci_locations() {
+        let discovery = for_machine(&host_for_platform(HardwareType::WiwynnGB200Nvl));
+
+        assert_eq!(
+            discovery
+                .network_interfaces
+                .iter()
+                .filter_map(|interface| interface.pci_properties.as_ref())
+                .map(|properties| {
+                    (
+                        properties.slot.as_deref().expect("PCI slot"),
+                        properties.path.as_str(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            [
+                (
+                    "0006:03:00.0",
+                    "/devices/pci0006:00/0006:00:00.0/0006:03:00.0/net/enp6s3np0",
+                ),
+                (
+                    "0016:03:00.0",
+                    "/devices/pci0016:00/0016:00:00.0/0016:03:00.0/net/enp22s3np0",
+                ),
+            ],
+            "Wiwynn DPUs must report distinct, internally consistent PCI locations",
+        );
     }
 
     #[test]

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -239,6 +239,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_scout_actions_total</td><td>counter</td><td>Number of scout control-loop actions handled, by action and outcome.</td></tr>
 <tr><td>carbide_scout_firmware_download_attempt_failures_total</td><td>counter</td><td>Number of failed Scout firmware download attempts, by download kind and next action.</td></tr>
 <tr><td>carbide_scout_mlx_failures_total</td><td>counter</td><td>Number of Scout MLX observation, read, mutation, and recovery failures, by operation and failure stage.</td></tr>
+<tr><td>carbide_scout_pci_evaluations_total</td><td>counter</td><td>Number of comparisons between PCI slots reported by Scout and the stored boot interface, by result.</td></tr>
 <tr><td>carbide_scout_storage_device_cleanup_duration_seconds</td><td>histogram</td><td>Duration of per-device scout storage cleanup operations, by device type and outcome.</td></tr>
 <tr><td>carbide_scout_stream_connections_total</td><td>counter</td><td>Number of scout stream connection attempts, by outcome.</td></tr>
 <tr><td>carbide_scout_stream_reconnects_total</td><td>counter</td><td>Number of scout stream reconnect cycles after a stream closed or errored.</td></tr>


### PR DESCRIPTION
> [!NOTE]
> While this PR seems large at first glance, just FYI that it contains:
>
> - +214/-2 lines of test changes.
>
> Don't let it scare you!

Scout already reports each host NIC's MAC address and PCI slot, and NICo already uses those slot strings elsewhere for ordering. This change starts using the same data after Scout discovery commits to compare the DPU attached to the lowest reported slot with the stored boot interface.

The comparison requires every eligible interface to match exactly one Scout row with a nonblank, unique slot. It records agreement, disagreement, incomplete evidence, or ambiguous evidence through a bounded metric and diagnostic log. A valid stored integrated or onboard boot interface is outside this DPU comparison and emits no result. A stored target that is not present on the host is incomplete evidence rather than a DPU disagreement.

This reuses the reported slot strings and does not add a PCI parser. It only observes: primary flags, addressing, DNS, desired boot targets, selection source, network generations, controller state, Redfish configuration, and power remain unchanged. Machine-A-Tron now tags host reports as Scout and supplies distinct PCI slots so the full integration flow exercises the comparison.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5081

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Coverage:

- Table-driven evaluator tests and a focused API Core database test cover slot ordering, normalization, input order, all four results, integrated and onboard targets, incomplete and ambiguous evidence, and the guarantee that disagreement does not change the stored selection.
- All 50 Machine-A-Tron tests and the full API integration pass, including the Scout PCI metric and metric catalogue. Formatting, Clippy, Carbide lints, Event name validation, and metric documentation validation also pass.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the simplified redesign. Claude returned five actionable findings; all five were adopted, and the final closure passes were clean.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 5 | 5 | 0 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **5** | **5** | **0** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- The optional postcommit read used a separate diagnostic transaction. **Resolution:** Read through the pool after discovery commits, keeping diagnostic failures outside registration.
2. **Adopted** -- The lookup and emitted diagnostic used different names for the resolved machine identity. **Resolution:** Use the stable machine ID consistently for both.
3. **Adopted** -- The Wiwynn PCI slot contract was asserted inside a broad platform smoke test. **Resolution:** Give that fixture a focused test.
4. **Adopted** -- The DGX GB300 fixture still used the old packed slot literal. **Resolution:** Encode its PCI domain and bus consistently with the updated fixture helper.
5. **Adopted** -- The Event test used positional cases that obscured which result each row covered. **Resolution:** Use named cases for all four bounded results.

### common-nits-reviewer

No findings.

</details>


Closes #5081
