### PR TITLE
fix(host-support): query flint per device and keep only BlueField

### DIFF
--- a/crates/host-support/src/hardware_enumeration/dpu.rs
+++ b/crates/host-support/src/hardware_enumeration/dpu.rs
@@ -29,19 +29,51 @@ pub enum DpuEnumerationError {
     Cmd(#[from] CmdError),
     #[error("DPU enumeration failed reading '{0}': {1}")]
     Read(&'static str, String),
+    #[error("no BlueField device found under /dev/mst")]
+    NoBlueField,
 }
 
 fn get_flint_query() -> Result<String, DpuEnumerationError> {
     if cfg!(test) {
         const TEST_DATA: &str = "test/flint_query.txt";
-        std::fs::read_to_string(TEST_DATA)
-            .map_err(|x| DpuEnumerationError::Read(TEST_DATA, x.to_string()))
-    } else {
-        Cmd::new("bash")
-            .args(vec!["-c", "flint -d /dev/mst/mt*_pciconf0 q full"])
-            .output()
-            .map_err(DpuEnumerationError::from)
+        return std::fs::read_to_string(TEST_DATA)
+            .map_err(|x| DpuEnumerationError::Read(TEST_DATA, x.to_string()));
     }
+
+    // Query each mst device on its own and keep only the BlueField ones,
+    // stopping at the first match since the parser below takes the first
+    // occurrence of each field regardless.
+    //
+    // Exiting non-zero when nothing could be queried is what keeps the two
+    // failures apart. `flint` missing, the mst driver not started, and
+    // /dev/mst unreadable all yield no output, and reporting those as "this
+    // host has no BlueField" would send diagnosis after the wrong thing. Only
+    // an empty result from devices that did answer means that.
+    const FLINT_QUERY: &str = r#"
+shopt -s nullglob
+queried=0
+for dev in /dev/mst/*_pciconf0; do
+    if out=$(flint -d "$dev" q full 2>&1); then
+        queried=1
+        if echo "$out" | grep -q "Description:.*BlueField"; then
+            echo "$out"
+            exit 0
+        fi
+    else
+        echo "$dev: $out" >&2
+    fi
+done
+[ "$queried" -eq 1 ] || exit 1
+"#;
+    let output = Cmd::new("bash").args(vec!["-c", FLINT_QUERY]).output()?;
+
+    // Devices answered and none of them is a BlueField. Reported here rather
+    // than left to the field parsing below, which would blame the empty output
+    // on a missing firmware version.
+    if output.trim().is_empty() {
+        return Err(DpuEnumerationError::NoBlueField);
+    }
+    Ok(output)
 }
 
 pub fn get_dpu_info() -> Result<DpuData, DpuEnumerationError> {


### PR DESCRIPTION
`flint -d /dev/mst/mt*_pciconf0 q full` passes the whole glob expansion to a flag that takes one device, so flint queries whichever device the glob expanded first. A host exposes non-DPU devices under `/dev/mst` too, and they sort ahead of the BlueField on some hosts, so the fields parsed out of the output could describe a ConnectX NIC rather than the DPU.

This queries each device separately and keeps the first whose description says BlueField, stopping there since the parser takes the first occurrence of each field regardless.

Finding no BlueField is now its own error rather than surfacing as a missing firmware version, and is kept distinct from being unable to ask: `flint` missing, the mst driver not started, and `/dev/mst` unreadable all produce no output too, so the loop exits non-zero and passes flint's own message through when no device answered at all.

## Related issues

None filed.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The shell loop was exercised against a stub `flint` covering: a NIC sorting ahead of a BlueField (BlueField reported), devices that answer but none BlueField (empty output, exit 0, `NoBlueField`), flint failing per device (exit 1, flint's message on stderr), flint not installed (exit 1), and an empty `/dev/mst` (exit 1). Existing unit tests read the `test/flint_query.txt` fixture and do not reach the command.
