### PR TITLE
feat(health): report NMX-C health for NVLink domains

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -205,6 +205,23 @@ api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
 workers = 2
 skip_empty_reports = true
 
+# Optional. Default: disabled.
+# Requires [collectors.nmxc] and a primary switch-host endpoint with NMX-C
+# enabled and an NVLink domain UUID. Submits supported NMX-C DomainStateInfo
+# controller health states for that domain. Healthy clears the
+# NmxControllerHealth probe. Unhealthy and UnhealthyDbCorrupted raise an alert.
+# Degraded, Unknown, and notifications that fail status or identity validation
+# do not generate a report.
+# Configuration validation rejects enabling this sink with
+# [collectors.nmxc.schema_override].
+[sinks.nvlink_domain_health_report]
+enabled = false
+# NICo API connection settings. The values below are the defaults.
+root_ca = "/var/run/secrets/spiffe.io/ca.crt"
+client_cert = "/var/run/secrets/spiffe.io/tls.crt"
+client_key = "/var/run/secrets/spiffe.io/tls.key"
+api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
+
 [sinks.power_shelf_health_report]
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
@@ -365,8 +382,8 @@ exclude_services = ["Journal"]
 # when switch discovery metadata says NMX-C is enabled for that switch.
 # FabricManager (NMX-C) must be running there. Without [tls.switch],
 # current switch endpoints use plaintext gRPC over HTTP/2 on 9370.
-# NMX-C notifications currently emit log events only; metrics and health reports
-# are separate scope.
+# NMX-C notifications emit log events. DomainStateInfo can also produce NVLink
+# domain health reports when [sinks.nvlink_domain_health_report] is enabled.
 [collectors.nmxc]
 # Enable the NMX-C streaming collector for eligible primary switch-host endpoints.
 enabled = false
@@ -406,7 +423,8 @@ max_backoff = "30s"
 #
 # Enabling the override requires at least one [[sinks.otlp.targets]] entry. The
 # descriptor and request are loaded at startup; changes require a carbide-health
-# restart.
+# restart. Configuration validation rejects enabling the override with
+# [sinks.nvlink_domain_health_report].
 #
 # [collectors.nmxc.schema_override]
 #

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -138,6 +138,33 @@ impl ApiClientWrapper {
         Ok(())
     }
 
+    /// Replaces one source's NVLink domain report using merge semantics.
+    ///
+    /// A success for a probe clears an alert from the same report source and
+    /// probe identifier.
+    pub async fn submit_nvlink_domain_health_report(
+        &self,
+        domain_id: &NvLinkDomainId,
+        report: health_report::HealthReport,
+    ) -> Result<(), HealthError> {
+        let ovrd = rpc::forge::HealthReportEntry {
+            report: Some(report.into()),
+            mode: rpc::forge::HealthReportApplyMode::Merge.into(),
+        };
+
+        let request = rpc::forge::InsertNvLinkDomainHealthReportRequest {
+            domain_id: Some(*domain_id),
+            health_report_entry: Some(ovrd),
+        };
+
+        self.client
+            .insert_nv_link_domain_health_report(request)
+            .await
+            .map_err(HealthError::ApiInvocationError)?;
+
+        Ok(())
+    }
+
     pub async fn submit_power_shelf_health_report(
         &self,
         power_shelf_id: &carbide_uuid::power_shelf::PowerShelfId,

--- a/crates/health/src/collectors/nmxc.rs
+++ b/crates/health/src/collectors/nmxc.rs
@@ -611,12 +611,11 @@ fn notification_name(notification: &Notification) -> &'static str {
     }
 }
 
-/// Emits `DomainStateInfo` as a log-only event until metric and report semantics are defined.
+/// Emits `DomainStateInfo` as a structured log event.
 fn domain_state_info_to_events(info: &DomainStateInfo) -> Vec<Result<CollectorEvent, HealthError>> {
-    // DomainStateInfo is the periodic NMX-C health signal, but this PR only
-    // routes NMX-C payloads through log-oriented sinks. Keep the complete
-    // notification as structured log attributes until metric/report semantics
-    // are designed separately.
+    // The complete payload remains available to log sinks. When domain health
+    // reporting is enabled, the event processor derives a domain report from
+    // the structured health and server-header attributes.
     vec![Ok(notification_to_log(&Notification::DomainStateInfo(
         info.clone(),
     )))]

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -473,6 +473,12 @@ pub struct SinksConfig {
     #[serde(alias = "switch_health_override")]
     pub switch_health_report: Configurable<SwitchHealthReportSinkConfig>,
 
+    /// Sends generated NMX-C domain health reports to the NICo API.
+    ///
+    /// This sink is disabled by default and cannot be combined with the NMX-C
+    /// schema override collector.
+    pub nvlink_domain_health_report: Configurable<NvLinkDomainHealthReportSinkConfig>,
+
     /// Power shelf health report sink: sends power-shelf-level health reports to the NICo API.
     #[serde(alias = "power_shelf_health_override")]
     pub power_shelf_health_report: Configurable<PowerShelfHealthReportSinkConfig>,
@@ -492,6 +498,7 @@ impl Default for SinksConfig {
             health_report: Configurable::Enabled(HealthReportSinkConfig::default()),
             rack_health_report: Configurable::Enabled(RackHealthReportSinkConfig::default()),
             switch_health_report: Configurable::Enabled(SwitchHealthReportSinkConfig::default()),
+            nvlink_domain_health_report: Configurable::Disabled,
             power_shelf_health_report: Configurable::Enabled(
                 PowerShelfHealthReportSinkConfig::default(),
             ),
@@ -884,6 +891,15 @@ impl Default for SwitchHealthReportSinkConfig {
             skip_empty_reports: true,
         }
     }
+}
+
+/// Configuration for ordered NVLink domain health report submission.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NvLinkDomainHealthReportSinkConfig {
+    /// NICo API connection used to submit NVLink domain health reports.
+    #[serde(flatten)]
+    pub connection: CarbideApiConnectionConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2202,6 +2218,14 @@ impl Config {
                     "collectors.nmxc.schema_override requires at least one OTLP target".to_string(),
                 );
             }
