### PR TITLE
fix(ib): record force-delete memberships as retired

### DIFF
--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -1970,6 +1970,29 @@ fn snapshot_to_instance(
         })
 }
 
+/// Records every exact IB membership available from the current `Instance`
+/// before force-delete removes its last live database owner.
+///
+/// The caller holds the owning `Machine` lock. This lookup deliberately does
+/// not lock the `Instance`, because IB config updates acquire those records in
+/// Instance-then-Machine order.
+pub(super) async fn record_force_delete_retired_ib_memberships(
+    txn: &mut PgConnection,
+    instance_id: InstanceId,
+) -> CarbideResult<()> {
+    let instance = db::instance::find_by_id(&mut *txn, instance_id)
+        .await?
+        .ok_or_else(|| {
+            CarbideError::internal(format!("could not find an instance for {instance_id}"))
+        })?;
+    let pkeys = load_ib_partition_pkeys(txn, &[&instance.config.infiniband]).await?;
+    for membership in ib_memberships_from_config(&instance.config.infiniband, &pkeys) {
+        db::retired_ib_membership::record(txn, &membership).await?;
+    }
+
+    Ok(())
+}
+
 pub(super) async fn force_delete_instance(
     instance_id: InstanceId,
     api: &Api,

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -737,6 +737,17 @@ pub(crate) async fn admin_force_delete_machine(
         .await?;
     }
 
+    if let Some(instance_id) = instance_id {
+        // Record the current IB memberships after acquiring the Machine lock,
+        // in the same transaction as ForceDeletion. UFM cleanup runs only
+        // after this transaction commits.
+        crate::handlers::instance::record_force_delete_retired_ib_memberships(
+            &mut txn,
+            instance_id,
+        )
+        .await?;
+    }
+
     // Commit the transaction to make the the ForceDeletion state visible to other consumers, and to
     // avoid holding a long-running transaction while we issue redfish calls.
     txn.commit().await?;

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -26,7 +26,7 @@ use ::rpc::forge::{
 };
 use carbide_dpf::DpuDeploymentType;
 use carbide_ib_fabric::config::IBFabricConfig;
-use carbide_ib_fabric::ib::{self, IBFabricManager};
+use carbide_ib_fabric::ib::{self, GetPartitionOptions, IBFabricManager};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::instance::InstanceId;
@@ -43,7 +43,8 @@ use common::api_fixtures::{
 };
 use config_version::ConfigVersion;
 use model::hardware_info::TpmEkCertificate;
-use model::ib::DEFAULT_IB_FABRIC_NAME;
+use model::ib::{DEFAULT_IB_FABRIC_NAME, IbMembership};
+use model::ib_partition::PartitionKey;
 use model::instance::NewInstance;
 use model::instance::config::InstanceConfig;
 use model::instance::config::extension_services::InstanceExtensionServicesConfig;
@@ -628,18 +629,29 @@ async fn force_delete(
     machine_id: &MachineId,
 ) -> rpc::forge::AdminForceDeleteMachineResponse {
     env.api
-        .admin_force_delete_machine(tonic::Request::new(AdminForceDeleteMachineRequest {
-            host_query: machine_id.to_string(),
-            delete_interfaces: false,
-            delete_bmc_interfaces: false,
-            delete_bmc_credentials: false,
-            allow_delete_with_orphaned_dpf_crds: false,
-            delete_bmc_suppressions: false,
-            delete_retained_boot_interfaces: false,
-        }))
+        .admin_force_delete_machine(tonic::Request::new(force_delete_request(machine_id)))
         .await
         .unwrap()
         .into_inner()
+}
+
+fn force_delete_request(machine_id: &MachineId) -> AdminForceDeleteMachineRequest {
+    AdminForceDeleteMachineRequest {
+        host_query: machine_id.to_string(),
+        delete_interfaces: false,
+        delete_bmc_interfaces: false,
+        delete_bmc_credentials: false,
+        allow_delete_with_orphaned_dpf_crds: false,
+        delete_bmc_suppressions: false,
+        delete_retained_boot_interfaces: false,
+    }
+}
+
+async fn retired_membership_is_recorded(pool: &sqlx::PgPool, membership: &IbMembership) -> bool {
+    db::retired_ib_membership::find_recorded_candidates(pool, std::slice::from_ref(membership))
+        .await
+        .unwrap()
+        == vec![membership.clone()]
 }
 
 fn validate_delete_response(
@@ -1000,13 +1012,52 @@ async fn test_admin_force_delete_host_with_ib_instance(pool: sqlx::PgPool) {
     let hex_pkey = ib_partition.status.clone().unwrap().pkey.unwrap();
     let pkey: u16 = u16::from_str_radix(hex_pkey.strip_prefix("0x").unwrap(), 16)
         .expect("Failed to parse string to integer");
-    let guids = HashSet::from_iter([ib_status.ib_interfaces[0].guid.clone().unwrap()]);
+    let guid = ib_status.ib_interfaces[0].guid.clone().unwrap();
+    let guids = HashSet::from_iter([guid.clone()]);
     let filter = ib::Filter {
         guids: Some(guids.clone()),
         pkey: Some(pkey),
         state: Some(model::ib::IBPortState::Active),
     };
     assert_eq!(ib_fabric.find_ib_port(Some(filter)).await.unwrap().len(), 1);
+
+    let retired_membership = IbMembership {
+        fabric: DEFAULT_IB_FABRIC_NAME.to_string(),
+        pkey: PartitionKey::try_from(pkey).unwrap(),
+        guid,
+    };
+    let ib_network = ib_fabric
+        .get_ib_network(
+            pkey,
+            GetPartitionOptions {
+                include_guids_data: false,
+                include_qos_conf: true,
+            },
+        )
+        .await
+        .unwrap();
+
+    let mock_fabric = env.ib_fabric_manager.get_mock_manager();
+    mock_fabric.set_unbind_failure(true);
+    let error = env
+        .api
+        .admin_force_delete_machine(Request::new(force_delete_request(&mh.id)))
+        .await
+        .expect_err("the simulated UFM failure must stop force-delete");
+    assert!(error.message().contains("simulated UFM unbind failure"));
+    assert!(
+        db::instance::find_by_id(&env.pool, tinstance.id)
+            .await
+            .unwrap()
+            .is_some(),
+        "UFM failure must not delete the Instance"
+    );
+    assert!(
+        retired_membership_is_recorded(&env.pool, &retired_membership).await,
+        "force-delete must commit the retired membership before calling UFM"
+    );
+
+    mock_fabric.set_unbind_failure(false);
 
     let response = force_delete(&env, &mh.id).await;
     validate_delete_response(&response, Some(&mh.id), &mh.dpu().id);
@@ -1024,6 +1075,28 @@ async fn test_admin_force_delete_host_with_ib_instance(pool: sqlx::PgPool) {
 
     assert_eq!(response.ufm_unregistrations, 1);
     assert!(response.all_done, "Host and DPU must be deleted");
+    assert!(
+        retired_membership_is_recorded(&env.pool, &retired_membership).await,
+        "successful retry must keep the exact retired membership"
+    );
+
+    // Model a bind from an older monitor pass completing after force-delete.
+    // The durable record must let a later pass remove it again.
+    ib_fabric
+        .bind_ib_ports(ib_network, vec![retired_membership.guid.clone()])
+        .await
+        .unwrap();
+    env.run_ib_fabric_monitor_iteration().await;
+    let filter = ib::Filter {
+        guids: Some(guids),
+        pkey: Some(pkey),
+        state: Some(model::ib::IBPortState::Active),
+    };
+    assert_eq!(ib_fabric.find_ib_port(Some(filter)).await.unwrap().len(), 0);
+    assert!(
+        retired_membership_is_recorded(&env.pool, &retired_membership).await,
+        "monitor cleanup must keep the exact retired membership"
+    );
 
     // Everything should be gone now
     for id in [mh.id, mh.dpu().id] {


### PR DESCRIPTION
Admin force-delete removes an Instance's InfiniBand memberships from UFM before deleting the Instance and Machine. An older IB monitor pass may still finish a bind after that deletion. Once the database owners are gone, reconciliation can repair the stale bind only if the exact `(fabric, pkey, guid)` membership was retained in `retired_ib_memberships`.

This change resolves every exact membership available from the authoritative Instance found after force-delete acquires the Machine boundary, and records those memberships in the same short transaction that commits `ForceDeletion`. That commit happens before the existing UFM cleanup. The records are idempotent and survive both failed UFM attempts and successful physical deletion, so retries reuse the same tuples and a later monitor pass can remove a delayed bind.

Memberships without enough stored data to identify an exact tuple are skipped consistently with normal release and config update; every other resolvable tuple is recorded. No UFM call runs while a database transaction is open.

## Related issues

This implements [#5139](https://github.com/NVIDIA/infra-controller/issues/5139). It completes the focused durable IB retirement series under [#5131](https://github.com/NVIDIA/infra-controller/issues/5131) and [#3883](https://github.com/NVIDIA/infra-controller/issues/3883), whose storage and reconciliation work merged in [#5142](https://github.com/NVIDIA/infra-controller/pull/5142) and whose normal release and config-update writers merged in [#5287](https://github.com/NVIDIA/infra-controller/pull/5287). It unblocks [#5112](https://github.com/NVIDIA/infra-controller/issues/5112).

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Integration coverage verifies that UFM failure retains the exact current membership before physical deletion, a retry completes deletion without losing the record, and a later monitor pass removes a bind that completes after force-delete. Existing monitor tests also verify record retention across monitor failure and delayed-bind repair after monitor restart.

Closes #5139
