### PR TITLE
test(rest-api): replay expected-inventory cutover histories

### DIFF
--- a/rest-api/site-agent/pkg/components/managers/expected_inventory_compatibility_test.go
+++ b/rest-api/site-agent/pkg/components/managers/expected_inventory_compatibility_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package managers_test
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/expectedmachine"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/expectedpowershelf"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/expectedrack"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/expectedswitch"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/elektratypes"
+	workflowtypes "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/managertypes/workflow"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/worker"
+)
+
+type subscriberWorker struct {
+	worker.Worker
+	activityNames []string
+}
+
+func (w *subscriberWorker) RegisterWorkflow(any) {}
+
+func (w *subscriberWorker) RegisterActivity(fn any) {
+	w.activityNames = append(w.activityNames, temporalFunctionName(fn))
+}
+
+func (w *subscriberWorker) legacyFlowActivityNames() []string {
+	var names []string
+	for _, name := range w.activityNames {
+		if strings.HasSuffix(name, "OnFlow") {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func temporalFunctionName(fn any) string {
+	// `RegisterActivity` exposes a method's short name to Temporal. The worker
+	// interface has no registry lookup, so mirror that naming rule while we
+	// record the real subscriber calls.
+	fullName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	shortName := fullName[strings.LastIndex(fullName, ".")+1:]
+	return strings.TrimSuffix(shortName, "-fm")
+}
+
+// In-flight pre-cutover executions can still schedule these activity names, so
+// current site-agent workers must keep their no-op handlers registered.
+func TestExpectedInventorySubscribersRegisterLegacyFlowActivities(t *testing.T) {
+	tests := []struct {
+		name     string
+		register func(*elektratypes.Elektra) error
+		expected []string
+	}{
+		{
+			name: "expected machine",
+			register: func(e *elektratypes.Elektra) error {
+				return expectedmachine.NewExpectedMachineManager(e, nil, nil).RegisterSubscriber()
+			},
+			expected: []string{
+				"CreateExpectedMachineOnFlow",
+				"CreateExpectedMachinesOnFlow",
+			},
+		},
+		{
+			name: "expected switch",
+			register: func(e *elektratypes.Elektra) error {
+				return expectedswitch.NewExpectedSwitchManager(e, nil, nil).RegisterSubscriber()
+			},
+			expected: []string{"CreateExpectedSwitchOnFlow"},
+		},
+		{
+			name: "expected power shelf",
+			register: func(e *elektratypes.Elektra) error {
+				return expectedpowershelf.NewExpectedPowerShelfManager(e, nil, nil).RegisterSubscriber()
+			},
+			expected: []string{"CreateExpectedPowerShelfOnFlow"},
+		},
+		{
+			name: "expected rack",
+			register: func(e *elektratypes.Elektra) error {
+				return expectedrack.NewExpectedRackManager(e, nil, nil).RegisterSubscriber()
+			},
+			expected: []string{"CreateExpectedRackOnFlow"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			temporalWorker := &subscriberWorker{}
+			elektra := elektratypes.NewElektraTypes()
+			elektra.Managers.Workflow.Temporal = workflowtypes.Temporal{Worker: temporalWorker}
+
+			require.NoError(t, tc.register(elektra))
+			require.ElementsMatch(t, tc.expected, temporalWorker.legacyFlowActivityNames())
+		})
+	}
+}

--- a/rest-api/site-workflow/pkg/workflow/replay_test.go
+++ b/rest-api/site-workflow/pkg/workflow/replay_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/util"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/worker"
+)
+
+func TestExpectedInventoryPreCutoverHistoriesReplay(t *testing.T) {
+	tests := []struct {
+		name           string
+		workflow       any
+		history        string
+		legacyActivity string
+	}{
+		{
+			name:           "create expected machine",
+			workflow:       CreateExpectedMachine,
+			history:        "pre_cutover_create_expected_machine.json",
+			legacyActivity: "CreateExpectedMachineOnFlow",
+		},
+		{
+			name:           "batch create expected machines",
+			workflow:       CreateExpectedMachines,
+			history:        "pre_cutover_create_expected_machines.json",
+			legacyActivity: "CreateExpectedMachinesOnFlow",
+		},
+		{
+			name:           "create expected power shelf",
+			workflow:       CreateExpectedPowerShelf,
+			history:        "pre_cutover_create_expected_power_shelf.json",
+			legacyActivity: "CreateExpectedPowerShelfOnFlow",
+		},
+		{
+			name:           "create expected rack",
+			workflow:       CreateExpectedRack,
+			history:        "pre_cutover_create_expected_rack.json",
+			legacyActivity: "CreateExpectedRackOnFlow",
+		},
+		{
+			name:           "create expected switch",
+			workflow:       CreateExpectedSwitch,
+			history:        "pre_cutover_create_expected_switch.json",
+			legacyActivity: "CreateExpectedSwitchOnFlow",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			historyPath := filepath.Join("testdata", tc.history)
+			history, err := os.ReadFile(historyPath)
+			require.NoError(t, err)
+			require.Contains(t, string(history), tc.legacyActivity)
+
+			replayer, err := worker.NewWorkflowReplayerWithOptions(worker.WorkflowReplayerOptions{
+				DataConverter: util.NewTemporalDataConverter(),
+			})
+			require.NoError(t, err)
+			replayer.RegisterWorkflow(tc.workflow)
+
+			// These histories came from `ed8afcec818002b7a1603f9a365f9d3e13c5fe26`,
+			// the parent of the #4328 merge commit on `main`.
+			// Each one includes the old `OnFlow` activity in an
+			// `EVENT_TYPE_ACTIVITY_TASK_SCHEDULED` event, so replay fails if the
+			// compatibility branch stops scheduling it.
+			require.NoError(t, replayer.ReplayWorkflowHistoryFromJSONFile(
+				nil,
+				historyPath,
+			))
+		})
+	}
+}

--- a/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_machine.json
+++ b/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_machine.json
@@ -1,0 +1,324 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-26T07:14:15.908046295Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1049087",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CreateExpectedMachine"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRNYWNoaW5l"
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NTUiLCAiY2hhc3Npc1NlcmlhbE51bWJlciI6Ik1BQ0hJTkUtMDAxIiwgImlkIjp7InZhbHVlIjoicHJlLWN1dG92ZXItbWFjaGluZS0wMDEifX0="
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "01a03ceb-68e4-70af-83c2-214ae2f2d692",
+        "identity": "expected-inventory-history-capture",
+        "firstExecutionRunId": "01a03ceb-68e4-70af-83c2-214ae2f2d692",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "pre-cutover-create-expected-machine"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-26T07:14:15.908143311Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049088",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-26T07:14:16.033943725Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049095",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "31e80669-96fc-41e1-a9ec-6bd06fa54927",
+        "historySizeBytes": "1060",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-26T07:14:16.068499425Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049099",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.39.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-26T07:14:16.068533977Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049100",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "CreateExpectedMachineOnSite"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRNYWNoaW5l"
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NTUiLCAiY2hhc3Npc1NlcmlhbE51bWJlciI6Ik1BQ0hJTkUtMDAxIiwgImlkIjp7InZhbHVlIjoicHJlLWN1dG92ZXItbWFjaGluZS0wMDEifX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "120s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-26T07:14:16.114255955Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049106",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "991fbb97-5dc1-4175-a06a-9b256399e7de",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-26T07:14:16.147875291Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049107",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-26T07:14:16.147881040Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049108",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-26T07:14:16.180182668Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049112",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "83155d9c-741a-46be-a36a-7fc49454c7bd",
+        "historySizeBytes": "1993",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-26T07:14:16.211860876Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049116",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-26T07:14:16.211884672Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049117",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "CreateExpectedMachineOnFlow"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRNYWNoaW5l"
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NTUiLCAiY2hhc3Npc1NlcmlhbE51bWJlciI6Ik1BQ0hJTkUtMDAxIiwgImlkIjp7InZhbHVlIjoicHJlLWN1dG92ZXItbWFjaGluZS0wMDEifX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "120s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-26T07:14:16.243756302Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049122",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "43533cad-9eb2-44ff-ad92-5dcf7b645916",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-26T07:14:16.260633537Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049123",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-26T07:14:16.260636832Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049124",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-26T07:14:16.292158393Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049128",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "f619480f-c21e-4cf0-b68a-fae3c9e426ab",
+        "historySizeBytes": "2903",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-26T07:14:16.324386701Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049132",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-26T07:14:16.324409035Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1049133",
+      "workflowExecutionCompletedEventAttributes": {
+        "workflowTaskCompletedEventId": "16"
+      }
+    }
+  ]
+}

