### PR TITLE
docs: document rack_capabilities count field

### DIFF
--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -238,7 +238,7 @@ to descriptor-based RMS operations.
 
 Each `rack_capabilities.<role>` section also requires a `count` field. This
 field is independent of RMS: it tells the rack state machine how many devices
-of that role the rack must have before it can progress. A rack stays in
+with that role the rack must have before it can progress. A rack stays in
 `Created` until all three roles have at least `count` devices registered; it
 stays in `Discovering` until all three roles have at least `count` devices in
 `Ready` state. All three roles — `compute`, `switch`, and `power_shelf` —

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -236,6 +236,16 @@ For product families other than `gb200` and `gb300`, the `GetRackProfile`
 `product_family` enum is `UNSPECIFIED`. The configured string remains available
 to descriptor-based RMS operations.
 
+Each `rack_capabilities.<role>` section also requires a `count` field. This
+field is independent of RMS: it tells the rack state machine how many devices
+of that role the rack must have before it can progress. A rack stays in
+`Created` until all three roles have at least `count` devices registered; it
+stays in `Discovering` until all three roles have at least `count` devices in
+`Ready` state. All three roles — `compute`, `switch`, and `power_shelf` —
+require a `count` regardless of which backends are set to `rms`. The third
+example below shows `count` on `compute` and `switch` even though those roles
+use non-RMS backends.
+
 The examples below only show the component-manager and rack-profile fields.
 Configure `[rms]` separately when NICo needs to call RMS.
 
@@ -253,12 +263,15 @@ rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
 
 [rack_profiles.NVL72.rack_capabilities.compute]
 vendor = "NVIDIA"
+count = 18
 
 [rack_profiles.NVL72.rack_capabilities.switch]
 vendor = "NVIDIA"
+count = 9
 
 [rack_profiles.NVL72.rack_capabilities.power_shelf]
 vendor = "LiteOn"
+count = 8
 ```
 
 Example: GB300 rack with Lenovo compute trays and Delta power shelves:
@@ -275,12 +288,15 @@ rack_hardware_topology = "gb300_nvl72r1_c2g4_topology"
 
 [rack_profiles.NVL72_GB300.rack_capabilities.compute]
 vendor = "Lenovo"
+count = 18
 
 [rack_profiles.NVL72_GB300.rack_capabilities.switch]
 vendor = "nvidia"
+count = 9
 
 [rack_profiles.NVL72_GB300.rack_capabilities.power_shelf]
 vendor = "delta"
+count = 6
 ```
 
 Example: only the component-manager power shelf backend uses RMS. The compute
@@ -301,8 +317,15 @@ url = "http://nsm.example.internal:50052"
 product_family = "gb200"
 rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
 
+[rack_profiles.NVL72_POWER.rack_capabilities.compute]
+count = 18
+
+[rack_profiles.NVL72_POWER.rack_capabilities.switch]
+count = 9
+
 [rack_profiles.NVL72_POWER.rack_capabilities.power_shelf]
 vendor = "Lite-On"
+count = 8
 ```
 
 Each rack that uses an RMS-backed operation must have a `rack_profile_id`

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -185,6 +185,16 @@ For product families other than `gb200` and `gb300`, the `GetRackProfile`
 `product_family` enum is `UNSPECIFIED`. The configured string remains available
 to descriptor-based RMS operations.
 
+Each `rack_capabilities.<role>` section also requires a `count` field. This
+field is independent of RMS: it tells the rack state machine how many devices
+of that role the rack must have before it can progress. A rack stays in
+`Created` until all three roles have at least `count` devices registered; it
+stays in `Discovering` until all three roles have at least `count` devices in
+`Ready` state. All three roles — `compute`, `switch`, and `power_shelf` —
+require a `count` regardless of which backends are set to `rms`. The third
+example below shows `count` on `compute` and `switch` even though those roles
+use non-RMS backends.
+
 The examples below only show the component-manager and rack-profile fields.
 Configure `[rms]` separately when NICo needs to call RMS.
 
@@ -206,12 +216,15 @@ fetch_timeout = "30s"
 
 [rack_profiles.NVL72.rack_capabilities.compute]
 vendor = "NVIDIA"
+count = 18
 
 [rack_profiles.NVL72.rack_capabilities.switch]
 vendor = "NVIDIA"
+count = 9
 
 [rack_profiles.NVL72.rack_capabilities.power_shelf]
 vendor = "LiteOn"
+count = 8
 ```
 
 Example: GB300 rack with Lenovo compute trays and Delta power shelves:
