### PR TITLE
feat(helm): machine-a-tron dhcp relay deployment

### DIFF
--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -379,6 +379,90 @@ depends on that volume's reclaim policy.
 | `generic_ami` | Generic AMI BMC |
 | `generic_supermicro` | Generic Supermicro BMC |
 
+### DHCP Relay Mode
+
+By default, machine-a-tron obtains IP addresses for simulated BMCs directly
+through the NICo API. DHCP relay mode exercises the real DHCP packet path
+by sending UDP DISCOVER/REQUEST packets to the nico-dhcp server.
+
+**When to use:** Scale testing that needs to validate the DHCP server's packet
+handling under load, or when testing DHCP relay agent behavior.
+
+**Prerequisites:**
+
+- `nico-dhcp` must be deployed (default: `nico-system` namespace)
+- A dedicated ServiceCIDR for DHCP relay IPs (recommended)
+
+**Setup:**
+
+1. Create a ServiceCIDR for DHCP relay services (Kubernetes 1.29+):
+
+   ```yaml
+   apiVersion: networking.k8s.io/v1beta1
+   kind: ServiceCIDR
+   metadata:
+     name: mat-dhcp-services
+   spec:
+     cidrs:
+       - 10.96.127.0/24
+   ```
+
+2. Configure the chart:
+
+   ```yaml
+   # values.yaml
+   dhcpRelay:
+     baseIP: "10.96.127.10" # First relay IP (from mat-dhcp-services CIDR)
+     listenPort: 67
+     # serverAddress: ""    # Optional: override DHCP server (default: nico-dhcp.nico-system.svc.cluster.local:67)
+
+   pods:
+     mat-0:
+       machines:
+         compute:
+           hwType: wiwynn_gb200_nvl
+           hostCount: 100
+     mat-1:
+       machines:
+         compute:
+           hwType: wiwynn_gb200_nvl
+           hostCount: 100
+   ```
+
+3. Each pod gets a unique ClusterIP for receiving DHCP replies:
+   - Pod `mat-0`: `10.96.127.10`
+   - Pod `mat-1`: `10.96.127.11`
+   - Pod `mat-2`: `10.96.127.12`
+   - etc.
+
+**How it works:**
+
+1. The chart creates a UDP Service per pod with an explicit ClusterIP from
+   `dhcpRelay.baseIP + podIndex`
+2. The pod's `mat.toml` is configured with `[dhcp] type = "udp_relay"`:
+   - `server_address` points to nico-dhcp ClusterIP
+   - `listen_address` binds to `0.0.0.0:<listenPort>`
+   - `advertise_address` is the pod's relay Service ClusterIP
+3. All machine groups in that pod automatically use the relay IP as their
+   `oob_dhcp_relay_address` (any user-provided value is overridden)
+4. Machine-a-tron sends DHCP packets with `giaddr` set to the advertise address
+5. nico-dhcp replies to the advertise address (the relay Service ClusterIP)
+6. The Service routes replies to the correct pod
+
+**Constraints:**
+
+- Relay Service ClusterIPs are **immutable** - changing `dhcpRelay.baseIP`
+  after deployment requires deleting the existing Services first
+- Each pod must have a unique IP - the chart auto-increments from baseIP
+- The baseIP range must not overlap with BMC Services or other Kubernetes
+  Services
+- When relay is enabled, you cannot use different `oob_dhcp_relay_address`
+  values per machine group within a pod - all machines share the pod's relay IP
+
+**Disable relay mode:**
+
+To use API mode (default), don't set `dhcpRelay.baseIP` (or set it to empty string).
+
 ---
 
 ## Troubleshooting

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -395,9 +395,12 @@ handling under load, or when testing DHCP relay agent behavior.
 
 **Setup:**
 
-1. Create a ServiceCIDR for DHCP relay services (Kubernetes 1.29+):
+1. Create a ServiceCIDR for DHCP relay services:
 
    ```yaml
+   # Kubernetes 1.29-1.30: networking.k8s.io/v1alpha1 (requires MultiCIDRServiceAllocator feature gate)
+   # Kubernetes 1.31-1.32: networking.k8s.io/v1beta1 (requires MultiCIDRServiceAllocator feature gate)
+   # Kubernetes 1.33+: networking.k8s.io/v1 (GA, no feature gate required)
    apiVersion: networking.k8s.io/v1beta1
    kind: ServiceCIDR
    metadata:
@@ -406,6 +409,12 @@ handling under load, or when testing DHCP relay agent behavior.
      cidrs:
        - 10.96.127.0/24
    ```
+
+   <Note>
+   Adjust `apiVersion` based on your Kubernetes version. The `MultiCIDRServiceAllocator`
+   feature gate must be enabled for versions prior to 1.33. For clusters without this feature,
+   select ClusterIPs from the default service CIDR range instead.
+   </Note>
 
 2. Configure the chart:
 

