### PR TITLE
Cherry-pick #3233 to release/v2.0

### DIFF
--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -916,7 +916,7 @@ async fn set_ib_link_up() -> Result<(), CarbideClientError> {
                     let slot = p.slot.unwrap();
                     // Set P1 (required - all IB devices have P1)
                     match cmdrun::run_prog(
-                        "mstconfig",
+                        "mlxconfig",
                         ["-y", "-d", &slot, "set", "KEEP_IB_LINK_UP_P1=1"],
                     )
                     .await
@@ -934,7 +934,7 @@ async fn set_ib_link_up() -> Result<(), CarbideClientError> {
                     }
                     // Set P2 (optional - only dual-port devices have P2)
                     match cmdrun::run_prog(
-                        "mstconfig",
+                        "mlxconfig",
                         ["-y", "-d", &slot, "set", "KEEP_IB_LINK_UP_P2=1"],
                     )
                     .await
@@ -978,7 +978,7 @@ async fn reset_ib_devices() -> Result<(), CarbideClientError> {
             for ib in ibs {
                 if let Some(p) = ib.pci_properties {
                     let slot = p.slot.unwrap();
-                    match cmdrun::run_prog("mstconfig", ["-y", "-d", &slot, "reset"]).await {
+                    match cmdrun::run_prog("mlxconfig", ["-y", "-d", &slot, "reset"]).await {
                         Ok(_) => {
                             tracing::info!("reset IB device {} successfully.", slot);
                         }


### PR DESCRIPTION
## Proposal

Should release/v2.0 take the fix from #3233?

#3233 is already present on main and release/v2.1, but not on release/v2.0. This backport makes the same three mstconfig to mlxconfig substitutions in Scout IB reset and configuration paths for #4102.

@hasayesh, should this fix be included in v2.0? If v2.0 is closed to patches, this proposal can be closed without merging.

## Validation

- cargo fmt --all -- --check passed.
- cargo test -p carbide-scout --lib --locked compiled successfully in the official Linux build container and exited 0.
- The crate contains no library tests, so validation was compile-only.
- Behavioral verification on a CX7 host completing discovery remains outstanding.

## Older release policy question

release/v0.11.0 and release/v0.10.0 are also unpatched. Whether either release should receive the same fix is a separate policy decision and is not included in this proposal.