### PR TITLE
Handling multiple shim files by order of preference.

### DIFF
--- a/pxe/common_files/disk_imaging.sh
+++ b/pxe/common_files/disk_imaging.sh
@@ -470,33 +470,30 @@ function create_efi_boot_entry() {
 		fi
 
 		# Match shim's lookup order: use BOOT.CSV only when the
-		# architecture-specific file is absent or cannot be decoded.
-		candidate_csv=$(find "$candidate_dir" -maxdepth 1 -type f -iname "$boot_csv_name" -print -quit 2>/dev/null)
-		if [ ! -z "$candidate_csv" ]; then
-			candidate_csv_contents=$(iconv -f UTF-16 -t UTF-8 "$candidate_csv" 2>/dev/null)
-			[ $? -ne 0 ] && candidate_csv=
-		fi
-		if [ -z "$candidate_csv" ]; then
-			candidate_csv=$(find "$candidate_dir" -maxdepth 1 -type f -iname "BOOT.CSV" -print -quit 2>/dev/null)
-			[ -z "$candidate_csv" ] && continue
-			candidate_csv_contents=$(iconv -f UTF-16 -t UTF-8 "$candidate_csv" 2>/dev/null)
-			[ $? -ne 0 ] && continue
-		fi
-
-		# A boot hint can contain more than one loader record.
+		# architecture-specific file is absent, cannot be decoded, or has no
+		# matching loader record with a non-empty label.
 		candidate_shim_name=$(basename "$candidate_shim")
 		candidate_csv_matches=
 		candidate_csv_label=
-		while IFS= read -r candidate_csv_line || [ ! -z "$candidate_csv_line" ]; do
-			candidate_csv_line=${candidate_csv_line%$'\r'}
-			[ -z "$candidate_csv_line" ] && continue
-			IFS=',' read -r candidate_loader candidate_label _ <<< "$candidate_csv_line"
-			if [ ! -z "$candidate_label" ] && [ "${candidate_loader,,}" == "${candidate_shim_name,,}" ]; then
-				candidate_csv_matches=true
-				candidate_csv_label="$candidate_label"
-				break
-			fi
-		done <<< "$candidate_csv_contents"
+		for candidate_csv_name in "$boot_csv_name" "BOOT.CSV"; do
+			candidate_csv=$(find "$candidate_dir" -maxdepth 1 -type f -iname "$candidate_csv_name" -print -quit 2>/dev/null)
+			[ -z "$candidate_csv" ] && continue
+			candidate_csv_contents=$(iconv -f UTF-16 -t UTF-8 "$candidate_csv" 2>/dev/null)
+			[ $? -ne 0 ] && continue
+
+			# A boot hint can contain more than one loader record.
+			while IFS= read -r candidate_csv_line || [ ! -z "$candidate_csv_line" ]; do
+				candidate_csv_line=${candidate_csv_line%$'\r'}
+				[ -z "$candidate_csv_line" ] && continue
+				IFS=',' read -r candidate_loader candidate_label _ <<< "$candidate_csv_line"
+				if [ ! -z "$candidate_label" ] && [ "${candidate_loader,,}" == "${candidate_shim_name,,}" ]; then
+					candidate_csv_matches=true
+					candidate_csv_label="$candidate_label"
+					break
+				fi
+			done <<< "$candidate_csv_contents"
+			[ "$candidate_csv_matches" == true ] && break
+		done
 		[ "$candidate_csv_matches" != true ] && continue
 
 		if [ "$candidate_is_distro" == true ]; then

--- a/pxe/common_files/disk_imaging.sh
+++ b/pxe/common_files/disk_imaging.sh
@@ -425,11 +425,14 @@ function create_efi_boot_entry() {
 	fi
 
 	shim_arch=
+	boot_csv_name=
 	efi_arch=$(uname -m)
 	if [ "$efi_arch" == "x86_64" ]; then
 		shim_arch="x64"
+		boot_csv_name="BOOTX64.CSV"
 	elif [ "$efi_arch" == "aarch64" ]; then
 		shim_arch="aa64"
+		boot_csv_name="BOOTAA64.CSV"
 	else
 		echo "Unsupported arch $efi_arch for EFI boot entry creation" | tee $log_output
 		return 0
@@ -442,19 +445,77 @@ function create_efi_boot_entry() {
 	# Sort rather than taking whatever the filesystem yields first: an ESP
 	# reprovisioned over a different distro can hold more than one shim (e.g.
 	# a leftover EFI/dgx alongside the new EFI/ubuntu), and -print -quit
-	# would pick between them nondeterministically. Prefer the directory
-	# matching distro_name when it was supplied on the kernel cmdline.
-	shim_paths=$(find /mnt/boot/efi/EFI -mindepth 2 -maxdepth 2 -iname "shim${shim_arch}.efi" 2>/dev/null | sort)
+	# would pick between them nondeterministically. Prefer the distro_name
+	# directory when one was supplied, then a shim paired with an architecture-
+	# matching boot hint CSV whose first field names that shim.
+	shim_paths=$(find /mnt/boot/efi/EFI -mindepth 2 -maxdepth 2 -type f -iname "shim${shim_arch}.efi" 2>/dev/null | sort)
 	if [ -z "$shim_paths" ]; then
 		echo "No shim${shim_arch}.efi found under /mnt/boot/efi/EFI/*, skipping EFI boot entry creation" | tee $log_output
 		return 0
 	fi
-	shim_path=
-	if [ ! -z "$distro_name" ]; then
-		shim_path=$(printf '%s\n' "$shim_paths" | grep -iE "/EFI/$distro_name/[^/]+$" | head -n1)
-	fi
-	if [ -z "$shim_path" ]; then
-		shim_path=$(printf '%s\n' "$shim_paths" | head -n1)
+	shim_path=$(printf '%s\n' "$shim_paths" | head -n1)
+	distro_shim_path=
+	paired_shim_path=
+	paired_csv_label=
+	csv_label=
+	while IFS= read -r candidate_shim; do
+		candidate_dir=$(dirname "$candidate_shim")
+		candidate_distro_name=$(basename "$candidate_dir")
+		candidate_is_distro=
+		if [ ! -z "$distro_name" ] && [ "${candidate_distro_name,,}" == "${distro_name,,}" ]; then
+			candidate_is_distro=true
+			if [ -z "$distro_shim_path" ]; then
+				distro_shim_path="$candidate_shim"
+			fi
+		fi
+
+		# Match shim's lookup order: use BOOT.CSV only when the
+		# architecture-specific file is absent or cannot be decoded.
+		candidate_csv=$(find "$candidate_dir" -maxdepth 1 -type f -iname "$boot_csv_name" -print -quit 2>/dev/null)
+		if [ ! -z "$candidate_csv" ]; then
+			candidate_csv_contents=$(iconv -f UTF-16 -t UTF-8 "$candidate_csv" 2>/dev/null)
+			[ $? -ne 0 ] && candidate_csv=
+		fi
+		if [ -z "$candidate_csv" ]; then
+			candidate_csv=$(find "$candidate_dir" -maxdepth 1 -type f -iname "BOOT.CSV" -print -quit 2>/dev/null)
+			[ -z "$candidate_csv" ] && continue
+			candidate_csv_contents=$(iconv -f UTF-16 -t UTF-8 "$candidate_csv" 2>/dev/null)
+			[ $? -ne 0 ] && continue
+		fi
+
+		# A boot hint can contain more than one loader record.
+		candidate_shim_name=$(basename "$candidate_shim")
+		candidate_csv_matches=
+		candidate_csv_label=
+		while IFS= read -r candidate_csv_line || [ ! -z "$candidate_csv_line" ]; do
+			candidate_csv_line=${candidate_csv_line%$'\r'}
+			[ -z "$candidate_csv_line" ] && continue
+			IFS=',' read -r candidate_loader candidate_label _ <<< "$candidate_csv_line"
+			if [ ! -z "$candidate_label" ] && [ "${candidate_loader,,}" == "${candidate_shim_name,,}" ]; then
+				candidate_csv_matches=true
+				candidate_csv_label="$candidate_label"
+				break
+			fi
+		done <<< "$candidate_csv_contents"
+		[ "$candidate_csv_matches" != true ] && continue
+
+		if [ "$candidate_is_distro" == true ]; then
+			shim_path="$candidate_shim"
+			csv_label="$candidate_csv_label"
+			break
+		fi
+		if [ -z "$paired_shim_path" ]; then
+			paired_shim_path="$candidate_shim"
+			paired_csv_label="$candidate_csv_label"
+		fi
+	done <<< "$shim_paths"
+	if [ -z "$csv_label" ]; then
+		if [ ! -z "$distro_shim_path" ]; then
+			shim_path="$distro_shim_path"
+		elif [ ! -z "$paired_shim_path" ]; then
+			shim_path="$paired_shim_path"
+			csv_label="$paired_csv_label"
+		fi
 	fi
 	if [ "$(printf '%s\n' "$shim_paths" | wc -l)" -gt 1 ]; then
 		echo "Multiple shim${shim_arch}.efi found on ESP, using $shim_path:" | tee $log_output
@@ -470,11 +531,7 @@ function create_efi_boot_entry() {
 	# authoritative source per the UEFI shim convention: <loader>,<label>,
 	# <optional args>,<description>, UTF-16 encoded), falling back to the
 	# ESP directory name.
-	label=
-	csv_file=$(find "$efi_dir" -maxdepth 1 -iname "*.csv" -print -quit 2>/dev/null)
-	if [ ! -z "$csv_file" ]; then
-		label=$(iconv -f UTF-16 -t UTF-8 "$csv_file" 2>/dev/null | tr -d '\r' | head -n1 | cut -d',' -f2)
-	fi
+	label="$csv_label"
 	if [ -z "$label" ]; then
 		label="$distro_dir"
 	fi


### PR DESCRIPTION
During testing we found that Rocky Linux installs multiple shim files.   The existing code was selecting the one in the redhat directory, because it was alphabetically lower.  However this one did not work.

We now look at the distro_name (if supplied) and any boot hint CSV files to generate the list of options.   First preference is distro_name, second is a shim with a matching CSV file, then we fall back to the first valid shim.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Single shim test from Ubuntu
```
Creating EFI boot entry for ubuntu (\EFI\ubuntu\shimx64.efi on /dev/nvme1n1 part 15)
```

Multiple shim test from Rocky
```
Multiple shimx64.efi found on ESP, using /mnt/boot/efi/EFI/rocky/shimx64.efi:
/mnt/boot/efi/EFI/redhat/shimx64.efi
/mnt/boot/efi/EFI/rocky/shimx64.efi
Creating EFI boot entry for rocky (\EFI\rocky\shimx64.efi on /dev/nvme0n1 part 1)
```