### PR TITLE
fix: don't fail IB reset when KEEP_IB_LINK_UP_P1 is unsupported

### DIFF
--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -937,7 +937,8 @@ async fn set_ib_link_up() -> Result<(), CarbideClientError> {
                                 error = %e,
                                 "Failed to set KEEP_IB_LINK_UP_P1=1 on IB device",
                             );
-                            return Err(e);
+                            //Allow to pass error to support Nvidia ConnectX7 mezz for Nvidia B300 System
+                            //It has no appropriate FW and functionality.
                         }
                     }
                     // Set P2 (optional - only dual-port devices have P2)
@@ -996,7 +997,8 @@ async fn reset_ib_devices() -> Result<(), CarbideClientError> {
                                 error = %e,
                                 "Failed to reset IB device",
                             );
-                            return Err(e);
+                            //Allow to pass error to support Nvidia ConnectX7 mezz for Nvidia B300 System
+                            //It has no appropriate FW and functionality.
                         }
                     }
                 }


### PR DESCRIPTION
don't fail IB reset when KEEP_IB_LINK_UP_P1 is unsupported (ConvectX-7 mezz on B300)
## Related issues
[Add support for PowerEdge XE9780 platform](https://github.com/NVIDIA/infra-controller/issues/3227)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

