### PR TITLE
fix(machine-a-tron): set SSH console as enabled for dynamic ports

### DIFF
--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -66,6 +66,12 @@ impl BmcState {
         self.system_state.set_serial_console_ssh_port(port)
     }
 
+    /// Advertises an SSH console supplied by a simulator without changing the hardware profile.
+    pub fn set_simulated_serial_console_ssh_port(&self, port: Option<u16>) -> bool {
+        self.system_state
+            .set_simulated_serial_console_ssh_port(port)
+    }
+
     pub fn on_event(&self, event: &BmcEvent) {
         match event {
             BmcEvent::PowerOn => {

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -350,6 +350,18 @@ impl SystemState {
         }
         updated
     }
+
+    /// Advertises a simulated SSH console even when the captured hardware profile omits the
+    /// optional Redfish `SerialConsole` property.
+    pub(crate) fn set_simulated_serial_console_ssh_port(&self, port: Option<u16>) -> bool {
+        self.systems.iter().for_each(|system| {
+            *system
+                .serial_console_ssh_port_override
+                .lock()
+                .expect("mutex poisoned") = port;
+        });
+        !self.systems.is_empty()
+    }
 }
 
 impl SingleSystemState {
@@ -626,15 +638,17 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
         }
     };
 
-    if let Some(serial_console) = &config.serial_console {
-        let serial_console = system_state
-            .serial_console_ssh_port_override
-            .lock()
-            .expect("mutex poisoned")
-            .map_or_else(
-                || serial_console.clone(),
-                |port| serial_console.with_ssh_port(port),
-            );
+    let simulated_ssh_port = *system_state
+        .serial_console_ssh_port_override
+        .lock()
+        .expect("mutex poisoned");
+    let serial_console = match (&config.serial_console, simulated_ssh_port) {
+        (Some(serial_console), Some(port)) => Some(serial_console.with_ssh_port(port)),
+        (Some(serial_console), None) => Some(serial_console.clone()),
+        (None, Some(port)) => Some(redfish::serial_console::simulated_ssh(port)),
+        (None, None) => None,
+    };
+    if let Some(serial_console) = serial_console {
         b = b.serial_console(&serial_console);
     }
 
@@ -1423,5 +1437,27 @@ mod tests {
         assert_eq!(updated["PersistentBootConfigOrder"], updated_order);
         let system = get_json(&router, &resource("1").odata_id).await;
         assert_eq!(system["Boot"]["BootOrder"], json!(["Boot0000", "Boot0001"]));
+    }
+
+    #[tokio::test]
+    async fn simulated_ssh_port_can_be_added_without_profile_serial_console_data() {
+        let (router, state) = machine_router(
+            &host_info(HardwareType::LenovoGB300Nvl),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions::default(),
+        );
+        let router = router.layer(NormalizePathLayer::trim_trailing_slash());
+
+        assert!(!state.has_enabled_ssh_serial_console());
+        assert!(!state.set_serial_console_ssh_port(Some(3222)));
+        assert!(state.set_simulated_serial_console_ssh_port(Some(3222)));
+
+        for system_id in ["HGX_Baseboard_0", "System_0"] {
+            let system = get_json(&router, &resource(system_id).odata_id).await;
+            assert_eq!(system["SerialConsole"]["SSH"]["ServiceEnabled"], true);
+            assert_eq!(system["SerialConsole"]["SSH"]["Port"], 3222);
+        }
     }
 }

--- a/crates/bmc-mock/src/redfish/serial_console.rs
+++ b/crates/bmc-mock/src/redfish/serial_console.rs
@@ -49,6 +49,12 @@ pub(crate) fn builder() -> SerialConsoleBuilder {
     SerialConsoleBuilder { value: json!({}) }
 }
 
+pub(crate) fn simulated_ssh(port: u16) -> SerialConsole {
+    builder()
+        .ssh(&protocol_builder().service_enabled(true).port(port).build())
+        .build()
+}
+
 pub(crate) struct SerialConsoleBuilder {
     value: serde_json::Value,
 }

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use axum::Router;
 use bmc_mock::injection::InjectionStore;
 use bmc_mock::ipmi_sim::{IpmiSimConfig, IpmiSimHandle};
-use bmc_mock::{BmcState, Callbacks, CombinedServer, HostnameQuerying, MachineInfo};
+use bmc_mock::{BmcState, Callbacks, CombinedServer, HardwareType, HostnameQuerying, MachineInfo};
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -38,6 +38,7 @@ pub(super) struct BmcMockWrapper {
     bmc_mock_state: BmcState,
     hostname: Arc<dyn HostnameQuerying>,
     needs_ipmi_console: bool,
+    requires_ssh_console: bool,
     stable_id: String,
     ssh_prompt_behavior: PromptBehavior,
 }
