### PR TITLE
fix(rest-api): defer unavailable expected machine links

### DIFF
--- a/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine.go
+++ b/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine.go
@@ -101,13 +101,43 @@ func (mei ManageExpectedMachine) UpdateExpectedMachinesInDB(ctx context.Context,
 		}
 	}
 
-	// Build a map of BmcMacAddress to linked Machine ID
-	linkedMachineByBmcMac := map[string]string{}
+	// Collect the linked Machine IDs reported by Core so they can be checked
+	// against REST inventory before Expected Machine reconciliation.
+	linkedMachineCandidatesByBmcMac := map[string]string{}
+	linkedMachineIDs := []string{}
 	for _, lm := range expectedMachineInventory.GetLinkedMachines() {
 		if lm == nil || lm.MachineId == nil || lm.BmcMacAddress == "" {
 			continue
 		}
-		linkedMachineByBmcMac[lm.BmcMacAddress] = lm.MachineId.Id
+		machineID := lm.MachineId.Id
+		if machineID == "" {
+			continue
+		}
+		linkedMachineCandidatesByBmcMac[lm.BmcMacAddress] = machineID
+		linkedMachineIDs = append(linkedMachineIDs, machineID)
+	}
+
+	linkedMachineByBmcMac := map[string]string{}
+	if len(linkedMachineIDs) > 0 {
+		mDAO := cdbm.NewMachineDAO(mei.dbSession)
+		machines, _, merr := mDAO.GetAll(ctx, nil, cdbm.MachineFilterInput{
+			MachineIDs:      linkedMachineIDs,
+			ExcludeMetadata: true,
+		}, cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if merr != nil {
+			logger.Error().Err(merr).Msg("failed to validate linked Machines against REST inventory")
+			return merr
+		}
+
+		existingMachineIDs := make(map[string]bool, len(machines))
+		for _, machine := range machines {
+			existingMachineIDs[machine.ID] = true
+		}
+		for bmcMacAddress, machineID := range linkedMachineCandidatesByBmcMac {
+			if existingMachineIDs[machineID] {
+				linkedMachineByBmcMac[bmcMacAddress] = machineID
+			}
+		}
 	}
 
 	// iterate over current page or all (single load) if paging disabled

--- a/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine.go
+++ b/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine.go
@@ -111,6 +111,7 @@ func (mei ManageExpectedMachine) UpdateExpectedMachinesInDB(ctx context.Context,
 		}
 		machineID := lm.MachineId.Id
 		if machineID == "" {
+			logger.Error().Str("BMC MAC", lm.BmcMacAddress).Msg("received linked Machine with empty ID, skipping")
 			continue
 		}
 		linkedMachineCandidatesByBmcMac[lm.BmcMacAddress] = machineID

--- a/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine_test.go
+++ b/rest-api/workflow/pkg/activity/expectedmachine/expectedmachine_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"go.temporal.io/sdk/testsuite"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -28,7 +27,6 @@ import (
 	cwu "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
-	cwutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
 
@@ -95,6 +93,7 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 	st := cwu.TestBuildSite(t, dbSession, ip, "test-site", cdbm.SiteStatusRegistered, nil, ipu)
 	st2 := cwu.TestBuildSite(t, dbSession, ip, "test-site-2", cdbm.SiteStatusRegistered, nil, ipu)
 	st3 := cwu.TestBuildSite(t, dbSession, ip, "test-site-3", cdbm.SiteStatusRegistered, nil, ipu)
+	st4 := cwu.TestBuildSite(t, dbSession, ip, "test-site-linked-machine", cdbm.SiteStatusRegistered, nil, ipu)
 
 	// Build ExpectedMachine inventory that is paginated
 	// Generate data for 34 ExpectedMachines reported from Site Agent while Cloud has 38 ExpectedMachines
@@ -126,8 +125,8 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 
 		// Update creation and update timestamp to be earlier than inventory processing interval
 		_, uerr := dbSession.DB.Exec("UPDATE expected_machine SET created = ?, updated = ? WHERE id = ?",
-			time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)),
-			time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)),
+			time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval*2)),
 			em.ID.String())
 		assert.NoError(t, uerr)
 
@@ -166,7 +165,8 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 		}
 
 		// Test label updates: add/modify labels for some machines
