### PR TITLE
ci(pxe): run ephemeral mkosi build in pxe-build-container

### DIFF
--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -154,9 +154,12 @@ jobs:
           path: .
         continue-on-error: false
 
-      # Setup mkosi environment for ephemeral builds (runs on shell)
+      # Install the mkosi toolchain on the runner only for the non-container
+      # (shell) path. Container-mode ephemeral builds get the toolchain from
+      # pxe-build-container instead, keeping the flaky distro mirror off the
+      # per-run critical path (#5249).
       - name: Setup mkosi environment
-        if: inputs.build_type == 'ephemeral'
+        if: inputs.build_type == 'ephemeral' && inputs.use_container == false
         uses: ./.github/actions/setup-mkosi-environment
         with:
           rust-version: '1.96.0'
@@ -421,6 +424,14 @@ jobs:
           echo "============================================"
 
           EXTRA_DOCKER_ARGS="-v ${SCCACHE_SECRETS}:/run/secrets:ro"
+
+          # mkosi needs Linux user namespaces plus loop/device access to assemble
+          # the image, so the ephemeral build runs privileged -- the same way the
+          # local `cargo make pxe-docker-x86` flow invokes pxe-build-container.
+          if [[ "${{ inputs.build_type }}" == "ephemeral" ]]; then
+            EXTRA_DOCKER_ARGS="${EXTRA_DOCKER_ARGS} --privileged"
+          fi
+
           if [[ "${{ inputs.cargo_make_task }}" == "build-boot-artifacts-bfb-ci" ]]; then
             # bfb build runs `docker pull/save` (see pxe/Makefile.toml tasks.bfb-hbn-pull/export).
             # Allow docker CLI inside the build container to talk to the host Docker daemon.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,6 +154,14 @@ jobs:
       build_artifacts_container_aarch64_run: ${{ steps.base-container-gate.outputs.build_artifacts_container_aarch64_run }}
       build_artifacts_container_aarch64_version: ${{ steps.base-container-gate.outputs.build_artifacts_container_aarch64_version }}
       build_artifacts_container_aarch64_version_latest: ${{ steps.base-container-gate.outputs.build_artifacts_container_aarch64_version_latest }}
+      pxe_build_container_x86_64_run: ${{ steps.base-container-gate.outputs.pxe_build_container_x86_64_run }}
+      pxe_build_container_x86_64_version: ${{ steps.base-container-gate.outputs.pxe_build_container_x86_64_version }}
+      pxe_build_container_x86_64_version_latest: ${{ steps.base-container-gate.outputs.pxe_build_container_x86_64_version_latest }}
+      pxe_build_container_x86_64_ref: ${{ steps.base-container-gate.outputs.pxe_build_container_x86_64_ref }}
+      pxe_build_container_aarch64_run: ${{ steps.base-container-gate.outputs.pxe_build_container_aarch64_run }}
+      pxe_build_container_aarch64_version: ${{ steps.base-container-gate.outputs.pxe_build_container_aarch64_version }}
+      pxe_build_container_aarch64_version_latest: ${{ steps.base-container-gate.outputs.pxe_build_container_aarch64_version_latest }}
+      pxe_build_container_aarch64_ref: ${{ steps.base-container-gate.outputs.pxe_build_container_aarch64_ref }}
       runtime_container_aarch64_run: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_run }}
       runtime_container_aarch64_version: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_version }}
       runtime_container_aarch64_version_latest: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_version_latest }}
@@ -195,6 +203,8 @@ jobs:
               - 'dev/docker/Dockerfile.build-artifacts-container-x86_64'
             build_artifacts_aarch64:
               - 'dev/docker/Dockerfile.build-artifacts-container-aarch64'
+            pxe_build_container:
+              - 'dev/docker/Dockerfile.pxe-build-container'
             proto_files:
               - '**/*.proto'
             core_rpc_proto_files:
@@ -391,6 +401,7 @@ jobs:
           BUILD_CONTAINER_AARCH64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.build_container_aarch64 }}
           BUILD_ARTIFACTS_X86_64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.build_artifacts_x86_64 }}
           BUILD_ARTIFACTS_AARCH64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.build_artifacts_aarch64 }}
