### PR TITLE
fix(flow): reconcile switch and power-shelf drift

### DIFF
--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -192,6 +192,76 @@ func (c *grpcClient) GetMachines(ctx context.Context) ([]MachineDetail, error) {
 	return result, nil
 }
 
+// GetSwitches retrieves a complete active-switch snapshot. ID discovery and
+// detail lookup each receive the configured RPC timeout so a slow first call
+// cannot starve the second call. FindSwitchesByIds is routed through the shared
+// batching client, which also verifies response completeness.
+func (c *grpcClient) GetSwitches(ctx context.Context) ([]ObservedControllerDevice, error) {
+	idsCtx, idsCancel := context.WithTimeout(ctx, c.grpcTimeout)
+	idsResponse, err := c.gclient.FindSwitchIds(idsCtx, &corev1.SwitchSearchFilter{})
+	idsCancel()
+	if err != nil {
+		return nil, fmt.Errorf("FindSwitchIds for actual inventory: %w", err)
+	}
+
+	switchIDs := idsResponse.GetIds()
+	if len(switchIDs) == 0 {
+		return []ObservedControllerDevice{}, nil
+	}
+
+	detailsCtx, detailsCancel := context.WithTimeout(ctx, c.grpcTimeout)
+	defer detailsCancel()
+	response, err := c.gclient.FindSwitchesByIds(detailsCtx, &corev1.SwitchesByIdsRequest{
+		SwitchIds: switchIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("FindSwitchesByIds for actual inventory: %w", err)
+	}
+
+	result := make([]ObservedControllerDevice, 0, len(response.GetSwitches()))
+	for _, sw := range response.GetSwitches() {
+		result = append(result, ObservedControllerDevice{
+			ID:     sw.GetId().GetId(),
+			BmcMac: sw.GetBmcInfo().GetMac(),
+		})
+	}
+	return result, nil
+}
+
+// GetPowerShelves is the power-shelf equivalent of GetSwitches, including the
+// independent per-RPC timeout and complete batched detail lookup.
+func (c *grpcClient) GetPowerShelves(ctx context.Context) ([]ObservedControllerDevice, error) {
+	idsCtx, idsCancel := context.WithTimeout(ctx, c.grpcTimeout)
+	idsResponse, err := c.gclient.FindPowerShelfIds(idsCtx, &corev1.PowerShelfSearchFilter{})
+	idsCancel()
+	if err != nil {
+		return nil, fmt.Errorf("FindPowerShelfIds for actual inventory: %w", err)
+	}
+
+	shelfIDs := idsResponse.GetIds()
+	if len(shelfIDs) == 0 {
+		return []ObservedControllerDevice{}, nil
+	}
+
+	detailsCtx, detailsCancel := context.WithTimeout(ctx, c.grpcTimeout)
+	defer detailsCancel()
+	response, err := c.gclient.FindPowerShelvesByIds(detailsCtx, &corev1.PowerShelvesByIdsRequest{
+		PowerShelfIds: shelfIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("FindPowerShelvesByIds for actual inventory: %w", err)
+	}
+
+	result := make([]ObservedControllerDevice, 0, len(response.GetPowerShelves()))
+	for _, shelf := range response.GetPowerShelves() {
+		result = append(result, ObservedControllerDevice{
+			ID:     shelf.GetId().GetId(),
+			BmcMac: shelf.GetBmcInfo().GetMac(),
+		})
+	}
+	return result, nil
+}
+
 // GetLeakingMachineIds retrieves IDs of all machines which are leaking and are powered on.
 // The search filter passed in to FindMachineIds limits the results to these two conditions.
 func (c *grpcClient) GetLeakingMachineIds(ctx context.Context) ([]string, error) {
@@ -1570,6 +1640,14 @@ func (c *grpcClient) SetSwitchNvosIP(switchID, ip string) {
 }
 
 func (c *grpcClient) SetPowerShelfControllerState(shelfID, state string) {
+	panic("Not a unit test")
+}
+
+func (c *grpcClient) SetObservedSwitches(devices []ObservedControllerDevice) {
+	panic("Not a unit test")
+}
+
+func (c *grpcClient) SetObservedPowerShelves(devices []ObservedControllerDevice) {
 	panic("Not a unit test")
 }
 

--- a/rest-api/flow/internal/nicoapi/grpc_batch_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_batch_test.go
@@ -24,9 +24,14 @@ type recordingForgeClient struct {
 	versionErr      error
 	versionErrors   []error
 	versionDelay    time.Duration
+	switchIDDelay   time.Duration
 	switchDelay     time.Duration
+	shelfIDDelay    time.Duration
+	shelfDelay      time.Duration
 	versionRequests []*corev1.VersionRequest
 	machineIDs      []string
+	switchIDs       []string
+	shelfIDs        []string
 	machineBatches  [][]string
 	switchBatches   [][]string
 	shelfBatches    [][]string
@@ -95,6 +100,36 @@ func (c *recordingForgeClient) FindMachinesByIds(
 	return &corev1.MachineList{Machines: machines}, nil
 }
 
+func (c *recordingForgeClient) FindSwitchIds(
+	ctx context.Context,
+	_ *corev1.SwitchSearchFilter,
+	_ ...grpc.CallOption,
+) (*corev1.SwitchIdList, error) {
+	if c.switchIDDelay > 0 {
+		select {
+		case <-time.After(c.switchIDDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return &corev1.SwitchIdList{Ids: stringsToSwitchIds(c.switchIDs)}, nil
+}
+
+func (c *recordingForgeClient) FindPowerShelfIds(
+	ctx context.Context,
+	_ *corev1.PowerShelfSearchFilter,
+	_ ...grpc.CallOption,
+) (*corev1.PowerShelfIdList, error) {
+	if c.shelfIDDelay > 0 {
+		select {
+		case <-time.After(c.shelfIDDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return &corev1.PowerShelfIdList{Ids: stringsToPowerShelfIds(c.shelfIDs)}, nil
+}
+
 func (c *recordingForgeClient) FindSwitchesByIds(
 	ctx context.Context,
 	request *corev1.SwitchesByIdsRequest,
@@ -122,11 +157,13 @@ func (c *recordingForgeClient) FindSwitchesByIds(
 	for _, id := range batch {
 		if id != omitID {
 			nvosIP := "ip-" + id
+			bmcMAC := "mac-" + id
 			switches = append(switches, &corev1.Switch{
 				Id:              &corev1.SwitchId{Id: id},
 				RackId:          &corev1.RackId{Id: "rack-" + id},
 				ControllerState: "state-" + id,
 				NvosInfo:        &corev1.SwitchNvosInfo{Ip: &nvosIP},
+				BmcInfo:         &corev1.BmcInfo{Mac: &bmcMAC},
 			})
 		}
 	}
@@ -134,7 +171,7 @@ func (c *recordingForgeClient) FindSwitchesByIds(
 }
 
 func (c *recordingForgeClient) FindPowerShelvesByIds(
-	_ context.Context,
+	ctx context.Context,
 	request *corev1.PowerShelvesByIdsRequest,
 	_ ...grpc.CallOption,
 ) (*corev1.PowerShelfList, error) {
@@ -143,7 +180,15 @@ func (c *recordingForgeClient) FindPowerShelvesByIds(
 	c.shelfBatches = append(c.shelfBatches, batch)
 	failed := c.failCall == len(c.shelfBatches)
 	omitID := c.omitID
+	delay := c.shelfDelay
 	c.mu.Unlock()
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	if failed {
 		return nil, errors.New("injected power shelf lookup failure")
 	}
@@ -151,10 +196,12 @@ func (c *recordingForgeClient) FindPowerShelvesByIds(
 	shelves := make([]*corev1.PowerShelf, 0, len(batch))
 	for _, id := range batch {
 		if id != omitID {
+			bmcMAC := "mac-" + id
 			shelves = append(shelves, &corev1.PowerShelf{
 				Id:              &corev1.PowerShelfId{Id: id},
 				RackId:          &corev1.RackId{Id: "rack-" + id},
 				ControllerState: "state-" + id,
+				BmcInfo:         &corev1.BmcInfo{Mac: &bmcMAC},
 			})
 		}
 	}
@@ -163,6 +210,103 @@ func (c *recordingForgeClient) FindPowerShelvesByIds(
 
 func newRecordingGRPCClient(fake *recordingForgeClient) *grpcClient {
 	return &grpcClient{gclient: newBatchingForgeClient(fake), grpcTimeout: time.Second}
+}
+
+func stringsToSwitchIds(ids []string) []*corev1.SwitchId {
+	result := make([]*corev1.SwitchId, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, &corev1.SwitchId{Id: id})
+	}
+	return result
+}
+
+func stringsToPowerShelfIds(ids []string) []*corev1.PowerShelfId {
+	result := make([]*corev1.PowerShelfId, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, &corev1.PowerShelfId{Id: id})
+	}
+	return result
+}
+
+func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {
+	testCases := []struct {
+		name   string
+		fake   *recordingForgeClient
+		invoke func(context.Context, *grpcClient) ([]ObservedControllerDevice, error)
+	}{
+		{
+			name: "switches",
+			fake: &recordingForgeClient{
+				switchIDs:     []string{"switch-1"},
+				switchIDDelay: 120 * time.Millisecond,
+				switchDelay:   120 * time.Millisecond,
+			},
+			invoke: func(ctx context.Context, client *grpcClient) ([]ObservedControllerDevice, error) {
+				return client.GetSwitches(ctx)
+			},
+		},
+		{
+			name: "power shelves",
+			fake: &recordingForgeClient{
+				shelfIDs:     []string{"shelf-1"},
+				shelfIDDelay: 120 * time.Millisecond,
+				shelfDelay:   120 * time.Millisecond,
+			},
+			invoke: func(ctx context.Context, client *grpcClient) ([]ObservedControllerDevice, error) {
+				return client.GetPowerShelves(ctx)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newRecordingGRPCClient(tc.fake)
+			client.grpcTimeout = 200 * time.Millisecond
+
+			devices, err := tc.invoke(context.Background(), client)
+
+			require.NoError(t, err)
+			require.Len(t, devices, 1)
+			assert.NotEmpty(t, devices[0].ID)
+			assert.NotEmpty(t, devices[0].BmcMac)
+		})
+	}
+}
+
+func TestGrpcClient_ActualInventoryEmptyIDsAvoidDetailLookup(t *testing.T) {
+	testCases := []struct {
+		name       string
+		invoke     func(context.Context, *grpcClient) ([]ObservedControllerDevice, error)
+		batchCalls func(*recordingForgeClient) [][]string
+	}{
+		{
+			name: "switches",
+			invoke: func(ctx context.Context, client *grpcClient) ([]ObservedControllerDevice, error) {
+				return client.GetSwitches(ctx)
+			},
+			batchCalls: func(fake *recordingForgeClient) [][]string { return fake.switchBatches },
+		},
+		{
+			name: "power shelves",
+			invoke: func(ctx context.Context, client *grpcClient) ([]ObservedControllerDevice, error) {
+				return client.GetPowerShelves(ctx)
+			},
+			batchCalls: func(fake *recordingForgeClient) [][]string { return fake.shelfBatches },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &recordingForgeClient{}
+
+			devices, err := tc.invoke(context.Background(), newRecordingGRPCClient(fake))
+
+			require.NoError(t, err)
+			assert.Empty(t, devices)
+			assert.Empty(t, tc.batchCalls(fake))
+			assert.Empty(t, fake.versionRequests)
+		})
+	}
 }
 
 func TestGrpcClient_ByIDLookupsHonorCoreBatchLimit(t *testing.T) {
@@ -205,6 +349,14 @@ func TestGrpcClient_ByIDLookupsHonorCoreBatchLimit(t *testing.T) {
 			batchCalls: func(fake *recordingForgeClient) [][]string { return fake.switchBatches },
 		},
 		{
+			name: "active switches",
+			invoke: func(ctx context.Context, client *grpcClient, _ []string) (int, error) {
+				values, err := client.GetSwitches(ctx)
+				return len(values), err
+			},
+			batchCalls: func(fake *recordingForgeClient) [][]string { return fake.switchBatches },
+		},
+		{
 			name: "switch rack IDs",
 			invoke: func(ctx context.Context, client *grpcClient, ids []string) (int, error) {
 				values, err := client.FindSwitchRackIDs(ctx, ids)
@@ -229,6 +381,14 @@ func TestGrpcClient_ByIDLookupsHonorCoreBatchLimit(t *testing.T) {
 			batchCalls: func(fake *recordingForgeClient) [][]string { return fake.switchBatches },
 		},
 		{
+			name: "active power shelves",
+			invoke: func(ctx context.Context, client *grpcClient, _ []string) (int, error) {
+				values, err := client.GetPowerShelves(ctx)
+				return len(values), err
+			},
+			batchCalls: func(fake *recordingForgeClient) [][]string { return fake.shelfBatches },
+		},
+		{
 			name: "power shelf rack IDs",
 			invoke: func(ctx context.Context, client *grpcClient, ids []string) (int, error) {
 				values, err := client.FindPowerShelfRackIDs(ctx, ids)
@@ -251,6 +411,8 @@ func TestGrpcClient_ByIDLookupsHonorCoreBatchLimit(t *testing.T) {
 			fake := &recordingForgeClient{
 				runtimeConfig: &corev1.RuntimeConfig{MaxFindByIds: 2},
 				machineIDs:    ids,
+				switchIDs:     ids,
+				shelfIDs:      ids,
 			}
 			count, err := test.invoke(context.Background(), newRecordingGRPCClient(fake), ids)
 

--- a/rest-api/flow/internal/nicoapi/mock.go
+++ b/rest-api/flow/internal/nicoapi/mock.go
@@ -31,6 +31,8 @@ type mockClient struct {
 	switchNvosIPs              map[string]string // switch ID → resolved NVOS host IP
 	nvLinkDomainMemberships    []NVLinkDomainMembership
 	powerShelfControllerStates map[string]string // shelf ID → raw core controller_state
+	observedSwitches           []ObservedControllerDevice
+	observedPowerShelves       []ObservedControllerDevice
 	hostMachinesByRackID       map[string][]string
 	// Detail tables for the GetAllExpected*Details RPCs (Flow's mirror sync).
 	// Keyed by the natural identifier the test cares about so test helpers can
@@ -404,6 +406,22 @@ func (c *mockClient) GetAllExpectedSwitchesLinked(_ context.Context) ([]LinkedEx
 
 func (c *mockClient) GetAllExpectedPowerShelvesLinked(_ context.Context) ([]LinkedExpectedPowerShelf, error) {
 	return nil, nil
+}
+
+func (c *mockClient) GetSwitches(_ context.Context) ([]ObservedControllerDevice, error) {
+	return append([]ObservedControllerDevice(nil), c.observedSwitches...), nil
+}
+
+func (c *mockClient) GetPowerShelves(_ context.Context) ([]ObservedControllerDevice, error) {
+	return append([]ObservedControllerDevice(nil), c.observedPowerShelves...), nil
+}
+
+func (c *mockClient) SetObservedSwitches(devices []ObservedControllerDevice) {
+	c.observedSwitches = append([]ObservedControllerDevice(nil), devices...)
+}
+
+func (c *mockClient) SetObservedPowerShelves(devices []ObservedControllerDevice) {
+	c.observedPowerShelves = append([]ObservedControllerDevice(nil), devices...)
 }
 
 func (c *mockClient) GetDesiredFirmwareVersions(_ context.Context) ([]*corev1.DesiredFirmwareVersionEntry, error) {

--- a/rest-api/flow/internal/nicoapi/mod.go
+++ b/rest-api/flow/internal/nicoapi/mod.go
@@ -72,6 +72,13 @@ type Client interface {
 	// FindSwitchControllerStates.
 	FindPowerShelfControllerStates(ctx context.Context, shelfIds []string) (map[string]string, error)
 
+	// GetSwitches returns a complete snapshot of active Core switches with the
+	// runtime ID and BMC MAC needed for actual-inventory reconciliation.
+	GetSwitches(ctx context.Context) ([]ObservedControllerDevice, error)
+
+	// GetPowerShelves is the power-shelf equivalent of GetSwitches.
+	GetPowerShelves(ctx context.Context) ([]ObservedControllerDevice, error)
+
 	// GetMachinePositionInfo returns position information for the given machine IDs
 	GetMachinePositionInfo(ctx context.Context, machineIds []string) ([]MachinePosition, error)
 
@@ -261,6 +268,8 @@ type Client interface {
 	SetSwitchNvosIP(switchID, ip string)
 	SetObservedNVLinkDomainMemberships(memberships []NVLinkDomainMembership)
 	SetPowerShelfControllerState(shelfID, state string)
+	SetObservedSwitches(devices []ObservedControllerDevice)
+	SetObservedPowerShelves(devices []ObservedControllerDevice)
 	SetRackHostMachineIDs(rackID string, machineIDs []string)
 	AddExpectedRackDetail(detail ExpectedRackDetail)
 	AddExpectedMachineDetail(detail ExpectedMachineDetail)

--- a/rest-api/flow/internal/nicoapi/model.go
+++ b/rest-api/flow/internal/nicoapi/model.go
@@ -45,6 +45,14 @@ type MachinePosition struct {
 	TopologyID       *int32
 }
 
+// ObservedControllerDevice is the actual-inventory identity shared by Core
+// switches and power shelves. The resource-specific runtime ID is matched to a
+// Flow component through its normalized BMC controller MAC.
+type ObservedControllerDevice struct {
+	ID     string
+	BmcMac string
+}
+
 func machineDetailFromPb(machine *corev1.Machine) MachineDetail {
 	config := machine.GetConfig()
 	status := machine.GetStatus()

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
@@ -20,30 +20,31 @@ import (
 // runActualSync runs every per-type actual-vs-expected drift detector, projects
 // observed NVLink domain topology, concatenates the component drifts, and logs
 // a per-type inventory summary. Each type-specific function handles its own
-// errors internally and falls back to nil drifts; one type's RPC failure
-// doesn't suppress the others.
+// errors internally and falls back to nil drifts; one type's snapshot or
+// reconciliation failure doesn't suppress the others.
 //
-// allRPCOK is true only when every type's drift-affecting RPCs succeeded. The
+// allSyncOK is true only when every type obtained a complete drift-affecting
+// snapshot and safely reconciled the identity state needed to interpret it. The
 // drift table is a full-table replace with no per-type discriminator, so the
-// caller must not overwrite it from a partial view: if any type's RPC failed,
-// the previously persisted drifts are kept rather than being wiped. The
-// observed-domain projection is best effort and does not affect allRPCOK
+// caller must not overwrite it from a partial view: if any type failed, the
+// previously persisted drifts are kept rather than being wiped. The
+// observed-domain projection is best effort and does not affect allSyncOK
 // because it does not contribute component drifts. The returned drifts are not
 // yet persisted — runInventoryOne owns the table-replacement transaction.
 func runActualSync(
 	ctx context.Context,
 	pool *cdb.Session,
 	nicoClient nicoapi.Client,
-) (drifts []model.ComponentDrift, allRPCOK bool) {
-	allRPCOK = true
+) (drifts []model.ComponentDrift, allSyncOK bool) {
+	allSyncOK = true
 
 	computeReceived, machineDrifts, machineOK := syncMachines(ctx, pool, nicoClient)
 	drifts = append(drifts, machineDrifts...)
-	allRPCOK = allRPCOK && machineOK
+	allSyncOK = allSyncOK && machineOK
 
 	switchesReceived, nvSwitchDrifts, switchOK := syncNVSwitchesNICo(ctx, pool, nicoClient)
 	drifts = append(drifts, nvSwitchDrifts...)
-	allRPCOK = allRPCOK && switchOK
+	allSyncOK = allSyncOK && switchOK
 
 	// Domain membership is observed topology rather than expected inventory.
 	// Project it after switch sync so this cycle's switch links are available.
@@ -51,17 +52,21 @@ func runActualSync(
 
 	powershelvesReceived, powershelfDrifts, powershelfOK := syncPowershelvesNICo(ctx, pool, nicoClient)
 	drifts = append(drifts, powershelfDrifts...)
-	allRPCOK = allRPCOK && powershelfOK
+	allSyncOK = allSyncOK && powershelfOK
 
 	log.Info().
 		Int("compute", computeReceived).
 		Int("nvswitches", switchesReceived).
 		Int("powershelves", powershelvesReceived).
-		Bool("all_rpc_ok", allRPCOK).
+		// Keep the established field for log-query compatibility. Its value has
+		// always represented the safety of the complete drift replacement, which
+		// now includes identity-reconciliation failures as well as RPC failures.
+		Bool("all_rpc_ok", allSyncOK).
+		Bool("all_sync_ok", allSyncOK).
 		Msgf("Inventory received from Core: compute=%d nvswitches=%d powershelves=%d",
 			computeReceived, switchesReceived, powershelvesReceived)
 
-	return drifts, allRPCOK
+	return drifts, allSyncOK
 }
 
 // mapKeys returns the keys of a string-keyed component map in arbitrary

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_linked_component.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_linked_component.go
@@ -235,8 +235,11 @@ func applyComponentExternalIDUpdates(
 		return updates[i].component.ID.String() < updates[j].component.ID.String()
 	})
 	if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		// Release every changing external ID before assigning replacements. The
+		// database enforces uniqueness on (type, external_id), so updating the
+		// rows directly can fail when two same-type components exchange IDs.
 		for _, update := range updates {
-			patch := model.Component{ID: update.component.ID, ComponentID: update.externalID}
+			patch := model.Component{ID: update.component.ID}
 			result, err := tx.NewUpdate().Model(&patch).
 				Column("external_id").
 				Where("id = ?", update.component.ID).
@@ -251,6 +254,31 @@ func applyComponentExternalIDUpdates(
 			if rowsAffected != 1 {
 				return fmt.Errorf(
 					"update %s component %s external ID affected %d rows, expected 1",
+					resource,
+					update.component.ID,
+					rowsAffected,
+				)
+			}
+		}
+		for _, update := range updates {
+			if update.externalID == nil {
+				continue
+			}
+			patch := model.Component{ID: update.component.ID, ComponentID: update.externalID}
+			result, err := tx.NewUpdate().Model(&patch).
+				Column("external_id").
+				Where("id = ?", update.component.ID).
+				Exec(ctx)
+			if err != nil {
+				return fmt.Errorf("assign %s component %s external ID: %w", resource, update.component.ID, err)
+			}
+			rowsAffected, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("count assigned %s component %s external ID rows: %w", resource, update.component.ID, err)
+			}
+			if rowsAffected != 1 {
+				return fmt.Errorf(
+					"assign %s component %s external ID affected %d rows, expected 1",
 					resource,
 					update.component.ID,
 					rowsAffected,

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_linked_component.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_linked_component.go
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventorysync
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/uptrace/bun"
+
+	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+// actualControllerDevice is the common projection of an active Core switch or
+// power shelf used by Flow's actual-inventory reconciliation.
+type actualControllerDevice struct {
+	controllerMAC string
+	externalID    string
+}
+
+type componentExternalIDUpdate struct {
+	component  *model.Component
+	externalID *string
+}
+
+// reconcileActualControllerDevices validates one complete Core active snapshot,
+// atomically converges Flow's runtime external IDs, and derives drift from the
+// current snapshot rather than from previously persisted IDs.
+func reconcileActualControllerDevices(
+	ctx context.Context,
+	pool *cdb.Session,
+	resource string,
+	expected []model.Component,
+	observed []actualControllerDevice,
+) (
+	received int,
+	componentsByExternalID map[string]*model.Component,
+	drifts []model.ComponentDrift,
+	reconcileOK bool,
+) {
+	expectedByMAC := make(map[string]*model.Component, len(expected))
+	expectedMACByComponentID := make(map[uuid.UUID]string, len(expected))
+	ambiguousExpectedMACs := make(map[string]struct{})
+	for i := range expected {
+		component := &expected[i]
+		controllerMAC, ok := authoritativeControllerMAC(component, resource)
+		if !ok {
+			continue
+		}
+		if _, ambiguous := ambiguousExpectedMACs[controllerMAC]; ambiguous {
+			continue
+		}
+		if previous, exists := expectedByMAC[controllerMAC]; exists {
+			log.Error().
+				Str("resource", resource).
+				Str("controller_mac", controllerMAC).
+				Str("component_id", component.ID.String()).
+				Str("conflicting_component_id", previous.ID.String()).
+				Msg("Flow components share an authoritative controller MAC; neither can be matched this cycle")
+			delete(expectedByMAC, controllerMAC)
+			delete(expectedMACByComponentID, previous.ID)
+			ambiguousExpectedMACs[controllerMAC] = struct{}{}
+			continue
+		}
+		expectedByMAC[controllerMAC] = component
+		expectedMACByComponentID[component.ID] = controllerMAC
+	}
+
+	linkedByMAC := make(map[string]actualControllerDevice, len(observed))
+	macByExternalID := make(map[string]string, len(observed))
+	for _, actual := range observed {
+		mac, err := normalizedBMCAddress(actual.controllerMAC)
+		if err != nil {
+			log.Error().Err(err).
+				Str("resource", resource).
+				Str("external_id", actual.externalID).
+				Msg("Core linked inventory contains an invalid controller MAC")
+			return 0, nil, nil, false
+		}
+		actual.controllerMAC = mac
+		if previous, exists := linkedByMAC[mac]; exists {
+			log.Error().
+				Str("resource", resource).
+				Str("controller_mac", mac).
+				Str("external_id", actual.externalID).
+				Str("conflicting_external_id", previous.externalID).
+				Msg("Core linked inventory contains duplicate controller MAC entries")
+			return 0, nil, nil, false
+		}
+		linkedByMAC[mac] = actual
+		if actual.externalID == "" {
+			continue
+		}
+		if previousMAC, exists := macByExternalID[actual.externalID]; exists {
+			log.Error().
+				Str("resource", resource).
+				Str("external_id", actual.externalID).
+				Str("controller_mac", mac).
+				Str("conflicting_controller_mac", previousMAC).
+				Msg("Core linked inventory maps one runtime ID to multiple controller MACs")
+			return 0, nil, nil, false
+		}
+		macByExternalID[actual.externalID] = mac
+		received++
+	}
+
+	updates := make([]componentExternalIDUpdate, 0, len(expected))
+	matchedExternalIDByComponent := make(map[uuid.UUID]string, len(expected))
+	for i := range expected {
+		component := &expected[i]
+		actual, matched := linkedActualForComponent(component, expectedMACByComponentID, linkedByMAC)
+		if matched {
+			matchedExternalIDByComponent[component.ID] = actual.externalID
+			if component.ComponentID == nil || *component.ComponentID != actual.externalID {
+				externalID := actual.externalID
+				updates = append(updates, componentExternalIDUpdate{component: component, externalID: &externalID})
+			}
+			continue
+		}
+
+		if component.ComponentID != nil {
+			updates = append(updates, componentExternalIDUpdate{component: component})
+		}
+	}
+
+	if err := applyComponentExternalIDUpdates(ctx, pool, resource, updates); err != nil {
+		log.Error().Err(err).
+			Str("resource", resource).
+			Msg("Unable to converge runtime external IDs; preserving the previous drift snapshot")
+		return received, nil, nil, false
+	}
+
+	componentsByExternalID = make(map[string]*model.Component, len(matchedExternalIDByComponent))
+	now := time.Now()
+	for i := range expected {
+		component := &expected[i]
+		externalID, matched := matchedExternalIDByComponent[component.ID]
+		if matched {
+			componentsByExternalID[externalID] = component
+			continue
+		}
+		componentID := component.ID
+		drifts = append(drifts, model.ComponentDrift{
+			ComponentID: &componentID,
+			ExternalID:  nil,
+			DriftType:   model.DriftTypeMissingInActual,
+			Diffs:       []model.FieldDiff{},
+			CheckedAt:   now,
+		})
+	}
+
+	for mac, actual := range linkedByMAC {
+		if actual.externalID == "" {
+			continue
+		}
+		if _, expected := expectedByMAC[mac]; expected {
+			continue
+		}
+		externalID := actual.externalID
+		drifts = append(drifts, model.ComponentDrift{
+			ComponentID: nil,
+			ExternalID:  &externalID,
+			DriftType:   model.DriftTypeMissingInExpected,
+			Diffs:       []model.FieldDiff{},
+			CheckedAt:   now,
+		})
+	}
+
+	sort.Slice(drifts, func(i, j int) bool {
+		return driftSortKey(drifts[i]) < driftSortKey(drifts[j])
+	})
+	return received, componentsByExternalID, drifts, true
+}
+
+func authoritativeControllerMAC(component *model.Component, resource string) (string, bool) {
+	hostType := devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)
+	var controller *model.BMC
+	hostCount := 0
+	for i := range component.BMCs {
+		if component.BMCs[i].Type != hostType {
+			continue
+		}
+		hostCount++
+		controller = &component.BMCs[i]
+	}
+	if hostCount != 1 {
+		log.Error().
+			Str("resource", resource).
+			Str("component_id", component.ID.String()).
+			Int("host_bmc_count", hostCount).
+			Msg("Expected component must have exactly one Host BMC controller")
+		return "", false
+	}
+	mac, err := normalizedBMCAddress(controller.MacAddress)
+	if err != nil {
+		log.Error().Err(err).
+			Str("resource", resource).
+			Str("component_id", component.ID.String()).
+			Msg("Expected component has an invalid Host BMC controller MAC")
+		return "", false
+	}
+	return mac, true
+}
+
+func linkedActualForComponent(
+	component *model.Component,
+	expectedMACByComponentID map[uuid.UUID]string,
+	linkedByMAC map[string]actualControllerDevice,
+) (actualControllerDevice, bool) {
+	mac, expected := expectedMACByComponentID[component.ID]
+	if !expected {
+		return actualControllerDevice{}, false
+	}
+	actual, found := linkedByMAC[mac]
+	return actual, found && actual.externalID != ""
+}
+
+func applyComponentExternalIDUpdates(
+	ctx context.Context,
+	pool *cdb.Session,
+	resource string,
+	updates []componentExternalIDUpdate,
+) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	sort.Slice(updates, func(i, j int) bool {
+		return updates[i].component.ID.String() < updates[j].component.ID.String()
+	})
+	if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		for _, update := range updates {
+			patch := model.Component{ID: update.component.ID, ComponentID: update.externalID}
+			result, err := tx.NewUpdate().Model(&patch).
+				Column("external_id").
+				Where("id = ?", update.component.ID).
+				Exec(ctx)
+			if err != nil {
+				return fmt.Errorf("update %s component %s external ID: %w", resource, update.component.ID, err)
+			}
+			rowsAffected, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("count updated %s component %s external ID rows: %w", resource, update.component.ID, err)
+			}
+			if rowsAffected != 1 {
+				return fmt.Errorf(
+					"update %s component %s external ID affected %d rows, expected 1",
+					resource,
+					update.component.ID,
+					rowsAffected,
+				)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	for _, update := range updates {
+		if update.externalID == nil {
+			update.component.ComponentID = nil
+			continue
+		}
+		externalID := *update.externalID
+		update.component.ComponentID = &externalID
+	}
+	return nil
+}
+
+func driftSortKey(drift model.ComponentDrift) string {
+	if drift.ComponentID != nil {
+		return "component:" + drift.ComponentID.String()
+	}
+	if drift.ExternalID != nil {
+		return "external:" + *drift.ExternalID
+	}
+	return ""
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_linked_component_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_linked_component_test.go
@@ -1,0 +1,364 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventorysync
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+type linkedInventoryTestClient struct {
+	nicoapi.Client
+	switches        []nicoapi.ObservedControllerDevice
+	powerShelves    []nicoapi.ObservedControllerDevice
+	switchErr       error
+	powerShelfErr   error
+	switchCalls     int
+	powerShelfCalls int
+}
+
+func (c *linkedInventoryTestClient) GetSwitches(
+	_ context.Context,
+) ([]nicoapi.ObservedControllerDevice, error) {
+	c.switchCalls++
+	return c.switches, c.switchErr
+}
+
+func (c *linkedInventoryTestClient) GetPowerShelves(
+	_ context.Context,
+) ([]nicoapi.ObservedControllerDevice, error) {
+	c.powerShelfCalls++
+	return c.powerShelves, c.powerShelfErr
+}
+
+type linkedResourceTestCase struct {
+	name          string
+	componentType devicetypes.ComponentType
+	runtimeID     string
+	sync          func(context.Context, *cdb.Session, nicoapi.Client) (int, []model.ComponentDrift, bool)
+	setLinked     func(*linkedInventoryTestClient, string, string)
+	setError      func(*linkedInventoryTestClient, error)
+	callCount     func(*linkedInventoryTestClient) int
+}
+
+func TestLinkedActualInventoryReconciliation(t *testing.T) {
+	resources := []linkedResourceTestCase{
+		{
+			name:          "NVSwitch",
+			componentType: devicetypes.ComponentTypeNVSwitch,
+			runtimeID:     "core-switch-1",
+			sync:          syncNVSwitchesNICo,
+			setLinked: func(client *linkedInventoryTestClient, mac, runtimeID string) {
+				client.switches = []nicoapi.ObservedControllerDevice{{BmcMac: mac, ID: runtimeID}}
+			},
+			setError:  func(client *linkedInventoryTestClient, err error) { client.switchErr = err },
+			callCount: func(client *linkedInventoryTestClient) int { return client.switchCalls },
+		},
+		{
+			name:          "PowerShelf",
+			componentType: devicetypes.ComponentTypePowerShelf,
+			runtimeID:     "core-power-shelf-1",
+			sync:          syncPowershelvesNICo,
+			setLinked: func(client *linkedInventoryTestClient, mac, runtimeID string) {
+				client.powerShelves = []nicoapi.ObservedControllerDevice{{BmcMac: mac, ID: runtimeID}}
+			},
+			setError:  func(client *linkedInventoryTestClient, err error) { client.powerShelfErr = err },
+			callCount: func(client *linkedInventoryTestClient) int { return client.powerShelfCalls },
+		},
+	}
+
+	for _, resource := range resources {
+		resource := resource
+		t.Run(resource.name, func(t *testing.T) {
+			t.Run("current match replaces stale external ID", func(t *testing.T) {
+				ctx, pool := mirrorTestPool(t)
+				component := createLinkedTestComponent(t, ctx, pool, resource.componentType, "aa:bb:cc:dd:ee:01", strPtr("stale-runtime-id"))
+				client := &linkedInventoryTestClient{Client: nicoapi.NewMockClient()}
+				resource.setLinked(client, "AA-BB-CC-DD-EE-01", resource.runtimeID)
+
+				received, drifts, ok := resource.sync(ctx, pool, client)
+
+				require.True(t, ok)
+				assert.Equal(t, 1, received)
+				assert.Empty(t, drifts)
+				persisted := loadLinkedTestComponent(t, ctx, pool, component.ID)
+				require.NotNil(t, persisted.ComponentID)
+				assert.Equal(t, resource.runtimeID, *persisted.ComponentID)
+			})
+
+			t.Run("missing current match clears stale external ID and reports drift", func(t *testing.T) {
+				ctx, pool := mirrorTestPool(t)
+				component := createLinkedTestComponent(t, ctx, pool, resource.componentType, "aa:bb:cc:dd:ee:02", strPtr("stale-runtime-id"))
+				client := &linkedInventoryTestClient{Client: nicoapi.NewMockClient()}
+
+				received, drifts, ok := resource.sync(ctx, pool, client)
+
+				require.True(t, ok)
+				assert.Zero(t, received)
+				require.Len(t, drifts, 1)
+				assert.Equal(t, model.DriftTypeMissingInActual, drifts[0].DriftType)
+				require.NotNil(t, drifts[0].ComponentID)
+				assert.Equal(t, component.ID, *drifts[0].ComponentID)
+				assert.Nil(t, loadLinkedTestComponent(t, ctx, pool, component.ID).ComponentID)
+			})
+
+			t.Run("empty Flow expected inventory still reports observed actual", func(t *testing.T) {
+				ctx, pool := mirrorTestPool(t)
+				client := &linkedInventoryTestClient{Client: nicoapi.NewMockClient()}
+				resource.setLinked(client, "aa:bb:cc:dd:ee:03", resource.runtimeID)
+
+				received, drifts, ok := resource.sync(ctx, pool, client)
+
+				require.True(t, ok)
+				assert.Equal(t, 1, received)
+				assert.Equal(t, 1, resource.callCount(client))
+				require.Len(t, drifts, 1)
+				assert.Equal(t, model.DriftTypeMissingInExpected, drifts[0].DriftType)
+				assert.Nil(t, drifts[0].ComponentID)
+				require.NotNil(t, drifts[0].ExternalID)
+				assert.Equal(t, resource.runtimeID, *drifts[0].ExternalID)
+			})
+
+			t.Run("one Host controller plus an auxiliary BMC matches normally", func(t *testing.T) {
+				ctx, pool := mirrorTestPool(t)
+				component := createLinkedTestComponent(t, ctx, pool, resource.componentType, "aa:bb:cc:dd:ee:04", nil)
+				insertLinkedTestBMC(t, ctx, pool, component.ID, "aa:bb:cc:dd:ee:14", devicetypes.BMCTypeDPU)
+				client := &linkedInventoryTestClient{Client: nicoapi.NewMockClient()}
+				resource.setLinked(client, "aa:bb:cc:dd:ee:04", resource.runtimeID)
+
+				_, drifts, ok := resource.sync(ctx, pool, client)
+
+				require.True(t, ok)
+				assert.Empty(t, drifts)
+				persisted := loadLinkedTestComponent(t, ctx, pool, component.ID)
+				require.NotNil(t, persisted.ComponentID)
+				assert.Equal(t, resource.runtimeID, *persisted.ComponentID)
+			})
+
+			t.Run("actual snapshot RPC failure preserves stale external ID", func(t *testing.T) {
+				ctx, pool := mirrorTestPool(t)
+				component := createLinkedTestComponent(t, ctx, pool, resource.componentType, "aa:bb:cc:dd:ee:05", strPtr("stale-runtime-id"))
+				client := &linkedInventoryTestClient{Client: nicoapi.NewMockClient()}
+				resource.setError(client, errors.New("injected linked snapshot failure"))
+
+				_, drifts, ok := resource.sync(ctx, pool, client)
+
+				assert.False(t, ok)
+				assert.Empty(t, drifts)
+				persisted := loadLinkedTestComponent(t, ctx, pool, component.ID)
+				require.NotNil(t, persisted.ComponentID)
+				assert.Equal(t, "stale-runtime-id", *persisted.ComponentID)
+			})
+		})
+	}
+}
+
+func TestReconcileLinkedActualComponentsPersistenceFailureDoesNotMutateMatchState(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	expected := []model.Component{{
+		ID:   uuid.New(),
+		Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeNVSwitch),
+		BMCs: []model.BMC{{
+			MacAddress: "aa:bb:cc:dd:ee:20",
+			Type:       devicetypes.BMCTypeToString(devicetypes.BMCTypeHost),
+		}},
+	}}
+
+	received, matched, drifts, ok := reconcileActualControllerDevices(
+		ctx,
+		pool,
+		"NVSwitch",
+		expected,
+		[]actualControllerDevice{{controllerMAC: "aa:bb:cc:dd:ee:20", externalID: "core-switch-missing-row"}},
+	)
+
+	assert.False(t, ok)
+	assert.Equal(t, 1, received)
+	assert.Nil(t, matched)
+	assert.Nil(t, drifts)
+	assert.Nil(t, expected[0].ComponentID)
+}
+
+func TestReconcileLinkedActualComponentsMixedUnknownActual(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	component := createLinkedTestComponent(
+		t,
+		ctx,
+		pool,
+		devicetypes.ComponentTypeNVSwitch,
+		"aa:bb:cc:dd:ee:30",
+		nil,
+	)
+	expected, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeNVSwitch)
+	require.NoError(t, err)
+
+	received, matched, drifts, ok := reconcileActualControllerDevices(
+		ctx,
+		pool,
+		"NVSwitch",
+		expected,
+		[]actualControllerDevice{
+			{controllerMAC: "aa:bb:cc:dd:ee:30", externalID: "core-switch-known"},
+			{controllerMAC: "aa:bb:cc:dd:ee:31", externalID: "core-switch-unknown"},
+		},
+	)
+
+	require.True(t, ok)
+	assert.Equal(t, 2, received)
+	require.Contains(t, matched, "core-switch-known")
+	assert.Equal(t, component.ID, matched["core-switch-known"].ID)
+	require.Len(t, drifts, 1)
+	assert.Equal(t, model.DriftTypeMissingInExpected, drifts[0].DriftType)
+	require.NotNil(t, drifts[0].ExternalID)
+	assert.Equal(t, "core-switch-unknown", *drifts[0].ExternalID)
+}
+
+func TestReconcileLinkedActualComponentsInvalidMixedSnapshotIsNotApplied(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	component := createLinkedTestComponent(
+		t,
+		ctx,
+		pool,
+		devicetypes.ComponentTypeNVSwitch,
+		"aa:bb:cc:dd:ee:40",
+		strPtr("old-switch-id"),
+	)
+	expected, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeNVSwitch)
+	require.NoError(t, err)
+
+	received, matched, drifts, ok := reconcileActualControllerDevices(
+		ctx,
+		pool,
+		"NVSwitch",
+		expected,
+		[]actualControllerDevice{
+			{controllerMAC: "aa:bb:cc:dd:ee:40", externalID: "new-switch-id"},
+			{controllerMAC: "not-a-mac", externalID: "invalid-switch-id"},
+		},
+	)
+
+	assert.False(t, ok)
+	assert.Zero(t, received)
+	assert.Nil(t, matched)
+	assert.Nil(t, drifts)
+	persisted := loadLinkedTestComponent(t, ctx, pool, component.ID)
+	require.NotNil(t, persisted.ComponentID)
+	assert.Equal(t, "old-switch-id", *persisted.ComponentID)
+}
+
+func TestReconcileLinkedActualComponentsInvalidHostControllerCountsAreActionable(t *testing.T) {
+	testCases := []struct {
+		name string
+		bmcs []model.BMC
+	}{
+		{
+			name: "no Host controller",
+			bmcs: []model.BMC{{
+				MacAddress: "aa:bb:cc:dd:ee:50",
+				Type:       devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU),
+			}},
+		},
+		{
+			name: "multiple Host controllers",
+			bmcs: []model.BMC{
+				{MacAddress: "aa:bb:cc:dd:ee:51", Type: devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)},
+				{MacAddress: "aa:bb:cc:dd:ee:52", Type: devicetypes.BMCTypeToString(devicetypes.BMCTypeHost)},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, pool := mirrorTestPool(t)
+			component := model.Component{
+				Type:         devicetypes.ComponentTypeToString(devicetypes.ComponentTypeNVSwitch),
+				Manufacturer: "TestMfg",
+				SerialNumber: uuid.NewString(),
+				ComponentID:  strPtr("stale-switch-id"),
+			}
+			require.NoError(t, component.Create(ctx, pool.DB))
+			for _, bmc := range tc.bmcs {
+				bmc.ComponentID = component.ID
+				_, err := pool.DB.NewInsert().Model(&bmc).Exec(ctx)
+				require.NoError(t, err)
+			}
+			expected, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeNVSwitch)
+			require.NoError(t, err)
+
+			_, matched, drifts, ok := reconcileActualControllerDevices(
+				ctx,
+				pool,
+				"NVSwitch",
+				expected,
+				nil,
+			)
+
+			require.True(t, ok)
+			assert.Empty(t, matched)
+			require.Len(t, drifts, 1)
+			assert.Equal(t, model.DriftTypeMissingInActual, drifts[0].DriftType)
+			assert.Nil(t, loadLinkedTestComponent(t, ctx, pool, component.ID).ComponentID)
+		})
+	}
+}
+
+func createLinkedTestComponent(
+	t *testing.T,
+	ctx context.Context,
+	pool *cdb.Session,
+	componentType devicetypes.ComponentType,
+	controllerMAC string,
+	externalID *string,
+) model.Component {
+	t.Helper()
+	component := model.Component{
+		Type:         devicetypes.ComponentTypeToString(componentType),
+		Manufacturer: "TestMfg",
+		SerialNumber: uuid.NewString(),
+		ComponentID:  externalID,
+	}
+	require.NoError(t, component.Create(ctx, pool.DB))
+	insertLinkedTestBMC(t, ctx, pool, component.ID, controllerMAC, devicetypes.BMCTypeHost)
+	return component
+}
+
+func insertLinkedTestBMC(
+	t *testing.T,
+	ctx context.Context,
+	pool *cdb.Session,
+	componentID uuid.UUID,
+	mac string,
+	bmcType devicetypes.BMCType,
+) {
+	t.Helper()
+	bmc := model.BMC{
+		MacAddress:  mac,
+		Type:        devicetypes.BMCTypeToString(bmcType),
+		ComponentID: componentID,
+	}
+	_, err := pool.DB.NewInsert().Model(&bmc).Exec(ctx)
+	require.NoError(t, err)
+}
+
+func loadLinkedTestComponent(
+	t *testing.T,
+	ctx context.Context,
+	pool *cdb.Session,
+	componentID uuid.UUID,
+) model.Component {
+	t.Helper()
+	var component model.Component
+	require.NoError(t, pool.DB.NewSelect().Model(&component).Where("id = ?", componentID).Scan(ctx))
+	return component
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_linked_component_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_linked_component_test.go
@@ -224,6 +224,138 @@ func TestReconcileLinkedActualComponentsMixedUnknownActual(t *testing.T) {
 	assert.Equal(t, "core-switch-unknown", *drifts[0].ExternalID)
 }
 
+func TestReconcileLinkedActualComponentsSwapsExternalIDs(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	first := createLinkedTestComponent(
+		t,
+		ctx,
+		pool,
+		devicetypes.ComponentTypeNVSwitch,
+		"aa:bb:cc:dd:ee:32",
+		strPtr("core-switch-first"),
+	)
+	second := createLinkedTestComponent(
+		t,
+		ctx,
+		pool,
+		devicetypes.ComponentTypeNVSwitch,
+		"aa:bb:cc:dd:ee:33",
+		strPtr("core-switch-second"),
+	)
+	expected, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeNVSwitch)
+	require.NoError(t, err)
+
+	_, matched, drifts, ok := reconcileActualControllerDevices(
+		ctx,
+		pool,
+		"NVSwitch",
+		expected,
+		[]actualControllerDevice{
+			{controllerMAC: "aa:bb:cc:dd:ee:32", externalID: "core-switch-second"},
+			{controllerMAC: "aa:bb:cc:dd:ee:33", externalID: "core-switch-first"},
+		},
+	)
+
+	require.True(t, ok)
+	assert.Empty(t, drifts)
+	assert.Equal(t, first.ID, matched["core-switch-second"].ID)
+	assert.Equal(t, second.ID, matched["core-switch-first"].ID)
+	assert.Equal(t, "core-switch-second", *loadLinkedTestComponent(t, ctx, pool, first.ID).ComponentID)
+	assert.Equal(t, "core-switch-first", *loadLinkedTestComponent(t, ctx, pool, second.ID).ComponentID)
+}
+
+func TestReconcileLinkedActualComponentsRejectsConflictingObservedIdentity(t *testing.T) {
+	testCases := []struct {
+		name     string
+		observed []actualControllerDevice
+	}{
+		{
+			name: "duplicate controller MAC",
+			observed: []actualControllerDevice{
+				{controllerMAC: "aa:bb:cc:dd:ee:34", externalID: "core-switch-new"},
+				{controllerMAC: "AA-BB-CC-DD-EE-34", externalID: "core-switch-conflict"},
+			},
+		},
+		{
+			name: "runtime ID mapped to multiple controller MACs",
+			observed: []actualControllerDevice{
+				{controllerMAC: "aa:bb:cc:dd:ee:34", externalID: "core-switch-new"},
+				{controllerMAC: "aa:bb:cc:dd:ee:35", externalID: "core-switch-new"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, pool := mirrorTestPool(t)
+			component := createLinkedTestComponent(
+				t,
+				ctx,
+				pool,
+				devicetypes.ComponentTypeNVSwitch,
+				"aa:bb:cc:dd:ee:34",
+				strPtr("core-switch-old"),
+			)
+			expected, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeNVSwitch)
+			require.NoError(t, err)
+
+			_, matched, drifts, ok := reconcileActualControllerDevices(
+				ctx,
+				pool,
+				"NVSwitch",
+				expected,
+				tc.observed,
+			)
+
+			assert.False(t, ok)
+			assert.Nil(t, matched)
+			assert.Nil(t, drifts)
+			persisted := loadLinkedTestComponent(t, ctx, pool, component.ID)
+			require.NotNil(t, persisted.ComponentID)
+			assert.Equal(t, "core-switch-old", *persisted.ComponentID)
+		})
+	}
+}
+
+func TestReconcileLinkedActualComponentsReportsAmbiguousExpectedIdentity(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	first := createLinkedTestComponent(
+		t,
+		ctx,
+		pool,
+		devicetypes.ComponentTypeNVSwitch,
+		"aa:bb:cc:dd:ee:36",
+		strPtr("core-switch-first"),
+	)
+	second := createLinkedTestComponent(
+		t,
+		ctx,
+		pool,
+		devicetypes.ComponentTypeNVSwitch,
+		"AA-BB-CC-DD-EE-36",
+		strPtr("core-switch-second"),
+	)
+	expected, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeNVSwitch)
+	require.NoError(t, err)
+
+	_, matched, drifts, ok := reconcileActualControllerDevices(
+		ctx,
+		pool,
+		"NVSwitch",
+		expected,
+		[]actualControllerDevice{{controllerMAC: "aa:bb:cc:dd:ee:36", externalID: "core-switch-observed"}},
+	)
+
+	require.True(t, ok)
+	assert.Empty(t, matched)
+	require.Len(t, drifts, 3)
+	assert.Equal(t, model.DriftTypeMissingInActual, drifts[0].DriftType)
+	assert.Equal(t, model.DriftTypeMissingInActual, drifts[1].DriftType)
+	assert.Equal(t, model.DriftTypeMissingInExpected, drifts[2].DriftType)
+	assert.Nil(t, loadLinkedTestComponent(t, ctx, pool, first.ID).ComponentID)
+	assert.Nil(t, loadLinkedTestComponent(t, ctx, pool, second.ID).ComponentID)
+}
+
 func TestReconcileLinkedActualComponentsInvalidMixedSnapshotIsNotApplied(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 	component := createLinkedTestComponent(

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_powershelf.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_powershelf.go
@@ -5,13 +5,10 @@ package inventorysync
 
 import (
 	"context"
-	"net"
-	"time"
 
 	"github.com/rs/zerolog/log"
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/utils"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -26,17 +23,17 @@ import (
 // Uses Core's NICo API. Core's PSM backend auto-registers power shelves, so no
 // registration step is needed.
 //
-// NICo API calls (2 round-trips):
-//   - GetAllExpectedPowerShelvesLinked: discover Core power shelf IDs by PMC MAC
+// Primary NICo API calls:
+//   - GetPowerShelves: list every active Core power shelf and its BMC MAC
 //   - GetComponentInventory: get firmware, power state from site explorer
 //
 // Flow:
 //  1. DB: get all PowerShelf components with PMCs
-//  2. NICo GetAllExpectedPowerShelvesLinked: map PMC MAC → Core PowerShelfId
-//  3. Direct-write external_id (Core's PowerShelfId) for matched components
+//  2. NICo GetPowerShelves: map PMC MAC → Core PowerShelfId
+//  3. Transactionally converge external_id from this snapshot
 //  4. NICo GetComponentInventory: extract firmware_version, power_state
 //  5. Direct-write inventory fields to DB
-//  6. Return drifts (missing_in_actual for components without a Core PowerShelfId)
+//  6. Return current-snapshot drifts in both directions
 func syncPowershelvesNICo(
 	ctx context.Context,
 	pool *cdb.Session,
@@ -50,62 +47,29 @@ func syncPowershelvesNICo(
 		return 0, nil, false
 	}
 
-	if len(expectedPowershelves) == 0 {
-		return 0, nil, true
-	}
-
-	expectedByPmcMac := make(map[string]*model.Component)
-	for i := range expectedPowershelves {
-		ps := &expectedPowershelves[i]
-		if len(ps.BMCs) != 1 {
-			log.Error().Msgf("Powershelf %s has %d BMCs, expected exactly 1; skipping", ps.SerialNumber, len(ps.BMCs))
-			continue
-		}
-		pmcMacAddr, err := net.ParseMAC(ps.BMCs[0].MacAddress)
-		if err != nil || pmcMacAddr == nil {
-			log.Error().Msgf("Powershelf %s has invalid BMC MAC address %s; skipping", ps.SerialNumber, ps.BMCs[0].MacAddress)
-			continue
-		}
-		expectedByPmcMac[pmcMacAddr.String()] = ps
-	}
-
-	// ID discovery: map PMC MAC → Core PowerShelfId
-	linked, err := nicoClient.GetAllExpectedPowerShelvesLinked(ctx)
+	// Actual snapshot: map PMC MAC → Core PowerShelfId.
+	observed, err := nicoClient.GetPowerShelves(ctx)
 	if err != nil {
-		log.Error().Msgf("Unable to retrieve linked expected power shelves from NICo: %v", err)
+		log.Error().Msgf("Unable to retrieve active power shelves from NICo: %v", err)
 		return 0, nil, false
 	}
-	received = len(linked)
-
-	linkedByMac := make(map[string]nicoapi.LinkedExpectedPowerShelf)
-	for _, leps := range linked {
-		if leps.BMCMACAddress != "" {
-			linkedByMac[utils.NormalizeMAC(leps.BMCMACAddress)] = leps
-		}
+	linkedActual := make([]actualControllerDevice, 0, len(observed))
+	for _, shelf := range observed {
+		linkedActual = append(linkedActual, actualControllerDevice{
+			controllerMAC: shelf.BmcMac,
+			externalID:    shelf.ID,
+		})
+	}
+	received, componentsByShelfID, drifts, reconcileOK := reconcileActualControllerDevices(
+		ctx, pool, "PowerShelf", expectedPowershelves, linkedActual,
+	)
+	if !reconcileOK {
+		return received, nil, false
 	}
 
-	// Direct-write external_id for matched components
-	var shelfIDs []*corev1.PowerShelfId
-	componentsByShelfID := make(map[string]*model.Component)
-
-	for pmcMac, ps := range expectedByPmcMac {
-		leps, found := linkedByMac[pmcMac]
-		if !found || leps.PowerShelfID == "" {
-			continue
-		}
-
-		if ps.ComponentID == nil || *ps.ComponentID != leps.PowerShelfID {
-			shelfID := leps.PowerShelfID
-			ps.ComponentID = &shelfID
-			if err := ps.Patch(ctx, pool.DB); err != nil {
-				log.Error().Msgf("Powershelf %s (PMC %s): unable to update external_id: %v", ps.ID, pmcMac, err)
-				continue
-			}
-			log.Info().Msgf("Powershelf %s (PMC %s): set external_id to Core PowerShelfId %s", ps.ID, pmcMac, shelfID)
-		}
-
-		shelfIDs = append(shelfIDs, &corev1.PowerShelfId{Id: leps.PowerShelfID})
-		componentsByShelfID[leps.PowerShelfID] = ps
+	shelfIDs := make([]*corev1.PowerShelfId, 0, len(componentsByShelfID))
+	for shelfID := range componentsByShelfID {
+		shelfIDs = append(shelfIDs, &corev1.PowerShelfId{Id: shelfID})
 	}
 
 	// Fetch inventory from Core for all matched power shelves. Inventory only
@@ -127,21 +91,6 @@ func syncPowershelvesNICo(
 	}
 
 	syncPowershelfStatuses(ctx, pool, nicoClient, componentsByShelfID)
-
-	// Build drifts for components that don't have a Core PowerShelfId yet
-	now := time.Now()
-	for _, ps := range expectedByPmcMac {
-		if ps.ComponentID == nil || *ps.ComponentID == "" {
-			compID := ps.ID
-			drifts = append(drifts, model.ComponentDrift{
-				ComponentID: &compID,
-				ExternalID:  nil,
-				DriftType:   model.DriftTypeMissingInActual,
-				Diffs:       []model.FieldDiff{},
-				CheckedAt:   now,
-			})
-		}
-	}
 
 	log.Info().Msgf("Powershelf NICo sync: %d drift(s) out of %d expected", len(drifts), len(expectedPowershelves))
 	return received, drifts, true

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_switch.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_switch.go
@@ -5,13 +5,10 @@ package inventorysync
 
 import (
 	"context"
-	"net"
-	"time"
 
 	"github.com/rs/zerolog/log"
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/utils"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -31,17 +28,17 @@ const nvosIPDescriptionKey = "nvos_ip"
 // Uses Core's NICo API. Core's NSM backend auto-registers switches, so no
 // registration step is needed.
 //
-// NICo API calls (2 round-trips):
-//   - GetAllExpectedSwitchesLinked: discover Core switch IDs by BMC MAC
+// Primary NICo API calls:
+//   - GetSwitches: list every active Core switch and its BMC MAC
 //   - GetComponentInventory: get firmware, serial, power state from site explorer
 //
 // Flow:
 //  1. DB: get all NVSwitch components with BMCs
-//  2. NICo GetAllExpectedSwitchesLinked: map BMC MAC → Core SwitchId
-//  3. Direct-write external_id (Core's SwitchId) for matched components
+//  2. NICo GetSwitches: map BMC MAC → Core SwitchId
+//  3. Transactionally converge external_id from this snapshot
 //  4. NICo GetComponentInventory: extract firmware_version, serial_number, power_state
 //  5. Direct-write inventory fields to DB
-//  6. Return drifts (missing_in_actual for components without a Core SwitchId)
+//  6. Return current-snapshot drifts in both directions
 func syncNVSwitchesNICo(
 	ctx context.Context,
 	pool *cdb.Session,
@@ -55,62 +52,29 @@ func syncNVSwitchesNICo(
 		return 0, nil, false
 	}
 
-	if len(expectedSwitches) == 0 {
-		return 0, nil, true
-	}
-
-	expectedByBmcMac := make(map[string]*model.Component)
-	for i := range expectedSwitches {
-		sw := &expectedSwitches[i]
-		if len(sw.BMCs) != 1 {
-			log.Error().Msgf("NVSwitch %s has %d BMCs, expected exactly 1; skipping", sw.SerialNumber, len(sw.BMCs))
-			continue
-		}
-		bmcMacAddr, err := net.ParseMAC(sw.BMCs[0].MacAddress)
-		if err != nil || bmcMacAddr == nil {
-			log.Error().Msgf("NVSwitch %s has invalid BMC MAC address %s; skipping", sw.SerialNumber, sw.BMCs[0].MacAddress)
-			continue
-		}
-		expectedByBmcMac[bmcMacAddr.String()] = sw
-	}
-
-	// ID discovery: map BMC MAC → Core SwitchId
-	linked, err := nicoClient.GetAllExpectedSwitchesLinked(ctx)
+	// Actual snapshot: map BMC MAC → Core SwitchId.
+	observed, err := nicoClient.GetSwitches(ctx)
 	if err != nil {
-		log.Error().Msgf("Unable to retrieve linked expected switches from NICo: %v", err)
+		log.Error().Msgf("Unable to retrieve active switches from NICo: %v", err)
 		return 0, nil, false
 	}
-	received = len(linked)
-
-	linkedByMac := make(map[string]nicoapi.LinkedExpectedSwitch)
-	for _, les := range linked {
-		if les.BMCMACAddress != "" {
-			linkedByMac[utils.NormalizeMAC(les.BMCMACAddress)] = les
-		}
+	linkedActual := make([]actualControllerDevice, 0, len(observed))
+	for _, sw := range observed {
+		linkedActual = append(linkedActual, actualControllerDevice{
+			controllerMAC: sw.BmcMac,
+			externalID:    sw.ID,
+		})
+	}
+	received, componentsBySwitchID, drifts, reconcileOK := reconcileActualControllerDevices(
+		ctx, pool, "NVSwitch", expectedSwitches, linkedActual,
+	)
+	if !reconcileOK {
+		return received, nil, false
 	}
 
-	// Direct-write external_id for matched components
-	var switchIDs []*corev1.SwitchId
-	componentsBySwitchID := make(map[string]*model.Component)
-
-	for bmcMac, sw := range expectedByBmcMac {
-		les, found := linkedByMac[bmcMac]
-		if !found || les.SwitchID == "" {
-			continue
-		}
-
-		if sw.ComponentID == nil || *sw.ComponentID != les.SwitchID {
-			switchID := les.SwitchID
-			sw.ComponentID = &switchID
-			if err := sw.Patch(ctx, pool.DB); err != nil {
-				log.Error().Msgf("NVSwitch %s (BMC %s): unable to update external_id: %v", sw.ID, bmcMac, err)
-				continue
-			}
-			log.Info().Msgf("NVSwitch %s (BMC %s): set external_id to Core SwitchId %s", sw.ID, bmcMac, switchID)
-		}
-
-		switchIDs = append(switchIDs, &corev1.SwitchId{Id: les.SwitchID})
-		componentsBySwitchID[les.SwitchID] = sw
+	switchIDs := make([]*corev1.SwitchId, 0, len(componentsBySwitchID))
+	for switchID := range componentsBySwitchID {
+		switchIDs = append(switchIDs, &corev1.SwitchId{Id: switchID})
 	}
 
 	// Fetch inventory from Core for all matched switches. Inventory only feeds
@@ -134,21 +98,6 @@ func syncNVSwitchesNICo(
 	syncSwitchStatuses(ctx, pool, nicoClient, componentsBySwitchID)
 
 	syncSwitchNvosIPs(ctx, pool, nicoClient, componentsBySwitchID)
-
-	// Build drifts for components that don't have a Core SwitchId yet
-	now := time.Now()
-	for _, sw := range expectedByBmcMac {
-		if sw.ComponentID == nil || *sw.ComponentID == "" {
-			compID := sw.ID
-			drifts = append(drifts, model.ComponentDrift{
-				ComponentID: &compID,
-				ExternalID:  nil,
-				DriftType:   model.DriftTypeMissingInActual,
-				Diffs:       []model.FieldDiff{},
-				CheckedAt:   now,
-			})
-		}
-	}
 
 	log.Info().Msgf("NVSwitch NICo sync: %d drift(s) out of %d expected", len(drifts), len(expectedSwitches))
 	return received, drifts, true

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory.go
@@ -42,10 +42,11 @@ import (
 //     half — see actual_sync*.go).
 //  3. The drift set replaces the whole component_drift table atomically so
 //     stale rows from previous runs can't linger. The replace is skipped
-//     when any actual-sync RPC failed: component_drift is a full-table
-//     replace with no per-type discriminator, so writing a partial view
-//     would wipe the drifts of the types whose RPC failed. The existing
-//     table is left intact until a fully successful cycle refreshes it.
+//     when any actual-sync snapshot or reconciliation failed:
+//     component_drift is a full-table replace with no per-type discriminator,
+//     so writing a partial view would wipe the drifts of the failed types. The
+//     existing table is left intact until a fully successful cycle refreshes
+//     it.
 //
 // Errors are handled inside each step: any per-type RPC failure is logged
 // and that type's drifts are skipped, but the rest of the cycle continues.
@@ -63,10 +64,10 @@ func runInventoryOne(
 		log.Debug().Msgf("Expected-inventory mirror: skipped this cycle (gate %s is off)", envExpectedSyncEnabled)
 	}
 
-	drifts, allRPCOK := runActualSync(ctx, pool, nicoClient)
-	if !allRPCOK {
+	drifts, allSyncOK := runActualSync(ctx, pool, nicoClient)
+	if !allSyncOK {
 		log.Warn().Int("drifts_this_cycle", len(drifts)).
-			Msg("Drift detection: one or more actual-sync RPCs failed; preserving existing component_drift table this cycle instead of overwriting it with a partial view")
+			Msg("Drift detection: one or more actual-sync snapshots or reconciliations failed; preserving existing component_drift table this cycle instead of overwriting it with a partial view")
 		return
 	}
 


### PR DESCRIPTION
Flow's switch and power-shelf actual sync treated a persisted Core runtime ID as proof that a device matched in the current cycle. When a device disappeared, the stale ID suppressed `missing_in_actual`; when an ID update failed, the in-memory mutation could also make an uncommitted link look successful. The sync additionally returned before querying Core whenever Flow's expected set was empty, so untracked actual devices were invisible.

This change reads complete active switch and power-shelf snapshots through `Find*Ids` followed by the existing batched and completeness-checked `Find*ByIds` client. ID discovery and detail lookup receive independent RPC timeout scopes so the first call cannot starve the second. Flow matches the snapshot by the single authoritative Host BMC controller while allowing auxiliary non-Host BMCs, transactionally converges runtime external IDs with checked affected-row counts, and derives both `missing_in_actual` and `missing_in_expected` from current-cycle matches. Invalid or incomplete Core snapshots and persistence failures preserve the previous drift table instead of applying a partial view.

## Related issues

Fixes #4358

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes 
