### PR TITLE
feat(helm): machine-a-tron hostFirmwareVersions description

### DIFF
--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -196,7 +196,8 @@ data:
     oob_dhcp_relay_address = {{ $section.oobDhcpRelayAddress | default "192.168.192.1" | quote }}
     admin_dhcp_relay_address = {{ $section.adminDhcpRelayAddress | default "192.168.176.1" | quote }}
     dpus_in_nic_mode = {{ $section.dpusInNicMode | default $defaults.dpusInNicMode | default false }}
-    {{- with $section.hostFirmwareVersions }}
+    {{- $hostFw := $section.hostFirmwareVersions | default $defaults.hostFirmwareVersions }}
+    {{- with $hostFw }}
 
     [machines.{{ $sectionName }}.host_firmware_versions]
     {{- if .bmc }}

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -196,7 +196,7 @@ data:
     oob_dhcp_relay_address = {{ $section.oobDhcpRelayAddress | default "192.168.192.1" | quote }}
     admin_dhcp_relay_address = {{ $section.adminDhcpRelayAddress | default "192.168.176.1" | quote }}
     dpus_in_nic_mode = {{ $section.dpusInNicMode | default $defaults.dpusInNicMode | default false }}
-    {{- $hostFw := $section.hostFirmwareVersions | default $defaults.hostFirmwareVersions }}
+    {{- $hostFw := ternary $section.hostFirmwareVersions (default $defaults.hostFirmwareVersions $section.hostFirmwareVersions) (hasKey $section "hostFirmwareVersions") }}
     {{- with $hostFw }}
 
     [machines.{{ $sectionName }}.host_firmware_versions]

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -185,6 +185,12 @@ machineDefaults:
   runIntervalIdle: "10s"
   networkStatusRunInterval: "20s"
   dpusInNicMode: false
+  ## Host firmware upgrade simulation. Set initial BMC/UEFI versions here to
+  ## apply to all machine groups. Override per-group in pods.*.machines.*.
+  ## When set, NICo detects version delta and triggers the upgrade flow.
+  # hostFirmwareVersions:
+  #   bmc: "24.08.00"
+  #   uefi: "01.04.00"
 
 ## =============================================================================
 ## MAC Address Pool - Standalone MACs for BMC and management interfaces
@@ -288,6 +294,12 @@ pods:
         dpuPerHostCount: 2
         oobDhcpRelayAddress: "192.168.192.1"
         adminDhcpRelayAddress: "192.168.176.1"
+        ## Host firmware upgrade simulation (optional).
+        ## Set initial versions older than the API's desired versions to trigger
+        ## Supported platforms: DGX H100, Wiwynn GB200, Lenovo GB300, Dell R750/R760.
+        # hostFirmwareVersions:
+        #   bmc: "24.08.00"
+        #   uefi: "01.04.00"
 
 ## =============================================================================
 ## Multi-Pod Example (mat-k8s-controller.enabled is required)

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -296,6 +296,8 @@ pods:
         adminDhcpRelayAddress: "192.168.176.1"
         ## Host firmware upgrade simulation (optional).
         ## Set initial versions older than the API's desired versions to trigger
+        ## the upgrade flow: version detection -> upload -> task polling ->
+        ## power-cycle -> inventory verification.
         ## Supported platforms: DGX H100, Wiwynn GB200, Lenovo GB300, Dell R750/R760.
         # hostFirmwareVersions:
         #   bmc: "24.08.00"


### PR DESCRIPTION
Add Helm chart documentation and defaults support for the host firmware upgrade simulation feature introduced in #4678

## Related issues
Follow-up to #4678
Related to #3363

## Type of Change
- [x] **Change** - Changes in existing functionality

## Testing
- [x] Manual testing performed