+          PXE_BUILD_CONTAINER_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.pxe_build_container }}
           PROTO_FILES_CHANGED: ${{ steps.build-container-changes.outputs.proto_files }}
           CORE_RPC_PROTO_FILES_CHANGED: ${{ steps.build-container-changes.outputs.core_rpc_proto_files }}
           SOURCE_FILES_CHANGED: ${{ steps.build-container-changes.outputs.source_files }}
@@ -401,6 +412,10 @@ jobs:
           runtime_container_aarch64_run=false
           build_artifacts_container_x86_64_run=false
           build_artifacts_container_aarch64_run=false
+          # One Dockerfile.pxe-build-container serves both arches, so a single
+          # change (or the force directive) rebuilds both.
+          pxe_build_container_x86_64_run=false
+          pxe_build_container_aarch64_run=false
           proto_files_changed=false
           core_rpc_proto_files_changed=false
           source_files_changed=false
@@ -412,8 +427,15 @@ jobs:
             runtime_container_aarch64_run=true
             build_artifacts_container_x86_64_run=true
             build_artifacts_container_aarch64_run=true
+            pxe_build_container_x86_64_run=true
+            pxe_build_container_aarch64_run=true
           elif [[ "${BUILD_CONTAINER_X86_64_DOCKERFILE_CHANGED}" == "true" ]]; then
             build_container_x86_64_run=true
+          fi
+
+          if [[ "${PXE_BUILD_CONTAINER_DOCKERFILE_CHANGED}" == "true" ]]; then
+            pxe_build_container_x86_64_run=true
+            pxe_build_container_aarch64_run=true
           fi
 
           if [[ "${PROTO_FILES_CHANGED}" == "true" ]]; then
@@ -454,6 +476,8 @@ jobs:
           echo "runtime_container_aarch64_run=${runtime_container_aarch64_run}" >> "$GITHUB_OUTPUT"
           echo "build_artifacts_container_x86_64_run=${build_artifacts_container_x86_64_run}" >> "$GITHUB_OUTPUT"
           echo "build_artifacts_container_aarch64_run=${build_artifacts_container_aarch64_run}" >> "$GITHUB_OUTPUT"
+          echo "pxe_build_container_x86_64_run=${pxe_build_container_x86_64_run}" >> "$GITHUB_OUTPUT"
+          echo "pxe_build_container_aarch64_run=${pxe_build_container_aarch64_run}" >> "$GITHUB_OUTPUT"
           echo "proto_files_changed=${proto_files_changed}" >> "$GITHUB_OUTPUT"
           echo "core_rpc_proto_files_changed=${core_rpc_proto_files_changed}" >> "$GITHUB_OUTPUT"
           echo "source_files_changed=${source_files_changed}" >> "$GITHUB_OUTPUT"
@@ -519,6 +543,26 @@ jobs:
             echo "build_artifacts_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_aarch64_ref=${SOURCE_REGISTRY}/build-artifacts-container-aarch64:latest" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "$pxe_build_container_x86_64_run" == "true" ]]; then
+            echo "pxe_build_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "pxe_build_container_x86_64_ref=${TARGET_REGISTRY}/pxe-build-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "pxe_build_container_x86_64_version_latest=${TARGET_REGISTRY}/pxe-build-container-x86_64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "pxe_build_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
+            echo "pxe_build_container_x86_64_ref=${SOURCE_REGISTRY}/pxe-build-container-x86_64:latest" >> "$GITHUB_OUTPUT"
+            echo "pxe_build_container_x86_64_version_latest=" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "$pxe_build_container_aarch64_run" == "true" ]]; then
+            echo "pxe_build_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "pxe_build_container_aarch64_ref=${TARGET_REGISTRY}/pxe-build-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "pxe_build_container_aarch64_version_latest=${TARGET_REGISTRY}/pxe-build-container-aarch64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "pxe_build_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
+            echo "pxe_build_container_aarch64_ref=${SOURCE_REGISTRY}/pxe-build-container-aarch64:latest" >> "$GITHUB_OUTPUT"
+            echo "pxe_build_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Decide release container publish strategy
@@ -702,6 +746,46 @@ jobs:
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
       additional_tags: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version_latest }}
