### PR TITLE
fix(flow): raise Core gRPC receive limit

### DIFF
--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -57,6 +57,11 @@ const (
 	// zero Core value means the server is unlimited, not that Flow should build
 	// one unbounded response.
 	flowFindByIDsBatchSize = 100
+
+	// coreGRPCMaxRecvMsgSize raises the Go gRPC 4 MiB default for Core responses.
+	// Core's expected-inventory RPCs return complete snapshots in one response,
+	// which can exceed that default for larger sites.
+	coreGRPCMaxRecvMsgSize = 32 * 1024 * 1024
 )
 
 type grpcClient struct {
@@ -171,6 +176,14 @@ func (c *batchingForgeClient) visitPowerShelfBatches(
 
 var testingMsgOnce sync.Once
 
+func coreGRPCDialOptions(transportCredentials credentials.TransportCredentials) []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithTransportCredentials(transportCredentials),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(coreGRPCMaxRecvMsgSize)),
+		grpc.WithChainUnaryInterceptor(grpclog.UnaryClientInterceptor("nico-core-api")),
+	}
+}
+
 // NewClient creates a GRPC connection pool to nico-core-api.  Returning success does not mean that we have yet made an actual connection;
 // that happens when making an actual request.
 func NewClient(grpcTimeout time.Duration) (Client, error) {
@@ -194,11 +207,7 @@ func NewClient(grpcTimeout time.Duration) (Client, error) {
 		return nil, err
 	}
 
-	conn, err := grpc.NewClient(
-		nicoURL,
-		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-		grpc.WithChainUnaryInterceptor(grpclog.UnaryClientInterceptor("nico-core-api")),
-	)
+	conn, err := grpc.NewClient(nicoURL, coreGRPCDialOptions(credentials.NewTLS(tlsConfig))...)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to connect to nico-core-api: %w", err)
 	}

--- a/rest-api/flow/internal/nicoapi/grpc_transport_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_transport_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nicoapi
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const (
+	testGRPCBufferSize          = 1 << 20
+	testExpectedMachineCount    = 65
+	testMachineDescriptionBytes = 64 * 1024
+)
+
+type expectedMachineForgeServer struct {
+	corev1.UnimplementedForgeServer
+	response *corev1.ExpectedMachineList
+}
+
+func (s *expectedMachineForgeServer) GetAllExpectedMachines(
+	context.Context,
+	*emptypb.Empty,
+) (*corev1.ExpectedMachineList, error) {
+	return s.response, nil
+}
+
+func TestCoreGRPCDialOptionsReceiveExpectedInventory(t *testing.T) {
+	response := &corev1.ExpectedMachineList{
+		ExpectedMachines: make([]*corev1.ExpectedMachine, 0, testExpectedMachineCount),
+	}
+	for range testExpectedMachineCount {
+		response.ExpectedMachines = append(response.ExpectedMachines, &corev1.ExpectedMachine{
+			Metadata: &corev1.Metadata{
+				Description: strings.Repeat("a", testMachineDescriptionBytes),
+			},
+		})
+	}
+
+	responseSize := proto.Size(response)
+	require.Greater(t, responseSize, 4*1024*1024)
+	require.Less(t, responseSize, coreGRPCMaxRecvMsgSize)
+
+	listener := bufconn.Listen(testGRPCBufferSize)
+	server := grpc.NewServer()
+	corev1.RegisterForgeServer(server, &expectedMachineForgeServer{response: response})
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+		require.NoError(t, listener.Close())
+	})
+
+	dialer := grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	})
+	tests := map[string]struct {
+		dialOptions []grpc.DialOption
+		wantCode    codes.Code
+		wantCount   int
+	}{
+		"gRPC default rejects response over 4 MiB": {
+			dialOptions: []grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				dialer,
+			},
+			wantCode: codes.ResourceExhausted,
+		},
+		"Flow accepts response under 32 MiB": {
+			dialOptions: append(coreGRPCDialOptions(insecure.NewCredentials()), dialer),
+			wantCode:    codes.OK,
+			wantCount:   testExpectedMachineCount,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			connection, err := grpc.NewClient("passthrough:///core", test.dialOptions...)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, connection.Close())
+			})
+
+			result, err := corev1.NewForgeClient(connection).GetAllExpectedMachines(t.Context(), &emptypb.Empty{})
+			assert.Equal(t, test.wantCode, status.Code(err))
+			if test.wantCode != codes.OK {
+				assert.Nil(t, result)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, result.GetExpectedMachines(), test.wantCount)
+		})
+	}
+}


### PR DESCRIPTION
Flow's Core client currently uses grpc-go's default 4 MiB receive limit. Core's expected machine, rack, switch, and power-shelf RPCs each return a complete collection in one unary response, so a larger site can exceed that limit. The RPC then fails with `ResourceExhausted`, and Flow cannot refresh that resource type.

This change sets a 32 MiB receive ceiling on Flow's Core client, matching the existing site-workflow setting. The limit applies to every Core response received through this client and allocates memory only as a response is received. A transport-level test proves that the old default rejects an expected-inventory response over 4 MiB while the Flow client accepts the complete response.

## Related issues

- Related to #4355

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

This is a short-term guard rather than the complete resolution of #4355. The issue remains open to define a bounded pagination or streaming contract for expected inventory above 32 MiB. Because the current RPCs are unary, an oversized or otherwise failed response is returned as an error and is not applied as a partial snapshot.
 
