### PR TITLE
fix(agent,tests): avoid global logger initialization in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,6 @@ dependencies = [
  "colored",
  "config-version",
  "containerd-client",
- "ctor",
  "data-encoding",
  "diff",
  "eyre",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -140,7 +140,6 @@ tonic-prost-build = { workspace = true }
 [dev-dependencies]
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
-ctor = { workspace = true }
 rcgen = { workspace = true }
 prost = { workspace = true }
 rustls-pki-types = { workspace = true }

--- a/crates/agent/src/astra_weave.rs
+++ b/crates/agent/src/astra_weave.rs
@@ -1181,11 +1181,6 @@ mod tests {
     use crate::weave_ew_vpc_client::proto::state::Phase as WeaveEwVpcPhase;
     use crate::weave_ew_vpc_client::proto::{self, State};
 
-    #[ctor::ctor(unsafe)]
-    fn setup() {
-        carbide_host_support::init_logging("nico-dpu-agent").unwrap();
-    }
-
     #[derive(Default)]
     struct RecordedWeaveEwVpcCalls {
         list_virtual_networks: usize,

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -1864,11 +1864,6 @@ mod tests {
         InterfaceState, ServiceAddresses, needed_interface_state,
     };
     use crate::{HBNDeviceNames, dhcp, nvue};
-    #[ctor::ctor(unsafe)]
-    fn setup() {
-        carbide_host_support::init_logging("nico-dpu-agent").unwrap();
-    }
-
     #[test]
     fn test_parse_managed_host_loopback_ips() {
         use carbide_test_support::Outcome::*;

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -294,8 +294,6 @@ async fn run_common_parts(
     virtualization_type: VpcVirtualizationType,
     test_metadata_service: bool,
 ) -> eyre::Result<TestOut> {
-    carbide_host_support::init_logging("nico-dpu-agent")?;
-
     let state: Arc<Mutex<State>> = Arc::new(Mutex::new(Default::default()));
     state.lock().await.virtualization_type = virtualization_type;
 

--- a/crates/agent/src/tests/test_network_monitor.rs
+++ b/crates/agent/src/tests/test_network_monitor.rs
@@ -52,8 +52,6 @@ struct State {
 
 #[tokio::test]
 async fn test_network_monitor() -> eyre::Result<()> {
-    carbide_host_support::init_logging("nico-dpu-agent")?;
-
     let state: Arc<Mutex<State>> = Arc::new(Mutex::new(Default::default()));
 
     // Start carbide API

--- a/crates/agent/src/tests/upgrade.rs
+++ b/crates/agent/src/tests/upgrade.rs
@@ -29,8 +29,6 @@ const ROOT_CERT_PATH: &str = "dev/certs/forge_developer_local_only_root_cert_pem
 
 #[tokio::test]
 async fn test_upgrade_check() -> eyre::Result<()> {
-    carbide_host_support::init_logging("nico-dpu-agent")?;
-
     // SAFETY: Initial lint enablement: these test settings are installed before the
     // upgrade begins, but the parallel test harness may already have other threads.
     // Unix process-wide exclusion from environment readers is not proven; this needs


### PR DESCRIPTION
Do not initialize the production logger in `carbide-agent` tests. Its stdout writer bypasses libtest capture and adds expected INFO, WARN, and ERROR events to successful CI output. Production logging is unchanged.

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