--- a/helm/charts/nico-machine-a-tron/templates/_helpers.tpl
+++ b/helm/charts/nico-machine-a-tron/templates/_helpers.tpl
@@ -115,3 +115,42 @@ selector:
   matchLabels:
     app.kubernetes.io/metrics: {{ .name }}
 {{- end }}
+
+{{/*
+Calculate DHCP relay ClusterIP for a pod.
+Adds podIndex to the base IP's last octet.
+Usage: include "nico-machine-a-tron.dhcpRelayIP" (dict "baseIP" "10.96.127.10" "podIndex" 0)
+Returns: "10.96.127.10" for podIndex 0, "10.96.127.11" for podIndex 1, etc.
+*/}}
+{{- define "nico-machine-a-tron.dhcpRelayIP" -}}
+{{- $parts := splitList "." .baseIP -}}
+{{- $lastOctet := index $parts 3 | int -}}
+{{- $newLastOctet := add $lastOctet .podIndex -}}
+{{- if gt $newLastOctet 255 -}}
+{{- fail (printf "DHCP relay IP overflow: base %s + pod index %d exceeds .255" .baseIP .podIndex) -}}
+{{- end -}}
+{{- printf "%s.%s.%s.%d" (index $parts 0) (index $parts 1) (index $parts 2) $newLastOctet -}}
+{{- end }}
+
+{{/*
+Check if DHCP relay mode is enabled.
+Returns "true" if dhcpRelay.baseIP is set.
+*/}}
+{{- define "nico-machine-a-tron.dhcpRelayEnabled" -}}
+{{- if and .Values.dhcpRelay .Values.dhcpRelay.baseIP -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Get DHCP server address.
+Uses dhcpRelay.serverAddress if set, otherwise defaults to nico-dhcp.nico-system.
+Returns: "<host>:<port>"
+*/}}
+{{- define "nico-machine-a-tron.dhcpServerAddress" -}}
+{{- if and .Values.dhcpRelay .Values.dhcpRelay.serverAddress -}}
+{{- .Values.dhcpRelay.serverAddress -}}
+{{- else -}}
+{{- print "nico-dhcp.nico-system.svc.cluster.local:67" -}}
+{{- end -}}
+{{- end }}

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -56,6 +56,13 @@ Skip unconfigured pods
 {{- end }}
 
 {{- $name := printf "%s-%s" $baseName $podName }}
