### PR TITLE
chore(machine-a-tron): acceleration factor in dev environments

### DIFF
--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -164,6 +164,8 @@ nico-machine-a-tron:
   # No need to copy secrets or configure cross-namespace access
   machineATron:
     nicoApiUrl: "https://nico-api.nico-system.svc.cluster.local:1079"
+  machineDefaults:
+    accelerationFactor: 0.01
   # Preserve simulated machine identity and installed OS across pod restarts.
   # Without this, Core can remain in an Assigned state while a restarted
   # machine-a-tron has reset the corresponding host and DPUs to MachineDown.

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -242,6 +242,7 @@ nico-machine-a-tron:
         ids = ["rack-001"]
         dpu_reboot_delay = 20
         host_reboot_delay = 10
+        acceleration_factor = 0.01
         discovery_retry_interval = "5s"
         oob_dhcp_relay_address = "192.168.192.1"
         admin_dhcp_relay_address = "192.168.176.1"
@@ -254,6 +255,7 @@ nico-machine-a-tron:
         dpu_per_host_count = 2
         dpu_reboot_delay = 1
         host_reboot_delay = 1
+        acceleration_factor = 0.01
         scout_run_interval = "60s"
         discovery_retry_interval = "5s"
         run_interval_working = "1s"

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -173,6 +173,7 @@ data:
     ids = {{ $section.ids | toJson }}
     dpu_reboot_delay = {{ $section.dpu_reboot_delay | default $defaults.dpuRebootDelay | int }}
     host_reboot_delay = {{ $section.host_reboot_delay | default $defaults.hostRebootDelay | int }}
+    acceleration_factor = {{ $section.acceleration_factor | default $defaults.accelerationFactor | default 1.0 }}
     discovery_retry_interval = {{ $section.discovery_retry_interval | default $defaults.discoveryRetryInterval | default "60s" | quote }}
     oob_dhcp_relay_address = {{ $section.oob_dhcp_relay_address | quote }}
     admin_dhcp_relay_address = {{ $section.admin_dhcp_relay_address | quote }}
@@ -191,6 +192,7 @@ data:
     dpu_per_host_count = {{ $section.dpuPerHostCount | default 0 }}
     dpu_reboot_delay = {{ $section.dpuRebootDelay | default $defaults.dpuRebootDelay | default 1 }}
     host_reboot_delay = {{ $section.hostRebootDelay | default $defaults.hostRebootDelay | default 1 }}
+    acceleration_factor = {{ $section.accelerationFactor | default $defaults.accelerationFactor | default 1.0 }}
     scout_run_interval = {{ $section.scoutRunInterval | default $defaults.scoutRunInterval | default "60s" | quote }}
     discovery_retry_interval = {{ $section.discoveryRetryInterval | default $defaults.discoveryRetryInterval | default "60s" | quote }}
     run_interval_working = {{ $section.runIntervalWorking | default $defaults.runIntervalWorking | default "1s" | quote }}

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -95,6 +95,7 @@ tests:
                 - rack-001
               dpu_reboot_delay: 20
               host_reboot_delay: 10
+              acceleration_factor: 0.03
               oob_dhcp_relay_address: 10.96.64.1
               admin_dhcp_relay_address: 192.168.176.1
     asserts:
@@ -104,6 +105,9 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: 'rack_profile_id = "NVL72"'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'acceleration_factor = 0\.03'
       - matchRegex:
           path: data["mat.toml"]
           pattern: '\[machines\]'
@@ -139,6 +143,7 @@ tests:
         runIntervalIdle: "30s"
         scoutRunInterval: "120s"
         discoveryRetryInterval: "7s"
+        accelerationFactor: 0.02
       pods:
         mat-0:
           machines:
@@ -155,6 +160,9 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: 'discovery_retry_interval = "7s"'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'acceleration_factor = 0\.02'
 
   - it: should not include enable_ipmi_simulation by default
     asserts:

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -181,6 +181,8 @@ machineDefaults:
   subnetsPerVpc: 0
   dpuRebootDelay: 1
   hostRebootDelay: 1
+  ## Positive multiplier applied after timing overrides. Default 1.0; values below 1 speed up the simulation.
+  accelerationFactor: 1.0
   scoutRunInterval: "60s"
   ## Delay after a failed DiscoverMachine call; the default matches the production DPU agent.
   discoveryRetryInterval: "60s"


### PR DESCRIPTION
Configure Tilt and DevSpace to run machine-a-tron lifecycle timings with `acceleration_factor = 0.01`.

Add Helm support for global and per-group acceleration settings. The chart default remains `1.0`, so non-development deployments are unchanged.

## Related issues

Follow-up to #5306

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
