### PR TITLE
fix(build): build only required release artifacts

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -674,10 +674,39 @@ fi
 '''
 
 [tasks.build-release]
+workspace = false
+description = "Build the production artifacts copied into the release container"
+command = "cargo"
+# Keep this package set aligned with the artifacts copied by the
+# Dockerfile.release-container-* files and checked below.
 args = [
   "build",
   "--locked",
   "--release",
+  "-p",
+  "carbide-api",
+  "-p",
+  "carbide-pxe",
+  "-p",
+  "carbide-dns",
+  "-p",
+  "nico-admin-cli",
+  "-p",
+  "carbide-dsx-exchange-consumer",
+  "-p",
+  "carbide-agent",
+  "-p",
+  "carbide-dhcp-server",
+  "-p",
+  "carbide-health",
+  "-p",
+  "carbide-log-parser",
+  "-p",
+  "carbide-ssh-console",
+  "-p",
+  "carbide-bmc-proxy",
+  "-p",
+  "carbide-dhcp",
   "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )",
 ]
 

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -3702,6 +3702,7 @@ pub struct DefaultCredential {
     _key: String,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl DefaultCredential {
     pub(crate) fn key(&self) -> &str {
         &self._key

--- a/dev/docker/Dockerfile.release-container-sa-x86_64
+++ b/dev/docker/Dockerfile.release-container-sa-x86_64
@@ -41,15 +41,9 @@ RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
-  # --no-workspace: runs the task once at workspace root instead of once per workspace member.
-  # Without this flag, cargo-make iterates all 64 crates and invokes `cargo clippy` / `cargo build`
-  # per member, which causes shared deps (tonic, sqlx, carbide-rpc, etc.) to be recompiled
-  # repeatedly. With --no-workspace, a single invocation at the root builds everything once.
-  #
-  # Trade-off: per-crate feature isolation is lost — features are unified across the whole
-  # workspace at compile time. This is acceptable here because all crates ship together as a
-  # single release image; feature conflicts between separately-deployed services are not a concern.
-  # clippy-release shares release artifacts with build-release below, avoiding a full double-compile.
+  # Run clippy once at the workspace root. build-release itself selects only the packages whose
+  # artifacts are copied into the runtime image, so test-only workspace members cannot enable
+  # features in production dependencies.
   cargo make --no-workspace clippy-release && \
   echo "$(date): Finished cargo make clippy-release\n" && \
   cargo make carbide-lints && \

--- a/docs/development/build-guide.md
+++ b/docs/development/build-guide.md
@@ -75,30 +75,28 @@ locally with `debug = true` in a `[profile.dev]` override or a local `Cargo.toml
 Release container builds override the default back to full debug info via the
 `CARGO_PROFILE_RELEASE_DEBUG=true` environment variable in the Dockerfiles.
 
-### `--no-workspace` on `clippy-release` and `build-release`
+### Workspace clippy and targeted release builds
 
-**What it does:** Both tasks are invoked with `cargo make --no-workspace` in the Dockerfile.
-Without this flag, cargo-make iterates all workspace members (64 crates) and calls `cargo build`
-or `cargo clippy` once per crate. With `--no-workspace`, cargo-make runs the task once at the
-workspace root, which is equivalent to running `cargo build --workspace` — a single invocation
-that builds everything once.
+**What it does:** `clippy-release` is invoked with `cargo make --no-workspace` in the SA
+Dockerfile, so cargo-make runs clippy once at the workspace root instead of once per workspace
+member. `build-release` is itself a non-workspace task and explicitly selects the packages that
+produce artifacts copied into the release container.
 
 **Why:** The per-member iteration caused shared dependencies (`tonic`, `sqlx`, `nico-rpc`, etc.)
 to be recompiled repeatedly across members. Switching to `--no-workspace` reduced the build from
-~98 minutes to ~21 minutes on a 72-core server.
+~98 minutes to ~21 minutes on a 72-core server. Selecting the production packages also prevents
+test-only workspace members from enabling test-support features in production dependencies.
 
-**Trade-off:** Per-crate feature isolation is lost. Cargo unifies features across all workspace
-members at once rather than resolving each crate independently. For this project all crates ship
-together as a single release image, so cross-crate feature conflicts are not a concern. If you
-ever extract a crate for standalone deployment, validate its feature set independently with
-`cargo build -p <crate>`.
+Keep the package selection in `build-release` synchronized with the explicit artifact list in the
+`Dockerfile.release-container-*` files. A clean container build fails at its `COPY --from=builder`
+step if a required artifact is missing.
 
 ### `clippy-release` shares artifacts with `build-release`
 
 **What it does:** The `clippy-release` Makefile task runs clippy with `--release`, and
-`build-release` also compiles in release mode. Because they share the same compilation flags and
-profile, the compiled `.rlib` and `.rmeta` artifacts from the clippy step are reused by the build
-step — no second compile of all 64 crates.
+`build-release` also compiles the production packages in release mode. Cargo reuses compatible
+`.rlib` and `.rmeta` artifacts from the clippy step. A dependency whose production feature set
+differs from clippy's `--all-features` graph is rebuilt with the narrower feature set.
 
 **Trade-off:** `clippy-release` passes `--all-targets`, which includes test and benchmark targets
 that `build-release` does not compile. Clippy therefore lints slightly more code than is shipped


### PR DESCRIPTION
Today, we build the entire workspace to produce release artifacts. This has undesirable side effects:

1. We build test-only crates that can enable `test-support` features in production builds. For example, building `carbide-test-harness` enables `test-support` for `carbide-api-core`.
2. We build crates that are not required for the release, increasing the build time.

This PR selects only the packages required to produce the artifacts copied into the release container images. This prevents test-only crates from affecting production features and avoids building unnecessary crates.

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

