### PR TITLE
feat(helm): allow health and SSH resource overrides

### DIFF
--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -50,7 +50,8 @@ spec:
               containerPort: {{ .Values.service.port }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
-          resources: {}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: "/var/run/secrets/spiffe.io"
               name: spiffe

--- a/helm/charts/nico-hardware-health/tests/resources_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/resources_test.yaml
@@ -1,0 +1,29 @@
+suite: hardware-health resources
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: leaves resources empty by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value: {}
+
+  - it: allows resource requests and limits
+    set:
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          cpu: "1"
+          memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -27,6 +27,9 @@ namespaceOverride: ""
 
 replicas: 1
 
+## Container resource requests and limits. Empty by default.
+resources: {}
+
 ## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
 fileDescriptorLimit: 65536
 

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -54,7 +54,8 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
-          resources: {}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             # Mount config at both paths so the binary finds it regardless of nico/carbide image variant.
             - name: {{ include "nico-ssh-console-rs.name" . }}-config-files

--- a/helm/charts/nico-ssh-console-rs/tests/resources_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/resources_test.yaml
@@ -1,0 +1,29 @@
+suite: ssh-console resources
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: leaves resources empty by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value: {}
+
+  - it: allows resource requests and limits
+    set:
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          cpu: "1"
+          memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -26,6 +26,10 @@ global:
 namespaceOverride: ""
 
 replicas: 1
+
+## Container resource requests and limits. Empty by default.
+resources: {}
+
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-ssh-console-rs.name" . }}-config-files'
 


### PR DESCRIPTION
The hardware-health and SSH console charts hard-code empty container resources, so site-level CPU and memory overrides are accepted by Helm but discarded from the rendered Deployments.

This change adds an empty-by-default `resources` value to both charts and renders it into each primary container. Existing installations retain the current empty resource configuration, while sites can now set requests and limits through normal Helm values. Focused Helm unit tests cover both the unchanged default and concrete CPU/memory overrides.

## Related issues

Closes #4998

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Test-first verification confirmed both new override cases failed against the hard-coded `resources: {}` before the template change.

- `helm unittest helm/charts/nico-hardware-health` — 7 passed
- `helm unittest helm/charts/nico-ssh-console-rs` — 9 passed
- `helm lint helm` — passed
- Rendered both subcharts through the umbrella chart with CPU and memory overrides and verified the resulting Deployment resources.

The full umbrella Helm unit inventory has the same 10 unrelated failures on this branch and clean `main` (stale nico-api certificate expectations and one nico-pxe null-environment expectation); this change adds four passing resource cases.

## Additional Notes

This is an attempt at fully automated issue resolution using Codex.