+      platforms: linux/arm64
+      runner: linux-arm64-cpu4
+      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
+      load: false
+      tag_latest: ${{ github.ref == 'refs/heads/main' }}
+    secrets: inherit
+
+  # The ephemeral (mkosi) image jobs run inside this container instead of
+  # apt-installing the mkosi toolchain on the runner every run (the flaky-mirror
+  # path from #5249). One Dockerfile.pxe-build-container serves both arches;
+  # the gate rebuilds it only when that file changes.
+  pxe-build-container-x86_64:
+    if: needs.prepare.outputs.pxe_build_container_x86_64_run == 'true'
+    needs:
+      - prepare
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      dockerfile_path: dev/docker/Dockerfile.pxe-build-container
+      image_name: ${{ needs.prepare.outputs.image_registry }}/pxe-build-container-x86_64
+      image_tag: ${{ needs.prepare.outputs.pxe_build_container_x86_64_version }}
+      additional_tags: ${{ needs.prepare.outputs.pxe_build_container_x86_64_version_latest }}
+      platforms: linux/amd64
+      runner: linux-amd64-cpu4
+      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
+      load: true
+      tag_latest: ${{ github.ref == 'refs/heads/main' }}
+    secrets: inherit
+
+  pxe-build-container-aarch64:
+    if: needs.prepare.outputs.pxe_build_container_aarch64_run == 'true'
+    needs:
+      - prepare
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      dockerfile_path: dev/docker/Dockerfile.pxe-build-container
+      image_name: ${{ needs.prepare.outputs.image_registry }}/pxe-build-container-aarch64
+      image_tag: ${{ needs.prepare.outputs.pxe_build_container_aarch64_version }}
+      additional_tags: ${{ needs.prepare.outputs.pxe_build_container_aarch64_version_latest }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
@@ -1196,7 +1280,8 @@ jobs:
     needs:
       - prepare
       - build-boot-artifacts-x86
-    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-boot-artifacts-x86.result == 'success' }}
+      - pxe-build-container-x86_64
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-boot-artifacts-x86.result == 'success' && contains('success,skipped', needs.pxe-build-container-x86_64.result) }}
     uses: ./.github/workflows/build-boot-artifacts.yml
     with:
       target_login: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1205,7 +1290,10 @@ jobs:
       cargo_make_task: create-ephemeral-image-x86-host-ci
       version: ${{ needs.prepare.outputs.version }}
       runner: linux-amd64-cpu16
-      use_container: false
+      # Run mkosi inside pxe-build-container (privileged) instead of
+      # apt-installing the toolchain on the runner. See build-boot-artifacts.yml.
+      use_container: true
+      build_container: ${{ needs.prepare.outputs.pxe_build_container_x86_64_ref }}
       sa_enablement: true
       inject_extras: true
       extras_container: ${{ needs.prepare.outputs.extras_container_ref }}
@@ -1215,11 +1303,12 @@ jobs:
     needs:
       - prepare
       - build-package-scout-aarch64
+      - pxe-build-container-aarch64
     # Depends on the scout package, not the full bfb build: the forge-scout
     # `.deb` is the only boot-stage input the mkosi build reads. The
     # release-artifacts carrier downstream still requires bfb to have
     # succeeded, so a bfb failure fails the run exactly as before.
-    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-package-scout-aarch64.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-package-scout-aarch64.result == 'success' && contains('success,skipped', needs.pxe-build-container-aarch64.result) }}
     uses: ./.github/workflows/build-boot-artifacts.yml
     with:
       target_login: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1228,7 +1317,11 @@ jobs:
       cargo_make_task: create-ephemeral-image-arm-host-ci
       version: ${{ needs.prepare.outputs.version }}
       runner: linux-arm64-cpu16
