### PR TITLE
feat(flow): bound batched inventory lookup memory

### DIFF
--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -50,10 +50,17 @@ const (
 	// HealthAlertClassification::prevent_allocations() in
 	// crates/health-report/src/lib.rs.
 	classificationPreventAllocations = "PreventAllocations"
+
+	// flowFindByIDsBatchSize bounds the number of full protobuf resources Flow
+	// retains in one detail-lookup batch. Core's max_find_by_ids remains the
+	// authoritative server maximum; Flow uses the smaller non-zero limit. A
+	// zero Core value means the server is unlimited, not that Flow should build
+	// one unbounded response.
+	flowFindByIDsBatchSize = 100
 )
 
 type grpcClient struct {
-	gclient     corev1.ForgeClient
+	gclient     *batchingForgeClient
 	grpcTimeout time.Duration
 }
 
@@ -68,7 +75,7 @@ type batchingForgeClient struct {
 	maxFindByIDsLoaded bool
 }
 
-func newBatchingForgeClient(client corev1.ForgeClient) corev1.ForgeClient {
+func newBatchingForgeClient(client corev1.ForgeClient) *batchingForgeClient {
 	return &batchingForgeClient{ForgeClient: client}
 }
 
@@ -77,11 +84,11 @@ func (c *batchingForgeClient) FindMachinesByIds(
 	request *corev1.MachinesByIdsRequest,
 	options ...grpc.CallOption,
 ) (*corev1.MachineList, error) {
-	machineIDs := protoIDsToStrings(request.GetMachineIds())
-	machines, err := findByIDBatches(ctx, c.loadMaxFindByIDs, machineIDs,
-		func(ctx context.Context, batch []string) ([]*corev1.Machine, error) {
-			return c.fetchMachinesByIDs(ctx, request, batch, options...)
-		})
+	machines := make([]*corev1.Machine, 0, len(request.GetMachineIds()))
+	err := c.visitMachineBatches(ctx, request, func(batch []*corev1.Machine) error {
+		machines = append(machines, batch...)
+		return nil
+	}, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -93,11 +100,11 @@ func (c *batchingForgeClient) FindSwitchesByIds(
 	request *corev1.SwitchesByIdsRequest,
 	options ...grpc.CallOption,
 ) (*corev1.SwitchList, error) {
-	switchIDs := protoIDsToStrings(request.GetSwitchIds())
-	switches, err := findByIDBatches(ctx, c.loadMaxFindByIDs, switchIDs,
-		func(ctx context.Context, batch []string) ([]*corev1.Switch, error) {
-			return c.fetchSwitchesByIDs(ctx, request, batch, options...)
-		})
+	switches := make([]*corev1.Switch, 0, len(request.GetSwitchIds()))
+	err := c.visitSwitchBatches(ctx, request, func(batch []*corev1.Switch) error {
+		switches = append(switches, batch...)
+		return nil
+	}, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -109,15 +116,51 @@ func (c *batchingForgeClient) FindPowerShelvesByIds(
 	request *corev1.PowerShelvesByIdsRequest,
 	options ...grpc.CallOption,
 ) (*corev1.PowerShelfList, error) {
-	shelfIDs := protoIDsToStrings(request.GetPowerShelfIds())
-	shelves, err := findByIDBatches(ctx, c.loadMaxFindByIDs, shelfIDs,
-		func(ctx context.Context, batch []string) ([]*corev1.PowerShelf, error) {
-			return c.fetchPowerShelvesByIDs(ctx, request, batch, options...)
-		})
+	shelves := make([]*corev1.PowerShelf, 0, len(request.GetPowerShelfIds()))
+	err := c.visitPowerShelfBatches(ctx, request, func(batch []*corev1.PowerShelf) error {
+		shelves = append(shelves, batch...)
+		return nil
+	}, options...)
 	if err != nil {
 		return nil, err
 	}
 	return &corev1.PowerShelfList{PowerShelves: shelves}, nil
+}
+
+func (c *batchingForgeClient) visitMachineBatches(
+	ctx context.Context,
+	request *corev1.MachinesByIdsRequest,
+	visit func([]*corev1.Machine) error,
+	options ...grpc.CallOption,
+) error {
+	return visitFindByIDBatches(ctx, c.loadMaxFindByIDs, protoIDsToStrings(request.GetMachineIds()),
+		func(ctx context.Context, batch []string) ([]*corev1.Machine, error) {
+			return c.fetchMachinesByIDs(ctx, request, batch, options...)
+		}, visit)
+}
+
+func (c *batchingForgeClient) visitSwitchBatches(
+	ctx context.Context,
+	request *corev1.SwitchesByIdsRequest,
+	visit func([]*corev1.Switch) error,
+	options ...grpc.CallOption,
+) error {
+	return visitFindByIDBatches(ctx, c.loadMaxFindByIDs, protoIDsToStrings(request.GetSwitchIds()),
+		func(ctx context.Context, batch []string) ([]*corev1.Switch, error) {
+			return c.fetchSwitchesByIDs(ctx, request, batch, options...)
+		}, visit)
+}
+
+func (c *batchingForgeClient) visitPowerShelfBatches(
+	ctx context.Context,
+	request *corev1.PowerShelvesByIdsRequest,
+	visit func([]*corev1.PowerShelf) error,
+	options ...grpc.CallOption,
+) error {
+	return visitFindByIDBatches(ctx, c.loadMaxFindByIDs, protoIDsToStrings(request.GetPowerShelfIds()),
+		func(ctx context.Context, batch []string) ([]*corev1.PowerShelf, error) {
+			return c.fetchPowerShelvesByIDs(ctx, request, batch, options...)
+		}, visit)
 }
 
 var testingMsgOnce sync.Once
@@ -163,10 +206,9 @@ func NewClient(grpcTimeout time.Duration) (Client, error) {
 // GetMachines retrieves all machines known by nico-core-api
 // (FindMachineIds + FindMachinesByIds).
 func (c *grpcClient) GetMachines(ctx context.Context) ([]MachineDetail, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.grpcTimeout)
-	defer cancel()
-
-	machineIDs, err := c.gclient.FindMachineIds(ctx, &corev1.MachineSearchConfig{})
+	idsCtx, idsCancel := context.WithTimeout(ctx, c.grpcTimeout)
+	machineIDs, err := c.gclient.FindMachineIds(idsCtx, &corev1.MachineSearchConfig{})
+	idsCancel()
 	if err != nil {
 		return nil, err
 	}
@@ -180,14 +222,16 @@ func (c *grpcClient) GetMachines(ctx context.Context) ([]MachineDetail, error) {
 		return nil, nil
 	}
 
-	machines, err := c.gclient.FindMachinesByIds(ctx, req)
-	if err != nil {
+	detailsCtx, detailsCancel := context.WithTimeout(ctx, c.grpcTimeout)
+	defer detailsCancel()
+	result := make([]MachineDetail, 0, len(req.MachineIds))
+	if err := c.gclient.visitMachineBatches(detailsCtx, req, func(batch []*corev1.Machine) error {
+		for _, machine := range batch {
+			result = append(result, machineDetailFromPb(machine))
+		}
+		return nil
+	}); err != nil {
 		return nil, err
-	}
-
-	var result []MachineDetail
-	for _, machine := range machines.Machines {
-		result = append(result, machineDetailFromPb(machine))
 	}
 	return result, nil
 }
@@ -211,19 +255,20 @@ func (c *grpcClient) GetSwitches(ctx context.Context) ([]ObservedControllerDevic
 
 	detailsCtx, detailsCancel := context.WithTimeout(ctx, c.grpcTimeout)
 	defer detailsCancel()
-	response, err := c.gclient.FindSwitchesByIds(detailsCtx, &corev1.SwitchesByIdsRequest{
+	request := &corev1.SwitchesByIdsRequest{
 		SwitchIds: switchIDs,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("FindSwitchesByIds for actual inventory: %w", err)
 	}
-
-	result := make([]ObservedControllerDevice, 0, len(response.GetSwitches()))
-	for _, sw := range response.GetSwitches() {
-		result = append(result, ObservedControllerDevice{
-			ID:     sw.GetId().GetId(),
-			BmcMac: sw.GetBmcInfo().GetMac(),
-		})
+	result := make([]ObservedControllerDevice, 0, len(switchIDs))
+	if err := c.gclient.visitSwitchBatches(detailsCtx, request, func(batch []*corev1.Switch) error {
+		for _, sw := range batch {
+			result = append(result, ObservedControllerDevice{
+				ID:     sw.GetId().GetId(),
+				BmcMac: sw.GetBmcInfo().GetMac(),
+			})
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("FindSwitchesByIds for actual inventory: %w", err)
 	}
 	return result, nil
 }
@@ -245,19 +290,20 @@ func (c *grpcClient) GetPowerShelves(ctx context.Context) ([]ObservedControllerD
 
 	detailsCtx, detailsCancel := context.WithTimeout(ctx, c.grpcTimeout)
 	defer detailsCancel()
-	response, err := c.gclient.FindPowerShelvesByIds(detailsCtx, &corev1.PowerShelvesByIdsRequest{
+	request := &corev1.PowerShelvesByIdsRequest{
 		PowerShelfIds: shelfIDs,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("FindPowerShelvesByIds for actual inventory: %w", err)
 	}
-
-	result := make([]ObservedControllerDevice, 0, len(response.GetPowerShelves()))
-	for _, shelf := range response.GetPowerShelves() {
-		result = append(result, ObservedControllerDevice{
-			ID:     shelf.GetId().GetId(),
-			BmcMac: shelf.GetBmcInfo().GetMac(),
-		})
+	result := make([]ObservedControllerDevice, 0, len(shelfIDs))
+	if err := c.gclient.visitPowerShelfBatches(detailsCtx, request, func(batch []*corev1.PowerShelf) error {
+		for _, shelf := range batch {
+			result = append(result, ObservedControllerDevice{
+				ID:     shelf.GetId().GetId(),
+				BmcMac: shelf.GetBmcInfo().GetMac(),
+			})
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("FindPowerShelvesByIds for actual inventory: %w", err)
 	}
 	return result, nil
 }
@@ -344,39 +390,41 @@ func (c *batchingForgeClient) loadMaxFindByIDs(ctx context.Context) (uint32, err
 	return c.maxFindByIDs, nil
 }
 
-// findByIDBatches loads the shared server limit, fetches every chunk in order,
-// and returns only a complete aggregate. The caller's context covers limit
-// discovery and all batch RPCs; deadline exhaustion therefore fails the whole
-// lookup without returning values from earlier batches.
-func findByIDBatches[T any](
+// visitFindByIDBatches loads the shared server limit and visits each complete
+// batch before fetching the next one. This lets callers project full protobuf
+// resources into their smaller result shape without retaining earlier batches.
+// The caller's context covers limit discovery and all batch RPCs.
+func visitFindByIDBatches[T any](
 	ctx context.Context,
 	loadLimit func(context.Context) (uint32, error),
 	ids []string,
 	fetch func(context.Context, []string) ([]T, error),
-) ([]T, error) {
+	visit func([]T) error,
+) error {
 	if len(ids) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	limit, err := loadLimit(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	batchSize := len(ids)
+	batchSize := min(len(ids), flowFindByIDsBatchSize)
 	if limit > 0 && uint64(limit) < uint64(batchSize) {
 		batchSize = int(limit)
 	}
 
-	result := make([]T, 0, len(ids))
 	for batch := range slices.Chunk(ids, batchSize) {
 		values, err := fetch(ctx, batch)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		result = append(result, values...)
+		if err := visit(values); err != nil {
+			return err
+		}
 	}
-	return result, nil
+	return nil
 }
 
 // validateByIDsResponse rejects a batch response that omits any requested ID.
@@ -543,14 +591,14 @@ func (c *grpcClient) FindMachinesByIds(ctx context.Context, machineIds []string)
 		MachineIds: stringsToMachineIds(machineIds),
 	}
 
-	res, err := c.gclient.FindMachinesByIds(ctx, req)
-	if err != nil {
+	result := make([]MachineDetail, 0, len(machineIds))
+	if err := c.gclient.visitMachineBatches(ctx, req, func(batch []*corev1.Machine) error {
+		for _, machine := range batch {
+			result = append(result, machineDetailFromPb(machine))
+		}
+		return nil
+	}); err != nil {
 		return nil, fmt.Errorf("failed to find machines by IDs: %w", err)
-	}
-
-	var result []MachineDetail
-	for _, machine := range res.Machines {
-		result = append(result, machineDetailFromPb(machine))
 	}
 	return result, nil
 }
@@ -661,20 +709,20 @@ func (c *grpcClient) FindSwitchRackIDs(ctx context.Context, switchIds []string) 
 		req.SwitchIds = append(req.SwitchIds, &corev1.SwitchId{Id: id})
 	}
 
-	resp, err := c.gclient.FindSwitchesByIds(ctx, req)
-	if err != nil {
+	result := make(map[string]string, len(switchIds))
+	if err := c.gclient.visitSwitchBatches(ctx, req, func(batch []*corev1.Switch) error {
+		for _, sw := range batch {
+			sid := sw.GetId().GetId()
+			if sid == "" {
+				continue
+			}
+			if rid := sw.GetRackId().GetId(); rid != "" {
+				result[sid] = rid
+			}
+		}
+		return nil
+	}); err != nil {
 		return nil, fmt.Errorf("FindSwitchesByIds: %w", err)
-	}
-
-	result := make(map[string]string, len(resp.GetSwitches()))
-	for _, sw := range resp.GetSwitches() {
-		sid := sw.GetId().GetId()
-		if sid == "" {
-			continue
-		}
-		if rid := sw.GetRackId().GetId(); rid != "" {
-			result[sid] = rid
-		}
 	}
 	return result, nil
 }
@@ -697,20 +745,20 @@ func (c *grpcClient) FindSwitchControllerStates(ctx context.Context, switchIds [
 		req.SwitchIds = append(req.SwitchIds, &corev1.SwitchId{Id: id})
 	}
 
-	resp, err := c.gclient.FindSwitchesByIds(ctx, req)
-	if err != nil {
+	result := make(map[string]string, len(switchIds))
+	if err := c.gclient.visitSwitchBatches(ctx, req, func(batch []*corev1.Switch) error {
+		for _, sw := range batch {
+			sid := sw.GetId().GetId()
+			if sid == "" {
+				continue
+			}
+			if state := sw.GetControllerState(); state != "" {
+				result[sid] = state
+			}
+		}
+		return nil
+	}); err != nil {
 		return nil, fmt.Errorf("FindSwitchesByIds: %w", err)
-	}
-
-	result := make(map[string]string, len(resp.GetSwitches()))
-	for _, sw := range resp.GetSwitches() {
-		sid := sw.GetId().GetId()
-		if sid == "" {
-			continue
-		}
-		if s := sw.GetControllerState(); s != "" {
-			result[sid] = s
-		}
 	}
 	return result, nil
 }
@@ -734,20 +782,20 @@ func (c *grpcClient) FindSwitchNvosIPs(ctx context.Context, switchIds []string) 
 		req.SwitchIds = append(req.SwitchIds, &corev1.SwitchId{Id: id})
 	}
 
-	resp, err := c.gclient.FindSwitchesByIds(ctx, req)
-	if err != nil {
+	result := make(map[string]string, len(switchIds))
+	if err := c.gclient.visitSwitchBatches(ctx, req, func(batch []*corev1.Switch) error {
+		for _, sw := range batch {
+			sid := sw.GetId().GetId()
+			if sid == "" {
+				continue
+			}
+			if ip := sw.GetNvosInfo().GetIp(); ip != "" {
+				result[sid] = ip
+			}
+		}
+		return nil
+	}); err != nil {
 		return nil, fmt.Errorf("FindSwitchesByIds: %w", err)
-	}
-
-	result := make(map[string]string, len(resp.GetSwitches()))
-	for _, sw := range resp.GetSwitches() {
-		sid := sw.GetId().GetId()
-		if sid == "" {
-			continue
-		}
-		if ip := sw.GetNvosInfo().GetIp(); ip != "" {
-			result[sid] = ip
-		}
 	}
 	return result, nil
 }
@@ -771,14 +819,22 @@ func (c *grpcClient) GetObservedNVLinkDomainMemberships(ctx context.Context) ([]
 
 	detailsCtx, detailsCancel := context.WithTimeout(ctx, c.grpcTimeout)
 	defer detailsCancel()
-	detailsResponse, err := c.gclient.FindSwitchesByIds(detailsCtx, &corev1.SwitchesByIdsRequest{
+	request := &corev1.SwitchesByIdsRequest{
 		SwitchIds: switchIDs,
-	})
-	if err != nil {
+	}
+	memberships := make([]NVLinkDomainMembership, 0, len(switchIDs))
+	if err := c.gclient.visitSwitchBatches(detailsCtx, request, func(batch []*corev1.Switch) error {
+		projected, err := nvLinkDomainMembershipsFromSwitches(nil, batch)
+		if err != nil {
+			return err
+		}
+		memberships = append(memberships, projected...)
+		return nil
+	}); err != nil {
 		return nil, fmt.Errorf("FindSwitchesByIds for NVLink domain topology: %w", err)
 	}
 
-	return nvLinkDomainMembershipsFromSwitches(switchIDs, detailsResponse.GetSwitches())
+	return memberships, nil
 }
 
 func nvLinkDomainMembershipsFromSwitches(
@@ -839,20 +895,20 @@ func (c *grpcClient) FindPowerShelfRackIDs(ctx context.Context, shelfIds []strin
 		req.PowerShelfIds = append(req.PowerShelfIds, &corev1.PowerShelfId{Id: id})
 	}
 
-	resp, err := c.gclient.FindPowerShelvesByIds(ctx, req)
-	if err != nil {
+	result := make(map[string]string, len(shelfIds))
+	if err := c.gclient.visitPowerShelfBatches(ctx, req, func(batch []*corev1.PowerShelf) error {
+		for _, shelf := range batch {
+			pid := shelf.GetId().GetId()
+			if pid == "" {
+				continue
+			}
+			if rid := shelf.GetRackId().GetId(); rid != "" {
+				result[pid] = rid
+			}
+		}
+		return nil
+	}); err != nil {
 		return nil, fmt.Errorf("FindPowerShelvesByIds: %w", err)
-	}
-
-	result := make(map[string]string, len(resp.GetPowerShelves()))
-	for _, ps := range resp.GetPowerShelves() {
-		pid := ps.GetId().GetId()
-		if pid == "" {
-			continue
-		}
-		if rid := ps.GetRackId().GetId(); rid != "" {
-			result[pid] = rid
-		}
 	}
 	return result, nil
 }
@@ -875,20 +931,20 @@ func (c *grpcClient) FindPowerShelfControllerStates(ctx context.Context, shelfId
 		req.PowerShelfIds = append(req.PowerShelfIds, &corev1.PowerShelfId{Id: id})
 	}
 
-	resp, err := c.gclient.FindPowerShelvesByIds(ctx, req)
-	if err != nil {
+	result := make(map[string]string, len(shelfIds))
+	if err := c.gclient.visitPowerShelfBatches(ctx, req, func(batch []*corev1.PowerShelf) error {
+		for _, shelf := range batch {
+			pid := shelf.GetId().GetId()
+			if pid == "" {
+				continue
+			}
+			if state := shelf.GetControllerState(); state != "" {
+				result[pid] = state
+			}
+		}
+		return nil
+	}); err != nil {
 		return nil, fmt.Errorf("FindPowerShelvesByIds: %w", err)
-	}
-
-	result := make(map[string]string, len(resp.GetPowerShelves()))
-	for _, ps := range resp.GetPowerShelves() {
-		pid := ps.GetId().GetId()
-		if pid == "" {
-			continue
-		}
-		if s := ps.GetControllerState(); s != "" {
-			result[pid] = s
-		}
 	}
 	return result, nil
 }
@@ -1330,17 +1386,23 @@ func (c *grpcClient) findAssociatedDpuMachineIdsLocked(
 		return nil, fmt.Errorf("host machine id is required")
 	}
 
-	resp, err := c.gclient.FindMachinesByIds(ctx, &corev1.MachinesByIdsRequest{
+	request := &corev1.MachinesByIdsRequest{
 		MachineIds: []*corev1.MachineId{{Id: hostMachineID}},
-	})
-	if err != nil {
+	}
+	var machine *corev1.Machine
+	if err := c.gclient.visitMachineBatches(ctx, request, func(batch []*corev1.Machine) error {
+		if len(batch) > 0 {
+			machine = batch[0]
+		}
+		return nil
+	}); err != nil {
 		return nil, fmt.Errorf("failed to find machine %s: %w", hostMachineID, err)
 	}
-	if len(resp.GetMachines()) == 0 {
+	if machine == nil {
 		return nil, fmt.Errorf("machine %s not found", hostMachineID)
 	}
 
-	dpus := resp.GetMachines()[0].GetStatus().GetAssociatedDpuMachineIds()
+	dpus := machine.GetStatus().GetAssociatedDpuMachineIds()
 	out := make([]string, 0, len(dpus))
 	for _, id := range dpus {
 		if v := id.GetId(); v != "" {

--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -133,9 +133,11 @@ func (c *batchingForgeClient) visitMachineBatches(
 	visit func([]*corev1.Machine) error,
 	options ...grpc.CallOption,
 ) error {
-	return visitFindByIDBatches(ctx, c.loadMaxFindByIDs, protoIDsToStrings(request.GetMachineIds()),
+	return visitFindByIDBatches(ctx, "FindMachinesByIds", c.loadMaxFindByIDs, protoIDsToStrings(request.GetMachineIds()),
 		func(ctx context.Context, batch []string) ([]*corev1.Machine, error) {
 			return c.fetchMachinesByIDs(ctx, request, batch, options...)
+		}, func(machine *corev1.Machine) string {
+			return machine.GetId().GetId()
 		}, visit)
 }
 
@@ -145,9 +147,11 @@ func (c *batchingForgeClient) visitSwitchBatches(
 	visit func([]*corev1.Switch) error,
 	options ...grpc.CallOption,
 ) error {
-	return visitFindByIDBatches(ctx, c.loadMaxFindByIDs, protoIDsToStrings(request.GetSwitchIds()),
+	return visitFindByIDBatches(ctx, "FindSwitchesByIds", c.loadMaxFindByIDs, protoIDsToStrings(request.GetSwitchIds()),
 		func(ctx context.Context, batch []string) ([]*corev1.Switch, error) {
 			return c.fetchSwitchesByIDs(ctx, request, batch, options...)
+		}, func(sw *corev1.Switch) string {
+			return sw.GetId().GetId()
 		}, visit)
 }
 
@@ -157,9 +161,11 @@ func (c *batchingForgeClient) visitPowerShelfBatches(
 	visit func([]*corev1.PowerShelf) error,
 	options ...grpc.CallOption,
 ) error {
-	return visitFindByIDBatches(ctx, c.loadMaxFindByIDs, protoIDsToStrings(request.GetPowerShelfIds()),
+	return visitFindByIDBatches(ctx, "FindPowerShelvesByIds", c.loadMaxFindByIDs, protoIDsToStrings(request.GetPowerShelfIds()),
 		func(ctx context.Context, batch []string) ([]*corev1.PowerShelf, error) {
 			return c.fetchPowerShelvesByIDs(ctx, request, batch, options...)
+		}, func(shelf *corev1.PowerShelf) string {
+			return shelf.GetId().GetId()
 		}, visit)
 }
 
@@ -396,13 +402,18 @@ func (c *batchingForgeClient) loadMaxFindByIDs(ctx context.Context) (uint32, err
 // The caller's context covers limit discovery and all batch RPCs.
 func visitFindByIDBatches[T any](
 	ctx context.Context,
+	rpcName string,
 	loadLimit func(context.Context) (uint32, error),
 	ids []string,
 	fetch func(context.Context, []string) ([]T, error),
+	identity func(T) string,
 	visit func([]T) error,
 ) error {
 	if len(ids) == 0 {
 		return nil
+	}
+	if err := validateByIDsRequest(ids, rpcName); err != nil {
+		return err
 	}
 
 	limit, err := loadLimit(ctx)
@@ -420,6 +431,13 @@ func visitFindByIDBatches[T any](
 		if err != nil {
 			return err
 		}
+		returnedIDs := make([]string, 0, len(values))
+		for _, value := range values {
+			returnedIDs = append(returnedIDs, identity(value))
+		}
+		if err := validateByIDsResponse(batch, returnedIDs, rpcName); err != nil {
+			return err
+		}
 		if err := visit(values); err != nil {
 			return err
 		}
@@ -427,10 +445,39 @@ func visitFindByIDBatches[T any](
 	return nil
 }
 
-// validateByIDsResponse rejects a batch response that omits any requested ID.
+// validateByIDsRequest rejects identities that cannot form an exact result set.
+func validateByIDsRequest(ids []string, rpcName string) error {
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			return fmt.Errorf("%s request contains an empty ID", rpcName)
+		}
+		if _, ok := seen[id]; ok {
+			return fmt.Errorf("%s request contains duplicate ID: %s", rpcName, id)
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
+}
+
+// validateByIDsResponse requires the response identities to exactly match the request.
 func validateByIDsResponse(requested, returned []string, rpcName string) error {
+	requestedSet := make(map[string]struct{}, len(requested))
+	for _, id := range requested {
+		requestedSet[id] = struct{}{}
+	}
+
 	returnedSet := make(map[string]struct{}, len(returned))
 	for _, id := range returned {
+		if id == "" {
+			return fmt.Errorf("%s returned an empty ID", rpcName)
+		}
+		if _, ok := requestedSet[id]; !ok {
+			return fmt.Errorf("%s returned unrequested ID: %s", rpcName, id)
+		}
+		if _, ok := returnedSet[id]; ok {
+			return fmt.Errorf("%s returned duplicate ID: %s", rpcName, id)
+		}
 		returnedSet[id] = struct{}{}
 	}
 
@@ -460,8 +507,7 @@ func protoIDsToStrings[T protoID](ids []T) []string {
 	return result
 }
 
-// fetchMachinesByIDs clones the caller's request for one raw Core batch and
-// verifies that Core returned every requested machine.
+// fetchMachinesByIDs clones the caller's request for one raw Core batch.
 func (c *batchingForgeClient) fetchMachinesByIDs(
 	ctx context.Context,
 	request *corev1.MachinesByIdsRequest,
@@ -475,15 +521,7 @@ func (c *batchingForgeClient) fetchMachinesByIDs(
 		return nil, fmt.Errorf("FindMachinesByIds: %w", err)
 	}
 
-	machines := response.GetMachines()
-	returned := make([]string, 0, len(machines))
-	for _, machine := range machines {
-		returned = append(returned, machine.GetId().GetId())
-	}
-	if err := validateByIDsResponse(batch, returned, "FindMachinesByIds"); err != nil {
-		return nil, err
-	}
-	return machines, nil
+	return response.GetMachines(), nil
 }
 
 // GetPowerStates returns the power states of the given machines (all machines if given an empty machineIds)
@@ -652,15 +690,7 @@ func (c *batchingForgeClient) fetchSwitchesByIDs(
 		return nil, fmt.Errorf("FindSwitchesByIds: %w", err)
 	}
 
-	switches := response.GetSwitches()
-	returned := make([]string, 0, len(switches))
-	for _, sw := range switches {
-		returned = append(returned, sw.GetId().GetId())
-	}
-	if err := validateByIDsResponse(batch, returned, "FindSwitchesByIds"); err != nil {
-		return nil, err
-	}
-	return switches, nil
+	return response.GetSwitches(), nil
 }
 
 // fetchPowerShelvesByIDs clones the caller's request for one raw Core batch and
@@ -682,15 +712,7 @@ func (c *batchingForgeClient) fetchPowerShelvesByIDs(
 		return nil, fmt.Errorf("FindPowerShelvesByIds: %w", err)
 	}
 
-	shelves := response.GetPowerShelves()
-	returned := make([]string, 0, len(shelves))
-	for _, shelf := range shelves {
-		returned = append(returned, shelf.GetId().GetId())
-	}
-	if err := validateByIDsResponse(batch, returned, "FindPowerShelvesByIds"); err != nil {
-		return nil, err
-	}
-	return shelves, nil
+	return response.GetPowerShelves(), nil
 }
 
 // FindSwitchRackIDs returns the rack assignment of each given switch.

--- a/rest-api/flow/internal/nicoapi/grpc_batch_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_batch_test.go
@@ -6,6 +6,9 @@ package nicoapi
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -24,6 +27,8 @@ type recordingForgeClient struct {
 	versionErr      error
 	versionErrors   []error
 	versionDelay    time.Duration
+	machineIDDelay  time.Duration
+	machineDelay    time.Duration
 	switchIDDelay   time.Duration
 	switchDelay     time.Duration
 	shelfIDDelay    time.Duration
@@ -69,15 +74,22 @@ func (c *recordingForgeClient) Version(
 }
 
 func (c *recordingForgeClient) FindMachineIds(
-	_ context.Context,
+	ctx context.Context,
 	_ *corev1.MachineSearchConfig,
 	_ ...grpc.CallOption,
 ) (*corev1.MachineIdList, error) {
+	if c.machineIDDelay > 0 {
+		select {
+		case <-time.After(c.machineIDDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	return &corev1.MachineIdList{MachineIds: stringsToMachineIds(c.machineIDs)}, nil
 }
 
 func (c *recordingForgeClient) FindMachinesByIds(
-	_ context.Context,
+	ctx context.Context,
 	request *corev1.MachinesByIdsRequest,
 	_ ...grpc.CallOption,
 ) (*corev1.MachineList, error) {
@@ -86,7 +98,15 @@ func (c *recordingForgeClient) FindMachinesByIds(
 	c.machineBatches = append(c.machineBatches, batch)
 	failed := c.failCall == len(c.machineBatches)
 	omitID := c.omitID
+	delay := c.machineDelay
 	c.mu.Unlock()
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	if failed {
 		return nil, errors.New("injected machine lookup failure")
 	}
@@ -232,8 +252,20 @@ func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {
 	testCases := []struct {
 		name   string
 		fake   *recordingForgeClient
-		invoke func(context.Context, *grpcClient) ([]ObservedControllerDevice, error)
+		invoke func(context.Context, *grpcClient) (int, error)
 	}{
+		{
+			name: "machines",
+			fake: &recordingForgeClient{
+				machineIDs:     []string{"machine-1"},
+				machineIDDelay: 120 * time.Millisecond,
+				machineDelay:   120 * time.Millisecond,
+			},
+			invoke: func(ctx context.Context, client *grpcClient) (int, error) {
+				machines, err := client.GetMachines(ctx)
+				return len(machines), err
+			},
+		},
 		{
 			name: "switches",
 			fake: &recordingForgeClient{
@@ -241,8 +273,9 @@ func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {
 				switchIDDelay: 120 * time.Millisecond,
 				switchDelay:   120 * time.Millisecond,
 			},
-			invoke: func(ctx context.Context, client *grpcClient) ([]ObservedControllerDevice, error) {
-				return client.GetSwitches(ctx)
+			invoke: func(ctx context.Context, client *grpcClient) (int, error) {
+				devices, err := client.GetSwitches(ctx)
+				return len(devices), err
 			},
 		},
 		{
@@ -252,8 +285,9 @@ func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {
 				shelfIDDelay: 120 * time.Millisecond,
 				shelfDelay:   120 * time.Millisecond,
 			},
-			invoke: func(ctx context.Context, client *grpcClient) ([]ObservedControllerDevice, error) {
-				return client.GetPowerShelves(ctx)
+			invoke: func(ctx context.Context, client *grpcClient) (int, error) {
+				devices, err := client.GetPowerShelves(ctx)
+				return len(devices), err
 			},
 		},
 	}
@@ -263,12 +297,10 @@ func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {
 			client := newRecordingGRPCClient(tc.fake)
 			client.grpcTimeout = 200 * time.Millisecond
 
-			devices, err := tc.invoke(context.Background(), client)
+			count, err := tc.invoke(context.Background(), client)
 
 			require.NoError(t, err)
-			require.Len(t, devices, 1)
-			assert.NotEmpty(t, devices[0].ID)
-			assert.NotEmpty(t, devices[0].BmcMac)
+			assert.Equal(t, 1, count)
 		})
 	}
 }
@@ -425,7 +457,7 @@ func TestGrpcClient_ByIDLookupsHonorCoreBatchLimit(t *testing.T) {
 	}
 }
 
-func TestGrpcClient_ByIDLookupsTreatZeroOrAbsentLimitAsUnlimited(t *testing.T) {
+func TestGrpcClient_ByIDLookupsTreatZeroOrAbsentLimitAsServerUnlimited(t *testing.T) {
 	ids := []string{"a", "b", "c"}
 	tests := []struct {
 		name   string
@@ -443,6 +475,101 @@ func TestGrpcClient_ByIDLookupsTreatZeroOrAbsentLimitAsUnlimited(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, result, len(ids))
 			assert.Equal(t, [][]string{ids}, fake.switchBatches)
+		})
+	}
+}
+
+func TestGrpcClient_ByIDLookupsApplyFlowClientBatchCap(t *testing.T) {
+	ids := make([]string, 0, flowFindByIDsBatchSize*2+1)
+	for i := range flowFindByIDsBatchSize*2 + 1 {
+		ids = append(ids, fmt.Sprintf("switch-%03d", i))
+	}
+
+	tests := []struct {
+		name            string
+		coreLimit       uint32
+		expectedLengths []int
+	}{
+		{
+			name:            "unlimited Core still uses Flow cap",
+			coreLimit:       0,
+			expectedLengths: []int{flowFindByIDsBatchSize, flowFindByIDsBatchSize, 1},
+		},
+		{
+			name:            "larger Core limit uses Flow cap",
+			coreLimit:       flowFindByIDsBatchSize + 50,
+			expectedLengths: []int{flowFindByIDsBatchSize, flowFindByIDsBatchSize, 1},
+		},
+		{
+			name:            "smaller Core limit remains authoritative",
+			coreLimit:       60,
+			expectedLengths: []int{60, 60, 60, 21},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &recordingForgeClient{
+				runtimeConfig: &corev1.RuntimeConfig{MaxFindByIds: test.coreLimit},
+			}
+
+			result, err := newRecordingGRPCClient(fake).FindSwitchRackIDs(context.Background(), ids)
+
+			require.NoError(t, err)
+			assert.Len(t, result, len(ids))
+			require.Len(t, fake.switchBatches, len(test.expectedLengths))
+			for i, expectedLength := range test.expectedLengths {
+				assert.Len(t, fake.switchBatches[i], expectedLength)
+			}
+		})
+	}
+}
+
+func TestVisitFindByIDBatches(t *testing.T) {
+	tests := []struct {
+		name       string
+		visitError bool
+		wantEvents []string
+		wantError  string
+	}{
+		{
+			name:       "projects each batch before fetching the next",
+			wantEvents: []string{"fetch:a,b", "visit:a,b", "fetch:c,d", "visit:c,d"},
+		},
+		{
+			name:       "projection failure stops the lookup",
+			visitError: true,
+			wantEvents: []string{"fetch:a,b", "visit:a,b"},
+			wantError:  "injected projection failure",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var events []string
+			err := visitFindByIDBatches(
+				context.Background(),
+				func(context.Context) (uint32, error) { return 2, nil },
+				[]string{"a", "b", "c", "d"},
+				func(_ context.Context, batch []string) ([]string, error) {
+					events = append(events, "fetch:"+strings.Join(batch, ","))
+					return slices.Clone(batch), nil
+				},
+				func(batch []string) error {
+					events = append(events, "visit:"+strings.Join(batch, ","))
+					if test.visitError {
+						return errors.New("injected projection failure")
+					}
+					return nil
+				},
+			)
+
+			assert.Equal(t, test.wantEvents, events)
+			if test.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantError)
+			}
 		})
 	}
 }
@@ -485,6 +612,58 @@ func TestGrpcClient_ByIDLookupsRejectPartialResults(t *testing.T) {
 
 			require.Error(t, err)
 			assert.ErrorContains(t, err, test.errorString)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestGrpcClient_ActualInventoryRejectsPartialProjectedSnapshots(t *testing.T) {
+	ids := []string{"a", "b", "c", "d"}
+	tests := []struct {
+		name   string
+		fake   *recordingForgeClient
+		invoke func(context.Context, *grpcClient) (any, error)
+	}{
+		{
+			name: "machines",
+			fake: &recordingForgeClient{
+				runtimeConfig: &corev1.RuntimeConfig{MaxFindByIds: 2},
+				machineIDs:    ids,
+				failCall:      2,
+			},
+			invoke: func(ctx context.Context, client *grpcClient) (any, error) {
+				return client.GetMachines(ctx)
+			},
+		},
+		{
+			name: "switches",
+			fake: &recordingForgeClient{
+				runtimeConfig: &corev1.RuntimeConfig{MaxFindByIds: 2},
+				switchIDs:     ids,
+				failCall:      2,
+			},
+			invoke: func(ctx context.Context, client *grpcClient) (any, error) {
+				return client.GetSwitches(ctx)
+			},
+		},
+		{
+			name: "power shelves",
+			fake: &recordingForgeClient{
+				runtimeConfig: &corev1.RuntimeConfig{MaxFindByIds: 2},
+				shelfIDs:      ids,
+				failCall:      2,
+			},
+			invoke: func(ctx context.Context, client *grpcClient) (any, error) {
+				return client.GetPowerShelves(ctx)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := test.invoke(context.Background(), newRecordingGRPCClient(test.fake))
+
+			require.Error(t, err)
 			assert.Nil(t, result)
 		})
 	}

--- a/rest-api/flow/internal/nicoapi/grpc_batch_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_batch_test.go
@@ -22,26 +22,27 @@ import (
 type recordingForgeClient struct {
 	corev1.ForgeClient
 
-	mu              sync.Mutex
-	runtimeConfig   *corev1.RuntimeConfig
-	versionErr      error
-	versionErrors   []error
-	versionDelay    time.Duration
-	machineIDDelay  time.Duration
-	machineDelay    time.Duration
-	switchIDDelay   time.Duration
-	switchDelay     time.Duration
-	shelfIDDelay    time.Duration
-	shelfDelay      time.Duration
-	versionRequests []*corev1.VersionRequest
-	machineIDs      []string
-	switchIDs       []string
-	shelfIDs        []string
-	machineBatches  [][]string
-	switchBatches   [][]string
-	shelfBatches    [][]string
-	failCall        int
-	omitID          string
+	mu                sync.Mutex
+	runtimeConfig     *corev1.RuntimeConfig
+	versionErr        error
+	versionErrors     []error
+	versionDelay      time.Duration
+	machineIDDelay    time.Duration
+	machineDelay      time.Duration
+	switchIDDelay     time.Duration
+	switchDelay       time.Duration
+	shelfIDDelay      time.Duration
+	shelfDelay        time.Duration
+	versionRequests   []*corev1.VersionRequest
+	machineIDs        []string
+	switchIDs         []string
+	shelfIDs          []string
+	switchResponseIDs []string
+	machineBatches    [][]string
+	switchBatches     [][]string
+	shelfBatches      [][]string
+	failCall          int
+	omitID            string
 }
 
 func (c *recordingForgeClient) Version(
@@ -161,6 +162,10 @@ func (c *recordingForgeClient) FindSwitchesByIds(
 	failed := c.failCall == len(c.switchBatches)
 	omitID := c.omitID
 	delay := c.switchDelay
+	responseIDs := batch
+	if c.switchResponseIDs != nil {
+		responseIDs = slices.Clone(c.switchResponseIDs)
+	}
 	c.mu.Unlock()
 	if delay > 0 {
 		select {
@@ -173,9 +178,9 @@ func (c *recordingForgeClient) FindSwitchesByIds(
 		return nil, errors.New("injected switch lookup failure")
 	}
 
-	switches := make([]*corev1.Switch, 0, len(batch))
-	for _, id := range batch {
-		if id != omitID {
+	switches := make([]*corev1.Switch, 0, len(responseIDs))
+	for _, id := range responseIDs {
+		if omitID == "" || id != omitID {
 			nvosIP := "ip-" + id
 			bmcMAC := "mac-" + id
 			switches = append(switches, &corev1.Switch{
@@ -549,12 +554,14 @@ func TestVisitFindByIDBatches(t *testing.T) {
 			var events []string
 			err := visitFindByIDBatches(
 				context.Background(),
+				"FindByIds",
 				func(context.Context) (uint32, error) { return 2, nil },
 				[]string{"a", "b", "c", "d"},
 				func(_ context.Context, batch []string) ([]string, error) {
 					events = append(events, "fetch:"+strings.Join(batch, ","))
 					return slices.Clone(batch), nil
 				},
+				func(value string) string { return value },
 				func(batch []string) error {
 					events = append(events, "visit:"+strings.Join(batch, ","))
 					if test.visitError {
@@ -570,6 +577,148 @@ func TestVisitFindByIDBatches(t *testing.T) {
 			} else {
 				require.ErrorContains(t, err, test.wantError)
 			}
+		})
+	}
+}
+
+func TestVisitFindByIDBatchesRejectsInvalidRequestsBeforeFetch(t *testing.T) {
+	tests := []struct {
+		name      string
+		ids       []string
+		wantError string
+	}{
+		{
+			name:      "empty ID",
+			ids:       []string{"a", ""},
+			wantError: "FindByIds request contains an empty ID",
+		},
+		{
+			name:      "duplicate ID across prospective batches",
+			ids:       []string{"a", "b", "a"},
+			wantError: "FindByIds request contains duplicate ID: a",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loadedLimit := false
+			fetched := false
+			visited := false
+			err := visitFindByIDBatches(
+				context.Background(),
+				"FindByIds",
+				func(context.Context) (uint32, error) {
+					loadedLimit = true
+					return 2, nil
+				},
+				test.ids,
+				func(context.Context, []string) ([]string, error) {
+					fetched = true
+					return nil, nil
+				},
+				func(value string) string { return value },
+				func([]string) error {
+					visited = true
+					return nil
+				},
+			)
+
+			require.ErrorContains(t, err, test.wantError)
+			assert.False(t, loadedLimit)
+			assert.False(t, fetched)
+			assert.False(t, visited)
+		})
+	}
+}
+
+func TestValidateByIDsResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested []string
+		returned  []string
+		wantError string
+	}{
+		{
+			name:      "exact identity set",
+			requested: []string{"a", "b"},
+			returned:  []string{"b", "a"},
+		},
+		{
+			name:      "empty returned ID",
+			requested: []string{"a"},
+			returned:  []string{""},
+			wantError: "FindByIds returned an empty ID",
+		},
+		{
+			name:      "duplicate returned ID",
+			requested: []string{"a", "b"},
+			returned:  []string{"a", "a", "b"},
+			wantError: "FindByIds returned duplicate ID: a",
+		},
+		{
+			name:      "unrequested returned ID",
+			requested: []string{"a"},
+			returned:  []string{"a", "b"},
+			wantError: "FindByIds returned unrequested ID: b",
+		},
+		{
+			name:      "missing returned ID",
+			requested: []string{"a", "b"},
+			returned:  []string{"a"},
+			wantError: "FindByIds returned an incomplete response; missing IDs: b",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateByIDsResponse(test.requested, test.returned, "FindByIds")
+
+			if test.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestGrpcClient_ByIDLookupsRejectInvalidReturnedIdentitiesBeforeProjection(t *testing.T) {
+	tests := []struct {
+		name        string
+		returnedIDs []string
+		wantError   string
+	}{
+		{
+			name:        "empty ID",
+			returnedIDs: []string{"", "b"},
+			wantError:   "returned an empty ID",
+		},
+		{
+			name:        "duplicate ID",
+			returnedIDs: []string{"a", "a", "b"},
+			wantError:   "returned duplicate ID: a",
+		},
+		{
+			name:        "unrequested ID",
+			returnedIDs: []string{"a", "unexpected"},
+			wantError:   "returned unrequested ID: unexpected",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &recordingForgeClient{
+				runtimeConfig:     &corev1.RuntimeConfig{MaxFindByIds: 2},
+				switchResponseIDs: test.returnedIDs,
+			}
+
+			result, err := newRecordingGRPCClient(fake).FindSwitchRackIDs(
+				context.Background(),
+				[]string{"a", "b"},
+			)
+
+			require.ErrorContains(t, err, test.wantError)
+			assert.Nil(t, result)
 		})
 	}
 }

--- a/rest-api/flow/internal/nicoapi/grpc_domain_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_domain_test.go
@@ -37,6 +37,15 @@ func (c *deadlineTrackingForgeClient) FindSwitchIds(
 	return &corev1.SwitchIdList{Ids: []*corev1.SwitchId{{Id: "switch-a"}}}, nil
 }
 
+func (c *deadlineTrackingForgeClient) Version(
+	ctx context.Context,
+	_ *corev1.VersionRequest,
+	_ ...grpc.CallOption,
+) (*corev1.BuildInfo, error) {
+	c.recordDeadline(ctx)
+	return &corev1.BuildInfo{RuntimeConfig: &corev1.RuntimeConfig{MaxFindByIds: 100}}, nil
+}
+
 func (c *deadlineTrackingForgeClient) FindSwitchesByIds(
 	ctx context.Context,
 	_ *corev1.SwitchesByIdsRequest,
@@ -54,13 +63,14 @@ func (c *deadlineTrackingForgeClient) FindSwitchesByIds(
 
 func TestGetObservedNVLinkDomainMembershipsUsesPerRPCTimeouts(t *testing.T) {
 	forgeClient := &deadlineTrackingForgeClient{}
-	client := &grpcClient{gclient: forgeClient, grpcTimeout: time.Minute}
+	client := &grpcClient{gclient: newBatchingForgeClient(forgeClient), grpcTimeout: time.Minute}
 
 	memberships, err := client.GetObservedNVLinkDomainMemberships(context.Background())
 	require.NoError(t, err)
 	require.Len(t, memberships, 1)
-	require.Len(t, forgeClient.deadlines, 2)
+	require.Len(t, forgeClient.deadlines, 3)
 	assert.Greater(t, forgeClient.deadlines[1].Sub(forgeClient.deadlines[0]), 5*time.Millisecond)
+	assert.Equal(t, forgeClient.deadlines[1], forgeClient.deadlines[2])
 }
 
 func TestNVLinkDomainMembershipsFromSwitches(t *testing.T) {


### PR DESCRIPTION
Flow already splits Core `*ByIds` requests to honor `runtime_config.max_find_by_ids`, but the batching layer collects every full protobuf resource before inventory code projects the response into its smaller snapshot shape. Peak memory therefore still grows with the complete Core response for machines, switches, and power shelves.

This change lets the affected Flow lookups validate and project each complete batch before fetching the next one. Reconciliation retains the final lightweight snapshot plus only the current full protobuf batch. A failed RPC, incomplete batch, or projection error rejects the entire lookup and returns no partial snapshot.

The Flow client uses a fixed batch cap of 100 and still treats Core's advertised non-zero `max_find_by_ids` as authoritative when it is smaller. A zero or absent Core limit means the server is unlimited, while Flow continues to use its client-side cap to bound memory.

## Related issues

Fixes #5322

Part of #4348

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
 

## Additional Notes
 
