### PR TITLE
refactor(tests): move dns resolution tests to integration suite

### DIFF
--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -18,7 +18,6 @@
 mod boot_interface_resolution;
 mod client_resolution;
 pub(in crate::tests) mod common;
-mod dns;
 mod dpa_interfaces;
 mod dpf;
 mod dpu_agent_upgrade;

--- a/crates/api-core/tests/integration/dns_resolution.rs
+++ b/crates/api-core/tests/integration/dns_resolution.rs
@@ -14,44 +14,95 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 use std::net::IpAddr;
 
+use carbide_test_harness::TestNetworkSegment;
+use carbide_test_harness::prelude::*;
 use carbide_uuid::machine::MachineId;
-use common::api_fixtures::{create_managed_host, create_test_env};
 use const_format::concatcp;
-use rpc::forge::forge_server::Forge;
-use sqlx::{Postgres, Row};
+use rpc::forge::DhcpDiscovery;
+use tonic::Request;
 
-use crate::tests::common;
-use crate::tests::common::rpc_builder::DhcpDiscovery;
-
-// These should probably go in a common place for both
-// this and tests/integration/api_server.rs to share.
 const DOMAIN_NAME: &str = "dwrt1.com";
 const DNS_ADM_SUBDOMAIN: &str = concatcp!("adm.", DOMAIN_NAME);
 const DNS_BMC_SUBDOMAIN: &str = concatcp!("bmc.", DOMAIN_NAME);
 
