### PR TITLE
docs: align tested BlueField software guidance

### DIFF
--- a/docs/getting-started/prerequisites/hardware.md
+++ b/docs/getting-started/prerequisites/hardware.md
@@ -29,8 +29,8 @@ DPUs are generally preferred in nodes hosting the NICo control plane components,
 - You have the correct DPU power cable from the server vendor.
 - The Bluefield-3's operating mode is DPU mode.
 - For BF3 DPUs, verify link speed and optics: BF3 runs at 200 Gb, so match ports to 200 Gb-capable optics, fiber, or DACs.
-- Verify that the DPU can connect to the outside world (curl -I https://www.nvidia.com)
-- The DPUs are at the latest tested firmware version: DOCA 3.2.2 and HBN 3.2.2
+- Verify that the DPU can connect to the outside world (`curl -I https://www.nvidia.com`).
+- The DPUs use the [tested BlueField-3 software versions](../../hcl.md#dpus).
 
 ### NICo Pod Network Reachability
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -36,21 +36,18 @@ The cluster must have:
 
 DPUs are generally preferred in nodes hosting the NICo control plane components, but not strictly required. DPUs in these nodes are, however, the configuration that NICo QA regularly tests. NICo does not provision the site controller nodes' own DPUs — it only manages DPUs on downstream bare-metal hosts after ingestion.
 
-If your site controller nodes are equipped with Bluefield-3 DPUs, they must be fully provisioned **before** the Kubernetes cluster is set up. Specifically, complete the following before proceeding:
+If your site controller nodes are equipped with BlueField-3 DPUs, they must be fully provisioned **before** the Kubernetes cluster is set up. Specifically, complete the following before proceeding:
 
-- Flash the DPU firmware to the latest tested version using the BlueField Firmware Bundle. Latest tested firmware versions:
-
-  | DOCA  | HBN   |
-  | ----- | ----- |
-  | 3.2.2 | 3.2.2 |
+- Flash the DPU firmware using the BlueField Firmware Bundle for the
+  [tested BlueField-3 software versions](../hcl.md#dpus).
 
 - Configure the Bluefield-3 device in DPU mode (operating mode).
 - Ensure the DPU ARM OS is booted and reachable via its management interface.
 - Verify that the DPU can connect to the outside world with `curl -I https://www.google.com`
 
-Refer to the NVIDIA DOCA documentation and the BlueField Firmware Bundle download archive for firmware flashing instructions and supported firmware versions:
-
-[https://developer.nvidia.com/doca-2-9-3-download-archive?deployment_platform=BlueField&deployment_package=BF-FW-Bundle](https://developer.nvidia.com/doca-2-9-3-download-archive?deployment_platform=BlueField&deployment_package=BF-FW-Bundle)
+Refer to the
+[NVIDIA DOCA 3.2.2 download archive](https://developer.nvidia.com/doca-3-2-2-download-archive?deployment_platform=BlueField&deployment_package=BF-FW-Bundle)
+for firmware flashing instructions and the BlueField Firmware Bundle.
 
 ### Required tools (local machine)
 

--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -57,10 +57,13 @@ This list outlines platforms that are under development and have not undergone f
 
 ## DPUs
 
-| DPU | Firmware / Software Version |
-| --- | --------------------------- |
-| BlueField 2 | DOCA 3.2.0 |
-| BlueField 3 | DOCA 3.2.0 |
+The following versions are the tested software pins, not automatically the
+latest available releases. DOCA and HBN are versioned separately.
+
+| DPU | DOCA | HBN |
+| --- | --- | --- |
+| BlueField 2 | 3.2.0 | Not specified |
+| BlueField 3 | 3.2.2 | 3.2.2 |
 
 ## GPUs
 


### PR DESCRIPTION
## Summary

- make the HCL the canonical v2.1 tested BlueField-3 software boundary of DOCA 3.2.2 and HBN 3.2.2
- point the hardware prerequisites and quick start to that canonical entry
- replace the stale DOCA 2.9.3 archive link with the matching 3.2.2 archive

This resolves the conflicting public guidance tracked by NVBugs 6592759 without changing the separate managed-host DPF runtime defaults.

## Test plan

- [x] `rumdl check --config docs/.rumdl.toml AGENTS.md docs/getting-started/quick-start.md docs/getting-started/prerequisites/hardware.md docs/hcl.md`
- [x] `fern docs md check`
- [x] `fern check`
- [x] verified the DOCA 3.2.2 archive URL returns HTTP 200