--- a/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_machines.json
+++ b/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_machines.json
@@ -1,0 +1,346 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-26T07:14:16.393197457Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1049138",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CreateExpectedMachines"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuQmF0Y2hFeHBlY3RlZE1hY2hpbmVPcGVyYXRpb25SZXF1ZXN0"
+              },
+              "data": "eyJleHBlY3RlZE1hY2hpbmVzIjp7ImV4cGVjdGVkTWFjaGluZXMiOlt7ImJtY01hY0FkZHJlc3MiOiIwMDoxMToyMjozMzo0NDo1NSIsICJjaGFzc2lzU2VyaWFsTnVtYmVyIjoiTUFDSElORS0wMDEiLCAiaWQiOnsidmFsdWUiOiJwcmUtY3V0b3Zlci1tYWNoaW5lLTAwMSJ9fV19LCAiYWNjZXB0UGFydGlhbFJlc3VsdHMiOnRydWV9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "01a03ceb-6ac9-7301-a2bb-e00fb20376f8",
+        "identity": "expected-inventory-history-capture",
+        "firstExecutionRunId": "01a03ceb-6ac9-7301-a2bb-e00fb20376f8",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "pre-cutover-create-expected-machines"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-26T07:14:16.393243426Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049139",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-26T07:14:16.441125583Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049146",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "8223dd5a-0ade-4ca1-b689-4643ddd358f2",
+        "historySizeBytes": "1254",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-26T07:14:16.491703488Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049150",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.39.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-26T07:14:16.491739532Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049151",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "CreateExpectedMachinesOnSite"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuQmF0Y2hFeHBlY3RlZE1hY2hpbmVPcGVyYXRpb25SZXF1ZXN0"
+              },
+              "data": "eyJleHBlY3RlZE1hY2hpbmVzIjp7ImV4cGVjdGVkTWFjaGluZXMiOlt7ImJtY01hY0FkZHJlc3MiOiIwMDoxMToyMjozMzo0NDo1NSIsICJjaGFzc2lzU2VyaWFsTnVtYmVyIjoiTUFDSElORS0wMDEiLCAiaWQiOnsidmFsdWUiOiJwcmUtY3V0b3Zlci1tYWNoaW5lLTAwMSJ9fV19LCAiYWNjZXB0UGFydGlhbFJlc3VsdHMiOnRydWV9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "300s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-26T07:14:16.524670670Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049157",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "468673d8-9601-4d25-944c-1eb5b34f4bd2",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-26T07:14:16.557985427Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049158",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuQmF0Y2hFeHBlY3RlZE1hY2hpbmVPcGVyYXRpb25SZXNwb25zZQ=="
+              },
+              "data": "e30="
+            }
+          ]
+        },
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-26T07:14:16.557991436Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049159",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-26T07:14:16.590901403Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049163",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "7c3e40ea-88c3-4531-9e56-04bca83ddc8f",
+        "historySizeBytes": "2388",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-26T07:14:16.624001997Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049167",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-26T07:14:16.624021126Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049168",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "CreateExpectedMachinesOnFlow"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuQmF0Y2hFeHBlY3RlZE1hY2hpbmVPcGVyYXRpb25SZXF1ZXN0"
+              },
+              "data": "eyJleHBlY3RlZE1hY2hpbmVzIjp7ImV4cGVjdGVkTWFjaGluZXMiOlt7ImJtY01hY0FkZHJlc3MiOiIwMDoxMToyMjozMzo0NDo1NSIsICJjaGFzc2lzU2VyaWFsTnVtYmVyIjoiTUFDSElORS0wMDEiLCAiaWQiOnsidmFsdWUiOiJwcmUtY3V0b3Zlci1tYWNoaW5lLTAwMSJ9fV19LCAiYWNjZXB0UGFydGlhbFJlc3VsdHMiOnRydWV9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "300s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-26T07:14:16.656634554Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049173",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "22939372-6a57-4ce8-93ff-60c3dc46069e",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-26T07:14:16.672882831Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049174",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-26T07:14:16.672885705Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049175",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-26T07:14:16.704956966Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049179",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "53b5dcf9-478f-440f-899f-1353637a5ada",
+        "historySizeBytes": "3401",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-26T07:14:16.737607591Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049183",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-26T07:14:16.737624717Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1049184",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuQmF0Y2hFeHBlY3RlZE1hY2hpbmVPcGVyYXRpb25SZXNwb25zZQ=="
+              },
+              "data": "e30="
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "16"
+      }
+    }
+  ]
+}

