### PR TITLE
fix(fmds): add opt-in compatibility REST address

### DIFF
--- a/bluefield/charts/nico-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/nico-fmds/templates/daemonset.yaml
@@ -113,7 +113,9 @@ spec:
             {{- $dir := .Values.certsDir | default "/opt/forge" }}
             {{- $rootCa := .Values.rootCaFile | default "forge_root.pem" }}
             - "--grpc-address=$(POD_IP):50052"
-            - "--rest-address={{ .Values.restAddress }}"
+            {{- with .Values.restAddress }}
+            - "--rest-address={{ . }}"
+            {{- end }}
             {{- with .Values.compatibilityRestAddress }}
             - "--compatibility-rest-address={{ . }}"
             {{- end }}

--- a/bluefield/charts/nico-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/nico-fmds/templates/daemonset.yaml
@@ -113,6 +113,9 @@ spec:
             {{- $dir := .Values.certsDir | default "/opt/forge" }}
             {{- $rootCa := .Values.rootCaFile | default "forge_root.pem" }}
             - "--grpc-address=$(POD_IP):50052"
+            {{- with .Values.compatibilityRestAddress }}
+            - "--compatibility-rest-address={{ . }}"
+            {{- end }}
             {{- if .Values.useNodeTokens }}
             - "--root-ca={{ $dir }}/pub/{{ $rootCa }}"
             - "--node-token-socket={{ $dir }}/run/agent.sock"

--- a/bluefield/charts/nico-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/nico-fmds/templates/daemonset.yaml
@@ -113,6 +113,7 @@ spec:
             {{- $dir := .Values.certsDir | default "/opt/forge" }}
             {{- $rootCa := .Values.rootCaFile | default "forge_root.pem" }}
             - "--grpc-address=$(POD_IP):50052"
+            - "--rest-address={{ .Values.restAddress }}"
             {{- with .Values.compatibilityRestAddress }}
             - "--compatibility-rest-address={{ . }}"
             {{- end }}

--- a/bluefield/charts/nico-fmds/tests/compatibility_port_test.yaml
+++ b/bluefield/charts/nico-fmds/tests/compatibility_port_test.yaml
@@ -11,9 +11,8 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --rest-address=0.0.0.0:80
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: --compatibility-rest-address=0.0.0.0:7777
+      - notExists:
+          path: 'spec.template.spec.containers[0].args[?(@ =~ /^--compatibility-rest-address=/)]'
 
   - it: should configure the primary and compatibility listeners independently
     set:

--- a/bluefield/charts/nico-fmds/tests/compatibility_port_test.yaml
+++ b/bluefield/charts/nico-fmds/tests/compatibility_port_test.yaml
@@ -8,17 +8,24 @@ tests:
         repository: test
         tag: test
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --rest-address=0.0.0.0:80
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --compatibility-rest-address=0.0.0.0:7777
 
-  - it: should enable the compatibility listener when configured
+  - it: should configure the primary and compatibility listeners independently
     set:
       image:
         repository: test
         tag: test
+      restAddress: 127.0.0.1:8080
       compatibilityRestAddress: 0.0.0.0:7777
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --rest-address=127.0.0.1:8080
       - contains:
           path: spec.template.spec.containers[0].args
           content: --compatibility-rest-address=0.0.0.0:7777

--- a/bluefield/charts/nico-fmds/tests/compatibility_port_test.yaml
+++ b/bluefield/charts/nico-fmds/tests/compatibility_port_test.yaml
@@ -1,0 +1,24 @@
+suite: compatibility REST port
+templates:
+  - daemonset.yaml
+tests:
+  - it: should leave the compatibility listener disabled by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --compatibility-rest-address=0.0.0.0:7777
+
+  - it: should enable the compatibility listener when configured
+    set:
+      image:
+        repository: test
+        tag: test
+      compatibilityRestAddress: 0.0.0.0:7777
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --compatibility-rest-address=0.0.0.0:7777

