### PR TITLE
feat(security): onboard the central security scanning surfaces

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Security Suite (Pulse + CodeQL)
+
+on:
+  push:
+    branches:
+      - main
+      - "pull-request/[0-9]+"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Mirrors the Core CI policy in ci.yaml.
+concurrency:
+  group: ${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') && format('security-pr-{0}', github.ref_name) || format('security-run-{0}-{1}', github.run_id, github.run_attempt) }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') }}
+
+jobs:
+  security-suite:
+    name: Security Suite
+    # Forks have no nv-gha-runners grant, so Pulse cannot reach Vault or nvcr.io there.
+    if: github.repository == 'NVIDIA/infra-controller'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write  # OIDC -> Vault -> nvcr.io
+      security-events: write
+    uses: NVIDIA/security-workflows/.github/workflows/security-suite.yml@c736f0454dc99764a66af6b906adfcdfbf621985  # v0.4.0
+    with:
+      enable-secret-scan: true
+      enable-sast-scan: true
+      # The only scan needing a self-hosted runner; CodeQL keeps the hosted default.
+      secret-runs-on: linux-amd64-cpu4
+      # Set failure_policy explicitly so enforcement can't drift with upstream defaults.
+      #   unverified — fail on verified/live secrets (183); warn on unverified (185)  [default]
+      #   strict     — fail on any finding (verified or unverified)
+      #   all        — warn only; never fail the job on findings
+      secret-failure-policy: unverified
+      sast-languages: '["actions","python","rust"]'

--- a/.gitignore
+++ b/.gitignore
@@ -66,9 +66,6 @@ devenv.local.yaml
 # direnv
 .direnv
 
-# pre-commit
-.pre-commit-config.yaml
-
 # Trust anchor the dpu-agent mirrors for key-less consumers (issue #355). The
 # agent tests point `[forge-system] root-ca` at dev/certs/forge_root.pem, so
 # running them publishes a copy beside it. Runtime artifact, never committed.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# One hook on purpose: the workspace's own pre-commit checks are cargo-make tasks
+# (`cargo make pre-commit-verify-workspace`). Enforcement is the Pulse scan in
+# .github/workflows/security-suite.yml.
+
+repos:
+  - repo: https://github.com/NVIDIA/security-workflows
+    rev: c736f0454dc99764a66af6b906adfcdfbf621985  # frozen: v0.4.0
+    hooks:
+      - id: secret-scan-trufflehog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ We welcome contributions of all sizes — from fixing a typo in the docs to addi
 - [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
 - [Cryptographic Commit Signatures](#cryptographic-commit-signatures)
 - [Fork and Setup](#fork-and-setup)
+- [Secret Scanning](#secret-scanning)
 - [Contribution Process](#contribution-process)
 - [Engineering Guidelines](#engineering-guidelines)
 - [Pull Request Guidelines](#pull-request-guidelines)
@@ -191,6 +192,25 @@ Use descriptive branch names like:
 - `feature/add-new-api`
 - `fix/resolve-dhcp-issue`
 - `docs/update-readme`
+
+## Secret Scanning
+
+Credentials are the one class of mistake that a later commit cannot take back, so this repository scans for them locally as well as in CI.
+The [`.pre-commit-config.yaml`](.pre-commit-config.yaml) at the repository root declares a single hook, `secret-scan-trufflehog`, from [`NVIDIA/security-workflows`](https://github.com/NVIDIA/security-workflows).
+
+It checks your staged files at `git commit` time:
+
+```bash
+pip install pre-commit   # or: brew install pre-commit
+pre-commit install
+```
+
+The hook installs its own pinned TruffleHog build into an isolated environment on first run, so there is no scanner to install separately, on Linux, macOS, or Windows.
+
+When the hook reports a finding, treat the credential as compromised — remove it *and* rotate it, because deleting the line leaves the value in your local history.
+
+This check is advisory and skippable (`git commit --no-verify`).
+The authoritative check is the Pulse secret scan in [`.github/workflows/security-suite.yml`](.github/workflows/security-suite.yml), which runs server-side on pushes to `main` and to the `pull-request/[0-9]+` mirror of your pull request, and fails on verified secrets.
 
 ## Contribution Process
 


### PR DESCRIPTION
Scan through NVIDIA/security-workflows instead of growing another per-repo scan implementation: a caller for the security suite (Pulse secret scan and CodeQL SAST, pinned to v0.4.0) plus the matching secret-scan-trufflehog pre-commit hook.

The hook is the first .pre-commit-config.yaml at the repository root. It declares one hook rather than mirroring the cargo-make checks, which stay where they are: a formatting miss is fixable in the next commit, a pushed credential is not. 

CONTRIBUTING.md covers the setup, what to do with a finding, and how this coexists with dev/pre-commit.example in the single .git/hooks/pre-commit slot.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

