### PR TITLE
fix(ib): retain retired membership tuples

### DIFF
--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -66,9 +66,9 @@ use crate::ethernet_virtualization::validate_instance_interface_routing_profiles
 use crate::handlers::utils::convert_and_log_machine_id;
 use crate::instance::{
     InstanceAllocationRequest, allocate_ib_port_guid, allocate_instance, allocate_network,
-    allocate_spx_port_mac, validate_ib_partition_ownership,
-    validate_instance_vfs_against_dpf_topology, validate_os_definition_usable,
-    validate_spx_partition_ownership,
+    allocate_spx_port_mac, ib_memberships_from_config, load_ib_partition_pkeys,
+    validate_ib_partition_ownership, validate_instance_vfs_against_dpf_topology,
+    validate_os_definition_usable, validate_spx_partition_ownership,
 };
 use crate::{CarbideError, CarbideResult};
 
@@ -696,6 +696,11 @@ async fn handle_instance_release_from_regular_tenant_and_report_issue(
 /// (and regular-tenant issue) health logic so the repair system can clear or update overrides, then returns
 /// success without calling `mark_as_deleted` again.
 ///
+/// **Membership serialization:** The release transaction locks and rereads the
+/// authoritative `Instance`, then records its exact IB memberships in the same
+/// transaction that marks the live `Instance` for deletion. An already-deleted
+/// retry does not resolve or record memberships.
+///
 /// ## Repair Tenant Workflow
 /// When `is_repair_tenant=true`, this indicates the RepairSystem is releasing an instance after
 /// attempting repairs. The function:
@@ -725,33 +730,39 @@ pub(crate) async fn release(
 
     let mut txn = api.txn_begin().await?;
 
-    let instance = db::instance::find_by_id(&mut txn, instance_id)
+    // Take the Instance lock before any optional Machine health update. IB
+    // config changes use the same Instance-before-Machine order, and a
+    // controller DELETE must acquire this Instance record before proceeding.
+    let instance = db::instance::find_by_id_for_update(txn.as_mut(), instance_id)
         .await?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "instance",
             id: instance_id.to_string(),
         })?;
+    let machine_id = instance.machine_id;
+    let instance_is_live = instance.deleted.is_none();
+    let is_repair_tenant = delete_instance.is_repair_tenant == Some(true);
 
-    log_machine_id(&instance.machine_id);
-    log_tenant_organization_id(instance.config.tenant.tenant_organization_id.as_str());
+    log_machine_id(&machine_id);
+    log_tenant_organization_id(instance.tenant_organization_id.as_str());
     log_delete_attribution(delete_instance.delete_attribution.as_ref());
 
