### PR TITLE
refactor(rest-api): move encryption cipher to common

### DIFF
--- a/rest-api/common/pkg/encryption/cipher.go
+++ b/rest-api/common/pkg/encryption/cipher.go
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package secret encrypts sensitive Flow data before it is persisted or sent
-// through Temporal.
-package secret
+// Package encryption provides versioned authenticated encryption for sensitive
+// data persisted or sent through workflow systems.
+package encryption
 
 import (
 	"crypto/aes"
@@ -19,10 +19,6 @@ import (
 	"os"
 	"strings"
 )
-
-// EncryptionKeyPathEnvVar names the environment variable containing the path
-// to Flow's mounted data-encryption key.
-const EncryptionKeyPathEnvVar = "FLOW_DATA_ENCRYPTION_KEY_PATH"
 
 // EncryptedDataVersion identifies the persisted ciphertext envelope format.
 const EncryptedDataVersion uint32 = 1

--- a/rest-api/common/pkg/encryption/cipher_test.go
+++ b/rest-api/common/pkg/encryption/cipher_test.go
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package secret
+package encryption
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -163,6 +164,25 @@ func TestCipherEncryptedDataEnvelope(t *testing.T) {
 	plaintext, err := cipher.DecryptData(encrypted, additionalData)
 	require.NoError(t, err)
 	require.Equal(t, []byte("download-credential"), plaintext)
+
+	t.Run("JSON wire shape", func(t *testing.T) {
+		candidate := EncryptedData{
+			Version:    1,
+			KeyID:      "key-id",
+			Ciphertext: []byte{0x01, 0x02},
+		}
+		wire, err := json.Marshal(candidate)
+		require.NoError(t, err)
+		require.JSONEq(
+			t,
+			`{"version":1,"key_id":"key-id","ciphertext":"AQI="}`,
+			string(wire),
+		)
+
+		var restored EncryptedData
+		require.NoError(t, json.Unmarshal(wire, &restored))
+		require.Equal(t, candidate, restored)
+	})
 
 	t.Run("wrong purpose AAD", func(t *testing.T) {
 		_, err := cipher.DecryptData(encrypted, []byte("flow:another-purpose"))

--- a/rest-api/flow/cmd/serve.go
+++ b/rest-api/flow/cmd/serve.go
@@ -17,11 +17,11 @@ import (
 	"github.com/spf13/cobra"
 	"go.temporal.io/sdk/worker"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/authz"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/config"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	svc "github.com/NVIDIA/infra-controller/rest-api/flow/internal/service"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
 	cmbuiltin "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/builtin"
@@ -37,6 +37,7 @@ const (
 	componentMgrCfgEnvVar              = "COMPONENT_MANAGER_CONFIG"
 	allowedServiceIdentitiesFileEnvVar = "FLOW_AUTHORIZATION_ALLOWED_SERVICE_IDENTITIES_FILE"
 	authorizationModeEnvVar            = "FLOW_AUTHORIZATION_MODE"
+	dataEncryptionKeyPathEnvVar        = "FLOW_DATA_ENCRYPTION_KEY_PATH"
 
 	// computeImplEnvVar selects the compute component manager
 	// implementation at deploy time. This override exists for the
@@ -349,13 +350,13 @@ func doServe() {
 	}
 }
 
-func loadDataCipherFromEnv() (*secret.Cipher, error) {
-	path := strings.TrimSpace(os.Getenv(secret.EncryptionKeyPathEnvVar))
+func loadDataCipherFromEnv() (*encryption.Cipher, error) {
+	path := strings.TrimSpace(os.Getenv(dataEncryptionKeyPathEnvVar))
 	if path == "" {
-		return nil, fmt.Errorf("%s is not set", secret.EncryptionKeyPathEnvVar)
+		return nil, fmt.Errorf("%s is not set", dataEncryptionKeyPathEnvVar)
 	}
 
-	return secret.NewCipherFromFile(path)
+	return encryption.NewCipherFromFile(path)
 }
 
 func loadAuthorizationConfig() (authz.Config, error) {

--- a/rest-api/flow/cmd/serve_test.go
+++ b/rest-api/flow/cmd/serve_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/authz"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	cmconfig "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 )
@@ -192,7 +191,7 @@ func TestLoadDataCipherFromEnv(t *testing.T) {
 		keyContents *string
 		wantErr     string
 	}{
-		{name: "missing environment variable", wantErr: secret.EncryptionKeyPathEnvVar + " is not set"},
+		{name: "missing environment variable", wantErr: dataEncryptionKeyPathEnvVar + " is not set"},
 		{name: "valid key", keyContents: &validKey},
 		{
 			name:        "invalid key",
@@ -203,14 +202,14 @@ func TestLoadDataCipherFromEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(secret.EncryptionKeyPathEnvVar, "")
+			t.Setenv(dataEncryptionKeyPathEnvVar, "")
 			if tt.keyContents != nil {
 				path := filepath.Join(t.TempDir(), "encryption-key")
 				require.NoError(
 					t,
 					os.WriteFile(path, []byte(*tt.keyContents), 0o600),
 				)
-				t.Setenv(secret.EncryptionKeyPathEnvVar, path)
+				t.Setenv(dataEncryptionKeyPathEnvVar, path)
 			}
 
 			cipher, err := loadDataCipherFromEnv()

--- a/rest-api/flow/internal/converter/protobuf/operationrun_converter.go
+++ b/rest-api/flow/internal/converter/protobuf/operationrun_converter.go
@@ -13,9 +13,9 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	operationrun "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -36,14 +36,14 @@ func OperationRunFrom(req *pb.CreateOperationRunRequest) (*operationrun.Operatio
 // template before its first serialization.
 func OperationRunFromWithFirmwareAuthentication(
 	req *pb.CreateOperationRunRequest,
-	authenticationData *secret.EncryptedData,
+	authenticationData *encryption.EncryptedData,
 ) (*operationrun.OperationRun, error) {
 	return operationRunFrom(req, authenticationData)
 }
 
 func operationRunFrom(
 	req *pb.CreateOperationRunRequest,
-	firmwareAuthenticationData *secret.EncryptedData,
+	firmwareAuthenticationData *encryption.EncryptedData,
 ) (*operationrun.OperationRun, error) {
 	if req == nil {
 		return nil, fmt.Errorf("create operation run request is required")

--- a/rest-api/flow/internal/firmwareauth/authentication.go
+++ b/rest-api/flow/internal/firmwareauth/authentication.go
@@ -11,7 +11,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/firmwarecomponents"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
@@ -47,10 +47,10 @@ func IsInvalidData(err error) bool {
 // encrypts it. An absent or explicitly empty value is represented by nil so
 // callers can omit it from persisted payloads.
 func Encrypt(
-	cipher *secret.Cipher,
+	cipher *encryption.Cipher,
 	authenticationData *pb.FirmwareAuthenticationData,
 	subTargets []string,
-) (*secret.EncryptedData, error) {
+) (*encryption.EncryptedData, error) {
 	empty, err := validate(authenticationData)
 	if err != nil {
 		return nil, &InvalidDataError{err: err}
@@ -86,8 +86,8 @@ func Encrypt(
 // component type. A shared value applies to every supported component type. A
 // missing per-component field means that type receives no authentication data.
 func DecryptFor(
-	cipher *secret.Cipher,
-	encrypted *secret.EncryptedData,
+	cipher *encryption.Cipher,
+	encrypted *encryption.EncryptedData,
 	componentType devicetypes.ComponentType,
 ) (string, error) {
 	if encrypted == nil {

--- a/rest-api/flow/internal/firmwareauth/authentication_test.go
+++ b/rest-api/flow/internal/firmwareauth/authentication_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
 )
@@ -65,7 +65,7 @@ func TestEncryptAndDecryptFor(t *testing.T) {
 			encrypted, err := Encrypt(cipher, tt.authenticationData, nil)
 			require.NoError(t, err)
 			require.NotNil(t, encrypted)
-			require.Equal(t, secret.EncryptedDataVersion, encrypted.Version)
+			require.Equal(t, encryption.EncryptedDataVersion, encrypted.Version)
 			require.NotEmpty(t, encrypted.KeyID)
 			if tt.want != "" {
 				require.NotContains(t, string(encrypted.Ciphertext), tt.want)
@@ -119,8 +119,8 @@ func TestDecryptRejectsEnvelopeFailures(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		cipher  *secret.Cipher
-		mutate  func(*secret.EncryptedData)
+		cipher  *encryption.Cipher
+		mutate  func(*encryption.EncryptedData)
 		wantErr string
 	}{
 		{
@@ -131,7 +131,7 @@ func TestDecryptRejectsEnvelopeFailures(t *testing.T) {
 		{
 			name:   "wrong key ID",
 			cipher: cipher,
-			mutate: func(data *secret.EncryptedData) {
+			mutate: func(data *encryption.EncryptedData) {
 				data.KeyID = "different-key"
 			},
 			wantErr: "does not match configured key ID",
@@ -139,7 +139,7 @@ func TestDecryptRejectsEnvelopeFailures(t *testing.T) {
 		{
 			name:   "unsupported envelope version",
 			cipher: cipher,
-			mutate: func(data *secret.EncryptedData) {
+			mutate: func(data *encryption.EncryptedData) {
 				data.Version++
 			},
 			wantErr: "unsupported encrypted data version",
@@ -147,7 +147,7 @@ func TestDecryptRejectsEnvelopeFailures(t *testing.T) {
 		{
 			name:   "malformed ciphertext",
 			cipher: cipher,
-			mutate: func(data *secret.EncryptedData) {
+			mutate: func(data *encryption.EncryptedData) {
 				data.Ciphertext = []byte("short")
 			},
 			wantErr: "encrypted data is too short",
@@ -269,14 +269,14 @@ func perComponentAuthenticationData(
 	}
 }
 
-func newTestCipher(t *testing.T, fill byte) *secret.Cipher {
+func newTestCipher(t *testing.T, fill byte) *encryption.Cipher {
 	t.Helper()
 
 	key := make([]byte, 32)
 	for idx := range key {
 		key[idx] = fill
 	}
-	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
+	cipher, err := encryption.NewCipher(base64.StdEncoding.EncodeToString(key))
 	require.NoError(t, err)
 	return cipher
 }

--- a/rest-api/flow/internal/service/config.go
+++ b/rest-api/flow/internal/service/config.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/endpoint"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/authz"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/certs"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/clients/temporal"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/config"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	cmconfig "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/config"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/providerapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/executor"
@@ -69,7 +69,7 @@ type Config struct {
 	FlowConfig       config.Config
 	CMConfig         cmconfig.Config
 	ProviderRegistry *providerapi.ProviderRegistry
-	DataCipher       *secret.Cipher
+	DataCipher       *encryption.Cipher
 
 	// DevMode enables developer options such as gRPC reflection and debug
 	// logging. Must not be set in staging/production environments.

--- a/rest-api/flow/internal/service/config_test.go
+++ b/rest-api/flow/internal/service/config_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/authz"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	pkgcerts "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/certs"
 )
 
@@ -330,11 +330,11 @@ func TestConfigValidateRequiresDataCipher(t *testing.T) {
 	require.EqualError(t, err, "data encryption cipher is required")
 }
 
-func testDataCipher(t *testing.T) *secret.Cipher {
+func testDataCipher(t *testing.T) *encryption.Cipher {
 	t.Helper()
 
 	key := make([]byte, 32)
-	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
+	cipher, err := encryption.NewCipher(base64.StdEncoding.EncodeToString(key))
 	require.NoError(t, err)
 	return cipher
 }

--- a/rest-api/flow/internal/service/server_impl.go
+++ b/rest-api/flow/internal/service/server_impl.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/protobuf"
 	dbquery "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/query"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
@@ -29,7 +30,6 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	operationrunmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun/manager"
 	taskschedule "github.com/NVIDIA/infra-controller/rest-api/flow/internal/scheduler/taskschedule"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/conflict"
 	taskmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/manager"
@@ -55,7 +55,7 @@ type FlowServerImpl struct {
 	taskScheduleDispatcher     *taskschedule.Dispatcher    // Background poller that fires due task schedules
 	operationRunManager        operationrunmanager.Manager // Operation-run manager for run planning and persistence
 	conflictResolver           *conflict.Resolver          // Reused for inter-schedule conflict detection
-	dataCipher                 *secret.Cipher
+	dataCipher                 *encryption.Cipher
 	pb.UnimplementedFlowServer // Embedded protobuf server interface for forward compatibility
 }
 
@@ -78,7 +78,7 @@ func newServerImplementation(
 	taskScheduleStore taskschedule.Store,
 	taskScheduleDispatcher *taskschedule.Dispatcher,
 	operationRunManager operationrunmanager.Manager,
-	dataCipher *secret.Cipher,
+	dataCipher *encryption.Cipher,
 ) (*FlowServerImpl, error) {
 	return &FlowServerImpl{
 		inventoryManager:       inventoryManager,

--- a/rest-api/flow/internal/service/server_impl_firmware_test.go
+++ b/rest-api/flow/internal/service/server_impl_firmware_test.go
@@ -14,9 +14,9 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
@@ -70,7 +70,7 @@ func TestUpgradeFirmwareEncryptsAuthenticationDataBeforeSubmittingTask(t *testin
 func TestUpgradeFirmwareAuthenticationDataStatusCodes(t *testing.T) {
 	tests := []struct {
 		name               string
-		cipher             *secret.Cipher
+		cipher             *encryption.Cipher
 		authenticationData *pb.FirmwareAuthenticationData
 		subTargets         []string
 		wantCode           codes.Code
@@ -133,11 +133,11 @@ func (m *firmwareTaskManager) SubmitTask(
 }
 func (*firmwareTaskManager) CancelTask(context.Context, uuid.UUID) error { return nil }
 
-func newServiceTestCipher(t *testing.T) *secret.Cipher {
+func newServiceTestCipher(t *testing.T) *encryption.Cipher {
 	t.Helper()
 
 	key := make([]byte, 32)
-	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
+	cipher, err := encryption.NewCipher(base64.StdEncoding.EncodeToString(key))
 	require.NoError(t, err)
 	return cipher
 }

--- a/rest-api/flow/internal/service/server_impl_operation_run_test.go
+++ b/rest-api/flow/internal/service/server_impl_operation_run_test.go
@@ -15,13 +15,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/protobuf"
 	dbquery "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/query"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	operationrun "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun"
 	operationrunmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun/manager"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
@@ -92,7 +92,7 @@ func TestCreateOperationRunEncryptsFirmwareAuthenticationData(t *testing.T) {
 func TestCreateOperationRunAuthenticationDataStatusCodes(t *testing.T) {
 	tests := []struct {
 		name               string
-		cipher             *secret.Cipher
+		cipher             *encryption.Cipher
 		authenticationData *pb.FirmwareAuthenticationData
 		subTargets         []string
 		wantCode           codes.Code

--- a/rest-api/flow/internal/service/server_impl_task_schedule_test.go
+++ b/rest-api/flow/internal/service/server_impl_task_schedule_test.go
@@ -16,11 +16,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	taskschedule "github.com/NVIDIA/infra-controller/rest-api/flow/internal/scheduler/taskschedule"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	identifier "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/Identifier"
@@ -76,7 +76,7 @@ func TestCreateTaskScheduleAuthenticationDataStatusCodes(t *testing.T) {
 	componentID := uuid.New()
 	tests := []struct {
 		name               string
-		cipher             *secret.Cipher
+		cipher             *encryption.Cipher
 		authenticationData *pb.FirmwareAuthenticationData
 		subTargets         []string
 		wantCode           codes.Code

--- a/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/firmwareauth"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/capability"
 	cmcatalog "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/catalog"
@@ -308,12 +308,12 @@ func (m *capabilityTestManager) GetFirmwareStatus(
 	return nil, nil
 }
 
-func newActivityTestCipher(t *testing.T) *secret.Cipher {
+func newActivityTestCipher(t *testing.T) *encryption.Cipher {
 	t.Helper()
 
 	key := make([]byte, 32)
 	encodedKey := base64.StdEncoding.EncodeToString(key)
-	cipher, err := secret.NewCipher(encodedKey)
+	cipher, err := encryption.NewCipher(encodedKey)
 	require.NoError(t, err)
 	return cipher
 }

--- a/rest-api/flow/internal/task/executor/temporalworkflow/activity/registry.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/activity/registry.go
@@ -4,7 +4,7 @@
 package activity
 
 import (
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/task"
 )
@@ -18,7 +18,7 @@ type Activities struct {
 	updater       task.TaskStatusUpdater
 	reportUpdater task.TaskReportUpdater
 	registry      *componentmanager.Registry
-	dataCipher    *secret.Cipher
+	dataCipher    *encryption.Cipher
 }
 
 // New creates an Activities instance. Any argument may be nil; activity
@@ -27,7 +27,7 @@ func New(
 	updater task.TaskStatusUpdater,
 	reportUpdater task.TaskReportUpdater,
 	registry *componentmanager.Registry,
-	dataCipher *secret.Cipher,
+	dataCipher *encryption.Cipher,
 ) *Activities {
 	return &Activities{
 		updater:       updater,

--- a/rest-api/flow/internal/task/executor/temporalworkflow/manager/config_test.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/manager/config_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/worker"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/endpoint"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/clients/temporal"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 )
 
 func TestConfigValidateRequiresDataCipher(t *testing.T) {
@@ -32,7 +32,7 @@ func TestConfigValidateRequiresDataCipher(t *testing.T) {
 
 func TestConfigValidateAcceptsDataCipher(t *testing.T) {
 	key := make([]byte, 32)
-	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
+	cipher, err := encryption.NewCipher(base64.StdEncoding.EncodeToString(key))
 	require.NoError(t, err)
 	conf := Config{
 		ClientConf: temporal.Config{

--- a/rest-api/flow/internal/task/executor/temporalworkflow/manager/manager.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/manager/manager.go
@@ -14,8 +14,8 @@ import (
 	"go.temporal.io/sdk/worker"
 	temporalworkflow "go.temporal.io/sdk/workflow"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/clients/temporal"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/capabilityrequirements"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager"
@@ -43,7 +43,7 @@ type Config struct {
 
 	// DataCipher decrypts sensitive operation fields only inside the final
 	// activity that needs their plaintext value.
-	DataCipher *secret.Cipher
+	DataCipher *encryption.Cipher
 }
 
 // Validate checks that the configuration is complete and consistent.

--- a/rest-api/flow/internal/task/operations/operations.go
+++ b/rest-api/flow/internal/task/operations/operations.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/encryption"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 )
 
@@ -286,8 +286,8 @@ type FirmwareControlTaskInfo struct {
 	// AuthenticationData remains encrypted while this payload is persisted in
 	// Flow or carried by Temporal. The final FirmwareControl activity decrypts
 	// it and sets AccessToken only on its in-memory copy.
-	AuthenticationData *secret.EncryptedData `json:"authentication_data,omitempty"`
-	AccessToken        string                `json:"-"`
+	AuthenticationData *encryption.EncryptedData `json:"authentication_data,omitempty"`
+	AccessToken        string                    `json:"-"`
 }
 
 func (t *FirmwareControlTaskInfo) Validate() error {


### PR DESCRIPTION
## Summary

- move the versioned AES-GCM Cipher and EncryptedData envelope from Flow internals to rest-api/common
- keep the Flow-specific encryption-key environment variable in the Flow command layer
- update all Flow consumers to use the common package
- pin the persisted JSON envelope shape in a compatibility test

## Compatibility

This is a behavior-preserving move. The v1 envelope version, key ID derivation, nonce-prefixed ciphertext layout, Flow AAD domain separator, key validation, and error behavior are unchanged.

## Testing

- go test ./common/pkg/encryption ./flow/...
- go tool golangci-lint run ./common/pkg/encryption/...
- go tool golangci-lint run --new-from-rev=origin/main ./flow/...

Part of #5069.