### PR TITLE
fix(machine-a-tron): use per-machine SSH listeners

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1458,7 +1458,6 @@ where
         dpu_bmc_password: None,
         api_refresh_interval: Duration::from_millis(500),
         mock_bmc_ssh_server: false,
-        mock_bmc_ssh_port: None,
         enable_ipmi_simulation: false,
         ipmi_reachable_port: None,
         hw_mac_address_ranges: None,

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -181,7 +181,6 @@ async fn run_machine_a_tron_racks_test(
         dpu_bmc_password: None,
         api_refresh_interval: Duration::from_millis(500),
         mock_bmc_ssh_server: false,
-        mock_bmc_ssh_port: None,
         enable_ipmi_simulation: false,
         ipmi_reachable_port: None,
         hw_mac_address_ranges: None,

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -93,7 +93,6 @@ pub async fn run_local(
         forge_api_client,
         dhcp_client,
         mac_address_pool,
-        combined_bmc_ssh_port: std::sync::OnceLock::new(),
     });
 
     let mat = MachineATron::new(app_context.clone());

--- a/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
@@ -52,6 +52,7 @@ async fn explore_bluefield3_baseline() {
 #[test]
 async fn explore_bluefield3_uses_dynamic_system_console_port_not_manager_ssh() {
     let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+    assert!(h.state.has_enabled_ssh_serial_console());
     assert!(h.state.set_serial_console_ssh_port(Some(3222)));
     h.state.injection.put(vec![bmc_mock::injection::Rule {
         id: "manager_ssh_port".into(),

--- a/crates/bmc-explorer/tests/integration/dell_poweredge_r750_explore.rs
+++ b/crates/bmc-explorer/tests/integration/dell_poweredge_r750_explore.rs
@@ -24,6 +24,7 @@ use crate::common;
 #[test]
 async fn explore_dell_poweredge_r750() {
     let h = test_support::dell_poweredge_r750_bmc().await;
+    assert!(!h.state.has_enabled_ssh_serial_console());
     assert!(!h.state.set_serial_console_ssh_port(Some(3222)));
     let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -53,6 +53,11 @@ pub enum BmcEvent {
 }
 
 impl BmcState {
+    /// Returns whether this BMC advertises an enabled SSH serial console.
+    pub fn has_enabled_ssh_serial_console(&self) -> bool {
+        self.system_state.has_enabled_ssh_serial_console()
+    }
+
     /// Overrides the client-reachable SSH serial-console port on supported systems.
     pub fn set_serial_console_ssh_port(&self, port: Option<u16>) -> bool {
         self.system_state.set_serial_console_ssh_port(port)

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -319,6 +319,17 @@ impl SystemState {
         self.systems.iter().for_each(|s| s.on_boot_completed())
     }
 
+    /// Returns whether any system advertises an enabled SSH serial console.
+    pub fn has_enabled_ssh_serial_console(&self) -> bool {
+        self.systems.iter().any(|system| {
+            system
+                .config
+                .serial_console
+                .as_ref()
+                .is_some_and(redfish::serial_console::SerialConsole::has_enabled_ssh)
+        })
+    }
+
     /// Overrides the advertised SSH serial-console port only for systems whose
     /// hardware profile already declares an enabled SSH serial console.
     pub fn set_serial_console_ssh_port(&self, port: Option<u16>) -> bool {

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -40,7 +40,7 @@ pub(super) struct BmcMockWrapper {
     hostname: Arc<dyn HostnameQuerying>,
     needs_ipmi_console: bool,
     stable_id: String,
-    is_dpu: bool,
+    ssh_prompt_behavior: PromptBehavior,
 }
 
 impl BmcMockWrapper {
@@ -67,17 +67,21 @@ impl BmcMockWrapper {
             hostname,
             needs_ipmi_console: machine_info.needs_ipmi_console(),
             stable_id: host_id.to_string(),
-            is_dpu: matches!(machine_info, MachineInfo::Dpu(_)),
+            ssh_prompt_behavior: match machine_info {
+                MachineInfo::Dpu(_) => PromptBehavior::Dpu,
+                MachineInfo::Host(_) => PromptBehavior::Dell,
+            },
         }
     }
 
-    /// Starts per-machine console simulators when Redfish is served by a shared BMC mock.
-    /// Hosts use the shared SSH listener, while DPUs get a direct per-machine SSH listener.
-    /// Returns `None` when the hardware profile advertises neither an SSH nor IPMI console.
+    /// Starts per-machine console simulators when Redfish is served by a combined BMC mock.
+    /// Returns `None` when no simulator is enabled for the hardware profile.
     pub(super) async fn start(&self) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
-        let ssh_handle = if self.app_context.app_config.mock_bmc_ssh_server && self.is_dpu {
+        let ssh_handle = if self.app_context.app_config.mock_bmc_ssh_server
+            && self.bmc_mock_state.has_enabled_ssh_serial_console()
+        {
             Some(
-                mock_ssh_server::spawn(None, self.hostname.clone(), None, PromptBehavior::Dpu)
+                mock_ssh_server::spawn(None, self.hostname.clone(), None, self.ssh_prompt_behavior)
                     .await
                     .map_err(|error| MachineStateError::MockSshServer(error.to_string()))?,
             )
@@ -89,24 +93,17 @@ impl BmcMockWrapper {
         } else {
             None
         };
-        let ssh_endpoint_port = ssh_handle.as_ref().map(|handle| handle.port).or_else(|| {
-            (!self.is_dpu)
-                .then(|| self.app_context.combined_bmc_ssh_port.get().copied())
-                .flatten()
-        });
-        let advertises_ssh = self
-            .bmc_mock_state
+        let ssh_endpoint_port = ssh_handle.as_ref().map(|handle| handle.port);
+        self.bmc_mock_state
             .set_serial_console_ssh_port(ssh_endpoint_port);
 
         Ok(
-            (ipmi_sim_handle.is_some() || ssh_handle.is_some() || advertises_ssh).then_some(
-                BmcMockWrapperHandle {
-                    _bmc_mock: None,
-                    ssh_handle,
-                    ssh_endpoint_port,
-                    _ipmi_sim_handle: ipmi_sim_handle,
-                },
-            ),
+            (ipmi_sim_handle.is_some() || ssh_handle.is_some()).then_some(BmcMockWrapperHandle {
+                _bmc_mock: None,
+                ssh_handle,
+                ssh_endpoint_port,
+                _ipmi_sim_handle: ipmi_sim_handle,
+            }),
         )
     }
 

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -17,7 +17,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use bmc_mock::mac_address_pool::MacAddressPool;
@@ -497,11 +497,6 @@ pub struct MachineATronConfig {
     #[serde(default)]
     pub ipmi_reachable_port: Option<u16>,
 
-    /// Set this to configure the port to use when mocking a BMC SSH
-    /// server. If unset it will pick a random port.
-    #[serde(default)]
-    pub mock_bmc_ssh_port: Option<u16>,
-
     /// Set this to a hostname or IP If you want machine-a-tron to register its BMC-mock as the
     /// bmc_proxy host (this will be combined with bmc_mock_port.)
     pub configure_carbide_bmc_proxy_host: Option<String>,
@@ -946,8 +941,6 @@ pub struct MachineATronContext {
     pub forge_api_client: ForgeApiClient,
     pub dhcp_client: crate::dhcp_wrapper::DhcpClient,
     pub mac_address_pool: Arc<Mutex<MacAddressPool>>,
-    /// Client-reachable port of the shared host SSH listener in combined-BMC mode.
-    pub combined_bmc_ssh_port: OnceLock<u16>,
 }
 
 impl MachineATronContext {

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -19,7 +19,6 @@
 mod logging;
 mod ufm_mock;
 
-use std::borrow::Cow;
 use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -29,7 +28,7 @@ use bmc_mock::mac_address_pool::{
     Config as MacAddressConfig, MacAddressPool, PoolConfig as MacAddressPoolConfig,
     RangesConfig as MacAddressRangesConfig,
 };
-use bmc_mock::{CombinedServer, HostnameQuerying, ListenerOrAddress};
+use bmc_mock::{CombinedServer, ListenerOrAddress};
 use clap::Parser;
 use figment::Figment;
 use figment::providers::{Format, Toml};
@@ -39,9 +38,8 @@ use forge_tls::client_config::{
 use mac_address::MacAddress;
 use machine_a_tron::{
     AppEvent, BmcMockRegistry, ControlState, DeviceStatusConfig, DhcpClient, MachineATron,
-    MachineATronArgs, MachineATronConfig, MachineATronContext, MockSshServerHandle, PromptBehavior,
-    SimulatorLifecycle, Tui, TuiHostLogs, api_throttler, append_control_routes,
-    spawn_mock_ssh_server,
+    MachineATronArgs, MachineATronConfig, MachineATronContext, SimulatorLifecycle, Tui,
+    TuiHostLogs, api_throttler, append_control_routes,
 };
 use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use rpc::protos::forge_api_client::ForgeApiClient;
@@ -162,7 +160,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         forge_api_client,
         dhcp_client,
         mac_address_pool: Mutex::new(mac_address_pool).into(),
-        combined_bmc_ssh_port: std::sync::OnceLock::new(),
     });
 
     let info = app_context.forge_api_client.version(false).await?;
@@ -210,7 +207,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .parent()
                 .map(Path::to_path_buf)
         });
-    let server_handles: (CombinedServer, Option<MockSshServerHandle>) = {
+    let mut server_handle: CombinedServer = {
         let server_config = bmc_mock::tls::server_config(certs_dir.clone())?;
         let bmc_router = bmc_mock::combined_router(app_context.bmc_registry.clone());
         let bmc_router = match ufm_router.clone() {
@@ -218,44 +215,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
             None => bmc_router,
         };
         let router = append_control_routes(Some(bmc_router), control_state.clone());
-        let bmc_https_mock = bmc_mock::CombinedServer::run_router(
+        bmc_mock::CombinedServer::run_router(
             "bmc-mock",
             router,
             Some(ListenerOrAddress::Address(
                 format!("0.0.0.0:{bmc_mock_port}").parse().unwrap(),
             )),
             server_config,
-        );
-
-        let bmc_ssh_mock = if app_context.app_config.mock_bmc_ssh_server {
-            // Spawn a single mock SSH server too. ssh-console can be configured to talk to
-            // this instead of the carbide-assigned BMC IP for each host, so that
-            // machine-a-tron-based dev environments can have a "working" ssh-console too.
-            Some(
-                spawn_mock_ssh_server(
-                    app_context.app_config.mock_bmc_ssh_port,
-                    Arc::new(KnownHostname("shared-bmc-mock".to_string())),
-                    // Accept any credentials. We don't support mocking changing BMC
-                    // credentials, so we can't properly emulate BMC SSH credentials in dev
-                    // environments today. (Only ssh-console integration tests use
-                    // credentials here as of today.)
-                    None,
-                    PromptBehavior::Dell,
-                )
-                .await?,
-            )
-        } else {
-            None
-        };
-        (bmc_https_mock, bmc_ssh_mock)
+        )
     };
-
-    if let Some(ssh_handle) = &server_handles.1 {
-        app_context
-            .combined_bmc_ssh_port
-            .set(ssh_handle.port)
-            .expect("combined BMC SSH port must only be initialized once");
-    }
 
     // Run TUI
     let (app_tx, app_rx) = mpsc::channel(5000);
@@ -316,20 +284,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .ok();
     }
 
-    let (mut server_handle, _mock_ssh_server_handle) = server_handles;
     server_handle.stop().await?;
     if let Some(dhcp_service) = dhcp_service {
         dhcp_service.shutdown().await?;
     }
     mat_result?;
     Ok(())
-}
-
-#[derive(Debug)]
-struct KnownHostname(String);
-
-impl HostnameQuerying for KnownHostname {
-    fn get_hostname(&'_ self) -> Cow<'_, str> {
-        Cow::Borrowed(self.0.as_str())
-    }
 }

--- a/dev/deployment/tilt/Tiltfile
+++ b/dev/deployment/tilt/Tiltfile
@@ -1022,6 +1022,8 @@ k8s_resource(
 )
 
 machine_a_tron_ssh_service_name = 'nico-machine-a-tron-%s-ssh' % machine_a_tron_dhcp_pod
+# This headless Service only supplies stable pod DNS. ssh-console keeps the
+# per-machine port discovered through Redfish and connects directly to the pod.
 machine_a_tron_ssh_service = {
     'apiVersion': 'v1',
     'kind': 'Service',
@@ -1033,12 +1035,6 @@ machine_a_tron_ssh_service = {
             'app.kubernetes.io/component': 'machine-a-tron',
             'nvidia-infra-controller/pod-name': machine_a_tron_dhcp_pod,
         },
-        'ports': [{
-            'name': 'ssh',
-            'port': 2222,
-            'targetPort': 'ssh',
-            'protocol': 'TCP',
-        }],
     },
 }
 k8s_yaml(encode_yaml(machine_a_tron_ssh_service))

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -224,7 +224,6 @@ nico-machine-a-tron:
         log_format = "logfmt"
         bmc_mock_port = 1266
         mock_bmc_ssh_server = true
-        mock_bmc_ssh_port = 2222
         enable_ipmi_simulation = true
         ipmi_reachable_port = 0
         persist_dir = "/tmp/machine-a-tron-data"

--- a/dev/k8s/machine-a-tron-controller/README.md
+++ b/dev/k8s/machine-a-tron-controller/README.md
@@ -8,8 +8,8 @@ Services for mock BMC endpoints.
 - Auto-discovers machine-a-tron pods via `nvidia-infra-controller/mat-service=true`
   label
 - Creates ClusterIP Services with BMC IP for each mock BMC
-- Supports Redfish (TCP 443) and IPMI (UDP 623) ports
-- IPMI ports are dynamically added when machine-a-tron reports `bmc.ipmi` in status
+- Supports Redfish (TCP 443), IPMI (UDP 623), and per-machine SSH ports
+- IPMI and SSH ports are dynamically added when machine-a-tron reports their endpoints in status
 - Multi-pod deployments with pod-specific routing
 - Automatic cleanup of stale Services
 
@@ -83,11 +83,13 @@ Created Services have:
 - `nvidia-infra-controller/mat-power-state`
 - `nvidia-infra-controller/mat-hardware-type`
 - `nvidia-infra-controller/mat-ipmi-listen-port` (when `bmc.ipmi` reported in status)
+- `nvidia-infra-controller/mat-ssh-listen-port` (when `bmc.ssh` reported in status)
 
 **Ports:**
 
 - `redfish` (TCP) - Always present for Redfish API access
 - `ipmi` (UDP) - Present only when machine-a-tron reports `bmc.ipmi` in status
+- `ssh` (TCP) - Present only when machine-a-tron reports `bmc.ssh` in status
 
 ## Development
 

--- a/dev/k8s/machine-a-tron-controller/pkg/controller/controller.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/controller/controller.go
@@ -52,6 +52,8 @@ const (
 	AnnotationRedfishListenPort = "nvidia-infra-controller/mat-redfish-listen-port"
 	// AnnotationIPMIListenPort is the IPMI listen port annotation.
 	AnnotationIPMIListenPort = "nvidia-infra-controller/mat-ipmi-listen-port"
+	// AnnotationSSHListenPort is the SSH listen port annotation.
+	AnnotationSSHListenPort = "nvidia-infra-controller/mat-ssh-listen-port"
 
 	// MachineTypeHost is the machine type for hosts.
 	MachineTypeHost = "host"
@@ -62,6 +64,8 @@ const (
 	PortNameRedfish = "redfish"
 	// PortNameIPMI is the name of the IPMI port.
 	PortNameIPMI = "ipmi"
+	// PortNameSSH is the name of the SSH port.
+	PortNameSSH = "ssh"
 
 	// DefaultConcurrency is the default number of concurrent workers for K8s API calls.
 	DefaultConcurrency = 50
@@ -138,6 +142,17 @@ func (b *ServiceBuilder) BuildService(machine *matclient.MachineStatus, machineT
 			TargetPort: intstr.FromInt32(int32(machine.BMC.IPMI.ListenPort)),
 		})
 		annotations[AnnotationIPMIListenPort] = strconv.Itoa(int(machine.BMC.IPMI.ListenPort))
+	}
+
+	// Add SSH port if available
+	if machine.BMC.SSH != nil {
+		ports = append(ports, corev1.ServicePort{
+			Name:       PortNameSSH,
+			Protocol:   corev1.ProtocolTCP,
+			Port:       int32(machine.BMC.SSH.ReachablePort),
+			TargetPort: intstr.FromInt32(int32(machine.BMC.SSH.ListenPort)),
+		})
+		annotations[AnnotationSSHListenPort] = strconv.Itoa(int(machine.BMC.SSH.ListenPort))
 	}
 
 	// Build selector - include pod name for multi-pod deployments
@@ -374,7 +389,7 @@ func isControllerLabel(k string) bool {
 
 func isControllerAnnotation(k string) bool {
 	switch k {
-	case AnnotationBMCIP, AnnotationAPIState, AnnotationPowerState, AnnotationHardwareType, AnnotationRedfishListenPort, AnnotationIPMIListenPort:
+	case AnnotationBMCIP, AnnotationAPIState, AnnotationPowerState, AnnotationHardwareType, AnnotationRedfishListenPort, AnnotationIPMIListenPort, AnnotationSSHListenPort:
 		return true
 	default:
 		return false

--- a/dev/k8s/machine-a-tron-controller/pkg/controller/controller_test.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/controller/controller_test.go
@@ -166,6 +166,41 @@ func TestServiceBuilder_BuildService_WithIPMI(t *testing.T) {
 	assert.Equal(t, "16023", svc.Annotations[AnnotationIPMIListenPort])
 }
 
+func TestServiceBuilder_BuildService_WithSSH(t *testing.T) {
+	builder := &ServiceBuilder{
+		Namespace: "test-ns",
+		BaseSelector: map[string]string{
+			"app": "machine-a-tron",
+		},
+	}
+
+	machine := &matclient.MachineStatus{
+		MatID:      "dpu-uuid-12345678",
+		APIState:   "Ready",
+		PowerState: "On",
+		BMC: matclient.BMCStatus{
+			IP: ptr("192.168.1.101"),
+			Redfish: matclient.EndpointStatus{
+				ReachablePort: 443,
+				ListenPort:    8444,
+			},
+			SSH: &matclient.EndpointStatus{
+				ReachablePort: 32022,
+				ListenPort:    32022,
+			},
+		},
+	}
+
+	svc := builder.BuildService(machine, MachineTypeDPU, "parent-host-uuid", "")
+
+	require.Len(t, svc.Spec.Ports, 2)
+	assert.Equal(t, PortNameSSH, svc.Spec.Ports[1].Name)
+	assert.Equal(t, corev1.ProtocolTCP, svc.Spec.Ports[1].Protocol)
+	assert.Equal(t, int32(32022), svc.Spec.Ports[1].Port)
+	assert.Equal(t, intstr.FromInt32(32022), svc.Spec.Ports[1].TargetPort)
+	assert.Equal(t, "32022", svc.Annotations[AnnotationSSHListenPort])
+}
+
 func TestServiceBuilder_BuildService_DPU(t *testing.T) {
 	builder := &ServiceBuilder{
 		Namespace: "test-ns",

--- a/dev/k8s/machine-a-tron-controller/pkg/matclient/client_test.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/matclient/client_test.go
@@ -59,6 +59,10 @@ func TestClient_GetMachinesStatus(t *testing.T) {
 										ReachablePort: 443,
 										ListenPort:    8444,
 									},
+									SSH: &EndpointStatus{
+										ReachablePort: 32022,
+										ListenPort:    32022,
+									},
 								},
 							},
 						},

--- a/dev/k8s/machine-a-tron-controller/pkg/matclient/types.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/matclient/types.go
@@ -39,6 +39,8 @@ type BMCStatus struct {
 	Redfish EndpointStatus `json:"redfish"`
 	// IPMI contains the IPMI endpoint configuration, if enabled.
 	IPMI *EndpointStatus `json:"ipmi,omitempty"`
+	// SSH contains the SSH serial-console endpoint configuration, if enabled.
+	SSH *EndpointStatus `json:"ssh,omitempty"`
 }
 
 // EndpointStatus describes port mapping for an endpoint.


### PR DESCRIPTION
The shared SSH mock was useful when machine-a-tron simulated only a single machine type and did not model machine-specific behavior. As part of improving simulation fidelity, we plan to generate dynamic console output corresponding to the system boot process. A shared SSH mock cannot support this because it cannot associate an SSH session with a specific machine.

After SSH port plumbing through Redfish was implemented in #5209, ssh-console can connect to a dynamic port advertised through Redfish.

This PR removes the obsolete shared SSH mock and creates a dedicated SSH listener for each SSH-capable simulated BMC. It also adds SSH endpoint support to the per-machine Kubernetes Services managed by the machine-a-tron Kubernetes controller.

## Related issues

#3804 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

