### PR TITLE
fix(api-core): forward compute tray firmware force update

### DIFF
--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -2444,7 +2444,10 @@ pub(crate) async fn update_component_firmware(
                             &resolved.resolved.endpoints,
                             &req.target_version,
                             &components,
-                            &FirmwareUpdateOptions::default(),
+                            &FirmwareUpdateOptions {
+                                force_update,
+                                ..FirmwareUpdateOptions::default()
+                            },
                         )
                         .await
                         .map_err(component_manager_error_to_status)?;

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -188,6 +188,10 @@ pub(in crate::tests) struct TestEnvOverrides {
     pub(in crate::tests) nmxc_simulator: Option<bool>,
     pub(in crate::tests) redfish_overrides: Option<RedfishOverrides>,
 
+    /// Optional compute-tray backend injected into the component manager.
+    pub(in crate::tests) compute_tray_manager:
+        Option<Arc<dyn component_manager::compute_tray_manager::ComputeTrayManager>>,
+
     /// Optional firmware-object fetcher injected into the rack state handler.
     pub(in crate::tests) firmware_object_fetcher: Option<Arc<dyn FirmwareObjectFetcher>>,
 
@@ -1386,7 +1390,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
         .rack_profiles
         .extend(config.rack_profiles.rack_profiles.clone());
 
-    let test_component_manager = component_manager::component_manager::build_component_manager(
+    let mut test_component_manager = component_manager::component_manager::build_component_manager(
         &component_manager::config::ComponentManagerConfig {
             nv_switch_backend: component_manager::nv_switch_manager::Backend::Rms,
             power_shelf_backend: component_manager::power_shelf_manager::Backend::Rms,
@@ -1403,6 +1407,9 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
     )
     .await
     .expect("test component manager should build");
+    if let Some(compute_tray_manager) = overrides.compute_tray_manager.clone() {
+        test_component_manager.compute_tray = compute_tray_manager;
+    }
     let test_component_manager = Some(Arc::new(test_component_manager));
     let fake_endpoint_explorer = MockEndpointExplorer::default();
 

--- a/crates/api-core/src/tests/firmware_component_manager.rs
+++ b/crates/api-core/src/tests/firmware_component_manager.rs
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use component_manager::compute_tray_manager::{
+    Backend, ComputeTrayEndpoint, ComputeTrayFirmwareUpdateStatus, ComputeTrayManager,
+    ComputeTrayResult,
+};
+use component_manager::error::ComponentManagerError;
+use component_manager::mock::MockComputeTrayManager;
+use component_manager::types::FirmwareUpdateOptions;
+use model::component_manager::{ComputeTrayComponent, PowerAction};
+use model::test_support::HardwareInfoTemplate;
+use rpc::forge as rpc;
+use tonic::Request;
+
+use crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_1_INFO_JSON;
+use crate::tests::common::api_fixtures::{
+    TestEnvOverrides, create_managed_host_with_hardware_info_template,
+    create_test_env_with_overrides,
+};
+
+#[derive(Debug, Default)]
+struct RecordingComputeTrayManager {
+    inner: MockComputeTrayManager,
+    firmware_update_options: Mutex<Vec<FirmwareUpdateOptions>>,
+}
+
+impl RecordingComputeTrayManager {
+    fn clear_firmware_update_options(&self) {
+        self.firmware_update_options.lock().unwrap().clear();
+    }
+
+    fn firmware_update_options(&self) -> Vec<FirmwareUpdateOptions> {
+        self.firmware_update_options.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ComputeTrayManager for RecordingComputeTrayManager {
+    fn name(&self) -> &str {
+        "recording-compute-tray-manager"
+    }
+
+    fn backend(&self) -> Backend {
+        self.inner.backend()
+    }
+
+    async fn power_control(
+        &self,
+        endpoints: &[ComputeTrayEndpoint],
+        action: PowerAction,
+    ) -> Result<Vec<ComputeTrayResult>, ComponentManagerError> {
+        self.inner.power_control(endpoints, action).await
+    }
+
+    async fn update_firmware(
+        &self,
+        endpoints: &[ComputeTrayEndpoint],
+        target_version: &str,
+        components: &[ComputeTrayComponent],
+        options: &FirmwareUpdateOptions,
+    ) -> Result<Vec<ComputeTrayResult>, ComponentManagerError> {
+        self.firmware_update_options
+            .lock()
+            .unwrap()
+            .push(options.clone());
+        self.inner
+            .update_firmware(endpoints, target_version, components, options)
+            .await
+    }
+
+    async fn get_firmware_status(
+        &self,
+        endpoints: &[ComputeTrayEndpoint],
+    ) -> Result<Vec<ComputeTrayFirmwareUpdateStatus>, ComponentManagerError> {
+        self.inner.get_firmware_status(endpoints).await
+    }
+
+    async fn list_firmware_bundles(&self) -> Result<Vec<String>, ComponentManagerError> {
+        self.inner.list_firmware_bundles().await
+    }
+}
+
+#[crate::sqlx_test]
+async fn compute_tray_direct_dispatch_forwards_force_update(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let compute_tray_manager = Arc::new(RecordingComputeTrayManager::default());
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            compute_tray_manager: Some(compute_tray_manager.clone()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let managed_host = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(GB200_COMPUTE_TRAY_1_INFO_JSON),
+    )
+    .await;
+    compute_tray_manager.clear_firmware_update_options();
+
+    for force_update in [false, true] {
+        let response = crate::handlers::component_manager::update_component_firmware(
+            &env.api,
+            Request::new(rpc::UpdateComponentFirmwareRequest {
+                target_version: r#"{"Id":"test-firmware"}"#.to_string(),
+                access_token: None,
+                force_update,
+                bypass_state_controller: true,
+                target: Some(
+                    rpc::update_component_firmware_request::Target::ComputeTrays(
+                        rpc::UpdateComputeTrayFirmwareTarget {
+                            machine_ids: Some(::rpc::common::MachineIdList {
+                                machine_ids: vec![managed_host.id.into()],
+                            }),
+                            components: vec![],
+                        },
+                    ),
+                ),
+            }),
+        )
+        .await?
+        .into_inner();
+
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(
+            response.results[0].status,
+            rpc::ComponentManagerStatusCode::Success as i32,
+        );
+    }
+
+    let options = compute_tray_manager.firmware_update_options();
+    assert_eq!(
+        options
+            .iter()
+            .map(|options| options.force_update)
+            .collect::<Vec<_>>(),
+        vec![false, true],
+    );
+    assert!(
+        options.iter().all(|options| options.access_token.is_none()),
+        "the force-update fix must not change access-token handling",
+    );
+
+    Ok(())
+}

--- a/crates/api-core/src/tests/firmware_component_manager.rs
+++ b/crates/api-core/src/tests/firmware_component_manager.rs
@@ -130,7 +130,7 @@ async fn compute_tray_direct_dispatch_forwards_force_update(
                     rpc::update_component_firmware_request::Target::ComputeTrays(
                         rpc::UpdateComputeTrayFirmwareTarget {
                             machine_ids: Some(::rpc::common::MachineIdList {
-                                machine_ids: vec![managed_host.id.into()],
+                                machine_ids: vec![managed_host.id],
                             }),
                             components: vec![],
                         },

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -34,6 +34,7 @@ mod expected_switch;
 mod explored_endpoint_find;
 mod extension_service;
 mod finder;
+mod firmware_component_manager;
 mod host_bmc_firmware_test;
 mod host_firmware_config;
 mod ib_fabric_monitor;


### PR DESCRIPTION
## Summary

- Forward the request's `force_update` value when compute-tray firmware updates use direct dispatch.
- Keep existing access-token handling and other firmware-update defaults unchanged.
- Add handler-level regression coverage using a recording compute-tray backend.
- Assert that the fixture resolves the endpoint successfully and that both `force_update=false` and `force_update=true` reach the backend.

Fixes #5216

## Testing

Passed:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p carbide-api-core --no-default-features --lib`
- `cargo clippy -p carbide-api-core --no-default-features --lib -- -D warnings`
- `cargo test -p component-manager direct_rms_firmware_object_json_request_defaults_missing_access_token_to_noauth`
- Linux Docker/PostgreSQL targeted test:

  ```text
  cargo test -p carbide-api-core --lib \
    compute_tray_direct_dispatch_forwards_force_update \
    --locked -- --nocapture
  ```

  Result: 1 passed, 0 failed.

Additional package-suite validation:

```text
cargo test -p carbide-api-core --lib --locked
```

Result: 1,723 passed, 9 failed, 4 ignored. The issue-specific regression test passed. The nine failures were unrelated to this change and occurred in unchanged tests: three required Git-derived version metadata unavailable in the container, and six required the missing `tpm2` executable.

Full Linux all-targets/all-features Clippy was not run because the available container did not include the Clippy component. Production-library Clippy passed locally with warnings denied.
