### PR TITLE
remove(machine-a-tron): advertised IPMI port configuration

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1246,7 +1246,6 @@ where
         api_refresh_interval: Duration::from_millis(500),
         mock_bmc_ssh_server: false,
         enable_ipmi_simulation: false,
-        ipmi_reachable_port: None,
         hw_mac_address_ranges: None,
         mac_address_pool: None,
         ufm_mock: Default::default(),

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -205,7 +205,6 @@ async fn run_machine_a_tron_racks_test(
         api_refresh_interval: Duration::from_millis(500),
         mock_bmc_ssh_server: false,
         enable_ipmi_simulation: false,
-        ipmi_reachable_port: None,
         hw_mac_address_ranges: None,
         mac_address_pool: None,
         ufm_mock: Default::default(),

--- a/crates/bmc-mock/src/ipmi_sim.rs
+++ b/crates/bmc-mock/src/ipmi_sim.rs
@@ -46,26 +46,8 @@ const CHASSIS_CONTROL_FIFO: &str = "chassis-control.fifo";
 
 #[derive(Debug, Clone)]
 pub struct IpmiSimConfig {
-    /// Client-facing port advertised through Redfish. When absent, clients connect directly to
-    /// the dynamically allocated simulator port.
-    pub reachable_port: Option<u16>,
     pub stable_id: String,
     pub console_prompt: String,
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct IpmiEndpoint {
-    pub reachable_port: u16,
-    pub listen_port: u16,
-}
-
-impl IpmiEndpoint {
-    fn new(listen_port: u16, reachable_port: Option<u16>) -> Self {
-        Self {
-            reachable_port: reachable_port.unwrap_or(listen_port),
-            listen_port,
-        }
-    }
 }
 
 pub struct IpmiSimHandle {
@@ -75,14 +57,15 @@ pub struct IpmiSimHandle {
     _console: MockConsole,
     manager: Arc<ManagerState>,
     _password_updater: Arc<dyn PasswordUpdater>,
-    pub endpoint: IpmiEndpoint,
+    /// UDP port on which the simulator listens and which clients must use.
+    pub port: u16,
 }
 
 impl std::fmt::Debug for IpmiSimHandle {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("IpmiSimHandle")
-            .field("endpoint", &self.endpoint)
+            .field("port", &self.port)
             .finish_non_exhaustive()
     }
 }
@@ -223,7 +206,6 @@ pub async fn start(state: &BmcState, config: IpmiSimConfig) -> Result<IpmiSimHan
 
         match wait_until_ready(&mut child, ipmi_sim_lan_port, ipmi_sim_serial_port).await {
             Ok(()) => {
-                let endpoint = IpmiEndpoint::new(ipmi_sim_lan_port, config.reachable_port);
                 let connect_ip = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
                 let password_updater: Arc<dyn PasswordUpdater> = Arc::new(IpmiPasswordUpdater {
                     connect_ip,
@@ -232,9 +214,7 @@ pub async fn start(state: &BmcState, config: IpmiSimConfig) -> Result<IpmiSimHan
                 state
                     .account_service_state
                     .set_password_updater(&password_updater);
-                state
-                    .manager
-                    .set_ipmi_endpoint(Some(endpoint.reachable_port));
+                state.manager.set_ipmi_endpoint(Some(ipmi_sim_lan_port));
                 return Ok(IpmiSimHandle {
                     child,
                     _chassis_control: chassis_control,
@@ -242,7 +222,7 @@ pub async fn start(state: &BmcState, config: IpmiSimConfig) -> Result<IpmiSimHan
                     _console: console,
                     manager: state.manager.clone(),
                     _password_updater: password_updater,
-                    endpoint,
+                    port: ipmi_sim_lan_port,
                 });
             }
             Err(error) => {
@@ -571,8 +551,8 @@ mod tests {
     use tokio::sync::Notify;
 
     use super::{
-        ChassisControlEvent, Error, IPMI_SIM_EXECUTABLE, IpmiEndpoint, IpmiSimConfig, MockConsole,
-        stable_guid, start, validate_credential, validate_executable_in_path,
+        ChassisControlEvent, Error, IPMI_SIM_EXECUTABLE, IpmiSimConfig, MockConsole, stable_guid,
+        start, validate_credential, validate_executable_in_path,
     };
     use crate::{Callbacks, MockPowerState, SetSystemPowerError, SystemPowerControl};
 
@@ -613,36 +593,6 @@ mod tests {
         }
 
         fn state_refresh_indication(&self) {}
-    }
-
-    #[test]
-    fn endpoint_uses_configured_reachable_port_or_listen_port() {
-        for (name, listen_port, reachable_port, expected) in [
-            (
-                "direct",
-                16_020,
-                None,
-                IpmiEndpoint {
-                    reachable_port: 16_020,
-                    listen_port: 16_020,
-                },
-            ),
-            (
-                "forwarded",
-                16_020,
-                Some(623),
-                IpmiEndpoint {
-                    reachable_port: 623,
-                    listen_port: 16_020,
-                },
-            ),
-        ] {
-            assert_eq!(
-                IpmiEndpoint::new(listen_port, reachable_port),
-                expected,
-                "{name}",
-            );
-        }
     }
 
     #[test]
@@ -706,7 +656,6 @@ mod tests {
         let error = start(
             &state,
             IpmiSimConfig {
-                reachable_port: None,
                 stable_id: "missing-callback".to_string(),
                 console_prompt: "root@bmc-mock # ".to_string(),
             },
@@ -729,14 +678,13 @@ mod tests {
         let simulator = start(
             &state,
             IpmiSimConfig {
-                reachable_port: None,
                 stable_id: "chassis-reset".to_string(),
                 console_prompt: "root@bmc-mock # ".to_string(),
             },
         )
         .await
         .unwrap();
-        let port = simulator.endpoint.listen_port.to_string();
+        let port = simulator.port.to_string();
         let output = tokio::time::timeout(
             Duration::from_secs(10),
             tokio::process::Command::new("ipmitool")

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -137,7 +137,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             bmc_mock::ipmi_sim::start(
                 state,
                 bmc_mock::ipmi_sim::IpmiSimConfig {
-                    reachable_port: None,
                     stable_id: "standalone-bmc-mock".to_string(),
                     console_prompt: "root@bmc-mock # ".to_string(),
                 },

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -19,9 +19,8 @@ use std::sync::Arc;
 
 use axum::Router;
 use bmc_mock::injection::InjectionStore;
-use bmc_mock::ipmi_sim::{IpmiEndpoint, IpmiSimConfig, IpmiSimHandle};
+use bmc_mock::ipmi_sim::{IpmiSimConfig, IpmiSimHandle};
 use bmc_mock::{BmcState, Callbacks, CombinedServer, HostnameQuerying, MachineInfo};
-use carbide_ipmi::DEFAULT_IPMI_PORT;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -108,21 +107,10 @@ impl BmcMockWrapper {
     }
 
     async fn start_ipmi_sim(&self) -> Result<IpmiSimHandle, MachineStateError> {
-        // Determine the reachable port advertised through Redfish:
-        // - None (unset): Use default port
-        // - Some(0): Use dynamic port (same as listen port)
-        // - Some(n): Use the specified port
-        let reachable_port = match self.app_context.app_config.ipmi_reachable_port {
-            None => Some(DEFAULT_IPMI_PORT),
-            Some(0) => None,
-            Some(port) => Some(port),
-        };
-
         let console_prompt = format!("root@{} # ", self.hostname.get_hostname());
         bmc_mock::ipmi_sim::start(
             &self.bmc_mock_state,
             IpmiSimConfig {
-                reachable_port,
                 stable_id: self.stable_id.clone(),
                 console_prompt,
             },
@@ -153,8 +141,8 @@ pub(super) struct BmcMockWrapperHandle {
 }
 
 impl BmcMockWrapperHandle {
-    pub(super) fn ipmi_endpoint(&self) -> Option<IpmiEndpoint> {
-        self._ipmi_sim_handle.as_ref().map(|handle| handle.endpoint)
+    pub(super) fn ipmi_port(&self) -> Option<u16> {
+        self._ipmi_sim_handle.as_ref().map(|handle| handle.port)
     }
 
     pub(super) fn ssh_endpoint_port(&self) -> Option<u16> {

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -525,13 +525,6 @@ pub struct MachineATronConfig {
     #[serde(default = "default_false")]
     pub enable_ipmi_simulation: bool,
 
-    /// IPMI port advertised through Redfish for client connections.
-    /// - Unset/None: Use default port
-    /// - 0: Use dynamic port (same as listen port)
-    /// - 1-65535: Use this specific port
-    #[serde(default)]
-    pub ipmi_reachable_port: Option<u16>,
-
     /// Set this to a hostname or IP If you want machine-a-tron to register its BMC-mock as the
     /// bmc_proxy host (this will be combined with bmc_mock_port.)
     pub configure_carbide_bmc_proxy_host: Option<String>,
@@ -1358,11 +1351,6 @@ scout_run_interval = "5s"
     #[test]
     fn ipmi_simulation_is_disabled_by_default() {
         assert!(!rack_config().enable_ipmi_simulation);
-    }
-
-    #[test]
-    fn ipmi_reachable_port_is_unset_by_default() {
-        assert!(rack_config().ipmi_reachable_port.is_none());
     }
 
     #[test]

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -314,7 +314,6 @@ mod tests {
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request, StatusCode};
     use axum::routing::get;
-    use bmc_mock::ipmi_sim::IpmiEndpoint;
     use bmc_mock::{HardwareType, RackInfo, RackType};
     use carbide_uuid::rack::{RackId, RackProfileId};
     use tower::ServiceExt;
@@ -423,21 +422,9 @@ mod tests {
 
     #[tokio::test]
     async fn machines_status_reports_each_bmc_console_endpoint() {
-        let first = DeviceHandle::for_control_test(
-            Vec::new(),
-            Some(IpmiEndpoint {
-                reachable_port: 623,
-                listen_port: 16_020,
-            }),
-        )
-        .with_control_test_ssh_endpoint(22_020);
-        let second = DeviceHandle::for_control_test(
-            Vec::new(),
-            Some(IpmiEndpoint {
-                reachable_port: 623,
-                listen_port: 16_021,
-            }),
-        );
+        let first = DeviceHandle::for_control_test(Vec::new(), Some(16_020))
+            .with_control_test_ssh_endpoint(22_020);
+        let second = DeviceHandle::for_control_test(Vec::new(), Some(16_021));
         let without_ipmi = DeviceHandle::for_control_test(Vec::new(), None);
         let router = append(None, control_state(vec![first, second, without_ipmi]));
 
@@ -454,11 +441,11 @@ mod tests {
         let status: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let machines = status["machines"].as_array().unwrap();
 
-        assert_eq!(machines[0]["bmc"]["ipmi"]["reachable_port"], 623);
+        assert_eq!(machines[0]["bmc"]["ipmi"]["reachable_port"], 16_020);
         assert_eq!(machines[0]["bmc"]["ipmi"]["listen_port"], 16_020);
         assert_eq!(machines[0]["bmc"]["ssh"]["reachable_port"], 22_020);
         assert_eq!(machines[0]["bmc"]["ssh"]["listen_port"], 22_020);
-        assert_eq!(machines[1]["bmc"]["ipmi"]["reachable_port"], 623);
+        assert_eq!(machines[1]["bmc"]["ipmi"]["reachable_port"], 16_021);
         assert_eq!(machines[1]["bmc"]["ipmi"]["listen_port"], 16_021);
         assert!(machines[1]["bmc"].get("ssh").is_none());
         assert!(machines[2]["bmc"].get("ipmi").is_none());

--- a/crates/machine-a-tron/src/device_handle.rs
+++ b/crates/machine-a-tron/src/device_handle.rs
@@ -232,11 +232,8 @@ impl DeviceHandle {
     }
 
     #[cfg(test)]
-    pub(crate) fn for_control_test(
-        dpus: Vec<DpuMachineHandle>,
-        ipmi_endpoint: Option<bmc_mock::ipmi_sim::IpmiEndpoint>,
-    ) -> Self {
-        Self::machine(MachineHandle::for_control_test(dpus, ipmi_endpoint))
+    pub(crate) fn for_control_test(dpus: Vec<DpuMachineHandle>, ipmi_port: Option<u16>) -> Self {
+        Self::machine(MachineHandle::for_control_test(dpus, ipmi_port))
     }
 
     #[cfg(test)]

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -484,8 +484,8 @@ impl DpuMachineHandle {
             bmc: BmcStatus {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
-                ipmi: live_state.ipmi_endpoint.map(Into::into),
-                ssh: live_state.ssh_endpoint_port.map(EndpointStatus::ssh),
+                ipmi: live_state.ipmi_port.map(EndpointStatus::same_port),
+                ssh: live_state.ssh_endpoint_port.map(EndpointStatus::same_port),
             },
             dpus: Vec::new(),
         }

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -619,23 +619,20 @@ pub(crate) struct MachineHandle(Arc<HostMachineActor>);
 
 impl MachineHandle {
     #[cfg(test)]
-    pub(crate) fn for_control_test(
-        dpus: Vec<DpuMachineHandle>,
-        ipmi_endpoint: Option<bmc_mock::ipmi_sim::IpmiEndpoint>,
-    ) -> Self {
-        Self::for_control_test_in_section(dpus, ipmi_endpoint, "test")
+    pub(crate) fn for_control_test(dpus: Vec<DpuMachineHandle>, ipmi_port: Option<u16>) -> Self {
+        Self::for_control_test_in_section(dpus, ipmi_port, "test")
     }
 
     #[cfg(test)]
     pub(crate) fn for_control_test_in_section(
         dpus: Vec<DpuMachineHandle>,
-        ipmi_endpoint: Option<bmc_mock::ipmi_sim::IpmiEndpoint>,
+        ipmi_port: Option<u16>,
         machine_config_section: &str,
     ) -> Self {
         let (message_tx, _message_rx) = mpsc::unbounded_channel();
         let mac = mac_address::MacAddress::new([2, 0, 0, 0, 0, 2]);
         let live_state = LiveState {
-            ipmi_endpoint,
+            ipmi_port,
             ..LiveState::default()
         };
         Self(Arc::new(HostMachineActor {
@@ -790,8 +787,8 @@ impl MachineHandle {
             bmc: BmcStatus {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
-                ipmi: live_state.ipmi_endpoint.map(Into::into),
-                ssh: live_state.ssh_endpoint_port.map(EndpointStatus::ssh),
+                ipmi: live_state.ipmi_port.map(EndpointStatus::same_port),
+                ssh: live_state.ssh_endpoint_port.map(EndpointStatus::same_port),
             },
             dpus: self.0.dpus.iter().map(|dpu| dpu.status(config)).collect(),
         }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -22,7 +22,6 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use bmc_mock::injection::InjectionStore;
-use bmc_mock::ipmi_sim::IpmiEndpoint;
 use bmc_mock::{
     BmcCommand, BmcEvent, BmcState, BootOptionKind, Callbacks, HostnameQuerying, MachineInfo,
     MockPowerState, SetSystemPowerError, SetSystemPowerResult, SystemPowerControl,
@@ -209,7 +208,7 @@ pub(super) struct LiveState {
     pub(super) observed_machine_id: Option<MachineId>,
     pub(super) machine_ip: Option<Ipv4Addr>,
     pub(super) bmc_ip: Option<Ipv4Addr>,
-    pub(super) ipmi_endpoint: Option<IpmiEndpoint>,
+    pub(super) ipmi_port: Option<u16>,
     pub(super) ssh_endpoint_port: Option<u16>,
     pub(super) booted_os: MaybeOsImage,
     pub(super) next_boot_kind: Option<BootOptionKind>,
@@ -238,7 +237,7 @@ impl Default for LiveState {
             observed_machine_id: None,
             machine_ip: None,
             bmc_ip: None,
-            ipmi_endpoint: None,
+            ipmi_port: None,
             ssh_endpoint_port: None,
             booted_os: Default::default(),
             next_boot_kind: None,
@@ -986,10 +985,10 @@ impl MachineStateMachine {
         live_state.is_up = self.fsm.is_up();
         live_state.machine_ip = self.machine_ip();
         live_state.bmc_ip = self.bmc_ip();
-        live_state.ipmi_endpoint = self
+        live_state.ipmi_port = self
             .bmc_mock
             .as_ref()
-            .and_then(|bmc_mock| bmc_mock.ipmi_endpoint());
+            .and_then(|bmc_mock| bmc_mock.ipmi_port());
         live_state.ssh_endpoint_port = self
             .bmc_mock
             .as_ref()

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -21,7 +21,6 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use bmc_mock::injection::InjectionStore;
-use bmc_mock::ipmi_sim::IpmiEndpoint;
 use bmc_mock::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use bmc_mock::{
     BmcCommand, Callbacks, HardwareType, HostMachineInfo, HostnameQuerying, MachineInfo,
@@ -46,7 +45,7 @@ use crate::tui::UiUpdate;
 struct PowerShelfLiveState {
     power_state: MockPowerState,
     bmc_ip: Option<Ipv4Addr>,
-    ipmi_endpoint: Option<IpmiEndpoint>,
+    ipmi_port: Option<u16>,
     ssh_endpoint_port: Option<u16>,
     ssh_host_key: Option<String>,
     state: &'static str,
@@ -57,7 +56,7 @@ impl PowerShelfLiveState {
         Self {
             power_state: fsm.power_state(),
             bmc_ip: None,
-            ipmi_endpoint: None,
+            ipmi_port: None,
             ssh_endpoint_port: None,
             ssh_host_key: None,
             state: fsm.state_string(),
@@ -388,9 +387,7 @@ impl PowerShelfActor {
         {
             let mut state = self.live_state.write().unwrap();
             state.bmc_ip = Some(dhcp_info.ip_address);
-            state.ipmi_endpoint = bmc_handle
-                .as_ref()
-                .and_then(|handle| handle.ipmi_endpoint());
+            state.ipmi_port = bmc_handle.as_ref().and_then(|handle| handle.ipmi_port());
             state.ssh_endpoint_port = bmc_handle
                 .as_ref()
                 .and_then(|handle| handle.ssh_endpoint_port());
@@ -542,8 +539,8 @@ impl PowerShelfHandle {
             bmc: BmcStatus {
                 ip: state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
-                ipmi: state.ipmi_endpoint.map(Into::into),
-                ssh: state.ssh_endpoint_port.map(EndpointStatus::ssh),
+                ipmi: state.ipmi_port.map(EndpointStatus::same_port),
+                ssh: state.ssh_endpoint_port.map(EndpointStatus::same_port),
             },
             dpus: Vec::new(),
         }

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 use bmc_mock::HardwareType;
-use bmc_mock::ipmi_sim::IpmiEndpoint;
 use serde::Serialize;
 use ufm_mock::{EpochId, Generation, InventoryId};
 
@@ -129,19 +128,10 @@ impl EndpointStatus {
         }
     }
 
-    pub fn ssh(port: u16) -> Self {
+    pub fn same_port(port: u16) -> Self {
         Self {
             reachable_port: port,
             listen_port: port,
-        }
-    }
-}
-
-impl From<IpmiEndpoint> for EndpointStatus {
-    fn from(endpoint: IpmiEndpoint) -> Self {
-        Self {
-            reachable_port: endpoint.reachable_port,
-            listen_port: endpoint.listen_port,
         }
     }
 }

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -21,7 +21,6 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use bmc_mock::injection::InjectionStore;
-use bmc_mock::ipmi_sim::IpmiEndpoint;
 use bmc_mock::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use bmc_mock::{
     BmcCommand, Callbacks, HostMachineInfo, HostnameQuerying, MachineInfo, MockPowerState,
@@ -50,7 +49,7 @@ struct SwitchLiveState {
     power_state: MockPowerState,
     bmc_ip: Option<Ipv4Addr>,
     nvos_ip: Option<Ipv4Addr>,
-    ipmi_endpoint: Option<IpmiEndpoint>,
+    ipmi_port: Option<u16>,
     ssh_endpoint_port: Option<u16>,
     ssh_host_key: Option<String>,
     state: &'static str,
@@ -62,7 +61,7 @@ impl SwitchLiveState {
             power_state: fsm.power_state(),
             bmc_ip: None,
             nvos_ip: None,
-            ipmi_endpoint: None,
+            ipmi_port: None,
             ssh_endpoint_port: None,
             ssh_host_key: None,
             state: fsm.state_string(),
@@ -430,9 +429,7 @@ impl SwitchActor {
         {
             let mut state = self.live_state.write().unwrap();
             state.bmc_ip = Some(dhcp_info.ip_address);
-            state.ipmi_endpoint = bmc_handle
-                .as_ref()
-                .and_then(|handle| handle.ipmi_endpoint());
+            state.ipmi_port = bmc_handle.as_ref().and_then(|handle| handle.ipmi_port());
             state.ssh_endpoint_port = bmc_handle
                 .as_ref()
                 .and_then(|handle| handle.ssh_endpoint_port());
@@ -588,8 +585,8 @@ impl SwitchHandle {
             bmc: BmcStatus {
                 ip: state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
-                ipmi: state.ipmi_endpoint.map(Into::into),
-                ssh: state.ssh_endpoint_port.map(EndpointStatus::ssh),
+                ipmi: state.ipmi_port.map(EndpointStatus::same_port),
+                ssh: state.ssh_endpoint_port.map(EndpointStatus::same_port),
             },
             dpus: Vec::new(),
         }

--- a/crates/ssh-console/tests/util/ipmi_sim.rs
+++ b/crates/ssh-console/tests/util/ipmi_sim.rs
@@ -183,7 +183,6 @@ pub(super) async fn run(prompt: String) -> eyre::Result<IpmiSimHandle> {
     bmc_mock::ipmi_sim::start(
         &bmc.state,
         bmc_mock::ipmi_sim::IpmiSimConfig {
-            reachable_port: None,
             stable_id: prompt.clone(),
             console_prompt: prompt,
         },

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -156,7 +156,7 @@ pub(crate) async fn run_baseline_test_environment(
                 },
                 ipmi_port: match &bmc_handle {
                     MockBmcHandle::Ssh(_) => None,
-                    MockBmcHandle::Ipmi(i) => Some(i.endpoint.listen_port),
+                    MockBmcHandle::Ipmi(i) => Some(i.port),
                 },
                 bmc_user: "root".to_string(),
                 bmc_password: "password".to_string(),

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -225,7 +225,6 @@ nico-machine-a-tron:
         bmc_mock_port = 1266
         mock_bmc_ssh_server = true
         enable_ipmi_simulation = true
-        ipmi_reachable_port = 0
         persist_dir = "/tmp/machine-a-tron-data"
         cleanup_on_quit = false
         register_expected_machines = true

--- a/dev/k8s/machine-a-tron-controller/pkg/controller/controller_test.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/controller/controller_test.go
@@ -130,7 +130,7 @@ func TestServiceBuilder_BuildService_WithIPMI(t *testing.T) {
 				ListenPort:    8443,
 			},
 			IPMI: &matclient.EndpointStatus{
-				ReachablePort: 623,
+				ReachablePort: 16023,
 				ListenPort:    16023,
 			},
 		},
@@ -159,7 +159,7 @@ func TestServiceBuilder_BuildService_WithIPMI(t *testing.T) {
 
 	require.NotNil(t, ipmiPort)
 	assert.Equal(t, corev1.ProtocolUDP, ipmiPort.Protocol)
-	assert.Equal(t, int32(623), ipmiPort.Port)
+	assert.Equal(t, int32(16023), ipmiPort.Port)
 	assert.Equal(t, intstr.FromInt32(16023), ipmiPort.TargetPort)
 
 	// Check IPMI annotation

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -195,7 +195,7 @@ spec:
     targetPort: 1266  # Redfish listen port from machine-a-tron (default: service.bmcMock.port)
     protocol: TCP
   - name: ipmi        # Only present when IPMI simulation is enabled and BMC reports bmc.ipmi
-    port: 623
+    port: 16023
     targetPort: 16023  # IPMI listen port from machine-a-tron
     protocol: UDP
   selector:

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -275,47 +275,39 @@ hardware types have IPMI support).
 ```yaml
 machineATron:
   enableIpmiSimulation: true
-  # For K8s controller mode, use dynamic ports so each BMC gets a unique port
-  ipmiReachablePort: 0
 ```
 
-**Port Configuration:**
-
-| `ipmiReachablePort` | Behavior |
-|---------------------|----------|
-| Unset (default) | Advertise port 623 in Redfish |
-| `0` | Use dynamic port (required for K8s controller mode) |
-| `1-65535` | Use specified port |
+Machine-a-tron assigns each IPMI simulator a unique dynamic UDP port. The same
+port is advertised through Redfish and used by the simulator. IPMI SOL requires
+these ports to match because payload activation can direct the client to the
+simulator's bound port.
 
 **Deployment Mode Considerations:**
 
 | Mode | IPMI Accessible? | Notes |
 |------|------------------|-------|
-| Controller mode (`useSingleBmcMock: true` + `mat-k8s-controller`) |Yes | Use `ipmiReachablePort: 0`. Controller creates per-BMC Services with dynamic IPMI ports. |
-| Shared-proxy mode (`useSingleBmcMock: true` without controller) |No | No per-BMC Services to route dynamic IPMI ports. IPMI simulators run but are not externally reachable. |
-| Override mode (`useSingleBmcMock: false`) |Yes | Each BMC gets its own IP address. Use `ipmiReachablePort: 623` (default) or a fixed port. |
+| Controller mode (`useSingleBmcMock: true` + `mat-k8s-controller`) | Yes | The controller creates per-BMC Services using each simulator's dynamic port. |
+| Shared-proxy mode (`useSingleBmcMock: true` without controller) | No | No per-BMC Services expose the dynamic IPMI ports. |
+| Override mode (`useSingleBmcMock: false`) | Yes | Each BMC advertises its simulator's dynamic port through Redfish. |
 
 > **Note:** IPMI ports are only added to Services for host machines with
-> IPMI-capable hardware types (eg, NVIDIA GB300, Supermicro GB300)
-
-When using K8s controller mode (`machineATron.useSingleBmcMock: true`), set
-`ipmiReachablePort: 0` so each IPMI simulator gets a unique dynamic port that
-the `mat-k8s-controller` can map to individual Services.
+> IPMI-capable hardware types (eg, NVIDIA GB300, Supermicro GB300).
 
 When enabled:
 
 1. Machine-a-tron starts an independent IPMI simulator (`ipmi_sim`) for each
-   IPMI-capable host BMC
+   IPMI-capable host BMC.
 2. The `/machines/status` API reports `bmc.ipmi` with `reachable_port` and
-   `listen_port` for each BMC with IPMI enabled
+   `listen_port` set to the same dynamic port for each BMC with IPMI enabled.
 3. The `mat-k8s-controller` creates UDP Service ports for IPMI access alongside
-   the existing TCP Redfish port (controller mode only)
+   the existing TCP Redfish port, using the dynamic IPMI port for both `port`
+   and `targetPort` (controller mode only).
 
 **Requirements:**
 
 - The machine-a-tron container image must include `ipmi_sim` (from `openipmi`)
-  and `ipmitool` - these are included in the standard image
-- Only IPMI-capable hardware types will expose IPMI endpoints
+  and `ipmitool` - these are included in the standard image.
+- Only IPMI-capable hardware types will expose IPMI endpoints.
 
 ### MAC Address Pool Configuration
 

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -96,9 +96,6 @@ data:
     {{- if $root.Values.machineATron.enableIpmiSimulation }}
     enable_ipmi_simulation = true
     {{- end }}
-    {{- if (hasKey $root.Values.machineATron "ipmiReachablePort") }}
-    ipmi_reachable_port = {{ $root.Values.machineATron.ipmiReachablePort }}
-    {{- end }}
     {{- if $root.Values.machineATron.hostBmcPassword }}
     host_bmc_password = {{ $root.Values.machineATron.hostBmcPassword | quote }}
     {{- end }}

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -170,29 +170,3 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: "enable_ipmi_simulation = true"
-
-  - it: should not include ipmi_reachable_port by default
-    asserts:
-      - notMatchRegex:
-          path: data["mat.toml"]
-          pattern: "ipmi_reachable_port"
-
-  - it: should include ipmi_reachable_port when set to 0 for dynamic
-    set:
-      machineATron:
-        enableIpmiSimulation: true
-        ipmiReachablePort: 0
-    asserts:
-      - matchRegex:
-          path: data["mat.toml"]
-          pattern: "ipmi_reachable_port = 0"
-
-  - it: should include ipmi_reachable_port when set to custom value
-    set:
-      machineATron:
-        enableIpmiSimulation: true
-        ipmiReachablePort: 12345
-    asserts:
-      - matchRegex:
-          path: data["mat.toml"]
-          pattern: "ipmi_reachable_port = 12345"

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -162,9 +162,6 @@ machineATron:
   persistDir: "/tmp/machine-a-tron-data"
   cleanupOnQuit: false
   enableIpmiSimulation: false
-  # IPMI port advertised through Redfish. Unset uses default 623
-  # Set to 0 for dynamic port (required for mat-k8s-controller)
-  # ipmiReachablePort: 0
   registerExpectedMachines: true
   hostBmcPassword: ""
   dpuBmcPassword: ""


### PR DESCRIPTION
IPMI SOL expects the port returned during payload activation to match the port used by the simulator, so advertising a different port does not work. Machine-a-tron now always advertises its dynamically allocated listener port.

## Related issues

#4687 
#4884 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