+
+{{/* Calculate DHCP relay IP for this pod (used in [dhcp] and machine configs) */}}
+{{- $dhcpRelayEnabled := include "nico-machine-a-tron.dhcpRelayEnabled" $root }}
+{{- $relayIP := "" }}
+{{- if $dhcpRelayEnabled }}
+{{- $relayIP = include "nico-machine-a-tron.dhcpRelayIP" (dict "baseIP" $root.Values.dhcpRelay.baseIP "podIndex" $podIndex) }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -103,6 +110,22 @@ data:
     dpu_bmc_password = {{ $root.Values.machineATron.dpuBmcPassword | quote }}
     {{- end }}
     api_refresh_interval = {{ $root.Values.machineATron.apiRefreshInterval | quote }}
+
+    {{/*
+    DHCP Configuration
+    When global.dhcp.enabled and dhcpRelay.baseIP are set, use UDP relay mode.
+    Otherwise, use API mode (default, no [dhcp] section needed).
+    */}}
+    {{- if $dhcpRelayEnabled }}
+    {{- $serverAddress := include "nico-machine-a-tron.dhcpServerAddress" $root }}
+    {{- $listenPort := $root.Values.dhcpRelay.listenPort | default 67 }}
+
+    [dhcp]
+    type = "udp_relay"
+    server_address = {{ $serverAddress | quote }}
+    listen_address = "0.0.0.0:{{ $listenPort }}"
+    advertise_address = {{ $relayIP | quote }}
+    {{- end }}
 
     [ufm_mock]
     enabled = {{ $root.Values.ufmMock.enabled }}
@@ -172,7 +195,11 @@ data:
     host_reboot_delay = {{ $section.host_reboot_delay | default $defaults.hostRebootDelay | int }}
     acceleration_factor = {{ $section.acceleration_factor | default $defaults.accelerationFactor | default 1.0 }}
     discovery_retry_interval = {{ $section.discovery_retry_interval | default $defaults.discoveryRetryInterval | default "60s" | quote }}
+    {{- if $dhcpRelayEnabled }}
+    oob_dhcp_relay_address = {{ $relayIP | quote }}
+    {{- else }}
     oob_dhcp_relay_address = {{ $section.oob_dhcp_relay_address | quote }}
+    {{- end }}
     admin_dhcp_relay_address = {{ $section.admin_dhcp_relay_address | quote }}
     {{- end }}
 
@@ -193,7 +220,11 @@ data:
     run_interval_working = {{ $section.runIntervalWorking | default $defaults.runIntervalWorking | default "1s" | quote }}
     run_interval_idle = {{ $section.runIntervalIdle | default $defaults.runIntervalIdle | default "10s" | quote }}
     network_status_run_interval = {{ $section.networkStatusRunInterval | default $defaults.networkStatusRunInterval | default "20s" | quote }}
+    {{- if $dhcpRelayEnabled }}
+    oob_dhcp_relay_address = {{ $relayIP | quote }}
+    {{- else }}
     oob_dhcp_relay_address = {{ $section.oobDhcpRelayAddress | default "192.168.192.1" | quote }}
+    {{- end }}
     admin_dhcp_relay_address = {{ $section.adminDhcpRelayAddress | default "192.168.176.1" | quote }}
     dpus_in_nic_mode = {{ $section.dpusInNicMode | default $defaults.dpusInNicMode | default false }}
     {{- with $section.hostFirmwareVersions }}

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -113,7 +113,7 @@ data:
 
     {{/*
     DHCP Configuration
-    When global.dhcp.enabled and dhcpRelay.baseIP are set, use UDP relay mode.
+    When dhcpRelay.baseIP is set, use UDP relay mode.
     Otherwise, use API mode (default, no [dhcp] section needed).
     */}}
     {{- if $dhcpRelayEnabled }}

--- a/helm/charts/nico-machine-a-tron/templates/deployment.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/deployment.yaml
@@ -84,6 +84,11 @@ spec:
               containerPort: {{ $root.Values.machineATron.mockBmcSshPort }}
               protocol: TCP
             {{- end }}
+            {{- if include "nico-machine-a-tron.dhcpRelayEnabled" $root }}
+            - name: dhcp-relay
+              containerPort: {{ $root.Values.dhcpRelay.listenPort | default 67 }}
+              protocol: UDP
+            {{- end }}
           {{- with $root.Values.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nico-machine-a-tron/templates/service.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/service.yaml
@@ -60,7 +60,7 @@ spec:
 {{- if $dhcpRelayEnabled }}
 {{- $dhcpRelay := $root.Values.dhcpRelay }}
 {{- $relayIP := include "nico-machine-a-tron.dhcpRelayIP" (dict "baseIP" $dhcpRelay.baseIP "podIndex" $podIndex) }}
-{{- $relayPort := $root.Values.service.dhcpRelay.port | default 67 }}
+{{- $relayPort := $dhcpRelay.listenPort | default 67 }}
 ---
 ## DHCP Relay Service
 ## Provides a stable ClusterIP for receiving DHCP server replies.

--- a/helm/charts/nico-machine-a-tron/templates/service.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/service.yaml
@@ -2,12 +2,32 @@
 {{- $namespace := include "nico-machine-a-tron.namespace" . }}
 {{- $baseName := include "nico-machine-a-tron.name" . }}
 
+{{/* Build ordered list of pod names for consistent indexing */}}
+{{- $podList := list }}
+{{- range $podName, $podConfig := .Values.pods }}
+{{- if and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0)) }}
+{{- $podList = append $podList $podName }}
+{{- end }}
+{{- end }}
+{{- $podList = $podList | sortAlpha }}
+
+{{/* Check if DHCP relay is enabled */}}
+{{- $dhcpRelayEnabled := include "nico-machine-a-tron.dhcpRelayEnabled" . }}
+
 {{- range $podName, $podConfig := .Values.pods }}
 {{/*
 Skip unconfigured pods
 */}}
 {{- if not (and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0))) }}
 {{- continue }}
+{{- end }}
+
+{{/* Get pod index */}}
+{{- $podIndex := 0 }}
+{{- range $i, $p := $podList }}
+{{- if eq $p $podName }}
+{{- $podIndex = $i }}
+{{- end }}
 {{- end }}
 
 {{- $name := printf "%s-%s" $baseName $podName }}
@@ -37,4 +57,34 @@ spec:
       targetPort: ssh
       protocol: TCP
     {{- end }}