@@ -64,17 +65,27 @@ impl BmcMockWrapper {
             },
         );
 
+        let (ssh_prompt_behavior, requires_ssh_console) = match machine_info {
+            MachineInfo::Dpu(_) => (PromptBehavior::Dpu, true),
+            MachineInfo::Host(host) => match host.hw_type {
+                HardwareType::DellPowerEdgeR750 | HardwareType::DellPowerEdgeR760Bf4 => {
+                    (PromptBehavior::Dell, true)
+                }
+                HardwareType::LenovoGB300Nvl => (PromptBehavior::LenovoAmi, true),
+                HardwareType::HpeProliantDl380aGen11 => (PromptBehavior::Hpe, true),
+                _ => (PromptBehavior::Dell, false),
+            },
+        };
+
         BmcMockWrapper {
             app_context,
             bmc_mock_router,
             bmc_mock_state,
             hostname,
             needs_ipmi_console: machine_info.needs_ipmi_console(),
+            requires_ssh_console,
             stable_id: host_id.to_string(),
-            ssh_prompt_behavior: match machine_info {
-                MachineInfo::Dpu(_) => PromptBehavior::Dpu,
-                MachineInfo::Host(_) => PromptBehavior::Dell,
-            },
+            ssh_prompt_behavior,
         }
     }
 