@@ -228,12 +241,15 @@ rack_hardware_topology = "gb300_nvl72r1_c2g4_topology"
 
 [rack_profiles.NVL72_GB300.rack_capabilities.compute]
 vendor = "Lenovo"
+count = 18
 
 [rack_profiles.NVL72_GB300.rack_capabilities.switch]
 vendor = "nvidia"
+count = 9
 
 [rack_profiles.NVL72_GB300.rack_capabilities.power_shelf]
 vendor = "delta"
+count = 6
 ```
 
 Example: only the component-manager power shelf backend uses RMS. The compute
@@ -253,8 +269,15 @@ url = "http://nsm.example.internal:50052"
 product_family = "gb200"
 rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
 
+[rack_profiles.NVL72_POWER.rack_capabilities.compute]
+count = 18
+
+[rack_profiles.NVL72_POWER.rack_capabilities.switch]
+count = 9
+
 [rack_profiles.NVL72_POWER.rack_capabilities.power_shelf]
 vendor = "Lite-On"
+count = 8
 ```
 
 Each rack that uses an RMS-backed operation must have a `rack_profile_id`

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -187,7 +187,7 @@ to descriptor-based RMS operations.
 
 Each `rack_capabilities.<role>` section also requires a `count` field. This
 field is independent of RMS: it tells the rack state machine how many devices
-of that role the rack must have before it can progress. A rack stays in
+with that role the rack must have before it can progress. A rack stays in
 `Created` until all three roles have at least `count` devices registered; it
 stays in `Discovering` until all three roles have at least `count` devices in
 `Ready` state. All three roles — `compute`, `switch`, and `power_shelf` —

--- a/docs/configuration/component-manager-rms.md
+++ b/docs/configuration/component-manager-rms.md
@@ -33,6 +33,14 @@ both to be non-empty. Case and internal punctuation are preserved after
 trimming. NICo does not map these values to a supported-hardware list. RMS
 validates each role/vendor/product-family combination when a request is made.
 
+Each `rack_capabilities.<role>` section also requires a `count` field. This
+field is independent of RMS: it tells the rack state machine how many devices
+of that role the rack must have before it can progress. A rack stays in
+`Created` until all three roles have at least `count` devices registered; it
+stays in `Discovering` until all three roles have at least `count` devices in
+`Ready` state. All three roles — `compute`, `switch`, and `power_shelf` —
+require a `count` regardless of which backends are set to `rms`.
+
 For product families other than `gb200` and `gb300`, the `GetRackProfile`
 `product_family` enum is `UNSPECIFIED`. The configured string remains available
 to descriptor-based RMS operations.
@@ -110,12 +118,15 @@ rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
 
 [rack_profiles.NVL72.rack_capabilities.compute]
 vendor = "NVIDIA"
+count = 18
 
 [rack_profiles.NVL72.rack_capabilities.switch]
 vendor = "NVIDIA"
+count = 9
 
 [rack_profiles.NVL72.rack_capabilities.power_shelf]
 vendor = "LiteOn"
+count = 8
 ```
 
 ### GB300 rack, Lenovo compute trays and Delta power shelves
@@ -132,12 +143,15 @@ rack_hardware_topology = "gb300_nvl72r1_c2g4_topology"
 
 [rack_profiles.NVL72_GB300.rack_capabilities.compute]
 vendor = "Lenovo"
+count = 18
 
 [rack_profiles.NVL72_GB300.rack_capabilities.switch]
 vendor = "nvidia"
+count = 9
 
 [rack_profiles.NVL72_GB300.rack_capabilities.power_shelf]
 vendor = "delta"
+count = 6
 ```
 
 ### Power shelf backend uses RMS; compute and switch do not
@@ -159,8 +173,15 @@ url = "http://nsm.example.internal:50052"
 product_family = "gb200"
 rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
 
+[rack_profiles.NVL72_POWER.rack_capabilities.compute]
+count = 18
+
+[rack_profiles.NVL72_POWER.rack_capabilities.switch]
+count = 9
+
 [rack_profiles.NVL72_POWER.rack_capabilities.power_shelf]
 vendor = "Lite-On"
