### PR TITLE
Fix: Extend host BMC intermittent-auth retry to GB200, GB300, and Vera Rubin

### DIFF
--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -757,13 +757,20 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     .await
                 {
                     Ok(report) => report,
-                    // BMCs (HPEs currently) can return intermittent 401 errors even with valid credentials.
+                    // BMCs (HPE iLO, NVIDIA GB200/GB300, Vera Rubin) can return
+                    // intermittent 401 errors even with valid credentials.
                     // Allow up to MAX_AUTH_RETRIES before escalating to regular Unauthorized.
                     Err(EndpointExplorationError::Unauthorized {
                         details,
                         response_body,
                         response_code,
-                    }) if vendor == RedfishVendor::Hpe => {
+                    }) if matches!(
+                        vendor,
+                        RedfishVendor::Hpe
+                            | RedfishVendor::NvidiaGBx00
+                            | RedfishVendor::LenovoGB300
+                            | RedfishVendor::VeraRubin
+                    ) => {
                         const MAX_AUTH_RETRIES: u32 = 5;
 
                         let previous_count = last_exploration_error

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -770,7 +770,8 @@ impl EndpointExplorer for BmcEndpointExplorer {
                             | RedfishVendor::NvidiaGBx00
                             | RedfishVendor::LenovoGB300
                             | RedfishVendor::VeraRubin
-                    ) => {
+                    ) =>
+                    {
                         const MAX_AUTH_RETRIES: u32 = 5;
 
                         let previous_count = last_exploration_error

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -757,8 +757,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     .await
                 {
                     Ok(report) => report,
-                    // BMCs (HPE iLO, NVIDIA GB200/GB300, Vera Rubin) can return
-                    // intermittent 401 errors even with valid credentials.
+                    // BMCs (HPE iLO, NVIDIA GB200/GB300, Vera Rubin, Lenovo AMI,
+                    // Viking AMI) can return intermittent 401 errors even with
+                    // valid credentials.
                     // Allow up to MAX_AUTH_RETRIES before escalating to regular Unauthorized.
                     Err(EndpointExplorationError::Unauthorized {
                         details,
@@ -769,6 +770,8 @@ impl EndpointExplorer for BmcEndpointExplorer {
                         RedfishVendor::Hpe
                             | RedfishVendor::NvidiaGBx00
                             | RedfishVendor::LenovoGB300
+                            | RedfishVendor::LenovoAMI
+                            | RedfishVendor::AMI
                             | RedfishVendor::VeraRubin
                     ) =>
                     {


### PR DESCRIPTION
Summary:

Site Explorer already treats HPE host BMC auth failures as intermittent for five explore cycles before Unauthorized. Apply that same retry budget to NVIDIA GB200, GB300, and Vera Rubin host BMCs (NvidiaGBx00, LenovoGB300, VeraRubin). Other vendors are unchanged.