+
+            if nmxc.schema_override.is_some() && self.sinks.nvlink_domain_health_report.is_enabled()
+            {
+                return Err(
+                    "sinks.nvlink_domain_health_report is not supported with collectors.nmxc.schema_override"
+                        .to_string(),
+                );
+            }
         }
 
         if let Configurable::Enabled(reachability) = &self.collectors.reachability {
@@ -3017,6 +3041,31 @@ username = "root"
                 }) => FailsWith(
                     "[collectors.nmxc].grpc_port must be greater than 0".to_string()
                 ),
+
+                config_with(|config| {
+                    config.collectors.nmxc = Configurable::Enabled(NmxcCollectorConfig {
+                        schema_override: Some(NmxcSchemaOverrideConfig {
+                            descriptor_set_path: PathBuf::from("nmx_c.desc"),
+                            hello_rpc_path: default_nmxc_hello_rpc_path(),
+                            subscribe_rpc_path: default_nmxc_subscribe_rpc_path(),
+                            max_frame_size_bytes: DEFAULT_NMX_C_MAX_FRAME_SIZE_BYTES,
+                            subscribe_fields: Default::default(),
+                        }),
+                        ..NmxcCollectorConfig::default()
+                    });
+
+                    config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
+                        targets: vec![otlp_target("http://localhost:4317")],
+                    });
+
+                    config.sinks.nvlink_domain_health_report = Configurable::Enabled(
+                        NvLinkDomainHealthReportSinkConfig::default(),
+                    );
+
+                }) => FailsWith(
+                    "sinks.nvlink_domain_health_report is not supported with collectors.nmxc.schema_override"
+                        .to_string()
+                ),
             }
 
             "GPU inventory" {
@@ -3648,6 +3697,28 @@ reload_interval = "30s"
             .extract::<Config>();
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn nvlink_domain_health_report_sink_is_opt_in() {
+        assert!(matches!(
+            SinksConfig::default().nvlink_domain_health_report,
+            Configurable::Disabled
+        ));
+
+        let config: Config = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Toml::string(
+                r#"
+[sinks.nvlink_domain_health_report]
+"#,
+            ))
+            .extract()
+            .expect("NVLink domain health report sink config should parse");
+
+        let Configurable::Enabled(_) = config.sinks.nvlink_domain_health_report else {
+            panic!("NVLink domain health report sink should be enabled");
+        };
     }
 
     #[test]

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -282,6 +282,9 @@ pub struct DiscoveryLoopContext {
     /// Whether any enabled sink consumes `CollectorEvent::Log` payloads.
     pub(crate) log_event_sink_enabled: bool,
 
+    /// Whether NMX-C domain health reports have an enabled consumer.
+    pub(crate) nvlink_domain_health_report_sink_enabled: bool,
+
     /// Active reachability configuration.
     ///
     /// This is absent when the collector is disabled or no metric or log sink
@@ -373,6 +376,10 @@ impl DiscoveryLoopContext {
             tls_config,
             tls_http_client_provider,
             log_event_sink_enabled: config.sinks.includes_log_events(),
+            nvlink_domain_health_report_sink_enabled: config
+                .sinks
+                .nvlink_domain_health_report
+                .is_enabled(),
             reachability_config,
             gpu_inventory_config: config.collectors.gpu_inventory.clone(),
             api_client: match &config.endpoint_sources.carbide_api {

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -132,11 +132,10 @@ pub(super) fn collector_eligibility(
 
     let nvue = ctx.nvue_config.as_option();
 
-    // NMX-C emits log events, so spawning requires both a
-    // log-capable configured sink and the constructed sink pipeline.
+    // NMX-C starts only when an enabled sink consumes its logs or domain reports.
     let nmxc = ctx.nmxc_config.is_enabled()
         && switch_supports_nmxc_subscription(endpoint)
-        && ctx.log_event_sink_enabled
+        && (ctx.log_event_sink_enabled || ctx.nvlink_domain_health_report_sink_enabled)
         && data_sink_present;
 
     CollectorEligibility {
@@ -753,11 +752,11 @@ fn spawn_switch_host_collectors(
         && !ctx.collectors.contains(CollectorKind::Nmxc, &key)
         && switch_supports_nmxc_subscription(endpoint)
     {
-        if !ctx.log_event_sink_enabled {
+        if !ctx.log_event_sink_enabled && !ctx.nvlink_domain_health_report_sink_enabled {
             tracing::warn!(
                 endpoint_key = %key,
                 rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
-                "NMX-C streaming collector requires an enabled tracing, log_file, or OTLP sink, skipping"
+                "NMX-C streaming collector requires an enabled log or NVLink domain health report sink, skipping"
             );
         } else if let Some(data_sink) = data_sink.clone() {
             let collector_registry = Arc::new(
@@ -904,7 +903,8 @@ mod tests {
     use crate::collectors::DowngradeReason;
     use crate::config::{
         AutoModeConfig, CarbideApiConnectionConfig, Config, Configurable, LogsCollectorConfig,
-        NvueCollectorConfig, NvueGnmiConfig, PeriodicLogConfig, TracingSinkConfig,
+        NvLinkDomainHealthReportSinkConfig, NvueCollectorConfig, NvueGnmiConfig, PeriodicLogConfig,
+        TracingSinkConfig,
     };
     use crate::endpoint::test_support::endpoint_with_creds;
     use crate::endpoint::{
@@ -1180,6 +1180,36 @@ mod tests {
             &endpoint,
             Some(Arc::new(NoopSink)),
             "test_switch_host_nmxc_enabled",
+        )
+        .expect("spawn should succeed");
+
+        assert_eq!(ctx.collectors.len(CollectorKind::Nmxc), 1);
+    }
+
+    #[tokio::test]
+    async fn test_switch_host_starts_nmxc_for_domain_health_report_sink() {
+        let mut config = nmxc_only_config(false);
+        config.sinks.nvlink_domain_health_report =
+            Configurable::Enabled(NvLinkDomainHealthReportSinkConfig::default());
+
+        let mut ctx = context_with_config(config, "test_switch_host_nmxc_domain_health");
+
+        let endpoint = test_endpoint(
+            Ipv4Addr::new(10, 0, 0, 17),
+            "55:66:77:88:99:f4",
+            Some(switch_metadata_with_role(
+                SwitchEndpointRole::Host,
+                true,
+                false,
+                "switch-host",
+            )),
+        );
+
+        spawn_collectors_for_endpoint(
+            &mut ctx,
+            &endpoint,
+            Some(Arc::new(NoopSink)),
+            "test_switch_host_nmxc_domain_health",
         )
         .expect("spawn should succeed");
 

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -51,14 +51,14 @@ use crate::limiter::{BucketLimiter, NoopLimiter, RateLimiter};
 use crate::metrics::{BmcLatencyMetrics, MetricsManager, run_metrics_server};
 use crate::processor::{
     BmcIntrusionEventProcessor, EventProcessingPipeline, EventProcessor, HealthReportProcessor,
-    LeakEventProcessor, RackLeakProcessor,
+    LeakEventProcessor, NmxcDomainStateProcessor, RackLeakProcessor,
 };
 use crate::sharding::ShardManager;
 use crate::sink::event_mapper::{OpenBmcEventMapper, RedfishEventMapper};
 use crate::sink::{
-    CompositeDataSink, DataSink, HealthReportSink, LogFileSink, OtlpSink,
-    PowerShelfHealthReportSink, PrometheusSink, RackHealthReportSink, SwitchHealthReportSink,
-    TracingSink,
+    CompositeDataSink, DataSink, HealthReportSink, LogFileSink, NvLinkDomainHealthReportSink,
+    OtlpSink, PowerShelfHealthReportSink, PrometheusSink, RackHealthReportSink,
+    SwitchHealthReportSink, TracingSink,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -249,6 +249,10 @@ fn build_data_sink(
         processors.push(Arc::new(BmcIntrusionEventProcessor::new()));
     }
 
+    if config.sinks.nvlink_domain_health_report.is_enabled() {
+        processors.push(Arc::new(NmxcDomainStateProcessor::new()));
+    }
+
     if let Configurable::Enabled(ref leak_detection_cfg) = config.processors.leak_detection {
         processors.push(Arc::new(LeakEventProcessor::new(
             leak_detection_cfg.minimum_alerts_per_report,
@@ -277,6 +281,10 @@ fn build_data_sink(
 
     if let Configurable::Enabled(ref sink_cfg) = config.sinks.switch_health_report {
         sinks.push(Arc::new(SwitchHealthReportSink::new(sink_cfg)?));
+    }
+
+    if let Configurable::Enabled(ref sink_cfg) = config.sinks.nvlink_domain_health_report {
+        sinks.push(Arc::new(NvLinkDomainHealthReportSink::new(sink_cfg)?));
     }
 
     if let Configurable::Enabled(ref sink_cfg) = config.sinks.power_shelf_health_report {

--- a/crates/health/src/processor/mod.rs
+++ b/crates/health/src/processor/mod.rs
@@ -23,10 +23,12 @@ use std::time::Instant;
 mod health_report;
 mod intrusion_events;
 mod leak_events;
+mod nmxc_domain_state;
 mod rack_leak;
 pub use health_report::HealthReportProcessor;
 pub use intrusion_events::BmcIntrusionEventProcessor;
 pub use leak_events::LeakEventProcessor;
+pub use nmxc_domain_state::NmxcDomainStateProcessor;
 pub use rack_leak::RackLeakProcessor;
 
 use crate::HealthError;

--- a/crates/health/src/processor/nmxc_domain_state.rs
+++ b/crates/health/src/processor/nmxc_domain_state.rs
@@ -1,0 +1,255 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use carbide_uuid::nvlink::NvLinkDomainId;
+use rpc::protos::nmx_c::NmxControllerHealth;
+
+use super::{CollectorEvent, EventContext, EventProcessor};
+use crate::sink::{
+    HealthReport, HealthReportAlert, HealthReportSuccess, HealthReportTarget, LogRecord, Probe,
+    ReportSource,
+};
+
+const DOMAIN_STATE_NOTIFICATION: &str = "domain_state_info";
+const SUCCESS_RETURN_CODE: &str = "NMX_ST_SUCCESS";
+
+/// Derives NVLink domain health reports from generated NMX-C log events.
+#[derive(Default)]
+pub struct NmxcDomainStateProcessor;
+
+impl NmxcDomainStateProcessor {
+    /// Creates a processor that derives NVLink domain reports from NMX-C state logs.
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn attr<'a>(record: &'a LogRecord, key: &str) -> Option<&'a str> {
+        record
+            .attributes
+            .iter()
+            .find(|(name, _)| name.as_ref() == key)
+            .map(|(_, value)| value.as_str())
+    }
+
+    fn report(context: &EventContext, record: &LogRecord) -> Option<HealthReport> {
+        if context.collector_type != "nmxc"
+            || Self::attr(record, "notification") != Some(DOMAIN_STATE_NOTIFICATION)
+            || Self::attr(record, "return_code") != Some(SUCCESS_RETURN_CODE)
+        {
+            return None;
+        }
+
+        let expected_domain_id = context.nvlink_domain_uuid()?;
+
+        let reported_domain_id = Self::attr(record, "domain_uuid")?
+            .parse::<NvLinkDomainId>()
+            .ok()?;
+
+        if reported_domain_id != expected_domain_id {
+            tracing::warn!(
+                %expected_domain_id,
+                %reported_domain_id,
+                "NMX-C domain state does not match endpoint metadata"
+            );
+
+            return None;
+        }
+
+        let health =
+            NmxControllerHealth::from_str_name(Self::attr(record, "nmx_controller_health")?)?;
+
+        let (successes, alerts) = match health {
+            NmxControllerHealth::Healthy => (
+                vec![HealthReportSuccess {
+                    probe_id: Probe::NmxControllerHealth,
+                    target: None,
+                }],
+                Vec::new(),
+            ),
+            NmxControllerHealth::Unhealthy | NmxControllerHealth::UnhealthyDbCorrupted => (
+                Vec::new(),
+                vec![HealthReportAlert {
+                    probe_id: Probe::NmxControllerHealth,
+                    target: None,
+                    message: format!("NMX-C controller health is {}", health.as_str_name()),
+                    classifications: Vec::new(),
+                }],
+            ),
+            NmxControllerHealth::Unknown | NmxControllerHealth::Degraded => return None,
+        };
+
+        Some(HealthReport {
+            source: ReportSource::NmxcDomainState,
+            target: Some(HealthReportTarget::NvLinkDomain),
+            observed_at: Some(chrono::Utc::now()),
+            successes,
+            alerts,
+        })
+    }
+}
+
+impl EventProcessor for NmxcDomainStateProcessor {
+    fn processor_type(&self) -> &'static str {
+        "nmxc_domain_state_processor"
+    }
+
+    fn process_event(&self, context: &EventContext, event: &CollectorEvent) -> Vec<CollectorEvent> {
+        let CollectorEvent::Log(record) = event else {
+            return Vec::new();
+        };
+
+        Self::report(context, record)
+            .map(|report| vec![CollectorEvent::HealthReport(Arc::new(report))])
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
+
+    use carbide_test_support::value_scenarios;
+    use mac_address::MacAddress;
+
+    use super::*;
+    use crate::endpoint::{BmcAddr, EndpointMetadata, SwitchData, SwitchEndpointRole};
+    use crate::sink::LogSeverity;
+
+    const DOMAIN_UUID: &str = "9f4b45ec-705a-4af4-89f7-a112bc9c8f4e";
+
+    fn context() -> EventContext {
+        EventContext {
+            endpoint_key: "00:11:22:33:44:55".to_string(),
+            addr: BmcAddr {
+                ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+                port: None,
+                mac: MacAddress::from_str("00:11:22:33:44:55").expect("valid MAC address"),
+            },
+            collector_type: "nmxc",
+            metadata: Some(EndpointMetadata::Switch(SwitchData {
+                id: None,
+                serial: "SW-001".to_string(),
+                slot_number: None,
+                tray_index: None,
+                nvlink_domain_uuid: Some(DOMAIN_UUID.parse().expect("valid domain ID")),
+                endpoint_role: SwitchEndpointRole::Host,
+                is_primary: true,
+                nmxc_enabled: true,
+                nmxt_enabled: false,
+            })),
+            rack_id: None,
+            labels: Default::default(),
+        }
+    }
+
+    fn log(health: NmxControllerHealth) -> CollectorEvent {
+        CollectorEvent::Log(Box::new(LogRecord {
+            body: "NMX-C domain state".to_string(),
+            severity: LogSeverity::Info,
+            attributes: vec![
+                (
+                    Cow::Borrowed("notification"),
+                    DOMAIN_STATE_NOTIFICATION.to_string(),
+                ),
+                (
+                    Cow::Borrowed("return_code"),
+                    SUCCESS_RETURN_CODE.to_string(),
+                ),
+                (Cow::Borrowed("domain_uuid"), DOMAIN_UUID.to_string()),
+                (
+                    Cow::Borrowed("nmx_controller_health"),
+                    health.as_str_name().to_string(),
+                ),
+            ],
+            diagnostic_record: None,
+        }))
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum ResultSummary {
+        Alert,
+        None,
+        Success,
+    }
+
+    fn summary(health: NmxControllerHealth) -> ResultSummary {
+        let events = NmxcDomainStateProcessor::new().process_event(&context(), &log(health));
+
+        let Some(CollectorEvent::HealthReport(report)) = events.first() else {
+            return ResultSummary::None;
+        };
+
+        if report.alerts.is_empty() {
+            ResultSummary::Success
+        } else {
+            ResultSummary::Alert
+        }
+    }
+
+    #[test]
+    fn controller_health_maps_to_domain_reports() {
+        value_scenarios!(
+            run = summary;
+
+            "healthy clears" {
+                NmxControllerHealth::Healthy => ResultSummary::Success,
+            }
+
+            "unhealthy alerts" {
+                NmxControllerHealth::Unhealthy => ResultSummary::Alert,
+            }
+
+            "database corruption alerts" {
+                NmxControllerHealth::UnhealthyDbCorrupted => ResultSummary::Alert,
+            }
+
+            "degraded remains log only" {
+                NmxControllerHealth::Degraded => ResultSummary::None,
+            }
+
+            "unknown remains log only" {
+                NmxControllerHealth::Unknown => ResultSummary::None,
+            }
+        );
+    }
+
+    #[test]
+    fn mismatched_domain_is_not_reported() {
+        let mut context = context();
+
+        let EndpointMetadata::Switch(switch) = context.metadata.as_mut().expect("switch metadata")
+        else {
+            panic!("expected switch metadata");
+        };
+
+        switch.nvlink_domain_uuid = Some(
+            "00000000-0000-0000-0000-000000000001"
+                .parse()
+                .expect("valid domain ID"),
+        );
+
+        assert!(
+            NmxcDomainStateProcessor::new()
+                .process_event(&context, &log(NmxControllerHealth::Unhealthy))
+                .is_empty()
+        );
+    }
+}

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -37,6 +37,10 @@ use crate::metrics::MetricLabel;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, carbide_instrument::LabelValue)]
 pub enum HealthReportTarget {
     Machine,
+
+    /// NVLink domain identified by the event context.
+    NvLinkDomain,
+
     PowerShelf,
     Rack,
     Switch,
@@ -46,6 +50,7 @@ impl HealthReportTarget {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Machine => "machine",
+            Self::NvLinkDomain => "nvlink-domain",
             Self::PowerShelf => "power-shelf",
             Self::Rack => "rack",
             Self::Switch => "switch",
@@ -456,6 +461,10 @@ pub enum ReportSource {
     BmcSensors,
     BmcEvents,
     BmcLeakDetectors,
+
+    /// NMX-C `DomainStateInfo` health observations.
+    NmxcDomainState,
+
     TrayLeakDetection,
     RackLeakDetection,
     NvueLeakage,
@@ -468,6 +477,7 @@ impl ReportSource {
             Self::BmcSensors => "bmc-sensors",
             Self::BmcEvents => "bmc-events",
             Self::BmcLeakDetectors => "bmc-leak-detectors",
+            Self::NmxcDomainState => "nmxc-domain-state",
             Self::TrayLeakDetection => "tray-leak-detection",
             Self::RackLeakDetection => "rack-leak-detection",
             Self::NvueLeakage => "nvue-leakage",
@@ -481,6 +491,10 @@ pub enum Probe {
     Sensor,
     IntrusionSensorTriggered,
     LeakDetection,
+
+    /// Health state reported by the NMX-C controller.
+    NmxControllerHealth,
+
     NvueLeakage,
     GpuInventory,
 }
@@ -491,6 +505,7 @@ impl Probe {
             Self::Sensor => "BmcSensor",
             Self::IntrusionSensorTriggered => "IntrusionSensorTriggered",
             Self::LeakDetection => "BmcLeakDetection",
+            Self::NmxControllerHealth => "NmxControllerHealth",
             Self::NvueLeakage => "NvueLeakage",
             // Reuse the existing shared "SkuValidation" probe id so OOB GPU-count
             // alerts dedup with the machine-controller's in-band SKU alerts.
@@ -915,6 +930,10 @@ mod tests {
                 ReportSource::BmcLeakDetectors => "bmc-leak-detectors",
             }
 
+            "NMX-C domain state" {
+                ReportSource::NmxcDomainState => "nmxc-domain-state",
+            }
+
             "tray leak detection" {
                 ReportSource::TrayLeakDetection => "tray-leak-detection",
             }
@@ -939,6 +958,10 @@ mod tests {
             run = HealthReportTarget::as_str;
             "machine" {
                 HealthReportTarget::Machine => "machine",
+            }
+
+            "NVLink domain" {
+                HealthReportTarget::NvLinkDomain => "nvlink-domain",
             }
 
             "power shelf" {
@@ -983,6 +1006,13 @@ mod tests {
                 Probe::LeakDetection => ProbeSummary {
                     as_str: "BmcLeakDetection",
                     health_report_id: "BmcLeakDetection".to_string(),
+                },
+            }
+
+            "NMX-C controller health" {
+                Probe::NmxControllerHealth => ProbeSummary {
+                    as_str: "NmxControllerHealth",
+                    health_report_id: "NmxControllerHealth".to_string(),
                 },
             }
 

--- a/crates/health/src/sink/mod.rs
+++ b/crates/health/src/sink/mod.rs
@@ -24,6 +24,7 @@ pub mod event_mapper;
 mod events;
 mod health_report;
 mod log_file;
+mod nvlink_domain_health_report;
 pub(crate) mod otlp;
 mod power_shelf_health_report;
 mod prometheus;
@@ -39,6 +40,7 @@ pub use events::{
 };
 pub use health_report::HealthReportSink;
 pub use log_file::LogFileSink;
+pub use nvlink_domain_health_report::NvLinkDomainHealthReportSink;
 pub use power_shelf_health_report::PowerShelfHealthReportSink;
 pub use prometheus::PrometheusSink;
 pub use rack_health_report::RackHealthReportSink;
@@ -96,7 +98,8 @@ pub(crate) struct HealthReportSubmitted {
     pub target: HealthReportTarget,
     #[label]
     pub outcome: carbide_instrument::Outcome,
-    /// The machine, rack, switch, or power shelf the report describes.
+
+    /// The machine, NVLink domain, rack, switch, or power shelf the report describes.
     #[context]
     pub id: String,
     #[context]

--- a/crates/health/src/sink/nvlink_domain_health_report.rs
+++ b/crates/health/src/sink/nvlink_domain_health_report.rs
@@ -1,0 +1,276 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Ordered submission of NVLink domain health reports to the NICo API.
+//!
+//! The queue retains the latest pending report for each domain and source. A
+//! single worker prevents an older alert submission from completing after its
+//! recovery and restoring stale health state.
+
+use std::sync::Arc;
+
+use carbide_instrument::{Outcome, emit};
+use carbide_uuid::nvlink::NvLinkDomainId;
+use tokio_util::sync::CancellationToken;
+
+use super::dedup_queue::DedupQueue;
+use super::{
+    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportSubmitted,
+    HealthReportTarget, ReportSource,
+};
+use crate::HealthError;
+use crate::api_client::ApiClientWrapper;
+use crate::config::NvLinkDomainHealthReportSinkConfig;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct NvLinkDomainHealthReportKey {
+    id: NvLinkDomainId,
+    source: ReportSource,
+}
+
+/// Submits `NvLinkDomain`-target health reports to the NICo API.
+pub struct NvLinkDomainHealthReportSink {
+    queue: Arc<DedupQueue<NvLinkDomainHealthReportKey, Arc<HealthReport>>>,
+    cancel_token: CancellationToken,
+}
+
+impl NvLinkDomainHealthReportSink {
+    /// Creates the sink and its ordered submission worker.
+    ///
+    /// Returns an error when called without an active Tokio runtime.
+    pub fn new(config: &NvLinkDomainHealthReportSinkConfig) -> Result<Self, HealthError> {
+        let handle = tokio::runtime::Handle::try_current().map_err(|error| {
+            HealthError::GenericError(format!(
+                "NVLink domain health report sink requires active Tokio runtime: {error}"
+            ))
+        })?;
+
+        let client = ApiClientWrapper::new(
+            config.connection.root_ca.clone(),
+            config.connection.client_cert.clone(),
+            config.connection.client_key.clone(),
+            &config.connection.api_url,
+        );
+
+        let queue: Arc<DedupQueue<NvLinkDomainHealthReportKey, Arc<HealthReport>>> =
+            Arc::new(DedupQueue::new());
+
+        let cancel_token = CancellationToken::new();
+        let worker_cancel_token = cancel_token.clone();
+        let worker_queue = Arc::clone(&queue);
+
+        // A single worker preserves alert and recovery order for each domain.
+        // Its cancellation token bounds the worker lifetime to the sink.
+        handle.spawn(async move {
+            loop {
+                let Some((key, report)) = worker_cancel_token
+                    .run_until_cancelled(worker_queue.next())
+                    .await
+                else {
+                    return;
+                };
+
+                match report.as_ref().try_into() {
+                    Ok(converted) => {
+                        let Some(result) = worker_cancel_token
+                            .run_until_cancelled(
+                                client.submit_nvlink_domain_health_report(&key.id, converted),
+                            )
+                            .await
+                        else {
+                            return;
+                        };
+
+                        emit(HealthReportSubmitted {
+                            target: HealthReportTarget::NvLinkDomain,
+                            outcome: Outcome::from(&result),
+                            id: key.id.to_string(),
+                            worker_id: 0,
+                            error: result
+                                .err()
+                                .map(|error| error.to_string())
+                                .unwrap_or_default(),
+                        });
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            ?error,
+                            nvlink_domain_id = %key.id,
+                            "Failed to convert NVLink domain health report"
+                        );
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            queue,
+            cancel_token,
+        })
+    }
+}
+
+impl Drop for NvLinkDomainHealthReportSink {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
+    }
+}
+
+impl DataSink for NvLinkDomainHealthReportSink {
+    fn sink_type(&self) -> &'static str {
+        "nvlink_domain_health_report_sink"
+    }
+
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
+        let CollectorEvent::HealthReport(report) = event else {
+            return Ok(());
+        };
+
+        if report.target != Some(HealthReportTarget::NvLinkDomain) {
+            return Ok(());
+        }
+
+        let Some(domain_id) = context.nvlink_domain_uuid() else {
+            tracing::warn!(
+                endpoint_key = context.endpoint_key(),
+                "Received NVLink-domain-target HealthReport event without domain context"
+            );
+
+            return Err(HealthError::GenericError(
+                "NVLink-domain-target health report event without domain context".to_string(),
+            ));
+        };
+
+        let key = NvLinkDomainHealthReportKey {
+            id: domain_id,
+            source: report.source,
+        };
+
+        self.queue.save_latest(key, Arc::clone(report));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    use mac_address::MacAddress;
+
+    use super::*;
+    use crate::endpoint::{BmcAddr, EndpointMetadata, SwitchData, SwitchEndpointRole};
+    use crate::sink::{HealthReportAlert, HealthReportSuccess, Probe};
+
+    #[test]
+    fn queued_recovery_replaces_alert_for_the_same_domain_source() {
+        let domain_id = NvLinkDomainId::from_str("9f4b45ec-705a-4af4-89f7-a112bc9c8f4e")
+            .expect("valid NVLink domain ID");
+
+        let queue = Arc::new(DedupQueue::new());
+
+        let sink = NvLinkDomainHealthReportSink {
+            queue: Arc::clone(&queue),
+            cancel_token: CancellationToken::new(),
+        };
+
+        let context = EventContext {
+            endpoint_key: "00:11:22:33:44:55".to_string(),
+            addr: BmcAddr {
+                ip: IpAddr::from_str("10.0.0.1").expect("valid IP address"),
+                port: Some(443),
+                mac: MacAddress::from_str("00:11:22:33:44:55").expect("valid MAC address"),
+            },
+            collector_type: "nmxc",
+            metadata: Some(EndpointMetadata::Switch(SwitchData {
+                id: None,
+                serial: "SW-001".to_string(),
+                slot_number: None,
+                tray_index: None,
+                nvlink_domain_uuid: Some(domain_id),
+                endpoint_role: SwitchEndpointRole::Host,
+                is_primary: true,
+                nmxc_enabled: true,
+                nmxt_enabled: false,
+            })),
+            rack_id: None,
+            labels: Default::default(),
+        };
+
+        let alert = CollectorEvent::HealthReport(Arc::new(HealthReport {
+            source: ReportSource::NmxcDomainState,
+            target: Some(HealthReportTarget::NvLinkDomain),
+            observed_at: None,
+            successes: Vec::new(),
+            alerts: vec![HealthReportAlert {
+                probe_id: Probe::NmxControllerHealth,
+                target: None,
+                message: "NMX-C controller health is degraded".to_string(),
+                classifications: Vec::new(),
+            }],
+        }));
+
+        let recovery = CollectorEvent::HealthReport(Arc::new(HealthReport {
+            source: ReportSource::NmxcDomainState,
+            target: Some(HealthReportTarget::NvLinkDomain),
+            observed_at: None,
+            successes: vec![HealthReportSuccess {
+                probe_id: Probe::NmxControllerHealth,
+                target: None,
+            }],
+            alerts: Vec::new(),
+        }));
+
+        sink.try_handle_event(&context, &alert)
+            .expect("alert should be queued");
+
+        sink.try_handle_event(&context, &recovery)
+            .expect("recovery should be queued");
+
+        let (key, report) = queue.pop().expect("latest report should remain queued");
+
+        assert_eq!(key.id, domain_id);
+        assert_eq!(key.source, ReportSource::NmxcDomainState);
+        assert!(report.alerts.is_empty());
+        assert_eq!(report.successes.len(), 1);
+        assert!(queue.pop().is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_sink_releases_submission_worker_queue() {
+        let sink = NvLinkDomainHealthReportSink::new(&Default::default())
+            .expect("sink should start inside a Tokio runtime");
+
+        let queue = Arc::downgrade(&sink.queue);
+
+        drop(sink);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while queue.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("submission worker should release its queue after sink shutdown");
+    }
+}

--- a/docs/architecture/health/health_probe_ids.md
+++ b/docs/architecture/health/health_probe_ids.md
@@ -1,7 +1,7 @@
 # Health probe IDs
 
-This page provides a list of health probes provided by NVIDIA Infra Controller (NICo), along with their IDs.
-Health reports will contain these IDs in the `alerts` section in case the associated check or validation has failed.
+NICo health reports identify each check with a stable probe ID. Failed checks
+appear in `alerts`; successful checks can appear in `successes`.
 
 ## Machine validation health probe identifiers
 
@@ -76,6 +76,14 @@ Example:
 ```text
 power_supply 'PSU0_OutputPower': Critical - reading 1320.00W (power), valid range: 0.0 to 1500.0, caution: 1200.0 to 1300.0, critical: 0.0 to 1310.0
 ```
+
+## NVLink domain health probe identifiers
+
+### `NmxControllerHealth`
+
+Indicates that NMX-C reported `Unhealthy` or `UnhealthyDbCorrupted` controller
+health for an NVLink domain. A `Healthy` report clears the probe. `Degraded` and
+`Unknown` do not generate a domain health report.
 
 ## DPU related health probe identifiers
 

--- a/docs/architecture/health_aggregation.md
+++ b/docs/architecture/health_aggregation.md
@@ -336,10 +336,10 @@ Additional fields may be present besides the minimum ones listed below.
 | `health_report.alert_count` | `int_value` (signed 64-bit) | Always | Number of alerts in the report, including any omitted from `health_report.alerts`, bounded to `0..=i64::MAX`. |
 | `health_report.observed_at` | string | Optional | Observation time as RFC 3339 UTC with nanosecond precision, for example `2026-07-31T12:34:56.000000000Z`. Omitted when the report carries no observation time. |
 | `health_report.schema_version` | string | Always | `v1` for the contract documented here. |
-| `health_report.source` | string | Always | The collector that assessed the report: `bmc-sensors`, `bmc-events`, `bmc-leak-detectors`, `tray-leak-detection`, `rack-leak-detection`, `nvue-leakage`, or `gpu-inventory`. |
+| `health_report.source` | string | Always | The collector that assessed the report: `bmc-sensors`, `bmc-events`, `bmc-leak-detectors`, `nmxc-domain-state`, `tray-leak-detection`, `rack-leak-detection`, `nvue-leakage`, or `gpu-inventory`. |
 | `health_report.success_count` | `int_value` (signed 64-bit) | Always | Number of entries in `health_report.successes`, bounded to `0..=i64::MAX`. |
 | `health_report.successes` | array of `kvlist` | Always | One entry per succeeded probe, empty when the report has none. |
-| `health_report.target` | string | Optional | The kind of inventory object assessed: `machine`, `power-shelf`, `rack`, or `switch`. Omitted when the report names no target. |
+| `health_report.target` | string | Optional | The kind of inventory object assessed: `machine`, `nvlink-domain`, `power-shelf`, `rack`, or `switch`. Omitted when the report names no target. |
 
 `health_report.success_count` equals the length of `health_report.successes`
 while that length is representable as `i64`, and otherwise saturates at
@@ -352,7 +352,7 @@ Every `health_report.successes` entry carries at least these fields:
 
 | Field | OTLP type | Presence | Value |
 | --------- | --------- | -------- | ----- |
-| `probe_id` | string | Always | The probe that ran: `BmcSensor`, `IntrusionSensorTriggered`, `BmcLeakDetection`, `NvueLeakage`, or `SkuValidation`. See [Health probe IDs](health/health_probe_ids.md) for the shared probe-ID catalogue. |
+| `probe_id` | string | Always | The probe that ran. See [Health probe IDs](health/health_probe_ids.md) for the supported IDs. |
 | `target` | string | Optional | The probed component, such as a sensor or leak-detector ID. Omitted when the probe ID fully describes what was tested. |
 
 When `health_report.alerts` is present, every JSON object carries the same

--- a/docs/operations/monitoring-health.md
+++ b/docs/operations/monitoring-health.md
@@ -33,6 +33,7 @@ alerts from a reporting source. Common health sources are:
 | DPU agent | DPU service health, DPU networking health, BGP state, DHCP service health, and agent heartbeat. |
 | Validation and discovery | SKU validation, host validation, endpoint discovery, and inventory checks. |
 | Rack health | Rack-level health input when rack health reporting is configured. |
+| NVLink domain health | NMX-C controller health for an NVLink domain when domain health reporting is configured. |
 | Health overrides | Manual or service-created health reports used for maintenance, repair, validation, or other controlled workflows. |
 
 Each alert has an ID, an optional target, a message, a start time, and one or
@@ -175,8 +176,13 @@ switch config has NMX-C enabled; it does not use BMC or NICo API TLS material.
 For static switch-host endpoints, `switch.nmxc_enabled` controls this target
 eligibility after the `endpoint_role = "host"` and `is_primary = true` checks;
 it defaults to `switch.is_primary` when omitted.
-NMX-C notifications emit log events for tracing, log-file, and OTLP
-log sinks only; Prometheus metrics and switch health reports are separate scope.
+NMX-C notifications emit log events for tracing, log-file, and OTLP log sinks.
+With `[collectors.nmxc]` and `[sinks.nvlink_domain_health_report]` enabled,
+supported `DomainStateInfo` controller health states also produce NVLink domain
+health reports. Both settings are disabled by default. Configuration validation
+rejects enabling the sink with `[collectors.nmxc.schema_override]`. See
+[NVLink Domain Health Reports](./nvlink-domain-health-reports.md) for state
+mapping, identity checks, report persistence, and configuration behavior.
 
 NMX-C collection uses plaintext gRPC over HTTP/2. TLS, certificate
 bypass, custom certificate loading, and mTLS are intentionally separate scope; do not model them with the NICo API SPIFFE certificate fields.

--- a/docs/operations/nvlink-domain-health-reports.md
+++ b/docs/operations/nvlink-domain-health-reports.md
@@ -1,7 +1,7 @@
 # NVLink Domain Health Reports (Day 2)
 
 Operator guide for managing **NVLink domain health reports**: health information
-submitted by external tools or operators against an NVLink domain.
+submitted by services, tools, or operators against an NVLink domain.
 
 Each report is keyed by a **source** identifier. Multiple merge-mode sources
 coexist and contribute to the domain's aggregate health. A replace-mode source
@@ -27,11 +27,47 @@ Background: [Health Aggregation](../architecture/health_aggregation.md) and
 ## Report sources
 
 A **report source** is the identifier of the system or user that submitted a
-report (the `HealthReport::source` field, for example, `overrides.sre-team`). Keeping
-each external system or operator on a distinct source lets their merge-mode
-reports coexist. Submitting a report with an existing source replaces that
-source's prior report. `show` lists sources and modes applied to a domain;
-`remove` deletes one source's report.
+report (the `HealthReport::source` field, for example,
+`overrides.sre-team`). Keeping each reporting system or operator on a distinct
+source lets their merge-mode reports coexist. Submitting a report with an
+existing source replaces that source's prior report. `show` lists sources and
+modes applied to a domain; `remove` deletes one source's report.
+
+With `[collectors.nmxc]` and `[sinks.nvlink_domain_health_report]` enabled, the
+hardware health service submits supported NMX-C controller health states under the
+merge-mode source `hardware-health.nmxc-domain-state`. Both settings are
+disabled by default. Collection starts only for primary switch-host endpoints
+with NMX-C enabled in discovery metadata and an NVLink domain UUID.
+
+The reported domain UUID must be valid and match the endpoint's NVLink domain
+metadata. The NMX-C server header must report success. Notifications that fail
+validation do not generate a domain health report. Configured log sinks still
+receive the original NMX-C notification.
+
+Controller health states map to reports as follows:
+
+| NMX-C state | Report behavior |
+|---|---|
+| `Healthy` | Clears the `NmxControllerHealth` probe. |
+| `Unhealthy` | Raises a `NmxControllerHealth` alert. |
+| `UnhealthyDbCorrupted` | Raises a `NmxControllerHealth` alert. |
+| `Degraded` or `Unknown` | Emits a log but does not generate a domain health report. |
+
+NMX-C controller health alerts carry the `Hardware` classification and do not
+add `PreventAllocations`.
+
+Configuration validation rejects enabling
+`[sinks.nvlink_domain_health_report]` with
+`[collectors.nmxc.schema_override]`. The sink uses the configured NICo API
+connection fields: `root_ca`, `client_cert`, `client_key`, and `api_url`.
+Configuration is loaded when the hardware health service starts. Restart the
+service to apply changes.
+
+Stream loss does not remove the stored `hardware-health.nmxc-domain-state`
+report. The latest report remains until a later `Healthy`, `Unhealthy`, or
+`UnhealthyDbCorrupted` notification replaces it or an operator removes the
+source. A later notification in one of these states can recreate a source that
+an operator removed while collection remains active.
 
 ## CLI commands
 


### PR DESCRIPTION
Add optional NVLink domain health reporting from NMX-C `DomainStateInfo` notifications. Successful responses with a domain UUID matching endpoint metadata produce merge-mode reports: `Healthy` clears the `NmxControllerHealth` probe, while `Unhealthy` and `UnhealthyDbCorrupted` raise alerts. `Degraded` and `Unknown` remain log-only.

Example:

<img width="3075" height="858" alt="image" src="https://github.com/user-attachments/assets/28420905-ea58-40a4-b124-02f38ffd10c3" />

## Related issues

Supports #4398

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)