### PR TITLE
feat: validate DPU network status during boot configuration

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -58,10 +58,12 @@ use model::machine::{
     BiosConfigInfo, BiosConfigState, BomValidating, BomValidatingContext, CleanupContext,
     CleanupState, CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState,
     DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
-    HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode, MachineState,
-    MachineValidatingState, MachineValidationContext, ManagedHostState, MeasuringState, PowerState,
-    ReadyBootConfigState, ReadyBootConfigTerminalFailure, SecureEraseBossState, SetBootOrderInfo,
-    SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea, ValidationState,
+    HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode,
+    MachineLastRebootRequested, MachineLastRebootRequestedMode, MachineMaintenanceOperation,
+    MachineState, MachineValidatingState, MachineValidationContext, ManagedHostState,
+    MeasuringState, PowerState, ReadyBootConfigPostLockAction, ReadyBootConfigState,
+    SecureEraseBossState, SetBootOrderInfo, SetBootOrderState, SetSecureBootState,
+    SpdmMeasuringState, StateMachineArea, ValidationState,
 };
 use model::machine_boot_interface::{BootInterfaceSelectionSource, MachineBootInterfaceTarget};
 use model::machine_validation::MachineValidationState;
@@ -3200,6 +3202,294 @@ async fn test_discovered_host_with_pending_boot_config_enters_convergence(pool: 
     );
 }
 