@@ -82,7 +93,7 @@ impl BmcMockWrapper {
     /// Returns `None` when no simulator is enabled for the hardware profile.
     pub(super) async fn start(&self) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
         let ssh_handle = if self.app_context.app_config.mock_bmc_ssh_server
-            && self.bmc_mock_state.has_enabled_ssh_serial_console()
+            && (self.requires_ssh_console || self.bmc_mock_state.has_enabled_ssh_serial_console())
         {
             Some(
                 mock_ssh_server::spawn(None, self.hostname.clone(), None, self.ssh_prompt_behavior)
@@ -98,8 +109,12 @@ impl BmcMockWrapper {
             None
         };
         let ssh_endpoint_port = ssh_handle.as_ref().map(|handle| handle.port);
-        self.bmc_mock_state
-            .set_serial_console_ssh_port(ssh_endpoint_port);
+        if let Some(port) = ssh_endpoint_port
+            && !self.bmc_mock_state.set_serial_console_ssh_port(Some(port))
+        {
+            self.bmc_mock_state
+                .set_simulated_serial_console_ssh_port(Some(port));
+        }
 
         Ok(
             (ipmi_sim_handle.is_some() || ssh_handle.is_some()).then_some(BmcMockWrapperHandle {

--- a/crates/machine-a-tron/src/mock_ssh_server.rs
+++ b/crates/machine-a-tron/src/mock_ssh_server.rs
@@ -43,9 +43,16 @@ pub struct Credentials {
 
 #[derive(Copy, Clone)]
 pub enum PromptBehavior {
+    /// Dell iDRAC starts at its BMC prompt and enters the host console with `connect com2`.
     Dell,
+    /// A DPU SSH connection opens directly into its system console.
     Dpu,
+    /// Lenovo XClarity starts at its BMC prompt and enters the host console with `console start`.
     LenovoSr650,
+    /// A Lenovo AMI SSH connection opens directly into its system console.
+    LenovoAmi,
+    /// HPE iLO starts at its BMC prompt and enters the host console with `vsp`.
+    Hpe,
 }
 
 pub async fn spawn(
@@ -207,7 +214,9 @@ impl MockSshHandler {
             }
             ConsoleState::Bmc => match self.prompt_behavior {
                 PromptBehavior::LenovoSr650 => session.data(channel, "\nsystem>")?,
-                _ => session.data(channel, "\nracadm>>")?,
+                PromptBehavior::Hpe => session.data(channel, "\n</>hpiLO->")?,
+                PromptBehavior::Dell => session.data(channel, "\nracadm>>")?,
+                PromptBehavior::Dpu | PromptBehavior::LenovoAmi => {}
             },
             ConsoleState::NoShell => {
                 // Do nothing
@@ -262,10 +271,10 @@ impl server::Handler for MockSshHandler {
     ) -> StdResult<(), Self::Error> {
         tracing::debug!("shell_request");
         match self.prompt_behavior {
-            PromptBehavior::Dell | PromptBehavior::LenovoSr650 => {
+            PromptBehavior::Dell | PromptBehavior::LenovoSr650 | PromptBehavior::Hpe => {
                 self.console_state = ConsoleState::Bmc;
             }
-            PromptBehavior::Dpu => {
+            PromptBehavior::Dpu | PromptBehavior::LenovoAmi => {
                 self.console_state = ConsoleState::SystemConsole;
             }
         }
@@ -346,6 +355,10 @@ impl server::Handler for MockSshHandler {
                         }
                         PromptBehavior::LenovoSr650 if command.starts_with(b"console start") => {
                             tracing::info!("Got Lenovo `console start`, simulating system console");
+                            self.console_state = ConsoleState::SystemConsole;
+                        }
+                        PromptBehavior::Hpe if command.starts_with(b"vsp") => {
+                            tracing::info!("Got HPE `vsp`, simulating system console");
                             self.console_state = ConsoleState::SystemConsole;
                         }
                         _ => {}

--- a/crates/ssh-console/tests/main.rs
+++ b/crates/ssh-console/tests/main.rs
@@ -54,6 +54,7 @@ async fn test_ssh_console() -> eyre::Result<()> {
     let Some(env) = run_baseline_test_environment(vec![
         MockBmcType::Ipmi,
         MockBmcType::Ssh,
+        MockBmcType::LenovoAmiSsh,
         MockBmcType::DpuSsh,
     ])
     .await?

--- a/crates/ssh-console/tests/util/metrics.rs
+++ b/crates/ssh-console/tests/util/metrics.rs
@@ -69,7 +69,7 @@ pub(super) async fn assert_metrics(
             "ssh_console_client_auth_failures_total",
             vec![ExpectedObservation {
                 attribute_key_value: Some(("auth_type", Cow::Borrowed("public_key"))),
-                value: Some(3u64),
+                value: Some(mock_hosts.len() as u64),
             }],
         ),
         (

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -92,9 +92,10 @@ pub(crate) async fn run_baseline_test_environment(
                 MachineIdSource::Tpm,
                 rand::random(),
                 match bmc_type {
-                    MockBmcType::Ssh | MockBmcType::LenovoSr650Ssh | MockBmcType::Ipmi => {
-                        MachineType::Host
-                    }
+                    MockBmcType::Ssh
+                    | MockBmcType::LenovoSr650Ssh
+                    | MockBmcType::LenovoAmiSsh
+                    | MockBmcType::Ipmi => MachineType::Host,
                     MockBmcType::DpuSsh => MachineType::Dpu,
                 },
             );
@@ -103,6 +104,7 @@ pub(crate) async fn run_baseline_test_environment(
                 let bmc_handle = match bmc_type {
                     ssh_type @ MockBmcType::Ssh
                     | ssh_type @ MockBmcType::LenovoSr650Ssh
+                    | ssh_type @ MockBmcType::LenovoAmiSsh
                     | ssh_type @ MockBmcType::DpuSsh => {
                         Ok::<MockBmcHandle, eyre::Error>(MockBmcHandle::Ssh(
                             machine_a_tron::spawn_mock_ssh_server(
@@ -115,6 +117,7 @@ pub(crate) async fn run_baseline_test_environment(
                                 match ssh_type {
                                     MockBmcType::Ssh => PromptBehavior::Dell,
                                     MockBmcType::LenovoSr650Ssh => PromptBehavior::LenovoSr650,
+                                    MockBmcType::LenovoAmiSsh => PromptBehavior::LenovoAmi,
                                     MockBmcType::DpuSsh => PromptBehavior::Dpu,
                                     MockBmcType::Ipmi => unreachable!(),
                                 },
@@ -145,6 +148,7 @@ pub(crate) async fn run_baseline_test_environment(
                 sys_vendor: match &bmc_handle {
                     MockBmcHandle::Ssh(_) => match bmc_type {
                         MockBmcType::LenovoSr650Ssh => "Lenovo",
+                        MockBmcType::LenovoAmiSsh => "LenovoAMI",
                         _ => "Dell",
                     },
                     MockBmcHandle::Ipmi(_) => "Supermicro",
@@ -190,6 +194,7 @@ pub(crate) async fn run_baseline_test_environment(
 pub(crate) enum MockBmcType {
     Ssh,
     LenovoSr650Ssh,
+    LenovoAmiSsh,
     DpuSsh,
     Ipmi,
 }


### PR DESCRIPTION
After machine-a-tron switched from a shared SSH listener to per-machine listeners on dynamically allocated ports, SSH console access stopped working for some simulated hosts. Their real hardware profiles do not advertise an SSH serial console through Redfish ComputerSystem, so machine-a-tron had nowhere to publish the dynamically allocated port.

This does not affect real hardware, where the SSH console uses a fixed port and does not require machine-a-tron to publish a dynamic endpoint.

This PR makes machine-a-tron expose its simulated SSH console through ComputerSystem.SerialConsole, even when that property is absent from the corresponding real hardware profile.

## Related issues

#5281

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