--- a/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_power_shelf.json
+++ b/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_power_shelf.json
@@ -1,0 +1,324 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-26T07:14:16.821151206Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1049189",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CreateExpectedPowerShelf"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRQb3dlclNoZWxm"
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NzciLCAic2hlbGZTZXJpYWxOdW1iZXIiOiJTSEVMRi0wMDEiLCAiZXhwZWN0ZWRQb3dlclNoZWxmSWQiOnsidmFsdWUiOiJwcmUtY3V0b3Zlci1wb3dlci1zaGVsZi0wMDEifX0="
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "01a03ceb-6c75-724c-9509-ddb1a121b9e2",
+        "identity": "expected-inventory-history-capture",
+        "firstExecutionRunId": "01a03ceb-6c75-724c-9509-ddb1a121b9e2",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "pre-cutover-create-expected-power-shelf"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-26T07:14:16.821206510Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049190",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-26T07:14:16.868527289Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049197",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "12746431-b468-49b3-9638-e5560e5938ac",
+        "historySizeBytes": "1118",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-26T07:14:16.917406391Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049201",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.39.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-26T07:14:16.917452060Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049202",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "CreateExpectedPowerShelfOnSite"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRQb3dlclNoZWxm"
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NzciLCAic2hlbGZTZXJpYWxOdW1iZXIiOiJTSEVMRi0wMDEiLCAiZXhwZWN0ZWRQb3dlclNoZWxmSWQiOnsidmFsdWUiOiJwcmUtY3V0b3Zlci1wb3dlci1zaGVsZi0wMDEifX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "120s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-26T07:14:16.949625575Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049208",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "077beaea-2a83-4f49-a703-47cd4279af54",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-26T07:14:16.982817266Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049209",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-26T07:14:16.982821953Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049210",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-26T07:14:17.014398348Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049214",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "035d9a04-5c3c-438d-8556-7423c96f3b2a",
+        "historySizeBytes": "2083",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-26T07:14:17.046852456Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049218",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-26T07:14:17.046884474Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049219",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "CreateExpectedPowerShelfOnFlow"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRQb3dlclNoZWxm"
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NzciLCAic2hlbGZTZXJpYWxOdW1iZXIiOiJTSEVMRi0wMDEiLCAiZXhwZWN0ZWRQb3dlclNoZWxmSWQiOnsidmFsdWUiOiJwcmUtY3V0b3Zlci1wb3dlci1zaGVsZi0wMDEifX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "120s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-26T07:14:17.077789916Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049224",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "0df6b88c-ce39-4352-9143-b4a9d904f0f4",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-26T07:14:17.094061137Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049225",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-26T07:14:17.094065013Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049226",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-26T07:14:17.126340251Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049230",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "02b9d7ed-ceea-4da8-8e98-437cdf0ff1d3",
+        "historySizeBytes": "3018",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-26T07:14:17.158139732Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049234",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-26T07:14:17.158155626Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1049235",
+      "workflowExecutionCompletedEventAttributes": {
+        "workflowTaskCompletedEventId": "16"
+      }
+    }
+  ]
+}

