### PR TITLE
perf(ci): combine API integration tests in one binary

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -14,6 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Keep the rack test in this executable so libtest can run it alongside `test_integration`.
+mod rack;
+
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::net::{Ipv4Addr, SocketAddr, TcpListener};

--- a/crates/api-integration-tests/tests/rack/mod.rs
+++ b/crates/api-integration-tests/tests/rack/mod.rs
@@ -37,11 +37,6 @@ use tokio_util::sync::CancellationToken;
 
 const UNDERLAY_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 20, 1, 1);
 
-#[ctor::ctor(unsafe)]
-fn setup() {
-    api_test_helper::setup_logging()
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_machine_a_tron_racks_integration() -> eyre::Result<()> {
     let Some(mut test_env) = IntegrationTestEnvironment::try_from_environment(


### PR DESCRIPTION
Combine API tests in one binary to run them in parallel. This reduces tests execution time by 140 seconds.

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