+{{- if $dhcpRelayEnabled }}
+{{- $dhcpRelay := $root.Values.dhcpRelay }}
+{{- $relayIP := include "nico-machine-a-tron.dhcpRelayIP" (dict "baseIP" $dhcpRelay.baseIP "podIndex" $podIndex) }}
+{{- $relayPort := $root.Values.service.dhcpRelay.port | default 67 }}
+---
+## DHCP Relay Service
+## Provides a stable ClusterIP for receiving DHCP server replies.
+## The ClusterIP is used as the advertise_address in machine-a-tron config.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}-dhcp-relay
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "nico-machine-a-tron.labels" $root | nindent 4 }}
+    app: {{ $baseName }}
+    nvidia-infra-controller/dhcp-relay: "true"
+    nvidia-infra-controller/pod-name: {{ $podName | quote }}
+spec:
+  type: ClusterIP
+  clusterIP: {{ $relayIP }}
+  selector:
+    {{- include "nico-machine-a-tron.selectorLabels" $root | nindent 4 }}
+    nvidia-infra-controller/pod-name: {{ $podName | quote }}
+  ports:
+    - port: {{ $relayPort }}
+      name: dhcp-relay
+      targetPort: dhcp-relay
+      protocol: UDP
+{{- end }}
 {{- end }}

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -72,8 +72,6 @@ service:
     targetPort: 2222
   metrics:
     port: 9090
-  dhcpRelay:
-    port: 67
 
 ## =============================================================================
 ## DHCP Relay Mode

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -81,7 +81,7 @@ service:
 ## path in Kubernetes deployments.
 ##
 ## Prerequisites:
-##   - nico-dhcp must be deployed in the same namespace
+##   - nico-dhcp must be deployed (default: nico-system namespace)
 ##   - A dedicated K8s ServiceCIDR for relay IPs (e.g., mat-dhcp-services)
 ##
 ## Each pod gets a unique ClusterIP Service for receiving DHCP replies:

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -72,6 +72,41 @@ service:
     targetPort: 2222
   metrics:
     port: 9090
+  dhcpRelay:
+    port: 67
+
+## =============================================================================
+## DHCP Relay Mode
+## =============================================================================
+## When enabled, machine-a-tron obtains IP addresses through UDP relay to a
+## DHCP server instead of the Carbide API. This exercises the real DHCP packet
+## path in Kubernetes deployments.
+##
+## Prerequisites:
+##   - nico-dhcp must be deployed in the same namespace
+##   - A dedicated K8s ServiceCIDR for relay IPs (e.g., mat-dhcp-services)
+##
+## Each pod gets a unique ClusterIP Service for receiving DHCP replies:
+##   - Pod 0 (mat-0): baseIP + 0 (e.g., 10.96.127.10)
+##   - Pod 1 (mat-1): baseIP + 1 (e.g., 10.96.127.11)
+##
+## WARNING: Kubernetes ClusterIP addresses are immutable. Changing baseIP
+## after initial deployment requires deleting and recreating the Services.
+##
+dhcpRelay:
+  ## Base IP address for DHCP relay Services. Setting this enables relay mode.
+  ## Each pod's ClusterIP = baseIP + podIndex.
+  ## Must be from a ServiceCIDR available to the cluster.
+  ## Leave empty to use API mode (default).
+  baseIP: ""
+
+  ## UDP port for receiving DHCP replies. Must match the DHCP server's
+  ## relay response port (typically 67).
+  listenPort: 67
+
+  ## DHCP server address (host:port). Default: nico-dhcp.nico-system.svc.cluster.local:67
+  ## Override if nico-dhcp is deployed in a different namespace or uses a non-standard port.
+  serverAddress: ""
 
 certificate:
   serviceName: ""
@@ -101,9 +136,9 @@ envFrom:
 
 # startupProbe gates the livenessProbe until MAT has bound its redfish port.
 # MAT binds the port only after registering all expected machines via the API,
-# which takes O(hosts) time. Without a startupProbe the kubelet kills the pod
-# mid-registration (exit 137) once livenessProbe failures exceed failureThreshold
-# (issue #4298). Scale the failureThreshold to cover your largest deployment:
+# which can take a while for large deployments (time scales with host count).
+# Without a startupProbe the kubelet kills the pod mid-registration (exit 137)
+# Scale the failureThreshold to cover your largest deployment:
 #   hosts=2300  → default (20 * 30s = 10 min)
 #   hosts=4500  → failureThreshold: 60  (30 min)
 #   hosts=13500 → failureThreshold: 1200 (10 h, see machine-a-tron-scale.yaml)


### PR DESCRIPTION
Adds Helm chart support for configuring machine-a-tron's DHCP relay mode. When enabled, machine-a-tron obtains IP addresses through the nico-dhcp server instead of the NICo API

## Related issues
- closes #4204

## Type of Change
- [x] **Add** - New feature or capability

## Testing
- [x] Manual testing performed

## Additional Notes
**Validation:**
- IP overflow check: fails if `baseIP + podIndex > x.x.x.255`
- Relay mode enables only when `dhcpRelay.baseIP` is set
- API mode (default) preserved when `baseIP` is empty