--- a/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_rack.json
+++ b/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_rack.json
@@ -1,0 +1,324 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-26T07:14:17.224782626Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1049240",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CreateExpectedRack"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRSYWNr"
+              },
+              "data": "eyJyYWNrSWQiOnsiaWQiOiJwcmUtY3V0b3Zlci1yYWNrLTAwMSJ9LCAicmFja1Byb2ZpbGVJZCI6eyJpZCI6InByZS1jdXRvdmVyLXJhY2stcHJvZmlsZS0wMDEifX0="
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "01a03ceb-6e08-7bef-98f6-8924dac8d6fd",
+        "identity": "expected-inventory-history-capture",
+        "firstExecutionRunId": "01a03ceb-6e08-7bef-98f6-8924dac8d6fd",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "pre-cutover-create-expected-rack"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-26T07:14:17.224816588Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049241",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-26T07:14:17.273426012Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049248",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "c60d2d4f-fe03-46f5-bb92-eb0080d9a6f0",
+        "historySizeBytes": "996",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-26T07:14:17.322578005Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049252",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.39.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-26T07:14:17.322601140Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049253",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "CreateExpectedRackOnSite"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRSYWNr"
+              },
+              "data": "eyJyYWNrSWQiOnsiaWQiOiJwcmUtY3V0b3Zlci1yYWNrLTAwMSJ9LCAicmFja1Byb2ZpbGVJZCI6eyJpZCI6InByZS1jdXRvdmVyLXJhY2stcHJvZmlsZS0wMDEifX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "120s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-26T07:14:17.355353328Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049259",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "d0e7bee4-293d-4cdf-895a-e9c4c45825d8",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-26T07:14:17.389814075Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049260",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-26T07:14:17.389819563Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049261",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-26T07:14:17.422277678Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049265",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "77dc280c-50c4-493b-84a0-c84ecfb61918",
+        "historySizeBytes": "1909",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-26T07:14:17.455404922Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049269",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-26T07:14:17.455429268Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049270",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "CreateExpectedRackOnFlow"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRSYWNr"
+              },
+              "data": "eyJyYWNrSWQiOnsiaWQiOiJwcmUtY3V0b3Zlci1yYWNrLTAwMSJ9LCAicmFja1Byb2ZpbGVJZCI6eyJpZCI6InByZS1jdXRvdmVyLXJhY2stcHJvZmlsZS0wMDEifX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "120s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-26T07:14:17.486913063Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049275",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "6188af6d-3374-4175-b1ec-a18e715a70ca",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-26T07:14:17.502889128Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049276",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-26T07:14:17.502893755Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049277",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-26T07:14:17.534388917Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049281",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "7e8163ff-1ad4-4201-bedf-cd60b78a3c88",
+        "historySizeBytes": "2798",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-26T07:14:17.567386365Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049285",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-26T07:14:17.567413356Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1049286",
+      "workflowExecutionCompletedEventAttributes": {
+        "workflowTaskCompletedEventId": "16"
+      }
+    }
+  ]
+}