--- a/bluefield/charts/nico-fmds/tests/compatibility_port_test.yaml
+++ b/bluefield/charts/nico-fmds/tests/compatibility_port_test.yaml
@@ -8,7 +8,7 @@ tests:
         repository: test
         tag: test
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[0].args
           content: --rest-address=0.0.0.0:80
       - notContains:

--- a/bluefield/charts/nico-fmds/values.schema.json
+++ b/bluefield/charts/nico-fmds/values.schema.json
@@ -158,6 +158,11 @@
           }
         }
       }
+    },
+    "compatibilityRestAddress": {
+      "description": "Optional additional tenant metadata listener address for compatibility",
+      "type": ["string", "null"],
+      "default": null
     }
   },
   "additionalProperties": true

--- a/bluefield/charts/nico-fmds/values.schema.json
+++ b/bluefield/charts/nico-fmds/values.schema.json
@@ -160,9 +160,9 @@
       }
     },
     "restAddress": {
-      "description": "Primary tenant metadata listener address",
-      "type": "string",
-      "default": "0.0.0.0:80"
+      "description": "Optional primary tenant metadata listener address override",
+      "type": ["string", "null"],
+      "default": null
     },
     "compatibilityRestAddress": {
       "description": "Optional additional tenant metadata listener address for compatibility",

--- a/bluefield/charts/nico-fmds/values.schema.json
+++ b/bluefield/charts/nico-fmds/values.schema.json
@@ -159,6 +159,11 @@
         }
       }
     },
