### PR TITLE
feat(flow): make data encryption key optional at startup

### DIFF
--- a/rest-api/flow/README.md
+++ b/rest-api/flow/README.md
@@ -53,6 +53,12 @@ export TEMPORAL_HOST=localhost TEMPORAL_PORT=7233 TEMPORAL_NAMESPACE=flow
 ./flow serve --dev-mode
 ```
 
+`FLOW_DATA_ENCRYPTION_KEY_PATH` is optional when Flow does not need firmware
+authentication data. If it is unset, Flow starts with a warning and rejects
+requests containing non-empty `authentication_data` with `FailedPrecondition`.
+If the variable is set, the referenced file must remain readable and contain a
+valid base64-encoded 32-byte key or Flow fails at startup.
+
 **Note:** NICo is not available locally; power/firmware operations will fail. Use dev/staging for those tests.
 
 ### Test with grpcui

--- a/rest-api/flow/cmd/serve.go
+++ b/rest-api/flow/cmd/serve.go
@@ -222,6 +222,14 @@ func doServe() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load Flow data encryption key")
 	}
+	if dataCipher == nil {
+		log.Warn().
+			Str("env_var", secret.EncryptionKeyPathEnvVar).
+			Msg(
+				"Flow data encryption key is not configured; requests with firmware " +
+					"authentication data and existing encrypted operations will fail",
+			)
+	}
 
 	ctx := context.Background()
 
@@ -350,9 +358,14 @@ func doServe() {
 }
 
 func loadDataCipherFromEnv() (*secret.Cipher, error) {
-	path := strings.TrimSpace(os.Getenv(secret.EncryptionKeyPathEnvVar))
+	path, configured := os.LookupEnv(secret.EncryptionKeyPathEnvVar)
+	if !configured {
+		return nil, nil
+	}
+
+	path = strings.TrimSpace(path)
 	if path == "" {
-		return nil, fmt.Errorf("%s is not set", secret.EncryptionKeyPathEnvVar)
+		return nil, fmt.Errorf("%s is set but empty", secret.EncryptionKeyPathEnvVar)
 	}
 
 	return secret.NewCipherFromFile(path)

--- a/rest-api/flow/cmd/serve_test.go
+++ b/rest-api/flow/cmd/serve_test.go
@@ -187,23 +187,44 @@ const allowedServiceIdentityForTest = "spiffe://example.test/ns/site/sa/site-wor
 func TestLoadDataCipherFromEnv(t *testing.T) {
 	validKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
 	emptyKey := ""
+	malformedKey := "not-base64"
 	tests := []struct {
 		name        string
+		envSet      bool
+		envValue    string
 		keyContents *string
 		wantErr     string
+		wantCipher  bool
 	}{
-		{name: "missing environment variable", wantErr: secret.EncryptionKeyPathEnvVar + " is not set"},
-		{name: "valid key", keyContents: &validKey},
+		{name: "missing environment variable"},
 		{
-			name:        "invalid key",
+			name:    "empty environment variable",
+			envSet:  true,
+			wantErr: secret.EncryptionKeyPathEnvVar + " is set but empty",
+		},
+		{
+			name:     "missing key file",
+			envSet:   true,
+			envValue: "/missing/encryption-key",
+			wantErr:  "read data encryption key",
+		},
+		{name: "valid key", keyContents: &validKey, wantCipher: true},
+		{
+			name:        "empty key",
 			keyContents: &emptyKey,
 			wantErr:     "data encryption key is empty",
+		},
+		{
+			name:        "malformed key",
+			keyContents: &malformedKey,
+			wantErr:     "data encryption key must be base64 encoded",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(secret.EncryptionKeyPathEnvVar, "")
+			t.Setenv(secret.EncryptionKeyPathEnvVar, "temporary")
+			require.NoError(t, os.Unsetenv(secret.EncryptionKeyPathEnvVar))
 			if tt.keyContents != nil {
 				path := filepath.Join(t.TempDir(), "encryption-key")
 				require.NoError(
@@ -211,6 +232,8 @@ func TestLoadDataCipherFromEnv(t *testing.T) {
 					os.WriteFile(path, []byte(*tt.keyContents), 0o600),
 				)
 				t.Setenv(secret.EncryptionKeyPathEnvVar, path)
+			} else if tt.envSet {
+				t.Setenv(secret.EncryptionKeyPathEnvVar, tt.envValue)
 			}
 
 			cipher, err := loadDataCipherFromEnv()
@@ -221,7 +244,11 @@ func TestLoadDataCipherFromEnv(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.NotNil(t, cipher)
+			if tt.wantCipher {
+				require.NotNil(t, cipher)
+			} else {
+				require.Nil(t, cipher)
+			}
 		})
 	}
 }

--- a/rest-api/flow/docs/flow-architecture.md
+++ b/rest-api/flow/docs/flow-architecture.md
@@ -664,7 +664,7 @@ Stores task execution records.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `FLOW_DATA_ENCRYPTION_KEY_PATH` | Path to the base64-encoded 32-byte key used to protect persisted sensitive Flow data | Required; the Helm chart mounts this automatically |
+| `FLOW_DATA_ENCRYPTION_KEY_PATH` | Path to the base64-encoded 32-byte key used to protect persisted sensitive Flow data | Unset; the Helm chart mounts a key automatically |
 
 Flow encrypts firmware authentication data before task, schedule, operation-run,
 or Temporal persistence. Ciphertext envelope version 1 records the encryption
@@ -676,6 +676,16 @@ authorization and integrity controls must prevent replay or relocation of a
 complete envelope. The scope of
 [issue #4392](https://github.com/NVIDIA/infra-controller/issues/4392) uses one
 preserved key and does not provide a key-rotation operation.
+
+When `FLOW_DATA_ENCRYPTION_KEY_PATH` is unset, Flow starts with a warning and
+continues to serve operations that do not contain firmware authentication data.
+Requests with non-empty `authentication_data` fail with `FailedPrecondition`
+before Flow persists or submits the operation. If the variable is set but its
+file is unreadable, empty, or does not contain a valid key, Flow fails at
+startup. Existing encrypted operations also require the original key when their
+final firmware-control activity executes. Operators can enable encryption later
+by configuring a persistent key and restarting Flow before submitting firmware
+authentication data.
 
 ### Component Manager Configuration
 

--- a/rest-api/flow/internal/firmwareauth/authentication.go
+++ b/rest-api/flow/internal/firmwareauth/authentication.go
@@ -23,6 +23,10 @@ import (
 // or relocation between otherwise valid firmware operations.
 const authenticationAAD = "flow:firmware-authentication"
 
+// ErrDataCipherNotConfigured identifies an operation that requires firmware
+// authentication encryption or decryption while Flow has no data cipher.
+var ErrDataCipherNotConfigured = errors.New("data encryption cipher is not configured")
+
 // InvalidDataError identifies authentication data rejected at the API
 // boundary. Other errors returned by this package are internal failures.
 type InvalidDataError struct {
@@ -64,7 +68,7 @@ func Encrypt(
 		)}
 	}
 	if cipher == nil {
-		return nil, fmt.Errorf("data encryption cipher is not configured")
+		return nil, ErrDataCipherNotConfigured
 	}
 
 	plaintext, err := proto.MarshalOptions{Deterministic: true}.Marshal(
@@ -94,7 +98,7 @@ func DecryptFor(
 		return "", nil
 	}
 	if cipher == nil {
-		return "", fmt.Errorf("data encryption cipher is not configured")
+		return "", ErrDataCipherNotConfigured
 	}
 
 	plaintext, err := cipher.DecryptData(encrypted, []byte(authenticationAAD))

--- a/rest-api/flow/internal/firmwareauth/authentication_test.go
+++ b/rest-api/flow/internal/firmwareauth/authentication_test.go
@@ -5,6 +5,7 @@ package firmwareauth
 
 import (
 	"encoding/base64"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,31 +84,50 @@ func TestEncryptRejectsInvalidTypedData(t *testing.T) {
 
 	tests := []struct {
 		name               string
+		cipher             *secret.Cipher
 		authenticationData *pb.FirmwareAuthenticationData
 		subTargets         []string
+		wantInvalid        bool
+		wantUnavailable    bool
 	}{
 		{
 			name:               "missing value",
+			cipher:             cipher,
 			authenticationData: &pb.FirmwareAuthenticationData{},
+			wantInvalid:        true,
 		},
 		{
-			name: "missing per-component data",
+			name:   "missing per-component data",
+			cipher: cipher,
 			authenticationData: &pb.FirmwareAuthenticationData{
 				Value: &pb.FirmwareAuthenticationData_PerComponent{},
 			},
+			wantInvalid: true,
 		},
 		{
 			name:               "authentication with dpu-only subtargets",
+			cipher:             cipher,
 			authenticationData: sharedAuthenticationData("token"),
 			subTargets:         []string{"DPU"},
+			wantInvalid:        true,
+		},
+		{
+			name:               "authentication without data cipher",
+			authenticationData: sharedAuthenticationData("token"),
+			wantUnavailable:    true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := Encrypt(cipher, tt.authenticationData, tt.subTargets)
+			_, err := Encrypt(tt.cipher, tt.authenticationData, tt.subTargets)
 			require.Error(t, err)
-			require.True(t, IsInvalidData(err))
+			require.Equal(t, tt.wantInvalid, IsInvalidData(err))
+			require.Equal(
+				t,
+				tt.wantUnavailable,
+				errors.Is(err, ErrDataCipherNotConfigured),
+			)
 		})
 	}
 }
@@ -118,11 +138,17 @@ func TestDecryptRejectsEnvelopeFailures(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name    string
-		cipher  *secret.Cipher
-		mutate  func(*secret.EncryptedData)
-		wantErr string
+		name            string
+		cipher          *secret.Cipher
+		mutate          func(*secret.EncryptedData)
+		wantErr         string
+		wantUnavailable bool
 	}{
+		{
+			name:            "missing data cipher",
+			wantErr:         ErrDataCipherNotConfigured.Error(),
+			wantUnavailable: true,
+		},
 		{
 			name:    "wrong key",
 			cipher:  newTestCipher(t, 2),
@@ -168,6 +194,11 @@ func TestDecryptRejectsEnvelopeFailures(t *testing.T) {
 				devicetypes.ComponentTypeCompute,
 			)
 			require.ErrorContains(t, err, tt.wantErr)
+			require.Equal(
+				t,
+				tt.wantUnavailable,
+				errors.Is(err, ErrDataCipherNotConfigured),
+			)
 		})
 	}
 }

--- a/rest-api/flow/internal/service/config.go
+++ b/rest-api/flow/internal/service/config.go
@@ -69,7 +69,9 @@ type Config struct {
 	FlowConfig       config.Config
 	CMConfig         cmconfig.Config
 	ProviderRegistry *providerapi.ProviderRegistry
-	DataCipher       *secret.Cipher
+	// DataCipher protects optional firmware authentication data. When nil,
+	// operations without authentication data remain available.
+	DataCipher *secret.Cipher
 
 	// DevMode enables developer options such as gRPC reflection and debug
 	// logging. Must not be set in staging/production environments.
@@ -90,10 +92,9 @@ type Config struct {
 //
 //  1. Unknown or unset FLOW_ENV — always rejected regardless of other settings.
 //  2. DevMode in a non-development environment — staging and production block it.
-//  3. Missing data-encryption cipher.
-//  4. Partial CertConfig — all three cert paths must be set together or not at all.
-//  5. Missing TLS in staging or production — those environments require mTLS.
-//  6. Secure gRPC without a valid service-identity allowlist.
+//  3. Partial CertConfig — all three cert paths must be set together or not at all.
+//  4. Missing TLS in staging or production — those environments require mTLS.
+//  5. Secure gRPC without a valid service-identity allowlist.
 func (c Config) Validate() error {
 	envStr, err := GetDeploymentEnv()
 	if err != nil {
@@ -106,10 +107,6 @@ func (c Config) Validate() error {
 	if c.DevMode && env != envDevelopment {
 		return fmt.Errorf("--dev-mode is not allowed in %q environment", env)
 	}
-	if c.DataCipher == nil {
-		return errors.New("data encryption cipher is required")
-	}
-
 	// Reject partial CertConfig before reaching IsTLSAvailable. A
 	// partial config would cause IsSet() to return false, letting the CERTDIR /
 	// SPIFFE fallback satisfy the TLS check even though those certs would never

--- a/rest-api/flow/internal/service/config_test.go
+++ b/rest-api/flow/internal/service/config_test.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/authz"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 	pkgcerts "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/certs"
 )
 
@@ -231,7 +229,6 @@ func TestConfigValidate(t *testing.T) {
 				DevMode:       tt.devMode,
 				CertConfig:    tt.certConf,
 				Authorization: authorization,
-				DataCipher:    testDataCipher(t),
 			}
 			err := c.Validate()
 
@@ -307,7 +304,6 @@ func TestConfigValidateAuthorization(t *testing.T) {
 			config := Config{
 				CertConfig:    test.certConfig,
 				Authorization: test.authorization,
-				DataCipher:    testDataCipher(t),
 			}
 			err := config.Validate()
 			if test.wantErr != "" {
@@ -317,24 +313,4 @@ func TestConfigValidateAuthorization(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-}
-
-func TestConfigValidateRequiresDataCipher(t *testing.T) {
-	t.Setenv("CERTDIR", t.TempDir())
-	t.Setenv(EnvVarName, string(envDevelopment))
-
-	err := (Config{
-		Authorization: authz.Config{Mode: authz.ModeAudit},
-	}).Validate()
-
-	require.EqualError(t, err, "data encryption cipher is required")
-}
-
-func testDataCipher(t *testing.T) *secret.Cipher {
-	t.Helper()
-
-	key := make([]byte, 32)
-	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
-	require.NoError(t, err)
-	return cipher
 }

--- a/rest-api/flow/internal/service/server_impl.go
+++ b/rest-api/flow/internal/service/server_impl.go
@@ -1395,6 +1395,9 @@ func firmwareAuthenticationStatusError(err error) error {
 	if firmwareauth.IsInvalidData(err) {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
+	if errors.Is(err, firmwareauth.ErrDataCipherNotConfigured) {
+		return status.Error(codes.FailedPrecondition, err.Error())
+	}
 
 	return status.Error(codes.Internal, err.Error())
 }

--- a/rest-api/flow/internal/service/server_impl_firmware_test.go
+++ b/rest-api/flow/internal/service/server_impl_firmware_test.go
@@ -74,7 +74,13 @@ func TestUpgradeFirmwareAuthenticationDataStatusCodes(t *testing.T) {
 		authenticationData *pb.FirmwareAuthenticationData
 		subTargets         []string
 		wantCode           codes.Code
+		wantSubmitted      bool
 	}{
+		{
+			name:          "missing cipher without authentication",
+			wantCode:      codes.OK,
+			wantSubmitted: true,
+		},
 		{
 			name:               "invalid input",
 			cipher:             newServiceTestCipher(t),
@@ -84,7 +90,7 @@ func TestUpgradeFirmwareAuthenticationDataStatusCodes(t *testing.T) {
 		{
 			name:               "missing cipher",
 			authenticationData: sharedServiceAuthenticationData("token"),
-			wantCode:           codes.Internal,
+			wantCode:           codes.FailedPrecondition,
 		},
 		{
 			name:               "authentication with dpu-only subtargets",
@@ -97,8 +103,9 @@ func TestUpgradeFirmwareAuthenticationDataStatusCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			manager := &firmwareTaskManager{}
 			server := &FlowServerImpl{
-				taskManager: &firmwareTaskManager{},
+				taskManager: manager,
 				dataCipher:  tt.cipher,
 			}
 			_, err := server.UpgradeFirmware(
@@ -107,13 +114,22 @@ func TestUpgradeFirmwareAuthenticationDataStatusCodes(t *testing.T) {
 					SubTargets: tt.subTargets,
 					TargetSpec: &pb.OperationTargetSpec{
 						Targets: &pb.OperationTargetSpec_Components{
-							Components: &pb.ComponentTargets{},
+							Components: &pb.ComponentTargets{
+								Targets: []*pb.ComponentTarget{
+									{
+										Identifier: &pb.ComponentTarget_Id{
+											Id: &pb.UUID{Id: uuid.NewString()},
+										},
+									},
+								},
+							},
 						},
 					},
 					AuthenticationData: tt.authenticationData,
 				},
 			)
 			require.Equal(t, tt.wantCode, status.Code(err))
+			require.Equal(t, tt.wantSubmitted, manager.request != nil)
 		})
 	}
 }

--- a/rest-api/flow/internal/service/server_impl_operation_run_test.go
+++ b/rest-api/flow/internal/service/server_impl_operation_run_test.go
@@ -106,7 +106,7 @@ func TestCreateOperationRunAuthenticationDataStatusCodes(t *testing.T) {
 		{
 			name:               "missing cipher",
 			authenticationData: sharedServiceAuthenticationData("token"),
-			wantCode:           codes.Internal,
+			wantCode:           codes.FailedPrecondition,
 		},
 		{
 			name:               "authentication with dpu-only subtargets",
@@ -124,14 +124,16 @@ func TestCreateOperationRunAuthenticationDataStatusCodes(t *testing.T) {
 				tt.authenticationData
 			req.Configuration.Operation.GetUpgradeFirmware().SubTargets =
 				tt.subTargets
+			manager := &mockOperationRunManager{}
 			server := &FlowServerImpl{
-				operationRunManager: &mockOperationRunManager{},
+				operationRunManager: manager,
 				dataCipher:          tt.cipher,
 			}
 
 			_, err := server.CreateOperationRun(context.Background(), req)
 
 			require.Equal(t, tt.wantCode, status.Code(err))
+			require.Zero(t, manager.createCalls)
 		})
 	}
 }

--- a/rest-api/flow/internal/service/server_impl_task_schedule_test.go
+++ b/rest-api/flow/internal/service/server_impl_task_schedule_test.go
@@ -31,45 +31,78 @@ import (
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
 )
 
-func TestCreateTaskScheduleEncryptsFirmwareAuthenticationData(t *testing.T) {
-	rackID := uuid.New()
-	componentID := uuid.New()
-	inventory := newMockManager()
-	inventory.components[componentID] = &component.Component{
-		Info:   deviceinfo.DeviceInfo{ID: componentID},
-		RackID: rackID,
-		Type:   devicetypes.ComponentTypeCompute,
+func TestCreateTaskScheduleFirmwareAuthenticationData(t *testing.T) {
+	tests := []struct {
+		name               string
+		withCipher         bool
+		authenticationData string
+	}{
+		{
+			name:               "encrypts authentication data before persistence",
+			withCipher:         true,
+			authenticationData: "schedule-token",
+		},
+		{name: "missing cipher allows schedule without authentication data"},
 	}
-	store := &capturingScheduleStore{id: uuid.New()}
-	cipher := newServiceTestCipher(t)
-	server := &FlowServerImpl{
-		inventoryManager:  inventory,
-		taskScheduleStore: store,
-		dataCipher:        cipher,
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rackID := uuid.New()
+			componentID := uuid.New()
+			inventory := newMockManager()
+			inventory.components[componentID] = &component.Component{
+				Info:   deviceinfo.DeviceInfo{ID: componentID},
+				RackID: rackID,
+				Type:   devicetypes.ComponentTypeCompute,
+			}
+			store := &capturingScheduleStore{id: uuid.New()}
+			var cipher *secret.Cipher
+			if tt.withCipher {
+				cipher = newServiceTestCipher(t)
+			}
+			server := &FlowServerImpl{
+				inventoryManager:  inventory,
+				taskScheduleStore: store,
+				dataCipher:        cipher,
+			}
+			var authenticationData *pb.FirmwareAuthenticationData
+			if tt.authenticationData != "" {
+				authenticationData = sharedServiceAuthenticationData(
+					tt.authenticationData,
+				)
+			}
+
+			_, err := server.CreateTaskSchedule(
+				context.Background(),
+				firmwareScheduleRequest(componentID, authenticationData),
+			)
+
+			require.NoError(t, err)
+			if tt.authenticationData != "" {
+				require.NotContains(
+					t,
+					string(store.row.OperationTemplate),
+					tt.authenticationData,
+				)
+			}
+			wrapper, err := taskschedule.WrapperFromTemplate(store.row.OperationTemplate)
+			require.NoError(t, err)
+			var info operations.FirmwareControlTaskInfo
+			require.NoError(t, info.Unmarshal(wrapper.Info))
+			if tt.authenticationData == "" {
+				require.Nil(t, info.AuthenticationData)
+				return
+			}
+
+			got, err := firmwareauth.DecryptFor(
+				cipher,
+				info.AuthenticationData,
+				devicetypes.ComponentTypeCompute,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tt.authenticationData, got)
+		})
 	}
-	authenticationData := "schedule-token"
-
-	_, err := server.CreateTaskSchedule(
-		context.Background(),
-		firmwareScheduleRequest(
-			componentID,
-			sharedServiceAuthenticationData(authenticationData),
-		),
-	)
-
-	require.NoError(t, err)
-	require.NotContains(t, string(store.row.OperationTemplate), authenticationData)
-	wrapper, err := taskschedule.WrapperFromTemplate(store.row.OperationTemplate)
-	require.NoError(t, err)
-	var info operations.FirmwareControlTaskInfo
-	require.NoError(t, info.Unmarshal(wrapper.Info))
-	got, err := firmwareauth.DecryptFor(
-		cipher,
-		info.AuthenticationData,
-		devicetypes.ComponentTypeCompute,
-	)
-	require.NoError(t, err)
-	require.Equal(t, authenticationData, got)
 }
 
 func TestCreateTaskScheduleAuthenticationDataStatusCodes(t *testing.T) {
@@ -90,7 +123,7 @@ func TestCreateTaskScheduleAuthenticationDataStatusCodes(t *testing.T) {
 		{
 			name:               "missing cipher",
 			authenticationData: sharedServiceAuthenticationData("token"),
-			wantCode:           codes.Internal,
+			wantCode:           codes.FailedPrecondition,
 		},
 		{
 			name:               "authentication with dpu-only subtargets",
@@ -103,7 +136,11 @@ func TestCreateTaskScheduleAuthenticationDataStatusCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := &FlowServerImpl{dataCipher: tt.cipher}
+			store := &capturingScheduleStore{id: uuid.New()}
+			server := &FlowServerImpl{
+				dataCipher:        tt.cipher,
+				taskScheduleStore: store,
+			}
 			req := firmwareScheduleRequest(componentID, tt.authenticationData)
 			req.Operation.GetUpgradeFirmware().SubTargets = tt.subTargets
 			_, err := server.CreateTaskSchedule(
@@ -111,6 +148,7 @@ func TestCreateTaskScheduleAuthenticationDataStatusCodes(t *testing.T) {
 				req,
 			)
 			require.Equal(t, tt.wantCode, status.Code(err))
+			require.Nil(t, store.row)
 		})
 	}
 }

--- a/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/activity/activity_test.go
@@ -88,13 +88,8 @@ func TestActivityCallsManagerWhenCapabilityIsSupported(t *testing.T) {
 	require.True(t, manager.called)
 }
 
-func TestFirmwareControlDecryptsAuthenticationDataInActivity(t *testing.T) {
-	acts, manager := newCapabilityTestActivities(
-		t,
-		capability.CapabilityFirmwareControl,
-	)
+func TestFirmwareControlDataCipherAvailability(t *testing.T) {
 	cipher := newActivityTestCipher(t)
-	acts.dataCipher = cipher
 	encrypted, err := firmwareauth.Encrypt(
 		cipher,
 		&pb.FirmwareAuthenticationData{
@@ -109,17 +104,58 @@ func TestFirmwareControlDecryptsAuthenticationDataInActivity(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = acts.FirmwareControl(
-		context.Background(),
-		newActivityTestTarget(),
-		operations.FirmwareControlTaskInfo{
-			Operation:          operations.FirmwareOperationUpgrade,
-			AuthenticationData: encrypted,
+	tests := []struct {
+		name               string
+		dataCipher         *secret.Cipher
+		authenticationData *secret.EncryptedData
+		wantAccessToken    string
+		wantUnavailable    bool
+		wantManagerCall    bool
+	}{
+		{
+			name:               "configured cipher decrypts authentication data",
+			dataCipher:         cipher,
+			authenticationData: encrypted,
+			wantAccessToken:    "compute-token",
+			wantManagerCall:    true,
 		},
-	)
+		{
+			name:            "missing cipher allows operation without authentication data",
+			wantManagerCall: true,
+		},
+		{
+			name:               "missing cipher rejects encrypted authentication data",
+			authenticationData: encrypted,
+			wantUnavailable:    true,
+		},
+	}
 
-	require.NoError(t, err)
-	require.Equal(t, "compute-token", manager.firmwareInfo.AccessToken)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acts, manager := newCapabilityTestActivities(
+				t,
+				capability.CapabilityFirmwareControl,
+			)
+			acts.dataCipher = tt.dataCipher
+
+			err := acts.FirmwareControl(
+				context.Background(),
+				newActivityTestTarget(),
+				operations.FirmwareControlTaskInfo{
+					Operation:          operations.FirmwareOperationUpgrade,
+					AuthenticationData: tt.authenticationData,
+				},
+			)
+
+			if tt.wantUnavailable {
+				require.ErrorIs(t, err, firmwareauth.ErrDataCipherNotConfigured)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantManagerCall, manager.called)
+			require.Equal(t, tt.wantAccessToken, manager.firmwareInfo.AccessToken)
+		})
+	}
 }
 
 func TestActivityRequiresOperationInterfaceAfterCapabilityValidation(t *testing.T) {

--- a/rest-api/flow/internal/task/executor/temporalworkflow/manager/config_test.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/manager/config_test.go
@@ -15,34 +15,32 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/secret"
 )
 
-func TestConfigValidateRequiresDataCipher(t *testing.T) {
-	conf := Config{
-		ClientConf: temporal.Config{
-			Endpoint: endpoint.Config{Host: "temporal", Port: 7233},
-		},
-		WorkerOptions: map[string]worker.Options{
-			WorkflowQueue: {},
-		},
-	}
-
-	err := conf.Validate()
-
-	require.EqualError(t, err, "data encryption cipher is required")
-}
-
-func TestConfigValidateAcceptsDataCipher(t *testing.T) {
+func TestConfigValidateDataCipher(t *testing.T) {
 	key := make([]byte, 32)
 	cipher, err := secret.NewCipher(base64.StdEncoding.EncodeToString(key))
 	require.NoError(t, err)
-	conf := Config{
-		ClientConf: temporal.Config{
-			Endpoint: endpoint.Config{Host: "temporal", Port: 7233},
-		},
-		WorkerOptions: map[string]worker.Options{
-			WorkflowQueue: {},
-		},
-		DataCipher: cipher,
+
+	tests := []struct {
+		name       string
+		dataCipher *secret.Cipher
+	}{
+		{name: "missing data cipher"},
+		{name: "configured data cipher", dataCipher: cipher},
 	}
 
-	require.NoError(t, conf.Validate())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := Config{
+				ClientConf: temporal.Config{
+					Endpoint: endpoint.Config{Host: "temporal", Port: 7233},
+				},
+				WorkerOptions: map[string]worker.Options{
+					WorkflowQueue: {},
+				},
+				DataCipher: tt.dataCipher,
+			}
+
+			require.NoError(t, conf.Validate())
+		})
+	}
 }

--- a/rest-api/flow/internal/task/executor/temporalworkflow/manager/manager.go
+++ b/rest-api/flow/internal/task/executor/temporalworkflow/manager/manager.go
@@ -41,8 +41,9 @@ type Config struct {
 	// ComponentManagerRegistry is the registry containing initialized component managers.
 	ComponentManagerRegistry *componentmanager.Registry
 
-	// DataCipher decrypts sensitive operation fields only inside the final
-	// activity that needs their plaintext value.
+	// DataCipher decrypts optional sensitive operation fields only inside the
+	// final activity that needs their plaintext value. A nil cipher leaves
+	// operations without authentication data available.
 	DataCipher *secret.Cipher
 }
 
@@ -67,10 +68,6 @@ func (c *Config) Validate() error {
 			WorkflowQueue,
 		)
 	}
-	if c.DataCipher == nil {
-		return errors.New("data encryption cipher is required")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Flow currently refuses to start without a data-encryption key even though the key is only needed for non-empty firmware authentication data. That makes unrelated inventory and operation APIs unavailable in direct or custom deployments that do not use firmware download credentials.

This change treats an unset `FLOW_DATA_ENCRYPTION_KEY_PATH` as a disabled firmware-authentication capability. Flow starts with an explicit warning, while an environment variable that is present but points to an unreadable, empty, or malformed key remains a startup error.

Requests with non-empty `authentication_data` now fail with gRPC `FailedPrecondition` before Flow creates a task, schedule, or operation run. Requests without authentication data continue normally. Existing encrypted operations remain fail-closed at their final firmware-control activity when the cipher is unavailable.

## Related issues

Follow-up to #5140.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
 
## Additional Notes
 
