### PR TITLE
fix(api-core): gate test-only credential accessor

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -3702,6 +3702,7 @@ pub struct DefaultCredential {
     _key: String,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl DefaultCredential {
     pub(crate) fn key(&self) -> &str {
         &self._key


### PR DESCRIPTION
Normal DevSpace core-artifact builds compile `carbide-api-core` without test support, so the test-only `DefaultCredential::key` method triggers the workspace's denied dead-code warning. This gates that accessor behind the same test-support configuration as its only caller, restoring the production build without changing runtime behavior.

## Related issues

None.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

- Built the DevSpace core-artifacts Dockerfile successfully.
- Ran `credential_management::test_missing_default_credentials` successfully.