+    "restAddress": {
+      "description": "Primary tenant metadata listener address",
+      "type": "string",
+      "default": "0.0.0.0:80"
+    },
     "compatibilityRestAddress": {
       "description": "Optional additional tenant metadata listener address for compatibility",
       "type": ["string", "null"],

--- a/bluefield/charts/nico-fmds/values.yaml
+++ b/bluefield/charts/nico-fmds/values.yaml
@@ -38,6 +38,10 @@ rootCaFile: forge_root.pem
 useNodeTokens: false
 
 ### Service specific values ###
+# Optional additional tenant metadata listener address for compatibility.
+# Unset by default.
+compatibilityRestAddress: null
+
 # Prometheus /metrics listen port (must match nico-otelcol scrape target).
 metricsPort: 8888
 image:

--- a/bluefield/charts/nico-fmds/values.yaml
+++ b/bluefield/charts/nico-fmds/values.yaml
@@ -38,6 +38,9 @@ rootCaFile: forge_root.pem
 useNodeTokens: false
 
 ### Service specific values ###
+# Primary tenant metadata listener address.
+restAddress: 0.0.0.0:80
+
 # Optional additional tenant metadata listener address for compatibility.
 # Unset by default.
 compatibilityRestAddress: null

--- a/bluefield/charts/nico-fmds/values.yaml
+++ b/bluefield/charts/nico-fmds/values.yaml
@@ -38,8 +38,8 @@ rootCaFile: forge_root.pem
 useNodeTokens: false
 
 ### Service specific values ###
-# Primary tenant metadata listener address.
-restAddress: 0.0.0.0:80
+# Optional primary tenant metadata listener address override. Unset by default.
+restAddress: null
 
 # Optional additional tenant metadata listener address for compatibility.
 # Unset by default.

--- a/crates/fmds/src/cfg.rs
+++ b/crates/fmds/src/cfg.rs
@@ -36,6 +36,11 @@ pub struct Options {
     #[clap(long, default_value = "0.0.0.0:80")]
     pub rest_address: SocketAddr,
 
+    /// Optional additional REST listen address for compatibility. When
+    /// omitted, FMDS listens only on `rest_address`.
+    #[clap(long)]
+    pub compatibility_rest_address: Option<SocketAddr>,
+
     /// Prometheus scrape address for `/metrics` (HTTP request stats for the REST metadata API).
     #[clap(long, default_value = "0.0.0.0:8888")]
     pub metrics_address: SocketAddr,
@@ -82,5 +87,36 @@ pub struct Options {
 impl Options {
     pub fn load() -> Self {
         Self::parse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compatibility_rest_address_is_disabled_by_default() {
+        let options = Options::try_parse_from(["carbide-fmds"]).unwrap();
+
+        assert_eq!(options.rest_address, "0.0.0.0:80".parse().unwrap());
+        assert_eq!(options.compatibility_rest_address, None);
+    }
+
+    #[test]
+    fn rest_addresses_can_be_overridden_independently() {
+        let options = Options::try_parse_from([
+            "carbide-fmds",
+            "--rest-address",
+            "127.0.0.1:8080",
+            "--compatibility-rest-address",
+            "127.0.0.1:7778",
+        ])
+        .unwrap();
+
+        assert_eq!(options.rest_address, "127.0.0.1:8080".parse().unwrap());
+        assert_eq!(
+            options.compatibility_rest_address,
+            Some("127.0.0.1:7778".parse().unwrap())
+        );
     }
 }

--- a/crates/fmds/src/main.rs
+++ b/crates/fmds/src/main.rs
@@ -155,26 +155,31 @@ async fn main() -> eyre::Result<()> {
         }
     });
 
-    // Start REST server for tenant metadata queries
+    // Build the REST service once so both the standard endpoint and the
+    // compatibility endpoint expose exactly the same metadata API.
     let rest_state = state.clone();
-    let rest_address = options.rest_address;
-    let rest_http_metrics = http_request_metrics_state.clone();
-    tokio::spawn(async move {
-        // We serve metadata under both /latest and /2009-04-04 for
-        // compatibility with cloud-init, which uses the AWS EC2 instance
-        // metadata API versioned path format.
-        let router = axum::Router::new()
-            .nest("/latest", get_fmds_router(rest_state.clone()))
-            .nest("/2009-04-04", get_fmds_router(rest_state));
-        let router = http_request_metrics::with_http_request_trace_layer(router, rest_http_metrics);
+    // We serve metadata under both /latest and /2009-04-04 for
+    // compatibility with cloud-init, which uses the AWS EC2 instance
+    // metadata API versioned path format.
+    let router = axum::Router::new()
+        .nest("/latest", get_fmds_router(rest_state.clone()))
+        .nest("/2009-04-04", get_fmds_router(rest_state));
+    let router =
+        http_request_metrics::with_http_request_trace_layer(router, http_request_metrics_state);
 
-        let server = axum_server::Server::bind(rest_address);
+    let rest_addresses =
+        std::iter::once(options.rest_address).chain(options.compatibility_rest_address);
+    for rest_address in rest_addresses {
+        let router = router.clone();
+        tokio::spawn(async move {
+            let server = axum_server::Server::bind(rest_address);
 
-        tracing::info!(%rest_address, "REST server listening");
-        if let Err(err) = server.serve(router.into_make_service()).await {
-            tracing::error!(error = %err, "REST server error");
-        }
-    });
+            tracing::info!(%rest_address, "REST server listening");
+            if let Err(err) = server.serve(router.into_make_service()).await {
+                tracing::error!(%rest_address, error = %err, "REST server error");
+            }
+        });
+    }
 
     // Start gRPC server for receiving config updates from agent
     let grpc_server = FmdsGrpcServer::new(state);


### PR DESCRIPTION
Add an opt-in compatibility listener that serves the same FMDS router and request instrumentation on a second address.

The compatibility listener remains disabled by default. Operators can enable port 7777 with either:

```text
--compatibility-rest-address 0.0.0.0:7777
```

or the optional `nico-fmds` chart values:

```yaml
restAddress: 0.0.0.0:80
compatibilityRestAddress: 0.0.0.0:7777
```

## Related issues

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `cargo test -p carbide-fmds` (38 passed)
- `cargo clippy -p carbide-fmds --all-targets -- -D warnings`
- `helm lint bluefield/charts/nico-fmds`
- Default and opt-in `helm template` renders
- `cargo run -q -p carbide-fmds -- --help`

## Additional Notes

Port 80 remains FMDS's only REST listener unless the CLI flag or Helm value is set.