+count = 8
 ```
 
 ---
@@ -174,6 +195,7 @@ vendor = "Lite-On"
 | Compute profile vendor, when `compute_tray_backend = "rms"` | Non-empty string; RMS validates support at request time |
 | Switch profile vendor, when `nv_switch_backend = "rms"` | Non-empty string; RMS validates support at request time |
 | Power shelf profile vendor, when `power_shelf_backend = "rms"` | Non-empty string; RMS validates support at request time |
+| `rack_capabilities.<role>.count` (all three roles, always required) | Non-negative integer. Minimum devices of that role that must be registered before the rack leaves `Created`, and in `Ready` state before it leaves `Discovering`. Independent of RMS backend selection. |
 
 ## Machine ingestion note
 

--- a/docs/configuration/component-manager-rms.md
+++ b/docs/configuration/component-manager-rms.md
@@ -35,7 +35,7 @@ validates each role/vendor/product-family combination when a request is made.
 
 Each `rack_capabilities.<role>` section also requires a `count` field. This
 field is independent of RMS: it tells the rack state machine how many devices
-of that role the rack must have before it can progress. A rack stays in
+with that role the rack must have before it can progress. A rack stays in
 `Created` until all three roles have at least `count` devices registered; it
 stays in `Discovering` until all three roles have at least `count` devices in
 `Ready` state. All three roles — `compute`, `switch`, and `power_shelf` —

--- a/docs/operations/firmware-updates/configuration.md
+++ b/docs/operations/firmware-updates/configuration.md
@@ -394,6 +394,18 @@ product_family = "gb200"
 [rack_profiles.NVL72.firmware_object]
 url = "https://firmware.example.com/objects/nvl72.json"
 fetch_timeout = "30s"
+
+[rack_profiles.NVL72.rack_capabilities.compute]
+vendor = "NVIDIA"
+count = 18
+
+[rack_profiles.NVL72.rack_capabilities.switch]
+vendor = "NVIDIA"
+count = 9
+
+[rack_profiles.NVL72.rack_capabilities.power_shelf]
+vendor = "LiteOn"
+count = 8
 ```
 
 The `url` field identifies the document location. The optional `fetch_timeout`

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -79,6 +79,7 @@ nico-api:
   #   nicoApiSiteConfig: |
   #     [rack_profiles.NVL72.rack_capabilities.compute]
   #     vendor = "Lenovo"   # override compute vendor only
+  #     count = 18          # required; override only if rack uses non-standard count
 
   ## MetalLB VIP for the nico-api LoadBalancer service.
   ## Must be an IP within your external IPAddressPool (values/metallb-config.yaml).


### PR DESCRIPTION
The `rack_capabilities.<role>.count` field was present in the authoritative
global config (`helm/charts/nico-api/files/carbide-api-config.toml`) and in
the internal test fixture, but was absent from every operator-facing
documentation example. Because `count` has no serde default, any new rack
profile defined verbatim from these examples would fail to deserialize at
startup. The field was also never explained in prose — operators had no way
to know it exists, what it controls, or that it is required on all three
roles regardless of which component-manager backends use RMS.

This PR adds `count` to all affected examples and documents what the field
does: it is the threshold the rack state machine checks before advancing a
rack from `Created` (device presence check) through `Discovering` (device
readiness check) to `Maintenance`.

## Related issues

Closes #5350 .

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Five files changed, all documentation:

- **`docs/configuration/component-manager-rms.md`** — Added `count` to all
  three TOML examples. Added a paragraph in "What the rack profile provides"
  explaining that `count` is independent of RMS and required on all three
  roles. Added a row to the "Accepted values" table.
- **`crates/api-core/src/cfg/README.md`** — Same example fixes and prose.
- **`book/src/configuration/configurability.md`** — Same (mirrors the README
  for this section).
- **`docs/operations/firmware-updates/configuration.md`** — The snippet
  showed only a `firmware_object` block with no `rack_capabilities` at all.
  Added a complete `rack_capabilities` section so the snippet represents a
  valid standalone profile.
- **`helm-prereqs/values/nico-core.yaml`** — Added `count = 18` to the
  commented site-config override example with a note that it is required.

Counts used match the authoritative global config: NVL72 (GB200) — compute 18,
switch 9, power\_shelf 8; NVL72\_GB300 (GB300) — compute 18, switch 9,
power\_shelf 6.