### PR TITLE
chore: bump libredfish to v0.47.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6932,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.9#cb00c08928241f9b3f3f4ed6617cecac336a74e2"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.47.1#6cff6843cd09dfee5b066ea6f16c2b9c69ca5953"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.9" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.47.1" }
 librms = { git = "https://github.com/dsx-ai-factory/nv-rms-client.git", tag = "v0.10.1" }
 ansi-to-html = "0.2.2"
 

--- a/crates/credential-rotation/src/lib.rs
+++ b/crates/credential-rotation/src/lib.rs
@@ -1576,7 +1576,7 @@ mod tests {
             ("Delta Electronics", RedfishVendor::DeltaPowerShelf),
         ] {
             let sim = RedfishSim::default();
-            sim.set_service_root_vendor(Some("Contoso".to_string()));
+            sim.set_service_root_vendor(Some("Unrecognized Vendor".to_string()));
             sim.set_chassis_manufacturer(Some(manufacturer.to_string()));
             let vendor = resolve_dispatch_vendor(
                 &sim,

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -166,7 +166,7 @@ pub fn bmc_vendor(r: libredfish::model::service_root::RedfishVendor) -> BMCVendo
         RedfishVendor::LiteOnPowerShelf => BMCVendor::Liteon,
         RedfishVendor::DeltaPowerShelf => BMCVendor::Delta,
         RedfishVendor::Supermicro => BMCVendor::Supermicro,
-        RedfishVendor::Unknown => BMCVendor::Unknown,
+        RedfishVendor::Sushy | RedfishVendor::Unknown => BMCVendor::Unknown,
     }
 }
 
@@ -225,6 +225,7 @@ mod tests {
                 RedfishVendor::LiteOnPowerShelf => BMCVendor::Liteon,
                 RedfishVendor::DeltaPowerShelf => BMCVendor::Delta,
                 RedfishVendor::Supermicro => BMCVendor::Supermicro,
+                RedfishVendor::Sushy => BMCVendor::Unknown,
                 RedfishVendor::Unknown => BMCVendor::Unknown,
             }
         );

--- a/crates/redfish/src/libredfish/instrumented.rs
+++ b/crates/redfish/src/libredfish/instrumented.rs
@@ -61,6 +61,7 @@ use libredfish::model::task::Task;
 use libredfish::model::thermal::Thermal;
 use libredfish::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
 use libredfish::model::{BootOption, ComputerSystem, Manager, ODataId};
+use libredfish::standard::RedfishStandard;
 use libredfish::{
     Assembly, BiosProfileType, BiosProfileVendor, Boot, BootInterfaceRef, BootOptions,
     BootOverride, Chassis, Collection, EnabledDisabled, EthernetInterface, JobState,
@@ -167,6 +168,10 @@ macro_rules! delegate_with_red {
 }
 
 impl Redfish for InstrumentedRedfish {
+    fn std_redfish(&self) -> &RedfishStandard {
+        self.inner.std_redfish()
+    }
+
     delegate_with_red! {
         fn change_username<'a>(&'a self, old_name: &'a str, new_name: &'a str) -> ();
         fn get_accounts<'a>(&'a self) -> Vec<ManagerAccount>;

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -1181,7 +1181,7 @@ mod tests {
             let sim = RedfishSim::default();
             // Force the anonymous service-root probe to yield an unrecognized
             // vendor so probing falls through to the Chassis Manufacturer.
-            sim.set_service_root_vendor(Some("Contoso".to_string()));
+            sim.set_service_root_vendor(Some("Unrecognized Vendor".to_string()));
             sim.set_chassis_manufacturer(Some(manufacturer.to_string()));
 
             let vendor = sim
@@ -1198,7 +1198,7 @@ mod tests {
     #[tokio::test]
     async fn probe_bmc_vendor_errors_when_vendor_unresolvable() {
         let sim = RedfishSim::default();
-        sim.set_service_root_vendor(Some("Contoso".to_string()));
+        sim.set_service_root_vendor(Some("Unrecognized Vendor".to_string()));
         sim.set_chassis_manufacturer(Some("Acme".to_string()));
 
         let err = sim

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -451,6 +451,8 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                     .map_err(|err| redact_password(err, curr_password.as_str()))
                     .map_err(RedfishClientCreationError::RedfishError)?;
             }
+            // Sushy is a development emulator without an AccountService.
+            RedfishVendor::Sushy => {}
             RedfishVendor::Unknown => {
                 // Defensive guard: callers resolve the vendor via
                 // `probe_bmc_vendor` (or site-explorer's `get_redfish_vendor`),

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -36,6 +36,7 @@ use libredfish::model::storage::Drives;
 use libredfish::model::task::Task;
 use libredfish::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
 use libredfish::model::{ODataId, ODataLinks};
+use libredfish::standard::RedfishStandard;
 use libredfish::{
     Assembly, Chassis, Collection, EnabledDisabled, JobState, ManagerResetType, NetworkAdapter,
     PowerState, Redfish, RedfishError, Resource, SystemPowerControl,
@@ -647,6 +648,10 @@ impl RedfishSimClient {
 }
 
 impl Redfish for RedfishSimClient {
+    fn std_redfish(&self) -> &RedfishStandard {
+        panic!("RedfishSimClient must implement Redfish operations directly")
+    }
+
     fn get_power_state<'a>(
         &'a self,
     ) -> libredfish::RedfishFuture<'a, Result<libredfish::PowerState, RedfishError>> {


### PR DESCRIPTION
This PR bumps libredfish to `v0.47.1` which brings in the following changes:

- feat: network transport mtls support by @yoks in https://github.com/NVIDIA/libredfish/pull/131
- refactor: delegate Redfish defaults to RedfishStandard by @poroh in https://github.com/NVIDIA/libredfish/pull/132
- feat: add Sushy emulator vendor implementation by @fabiendupont in https://github.com/NVIDIA/libredfish/pull/115
- chore: add SECURITY.md by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/133
- fix: distinguish Supermicro and DGX GB300 BIOS behavior by @martinraumann in https://github.com/NVIDIA/libredfish/pull/129

## Related issues
https://github.com/NVIDIA/infra-controller/issues/5215

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
