### PR TITLE
fix(machine-a-tron): accelerate DevSpace inventory lifecycle

### DIFF
--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -180,6 +180,9 @@ nico-machine-a-tron:
           hwType: wiwynn_gb200_nvl
           hostCount: 2
           dpuPerHostCount: 2
+          # Keep local inventory cycles fast while production-like simulations
+          # continue to use the platform timing defaults.
+          accelerationFactor: 0.05
           oobDhcpRelayAddress: "192.168.192.1"
           adminDhcpRelayAddress: "192.168.176.1"
 nico-dhcp:

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -266,6 +266,29 @@ pods:
         adminDhcpRelayAddress: "192.168.176.1"
 ```
 
+### Lifecycle timing
+
+Machine-a-tron uses platform-specific lifecycle durations. The chart-level
+`machineDefaults.accelerationFactor` defaults to `1.0`, which preserves those
+durations. Set a non-negative factor below `1.0` to accelerate simulated power
+and boot operations, `0` to remove their delays, or a factor above `1.0` to
+slow them down. A machine group can override the default independently:
+
+```yaml
+machineDefaults:
+  accelerationFactor: 0.05
+
+pods:
+  mat-0:
+    machines:
+      rack-machines:
+        accelerationFactor: 0.01
+```
+
+Atomic rack entries use the equivalent `acceleration_factor` field. A
+`configFiles.matConfigs` override owns the complete TOML configuration, so the
+chart does not add an acceleration factor to that content.
+
 ### IPMI/SOL Simulation
 
 Enable IPMI/SOL simulation to expose per-BMC IPMI endpoints for IPMI-capable

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -15,6 +15,10 @@ Build ordered list of pod names for consistent MAC address indexing
 
 {{/* Machine defaults */}}
 {{- $defaults := .Values.machineDefaults | default dict }}
+{{- $defaultAccelerationFactor := 1.0 }}
+{{- if hasKey $defaults "accelerationFactor" }}
+{{- $defaultAccelerationFactor = $defaults.accelerationFactor }}
+{{- end }}
 {{/* MAC address pool config */}}
 {{- $macPool := .Values.macAddressPool | default dict }}
 {{- $macPoolEnabled := true }}
@@ -173,6 +177,11 @@ data:
     ids = {{ $section.ids | toJson }}
     dpu_reboot_delay = {{ $section.dpu_reboot_delay | default $defaults.dpuRebootDelay | int }}
     host_reboot_delay = {{ $section.host_reboot_delay | default $defaults.hostRebootDelay | int }}
+    {{- $accelerationFactor := $defaultAccelerationFactor }}
+    {{- if hasKey $section "acceleration_factor" }}
+    {{- $accelerationFactor = $section.acceleration_factor }}
+    {{- end }}
+    acceleration_factor = {{ $accelerationFactor }}
     discovery_retry_interval = {{ $section.discovery_retry_interval | default $defaults.discoveryRetryInterval | default "60s" | quote }}
     oob_dhcp_relay_address = {{ $section.oob_dhcp_relay_address | quote }}
     admin_dhcp_relay_address = {{ $section.admin_dhcp_relay_address | quote }}
@@ -191,6 +200,11 @@ data:
     dpu_per_host_count = {{ $section.dpuPerHostCount | default 0 }}
     dpu_reboot_delay = {{ $section.dpuRebootDelay | default $defaults.dpuRebootDelay | default 1 }}
     host_reboot_delay = {{ $section.hostRebootDelay | default $defaults.hostRebootDelay | default 1 }}
+    {{- $accelerationFactor := $defaultAccelerationFactor }}
+    {{- if hasKey $section "accelerationFactor" }}
+    {{- $accelerationFactor = $section.accelerationFactor }}
+    {{- end }}
+    acceleration_factor = {{ $accelerationFactor }}
     scout_run_interval = {{ $section.scoutRunInterval | default $defaults.scoutRunInterval | default "60s" | quote }}
     discovery_retry_interval = {{ $section.discoveryRetryInterval | default $defaults.discoveryRetryInterval | default "60s" | quote }}
     run_interval_working = {{ $section.runIntervalWorking | default $defaults.runIntervalWorking | default "1s" | quote }}

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -23,7 +23,7 @@ tests:
           pattern: 'discovery_retry_interval = "60s"'
       - matchRegex:
           path: data["mat.toml"]
-          pattern: "acceleration_factor = 1"
+          pattern: '(?m)^acceleration_factor = 1$'
 
   - it: should allow compact log output
     set:
@@ -116,7 +116,7 @@ tests:
           pattern: '\[machines\.rack-machines\]'
       - matchRegex:
           path: data["mat.toml"]
-          pattern: "acceleration_factor = 0.02"
+          pattern: '(?m)^acceleration_factor = 0.02$'
 
   - it: should render racks and machines together
     set:
@@ -165,7 +165,7 @@ tests:
           pattern: 'discovery_retry_interval = "7s"'
       - matchRegex:
           path: data["mat.toml"]
-          pattern: "acceleration_factor = 0.05"
+          pattern: '(?m)^acceleration_factor = 0.05$'
 
   - it: should allow a per-machine-group acceleration factor
     set:
@@ -179,7 +179,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["mat.toml"]
-          pattern: "acceleration_factor = 0"
+          pattern: '(?m)^acceleration_factor = 0$'
 
   - it: should not include enable_ipmi_simulation by default
     asserts:

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -21,6 +21,9 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: 'discovery_retry_interval = "60s"'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: "acceleration_factor = 1"
 
   - it: should allow compact log output
     set:
@@ -95,6 +98,7 @@ tests:
                 - rack-001
               dpu_reboot_delay: 20
               host_reboot_delay: 10
+              acceleration_factor: 0.02
               oob_dhcp_relay_address: 10.96.64.1
               admin_dhcp_relay_address: 192.168.176.1
     asserts:
@@ -110,6 +114,9 @@ tests:
       - notMatchRegex:
           path: data["mat.toml"]
           pattern: '\[machines\.rack-machines\]'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: "acceleration_factor = 0.02"
 
   - it: should render racks and machines together
     set:
@@ -139,6 +146,7 @@ tests:
         runIntervalIdle: "30s"
         scoutRunInterval: "120s"
         discoveryRetryInterval: "7s"
+        accelerationFactor: 0.05
       pods:
         mat-0:
           machines:
@@ -155,6 +163,23 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: 'discovery_retry_interval = "7s"'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: "acceleration_factor = 0.05"
+
+  - it: should allow a per-machine-group acceleration factor
+    set:
+      machineDefaults:
+        accelerationFactor: 0.05
+      pods:
+        mat-0:
+          machines:
+            rack-machines:
+              accelerationFactor: 0
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: "acceleration_factor = 0"
 
   - it: should not include enable_ipmi_simulation by default
     asserts:

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -181,6 +181,9 @@ machineDefaults:
   subnetsPerVpc: 0
   dpuRebootDelay: 1
   hostRebootDelay: 1
+  ## Scale platform lifecycle timings. 1.0 uses realistic platform durations;
+  ## values below 1.0 accelerate simulated power operations and boot cycles.
+  accelerationFactor: 1.0
   scoutRunInterval: "60s"
   ## Delay after a failed DiscoverMachine call; the default matches the production DPU agent.
   discoveryRetryInterval: "60s"


### PR DESCRIPTION
Machine-a-tron now uses realistic platform lifecycle timings and no longer consumes the legacy host and DPU reboot-delay fields. The Helm chart still emitted only those ignored fields, so the DevSpace Wiwynn GB200 topology waited 600 seconds per host boot. Initial inventory requires more than one boot cycle and exceeded the 15-minute REST setup timeout.

Expose the supported acceleration factor through the Helm chart while retaining 1.0 as the chart default. Configure only the local DevSpace topology with a 0.05 factor so its simulated lifecycle runs 20 times faster. Machine groups and atomic racks can override the chart-level default independently.

## Related issues

This regression was discovered during end-to-end validation of #2092 but is independent of that feature.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Integration tests added/updated
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- cargo test -p carbide-machine-a-tron --no-default-features lifecycle_timings (17 passed)
- helm lint for the machine-a-tron chart and umbrella chart
- Helm rendering of the DevSpace values, confirming acceleration_factor = 0.05
- rumdl for the changed chart documentation
