### PR TITLE
tests(power-shelf-controller): move integration tests from api-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,17 +2721,23 @@ dependencies = [
  "carbide-rack",
  "carbide-redfish",
  "carbide-secrets",
+ "carbide-test-harness",
  "carbide-utils",
  "carbide-uuid",
+ "chrono",
  "component-manager",
  "config-version",
  "eyre",
  "librms",
  "mac_address",
  "opentelemetry 0.32.0",
+ "serde_json",
  "sqlx",
  "state-controller",
+ "tokio-util",
+ "tonic",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -100,15 +100,12 @@ use model::machine::{
 };
 use model::metadata::Metadata;
 use model::network_security_group;
-use model::rack_type::{
-    RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
-    RackHardwareTopology, RackProductFamily, RackProfile, RackProfileConfig,
-};
+use model::rack_type::{RackProfile, RackProfileConfig};
 use model::resource_pool::common::CommonPools;
 use model::resource_pool::{self};
 use model::tenant::TenantOrganizationId;
 use model::test_support::dpu::{DPU_BF3_INFO_JSON, DPU_BF4_INFO_JSON};
-use model::test_support::{DpuConfig, HardwareInfoTemplate, ManagedHostConfig};
+use model::test_support::{DpuConfig, HardwareInfoTemplate, ManagedHostConfig, rms_rack_profiles};
 use nras::{
     DeviceAttestationInfo, NrasError, ProcessedAttestationOutcome, RawAttestationOutcome,
     VerifierClient,
@@ -1042,41 +1039,12 @@ pub(in crate::tests) fn get_config() -> CarbideConfig {
     default_config::get()
 }
 
-/// Rack profile ID used by RMS-ready test fixtures.
-pub(in crate::tests) const TEST_RMS_RACK_PROFILE_ID: &str = "NVL72";
+pub(in crate::tests) use model::test_support::TEST_RMS_RACK_PROFILE_ID;
 
 /// Returns the default test config plus an RMS-ready NVL72 rack profile.
 pub(in crate::tests) fn get_config_with_rack_profiles() -> CarbideConfig {
     let mut config = get_config();
-    config.rack_profiles = RackProfileConfig {
-        rack_profiles: [(
-            TEST_RMS_RACK_PROFILE_ID.to_string(),
-            RackProfile {
-                product_family: Some(RackProductFamily::Gb200),
-                rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
-                rack_capabilities: RackCapabilitiesSet {
-                    compute: RackCapabilityCompute {
-                        count: 18,
-                        vendor: Some("NVIDIA".to_string()),
-                        ..Default::default()
-                    },
-                    switch: RackCapabilitySwitch {
-                        count: 9,
-                        vendor: Some("NVIDIA".to_string()),
-                        ..Default::default()
-                    },
-                    power_shelf: RackCapabilityPowerShelf {
-                        count: 8,
-                        vendor: Some("LiteOn".to_string()),
-                        ..Default::default()
-                    },
-                },
-                ..Default::default()
-            },
-        )]
-        .into_iter()
-        .collect(),
-    };
+    config.rack_profiles = rms_rack_profiles();
 
     config
 }

--- a/crates/api-core/src/tests/power_shelf_state_controller/fixtures/power_shelf.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/fixtures/power_shelf.rs
@@ -33,16 +33,3 @@ pub(in crate::tests) async fn set_power_shelf_controller_state(
 
     Ok(())
 }
-
-/// Helper function to mark power shelf as deleted
-pub(in crate::tests) async fn mark_power_shelf_as_deleted(
-    txn: &mut PgConnection,
-    power_shelf_id: &PowerShelfId,
-) -> Result<(), sqlx::Error> {
-    sqlx::query("UPDATE power_shelves SET deleted = NOW() WHERE id = $1")
-        .bind(power_shelf_id)
-        .execute(txn)
-        .await?;
-
-    Ok(())
-}

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -38,6 +38,7 @@ mod nvlink_domain_health;
 mod operating_system;
 mod power_options;
 mod power_shelf;
+mod power_shelf_decommission;
 mod power_shelf_delete;
 mod power_shelf_find;
 mod power_shelf_maintenance;

--- a/crates/api-core/tests/integration/power_shelf_decommission.rs
+++ b/crates/api-core/tests/integration/power_shelf_decommission.rs
@@ -15,50 +15,57 @@
  * limitations under the License.
  */
 
+use carbide_test_harness::prelude::*;
 use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
 use carbide_uuid::power_shelf::PowerShelfId;
-use carbide_uuid::rack::RackId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+use model::rack::RackConfig;
+use model::test_support::{TEST_RMS_RACK_PROFILE_ID, power_shelf_config};
 use rpc::forge::DecommissionPowerShelfRequest;
-use rpc::forge::forge_server::Forge;
+use sqlx::PgConnection;
 use tonic::{Code, Request};
-
-use super::fixtures::power_shelf::set_power_shelf_controller_state;
-use crate::tests::common;
-use crate::tests::common::api_fixtures::create_test_env;
-use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
-async fn load_power_shelf(pool: &sqlx::PgPool, id: PowerShelfId) -> TestResult<PowerShelf> {
+async fn load_power_shelf(pool: &PgPool, id: PowerShelfId) -> TestResult<PowerShelf> {
     let mut conn = pool.acquire().await?;
     Ok(db::power_shelf::find_by_id(&mut conn, &id)
         .await?
         .expect("power shelf should exist"))
 }
 
-#[crate::sqlx_test]
-async fn decommission_requires_ready_power_shelf(pool: sqlx::PgPool) -> TestResult {
-    let env = create_test_env(pool).await;
+async fn set_power_shelf_controller_state(
+    txn: &mut PgConnection,
+    power_shelf_id: &PowerShelfId,
+    state: PowerShelfControllerState,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE power_shelves SET controller_state = $1 WHERE id = $2")
+        .bind(serde_json::to_value(state).unwrap())
+        .bind(power_shelf_id)
+        .execute(txn)
+        .await?;
+
+    Ok(())
+}
+
+#[sqlx_test]
+async fn decommission_requires_ready_power_shelf(pool: PgPool) -> TestResult {
+    let env = TestHarness::builder(pool).build().await;
 
     let error = env
-        .api
+        .api()
         .decommission_power_shelf(Request::new(DecommissionPowerShelfRequest::default()))
         .await
         .expect_err("a missing power shelf ID must be rejected");
     assert_eq!(error.code(), Code::InvalidArgument);
 
-    let power_shelf_id = common::api_fixtures::site_explorer::new_power_shelf(
-        &env,
-        Some("Decommission precondition".to_string()),
-        None,
-        None,
-        None,
-    )
-    .await?;
+    let TestPowerShelf { id: power_shelf_id } = env
+        .create_power_shelf(power_shelf_config("Decommission precondition"))
+        .await;
 
     let error = env
-        .api
+        .api()
         .decommission_power_shelf(Request::new(DecommissionPowerShelfRequest {
             power_shelf_id: Some(power_shelf_id),
         }))
@@ -68,20 +75,16 @@ async fn decommission_requires_ready_power_shelf(pool: sqlx::PgPool) -> TestResu
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn decommission_rejects_instance_assigned_host_in_power_shelf_rack(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> TestResult {
-    let env = create_test_env(pool.clone()).await;
-    let power_shelf_id = common::api_fixtures::site_explorer::new_power_shelf(
-        &env,
-        Some("Assigned host preflight".to_string()),
-        None,
-        None,
-        None,
-    )
-    .await?;
+    let env = TestHarness::builder(pool.clone()).build().await;
+    let TestPowerShelf { id: power_shelf_id } = env
+        .create_power_shelf(power_shelf_config("Assigned host preflight"))
+        .await;
     let rack_id = RackId::new("power-shelf-decommission-rack");
+    let rack_profile_id = RackProfileId::new(TEST_RMS_RACK_PROFILE_ID);
     let host_id = MachineId::new(
         MachineIdSource::ProductBoardChassisSerial,
         [0x45; 32],
@@ -89,10 +92,14 @@ async fn decommission_rejects_instance_assigned_host_in_power_shelf_rack(
     );
 
     let mut txn = pool.begin().await?;
-    TestRackDbBuilder::new()
-        .with_rack_id(rack_id.clone())
-        .persist(txn.as_mut())
-        .await?;
+    db::rack::create(
+        txn.as_mut(),
+        &rack_id,
+        Some(&rack_profile_id),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
     sqlx::query("UPDATE power_shelves SET rack_id = $1 WHERE id = $2")
         .bind(&rack_id)
         .bind(power_shelf_id)
@@ -116,7 +123,7 @@ async fn decommission_rejects_instance_assigned_host_in_power_shelf_rack(
     txn.commit().await?;
 
     let error = env
-        .api
+        .api()
         .decommission_power_shelf(Request::new(DecommissionPowerShelfRequest {
             power_shelf_id: Some(power_shelf_id),
         }))
@@ -134,7 +141,7 @@ async fn decommission_rejects_instance_assigned_host_in_power_shelf_rack(
         .bind(host_id)
         .execute(&pool)
         .await?;
-    env.api
+    env.api()
         .decommission_power_shelf(Request::new(DecommissionPowerShelfRequest {
             power_shelf_id: Some(power_shelf_id),
         }))

--- a/crates/api-core/tests/integration/power_shelf_find.rs
+++ b/crates/api-core/tests/integration/power_shelf_find.rs
@@ -17,6 +17,7 @@
 
 use carbide_test_harness::prelude::*;
 use carbide_uuid::power_shelf::PowerShelfId;
+use model::test_support::power_shelf_config;
 use rpc::forge::PowerShelfQuery;
 
 use crate::power_shelf::create_custom_power_shelf;
@@ -26,8 +27,12 @@ async fn test_find_power_shelf_ids_and_by_ids(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool).build().await;
-    let TestPowerShelf { id: ps_id1 } = env.create_power_shelf().await;
-    let TestPowerShelf { id: ps_id2 } = env.create_power_shelf().await;
+    let TestPowerShelf { id: ps_id1 } = env
+        .create_power_shelf(power_shelf_config("Test Power Shelf 1"))
+        .await;
+    let TestPowerShelf { id: ps_id2 } = env
+        .create_power_shelf(power_shelf_config("Test Power Shelf 2"))
+        .await;
 
     // FindPowerShelfIds should return both power shelves
     let power_shelf_ids = env
@@ -76,8 +81,12 @@ async fn test_find_power_shelf_ids_excludes_deleted(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool).build().await;
-    let TestPowerShelf { id: ps_id1 } = env.create_power_shelf().await;
-    let TestPowerShelf { id: ps_id2 } = env.create_power_shelf().await;
+    let TestPowerShelf { id: ps_id1 } = env
+        .create_power_shelf(power_shelf_config("Test Power Shelf 1"))
+        .await;
+    let TestPowerShelf { id: ps_id2 } = env
+        .create_power_shelf(power_shelf_config("Test Power Shelf 2"))
+        .await;
 
     // Delete ps2
     env.api()
@@ -106,8 +115,12 @@ async fn test_find_power_shelf_ids_deleted_only(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool).build().await;
-    let TestPowerShelf { id: ps_id1 } = env.create_power_shelf().await;
-    let TestPowerShelf { id: ps_id2 } = env.create_power_shelf().await;
+    let TestPowerShelf { id: ps_id1 } = env
+        .create_power_shelf(power_shelf_config("Test Power Shelf 1"))
+        .await;
+    let TestPowerShelf { id: ps_id2 } = env
+        .create_power_shelf(power_shelf_config("Test Power Shelf 2"))
+        .await;
 
     env.api()
         .delete_power_shelf(tonic::Request::new(rpc::forge::PowerShelfDeletionRequest {
@@ -149,7 +162,9 @@ async fn test_find_power_shelf_ids_by_controller_state(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool).build().await;
-    let TestPowerShelf { id: ps_id } = env.create_power_shelf().await;
+    let TestPowerShelf { id: ps_id } = env
+        .create_power_shelf(power_shelf_config("Test Power Shelf"))
+        .await;
 
     // New power shelves start in "initializing" state
     let power_shelf_ids = env
@@ -183,7 +198,9 @@ async fn test_find_power_shelves_by_ids_response_fields(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool).build().await;
-    let TestPowerShelf { id: ps_id } = env.create_power_shelf().await;
+    let TestPowerShelf { id: ps_id } = env
+        .create_power_shelf(power_shelf_config("Test Power Shelf"))
+        .await;
 
     let power_shelves = env
         .api()

--- a/crates/api-core/tests/integration/rack_find.rs
+++ b/crates/api-core/tests/integration/rack_find.rs
@@ -16,15 +16,15 @@
  */
 
 use carbide_test_harness::prelude::*;
-use carbide_uuid::rack::RackId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use rpc::forge::{AdminForceDeleteRackRequest, DeleteRackRequest};
 use tonic::Code;
 
 #[sqlx_test]
 async fn test_find_rack_by_id(pool: PgPool) {
     let env = TestHarness::builder(pool).build().await;
-    let TestRack { id: rack_id1 } = env.create_rack().await;
-    let TestRack { id: rack_id2 } = env.create_rack().await;
+    let TestRack { id: rack_id1 } = env.create_rack(RackProfileId::new("rack")).await;
+    let TestRack { id: rack_id2 } = env.create_rack(RackProfileId::new("rack")).await;
 
     // Check the returned list of rack ids is what we expect.
     let rack_ids: Vec<RackId> = env
@@ -100,7 +100,7 @@ async fn test_find_rack_by_id(pool: PgPool) {
 #[sqlx_test]
 async fn test_force_delete_rack_success(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool.clone()).build().await;
-    let TestRack { id: rack_id } = env.create_rack().await;
+    let TestRack { id: rack_id } = env.create_rack(RackProfileId::new("rack")).await;
 
     let mut txn = pool.begin().await?;
     db::state_history::persist(
@@ -174,7 +174,7 @@ async fn test_force_delete_rack_already_soft_deleted(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool).build().await;
-    let TestRack { id: rack_id } = env.create_rack().await;
+    let TestRack { id: rack_id } = env.create_rack(RackProfileId::new("rack")).await;
 
     env.api()
         .delete_rack(tonic::Request::new(DeleteRackRequest {

--- a/crates/api-model/src/test_support/mod.rs
+++ b/crates/api-model/src/test_support/mod.rs
@@ -21,11 +21,15 @@ pub mod alloc_counter;
 pub mod dpu;
 pub mod machine_snapshot;
 pub mod managed_host;
+pub mod power_shelf;
+pub mod rack;
 
 pub use dpu::DpuConfig;
 pub use managed_host::{
     ManagedDpuExplorationReport, ManagedHostConfig, ManagedHostExplorationResults,
 };
+pub use power_shelf::power_shelf_config;
+pub use rack::{TEST_RMS_RACK_PROFILE_ID, rms_rack_profiles};
 
 #[derive(Debug, Clone)]
 pub enum HardwareInfoTemplate {

--- a/crates/api-model/src/test_support/power_shelf.rs
+++ b/crates/api-model/src/test_support/power_shelf.rs
@@ -15,5 +15,15 @@
  * limitations under the License.
  */
 
-mod bmc_rotation;
-mod fixtures;
+//! Power shelf model fixtures.
+
+use crate::power_shelf::PowerShelfConfig;
+
+/// Returns a power shelf config with capacity 100 and voltage 240.
+pub fn power_shelf_config(name: &str) -> PowerShelfConfig {
+    PowerShelfConfig {
+        name: name.to_string(),
+        capacity: Some(100),
+        voltage: Some(240),
+    }
+}

--- a/crates/api-model/src/test_support/rack.rs
+++ b/crates/api-model/src/test_support/rack.rs
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Rack model fixtures.
+
+use crate::rack_type::{
+    RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
+    RackHardwareTopology, RackProductFamily, RackProfile, RackProfileConfig,
+};
+
+/// Rack profile ID used by RMS-backed test fixtures.
+pub const TEST_RMS_RACK_PROFILE_ID: &str = "NVL72";
+
+/// Returns one RMS-ready GB200 NVL72 profile with 18 compute trays, 9 switches,
+/// and 8 power shelves.
+pub fn rms_rack_profiles() -> RackProfileConfig {
+    RackProfileConfig {
+        rack_profiles: [(
+            TEST_RMS_RACK_PROFILE_ID.to_string(),
+            RackProfile {
+                product_family: Some(RackProductFamily::Gb200),
+                rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+                rack_capabilities: RackCapabilitiesSet {
+                    compute: RackCapabilityCompute {
+                        count: 18,
+                        vendor: Some("NVIDIA".to_string()),
+                        ..Default::default()
+                    },
+                    switch: RackCapabilitySwitch {
+                        count: 9,
+                        vendor: Some("NVIDIA".to_string()),
+                        ..Default::default()
+                    },
+                    power_shelf: RackCapabilityPowerShelf {
+                        count: 8,
+                        vendor: Some("LiteOn".to_string()),
+                        ..Default::default()
+                    },
+                },
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect(),
+    }
+}

--- a/crates/api-web/Cargo.toml
+++ b/crates/api-web/Cargo.toml
@@ -108,6 +108,7 @@ workspace = true
 # test-only crates not needed by the library itself (e.g. the sqlx_test macro and request-body
 # helpers). `db`/`model` resolve via carbide-api-db/carbide-api-model's lib names, already normal
 # deps.
+carbide-api-model = { path = "../api-model", features = ["test-support"] }
 carbide-macros = { path = "../macros" }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }

--- a/crates/api-web/src/tests/component_detail.rs
+++ b/crates/api-web/src/tests/component_detail.rs
@@ -16,7 +16,9 @@
  */
 
 use axum::body::Body;
+use carbide_uuid::rack::RackProfileId;
 use hyper::http::StatusCode;
+use model::test_support::power_shelf_config;
 use tower::ServiceExt;
 
 use crate::tests::env::TestEnv;
@@ -27,9 +29,17 @@ async fn test_component_detail_pages_return_not_found_for_missing_resources(pool
     let env = TestEnv::new(pool).await;
     let app = make_test_app(&env.test_harness);
 
-    let rack_id = env.test_harness.create_rack().await.id;
+    let rack_id = env
+        .test_harness
+        .create_rack(RackProfileId::new("rack"))
+        .await
+        .id;
     let switch_id = env.test_harness.create_switch(1, 1).await.id;
-    let power_shelf_id = env.test_harness.create_power_shelf().await.id;
+    let power_shelf_id = env
+        .test_harness
+        .create_power_shelf(power_shelf_config("Component Detail Test Power Shelf"))
+        .await
+        .id;
 
     for route in [
         format!("/admin/rack/{rack_id}"),

--- a/crates/api-web/src/tests/health.rs
+++ b/crates/api-web/src/tests/health.rs
@@ -16,8 +16,10 @@
  */
 
 use axum::body::Body;
+use carbide_uuid::rack::RackProfileId;
 use http_body_util::BodyExt;
 use hyper::http::{Method, StatusCode};
+use model::test_support::power_shelf_config;
 use rpc::forge::AdminForceDeleteMachineRequest;
 use rpc::forge::forge_server::Forge;
 use tower::ServiceExt;
@@ -331,7 +333,11 @@ async fn test_add_replace_remove_dpu_health_report_via_web_ui(pool: sqlx::PgPool
 async fn test_health_of_rack(pool: sqlx::PgPool) {
     let env = TestEnv::new(pool).await;
     let app = make_test_app(&env.test_harness);
-    let rack_id = env.test_harness.create_rack().await.id;
+    let rack_id = env
+        .test_harness
+        .create_rack(RackProfileId::new("rack"))
+        .await
+        .id;
 
     let response = app
         .clone()
@@ -565,7 +571,11 @@ async fn test_health_of_switch(pool: sqlx::PgPool) {
 async fn test_health_of_power_shelf(pool: sqlx::PgPool) {
     let env = TestEnv::new(pool).await;
     let app = make_test_app(&env.test_harness);
-    let power_shelf_id = env.test_harness.create_power_shelf().await.id;
+    let power_shelf_id = env
+        .test_harness
+        .create_power_shelf(power_shelf_config("Power Shelf Health Test"))
+        .await
+        .id;
 
     let response = app
         .clone()

--- a/crates/power-shelf-controller/Cargo.toml
+++ b/crates/power-shelf-controller/Cargo.toml
@@ -45,5 +45,18 @@ opentelemetry = { workspace = true }
 sqlx = { workspace = true }
 tracing = { workspace = true }
 
+[dev-dependencies]
+carbide-api-model = { path = "../api-model", features = ["test-support"] }
+carbide-rack = { path = "../rack", features = ["test-support"] }
+carbide-redfish = { path = "../redfish", features = ["test-support"] }
+carbide-secrets = { path = "../secrets", features = ["test-support"] }
+carbide-test-harness = { path = "../test-harness" }
+state-controller = { path = "../state-controller", features = ["test-support"] }
+chrono = { workspace = true }
+serde_json = { workspace = true }
+tokio-util = { workspace = true }
+tonic = { workspace = true }
+uuid = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/power-shelf-controller/tests/integration/common.rs
+++ b/crates/power-shelf-controller/tests/integration/common.rs
@@ -1,0 +1,193 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use carbide_health_metrics::PerObjectMetricsRegistry;
+use carbide_power_shelf_controller::context::{
+    PowerShelfStateHandlerContextObjects, PowerShelfStateHandlerServices,
+};
+use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
+use carbide_power_shelf_controller::metrics::PowerShelfMetrics;
+use carbide_rack::rms_client::test_support::RmsSim;
+use carbide_redfish::libredfish::test_support::RedfishSim;
+use carbide_secrets::test_support::credentials::TestCredentialManager;
+use carbide_test_harness::TestHarness;
+use carbide_uuid::power_shelf::PowerShelfId;
+use component_manager::compute_tray_manager::Backend as ComputeBackend;
+use component_manager::config::ComponentManagerConfig;
+use component_manager::nv_switch_manager::Backend as NvSwitchBackend;
+use component_manager::power_shelf_manager::Backend as PowerShelfBackend;
+use db::power_shelf as db_power_shelf;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+use model::rack_type::RackProfileConfig;
+use model::test_support::rms_rack_profiles;
+use sqlx::{PgConnection, PgPool};
+use state_controller::db_write_batch::DbWriteBatch;
+use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
+
+pub(super) struct ControllerEnv {
+    pub(super) harness: TestHarness,
+    pub(super) pool: PgPool,
+    pub(super) redfish_sim: Arc<RedfishSim>,
+    pub(super) rms_sim: Arc<RmsSim>,
+    pub(super) rack_profiles: RackProfileConfig,
+    pub(super) per_object_metrics_registry: Arc<PerObjectMetricsRegistry>,
+}
+
+impl ControllerEnv {
+    pub(super) async fn new(pool: PgPool) -> Self {
+        let redfish_sim = Arc::new(RedfishSim::default());
+        let rms_sim = Arc::new(RmsSim::default());
+        let rack_profiles = rms_rack_profiles();
+        let mut runtime_config = carbide_test_harness::test_support::default_config::get();
+        runtime_config.rack_profiles = rack_profiles.clone();
+        let per_object_metrics_registry = PerObjectMetricsRegistry::new(
+            runtime_config
+                .observability
+                .per_object_metrics_for_classifications
+                .clone(),
+            Duration::from_secs(60),
+        );
+        let api_component_manager = component_manager::component_manager::build_component_manager(
+            &ComponentManagerConfig {
+                nv_switch_backend: NvSwitchBackend::Rms,
+                power_shelf_backend: PowerShelfBackend::Rms,
+                compute_tray_backend: ComputeBackend::Mock,
+                nv_switch_use_state_controller: true,
+                power_shelf_use_state_controller: true,
+                ..Default::default()
+            },
+            rack_profiles.clone(),
+            rms_sim.as_rms_client(),
+            None,
+            Some(pool.clone()),
+            None,
+        )
+        .await
+        .expect("test component manager should build");
+        let api_redfish_sim = redfish_sim.clone();
+        let api_rms_client = rms_sim
+            .as_rms_client()
+            .expect("RMS simulator should provide a client");
+        let runtime_config = Arc::new(runtime_config);
+        let harness = TestHarness::builder(pool.clone())
+            .with_api_builder_fn(move |builder| {
+                builder
+                    .with_runtime_config(runtime_config)
+                    .with_redfish_pool(api_redfish_sim)
+                    .with_rms_client(api_rms_client)
+                    .with_component_manager(Arc::new(api_component_manager))
+            })
+            .build()
+            .await;
+
+        Self {
+            harness,
+            pool,
+            redfish_sim,
+            rms_sim,
+            rack_profiles,
+            per_object_metrics_registry,
+        }
+    }
+}
+
+pub(super) fn services_without_component_manager(
+    pool: &PgPool,
+    rack_firmware_reprovisioning_enabled: bool,
+) -> PowerShelfStateHandlerServices {
+    PowerShelfStateHandlerServices {
+        db_pool: pool.clone(),
+        component_manager: None,
+        credential_manager: Arc::new(TestCredentialManager::default()),
+        per_object_metrics_registry: carbide_health_metrics::PerObjectMetricsRegistry::new(
+            Vec::new(),
+            Duration::from_secs(60),
+        ),
+        rack_firmware_reprovisioning_enabled,
+        redfish_client_pool: Arc::new(RedfishSim::default()),
+        bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
+            db::credential_rotation::CredentialRotationType::Bmc,
+        ),
+        bmc_rotation_enabled: false,
+    }
+}
+
+pub(super) async fn load_power_shelf(pool: &PgPool, id: &PowerShelfId) -> PowerShelf {
+    let mut conn = pool.acquire().await.unwrap();
+    db_power_shelf::find_by_id(conn.as_mut(), id)
+        .await
+        .unwrap()
+        .expect("power shelf should exist")
+}
+
+pub(super) async fn run_handler(
+    services: &mut PowerShelfStateHandlerServices,
+    state: &mut PowerShelf,
+) -> StateHandlerOutcome<PowerShelfControllerState> {
+    let handler = PowerShelfStateHandler::default();
+    let mut metrics = PowerShelfMetrics::default();
+    let mut writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<PowerShelfStateHandlerContextObjects> {
+        services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut writes,
+    };
+    let controller_state = state.controller_state.value.clone();
+    let power_shelf_id = state.id;
+    handler
+        .handle_object_state(&power_shelf_id, state, &controller_state, &mut ctx)
+        .await
+        .expect("state handler should not return an error result")
+}
+
+pub(super) fn extract_transition(
+    outcome: StateHandlerOutcome<PowerShelfControllerState>,
+) -> Option<PowerShelfControllerState> {
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => Some(next_state),
+        _ => None,
+    }
+}
+
+pub(super) async fn set_power_shelf_controller_state(
+    txn: &mut PgConnection,
+    power_shelf_id: &PowerShelfId,
+    state: PowerShelfControllerState,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE power_shelves SET controller_state = $1 WHERE id = $2")
+        .bind(serde_json::to_value(state).unwrap())
+        .bind(power_shelf_id)
+        .execute(txn)
+        .await?;
+
+    Ok(())
+}
+
+pub(super) async fn mark_power_shelf_as_deleted(
+    txn: &mut PgConnection,
+    power_shelf_id: &PowerShelfId,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE power_shelves SET deleted = NOW() WHERE id = $1")
+        .bind(power_shelf_id)
+        .execute(txn)
+        .await?;
+
+    Ok(())
+}

--- a/crates/power-shelf-controller/tests/integration/error_state.rs
+++ b/crates/power-shelf-controller/tests/integration/error_state.rs
@@ -19,39 +19,37 @@
 
 use std::sync::Arc;
 
-use carbide_power_shelf_controller::context::{
-    PowerShelfStateHandlerContextObjects, PowerShelfStateHandlerServices,
-};
-use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
-use carbide_power_shelf_controller::metrics::PowerShelfMetrics;
+use carbide_power_shelf_controller::context::PowerShelfStateHandlerServices;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
+use carbide_test_harness::prelude::*;
 use carbide_uuid::power_shelf::PowerShelfId;
+use component_manager::compute_tray_manager::Backend as ComputeBackend;
+use component_manager::config::ComponentManagerConfig;
+use component_manager::nv_switch_manager::Backend as NvSwitchBackend;
+use component_manager::power_shelf_manager::Backend as PowerShelfBackend;
 use db::power_shelf as db_power_shelf;
-use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
+use model::power_shelf::{PowerShelfControllerState, PowerShelfMaintenanceOperation};
+use model::test_support::power_shelf_config;
 use sqlx::PgConnection;
-use state_controller::db_write_batch::DbWriteBatch;
-use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
+use state_controller::state_handler::StateHandlerOutcome;
 
-use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
-use crate::tests::common::api_fixtures::{create_test_env, get_config_with_rack_profiles};
-use crate::tests::power_shelf_state_controller::fixtures::power_shelf::{
-    mark_power_shelf_as_deleted, set_power_shelf_controller_state,
+use crate::common::{
+    ControllerEnv, extract_transition, load_power_shelf, mark_power_shelf_as_deleted, run_handler,
+    set_power_shelf_controller_state,
 };
 
 const TEST_ERROR_CAUSE: &str = "test error";
 
-async fn services(
-    env: &crate::tests::common::api_fixtures::TestEnv,
-) -> PowerShelfStateHandlerServices {
-    let config = component_manager::config::ComponentManagerConfig {
-        nv_switch_backend: component_manager::nv_switch_manager::Backend::Mock,
-        power_shelf_backend: component_manager::power_shelf_manager::Backend::Rms,
-        compute_tray_backend: component_manager::compute_tray_manager::Backend::Mock,
+async fn services(env: &ControllerEnv) -> PowerShelfStateHandlerServices {
+    let config = ComponentManagerConfig {
+        nv_switch_backend: NvSwitchBackend::Mock,
+        power_shelf_backend: PowerShelfBackend::Rms,
+        compute_tray_backend: ComputeBackend::Mock,
         ..Default::default()
     };
     let component_manager = component_manager::component_manager::build_component_manager(
         &config,
-        get_config_with_rack_profiles().rack_profiles,
+        env.rack_profiles.clone(),
         env.rms_sim.as_rms_client(),
         None,
         Some(env.pool.clone()),
@@ -65,7 +63,7 @@ async fn services(
         db_pool: env.pool.clone(),
         component_manager,
         credential_manager: Arc::new(TestCredentialManager::default()),
-        per_object_metrics_registry: env.per_object_metrics_registry(),
+        per_object_metrics_registry: env.per_object_metrics_registry.clone(),
         rack_firmware_reprovisioning_enabled: false,
         redfish_client_pool: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
@@ -73,14 +71,6 @@ async fn services(
         ),
         bmc_rotation_enabled: false,
     }
-}
-
-async fn load_power_shelf(pool: &sqlx::PgPool, id: &PowerShelfId) -> PowerShelf {
-    let mut conn = pool.acquire().await.unwrap();
-    db_power_shelf::find_by_id(conn.as_mut(), id)
-        .await
-        .unwrap()
-        .expect("power shelf should exist")
 }
 
 async fn park_in_error(txn: &mut PgConnection, power_shelf_id: &PowerShelfId) {
@@ -95,48 +85,16 @@ async fn park_in_error(txn: &mut PgConnection, power_shelf_id: &PowerShelfId) {
     .unwrap();
 }
 
-async fn run_handler(
-    services: &mut PowerShelfStateHandlerServices,
-    state: &mut PowerShelf,
-) -> StateHandlerOutcome<PowerShelfControllerState> {
-    let handler = PowerShelfStateHandler::default();
-    let mut metrics = PowerShelfMetrics::default();
-    let mut writes = DbWriteBatch::default();
-    let mut ctx = StateHandlerContext::<PowerShelfStateHandlerContextObjects> {
-        services,
-        metrics: &mut metrics,
-        pending_db_writes: &mut writes,
-    };
-    let controller_state = state.controller_state.value.clone();
-    let power_shelf_id = state.id;
-    handler
-        .handle_object_state(&power_shelf_id, state, &controller_state, &mut ctx)
-        .await
-        .expect("state handler should not return an error result")
-}
-
-fn extract_transition(
-    outcome: StateHandlerOutcome<PowerShelfControllerState>,
-) -> Option<PowerShelfControllerState> {
-    match outcome {
-        StateHandlerOutcome::Transition { next_state, .. } => Some(next_state),
-        _ => None,
-    }
-}
-
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn error_with_power_on_maintenance_request_transitions_to_maintenance(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-    let power_shelf_id = new_power_shelf(
-        &env,
-        Some("Error->Maintenance PowerOn".into()),
-        None,
-        None,
-        None,
-    )
-    .await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("Error->Maintenance PowerOn"))
+        .await
+        .id;
 
     {
         let mut txn = pool.acquire().await?;
@@ -168,19 +126,16 @@ async fn error_with_power_on_maintenance_request_transitions_to_maintenance(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn error_with_power_off_maintenance_request_transitions_to_maintenance(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-    let power_shelf_id = new_power_shelf(
-        &env,
-        Some("Error->Maintenance PowerOff".into()),
-        None,
-        None,
-        None,
-    )
-    .await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("Error->Maintenance PowerOff"))
+        .await
+        .id;
 
     {
         let mut txn = pool.acquire().await?;
@@ -212,13 +167,16 @@ async fn error_with_power_off_maintenance_request_transitions_to_maintenance(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn error_without_maintenance_request_holds_in_error(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("Error stays in Error".into()), None, None, None).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("Error stays in Error"))
+        .await
+        .id;
 
     {
         let mut txn = pool.acquire().await?;
@@ -236,19 +194,16 @@ async fn error_without_maintenance_request_holds_in_error(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn error_with_deletion_takes_precedence_over_maintenance(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-    let power_shelf_id = new_power_shelf(
-        &env,
-        Some("Error deletion wins over maintenance".into()),
-        None,
-        None,
-        None,
-    )
-    .await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("Error deletion wins over maintenance"))
+        .await
+        .id;
 
     {
         let mut txn = pool.acquire().await?;

--- a/crates/power-shelf-controller/tests/integration/main.rs
+++ b/crates/power-shelf-controller/tests/integration/main.rs
@@ -15,5 +15,8 @@
  * limitations under the License.
  */
 
-mod bmc_rotation;
-mod fixtures;
+mod common;
+mod error_state;
+mod maintenance;
+mod power_shelf_deletion;
+mod reprovisioning;

--- a/crates/power-shelf-controller/tests/integration/maintenance.rs
+++ b/crates/power-shelf-controller/tests/integration/maintenance.rs
@@ -36,43 +36,38 @@
 
 use std::sync::Arc;
 
-use carbide_power_shelf_controller::context::{
-    PowerShelfStateHandlerContextObjects, PowerShelfStateHandlerServices,
-};
-use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
-use carbide_power_shelf_controller::metrics::PowerShelfMetrics;
+use carbide_power_shelf_controller::context::PowerShelfStateHandlerServices;
 use carbide_secrets::credentials::Credentials;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
+use carbide_test_harness::prelude::*;
 use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use component_manager::compute_tray_manager::Backend as ComputeBackend;
 use component_manager::config::ComponentManagerConfig;
 use component_manager::nv_switch_manager::Backend as NvSwitchBackend;
 use component_manager::power_shelf_manager::Backend as PowerShelfBackend;
-use db::{
-    expected_power_shelf as db_expected_power_shelf, power_shelf as db_power_shelf, rack as db_rack,
-};
+use db::{expected_power_shelf as db_expected_power_shelf, power_shelf as db_power_shelf};
 use librms::protos::rack_manager as rms;
 use mac_address::MacAddress;
 use model::expected_power_shelf::ExpectedPowerShelf;
 use model::metadata::Metadata;
-use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
-use model::rack::RackConfig;
+use model::power_shelf::{PowerShelfControllerState, PowerShelfMaintenanceOperation};
+use model::test_support::{TEST_RMS_RACK_PROFILE_ID, power_shelf_config};
 use rpc::common::SystemPowerControl;
 use rpc::forge::component_power_control_request::Target;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{ComponentPowerControlRequest, PowerShelfIdList};
 use sqlx::PgConnection;
-use state_controller::db_write_batch::DbWriteBatch;
-use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
+use state_controller::state_handler::StateHandlerOutcome;
 use tonic::Request;
 
-use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
-use crate::tests::common::api_fixtures::{
-    TEST_RMS_RACK_PROFILE_ID, TestEnv, TestEnvOverrides, create_test_env_with_overrides,
-    get_config_with_rack_profiles,
+use crate::common::{
+    ControllerEnv, extract_transition, load_power_shelf, run_handler,
+    set_power_shelf_controller_state,
 };
-use crate::tests::power_shelf_state_controller::fixtures::power_shelf::set_power_shelf_controller_state;
+
+const TEST_BMC_USER: &str = "root";
+const TEST_BMC_PASSWORD: &str = "password";
 
 fn cm_power_action(operation: PowerShelfMaintenanceOperation) -> SystemPowerControl {
     match operation {
@@ -81,12 +76,22 @@ fn cm_power_action(operation: PowerShelfMaintenanceOperation) -> SystemPowerCont
     }
 }
 
+async fn commit_and_extract_transition(
+    mut outcome: StateHandlerOutcome<PowerShelfControllerState>,
+) -> Option<PowerShelfControllerState> {
+    if let Some(txn) = outcome.take_transaction() {
+        txn.commit().await.unwrap();
+    }
+    extract_transition(outcome)
+}
+
 async fn request_power_shelf_maintenance_via_cm(
-    env: &TestEnv,
+    env: &ControllerEnv,
     power_shelf_id: &PowerShelfId,
     operation: PowerShelfMaintenanceOperation,
 ) {
-    env.api
+    env.harness
+        .api()
         .component_power_control(Request::new(ComponentPowerControlRequest {
             target: Some(Target::PowerShelfIds(PowerShelfIdList {
                 ids: vec![*power_shelf_id],
@@ -98,39 +103,11 @@ async fn request_power_shelf_maintenance_via_cm(
         .expect("component_power_control should succeed");
 }
 
-const TEST_BMC_USER: &str = "root";
-const TEST_BMC_PASSWORD: &str = "password";
-
-async fn create_power_shelf_test_env(pool: sqlx::PgPool) -> TestEnv {
-    create_test_env_with_overrides(
-        pool,
-        TestEnvOverrides::with_config(get_config_with_rack_profiles()),
-    )
-    .await
-}
-
-async fn create_rms_power_shelf_rack(
-    pool: &sqlx::PgPool,
-) -> Result<RackId, Box<dyn std::error::Error>> {
-    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
-    let rack_profile_id = RackProfileId::new(TEST_RMS_RACK_PROFILE_ID);
-    let mut txn = pool.acquire().await?;
-    db_rack::create(
-        &mut txn,
-        &rack_id,
-        Some(&rack_profile_id),
-        &RackConfig::default(),
-        None,
-    )
-    .await?;
-    Ok(rack_id)
-}
-
 /// Build a `PowerShelfStateHandlerServices` whose `component_manager` may be
 /// cleared (to exercise the "component manager not configured" path) while
 /// preserving the rest of the test environment's services.
 fn services_with_component_manager(
-    env: &TestEnv,
+    env: &ControllerEnv,
     component_manager: Option<Arc<component_manager::component_manager::ComponentManager>>,
 ) -> PowerShelfStateHandlerServices {
     PowerShelfStateHandlerServices {
@@ -143,7 +120,7 @@ fn services_with_component_manager(
             username: TEST_BMC_USER.into(),
             password: TEST_BMC_PASSWORD.into(),
         })),
-        per_object_metrics_registry: env.per_object_metrics_registry(),
+        per_object_metrics_registry: env.per_object_metrics_registry.clone(),
         rack_firmware_reprovisioning_enabled: false,
         redfish_client_pool: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
@@ -154,7 +131,7 @@ fn services_with_component_manager(
 }
 
 async fn build_test_component_manager(
-    env: &TestEnv,
+    env: &ControllerEnv,
     rms_client: Option<Arc<dyn librms::RmsApi>>,
 ) -> Option<Arc<component_manager::component_manager::ComponentManager>> {
     let config = ComponentManagerConfig {
@@ -170,7 +147,7 @@ async fn build_test_component_manager(
     };
     let component_manager = component_manager::component_manager::build_component_manager(
         &config,
-        get_config_with_rack_profiles().rack_profiles,
+        env.rack_profiles.clone(),
         rms_client,
         None,
         Some(env.pool.clone()),
@@ -207,7 +184,7 @@ async fn enter_maintenance(
 }
 
 /// Set the power shelf's BMC MAC and rack association directly. The
-/// `new_power_shelf` site-explorer fixture leaves both as `None`, but the
+/// shared power shelf fixture leaves both as `None`, but the
 /// handler's `batch_set_power_state` path needs both before it
 /// will even attempt the BMC IP lookup.
 ///
@@ -247,49 +224,6 @@ async fn set_power_shelf_rack_and_bmc(
         .unwrap();
 }
 
-async fn load_power_shelf(pool: &sqlx::PgPool, id: &PowerShelfId) -> PowerShelf {
-    let mut conn = pool.acquire().await.unwrap();
-    db_power_shelf::find_by_id(conn.as_mut(), id)
-        .await
-        .unwrap()
-        .expect("power shelf should exist")
-}
-
-/// Run one iteration of the state handler against the supplied power shelf.
-async fn run_handler(
-    services: &mut PowerShelfStateHandlerServices,
-    state: &mut PowerShelf,
-) -> StateHandlerOutcome<PowerShelfControllerState> {
-    let handler = PowerShelfStateHandler::default();
-    let mut metrics = PowerShelfMetrics::default();
-    let mut writes = DbWriteBatch::default();
-    let mut ctx = StateHandlerContext::<PowerShelfStateHandlerContextObjects> {
-        services,
-        metrics: &mut metrics,
-        pending_db_writes: &mut writes,
-    };
-    let controller_state = state.controller_state.value.clone();
-    let power_shelf_id = state.id;
-    handler
-        .handle_object_state(&power_shelf_id, state, &controller_state, &mut ctx)
-        .await
-        .expect("state handler should not return an error result")
-}
-
-/// Commit any txn embedded in the outcome (so DB side-effects land) and
-/// return the (now-detached) outcome's transition target if it is one.
-async fn commit_and_extract_transition(
-    mut outcome: StateHandlerOutcome<PowerShelfControllerState>,
-) -> Option<PowerShelfControllerState> {
-    if let Some(txn) = outcome.take_transaction() {
-        txn.commit().await.unwrap();
-    }
-    match outcome {
-        StateHandlerOutcome::Transition { next_state, .. } => Some(next_state),
-        _ => None,
-    }
-}
-
 fn assert_error_with_substring(state: &PowerShelfControllerState, expected_substring: &str) {
     match state {
         PowerShelfControllerState::Error { cause } => {
@@ -309,13 +243,16 @@ fn assert_error_with_substring(state: &PowerShelfControllerState, expected_subst
 
 // ── PowerOn ─────────────────────────────────────────────────────────────────
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn ready_transitions_to_maintenance_when_request_is_set_via_component_power_control(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("CM power-off".into()), None, None, None).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("CM power-off"))
+        .await
+        .id;
 
     request_power_shelf_maintenance_via_cm(
         &env,
@@ -358,15 +295,22 @@ async fn ready_transitions_to_maintenance_when_request_is_set_via_component_powe
 /// underlay machine_interface is not provisioned in this layer's fixtures.
 /// The handler must surface a precise `no BMC IP found` error, must not
 /// invoke RMS, and must clear the maintenance request.
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("PowerOn no-ip".into()), None, None, None).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("PowerOn no-ip"))
+        .await
+        .id;
 
-    let rack_id = create_rms_power_shelf_rack(&pool).await?;
+    let rack_id = env
+        .harness
+        .create_rack(RackProfileId::new(TEST_RMS_RACK_PROFILE_ID))
+        .await
+        .id;
     let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:01".parse().unwrap();
 
     // Queue a success response so we can assert it was *not* consumed.
@@ -421,13 +365,16 @@ async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn power_on_transitions_to_error_when_component_manager_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("PowerOn no-rms".into()), None, None, None).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("PowerOn no-rms"))
+        .await
+        .id;
     {
         let mut txn = pool.acquire().await?;
         enter_maintenance(
@@ -450,13 +397,16 @@ async fn power_on_transitions_to_error_when_component_manager_missing(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn power_on_transitions_to_error_when_rack_id_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("PowerOn no-rack".into()), None, None, None).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("PowerOn no-rack"))
+        .await
+        .id;
     let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:02".parse().unwrap();
 
     {
@@ -486,14 +436,21 @@ async fn power_on_transitions_to_error_when_rack_id_missing(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn power_on_transitions_to_error_when_bmc_mac_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("PowerOn no-mac".into()), None, None, None).await?;
-    let rack_id = create_rms_power_shelf_rack(&pool).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("PowerOn no-mac"))
+        .await
+        .id;
+    let rack_id = env
+        .harness
+        .create_rack(RackProfileId::new(TEST_RMS_RACK_PROFILE_ID))
+        .await
+        .id;
 
     {
         let mut txn = pool.acquire().await?;
@@ -527,13 +484,16 @@ async fn power_on_transitions_to_error_when_bmc_mac_missing(
 
 // ── PowerOff ───────────────────────────────────────────────────────────────
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn power_off_transitions_to_error_when_component_manager_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("PowerOff no-rms".into()), None, None, None).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("PowerOff no-rms"))
+        .await
+        .id;
     {
         let mut txn = pool.acquire().await?;
         enter_maintenance(
@@ -565,13 +525,16 @@ async fn power_off_transitions_to_error_when_component_manager_missing(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn power_off_transitions_to_error_when_rack_id_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("PowerOff no-rack".into()), None, None, None).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("PowerOff no-rack"))
+        .await
+        .id;
     let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:03".parse().unwrap();
 
     {
@@ -603,14 +566,21 @@ async fn power_off_transitions_to_error_when_rack_id_missing(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn power_off_transitions_to_error_when_bmc_mac_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("PowerOff no-mac".into()), None, None, None).await?;
-    let rack_id = create_rms_power_shelf_rack(&pool).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("PowerOff no-mac"))
+        .await
+        .id;
+    let rack_id = env
+        .harness
+        .create_rack(RackProfileId::new(TEST_RMS_RACK_PROFILE_ID))
+        .await
+        .id;
 
     {
         let mut txn = pool.acquire().await?;
@@ -642,13 +612,16 @@ async fn power_off_transitions_to_error_when_bmc_mac_missing(
 
 /// `Ready` should never invoke `batch_set_power_state`. This guards
 /// against accidentally wiring the maintenance dispatch into other states.
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn ready_state_does_not_invoke_rms_set_power_state(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_power_shelf_test_env(pool.clone()).await;
-    let power_shelf_id =
-        new_power_shelf(&env, Some("Ready no-rms-call".into()), None, None, None).await?;
+    let env = ControllerEnv::new(pool.clone()).await;
+    let power_shelf_id = env
+        .harness
+        .create_power_shelf(power_shelf_config("Ready no-rms-call"))
+        .await
+        .id;
     {
         let mut txn = pool.acquire().await?;
         set_power_shelf_controller_state(

--- a/crates/power-shelf-controller/tests/integration/power_shelf_deletion.rs
+++ b/crates/power-shelf-controller/tests/integration/power_shelf_deletion.rs
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
+use carbide_power_shelf_controller::io::PowerShelfStateControllerIO;
+use carbide_test_harness::prelude::*;
+use model::power_shelf::PowerShelfConfig;
+use model::test_support::power_shelf_config;
+use state_controller::config::IterationConfig;
+use state_controller::controller::StateController;
+use tokio_util::sync::CancellationToken;
+use tonic::Request;
+
+use crate::common::{mark_power_shelf_as_deleted, services_without_component_manager};
+
+#[sqlx_test]
+async fn test_power_shelf_deletion_with_state_controller(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool.clone()).build().await;
+
+    // Create a power shelf
+    let power_shelf_id = env
+        .create_power_shelf(PowerShelfConfig {
+            capacity: Some(5000),
+            ..power_shelf_config("Deletion with State Controller Test Power Shelf")
+        })
+        .await
+        .id;
+
+    // Start the state controller
+    let power_shelf_handler = Arc::new(PowerShelfStateHandler::default());
+    const ITERATION_TIME: Duration = Duration::from_millis(50);
+
+    let cancel_token = CancellationToken::new();
+    let mut controller = StateController::<PowerShelfStateControllerIO>::builder()
+        .iteration_config(IterationConfig {
+            iteration_time: ITERATION_TIME,
+            processor_dispatch_interval: Duration::from_millis(10),
+            ..Default::default()
+        })
+        .database(pool.clone(), env.api().work_lock_manager_handle())
+        .processor_id(uuid::Uuid::new_v4().to_string())
+        .services(services_without_component_manager(&pool, false).into())
+        .state_handler(power_shelf_handler.clone())
+        .build_for_manual_iterations(cancel_token.clone())
+        .unwrap();
+
+    // Walk through state machine
+    for _ in 0..20 {
+        controller.run_single_iteration().await;
+    }
+
+    let power_shelf = env
+        .api()
+        .find_power_shelves_by_ids(Request::new(rpc::forge::PowerShelvesByIdsRequest {
+            power_shelf_ids: vec![power_shelf_id],
+        }))
+        .await?
+        .into_inner()
+        .power_shelves
+        .remove(0);
+    assert_eq!(
+        power_shelf.controller_state,
+        "{\"state\":\"ready\"}".to_string()
+    );
+
+    // Mark the power shelf as deleted
+    let mut txn = env.db_txn().await;
+    mark_power_shelf_as_deleted(txn.as_mut(), &power_shelf_id).await?;
+    txn.commit().await?;
+
+    // Walk through state machine
+    for _ in 0..20 {
+        controller.run_single_iteration().await;
+    }
+
+    // Verify that the DB object is gone
+    let power_shelves = env
+        .api()
+        .find_power_shelves_by_ids(Request::new(rpc::forge::PowerShelvesByIdsRequest {
+            power_shelf_ids: vec![power_shelf_id],
+        }))
+        .await?
+        .into_inner()
+        .power_shelves;
+    assert!(power_shelves.is_empty());
+
+    Ok(())
+}

--- a/crates/power-shelf-controller/tests/integration/reprovisioning.rs
+++ b/crates/power-shelf-controller/tests/integration/reprovisioning.rs
@@ -17,25 +17,19 @@
 
 //! Tests for power-shelf rack firmware reprovisioning.
 
-use std::sync::Arc;
-
-use carbide_power_shelf_controller::context::{
-    PowerShelfStateHandlerContextObjects, PowerShelfStateHandlerServices,
-};
-use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
-use carbide_power_shelf_controller::metrics::PowerShelfMetrics;
-use carbide_secrets::test_support::credentials::TestCredentialManager;
+use carbide_test_harness::prelude::*;
 use carbide_uuid::power_shelf::PowerShelfId;
 use db::power_shelf as db_power_shelf;
-use model::power_shelf::{PowerShelf, PowerShelfControllerState, ReProvisioningState};
+use model::power_shelf::{PowerShelfControllerState, ReProvisioningState};
 use model::rack::MaintenanceActivity;
+use model::test_support::power_shelf_config;
 use sqlx::PgConnection;
-use state_controller::db_write_batch::DbWriteBatch;
-use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
+use state_controller::state_handler::StateHandlerOutcome;
 
-use crate::tests::common::api_fixtures::create_test_env;
-use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
-use crate::tests::power_shelf_state_controller::fixtures::power_shelf::set_power_shelf_controller_state;
+use crate::common::{
+    load_power_shelf, run_handler, services_without_component_manager,
+    set_power_shelf_controller_state,
+};
 
 fn firmware_only_activities() -> Vec<MaintenanceActivity> {
     vec![MaintenanceActivity::FirmwareUpgrade {
@@ -43,52 +37,6 @@ fn firmware_only_activities() -> Vec<MaintenanceActivity> {
         components: vec![],
         force_update: false,
     }]
-}
-
-fn services(
-    env: &crate::tests::common::api_fixtures::TestEnv,
-    rack_firmware_reprovisioning_enabled: bool,
-) -> PowerShelfStateHandlerServices {
-    PowerShelfStateHandlerServices {
-        db_pool: env.pool.clone(),
-        component_manager: None,
-        credential_manager: Arc::new(TestCredentialManager::default()),
-        per_object_metrics_registry: env.per_object_metrics_registry(),
-        rack_firmware_reprovisioning_enabled,
-        redfish_client_pool: env.redfish_sim.clone(),
-        bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
-            db::credential_rotation::CredentialRotationType::Bmc,
-        ),
-        bmc_rotation_enabled: false,
-    }
-}
-
-async fn load_power_shelf(pool: &sqlx::PgPool, id: &PowerShelfId) -> PowerShelf {
-    let mut conn = pool.acquire().await.unwrap();
-    db_power_shelf::find_by_id(conn.as_mut(), id)
-        .await
-        .unwrap()
-        .expect("power shelf should exist")
-}
-
-async fn run_handler(
-    services: &mut PowerShelfStateHandlerServices,
-    state: &mut PowerShelf,
-) -> StateHandlerOutcome<PowerShelfControllerState> {
-    let handler = PowerShelfStateHandler::default();
-    let mut metrics = PowerShelfMetrics::default();
-    let mut writes = DbWriteBatch::default();
-    let mut ctx = StateHandlerContext::<PowerShelfStateHandlerContextObjects> {
-        services,
-        metrics: &mut metrics,
-        pending_db_writes: &mut writes,
-    };
-    let controller_state = state.controller_state.value.clone();
-    let power_shelf_id = state.id;
-    handler
-        .handle_object_state(&power_shelf_id, state, &controller_state, &mut ctx)
-        .await
-        .expect("state handler should not return an error result")
 }
 
 async fn commit_outcome(mut outcome: StateHandlerOutcome<PowerShelfControllerState>) {
@@ -103,12 +51,14 @@ async fn park_ready(txn: &mut PgConnection, power_shelf_id: &PowerShelfId) {
         .expect("set Ready");
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_ready_clears_reprovision_request_when_flag_disabled(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
+    let env = TestHarness::builder(pool.clone()).build().await;
+    let TestPowerShelf { id: power_shelf_id } = env
+        .create_power_shelf(power_shelf_config("Reprovision request disabled"))
+        .await;
 
     let mut txn = pool.begin().await?;
     park_ready(txn.as_mut(), &power_shelf_id).await;
@@ -122,7 +72,7 @@ async fn test_ready_clears_reprovision_request_when_flag_disabled(
     txn.commit().await?;
 
     let mut state = load_power_shelf(&pool, &power_shelf_id).await;
-    let mut services = services(&env, false);
+    let mut services = services_without_component_manager(&pool, false);
     let outcome = run_handler(&mut services, &mut state).await;
     assert!(matches!(outcome, StateHandlerOutcome::DoNothing { .. }));
     commit_outcome(outcome).await;
@@ -136,12 +86,14 @@ async fn test_ready_clears_reprovision_request_when_flag_disabled(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_ready_enters_waiting_for_rack_firmware_when_flag_enabled(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
+    let env = TestHarness::builder(pool.clone()).build().await;
+    let TestPowerShelf { id: power_shelf_id } = env
+        .create_power_shelf(power_shelf_config("Reprovision request enabled"))
+        .await;
 
     let mut txn = pool.begin().await?;
     park_ready(txn.as_mut(), &power_shelf_id).await;
@@ -155,7 +107,7 @@ async fn test_ready_enters_waiting_for_rack_firmware_when_flag_enabled(
     txn.commit().await?;
 
     let mut state = load_power_shelf(&pool, &power_shelf_id).await;
-    let mut services = services(&env, true);
+    let mut services = services_without_component_manager(&pool, true);
     let outcome = run_handler(&mut services, &mut state).await;
     assert!(matches!(
         outcome,
@@ -169,12 +121,14 @@ async fn test_ready_enters_waiting_for_rack_firmware_when_flag_enabled(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_waiting_for_rack_firmware_completes_to_ready(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
+    let env = TestHarness::builder(pool.clone()).build().await;
+    let TestPowerShelf { id: power_shelf_id } = env
+        .create_power_shelf(power_shelf_config("Reprovision request completed"))
+        .await;
 
     let mut txn = pool.begin().await?;
     db_power_shelf::set_power_shelf_reprovisioning_requested(
@@ -214,7 +168,7 @@ async fn test_waiting_for_rack_firmware_completes_to_ready(
     txn.commit().await?;
 
     let mut state = load_power_shelf(&pool, &power_shelf_id).await;
-    let mut services = services(&env, true);
+    let mut services = services_without_component_manager(&pool, true);
     let outcome = run_handler(&mut services, &mut state).await;
     assert!(matches!(
         outcome,

--- a/crates/test-harness/src/asset.rs
+++ b/crates/test-harness/src/asset.rs
@@ -32,9 +32,8 @@ pub struct TestRack {
 }
 
 impl TestRack {
-    pub(crate) async fn create(test_harness: &TestHarness) -> Self {
+    pub(crate) async fn create(test_harness: &TestHarness, rack_profile_id: RackProfileId) -> Self {
         let id = RackId::new(uuid::Uuid::new_v4().to_string());
-        let rack_profile_id = RackProfileId::new("rack");
         let mut txn = test_harness.db_txn().await;
         db::rack::create(
             &mut txn,
@@ -196,13 +195,9 @@ pub struct TestPowerShelf {
 }
 
 impl TestPowerShelf {
-    pub(crate) async fn create(test_harness: &TestHarness) -> Self {
-        let name = format!(
-            "Test Power Shelf {}",
-            &uuid::Uuid::new_v4().to_string()[..8]
-        );
+    pub(crate) async fn create(test_harness: &TestHarness, config: PowerShelfConfig) -> Self {
         let id = power_shelf_id::from_hardware_info(
-            &name,
+            &config.name,
             "NVIDIA",
             "PowerShelf",
             PowerShelfIdSource::ProductBoardChassisSerial,
@@ -211,11 +206,7 @@ impl TestPowerShelf {
         .expect("power shelf id should be derived from test hardware info");
         let new_power_shelf = NewPowerShelf {
             id,
-            config: PowerShelfConfig {
-                name,
-                capacity: Some(100),
-                voltage: Some(240),
-            },
+            config,
             bmc_mac_address: None,
             metadata: None,
             rack_id: None,

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -162,8 +162,12 @@ impl TestHarness {
             .machines
     }
 
-    pub async fn create_rack(&self) -> TestRack {
-        TestRack::create(self).await
+    /// Creates a randomly identified rack with the supplied profile and default config.
+    pub async fn create_rack(
+        &self,
+        rack_profile_id: carbide_uuid::rack::RackProfileId,
+    ) -> TestRack {
+        TestRack::create(self, rack_profile_id).await
     }
 
     pub async fn create_switch(&self, slot_number: i32, tray_index: i32) -> TestSwitch {
@@ -178,8 +182,15 @@ impl TestHarness {
         TestExpectedSwitch::create(self, expected_switch).await
     }
 
-    pub async fn create_power_shelf(&self) -> TestPowerShelf {
-        TestPowerShelf::create(self).await
+    /// Creates a power shelf directly in the database with the supplied config.
+    ///
+    /// The ID is derived from `config.name`, so repeated names collide in the
+    /// same database. BMC MAC, metadata, and rack association are left unset.
+    pub async fn create_power_shelf(
+        &self,
+        config: model::power_shelf::PowerShelfConfig,
+    ) -> TestPowerShelf {
+        TestPowerShelf::create(self, config).await
     }
 }
 


### PR DESCRIPTION
Move 17 deletion, Error, maintenance, and reprovisioning tests from `api-core` into the owning power shelf controller integration suite. Move two decommission API tests added by [#4680](https://github.com/NVIDIA/infra-controller/pull/4680) into the api-core integration suite. Share the controller environment and reusable power shelf and RMS rack-profile fixtures, with fixture configuration explicit at call sites.

## Related issues

#2001

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

