### PR TITLE
patch(v0.10): switch Scout from mstconfig to mlxconfig for CX7 compatibility

### DIFF
--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -894,7 +894,7 @@ async fn set_ib_link_up() -> Result<(), CarbideClientError> {
                     let slot = p.slot.unwrap();
                     // Set P1 (required - all IB devices have P1)
                     match cmdrun::run_prog(
-                        "mstconfig",
+                        "mlxconfig",
                         ["-y", "-d", &slot, "set", "KEEP_IB_LINK_UP_P1=1"],
                     )
                     .await
@@ -912,7 +912,7 @@ async fn set_ib_link_up() -> Result<(), CarbideClientError> {
                     }
                     // Set P2 (optional - only dual-port devices have P2)
                     match cmdrun::run_prog(
-                        "mstconfig",
+                        "mlxconfig",
                         ["-y", "-d", &slot, "set", "KEEP_IB_LINK_UP_P2=1"],
                     )
                     .await
@@ -956,7 +956,7 @@ async fn reset_ib_devices() -> Result<(), CarbideClientError> {
             for ib in ibs {
                 if let Some(p) = ib.pci_properties {
                     let slot = p.slot.unwrap();
-                    match cmdrun::run_prog("mstconfig", ["-y", "-d", &slot, "reset"]).await {
+                    match cmdrun::run_prog("mlxconfig", ["-y", "-d", &slot, "reset"]).await {
                         Ok(_) => {
                             tracing::info!("reset IB device {} successfully.", slot);
                         }


### PR DESCRIPTION
## Summary

Backports the Scout IB configuration fix from #3233 to the v0.10.x release line.

#4102 was reported on v0.10.8. The fix is already present on main and release/v2.1, and is proposed for release/v2.0 in #5434, while release/v0.10.0 still uses mstconfig. This change makes the same three mstconfig to mlxconfig substitutions in the Scout IB reset and configuration paths.

@hasayesh, please review this v0.10 backport.

## Validation

- cargo fmt --all -- --check passed.
- cargo test -p carbide-scout --locked passed in the official Linux build container: 29 passed, 0 failed.
- Existing tests do not exercise the changed IB command path.
- Behavioral verification on a CX7 host completing discovery remains outstanding.

release/v0.11.0 is not included in this backport.