-      use_container: false
+      # Run mkosi inside pxe-build-container (privileged) instead of
+      # apt-installing the toolchain on the runner (the flaky ports.ubuntu.com
+      # path from #5249). See build-boot-artifacts.yml.
+      use_container: true
+      build_container: ${{ needs.prepare.outputs.pxe_build_container_aarch64_ref }}
       sa_enablement: true
       inject_extras: true
       extras_container: ${{ needs.prepare.outputs.extras_container_ref }}

--- a/dev/docker/Dockerfile.pxe-build-container
+++ b/dev/docker/Dockerfile.pxe-build-container
@@ -26,6 +26,14 @@ FROM ubuntu:24.04
 
 ARG RUST_VERSION=1.97.1
 
+# Fail faster and retry more against a flaky distro mirror rather than hanging
+# for minutes on one bad IP. Retries only re-ask the same host, but this image
+# is rebuilt only when this file changes, so its exposure to the mirror is
+# already rare; the full multi-mirror fallback in
+# .github/actions/setup-mkosi-environment is deliberately not duplicated here.
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "20";\nAcquire::https::Timeout "20";\nAcquire::Languages "none";\n' \
+	> /etc/apt/apt.conf.d/99-nico-acquire
+
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	# Rust install


### PR DESCRIPTION
## Summary

The ephemeral image jobs (`build-boot-artifacts-ephemeral-image-{x86,arm}-host`) installed the mkosi toolchain on the runner via `setup-mkosi-environment` on every run. That put the flaky distro mirror (`ports.ubuntu.com` on arm64, see #5249) on the per-run critical path.

This runs the ephemeral mkosi build inside `pxe-build-container` instead. That image already bakes in the mkosi toolchain and is the exact image the local `cargo make pxe-docker-x86` flow uses.

- Wire `pxe-build-container-{x86_64,aarch64}` as gated base-image build jobs, using the same paths-filter + gate + `docker-build.yml` pattern as the other six base images. They rebuild only when `Dockerfile.pxe-build-container` changes.
- Flip both ephemeral jobs to `use_container: true` and run mkosi `--privileged`, matching the local flow.
- Skip `setup-mkosi-environment` on the containerized path, so the ephemeral build no longer apt-installs the toolchain per run.
- Harden the `pxe-build-container` apt step with retries and shorter timeouts.

No content-addressing here by design. This uses the same paths-filter gating the other base images already use.

## Why pxe-build-container and not build-artifacts-container

They are different containers. `build-artifacts-container` is Debian bullseye with the Rust and test tooling (postgres, kind, kubectl) and no mkosi deps. `pxe-build-container` is Ubuntu 24.04, chosen to match the mkosi `ToolsTreeRelease=noble` the PXE profiles use, with the mkosi host deps. The local `pxe-docker-x86` flow already runs this ephemeral pipeline inside it, so this uses the image for its designed purpose and converges CI with local dev.

## Side benefit

Fixes a Rust drift. The old apt path pinned `1.96.0` while `rust-toolchain.toml`, `build-artifacts-container` and `pxe-build-container` are all `1.97.1`.

## Risks to watch on the first run

- The ephemeral runners (`linux-{amd64,arm64}-cpu16`) must allow `docker run --privileged`. mkosi needs user namespaces and loop/device access. The local flow relies on this and the bfb job already does privileged docker-socket work on the same runner class.
- Bootstrap. The first `main` build after merge publishes `pxe-build-container-*:latest` for later Dockerfile-unchanged runs to reuse. The Dockerfile edit in this PR triggers that first build through the paths-filter.

## Test plan

- [ ] `prepare` gate resolves the `pxe_build_container_*` outputs and both build jobs run on this PR (Dockerfile changed).
- [ ] Both ephemeral jobs pull `pxe-build-container-<arch>` and finish the mkosi build with no `setup-mkosi-environment` apt step.
- [ ] `docker run --privileged` works on the cpu16 runners.
- [ ] Boot output contract still passes for the ephemeral artifacts.