+/// `ReadyBootConfigState::Prepare` owns DPU action ordering, so generic restart
+/// verification cannot reboot a DPU before it consumes the current network
+/// status snapshot.
+#[crate::sqlx_test]
+async fn test_ready_boot_config_defers_dpu_restart_verification(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::default()).await;
+    let pending = set_pending_boot_interface(&env, &mh).await;
+    let prepare = ManagedHostState::BootConfiguring {
+        desired_version: pending.version,
+        desired_boot_interface: pending.value.clone(),
+        post_lock_verification_retry_count: 0,
+        boot_config_state: ReadyBootConfigState::Prepare,
+    };
+    set_host_controller_state_stuck_in(&env, mh.host().id, &prepare, 0).await;
+    common::api_fixtures::network_configured(&env, &mh.dpu_ids).await;
+
+    let threshold_retry = MachineLastRebootRequested {
+        time: Utc::now(),
+        mode: MachineLastRebootRequestedMode::Reboot,
+        restart_verified: Some(false),
+        verification_attempts: Some(2),
+    };
+    let mut txn = env.db_txn().await;
+    db::machine::update_restart_verification_status(
+        &mh.dpu().id,
+        threshold_retry,
+        Some(false),
+        2,
+        txn.as_mut(),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.redfish_sim.set_is_bios_setup(true);
+    env.redfish_sim.set_is_boot_order_setup(true);
+    let checkpoint = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let dpu_retry = mh
+        .dpu()
+        .db_machine(&mut txn)
+        .await
+        .status
+        .last_reboot_requested
+        .expect("DPU restart verification should remain pending");
+    assert_eq!(dpu_retry.time, threshold_retry.time);
+    assert_eq!(dpu_retry.mode, threshold_retry.mode);
+    assert_eq!(dpu_retry.restart_verified, threshold_retry.restart_verified);
+    assert_eq!(
+        dpu_retry.verification_attempts,
+        threshold_retry.verification_attempts,
+    );
+    assert_eq!(
+        mh.host().db_machine(&mut txn).await.current_state(),
+        &ManagedHostState::BootConfiguring {
+            desired_version: pending.version,
+            desired_boot_interface: pending.value,
+            post_lock_verification_retry_count: 0,
+            boot_config_state: ReadyBootConfigState::LockHost {
+                post_lock_action: None,
+            },
+        },
+        "Prepare should continue with the synchronized snapshot",
+    );
+    assert!(
+        !env.redfish_sim
+            .actions_since(&checkpoint)
+            .all_hosts()
+            .iter()
+            .any(|action| matches!(
+                action,
+                RedfishSimAction::Power(libredfish::SystemPowerControl::ForceRestart)
+            )),
+        "generic restart verification must not reboot a DPU during boot convergence",
+    );
+}
+
+/// `ReadyBootConfigState::Prepare` waits for current network status from every
+/// DPU in the host topology while keeping maintenance available.
+#[crate::sqlx_test]
+async fn test_ready_boot_config_waits_for_all_dpu_network_config_versions(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh =
+        create_managed_host_with_config(&env, ManagedHostConfig::default().with_dpu_count(2)).await;
+    let pending = set_pending_boot_interface(&env, &mh).await;
+    let prepare = ManagedHostState::BootConfiguring {
+        desired_version: pending.version,
+        desired_boot_interface: pending.value.clone(),
+        post_lock_verification_retry_count: 0,
+        boot_config_state: ReadyBootConfigState::Prepare,
+    };
+    set_host_controller_state_stuck_in(&env, mh.host().id, &prepare, 0).await;
+
+    // Give both DPUs observations newer than Prepare, then advance the host
+    // network configuration version and update only one observation.
+    common::api_fixtures::network_configured(&env, &mh.dpu_ids).await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(
+        db::machine::try_update_network_config(
+            txn.as_mut(),
+            &host.id,
+            host.network_config.version,
+            &host.network_config.value,
+        )
+        .await
+        .expect("network configuration generation should advance"),
+    );
+    txn.commit().await.unwrap();
+
+    common::api_fixtures::network_configured_with_health(&env, &mh.dpu_ids[0], None).await;
+
+    let redfish_checkpoint = env.redfish_sim.timepoint();
+    let redfish_client_count = env.redfish_sim.create_client_calls().len();
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert_eq!(host.current_state(), &prepare);
+    assert!(matches!(
+        &host.controller_state_outcome,
+        Some(PersistentStateHandlerOutcome::Wait { reason, .. })
+            if reason == "Waiting for every DPU in the host topology to apply the current host network configuration"
+    ));
+    drop(txn);
+
+    assert!(
+        env.redfish_sim
+            .actions_since(&redfish_checkpoint)
+            .all_hosts()
+            .is_empty(),
+        "one stale DPU must prevent Redfish actions",
+    );
+    assert_eq!(
+        env.redfish_sim.create_client_calls().len(),
+        redfish_client_count,
+        "one current DPU is not enough to create a Redfish client",
+    );
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_machine_maintenance_requested(
+        txn.as_mut(),
+        mh.host().id,
+        "test",
+        MachineMaintenanceOperation::PowerOff,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    assert_eq!(
+        mh.host().db_machine(&mut txn).await.current_state(),
+        &ManagedHostState::Maintenance {
+            operation: MachineMaintenanceOperation::PowerOff,
+        },
+        "maintenance must remain available while Prepare waits",
+    );
+}
+
+/// A Supermicro host with stale DPU network status after unlocking restores
+/// lockdown and returns to `Prepare` even if that status becomes current during
+/// cleanup.
+#[crate::sqlx_test]
+async fn test_supermicro_ready_boot_config_stale_dpu_status_returns_to_prepare_after_cleanup(
+    pool: sqlx::PgPool,
+) {
+    let env = create_test_env(pool).await;
+    let mut host_config = ManagedHostConfig::default();
+    host_config.vendor = Some(bmc_vendor::BMCVendor::Supermicro);
+    let mh = create_managed_host_with_config(&env, host_config).await;
+    set_host_hardware_vendor(&env, &mh, "Supermicro").await;
+    let pending = set_pending_boot_interface(&env, &mh).await;
+    let boot_configuring = |boot_config_state| ManagedHostState::BootConfiguring {
+        desired_version: pending.version,
+        desired_boot_interface: pending.value.clone(),
+        post_lock_verification_retry_count: 0,
+        boot_config_state,
+    };
+    let prepare = boot_configuring(ReadyBootConfigState::Prepare);
+    let unlocking = boot_configuring(ReadyBootConfigState::UnlockHost {
+        unlock_host_state: model::machine::UnlockHostState::DisableLockdown,
+    });
+    let locking = boot_configuring(ReadyBootConfigState::LockHost {
+        post_lock_action: Some(ReadyBootConfigPostLockAction::ReturnToPrepare),
+    });
+
+    set_host_controller_state_stuck_in(&env, mh.host().id, &unlocking, 0).await;
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(
+        db::machine::try_update_network_config(
+            txn.as_mut(),
+            &host.id,
+            host.network_config.version,
+            &host.network_config.value,
+        )
+        .await
+        .expect("network configuration generation should advance"),
+    );
+    txn.commit().await.unwrap();
+
+    env.redfish_sim
+        .set_lockdown(libredfish::EnabledDisabled::Disabled);
+
+    env.run_machine_state_controller_iteration().await;
+    let mut txn = env.db_txn().await;
+    assert_eq!(
+        mh.host().db_machine(&mut txn).await.current_state(),
+        &locking,
+        "stale DPU network status after UnlockHost must first persist cleanup",
+    );
+    drop(txn);
+
+    // The cleanup decision is persisted. Current DPU network status on the next
+    // iteration must not let Supermicro's successful LockHost shortcut publish
+    // a boot verification that never happened.
+    common::api_fixtures::network_configured(&env, &mh.dpu_ids).await;
+    let threshold_retry = MachineLastRebootRequested {
+        time: Utc::now(),
+        mode: MachineLastRebootRequestedMode::Reboot,
+        restart_verified: Some(false),
+        verification_attempts: Some(2),
+    };
+    let mut txn = env.db_txn().await;
+    db::machine::update_restart_verification_status(
+        &mh.host().id,
+        threshold_retry,
+        Some(false),
+        2,
+        txn.as_mut(),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+    let cleanup_checkpoint = env.redfish_sim.timepoint();
+
+    env.run_machine_state_controller_iteration().await;
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert_eq!(
+        host.current_state(),
+        &prepare,
+        "LockHost must restore policy and return to Prepare",
+    );
+    assert_eq!(
+        host.pending_boot_interface_config_version(),
+        Some(pending.version),
+        "cleanup must not publish a boot verification",
+    );
+    let deferred_retry = host
+        .status
+        .last_reboot_requested
+        .expect("restart verification should remain deferred during cleanup");
+    assert_eq!(deferred_retry.restart_verified, Some(false));
+    assert_eq!(deferred_retry.verification_attempts, Some(2));
+    drop(txn);
+
+    assert!(
+        !env.redfish_sim
+            .actions_since(&cleanup_checkpoint)
+            .all_hosts()
+            .iter()
+            .any(|action| matches!(
+                action,
+                RedfishSimAction::Power(libredfish::SystemPowerControl::ForceRestart)
+            )),
+        "restart verification must not reboot the host before cleanup completes",
+    );
+
+    assert_eq!(
+        env.redfish_sim
+            .lockdown_states()
+            .iter()
+            .filter(|state| **state == libredfish::EnabledDisabled::Enabled)
+            .count(),
+        1,
+        "LockHost must restore the host policy before returning to Prepare",
+    );
+}
+
 /// Supermicro boot-order reads can be stale under lockdown. Ready must create
 /// its exact verification while unlocked, then retain that proof while
 /// restoring lockdown instead of trusting a contradictory locked read.
@@ -3217,7 +3507,7 @@ async fn test_supermicro_ready_boot_config_uses_unlocked_verification(pool: sqlx
         desired_boot_interface: pending.value.clone(),
         post_lock_verification_retry_count: 0,
         boot_config_state: ReadyBootConfigState::LockHost {
-            terminal_failure: None,
+            post_lock_action: None,
         },
     };
 
@@ -3421,7 +3711,7 @@ async fn test_ready_converges_pending_desired_boot_interface(pool: sqlx::PgPool)
                     desired_version,
                     desired_boot_interface,
                     boot_config_state: ReadyBootConfigState::LockHost {
-                        terminal_failure: None,
+                        post_lock_action: None,
                     },
                     ..
                 } if *desired_version == pending.version
@@ -3511,7 +3801,7 @@ async fn test_ready_boot_config_skips_unlock_when_already_correct(pool: sqlx::Pg
         ManagedHostState::BootConfiguring {
             desired_version,
             boot_config_state: ReadyBootConfigState::LockHost {
-                terminal_failure: None,
+                post_lock_action: None,
             },
             ..
         } if *desired_version == pending.version
@@ -4219,7 +4509,7 @@ async fn test_ready_boot_config_machine_failure_does_not_wait_for_redfish(pool: 
         desired_boot_interface: pending.value,
         post_lock_verification_retry_count: 0,
         boot_config_state: ReadyBootConfigState::LockHost {
-            terminal_failure: Some(ReadyBootConfigTerminalFailure::Machine {
+            post_lock_action: Some(ReadyBootConfigPostLockAction::Machine {
                 machine_id: mh.host().id,
                 details: details.clone(),
             }),
@@ -4261,7 +4551,7 @@ async fn test_ready_boot_config_lock_host_is_restart_safe(pool: sqlx::PgPool) {
         desired_boot_interface: pending.value.clone(),
         post_lock_verification_retry_count: 0,
         boot_config_state: ReadyBootConfigState::LockHost {
-            terminal_failure: None,
+            post_lock_action: None,
         },
     };
 
@@ -4317,7 +4607,7 @@ async fn test_ready_boot_config_lock_host_waits_for_redfish_access(pool: sqlx::P
         desired_boot_interface: pending.value,
         post_lock_verification_retry_count: 0,
         boot_config_state: ReadyBootConfigState::LockHost {
-            terminal_failure: None,
+            post_lock_action: None,
         },
     };
 
@@ -4364,7 +4654,7 @@ async fn test_ready_boot_config_waits_for_observed_lockdown_before_verifying(poo
         desired_boot_interface: pending.value.clone(),
         post_lock_verification_retry_count: 0,
         boot_config_state: ReadyBootConfigState::LockHost {
-            terminal_failure: None,
+            post_lock_action: None,
         },
     };
 

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -372,15 +372,12 @@ impl ManagedHostStateSnapshot {
     /// Those sites intentionally inspect both sides of this, so simply relying
     /// on this might not be what they'd want (at least for now).
     ///
-    /// NOTE(chet): When called from state-controller handlers (anything reached
-    /// via `MachineStateHandler::handle_object_state`), there is an upstream
-    /// guard that short-circuits with an error if topology reports DPUs but
-    /// `dpu_snapshots` is empty -- i.e. the DPU snapshots failed to load.
-    /// That guard runs before the `ManagedHostState` dispatch, so by the time
-    /// a state handler asks `has_managed_dpus()`, the potential bug of "topology
-    /// has DPUs, but snapshots are empty, so we think it has none" has
-    /// already been filtered out. A `false` return in that context means
-    /// genuinely no managed DPUs (both topology and snapshots agree).
+    /// NOTE(chet): State-controller handlers normally reject a topology with
+    /// no loaded DPU snapshots before dispatch, so `false` means no managed DPUs.
+    /// `ManagedHostState::BootConfiguring` is the exception: it must dispatch so
+    /// `ReadyBootConfigState::LockHost` can restore lockdown and
+    /// `ReadyBootConfigState::Prepare` can wait for a
+    /// `MachineNetworkStatusObservation` from every DPU in the host topology.
     ///
     /// Now, callers OUTSIDE the state-controller path DON'T get that upstream
     /// guard; if you need the stronger guarantee there, you'll need to
@@ -644,20 +641,27 @@ impl ManagedHostStateSnapshot {
         self.aggregate_health = output;
     }
 
-    /// Returns true if the desired managedhost networking configuration had been synced
-    /// to **all** DPUs.
+    /// Returns true when every DPU in the host topology has applied the current
+    /// host network configuration.
     ///
-    /// Each DPU's check compares the host-level `network_config.version`
-    /// against the version that DPU agent reported observing.
+    /// Each topology DPU must have a `MachineNetworkStatusObservation` whose
+    /// `network_config_version` matches `host_snapshot.network_config.version`.
+    /// Matching by machine ID prevents an empty or partial `dpu_snapshots` load
+    /// from appearing current. A host with no topology DPUs is already current.
     pub fn managed_host_network_config_version_synced(&self) -> bool {
         let host_version = self.host_snapshot.network_config.version;
-        for dpu_snapshot in self.dpu_snapshots.iter() {
-            if !dpu_snapshot.managed_host_network_config_version_synced(host_version) {
-                return false;
-            }
-        }
 
-        true
+        self.host_snapshot
+            .associated_dpu_machine_ids()
+            .into_iter()
+            .all(|dpu_machine_id| {
+                self.dpu_snapshots
+                    .iter()
+                    .find(|dpu_snapshot| dpu_snapshot.id == dpu_machine_id)
+                    .is_some_and(|dpu_snapshot| {
+                        dpu_snapshot.managed_host_network_config_version_synced(host_version)
+                    })
+            })
     }
 
     /// Sort the DPUs by pci address and then make sure the primary DPU is the first.
@@ -1246,7 +1250,7 @@ pub enum ManagedHostState {
     /// An unassigned Ready host is converging its Redfish boot configuration
     /// to the desired boot interface persisted on the machine.
     ///
-    /// The desired target and version are captured when the repair starts.
+    /// The desired target and version are captured when convergence starts.
     /// The controller checks that version before issuing new Redfish writes,
     /// uses the captured target while work is in flight, and records it
     /// verified only when the version is still current after final observation.
@@ -1501,11 +1505,14 @@ pub enum MachineValidatingState {
     },
 }
 
-/// `ReadyBootConfigTerminalFailure` defers a terminal condition until Ready
-/// boot convergence restores lockdown.
+/// Action to take after Ready boot convergence restores lockdown.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
-pub enum ReadyBootConfigTerminalFailure {
+pub enum ReadyBootConfigPostLockAction {
+    /// Return to `Prepare` after cleanup, even if DPU network status becomes
+    /// current while lockdown is being restored.
+    #[serde(rename = "return_to_prepare")]
+    ReturnToPrepare,
     /// The boot-config convergence flow could not complete automatically.
     Convergence { failure: String },
     /// An independent host or DPU failure appeared while lockdown was open.
@@ -1525,14 +1532,15 @@ pub enum ReadyBootConfigTerminalFailure {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(tag = "state", rename_all = "lowercase")]
 pub enum ReadyBootConfigState {
-    /// Observe the target, then inspect lockdown only when a repair may write.
+    /// Observe the target, then inspect lockdown only when convergence may
+    /// require a write.
     Prepare,
     /// Disable lockdown, including any vendor-specific reboot and wait.
     UnlockHost {
         #[serde(default)]
         unlock_host_state: UnlockHostState,
     },
-    /// Observe BIOS and boot order and select the smallest required repair.
+    /// Observe BIOS and boot order and select the smallest required update.
     CheckHostConfig,
     /// Run `machine_setup` for the desired boot interface.
     ConfigureBios {
@@ -1554,10 +1562,15 @@ pub enum ReadyBootConfigState {
     /// marking the desired boot-interface version verified or surfacing a
     /// terminal convergence failure.
     LockHost {
-        /// Failure deferred until lockdown has been restored. Absent on the
-        /// successful convergence path.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        terminal_failure: Option<ReadyBootConfigTerminalFailure>,
+        /// Action deferred until lockdown has been restored. Absent on the
+        /// successful convergence path. The persisted field keeps its original
+        /// name for compatibility with existing controller state.
+        #[serde(
+            rename = "terminal_failure",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        post_lock_action: Option<ReadyBootConfigPostLockAction>,
     },
     /// Automated convergence could not complete safely after lockdown was
     /// restored. The host remains unavailable until an operator changes its
@@ -3606,6 +3619,41 @@ mod tests {
     }
 
     #[test]
+    fn managed_host_network_config_sync_requires_every_expected_dpu() {
+        enum DpuNetworkConfigCase {
+            ZeroDpu,
+            AllExpectedCurrent,
+            MissingSnapshots,
+            PartialSnapshots,
+        }
+
+        value_scenarios!(run = |case| {
+                let mut state = managed_host_state_snapshot();
+
+                match case {
+                    DpuNetworkConfigCase::ZeroDpu => {
+                        for interface in &mut state.host_snapshot.status.interfaces {
+                            interface.attached_dpu_machine_id = None;
+                        }
+                        state.dpu_snapshots.clear();
+                    }
+                    DpuNetworkConfigCase::AllExpectedCurrent => {}
+                    DpuNetworkConfigCase::MissingSnapshots => state.dpu_snapshots.clear(),
+                    DpuNetworkConfigCase::PartialSnapshots => state.dpu_snapshots.truncate(1),
+                }
+
+                state.managed_host_network_config_version_synced()
+            };
+            "DPU network configuration" {
+                DpuNetworkConfigCase::ZeroDpu => true,
+                DpuNetworkConfigCase::AllExpectedCurrent => true,
+                DpuNetworkConfigCase::MissingSnapshots => false,
+                DpuNetworkConfigCase::PartialSnapshots => false,
+            }
+        );
+    }
+
+    #[test]
     fn ready_boot_config_defaults_survive_persisted_state_loading() {
         scenarios!(
             run = |json| serde_json::from_str::<ReadyBootConfigState>(json).map_err(drop);
@@ -3629,14 +3677,23 @@ mod tests {
 
             "lockdown restoration defaults to the success path" {
                 r#"{"state":"lockhost"}"# => Yields(ReadyBootConfigState::LockHost {
-                    terminal_failure: None,
+                    post_lock_action: None,
                 }),
+            }
+
+            "existing convergence failure field remains readable" {
+                r#"{"state":"lockhost","terminal_failure":{"kind":"convergence","failure":"stopped"}}"# =>
+                    Yields(ReadyBootConfigState::LockHost {
+                        post_lock_action: Some(ReadyBootConfigPostLockAction::Convergence {
+                            failure: "stopped".to_string(),
+                        }),
+                    }),
             }
         );
     }
 
     #[test]
-    fn ready_boot_config_terminal_outcomes_round_trip() {
+    fn ready_boot_config_post_lock_actions_round_trip() {
         let machine_id =
             MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")
                 .unwrap();
@@ -3651,9 +3708,16 @@ mod tests {
         check_values(
             [
                 Check {
+                    scenario: "stale DPU network status returns to Prepare after cleanup",
+                    input: ReadyBootConfigState::LockHost {
+                        post_lock_action: Some(ReadyBootConfigPostLockAction::ReturnToPrepare),
+                    },
+                    expect: true,
+                },
+                Check {
                     scenario: "convergence failure waits for lockdown",
                     input: ReadyBootConfigState::LockHost {
-                        terminal_failure: Some(ReadyBootConfigTerminalFailure::Convergence {
+                        post_lock_action: Some(ReadyBootConfigPostLockAction::Convergence {
                             failure: "BIOS job retries exhausted".to_string(),
                         }),
                     },
@@ -3662,7 +3726,7 @@ mod tests {
                 Check {
                     scenario: "independent machine failure keeps its attribution",
                     input: ReadyBootConfigState::LockHost {
-                        terminal_failure: Some(ReadyBootConfigTerminalFailure::Machine {
+                        post_lock_action: Some(ReadyBootConfigPostLockAction::Machine {
                             machine_id,
                             details: failure_details,
                         }),
@@ -3684,6 +3748,17 @@ mod tests {
                 .unwrap()
                     == state
             },
+        );
+
+        assert_eq!(
+            serde_json::to_value(ReadyBootConfigState::LockHost {
+                post_lock_action: Some(ReadyBootConfigPostLockAction::ReturnToPrepare),
+            })
+            .unwrap(),
+            serde_json::json!({
+                "state": "lockhost",
+                "terminal_failure": { "kind": "return_to_prepare" },
+            }),
         );
     }
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -82,7 +82,7 @@ use model::machine::{
     MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState,
     MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
     NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation, PowerDrainState,
-    PowerState, ReadyBootConfigState, ReadyBootConfigTerminalFailure, ReprovisionState, RetryInfo,
+    PowerState, ReadyBootConfigPostLockAction, ReadyBootConfigState, ReprovisionState, RetryInfo,
     SecureEraseBossContext, SecureEraseBossState, SetBootOrderInfo, SetBootOrderState,
     SetSecureBootState, SpdmMeasuringState, StateMachineArea, UefiSetupInfo, UefiSetupState,
     UnlockHostState, ValidationState, dpf_based_dpu_provisioning_possible, get_display_ids,
@@ -743,8 +743,35 @@ impl MachineStateHandler {
             }
         }
 
-        if let Some(outcome) = handle_restart_verification(mh_snapshot, ctx).await? {
-            return Ok(outcome);
+        // `ReadyBootConfigState::Prepare` must consume a snapshot with current
+        // DPU `MachineNetworkStatusObservation` values before
+        // `handle_restart_verification` can issue another reboot. A pending
+        // `ReadyBootConfigPostLockAction`, or a later state with stale DPU
+        // network status, must complete `LockHost` first.
+        let active_boot_config = match &mh_state {
+            ManagedHostState::BootConfiguring {
+                boot_config_state: ReadyBootConfigState::Failed { .. },
+                ..
+            } => None,
+            ManagedHostState::BootConfiguring {
+                boot_config_state, ..
+            } => Some(boot_config_state),
+            _ => None,
+        };
+        let defer_restart_verification = active_boot_config.is_some_and(|boot_config_state| {
+            matches!(
+                boot_config_state,
+                ReadyBootConfigState::Prepare
+                    | ReadyBootConfigState::LockHost {
+                        post_lock_action: Some(_),
+                    }
+            ) || !mh_snapshot.managed_host_network_config_version_synced()
+        });
+
+        if !defer_restart_verification
+            && let Some(restart_transition) = handle_restart_verification(mh_snapshot, ctx).await?
+        {
+            return Ok(restart_transition);
         }
 
         if dpu_reprovisioning_needed(&mh_snapshot.dpu_snapshots) {
@@ -772,8 +799,8 @@ impl MachineStateHandler {
                 ManagedHostState::BootConfiguring {
                     boot_config_state:
                         ReadyBootConfigState::LockHost {
-                            terminal_failure:
-                                Some(ReadyBootConfigTerminalFailure::Machine {
+                            post_lock_action:
+                                Some(ReadyBootConfigPostLockAction::Machine {
                                     machine_id: pending_machine_id,
                                     details: pending_details,
                                 }),
@@ -818,7 +845,7 @@ impl MachineStateHandler {
                                 version: *desired_version,
                             },
                             *post_lock_verification_retry_count,
-                            Some(ReadyBootConfigTerminalFailure::Machine {
+                            Some(ReadyBootConfigPostLockAction::Machine {
                                 machine_id,
                                 details,
                             }),
@@ -2667,22 +2694,8 @@ impl StateHandler for MachineStateHandler {
             .is_empty()
             && mh_snapshot.dpu_snapshots.is_empty()
         {
-            if let Some(next_state) =
-                ready_boot_config_missing_dpu_recovery(&mh_snapshot.managed_state)
-            {
-                tracing::error!(
-                    machine_id = %host_machine_id,
-                    "DPU snapshots disappeared during boot reconciliation; restoring lockdown before parking the repair",
-                );
-                return Ok(StateHandlerOutcome::transition(next_state));
-            }
-
-            let can_continue_without_dpu = match &mh_snapshot.managed_state {
-                ManagedHostState::BootConfiguring {
-                    boot_config_state, ..
-                } => !ready_boot_config_may_have_opened_lockdown(boot_config_state),
-                _ => false,
-            };
+            let can_continue_without_dpu =
+                ready_boot_config_handles_missing_dpu_snapshots(&mh_snapshot.managed_state);
             if !can_continue_without_dpu {
                 tracing::error!(machine_id = %host_machine_id, "No DPU snapshot found for host");
                 return Err(StateHandlerError::GenericError(eyre!(
@@ -2690,12 +2703,12 @@ impl StateHandler for MachineStateHandler {
                 )));
             }
 
-            // Prepare and Failed must still process desired-state changes, and
-            // LockHost only needs host Redfish. Keep those recovery paths
-            // dispatchable through a transient DPU snapshot gap.
+            // `ManagedHostState::BootConfiguring` performs the complete topology
+            // DPU check. Later states return through `LockHost`, while `Prepare`
+            // waits without touching the host until the snapshot is complete.
             tracing::warn!(
                 machine_id = %host_machine_id,
-                "Continuing boot reconciliation recovery without DPU snapshots",
+                "Continuing ManagedHostState::BootConfiguring with missing DPU snapshots",
             );
         }
 
@@ -5944,36 +5957,10 @@ fn ready_boot_config_may_have_opened_lockdown(state: &ReadyBootConfigState) -> b
     }
 }
 
-/// Routes an active repair through cleanup when expected DPU snapshots vanish.
-///
-/// `Prepare` has not opened lockdown, `LockHost` is already cleanup, and
-/// `Failed` is reached only after cleanup. Every other substate may have
-/// disabled lockdown.
-fn ready_boot_config_missing_dpu_recovery(state: &ManagedHostState) -> Option<ManagedHostState> {
-    let ManagedHostState::BootConfiguring {
-        desired_version,
-        desired_boot_interface,
-        post_lock_verification_retry_count,
-        boot_config_state,
-    } = state
-    else {
-        return None;
-    };
-    if !ready_boot_config_may_have_opened_lockdown(boot_config_state) {
-        return None;
-    }
-
-    Some(ready_boot_config_locking(
-        Versioned {
-            value: desired_boot_interface.clone(),
-            version: *desired_version,
-        },
-        *post_lock_verification_retry_count,
-        Some(ReadyBootConfigTerminalFailure::Convergence {
-            failure: "expected DPU snapshots disappeared while boot-interface reconciliation may have left lockdown disabled"
-                .to_string(),
-        }),
-    ))
+/// `ManagedHostState::BootConfiguring` must dispatch so `Prepare` can wait for
+/// DPU snapshots or `LockHost` can restore lockdown.
+fn ready_boot_config_handles_missing_dpu_snapshots(state: &ManagedHostState) -> bool {
+    matches!(state, ManagedHostState::BootConfiguring { .. })
 }
 
 fn ready_boot_config_requires_timeout_cleanup(
@@ -6010,12 +5997,12 @@ fn pending_ready_boot_config_state(machine: &Machine) -> Option<ManagedHostState
 fn ready_boot_config_locking(
     desired: Versioned<MachineBootInterfaceTarget>,
     post_lock_verification_retry_count: u32,
-    terminal_failure: Option<ReadyBootConfigTerminalFailure>,
+    post_lock_action: Option<ReadyBootConfigPostLockAction>,
 ) -> ManagedHostState {
     ready_boot_configuring(
         desired,
         post_lock_verification_retry_count,
-        ReadyBootConfigState::LockHost { terminal_failure },
+        ReadyBootConfigState::LockHost { post_lock_action },
     )
 }
 
@@ -6072,7 +6059,7 @@ async fn handle_ready_boot_config_stage(
             return Ok(StateHandlerOutcome::transition(ready_boot_config_locking(
                 desired,
                 post_lock_verification_retry_count,
-                Some(ReadyBootConfigTerminalFailure::Convergence { failure }),
+                Some(ReadyBootConfigPostLockAction::Convergence { failure }),
             )));
         }
         Err(error) => return Err(error),
@@ -6094,17 +6081,19 @@ async fn handle_ready_boot_config_stage(
             Ok(StateHandlerOutcome::transition(ready_boot_config_locking(
                 desired,
                 post_lock_verification_retry_count,
-                Some(ReadyBootConfigTerminalFailure::Convergence { failure }),
+                Some(ReadyBootConfigPostLockAction::Convergence { failure }),
             )))
         }
     }
 }
 
-/// Converges an unassigned Ready host to its persisted boot-interface target.
+/// Converges an unassigned Ready host to its persisted boot interface target.
 ///
 /// The outer state captures one target and desired version. Safe boundaries
-/// may adopt newer intent, while an in-flight vendor job or cleanup finishes
-/// against the captured target before the controller switches versions.
+/// may adopt newer intent. An in-flight vendor job keeps its captured target;
+/// if the DPU network status becomes stale within the cleanup deadline, the
+/// controller restores lockdown and returns to `Prepare` before using that
+/// target again. Work already beyond that deadline restores lockdown and parks.
 async fn handle_ready_boot_config(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     mh_snapshot: &ManagedHostStateSnapshot,
@@ -6113,10 +6102,19 @@ async fn handle_ready_boot_config(
     post_lock_verification_retry_count: u32,
     boot_config_state: ReadyBootConfigState,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    // `Prepare` has not changed the host yet, so an operator maintenance request
+    // can safely take control even while a DPU is still catching up.
+    if matches!(boot_config_state, ReadyBootConfigState::Prepare)
+        && let Some(maintenance_transition) =
+            maintenance::maintenance_transition_if_requested(mh_snapshot)
+    {
+        return Ok(maintenance_transition);
+    }
+
     // Only states that can adopt replacement intent need an unlocked read.
-    // LockHost re-reads under the machine-row lock before it commits a
-    // transition, and in-flight vendor stages deliberately finish their
-    // captured generation.
+    // `LockHost` reads again under the `Machine` row lock before it commits a
+    // transition. An in-flight vendor stage keeps its captured target while
+    // any required cleanup completes.
     let current_desired = if matches!(boot_config_state, ReadyBootConfigState::Failed { .. })
         || ready_boot_config_can_adopt_latest(&boot_config_state)
     {
@@ -6130,13 +6128,14 @@ async fn handle_ready_boot_config(
         None
     };
     let captured_boot_interface: BootInterfaceTarget = desired.value.clone().into();
+    let dpu_network_status_current = mh_snapshot.managed_host_network_config_version_synced();
 
     if ready_boot_config_requires_timeout_cleanup(
         &boot_config_state,
         mh_snapshot.host_snapshot.state.version.since_state_change(),
     ) {
         let failure = format!(
-            "boot-interface reconciliation stopped progressing in {boot_config_state:?} for longer than its {}-second cleanup deadline",
+            "boot configuration convergence stopped progressing in {boot_config_state:?} for longer than the {} second BootConfiguring cleanup deadline",
             model::machine::slas::BOOT_CONFIGURING.as_secs(),
         );
         tracing::error!(
@@ -6144,12 +6143,31 @@ async fn handle_ready_boot_config(
             desired_version = %desired.version,
             ?boot_config_state,
             reason = %failure,
-            "Restoring lockdown before parking timed-out boot reconciliation",
+            "Restoring lockdown before parking BootConfiguring after its cleanup deadline",
         );
         return Ok(StateHandlerOutcome::transition(ready_boot_config_locking(
             desired,
             post_lock_verification_retry_count,
-            Some(ReadyBootConfigTerminalFailure::Convergence { failure }),
+            Some(ReadyBootConfigPostLockAction::Convergence { failure }),
+        )));
+    }
+
+    // `Prepare` can safely wait in place. Any state that may have opened
+    // lockdown records why cleanup began so it returns to `Prepare` even if
+    // the DPU `MachineNetworkStatusObservation` values become current before
+    // the next controller iteration.
+    if !dpu_network_status_current && ready_boot_config_may_have_opened_lockdown(&boot_config_state)
+    {
+        tracing::warn!(
+            machine_id = %mh_snapshot.host_snapshot.id,
+            desired_version = %desired.version,
+            ?boot_config_state,
+            "DPU network status is stale; restoring lockdown before returning to ReadyBootConfigState::Prepare",
+        );
+        return Ok(StateHandlerOutcome::transition(ready_boot_config_locking(
+            desired,
+            post_lock_verification_retry_count,
+            Some(ReadyBootConfigPostLockAction::ReturnToPrepare),
         )));
     }
 
@@ -6199,19 +6217,25 @@ async fn handle_ready_boot_config(
         });
     }
 
-    if matches!(boot_config_state, ReadyBootConfigState::Prepare)
-        && !mh_snapshot
-            .host_snapshot
-            .associated_dpu_machine_ids()
-            .is_empty()
-        && mh_snapshot.dpu_snapshots.is_empty()
-    {
-        // Prepare has not opened lockdown, so it can safely process target
-        // replacement or removal above. Do not let the shared boot check
-        // mistake a transiently empty snapshot list for a zero-DPU host.
-        return Ok(StateHandlerOutcome::wait(
-            "Waiting for expected DPU snapshots before boot-interface reconciliation".to_string(),
-        ));
+    if matches!(boot_config_state, ReadyBootConfigState::Prepare) {
+        // Recover an unresponsive DPU before checking the `network_config_version` field on each
+        // `MachineNetworkStatusObservation`. The host boot check below can then reuse this
+        // decision from the same snapshot.
+        if !are_dpus_up_trigger_reboot_if_needed(mh_snapshot, reachability_params, ctx).await {
+            return Ok(StateHandlerOutcome::wait(
+                "Waiting for DPUs to come up.".to_string(),
+            ));
+        }
+
+        // Every DPU in the host topology must have a network status observation
+        // whose version matches `host_snapshot.network_config.version` before
+        // the controller starts host Redfish work.
+        if !dpu_network_status_current {
+            return Ok(StateHandlerOutcome::wait(
+                "Waiting for every DPU in the host topology to apply the current host network configuration"
+                    .to_string(),
+            ));
+        }
     }
 
     match boot_config_state {
@@ -6237,7 +6261,7 @@ async fn handle_ready_boot_config(
                 redfish_client.as_ref(),
                 mh_snapshot,
                 reachability_params,
-                HostBootConfigDpuFreshness::CurrentHostState,
+                HostBootConfigDpuFreshness::AlreadyValidated,
                 Some(&captured_boot_interface),
                 ctx,
             )
@@ -6253,14 +6277,14 @@ async fn handle_ready_boot_config(
             let next_state = if preflight_complete {
                 // Avoid opening an ordinary host that is already correct.
                 ReadyBootConfigState::LockHost {
-                    terminal_failure: None,
+                    post_lock_action: None,
                 }
             } else {
                 match redfish_client.lockdown_status().await {
                     Err(RedfishError::NotSupported(_)) => {
                         tracing::info!(
                             machine_id = %mh_snapshot.host_snapshot.id,
-                            "BMC vendor does not support checking lockdown status during Ready boot repair",
+                            "BMC vendor does not support checking lockdown status during BootConfiguring",
                         );
                         ReadyBootConfigState::CheckHostConfig
                     }
@@ -6268,7 +6292,7 @@ async fn handle_ready_boot_config(
                         tracing::warn!(
                             machine_id = %mh_snapshot.host_snapshot.id,
                             error = %error,
-                            "Failed to fetch lockdown status during Ready boot repair",
+                            "Failed to fetch lockdown status during BootConfiguring",
                         );
                         return Ok(StateHandlerOutcome::wait(format!(
                             "Failed to fetch lockdown status: {error}"
@@ -6302,7 +6326,7 @@ async fn handle_ready_boot_config(
                         Err(RedfishError::NotSupported(_)) => {
                             tracing::info!(
                                 machine_id = %mh_snapshot.host_snapshot.id,
-                                "BMC vendor does not support disabling lockdown during Ready boot repair",
+                                "BMC vendor does not support disabling lockdown during BootConfiguring",
                             );
                         }
                         Err(error) => return Err(redfish_error("lockdown_bmc", error)),
@@ -6381,7 +6405,7 @@ async fn handle_ready_boot_config(
                 }
                 HostBootConfigCheckOutcome::Ready(HostBootConfigDecision::Complete) => {
                     ReadyBootConfigState::LockHost {
-                        terminal_failure: None,
+                        post_lock_action: None,
                     }
                 }
             };
@@ -6460,16 +6484,23 @@ async fn handle_ready_boot_config(
             )
             .await
         }
-        ReadyBootConfigState::LockHost { terminal_failure } => {
+        ReadyBootConfigState::LockHost { post_lock_action } => {
             let lockdown_disabled = mh_snapshot.host_snapshot.host_profile.disable_lockdown;
 
             // A profile that deliberately leaves lockdown disabled has no
-            // cleanup barrier. Terminal failures can therefore be published
+            // cleanup barrier. Deferred actions can therefore be applied
             // without requiring Redfish access. Successful convergence still
             // performs the final exact-target observation below.
-            if lockdown_disabled && let Some(terminal_failure) = &terminal_failure {
-                match terminal_failure {
-                    ReadyBootConfigTerminalFailure::Machine {
+            if lockdown_disabled && let Some(post_lock_action) = &post_lock_action {
+                match post_lock_action {
+                    ReadyBootConfigPostLockAction::ReturnToPrepare => {
+                        return Ok(StateHandlerOutcome::transition(ready_boot_configuring(
+                            desired,
+                            post_lock_verification_retry_count,
+                            ReadyBootConfigState::Prepare,
+                        )));
+                    }
+                    ReadyBootConfigPostLockAction::Machine {
                         machine_id,
                         details,
                     } => {
@@ -6479,7 +6510,7 @@ async fn handle_ready_boot_config(
                             retry_count: 0,
                         }));
                     }
-                    ReadyBootConfigTerminalFailure::Convergence { failure } => {
+                    ReadyBootConfigPostLockAction::Convergence { failure } => {
                         let mut txn = ctx.services.db_pool.begin().await?;
                         let current_desired = db::machine_desired_boot_interface::lock(
                             txn.as_mut(),
@@ -6502,6 +6533,19 @@ async fn handle_ready_boot_config(
                 }
             }
 
+            if lockdown_disabled && !dpu_network_status_current {
+                tracing::warn!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    desired_version = %desired.version,
+                    "DPU network status is stale; returning to ReadyBootConfigState::Prepare because the host profile disables lockdown",
+                );
+                return Ok(StateHandlerOutcome::transition(ready_boot_configuring(
+                    desired,
+                    post_lock_verification_retry_count,
+                    ReadyBootConfigState::Prepare,
+                )));
+            }
+
             let redfish_client = match ctx
                 .services
                 .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
@@ -6512,10 +6556,10 @@ async fn handle_ready_boot_config(
                     tracing::warn!(
                         machine_id = %mh_snapshot.host_snapshot.id,
                         error = %error,
-                        "Waiting for Redfish access before completing Ready boot repair cleanup",
+                        "Waiting for Redfish access before completing BootConfiguring cleanup",
                     );
                     return Ok(StateHandlerOutcome::wait(
-                        "Waiting for host Redfish access before completing Ready boot repair cleanup"
+                        "Waiting for host Redfish access before completing BootConfiguring cleanup"
                             .to_string(),
                     ));
                 }
@@ -6524,7 +6568,7 @@ async fn handle_ready_boot_config(
             if lockdown_disabled {
                 tracing::info!(
                     machine_id = %mh_snapshot.host_snapshot.id,
-                    "Skipping lockdown re-enable after Ready boot repair per expected-machine config",
+                    "Skipping lockdown restoration because the host profile disables lockdown",
                 );
             } else {
                 let (lockdown_command_required, verify_after_command, require_supported_command) =
@@ -6536,7 +6580,7 @@ async fn handle_ready_boot_config(
                             tracing::info!(
                                 machine_id = %mh_snapshot.host_snapshot.id,
                                 ?lockdown_status,
-                                "Restoring lockdown after Ready boot repair",
+                                "Restoring lockdown during BootConfiguring",
                             );
                             (true, true, true)
                         }
@@ -6549,7 +6593,7 @@ async fn handle_ready_boot_config(
                             tracing::warn!(
                                 machine_id = %mh_snapshot.host_snapshot.id,
                                 error = %error,
-                                "Could not read lockdown status before Ready boot repair cleanup; attempting restoration",
+                                "Could not read lockdown status during BootConfiguring cleanup; attempting restoration",
                             );
                             (true, true, true)
                         }
@@ -6567,7 +6611,7 @@ async fn handle_ready_boot_config(
                         Err(RedfishError::NotSupported(_)) => {
                             tracing::info!(
                                 machine_id = %mh_snapshot.host_snapshot.id,
-                                "BMC vendor does not support re-enabling lockdown after Ready boot repair",
+                                "BMC vendor does not support restoring lockdown during BootConfiguring",
                             );
                             false
                         }
@@ -6584,10 +6628,10 @@ async fn handle_ready_boot_config(
                             tracing::info!(
                                 machine_id = %mh_snapshot.host_snapshot.id,
                                 ?lockdown_status,
-                                "Waiting for lockdown policy restoration after Ready boot repair",
+                                "Waiting for lockdown policy restoration during BootConfiguring",
                             );
                             return Ok(StateHandlerOutcome::wait(format!(
-                                "Waiting for lockdown to be fully enabled after Ready boot repair; current status: {lockdown_status:?}"
+                                "Waiting for lockdown to be fully enabled during BootConfiguring; current status: {lockdown_status:?}"
                             )));
                         }
                         Err(RedfishError::NotSupported(_)) => {
@@ -6603,19 +6647,26 @@ async fn handle_ready_boot_config(
                             tracing::warn!(
                                 machine_id = %mh_snapshot.host_snapshot.id,
                                 error = %error,
-                                "Failed to verify lockdown after Ready boot repair",
+                                "Failed to verify lockdown during BootConfiguring",
                             );
                             return Ok(StateHandlerOutcome::wait(format!(
-                                "Failed to verify lockdown after Ready boot repair: {error}"
+                                "Failed to verify lockdown during BootConfiguring: {error}"
                             )));
                         }
                     }
                 }
             }
 
-            if let Some(terminal_failure) = terminal_failure {
-                match terminal_failure {
-                    ReadyBootConfigTerminalFailure::Machine {
+            if let Some(post_lock_action) = post_lock_action {
+                match post_lock_action {
+                    ReadyBootConfigPostLockAction::ReturnToPrepare => {
+                        return Ok(StateHandlerOutcome::transition(ready_boot_configuring(
+                            desired,
+                            post_lock_verification_retry_count,
+                            ReadyBootConfigState::Prepare,
+                        )));
+                    }
+                    ReadyBootConfigPostLockAction::Machine {
                         machine_id,
                         details,
                     } => {
@@ -6625,7 +6676,7 @@ async fn handle_ready_boot_config(
                             retry_count: 0,
                         }));
                     }
-                    ReadyBootConfigTerminalFailure::Convergence { failure } => {
+                    ReadyBootConfigPostLockAction::Convergence { failure } => {
                         let mut txn = ctx.services.db_pool.begin().await?;
                         let current_desired = db::machine_desired_boot_interface::lock(
                             txn.as_mut(),
@@ -6644,6 +6695,19 @@ async fn handle_ready_boot_config(
                         return Ok(StateHandlerOutcome::transition(next_state).with_txn(txn));
                     }
                 }
+            }
+
+            if !dpu_network_status_current {
+                tracing::warn!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    desired_version = %desired.version,
+                    "DPU network status is stale; lockdown is restored and ReadyBootConfigState::Prepare will run next",
+                );
+                return Ok(StateHandlerOutcome::transition(ready_boot_configuring(
+                    desired,
+                    post_lock_verification_retry_count,
+                    ReadyBootConfigState::Prepare,
+                )));
             }
 
             let boot_config_verified =
@@ -13842,7 +13906,7 @@ mod tests {
             ready_boot_config_locking(
                 Versioned::new(desired_boot_interface.clone(), desired_version),
                 0,
-                Some(ReadyBootConfigTerminalFailure::Convergence {
+                Some(ReadyBootConfigPostLockAction::Convergence {
                     failure: failure.clone(),
                 }),
             ),
@@ -13851,54 +13915,25 @@ mod tests {
                 desired_boot_interface,
                 post_lock_verification_retry_count: 0,
                 boot_config_state: ReadyBootConfigState::LockHost {
-                    terminal_failure: Some(ReadyBootConfigTerminalFailure::Convergence { failure }),
+                    post_lock_action: Some(ReadyBootConfigPostLockAction::Convergence { failure }),
                 },
             }
         );
     }
 
     #[test]
-    fn missing_dpus_during_ready_boot_config_fails_closed() {
-        let desired_version = ConfigVersion::initial();
-        let desired_boot_interface =
-            MachineBootInterfaceTarget::MacOnly("02:00:00:00:00:01".parse().unwrap());
-        let active = ready_boot_configuring(
-            Versioned::new(desired_boot_interface.clone(), desired_version),
-            0,
-            ReadyBootConfigState::CheckHostConfig,
+    fn only_ready_boot_config_handles_missing_dpu_snapshots() {
+        let desired = Versioned::new(
+            MachineBootInterfaceTarget::MacOnly("02:00:00:00:00:01".parse().unwrap()),
+            ConfigVersion::initial(),
         );
 
-        assert!(matches!(
-            ready_boot_config_missing_dpu_recovery(&active),
-            Some(ManagedHostState::BootConfiguring {
-                desired_version: version,
-                desired_boot_interface: target,
-                boot_config_state: ReadyBootConfigState::LockHost {
-                    terminal_failure:
-                        Some(ReadyBootConfigTerminalFailure::Convergence { failure }),
-                },
-                ..
-            }) if version == desired_version
-                && target == desired_boot_interface
-                && failure.contains("DPU snapshots disappeared")
+        assert!(ready_boot_config_handles_missing_dpu_snapshots(
+            &ready_boot_configuring(desired, 0, ReadyBootConfigState::Prepare),
         ));
-
-        for safe_state in [
-            ReadyBootConfigState::Prepare,
-            ReadyBootConfigState::LockHost {
-                terminal_failure: None,
-            },
-            ReadyBootConfigState::Failed {
-                failure: "already parked".to_string(),
-            },
-        ] {
-            let state = ready_boot_configuring(
-                Versioned::new(desired_boot_interface.clone(), desired_version),
-                0,
-                safe_state,
-            );
-            assert_eq!(ready_boot_config_missing_dpu_recovery(&state), None);
-        }
+        assert!(!ready_boot_config_handles_missing_dpu_snapshots(
+            &ManagedHostState::Ready,
+        ));
     }
 
     #[test]
@@ -13918,7 +13953,7 @@ mod tests {
         for safe_state in [
             ReadyBootConfigState::Prepare,
             ReadyBootConfigState::LockHost {
-                terminal_failure: None,
+                post_lock_action: None,
             },
             ReadyBootConfigState::Failed {
                 failure: "already parked".to_string(),
@@ -13991,7 +14026,7 @@ mod tests {
             ReadyBootConfigState::PollingBiosSetup { retry_count: 0 },
             set_boot_order(SetBootOrderState::WaitForSetBootOrderJobCompletion),
             ReadyBootConfigState::LockHost {
-                terminal_failure: Some(ReadyBootConfigTerminalFailure::Convergence {
+                post_lock_action: Some(ReadyBootConfigPostLockAction::Convergence {
                     failure: "exhausted".to_string(),
                 }),
             },


### PR DESCRIPTION
A primary interface update advances `host_snapshot.network_config.version` before `machine-controller` applies the desired `MachineBootInterfaceTarget`. Each DPU records the applied version in the `network_config_version` field of `MachineNetworkStatusObservation`, and `ReadyBootConfigState::Prepare` is the boundary before the controller begins host Redfish work.

This change uses those status observations throughout the existing `ManagedHostState::BootConfiguring` flow:

- `ManagedHostStateSnapshot::managed_host_network_config_version_synced()` now checks every ID returned by `associated_dpu_machine_ids()`, so missing or partial `dpu_snapshots` cannot look current. A host with no expected DPUs still passes.
- `ReadyBootConfigState::Prepare` keeps DPU recovery and maintenance available, then waits until every expected DPU's `network_config_version` matches `host_snapshot.network_config.version` before Redfish work begins.
- Generic restart verification is deferred while `Prepare` consumes the current snapshot, while `ReadyBootConfigState::LockHost` has a pending `ReadyBootConfigPostLockAction`, and while a later `BootConfiguring` state sees stale DPU network status.
- If the versions stop matching after a state may have disabled lockdown, `ReadyBootConfigPostLockAction::ReturnToPrepare` records that `LockHost` must restore lockdown and return to `Prepare`, even if the observations become current during cleanup. The existing `BootConfiguring` cleanup deadline still takes precedence.

`ManagedHostState::HostInit { machine_state: MachineState::Discovered { .. } }` keeps its existing reboot handshake. `ReadyBootConfigState::LockHost` also keeps the serialized `terminal_failure` field name, so previously persisted convergence and machine failures remain readable.

## Related issues

Closes #5378

Part of #5008 and unblocks #5083.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Local verification covered complete DPU status comparison, compatibility when loading the serialized `terminal_failure` field, generic restart verification ordering, waiting for two DPUs in `Prepare` with maintenance, and the Supermicro `LockHost` path when DPU status becomes current during cleanup. The affected crates also passed Clippy with all targets and features, nightly formatting, and the workspace Carbide lints.

## Additional Notes

This controller prerequisite allows #5083 to validate and reconcile the stored primary interface from scout. It does not select a primary interface, change the shared primary interface transaction, add a database migration, or introduce a new timeout or retry policy.
