### PR TITLE
docs(switch): clarify mTLS service configuration

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -470,7 +470,7 @@ TOML section: `[switch_state_controller]`.
 
 `switch_mtls_services` selects server-side certificate bindings. It does not
 enable the underlying service. For workflow scope, see
-[Switch Certificate Configuration](../../../../docs/architecture/state_machines/switch_configure_certificate.md).
+[Switch Certificate Configuration](https://docs.nvidia.com/infra-controller/documentation/architecture/state-machines/switch-certificate-configuration).
 
 ### `ObservabilityConfig`
 

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -448,7 +448,7 @@ TOML section: `[rack_state_controller]`.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `controller` | `StateControllerConfig` | *(default)* | Common state controller timing (see [StateControllerConfig](#statecontrollerconfig)). |
-| `nmx_cluster_switch_mtls_services` | `Vec<SwitchMtlsService>` | `scale_up_fabric_manager`, `scale_up_fabric_telemetry_interface` | **Deprecated.** Accepted and ignored. Rack maintenance does not configure switch certificates; per-switch certificate configuration uses [`switch_mtls_services`](#switchstatecontrollerconfig). |
+| `nmx_cluster_switch_mtls_services` | `Vec<SwitchMtlsService>` | N/A (ignored) | **Deprecated.** Accepted and ignored. Rack maintenance does not configure switch certificates. |
 
 ### `SwitchStateControllerConfig`
 
@@ -457,19 +457,19 @@ TOML section: `[switch_state_controller]`.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `controller` | `StateControllerConfig` | *(default)* | Common state controller timing (see [StateControllerConfig](#statecontrollerconfig)). |
-| `switch_mtls_services` | `Vec<SwitchMtlsService>` | all four values below | mTLS certificate bindings applied by the per-switch certificate workflow. A non-empty list replaces the default. Omission and `[]` both use the default. |
+| `switch_mtls_services` | `Vec<SwitchMtlsService>` | all four values below | mTLS certificate bindings applied by switch state-controller operations and direct `ComponentConfigureSwitchCertificate` RPC calls. A non-empty list replaces the default. Omission and `[]` both use the default. |
 
-Both settings accept the same service names:
+`switch_mtls_services` accepts these RMS service values:
 
-| Value | Switch endpoint |
-|-------|-----------------|
-| `nvue_api` | NVUE REST API |
-| `scale_up_fabric_telemetry` | NMX-T cluster application (`nmx-telemetry`) |
-| `scale_up_fabric_manager` | NMX-C cluster application (`nmx-controller`) |
-| `scale_up_fabric_telemetry_interface` | NVOS gNMI server mTLS configuration |
+| Value | RMS service description |
+|-------|-------------------------|
+| `nvue_api` | NVUE REST API service |
+| `scale_up_fabric_telemetry` | Scale-up fabric telemetry service |
+| `scale_up_fabric_manager` | Scale-up fabric manager service |
+| `scale_up_fabric_telemetry_interface` | Scale-up fabric telemetry interface service |
 
-These lists select server-side certificate bindings. They do not enable the
-underlying service. For workflow scope, see
+`switch_mtls_services` selects server-side certificate bindings. It does not
+enable the underlying service. For workflow scope, see
 [Switch Certificate Configuration](../../../../docs/architecture/state_machines/switch_configure_certificate.md).
 
 ### `ObservabilityConfig`

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -3212,7 +3212,7 @@ pub struct SwitchStateControllerConfig {
 
     /// Switch services that receive installed mTLS certificates during RMS
     /// `configure_switch_certificate` calls initiated by the switch state
-    /// machine.
+    /// machine or the direct `ComponentConfigureSwitchCertificate` RPC path.
     ///
     /// When this field is omitted or empty, all supported services are used.
     ///

--- a/crates/component-manager/src/config.rs
+++ b/crates/component-manager/src/config.rs
@@ -108,7 +108,7 @@ pub fn effective_switch_mtls_services(services: &[SwitchMtlsService]) -> Vec<Swi
     }
 }
 
-/// Default ScaleUpFabric services configured during rack NMX cluster maintenance.
+/// Default services for the deprecated, ignored rack mTLS service setting.
 pub fn default_nmx_cluster_switch_mtls_services() -> Vec<SwitchMtlsService> {
     vec![
         SwitchMtlsService::ScaleUpFabricManager,

--- a/deploy/nico-base/api/config-files/carbide-api-config.toml
+++ b/deploy/nico-base/api/config-files/carbide-api-config.toml
@@ -118,11 +118,13 @@ test_selection_mode = "EnableAll"
 # Per-site [component_manager] configures switch and power shelf backends.
 
 # Optional per-site mTLS certificate bindings:
-# - [switch_state_controller].switch_mtls_services applies to each switch and
-#   defaults to all four SwitchMtlsService values.
+# - [switch_state_controller].switch_mtls_services applies to switch state
+#   controller operations and direct ComponentConfigureSwitchCertificate RPC
+#   calls. It defaults to all four SwitchMtlsService values.
 # - [rack_state_controller].nmx_cluster_switch_mtls_services is accepted and
 #   ignored. Rack maintenance does not configure switch certificates.
-# A non-empty list replaces its default; an omitted or empty list uses it.
+# A non-empty switch_mtls_services list replaces its default. An omitted or
+# empty list uses the default.
 # Service selection does not enable the underlying service. See
 # docs/architecture/state_machines/switch_configure_certificate.md for service
 # values and workflow scope.

--- a/docs/architecture/state_machines/switch_configure_certificate.md
+++ b/docs/architecture/state_machines/switch_configure_certificate.md
@@ -56,6 +56,8 @@ Job status values use `ConfigureSwitchCertificateState`: `Started`,
 
 ## Domain name (`domain_name`) and mTLS service selection
 
+### Switch state controller
+
 The switch state handler passes:
 
 - `domain_name = None` for both bring-up and maintenance reconfiguration.
@@ -65,22 +67,35 @@ The switch state handler passes:
   from `[switch_state_controller].switch_mtls_services` in site config. When
   omitted or empty, all four service values are used.
 
-NICo has two independent mTLS service lists:
+### Direct ComponentConfigureSwitchCertificate RPC
 
-| Setting | Workflow and target | Omitted or empty behavior |
-|---------|---------------------|---------------------------|
-| `[switch_state_controller].switch_mtls_services` | Per-switch certificate configuration for every switch handled by the switch state controller. | Uses all four service values. |
-| `[rack_state_controller].nmx_cluster_switch_mtls_services` | **Deprecated.** Accepted and ignored. Rack maintenance does not configure switch certificates; use `[switch_state_controller].switch_mtls_services`. | Uses `scale_up_fabric_manager` and `scale_up_fabric_telemetry_interface`. |
+`ComponentConfigureSwitchCertificate` uses the same
+`[switch_state_controller].switch_mtls_services` setting when the RPC runs
+directly because switch state-controller routing is disabled or
+`bypass_state_controller` is `true`. The direct path forwards the request's
+`domain_name` to Component Manager.
 
-A non-empty list replaces the corresponding default. Omission or an empty list
-uses the default.
+When switch state-controller routing is enabled and
+`bypass_state_controller` is `false`, the RPC queues a
+`ReconfigureCertificate` maintenance operation. The switch state handler then
+uses the state-controller behavior described above.
 
-| Service value | Binding target |
-|---------------|----------------|
-| `nvue_api` | NVUE REST API |
-| `scale_up_fabric_telemetry` | NMX-T cluster application (`nmx-telemetry`) |
-| `scale_up_fabric_manager` | NMX-C cluster application (`nmx-controller`) |
-| `scale_up_fabric_telemetry_interface` | NVOS gNMI server mTLS configuration |
+### Service list configuration
+
+`[switch_state_controller].switch_mtls_services` controls certificate bindings
+for both switch state-controller and direct RPC operations. A non-empty list
+replaces the default. Omission or an empty list uses all four values below.
+
+`[rack_state_controller].nmx_cluster_switch_mtls_services` is deprecated. The
+field is accepted and ignored because rack maintenance does not configure
+switch certificates.
+
+| Service value | RMS service description |
+|---------------|-------------------------|
+| `nvue_api` | NVUE REST API service |
+| `scale_up_fabric_telemetry` | Scale-up fabric telemetry service |
+| `scale_up_fabric_manager` | Scale-up fabric manager service |
+| `scale_up_fabric_telemetry_interface` | Scale-up fabric telemetry interface service |
 
 Service selection requests certificate bindings; it does not enable the
 underlying service. The target switch build must support each selected binding.


### PR DESCRIPTION
Clarify mTLS service selection for switch state-controller operations and direct `ComponentConfigureSwitchCertificate` calls, including routing and `domain_name` behavior. Align service descriptions with the pinned RMS schema and simplify the configuration layout.

## Related issues

Supports #5038 and `6658179`

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)