-    // Only enforce PreventInstanceDeletion for a real release (instance not yet marked deleted). Repair-tenant
-    // follow-up calls after deletion may still need to adjust health overrides below.
-    if instance.deleted.is_none() {
+    // Only enforce PreventInstanceDeletion for a real release. Repair tenant
+    // follow-up calls after deletion may still adjust health below.
+    if instance_is_live {
         ensure_instance_release_not_blocked_by_prevent_instance_deletion(
             &mut txn,
-            &instance.machine_id,
+            &machine_id,
             api.runtime_config.host_health,
         )
         .await?;
     }
 
     // Instance Release called from the Repair tenant.
-    if delete_instance.is_repair_tenant == Some(true) {
+    if is_repair_tenant {
         tracing::info!(
             %instance_id,
-            machine_id = %instance.machine_id,
+            %machine_id,
             has_issues = delete_instance.issue.is_some(),
             "Instance release requested by repair tenant"
         );
@@ -759,7 +770,7 @@ pub(crate) async fn release(
         // Get machine details for repair tenant workflow
         let machine = db::machine::find_one(
             &mut txn,
-            &instance.machine_id,
+            &machine_id,
             MachineSearchConfig {
                 for_update: false,
                 ..Default::default()
@@ -768,16 +779,16 @@ pub(crate) async fn release(
         .await?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "machine",
-            id: instance.machine_id.to_string(),
+            id: machine_id.to_string(),
         })?;
 
         // Handle repair tenant workflow
         handle_instance_release_from_repair_tenant(
             &mut txn,
-            &instance.machine_id,
+            &machine_id,
             delete_instance.issue.as_ref(),
             &machine,
-            instance.config.tenant.tenant_organization_id.as_str(),
+            instance.tenant_organization_id.as_str(),
         )
         .await
         .map_err(|e| CarbideError::Internal {
@@ -789,10 +800,10 @@ pub(crate) async fn release(
 
         handle_instance_release_from_regular_tenant_and_report_issue(
             &mut txn,
-            &instance.machine_id,
+            &machine_id,
             issue,
             auto_repair_enabled,
-            instance.config.tenant.tenant_organization_id.as_str(),
+            instance.tenant_organization_id.as_str(),
         )
         .await
         .map_err(|e| CarbideError::Internal {
@@ -800,7 +811,7 @@ pub(crate) async fn release(
         })?;
     }
 
-    if instance.deleted.is_some() {
+    if !instance_is_live {
         tracing::info!(
             %instance_id,
             "Instance is already marked for deletion.",
@@ -809,9 +820,11 @@ pub(crate) async fn release(
         return Ok(Response::new(rpc::InstanceReleaseResult {}));
     }
 
-    // TODO: This is racy. If the instance just got deleted we still
-    // see an error here that is not returned as `NotFound` error. Ideally
-    // we convert this case of the DatabaseError into NotFound too.
+    let pkeys = load_ib_partition_pkeys(txn.as_mut(), &[&instance.infiniband_config]).await?;
+    let memberships = ib_memberships_from_config(&instance.infiniband_config, &pkeys);
+    for membership in memberships {
+        db::retired_ib_membership::record(txn.as_mut(), &membership).await?;
+    }
     db::instance::mark_as_deleted(instance_id, &mut txn).await?;
 
     txn.commit().await?;
@@ -1236,53 +1249,79 @@ pub(crate) async fn update_instance_config(
     metadata.validate(true).map_err(|e| {
         CarbideError::InvalidArgument(format!("instance metadata is not valid: {e}"))
     })?;
-
     let mut txn = api.txn_begin().await?;
 
-    let instance = db::instance::find_by_id(&mut txn, instance_id)
-        .await?
+    let (machine_id, initial_config_version) = {
+        // Capture the Instance before any IB lock wait. If another request
+        // updates it while this request waits, this version remains the
+        // implicit optimistic token rather than silently rebasing.
+        let request_start_instance = db::instance::find_by_id(&mut txn, instance_id)
+            .await?
+            .ok_or(CarbideError::NotFoundError {
+                kind: "instance",
+                id: instance_id.to_string(),
+            })?;
+        (
+            request_start_instance.machine_id,
+            request_start_instance.config_version,
+        )
+    };
+
+    let mut mh_snapshot = db::managed_host::load_snapshot(
+        &mut txn,
+        &machine_id,
+        LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
+    )
+    .await?
+    .ok_or(CarbideError::NotFoundError {
+        kind: "machine",
+        id: machine_id.to_string(),
+    })?;
+    // We assign `initial_instance` from this first snapshot as the baseline for
+    // request validation and resource updates. An IB change later locks the
+    // Instance and Machine, reloads the snapshot, and uses the refreshed
+    // `instance` below.
+    let initial_instance = mh_snapshot
+        .instance
+        .as_ref()
+        .filter(|instance| instance.id == instance_id)
         .ok_or(CarbideError::NotFoundError {
             kind: "instance",
             id: instance_id.to_string(),
         })?;
 
-    // power_profile was added to the complete-config update request after the
-    // API was deployed. Preserve the stored value when older clients omit it;
-    // an explicit empty string is the wire representation for clearing it.
-    config.power_profile = match config.power_profile.take() {
-        Some(profile) if profile.is_empty() => None,
-        Some(profile) => Some(profile),
-        None => instance.config.power_profile.clone(),
-    };
+    log_machine_id(&initial_instance.machine_id);
+    log_tenant_organization_id(
+        initial_instance
+            .config
+            .tenant
+            .tenant_organization_id
+            .as_str(),
+    );
 
-    log_machine_id(&instance.machine_id);
-    log_tenant_organization_id(instance.config.tenant.tenant_organization_id.as_str());
-
-    let mh_snapshot = db::managed_host::load_snapshot(
-        &mut txn,
-        &instance.machine_id,
-        LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
-    )
-    .await?
-    .ok_or(CarbideError::NotFoundError {
-        kind: "instance",
-        id: instance_id.to_string(),
-    })?;
-
-    if mh_snapshot
-        .instance
-        .as_ref()
-        .map(|instance| instance.deleted.is_some())
-        .unwrap_or(true)
-    {
+    if initial_instance.deleted.is_some() {
         return Err(CarbideError::InvalidArgument(
             "configuration for a terminating instance can not be changed".to_string(),
         )
         .into());
     }
 
+    let ib_config_update_requested = initial_instance
+        .config
+        .infiniband
+        .is_ib_config_update_requested(&config.infiniband);
+
+    // power_profile was added to the complete config update request after the
+    // API was deployed. Preserve the stored value when older clients omit it;
+    // an explicit empty string is the wire representation for clearing it.
+    config.power_profile = match config.power_profile.take() {
+        Some(profile) if profile.is_empty() => None,
+        Some(profile) => Some(profile),
+        None => initial_instance.config.power_profile.clone(),
+    };
+
     if uses_deprecated_auto_without_config {
-        let Some(auto_config) = instance.config.network.auto_config else {
+        let Some(auto_config) = initial_instance.config.network.auto_config else {
             return Err(CarbideError::InvalidArgument(
                 "cannot enable automatic networking on an existing instance through deprecated `InstanceNetworkConfig.auto`"
                     .to_string(),
@@ -1293,7 +1332,7 @@ pub(crate) async fn update_instance_config(
     }
 
     // Check whether the update is allowed
-    instance
+    initial_instance
         .config
         .verify_update_allowed_to(&config)
         .map_err(CarbideError::from)?;
@@ -1302,7 +1341,7 @@ pub(crate) async fn update_instance_config(
 
     let expected_version = match request.if_version_match {
         Some(version) => version.parse().map_err(CarbideError::from)?,
-        None => instance.config_version,
+        None => initial_config_version,
     };
 
     // If an NSG is applied, we need to do a little more validation.
@@ -1390,22 +1429,85 @@ pub(crate) async fn update_instance_config(
 
     update_instance_network_config(
         &api.runtime_config,
-        &instance,
+        initial_instance,
         &mut config.network,
         &mh_snapshot,
         &mut txn,
     )
     .await?;
 
+    // Complete config requests acquire shared resource locks and perform any
+    // network change above. An IB change then locks and rereads the Instance
+    // (or confirms the lock taken by that network change), followed by the
+    // Machine lock used by the IB monitor and force-delete. Reread after both
+    // locks so no IB or later specialized config mutation uses stale state.
+    if ib_config_update_requested {
+        let locked_instance = db::instance::find_by_id_for_update(txn.as_mut(), instance_id)
+            .await?
+            .ok_or(CarbideError::NotFoundError {
+                kind: "instance",
+                id: instance_id.to_string(),
+            })?;
+
+        if locked_instance.deleted.is_some() {
+            return Err(CarbideError::InvalidArgument(
+                "configuration for a terminating instance can not be changed".to_string(),
+            )
+            .into());
+        }
+
+        let machine_id = locked_instance.machine_id;
+        if db::machine::find_one(
+            &mut txn,
+            &machine_id,
+            MachineSearchConfig {
+                for_update: true,
+                ..Default::default()
+            },
+        )
+        .await?
+        .is_none()
+        {
+            return Err(CarbideError::NotFoundError {
+                kind: "machine",
+                id: machine_id.to_string(),
+            }
+            .into());
+        }
+
+        mh_snapshot = db::managed_host::load_snapshot(
+            &mut txn,
+            &machine_id,
+            LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
+        )
+        .await?
+        .ok_or(CarbideError::NotFoundError {
+            kind: "machine",
+            id: machine_id.to_string(),
+        })?;
+    }
+
+    // Use the Instance from the latest managed-host snapshot for the remaining
+    // updates. For an IB change, this is the authoritative reread after locking
+    // both the Instance and Machine records.
+    let instance = mh_snapshot
+        .instance
+        .as_ref()
+        .filter(|instance| instance.id == instance_id)
+        .ok_or(CarbideError::NotFoundError {
+            kind: "instance",
+            id: instance_id.to_string(),
+        })?;
+
     // Checks if the instance IB configuration was updated
     // If yes - assign devices (GUIDs) to the new configuration, update
     // the database and increment the IB version number
-    update_instance_infiniband_config(&mh_snapshot, &instance, &mut config.infiniband, &mut txn)
+    update_instance_infiniband_config(&mh_snapshot, instance, &mut config.infiniband, &mut txn)
         .await?;
 
     update_instance_extension_services_config(
         &mh_snapshot,
-        &instance,
+        instance,
         &mut config.extension_services,
         &mut txn,
     )
@@ -1416,14 +1518,14 @@ pub(crate) async fn update_instance_config(
         nvlink = ?config.nvlink,
         "Updating instance NVLink configuration",
     );
-    update_instance_nvlink_config(&mh_snapshot, &instance, &config.nvlink, &mut txn).await?;
+    update_instance_nvlink_config(&mh_snapshot, instance, &config.nvlink, &mut txn).await?;
 
     tracing::debug!(
         instance_id = %instance.id,
         spx_config = ?config.spxconfig,
         "Updating instance SPX configuration",
     );
-    update_instance_spx_config(&mh_snapshot, &instance, &mut config.spxconfig, &mut txn).await?;
+    update_instance_spx_config(&mh_snapshot, instance, &mut config.spxconfig, &mut txn).await?;
 
     db::instance::update_config(&mut txn, instance.id, expected_version, config, metadata).await?;
 
@@ -1748,10 +1850,6 @@ async fn update_instance_infiniband_config(
         return Err(ConfigValidationError::InvalidState.into());
     }
 
-    if instance.deleted.is_some() {
-        return Err(ConfigValidationError::InstanceDeletionIsRequested.into());
-    }
-
     validate_ib_partition_ownership(
         txn,
         &instance.config.tenant.tenant_organization_id,
@@ -1764,6 +1862,11 @@ async fn update_instance_infiniband_config(
 
     *ib_config = ib_config_with_ports;
 
+    let pkeys =
+        load_ib_partition_pkeys(txn.as_mut(), &[&instance.config.infiniband, &*ib_config]).await?;
+    let current_memberships = ib_memberships_from_config(&instance.config.infiniband, &pkeys);
+    let requested_memberships = ib_memberships_from_config(ib_config, &pkeys);
+
     // Persist the GUID for Infiniband configuration.
     // We need to increment the version number.
     db::instance::update_ib_config(
@@ -1774,6 +1877,19 @@ async fn update_instance_infiniband_config(
         true,
     )
     .await?;
+
+    // The `Instance` and `Machine` records remain locked through this
+    // transaction. Apply every resolvable side of the transition in exact tuple
+    // order, so even inconsistent duplicate assignments cannot invert locks in
+    // the retirement table. An incomplete interface cannot identify a tuple to
+    // record or remove.
+    for membership in current_memberships.symmetric_difference(&requested_memberships) {
+        if requested_memberships.contains(membership) {
+            db::retired_ib_membership::remove_for_reuse(txn.as_mut(), membership).await?;
+        } else {
+            db::retired_ib_membership::record(txn.as_mut(), membership).await?;
+        }
+    }
 
     Ok(())
 }

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -41,6 +41,8 @@ use itertools::Itertools;
 use model::ConfigValidationError;
 use model::dpa_interface::{DpaInterface, DpaSearchConfig};
 use model::hardware_info::InfinibandInterface;
+use model::ib::{DEFAULT_IB_FABRIC_NAME, IbMembership};
+use model::ib_partition::PartitionKey;
 use model::instance::NewInstance;
 use model::instance::config::InstanceConfig;
 use model::instance::config::infiniband::InstanceInfinibandConfig;
@@ -1439,6 +1441,69 @@ pub(crate) fn allocate_ib_port_guid(
     Ok(updated_ib_config)
 }
 
+/// Loads the stored PKeys needed to resolve exact memberships for `configs`.
+///
+/// A referenced partition without a stored PKey is omitted because it cannot
+/// identify an exact membership tuple.
+pub(crate) async fn load_ib_partition_pkeys(
+    txn: &mut PgConnection,
+    configs: &[&InstanceInfinibandConfig],
+) -> CarbideResult<HashMap<IBPartitionId, PartitionKey>> {
+    let partition_ids = configs
+        .iter()
+        .flat_map(|config| {
+            config
+                .ib_interfaces
+                .iter()
+                .map(|interface| interface.ib_partition_id)
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    if partition_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    Ok(db::ib_partition::find_by(
+        &mut *txn,
+        ObjectColumnFilter::List(ib_partition::IdColumn, &partition_ids),
+    )
+    .await?
+    .into_iter()
+    .filter_map(|partition| {
+        partition
+            .status
+            .and_then(|status| status.pkey)
+            .map(|pkey| (partition.id, pkey))
+    })
+    .collect())
+}
+
+/// Resolves every exact membership available from one IB config on the
+/// supported default fabric.
+///
+/// Each membership uses the allocated interface GUID and the referenced
+/// partition's stored PKey. Memberships are returned in stable database-lock
+/// acquisition order. Interfaces missing either value cannot identify a tuple,
+/// so they are omitted while other valid memberships are retained.
+pub(crate) fn ib_memberships_from_config(
+    config: &InstanceInfinibandConfig,
+    pkeys: &HashMap<IBPartitionId, PartitionKey>,
+) -> BTreeSet<IbMembership> {
+    config
+        .ib_interfaces
+        .iter()
+        .filter_map(|interface| {
+            Some(IbMembership {
+                fabric: DEFAULT_IB_FABRIC_NAME.to_string(),
+                pkey: pkeys.get(&interface.ib_partition_id).copied()?,
+                guid: interface.guid.clone()?,
+            })
+        })
+        .collect()
+}
+
 /// sort ib device by slot and add devices with the same name are added to hashmap
 pub(crate) fn sort_ib_by_slot(
     ib_hw_info_vec: &[InfinibandInterface],
@@ -2184,7 +2249,21 @@ pub(crate) async fn batch_allocate_instances(
         .iter()
         .map(|(id, ver, cfg)| (*id, *ver, cfg))
         .collect();
+    let ib_configs = ib_config_updates
+        .iter()
+        .map(|(_, _, config)| config)
+        .collect::<Vec<_>>();
+    let ib_partition_pkeys = load_ib_partition_pkeys(txn.as_mut(), &ib_configs).await?;
+    let assigned_ib_memberships = ib_configs
+        .into_iter()
+        .flat_map(|config| ib_memberships_from_config(config, &ib_partition_pkeys))
+        .collect::<BTreeSet<_>>();
     db::instance::batch_update_ib_config(&mut txn, &ib_refs, false).await?;
+    // The Machine records are still locked here. Remove an exact retired record
+    // only after its live config write succeeds in this same transaction.
+    for membership in assigned_ib_memberships {
+        db::retired_ib_membership::remove_for_reuse(txn.as_mut(), &membership).await?;
+    }
 
     let nvlink_refs: Vec<_> = nvlink_config_updates
         .iter()
@@ -2471,8 +2550,55 @@ pub(crate) fn allocate_spx_port_mac(
 mod tests {
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, Check, check_cases, check_values, value_scenarios};
+    use model::instance::config::infiniband::InstanceIbInterfaceConfig;
 
     use super::*;
+
+    /// Test-specific helper that builds one allocated physical IB interface.
+    fn ib_interface(partition_id: IBPartitionId, guid: Option<&str>) -> InstanceIbInterfaceConfig {
+        InstanceIbInterfaceConfig {
+            function_id: InterfaceFunctionId::Physical {},
+            ib_partition_id: partition_id,
+            pf_guid: guid.map(str::to_string),
+            guid: guid.map(str::to_string),
+            device: "test-device".to_string(),
+            vendor: None,
+            device_instance: 0,
+        }
+    }
+
+    #[test]
+    fn ib_memberships_preserve_every_resolvable_tuple() {
+        let valid_partition = IBPartitionId::new();
+        let missing_pkey_partition = IBPartitionId::new();
+        let missing_guid_partition = IBPartitionId::new();
+        let valid_pkey = PartitionKey::try_from(0x101).unwrap();
+        let missing_guid_pkey = PartitionKey::try_from(0x102).unwrap();
+        let config = InstanceInfinibandConfig {
+            ib_interfaces: vec![
+                ib_interface(valid_partition, Some("valid-guid")),
+                ib_interface(missing_pkey_partition, Some("unknown-pkey-guid")),
+                ib_interface(missing_guid_partition, None),
+            ],
+        };
+
+        // Retirement bookkeeping can act only on exact tuples. Incomplete
+        // interfaces are skipped without discarding another valid membership.
+        assert_eq!(
+            ib_memberships_from_config(
+                &config,
+                &HashMap::from([
+                    (valid_partition, valid_pkey),
+                    (missing_guid_partition, missing_guid_pkey),
+                ]),
+            ),
+            BTreeSet::from([IbMembership {
+                fabric: DEFAULT_IB_FABRIC_NAME.to_string(),
+                pkey: valid_pkey,
+                guid: "valid-guid".to_string(),
+            }])
+        );
+    }
 
     #[test]
     fn interface_needs_prefix_allocation_only_without_durable_results() {

--- a/crates/api-core/src/tests/ib_fabric_monitor.rs
+++ b/crates/api-core/src/tests/ib_fabric_monitor.rs
@@ -65,9 +65,8 @@ fn retired_membership(fabric: &str, pkey: PartitionKey, guid: &str) -> IbMembers
     }
 }
 
-/// `insert_retired_membership` is a test-specific helper that seeds the
-/// monitor's durable input directly. The production writer is tracked by
-/// https://github.com/NVIDIA/infra-controller/issues/5147.
+/// `insert_retired_membership` seeds the monitor's durable input directly so
+/// these tests stay focused on monitor behavior rather than lifecycle writers.
 async fn insert_retired_membership(pool: &sqlx::PgPool, membership: &IbMembership) {
     sqlx::query("INSERT INTO retired_ib_memberships (fabric, pkey, guid) VALUES ($1, $2, $3)")
         .bind(membership.fabric.clone())
@@ -712,7 +711,6 @@ async fn live_membership_is_unbound_after_instance_deletion_while_retired_record
 async fn membership_reused_after_snapshot_is_not_unbound(pool: sqlx::PgPool) {
     let (env, _, instance_id, pkey, guid) = live_ib_instance(pool.clone()).await;
     let retired = retired_membership(DEFAULT_IB_FABRIC_NAME, pkey, &guid);
-    insert_retired_membership(&pool, &retired).await;
     let fabric = env
         .ib_fabric_manager
         .new_client(DEFAULT_IB_FABRIC_NAME)
@@ -738,38 +736,69 @@ async fn membership_reused_after_snapshot_is_not_unbound(pool: sqlx::PgPool) {
         .await
         .unwrap();
 
-    // Hold the retired membership query after the monitor has captured the
-    // empty IB configuration and its pending unbind.
-    let mut query_gate = pool.begin().await.unwrap();
-    let query_gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
-        .fetch_one(query_gate.as_mut())
-        .await
-        .unwrap();
-    sqlx::query("LOCK TABLE retired_ib_memberships IN ACCESS EXCLUSIVE MODE")
-        .execute(query_gate.as_mut())
+    // Hold only this retired record. The reuse transaction can acquire the
+    // Instance and then its owning Machine, then pause when it removes the
+    // retirement.
+    let mut membership_guard = pool.begin().await.unwrap();
+    sqlx::query(
+        "SELECT fabric FROM retired_ib_memberships \
+         WHERE fabric = $1 AND pkey = $2 AND guid = $3 FOR UPDATE",
+    )
+    .bind(&retired.fabric)
+    .bind(i32::from(u16::from(retired.pkey)))
+    .bind(&retired.guid)
+    .fetch_one(membership_guard.as_mut())
+    .await
+    .unwrap();
+    let membership_guard_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(membership_guard.as_mut())
         .await
         .unwrap();
 
-    let monitor = new_ib_monitor(&env);
-    let monitor_iteration = tokio::spawn(async move { monitor.run_single_iteration().await });
-    wait_for_blocked_query(&pool, query_gate_pid, "retired_ib_memberships").await;
+    let reuse_request = rpc::forge::InstanceConfigUpdateRequest {
+        instance_id: instance_id.into(),
+        if_version_match: None,
+        config: Some(original_config),
+        metadata: Some(instance.metadata().clone()),
+    };
+    let reuse_api = env.api.clone();
+    let (reuse_result, monitor_result) =
+        tokio::time::timeout(std::time::Duration::from_secs(60), async {
+            tokio::join!(
+                async {
+                    reuse_api
+                        .update_instance_config(tonic::Request::new(reuse_request))
+                        .await
+                },
+                async {
+                    let reuse_pid = wait_for_blocked_query(
+                        &pool,
+                        membership_guard_pid,
+                        "DELETE FROM retired_ib_memberships",
+                    )
+                    .await;
 
-    env.api
-        .update_instance_config(tonic::Request::new(
-            rpc::forge::InstanceConfigUpdateRequest {
-                instance_id: instance_id.into(),
-                if_version_match: None,
-                config: Some(original_config),
-                metadata: Some(instance.metadata().clone()),
-            },
-        ))
+                    // The monitor snapshots the still-committed empty
+                    // configuration, then its locked reread waits for the reuse
+                    // transaction that owns the Machine after its Instance.
+                    let monitor = new_ib_monitor(&env);
+                    let (monitor_result, ()) =
+                        tokio::join!(monitor.run_single_iteration(), async {
+                            wait_for_blocked_query(&pool, reuse_pid, MACHINE_LOCK_QUERY_MARKER)
+                                .await;
+                            membership_guard.commit().await.unwrap();
+                        });
+                    monitor_result
+                }
+            )
+        })
         .await
-        .unwrap();
-    query_gate.commit().await.unwrap();
+        .expect("membership reuse race should finish after both lock waits");
 
-    assert_eq!(monitor_iteration.await.unwrap().unwrap(), 0);
+    reuse_result.unwrap();
+    assert_eq!(monitor_result.unwrap(), 0);
     assert!(membership_is_present(&fabric, pkey, &guid).await);
-    assert!(retired_membership_exists(&pool, &retired).await);
+    assert!(!retired_membership_exists(&pool, &retired).await);
 }
 
 /// `membership_removed_from_hardware_after_snapshot_stays_retired` is a
@@ -941,9 +970,9 @@ async fn deleted_instance_keeps_the_retired_membership(pool: sqlx::PgPool) {
         .unwrap();
     assert!(membership_is_present(&fabric, pkey, &guid).await);
 
-    // Normal release first marks the `Instance` deleted. Until the membership
-    // is retired, the existing monitor behavior still treats its IB
-    // configuration as expected.
+    // Model legacy or incomplete state where an `Instance` was marked deleted
+    // without atomically recording its membership. Until the membership is
+    // retired, the monitor still treats its IB configuration as expected.
     let mut txn = pool.begin().await.unwrap();
     db::instance::mark_as_deleted(instance_id, txn.as_mut())
         .await

--- a/crates/api-core/src/tests/ib_instance.rs
+++ b/crates/api-core/src/tests/ib_instance.rs
@@ -21,13 +21,17 @@ use carbide_ib_fabric::config::IBFabricConfig;
 use carbide_ib_fabric::ib::{Filter, IBFabric, IBFabricManager};
 use carbide_instrument::testing::MetricsCapture;
 use carbide_uuid::infiniband::IBPartitionId;
+use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::MachineId;
 use common::api_fixtures::ib_partition::{DEFAULT_TENANT, create_ib_partition};
 use common::api_fixtures::instance::{config_for_ib_config, create_instance_with_ib_config};
 use common::api_fixtures::{TestEnv, create_managed_host};
+use config_version::ConfigVersion;
 use db::ObjectColumnFilter;
-use model::ib::DEFAULT_IB_FABRIC_NAME;
+use model::ib::{DEFAULT_IB_FABRIC_NAME, IbMembership};
+use model::ib_partition::PartitionKey;
 use model::machine::ManagedHostState;
+use model::machine::machine_search_config::MachineSearchConfig;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{IbPartitionStatus, TenantState};
 use tonic::Request;
@@ -35,6 +39,73 @@ use tonic::Request;
 use crate::api::Api;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::TestEnvOverrides;
+use crate::tests::common::postgres::wait_for_blocked_query;
+
+// `pg_stat_activity.query` can truncate the expanded Machine snapshot query
+// before its locking clause.
+const MACHINE_LOCK_QUERY_MARKER: &str = "SELECT row_to_json";
+const INSTANCE_LOCK_QUERY_MARKER: &str = "FOR UPDATE OF i";
+
+/// Aborts a spawned database task if a failed lock probe unwinds the test.
+struct TestTaskHandle<T>(tokio::task::JoinHandle<T>);
+
+impl<T> TestTaskHandle<T> {
+    fn new(task: tokio::task::JoinHandle<T>) -> Self {
+        Self(task)
+    }
+
+    fn abort(&self) {
+        self.0.abort();
+    }
+
+    async fn join(mut self) -> Result<T, tokio::task::JoinError> {
+        (&mut self.0).await
+    }
+}
+
+impl<T> Drop for TestTaskHandle<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+async fn backend_pid(txn: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> i32 {
+    sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(txn.as_mut())
+        .await
+        .unwrap()
+}
+
+async fn insert_retired_ib_membership(pool: &sqlx::PgPool, membership: &IbMembership) {
+    sqlx::query("INSERT INTO retired_ib_memberships (fabric, pkey, guid) VALUES ($1, $2, $3)")
+        .bind(&membership.fabric)
+        .bind(i32::from(u16::from(membership.pkey)))
+        .bind(&membership.guid)
+        .execute(pool)
+        .await
+        .expect("retired IB membership fixture should be insertable");
+}
+
+async fn retired_membership_count(pool: &sqlx::PgPool, membership: &IbMembership) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM retired_ib_memberships \
+         WHERE fabric = $1 AND pkey = $2 AND guid = $3",
+    )
+    .bind(&membership.fabric)
+    .bind(i32::from(u16::from(membership.pkey)))
+    .bind(&membership.guid)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn instance_is_deleted(pool: &sqlx::PgPool, instance_id: InstanceId) -> bool {
+    sqlx::query_scalar("SELECT deleted IS NOT NULL FROM instances WHERE id = $1")
+        .bind(instance_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
 
 async fn get_partition_status(api: &Api, ib_partition_id: IBPartitionId) -> IbPartitionStatus {
     let segment = api
@@ -67,6 +138,522 @@ fn assert_successful_ufm_changes(metrics: &MetricsCapture, operation: &str, mini
         observed >= minimum,
         "expected at least {minimum} successful {operation} changes, observed {observed}"
     );
+}
+
+/// Test-specific fixture for one live membership and a requested replacement.
+struct IbTransitionFixture {
+    env: TestEnv,
+    machine_id: MachineId,
+    instance_id: InstanceId,
+    initial_config_version: ConfigVersion,
+    requested_config: rpc::InstanceConfig,
+    metadata: rpc::Metadata,
+    original_partition_id: IBPartitionId,
+    requested_partition_id: IBPartitionId,
+    original_membership: IbMembership,
+    requested_membership: IbMembership,
+}
+
+/// Test-specific helper that enables IB for an isolated API fixture.
+async fn create_ib_test_env(pool: sqlx::PgPool) -> TestEnv {
+    let mut config = common::api_fixtures::get_config();
+    config.ib_config = Some(IBFabricConfig {
+        enabled: true,
+        max_partition_per_tenant: 16,
+        ..Default::default()
+    });
+    common::api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config),
+    )
+    .await
+}
+
+/// Test-specific helper that requests one physical port on `partition_id`.
+fn one_port_ib_config(partition_id: IBPartitionId) -> rpc::InstanceInfinibandConfig {
+    rpc::InstanceInfinibandConfig {
+        ib_interfaces: vec![rpc::InstanceIbInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            virtual_function_id: None,
+            ib_partition_id: Some(partition_id),
+            device: "MT2910 Family [ConnectX-7]".to_string(),
+            vendor: None,
+            device_instance: 0,
+        }],
+    }
+}
+
+/// Test-specific helper that identifies one membership on the default fabric.
+fn ib_membership(pkey: PartitionKey, guid: impl Into<String>) -> IbMembership {
+    IbMembership {
+        fabric: DEFAULT_IB_FABRIC_NAME.to_string(),
+        pkey,
+        guid: guid.into(),
+    }
+}
+
+/// Test-specific helper that creates an original membership and a requested
+/// replacement on the same physical port.
+async fn create_ib_transition_fixture(pool: sqlx::PgPool) -> IbTransitionFixture {
+    let env = create_ib_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let (original_partition_id, original_partition) = create_ib_partition(
+        &env,
+        "transition-original".to_string(),
+        DEFAULT_TENANT.to_string(),
+    )
+    .await;
+    let (requested_partition_id, requested_partition) = create_ib_partition(
+        &env,
+        "transition-requested".to_string(),
+        DEFAULT_TENANT.to_string(),
+    )
+    .await;
+    let original_pkey = original_partition
+        .status
+        .as_ref()
+        .and_then(|status| status.pkey.as_deref())
+        .expect("ready fixture partition must have a PKey")
+        .parse()
+        .expect("fixture PKey must be valid");
+    let requested_pkey = requested_partition
+        .status
+        .as_ref()
+        .and_then(|status| status.pkey.as_deref())
+        .expect("ready fixture partition must have a PKey")
+        .parse()
+        .expect("fixture PKey must be valid");
+
+    let managed_host = create_managed_host(&env).await;
+    let (test_instance, instance) = create_instance_with_ib_config(
+        &env,
+        &managed_host,
+        one_port_ib_config(original_partition_id),
+        segment_id,
+    )
+    .await;
+    let instance_id = test_instance.id;
+    let initial_config_version = instance.config_version();
+    let metadata = instance.metadata().clone();
+    let mut requested_config = instance.config().inner().clone();
+    requested_config.infiniband = Some(one_port_ib_config(requested_partition_id));
+    let original_guid = db::instance::find_by_id(&env.pool, instance_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .config
+        .infiniband
+        .ib_interfaces
+        .into_iter()
+        .next()
+        .and_then(|interface| interface.guid)
+        .expect("allocated fixture IB interface must have a GUID");
+
+    IbTransitionFixture {
+        env,
+        machine_id: managed_host.id,
+        instance_id,
+        initial_config_version,
+        requested_config,
+        metadata,
+        original_partition_id,
+        requested_partition_id,
+        original_membership: ib_membership(original_pkey, original_guid.clone()),
+        requested_membership: ib_membership(requested_pkey, original_guid),
+    }
+}
+
+/// Test-specific helper that builds the replacement complete config update.
+fn config_update_request(fixture: &IbTransitionFixture) -> rpc::forge::InstanceConfigUpdateRequest {
+    rpc::forge::InstanceConfigUpdateRequest {
+        instance_id: Some(fixture.instance_id),
+        if_version_match: None,
+        config: Some(fixture.requested_config.clone()),
+        metadata: Some(fixture.metadata.clone()),
+    }
+}
+
+/// Test-specific helper that builds a normal release request.
+fn release_request(instance_id: InstanceId) -> rpc::InstanceReleaseRequest {
+    rpc::InstanceReleaseRequest {
+        id: Some(instance_id),
+        issue: None,
+        is_repair_tenant: None,
+        delete_attribution: None,
+    }
+}
+
+/// Test-specific helper that bounds a spawned database race task.
+async fn join_test_task<T>(task: TestTaskHandle<T>, description: &str) -> T {
+    match tokio::time::timeout(std::time::Duration::from_secs(30), task.join()).await {
+        Ok(result) => result.unwrap_or_else(|error| panic!("{description} task failed: {error}")),
+        Err(_) => panic!("{description} did not finish within 30 seconds"),
+    }
+}
+
+/// Release records retirement atomically with deletion, then retries without
+/// rebuilding membership data for a transition that already committed.
+#[crate::sqlx_test]
+async fn release_records_atomically_and_retry_skips_resolution(pool: sqlx::PgPool) {
+    let fixture = create_ib_transition_fixture(pool).await;
+    // Hold an uncommitted copy of the exact retirement. Release can lock and
+    // reread the Instance, but its idempotent insert then waits here before it
+    // can mark the Instance deleted. Canceling at that boundary must roll back
+    // the whole release transaction.
+    let mut retirement_guard = fixture.env.pool.begin().await.unwrap();
+    sqlx::query("INSERT INTO retired_ib_memberships (fabric, pkey, guid) VALUES ($1, $2, $3)")
+        .bind(&fixture.original_membership.fabric)
+        .bind(i32::from(u16::from(fixture.original_membership.pkey)))
+        .bind(&fixture.original_membership.guid)
+        .execute(retirement_guard.as_mut())
+        .await
+        .unwrap();
+    let blocker_pid = backend_pid(&mut retirement_guard).await;
+
+    let release_api = fixture.env.api.clone();
+    let instance_id = fixture.instance_id;
+    let release_task = TestTaskHandle::new(tokio::spawn(async move {
+        release_api
+            .release_instance(Request::new(release_request(instance_id)))
+            .await
+    }));
+    wait_for_blocked_query(
+        &fixture.env.pool,
+        blocker_pid,
+        "INSERT INTO retired_ib_memberships",
+    )
+    .await;
+
+    release_task.abort();
+    assert!(release_task.join().await.unwrap_err().is_cancelled());
+    retirement_guard.rollback().await.unwrap();
+
+    assert!(!instance_is_deleted(&fixture.env.pool, fixture.instance_id).await);
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        0
+    );
+
+    fixture
+        .env
+        .api
+        .release_instance(Request::new(release_request(fixture.instance_id)))
+        .await
+        .expect("release after the canceled transaction must succeed");
+    assert!(instance_is_deleted(&fixture.env.pool, fixture.instance_id).await);
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        1
+    );
+
+    sqlx::query("UPDATE ib_partitions SET status = status - 'pkey' WHERE id = $1")
+        .bind(fixture.original_partition_id)
+        .execute(&fixture.env.pool)
+        .await
+        .unwrap();
+    fixture
+        .env
+        .api
+        .release_instance(Request::new(release_request(fixture.instance_id)))
+        .await
+        .expect("already deleted retry must not resolve the old PKey");
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        1
+    );
+}
+
+/// Incomplete partition state must not strand its Instance. The exact
+/// membership is unknowable without a PKey, but release can still mark the
+/// Instance deleted and retain any other complete memberships.
+#[crate::sqlx_test]
+async fn release_continues_when_stored_membership_has_no_pkey(pool: sqlx::PgPool) {
+    let fixture = create_ib_transition_fixture(pool).await;
+    sqlx::query("UPDATE ib_partitions SET status = status - 'pkey' WHERE id = $1")
+        .bind(fixture.original_partition_id)
+        .execute(&fixture.env.pool)
+        .await
+        .unwrap();
+
+    fixture
+        .env
+        .api
+        .release_instance(Request::new(release_request(fixture.instance_id)))
+        .await
+        .expect("a missing stored PKey must not block release");
+
+    assert!(instance_is_deleted(&fixture.env.pool, fixture.instance_id).await);
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        0
+    );
+}
+
+/// An implicit version captured before an Instance-lock wait does not silently
+/// rebase. The rejected update rolls every membership change back too.
+#[crate::sqlx_test]
+async fn config_update_does_not_rebase_and_rolls_back_membership_transition(pool: sqlx::PgPool) {
+    let fixture = create_ib_transition_fixture(pool).await;
+    insert_retired_ib_membership(&fixture.env.pool, &fixture.requested_membership).await;
+
+    // Hold the Instance while the request performs its initial unlocked read.
+    // Once the request waits for this record, advance the version in the
+    // guarding transaction so its captured optimistic token becomes stale.
+    let mut instance_guard = fixture.env.pool.begin().await.unwrap();
+    sqlx::query("SELECT id FROM instances WHERE id = $1 FOR UPDATE")
+        .bind(fixture.instance_id)
+        .fetch_one(instance_guard.as_mut())
+        .await
+        .unwrap();
+    let blocker_pid = backend_pid(&mut instance_guard).await;
+
+    let update_api = fixture.env.api.clone();
+    let update_request = config_update_request(&fixture);
+    let update_task = TestTaskHandle::new(tokio::spawn(async move {
+        update_api
+            .update_instance_config(Request::new(update_request))
+            .await
+    }));
+    wait_for_blocked_query(&fixture.env.pool, blocker_pid, INSTANCE_LOCK_QUERY_MARKER).await;
+
+    let concurrent_version = fixture.initial_config_version.increment();
+    sqlx::query("UPDATE instances SET config_version = $1 WHERE id = $2")
+        .bind(concurrent_version)
+        .bind(fixture.instance_id)
+        .execute(instance_guard.as_mut())
+        .await
+        .unwrap();
+    instance_guard.commit().await.unwrap();
+
+    let error = join_test_task(update_task, "Instance-blocked config update")
+        .await
+        .expect_err("a waiting update must retain its initially captured version");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+
+    let instance = db::instance::find_by_id(&fixture.env.pool, fixture.instance_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(instance.config_version, concurrent_version);
+    assert_eq!(
+        instance.config.infiniband.ib_interfaces[0].ib_partition_id,
+        fixture.original_partition_id
+    );
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        0
+    );
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.requested_membership).await,
+        1
+    );
+}
+
+/// A replacement can repair stored config from before GUID allocation. The old
+/// incomplete membership is skipped, while the fully resolved replacement
+/// still consumes its exact retired record.
+#[crate::sqlx_test]
+async fn config_update_replaces_stored_membership_without_guid(pool: sqlx::PgPool) {
+    let fixture = create_ib_transition_fixture(pool).await;
+    insert_retired_ib_membership(&fixture.env.pool, &fixture.requested_membership).await;
+    sqlx::query(
+        "UPDATE instances \
+         SET ib_config = ib_config #- ARRAY['ib_interfaces', '0', 'guid'] \
+         WHERE id = $1",
+    )
+    .bind(fixture.instance_id)
+    .execute(&fixture.env.pool)
+    .await
+    .unwrap();
+
+    fixture
+        .env
+        .api
+        .update_instance_config(Request::new(config_update_request(&fixture)))
+        .await
+        .expect("an incomplete stored membership must not block replacement");
+
+    let instance = db::instance::find_by_id(&fixture.env.pool, fixture.instance_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        instance.config.infiniband.ib_interfaces[0].ib_partition_id,
+        fixture.requested_partition_id
+    );
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        0
+    );
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.requested_membership).await,
+        0
+    );
+}
+
+/// Retirement bookkeeping must not make a previously accepted config update
+/// fail when the requested partition has no PKey. The known current membership
+/// is still retired, and the unresolved requested tuple is left untouched.
+#[crate::sqlx_test]
+async fn config_update_continues_when_requested_membership_has_no_pkey(pool: sqlx::PgPool) {
+    let fixture = create_ib_transition_fixture(pool).await;
+    insert_retired_ib_membership(&fixture.env.pool, &fixture.requested_membership).await;
+    sqlx::query("UPDATE ib_partitions SET status = status - 'pkey' WHERE id = $1")
+        .bind(fixture.requested_partition_id)
+        .execute(&fixture.env.pool)
+        .await
+        .unwrap();
+
+    fixture
+        .env
+        .api
+        .update_instance_config(Request::new(config_update_request(&fixture)))
+        .await
+        .expect("a missing requested PKey must not block the config update");
+
+    let instance = db::instance::find_by_id(&fixture.env.pool, fixture.instance_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        instance.config.infiniband.ib_interfaces[0].ib_partition_id,
+        fixture.requested_partition_id
+    );
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        1
+    );
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.requested_membership).await,
+        1
+    );
+}
+
+/// A config update owns the Instance before it waits for the Machine. If
+/// force-delete commits `ForceDeletion` at that boundary, the update must
+/// reject without applying the requested Instance or membership changes.
+#[crate::sqlx_test]
+async fn force_deletion_wins_waiting_ib_config_update(pool: sqlx::PgPool) {
+    let fixture = create_ib_transition_fixture(pool).await;
+    insert_retired_ib_membership(&fixture.env.pool, &fixture.requested_membership).await;
+
+    let mut force_deletion = fixture.env.pool.begin().await.unwrap();
+    let machine = db::machine::find_one(
+        force_deletion.as_mut(),
+        &fixture.machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .expect("fixture Machine must exist");
+    assert!(
+        db::machine::advance(
+            &machine,
+            force_deletion.as_mut(),
+            &ManagedHostState::ForceDeletion,
+            None,
+        )
+        .await
+        .unwrap()
+    );
+    let blocker_pid = backend_pid(&mut force_deletion).await;
+
+    let update_api = fixture.env.api.clone();
+    let update_request = config_update_request(&fixture);
+    let update_task = TestTaskHandle::new(tokio::spawn(async move {
+        update_api
+            .update_instance_config(Request::new(update_request))
+            .await
+    }));
+    wait_for_blocked_query(&fixture.env.pool, blocker_pid, MACHINE_LOCK_QUERY_MARKER).await;
+    force_deletion.commit().await.unwrap();
+
+    let error = join_test_task(update_task, "ForceDeletion-blocked config update")
+        .await
+        .expect_err("an IB update must reject ForceDeletion after its Machine wait");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+
+    let instance = db::instance::find_by_id(&fixture.env.pool, fixture.instance_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        instance.config.infiniband.ib_interfaces[0].ib_partition_id,
+        fixture.original_partition_id
+    );
+    assert_eq!(instance.config_version, fixture.initial_config_version);
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        0
+    );
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.requested_membership).await,
+        1
+    );
+}
+
+/// An IB update owns the Instance and then the Machine while it retires the
+/// original membership. Release waits for the Instance, rereads the committed
+/// replacement, and retires that membership with deletion.
+#[crate::sqlx_test]
+async fn ib_update_finishes_before_waiting_release(pool: sqlx::PgPool) {
+    let fixture = create_ib_transition_fixture(pool).await;
+    insert_retired_ib_membership(&fixture.env.pool, &fixture.requested_membership).await;
+    // Pause reuse after the config update owns both records, then start release
+    // and verify it waits for the Instance before rereading the replacement.
+    let mut membership_guard = fixture.env.pool.begin().await.unwrap();
+    sqlx::query(
+        "SELECT fabric FROM retired_ib_memberships \
+         WHERE fabric = $1 AND pkey = $2 AND guid = $3 FOR UPDATE",
+    )
+    .bind(&fixture.requested_membership.fabric)
+    .bind(i32::from(u16::from(fixture.requested_membership.pkey)))
+    .bind(&fixture.requested_membership.guid)
+    .fetch_one(membership_guard.as_mut())
+    .await
+    .unwrap();
+    let membership_blocker_pid = backend_pid(&mut membership_guard).await;
+
+    let update_api = fixture.env.api.clone();
+    let update_request = config_update_request(&fixture);
+    let update_task = TestTaskHandle::new(tokio::spawn(async move {
+        update_api
+            .update_instance_config(Request::new(update_request))
+            .await
+    }));
+    let update_pid = wait_for_blocked_query(
+        &fixture.env.pool,
+        membership_blocker_pid,
+        "DELETE FROM retired_ib_memberships",
+    )
+    .await;
+
+    let release_api = fixture.env.api.clone();
+    let instance_id = fixture.instance_id;
+    let release_task = TestTaskHandle::new(tokio::spawn(async move {
+        release_api
+            .release_instance(Request::new(release_request(instance_id)))
+            .await
+    }));
+    wait_for_blocked_query(&fixture.env.pool, update_pid, INSTANCE_LOCK_QUERY_MARKER).await;
+
+    membership_guard.commit().await.unwrap();
+    join_test_task(update_task, "IB config update")
+        .await
+        .expect("update holding the Instance must complete first");
+    join_test_task(release_task, "waiting release")
+        .await
+        .expect("release must reread and retire the replacement membership");
+
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.original_membership).await,
+        1
+    );
+    assert_eq!(
+        retired_membership_count(&fixture.env.pool, &fixture.requested_membership).await,
+        1
+    );
+    assert!(instance_is_deleted(&fixture.env.pool, fixture.instance_id).await);
 }
 
 #[crate::sqlx_test]
@@ -178,10 +765,19 @@ async fn test_create_instance_with_ib_config(pool: sqlx::PgPool) {
     let machine_guids = guids_by_device(&machine);
     let guid_cx7 = machine_guids.get("MT2910 Family [ConnectX-7]").unwrap()[1].clone();
     let guid_cx5 = machine_guids.get("MT27800 Family [ConnectX-5]").unwrap()[0].clone();
+    let reused_membership =
+        ib_membership(PartitionKey::try_from(pkey_u16).unwrap(), guid_cx7.clone());
+    // Allocation must consume the exact retirement for the membership it is
+    // about to make live again.
+    insert_retired_ib_membership(&env.pool, &reused_membership).await;
 
     let creation_metrics = MetricsCapture::start();
     let (tinstance, instance) =
         create_instance_with_ib_config(&env, &mh, ib_config.clone(), segment_id).await;
+    assert_eq!(
+        retired_membership_count(&env.pool, &reused_membership).await,
+        0
+    );
     assert_successful_ufm_changes(&creation_metrics, "bind_guid_to_pkey", 2.0);
     drop(creation_metrics);
 

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -35,6 +35,7 @@ use model::instance::config::spx::InstanceSpxConfig;
 use model::instance::snapshot::{self, InstanceSnapshot, InstanceSnapshotPgJson};
 use model::metadata::Metadata;
 use model::os::{InlineIpxe, OperatingSystem, OperatingSystemVariant};
+use model::tenant::TenantOrganizationId;
 use sqlx::PgConnection;
 use sqlx::types::Json;
 
@@ -428,6 +429,45 @@ pub async fn find_by_id(
         return Ok(None);
     };
     Ok(Some(instance_and_os_row.try_into()?))
+}
+
+/// Instance data returned while its database record is locked for update.
+#[derive(sqlx::FromRow)]
+pub struct InstanceForUpdate {
+    /// Instance identifier.
+    pub id: InstanceId,
+    /// Machine that owns the Instance.
+    pub machine_id: MachineId,
+    /// Tenant that owns the Instance.
+    pub tenant_organization_id: TenantOrganizationId,
+    /// Desired InfiniBand configuration stored on the Instance.
+    #[sqlx(json)]
+    pub infiniband_config: InstanceInfinibandConfig,
+    /// Time at which deletion was requested, if any.
+    pub deleted: Option<DateTime<Utc>>,
+}
+
+/// Finds an `Instance` by ID and locks its database record for update.
+///
+/// This includes an `Instance` already marked for deletion. The record remains
+/// locked until `txn` ends.
+pub async fn find_by_id_for_update(
+    txn: &mut PgConnection,
+    id: InstanceId,
+) -> Result<Option<InstanceForUpdate>, DatabaseError> {
+    let query = "SELECT i.id,
+            i.machine_id,
+            i.tenant_org AS tenant_organization_id,
+            i.ib_config AS infiniband_config,
+            i.deleted
+        FROM instances i
+        WHERE i.id = $1
+        FOR UPDATE OF i";
+    sqlx::query_as(query)
+        .bind(id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))
 }
 
 pub async fn find_id_by_machine_id(

--- a/crates/api-db/src/retired_ib_membership.rs
+++ b/crates/api-db/src/retired_ib_membership.rs
@@ -27,10 +27,12 @@ use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
 /// `record` records the exact membership in the transaction that retires it.
-// The first production caller, which retires the membership in the same
-// transaction, is tracked by https://github.com/NVIDIA/infra-controller/issues/5147.
-#[allow(dead_code)]
-async fn record(txn: &mut PgConnection, membership: &IbMembership) -> DatabaseResult<()> {
+///
+/// The caller must serialize the authoritative live `Instance` transition and
+/// use the same transaction for both changes. Repeated records for the exact
+/// membership are idempotent. Callers that process multiple memberships must
+/// acquire retired-membership locks in stable fabric, PKey, and GUID order.
+pub async fn record(txn: &mut PgConnection, membership: &IbMembership) -> DatabaseResult<()> {
     let query = "INSERT INTO retired_ib_memberships (fabric, pkey, guid)
         VALUES ($1, $2, $3)
         ON CONFLICT (fabric, pkey, guid) DO NOTHING";
@@ -109,14 +111,12 @@ fn membership_from_row(
 /// `remove_for_reuse` removes the retired record in the transaction that
 /// assigns the exact membership to a live `Instance`.
 ///
-/// Callers must hold the lock that serializes membership changes and verify the
-/// current `Instance` after locking its owning `Machine` row `FOR UPDATE` in
-/// this transaction. Removing the membership from UFM is not enough to delete
-/// the record. Returns `true` when the exact record existed and was deleted.
-// The first production caller, which assigns the exact membership in the same
-// transaction, is tracked by https://github.com/NVIDIA/infra-controller/issues/5147.
-#[allow(dead_code)]
-async fn remove_for_reuse(
+/// Callers must hold the locks that serialize assignment and verify the current
+/// `Instance` in this transaction. Removing the membership from UFM is not
+/// enough to delete the record. Callers that process multiple memberships must
+/// acquire retired-membership locks in stable fabric, PKey, and GUID order.
+/// Returns `true` when the exact record existed and was deleted.
+pub async fn remove_for_reuse(
     txn: &mut PgConnection,
     membership: &IbMembership,
 ) -> DatabaseResult<bool> {

--- a/crates/api-model/src/ib.rs
+++ b/crates/api-model/src/ib.rs
@@ -30,7 +30,7 @@ pub const DEFAULT_IB_FABRIC_NAME: &str = "default";
 
 /// `IbMembership` identifies one PKey membership through its fabric and port
 /// GUID.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct IbMembership {
     /// Fabric containing the membership.
     pub fabric: String,

--- a/crates/api-model/src/ib_partition/mod.rs
+++ b/crates/api-model/src/ib_partition/mod.rs
@@ -43,7 +43,7 @@ pub struct IbPartitionSearchFilter {
 /// Partition Keys are 16 bit values valid up to a value of 0x7fff
 /// Partition Keys are serialized as strings, since the hex represenation is
 /// their canonical representation.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PartitionKey(u16);
 
 impl PartitionKey {


### PR DESCRIPTION
An Instance's desired InfiniBand membership is identified by an exact `(fabric, pkey, guid)` tuple. A bind started through UFM can complete after a complete config update or normal release has removed that tuple from the live Instance. Without a durable retirement record, the IB monitor no longer has enough desired-state data to recognize and remove that stale membership.

Normal release now locks the Instance record and reads its latest committed state before resolving every exact membership available from the stored IB configuration. It records those tuples in `retired_ib_memberships` in the same transaction that marks the Instance deleted. An already-deleted retry continues to run the existing health-update logic, but does not resolve or record the memberships again.

For complete config updates, the handler captures the request-start config version for use as the implicit optimistic-concurrency token, then performs the existing validation, shared-resource, and network work. If the requested IB configuration differs from the initial Instance snapshot, it locks and rereads the Instance, locks the owning Machine through the existing full `db::machine::find_one(... for_update: true)` read, reloads the managed-host snapshot, and requires that the Instance is still live and the Machine is still `Assigned/Ready` before applying any remaining IB change. The Instance lock serializes this transition with release; the existing Machine lock boundary serializes it with force-delete and the IB monitor. This final diff adds the narrow Instance `find_by_id_for_update` helper, but no Machine lock helper, and does not change controller, power, or DPU paths.

An IB config change records each resolvable `old - new` tuple and removes a retired record only for an exact `new - old` reuse. Allocation likewise removes only exact retired records for memberships it makes live. The bookkeeping and corresponding Instance write commit together, and neither release nor complete config update calls UFM while its database transaction is open.

Tuple resolution uses the supported default fabric, the allocated interface GUID, and the referenced partition's stored PKey. If the interface has no GUID or the partition has no stored PKey, bookkeeping skips only that unresolved tuple, continues processing every other resolvable retirement or exact reuse, and does not itself block release, config update, or allocation. The IB monitor can later use durable retired records to remove stale or delayed UFM binds.

## Related issues

This implements [#5147](https://github.com/NVIDIA/infra-controller/issues/5147). Follow-up findings discovered while reviewing this PR are tracked separately: [#5313](https://github.com/NVIDIA/infra-controller/issues/5313) covers serialization between Instance IB partition references and partition deletion, and [#5333](https://github.com/NVIDIA/infra-controller/issues/5333) covers the broader audit of Machine and DPU lock ordering. Both findings predate this PR, and neither Task is a prerequisite.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

The findings below cover every unique model finding raised during the review iterations that produced the final reduced diff. Each adopted change received bounded closure review before publication.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 5 | 5 | 0 |
| CodeRabbit CLI | 2 | 0 | 2 |
| CodeRabbit hosted | 13 | 6 | 7 |
| Claude CLI | 14 | 7 | 7 |
| common-nits-reviewer | 4 | 4 | 0 |
| **Total** | **38** | **22** | **16** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- removed provisional Machine locks from pre-existing DPU flows and the unconditional state-controller path; #5333 tracks that broader work.
2. **Adopted** -- removed the power-path lock-order rewrite after the final Instance-first design made it unnecessary for #5147.
3. **Adopted** -- removed DPU approval sorting added only for the discarded power rewrite; pre-existing multi-DPU ordering remains in #5333.
4. **Adopted** -- preserved the request's initial optimistic version across the Instance wait without changing explicit-token validation.
5. **Adopted** -- removed the provisional `LockMachine`, `machine::lock_by_id`, and controller compatibility design; the final diff contains none of them.

### CodeRabbit CLI

1. **Declined** -- restoring the DPU heartbeat lock probe would test production locking removed from this PR and tracked by #5333.
2. **Declined** -- restoring the DPU reprovision lock probe would reintroduce the same separate locking project.

### CodeRabbit hosted

1. **Adopted** -- corrected the missing Machine snapshot error to report `machine` and `machine_id`.
2. **Adopted through scope reduction** -- the multi-membership assertion that needed an explanatory comment left the final focused test set.
3. **Declined** -- single-use blocked-query fragments remain local; separate marker constants could drift from production just as independently.
4. **Adopted through scope reduction** -- removing the generic Machine lock helper and shared host-lock harness also removed the proposed `lock_by_id` reuse.
5. **Adopted through scope reduction** -- removing the unconditional controller Machine lock eliminated its idle-tick contention.
6. **Declined** -- waiting for an aborted SQLx backend PID to disappear is not valid synchronization because the pooled backend can remain in `pg_stat_activity`; CodeRabbit withdrew the finding.
7. **Declined** -- the two local test modules use different retired-membership query contracts, so sharing the count helper would add coupling without a new proof.
8. **Declined** -- plain `tracing::` calls do not invent an `event_name`; that identity belongs to declared `carbide_instrument::Event` types, and CodeRabbit withdrew the finding.
9. **Declined** -- the partition allocation/final-delete race predates this change and is tracked separately in #5313.
10. **Adopted through scope reduction** -- removing the broader DPU lock retrofit also removed the lock probes that could otherwise pass without proving a DPU write.
11. **Declined** -- the database wait graph already proves update-before-release ordering, while an intermediate count would require another gate and duplicate direct reuse coverage; CodeRabbit withdrew the finding.
12. **Declined** -- release, power, and config update have different locking, ownership, and optimistic-version contracts, so a shared lock-and-snapshot helper would add machinery without strengthening an invariant; CodeRabbit withdrew the finding.
13. **Adopted** -- membership bookkeeping now handles every resolvable exact tuple and skips only interfaces whose missing PKey or GUID cannot identify one.

### Claude CLI

1. **Adopted** -- removed the stale test comment that described #5147's production writer as future work.
2. **Adopted** -- the authoritative Instance lock eliminates the release and physical-delete race, so the old race TODO no longer applies.
3. **Adopted** -- stopped describing force-delete as sharing release's transaction order.
4. **Declined** -- two local test modules use different membership helper contracts; sharing them adds coupling without new proof.
5. **Adopted** -- scoped the request-start Instance read to the two fields needed for its optimistic token, removing the explicit `drop` and clarifying the later authoritative reread.
6. **Declined** -- the two-value table input follows the repository's table-driven test convention without another local type.
7. **Declined** -- exact internal error text is not an API contract; the tests already prove that incomplete tuples do not block lifecycle progress.
8. **Declined** -- every membership transition uses the same derived total order; a test of field precedence does not prove more behavior.
9. **Adopted** -- removed the provisional generic Machine lock helper; the only Machine lock in the final diff uses the existing `db::machine::find_one(... for_update: true)` path for an IB config change.
10. **Declined** -- the concurrency tests stay beside the shared IB transition fixture they exercise.
11. **Adopted through scope reduction** -- removing the power lock-order test also removed its unused `operation: 0` fixture.
12. **Declined** -- broader DPU ordering predates this change and belongs in #5333.
13. **Adopted** -- incomplete tuples are skipped instead of blocking lifecycle progress, while every resolvable retirement or reuse is still handled exactly.
14. **Declined** -- retired records deliberately remain until exact reuse; deciding when to delete old records is separate work.

### common-nits-reviewer

1. **Adopted** -- bounded spawned database race tasks and used deterministic database gates.
2. **Adopted** -- made spawned database tasks abort when a missed lock probe unwinds a test.
3. **Adopted** -- replaced ambiguous membership labels with direct original and replacement wording.
4. **Adopted** -- consolidated repeated Instance deletion queries into one local test helper.

</details>
