### PR TITLE
chore(rest-api): Align Site Agent and Site worker on inventory interval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ services. It delegates to cargo-make or `rest-api/Makefile`.
 make help                # default goal: list available targets
 make core/check-isolated-package-builds # optional independent default-feature builds
 make rest-build          # build rest-api Go binaries
-make rest-test           # run rest-api unit tests
+make rest-test           # run rest-api unit tests (starts Postgres and mock gRPC servers)
 make rest-lint           # lint rest-api
 make rest-fmt            # go fmt check on rest-api
 make rest-helm-lint      # helm lint rest charts
@@ -191,6 +191,13 @@ make rest-docker-build-local
 make rest-kind-reset     # spin up the local kind dev cluster (~10 min)
 make rest-api/<target>   # pass any target through to rest-api/Makefile
 ```
+
+Test the `rest-api/` Go services through these targets or the `rest-api/Makefile` ones they
+delegate to, not by calling `go test` yourself. The targets start the PostgreSQL container and
+the mock Core and Flow gRPC servers the tests connect to, and skipping that setup does not fail
+fast: the `site-agent` tests retry on a `40s` backoff until the `10m` test timeout. See the
+[Testing section in `rest-api/AGENTS.md`](rest-api/AGENTS.md#testing) for which target covers
+which module.
 
 Published container artifacts must pin external base images by immutable
 digest. When architecture-specific targets share a base image, define one

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -303,9 +303,9 @@ deployments:
           CORE_GRPC_SEC_OPT: "2"
           FLOW_GRPC_ENABLED: "false"
           CLUSTER_ID: 00000000-0000-4000-8000-000000000001
-          # The REST workflow ignores inventory for 3m5s after a machine update.
-          # Keep the local inventory cadence beyond that guard to avoid skipped hosts.
-          TEMPORAL_INVENTORY_SCHEDULE: "@every 4m"
+          # The Site Agent reports this interval and Cloud derives its staleness guard from it,
+          # so a fast local cadence no longer needs padding to avoid skipped hosts.
+          TEMPORAL_INVENTORY_SCHEDULE: "@every 1m"
           TEMPORAL_SERVER: site.server.temporal.local
           TEMPORAL_SUBSCRIBE_NAMESPACE: 00000000-0000-4000-8000-000000000001
           TEMPORAL_SUBSCRIBE_QUEUE: site

--- a/rest-api/AGENTS.md
+++ b/rest-api/AGENTS.md
@@ -98,7 +98,7 @@ make test-workflow
 make test-auth
 make test-common
 make test-cert-manager
-make test-site-agent        # requires mock gRPC servers
+make test-site-agent        # starts mock Core and Flow gRPC servers first
 make test-site-manager
 make test-site-workflow
 make test-ipam
@@ -112,6 +112,20 @@ make migrate                # run database migrations against test DB
 
 Tests require a PostgreSQL container (postgres:14.4-alpine) on port 30432.
 The Makefile manages this automatically via `ensure-postgres`.
+
+Use these targets rather than calling `go test` yourself, because they start what the tests
+need and skipping that setup does not fail fast:
+
+- `make test-site-agent` starts mock Core and Flow gRPC servers. Without them the
+  `site-agent/pkg/components` tests retry the connection on a `40s` backoff until the `10m`
+  test timeout, so a bare `go test ./site-agent/...` looks like a hang rather than an error.
+  That target also scopes to `site-agent/pkg/components` and sets `CGO_ENABLED=1` for `-race`,
+  so it is not the same package set or the same build.
+- `test-api`, `test-auth`, `test-db`, `test-flow`, `test-ipam`, `test-nvswitch-manager`,
+  `test-powershelf-manager`, and `test-workflow` call `ensure-postgres` first.
+- Every Postgres-backed package resets the schema, so packages running in parallel drop and
+  recreate the same tables and fail in `TestSetupSchema`. Pass `-p 1` whenever you do run
+  `go test` against more than one of them directly.
 
 ### Linting and Formatting
 

--- a/rest-api/common/pkg/util/workflow.go
+++ b/rest-api/common/pkg/util/workflow.go
@@ -6,8 +6,14 @@ package util
 import "time"
 
 const (
-	// InventoryReceiptInterval is the interval between 2 subsequent inventory receipts
-	InventoryReceiptInterval = 3 * time.Minute
+	// DefaultInventoryReceiptInterval is the assumed interval between 2 subsequent inventory
+	// receipts for a Site that has not reported its own collection interval. Prefer
+	// Site.IsTimeWithinStaleInventoryThreshold, which follows the reported interval where there
+	// is one.
+	DefaultInventoryReceiptInterval = 3 * time.Minute
+	// StaleInventoryBuffer keeps the staleness check from sitting exactly on the collection
+	// interval, where clock skew between the Site and Cloud decides the outcome.
+	StaleInventoryBuffer = 10 * time.Second
 	// WorkflowExecutionTimeout is the timeout for a workflow execution
 	WorkflowExecutionTimeout = time.Minute * 1
 	// WorkflowContextTimeout is the timeout for a workflow context

--- a/rest-api/common/pkg/util/workflow.go
+++ b/rest-api/common/pkg/util/workflow.go
@@ -12,8 +12,13 @@ const (
 	// is one.
 	DefaultInventoryReceiptInterval = 3 * time.Minute
 	// StaleInventoryBuffer keeps the staleness check from sitting exactly on the collection
-	// interval, where clock skew between the Site and Cloud decides the outcome.
+	// interval, where clock skew between the Site and REST layer decides the outcome.
 	StaleInventoryBuffer = 10 * time.Second
+	// MaxInventoryReceiptInterval is the slowest inventory collection the system supports. REST
+	// layer waits out the reported interval before acting on an object, so a slower Site would
+	// hold off deletions and status updates long enough to destabilize it. The Site Agent rejects
+	// a schedule past this at config load rather than run in that state.
+	MaxInventoryReceiptInterval = 5 * time.Minute
 	// WorkflowExecutionTimeout is the timeout for a workflow execution
 	WorkflowExecutionTimeout = time.Minute * 1
 	// WorkflowContextTimeout is the timeout for a workflow context

--- a/rest-api/db/pkg/db/model/site.go
+++ b/rest-api/db/pkg/db/model/site.go
@@ -106,7 +106,8 @@ type SiteContact struct {
 // arriving inventory may predate it, which means the inventory should not be acted on for that
 // object. The threshold follows the collection interval the Site Agent reports, and falls back
 // to the default for a Site that has not reported one yet, so an unreported Site keeps the
-// protection it had before the field existed.
+// protection it had before the field existed. The Site Agent refuses a schedule slower than
+// cutil.MaxInventoryReceiptInterval, so the reported interval is followed as given.
 func (st *Site) IsTimeWithinStaleInventoryThreshold(actionTime time.Time) bool {
 	interval := cutil.DefaultInventoryReceiptInterval
 	if st != nil && st.InventoryIntervalSeconds != nil && *st.InventoryIntervalSeconds > 0 {

--- a/rest-api/db/pkg/db/model/site.go
+++ b/rest-api/db/pkg/db/model/site.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
@@ -99,6 +100,19 @@ type SiteLocation struct {
 
 type SiteContact struct {
 	Email string `json:"email"`
+}
+
+// IsTimeWithinStaleInventoryThreshold reports whether actionTime is recent enough that an
+// arriving inventory may predate it, which means the inventory should not be acted on for that
+// object. The threshold follows the collection interval the Site Agent reports, and falls back
+// to the default for a Site that has not reported one yet, so an unreported Site keeps the
+// protection it had before the field existed.
+func (st *Site) IsTimeWithinStaleInventoryThreshold(actionTime time.Time) bool {
+	interval := cutil.DefaultInventoryReceiptInterval
+	if st != nil && st.InventoryIntervalSeconds != nil && *st.InventoryIntervalSeconds > 0 {
+		interval = time.Duration(*st.InventoryIntervalSeconds) * time.Second
+	}
+	return time.Since(actionTime) < interval+cutil.StaleInventoryBuffer
 }
 
 type SiteCreateInput struct {

--- a/rest-api/db/pkg/db/model/site.go
+++ b/rest-api/db/pkg/db/model/site.go
@@ -79,6 +79,7 @@ type Site struct {
 	SerialConsoleMaxSessionLength *int                    `bun:"serial_console_max_session_length"`
 	IsInfinityEnabled             bool                    `bun:"is_infinity_enabled,notnull"`
 	InventoryReceived             *time.Time              `bun:"inventory_received"`
+	InventoryIntervalSeconds      *int                    `bun:"inventory_interval_seconds"`
 	Status                        string                  `bun:"status,notnull"`
 	Created                       time.Time               `bun:"created,nullzero,notnull,default:current_timestamp"`
 	Updated                       time.Time               `bun:"updated,nullzero,notnull,default:current_timestamp"`
@@ -150,6 +151,7 @@ type SiteUpdateInput struct {
 	SerialConsoleMaxSessionLength *int
 	IsInfinityEnabled             *bool
 	InventoryReceived             *time.Time
+	InventoryIntervalSeconds      *int
 	Status                        *string
 	Location                      *SiteLocation
 	Contact                       *SiteContact
@@ -546,6 +548,12 @@ func (ssd SiteSQLDAO) Update(ctx context.Context, tx *db.Tx, input SiteUpdateInp
 		st.InventoryReceived = input.InventoryReceived
 		updatedFields = append(updatedFields, "inventory_received")
 		ssd.tracerSpan.SetAttribute(stDAOSpan, "inventory_received", *input.InventoryReceived)
+	}
+
+	if input.InventoryIntervalSeconds != nil {
+		st.InventoryIntervalSeconds = input.InventoryIntervalSeconds
+		updatedFields = append(updatedFields, "inventory_interval_seconds")
+		ssd.tracerSpan.SetAttribute(stDAOSpan, "inventory_interval_seconds", *input.InventoryIntervalSeconds)
 	}
 
 	if input.Status != nil {

--- a/rest-api/db/pkg/db/model/site_test.go
+++ b/rest-api/db/pkg/db/model/site_test.go
@@ -1893,3 +1893,82 @@ func validateSite(t *testing.T, got Site, want Site) {
 	assert.Equal(t, want.Location, got.Location)
 	assert.Equal(t, want.Contact, got.Contact)
 }
+
+func TestSite_IsTimeWithinStaleInventoryThreshold(t *testing.T) {
+	reportedOneMinute := &Site{InventoryIntervalSeconds: cutil.GetPtr(60)}
+
+	tests := []struct {
+		name       string
+		site       *Site
+		actionTime time.Time
+		want       bool
+	}{
+		{
+			name:       "a change just now is too recent to act on",
+			site:       &Site{},
+			actionTime: time.Now(),
+			want:       true,
+		},
+		{
+			name:       "a change older than the fallback threshold is safe to act on",
+			site:       &Site{},
+			actionTime: time.Now().Add(-(cutil.DefaultInventoryReceiptInterval + cutil.StaleInventoryBuffer + time.Second)),
+			want:       false,
+		},
+		{
+			// The same age that clears the fallback is still too recent for a slower Site.
+			name:       "follows a reported interval longer than the fallback",
+			site:       &Site{InventoryIntervalSeconds: cutil.GetPtr(600)},
+			actionTime: time.Now().Add(-(cutil.DefaultInventoryReceiptInterval + cutil.StaleInventoryBuffer + time.Second)),
+			want:       true,
+		},
+		{
+			// The same age is stale against the fallback and safe against a faster Site, which
+			// is the whole point of following the reported interval.
+			name:       "an age between the two intervals depends on the reported one",
+			site:       reportedOneMinute,
+			actionTime: time.Now().Add(-2 * time.Minute),
+			want:       false,
+		},
+		{
+			name:       "the same age is still too recent against the fallback",
+			site:       &Site{},
+			actionTime: time.Now().Add(-2 * time.Minute),
+			want:       true,
+		},
+		{
+			// The buffer keeps the check off the exact interval, where clock skew between the
+			// Site and Cloud would decide the outcome.
+			name:       "a change inside the buffer past the interval is still too recent",
+			site:       reportedOneMinute,
+			actionTime: time.Now().Add(-(time.Minute + cutil.StaleInventoryBuffer/2)),
+			want:       true,
+		},
+		{
+			// A stored zero or negative would otherwise collapse the threshold to the buffer
+			// alone and let inventory act on data it should treat as newer.
+			name:       "falls back on a zero reported interval",
+			site:       &Site{InventoryIntervalSeconds: cutil.GetPtr(0)},
+			actionTime: time.Now().Add(-(cutil.StaleInventoryBuffer + time.Second)),
+			want:       true,
+		},
+		{
+			name:       "falls back on a negative reported interval",
+			site:       &Site{InventoryIntervalSeconds: cutil.GetPtr(-30)},
+			actionTime: time.Now().Add(-(cutil.StaleInventoryBuffer + time.Second)),
+			want:       true,
+		},
+		{
+			name:       "falls back on a nil Site",
+			site:       nil,
+			actionTime: time.Now().Add(-(cutil.StaleInventoryBuffer + time.Second)),
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.site.IsTimeWithinStaleInventoryThreshold(tt.actionTime))
+		})
+	}
+}

--- a/rest-api/db/pkg/db/model/site_test.go
+++ b/rest-api/db/pkg/db/model/site_test.go
@@ -1918,7 +1918,7 @@ func TestSite_IsTimeWithinStaleInventoryThreshold(t *testing.T) {
 		{
 			// The same age that clears the fallback is still too recent for a slower Site.
 			name:       "follows a reported interval longer than the fallback",
-			site:       &Site{InventoryIntervalSeconds: cutil.GetPtr(600)},
+			site:       &Site{InventoryIntervalSeconds: cutil.GetPtr(300)},
 			actionTime: time.Now().Add(-(cutil.DefaultInventoryReceiptInterval + cutil.StaleInventoryBuffer + time.Second)),
 			want:       true,
 		},

--- a/rest-api/db/pkg/migrations/20260821191500_site_inventory_interval.go
+++ b/rest-api/db/pkg/migrations/20260821191500_site_inventory_interval.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		tx, terr := db.BeginTx(ctx, &sql.TxOptions{})
+		if terr != nil {
+			handlePanic(terr, "failed to begin transaction")
+		}
+
+		// Nullable because the Site Agent reports this on its Site Config inventory, so a Site
+		// stays NULL until its first report. Readers fall back to the built-in interval rather
+		// than treating a missing value as zero.
+		_, err := tx.NewAddColumn().
+			Model((*model.Site)(nil)).
+			IfNotExists().
+			ColumnExpr("inventory_interval_seconds INTEGER").
+			Exec(ctx)
+		handleError(tx, err)
+
+		terr = tx.Commit()
+		if terr != nil {
+			handlePanic(terr, "failed to commit transaction")
+		}
+
+		fmt.Print(" [up migration] Added 'inventory_interval_seconds' column to 'site' table successfully. ")
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		// Safe to drop. The Site Agent re-reports the interval on its next inventory tick, so
+		// nothing here has to be reconstructed by hand.
+		_, err := db.ExecContext(ctx, `ALTER TABLE site DROP COLUMN IF EXISTS inventory_interval_seconds`)
+		if err != nil {
+			return err
+		}
+		fmt.Print(" [down migration] Dropped 'inventory_interval_seconds' column from 'site' table successfully. ")
+		return nil
+	})
+}

--- a/rest-api/deploy/INSTALLATION.md
+++ b/rest-api/deploy/INSTALLATION.md
@@ -712,7 +712,7 @@ The site agent bootstrap flow is:
 | `TEMPORAL_PUBLISH_NAMESPACE` | `site` | Temporal namespace for publishing (site-side workflows) |
 | `TEMPORAL_SUBSCRIBE_NAMESPACE` | `00000000-0000-4000-8000-000000000001` | Per-site Temporal namespace — **must match site UUID** |
 | `TEMPORAL_SUBSCRIBE_QUEUE` | `00000000-0000-4000-8000-000000000001` | Per-site Temporal queue — **must match site UUID** |
-| `TEMPORAL_INVENTORY_SCHEDULE` | `@every 3m` | How often the agent reports hardware inventory |
+| `TEMPORAL_INVENTORY_SCHEDULE` | `@every 3m` | How often the agent reports hardware inventory. The agent reports this interval to Cloud as staleness window. A schedule slower than `5m` is rejected at startup |
 | `TEMPORAL_CERT_PATH` | `/etc/temporal-certs` | Path to mounted Temporal TLS certs |
 
 ### Secrets mounted at runtime

--- a/rest-api/deploy/INSTALLATION.md
+++ b/rest-api/deploy/INSTALLATION.md
@@ -712,7 +712,7 @@ The site agent bootstrap flow is:
 | `TEMPORAL_PUBLISH_NAMESPACE` | `site` | Temporal namespace for publishing (site-side workflows) |
 | `TEMPORAL_SUBSCRIBE_NAMESPACE` | `00000000-0000-4000-8000-000000000001` | Per-site Temporal namespace — **must match site UUID** |
 | `TEMPORAL_SUBSCRIBE_QUEUE` | `00000000-0000-4000-8000-000000000001` | Per-site Temporal queue — **must match site UUID** |
-| `TEMPORAL_INVENTORY_SCHEDULE` | `@every 3m` | How often the agent reports hardware inventory. The agent reports this interval to Cloud as staleness window. A schedule slower than `5m` is rejected at startup |
+| `TEMPORAL_INVENTORY_SCHEDULE` | `@every 3m` | How often the agent reports hardware inventory, as an `@every <duration>` schedule. The agent reports this interval to Cloud as staleness window. A schedule slower than `5m`, or in any other format, is rejected at startup |
 | `TEMPORAL_CERT_PATH` | `/etc/temporal-certs` | Path to mounted Temporal TLS certs |
 
 ### Secrets mounted at runtime

--- a/rest-api/proto/core/gen/v1/inventory.pb.go
+++ b/rest-api/proto/core/gen/v1/inventory.pb.go
@@ -12,6 +12,7 @@ package core
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -157,6 +158,120 @@ func (x *InventoryPage) GetItemIds() []string {
 	return nil
 }
 
+// SiteAgentBuildInfo - build metadata and configuration the Site Agent reports about itself,
+// as opposed to the Core configuration it relays
+type SiteAgentBuildInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Site Agent build version
+	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	// How often the Site Agent collects inventory, derived from its configured schedule.
+	// Cloud compares object timestamps against this to decide whether an inventory is stale.
+	InventoryInterval *durationpb.Duration `protobuf:"bytes,2,opt,name=inventory_interval,json=inventoryInterval,proto3" json:"inventory_interval,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *SiteAgentBuildInfo) Reset() {
+	*x = SiteAgentBuildInfo{}
+	mi := &file_inventory_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SiteAgentBuildInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SiteAgentBuildInfo) ProtoMessage() {}
+
+func (x *SiteAgentBuildInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SiteAgentBuildInfo.ProtoReflect.Descriptor instead.
+func (*SiteAgentBuildInfo) Descriptor() ([]byte, []int) {
+	return file_inventory_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *SiteAgentBuildInfo) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *SiteAgentBuildInfo) GetInventoryInterval() *durationpb.Duration {
+	if x != nil {
+		return x.InventoryInterval
+	}
+	return nil
+}
+
+// SiteConfigInventory - Site configuration reported periodically. Site-level reporting is
+// added to this message rather than as another workflow argument, so extending it does not
+// require a new workflow.
+type SiteConfigInventory struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Core build metadata, advertised capabilities, and runtime configuration
+	CoreBuildInfo *BuildInfo `protobuf:"bytes,1,opt,name=core_build_info,json=coreBuildInfo,proto3" json:"core_build_info,omitempty"`
+	// Build metadata and configuration owned by the Site Agent itself
+	SiteAgentBuildInfo *SiteAgentBuildInfo `protobuf:"bytes,2,opt,name=site_agent_build_info,json=siteAgentBuildInfo,proto3" json:"site_agent_build_info,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *SiteConfigInventory) Reset() {
+	*x = SiteConfigInventory{}
+	mi := &file_inventory_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SiteConfigInventory) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SiteConfigInventory) ProtoMessage() {}
+
+func (x *SiteConfigInventory) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SiteConfigInventory.ProtoReflect.Descriptor instead.
+func (*SiteConfigInventory) Descriptor() ([]byte, []int) {
+	return file_inventory_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *SiteConfigInventory) GetCoreBuildInfo() *BuildInfo {
+	if x != nil {
+		return x.CoreBuildInfo
+	}
+	return nil
+}
+
+func (x *SiteConfigInventory) GetSiteAgentBuildInfo() *SiteAgentBuildInfo {
+	if x != nil {
+		return x.SiteAgentBuildInfo
+	}
+	return nil
+}
+
 // DpuExtensionServiceInventory - inventory of all DPU Extension Services on Site, collected periodically
 type DpuExtensionServiceInventory struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -176,7 +291,7 @@ type DpuExtensionServiceInventory struct {
 
 func (x *DpuExtensionServiceInventory) Reset() {
 	*x = DpuExtensionServiceInventory{}
-	mi := &file_inventory_proto_msgTypes[1]
+	mi := &file_inventory_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -188,7 +303,7 @@ func (x *DpuExtensionServiceInventory) String() string {
 func (*DpuExtensionServiceInventory) ProtoMessage() {}
 
 func (x *DpuExtensionServiceInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[1]
+	mi := &file_inventory_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -201,7 +316,7 @@ func (x *DpuExtensionServiceInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DpuExtensionServiceInventory.ProtoReflect.Descriptor instead.
 func (*DpuExtensionServiceInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{1}
+	return file_inventory_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *DpuExtensionServiceInventory) GetInventoryStatus() InventoryStatus {
@@ -260,7 +375,7 @@ type ExpectedMachineInventory struct {
 
 func (x *ExpectedMachineInventory) Reset() {
 	*x = ExpectedMachineInventory{}
-	mi := &file_inventory_proto_msgTypes[2]
+	mi := &file_inventory_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -272,7 +387,7 @@ func (x *ExpectedMachineInventory) String() string {
 func (*ExpectedMachineInventory) ProtoMessage() {}
 
 func (x *ExpectedMachineInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[2]
+	mi := &file_inventory_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -285,7 +400,7 @@ func (x *ExpectedMachineInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpectedMachineInventory.ProtoReflect.Descriptor instead.
 func (*ExpectedMachineInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{2}
+	return file_inventory_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ExpectedMachineInventory) GetInventoryStatus() InventoryStatus {
@@ -349,7 +464,7 @@ type ExpectedRackInventory struct {
 
 func (x *ExpectedRackInventory) Reset() {
 	*x = ExpectedRackInventory{}
-	mi := &file_inventory_proto_msgTypes[3]
+	mi := &file_inventory_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -361,7 +476,7 @@ func (x *ExpectedRackInventory) String() string {
 func (*ExpectedRackInventory) ProtoMessage() {}
 
 func (x *ExpectedRackInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[3]
+	mi := &file_inventory_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -374,7 +489,7 @@ func (x *ExpectedRackInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpectedRackInventory.ProtoReflect.Descriptor instead.
 func (*ExpectedRackInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{3}
+	return file_inventory_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ExpectedRackInventory) GetInventoryStatus() InventoryStatus {
@@ -433,7 +548,7 @@ type ExpectedPowerShelfInventory struct {
 
 func (x *ExpectedPowerShelfInventory) Reset() {
 	*x = ExpectedPowerShelfInventory{}
-	mi := &file_inventory_proto_msgTypes[4]
+	mi := &file_inventory_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -445,7 +560,7 @@ func (x *ExpectedPowerShelfInventory) String() string {
 func (*ExpectedPowerShelfInventory) ProtoMessage() {}
 
 func (x *ExpectedPowerShelfInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[4]
+	mi := &file_inventory_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -458,7 +573,7 @@ func (x *ExpectedPowerShelfInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpectedPowerShelfInventory.ProtoReflect.Descriptor instead.
 func (*ExpectedPowerShelfInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{4}
+	return file_inventory_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ExpectedPowerShelfInventory) GetInventoryStatus() InventoryStatus {
@@ -524,7 +639,7 @@ type ExpectedSwitchInventory struct {
 
 func (x *ExpectedSwitchInventory) Reset() {
 	*x = ExpectedSwitchInventory{}
-	mi := &file_inventory_proto_msgTypes[5]
+	mi := &file_inventory_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -536,7 +651,7 @@ func (x *ExpectedSwitchInventory) String() string {
 func (*ExpectedSwitchInventory) ProtoMessage() {}
 
 func (x *ExpectedSwitchInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[5]
+	mi := &file_inventory_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -549,7 +664,7 @@ func (x *ExpectedSwitchInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpectedSwitchInventory.ProtoReflect.Descriptor instead.
 func (*ExpectedSwitchInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{5}
+	return file_inventory_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ExpectedSwitchInventory) GetInventoryStatus() InventoryStatus {
@@ -613,7 +728,7 @@ type InfiniBandPartitionInventory struct {
 
 func (x *InfiniBandPartitionInventory) Reset() {
 	*x = InfiniBandPartitionInventory{}
-	mi := &file_inventory_proto_msgTypes[6]
+	mi := &file_inventory_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -625,7 +740,7 @@ func (x *InfiniBandPartitionInventory) String() string {
 func (*InfiniBandPartitionInventory) ProtoMessage() {}
 
 func (x *InfiniBandPartitionInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[6]
+	mi := &file_inventory_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -638,7 +753,7 @@ func (x *InfiniBandPartitionInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InfiniBandPartitionInventory.ProtoReflect.Descriptor instead.
 func (*InfiniBandPartitionInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{6}
+	return file_inventory_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *InfiniBandPartitionInventory) GetInventoryStatus() InventoryStatus {
@@ -697,7 +812,7 @@ type InstanceInventory struct {
 
 func (x *InstanceInventory) Reset() {
 	*x = InstanceInventory{}
-	mi := &file_inventory_proto_msgTypes[7]
+	mi := &file_inventory_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -709,7 +824,7 @@ func (x *InstanceInventory) String() string {
 func (*InstanceInventory) ProtoMessage() {}
 
 func (x *InstanceInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[7]
+	mi := &file_inventory_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -722,7 +837,7 @@ func (x *InstanceInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstanceInventory.ProtoReflect.Descriptor instead.
 func (*InstanceInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{7}
+	return file_inventory_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *InstanceInventory) GetInstances() []*Instance {
@@ -786,7 +901,7 @@ type InstanceTypeInventory struct {
 
 func (x *InstanceTypeInventory) Reset() {
 	*x = InstanceTypeInventory{}
-	mi := &file_inventory_proto_msgTypes[8]
+	mi := &file_inventory_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -798,7 +913,7 @@ func (x *InstanceTypeInventory) String() string {
 func (*InstanceTypeInventory) ProtoMessage() {}
 
 func (x *InstanceTypeInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[8]
+	mi := &file_inventory_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -811,7 +926,7 @@ func (x *InstanceTypeInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstanceTypeInventory.ProtoReflect.Descriptor instead.
 func (*InstanceTypeInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{8}
+	return file_inventory_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *InstanceTypeInventory) GetInstanceTypes() []*InstanceType {
@@ -860,7 +975,7 @@ type MachineInfo struct {
 
 func (x *MachineInfo) Reset() {
 	*x = MachineInfo{}
-	mi := &file_inventory_proto_msgTypes[9]
+	mi := &file_inventory_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -872,7 +987,7 @@ func (x *MachineInfo) String() string {
 func (*MachineInfo) ProtoMessage() {}
 
 func (x *MachineInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[9]
+	mi := &file_inventory_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -885,7 +1000,7 @@ func (x *MachineInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineInfo.ProtoReflect.Descriptor instead.
 func (*MachineInfo) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{9}
+	return file_inventory_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *MachineInfo) GetMachine() *Machine {
@@ -921,7 +1036,7 @@ type MachineInventory struct {
 
 func (x *MachineInventory) Reset() {
 	*x = MachineInventory{}
-	mi := &file_inventory_proto_msgTypes[10]
+	mi := &file_inventory_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -933,7 +1048,7 @@ func (x *MachineInventory) String() string {
 func (*MachineInventory) ProtoMessage() {}
 
 func (x *MachineInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[10]
+	mi := &file_inventory_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -946,7 +1061,7 @@ func (x *MachineInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineInventory.ProtoReflect.Descriptor instead.
 func (*MachineInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{10}
+	return file_inventory_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *MachineInventory) GetMachines() []*MachineInfo {
@@ -1003,7 +1118,7 @@ type NetworkSecurityGroupInventory struct {
 
 func (x *NetworkSecurityGroupInventory) Reset() {
 	*x = NetworkSecurityGroupInventory{}
-	mi := &file_inventory_proto_msgTypes[11]
+	mi := &file_inventory_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1015,7 +1130,7 @@ func (x *NetworkSecurityGroupInventory) String() string {
 func (*NetworkSecurityGroupInventory) ProtoMessage() {}
 
 func (x *NetworkSecurityGroupInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[11]
+	mi := &file_inventory_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1028,7 +1143,7 @@ func (x *NetworkSecurityGroupInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkSecurityGroupInventory.ProtoReflect.Descriptor instead.
 func (*NetworkSecurityGroupInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{11}
+	return file_inventory_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *NetworkSecurityGroupInventory) GetNetworkSecurityGroups() []*NetworkSecurityGroup {
@@ -1085,7 +1200,7 @@ type NVLinkLogicalPartitionInventory struct {
 
 func (x *NVLinkLogicalPartitionInventory) Reset() {
 	*x = NVLinkLogicalPartitionInventory{}
-	mi := &file_inventory_proto_msgTypes[12]
+	mi := &file_inventory_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1097,7 +1212,7 @@ func (x *NVLinkLogicalPartitionInventory) String() string {
 func (*NVLinkLogicalPartitionInventory) ProtoMessage() {}
 
 func (x *NVLinkLogicalPartitionInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[12]
+	mi := &file_inventory_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1110,7 +1225,7 @@ func (x *NVLinkLogicalPartitionInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NVLinkLogicalPartitionInventory.ProtoReflect.Descriptor instead.
 func (*NVLinkLogicalPartitionInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{12}
+	return file_inventory_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *NVLinkLogicalPartitionInventory) GetInventoryStatus() InventoryStatus {
@@ -1167,7 +1282,7 @@ type OsImageInventory struct {
 
 func (x *OsImageInventory) Reset() {
 	*x = OsImageInventory{}
-	mi := &file_inventory_proto_msgTypes[13]
+	mi := &file_inventory_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1179,7 +1294,7 @@ func (x *OsImageInventory) String() string {
 func (*OsImageInventory) ProtoMessage() {}
 
 func (x *OsImageInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[13]
+	mi := &file_inventory_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1192,7 +1307,7 @@ func (x *OsImageInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OsImageInventory.ProtoReflect.Descriptor instead.
 func (*OsImageInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{13}
+	return file_inventory_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *OsImageInventory) GetOsImages() []*OsImage {
@@ -1249,7 +1364,7 @@ type OperatingSystemInventory struct {
 
 func (x *OperatingSystemInventory) Reset() {
 	*x = OperatingSystemInventory{}
-	mi := &file_inventory_proto_msgTypes[14]
+	mi := &file_inventory_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1261,7 +1376,7 @@ func (x *OperatingSystemInventory) String() string {
 func (*OperatingSystemInventory) ProtoMessage() {}
 
 func (x *OperatingSystemInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[14]
+	mi := &file_inventory_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1274,7 +1389,7 @@ func (x *OperatingSystemInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperatingSystemInventory.ProtoReflect.Descriptor instead.
 func (*OperatingSystemInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{14}
+	return file_inventory_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *OperatingSystemInventory) GetOperatingSystems() []*OperatingSystem {
@@ -1331,7 +1446,7 @@ type IpxeTemplateInventory struct {
 
 func (x *IpxeTemplateInventory) Reset() {
 	*x = IpxeTemplateInventory{}
-	mi := &file_inventory_proto_msgTypes[15]
+	mi := &file_inventory_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1343,7 +1458,7 @@ func (x *IpxeTemplateInventory) String() string {
 func (*IpxeTemplateInventory) ProtoMessage() {}
 
 func (x *IpxeTemplateInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[15]
+	mi := &file_inventory_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1356,7 +1471,7 @@ func (x *IpxeTemplateInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IpxeTemplateInventory.ProtoReflect.Descriptor instead.
 func (*IpxeTemplateInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{15}
+	return file_inventory_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *IpxeTemplateInventory) GetTemplates() []*IpxeTemplate {
@@ -1413,7 +1528,7 @@ type SkuInventory struct {
 
 func (x *SkuInventory) Reset() {
 	*x = SkuInventory{}
-	mi := &file_inventory_proto_msgTypes[16]
+	mi := &file_inventory_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1425,7 +1540,7 @@ func (x *SkuInventory) String() string {
 func (*SkuInventory) ProtoMessage() {}
 
 func (x *SkuInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[16]
+	mi := &file_inventory_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1438,7 +1553,7 @@ func (x *SkuInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkuInventory.ProtoReflect.Descriptor instead.
 func (*SkuInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{16}
+	return file_inventory_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SkuInventory) GetInventoryStatus() InventoryStatus {
@@ -1495,7 +1610,7 @@ type SSHKeyGroupInventory struct {
 
 func (x *SSHKeyGroupInventory) Reset() {
 	*x = SSHKeyGroupInventory{}
-	mi := &file_inventory_proto_msgTypes[17]
+	mi := &file_inventory_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1507,7 +1622,7 @@ func (x *SSHKeyGroupInventory) String() string {
 func (*SSHKeyGroupInventory) ProtoMessage() {}
 
 func (x *SSHKeyGroupInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[17]
+	mi := &file_inventory_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1520,7 +1635,7 @@ func (x *SSHKeyGroupInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSHKeyGroupInventory.ProtoReflect.Descriptor instead.
 func (*SSHKeyGroupInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{17}
+	return file_inventory_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SSHKeyGroupInventory) GetTenantKeysets() []*TenantKeyset {
@@ -1577,7 +1692,7 @@ type SubnetInventory struct {
 
 func (x *SubnetInventory) Reset() {
 	*x = SubnetInventory{}
-	mi := &file_inventory_proto_msgTypes[18]
+	mi := &file_inventory_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1589,7 +1704,7 @@ func (x *SubnetInventory) String() string {
 func (*SubnetInventory) ProtoMessage() {}
 
 func (x *SubnetInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[18]
+	mi := &file_inventory_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1602,7 +1717,7 @@ func (x *SubnetInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubnetInventory.ProtoReflect.Descriptor instead.
 func (*SubnetInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{18}
+	return file_inventory_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SubnetInventory) GetSegments() []*NetworkSegment {
@@ -1659,7 +1774,7 @@ type TenantInventory struct {
 
 func (x *TenantInventory) Reset() {
 	*x = TenantInventory{}
-	mi := &file_inventory_proto_msgTypes[19]
+	mi := &file_inventory_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1671,7 +1786,7 @@ func (x *TenantInventory) String() string {
 func (*TenantInventory) ProtoMessage() {}
 
 func (x *TenantInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[19]
+	mi := &file_inventory_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1684,7 +1799,7 @@ func (x *TenantInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TenantInventory.ProtoReflect.Descriptor instead.
 func (*TenantInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{19}
+	return file_inventory_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TenantInventory) GetTenants() []*Tenant {
@@ -1743,7 +1858,7 @@ type VPCInventory struct {
 
 func (x *VPCInventory) Reset() {
 	*x = VPCInventory{}
-	mi := &file_inventory_proto_msgTypes[20]
+	mi := &file_inventory_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1755,7 +1870,7 @@ func (x *VPCInventory) String() string {
 func (*VPCInventory) ProtoMessage() {}
 
 func (x *VPCInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[20]
+	mi := &file_inventory_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1768,7 +1883,7 @@ func (x *VPCInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VPCInventory.ProtoReflect.Descriptor instead.
 func (*VPCInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{20}
+	return file_inventory_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *VPCInventory) GetVpcs() []*Vpc {
@@ -1832,7 +1947,7 @@ type VPCPeeringInventory struct {
 
 func (x *VPCPeeringInventory) Reset() {
 	*x = VPCPeeringInventory{}
-	mi := &file_inventory_proto_msgTypes[21]
+	mi := &file_inventory_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1844,7 +1959,7 @@ func (x *VPCPeeringInventory) String() string {
 func (*VPCPeeringInventory) ProtoMessage() {}
 
 func (x *VPCPeeringInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[21]
+	mi := &file_inventory_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1857,7 +1972,7 @@ func (x *VPCPeeringInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VPCPeeringInventory.ProtoReflect.Descriptor instead.
 func (*VPCPeeringInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{21}
+	return file_inventory_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *VPCPeeringInventory) GetVpcPeerings() []*VpcPeering {
@@ -1914,7 +2029,7 @@ type VpcPrefixInventory struct {
 
 func (x *VpcPrefixInventory) Reset() {
 	*x = VpcPrefixInventory{}
-	mi := &file_inventory_proto_msgTypes[22]
+	mi := &file_inventory_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1926,7 +2041,7 @@ func (x *VpcPrefixInventory) String() string {
 func (*VpcPrefixInventory) ProtoMessage() {}
 
 func (x *VpcPrefixInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[22]
+	mi := &file_inventory_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1939,7 +2054,7 @@ func (x *VpcPrefixInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VpcPrefixInventory.ProtoReflect.Descriptor instead.
 func (*VpcPrefixInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{22}
+	return file_inventory_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *VpcPrefixInventory) GetVpcPrefixes() []*VpcPrefix {
@@ -1981,7 +2096,7 @@ var File_inventory_proto protoreflect.FileDescriptor
 
 const file_inventory_proto_rawDesc = "" +
 	"\n" +
-	"\x0finventory.proto\x12\tinventory\x1a\x11common_nico.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cmachine_discovery_nico.proto\x1a\x0fnico_nico.proto\"\xac\x01\n" +
+	"\x0finventory.proto\x12\tinventory\x1a\x11common_nico.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cmachine_discovery_nico.proto\x1a\x0fnico_nico.proto\"\xac\x01\n" +
 	"\rInventoryPage\x12\x1f\n" +
 	"\vtotal_pages\x18\x01 \x01(\x05R\n" +
 	"totalPages\x12!\n" +
@@ -1989,7 +2104,13 @@ const file_inventory_proto_rawDesc = "" +
 	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\x12\x1f\n" +
 	"\vtotal_items\x18\x04 \x01(\x05R\n" +
 	"totalItems\x12\x19\n" +
-	"\bitem_ids\x18\x05 \x03(\tR\aitemIds\"\xd1\x02\n" +
+	"\bitem_ids\x18\x05 \x03(\tR\aitemIds\"x\n" +
+	"\x12SiteAgentBuildInfo\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\tR\aversion\x12H\n" +
+	"\x12inventory_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x11inventoryInterval\"\xa1\x01\n" +
+	"\x13SiteConfigInventory\x128\n" +
+	"\x0fcore_build_info\x18\x01 \x01(\v2\x10.forge.BuildInfoR\rcoreBuildInfo\x12P\n" +
+	"\x15site_agent_build_info\x18\x02 \x01(\v2\x1d.inventory.SiteAgentBuildInfoR\x12siteAgentBuildInfo\"\xd1\x02\n" +
 	"\x1cDpuExtensionServiceInventory\x12E\n" +
 	"\x10inventory_status\x18\x01 \x01(\x0e2\x1a.inventory.InventoryStatusR\x0finventoryStatus\x12\x1d\n" +
 	"\n" +
@@ -2167,157 +2288,164 @@ func file_inventory_proto_rawDescGZIP() []byte {
 }
 
 var file_inventory_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_inventory_proto_goTypes = []any{
 	(InventoryStatus)(0),                                // 0: inventory.InventoryStatus
 	(*InventoryPage)(nil),                               // 1: inventory.InventoryPage
-	(*DpuExtensionServiceInventory)(nil),                // 2: inventory.DpuExtensionServiceInventory
-	(*ExpectedMachineInventory)(nil),                    // 3: inventory.ExpectedMachineInventory
-	(*ExpectedRackInventory)(nil),                       // 4: inventory.ExpectedRackInventory
-	(*ExpectedPowerShelfInventory)(nil),                 // 5: inventory.ExpectedPowerShelfInventory
-	(*ExpectedSwitchInventory)(nil),                     // 6: inventory.ExpectedSwitchInventory
-	(*InfiniBandPartitionInventory)(nil),                // 7: inventory.InfiniBandPartitionInventory
-	(*InstanceInventory)(nil),                           // 8: inventory.InstanceInventory
-	(*InstanceTypeInventory)(nil),                       // 9: inventory.InstanceTypeInventory
-	(*MachineInfo)(nil),                                 // 10: inventory.MachineInfo
-	(*MachineInventory)(nil),                            // 11: inventory.MachineInventory
-	(*NetworkSecurityGroupInventory)(nil),               // 12: inventory.NetworkSecurityGroupInventory
-	(*NVLinkLogicalPartitionInventory)(nil),             // 13: inventory.NVLinkLogicalPartitionInventory
-	(*OsImageInventory)(nil),                            // 14: inventory.OsImageInventory
-	(*OperatingSystemInventory)(nil),                    // 15: inventory.OperatingSystemInventory
-	(*IpxeTemplateInventory)(nil),                       // 16: inventory.IpxeTemplateInventory
-	(*SkuInventory)(nil),                                // 17: inventory.SkuInventory
-	(*SSHKeyGroupInventory)(nil),                        // 18: inventory.SSHKeyGroupInventory
-	(*SubnetInventory)(nil),                             // 19: inventory.SubnetInventory
-	(*TenantInventory)(nil),                             // 20: inventory.TenantInventory
-	(*VPCInventory)(nil),                                // 21: inventory.VPCInventory
-	(*VPCPeeringInventory)(nil),                         // 22: inventory.VPCPeeringInventory
-	(*VpcPrefixInventory)(nil),                          // 23: inventory.VpcPrefixInventory
-	(*timestamppb.Timestamp)(nil),                       // 24: google.protobuf.Timestamp
-	(*DpuExtensionService)(nil),                         // 25: forge.DpuExtensionService
-	(*ExpectedMachine)(nil),                             // 26: forge.ExpectedMachine
-	(*LinkedExpectedMachine)(nil),                       // 27: forge.LinkedExpectedMachine
-	(*ExpectedRack)(nil),                                // 28: forge.ExpectedRack
-	(*ExpectedPowerShelf)(nil),                          // 29: forge.ExpectedPowerShelf
-	(*LinkedExpectedPowerShelf)(nil),                    // 30: forge.LinkedExpectedPowerShelf
-	(*ExpectedSwitch)(nil),                              // 31: forge.ExpectedSwitch
-	(*LinkedExpectedSwitch)(nil),                        // 32: forge.LinkedExpectedSwitch
-	(*IBPartition)(nil),                                 // 33: forge.IBPartition
-	(*Instance)(nil),                                    // 34: forge.Instance
-	(*NetworkSecurityGroupPropagationObjectStatus)(nil), // 35: forge.NetworkSecurityGroupPropagationObjectStatus
-	(*InstanceType)(nil),                                // 36: forge.InstanceType
-	(*Machine)(nil),                                     // 37: forge.Machine
-	(*DiscoveryInfo)(nil),                               // 38: machine_discovery.DiscoveryInfo
-	(*NetworkSecurityGroup)(nil),                        // 39: forge.NetworkSecurityGroup
-	(*NVLinkLogicalPartition)(nil),                      // 40: forge.NVLinkLogicalPartition
-	(*OsImage)(nil),                                     // 41: forge.OsImage
-	(*OperatingSystem)(nil),                             // 42: forge.OperatingSystem
-	(*IpxeTemplate)(nil),                                // 43: forge.IpxeTemplate
-	(*Sku)(nil),                                         // 44: forge.Sku
-	(*TenantKeyset)(nil),                                // 45: forge.TenantKeyset
-	(*NetworkSegment)(nil),                              // 46: forge.NetworkSegment
-	(*Tenant)(nil),                                      // 47: forge.Tenant
-	(*Vpc)(nil),                                         // 48: forge.Vpc
-	(*VpcPeering)(nil),                                  // 49: forge.VpcPeering
-	(*VpcPrefix)(nil),                                   // 50: forge.VpcPrefix
+	(*SiteAgentBuildInfo)(nil),                          // 2: inventory.SiteAgentBuildInfo
+	(*SiteConfigInventory)(nil),                         // 3: inventory.SiteConfigInventory
+	(*DpuExtensionServiceInventory)(nil),                // 4: inventory.DpuExtensionServiceInventory
+	(*ExpectedMachineInventory)(nil),                    // 5: inventory.ExpectedMachineInventory
+	(*ExpectedRackInventory)(nil),                       // 6: inventory.ExpectedRackInventory
+	(*ExpectedPowerShelfInventory)(nil),                 // 7: inventory.ExpectedPowerShelfInventory
+	(*ExpectedSwitchInventory)(nil),                     // 8: inventory.ExpectedSwitchInventory
+	(*InfiniBandPartitionInventory)(nil),                // 9: inventory.InfiniBandPartitionInventory
+	(*InstanceInventory)(nil),                           // 10: inventory.InstanceInventory
+	(*InstanceTypeInventory)(nil),                       // 11: inventory.InstanceTypeInventory
+	(*MachineInfo)(nil),                                 // 12: inventory.MachineInfo
+	(*MachineInventory)(nil),                            // 13: inventory.MachineInventory
+	(*NetworkSecurityGroupInventory)(nil),               // 14: inventory.NetworkSecurityGroupInventory
+	(*NVLinkLogicalPartitionInventory)(nil),             // 15: inventory.NVLinkLogicalPartitionInventory
+	(*OsImageInventory)(nil),                            // 16: inventory.OsImageInventory
+	(*OperatingSystemInventory)(nil),                    // 17: inventory.OperatingSystemInventory
+	(*IpxeTemplateInventory)(nil),                       // 18: inventory.IpxeTemplateInventory
+	(*SkuInventory)(nil),                                // 19: inventory.SkuInventory
+	(*SSHKeyGroupInventory)(nil),                        // 20: inventory.SSHKeyGroupInventory
+	(*SubnetInventory)(nil),                             // 21: inventory.SubnetInventory
+	(*TenantInventory)(nil),                             // 22: inventory.TenantInventory
+	(*VPCInventory)(nil),                                // 23: inventory.VPCInventory
+	(*VPCPeeringInventory)(nil),                         // 24: inventory.VPCPeeringInventory
+	(*VpcPrefixInventory)(nil),                          // 25: inventory.VpcPrefixInventory
+	(*durationpb.Duration)(nil),                         // 26: google.protobuf.Duration
+	(*BuildInfo)(nil),                                   // 27: forge.BuildInfo
+	(*timestamppb.Timestamp)(nil),                       // 28: google.protobuf.Timestamp
+	(*DpuExtensionService)(nil),                         // 29: forge.DpuExtensionService
+	(*ExpectedMachine)(nil),                             // 30: forge.ExpectedMachine
+	(*LinkedExpectedMachine)(nil),                       // 31: forge.LinkedExpectedMachine
+	(*ExpectedRack)(nil),                                // 32: forge.ExpectedRack
+	(*ExpectedPowerShelf)(nil),                          // 33: forge.ExpectedPowerShelf
+	(*LinkedExpectedPowerShelf)(nil),                    // 34: forge.LinkedExpectedPowerShelf
+	(*ExpectedSwitch)(nil),                              // 35: forge.ExpectedSwitch
+	(*LinkedExpectedSwitch)(nil),                        // 36: forge.LinkedExpectedSwitch
+	(*IBPartition)(nil),                                 // 37: forge.IBPartition
+	(*Instance)(nil),                                    // 38: forge.Instance
+	(*NetworkSecurityGroupPropagationObjectStatus)(nil), // 39: forge.NetworkSecurityGroupPropagationObjectStatus
+	(*InstanceType)(nil),                                // 40: forge.InstanceType
+	(*Machine)(nil),                                     // 41: forge.Machine
+	(*DiscoveryInfo)(nil),                               // 42: machine_discovery.DiscoveryInfo
+	(*NetworkSecurityGroup)(nil),                        // 43: forge.NetworkSecurityGroup
+	(*NVLinkLogicalPartition)(nil),                      // 44: forge.NVLinkLogicalPartition
+	(*OsImage)(nil),                                     // 45: forge.OsImage
+	(*OperatingSystem)(nil),                             // 46: forge.OperatingSystem
+	(*IpxeTemplate)(nil),                                // 47: forge.IpxeTemplate
+	(*Sku)(nil),                                         // 48: forge.Sku
+	(*TenantKeyset)(nil),                                // 49: forge.TenantKeyset
+	(*NetworkSegment)(nil),                              // 50: forge.NetworkSegment
+	(*Tenant)(nil),                                      // 51: forge.Tenant
+	(*Vpc)(nil),                                         // 52: forge.Vpc
+	(*VpcPeering)(nil),                                  // 53: forge.VpcPeering
+	(*VpcPrefix)(nil),                                   // 54: forge.VpcPrefix
 }
 var file_inventory_proto_depIdxs = []int32{
-	0,  // 0: inventory.DpuExtensionServiceInventory.inventory_status:type_name -> inventory.InventoryStatus
-	24, // 1: inventory.DpuExtensionServiceInventory.timestamp:type_name -> google.protobuf.Timestamp
-	25, // 2: inventory.DpuExtensionServiceInventory.dpu_extension_services:type_name -> forge.DpuExtensionService
-	1,  // 3: inventory.DpuExtensionServiceInventory.inventory_page:type_name -> inventory.InventoryPage
-	0,  // 4: inventory.ExpectedMachineInventory.inventory_status:type_name -> inventory.InventoryStatus
-	24, // 5: inventory.ExpectedMachineInventory.timestamp:type_name -> google.protobuf.Timestamp
-	26, // 6: inventory.ExpectedMachineInventory.expected_machines:type_name -> forge.ExpectedMachine
-	1,  // 7: inventory.ExpectedMachineInventory.inventory_page:type_name -> inventory.InventoryPage
-	27, // 8: inventory.ExpectedMachineInventory.linked_machines:type_name -> forge.LinkedExpectedMachine
-	0,  // 9: inventory.ExpectedRackInventory.inventory_status:type_name -> inventory.InventoryStatus
-	24, // 10: inventory.ExpectedRackInventory.timestamp:type_name -> google.protobuf.Timestamp
-	28, // 11: inventory.ExpectedRackInventory.expected_racks:type_name -> forge.ExpectedRack
-	1,  // 12: inventory.ExpectedRackInventory.inventory_page:type_name -> inventory.InventoryPage
-	0,  // 13: inventory.ExpectedPowerShelfInventory.inventory_status:type_name -> inventory.InventoryStatus
-	24, // 14: inventory.ExpectedPowerShelfInventory.timestamp:type_name -> google.protobuf.Timestamp
-	29, // 15: inventory.ExpectedPowerShelfInventory.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
-	1,  // 16: inventory.ExpectedPowerShelfInventory.inventory_page:type_name -> inventory.InventoryPage
-	30, // 17: inventory.ExpectedPowerShelfInventory.linked_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
-	0,  // 18: inventory.ExpectedSwitchInventory.inventory_status:type_name -> inventory.InventoryStatus
-	24, // 19: inventory.ExpectedSwitchInventory.timestamp:type_name -> google.protobuf.Timestamp
-	31, // 20: inventory.ExpectedSwitchInventory.expected_switches:type_name -> forge.ExpectedSwitch
-	1,  // 21: inventory.ExpectedSwitchInventory.inventory_page:type_name -> inventory.InventoryPage
-	32, // 22: inventory.ExpectedSwitchInventory.linked_switches:type_name -> forge.LinkedExpectedSwitch
-	0,  // 23: inventory.InfiniBandPartitionInventory.inventory_status:type_name -> inventory.InventoryStatus
-	24, // 24: inventory.InfiniBandPartitionInventory.timestamp:type_name -> google.protobuf.Timestamp
-	33, // 25: inventory.InfiniBandPartitionInventory.ib_partitions:type_name -> forge.IBPartition
-	1,  // 26: inventory.InfiniBandPartitionInventory.inventory_page:type_name -> inventory.InventoryPage
-	34, // 27: inventory.InstanceInventory.instances:type_name -> forge.Instance
-	35, // 28: inventory.InstanceInventory.network_security_group_propagations:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
-	24, // 29: inventory.InstanceInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 30: inventory.InstanceInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 31: inventory.InstanceInventory.inventory_page:type_name -> inventory.InventoryPage
-	36, // 32: inventory.InstanceTypeInventory.instance_types:type_name -> forge.InstanceType
-	24, // 33: inventory.InstanceTypeInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 34: inventory.InstanceTypeInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 35: inventory.InstanceTypeInventory.inventory_page:type_name -> inventory.InventoryPage
-	37, // 36: inventory.MachineInfo.machine:type_name -> forge.Machine
-	38, // 37: inventory.MachineInfo.discovery_info:type_name -> machine_discovery.DiscoveryInfo
-	10, // 38: inventory.MachineInventory.machines:type_name -> inventory.MachineInfo
-	24, // 39: inventory.MachineInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 40: inventory.MachineInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 41: inventory.MachineInventory.inventory_page:type_name -> inventory.InventoryPage
-	39, // 42: inventory.NetworkSecurityGroupInventory.network_security_groups:type_name -> forge.NetworkSecurityGroup
-	24, // 43: inventory.NetworkSecurityGroupInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 44: inventory.NetworkSecurityGroupInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 45: inventory.NetworkSecurityGroupInventory.inventory_page:type_name -> inventory.InventoryPage
-	0,  // 46: inventory.NVLinkLogicalPartitionInventory.inventory_status:type_name -> inventory.InventoryStatus
-	24, // 47: inventory.NVLinkLogicalPartitionInventory.timestamp:type_name -> google.protobuf.Timestamp
-	40, // 48: inventory.NVLinkLogicalPartitionInventory.partitions:type_name -> forge.NVLinkLogicalPartition
-	1,  // 49: inventory.NVLinkLogicalPartitionInventory.inventory_page:type_name -> inventory.InventoryPage
-	41, // 50: inventory.OsImageInventory.os_images:type_name -> forge.OsImage
-	24, // 51: inventory.OsImageInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 52: inventory.OsImageInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 53: inventory.OsImageInventory.inventory_page:type_name -> inventory.InventoryPage
-	42, // 54: inventory.OperatingSystemInventory.operating_systems:type_name -> forge.OperatingSystem
-	24, // 55: inventory.OperatingSystemInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 56: inventory.OperatingSystemInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 57: inventory.OperatingSystemInventory.inventory_page:type_name -> inventory.InventoryPage
-	43, // 58: inventory.IpxeTemplateInventory.templates:type_name -> forge.IpxeTemplate
-	24, // 59: inventory.IpxeTemplateInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 60: inventory.IpxeTemplateInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 61: inventory.IpxeTemplateInventory.inventory_page:type_name -> inventory.InventoryPage
-	0,  // 62: inventory.SkuInventory.inventory_status:type_name -> inventory.InventoryStatus
-	24, // 63: inventory.SkuInventory.timestamp:type_name -> google.protobuf.Timestamp
-	44, // 64: inventory.SkuInventory.skus:type_name -> forge.Sku
-	1,  // 65: inventory.SkuInventory.inventory_page:type_name -> inventory.InventoryPage
-	45, // 66: inventory.SSHKeyGroupInventory.tenant_keysets:type_name -> forge.TenantKeyset
-	24, // 67: inventory.SSHKeyGroupInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 68: inventory.SSHKeyGroupInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 69: inventory.SSHKeyGroupInventory.inventory_page:type_name -> inventory.InventoryPage
-	46, // 70: inventory.SubnetInventory.segments:type_name -> forge.NetworkSegment
-	24, // 71: inventory.SubnetInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 72: inventory.SubnetInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 73: inventory.SubnetInventory.inventory_page:type_name -> inventory.InventoryPage
-	47, // 74: inventory.TenantInventory.tenants:type_name -> forge.Tenant
-	24, // 75: inventory.TenantInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 76: inventory.TenantInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 77: inventory.TenantInventory.inventory_page:type_name -> inventory.InventoryPage
-	48, // 78: inventory.VPCInventory.vpcs:type_name -> forge.Vpc
-	35, // 79: inventory.VPCInventory.network_security_group_propagations:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
-	24, // 80: inventory.VPCInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 81: inventory.VPCInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 82: inventory.VPCInventory.inventory_page:type_name -> inventory.InventoryPage
-	49, // 83: inventory.VPCPeeringInventory.vpc_peerings:type_name -> forge.VpcPeering
-	24, // 84: inventory.VPCPeeringInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 85: inventory.VPCPeeringInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 86: inventory.VPCPeeringInventory.inventory_page:type_name -> inventory.InventoryPage
-	50, // 87: inventory.VpcPrefixInventory.vpc_prefixes:type_name -> forge.VpcPrefix
-	24, // 88: inventory.VpcPrefixInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 89: inventory.VpcPrefixInventory.inventory_status:type_name -> inventory.InventoryStatus
-	1,  // 90: inventory.VpcPrefixInventory.inventory_page:type_name -> inventory.InventoryPage
-	91, // [91:91] is the sub-list for method output_type
-	91, // [91:91] is the sub-list for method input_type
-	91, // [91:91] is the sub-list for extension type_name
-	91, // [91:91] is the sub-list for extension extendee
-	0,  // [0:91] is the sub-list for field type_name
+	26, // 0: inventory.SiteAgentBuildInfo.inventory_interval:type_name -> google.protobuf.Duration
+	27, // 1: inventory.SiteConfigInventory.core_build_info:type_name -> forge.BuildInfo
+	2,  // 2: inventory.SiteConfigInventory.site_agent_build_info:type_name -> inventory.SiteAgentBuildInfo
+	0,  // 3: inventory.DpuExtensionServiceInventory.inventory_status:type_name -> inventory.InventoryStatus
+	28, // 4: inventory.DpuExtensionServiceInventory.timestamp:type_name -> google.protobuf.Timestamp
+	29, // 5: inventory.DpuExtensionServiceInventory.dpu_extension_services:type_name -> forge.DpuExtensionService
+	1,  // 6: inventory.DpuExtensionServiceInventory.inventory_page:type_name -> inventory.InventoryPage
+	0,  // 7: inventory.ExpectedMachineInventory.inventory_status:type_name -> inventory.InventoryStatus
+	28, // 8: inventory.ExpectedMachineInventory.timestamp:type_name -> google.protobuf.Timestamp
+	30, // 9: inventory.ExpectedMachineInventory.expected_machines:type_name -> forge.ExpectedMachine
+	1,  // 10: inventory.ExpectedMachineInventory.inventory_page:type_name -> inventory.InventoryPage
+	31, // 11: inventory.ExpectedMachineInventory.linked_machines:type_name -> forge.LinkedExpectedMachine
+	0,  // 12: inventory.ExpectedRackInventory.inventory_status:type_name -> inventory.InventoryStatus
+	28, // 13: inventory.ExpectedRackInventory.timestamp:type_name -> google.protobuf.Timestamp
+	32, // 14: inventory.ExpectedRackInventory.expected_racks:type_name -> forge.ExpectedRack
+	1,  // 15: inventory.ExpectedRackInventory.inventory_page:type_name -> inventory.InventoryPage
+	0,  // 16: inventory.ExpectedPowerShelfInventory.inventory_status:type_name -> inventory.InventoryStatus
+	28, // 17: inventory.ExpectedPowerShelfInventory.timestamp:type_name -> google.protobuf.Timestamp
+	33, // 18: inventory.ExpectedPowerShelfInventory.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
+	1,  // 19: inventory.ExpectedPowerShelfInventory.inventory_page:type_name -> inventory.InventoryPage
+	34, // 20: inventory.ExpectedPowerShelfInventory.linked_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
+	0,  // 21: inventory.ExpectedSwitchInventory.inventory_status:type_name -> inventory.InventoryStatus
+	28, // 22: inventory.ExpectedSwitchInventory.timestamp:type_name -> google.protobuf.Timestamp
+	35, // 23: inventory.ExpectedSwitchInventory.expected_switches:type_name -> forge.ExpectedSwitch
+	1,  // 24: inventory.ExpectedSwitchInventory.inventory_page:type_name -> inventory.InventoryPage
+	36, // 25: inventory.ExpectedSwitchInventory.linked_switches:type_name -> forge.LinkedExpectedSwitch
+	0,  // 26: inventory.InfiniBandPartitionInventory.inventory_status:type_name -> inventory.InventoryStatus
+	28, // 27: inventory.InfiniBandPartitionInventory.timestamp:type_name -> google.protobuf.Timestamp
+	37, // 28: inventory.InfiniBandPartitionInventory.ib_partitions:type_name -> forge.IBPartition
+	1,  // 29: inventory.InfiniBandPartitionInventory.inventory_page:type_name -> inventory.InventoryPage
+	38, // 30: inventory.InstanceInventory.instances:type_name -> forge.Instance
+	39, // 31: inventory.InstanceInventory.network_security_group_propagations:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
+	28, // 32: inventory.InstanceInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 33: inventory.InstanceInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 34: inventory.InstanceInventory.inventory_page:type_name -> inventory.InventoryPage
+	40, // 35: inventory.InstanceTypeInventory.instance_types:type_name -> forge.InstanceType
+	28, // 36: inventory.InstanceTypeInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 37: inventory.InstanceTypeInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 38: inventory.InstanceTypeInventory.inventory_page:type_name -> inventory.InventoryPage
+	41, // 39: inventory.MachineInfo.machine:type_name -> forge.Machine
+	42, // 40: inventory.MachineInfo.discovery_info:type_name -> machine_discovery.DiscoveryInfo
+	12, // 41: inventory.MachineInventory.machines:type_name -> inventory.MachineInfo
+	28, // 42: inventory.MachineInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 43: inventory.MachineInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 44: inventory.MachineInventory.inventory_page:type_name -> inventory.InventoryPage
+	43, // 45: inventory.NetworkSecurityGroupInventory.network_security_groups:type_name -> forge.NetworkSecurityGroup
+	28, // 46: inventory.NetworkSecurityGroupInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 47: inventory.NetworkSecurityGroupInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 48: inventory.NetworkSecurityGroupInventory.inventory_page:type_name -> inventory.InventoryPage
+	0,  // 49: inventory.NVLinkLogicalPartitionInventory.inventory_status:type_name -> inventory.InventoryStatus
+	28, // 50: inventory.NVLinkLogicalPartitionInventory.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 51: inventory.NVLinkLogicalPartitionInventory.partitions:type_name -> forge.NVLinkLogicalPartition
+	1,  // 52: inventory.NVLinkLogicalPartitionInventory.inventory_page:type_name -> inventory.InventoryPage
+	45, // 53: inventory.OsImageInventory.os_images:type_name -> forge.OsImage
+	28, // 54: inventory.OsImageInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 55: inventory.OsImageInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 56: inventory.OsImageInventory.inventory_page:type_name -> inventory.InventoryPage
+	46, // 57: inventory.OperatingSystemInventory.operating_systems:type_name -> forge.OperatingSystem
+	28, // 58: inventory.OperatingSystemInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 59: inventory.OperatingSystemInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 60: inventory.OperatingSystemInventory.inventory_page:type_name -> inventory.InventoryPage
+	47, // 61: inventory.IpxeTemplateInventory.templates:type_name -> forge.IpxeTemplate
+	28, // 62: inventory.IpxeTemplateInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 63: inventory.IpxeTemplateInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 64: inventory.IpxeTemplateInventory.inventory_page:type_name -> inventory.InventoryPage
+	0,  // 65: inventory.SkuInventory.inventory_status:type_name -> inventory.InventoryStatus
+	28, // 66: inventory.SkuInventory.timestamp:type_name -> google.protobuf.Timestamp
+	48, // 67: inventory.SkuInventory.skus:type_name -> forge.Sku
+	1,  // 68: inventory.SkuInventory.inventory_page:type_name -> inventory.InventoryPage
+	49, // 69: inventory.SSHKeyGroupInventory.tenant_keysets:type_name -> forge.TenantKeyset
+	28, // 70: inventory.SSHKeyGroupInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 71: inventory.SSHKeyGroupInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 72: inventory.SSHKeyGroupInventory.inventory_page:type_name -> inventory.InventoryPage
+	50, // 73: inventory.SubnetInventory.segments:type_name -> forge.NetworkSegment
+	28, // 74: inventory.SubnetInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 75: inventory.SubnetInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 76: inventory.SubnetInventory.inventory_page:type_name -> inventory.InventoryPage
+	51, // 77: inventory.TenantInventory.tenants:type_name -> forge.Tenant
+	28, // 78: inventory.TenantInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 79: inventory.TenantInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 80: inventory.TenantInventory.inventory_page:type_name -> inventory.InventoryPage
+	52, // 81: inventory.VPCInventory.vpcs:type_name -> forge.Vpc
+	39, // 82: inventory.VPCInventory.network_security_group_propagations:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
+	28, // 83: inventory.VPCInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 84: inventory.VPCInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 85: inventory.VPCInventory.inventory_page:type_name -> inventory.InventoryPage
+	53, // 86: inventory.VPCPeeringInventory.vpc_peerings:type_name -> forge.VpcPeering
+	28, // 87: inventory.VPCPeeringInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 88: inventory.VPCPeeringInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 89: inventory.VPCPeeringInventory.inventory_page:type_name -> inventory.InventoryPage
+	54, // 90: inventory.VpcPrefixInventory.vpc_prefixes:type_name -> forge.VpcPrefix
+	28, // 91: inventory.VpcPrefixInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 92: inventory.VpcPrefixInventory.inventory_status:type_name -> inventory.InventoryStatus
+	1,  // 93: inventory.VpcPrefixInventory.inventory_page:type_name -> inventory.InventoryPage
+	94, // [94:94] is the sub-list for method output_type
+	94, // [94:94] is the sub-list for method input_type
+	94, // [94:94] is the sub-list for extension type_name
+	94, // [94:94] is the sub-list for extension extendee
+	0,  // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_inventory_proto_init() }
@@ -2334,7 +2462,7 @@ func file_inventory_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_inventory_proto_rawDesc), len(file_inventory_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   23,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/rest-api/proto/core/src/v1/inventory.proto
+++ b/rest-api/proto/core/src/v1/inventory.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package inventory;
 
 import "common_nico.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "machine_discovery_nico.proto";
 import "nico_nico.proto";
@@ -31,6 +32,26 @@ message InventoryPage {
   int32 total_items = 4;
   // IDs of all items
   repeated string item_ids = 5;
+}
+
+// SiteAgentBuildInfo - build metadata and configuration the Site Agent reports about itself,
+// as opposed to the Core configuration it relays
+message SiteAgentBuildInfo {
+  // Site Agent build version
+  string version = 1;
+  // How often the Site Agent collects inventory, derived from its configured schedule.
+  // Cloud compares object timestamps against this to decide whether an inventory is stale.
+  google.protobuf.Duration inventory_interval = 2;
+}
+
+// SiteConfigInventory - Site configuration reported periodically. Site-level reporting is
+// added to this message rather than as another workflow argument, so extending it does not
+// require a new workflow.
+message SiteConfigInventory {
+  // Core build metadata, advertised capabilities, and runtime configuration
+  forge.BuildInfo core_build_info = 1;
+  // Build metadata and configuration owned by the Site Agent itself
+  SiteAgentBuildInfo site_agent_build_info = 2;
 }
 
 // DpuExtensionServiceInventory - inventory of all DPU Extension Services on Site, collected periodically

--- a/rest-api/site-agent/pkg/components/config/config_manager.go
+++ b/rest-api/site-agent/pkg/components/config/config_manager.go
@@ -329,7 +329,7 @@ func validateInventorySchedule(schedule string) error {
 
 	interval, err := swu.InventoryIntervalFromSchedule(schedule)
 	if err != nil {
-		return fmt.Errorf("Temporal inventory schedule %q is not a valid cron schedule: %w", schedule, err)
+		return fmt.Errorf("Temporal inventory %w", err)
 	}
 	if interval > cutil.MaxInventoryReceiptInterval {
 		return fmt.Errorf("Temporal inventory schedule %q collects every %v, which is slower than the %v maximum",

--- a/rest-api/site-agent/pkg/components/config/config_manager.go
+++ b/rest-api/site-agent/pkg/components/config/config_manager.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"time"
 
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/conftypes"
 	"github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
+	swu "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/util"
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog/log"
@@ -305,9 +307,36 @@ func NewElektraConfig(utMode bool) *conftypes.Config {
 		log.Fatal().Msg("error loading config, Temporal subscribe queue must be specified")
 	}
 
+	serr := validateInventorySchedule(conf.Temporal.TemporalInventorySchedule)
+	if serr != nil {
+		log.Fatal().Msgf("error loading config, %v", serr)
+	}
+
 	log.Info().Interface("config", conf).Msg("Config Manager: Config loaded")
 	flag.Parse()
 	return conf
+}
+
+// validateInventorySchedule rejects an inventory schedule the rest of the system cannot honor.
+// Cloud waits out the interval derived from this schedule before acting on an object, so a
+// schedule slower than MaxInventoryReceiptInterval would hold off deletions and status updates
+// long enough to destabilize it. This is the only place that bound is enforced. An empty
+// schedule falls back to the built-in default, which is well inside it.
+func validateInventorySchedule(schedule string) error {
+	if schedule == "" {
+		return nil
+	}
+
+	interval, err := swu.InventoryIntervalFromSchedule(schedule)
+	if err != nil {
+		return fmt.Errorf("Temporal inventory schedule %q is not a valid cron schedule: %w", schedule, err)
+	}
+	if interval > cutil.MaxInventoryReceiptInterval {
+		return fmt.Errorf("Temporal inventory schedule %q collects every %v, which is slower than the %v maximum",
+			schedule, interval, cutil.MaxInventoryReceiptInterval)
+	}
+
+	return nil
 }
 
 func determineEnvironment() conftypes.RunInEnvironment {

--- a/rest-api/site-agent/pkg/components/config/config_manager_test.go
+++ b/rest-api/site-agent/pkg/components/config/config_manager_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateInventorySchedule(t *testing.T) {
+	tests := []struct {
+		name     string
+		schedule string
+		wantErr  string
+	}{
+		{
+			// Empty falls back to the built-in default, which is inside the cap.
+			name:     "empty schedule is accepted",
+			schedule: "",
+		},
+		{
+			name:     "a schedule faster than the maximum is accepted",
+			schedule: "@every 1m",
+		},
+		{
+			name:     "a schedule at the maximum is accepted",
+			schedule: "@every 5m",
+		},
+		{
+			name:     "a schedule slower than the maximum is rejected",
+			schedule: "@every 6m",
+			wantErr:  "slower than the 5m0s maximum",
+		},
+		{
+			// The uneven gap decides it: this alternates 8h and 16h, so the 16h gap is what
+			// Cloud would have to honor.
+			name:     "an uneven schedule is rejected on its longest gap",
+			schedule: "0 9,17 * * *",
+			wantErr:  "slower than the 5m0s maximum",
+		},
+		{
+			name:     "an unparseable schedule is rejected",
+			schedule: "not-a-schedule",
+			wantErr:  "is not a valid cron schedule",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInventorySchedule(tt.schedule)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/rest-api/site-agent/pkg/components/config/config_manager_test.go
+++ b/rest-api/site-agent/pkg/components/config/config_manager_test.go
@@ -35,16 +35,15 @@ func TestValidateInventorySchedule(t *testing.T) {
 			wantErr:  "slower than the 5m0s maximum",
 		},
 		{
-			// The uneven gap decides it: this alternates 8h and 16h, so the 16h gap is what
-			// Cloud would have to honor.
-			name:     "an uneven schedule is rejected on its longest gap",
+			// Its gaps alternate 8h and 16h, so no single interval describes it.
+			name:     "a field expression is rejected",
 			schedule: "0 9,17 * * *",
-			wantErr:  "slower than the 5m0s maximum",
+			wantErr:  `must be an "@every" duration`,
 		},
 		{
 			name:     "an unparseable schedule is rejected",
 			schedule: "not-a-schedule",
-			wantErr:  "is not a valid cron schedule",
+			wantErr:  `must be an "@every" duration`,
 		},
 	}
 

--- a/rest-api/site-agent/pkg/components/managers/dpuextensionservice/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/dpuextensionservice/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -18,8 +19,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register cron
@@ -28,10 +27,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-dpu-extension-service-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("DpuExtensionService: Inventory Collect/Publish cron schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/expectedmachine/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/expectedmachine/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -16,8 +17,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
@@ -26,10 +25,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-expected-machine-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("ExpectedMachine: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/expectedpowershelf/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/expectedpowershelf/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -16,8 +17,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
@@ -26,10 +25,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-expected-power-shelf-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("ExpectedPowerShelf: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/expectedrack/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/expectedrack/cron.go
@@ -8,14 +8,13 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
 const (
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
@@ -24,10 +23,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-expected-rack-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("ExpectedRack: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/expectedswitch/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/expectedswitch/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -16,8 +17,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
@@ -26,10 +25,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-expected-switch-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("ExpectedSwitch: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/infinibandpartition/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/infinibandpartition/cron.go
@@ -6,6 +6,7 @@ package infinibandpartition
 import (
 	"context"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 
 	"go.temporal.io/sdk/client"
@@ -18,18 +19,13 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
 func (api *API) RegisterCron() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("InfiniBandPartition: Registering Inventory Discovery Cron")
 	workflowID := "inventory-infinibandpartition-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("InfiniBandPartition: Inventory Discovery Cron Schedule")
 
 	workflowOptions := client.StartWorkflowOptions{

--- a/rest-api/site-agent/pkg/components/managers/instance/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/instance/cron.go
@@ -6,6 +6,7 @@ package instance
 import (
 	"context"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 	"go.temporal.io/sdk/client"
 )
@@ -17,18 +18,13 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
 func (api *API) RegisterCron() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("Instance: Registering Inventory Discovery Cron")
 	workflowID := "inventory-instance-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("Instance: Inventory Discovery Cron Schedule")
 
 	workflowOptions := client.StartWorkflowOptions{

--- a/rest-api/site-agent/pkg/components/managers/instancetype/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/instancetype/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -16,8 +17,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register cron workflow
@@ -27,10 +26,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-instance-type-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("InstanceType: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/machine/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/machine/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -18,8 +19,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
@@ -29,10 +28,7 @@ func (api *API) RegisterCron() {
 
 	workflowID := "inventory-machine-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("Machine: Inventory Collect/Publish cron schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/networksecuritygroup/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/networksecuritygroup/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -16,8 +17,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register cron workflow
@@ -27,10 +26,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-network-security-group-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("NetworkSecurityGroup: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/nvlinklogicalpartition/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/nvlinklogicalpartition/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -16,8 +17,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
@@ -26,10 +25,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-nvlink-logical-partition-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("NVLinkLogicalPartition: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/operatingsystem/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/operatingsystem/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -18,8 +19,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron registers the OsImage, OperatingSystem, and iPXE template inventory
@@ -41,10 +40,7 @@ func (api *API) registerInventoryCron(label, workflowIDPrefix string, workflowFu
 
 	workflowID := workflowIDPrefix + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msgf("%s: Inventory Collect/Publish cron schedule", label)
 

--- a/rest-api/site-agent/pkg/components/managers/site/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/site/cron.go
@@ -8,24 +8,20 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
 const (
 	// InventoryQueuePrefix is the prefix for the inventory temporal queue.
 	InventoryQueuePrefix = "inventory-"
-	// InventoryDefaultSchedule is the default schedule for inventory discovery.
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron registers the Site Config inventory discovery cron.
 func (api *API) RegisterCron() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("Site: Registering Site Config Inventory Discovery Cron")
 	workflowID := "inventory-site-config-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("Site: Site Config Inventory Discovery Cron Schedule")
 
 	workflowOptions := client.StartWorkflowOptions{

--- a/rest-api/site-agent/pkg/components/managers/site/publisher.go
+++ b/rest-api/site-agent/pkg/components/managers/site/publisher.go
@@ -5,8 +5,13 @@ package site
 
 import (
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/durationpb"
 
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/metadata"
 	swa "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/activity"
+	swu "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/util"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -23,12 +28,28 @@ func (api *API) RegisterPublisher() error {
 		return err
 	}
 
+	siteAgentBuildInfo := &corev1.SiteAgentBuildInfo{
+		Version: metadata.Version,
+	}
+
+	// Cloud decides when reported data is stale from this interval, so an unparseable schedule
+	// leaves it unset rather than reporting a wrong number. The cron registration below fails on
+	// the same schedule anyway.
+	schedule := wfmgr.EffectiveCronSchedule()
+	inventoryInterval, err := swu.InventoryIntervalFromSchedule(schedule)
+	if err != nil {
+		ManagerAccess.Data.EB.Log.Error().Err(err).Str("Schedule", schedule).
+			Msg("Site: could not derive the inventory interval from the configured schedule")
+	} else {
+		siteAgentBuildInfo.InventoryInterval = durationpb.New(inventoryInterval)
+	}
+
 	inventoryManager := swa.NewManageSiteConfigInventory(swa.ManageInventoryConfig{
 		SiteID:                siteID,
 		CoreGrpcAtomicClient:  ManagerAccess.Data.EB.Managers.CoreGrpc.Client,
 		TemporalPublishClient: ManagerAccess.Data.EB.Managers.Workflow.Temporal.Publisher,
 		TemporalPublishQueue:  ManagerAccess.Conf.EB.Temporal.TemporalPublishQueue,
-	})
+	}, siteAgentBuildInfo)
 
 	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(inventoryManager.DiscoverSiteConfigInventory)
 	ManagerAccess.Data.EB.Log.Info().Msg("Site: Successfully registered DiscoverSiteConfigInventory activity")

--- a/rest-api/site-agent/pkg/components/managers/sku/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/sku/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -16,8 +17,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
@@ -26,10 +25,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-sku-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("SKU: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/sshkeygroup/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/sshkeygroup/cron.go
@@ -6,6 +6,7 @@ package sshkeygroup
 import (
 	"context"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 	"go.temporal.io/sdk/client"
 )
@@ -17,18 +18,13 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
 func (api *API) RegisterCron() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("SSHKeyGroup: Registering Inventory Discovery Cron")
 	workflowID := "inventory-sshkeygroup-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("SSHKeyGroup: Inventory Discovery Cron Schedule")
 
 	workflowOptions := client.StartWorkflowOptions{

--- a/rest-api/site-agent/pkg/components/managers/subnet/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/subnet/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -18,18 +19,13 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
 func (api *API) RegisterCron() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("Subnet: Registering Inventory Discovery Cron")
 	workflowID := "inventory-subnet-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("Subnet: Inventory Discovery Cron Schedule")
 
 	workflowOptions := client.StartWorkflowOptions{

--- a/rest-api/site-agent/pkg/components/managers/tenant/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/tenant/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -18,8 +19,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register cron
@@ -28,10 +27,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-tenant-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("Tenant: Inventory Collect/Publish cron schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/vpc/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/vpc/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -18,18 +19,13 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
 func (api *API) RegisterCron() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("Vpc: Registering Inventory Discovery Cron")
 	workflowID := "inventory-vpc-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("VPC: Inventory Discovery Cron Schedule")
 
 	workflowOptions := client.StartWorkflowOptions{

--- a/rest-api/site-agent/pkg/components/managers/vpcpeering/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/vpcpeering/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -16,8 +17,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to send to cloud per Temporal workflow page
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for VPC Peering inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - register cron
@@ -26,10 +25,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-vpcpeering-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("VpcPeering: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/vpcprefix/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/vpcprefix/cron.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	wfmgr "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/workflow"
 	sww "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/workflow"
 )
 
@@ -18,8 +19,6 @@ const (
 	InventoryCarbidePageSize = 100
 	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
 	InventoryCloudPageSize = 25
-	// InventoryDefaultSchedule is the default schedule for inventory discovery
-	InventoryDefaultSchedule = "@every 3m"
 )
 
 // RegisterCron - Register Cron
@@ -29,10 +28,7 @@ func (api *API) RegisterCron() error {
 
 	workflowID := "inventory-vpcprefix-" + ManagerAccess.Conf.EB.Temporal.TemporalSubscribeNamespace
 
-	cronSchedule := InventoryDefaultSchedule
-	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
-		cronSchedule = ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
-	}
+	cronSchedule := wfmgr.EffectiveCronSchedule()
 
 	ManagerAccess.Data.EB.Log.Info().Str("Schedule", cronSchedule).Msg("VpcPrefix: Inventory Discovery Cron Schedule")
 

--- a/rest-api/site-agent/pkg/components/managers/workflow/utils.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/utils.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workflow
+
+// InventoryDefaultSchedule is the schedule inventory discovery runs on when the deployment does
+// not configure one.
+const InventoryDefaultSchedule = "@every 3m"
+
+// EffectiveCronSchedule returns the schedule every inventory discovery cron runs on. The Site
+// Agent reports the interval derived from this same value to Cloud, which uses it to decide when
+// reported data is stale, so the two must not diverge.
+func EffectiveCronSchedule() string {
+	if ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule != "" {
+		return ManagerAccess.Conf.EB.Temporal.TemporalInventorySchedule
+	}
+	return InventoryDefaultSchedule
+}

--- a/rest-api/site-agent/pkg/components/managers/workflow/utils_test.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/utils_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+	swu "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/util"
+)
+
+// TestInventoryDefaultScheduleIsReportable pins the default against the two rules the rest of the
+// system applies to a configured schedule. Config validation skips an unset schedule, so a default
+// that broke either rule would leave the Site collecting on it while Cloud fell back to assuming
+// DefaultInventoryReceiptInterval.
+func TestInventoryDefaultScheduleIsReportable(t *testing.T) {
+	interval, err := swu.InventoryIntervalFromSchedule(InventoryDefaultSchedule)
+	require.NoError(t, err, "the default schedule must carry a derivable interval")
+	assert.LessOrEqual(t, interval, cutil.MaxInventoryReceiptInterval,
+		"the default schedule must not be slower than the supported maximum")
+}

--- a/rest-api/site-workflow/pkg/activity/site.go
+++ b/rest-api/site-workflow/pkg/activity/site.go
@@ -13,34 +13,39 @@ import (
 	tClient "go.temporal.io/sdk/client"
 )
 
-const updateSiteConfigInventoryWorkflowName = "UpdateSiteConfigInventory"
+const updateSiteConfigInventoryWorkflowName = "UpdateSiteConfigInventoryV2"
 
 // ManageSiteConfigInventory is an activity wrapper for Site Config inventory collection and publishing.
 type ManageSiteConfigInventory struct {
-	config ManageInventoryConfig
+	inventoryConfig ManageInventoryConfig
+	// siteAgentBuildInfo describes the Site Agent itself and is fixed for the life of the
+	// process, so the caller builds it once rather than the activity rebuilding it per run.
+	siteAgentBuildInfo *corev1.SiteAgentBuildInfo
 }
 
 // NewManageSiteConfigInventory returns a ManageSiteConfigInventory implementation.
-func NewManageSiteConfigInventory(config ManageInventoryConfig) ManageSiteConfigInventory {
+func NewManageSiteConfigInventory(inventoryConfig ManageInventoryConfig, siteAgentBuildInfo *corev1.SiteAgentBuildInfo) ManageSiteConfigInventory {
 	return ManageSiteConfigInventory{
-		config: config,
+		inventoryConfig:    inventoryConfig,
+		siteAgentBuildInfo: siteAgentBuildInfo,
 	}
 }
 
 // DiscoverSiteConfigInventory collects Core build metadata, advertised
-// capabilities, and runtime configuration. It publishes that snapshot to the
-// Cloud workflow, which stores the Core version and SLAAC capability and
-// creates IP Blocks for the Site fabric prefixes.
+// capabilities, and runtime configuration, alongside the Site Agent's own build info. It
+// publishes that snapshot to the Cloud workflow, which stores the Core version and SLAAC
+// capability, records the Site Agent build info, and creates IP Blocks for the Site fabric
+// prefixes.
 func (msi *ManageSiteConfigInventory) DiscoverSiteConfigInventory(ctx context.Context) error {
 	logger := log.With().Str("Activity", "DiscoverSiteConfigInventory").Logger()
 	logger.Info().Msg("Starting activity")
 
-	grpcClient := msi.config.CoreGrpcAtomicClient.GetClient()
+	grpcClient := msi.inventoryConfig.CoreGrpcAtomicClient.GetClient()
 	if grpcClient == nil {
 		return cClient.ErrCoreGrpcClientNotConnected
 	}
 
-	buildInfo, err := grpcClient.GrpcServiceClient().Version(ctx, &corev1.VersionRequest{
+	coreBuildInfo, err := grpcClient.GrpcServiceClient().Version(ctx, &corev1.VersionRequest{
 		DisplayConfig: true,
 	})
 	if err != nil {
@@ -48,17 +53,22 @@ func (msi *ManageSiteConfigInventory) DiscoverSiteConfigInventory(ctx context.Co
 		return err
 	}
 
-	workflowOptions := tClient.StartWorkflowOptions{
-		ID:        fmt.Sprintf("update-site-config-inventory-%s", msi.config.SiteID.String()),
-		TaskQueue: msi.config.TemporalPublishQueue,
+	inventory := &corev1.SiteConfigInventory{
+		CoreBuildInfo:      coreBuildInfo,
+		SiteAgentBuildInfo: msi.siteAgentBuildInfo,
 	}
 
-	if _, err = msi.config.TemporalPublishClient.ExecuteWorkflow(
+	workflowOptions := tClient.StartWorkflowOptions{
+		ID:        fmt.Sprintf("update-site-config-inventory-%s", msi.inventoryConfig.SiteID.String()),
+		TaskQueue: msi.inventoryConfig.TemporalPublishQueue,
+	}
+
+	if _, err = msi.inventoryConfig.TemporalPublishClient.ExecuteWorkflow(
 		ctx,
 		workflowOptions,
 		updateSiteConfigInventoryWorkflowName,
-		msi.config.SiteID.String(),
-		buildInfo,
+		msi.inventoryConfig.SiteID.String(),
+		inventory,
 	); err != nil {
 		logger.Error().Err(err).Msg("Failed to publish Site Config inventory to Cloud")
 		return err

--- a/rest-api/site-workflow/pkg/activity/site_test.go
+++ b/rest-api/site-workflow/pkg/activity/site_test.go
@@ -6,6 +6,7 @@ package activity
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	cClient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
@@ -15,71 +16,106 @@ import (
 	"github.com/stretchr/testify/require"
 	tClient "go.temporal.io/sdk/client"
 	tmocks "go.temporal.io/sdk/mocks"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func TestManageSiteConfigInventory_DiscoverSiteConfigInventory(t *testing.T) {
-	mockCoreGrpcClient := cClient.NewMockCoreGrpcClient()
-	coreGrpcAtomicClient := cClient.NewCoreGrpcAtomicClient(&cClient.CoreGrpcClientConfig{})
-	coreGrpcAtomicClient.SwapClient(mockCoreGrpcClient)
-
-	wid := "test-workflow-id"
-	wrun := &tmocks.WorkflowRun{}
-	wrun.On("GetID").Return(wid)
-
-	siteID := uuid.New()
 	siteFabricPrefixes := []string{"10.0.0.0/16", "2001:db8::/64"}
 	buildCapabilities := []corev1.BuildCapability{
 		corev1.BuildCapability_BUILD_CAPABILITY_VPC_SLAAC,
 	}
-	mockCoreService, ok := mockCoreGrpcClient.GrpcServiceClient().(*cClient.MockCoreGrpcServiceClient)
-	require.True(t, ok)
-	mockCoreService.BuildCapabilities = buildCapabilities
-	tc := &tmocks.Client{}
-	tc.Mock.On(
-		"ExecuteWorkflow",
-		mock.Anything,
-		mock.AnythingOfType("internal.StartWorkflowOptions"),
-		updateSiteConfigInventoryWorkflowName,
-		siteID.String(),
-		mock.Anything,
-	).Return(wrun, nil)
 
-	manageSiteConfigInventory := NewManageSiteConfigInventory(ManageInventoryConfig{
-		SiteID:                siteID,
-		CoreGrpcAtomicClient:  coreGrpcAtomicClient,
-		TemporalPublishClient: tc,
-		TemporalPublishQueue:  "test-queue",
-	})
+	tests := []struct {
+		name               string
+		coreClientMissing  bool
+		siteAgentBuildInfo *corev1.SiteAgentBuildInfo
+		wantErr            error
+	}{
+		{
+			name: "publishes Core build info alongside the Site Agent build info",
+			siteAgentBuildInfo: &corev1.SiteAgentBuildInfo{
+				Version:           "2.0.0",
+				InventoryInterval: durationpb.New(3 * time.Minute),
+			},
+		},
+		{
+			// The Site Agent leaves the interval unset when it cannot derive one, so Cloud can
+			// tell that apart from a real value and stay on its own default.
+			name:               "omits the interval when the Site Agent could not derive one",
+			siteAgentBuildInfo: &corev1.SiteAgentBuildInfo{Version: "2.0.0"},
+		},
+		{
+			name:               "fails when the Core gRPC client is not connected",
+			coreClientMissing:  true,
+			siteAgentBuildInfo: &corev1.SiteAgentBuildInfo{Version: "2.0.0"},
+			wantErr:            cClient.ErrCoreGrpcClientNotConnected,
+		},
+	}
 
-	ctx := context.WithValue(context.Background(), "siteFabricPrefixes", siteFabricPrefixes)
-	err := manageSiteConfigInventory.DiscoverSiteConfigInventory(ctx)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coreGrpcAtomicClient := cClient.NewCoreGrpcAtomicClient(&cClient.CoreGrpcClientConfig{})
+			if !tt.coreClientMissing {
+				mockCoreGrpcClient := cClient.NewMockCoreGrpcClient()
+				coreGrpcAtomicClient.SwapClient(mockCoreGrpcClient)
 
-	tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 1)
-	executeCtx, ok := tc.Calls[0].Arguments[0].(context.Context)
-	require.True(t, ok)
-	assert.Same(t, ctx, executeCtx)
+				mockCoreService, ok := mockCoreGrpcClient.GrpcServiceClient().(*cClient.MockCoreGrpcServiceClient)
+				require.True(t, ok)
+				mockCoreService.BuildCapabilities = buildCapabilities
+			}
 
-	workflowOptions, ok := tc.Calls[0].Arguments[1].(tClient.StartWorkflowOptions)
-	require.True(t, ok)
-	assert.Equal(t, "update-site-config-inventory-"+siteID.String(), workflowOptions.ID)
-	assert.Equal(t, "test-queue", workflowOptions.TaskQueue)
+			siteID := uuid.New()
+			wrun := &tmocks.WorkflowRun{}
+			wrun.On("GetID").Return("test-workflow-id")
 
-	buildInfo, ok := tc.Calls[0].Arguments[4].(*corev1.BuildInfo)
-	require.True(t, ok)
-	assert.Equal(t, buildCapabilities, buildInfo.GetCapabilities())
-	require.NotNil(t, buildInfo.GetRuntimeConfig(),
-		"Version request must set DisplayConfig, Core omits the runtime config without it")
-	assert.Equal(t, siteFabricPrefixes, buildInfo.GetRuntimeConfig().GetSiteFabricPrefixes())
-}
+			tc := &tmocks.Client{}
+			tc.Mock.On(
+				"ExecuteWorkflow",
+				mock.Anything,
+				mock.AnythingOfType("internal.StartWorkflowOptions"),
+				updateSiteConfigInventoryWorkflowName,
+				siteID.String(),
+				mock.Anything,
+			).Return(wrun, nil)
 
-func TestManageSiteConfigInventory_DiscoverSiteConfigInventory_NoCoreClient(t *testing.T) {
-	coreGrpcAtomicClient := cClient.NewCoreGrpcAtomicClient(&cClient.CoreGrpcClientConfig{})
-	manageSiteConfigInventory := NewManageSiteConfigInventory(ManageInventoryConfig{
-		SiteID:               uuid.New(),
-		CoreGrpcAtomicClient: coreGrpcAtomicClient,
-	})
+			manageSiteConfigInventory := NewManageSiteConfigInventory(ManageInventoryConfig{
+				SiteID:                siteID,
+				CoreGrpcAtomicClient:  coreGrpcAtomicClient,
+				TemporalPublishClient: tc,
+				TemporalPublishQueue:  "test-queue",
+			}, tt.siteAgentBuildInfo)
 
-	err := manageSiteConfigInventory.DiscoverSiteConfigInventory(context.Background())
-	assert.ErrorIs(t, err, cClient.ErrCoreGrpcClientNotConnected)
+			ctx := context.WithValue(context.Background(), "siteFabricPrefixes", siteFabricPrefixes)
+			err := manageSiteConfigInventory.DiscoverSiteConfigInventory(ctx)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 0)
+				return
+			}
+			require.NoError(t, err)
+
+			tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 1)
+			executeCtx, ok := tc.Calls[0].Arguments[0].(context.Context)
+			require.True(t, ok)
+			assert.Same(t, ctx, executeCtx)
+
+			workflowOptions, ok := tc.Calls[0].Arguments[1].(tClient.StartWorkflowOptions)
+			require.True(t, ok)
+			assert.Equal(t, "update-site-config-inventory-"+siteID.String(), workflowOptions.ID)
+			assert.Equal(t, "test-queue", workflowOptions.TaskQueue)
+
+			inventory, ok := tc.Calls[0].Arguments[4].(*corev1.SiteConfigInventory)
+			require.True(t, ok)
+
+			buildInfo := inventory.GetCoreBuildInfo()
+			require.NotNil(t, buildInfo)
+			assert.Equal(t, buildCapabilities, buildInfo.GetCapabilities())
+			require.NotNil(t, buildInfo.GetRuntimeConfig(),
+				"Version request must set DisplayConfig, Core omits the runtime config without it")
+			assert.Equal(t, siteFabricPrefixes, buildInfo.GetRuntimeConfig().GetSiteFabricPrefixes())
+
+			// The Site Agent build info is fixed at startup, so it is published as handed over.
+			assert.Equal(t, tt.siteAgentBuildInfo, inventory.GetSiteAgentBuildInfo())
+		})
+	}
 }

--- a/rest-api/site-workflow/pkg/util/schedule.go
+++ b/rest-api/site-workflow/pkg/util/schedule.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// scheduleSampleAnchor fixes the instant the interval is measured from, so the result depends
+// only on the schedule and not on when the Site Agent happens to start.
+var scheduleSampleAnchor = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// scheduleSampleGaps is how many gaps between fire times to compare. A schedule with uneven
+// gaps needs more than one to find the longest.
+const scheduleSampleGaps = 4
+
+// InventoryIntervalFromSchedule reports how much time can pass between two inventory
+// collections on the given Temporal cron schedule. A cron expression carries no interval
+// field, so this measures the gap between consecutive fire times and returns the longest
+// one it sees. Cloud uses the result to decide when reported data is stale, and a schedule
+// like `0 9,17 * * *` alternates between an 8 and a 16 hour gap, so returning the shorter
+// one would call fresh data stale.
+func InventoryIntervalFromSchedule(schedule string) (time.Duration, error) {
+	// Temporal parses cron schedules with the standard five fields plus descriptors such as
+	// `@every 3m`, which is exactly what ParseStandard accepts.
+	parsed, err := cron.ParseStandard(schedule)
+	if err != nil {
+		return 0, err
+	}
+
+	longest := time.Duration(0)
+	current := parsed.Next(scheduleSampleAnchor)
+	for range scheduleSampleGaps {
+		next := parsed.Next(current)
+		if gap := next.Sub(current); gap > longest {
+			longest = gap
+		}
+		current = next
+	}
+
+	return longest, nil
+}

--- a/rest-api/site-workflow/pkg/util/schedule.go
+++ b/rest-api/site-workflow/pkg/util/schedule.go
@@ -4,42 +4,38 @@
 package util
 
 import (
+	"fmt"
+	"strings"
 	"time"
-
-	"github.com/robfig/cron/v3"
 )
 
-// scheduleSampleAnchor fixes the instant the interval is measured from, so the result depends
-// only on the schedule and not on when the Site Agent happens to start.
-var scheduleSampleAnchor = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
-
-// scheduleSampleGaps is how many gaps between fire times to compare. A schedule with uneven
-// gaps needs more than one to find the longest.
-const scheduleSampleGaps = 4
+// everySchedulePrefix is the Temporal cron descriptor that carries its period directly.
+const everySchedulePrefix = "@every "
 
 // InventoryIntervalFromSchedule reports how much time can pass between two inventory
-// collections on the given Temporal cron schedule. A cron expression carries no interval
-// field, so this measures the gap between consecutive fire times and returns the longest
-// one it sees. Cloud uses the result to decide when reported data is stale, and a schedule
-// like `0 9,17 * * *` alternates between an 8 and a 16 hour gap, so returning the shorter
-// one would call fresh data stale.
+// collections on the given Temporal cron schedule.
+//
+// Only the `@every` descriptor is accepted. A field-based expression carries no period, and its
+// gaps can be uneven in ways that are not apparent from the first few fire times: `* 9 * * *`
+// fires every minute inside one hour, so it looks like a 1 minute schedule while really leaving
+// a 23 hour gap. Cloud decides when reported data is stale from this value, so reading it too
+// low would have Cloud acting on inventory far older than it assumes. Requiring a fixed period
+// makes the interval exact instead of estimated.
 func InventoryIntervalFromSchedule(schedule string) (time.Duration, error) {
-	// Temporal parses cron schedules with the standard five fields plus descriptors such as
-	// `@every 3m`, which is exactly what ParseStandard accepts.
-	parsed, err := cron.ParseStandard(schedule)
+	period, found := strings.CutPrefix(schedule, everySchedulePrefix)
+	if !found {
+		return 0, fmt.Errorf("schedule %q must be an %q duration, such as %q", schedule, strings.TrimSpace(everySchedulePrefix), "@every 3m")
+	}
+
+	// Temporal parses this descriptor's remainder with time.ParseDuration, so accepting exactly
+	// what that accepts keeps this from admitting a schedule Temporal would then reject.
+	interval, err := time.ParseDuration(strings.TrimSpace(period))
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("schedule %q does not carry a valid duration: %w", schedule, err)
+	}
+	if interval <= 0 {
+		return 0, fmt.Errorf("schedule %q must carry a positive duration", schedule)
 	}
 
-	longest := time.Duration(0)
-	current := parsed.Next(scheduleSampleAnchor)
-	for range scheduleSampleGaps {
-		next := parsed.Next(current)
-		if gap := next.Sub(current); gap > longest {
-			longest = gap
-		}
-		current = next
-	}
-
-	return longest, nil
+	return interval, nil
 }

--- a/rest-api/site-workflow/pkg/util/schedule_test.go
+++ b/rest-api/site-workflow/pkg/util/schedule_test.go
@@ -34,31 +34,28 @@ func TestInventoryIntervalFromSchedule(t *testing.T) {
 			want:     30 * time.Second,
 		},
 		{
-			name:     "five field expression",
+			name:     "compound duration",
+			schedule: "@every 1h30m",
+			want:     90 * time.Minute,
+		},
+		{
+			// The gaps are even here, but accepting it would mean accepting the field syntax
+			// whose gaps are not.
+			name:     "five field expression is rejected",
 			schedule: "*/5 * * * *",
-			want:     5 * time.Minute,
+			wantErr:  true,
 		},
 		{
-			name:     "hourly descriptor",
+			// Fires every minute inside hour 9, so the first fire times suggest a 1 minute
+			// period while the real gap to the next day is 23 hours.
+			name:     "expression whose early gaps hide a long one is rejected",
+			schedule: "* 9 * * *",
+			wantErr:  true,
+		},
+		{
+			name:     "named descriptor without a period is rejected",
 			schedule: "@hourly",
-			want:     time.Hour,
-		},
-		{
-			// Uneven gaps alternate between 8 and 16 hours. Reporting the shorter one would
-			// have Cloud call fresh data stale, so the longer gap is the answer.
-			name:     "uneven gaps report the longest",
-			schedule: "0 9,17 * * *",
-			want:     16 * time.Hour,
-		},
-		{
-			name:     "daily expression",
-			schedule: "0 0 * * *",
-			want:     24 * time.Hour,
-		},
-		{
-			name:     "weekly expression",
-			schedule: "0 9 * * 1",
-			want:     7 * 24 * time.Hour,
+			wantErr:  true,
 		},
 		{
 			name:     "unparseable schedule",
@@ -71,9 +68,24 @@ func TestInventoryIntervalFromSchedule(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			// Six fields include seconds, which Temporal does not accept, so neither do we.
-			name:     "six field expression is rejected",
-			schedule: "0 */5 * * * *",
+			name:     "descriptor without a duration",
+			schedule: "@every",
+			wantErr:  true,
+		},
+		{
+			name:     "descriptor with an unparseable duration",
+			schedule: "@every often",
+			wantErr:  true,
+		},
+		{
+			// Would otherwise fire continuously and report a zero interval.
+			name:     "zero duration is rejected",
+			schedule: "@every 0s",
+			wantErr:  true,
+		},
+		{
+			name:     "negative duration is rejected",
+			schedule: "@every -1m",
 			wantErr:  true,
 		},
 	}
@@ -82,8 +94,9 @@ func TestInventoryIntervalFromSchedule(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := InventoryIntervalFromSchedule(tt.schedule)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Zero(t, got)
+
 				return
 			}
 			require.NoError(t, err)

--- a/rest-api/site-workflow/pkg/util/schedule_test.go
+++ b/rest-api/site-workflow/pkg/util/schedule_test.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInventoryIntervalFromSchedule(t *testing.T) {
+	tests := []struct {
+		name     string
+		schedule string
+		want     time.Duration
+		wantErr  bool
+	}{
+		{
+			name:     "every minute descriptor, the co-located Site setting",
+			schedule: "@every 1m",
+			want:     time.Minute,
+		},
+		{
+			name:     "every three minutes descriptor, the chart default",
+			schedule: "@every 3m",
+			want:     3 * time.Minute,
+		},
+		{
+			name:     "sub-minute descriptor",
+			schedule: "@every 30s",
+			want:     30 * time.Second,
+		},
+		{
+			name:     "five field expression",
+			schedule: "*/5 * * * *",
+			want:     5 * time.Minute,
+		},
+		{
+			name:     "hourly descriptor",
+			schedule: "@hourly",
+			want:     time.Hour,
+		},
+		{
+			// Uneven gaps alternate between 8 and 16 hours. Reporting the shorter one would
+			// have Cloud call fresh data stale, so the longer gap is the answer.
+			name:     "uneven gaps report the longest",
+			schedule: "0 9,17 * * *",
+			want:     16 * time.Hour,
+		},
+		{
+			name:     "daily expression",
+			schedule: "0 0 * * *",
+			want:     24 * time.Hour,
+		},
+		{
+			name:     "weekly expression",
+			schedule: "0 9 * * 1",
+			want:     7 * 24 * time.Hour,
+		},
+		{
+			name:     "unparseable schedule",
+			schedule: "not-a-schedule",
+			wantErr:  true,
+		},
+		{
+			name:     "empty schedule",
+			schedule: "",
+			wantErr:  true,
+		},
+		{
+			// Six fields include seconds, which Temporal does not accept, so neither do we.
+			name:     "six field expression is rejected",
+			schedule: "0 */5 * * * *",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := InventoryIntervalFromSchedule(tt.schedule)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Zero(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/rest-api/workflow/cmd/workflow/main.go
+++ b/rest-api/workflow/cmd/workflow/main.go
@@ -276,7 +276,8 @@ func main() {
 
 		// Site workflows
 		w.RegisterWorkflow(siteWorkflow.UpdateAgentCertExpiry)
-		// V1 stays registered so a Site running an older Site Agent keeps reporting.
+		// V1 stays registered for the rollout window, where Cloud upgrades ahead of the Site
+		// Agents still publishing it.
 		w.RegisterWorkflow(siteWorkflow.UpdateSiteConfigInventory)
 		w.RegisterWorkflow(siteWorkflow.UpdateSiteConfigInventoryV2)
 

--- a/rest-api/workflow/cmd/workflow/main.go
+++ b/rest-api/workflow/cmd/workflow/main.go
@@ -276,7 +276,9 @@ func main() {
 
 		// Site workflows
 		w.RegisterWorkflow(siteWorkflow.UpdateAgentCertExpiry)
+		// V1 stays registered so a Site running an older Site Agent keeps reporting.
 		w.RegisterWorkflow(siteWorkflow.UpdateSiteConfigInventory)
+		w.RegisterWorkflow(siteWorkflow.UpdateSiteConfigInventoryV2)
 
 		// SSHKeyGroup workflows
 		w.RegisterWorkflow(sshKeyGroupWorkflow.UpdateSSHKeyGroupInventory)

--- a/rest-api/workflow/pkg/activity/dpuextensionservice/dpuextensionservice.go
+++ b/rest-api/workflow/pkg/activity/dpuextensionservice/dpuextensionservice.go
@@ -191,6 +191,15 @@ func (mde ManageDpuExtensionService) UpdateDpuExtensionServicesInDB(ctx context.
 			versionInfo != nil ||
 			activeVersions != nil
 
+		// VersionInfo carries the Data, Credentials and Observability an API update sets, so a
+		// row written since the Site collected this inventory holds changes the snapshot cannot
+		// know about and writing the reported values over them would lose those edits.
+		if needsUpdate && site.IsTimeWithinStaleInventoryThreshold(dpuExtensionService.Updated) {
+			slogger.Info().Msg("not updating DpuExtensionService yet because it changed more recently than the inventory interval")
+
+			continue
+		}
+
 		if needsUpdate {
 			_, err := dpuExtensionServiceDAO.Update(ctx, nil, cdbm.DpuExtensionServiceUpdateInput{
 				DpuExtensionServiceID: dpuExtensionService.ID,

--- a/rest-api/workflow/pkg/activity/dpuextensionservice/dpuextensionservice.go
+++ b/rest-api/workflow/pkg/activity/dpuextensionservice/dpuextensionservice.go
@@ -233,7 +233,7 @@ func (mde ManageDpuExtensionService) UpdateDpuExtensionServicesInDB(ctx context.
 		slogger := logger.With().Str("DPU Extension Service ID", dpuExtensionService.ID.String()).Logger()
 
 		// Avoid these actions if the object was updated since the inventory was received
-		if util.IsTimeWithinStaleInventoryThreshold(dpuExtensionService.Updated) {
+		if site.IsTimeWithinStaleInventoryThreshold(dpuExtensionService.Updated) {
 			continue
 		}
 

--- a/rest-api/workflow/pkg/activity/dpuextensionservice/dpuextensionservice_test.go
+++ b/rest-api/workflow/pkg/activity/dpuextensionservice/dpuextensionservice_test.go
@@ -453,7 +453,7 @@ func TestManageDpuExtensionService_UpdateDpuExtensionServicesInDB(t *testing.T) 
 	assert.NoError(t, err)
 
 	// Set updated timestamp to be older than the stale inventory threshold so it can be deleted
-	_, err = dbSession.DB.Exec("UPDATE dpu_extension_service SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), dpuExtensionService5.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE dpu_extension_service SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), dpuExtensionService5.ID.String())
 	assert.NoError(t, err)
 
 	for _, tt := range tests {

--- a/rest-api/workflow/pkg/activity/dpuextensionservice/dpuextensionservice_test.go
+++ b/rest-api/workflow/pkg/activity/dpuextensionservice/dpuextensionservice_test.go
@@ -168,6 +168,16 @@ func TestManageDpuExtensionService_UpdateDpuExtensionServicesInDB(t *testing.T) 
 		pagedInvIds = append(pagedInvIds, dpuExtService.ID.String())
 	}
 
+	// The activity defers an update for a row written within the staleness threshold, so age every
+	// fixture once they all exist. The two cases that fall back to the row's own write time read
+	// Updated from these structs, so refresh them to match what was stored.
+	util.TestInventoryAgeUpdatedTimestamp(ctx, t, dbSession, (*cdbm.DpuExtensionService)(nil))
+	for _, des := range []*cdbm.DpuExtensionService{dpuExtensionService6, dpuExtensionService7} {
+		refreshed, rerr := cdbm.NewDpuExtensionServiceDAO(dbSession).GetByID(ctx, nil, des.ID, nil)
+		assert.NoError(t, rerr)
+		des.Updated = refreshed.Updated
+	}
+
 	pagedCtrlDpuExtensionServices := []*corev1.DpuExtensionService{}
 	for i := 0; i < 30; i++ {
 		version := fmt.Sprintf("V1-T%d", time.Now().Unix()*1000000)

--- a/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine.go
+++ b/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine.go
@@ -194,6 +194,15 @@ func (mei ManageExpectedMachine) UpdateExpectedMachinesInDB(ctx context.Context,
 			continue
 		}
 
+		// A row written since the Site collected this inventory holds changes the snapshot
+		// cannot know about, including any made through the API, so writing the reported values
+		// over them would lose those edits.
+		if site.IsTimeWithinStaleInventoryThreshold(cur.Updated) {
+			logger.Info().Str("ExpectedMachineID", cur.ID.String()).Msg("not updating ExpectedMachine yet because it changed more recently than the inventory interval")
+
+			continue
+		}
+
 		// update if any field differs
 		if cur.BmcMacAddress != reported.BmcMacAddress ||
 			cur.ChassisSerialNumber != reported.ChassisSerialNumber ||

--- a/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine.go
+++ b/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine.go
@@ -55,7 +55,7 @@ func (mei ManageExpectedMachine) UpdateExpectedMachinesInDB(ctx context.Context,
 
 	// Ensure Site exists
 	stDAO := cdbm.NewSiteDAO(mei.dbSession)
-	_, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
+	site, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
 	if err != nil {
 		if errors.Is(err, cdb.ErrDoesNotExist) {
 			logger.Warn().Err(err).Msg("received inventory for unknown or deleted Site")
@@ -253,7 +253,7 @@ func (mei ManageExpectedMachine) UpdateExpectedMachinesInDB(ctx context.Context,
 				continue
 			}
 			// Avoid destructive actions inside race-condition window
-			if util.IsTimeWithinStaleInventoryThreshold(em.Updated) {
+			if site.IsTimeWithinStaleInventoryThreshold(em.Updated) {
 				continue
 			}
 			logger.Info().Str("ExpectedMachineID", em.ID.String()).Msg("deleting ExpectedMachine from DB since it was no longer reported in inventory from Site")

--- a/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine_test.go
+++ b/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine_test.go
@@ -125,8 +125,8 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 
 		// Update creation and update timestamp to be earlier than inventory processing interval
 		_, uerr := dbSession.DB.Exec("UPDATE expected_machine SET created = ?, updated = ? WHERE id = ?",
-			time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)),
-			time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)),
 			em.ID.String())
 		assert.NoError(t, uerr)
 
@@ -740,37 +740,6 @@ func TestNewManageExpectedMachine(t *testing.T) {
 			got := NewManageExpectedMachine(tt.args.dbSession, tt.args.siteClientPool)
 			assert.Equal(t, tt.want.dbSession, got.dbSession, "dbSession should match")
 			assert.Equal(t, tt.want.siteClientPool, got.siteClientPool, "siteClientPool should match")
-		})
-	}
-}
-
-func TestStaleInventoryThresholdCondition(t *testing.T) {
-	tests := []struct {
-		name       string
-		actionTime time.Time
-		want       bool
-	}{
-		{
-			name:       "recent action within stale inventory threshold",
-			actionTime: time.Now(),
-			want:       true,
-		},
-		{
-			name:       "action just outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval + time.Second*15)),
-			want:       false,
-		},
-		{
-			name:       "old action well outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Hour),
-			want:       false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := cwu.IsTimeWithinStaleInventoryThreshold(tt.actionTime); got != tt.want {
-				t.Errorf("IsTimeWithinStaleInventoryThreshold() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine_test.go
+++ b/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine_test.go
@@ -392,6 +392,8 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 				siteClientPool: tt.fields.siteClientPool,
 			}
 
+			cwu.TestInventoryAgeUpdatedTimestamp(tt.args.ctx, t, dbSession, (*cdbm.ExpectedMachine)(nil))
+
 			err := mei.UpdateExpectedMachinesInDB(tt.args.ctx, tt.args.siteID, tt.args.expectedMachineInventory)
 			assert.Equal(t, tt.wantErr, err != nil)
 
@@ -488,6 +490,7 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 		}
 
 		mei := ManageExpectedMachine{dbSession: dbSession}
+		cwu.TestInventoryAgeUpdatedTimestamp(ctx, t, dbSession, (*cdbm.ExpectedMachine)(nil))
 		err := mei.UpdateExpectedMachinesInDB(ctx, st4.ID, inventory)
 		require.NoError(t, err)
 
@@ -498,6 +501,7 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 		permanentMachine := cwu.TestBuildMachine(t, dbSession, ip.ID, st4.ID, nil, cutil.GetPtr(false), cdbm.MachineStatusReady)
 		inventory.LinkedMachines[0].MachineId.Id = permanentMachine.ID
 
+		cwu.TestInventoryAgeUpdatedTimestamp(ctx, t, dbSession, (*cdbm.ExpectedMachine)(nil))
 		err = mei.UpdateExpectedMachinesInDB(ctx, st4.ID, inventory)
 		require.NoError(t, err)
 
@@ -505,6 +509,83 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, &permanentMachine.ID, reconciled.MachineID)
 	})
+}
+
+// TestManageExpectedMachine_UpdateRespectsStaleInventoryThreshold covers the gate shared by every
+// inventory activity that overwrites provider-set fields: an inventory collected before an edge
+// edit must not undo it. ExpectedMachine stands in for the rest, which apply the same check.
+func TestManageExpectedMachine_UpdateRespectsStaleInventoryThreshold(t *testing.T) {
+	testCases := []struct {
+		name         string
+		writtenAgo   time.Duration
+		wantSerial   string
+		wantLabelSet bool
+	}{
+		{
+			name:         "a recently written ExpectedMachine keeps its stored values",
+			writtenAgo:   time.Second,
+			wantSerial:   "SET-THROUGH-API",
+			wantLabelSet: true,
+		},
+		{
+			name:       "an ExpectedMachine untouched for longer than the interval takes the reported values",
+			writtenAgo: 2 * cutil.DefaultInventoryReceiptInterval,
+			wantSerial: "REPORTED-BY-SITE",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			dbSession := testExpectedMachineInitDB(t)
+			defer dbSession.Close()
+			testExpectedMachineSetupSchema(t, dbSession)
+
+			ipOrg := "test-provider-org"
+			ipu := cwu.TestBuildUser(t, dbSession, uuid.NewString(), []string{ipOrg}, []string{"FORGE_PROVIDER_ADMIN"})
+			ip := cwu.TestBuildInfrastructureProvider(t, dbSession, "test-provider", ipOrg, ipu)
+			st := cwu.TestBuildSite(t, dbSession, ip, "test-site-stale", cdbm.SiteStatusRegistered, nil, ipu)
+
+			emDAO := cdbm.NewExpectedMachineDAO(dbSession)
+			emID := uuid.New()
+			_, err := emDAO.Create(ctx, nil, cdbm.ExpectedMachineCreateInput{
+				ExpectedMachineID:   emID,
+				SiteID:              st.ID,
+				BmcMacAddress:       "00:11:22:33:99:01",
+				ChassisSerialNumber: "SET-THROUGH-API",
+				Labels:              map[string]string{"owner": "provider"},
+				CreatedBy:           ipu.ID,
+			})
+			require.NoError(t, err)
+
+			_, err = dbSession.DB.NewUpdate().
+				Model((*cdbm.ExpectedMachine)(nil)).
+				Set("updated = ?", time.Now().Add(-tc.writtenAgo)).
+				Where("id = ?", emID).
+				Exec(ctx)
+			require.NoError(t, err)
+
+			mei := ManageExpectedMachine{dbSession: dbSession}
+			err = mei.UpdateExpectedMachinesInDB(ctx, st.ID, &corev1.ExpectedMachineInventory{
+				ExpectedMachines: []*corev1.ExpectedMachine{{
+					Id:                  &corev1.UUID{Value: emID.String()},
+					BmcMacAddress:       "00:11:22:33:99:01",
+					ChassisSerialNumber: "REPORTED-BY-SITE",
+				}},
+				Timestamp:       timestamppb.Now(),
+				InventoryStatus: corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
+			})
+			require.NoError(t, err)
+
+			got, err := emDAO.Get(ctx, nil, emID, nil, false)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantSerial, got.ChassisSerialNumber)
+			if tc.wantLabelSet {
+				assert.Equal(t, cdbm.Labels{"owner": "provider"}, got.Labels, "a deferred update must leave labels alone")
+			}
+		})
+	}
 }
 
 func TestManageExpectedMachine_UpdateExpectedMachinesInDB_BmcIpAddress(t *testing.T) {
@@ -583,6 +664,7 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB_BmcIpAddress(t *testin
 	})
 
 	mei := ManageExpectedMachine{dbSession: dbSession}
+	cwu.TestInventoryAgeUpdatedTimestamp(ctx, t, dbSession, (*cdbm.ExpectedMachine)(nil))
 	err := mei.UpdateExpectedMachinesInDB(ctx, st.ID, &corev1.ExpectedMachineInventory{
 		ExpectedMachines: reportedMachines,
 		Timestamp:        timestamppb.Now(),
@@ -618,6 +700,7 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB_BmcIpAddress(t *testin
 		require.NoError(t, err)
 
 		nonexistentSkuID := "nonexistent-sku"
+		cwu.TestInventoryAgeUpdatedTimestamp(ctx, t, dbSession, (*cdbm.ExpectedMachine)(nil))
 		err = mei.UpdateExpectedMachinesInDB(ctx, st.ID, &corev1.ExpectedMachineInventory{
 			ExpectedMachines: []*corev1.ExpectedMachine{
 				{

--- a/rest-api/workflow/pkg/activity/expectedpowershelf/expectedpowershelf.go
+++ b/rest-api/workflow/pkg/activity/expectedpowershelf/expectedpowershelf.go
@@ -55,7 +55,7 @@ func (mei ManageExpectedPowerShelf) UpdateExpectedPowerShelvesInDB(ctx context.C
 
 	// Ensure Site exists
 	stDAO := cdbm.NewSiteDAO(mei.dbSession)
-	_, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
+	site, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
 	if err != nil {
 		if errors.Is(err, cdb.ErrDoesNotExist) {
 			logger.Warn().Err(err).Msg("received inventory for unknown or deleted Site")
@@ -176,7 +176,7 @@ func (mei ManageExpectedPowerShelf) UpdateExpectedPowerShelvesInDB(ctx context.C
 				continue
 			}
 			// Avoid destructive actions inside race-condition window
-			if util.IsTimeWithinStaleInventoryThreshold(eps.Updated) {
+			if site.IsTimeWithinStaleInventoryThreshold(eps.Updated) {
 				continue
 			}
 			logger.Info().Str("ExpectedPowerShelfID", eps.ID.String()).Msg("deleting ExpectedPowerShelf from DB since it was no longer reported in inventory from Site")

--- a/rest-api/workflow/pkg/activity/expectedpowershelf/expectedpowershelf.go
+++ b/rest-api/workflow/pkg/activity/expectedpowershelf/expectedpowershelf.go
@@ -142,6 +142,15 @@ func (mei ManageExpectedPowerShelf) UpdateExpectedPowerShelvesInDB(ctx context.C
 			continue
 		}
 
+		// A row written since the Site collected this inventory holds changes the snapshot
+		// cannot know about, including any made through the API, so writing the reported values
+		// over them would lose those edits.
+		if site.IsTimeWithinStaleInventoryThreshold(cur.Updated) {
+			logger.Info().Str("ExpectedPowerShelfID", cur.ID.String()).Msg("not updating ExpectedPowerShelf yet because it changed more recently than the inventory interval")
+
+			continue
+		}
+
 		// update if any field differs
 		if cur.BmcMacAddress != reported.BmcMacAddress ||
 			cur.ShelfSerialNumber != reported.ShelfSerialNumber ||

--- a/rest-api/workflow/pkg/activity/expectedpowershelf/expectedpowershelf_test.go
+++ b/rest-api/workflow/pkg/activity/expectedpowershelf/expectedpowershelf_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"go.temporal.io/sdk/testsuite"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -127,8 +126,8 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelvesInDB(t *testing.T) {
 
 		// Update creation and update timestamp to be earlier than inventory processing interval
 		_, uerr := dbSession.DB.Exec("UPDATE expected_power_shelf SET created = ?, updated = ? WHERE id = ?",
-			time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)),
-			time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval*2)),
 			eps.ID.String())
 		assert.NoError(t, uerr)
 
@@ -590,37 +589,6 @@ func TestNewManageExpectedPowerShelf(t *testing.T) {
 			got := NewManageExpectedPowerShelf(tt.args.dbSession, tt.args.siteClientPool)
 			assert.Equal(t, tt.want.dbSession, got.dbSession, "dbSession should match")
 			assert.Equal(t, tt.want.siteClientPool, got.siteClientPool, "siteClientPool should match")
-		})
-	}
-}
-
-func TestStaleInventoryThresholdCondition(t *testing.T) {
-	tests := []struct {
-		name       string
-		actionTime time.Time
-		want       bool
-	}{
-		{
-			name:       "recent action within stale inventory threshold",
-			actionTime: time.Now(),
-			want:       true,
-		},
-		{
-			name:       "action just outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval + time.Second*15)),
-			want:       false,
-		},
-		{
-			name:       "old action well outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Hour),
-			want:       false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := util.IsTimeWithinStaleInventoryThreshold(tt.actionTime); got != tt.want {
-				t.Errorf("IsTimeWithinStaleInventoryThreshold() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/rest-api/workflow/pkg/activity/expectedrack/expectedrack.go
+++ b/rest-api/workflow/pkg/activity/expectedrack/expectedrack.go
@@ -134,6 +134,15 @@ func (mer ManageExpectedRack) UpdateExpectedRacksInDB(ctx context.Context, siteI
 			continue
 		}
 
+		// A row written since the Site collected this inventory holds changes the snapshot
+		// cannot know about, including any made through the API, so writing the reported values
+		// over them would lose those edits.
+		if site.IsTimeWithinStaleInventoryThreshold(cur.Updated) {
+			logger.Info().Str("ExpectedRackID", cur.ID.String()).Msg("not updating ExpectedRack yet because it changed more recently than the inventory interval")
+
+			continue
+		}
+
 		// update if any field differs
 		if cur.RackProfileID != reported.RackProfileID ||
 			cur.Name != reported.Name ||

--- a/rest-api/workflow/pkg/activity/expectedrack/expectedrack.go
+++ b/rest-api/workflow/pkg/activity/expectedrack/expectedrack.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
@@ -55,7 +54,7 @@ func (mer ManageExpectedRack) UpdateExpectedRacksInDB(ctx context.Context, siteI
 
 	// Ensure Site exists
 	stDAO := cdbm.NewSiteDAO(mer.dbSession)
-	_, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
+	site, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
 	if err != nil {
 		if errors.Is(err, cdb.ErrDoesNotExist) {
 			logger.Warn().Err(err).Msg("received inventory for unknown or deleted Site")
@@ -168,7 +167,7 @@ func (mer ManageExpectedRack) UpdateExpectedRacksInDB(ctx context.Context, siteI
 				continue
 			}
 			// Avoid destructive actions inside race-condition window
-			if util.IsTimeWithinStaleInventoryThreshold(er.Updated) {
+			if site.IsTimeWithinStaleInventoryThreshold(er.Updated) {
 				continue
 			}
 			logger.Info().Str("ExpectedRackID", er.ID.String()).Str("RackID", er.RackID).Msg("deleting ExpectedRack from DB since it was no longer reported in inventory from Site")

--- a/rest-api/workflow/pkg/activity/expectedrack/expectedrack_test.go
+++ b/rest-api/workflow/pkg/activity/expectedrack/expectedrack_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"go.temporal.io/sdk/testsuite"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -130,8 +129,8 @@ func TestManageExpectedRack_UpdateExpectedRacksInDB(t *testing.T) {
 		// Update creation and update timestamp to be earlier than inventory processing interval so
 		// reconciliation considers them outside the race-condition window.
 		_, uerr := dbSession.DB.Exec("UPDATE expected_rack SET created = ?, updated = ? WHERE id = ?",
-			time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)),
-			time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval*2)),
 			er.ID.String())
 		assert.NoError(t, uerr)
 
@@ -534,7 +533,7 @@ func TestManageExpectedRack_UpdateExpectedRacksInDB_NoChange(t *testing.T) {
 
 	// Push the row's Updated timestamp into the past so we can detect whether the activity
 	// touched it (an Update would refresh Updated to current time).
-	pastTime := time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval * 2))
+	pastTime := time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval * 2))
 	_, uerr := dbSession.DB.Exec("UPDATE expected_rack SET created = ?, updated = ? WHERE id = ?",
 		pastTime, pastTime, er.ID.String())
 	assert.NoError(t, uerr)
@@ -675,37 +674,6 @@ func TestNewManageExpectedRack(t *testing.T) {
 			got := NewManageExpectedRack(tt.args.dbSession, tt.args.siteClientPool)
 			assert.Equal(t, tt.want.dbSession, got.dbSession, "dbSession should match")
 			assert.Equal(t, tt.want.siteClientPool, got.siteClientPool, "siteClientPool should match")
-		})
-	}
-}
-
-func TestExpectedRackStaleInventoryThresholdCondition(t *testing.T) {
-	tests := []struct {
-		name       string
-		actionTime time.Time
-		want       bool
-	}{
-		{
-			name:       "recent action within stale inventory threshold",
-			actionTime: time.Now(),
-			want:       true,
-		},
-		{
-			name:       "action just outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval + time.Second*15)),
-			want:       false,
-		},
-		{
-			name:       "old action well outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Hour),
-			want:       false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := util.IsTimeWithinStaleInventoryThreshold(tt.actionTime); got != tt.want {
-				t.Errorf("IsTimeWithinStaleInventoryThreshold() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/rest-api/workflow/pkg/activity/expectedswitch/expectedswitch.go
+++ b/rest-api/workflow/pkg/activity/expectedswitch/expectedswitch.go
@@ -142,6 +142,15 @@ func (mei ManageExpectedSwitch) UpdateExpectedSwitchesInDB(ctx context.Context, 
 			continue
 		}
 
+		// A row written since the Site collected this inventory holds changes the snapshot
+		// cannot know about, including any made through the API, so writing the reported values
+		// over them would lose those edits.
+		if site.IsTimeWithinStaleInventoryThreshold(cur.Updated) {
+			logger.Info().Str("ExpectedSwitchID", cur.ID.String()).Msg("not updating ExpectedSwitch yet because it changed more recently than the inventory interval")
+
+			continue
+		}
+
 		// update if any field differs
 		if cur.BmcMacAddress != reported.BmcMacAddress ||
 			cur.SwitchSerialNumber != reported.SwitchSerialNumber ||

--- a/rest-api/workflow/pkg/activity/expectedswitch/expectedswitch.go
+++ b/rest-api/workflow/pkg/activity/expectedswitch/expectedswitch.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"slices"
 
-	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
@@ -56,7 +55,7 @@ func (mei ManageExpectedSwitch) UpdateExpectedSwitchesInDB(ctx context.Context, 
 
 	// Ensure Site exists
 	stDAO := cdbm.NewSiteDAO(mei.dbSession)
-	_, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
+	site, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
 	if err != nil {
 		if errors.Is(err, cdb.ErrDoesNotExist) {
 			logger.Warn().Err(err).Msg("received inventory for unknown or deleted Site")
@@ -183,7 +182,7 @@ func (mei ManageExpectedSwitch) UpdateExpectedSwitchesInDB(ctx context.Context, 
 				continue
 			}
 			// Avoid destructive actions inside race-condition window
-			if util.IsTimeWithinStaleInventoryThreshold(es.Updated) {
+			if site.IsTimeWithinStaleInventoryThreshold(es.Updated) {
 				continue
 			}
 			logger.Info().Str("ExpectedSwitchID", es.ID.String()).Msg("deleting ExpectedSwitch from DB since it was no longer reported in inventory from Site")

--- a/rest-api/workflow/pkg/activity/expectedswitch/expectedswitch_test.go
+++ b/rest-api/workflow/pkg/activity/expectedswitch/expectedswitch_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"go.temporal.io/sdk/testsuite"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -126,8 +125,8 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchesInDB(t *testing.T) {
 
 		// Update creation and update timestamp to be earlier than inventory processing interval
 		_, uerr := dbSession.DB.Exec("UPDATE expected_switch SET created = ?, updated = ? WHERE id = ?",
-			time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)),
-			time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval*2)),
 			es.ID.String())
 		assert.NoError(t, uerr)
 
@@ -581,37 +580,6 @@ func TestNewManageExpectedSwitch(t *testing.T) {
 			got := NewManageExpectedSwitch(tt.args.dbSession, tt.args.siteClientPool)
 			assert.Equal(t, tt.want.dbSession, got.dbSession, "dbSession should match")
 			assert.Equal(t, tt.want.siteClientPool, got.siteClientPool, "siteClientPool should match")
-		})
-	}
-}
-
-func TestStaleInventoryThresholdCondition(t *testing.T) {
-	tests := []struct {
-		name       string
-		actionTime time.Time
-		want       bool
-	}{
-		{
-			name:       "recent action within stale inventory threshold",
-			actionTime: time.Now(),
-			want:       true,
-		},
-		{
-			name:       "action just outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval + time.Second*15)),
-			want:       false,
-		},
-		{
-			name:       "old action well outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Hour),
-			want:       false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := util.IsTimeWithinStaleInventoryThreshold(tt.actionTime); got != tt.want {
-				t.Errorf("IsTimeWithinStaleInventoryThreshold() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/rest-api/workflow/pkg/activity/infinibandpartition/infinibandpartition.go
+++ b/rest-api/workflow/pkg/activity/infinibandpartition/infinibandpartition.go
@@ -5,7 +5,6 @@ package infinibandpartition
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -248,7 +247,7 @@ func (mibp ManageInfiniBandPartition) UpdateInfiniBandPartitionsInDB(ctx context
 			}
 		} else if ibp.ControllerIBPartitionID != nil {
 			// Was this created within inventory receipt interval? If so, we may be processing an older inventory
-			if time.Since(ibp.Created) < cwutil.InventoryReceiptInterval {
+			if site.IsTimeWithinStaleInventoryThreshold(ibp.Created) {
 				continue
 			}
 

--- a/rest-api/workflow/pkg/activity/infinibandpartition/infinibandpartition_test.go
+++ b/rest-api/workflow/pkg/activity/infinibandpartition/infinibandpartition_test.go
@@ -136,7 +136,7 @@ func TestManageInfiniBandPartition_UpdateInfiniBandPartitionsInDB(t *testing.T) 
 	ibp7 := util.TestBuildInfiniBandPartition(t, dbSession, "test-ibp-7", st1, tn, cutil.GetPtr(uuid.New()), cdbm.InfiniBandPartitionStatusReady, false)
 	assert.NotNil(t, ibp7)
 	// Set created earlier than the inventory receipt interval
-	_, err := dbSession.DB.Exec("UPDATE infiniband_partition SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), ibp7.ID.String())
+	_, err := dbSession.DB.Exec("UPDATE infiniband_partition SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), ibp7.ID.String())
 	assert.NoError(t, err)
 
 	ibp8 := util.TestBuildInfiniBandPartition(t, dbSession, "test-ibp-8", st1, tn, cutil.GetPtr(uuid.New()), cdbm.InfiniBandPartitionStatusError, true)
@@ -151,7 +151,7 @@ func TestManageInfiniBandPartition_UpdateInfiniBandPartitionsInDB(t *testing.T) 
 	ibp11 := util.TestBuildInfiniBandPartition(t, dbSession, "test-ibp-11", st1, tn, cutil.GetPtr(uuid.New()), cdbm.InfiniBandPartitionStatusReady, false)
 	assert.NotNil(t, ibp11)
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE infiniband_partition SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), ibp11.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE infiniband_partition SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), ibp11.ID.String())
 	assert.NoError(t, err)
 
 	// Build InfiniBand Partition inventory that is paginated
@@ -161,7 +161,7 @@ func TestManageInfiniBandPartition_UpdateInfiniBandPartitionsInDB(t *testing.T) 
 	for i := 0; i < 38; i++ {
 		ibp := util.TestBuildInfiniBandPartition(t, dbSession, fmt.Sprintf("test-vpc-paged-%d", i), st2, tn, cutil.GetPtr(uuid.New()), cdbm.InfiniBandPartitionStatusReady, false)
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE infiniband_partition SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), ibp.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE infiniband_partition SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), ibp.ID.String())
 		assert.NoError(t, err)
 		pagedIbps = append(pagedIbps, ibp)
 		pagedInvIds = append(pagedInvIds, ibp.ControllerIBPartitionID.String())

--- a/rest-api/workflow/pkg/activity/instance/instance.go
+++ b/rest-api/workflow/pkg/activity/instance/instance.go
@@ -187,7 +187,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 		// We'll add a 5 second buffer to account for a little clock skew/drift.
 		// The only thing that might be safe to perform is propagation status clearing,
 		// but only if we never allow multiple inventory processes to run concurrently.
-		if time.Since(instance.Updated) < cwutil.InventoryReceiptInterval+(time.Second*5) {
+		if site.IsTimeWithinStaleInventoryThreshold(instance.Updated) {
 			slogger.Warn().Msg("instance updated more recently than inventory received time, skipping processing")
 			continue
 		}
@@ -716,7 +716,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 		// Determine which InfiniBand Interfaces in Deleting state can be deleted
 		if isInfiniBandConfigStatusEmpty || isInfiniBandConfigSynced {
 			for _, ibifc := range deletingInfiniBandInterfaces {
-				if util.IsTimeWithinStaleInventoryThreshold(ibifc.Updated) {
+				if site.IsTimeWithinStaleInventoryThreshold(ibifc.Updated) {
 					// If the InfiniBand Interface was modified within stale inventory threshold, defer to next inventory update
 					continue
 				}
@@ -793,7 +793,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 
 			if !exists {
 				// If the DPU Extension Service Deployment was modified within stale inventory threshold, defer to next inventory update
-				if util.IsTimeWithinStaleInventoryThreshold(desd.Updated) {
+				if site.IsTimeWithinStaleInventoryThreshold(desd.Updated) {
 					continue
 				}
 
@@ -929,7 +929,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 		// Delete NVLink Interfaces that are not present in the controller Instance
 		if isNVLinkConfigStatusEmpty || isNVLinkConfigSynced {
 			for _, nvlifc := range deletingNVLinkInterfaces {
-				if util.IsTimeWithinStaleInventoryThreshold(nvlifc.Updated) {
+				if site.IsTimeWithinStaleInventoryThreshold(nvlifc.Updated) {
 					// If the NVLink Interface was modified within stale inventory threshold, defer to next inventory update
 					continue
 				}
@@ -1037,7 +1037,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 			}
 		} else if instance.ControllerInstanceID != nil {
 			// Was this created within inventory receipt interval? If so, we may be processing an older inventory
-			if time.Since(instance.Created) < cwutil.InventoryReceiptInterval {
+			if site.IsTimeWithinStaleInventoryThreshold(instance.Created) {
 				continue
 			}
 

--- a/rest-api/workflow/pkg/activity/instance/instance_test.go
+++ b/rest-api/workflow/pkg/activity/instance/instance_test.go
@@ -247,7 +247,7 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 		require.NoError(t, createErr)
 		_, createErr = dbSession.DB.Exec(
 			"UPDATE instance SET updated = ? WHERE id = ?",
-			time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+			time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2),
 			instance.ID,
 		)
 		require.NoError(t, createErr)
@@ -263,14 +263,14 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET power_profile = ?, updated = ? WHERE id = ?",
 		existingPowerProfile,
-		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2),
 		deviceInstance.ID,
 	)
 	require.NoError(t, err)
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET power_profile = ?, is_missing_on_site = true, updated = ? WHERE id = ?",
 		existingPowerProfile,
-		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2),
 		nilConfigInstance.ID,
 	)
 	require.NoError(t, err)
@@ -480,7 +480,7 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	inventory.Instances[0].Status.Network.ConfigsSynced = corev1.SyncState_PENDING
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET updated = ? WHERE id = ?",
-		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2),
 		deviceLessInstance.ID,
 	)
 	require.NoError(t, err)
@@ -500,7 +500,7 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	}
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET updated = ? WHERE id = ?",
-		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2),
 		deviceLessInstance.ID,
 	)
 	require.NoError(t, err)
@@ -524,7 +524,7 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	inventory.Instances[0].Status.Network.ConfigsSynced = corev1.SyncState_SYNCED
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET updated = ? WHERE id = ?",
-		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2),
 		deviceLessInstance.ID,
 	)
 	require.NoError(t, err)
@@ -541,7 +541,7 @@ func TestManageInstance_UpdateInstancesInDBVpcSelectionInventory(t *testing.T) {
 	inventory.Instances[0].Status.Network.Interfaces[0].ResolvedVpcPrefixes = nil
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET updated = ? WHERE id = ?",
-		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2),
 		deviceLessInstance.ID,
 	)
 	require.NoError(t, err)
@@ -772,7 +772,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance1.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance1.ID.String())
 	assert.NoError(t, err)
 
 	interface1 := util.TestBuildInterface(t, dbSession, &instance1.ID, &subnet1.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
@@ -792,7 +792,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.NotNil(t, ibInterface3)
 
 	// Make Deleting InfiniBand row old enough to pass IsTimeWithinStaleInventoryThreshold deferral during inventory reconcile
-	_, err = dbSession.DB.Exec("UPDATE infiniband_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), ibInterface3.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE infiniband_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), ibInterface3.ID.String())
 	assert.NoError(t, err)
 
 	// NVLink Interfaces
@@ -806,7 +806,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.NotNil(t, nvlinkInterface3)
 
 	// Set updated earlier than the inventory receipt interval for nvlinkInterface3 so it can be deleted
-	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlinkInterface3.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlinkInterface3.ID.String())
 	assert.NoError(t, err)
 
 	nvlinkInterface4 := util.TestBuildNVLinkInterface(t, dbSession, instance1.ID, site.ID, nvllPartition1.ID, cutil.GetPtr(""), 3, nil, nil, cdbm.NVLinkInterfaceStatusPending)
@@ -838,7 +838,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance2.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance2.ID.String())
 	assert.NoError(t, err)
 
 	instance2Subnet := util.TestBuildInterface(t, dbSession, &instance2.ID, &subnet1.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
@@ -876,11 +876,11 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	)
 	assert.Nil(t, err)
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), instance3.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance3.ID.String())
 	assert.NoError(t, err)
 
 	// Set updated earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance3.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance3.ID.String())
 	assert.NoError(t, err)
 
 	instance3Subnet := util.TestBuildInterface(t, dbSession, &instance3.ID, &subnet1.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
@@ -911,7 +911,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set updated earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance4.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance4.ID.String())
 	assert.NoError(t, err)
 
 	instance4Subnet := util.TestBuildInterface(t, dbSession, &instance4.ID, &subnet1.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusError)
@@ -944,7 +944,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance5.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance5.ID.String())
 	assert.NoError(t, err)
 
 	// Instance 6 is in Error state and gets restored to Ready state from inventory
@@ -976,7 +976,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set updated earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance6.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance6.ID.String())
 	assert.NoError(t, err)
 
 	// Instance 7 does not have controller Instance ID set and is present in inventory, and gets controller Instance ID set
@@ -1004,7 +1004,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set updated earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance7.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance7.ID.String())
 	assert.NoError(t, err)
 
 	// Instance 8 is in Terminating state and has no controller ID, gets deleted on inventory update
@@ -1032,7 +1032,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set updated earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance8.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance8.ID.String())
 	assert.NoError(t, err)
 
 	// Instance 9 is in Ready state and power status is Rebooting, gets set to BootCompleted
@@ -1061,7 +1061,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set updated earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance9.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance9.ID.String())
 	assert.NoError(t, err)
 
 	var vfID uint32 = 1
@@ -1095,11 +1095,11 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	// Update creation timestamp to be earlier than inventory processing interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET is_missing_on_site = true, created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance10.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET is_missing_on_site = true, created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance10.ID.String())
 	assert.NoError(t, err)
 
 	// Set updated earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance10.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance10.ID.String())
 	assert.NoError(t, err)
 
 	// Create status detail for instance 10
@@ -1135,7 +1135,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance11.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance11.ID.String())
 	assert.NoError(t, err)
 
 	// Replicate the bug fix test
@@ -1241,7 +1241,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance15.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance15.ID.String())
 	assert.NoError(t, err)
 
 	ifcvpc_deleting := util.TestBuildInterface(t, dbSession, &instance15.ID, nil, &vpcPrefix1.ID, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusDeleting)
@@ -1287,7 +1287,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance16.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance16.ID.String())
 	assert.NoError(t, err)
 
 	// Instance 17 starts with nil TPM EK certificate and gets updated with a certificate value
@@ -1319,7 +1319,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance17.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance17.ID.String())
 	assert.NoError(t, err)
 
 	// Sample base64 encoded TPM EK certificate (truncated for brevity but realistic format)
@@ -1352,7 +1352,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance18.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance18.ID.String())
 	assert.NoError(t, err)
 
 	interface18_1 := util.TestBuildInterface(t, dbSession, &instance18.ID, &subnet1.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
@@ -1372,7 +1372,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.NotNil(t, ibInterface18_3)
 
 	for _, ibd := range []*cdbm.InfiniBandInterface{ibInterface18_1, ibInterface18_2, ibInterface18_3} {
-		_, err = dbSession.DB.Exec("UPDATE infiniband_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), ibd.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE infiniband_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), ibd.ID.String())
 		assert.NoError(t, err)
 	}
 
@@ -1400,7 +1400,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = dbSession.DB.Exec(
 		"UPDATE instance SET updated = ? WHERE id = ?",
-		time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2),
+		time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2),
 		instance19.ID.String(),
 	)
 	assert.NoError(t, err)
@@ -1453,7 +1453,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	assert.NotNil(t, dpuExtServiceDeployment2)
 
 	// Set updated earlier than the inventory receipt interval for dpuExtServiceDeployment2 so it can be deleted
-	_, err = dbSession.DB.Exec("UPDATE dpu_extension_service_deployment SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), dpuExtServiceDeployment2.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE dpu_extension_service_deployment SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), dpuExtServiceDeployment2.ID.String())
 	assert.NoError(t, err)
 
 	instanceInventory := &corev1.InstanceInventory{
@@ -1939,11 +1939,11 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 
 		assert.NoError(t, err)
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE instance SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), ins.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE instance SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), ins.ID.String())
 		assert.NoError(t, err)
 
 		// Update updated timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), ins.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), ins.ID.String())
 		assert.NoError(t, err)
 
 		pagedIns = append(pagedIns, ins)
@@ -2010,7 +2010,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	// Update creation timestamp to be earlier than inventory processing interval
-	_, err = dbSession.DB.Exec("UPDATE instance SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), instance12.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instance12.ID.String())
 	assert.NoError(t, err)
 
 	// --- Site 4: NVLink Interface deletion strategy test scenarios ---
@@ -2035,12 +2035,12 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 		Labels: map[string]string{}, Status: cdbm.InstanceStatusProvisioning, CreatedBy: tnu.ID,
 	})
 	assert.Nil(t, err)
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlinkDelInstA.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlinkDelInstA.ID.String())
 	assert.NoError(t, err)
 	_ = util.TestBuildInterface(t, dbSession, &nvlinkDelInstA.ID, &subnet4.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
 
 	nvlifcDelA1 := util.TestBuildNVLinkInterface(t, dbSession, nvlinkDelInstA.ID, site4.ID, nvllPartition4.ID, cutil.GetPtr(""), 0, cutil.GetPtr(gpuGuidDel1), nil, cdbm.NVLinkInterfaceStatusDeleting)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlifcDelA1.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlifcDelA1.ID.String())
 	assert.NoError(t, err)
 
 	nvlifcDelA2 := util.TestBuildNVLinkInterface(t, dbSession, nvlinkDelInstA.ID, site4.ID, nvllPartition4.ID, cutil.GetPtr(""), 1, cutil.GetPtr(gpuGuidDel2), nil, cdbm.NVLinkInterfaceStatusPending)
@@ -2055,12 +2055,12 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 		Labels: map[string]string{}, Status: cdbm.InstanceStatusProvisioning, CreatedBy: tnu.ID,
 	})
 	assert.Nil(t, err)
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlinkDelInstB.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlinkDelInstB.ID.String())
 	assert.NoError(t, err)
 	_ = util.TestBuildInterface(t, dbSession, &nvlinkDelInstB.ID, &subnet4.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
 
 	nvlifcDelB1 := util.TestBuildNVLinkInterface(t, dbSession, nvlinkDelInstB.ID, site4.ID, nvllPartition4.ID, cutil.GetPtr(""), 0, cutil.GetPtr(gpuGuidDel3), nil, cdbm.NVLinkInterfaceStatusDeleting)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlifcDelB1.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlifcDelB1.ID.String())
 	assert.NoError(t, err)
 
 	nvlifcDelB2 := util.TestBuildNVLinkInterface(t, dbSession, nvlinkDelInstB.ID, site4.ID, nvllPartition4.ID, cutil.GetPtr(""), 1, cutil.GetPtr(gpuGuidDel3), nil, cdbm.NVLinkInterfaceStatusPending)
@@ -2075,12 +2075,12 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 		Labels: map[string]string{}, Status: cdbm.InstanceStatusProvisioning, CreatedBy: tnu.ID,
 	})
 	assert.Nil(t, err)
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlinkDelInstC.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlinkDelInstC.ID.String())
 	assert.NoError(t, err)
 	_ = util.TestBuildInterface(t, dbSession, &nvlinkDelInstC.ID, &subnet4.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
 
 	nvlifcDelC1 := util.TestBuildNVLinkInterface(t, dbSession, nvlinkDelInstC.ID, site4.ID, nvllPartition4.ID, cutil.GetPtr(""), 0, cutil.GetPtr(gpuGuidDel4), nil, cdbm.NVLinkInterfaceStatusDeleting)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlifcDelC1.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlifcDelC1.ID.String())
 	assert.NoError(t, err)
 	nvlifcDelC1.Instance = nvlinkDelInstC
 
@@ -2093,7 +2093,7 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 		Labels: map[string]string{}, Status: cdbm.InstanceStatusProvisioning, CreatedBy: tnu.ID,
 	})
 	assert.Nil(t, err)
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlinkDelInstD.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlinkDelInstD.ID.String())
 	assert.NoError(t, err)
 	_ = util.TestBuildInterface(t, dbSession, &nvlinkDelInstD.ID, &subnet4.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
 
@@ -2111,12 +2111,12 @@ func TestManageInstance_UpdateInstancesInDB(t *testing.T) {
 		Labels: map[string]string{}, Status: cdbm.InstanceStatusProvisioning, CreatedBy: tnu.ID,
 	})
 	assert.Nil(t, err)
-	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlinkDelInstE.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlinkDelInstE.ID.String())
 	assert.NoError(t, err)
 	_ = util.TestBuildInterface(t, dbSession, &nvlinkDelInstE.ID, &subnet4.ID, nil, true, nil, nil, nil, &tnu.ID, cdbm.InterfaceStatusPending)
 
 	nvlifcDelE1 := util.TestBuildNVLinkInterface(t, dbSession, nvlinkDelInstE.ID, site4.ID, nvllPartition4.ID, cutil.GetPtr(""), 0, cutil.GetPtr(gpuGuidDel1), nil, cdbm.NVLinkInterfaceStatusDeleting)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2), nvlifcDelE1.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_interface SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), nvlifcDelE1.ID.String())
 	assert.NoError(t, err)
 	nvlifcDelE1.Instance = nvlinkDelInstE
 

--- a/rest-api/workflow/pkg/activity/instancetype/instancetype.go
+++ b/rest-api/workflow/pkg/activity/instancetype/instancetype.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -130,7 +129,7 @@ func (mv ManageInstanceType) UpdateInstanceTypesInDB(ctx context.Context, siteID
 				// inventory, so make sure the object has existed for at least as
 				// long as our inventory interval with a little buffer to make
 				// sure we aren't in lock-step.
-				if time.Since(instanceType.Created) < cwutil.InventoryReceiptInterval+(time.Second*5) {
+				if site.IsTimeWithinStaleInventoryThreshold(instanceType.Created) {
 					continue
 				}
 

--- a/rest-api/workflow/pkg/activity/instancetype/instancetype.go
+++ b/rest-api/workflow/pkg/activity/instancetype/instancetype.go
@@ -101,10 +101,17 @@ func (mv ManageInstanceType) UpdateInstanceTypesInDB(ctx context.Context, siteID
 
 		} else if instanceType.Version != controllerInstanceType.Version {
 
-			err := mv.UpdateInstanceTypeInCloud(ctx, site, instanceTypeDAO, macCapDAO, instanceType, controllerInstanceType)
-			if err != nil {
-				slogger.Error().Err(err).Msg("failed to update instance type in DB")
-				continue
+			// The update overwrites Name and Description from the report, so a row written since
+			// the Site collected this inventory would lose an edit made through the API. Skipping
+			// only the update keeps the reported-ID bookkeeping below intact.
+			if site.IsTimeWithinStaleInventoryThreshold(instanceType.Updated) {
+				slogger.Info().Msg("not updating InstanceType yet because it changed more recently than the inventory interval")
+			} else {
+				err := mv.UpdateInstanceTypeInCloud(ctx, site, instanceTypeDAO, macCapDAO, instanceType, controllerInstanceType)
+				if err != nil {
+					slogger.Error().Err(err).Msg("failed to update instance type in DB")
+					continue
+				}
 			}
 
 		}

--- a/rest-api/workflow/pkg/activity/instancetype/instancetype_test.go
+++ b/rest-api/workflow/pkg/activity/instancetype/instancetype_test.go
@@ -16,6 +16,7 @@ import (
 	cdbu "github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
+	cwu "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -517,6 +518,8 @@ func TestManageInstanceType_UpdateInstanceTypesInDB(t *testing.T) {
 			}
 
 			mv.siteClientPool.IDClientMap[tt.args.siteID.String()] = tt.fields.clientPoolClient
+
+			cwu.TestInventoryAgeUpdatedTimestamp(tt.args.ctx, t, dbSession, (*cdbm.InstanceType)(nil))
 
 			err := mv.UpdateInstanceTypesInDB(tt.args.ctx, tt.args.siteID, tt.args.instanceTypeInventory)
 			assert.Equal(t, tt.wantErr, err != nil)

--- a/rest-api/workflow/pkg/activity/instancetype/instancetype_test.go
+++ b/rest-api/workflow/pkg/activity/instancetype/instancetype_test.go
@@ -212,17 +212,17 @@ func TestManageInstanceType_UpdateInstanceTypesInDB(t *testing.T) {
 
 	instanceType5 := testInstanceTypeBuildInstanceType(t, dbSession, "test-instanceType-5", ip, st, tnu, cdbm.InstanceTypeStatusError)
 
-	_, err := dbSession.DB.Exec("UPDATE instance_type SET deleted = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), instanceType5.ID.String())
+	_, err := dbSession.DB.Exec("UPDATE instance_type SET deleted = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), instanceType5.ID.String())
 	assert.NoError(t, err)
 
 	instanceType6 := testInstanceTypeBuildInstanceType(t, dbSession, "test-instanceType-6", ip, st, tnu, cdbm.InstanceTypeStatusError)
 
-	_, err = dbSession.DB.Exec("UPDATE instance_type SET deleted = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), instanceType6.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance_type SET deleted = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), instanceType6.ID.String())
 	assert.NoError(t, err)
 
 	instanceType7 := testInstanceTypeBuildInstanceType(t, dbSession, "test-instanceType-7", ip, st, tnu, cdbm.InstanceTypeStatusReady)
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance_type SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), instanceType7.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance_type SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instanceType7.ID.String())
 	assert.NoError(t, err)
 
 	instanceType8 := testInstanceTypeBuildInstanceType(t, dbSession, "test-instanceType-8", ip, st, tnu, cdbm.InstanceTypeStatusReady)
@@ -233,7 +233,7 @@ func TestManageInstanceType_UpdateInstanceTypesInDB(t *testing.T) {
 
 	instanceType11 := testInstanceTypeBuildInstanceType(t, dbSession, "test-instanceType-11", ip, st, tnu, cdbm.InstanceTypeStatusReady)
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE instance_type SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), instanceType11.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE instance_type SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), instanceType11.ID.String())
 	assert.NoError(t, err)
 
 	instanceType8, err = instanceTypeDAO.Update(ctx, nil, cdbm.InstanceTypeUpdateInput{ID: instanceType8.ID, Status: cutil.GetPtr(cdbm.InstanceTypeStatusError)})
@@ -249,7 +249,7 @@ func TestManageInstanceType_UpdateInstanceTypesInDB(t *testing.T) {
 	for i := range 38 {
 		instanceType := testInstanceTypeBuildInstanceType(t, dbSession, fmt.Sprintf("test-instanceType-paged-%d", i), ip, st3, tnu, cdbm.InstanceTypeStatusReady)
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE instance_type SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), instanceType.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE instance_type SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), instanceType.ID.String())
 		assert.NoError(t, err)
 		pagedInstanceTypes = append(pagedInstanceTypes, instanceType)
 	}

--- a/rest-api/workflow/pkg/activity/machine/machine.go
+++ b/rest-api/workflow/pkg/activity/machine/machine.go
@@ -449,7 +449,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 			// If the machine was updated at all since this inventory was received, we
 			// should consider the inventory details stale for this machine.
 			// We'll add a 5 second buffer to account for a little clock skew/drift.
-			if time.Since(existingCloudMachine.Updated) < cwutil.InventoryReceiptInterval+(time.Second*5) {
+			if site.IsTimeWithinStaleInventoryThreshold(existingCloudMachine.Updated) {
 				slogger.Warn().Msg("machine updated more recently than inventory received time, skipping processing")
 				txn.Rollback()
 				continue

--- a/rest-api/workflow/pkg/activity/machine/machine_test.go
+++ b/rest-api/workflow/pkg/activity/machine/machine_test.go
@@ -804,7 +804,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 	}
 
 	// Set updated for all machines earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE machine SET updated = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2))
+	_, err = dbSession.DB.Exec("UPDATE machine SET updated = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2))
 	assert.NoError(t, err)
 
 	type fields struct {
@@ -993,7 +993,7 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 
 			if tt.args.resetMachineUpdatedTimeBeforeInventoryTime {
 				// Set updated for all machines earlier than the inventory receipt interval
-				_, err := dbSession.DB.Exec("UPDATE machine SET updated = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)*2))
+				_, err := dbSession.DB.Exec("UPDATE machine SET updated = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2))
 				assert.NoError(t, err)
 			}
 

--- a/rest-api/workflow/pkg/activity/networksecuritygroup/networksecuritygroup.go
+++ b/rest-api/workflow/pkg/activity/networksecuritygroup/networksecuritygroup.go
@@ -6,7 +6,6 @@ package networksecuritygroup
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -206,7 +205,7 @@ func (mv ManageNetworkSecurityGroup) UpdateNetworkSecurityGroupsInDB(ctx context
 				// inventory, so make sure the object has existed for at least as
 				// long as our inventory interval with a little buffer to make
 				// sure we aren't in lock-step.
-				if time.Since(networkSecurityGroup.Created) < cwutil.InventoryReceiptInterval+(time.Second*5) {
+				if site.IsTimeWithinStaleInventoryThreshold(networkSecurityGroup.Created) {
 					slogger.Info().Msg("not going to delete yet because group is newer than the inventory interval")
 
 					continue

--- a/rest-api/workflow/pkg/activity/networksecuritygroup/networksecuritygroup.go
+++ b/rest-api/workflow/pkg/activity/networksecuritygroup/networksecuritygroup.go
@@ -154,6 +154,15 @@ func (mv ManageNetworkSecurityGroup) UpdateNetworkSecurityGroupsInDB(ctx context
 			//			but this isn't expensive.
 			reportedNetworkSecurityGroupIDMap[networkSecurityGroup.ID] = true
 
+			// A row written since the Site collected this inventory holds changes the snapshot
+			// cannot know about, including rules set through the API, so writing the reported
+			// values over them would lose those edits.
+			if site.IsTimeWithinStaleInventoryThreshold(networkSecurityGroup.Updated) {
+				slogger.Info().Msg("not updating NetworkSecurityGroup yet because it changed more recently than the inventory interval")
+
+				continue
+			}
+
 			if networkSecurityGroup.Version != controllerNetworkSecurityGroup.Version {
 				// If the record coming in from site is known to cloud but site
 				// reports a different version, time to update cloud.

--- a/rest-api/workflow/pkg/activity/networksecuritygroup/networksecuritygroup_test.go
+++ b/rest-api/workflow/pkg/activity/networksecuritygroup/networksecuritygroup_test.go
@@ -16,6 +16,7 @@ import (
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/queue"
+	cwu "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -506,6 +507,8 @@ func TestManageNetworkSecurityGroup_UpdateNetworkSecurityGroupsInDB(t *testing.T
 			}
 
 			mv.siteClientPool.IDClientMap[tt.args.siteID.String()] = tt.fields.clientPoolClient
+
+			cwu.TestInventoryAgeUpdatedTimestamp(tt.args.ctx, t, dbSession, (*cdbm.NetworkSecurityGroup)(nil))
 
 			err := mv.UpdateNetworkSecurityGroupsInDB(tt.args.ctx, tt.args.siteID, tt.args.networkSecurityGroupInventory)
 			assert.Equal(t, tt.wantErr, err != nil)

--- a/rest-api/workflow/pkg/activity/networksecuritygroup/networksecuritygroup_test.go
+++ b/rest-api/workflow/pkg/activity/networksecuritygroup/networksecuritygroup_test.go
@@ -210,17 +210,17 @@ func TestManageNetworkSecurityGroup_UpdateNetworkSecurityGroupsInDB(t *testing.T
 
 	networkSecurityGroup5 := testNetworkSecurityGroupBuildNetworkSecurityGroup(t, dbSession, "test-networkSecurityGroup-5", st, tn, tnu, cdbm.NetworkSecurityGroupStatusError)
 
-	_, err := dbSession.DB.Exec("UPDATE network_security_group SET deleted = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), networkSecurityGroup5.ID)
+	_, err := dbSession.DB.Exec("UPDATE network_security_group SET deleted = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), networkSecurityGroup5.ID)
 	assert.NoError(t, err)
 
 	networkSecurityGroup6 := testNetworkSecurityGroupBuildNetworkSecurityGroup(t, dbSession, "test-networkSecurityGroup-6", st, tn, tnu, cdbm.NetworkSecurityGroupStatusError)
 
-	_, err = dbSession.DB.Exec("UPDATE network_security_group SET deleted = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), networkSecurityGroup6.ID)
+	_, err = dbSession.DB.Exec("UPDATE network_security_group SET deleted = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), networkSecurityGroup6.ID)
 	assert.NoError(t, err)
 
 	networkSecurityGroup7 := testNetworkSecurityGroupBuildNetworkSecurityGroup(t, dbSession, "test-networkSecurityGroup-7", st, tn, tnu, cdbm.NetworkSecurityGroupStatusReady)
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE network_security_group SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), networkSecurityGroup7.ID)
+	_, err = dbSession.DB.Exec("UPDATE network_security_group SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), networkSecurityGroup7.ID)
 	assert.NoError(t, err)
 
 	networkSecurityGroup8 := testNetworkSecurityGroupBuildNetworkSecurityGroup(t, dbSession, "test-networkSecurityGroup-8", st, tn, tnu, cdbm.NetworkSecurityGroupStatusReady)
@@ -231,7 +231,7 @@ func TestManageNetworkSecurityGroup_UpdateNetworkSecurityGroupsInDB(t *testing.T
 
 	networkSecurityGroup11 := testNetworkSecurityGroupBuildNetworkSecurityGroup(t, dbSession, "test-networkSecurityGroup-11", st, tn, tnu, cdbm.NetworkSecurityGroupStatusReady)
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE network_security_group SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), networkSecurityGroup11.ID)
+	_, err = dbSession.DB.Exec("UPDATE network_security_group SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), networkSecurityGroup11.ID)
 	assert.NoError(t, err)
 
 	networkSecurityGroupDAO := cdbm.NewNetworkSecurityGroupDAO(dbSession)
@@ -246,7 +246,7 @@ func TestManageNetworkSecurityGroup_UpdateNetworkSecurityGroupsInDB(t *testing.T
 	for i := 0; i < 38; i++ {
 		networkSecurityGroup := testNetworkSecurityGroupBuildNetworkSecurityGroup(t, dbSession, fmt.Sprintf("test-networkSecurityGroup-paged-%d", i), st3, tn, tnu, cdbm.NetworkSecurityGroupStatusReady)
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE network_security_group SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), networkSecurityGroup.ID)
+		_, err = dbSession.DB.Exec("UPDATE network_security_group SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), networkSecurityGroup.ID)
 		assert.NoError(t, err)
 		pagedNetworkSecurityGroups = append(pagedNetworkSecurityGroups, networkSecurityGroup)
 		pagedInvIds = append(pagedInvIds, networkSecurityGroup.ID)

--- a/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition.go
+++ b/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition.go
@@ -143,6 +143,16 @@ func (mnlp ManageNVLinkLogicalPartition) UpdateNVLinkLogicalPartitionsInDB(ctx c
 		}
 
 		needsUpdate := name != nil || description != nil || isMissingOnSite != nil || status != nil
+
+		// A row written since the Site collected this inventory holds changes the snapshot cannot
+		// know about, including any made through the API, so writing the reported values over
+		// them would lose those edits.
+		if needsUpdate && site.IsTimeWithinStaleInventoryThreshold(nvllp.Updated) {
+			slogger.Info().Msg("not updating NVLinkLogicalPartition yet because it changed more recently than the inventory interval")
+
+			continue
+		}
+
 		if needsUpdate {
 			_, err := nvlinklogicalpartitionDAO.Update(
 				ctx,

--- a/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition.go
+++ b/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition.go
@@ -193,7 +193,7 @@ func (mnlp ManageNVLinkLogicalPartition) UpdateNVLinkLogicalPartitionsInDB(ctx c
 	for _, nvllp := range nvlinklogicalpartitionsToDelete {
 		slogger := logger.With().Str("NVLink Logical Partition ID", nvllp.ID.String()).Logger()
 
-		if util.IsTimeWithinStaleInventoryThreshold(nvllp.Updated) {
+		if site.IsTimeWithinStaleInventoryThreshold(nvllp.Updated) {
 			continue
 		}
 

--- a/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition_test.go
+++ b/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition_test.go
@@ -110,49 +110,49 @@ func TestManageNVLinkLogicalPartition_UpdateNVLinkLogicalPartitionsInDB(t *testi
 	assert.NotNil(t, nvllp1)
 
 	// Set updated earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err := dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp1.ID.String())
+	_, err := dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp1.ID.String())
 	assert.NoError(t, err)
 
 	nvllp2 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusProvisioning, false)
 	assert.NotNil(t, nvllp2)
 
 	// Set created earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp2.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp2.ID.String())
 	assert.NoError(t, err)
 
 	nvllp3 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-3", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusDeleting, false)
 	assert.NotNil(t, nvllp3)
 
 	// Set created earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp3.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp3.ID.String())
 	assert.NoError(t, err)
 
 	nvllp4 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-4", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusDeleting, false)
 	assert.NotNil(t, nvllp4)
 
 	// Set created earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp4.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp4.ID.String())
 	assert.NoError(t, err)
 
 	nvllp5 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-5", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusDeleting, false)
 	assert.NotNil(t, nvllp5)
 
 	// Set created earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp5.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp5.ID.String())
 	assert.NoError(t, err)
 
 	nvllp6 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-6", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusDeleting, false)
 	assert.NotNil(t, nvllp6)
 
 	// Set created earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp6.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp6.ID.String())
 	assert.NoError(t, err)
 
 	nvllp7 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-7", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusReady, false)
 	assert.NotNil(t, nvllp7)
 
 	// Set created and updated earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET created = ?, updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp7.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET created = ?, updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp7.ID.String())
 	assert.NoError(t, err)
 
 	nvllp8 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-8", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusError, true)
@@ -162,21 +162,21 @@ func TestManageNVLinkLogicalPartition_UpdateNVLinkLogicalPartitionsInDB(t *testi
 	assert.NotNil(t, nvllp9)
 
 	// Set created earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp9.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp9.ID.String())
 	assert.NoError(t, err)
 
 	nvllp10 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-10", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusDeleting, false)
 	assert.NotNil(t, nvllp10)
 
 	// Set created earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp10.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp10.ID.String())
 	assert.NoError(t, err)
 
 	nvllp11 := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-11", nil, st1, tn, cdbm.NVLinkLogicalPartitionStatusReady, false)
 	assert.NotNil(t, nvllp11)
 
 	// Set created and updated earlier than the inventory receipt interval (with buffer to exceed threshold)
-	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET created = ?, updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*2), nvllp11.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET created = ?, updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*2), nvllp11.ID.String())
 	assert.NoError(t, err)
 
 	// Build InfiniBand Partition inventory that is paginated
@@ -186,7 +186,7 @@ func TestManageNVLinkLogicalPartition_UpdateNVLinkLogicalPartitionsInDB(t *testi
 	for i := 0; i < 38; i++ {
 		nvllp := cwu.TestBuildNVLinkLogicalPartition(t, dbSession, fmt.Sprintf("test-vpc-paged-%d", i), nil, st2, tn, cdbm.NVLinkLogicalPartitionStatusReady, false)
 		// Update created and updated timestamps to be earlier than inventory processing interval (with buffer to exceed threshold)
-		_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET created = ?, updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*3), time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval)*3), nvllp.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE nvlink_logical_partition SET created = ?, updated = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*3), time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval)*3), nvllp.ID.String())
 		assert.NoError(t, err)
 		pagedIbps = append(pagedIbps, nvllp)
 		pagedInvIds = append(pagedInvIds, nvllp.ID.String())

--- a/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition_test.go
+++ b/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition_test.go
@@ -424,6 +424,8 @@ func TestManageNVLinkLogicalPartition_UpdateNVLinkLogicalPartitionsInDB(t *testi
 			mtc := &tmocks.Client{}
 			mnvllp.siteClientPool.IDClientMap[st1.ID.String()] = mtc
 
+			cwu.TestInventoryAgeUpdatedTimestamp(tt.args.ctx, t, dbSession, (*cdbm.NVLinkLogicalPartition)(nil))
+
 			err := mnvllp.UpdateNVLinkLogicalPartitionsInDB(tt.args.ctx, tt.args.siteID, tt.args.nvLinkLogicalPartitionInventory)
 			assert.Equal(t, tt.wantErr, err != nil)
 

--- a/rest-api/workflow/pkg/activity/operatingsystem/operatingsystem.go
+++ b/rest-api/workflow/pkg/activity/operatingsystem/operatingsystem.go
@@ -886,8 +886,12 @@ func (mos ManageOsImage) UpdateOperatingSystemsInDB(ctx context.Context, siteID 
 			return derr
 		}
 		candidateOSIDs := make([]uuid.UUID, 0, len(siteOssas))
+		// Deletion below requires a single association, so this Site's association is the only
+		// one and its creation time is when the OS became known to the Site.
+		assocCreatedByOS := make(map[uuid.UUID]time.Time, len(siteOssas))
 		for _, ossa := range siteOssas {
 			candidateOSIDs = append(candidateOSIDs, ossa.OperatingSystemID)
+			assocCreatedByOS[ossa.OperatingSystemID] = ossa.Created
 		}
 
 		if len(candidateOSIDs) > 0 {
@@ -925,8 +929,17 @@ func (mos ManageOsImage) UpdateOperatingSystemsInDB(ctx context.Context, siteID 
 				slogger := logger.With().Str("OperatingSystemID", ipxeOS.ID.String()).Logger()
 
 				if !deletionReportedIDs.Contains(ipxeOS.ID) {
+					// An OS associated to this Site after the inventory was collected is absent
+					// from it for that reason alone. A later inventory reads an already-deleted
+					// OS as a user decision and will not restore it, so defer to the next run.
+					if site.IsTimeWithinStaleInventoryThreshold(assocCreatedByOS[ipxeOS.ID]) {
+						slogger.Info().Msg("Not soft-deleting iPXE OS yet because its Site association is newer than the inventory interval")
+
+						continue
+					}
 					slogger.Info().Msg("Soft-deleting single-site iPXE OS absent from Site inventory")
-					if serr := osDAO.Delete(ctx, nil, ipxeOS.ID); serr != nil {
+					serr := osDAO.Delete(ctx, nil, ipxeOS.ID)
+					if serr != nil {
 						slogger.Error().Err(serr).Msg("Failed to soft-delete OS, DB error")
 						continue
 					}

--- a/rest-api/workflow/pkg/activity/operatingsystem/operatingsystem.go
+++ b/rest-api/workflow/pkg/activity/operatingsystem/operatingsystem.go
@@ -227,7 +227,7 @@ func (mos ManageOsImage) UpdateOsImagesInDB(ctx context.Context, siteID uuid.UUI
 			}
 		} else {
 			// Was this created within inventory receipt interval? If so, we may be processing an older inventory
-			if time.Since(ossa.Created) < cutil.InventoryReceiptInterval {
+			if site.IsTimeWithinStaleInventoryThreshold(ossa.Created) {
 				continue
 			}
 

--- a/rest-api/workflow/pkg/activity/operatingsystem/operatingsystem_test.go
+++ b/rest-api/workflow/pkg/activity/operatingsystem/operatingsystem_test.go
@@ -529,6 +529,19 @@ func TestManageOsImage_UpdateOperatingSystemStatusInDB(t *testing.T) {
 	}
 }
 
+// backdateOssaCreated ages a Site association past the staleness threshold. The create input
+// carries no creation time, so a freshly created association would otherwise defer deletion.
+func backdateOssaCreated(ctx context.Context, t *testing.T, dbSession *cdb.Session, osID uuid.UUID, age time.Duration) {
+	t.Helper()
+
+	_, err := dbSession.DB.NewUpdate().
+		Model((*cdbm.OperatingSystemSiteAssociation)(nil)).
+		Set("created = ?", time.Now().Add(-age)).
+		Where("operating_system_id = ?", osID).
+		Exec(ctx)
+	require.NoError(t, err)
+}
+
 // TestManageOsImage_UpdateOperatingSystemsInDB exercises the Operating System
 // inventory reconciliation performed for iPXE / Templated iPXE Operating Systems
 // pushed from nico-core: creation of provider- or tenant-owned single-site records
@@ -785,6 +798,7 @@ func TestManageOsImage_UpdateOperatingSystemsInDB(t *testing.T) {
 			CreatedBy:         ipu.ID,
 		})
 		require.NoError(t, err)
+		backdateOssaCreated(ctx, t, dbSession, osID, 2*cutil.DefaultInventoryReceiptInterval)
 
 		// Empty inventory: the Site no longer reports the OS, so it must be soft-deleted.
 		inventory := &corev1.OperatingSystemInventory{
@@ -798,6 +812,46 @@ func TestManageOsImage_UpdateOperatingSystemsInDB(t *testing.T) {
 
 		_, err = osDAO.GetByID(ctx, nil, osID, nil)
 		assert.ErrorIs(t, err, cdb.ErrDoesNotExist, "single-site OS absent from Site inventory should be soft-deleted")
+	})
+
+	t.Run("does not soft-delete an iPXE OS associated to the Site more recently than the inventory interval", func(t *testing.T) {
+		ip := util.TestBuildInfrastructureProvider(t, dbSession, "provider-fresh", "provider-fresh-org", ipu)
+		st := util.TestBuildSite(t, dbSession, ip, "site-fresh", cdbm.SiteStatusRegistered, nil, ipu)
+
+		osID := uuid.New()
+		_, err := osDAO.Create(ctx, nil, cdbm.OperatingSystemCreateInput{
+			ID:                       osID,
+			Name:                     "freshly-associated-single-site-os",
+			Org:                      st.Org,
+			InfrastructureProviderID: &ip.ID,
+			OsType:                   cdbm.OperatingSystemTypeIPXE,
+			IpxeScript:               cutil.GetPtr("#!ipxe\n"),
+			Status:                   cdbm.OperatingSystemStatusReady,
+			CreatedBy:                ipu.ID,
+		})
+		require.NoError(t, err)
+
+		// Left at its creation time, so the association is newer than the staleness threshold.
+		_, err = ossaDAO.Create(ctx, nil, cdbm.OperatingSystemSiteAssociationCreateInput{
+			OperatingSystemID: osID,
+			SiteID:            st.ID,
+			Status:            cdbm.OperatingSystemSiteAssociationStatusSynced,
+			CreatedBy:         ipu.ID,
+		})
+		require.NoError(t, err)
+
+		// The inventory was collected before the association existed, so it cannot report it.
+		inventory := &corev1.OperatingSystemInventory{
+			InventoryStatus:  corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
+			OperatingSystems: []*corev1.OperatingSystem{},
+			Timestamp:        timestamppb.Now(),
+		}
+
+		err = newManageOsImage().UpdateOperatingSystemsInDB(ctx, st.ID, inventory)
+		require.NoError(t, err)
+
+		_, err = osDAO.GetByID(ctx, nil, osID, nil)
+		require.NoError(t, err, "an OS associated to the Site within the inventory interval must survive")
 	})
 
 	t.Run("does not soft-delete an OS associated with a different Site", func(t *testing.T) {
@@ -864,6 +918,7 @@ func TestManageOsImage_UpdateOperatingSystemsInDB(t *testing.T) {
 				OperatingSystemID: id, SiteID: st.ID, Status: cdbm.OperatingSystemSiteAssociationStatusSynced, CreatedBy: ipu.ID,
 			})
 			require.NoError(t, err)
+			backdateOssaCreated(ctx, t, dbSession, id, 2*cutil.DefaultInventoryReceiptInterval)
 			return id
 		}
 		osA := mkOS("paged-os-a")

--- a/rest-api/workflow/pkg/activity/operatingsystem/operatingsystem_test.go
+++ b/rest-api/workflow/pkg/activity/operatingsystem/operatingsystem_test.go
@@ -372,7 +372,7 @@ func TestManageOsImage_UpdateOsImageInDB_IgnoresIpxeAssociations(t *testing.T) {
 
 	// Backdate both associations past the inventory-receipt grace window so the
 	// missing-on-Site path is reachable.
-	past := time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval * 2))
+	past := time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval * 2))
 	_, err = dbSession.DB.Exec("UPDATE operating_system_site_association SET created = ? WHERE id IN (?, ?)", past, imgOssa.ID.String(), ipxeOssa.ID.String())
 	require.NoError(t, err)
 

--- a/rest-api/workflow/pkg/activity/site/site.go
+++ b/rest-api/workflow/pkg/activity/site/site.go
@@ -75,8 +75,11 @@ type ManageSite struct {
 
 // Activity functions
 
-// UpdateSiteInDB is a Temporal activity that updates the Site metadata in the DB.
-func (mst ManageSite) UpdateSiteInDB(ctx context.Context, siteID uuid.UUID, buildInfo *corev1.BuildInfo) error {
+// UpdateSiteInDB is a Temporal activity that updates the Site metadata in the DB. A nil
+// siteAgentBuildInfo, which is what an older Site Agent reports, leaves the stored Site Agent
+// values alone rather than erasing what an earlier report established.
+func (mst ManageSite) UpdateSiteInDB(ctx context.Context, siteID uuid.UUID, coreBuildInfo *corev1.BuildInfo,
+	siteAgentBuildInfo *corev1.SiteAgentBuildInfo) error {
 	logger := log.With().Str("Activity", "UpdateSiteInDB").Str("Site ID", siteID.String()).Logger()
 
 	logger.Info().Msg("starting activity")
@@ -94,7 +97,7 @@ func (mst ManageSite) UpdateSiteInDB(ctx context.Context, siteID uuid.UUID, buil
 		return err
 	}
 
-	vpcSlaac := slices.Contains(buildInfo.GetCapabilities(), corev1.BuildCapability_BUILD_CAPABILITY_VPC_SLAAC)
+	vpcSlaac := slices.Contains(coreBuildInfo.GetCapabilities(), corev1.BuildCapability_BUILD_CAPABILITY_VPC_SLAAC)
 	updateInput := cdbm.SiteUpdateInput{
 		SiteID: site.ID,
 	}
@@ -109,12 +112,25 @@ func (mst ManageSite) UpdateSiteInDB(ctx context.Context, siteID uuid.UUID, buil
 	}
 
 	// Update build version for Site when Core reports a changed, non-empty value.
-	siteControllerVersion := buildInfo.GetBuildVersion()
+	siteControllerVersion := coreBuildInfo.GetBuildVersion()
 	if siteControllerVersion != "" && (site.SiteControllerVersion == nil || (site.SiteControllerVersion != nil && *site.SiteControllerVersion != siteControllerVersion)) {
 		updateInput.SiteControllerVersion = &siteControllerVersion
 	}
 
-	if updateInput.Config == nil && updateInput.SiteControllerVersion == nil {
+	siteAgentVersion := siteAgentBuildInfo.GetVersion()
+	if siteAgentVersion != "" && (site.SiteAgentVersion == nil || *site.SiteAgentVersion != siteAgentVersion) {
+		updateInput.SiteAgentVersion = &siteAgentVersion
+	}
+
+	// The Site Agent leaves the interval unset when it cannot derive one from its schedule, and
+	// a sub-second interval cannot come from a cron schedule, so neither is worth storing.
+	inventoryIntervalSeconds := int(siteAgentBuildInfo.GetInventoryInterval().AsDuration().Seconds())
+	if inventoryIntervalSeconds > 0 && (site.InventoryIntervalSeconds == nil || *site.InventoryIntervalSeconds != inventoryIntervalSeconds) {
+		updateInput.InventoryIntervalSeconds = &inventoryIntervalSeconds
+	}
+
+	if updateInput.Config == nil && updateInput.SiteControllerVersion == nil &&
+		updateInput.SiteAgentVersion == nil && updateInput.InventoryIntervalSeconds == nil {
 		return nil
 	}
 

--- a/rest-api/workflow/pkg/activity/site/site_test.go
+++ b/rest-api/workflow/pkg/activity/site/site_test.go
@@ -44,6 +44,7 @@ import (
 	tosv1mock "go.temporal.io/api/operatorservicemock/v1"
 	twsv1mock "go.temporal.io/api/workflowservicemock/v1"
 	tmocks "go.temporal.io/sdk/mocks"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // testTemporalSiteClientPool Building site client pool
@@ -1244,7 +1245,11 @@ func TestManageSite_UpdateSiteInDB(t *testing.T) {
 	mst := NewManageSite(resources.dbSession, nil, nil, nil)
 	siteDAO := cdbm.NewSiteDAO(resources.dbSession)
 
-	createSite := func(t *testing.T, version *string, config *cdbm.SiteConfig) *cdbm.Site {
+	// The stored Site Agent version every case starts from, so a case that expects it untouched
+	// does not have to restate it.
+	const existingAgentVersion = "1.0.0"
+
+	createSite := func(t *testing.T, version *string, config *cdbm.SiteConfig, intervalSeconds *int) *cdbm.Site {
 		t.Helper()
 		site := &cdbm.Site{
 			ID:                       uuid.New(),
@@ -1253,7 +1258,8 @@ func TestManageSite_UpdateSiteInDB(t *testing.T) {
 			Org:                      "test",
 			InfrastructureProviderID: resources.provider.ID,
 			SiteControllerVersion:    version,
-			SiteAgentVersion:         cutil.GetPtr("1.0.0"),
+			SiteAgentVersion:         cutil.GetPtr(existingAgentVersion),
+			InventoryIntervalSeconds: intervalSeconds,
 			IsInfinityEnabled:        true,
 			Status:                   cdbm.SiteStatusRegistered,
 			CreatedBy:                resources.user.ID,
@@ -1268,9 +1274,13 @@ func TestManageSite_UpdateSiteInDB(t *testing.T) {
 		name                  string
 		existingVersion       *string
 		existingConfig        *cdbm.SiteConfig
+		existingInterval      *int
 		buildInfo             *corev1.BuildInfo
+		siteAgentBuildInfo    *corev1.SiteAgentBuildInfo
 		wantVersion           *string
 		wantVpcSlaac          bool
+		wantAgentVersion      *string
+		wantInterval          *int
 		wantDBUpdate          bool
 		wantVpcSlaacKeyAbsent bool
 		wantErr               bool
@@ -1278,6 +1288,57 @@ func TestManageSite_UpdateSiteInDB(t *testing.T) {
 		useUnknownSiteID      bool
 		omitVpcSlaacKey       bool
 	}{
+		{
+			name:           "stores the reported Site Agent version and interval",
+			existingConfig: &cdbm.SiteConfig{},
+			buildInfo:      &corev1.BuildInfo{},
+			siteAgentBuildInfo: &corev1.SiteAgentBuildInfo{
+				Version:           "2.0.0",
+				InventoryInterval: durationpb.New(time.Minute),
+			},
+			wantAgentVersion: cutil.GetPtr("2.0.0"),
+			wantInterval:     cutil.GetPtr(60),
+			wantDBUpdate:     true,
+		},
+		{
+			name:             "updates a changed interval",
+			existingConfig:   &cdbm.SiteConfig{},
+			existingInterval: cutil.GetPtr(180),
+			buildInfo:        &corev1.BuildInfo{},
+			siteAgentBuildInfo: &corev1.SiteAgentBuildInfo{
+				Version:           existingAgentVersion,
+				InventoryInterval: durationpb.New(time.Minute),
+			},
+			wantInterval: cutil.GetPtr(60),
+			wantDBUpdate: true,
+		},
+		{
+			// An older Site Agent reports nothing about itself, which must not erase what an
+			// earlier report established.
+			name:             "leaves Site Agent values alone when nothing is reported",
+			existingConfig:   &cdbm.SiteConfig{},
+			existingInterval: cutil.GetPtr(180),
+			buildInfo:        &corev1.BuildInfo{},
+			wantInterval:     cutil.GetPtr(180),
+		},
+		{
+			name:               "keeps the stored interval when the report omits it",
+			existingConfig:     &cdbm.SiteConfig{},
+			existingInterval:   cutil.GetPtr(180),
+			buildInfo:          &corev1.BuildInfo{},
+			siteAgentBuildInfo: &corev1.SiteAgentBuildInfo{Version: existingAgentVersion},
+			wantInterval:       cutil.GetPtr(180),
+		},
+		{
+			// A sub-second interval cannot come from a cron schedule, so it is not stored.
+			name:           "ignores a sub-second interval",
+			existingConfig: &cdbm.SiteConfig{},
+			buildInfo:      &corev1.BuildInfo{},
+			siteAgentBuildInfo: &corev1.SiteAgentBuildInfo{
+				Version:           existingAgentVersion,
+				InventoryInterval: durationpb.New(500 * time.Millisecond),
+			},
+		},
 		{
 			name:            "updates version while VPC SLAAC remains false",
 			existingVersion: nil,
@@ -1413,7 +1474,7 @@ func TestManageSite_UpdateSiteInDB(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			site := createSite(t, tt.existingVersion, tt.existingConfig)
+			site := createSite(t, tt.existingVersion, tt.existingConfig, tt.existingInterval)
 			if tt.omitVpcSlaacKey {
 				_, err := resources.dbSession.DB.NewUpdate().
 					Model((*cdbm.Site)(nil)).
@@ -1436,7 +1497,7 @@ func TestManageSite_UpdateSiteInDB(t *testing.T) {
 				siteID = uuid.New()
 			}
 
-			err = mst.UpdateSiteInDB(ctx, siteID, tt.buildInfo)
+			err = mst.UpdateSiteInDB(ctx, siteID, tt.buildInfo, tt.siteAgentBuildInfo)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantNonRetryable {
@@ -1461,6 +1522,22 @@ func TestManageSite_UpdateSiteInDB(t *testing.T) {
 			}
 			require.NotNil(t, got.Config)
 			assert.Equal(t, tt.wantVpcSlaac, got.Config.VpcSlaac)
+
+			// A nil expectation means the report left the stored value as createSite wrote it.
+			wantAgentVersion := existingAgentVersion
+			if tt.wantAgentVersion != nil {
+				wantAgentVersion = *tt.wantAgentVersion
+			}
+			require.NotNil(t, got.SiteAgentVersion)
+			assert.Equal(t, wantAgentVersion, *got.SiteAgentVersion)
+
+			if tt.wantInterval == nil {
+				assert.Nil(t, got.InventoryIntervalSeconds)
+			} else {
+				require.NotNil(t, got.InventoryIntervalSeconds)
+				assert.Equal(t, *tt.wantInterval, *got.InventoryIntervalSeconds)
+			}
+
 			if tt.wantDBUpdate {
 				assert.True(t, got.Updated.After(originalUpdated))
 			} else {

--- a/rest-api/workflow/pkg/activity/sku/sku.go
+++ b/rest-api/workflow/pkg/activity/sku/sku.go
@@ -125,6 +125,15 @@ func (ms ManageSku) UpdateSkusInDB(ctx context.Context, siteID uuid.UUID, skuInv
 			continue
 		}
 
+		// Updated is the row's own write time, so a SKU written since the Site collected this
+		// inventory carries changes the snapshot cannot know about, including any made through
+		// the API. Writing the reported values over them would lose those edits.
+		if site.IsTimeWithinStaleInventoryThreshold(cur.Updated) {
+			logger.Info().Str("SkuId", cur.ID).Msg("not updating SKU yet because it changed more recently than the inventory interval")
+
+			continue
+		}
+
 		// Update existing SKU data in DB
 		createdChanged := !reported.Created.IsZero() && !cur.Created.Equal(reported.Created)
 		if createdChanged || cur.Description != reported.Description || cur.SchemaVersion != reported.SchemaVersion ||
@@ -171,10 +180,11 @@ func (ms ManageSku) UpdateSkusInDB(ctx context.Context, siteID uuid.UUID, skuInv
 			if _, keep := reportedIDs[sk.ID]; keep {
 				continue
 			}
-			// Created is Core's own creation time, so a SKU newer than the interval may be
-			// absent from this inventory only because it did not exist when the Site collected
-			// it. The delete is not recoverable, so defer to the next run.
-			if site.IsTimeWithinStaleInventoryThreshold(sk.Created) {
+			// Updated tracks when this row was last written, unlike Created which carries Core's
+			// timestamp and stays old for a SKU that Cloud only just learned about. A SKU
+			// written since the Site collected this inventory may be absent from it only because
+			// the snapshot predates the row, so deleting would drop a SKU that just arrived.
+			if site.IsTimeWithinStaleInventoryThreshold(sk.Updated) {
 				logger.Info().Str("SkuId", sk.ID).Msg("not deleting SKU yet because it is newer than the inventory interval")
 
 				continue

--- a/rest-api/workflow/pkg/activity/sku/sku.go
+++ b/rest-api/workflow/pkg/activity/sku/sku.go
@@ -45,7 +45,7 @@ func (ms ManageSku) UpdateSkusInDB(ctx context.Context, siteID uuid.UUID, skuInv
 
 	// Ensure Site exists
 	stDAO := cdbm.NewSiteDAO(ms.dbSession)
-	_, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
+	site, err := stDAO.GetByID(ctx, nil, siteID, nil, false)
 	if err != nil {
 		if errors.Is(err, cdb.ErrDoesNotExist) {
 			logger.Warn().Err(err).Msg("received inventory for unknown or deleted Site")
@@ -164,15 +164,24 @@ func (ms ManageSku) UpdateSkusInDB(ctx context.Context, siteID uuid.UUID, skuInv
 	}
 
 	// Delete any SKU present in DB not present in NICo.
-	// We only act if this is the last page (or paging disabled) and outside race window.
+	// We only act if this is the last page (or paging disabled).
 	// The source of truth for NICo is reportedIDs.
 	if skuInventory.InventoryPage == nil || skuInventory.InventoryPage.TotalPages == 0 || (skuInventory.InventoryPage.CurrentPage == skuInventory.InventoryPage.TotalPages) {
 		for _, sk := range existingSkus {
 			if _, keep := reportedIDs[sk.ID]; keep {
 				continue
 			}
+			// Created is Core's own creation time, so a SKU newer than the interval may be
+			// absent from this inventory only because it did not exist when the Site collected
+			// it. The delete is not recoverable, so defer to the next run.
+			if site.IsTimeWithinStaleInventoryThreshold(sk.Created) {
+				logger.Info().Str("SkuId", sk.ID).Msg("not deleting SKU yet because it is newer than the inventory interval")
+
+				continue
+			}
 			logger.Info().Str("SkuId", sk.ID).Msg("deleting SKU from DB since it was no longer reported in inventory from Site")
-			if derr := skuDAO.Delete(ctx, nil, sk.ID); derr != nil {
+			derr := skuDAO.Delete(ctx, nil, sk.ID)
+			if derr != nil {
 				logger.Error().Err(derr).Str("SkuID", sk.ID).Msg("failed to delete SKU from DB")
 			}
 		}

--- a/rest-api/workflow/pkg/activity/sku/sku_test.go
+++ b/rest-api/workflow/pkg/activity/sku/sku_test.go
@@ -189,11 +189,13 @@ func TestManageSku_PagedDeletion(t *testing.T) {
 	ip := cwu.TestBuildInfrastructureProvider(t, dbSession, "test-provider", ipOrg, ipu)
 	site := cwu.TestBuildSite(t, dbSession, ip, "test-site", cdbm.SiteStatusRegistered, nil, ipu)
 
-	// Seed three SKUs (ensure SiteID is set)
+	// Seed three SKUs (ensure SiteID is set). Backdate them past the staleness threshold so the
+	// deletion sweep is not deferred.
 	ssd := cdbm.NewSkuDAO(dbSession)
 	seed := []string{"sku-1", "sku-2", "sku-3"}
+	seedCreated := time.Now().Add(-2 * cutil.DefaultInventoryReceiptInterval)
 	for _, id := range seed {
-		_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{ID: id, SiteID: site.ID, Components: &cdbm.SkuComponents{}}).Exec(ctx)
+		_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{ID: id, SiteID: site.ID, Created: seedCreated, Components: &cdbm.SkuComponents{}}).Exec(ctx)
 		assert.NoError(t, err)
 	}
 
@@ -229,4 +231,89 @@ func TestManageSku_PagedDeletion(t *testing.T) {
 	assert.True(t, found[seed[0]])
 	assert.True(t, found[seed[1]])
 	assert.False(t, found[seed[2]])
+}
+
+func TestManageSku_DeletionRespectsStaleInventoryThreshold(t *testing.T) {
+	testCases := []struct {
+		name           string
+		createdAgo     time.Duration
+		intervalSecs   *int
+		expectSurvives bool
+	}{
+		{
+			name:           "created within the default threshold survives",
+			createdAgo:     time.Second,
+			expectSurvives: true,
+		},
+		{
+			name:       "created past the default threshold is deleted",
+			createdAgo: 2 * cutil.DefaultInventoryReceiptInterval,
+		},
+		{
+			name:           "created within a longer reported interval survives",
+			createdAgo:     2 * cutil.DefaultInventoryReceiptInterval,
+			intervalSecs:   cutil.GetPtr(int((10 * cutil.DefaultInventoryReceiptInterval).Seconds())),
+			expectSurvives: true,
+		},
+		{
+			name:         "created past a shorter reported interval is deleted",
+			createdAgo:   time.Minute,
+			intervalSecs: cutil.GetPtr(1),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			_ = config.GetTestConfig()
+
+			dbSession := cwu.TestInitDB(t)
+			defer dbSession.Close()
+			cwu.TestSetupSchema(t, dbSession)
+
+			ipOrg := "test-ip-org"
+			ipRoles := []string{"FORGE_PROVIDER_ADMIN"}
+			ipu := cwu.TestBuildUser(t, dbSession, uuid.NewString(), []string{ipOrg}, ipRoles)
+			ip := cwu.TestBuildInfrastructureProvider(t, dbSession, "test-provider", ipOrg, ipu)
+			site := cwu.TestBuildSite(t, dbSession, ip, "test-site", cdbm.SiteStatusRegistered, nil, ipu)
+
+			if tc.intervalSecs != nil {
+				stDAO := cdbm.NewSiteDAO(dbSession)
+				_, uerr := stDAO.Update(ctx, nil, cdbm.SiteUpdateInput{
+					SiteID:                   site.ID,
+					InventoryIntervalSeconds: tc.intervalSecs,
+				})
+				assert.NoError(t, uerr)
+			}
+
+			// Created carries Core's timestamp, which is what the guard compares against.
+			id := "sku-guarded"
+			_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{
+				ID:         id,
+				SiteID:     site.ID,
+				Created:    time.Now().Add(-tc.createdAgo),
+				Components: &cdbm.SkuComponents{},
+			}).Exec(ctx)
+			assert.NoError(t, err)
+
+			ms := NewManageSku(dbSession, cwu.TestTemporalSiteClientPool(t))
+
+			// A successful final page that omits the seeded SKU entirely.
+			inv := &corev1.SkuInventory{
+				Skus:            []*corev1.Sku{},
+				InventoryStatus: corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
+				InventoryPage:   &corev1.InventoryPage{CurrentPage: 1, TotalPages: 1, PageSize: 1, TotalItems: 0},
+			}
+			assert.NoError(t, ms.UpdateSkusInDB(ctx, site.ID, inv))
+
+			ssd := cdbm.NewSkuDAO(dbSession)
+			_, total, gerr := ssd.GetAll(ctx, nil, cdbm.SkuFilterInput{SiteIDs: []uuid.UUID{site.ID}}, cdbp.PageInput{Limit: cutil.GetPtr(100)})
+			assert.NoError(t, gerr)
+			if tc.expectSurvives {
+				assert.Equal(t, 1, total, "SKU newer than the threshold should not be deleted")
+			} else {
+				assert.Equal(t, 0, total, "SKU older than the threshold should be deleted")
+			}
+		})
+	}
 }

--- a/rest-api/workflow/pkg/activity/sku/sku_test.go
+++ b/rest-api/workflow/pkg/activity/sku/sku_test.go
@@ -250,9 +250,10 @@ func TestManageSku_DeletionRespectsStaleInventoryThreshold(t *testing.T) {
 			createdAgo: 2 * cutil.DefaultInventoryReceiptInterval,
 		},
 		{
+			// Older than the default threshold, still inside the reported one.
 			name:           "created within a longer reported interval survives",
-			createdAgo:     2 * cutil.DefaultInventoryReceiptInterval,
-			intervalSecs:   cutil.GetPtr(int((10 * cutil.DefaultInventoryReceiptInterval).Seconds())),
+			createdAgo:     4 * time.Minute,
+			intervalSecs:   cutil.GetPtr(300),
 			expectSurvives: true,
 		},
 		{

--- a/rest-api/workflow/pkg/activity/sku/sku_test.go
+++ b/rest-api/workflow/pkg/activity/sku/sku_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 
@@ -21,6 +23,20 @@ import (
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// ageSku backdates a SKU's write time past the staleness threshold. Both guards in the activity
+// read Updated, and the DAO rewrites it on every write, so a step that follows an earlier write
+// is otherwise deferred rather than applied.
+func ageSku(ctx context.Context, t *testing.T, dbSession *cdb.Session, id string) {
+	t.Helper()
+
+	_, err := dbSession.DB.NewUpdate().
+		Model((*cdbm.SKU)(nil)).
+		Set("updated = ?", time.Now().Add(-2*cutil.DefaultInventoryReceiptInterval)).
+		Where("id = ?", id).
+		Exec(ctx)
+	require.NoError(t, err)
+}
 
 func TestManageSku_Reconcile_CreateUpdateDelete(t *testing.T) {
 	ctx := context.Background()
@@ -62,6 +78,7 @@ func TestManageSku_Reconcile_CreateUpdateDelete(t *testing.T) {
 	}
 
 	// 2) Update: same id, ensure still one record
+	ageSku(ctx, t, dbSession, id1)
 	description2 := "Updated SKU description"
 	created2 := time.Date(2024, time.December, 1, 2, 3, 4, 567_890_123, time.UTC)
 	inv2 := &corev1.SkuInventory{Skus: []*corev1.Sku{{
@@ -81,6 +98,7 @@ func TestManageSku_Reconcile_CreateUpdateDelete(t *testing.T) {
 	assert.True(t, created2.Round(time.Microsecond).Equal(skus[0].Created))
 
 	// 3) Missing source timestamp preserves the stored creation time.
+	ageSku(ctx, t, dbSession, id1)
 	invWithoutCreated := &corev1.SkuInventory{Skus: []*corev1.Sku{{
 		Id:            id1,
 		Description:   &description2,
@@ -94,6 +112,7 @@ func TestManageSku_Reconcile_CreateUpdateDelete(t *testing.T) {
 	assert.True(t, created2.Round(time.Microsecond).Equal(skus[0].Created))
 
 	// 4) Delete: send empty inventory, final page implied
+	ageSku(ctx, t, dbSession, id1)
 	inv3 := &corev1.SkuInventory{Skus: []*corev1.Sku{}}
 	assert.NoError(t, ms.UpdateSkusInDB(ctx, site.ID, inv3))
 
@@ -116,10 +135,12 @@ func TestManageSku_NilComponents_ClearsExisting(t *testing.T) {
 	ip := cwu.TestBuildInfrastructureProvider(t, dbSession, "test-provider", ipOrg, ipu)
 	site := cwu.TestBuildSite(t, dbSession, ip, "test-site", cdbm.SiteStatusRegistered, nil, ipu)
 
-	// Seed a SKU with non-nil Components.
+	// Seed a SKU with non-nil Components. Age it so the update runs, since the seeded value
+	// would otherwise satisfy the assertion below without the clear ever happening.
 	id := "sku-clear"
 	_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{ID: id, SiteID: site.ID, Components: &cdbm.SkuComponents{SkuComponents: &corev1.SkuComponents{}}}).Exec(ctx)
 	assert.NoError(t, err)
+	ageSku(ctx, t, dbSession, id)
 
 	ms := NewManageSku(dbSession, cwu.TestTemporalSiteClientPool(t))
 
@@ -193,10 +214,10 @@ func TestManageSku_PagedDeletion(t *testing.T) {
 	// deletion sweep is not deferred.
 	ssd := cdbm.NewSkuDAO(dbSession)
 	seed := []string{"sku-1", "sku-2", "sku-3"}
-	seedCreated := time.Now().Add(-2 * cutil.DefaultInventoryReceiptInterval)
 	for _, id := range seed {
-		_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{ID: id, SiteID: site.ID, Created: seedCreated, Components: &cdbm.SkuComponents{}}).Exec(ctx)
+		_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{ID: id, SiteID: site.ID, Components: &cdbm.SkuComponents{}}).Exec(ctx)
 		assert.NoError(t, err)
+		ageSku(ctx, t, dbSession, id)
 	}
 
 	ms := NewManageSku(dbSession, cwu.TestTemporalSiteClientPool(t))
@@ -233,33 +254,117 @@ func TestManageSku_PagedDeletion(t *testing.T) {
 	assert.False(t, found[seed[2]])
 }
 
+func TestManageSku_UpdateRespectsStaleInventoryThreshold(t *testing.T) {
+	testCases := []struct {
+		name            string
+		writtenAgo      time.Duration
+		wantDescription string
+	}{
+		{
+			// The API can write a SKU, so a row written after the Site collected this inventory
+			// holds changes the snapshot cannot know about.
+			name:            "a recently written SKU keeps its stored values",
+			writtenAgo:      time.Second,
+			wantDescription: "set through the API",
+		},
+		{
+			name:            "a SKU untouched for longer than the interval takes the reported values",
+			writtenAgo:      2 * cutil.DefaultInventoryReceiptInterval,
+			wantDescription: "reported by the Site",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			_ = config.GetTestConfig()
+
+			dbSession := cwu.TestInitDB(t)
+			defer dbSession.Close()
+			cwu.TestSetupSchema(t, dbSession)
+
+			ipOrg := "test-ip-org"
+			ipRoles := []string{"FORGE_PROVIDER_ADMIN"}
+			ipu := cwu.TestBuildUser(t, dbSession, uuid.NewString(), []string{ipOrg}, ipRoles)
+			ip := cwu.TestBuildInfrastructureProvider(t, dbSession, "test-provider", ipOrg, ipu)
+			site := cwu.TestBuildSite(t, dbSession, ip, "test-site", cdbm.SiteStatusRegistered, nil, ipu)
+
+			id := "sku-updated"
+			_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{
+				ID:          id,
+				SiteID:      site.ID,
+				Description: "set through the API",
+				Components:  &cdbm.SkuComponents{},
+			}).Exec(ctx)
+			require.NoError(t, err)
+
+			_, err = dbSession.DB.NewUpdate().
+				Model((*cdbm.SKU)(nil)).
+				Set("updated = ?", time.Now().Add(-tc.writtenAgo)).
+				Where("id = ?", id).
+				Exec(ctx)
+			require.NoError(t, err)
+
+			ms := NewManageSku(dbSession, cwu.TestTemporalSiteClientPool(t))
+
+			// The Site reports a competing description for the same SKU.
+			reportedDescription := "reported by the Site"
+			inv := &corev1.SkuInventory{
+				Skus: []*corev1.Sku{{
+					Id:          id,
+					Description: &reportedDescription,
+					Components:  &corev1.SkuComponents{},
+				}},
+				InventoryStatus: corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
+			}
+			require.NoError(t, ms.UpdateSkusInDB(ctx, site.ID, inv))
+
+			ssd := cdbm.NewSkuDAO(dbSession)
+			got, gerr := ssd.Get(ctx, nil, id)
+			require.NoError(t, gerr)
+			assert.Equal(t, tc.wantDescription, got.Description)
+		})
+	}
+}
+
 func TestManageSku_DeletionRespectsStaleInventoryThreshold(t *testing.T) {
 	testCases := []struct {
-		name           string
+		name       string
+		writtenAgo time.Duration
+		// createdAgo defaults to writtenAgo, so a case only sets it to separate Core's creation
+		// time from the row's write time.
 		createdAgo     time.Duration
 		intervalSecs   *int
 		expectSurvives bool
 	}{
 		{
-			name:           "created within the default threshold survives",
-			createdAgo:     time.Second,
+			name:           "written within the default threshold survives",
+			writtenAgo:     time.Second,
 			expectSurvives: true,
 		},
 		{
-			name:       "created past the default threshold is deleted",
-			createdAgo: 2 * cutil.DefaultInventoryReceiptInterval,
+			name:       "written past the default threshold is deleted",
+			writtenAgo: 2 * cutil.DefaultInventoryReceiptInterval,
 		},
 		{
 			// Older than the default threshold, still inside the reported one.
-			name:           "created within a longer reported interval survives",
-			createdAgo:     4 * time.Minute,
+			name:           "written within a longer reported interval survives",
+			writtenAgo:     4 * time.Minute,
 			intervalSecs:   cutil.GetPtr(300),
 			expectSurvives: true,
 		},
 		{
-			name:         "created past a shorter reported interval is deleted",
-			createdAgo:   time.Minute,
+			name:         "written past a shorter reported interval is deleted",
+			writtenAgo:   time.Minute,
 			intervalSecs: cutil.GetPtr(1),
+		},
+		{
+			// Created stays at Core's timestamp for a SKU Cloud only just learned about, so
+			// anchoring on it would delete this row.
+			name:           "an old Core creation time does not expose a freshly written row",
+			writtenAgo:     time.Second,
+			createdAgo:     90 * 24 * time.Hour,
+			expectSurvives: true,
 		},
 	}
 
@@ -287,15 +392,28 @@ func TestManageSku_DeletionRespectsStaleInventoryThreshold(t *testing.T) {
 				assert.NoError(t, uerr)
 			}
 
-			// Created carries Core's timestamp, which is what the guard compares against.
+			createdAgo := tc.createdAgo
+			if createdAgo == 0 {
+				createdAgo = tc.writtenAgo
+			}
+
+			// The DAO rewrites Updated on insert, so set it afterwards to place the row's write
+			// time where the case wants it.
 			id := "sku-guarded"
 			_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{
 				ID:         id,
 				SiteID:     site.ID,
-				Created:    time.Now().Add(-tc.createdAgo),
+				Created:    time.Now().Add(-createdAgo),
 				Components: &cdbm.SkuComponents{},
 			}).Exec(ctx)
 			assert.NoError(t, err)
+
+			_, err = dbSession.DB.NewUpdate().
+				Model((*cdbm.SKU)(nil)).
+				Set("updated = ?", time.Now().Add(-tc.writtenAgo)).
+				Where("id = ?", id).
+				Exec(ctx)
+			require.NoError(t, err)
 
 			ms := NewManageSku(dbSession, cwu.TestTemporalSiteClientPool(t))
 

--- a/rest-api/workflow/pkg/activity/sshkeygroup/sshkeygroup.go
+++ b/rest-api/workflow/pkg/activity/sshkeygroup/sshkeygroup.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -373,7 +372,7 @@ func (mskg ManageSSHKeyGroup) UpdateSSHKeyGroupsInDB(ctx context.Context, siteID
 				} else {
 					if skgsa.Status == cdbm.SSHKeyGroupSiteAssociationStatusSynced {
 						// Was this created within inventory receipt interval? If so, we may be processing an older inventory
-						if time.Since(skgsa.Created) < cwutil.InventoryReceiptInterval {
+						if site.IsTimeWithinStaleInventoryThreshold(skgsa.Created) {
 							continue
 						}
 

--- a/rest-api/workflow/pkg/activity/sshkeygroup/sshkeygroup_test.go
+++ b/rest-api/workflow/pkg/activity/sshkeygroup/sshkeygroup_test.go
@@ -908,7 +908,7 @@ func TestManageSSHKeyGroup_UpdateSSHKeyGroupsInDB(t *testing.T) {
 	skgsa6 := util.TestBuildSSHKeyGroupSiteAssociation(t, dbSession, skg6.ID, st.ID, cutil.GetPtr("1137"), cdbm.SSHKeyGroupSiteAssociationStatusSynced, tnu.ID)
 	assert.NotNil(t, skgsa6)
 	// Set created earlier than the inventory receipt interval
-	_, err := dbSession.DB.Exec("UPDATE ssh_key_group_site_association SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), skgsa6.ID.String())
+	_, err := dbSession.DB.Exec("UPDATE ssh_key_group_site_association SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), skgsa6.ID.String())
 	assert.NoError(t, err)
 
 	// Build SSHKeyGroup7
@@ -942,14 +942,14 @@ func TestManageSSHKeyGroup_UpdateSSHKeyGroupsInDB(t *testing.T) {
 	for i := 0; i < 38; i++ {
 		keyGroup := util.TestBuildSSHKeyGroup(t, dbSession, fmt.Sprintf("test-sshkeygroup-paged-%d", i), tnOrg, cutil.GetPtr("description"), tn.ID, cutil.GetPtr("122346"), cdbm.SSHKeyGroupStatusSynced, tnu.ID)
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE sshkey_group SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), keyGroup.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE sshkey_group SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), keyGroup.ID.String())
 		assert.NoError(t, err)
 		pagedSSHKeyGroups = append(pagedSSHKeyGroups, keyGroup)
 		pagedInvSSHKeyGroupIDs = append(pagedInvSSHKeyGroupIDs, keyGroup.ID.String())
 
 		skgsa := util.TestBuildSSHKeyGroupSiteAssociation(t, dbSession, keyGroup.ID, st2.ID, cutil.GetPtr("1138"), cdbm.SSHKeyGroupSiteAssociationStatusSynced, tnu.ID)
 		assert.NotNil(t, skgsa)
-		_, err := dbSession.DB.Exec("UPDATE ssh_key_group_site_association SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), skgsa.ID.String())
+		_, err := dbSession.DB.Exec("UPDATE ssh_key_group_site_association SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), skgsa.ID.String())
 		assert.NoError(t, err)
 	}
 

--- a/rest-api/workflow/pkg/activity/subnet/subnet.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet.go
@@ -266,7 +266,7 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 			}
 		} else if subnet.ControllerNetworkSegmentID != nil {
 			// Was this created within inventory receipt interval? If so, we may be processing an older inventory
-			if time.Since(subnet.Created) < cwutil.InventoryReceiptInterval {
+			if site.IsTimeWithinStaleInventoryThreshold(subnet.Created) {
 				continue
 			}
 

--- a/rest-api/workflow/pkg/activity/subnet/subnet_test.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet_test.go
@@ -371,7 +371,7 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 	// Subnet 3 is missing from Site Controller inventory but was not requested by user to be deleted, hence gets missing flag set
 	subnet3 := testSubnetBuildSubnet(t, dbSession, "test-subnet-3", tn, vpc, nil, cutil.GetPtr(uuid.New()), &ipb.RoutingType, cutil.GetPtr("192.0.1.8"), cutil.GetPtr("192.0.1.8"), nil, 24, cdbm.SubnetStatusProvisioning, tnu)
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE subnet SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), subnet3.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE subnet SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), subnet3.ID.String())
 	assert.NoError(t, err)
 
 	sbPrefix, err = ipam.CreateChildIpamEntryForIPBlock(ctx, nil, dbSession, ipamStorage, ipb, 26)
@@ -417,7 +417,7 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 	for i := 0; i < 38; i++ {
 		subnet := testSubnetBuildSubnet(t, dbSession, fmt.Sprintf("test-vpc-paged-%d", i), tn, vpc, nil, cutil.GetPtr(uuid.New()), &ipb.RoutingType, &ipv4Prefix, &ipv4Gateway, &ipb.ID, 26, cdbm.SubnetStatusProvisioning, tnu)
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE subnet SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), subnet.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE subnet SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), subnet.ID.String())
 		assert.NoError(t, err)
 		pagedSubnets = append(pagedSubnets, subnet)
 		pagedInvIds = append(pagedInvIds, subnet.ControllerNetworkSegmentID.String())

--- a/rest-api/workflow/pkg/activity/tenant/tenant.go
+++ b/rest-api/workflow/pkg/activity/tenant/tenant.go
@@ -5,7 +5,6 @@ package tenant
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -151,7 +150,7 @@ func (mt ManageTenant) UpdateTenantsInDB(ctx context.Context, siteID uuid.UUID, 
 		slogger := logger.With().Str("Tenant Org", tenant.Org).Logger()
 
 		// Was this created within inventory receipt interval? If so, we may be processing an older inventory
-		if time.Since(tenant.Created) < cwutil.InventoryReceiptInterval {
+		if site.IsTimeWithinStaleInventoryThreshold(tenant.Created) {
 			continue
 		}
 

--- a/rest-api/workflow/pkg/activity/tenant/tenant_test.go
+++ b/rest-api/workflow/pkg/activity/tenant/tenant_test.go
@@ -104,7 +104,7 @@ func TestManageTenant_UpdateTenantsInDB(t *testing.T) {
 		cwu.TestBuildTenantSiteAssociation(t, dbSession, tn.Org, tn.ID, st3.ID, ipu.ID)
 
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err := dbSession.DB.Exec("UPDATE tenant SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)), tn.ID.String())
+		_, err := dbSession.DB.Exec("UPDATE tenant SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cwutil.DefaultInventoryReceiptInterval*2)), tn.ID.String())
 		assert.NoError(t, err)
 		pagedTenants = append(pagedTenants, tn)
 		pagedInvIds = append(pagedInvIds, tn.Org)

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -139,6 +139,10 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			vpc = existingVpcIDMap[controllerVpcIDStr]
 		}
 
+		// A VPC this run creates or undeletes carries the write time of that write, which the
+		// staleness gate below would read as a concurrent edit and defer to.
+		createdOrRestoredFromSite := false
+
 		// No active REST row for this inventory VPC: create one or undelete a soft-deleted match,
 		// then fall through so the main inventory loop applies Site-reported field updates.
 		if vpc == nil {
@@ -146,6 +150,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			if vpc == nil {
 				continue
 			}
+			createdOrRestoredFromSite = true
 
 			// Keep in-memory maps in sync so later inventory entries and missing-on-Site detection see this VPC.
 			existingVpcIDMap[vpc.ID.String()] = vpc
@@ -215,6 +220,15 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			// We should assume status _could start_ as null and then update to the active VPC VNI.
 			// Status should never go back to nil - that would be a bug.
 			(controllerActiveVni != nil && !util.PtrsEqual(vpc.ActiveVni, controllerActiveVni))
+
+		// A row written since the Site collected this inventory holds changes the snapshot cannot
+		// know about, including any made through the API, so the clears and the write below would
+		// lose those edits. The Site-owned fields they carry are reported again next run.
+		if needsUpdate && !createdOrRestoredFromSite && site.IsTimeWithinStaleInventoryThreshold(vpc.Updated) {
+			slogger.Info().Msg("not updating VPC yet because it changed more recently than the inventory interval")
+
+			continue
+		}
 
 		if needsUpdate {
 			if vpc.PowerResourceGroup != nil && reportedPowerResourceGroup == nil {

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -402,7 +402,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			}
 		} else if vpc.ControllerVpcID != nil {
 			// Was this created within inventory receipt interval? If so, we may be processing an older inventory
-			if time.Since(vpc.Created) < cwutil.InventoryReceiptInterval {
+			if site.IsTimeWithinStaleInventoryThreshold(vpc.Created) {
 				continue
 			}
 

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -259,7 +259,7 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 
 	vpc7 := testVPCBuildVPC(t, dbSession, "test-vpc-7", ip, tn, st, cutil.GetPtr(cdbm.VpcEthernetVirtualizer), cutil.GetPtr(uuid.New()), nil, tnu, cdbm.VpcStatusReady)
 	// Set created earlier than the inventory receipt interval
-	_, err := dbSession.DB.Exec("UPDATE vpc SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), vpc7.ID.String())
+	_, err := dbSession.DB.Exec("UPDATE vpc SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), vpc7.ID.String())
 	assert.NoError(t, err)
 
 	vpc8 := testVPCBuildVPC(t, dbSession, "test-vpc-8", ip, tn, st, cutil.GetPtr(cdbm.VpcEthernetVirtualizer), cutil.GetPtr(uuid.New()), nil, tnu, cdbm.VpcStatusReady)
@@ -270,7 +270,7 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 
 	vpc11 := testVPCBuildVPC(t, dbSession, "test-vpc-11", ip, tn, st, cutil.GetPtr(cdbm.VpcEthernetVirtualizer), cutil.GetPtr(uuid.New()), nil, tnu, cdbm.VpcStatusReady)
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE vpc SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), vpc11.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE vpc SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), vpc11.ID.String())
 	assert.NoError(t, err)
 
 	vpcDAO := cdbm.NewVpcDAO(dbSession)
@@ -344,7 +344,7 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 
 		vpc := testVPCBuildVPC(t, dbSession, fmt.Sprintf("test-vpc-paged-%d", i), ip, tn, st3, cutil.GetPtr(cdbm.VpcEthernetVirtualizer), cutil.GetPtr(uuid.New()), labels, tnu, cdbm.VpcStatusReady)
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE vpc SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), vpc.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE vpc SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), vpc.ID.String())
 		assert.NoError(t, err)
 		pagedVpcs = append(pagedVpcs, vpc)
 		pagedInvIds = append(pagedInvIds, vpc.ControllerVpcID.String())

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -705,6 +705,8 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 
 			mv.siteClientPool.IDClientMap[tt.args.siteID.String()] = tt.fields.clientPoolClient
 
+			cwu.TestInventoryAgeUpdatedTimestamp(tt.args.ctx, t, dbSession, (*cdbm.Vpc)(nil))
+
 			_, err := mv.UpdateVpcsInDB(tt.args.ctx, tt.args.siteID, tt.args.vpcInventory)
 			assert.Equal(t, tt.wantErr, err != nil)
 
@@ -1005,6 +1007,7 @@ func TestManageVpc_UpdateVpcsInDB_AutoCreatesAndRestores(t *testing.T) {
 		require.Len(t, deletedVpcs, 1)
 		require.NotNil(t, deletedVpcs[0].Deleted)
 
+		cwu.TestInventoryAgeUpdatedTimestamp(ctx, t, dbSession, (*cdbm.Vpc)(nil))
 		_, err = manager.UpdateVpcsInDB(ctx, site.ID, inventory)
 		require.NoError(t, err)
 		restoredVpc, err := vpcDAO.GetByID(ctx, nil, controllerVpcID, nil)

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering.go
@@ -6,7 +6,6 @@ package vpcpeering
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -138,7 +137,7 @@ func (mvp ManageVpcPeering) UpdateVpcPeeringsInDB(
 				// inventory, so make sure the object has existed for at least as
 				// long as our inventory interval with a little buffer to make
 				// sure we aren't in lock-step.
-				if time.Since(vpcPeering.Created) < cwutil.InventoryReceiptInterval {
+				if site.IsTimeWithinStaleInventoryThreshold(vpcPeering.Created) {
 					slogger.Info().Msg("not going to delete yet because VPC Peering is newer than the inventory interval")
 					continue
 				}

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
@@ -241,15 +241,15 @@ func TestManageVpcPeering_UpdateVpcPeeringsInDB(t *testing.T) {
 	assert.NotNil(t, vp1)
 	vp2 := testVpcPeeringBuildVpcPeering(t, dbSession, vpc2.ID, vpc1.ID, site.ID, false, user.ID)
 	assert.NotNil(t, vp2)
-	_, err := dbSession.DB.Exec("UPDATE vpc_peering SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), vp2.ID)
+	_, err := dbSession.DB.Exec("UPDATE vpc_peering SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), vp2.ID)
 	assert.NoError(t, err)
 	vp3 := testVpcPeeringBuildVpcPeering(t, dbSession, vpc1.ID, vpc3.ID, site.ID, false, user.ID)
 	assert.NotNil(t, vp3)
-	_, err = dbSession.DB.Exec("UPDATE vpc_peering SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), vp3.ID)
+	_, err = dbSession.DB.Exec("UPDATE vpc_peering SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), vp3.ID)
 	assert.NoError(t, err)
 	vp4 := testVpcPeeringBuildVpcPeering(t, dbSession, vpc2.ID, vpc3.ID, site.ID, false, user.ID)
 	assert.NotNil(t, vp4)
-	_, err = dbSession.DB.Exec("UPDATE vpc_peering SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), vp4.ID)
+	_, err = dbSession.DB.Exec("UPDATE vpc_peering SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), vp4.ID)
 	assert.NoError(t, err)
 
 	tSiteClientPool := testTemporalSiteClientPool(t)
@@ -276,7 +276,7 @@ func TestManageVpcPeering_UpdateVpcPeeringsInDB(t *testing.T) {
 		err = mvp.updateVpcPeeringStatusInDB(ctx, nil, vpcPeering.ID, cutil.GetPtr(cdbm.VpcPeeringStatusReady), cutil.GetPtr("VPC Peering was created in DB from site inventory"))
 		assert.NoError(t, err)
 		// Set created to 2x inventory interval ago
-		_, err := dbSession.DB.Exec("UPDATE vpc_peering SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), vpcPeering.ID)
+		_, err := dbSession.DB.Exec("UPDATE vpc_peering SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), vpcPeering.ID)
 		assert.NoError(t, err)
 
 		if i < 34 {

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -216,7 +215,7 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 			}
 		} else {
 			// Was this created within inventory receipt interval? If so, we may be processing an older inventory
-			if time.Since(vpcPrefix.Created) < cwutil.InventoryReceiptInterval {
+			if site.IsTimeWithinStaleInventoryThreshold(vpcPrefix.Created) {
 				continue
 			}
 

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
@@ -319,7 +319,7 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB(t *testing.T) {
 	vpcPrefix7 := testVPCBuildVPCPrefix(t, dbSession, "test-vpcprefix-7", st, tn, vpc7.ID, &ipb1.ID, cutil.GetPtr("192.168.0.0/24"), cutil.GetPtr(24), cdbm.VpcPrefixStatusReady, tnu)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE vpc_prefix SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), vpcPrefix7.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE vpc_prefix SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), vpcPrefix7.ID.String())
 	assert.NoError(t, err)
 
 	vpc8 := testVPCBuildVPC(t, dbSession, "test-vpc-8", ip, tn, st, cutil.GetPtr(uuid.New()), nil, tnu, cdbm.VpcStatusReady)
@@ -344,7 +344,7 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB(t *testing.T) {
 	vpcPrefix14 := testVPCBuildVPCPrefix(t, dbSession, "test-vpcprefix-14", st, tn, vpc14.ID, &ipb1.ID, cutil.GetPtr("192.168.0.0/24"), cutil.GetPtr(24), cdbm.VpcPrefixStatusDeleting, tnu)
 
 	// Set created earlier than the inventory receipt interval
-	_, err = dbSession.DB.Exec("UPDATE vpc_prefix SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval)), vpcPrefix11.ID.String())
+	_, err = dbSession.DB.Exec("UPDATE vpc_prefix SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval)*2), vpcPrefix11.ID.String())
 	assert.NoError(t, err)
 
 	vpcPrefixDAO := cdbm.NewVpcPrefixDAO(dbSession)
@@ -366,7 +366,7 @@ func TestManageVpcPrefix_UpdateVpcPrefixesInDB(t *testing.T) {
 		vpc := testVPCBuildVPC(t, dbSession, fmt.Sprintf("test-vpc-paged-%d", i), ip, tn, st3, cutil.GetPtr(uuid.New()), map[string]string{}, tnu, cdbm.VpcStatusReady)
 		vpcPrefix := testVPCBuildVPCPrefix(t, dbSession, fmt.Sprintf("test-vpc-prefix-paged-%d", i), st3, tn, vpc.ID, &ipb1.ID, cutil.GetPtr("192.168.0.0/24"), cutil.GetPtr(24), cdbm.VpcPrefixStatusReady, tnu)
 		// Update creation timestamp to be earlier than inventory processing interval
-		_, err = dbSession.DB.Exec("UPDATE vpc_prefix SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)), vpcPrefix.ID.String())
+		_, err = dbSession.DB.Exec("UPDATE vpc_prefix SET created = ? WHERE id = ?", time.Now().Add(-time.Duration(cutil.DefaultInventoryReceiptInterval*2)), vpcPrefix.ID.String())
 		assert.NoError(t, err)
 		pagedVpcPrefixes = append(pagedVpcPrefixes, vpcPrefix)
 		pagedInvIds = append(pagedInvIds, vpcPrefix.ID.String())

--- a/rest-api/workflow/pkg/util/common.go
+++ b/rest-api/workflow/pkg/util/common.go
@@ -5,9 +5,7 @@ package util
 
 import (
 	"context"
-	"time"
 
-	cwutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	"github.com/google/uuid"
@@ -42,11 +40,6 @@ func PtrsEqual[T comparable](i1 *T, i2 *T) bool {
 	}
 
 	return true
-}
-
-// IsTimeWithinStaleInventoryThreshold checks if the action time is within the threshold where we could be processing an older inventory
-func IsTimeWithinStaleInventoryThreshold(actionTime time.Time) bool {
-	return time.Since(actionTime) < cwutil.InventoryReceiptInterval+(time.Second*10)
 }
 
 // UpdateNVLinkLogicalPartitionStatusInDB updates the NVLinkLogicalPartition status in the DB and creates a new StatusDetail

--- a/rest-api/workflow/pkg/util/testing.go
+++ b/rest-api/workflow/pkg/util/testing.go
@@ -6,6 +6,7 @@ package util
 import (
 	"context"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -284,6 +285,32 @@ func TestBuildSubnet(t *testing.T, dbSession *cdb.Session, tenant *cdbm.Tenant, 
 	_, err := dbSession.DB.NewInsert().Model(subnet).Exec(context.Background())
 	assert.Nil(t, err)
 	return subnet
+}
+
+// TestInventoryAgeUpdatedTimestamp backdates every row of a table past the inventory staleness
+// threshold. The inventory activities skip updating a row written more recently than that, so a
+// fixture that seeds rows and then feeds them a competing inventory has to age them first. Each
+// test builds its own schema, so ageing the whole table keeps the fixture setup to one call.
+// Pass a typed nil model, for example (*cdbm.Vpc)(nil).
+func TestInventoryAgeUpdatedTimestamp(ctx context.Context, t *testing.T, dbSession *cdb.Session, models ...any) {
+	t.Helper()
+
+	for _, model := range models {
+		query := dbSession.DB.NewUpdate().
+			Model(model).
+			Set("updated = ?", time.Now().Add(-2*cutil.DefaultInventoryReceiptInterval)).
+			Where("1 = 1")
+
+		// Bun restricts an update on a soft-delete model to live rows, and a test that reconciles
+		// a deleted row still needs that row aged. Asking for deleted rows on a model without the
+		// field is an error, so only widen the scope where the field exists.
+		if dbSession.DB.Table(reflect.TypeOf(model).Elem()).SoftDeleteField != nil {
+			query = query.WhereAllWithDeleted()
+		}
+
+		_, err := query.Exec(ctx)
+		assert.NoError(t, err)
+	}
 }
 
 // TestBuildInfiniBandPartition builds and returns an InfiniBandPartition

--- a/rest-api/workflow/pkg/workflow/site/update.go
+++ b/rest-api/workflow/pkg/workflow/site/update.go
@@ -24,8 +24,8 @@ import (
 // reported by the Site Agent. It stores the Core build version and advertised
 // VPC SLAAC capability, then creates IP Blocks for Site fabric prefixes.
 //
-// Site Agents now publish UpdateSiteConfigInventoryV2. This stays registered so a Site
-// running an older Agent keeps reporting against an upgraded Cloud.
+// Site Agents now publish UpdateSiteConfigInventoryV2. This stays registered for the rollout
+// window, where Cloud upgrades ahead of the Site Agents still publishing V1.
 func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, coreBuildInfo *corev1.BuildInfo) error {
 	logger := log.With().Str("Workflow", "UpdateSiteConfigInventory").Str("SiteID", siteIDStr).Logger()
 

--- a/rest-api/workflow/pkg/workflow/site/update.go
+++ b/rest-api/workflow/pkg/workflow/site/update.go
@@ -23,7 +23,10 @@ import (
 // UpdateSiteConfigInventory applies Site metadata and runtime configuration
 // reported by the Site Agent. It stores the Core build version and advertised
 // VPC SLAAC capability, then creates IP Blocks for Site fabric prefixes.
-func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, buildInfo *corev1.BuildInfo) error {
+//
+// Site Agents now publish UpdateSiteConfigInventoryV2. This stays registered so a Site
+// running an older Agent keeps reporting against an upgraded Cloud.
+func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, coreBuildInfo *corev1.BuildInfo) error {
 	logger := log.With().Str("Workflow", "UpdateSiteConfigInventory").Str("SiteID", siteIDStr).Logger()
 
 	startTime := workflow.Now(ctx)
@@ -49,12 +52,13 @@ func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, buildInfo
 
 	var manageSite siteActivity.ManageSite
 
-	siteUpdateErr := workflow.ExecuteActivity(ctx, manageSite.UpdateSiteInDB, siteID, buildInfo).Get(ctx, nil)
+	// An older Site Agent reports no build info of its own, so the stored values are left alone.
+	siteUpdateErr := workflow.ExecuteActivity(ctx, manageSite.UpdateSiteInDB, siteID, coreBuildInfo, nil).Get(ctx, nil)
 	if siteUpdateErr != nil {
 		logger.Warn().Err(siteUpdateErr).Msg("failed to execute UpdateSiteInDB activity")
 	}
 
-	siteFabricPrefixes := buildInfo.GetRuntimeConfig().GetSiteFabricPrefixes()
+	siteFabricPrefixes := coreBuildInfo.GetRuntimeConfig().GetSiteFabricPrefixes()
 	ipBlockUpdateErr := workflow.ExecuteActivity(ctx, manageSite.UpdateIPBlocksInDBFromFabricPrefixes, siteID, siteFabricPrefixes).Get(ctx, nil)
 	if ipBlockUpdateErr != nil {
 		logger.Warn().Err(ipBlockUpdateErr).Msg("failed to execute UpdateIPBlocksInDBFromFabricPrefixes activity")
@@ -68,6 +72,70 @@ func UpdateSiteConfigInventory(ctx workflow.Context, siteIDStr string, buildInfo
 	}
 
 	// Record latency for this inventory call
+	var inventoryMetricsManager cwm.ManageInventoryMetrics
+
+	serr := workflow.ExecuteActivity(ctx, inventoryMetricsManager.RecordLatency, siteID, "UpdateSiteConfigInventory", inventoryErr != nil, workflow.Now(ctx).Sub(startTime)).Get(ctx, nil)
+	if serr != nil {
+		logger.Warn().Err(serr).Msg("failed to execute activity: RecordLatency")
+	}
+
+	logger.Info().Msg("completing workflow")
+
+	// Return every inventory update error after both updates have been attempted.
+	return inventoryErr
+}
+
+// UpdateSiteConfigInventoryV2 applies the Site configuration snapshot reported by the Site
+// Agent. It carries everything UpdateSiteConfigInventory did, plus the build info the Site
+// Agent reports about itself, so further Site-level reporting extends SiteConfigInventory
+// rather than needing another workflow.
+func UpdateSiteConfigInventoryV2(ctx workflow.Context, siteIDStr string, inventory *corev1.SiteConfigInventory) error {
+	logger := log.With().Str("Workflow", "UpdateSiteConfigInventoryV2").Str("SiteID", siteIDStr).Logger()
+
+	startTime := workflow.Now(ctx)
+
+	logger.Info().Msg("starting workflow")
+
+	siteID, err := uuid.Parse(siteIDStr)
+	if err != nil {
+		logger.Warn().Err(err).Msg(fmt.Sprintf("workflow triggered with invalid site ID: %s", siteIDStr))
+		return err
+	}
+
+	options := workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    1 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    1 * time.Minute,
+			MaximumAttempts:    3,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, options)
+
+	coreBuildInfo := inventory.GetCoreBuildInfo()
+
+	var manageSite siteActivity.ManageSite
+
+	siteUpdateErr := workflow.ExecuteActivity(ctx, manageSite.UpdateSiteInDB, siteID, coreBuildInfo, inventory.GetSiteAgentBuildInfo()).Get(ctx, nil)
+	if siteUpdateErr != nil {
+		logger.Warn().Err(siteUpdateErr).Msg("failed to execute UpdateSiteInDB activity")
+	}
+
+	siteFabricPrefixes := coreBuildInfo.GetRuntimeConfig().GetSiteFabricPrefixes()
+	ipBlockUpdateErr := workflow.ExecuteActivity(ctx, manageSite.UpdateIPBlocksInDBFromFabricPrefixes, siteID, siteFabricPrefixes).Get(ctx, nil)
+	if ipBlockUpdateErr != nil {
+		logger.Warn().Err(ipBlockUpdateErr).Msg("failed to execute UpdateIPBlocksInDBFromFabricPrefixes activity")
+	}
+
+	inventoryErr := siteUpdateErr
+	if inventoryErr == nil {
+		inventoryErr = ipBlockUpdateErr
+	} else if ipBlockUpdateErr != nil {
+		inventoryErr = errors.Join(siteUpdateErr, ipBlockUpdateErr)
+	}
+
+	// Record latency under the V1 name so the series stays continuous as Sites move over.
 	var inventoryMetricsManager cwm.ManageInventoryMetrics
 
 	serr := workflow.ExecuteActivity(ctx, inventoryMetricsManager.RecordLatency, siteID, "UpdateSiteConfigInventory", inventoryErr != nil, workflow.Now(ctx).Sub(startTime)).Get(ctx, nil)

--- a/rest-api/workflow/pkg/workflow/site/update_test.go
+++ b/rest-api/workflow/pkg/workflow/site/update_test.go
@@ -6,12 +6,14 @@ package site
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/testsuite"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	cwm "github.com/NVIDIA/infra-controller/rest-api/workflow/internal/metrics"
@@ -121,7 +123,9 @@ func TestUpdateSiteConfigInventory(t *testing.T) {
 
 			if tt.expectUpdateSiteInDB {
 				env.RegisterActivity(siteManager.UpdateSiteInDB)
-				env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo).Return(tt.updateSiteInDBErr)
+				// V1 carries no Site Agent build info, so the activity receives a typed nil.
+				env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo,
+					(*corev1.SiteAgentBuildInfo)(nil)).Return(tt.updateSiteInDBErr)
 			}
 			if tt.expectUpdateIPBlocks {
 				env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
@@ -140,6 +144,154 @@ func TestUpdateSiteConfigInventory(t *testing.T) {
 			}
 
 			env.ExecuteWorkflow(UpdateSiteConfigInventory, siteIDStr, buildInfo)
+			require.True(t, env.IsWorkflowCompleted())
+
+			err := env.GetWorkflowError()
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			for _, wantErr := range tt.wantErrContains {
+				assert.ErrorContains(t, err, wantErr)
+			}
+		})
+	}
+}
+
+func TestUpdateSiteConfigInventoryV2(t *testing.T) {
+	type testCase struct {
+		name                 string
+		siteIDStr            string
+		prefixes             []string
+		buildVersion         string
+		siteAgentBuildInfo   *corev1.SiteAgentBuildInfo
+		updateSiteInDBErr    error
+		updateIPBlocksErr    error
+		wantErr              bool
+		wantErrContains      []string
+		expectUpdateSiteInDB bool
+		expectUpdateIPBlocks bool
+		expectRecordLatency  bool
+		recordLatencyFailed  bool
+	}
+
+	tests := []testCase{
+		{
+			name:                 "Success",
+			prefixes:             []string{"10.0.0.0/16", "2001:db8::/64"},
+			buildVersion:         "1.2.3",
+			siteAgentBuildInfo:   &corev1.SiteAgentBuildInfo{Version: "2.0.0", InventoryInterval: durationpb.New(time.Minute)},
+			expectUpdateSiteInDB: true,
+			expectUpdateIPBlocks: true,
+			expectRecordLatency:  true,
+		},
+		{
+			// A Site Agent that reports nothing about itself still updates the Core-reported
+			// fields, and the activity decides to leave the Site Agent values alone.
+			name:                 "NoSiteAgentBuildInfo",
+			prefixes:             []string{"10.0.0.0/16"},
+			buildVersion:         "1.2.3",
+			expectUpdateSiteInDB: true,
+			expectUpdateIPBlocks: true,
+			expectRecordLatency:  true,
+		},
+		{
+			// UpdateSiteInDB failures do not stop the workflow from creating Site fabric IP
+			// Blocks, but they still fail the inventory workflow.
+			name:                 "UpdateSiteInDBFailsContinues",
+			prefixes:             []string{"10.0.0.0/16"},
+			buildVersion:         "1.2.3",
+			siteAgentBuildInfo:   &corev1.SiteAgentBuildInfo{Version: "2.0.0"},
+			updateSiteInDBErr:    errors.New("failed to update Site metadata"),
+			wantErr:              true,
+			wantErrContains:      []string{"failed to update Site metadata"},
+			expectUpdateSiteInDB: true,
+			expectUpdateIPBlocks: true,
+			expectRecordLatency:  true,
+			recordLatencyFailed:  true,
+		},
+		{
+			name:               "BothInventoryUpdatesFail",
+			prefixes:           []string{"10.0.0.0/16"},
+			buildVersion:       "1.2.3",
+			siteAgentBuildInfo: &corev1.SiteAgentBuildInfo{Version: "2.0.0"},
+			updateSiteInDBErr:  errors.New("failed to update Site metadata"),
+			updateIPBlocksErr:  errors.New("failed to update Site IP Blocks"),
+			wantErr:            true,
+			wantErrContains: []string{
+				"failed to update Site metadata",
+				"failed to update Site IP Blocks",
+			},
+			expectUpdateSiteInDB: true,
+			expectUpdateIPBlocks: true,
+			expectRecordLatency:  true,
+			recordLatencyFailed:  true,
+		},
+		{
+			name:      "InvalidSiteID",
+			siteIDStr: "not-a-site-id",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ts testsuite.WorkflowTestSuite
+			env := ts.NewTestWorkflowEnvironment()
+			t.Cleanup(func() {
+				env.AssertExpectations(t)
+			})
+
+			siteIDStr := tt.siteIDStr
+			var siteID uuid.UUID
+			if siteIDStr == "" {
+				siteID = uuid.New()
+				siteIDStr = siteID.String()
+			}
+
+			buildInfo := &corev1.BuildInfo{
+				BuildVersion: tt.buildVersion,
+			}
+			if tt.prefixes != nil {
+				buildInfo.RuntimeConfig = &corev1.RuntimeConfig{
+					SiteFabricPrefixes: tt.prefixes,
+				}
+			}
+			inventory := &corev1.SiteConfigInventory{
+				CoreBuildInfo:      buildInfo,
+				SiteAgentBuildInfo: tt.siteAgentBuildInfo,
+			}
+
+			var siteManager siteActivity.ManageSite
+			var metricsManager cwm.ManageInventoryMetrics
+
+			if tt.expectUpdateSiteInDB {
+				env.RegisterActivity(siteManager.UpdateSiteInDB)
+				// A message without Site Agent build info reaches the activity as a typed nil,
+				// which is what the pointer carries here when the case leaves it unset.
+				env.OnActivity(siteManager.UpdateSiteInDB, mock.Anything, siteID, buildInfo,
+					tt.siteAgentBuildInfo).Return(tt.updateSiteInDBErr)
+			}
+			if tt.expectUpdateIPBlocks {
+				env.RegisterActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes)
+				env.OnActivity(siteManager.UpdateIPBlocksInDBFromFabricPrefixes, mock.Anything, siteID, tt.prefixes).Return(tt.updateIPBlocksErr)
+			}
+			if tt.expectRecordLatency {
+				env.RegisterActivity(metricsManager.RecordLatency)
+				env.OnActivity(
+					metricsManager.RecordLatency,
+					mock.Anything,
+					siteID,
+					// V2 reports under the V1 name so the latency series stays continuous.
+					"UpdateSiteConfigInventory",
+					tt.recordLatencyFailed,
+					mock.Anything,
+				).Return(nil)
+			}
+
+			env.ExecuteWorkflow(UpdateSiteConfigInventoryV2, siteIDStr, inventory)
 			require.True(t, env.IsWorkflowCompleted())
 
 			err := env.GetWorkflowError()


### PR DESCRIPTION
Site workers currently use a default of `3m` regardless of Site Agent configuration. The Site Agent's collection interval is configurable through `TEMPORAL_INVENTORY_SCHEDULE` and runs as low as `@every 1m` where REST and Core share a cluster. This PR addresses this disconnect by allowing Site Agent to report it's interval instead.

Several inventory update/deletion steps were missing the staleness guard, they are fixed in this PR as well.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated

## Additional Notes
`UpdateSiteConfigInventory` will not be used after PR merges and will be removed in a future release.