### PR TITLE
fix: preserve sparse ExpectedMachine batch updates

### DIFF
--- a/rest-api/AGENTS.md
+++ b/rest-api/AGENTS.md
@@ -329,7 +329,7 @@ Keep handlers thin and reuse the common surfaces already in the tree:
    `Validate`; keep auth, ownership, site readiness, and DB-backed checks in the
    handler where context is available.
 3. Use `IsProviderOrTenant` from `rest-api/api/pkg/api/handler/util/common/common.go`
-   to retrieve Provider and Tenant objects. When adding list endpoints, reuse 
+   to retrieve Provider and Tenant objects. When adding list endpoints, reuse
    `pagination.PageRequest`, `common.ValidateKnownQueryParams`, and `common.GetSearchQuery`.
 4. Put request-to-proto conversion on the API request type and entity-to-proto
    conversion on the DB model, following the "Proto conversion methods" section
@@ -540,7 +540,8 @@ stays on the entity because there's no API request body for delete.
 `InstanceType` is the reference for everything else under this rollout
 (typed-slice validation, typed-map proto behavior, ozzo composition,
 shared conversion helpers): `(*cdbm.InstanceType).ToProto/FromProto`
-+ `(*InstanceType).AttachCapabilities` on the entity,
+
+- `(*InstanceType).AttachCapabilities` on the entity,
 `APIMachineCapabilities` + `APIMachineCapability` for the list/element
 split, `cdbm.Labels` for the typed map, and
 `common/pkg/util.IntPtrToUint32Ptr` for shared casts.
@@ -763,20 +764,18 @@ in its simplest form.
 
 ### Bulk updates must not clobber omitted (PATCH-preserved) columns
 
-`UpdateMultiple`-style DAOs build one shared column list and apply it to every
-row in a single bulk `UPDATE`. Any column added to that shared `columnsSet` is
-written for **every** row in the batch — including rows whose input omitted the
-field, which carry the model's zero value. For a field whose API contract is
-"omitting it preserves the existing value" (PATCH semantics), folding it into
-the shared set silently clears the stored value on untouched rows in a mixed
-batch.
+`UpdateMultiple`-style DAOs must preserve each input's field presence. A
+request-wide union of columns writes every selected column to every row,
+including zero values from inputs that omitted the field. That is safe only
+when every production caller guarantees a homogeneous update mask. Otherwise,
+group inputs by their exact set of present replacement fields or use SQL that
+retains per-row presence.
 
-When adding such a field to a bulk-update DAO:
+When updating a bulk-update DAO:
 
-- Do **not** add it to the shared `columnsSet`.
-- Apply it only to rows that provided it (carry per-row presence through the SQL
-  shape), or split the batch by identical column set. For flat JSONB
-  patch-style structs, prefer the Site config pattern:
+- Verify whether heterogeneous field sets can reach it from production callers.
+- Prefer grouping inputs by identical column set for ordinary replacement
+  fields. For flat JSONB patch-style structs, prefer the Site config pattern:
   `column = column || ?::jsonb`; an empty object is a no-op and future fields
   can be partial-patched without replacing the whole stored object.
 - Keep create vs. update straight: on create, an omitted optional field is
@@ -785,9 +784,10 @@ When adding such a field to a bulk-update DAO:
 - Add a mixed-batch test: some rows set the field, others omit it, and assert
   the omitted rows keep their prior value.
 
-`ExpectedMachine.UpdateMultiple` (`db/pkg/db/model/expectedmachine.go`) applies
-`bmc_ip_address` this way for a scalar value and `host_lifecycle_profile` for a
-JSONB patch; their mixed-batch tests are the guards.
+`ExpectedMachine.UpdateMultiple` (`db/pkg/db/model/expectedmachine.go`) groups
+ordinary replacement fields by identical column set and applies
+`host_lifecycle_profile` as a per-row JSONB merge. Its mixed-batch tests guard
+both behaviors.
 
 ## Git Workflow
 
@@ -814,9 +814,11 @@ When writing git commit messages, follow the conventions below:
 All commits **must** meet the following signing requirement:
 
 - **DCO sign-off** — certifies the Developer Certificate of Origin:
+
   ```bash
   git commit -s -m "Your commit message"
   ```
+
   DCO compliance is enforced automatically; unsigned commits block merging.
 
 ## Pull Request Guidelines