-		if i == 1 {
+		switch i {
+		case 1:
 			// Add labels to a machine that didn't have them before
 			ctrlExpectedMachine.Metadata = &corev1.Metadata{
 				Labels: []*corev1.Label{
@@ -174,7 +174,7 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 				},
 			}
 			expectedMachinesToUpdate = append(expectedMachinesToUpdate, pagedExpectedMachines[i])
-		} else if i == 5 {
+		case 5:
 			// Modify existing labels
 			ctrlExpectedMachine.Metadata = &corev1.Metadata{
 				Labels: []*corev1.Label{
@@ -184,13 +184,13 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 				},
 			}
 			expectedMachinesToUpdate = append(expectedMachinesToUpdate, pagedExpectedMachines[i])
-		} else if i == 10 {
+		case 10:
 			// Remove labels (set to empty labels array)
 			ctrlExpectedMachine.Metadata = &corev1.Metadata{
 				Labels: []*corev1.Label{},
 			}
 			expectedMachinesToUpdate = append(expectedMachinesToUpdate, pagedExpectedMachines[i])
-		} else if i == 15 {
+		case 15:
 			// Remove labels (set metadata to nil)
 			ctrlExpectedMachine.Metadata = nil
 			expectedMachinesToUpdate = append(expectedMachinesToUpdate, pagedExpectedMachines[i])
@@ -464,6 +464,47 @@ func TestManageExpectedMachine_UpdateExpectedMachinesInDB(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("defer association until the linked machine exists in REST", func(t *testing.T) {
+		emID := uuid.New()
+		bmcMAC := "00:11:22:33:77:01"
+		predictedMachineID := "fm100p-predicted-host"
+		inventory := &corev1.ExpectedMachineInventory{
+			ExpectedMachines: []*corev1.ExpectedMachine{
+				{
+					Id:                  &corev1.UUID{Value: emID.String()},
+					BmcMacAddress:       bmcMAC,
+					ChassisSerialNumber: "SN-LINKED-MACHINE",
+				},
+			},
+			LinkedMachines: []*corev1.LinkedExpectedMachine{
+				{
+					BmcMacAddress: bmcMAC,
+					MachineId:     &corev1.MachineId{Id: predictedMachineID},
+				},
+			},
+			Timestamp:       timestamppb.Now(),
+			InventoryStatus: corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
+		}
+
+		mei := ManageExpectedMachine{dbSession: dbSession}
+		err := mei.UpdateExpectedMachinesInDB(ctx, st4.ID, inventory)
+		require.NoError(t, err)
+
+		reconciled, err := emDAO.Get(ctx, nil, emID, nil, false)
+		require.NoError(t, err)
+		assert.Nil(t, reconciled.MachineID)
+
+		permanentMachine := cwu.TestBuildMachine(t, dbSession, ip.ID, st4.ID, nil, cutil.GetPtr(false), cdbm.MachineStatusReady)
+		inventory.LinkedMachines[0].MachineId.Id = permanentMachine.ID
+
+		err = mei.UpdateExpectedMachinesInDB(ctx, st4.ID, inventory)
+		require.NoError(t, err)
+
+		reconciled, err = emDAO.Get(ctx, nil, emID, nil, false)
+		require.NoError(t, err)
+		assert.Equal(t, &permanentMachine.ID, reconciled.MachineID)
+	})
 }
 
 func TestManageExpectedMachine_UpdateExpectedMachinesInDB_BmcIpAddress(t *testing.T) {
@@ -716,7 +757,7 @@ func TestStaleInventoryThresholdCondition(t *testing.T) {
 		},
 		{
 			name:       "action just outside stale inventory threshold",
-			actionTime: time.Now().Add(-time.Duration(cwutil.InventoryReceiptInterval + time.Second*15)),
+			actionTime: time.Now().Add(-time.Duration(cutil.InventoryReceiptInterval + time.Second*15)),
 			want:       false,
 		},
 		{
@@ -727,7 +768,7 @@ func TestStaleInventoryThresholdCondition(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := util.IsTimeWithinStaleInventoryThreshold(tt.actionTime); got != tt.want {
+			if got := cwu.IsTimeWithinStaleInventoryThreshold(tt.actionTime); got != tt.want {
 				t.Errorf("IsTimeWithinStaleInventoryThreshold() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Expected-machine inventory can temporarily link an ExpectedMachine to a predicted host that REST does not inventory. Reconciliation previously copied that ID directly into `expected_machine.machine_id`, causing the existing foreign key to reject the row and repeat the failure on every inventory cycle.

This change validates Core-reported linked machine IDs with one batched REST machine lookup before reconciliation. IDs absent from REST are omitted, allowing the ExpectedMachine to synchronize without an association. Once REST contains the permanent machine and Core reports its ID, the next reconciliation records the association normally. The foreign key remains unchanged.

## Related issues

Closes #5232

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The database-backed regression test was confirmed to fail before the fix with `expected_machine_machine_id_fkey`, then pass after the fix. It covers both required transitions: an absent predicted-host ID leaves `machine_id` unset, and a later permanent machine ID is recorded once its REST row exists.

Validated with:

- `go test ./workflow/pkg/activity/expectedmachine -count=1`
- `go tool golangci-lint run ./workflow/pkg/activity/expectedmachine`
- `make lint-go`
- All REST test targets other than the externally blocked API startup test

## Additional Notes

This is an attempt at fully automated issue resolution using Codex.
