### PR TITLE
fix(admin-ui): correct rack IDs and created-state duration

### DIFF
--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -133,13 +133,14 @@ pub async fn create(
         name => name.to_string(),
     };
     let version = ConfigVersion::initial();
-    let query = "INSERT INTO racks(id, rack_profile_id, config, controller_state, controller_state_outcome, name, description, labels, version)
-            VALUES($1, $2, $3::json, $4::json, $5::json, $6, $7, $8::jsonb, $9) RETURNING *";
+    let query = "INSERT INTO racks(id, rack_profile_id, config, controller_state, controller_state_version, controller_state_outcome, name, description, labels, version)
+            VALUES($1, $2, $3::json, $4::json, $5, $6::json, $7, $8, $9::jsonb, $10) RETURNING *";
     let rack: Rack = sqlx::query_as(query)
         .bind(rack_id)
         .bind(rack_profile_id)
         .bind(sqlx::types::Json(config))
         .bind(controller_state)
+        .bind(version)
         .bind(controller_state_outcome)
         .bind(name)
         .bind(&src_metadata.description)

--- a/crates/api-db/src/rack/test_metadata.rs
+++ b/crates/api-db/src/rack/test_metadata.rs
@@ -41,6 +41,7 @@ async fn test_rack_metadata_defaults(pool: sqlx::PgPool) -> Result<(), Box<dyn s
     assert_eq!(rack.metadata.description, "");
     assert!(rack.metadata.labels.is_empty());
     assert_eq!(rack.version.version_nr(), 1);
+    assert_eq!(rack.controller_state.version, rack.version);
 
     txn.rollback().await?;
     Ok(())

--- a/crates/api-web/src/filters.rs
+++ b/crates/api-web/src/filters.rs
@@ -79,12 +79,25 @@ fn escaped_shortened_id_link(id: impl Display, path: impl Display) -> ::askama::
     let mut escaped_id = String::new();
     askama_escape::Html.write_escaped(&mut escaped_id, &id)?;
 
-    let short_id = &escaped_id[escaped_id.len().saturating_sub(6)..];
+    if id.chars().count() <= 6 {
+        return Ok(format!(
+            r#"<a href="/admin/{path}/{link_path}">{escaped_id}</a>"#
+        ));
+    }
+
+    let short_id = id
+        .char_indices()
+        .rev()
+        .nth(5)
+        .map(|(index, _)| &id[index..])
+        .unwrap_or(&id);
+    let mut escaped_short_id = String::new();
+    askama_escape::Html.write_escaped(&mut escaped_short_id, short_id)?;
     let formatted = format!(
         r#"
     <a href="/admin/{path}/{link_path}">
         <div class="machine_id">
-            <div>{escaped_id}</div><div>{short_id}</div>
+            <div>{escaped_id}</div><div>{escaped_short_id}</div>
         </div>
     </a>"#
     );
@@ -463,7 +476,82 @@ pub(super) fn controller_state_reason_fmt(
 mod tests {
     use carbide_test_support::{Check, check_values};
 
-    use super::format_json;
+    use super::{escaped_shortened_id_link, format_json};
+
+    #[test]
+    fn shortened_id_links_render_exact_output() {
+        check_values(
+            [
+                Check {
+                    scenario: "short ID",
+                    input: "a12",
+                    expect: r#"<a href="/admin/rack/a12">a12</a>"#.to_string(),
+                },
+                Check {
+                    scenario: "long ASCII ID",
+                    input: "rack-a12",
+                    expect: concat!(
+                        "\n    <a href=\"/admin/rack/rack-a12\">\n",
+                        "        <div class=\"machine_id\">\n",
+                        "            <div>rack-a12</div><div>ck-a12</div>\n",
+                        "        </div>\n",
+                        "    </a>"
+                    )
+                    .to_string(),
+                },
+                Check {
+                    scenario: "six accented characters",
+                    input: "áéíóúñ",
+                    expect: concat!(
+                        "<a href=\"/admin/rack/",
+                        "%C3%A1%C3%A9%C3%AD%C3%B3%C3%BA%C3%B1",
+                        "\">áéíóúñ</a>"
+                    )
+                    .to_string(),
+                },
+                Check {
+                    scenario: "seven accented characters",
+                    input: "áéíóúñü",
+                    expect: concat!(
+                        "\n    <a href=\"/admin/rack/",
+                        "%C3%A1%C3%A9%C3%AD%C3%B3%C3%BA%C3%B1%C3%BC",
+                        "\">\n",
+                        "        <div class=\"machine_id\">\n",
+                        "            <div>áéíóúñü</div><div>éíóúñü</div>\n",
+                        "        </div>\n",
+                        "    </a>"
+                    )
+                    .to_string(),
+                },
+                Check {
+                    scenario: "Unicode suffix",
+                    input: "rack-abcdeå",
+                    expect: concat!(
+                        "\n    <a href=\"/admin/rack/rack-abcde%C3%A5\">\n",
+                        "        <div class=\"machine_id\">\n",
+                        "            <div>rack-abcdeå</div><div>abcdeå</div>\n",
+                        "        </div>\n",
+                        "    </a>"
+                    )
+                    .to_string(),
+                },
+                Check {
+                    scenario: "HTML metacharacters",
+                    input: "rack-<&abcd",
+                    expect: concat!(
+                        "\n    <a href=\"/admin/rack/rack-%3C%26abcd\">\n",
+                        "        <div class=\"machine_id\">\n",
+                        "            <div>rack-&#60;&#38;abcd</div>",
+                        "<div>&#60;&#38;abcd</div>\n",
+                        "        </div>\n",
+                        "    </a>"
+                    )
+                    .to_string(),
+                },
+            ],
+            |id| escaped_shortened_id_link(id, "rack").unwrap(),
+        );
+    }
 
     #[test]
     fn pretty_json_preserves_values_and_fallbacks() {


### PR DESCRIPTION
Short rack identifiers such as `a12` were rendered as both the full ID and the six-character suffix, producing `a12a12` in the managed and expected rack views. Rack creation also left `controller_state_version` on the stale schema default, which made the Created-state duration incorrect for new racks.

Render short identifiers once and initialize the rack state and resource versions from the same value at creation. This change does not add a migration or modify existing rack records.

## Related issues

Bug: 6575436

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