-#[crate::sqlx_test]
-async fn test_dns(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    env.create_vpc_and_tenant_segment().await;
-    let api = &env.api;
+struct DnsTestEnv {
+    env: TestHarness,
+    admin_segment: TestNetworkSegment,
+    underlay_segment: TestNetworkSegment,
+}
+
+async fn init(pool: PgPool) -> DnsTestEnv {
+    let resource_pools = ResourcePoolBuilder::default()
+        .with_vlan_ids(1, 5)
+        .with_vnis(10_001, 10_005)
+        .build();
+    let env = TestHarness::builder(pool)
+        .with_resource_pools(resource_pools)
+        .build()
+        .await;
+    let domain = env.create_test_domain(DOMAIN_NAME).await;
+    let network_controller = env.network_controller();
+    let admin_segment = network_controller.create_admin_segment(&domain).await;
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    let vpc_id = network_controller.create_vpc("dns-test-vpc").await;
+    network_controller
+        .create_tenant_segment(&domain, vpc_id)
+        .await;
+    DnsTestEnv {
+        env,
+        admin_segment,
+        underlay_segment,
+    }
+}
+
+async fn create_managed_host(
+    env: &TestHarness,
+    underlay_segment: TestNetworkSegment,
+    admin_segment: TestNetworkSegment,
+) -> TestManagedHost {
+    let site_explorer = env.default_test_site_explorer();
+    env.managed_host_builder(&site_explorer, underlay_segment)
+        .with_dpu_primary_interfaces(admin_segment)
+        .with_dpu_network_status_reported()
+        .build()
+        .await
+        .0
+}
+
+#[sqlx_test]
+async fn test_dns(pool: PgPool) {
+    let DnsTestEnv {
+        env,
+        admin_segment,
+        underlay_segment,
+    } = init(pool).await;
+    let api = env.api();
 
     // Database should have 0 rows in the dns_records view.
-    assert_eq!(0, get_dns_record_count(&env.pool).await);
+    assert_eq!(
+        0,
+        db::test_support::dns::record_count(&api.database_connection).await
+    );
 
-    let mac_address = "FF:FF:FF:FF:FF:FF".to_string();
+    let mac_address = "FF:FF:FF:FF:FF:FF";
     let interface1 = api
-        .discover_dhcp(DhcpDiscovery::builder(&mac_address, "192.0.2.1").tonic_request())
+        .discover_dhcp(
+            DhcpDiscovery::builder(mac_address, admin_segment.relay_address).tonic_request(),
+        )
         .await
         .unwrap()
         .into_inner();
 
     let fqdn1 = interface1.fqdn;
     let ip1 = interface1.address;
-    let mac_address = "F1:FF:FF:FF:FF:FF".to_string();
+    let mac_address = "F1:FF:FF:FF:FF:FF";
     let interface2 = api
-        .discover_dhcp(DhcpDiscovery::builder(&mac_address, "192.0.2.1").tonic_request())
+        .discover_dhcp(
+            DhcpDiscovery::builder(mac_address, admin_segment.relay_address).tonic_request(),
+        )
         .await
         .unwrap()
         .into_inner();
@@ -59,12 +110,9 @@ async fn test_dns(pool: sqlx::PgPool) {
     let fqdn2 = interface2.fqdn;
     let ip2 = interface2.address;
 
-    tracing::info!(
-        fqdn1 = %fqdn1,
-        "FQDN1",
-    );
+    tracing::info!(fqdn1 = %fqdn1, "FQDN1");
     let dns_record = api
-        .lookup_record(tonic::Request::new(
+        .lookup_record(Request::new(
             rpc::protos::dns::DnsResourceRecordLookupRequest {
                 qname: fqdn1 + ".",
                 zone_id: uuid::Uuid::new_v4().to_string(),
@@ -77,14 +125,8 @@ async fn test_dns(pool: sqlx::PgPool) {
         .await
         .unwrap()
         .into_inner();
-    tracing::info!(
-        dns_record = ?dns_record,
-        "DNS Record",
-    );
-    tracing::info!(
-        ip1 = %ip1,
-        "IP",
-    );
+    tracing::info!(dns_record = ?dns_record, "DNS Record");
+    tracing::info!(ip1 = %ip1, "IP");
     assert_eq!(
         ip1.split('/').collect::<Vec<&str>>()[0],
         &*dns_record.records[0].content
@@ -95,7 +137,7 @@ async fn test_dns(pool: sqlx::PgPool) {
     );
 
     let dns_record = api
-        .lookup_record(tonic::Request::new(
+        .lookup_record(Request::new(
             rpc::protos::dns::DnsResourceRecordLookupRequest {
                 qtype: "A".to_string(),
                 zone_id: uuid::Uuid::new_v4().to_string(),
@@ -121,14 +163,13 @@ async fn test_dns(pool: sqlx::PgPool) {
     // Create a managed host to make sure that the MachineId DNS
     // records for the Host and DPU are created + end up in the
     // dns_records view.
-    let (host_id, dpu_id) = create_managed_host(&env).await.into();
-    let api = &env.api;
+    let managed_host = create_managed_host(&env, underlay_segment, admin_segment).await;
 
     // And now check to make sure the DNS records exist and,
     // of course, that they are correct.
-    let machine_ids: [MachineId; 2] = [host_id, dpu_id];
-    for machine_id in machine_ids.iter() {
-        let mut txn = env.pool.begin().await.unwrap();
+    let machine_ids: [MachineId; 2] = [managed_host.host.id, managed_host.first_dpu().id];
+    for machine_id in &machine_ids {
+        let mut txn = env.db_txn().await;
 
         // First, check the BMC record by querying the MachineTopology
         // data for the current machine ID.
@@ -138,7 +179,7 @@ async fn test_dns(pool: sqlx::PgPool) {
             .unwrap();
         let topology = &topologies.get(machine_id).unwrap()[0];
         let bmc_record = api
-            .lookup_record(tonic::Request::new(
+            .lookup_record(Request::new(
                 rpc::protos::dns::DnsResourceRecordLookupRequest {
                     qname: format!("{}.{}.", machine_id, DNS_BMC_SUBDOMAIN),
                     zone_id: uuid::Uuid::new_v4().to_string(),
@@ -163,12 +204,11 @@ async fn test_dns(pool: sqlx::PgPool) {
         // And now check the ADM (Admin IP) record by querying the
         // MachineInterface data for the given machineID.
         tracing::info!(machine_id = %machine_id, subdomain = %DNS_ADM_SUBDOMAIN, "Checking ADM record");
-        let interface =
-            db::machine_interface::get_machine_interface_primary(&machine_id.clone(), &mut txn)
-                .await
-                .unwrap();
+        let interface = db::machine_interface::get_machine_interface_primary(machine_id, &mut txn)
+            .await
+            .unwrap();
         let adm_record = api
-            .lookup_record(tonic::Request::new(
+            .lookup_record(Request::new(
                 rpc::protos::dns::DnsResourceRecordLookupRequest {
                     qname: format!("{}.{}.", machine_id, DNS_ADM_SUBDOMAIN),
                     zone_id: uuid::Uuid::new_v4().to_string(),
@@ -198,10 +238,13 @@ async fn test_dns(pool: sqlx::PgPool) {
     //      - 2x fancy names
     //      - 2x admin machine ID names
     //      - 2x bmc machine ID names
-    assert_eq!(10, get_dns_record_count(&env.pool).await);
+    assert_eq!(
+        10,
+        db::test_support::dns::record_count(&api.database_connection).await
+    );
 
     let status = api
-        .lookup_record(tonic::Request::new(
+        .lookup_record(Request::new(
             rpc::protos::dns::DnsResourceRecordLookupRequest {
                 qname: "".to_string(),
                 zone_id: uuid::Uuid::new_v4().to_string(),
@@ -222,9 +265,9 @@ async fn test_dns(pool: sqlx::PgPool) {
         format!("unknown.{DNS_BMC_SUBDOMAIN}."),
     ] {
         let status = api
-            .lookup_record(tonic::Request::new(
+            .lookup_record(Request::new(
                 rpc::protos::dns::DnsResourceRecordLookupRequest {
-                    qname: name.clone(),
+                    qname: name,
                     zone_id: uuid::Uuid::new_v4().to_string(),
                     local: None,
                     remote: None,
@@ -236,25 +279,25 @@ async fn test_dns(pool: sqlx::PgPool) {
             .unwrap()
             .into_inner();
 
-        tracing::info!(
-            dns_lookup_response = ?status,
-            "Status",
-        );
+        tracing::info!(dns_lookup_response = ?status, "Status");
         assert_eq!(status.records.len(), 0);
     }
 }
 
 // test_dns_aaaa verifies that IPv6 addresses in the machine_interface_addresses
 // table produce AAAA DNS records (not A records) in the dns_records view.
-#[crate::sqlx_test]
-async fn test_dns_aaaa(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    env.create_vpc_and_tenant_segment().await;
-    let api = &env.api;
+#[sqlx_test]
+async fn test_dns_aaaa(pool: PgPool) {
+    let DnsTestEnv {
+        env,
+        admin_segment,
+        underlay_segment,
+    } = init(pool).await;
+    let api = env.api();
+    let managed_host = create_managed_host(&env, underlay_segment, admin_segment).await;
+    let host_id = managed_host.host.id;
 
-    let (host_id, _dpu_id) = create_managed_host(&env).await.into();
-
-    let mut txn = env.pool.begin().await.unwrap();
+    let mut txn = env.db_txn().await;
 
     // Get the primary interface for this host — it already has an IPv4 address
     // from the managed host creation flow.
@@ -283,9 +326,9 @@ async fn test_dns_aaaa(pool: sqlx::PgPool) {
     // AAAA records since the interface has both IPv4 and IPv6 addresses.
     let adm_qname = format!("{}.{}.", host_id, DNS_ADM_SUBDOMAIN);
     let dns_response = api
-        .lookup_record(tonic::Request::new(
+        .lookup_record(Request::new(
             rpc::protos::dns::DnsResourceRecordLookupRequest {
-                qname: adm_qname.clone(),
+                qname: adm_qname,
                 zone_id: uuid::Uuid::new_v4().to_string(),
                 local: None,
                 remote: None,
@@ -325,7 +368,7 @@ async fn test_dns_aaaa(pool: sqlx::PgPool) {
     // produce both A and AAAA records via dns_records_shortname_combined.
     let shortname_qname = format!("{}.{}.", interface.hostname, DOMAIN_NAME);
     let shortname_response = api
-        .lookup_record(tonic::Request::new(
+        .lookup_record(Request::new(
             rpc::protos::dns::DnsResourceRecordLookupRequest {
                 qname: shortname_qname,
                 zone_id: uuid::Uuid::new_v4().to_string(),
@@ -358,15 +401,18 @@ async fn test_dns_aaaa(pool: sqlx::PgPool) {
 // fully-qualified hostname of the interface that holds it. The handler parses the
 // in-addr.arpa / ip6.arpa qname back to an address and looks the interface up by
 // address, so this exercises both the IPv4 and IPv6 reverse paths end to end.
-#[crate::sqlx_test]
-async fn test_dns_ptr(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    env.create_vpc_and_tenant_segment().await;
-    let api = &env.api;
+#[sqlx_test]
+async fn test_dns_ptr(pool: PgPool) {
+    let DnsTestEnv {
+        env,
+        admin_segment,
+        underlay_segment,
+    } = init(pool).await;
+    let api = env.api();
+    let managed_host = create_managed_host(&env, underlay_segment, admin_segment).await;
+    let host_id = managed_host.host.id;
 
-    let (host_id, _dpu_id) = create_managed_host(&env).await.into();
-
-    let mut txn = env.pool.begin().await.unwrap();
+    let mut txn = env.db_txn().await;
     let interface = db::machine_interface::get_machine_interface_primary(&host_id, &mut txn)
         .await
         .unwrap();
@@ -412,7 +458,7 @@ async fn test_dns_ptr(pool: sqlx::PgPool) {
         PtrCase {
             description: "IPv6 reverse lookup resolves to the interface FQDN",
             qname: ip_to_arpa(ipv6_addr),
-            expected: Some(expected_fqdn.clone()),
+            expected: Some(expected_fqdn),
         },
         PtrCase {
             description: "an address no interface holds resolves to nothing",
@@ -450,11 +496,8 @@ async fn test_dns_ptr(pool: sqlx::PgPool) {
 }
 
 /// Issue a PTR `lookup_record` query and return the reply records.
-async fn lookup_ptr(
-    api: &crate::api::Api,
-    qname: &str,
-) -> Vec<rpc::protos::dns::DnsResourceRecord> {
-    api.lookup_record(tonic::Request::new(
+async fn lookup_ptr(api: &Api, qname: &str) -> Vec<rpc::protos::dns::DnsResourceRecord> {
+    api.lookup_record(Request::new(
         rpc::protos::dns::DnsResourceRecordLookupRequest {
             qname: qname.to_string(),
             zone_id: uuid::Uuid::new_v4().to_string(),
@@ -489,18 +532,4 @@ fn ip_to_arpa(addr: IpAddr) -> String {
         }
     }
     qname
-}
-
-// Get the current number of rows in the dns_records view,
-// which is expected to start at 0, and then progress, as
-// the test continues.
-//
-// TODO(chet): Find a common place for this and the same exact
-// function in api-test/tests/integration/main.rs to exist, instead
-// of it being in two places.
-pub(in crate::tests) async fn get_dns_record_count(pool: &sqlx::Pool<Postgres>) -> i64 {
-    let mut txn = pool.begin().await.unwrap();
-    let query = "SELECT COUNT(*) as row_cnt FROM dns_records";
-    let rows = sqlx::query::<_>(query).fetch_one(&mut *txn).await.unwrap();
-    rows.try_get("row_cnt").unwrap()
 }

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -20,6 +20,7 @@ mod compute_allocation;
 mod credential_management;
 mod credential_rotation;
 mod dhcp_lease_expiration;
+mod dns_resolution;
 mod dpu_machine_inventory;
 mod expected_power_shelf;
 mod expected_power_shelf_crud;

--- a/crates/api-db/src/test_support/dns.rs
+++ b/crates/api-db/src/test_support/dns.rs
@@ -15,9 +15,12 @@
  * limitations under the License.
  */
 
-use carbide_uuid::domain::DomainId;
+use sqlx::PgPool;
 
-pub struct TestDomain {
-    pub id: DomainId,
-    pub name: String,
+/// Returns the current number of rows exposed by the `dns_records` view.
+pub async fn record_count(pool: &PgPool) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM dns_records")
+        .fetch_one(pool)
+        .await
+        .expect("dns_records row count query should succeed")
 }

--- a/crates/api-db/src/test_support/mod.rs
+++ b/crates/api-db/src/test_support/mod.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+/// DNS database helpers for tests in downstream crates.
+pub mod dns;
 #[cfg(test)]
 pub(crate) mod expected_host;
 #[cfg(test)]

--- a/crates/api-integration-tests/Cargo.toml
+++ b/crates/api-integration-tests/Cargo.toml
@@ -33,7 +33,9 @@ carbide-api-test-helper = { path = "../api-test-helper" }
 carbide-kms-provider = { path = "../kms-provider" }
 carbide-secrets = { path = "../secrets" }
 carbide-api-core = { path = "../api-core", default-features = false }
-carbide-api-db = { path = "../api-db", default-features = false }
+carbide-api-db = { path = "../api-db", default-features = false, features = [
+  "test-support",
+] }
 carbide-api-model = { path = "../api-model", default-features = false }
 bmc-mock = { path = "../bmc-mock" }
 bmc-vendor = { path = "../bmc-vendor" }

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -40,7 +40,6 @@ use futures::future::join_all;
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::machine_boot_interface::BootInterfaceSelectionSource;
-use sqlx::{Postgres, Row};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
@@ -493,7 +492,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
 
     // Before the initial host bootstrap, the dns_records view
     // should contain 0 entries.
-    assert_eq!(0i64, get_dns_record_count(&db_pool).await);
+    assert_eq!(0i64, db::test_support::dns::record_count(&db_pool).await);
 
     run_machine_a_tron_machine_test(
         HardwareType::DellPowerEdgeR750,
@@ -516,7 +515,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
                 // - 2x "human friendly" (ADM) for Host + DPU.
                 // - 2x Machine ID (BMC) for Host + DPU.
                 // - 2x Machine ID (ADM) for Host + DPU.
-                assert_eq!(8i64, get_dns_record_count(&db_pool).await);
+                assert_eq!(8i64, db::test_support::dns::record_count(&db_pool).await);
 
                 // Metrics are only updated after the machine state controller run one more
                 // time since the emitted metrics are for states at the start of the iteration.
@@ -1315,19 +1314,4 @@ fn assert_relay_selection(
     }
 
     Ok(())
-}
-
-// Get the current number of rows in the dns_records view,
-// which is expected to start at 0, and then progress, as
-// the test continues.
-//
-// TODO(chet): Find a common place for this and the same exact
-// function in api/tests/dns.rs to exist, instead of it being
-// in two places.
-pub async fn get_dns_record_count(pool: &sqlx::Pool<Postgres>) -> i64 {
-    let mut txn = pool.begin().await.unwrap();
-    let query = "SELECT COUNT(*) as row_cnt FROM dns_records";
-    let rows = sqlx::query::<_>(query).fetch_one(&mut *txn).await.unwrap();
-    txn.commit().await.unwrap();
-    rows.try_get("row_cnt").unwrap()
 }

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -88,11 +88,15 @@ impl TestHarness {
     }
 
     pub async fn test_domain(&self) -> TestDomain {
-        let name = "testharness.example.com";
+        self.create_test_domain("testharness.example.com").await
+    }
+
+    pub async fn create_test_domain(&self, name: impl Into<String>) -> TestDomain {
+        let name = name.into();
         let id = self
             .api
             .create_domain(Request::new(rpc::protos::dns::CreateDomainRequest {
-                name: name.to_string(),
+                name: name.clone(),
             }))
             .await
             .unwrap()

--- a/crates/test-harness/src/managed_host.rs
+++ b/crates/test-harness/src/managed_host.rs
@@ -165,6 +165,7 @@ pub struct TestManagedHostBuilder<'a> {
     site_explorer: &'a TestSiteExplorer,
     segment: TestNetworkSegment,
     config: Option<ManagedHostConfig>,
+    dpu_primary_segment: Option<TestNetworkSegment>,
     report_dpu_network_status: bool,
 }
 
@@ -179,6 +180,7 @@ impl<'a> TestManagedHostBuilder<'a> {
             site_explorer,
             segment,
             config: None,
+            dpu_primary_segment: None,
             report_dpu_network_status: false,
         }
     }
@@ -197,9 +199,30 @@ impl<'a> TestManagedHostBuilder<'a> {
         }
     }
 
+    pub fn with_dpu_primary_interfaces(self, segment: TestNetworkSegment) -> Self {
+        Self {
+            dpu_primary_segment: Some(segment),
+            ..self
+        }
+    }
+
     pub async fn build(self) -> (TestManagedHost, TestManagedHostBuildData) {
         let config = self.config.unwrap_or_else(ManagedHostConfig::default);
         register_expected_machine(self.test_harness, &config).await;
+
+        if let Some(segment) = self.dpu_primary_segment {
+            for dpu in &config.dpus {
+                self.test_harness
+                    .api()
+                    .discover_dhcp(
+                        DhcpDiscovery::builder(dpu.oob_mac_address, segment.relay_address)
+                            .vendor_string("SomeVendor")
+                            .tonic_request(),
+                    )
+                    .await
+                    .expect("DPU primary interface DHCP discovery should succeed");
+            }
+        }
 
         let host_bmc_ip = discover_bmc(
             self.test_harness.api(),


### PR DESCRIPTION
Move forward and reverse DNS coverage onto the shared integration harness. Add reusable setup for named domains and pre-ingestion DPU primary interfaces.

## Related issues

#2001 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

