### PR TITLE
feat(machine-a-tron): simulate BMC self-reset offline window 

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1441,10 +1441,16 @@ where
                 timing_overrides: Some(LifecycleTimingOverrides {
                     host: PartialLifecycleTimings {
                         reboot: Some(Duration::from_secs(1)),
+                        // ZERO disables the BMC self-reset offline window entirely,
+                        // keeping ingestion at its pre-feature pace
+                        bmc_reset: Some(Duration::ZERO),
                         ..Default::default()
                     },
                     dpu: PartialLifecycleTimings {
                         reboot: Some(Duration::from_secs(1)),
+                        // ZERO disables the BMC self-reset offline window entirely,
+                        // keeping ingestion at its pre-feature pace
+                        bmc_reset: Some(Duration::ZERO),
                         ..Default::default()
                     },
                 }),

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -127,10 +127,16 @@ async fn run_machine_a_tron_racks_test(
                             timing_overrides: Some(LifecycleTimingOverrides {
                                 host: PartialLifecycleTimings {
                                     reboot: Some(Duration::from_secs(1)),
+                                    // ZERO disables the BMC self-reset offline window entirely,
+                                    // keeping ingestion at its pre-feature pace
+                                    bmc_reset: Some(Duration::ZERO),
                                     ..Default::default()
                                 },
                                 dpu: PartialLifecycleTimings {
                                     reboot: Some(Duration::from_secs(1)),
+                                    // ZERO disables the BMC self-reset offline window entirely,
+                                    // keeping ingestion at its pre-feature pace
+                                    bmc_reset: Some(Duration::ZERO),
                                     ..Default::default()
                                 },
                             }),
@@ -163,10 +169,16 @@ async fn run_machine_a_tron_racks_test(
                             timing_overrides: Some(LifecycleTimingOverrides {
                                 host: PartialLifecycleTimings {
                                     reboot: Some(Duration::from_secs(1)),
+                                    // ZERO disables the BMC self-reset offline window entirely,
+                                    // keeping ingestion at its pre-feature pace
+                                    bmc_reset: Some(Duration::ZERO),
                                     ..Default::default()
                                 },
                                 dpu: PartialLifecycleTimings {
                                     reboot: Some(Duration::from_secs(1)),
+                                    // ZERO disables the BMC self-reset offline window entirely,
+                                    // keeping ingestion at its pre-feature pace
+                                    bmc_reset: Some(Duration::ZERO),
                                     ..Default::default()
                                 },
                             }),

--- a/crates/bmc-mock/src/availability.rs
+++ b/crates/bmc-mock/src/availability.rs
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//! BMC self-reset simulation (machine-a-tron epic #3796, issue 4).
+//!
+//! Real BMCs go OFFLINE for a platform-specific window after a self-reset
+//! (`Manager.Reset` via Redfish, `ipmitool mc reset cold` via IPMI): every
+//! management request fails until the controller finishes rebooting, while
+//! the SERVER's power state is unaffected. The nico machine-controller
+//! issues such resets in five automated scenarios; without this simulation
+//! its retry/recovery behavior during the outage window is never exercised.
+//!
+//! Model: a per-mock [`BmcAvailabilityState`] holding `Online` or
+//! `Resetting { until }`. A reset trigger stamps `until = now + reset
+//! duration` (from the machine's resolved [`LifecycleTimings::bmc_reset`]);
+//! the request middleware answers `503 Service Unavailable` while the
+//! window is open and lazily flips back to `Online` on the first request
+//! after it expires — exactly how a real BMC "comes back": silently, by
+//! answering again. No timers, no tasks.
+
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum BmcAvailability {
+    Online,
+    Resetting { until: Instant },
+}
+
+/// Shared availability state for one mock BMC.
+#[derive(Debug)]
+pub struct BmcAvailabilityState {
+    /// How long the BMC stays offline after a self-reset
+    /// (resolved per machine from its platform timing profile).
+    reset_duration: Duration,
+    state: Mutex<BmcAvailability>,
+}
+
+impl BmcAvailabilityState {
+    pub fn new(reset_duration: Duration) -> Self {
+        Self {
+            reset_duration,
+            state: Mutex::new(BmcAvailability::Online),
+        }
+    }
+
+    /// Lock the state, recovering from a poisoned mutex instead of
+    /// panicking: the enum inside is a `Copy` value only ever replaced
+    /// whole, so a poison (another thread panicked while holding the
+    /// lock) leaves at worst a stale-but-valid state. That other panic
+    /// is the bug to chase — log loudly here, but keep this mock
+    /// answering rather than cascading the failure.
+    fn lock_state(&self) -> MutexGuard<'_, BmcAvailability> {
+        self.state.lock().unwrap_or_else(|poisoned| {
+            tracing::error!(
+                "BMC availability mutex poisoned by a panic elsewhere; \
+                 continuing with the last recorded state"
+            );
+            poisoned.into_inner()
+        })
+    }
+
+    /// Enter the offline window (a self-reset was triggered).
+    /// Returns the window duration for logging.
+    pub fn begin_reset(&self) -> Duration {
+        let mut state = self.lock_state();
+        *state = BmcAvailability::Resetting {
+            until: Instant::now() + self.reset_duration,
+        };
+        self.reset_duration
+    }
+
+    /// True while the BMC is inside its offline window. Lazily recovers:
+    /// the first call after the window expires flips the state back to
+    /// `Online`.
+    pub fn is_offline(&self) -> bool {
+        let mut state = self.lock_state();
+        match *state {
+            BmcAvailability::Online => false,
+            BmcAvailability::Resetting { until } => {
+                if Instant::now() >= until {
+                    *state = BmcAvailability::Online;
+                    false
+                } else {
+                    true
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_online() {
+        let a = BmcAvailabilityState::new(Duration::from_secs(60));
+        assert!(!a.is_offline());
+    }
+
+    #[test]
+    fn reset_opens_the_offline_window() {
+        let a = BmcAvailabilityState::new(Duration::from_secs(60));
+        assert_eq!(a.begin_reset(), Duration::from_secs(60));
+        assert!(a.is_offline());
+        // still offline on repeated checks inside the window
+        assert!(a.is_offline());
+    }
+
+    #[test]
+    fn recovers_lazily_after_the_window() {
+        let a = BmcAvailabilityState::new(Duration::from_millis(10));
+        a.begin_reset();
+        assert!(a.is_offline());
+        std::thread::sleep(Duration::from_millis(20));
+        // first check after expiry flips back to Online
+        assert!(!a.is_offline());
+        assert!(!a.is_offline());
+    }
+
+    #[test]
+    fn survives_a_poisoned_mutex() {
+        use std::sync::Arc;
+
+        let a = Arc::new(BmcAvailabilityState::new(Duration::from_secs(60)));
+        let poisoner = Arc::clone(&a);
+        // poison the mutex: panic in another thread while holding the lock
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.state.lock().unwrap();
+            panic!("poison the availability mutex");
+        })
+        .join();
+        assert!(a.state.lock().is_err(), "mutex should be poisoned");
+
+        // no panic, state still fully usable
+        assert!(!a.is_offline());
+        a.begin_reset();
+        assert!(a.is_offline());
+    }
+
+    #[test]
+    fn second_reset_reopens_the_window() {
+        let a = BmcAvailabilityState::new(Duration::from_millis(10));
+        a.begin_reset();
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(!a.is_offline());
+        a.begin_reset();
+        assert!(a.is_offline());
+    }
+}

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -38,6 +38,9 @@ pub struct BmcState {
     pub account_service_state: Arc<AccountServiceState>,
     pub(crate) session_service_state: Arc<SessionServiceState>,
     pub injection: Arc<InjectionStore>,
+    /// BMC self-reset simulation window (None = feature disabled; resets
+    /// stay no-ops as before).
+    pub availability: Option<Arc<crate::availability::BmcAvailabilityState>>,
     pub(crate) callbacks: Option<Arc<dyn crate::Callbacks>>,
     /// Whether this BMC advertises and serves the `/redfish/v1/Systems`
     /// collection. Delta power shelves expose no `ComputerSystem` collection,

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -26,6 +26,7 @@ pub mod libvirt;
 pub mod simulated;
 
 mod auth_router;
+pub mod availability;
 mod bmc_state;
 mod combined_server;
 mod http;

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -650,6 +650,7 @@ esac
             "test-host-id".to_string(),
             false,
             MachineRouterOptions {
+                bmc_reset_duration: None,
                 virtual_media_devices: Some(vec![VirtualMediaDeviceConfig {
                     id: Cow::Borrowed("Cd"),
                     name: Cow::Borrowed("Operating System Virtual CD"),

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -360,6 +360,7 @@ fn generated_mock(config: GeneratedMockConfig) -> (Router, BmcState) {
             String::default(),
             false,
             MachineRouterOptions {
+                bmc_reset_duration: None,
                 virtual_media_devices: Some(vec![
                     VirtualMediaDeviceConfig {
                         id: Cow::Borrowed("Cd"),

--- a/crates/bmc-mock/src/middleware_router.rs
+++ b/crates/bmc-mock/src/middleware_router.rs
@@ -20,18 +20,20 @@ use std::sync::Arc;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::any;
 use carbide_axum_utils::router::call_router_with_new_request;
 use tracing::instrument;
 
 use crate::Callbacks;
+use crate::availability::BmcAvailabilityState;
 use crate::injection::InjectionStore;
 
 pub(super) fn append(
     mat_host_id: String,
     router: Router,
     injection: Arc<InjectionStore>,
+    availability: Option<Arc<BmcAvailabilityState>>,
     callbacks: Arc<dyn Callbacks>,
 ) -> Router {
     Router::new()
@@ -40,6 +42,7 @@ pub(super) fn append(
             mat_host_id,
             inner: router,
             injection,
+            availability,
             callbacks,
         })
 }
@@ -49,6 +52,23 @@ async fn process(State(mut state): State<Middleware>, request: Request<Body>) ->
     let is_safe = request.method().is_safe();
     let method = request.method().clone();
     let path = request.uri().path().to_string();
+
+    // BMC self-reset window: while the (simulated) controller reboots,
+    // NOTHING answers — before auth, before injection, before routing.
+    //
+    // A real BMC mid-reset yields transport errors first, then 503s while
+    // its web server restarts. We can only produce the latter: all mocks
+    // share one TLS listener (authority-multiplexed CombinedServer) with
+    // pooled keep-alive connections, so by the time a handler runs it can
+    // only return HTTP. Behaviorally equivalent for nico: its readiness
+    // probe and error paths collapse transport errors and error statuses
+    // into the same retry decision (machine-controller factory_reset.rs,
+    // `wait_for_bmc`).
+    if let Some(availability) = state.availability.as_ref()
+        && availability.is_offline()
+    {
+        return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+    }
 
     if let Some(short) = state.injection.pre_handle(&method, &path).await {
         return short;
@@ -76,6 +96,7 @@ struct Middleware {
     mat_host_id: String,
     inner: Router,
     injection: Arc<InjectionStore>,
+    availability: Option<Arc<BmcAvailabilityState>>,
     callbacks: Arc<dyn Callbacks>,
 }
 

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -31,6 +31,14 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct MachineRouterOptions {
     pub virtual_media_devices: Option<Vec<VirtualMediaDeviceConfig>>,
+    /// Enables the BMC self-reset simulation: after `Manager.Reset` the
+    /// mock answers 503 to everything for this duration (per-platform,
+    /// from the machine's resolved `LifecycleTimings::bmc_reset`).
+    /// `None` — and, deliberately, `Some(Duration::ZERO)` — keep resets
+    /// as no-ops (previous behavior, byte-for-byte: no offline window,
+    /// no state, no logging), so profiles/overrides with a zero timing
+    /// cannot perturb existing tests.
+    pub bmc_reset_duration: Option<std::time::Duration>,
 }
 
 #[derive(Debug)]
@@ -90,6 +98,7 @@ pub fn machine_router_with_injection_store(
     mat_host_id: String,
     redfish_auth: bool,
     injection: Arc<InjectionStore>,
+    options: MachineRouterOptions,
 ) -> (Router, BmcState) {
     machine_router_inner(
         machine_info,
@@ -97,7 +106,7 @@ pub fn machine_router_with_injection_store(
         mat_host_id,
         redfish_auth,
         injection,
-        MachineRouterOptions::default(),
+        options,
     )
 }
 
@@ -156,6 +165,10 @@ fn machine_router_inner(
     );
     let session_service_state =
         Arc::new(crate::redfish::session_service::SessionServiceState::new());
+    let availability = options
+        .bmc_reset_duration
+        .filter(|d| !d.is_zero())
+        .map(|d| Arc::new(crate::availability::BmcAvailabilityState::new(d)));
     let state = BmcState {
         bmc_vendor,
         bmc_product,
@@ -168,6 +181,7 @@ fn machine_router_inner(
         account_service_state,
         session_service_state,
         injection: injection.clone(),
+        availability: availability.clone(),
         callbacks: Some(callbacks.clone()),
         exposes_computer_systems: machine_info.exposes_computer_systems(),
     };
@@ -199,7 +213,7 @@ fn machine_router_inner(
             }
         }),
         Box::new(move |router| {
-            middleware_router::append(mat_host_id, router, injection, callbacks)
+            middleware_router::append(mat_host_id, router, injection, availability, callbacks)
         }),
     ] as [Box<dyn FnOnce(axum::Router) -> axum::Router>; _])
         .into_iter()

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -638,11 +638,22 @@ async fn post_reset_manager(
     State(state): State<BmcState>,
     Path(manager_id): Path<String>,
 ) -> Response {
-    state
-        .manager
-        .find(&manager_id)
-        .map(|_| json!({}).into_ok_response())
-        .unwrap_or_else(http::not_found)
+    if state.manager.find(&manager_id).is_none() {
+        return http::not_found();
+    }
+    // BMC self-reset: acknowledge, then go dark for the platform's
+    // bmc_reset window (the middleware answers 503 until it expires).
+    // The SERVER's power state is deliberately untouched — a BMC reset
+    // interrupts management visibility, not the machine.
+    if let Some(availability) = state.availability.as_ref() {
+        let window = availability.begin_reset();
+        tracing::info!(
+            manager_id,
+            offline_for = ?window,
+            "BMC self-reset: going offline"
+        );
+    }
+    json!({}).into_ok_response()
 }
 
 async fn get_log_services() -> Response {

--- a/crates/bmc-mock/src/redfish/virtual_media.rs
+++ b/crates/bmc-mock/src/redfish/virtual_media.rs
@@ -296,6 +296,7 @@ mod tests {
             "test-host-id".to_string(),
             false,
             MachineRouterOptions {
+                bmc_reset_duration: None,
                 virtual_media_devices: Some(vec![
                     DeviceConfig {
                         id: "Cd".into(),

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -626,6 +626,7 @@ mod test {
             "test-host-id".to_string(),
             false,
             injection.clone(),
+            crate::MachineRouterOptions::default(),
         );
 
         assert!(Arc::ptr_eq(&injection, &state.injection));
@@ -639,6 +640,156 @@ mod test {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// End-to-end BMC self-reset window (epic #3796 issue 4): the manager
+    /// reset is acknowledged, then EVERY request gets 503 until the window
+    /// expires, recovery is lazy, and the server's power is never touched.
+    #[tokio::test]
+    async fn manager_reset_takes_bmc_offline_then_recovers() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        #[derive(Debug, Default)]
+        struct PowerCommandCounter(AtomicUsize);
+        impl Callbacks for PowerCommandCounter {
+            fn get_power_state(&self) -> MockPowerState {
+                MockPowerState::On
+            }
+            fn send_power_command(
+                &self,
+                _reset_type: SystemPowerControl,
+            ) -> Result<(), SetSystemPowerError> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+            fn state_refresh_indication(&self) {}
+        }
+
+        let callbacks = Arc::new(PowerCommandCounter::default());
+        let (router, _state) = machine_router(
+            &host_info(HardwareType::DellPowerEdgeR750),
+            callbacks.clone(),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions {
+                bmc_reset_duration: Some(Duration::from_millis(100)),
+                ..Default::default()
+            },
+        );
+
+        let get = |path: &str| {
+            router
+                .clone()
+                .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+        };
+
+        // discover the manager's reset action target
+        let response = get("/redfish/v1/Managers").await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let managers: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let manager_path = managers["Members"][0]["@odata.id"]
+            .as_str()
+            .expect("at least one manager")
+            .to_string();
+        let reset_target = format!("{manager_path}/Actions/Manager.Reset");
+
+        // trigger the self-reset: acknowledged before going dark
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&reset_target)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // inside the window: EVERYTHING answers 503
+        for path in ["/redfish/v1", &manager_path, "/redfish/v1/Systems"] {
+            let response = get(path).await.unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::SERVICE_UNAVAILABLE,
+                "{path} should be offline during the reset window"
+            );
+        }
+
+        // after the window: silently back online
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let response = get("/redfish/v1").await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // a BMC reset must not touch the server's power
+        assert_eq!(callbacks.0.load(Ordering::SeqCst), 0);
+    }
+
+    /// Regression guard: a ZERO `bmc_reset_duration` (e.g. from a profile
+    /// or override with a zero timing) must behave exactly like `None` —
+    /// the pre-existing no-op reset, with no offline window at all.
+    #[tokio::test]
+    async fn zero_reset_duration_keeps_the_old_noop_behavior() {
+        use std::time::Duration;
+
+        let (router, state) = machine_router(
+            &host_info(HardwareType::DellPowerEdgeR750),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions {
+                bmc_reset_duration: Some(Duration::ZERO),
+                ..Default::default()
+            },
+        );
+        assert!(state.availability.is_none(), "zero must disable entirely");
+
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/redfish/v1/Managers")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let managers: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let manager_path = managers["Members"][0]["@odata.id"]
+            .as_str()
+            .expect("at least one manager");
+
+        // reset is acknowledged and the BMC stays online — old behavior
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("{manager_path}/Actions/Manager.Reset"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/redfish/v1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -51,6 +51,7 @@ impl BmcMockWrapper {
         hostname: Arc<dyn HostnameQuerying>,
         host_id: Uuid,
         injection: Arc<InjectionStore>,
+        bmc_reset: Option<std::time::Duration>,
     ) -> Self {
         let (bmc_mock_router, bmc_mock_state) = bmc_mock::machine_router_with_injection_store(
             machine_info,
@@ -58,6 +59,10 @@ impl BmcMockWrapper {
             host_id.to_string(),
             true,
             injection,
+            bmc_mock::MachineRouterOptions {
+                bmc_reset_duration: bmc_reset,
+                ..Default::default()
+            },
         );
 
         BmcMockWrapper {

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -1259,6 +1259,8 @@ impl MachineStateMachine {
             Arc::new(LiveStateHostnameQuery(self.live_state.clone())),
             self.mat_host_id,
             self.bmc_injection.clone(),
+            // wires LifecycleTimings::bmc_reset (epic #3796 issue 4)
+            Some(self.resolved_timings.bmc_reset),
         );
 
         let pw_override = match &self.machine_info {

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -358,6 +358,8 @@ impl PowerShelfActor {
             Arc::new(PowerShelfHostname),
             self.mat_id,
             self.bmc_injection.clone(),
+            // no lifecycle timing profile for this device kind yet
+            None,
         );
         if self.host_info.hw_type != HardwareType::LiteOnPowerShelf
             && let Some(password) = self.app_context.app_config.host_bmc_password.as_deref()

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -402,6 +402,8 @@ impl SwitchActor {
             Arc::new(SwitchHostname),
             self.mat_id,
             self.bmc_injection.clone(),
+            // no lifecycle timing profile for this device kind yet
+            None,
         );
         if let Some(password) = self.app_context.app_config.host_bmc_password.as_deref() {
             bmc_mock


### PR DESCRIPTION
This for epic #3…796, issue 4

After Manager.Reset the mock BMC now goes dark: every request answers 503 Service Unavailable for the machine's resolved LifecycleTimings::bmc_reset window (90-120s platform defaults), then lazily comes back online on the first request after expiry - like a real BMC, silently, by answering again. The server's power state is deliberately untouched.

- new bmc-mock availability module: Online/Resetting state, no timers, lazy recovery; poisoned-mutex recovery instead of panicking
- gate at the very top of the middleware router: a rebooting BMC answers nothing - before auth, before injection, before routing
- MachineRouterOptions.bmc_reset_duration opts in; None and Duration::ZERO keep the previous no-op behavior byte-for-byte so existing tests see no side effect
- machine_state_machine wires the resolved bmc_reset timing (the epic's field is now consumed); power shelf and switch simulators pass None
- 503 (not a transport error) is intentional: all mocks share one authority-multiplexed TLS listener with pooled keep-alive connections, and nico's probe/error paths collapse both shapes into the same retry decision (see comment at the middleware gate)
- Redfish-only trigger: IPMI "mc reset cold" is not modeled in ipmi_sim
- tests: 5 availability unit tests, end-to-end reset-503-recover router test asserting zero power commands, zero-duration regression guard

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

### Default-behavior note: 
Existing configs now get a realistic BMC offline window on Manager.Reset (platform defaults, e.g. 120 s host / 60 s DPU on GB200 NVL) — most visibly during pre-ingestion's InitialBmcReset, adding a few minutes of transient, self-healing exploration errors per ingestion cycle. This is intentional (realistic-by-default, per feature owner); anything expecting a no-op BMC reset should be fixed rather than masked. Opt-out for special rigs: bmc_reset = "0s" in timing_overrides — contract-tested to reproduce legacy behavior exactly.

Testing: unit + router tests (window entry, 503-then-lazy-recovery, power-state preservation, zero-disable). Validated end-to-end in a live single-VM nico dev site at both accelerated (12 s/6 s) and full-length (120 s/60 s) windows: pre-ingestion triggered all six mock BMCs' windows, nico rode out the blackouts, and ingestion completed to Ready untouched. Trigger is Redfish Manager.Reset only (IPMI mc reset isn't modeled in ipmi_sim).