### PR TITLE
docs: update AGENTS.md to try to get tests under control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,12 +111,32 @@ cargo test
 cargo make correctly-execute-tests
 ```
 
-When writing tests, prefer the **table-driven** style — see the [Testing section in `STYLE_GUIDE.md`](STYLE_GUIDE.md#testing).
-Enumerating a function's input variants as grouped `carbide-test-support` scenarios (`scenarios!` / `value_scenarios!`)
-or explicit cases (`check_cases` / `check_values`) is the easiest way to reach thorough coverage of parsers, validators,
-conversions, and the like.
-For functions that map multiple booleans or enums to state and action outputs,
-enumerate every input combination in one table before requesting review.
+When writing tests, prefer the **table-driven** style and helpers from
+`carbide-test-support`; use the [Testing section in `STYLE_GUIDE.md`](STYLE_GUIDE.md#testing)
+for table structure and API details. Use grouped `scenarios!` / `value_scenarios!`
+or explicit `check_cases` / `check_values` when cases share one operation and
+assertion form. When cases share setup but require different assertions, use a
+local case table that keeps each case's check next to its inputs.
+
+Before adding coverage, inventory the relevant unit, database, controller, and
+integration tests. Each new test should have one reason to exist: an observable
+contract or distinct failure boundary that no retained test protects. Use the
+smallest set of cases that exercise different behavior. Do not enumerate a
+Cartesian product merely because inputs are booleans or enums; enumerate a
+combination only when it is reachable and protects distinct observable behavior
+or a distinct failure boundary, including precedence between conflicting inputs.
+
+Place each proof at the narrowest layer that can exercise the contract.
+Higher-level tests should prove wiring, persistence, transaction behavior,
+concurrency, or external effects that lower-level tests cannot; do not repeat a
+lower-level case matrix at higher layers. For every new test or row, ask:
+**What regression does this catch that no retained test catches?** If there is
+no concrete answer, merge it into existing coverage or delete it.
+
+`STYLE_GUIDE.md` remains the source for helper APIs and table layout. For
+changes written by agents, the rules above for choosing cases replace its
+recommendation to enumerate every branch and input variant.
+
 For user-visible CLI table changes, exercise the public command in a test and
 assert the rendered headers plus populated and empty cell values. Helper-only
 tests do not prove the table contract.


### PR DESCRIPTION
I went back and forth with Codex a bit on this to figure out how we can get agents to chill out with all of the tests, and this is ultimately what it came to. Goal was to have it write up an `AGENTS.md` update that would be agent-friendly, for an agent to consume, so things chill.

All said, the finding was that repository guidance currently tells agents to enumerate every boolean and enum combination, while `STYLE_GUIDE.md` recommends turning every branch and input variant into a test row. That can turn a simple change into repeated unit, database, controller, and integration tests even when the same behavior is already protected.

This keeps the table-driven helpers, but asks agents to inventory existing coverage and add cases that protect a distinct contract or failure boundary. Higher-level tests remain focused on wiring, persistence, transaction behavior, concurrency, and external effects that lower layers cannot prove.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5343

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

`rumdl check --config docs/.rumdl.toml AGENTS.md`

## Review Findings

<details>
<summary>Model Findings Overview</summary>

Four local reviewers covered the same change to one file. Hosted CodeRabbit then found one wording issue, and the final wording was checked again after that finding was applied.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 1 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 3 | 3 | 0 |
| common-nits-reviewer | 0 | 0 | 0 |
| Hosted CodeRabbit | 1 | 1 | 0 |
| **Total** | **5** | **5** | **0** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- The callback sentence could imply that the named `carbide-test-support` helpers accept a different check for each row. **Resolution:** Helper tables now cover cases with one operation and assertion form, while a local case table keeps differing checks next to their inputs.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- The callback sentence implied support that the named table helpers do not provide. **Resolution:** The guidance separates helper tables from local case tables with differing checks.
2. **Adopted** -- The callback sentence conflicted with the statement that `STYLE_GUIDE.md` defines all table structure. **Resolution:** `STYLE_GUIDE.md` remains the source for helper APIs and table layout, while `AGENTS.md` defines which cases agents include.
3. **Adopted** -- `STYLE_GUIDE.md` still recommends enumerating every branch and input variant and says that applies to agents. **Resolution:** `AGENTS.md` now explicitly replaces that recommendation for changes written by agents.

### common-nits-reviewer

No findings.

### Hosted CodeRabbit

1. **Adopted** -- Requiring every input combination to be independently specified could exclude precedence conflicts that protect distinct behavior. **Resolution:** A combination now earns coverage when it is reachable and protects distinct observable behavior or a distinct failure boundary, including precedence between conflicting inputs.

</details>