--- a/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_switch.json
+++ b/rest-api/site-workflow/pkg/workflow/testdata/pre_cutover_create_expected_switch.json
@@ -1,0 +1,324 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-26T07:14:17.634803317Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1049291",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CreateExpectedSwitch"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRTd2l0Y2g="
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NjYiLCAic3dpdGNoU2VyaWFsTnVtYmVyIjoiU1dJVENILTAwMSIsICJleHBlY3RlZFN3aXRjaElkIjp7InZhbHVlIjoicHJlLWN1dG92ZXItc3dpdGNoLTAwMSJ9fQ=="
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "01a03ceb-6fa2-7c3f-a393-1965e8b8430f",
+        "identity": "expected-inventory-history-capture",
+        "firstExecutionRunId": "01a03ceb-6fa2-7c3f-a393-1965e8b8430f",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "pre-cutover-create-expected-switch"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-26T07:14:17.634852632Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049292",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-26T07:14:17.682282457Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049299",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "04bd61d2-5648-4e61-911b-5d71c2252476",
+        "historySizeBytes": "1076",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-26T07:14:17.732353456Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049303",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.39.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-26T07:14:17.732392405Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049304",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "CreateExpectedSwitchOnSite"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRTd2l0Y2g="
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NjYiLCAic3dpdGNoU2VyaWFsTnVtYmVyIjoiU1dJVENILTAwMSIsICJleHBlY3RlZFN3aXRjaElkIjp7InZhbHVlIjoicHJlLWN1dG92ZXItc3dpdGNoLTAwMSJ9fQ=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "120s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-26T07:14:17.764193789Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049310",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "a1f5d600-a845-43ab-92ce-af614c4f4dc9",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-26T07:14:17.796911114Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049311",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-26T07:14:17.796916563Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049312",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-26T07:14:17.828298373Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049316",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "238a6d9e-5d44-4165-8efa-ed0afd088039",
+        "historySizeBytes": "2025",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-26T07:14:17.859931994Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049320",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-26T07:14:17.859964402Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1049321",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "CreateExpectedSwitchOnFlow"
+        },
+        "taskQueue": {
+          "name": "expected-inventory-pre-cutover-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "Zm9yZ2UuRXhwZWN0ZWRTd2l0Y2g="
+              },
+              "data": "eyJibWNNYWNBZGRyZXNzIjoiMDA6MTE6MjI6MzM6NDQ6NjYiLCAic3dpdGNoU2VyaWFsTnVtYmVyIjoiU1dJVENILTAwMSIsICJleHBlY3RlZFN3aXRjaElkIjp7InZhbHVlIjoicHJlLWN1dG92ZXItc3dpdGNoLTAwMSJ9fQ=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "120s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "10s",
+          "maximumAttempts": 2
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-26T07:14:17.891046491Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1049326",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "d64821db-55b4-4d4c-9882-756bb60806d7",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-26T07:14:17.906961454Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1049327",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "expected-inventory-history-capture"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-26T07:14:17.906966962Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1049328",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "temporal-dev-server",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "expected-inventory-pre-cutover-capture"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-26T07:14:17.938627994Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1049332",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "expected-inventory-history-capture",
+        "requestId": "a7036c1c-25c1-4e9e-a0b6-1921660ab5ec",
+        "historySizeBytes": "2950",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-26T07:14:17.970234424Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1049336",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "expected-inventory-history-capture",
+        "workerVersion": {
+          "buildId": "b3faa49c6f6d9d9bdffc9566fd6ba5ec"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-26T07:14:17.970256267Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1049337",
+      "workflowExecutionCompletedEventAttributes": {
+        "workflowTaskCompletedEventId": "16"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
PR #4328 stopped new expected inventory workflows from writing directly to Flow. Temporal still needs to replay workflows that started before that change, and those workflows may still call the older `OnFlow` activities. This PR adds five saved workflow histories from before #4328 and replays them against the current code, covering expected machines, switches, power shelves, and racks.

It also tests the site-agent subscriber registrations to make sure the five older `OnFlow` activity names remain available. Existing tests continue to verify that new workflows skip the direct Flow write. [Task #5388](https://github.com/NVIDIA/infra-controller/issues/5388) tracks when workers running the older code are no longer active and the affected histories have expired, so these registrations can be removed.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4357

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Replayed all five exported histories with the production data converter and ran the subscriber registration test under the race detector.
- Captured the histories from the parent of #4328 against a disposable Temporal server, then verified their exact activity schedules and absence of version markers.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers examined the same stable tree before the fixes. The active model then reviewed the final diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 8 | 5 | 3 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **8** | **5** | **3** |

</details>

<details>
<summary>Findings and Resolutions</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** - The registration test did not explain the compatibility requirement. **Resolution:** Added the reason current workers must retain the legacy no-op handlers.
2. **Adopted** - The recording worker implemented an unused `RegisterActivityWithOptions` path. **Resolution:** Removed it because all four subscribers call `RegisterActivity`.
3. **Adopted** - The replay table used `interface{}` instead of the local `any` convention. **Resolution:** Changed the field to `any`.
4. **Adopted** - The name filter allocated an empty slice unnecessarily. **Resolution:** Used a nil slice and appended matching names.
5. **Adopted** - The replay comment called a recorded history event a command. **Resolution:** Named the `EVENT_TYPE_ACTIVITY_TASK_SCHEDULED` event and the activity that replay must schedule.
6. **Declined** - Add fixture capture instructions to the repository. **Reason:** These are one-time captures from the immutable parent of #4328, not generated output; the source commit is recorded beside the replay test.
7. **Declined** - Add production TODOs for eventual compatibility removal. **Reason:** Task #5388 records when old workers have drained, affected executions have closed, and namespace retention has expired without editing four production files.
8. **Declined** - Replace `cutover` throughout the test names and fixtures. **Reason:** The term comes from #4357 and distinguishes the compatibility boundary from each `remove-*-on-flow` change ID.

### common-nits-reviewer

No findings.

</details>