--- a/rest-api/api/pkg/api/handler/expectedmachine.go
+++ b/rest-api/api/pkg/api/handler/expectedmachine.go
@@ -1604,9 +1604,10 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Expected Machine due to DB error", nil)
 		}
 
-		// Clear first so UpdateMultiple's final SELECT sees nil. Its scoped
-		// BMC IP update cannot restore cleared rows. Every target row is already
-		// locked above, so the subset clear cannot introduce a second order.
+		// Clear first so UpdateMultiple's final SELECT sees nil. Cleared inputs
+		// omit BMC IP from their grouped update, so it cannot restore the value.
+		// Every target row is already locked above, so the subset clear cannot
+		// introduce a second order.
 		for _, input := range updateInputs {
 			expectedMachineID := input.ExpectedMachineID
 			if _, ok := bmcIPClearIDs[expectedMachineID]; !ok {

--- a/rest-api/db/pkg/db/model/expectedmachine.go
+++ b/rest-api/db/pkg/db/model/expectedmachine.go
@@ -687,9 +687,9 @@ func (emsd ExpectedMachineSQLDAO) Update(ctx context.Context, tx *db.Tx, input E
 }
 
 // UpdateMultiple updates multiple ExpectedMachines with the given parameters.
-// Fields shared by the inputs use one bulk UPDATE. BMC IP and host lifecycle
-// profile updates may be omitted by individual rows, so they are applied only
-// to the rows that provide them.
+// Each distinct set of present replacement fields uses one bulk UPDATE. Fields
+// omitted by an individual input are never included in that input's update.
+// Host lifecycle profiles use an individual JSONB merge per provided input.
 // The updated fields are assumed to be set to non-null values.
 // Since the updates are followed by a SELECT, this library call must happen
 // within a transaction.
@@ -705,99 +705,106 @@ func (emsd ExpectedMachineSQLDAO) UpdateMultiple(ctx context.Context, tx *db.Tx,
 		return []ExpectedMachine{}, nil
 	}
 
-	// Build expected machines and collect columns to update
-	expectedMachines := make([]*ExpectedMachine, 0, len(inputs))
+	type updateGroup struct {
+		columns  []string
+		machines []*ExpectedMachine
+	}
+
+	// Group inputs by their exact column set. A request-wide union would write
+	// zero values to rows that omitted a field merely because a sibling row
+	// provided it.
+	groupsByColumns := make(map[string]*updateGroup, len(inputs))
+	groups := make([]*updateGroup, 0, len(inputs))
 	ids := make([]uuid.UUID, 0, len(inputs))
-	columnsSet := make(map[string]bool)
-	// `bmc_ip_address` is applied only to rows that provide it. The shared
-	// column list would otherwise clear rows whose PATCH input omitted it.
-	bmcIPUpdates := make([]*ExpectedMachine, 0, len(inputs))
-	// host_lifecycle_profile is applied in its own bulk update scoped to only the
-	// rows that set it (see below), so rows that omit it keep their existing value.
+	// `host_lifecycle_profile` is merged separately for each row that provides it.
 	hlpUpdates := make([]*ExpectedMachine, 0, len(inputs))
 
 	for _, input := range inputs {
 		em := &ExpectedMachine{
 			ID: input.ExpectedMachineID,
 		}
+		var columns []string
 
 		if input.BmcMacAddress != nil {
 			em.BmcMacAddress = *input.BmcMacAddress
-			columnsSet["bmc_mac_address"] = true
+			columns = append(columns, "bmc_mac_address")
 		}
 		if input.ChassisSerialNumber != nil {
 			em.ChassisSerialNumber = *input.ChassisSerialNumber
-			columnsSet["chassis_serial_number"] = true
+			columns = append(columns, "chassis_serial_number")
 		}
 		if input.FallbackDpuSerialNumbers != nil {
 			em.FallbackDpuSerialNumbers = input.FallbackDpuSerialNumbers
-			columnsSet["fallback_dpu_serial_numbers"] = true
+			columns = append(columns, "fallback_dpu_serial_numbers")
 		}
 		if input.Labels != nil {
 			em.Labels = input.Labels
-			columnsSet["labels"] = true
+			columns = append(columns, "labels")
 		}
 		if input.SkuID != nil {
 			em.SkuID = input.SkuID
-			columnsSet["sku_id"] = true
+			columns = append(columns, "sku_id")
 		}
 		if input.MachineID != nil {
 			em.MachineID = input.MachineID
-			columnsSet["machine_id"] = true
+			columns = append(columns, "machine_id")
 		}
 		if input.BmcIpAddress != nil {
-			bmcIPUpdates = append(bmcIPUpdates, &ExpectedMachine{
-				ID:           input.ExpectedMachineID,
-				BmcIpAddress: input.BmcIpAddress,
-			})
+			em.BmcIpAddress = input.BmcIpAddress
+			columns = append(columns, "bmc_ip_address")
 		}
 		if input.RackID != nil {
 			em.RackID = input.RackID
-			columnsSet["rack_id"] = true
+			columns = append(columns, "rack_id")
 		}
 		if input.Name != nil {
 			em.Name = input.Name
-			columnsSet["name"] = true
+			columns = append(columns, "name")
 		}
 		if input.Manufacturer != nil {
 			em.Manufacturer = input.Manufacturer
-			columnsSet["manufacturer"] = true
+			columns = append(columns, "manufacturer")
 		}
 		if input.Model != nil {
 			em.Model = input.Model
-			columnsSet["model"] = true
+			columns = append(columns, "model")
 		}
 		if input.Description != nil {
 			em.Description = input.Description
-			columnsSet["description"] = true
+			columns = append(columns, "description")
 		}
 		if input.SlotID != nil {
 			em.SlotID = input.SlotID
-			columnsSet["slot_id"] = true
+			columns = append(columns, "slot_id")
 		}
 		if input.TrayIdx != nil {
 			em.TrayIdx = input.TrayIdx
-			columnsSet["tray_idx"] = true
+			columns = append(columns, "tray_idx")
 		}
 		if input.HostID != nil {
 			em.HostID = input.HostID
-			columnsSet["host_id"] = true
+			columns = append(columns, "host_id")
 		}
 		if input.IsDpfEnabled != nil {
 			em.IsDpfEnabled = input.IsDpfEnabled
-			columnsSet["is_dpf_enabled"] = true
+			columns = append(columns, "is_dpf_enabled")
 		}
 
-		expectedMachines = append(expectedMachines, em)
+		columns = append(columns, "updated")
+		columnKey := strings.Join(columns, ",")
+		group, groupExists := groupsByColumns[columnKey]
+		if !groupExists {
+			group = &updateGroup{columns: columns}
+			groupsByColumns[columnKey] = group
+			groups = append(groups, group)
+		}
+		group.machines = append(group.machines, em)
 		ids = append(ids, input.ExpectedMachineID)
 
-		// host_lifecycle_profile is deliberately kept out of the shared
-		// columnsSet. The bulk UPDATE applies one column list to every row, so
-		// folding it in would write the column for rows that omitted it (their
-		// model carries the zero value here), silently clearing the persisted
-		// profile. Apply it separately only to rows that included the field and
-		// merge the JSONB patch below so empty or partial profiles preserve
-		// existing stored values.
+		// host_lifecycle_profile uses a key-level JSONB merge rather than a
+		// replacement column update. Apply it separately only to rows that
+		// included the field so empty or partial profiles preserve existing
+		// stored values.
 		if input.HostLifecycleProfile != nil {
 			hlpUpdates = append(hlpUpdates, &ExpectedMachine{
 				ID:                   input.ExpectedMachineID,
@@ -806,18 +813,21 @@ func (emsd ExpectedMachineSQLDAO) UpdateMultiple(ctx context.Context, tx *db.Tx,
 		}
 	}
 
-	// Build column list
-	columns := make([]string, 0, len(columnsSet)+1)
-	for col := range columnsSet {
-		columns = append(columns, col)
-	}
-	columns = append(columns, "updated")
-
 	// Add summary tracing attributes
-	if expectedMachineDAOSpan != nil && len(inputs) > 0 {
-		traceColumns := append([]string(nil), columns...)
-		if len(bmcIPUpdates) > 0 {
-			traceColumns = append(traceColumns, "bmc_ip_address")
+	if expectedMachineDAOSpan != nil {
+		// Report the request-wide union: each listed column is written to at
+		// least one row, while the groups above preserve per-row omission.
+		var traceColumns []string
+		tracedColumns := make(map[string]struct{})
+		for _, group := range groups {
+			for _, column := range group.columns {
+				_, alreadyTraced := tracedColumns[column]
+				if alreadyTraced {
+					continue
+				}
+				tracedColumns[column] = struct{}{}
+				traceColumns = append(traceColumns, column)
+			}
 		}
 		if len(hlpUpdates) > 0 {
 			traceColumns = append(traceColumns, "host_lifecycle_profile")
@@ -829,20 +839,13 @@ func (emsd ExpectedMachineSQLDAO) UpdateMultiple(ctx context.Context, tx *db.Tx,
 		}
 	}
 
-	// Execute bulk update
-	_, err := db.GetIDB(tx, emsd.dbSession).NewUpdate().
-		Model(&expectedMachines).
-		Column(columns...).
-		Bulk().
-		Exec(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(bmcIPUpdates) > 0 {
+	// Execute one bulk update per column set in the order each set first
+	// appears in the request.
+	var err error
+	for _, group := range groups {
 		_, err = db.GetIDB(tx, emsd.dbSession).NewUpdate().
-			Model(&bmcIPUpdates).
-			Column("bmc_ip_address").
+			Model(&group.machines).
+			Column(group.columns...).
 			Bulk().
 			Exec(ctx)
 		if err != nil {

--- a/rest-api/db/pkg/db/model/expectedmachine_test.go
+++ b/rest-api/db/pkg/db/model/expectedmachine_test.go
@@ -1796,10 +1796,11 @@ func TestExpectedMachineSQLDAO_UpdateMultiple(t *testing.T) {
 	assert.Nil(t, err)
 
 	em2, err := emsd.Create(ctx, nil, ExpectedMachineCreateInput{
-		ExpectedMachineID:   uuid.New(),
-		SiteID:              site.ID,
-		BmcMacAddress:       "00:1B:44:11:3A:D2",
-		ChassisSerialNumber: "CHASSIS-UPDATE-002",
+		ExpectedMachineID:        uuid.New(),
+		SiteID:                   site.ID,
+		BmcMacAddress:            "00:1B:44:11:3A:D2",
+		ChassisSerialNumber:      "CHASSIS-UPDATE-002",
+		FallbackDpuSerialNumbers: []string{"DPU002"},
 		Labels: map[string]string{
 			"original": "label",
 		},
@@ -1826,9 +1827,10 @@ func TestExpectedMachineSQLDAO_UpdateMultiple(t *testing.T) {
 		expectError        bool
 		expectedCount      int
 		verifyChildSpanner bool
+		validate           func(*testing.T, []ExpectedMachine)
 	}{
 		{
-			desc: "batch update three expected machines",
+			desc: "heterogeneous batch preserves omitted fields",
 			inputs: []ExpectedMachineUpdateInput{
 				{
 					ExpectedMachineID:   em1.ID,
@@ -1842,7 +1844,7 @@ func TestExpectedMachineSQLDAO_UpdateMultiple(t *testing.T) {
 				{
 					ExpectedMachineID:        em2.ID,
 					BmcMacAddress:            cutil.GetPtr("00:1B:44:11:3A:E2"),
-					FallbackDpuSerialNumbers: []string{"DPU002", "DPU003"},
+					FallbackDpuSerialNumbers: []string{},
 				},
 				{
 					ExpectedMachineID: em3.ID,
@@ -1855,6 +1857,13 @@ func TestExpectedMachineSQLDAO_UpdateMultiple(t *testing.T) {
 			expectError:        false,
 			expectedCount:      3,
 			verifyChildSpanner: true,
+			validate: func(t *testing.T, got []ExpectedMachine) {
+				assert.Equal(t, "CHASSIS-UPDATE-002", got[1].ChassisSerialNumber)
+				assert.Equal(t, Labels{"original": "label"}, got[1].Labels)
+				assert.Equal(t, "00:1B:44:11:3A:D3", got[2].BmcMacAddress)
+				assert.Equal(t, "CHASSIS-UPDATE-003", got[2].ChassisSerialNumber)
+				assert.Equal(t, []string{"DPU001"}, got[2].FallbackDpuSerialNumbers)
+			},
 		},
 		{
 			desc:               "batch update with empty input",
@@ -1898,6 +1907,9 @@ func TestExpectedMachineSQLDAO_UpdateMultiple(t *testing.T) {
 					if tc.inputs[i].Labels != nil {
 						assert.Equal(t, Labels(tc.inputs[i].Labels), em.Labels)
 					}
+				}
+				if tc.validate != nil {
+					tc.validate(t, got)
 				}
 			}
 
@@ -1979,9 +1991,8 @@ func TestExpectedMachineSQLDAO_UpdateMultiple_BmcIpAddress(t *testing.T) {
 
 // TestExpectedMachineSQLDAO_UpdateMultiple_HostLifecycleProfile guards against a
 // mixed batch clearing host_lifecycle_profile on rows that did not set it.
-// Because the shared bulk UPDATE applies one column list to every row, the field
-// must be applied separately to only the rows that provide it; rows that omit it
-// must keep their persisted profile.
+// The field uses a per-row JSONB merge so omitted rows keep their persisted
+// profile and partial profiles do not replace sibling keys.
 func TestExpectedMachineSQLDAO_UpdateMultiple_HostLifecycleProfile(t *testing.T) {
 	ctx := context.Background()
 	dbSession := testInitDB(t)


### PR DESCRIPTION
An ExpectedMachine batch update can send a different set of fields for each row. The DAO built one union of every field present in the request and applied it to every row, so a field omitted by one item could be overwritten with that item's zero value when another item supplied the field.

The DAO now groups inputs by their exact replacement columns before each bulk update. Omitted fields remain unchanged, explicit empty values still clear the intended row, BMC IP uses the same grouped update, and host lifecycle profiles retain their existing JSONB merge for each row.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4364

This is related to https://github.com/NVIDIA/infra-controller/issues/4363, which tracks the broader effort to preserve omitted component PATCH fields across the REST-to-Core boundary.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

`TestExpectedMachineSQLDAO_UpdateMultiple` now starts with distinct values, updates disjoint fields, clears one populated fallback list, and asserts that omitted fields stay unchanged.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

The four required local review lanes completed. CodeRabbit reviewed the final tree, and Codex completed a closure pass after the review fixes. The two declined Cloud/Core findings describe the same pre-existing commit window and are counted once for each reviewer.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 2 | 1 | 1 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 8 | 6 | 2 |
| common-nits-reviewer | 1 | 0 | 1 |
| **Total** | **11** | **7** | **4** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- `expectedmachine_test.go`: The row used for the explicit clear started with an empty fallback DPU list. **Resolution:** Seeded it with `DPU002` so the assertion proves a populated value is cleared.
2. **Declined** -- `expectedmachine.go`: Core can commit before the enclosing Cloud transaction. **Reason:** This recovery gap predates the sparse update bug, and this patch does not change it.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- `expectedmachine.go`: The separate BMC IP update became redundant after replacement fields were grouped. **Resolution:** Included BMC IP in the grouped update while retaining its omission and clear behavior.
2. **Adopted** -- `rest-api/AGENTS.md`: The guidance still described the removed column union and BMC IP exception. **Resolution:** Updated it to describe groups defined by their exact columns and the remaining JSONB merge.
3. **Adopted** -- `expectedmachine.go`: The method documentation did not mention lifecycle profile statements. **Resolution:** Documented the grouped replacement updates and the individual JSONB merges.
4. **Adopted** -- `expectedmachine.go`: The first grouping implementation used an order list, repeated map lookups, hard-coded capacities, and a redundant guard. **Resolution:** Kept an ordered group slice plus its index and removed the extra code.
5. **Adopted** -- `expectedmachine.go`: A comment said ordered groups made each SQL statement deterministic. **Resolution:** Stated the actual guarantee that groups execute in the order they first appear.
6. **Declined** -- `expectedmachine_test.go`: The existing MAC swap test uses a nil transaction and a homogeneous field set. **Reason:** Production supplies a transaction, and changing this separate test is not required for the sparse update fix.
7. **Adopted** -- `expectedmachine_test.go`: A case-specific length check duplicated the shared result count assertion. **Resolution:** Removed the duplicate assertion.
8. **Declined** -- `expectedmachine_test.go`: Existing BMC IP and lifecycle profile scenarios are separate tests instead of table cases. **Reason:** They have independent fixtures and predate this patch, so reorganizing them would not test the reported bug.

### common-nits-reviewer

1. **Declined** -- `expectedmachine.go`: Core can commit before the Cloud transaction commits, and reconciliation does not update every mirrored field. **Reason:** The gap is pre-existing and this patch neither introduces nor expands it.

</details>
