### PR TITLE
fix(health): propagate rack IDs to collector outputs

### DIFF
--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -413,6 +413,7 @@ impl ApiEndpointSource {
                     Err(error) => tracing::warn!(
                         ?machine,
                         ?error,
+                        rack_id = machine.rack_id.as_ref().map(tracing::field::display),
                         "Could not add machine endpoint due to error"
                     ),
                 }
@@ -438,6 +439,7 @@ impl ApiEndpointSource {
                         Err(error) => tracing::warn!(
                             ?switch,
                             ?error,
+                            rack_id = switch.rack_id.as_ref().map(tracing::field::display),
                             "Could not add switch endpoint due to error"
                         ),
                     }
@@ -448,6 +450,7 @@ impl ApiEndpointSource {
                         Err(error) => tracing::warn!(
                             ?switch,
                             ?error,
+                            rack_id = switch.rack_id.as_ref().map(tracing::field::display),
                             "Could not add switch host endpoint due to error"
                         ),
                     }
@@ -482,6 +485,7 @@ impl ApiEndpointSource {
                         Err(error) => tracing::warn!(
                             ?power_shelf,
                             ?error,
+                            rack_id = power_shelf.rack_id.as_ref().map(tracing::field::display),
                             "Could not add power shelf endpoint due to error"
                         ),
                     }
@@ -611,7 +615,7 @@ impl ApiEndpointSource {
                 id: power_shelf.id,
                 serial,
             })),
-            None,
+            power_shelf.rack_id.clone(),
             ApiCredentialKind::Bmc,
         )
     }
@@ -935,6 +939,46 @@ mod tests {
                 switch.nvlink_domain_uuid
             },
         );
+    }
+
+    #[test]
+    fn power_shelf_endpoint_preserves_api_rack_id()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let api_url = Url::parse("https://127.0.0.1:1079")?;
+
+        let source = ApiEndpointSource::new(
+            Arc::new(ApiClientWrapper::new(
+                "test-ca.pem".to_string(),
+                "test-client.pem".to_string(),
+                "test-client-key.pem".to_string(),
+                &api_url,
+            )),
+            reqwest(),
+            None,
+            10,
+            None,
+        );
+
+        let rack_id = RackId::new("RACK_1");
+
+        let endpoint = source.extract_power_shelf_endpoint(&rpc::forge::PowerShelf {
+            config: Some(rpc::forge::PowerShelfConfig {
+                name: "power-shelf-a".to_string(),
+                ..Default::default()
+            }),
+            bmc_info: Some(rpc::forge::BmcInfo {
+                ip: Some("10.0.0.1".to_string()),
+                mac: Some(test_mac().to_string()),
+                port: Some(443),
+                ..Default::default()
+            }),
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        })?;
+
+        assert_eq!(endpoint.rack_id.as_ref(), Some(&rack_id));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/health/src/collectors/discovery.rs
+++ b/crates/health/src/collectors/discovery.rs
@@ -76,6 +76,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for EntityDiscoveryCollector<B> {
 
         tracing::info!(
             bmc = %self.endpoint.addr.mac,
+            rack_id = self.endpoint.rack_id.as_ref().map(tracing::field::display),
             entity_count,
             generation = self.generation,
             "Published entity inventory snapshot"
@@ -113,6 +114,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
                     ?error,
                     context,
                     bmc_address = ?self.endpoint.addr,
+                    rack_id = self.endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Discovery fetch failed"
                 );
                 None
@@ -349,6 +351,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
                 tracing::warn!(
                     ?error,
                     bmc_address = ?self.endpoint.addr,
+                    rack_id = self.endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Failed to get chassis sensors"
                 );
                 Vec::new()

--- a/crates/health/src/collectors/entity_metrics.rs
+++ b/crates/health/src/collectors/entity_metrics.rs
@@ -802,6 +802,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for MetricsCollector<B> {
         let Some(inventory) = self.shared.load_full() else {
             tracing::debug!(
                 bmc_address = ?self.endpoint.addr,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "No entity inventory available yet; skipping metrics iteration"
             );
             return Ok(IterationResult {
@@ -813,6 +814,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for MetricsCollector<B> {
 
         tracing::debug!(
             bmc_address = ?self.endpoint.addr,
+            rack_id = self.event_context.rack_id().map(tracing::field::display),
             generation = inventory.generation,
             inventory_age_seconds = inventory.discovered_at.elapsed().as_secs(),
             entity_count = inventory.entities.len(),
@@ -967,6 +969,7 @@ impl<B: Bmc + 'static> MetricsCollector<B> {
                     ?error,
                     context,
                     bmc_address = ?self.endpoint.addr,
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "Failed to fetch metrics resource"
                 );
                 None

--- a/crates/health/src/collectors/firmware.rs
+++ b/crates/health/src/collectors/firmware.rs
@@ -91,6 +91,7 @@ impl<B: Bmc + 'static> FirmwareCollector<B> {
             let Some(version) = firmware_data.version.clone().flatten() else {
                 tracing::debug!(
                     firmware_id = %firmware_data.base.id,
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "Skipping firmware with no version"
                 );
                 continue;

--- a/crates/health/src/collectors/gpu_inventory.rs
+++ b/crates/health/src/collectors/gpu_inventory.rs
@@ -178,6 +178,7 @@ impl<B: Bmc + 'static> GpuInventoryCollector<B> {
         tracing::warn!(
             bmc_mac_address = %self.endpoint.addr.mac,
             reason = %message,
+            rack_id = self.event_context.rack_id().map(tracing::field::display),
             "GPU inventory alert"
         );
         let report = HealthReport {
@@ -311,6 +312,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for GpuInventoryCollector<B> {
         let Some(actual) = self.count_gpus() else {
             tracing::debug!(
                 bmc_mac_address = %self.endpoint.addr.mac,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "Entity inventory not ready yet; skipping GPU inventory iteration"
             );
             return Ok(IterationResult {
@@ -326,6 +328,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for GpuInventoryCollector<B> {
                 bmc_mac_address = %self.endpoint.addr.mac,
                 expected_gpu_count = expected_count,
                 actual_gpu_count = actual,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "GPU count below SKU expectation"
             );
         }

--- a/crates/health/src/collectors/leak_detector.rs
+++ b/crates/health/src/collectors/leak_detector.rs
@@ -110,6 +110,7 @@ where
                 Ok(detector_ids) => {
                     tracing::info!(
                         detector_count = detector_ids.len(),
+                        rack_id = self.event_context.rack_id().map(tracing::field::display),
                         "Leak detector discovery complete"
                     );
                     self.state = Some(LeakDetectorCollectorState {
@@ -119,7 +120,12 @@ where
                     refresh_triggered = true;
                 }
                 Err(error) => {
-                    tracing::error!(?error, "Failed to discover leak detectors");
+                    tracing::error!(
+                        ?error,
+                        rack_id = self.event_context.rack_id().map(tracing::field::display),
+                        "Failed to discover leak detectors"
+                    );
+
                     if self.state.is_none() {
                         return Err(error);
                     }
@@ -218,6 +224,7 @@ fn build_health_report(detectors: Vec<Arc<LeakDetector>>, context: &EventContext
                 detector = %target,
                 leak_detector_state = ?detector.detector_state.flatten(),
                 leak_detector_resource_state = ?resource_state,
+                rack_id = context.rack_id().map(tracing::field::display),
                 "Leak detector resource state does not permit leak classification"
             );
             continue;
@@ -238,6 +245,7 @@ fn build_health_report(detectors: Vec<Arc<LeakDetector>>, context: &EventContext
                 tracing::warn!(
                     detector = %target,
                     leak_detector_state = ?detector.detector_state.flatten(),
+                    rack_id = context.rack_id().map(tracing::field::display),
                     "Leak detector is not reporting an actionable leak state"
                 );
             }

--- a/crates/health/src/collectors/logs/downgrade.rs
+++ b/crates/health/src/collectors/logs/downgrade.rs
@@ -18,6 +18,7 @@
 use std::borrow::Cow;
 use std::time::Instant;
 
+use carbide_uuid::rack::RackId;
 use dashmap::DashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,8 +56,16 @@ impl LogDowngradeRegistry {
         self.downgraded.contains_key(key)
     }
 
-    // first call for a key inserts + warns; subsequent calls are no-ops
-    pub fn mark_downgraded(&self, key: Cow<'static, str>, reason: DowngradeReason) {
+    /// Records the first downgrade for `key` and emits one warning.
+    ///
+    /// The warning includes `rack_id` when the endpoint has a rack identity.
+    /// Later calls for the same `key` do not change the recorded downgrade.
+    pub fn mark_downgraded(
+        &self,
+        key: Cow<'static, str>,
+        rack_id: Option<&RackId>,
+        reason: DowngradeReason,
+    ) {
         use dashmap::Entry;
         match self.downgraded.entry(key.clone()) {
             Entry::Vacant(slot) => {
@@ -66,6 +75,7 @@ impl LogDowngradeRegistry {
                 });
                 tracing::warn!(
                     endpoint_key = %key,
+                    rack_id = rack_id.map(tracing::field::display),
                     reason = reason.as_label(),
                     "SSE log collector downgraded to periodic polling; restart the \
                      health service to retry SSE once the underlying issue is resolved"
@@ -100,7 +110,12 @@ mod tests {
     #[test]
     fn test_mark_downgraded_records_key_and_reason() {
         let registry = LogDowngradeRegistry::new();
-        registry.mark_downgraded(Cow::Borrowed("bmc-1"), DowngradeReason::SseNotAvailable);
+
+        registry.mark_downgraded(
+            Cow::Borrowed("bmc-1"),
+            None,
+            DowngradeReason::SseNotAvailable,
+        );
 
         assert!(registry.is_downgraded("bmc-1"));
         assert_eq!(registry.len(), 1);
@@ -113,7 +128,13 @@ mod tests {
     #[test]
     fn test_mark_downgraded_is_idempotent_for_same_key() {
         let registry = LogDowngradeRegistry::new();
-        registry.mark_downgraded(Cow::Borrowed("bmc-1"), DowngradeReason::SseNotAvailable);
+
+        registry.mark_downgraded(
+            Cow::Borrowed("bmc-1"),
+            None,
+            DowngradeReason::SseNotAvailable,
+        );
+
         let first = registry
             .event_for("bmc-1")
             .expect("first mark should record");
@@ -122,6 +143,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(2));
         registry.mark_downgraded(
             Cow::Borrowed("bmc-1"),
+            None,
             DowngradeReason::ConnectFailureBudgetExhausted,
         );
         let second = registry
@@ -136,9 +158,16 @@ mod tests {
     #[test]
     fn test_mark_downgraded_tracks_multiple_endpoints_independently() {
         let registry = LogDowngradeRegistry::new();
-        registry.mark_downgraded(Cow::Borrowed("bmc-1"), DowngradeReason::SseNotAvailable);
+
+        registry.mark_downgraded(
+            Cow::Borrowed("bmc-1"),
+            None,
+            DowngradeReason::SseNotAvailable,
+        );
+
         registry.mark_downgraded(
             Cow::Borrowed("bmc-2"),
+            None,
             DowngradeReason::ConnectFailureBudgetExhausted,
         );
 

--- a/crates/health/src/collectors/logs/periodic.rs
+++ b/crates/health/src/collectors/logs/periodic.rs
@@ -208,6 +208,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
         tracing::info!(
             service_count = services.len(),
             excluded_service_count = excluded_count,
+            rack_id = self.event_context.rack_id().map(tracing::field::display),
             "Discovered distinct log services"
         );
 
@@ -224,11 +225,16 @@ impl<B: Bmc + 'static> LogsCollector<B> {
         let mut refresh_triggered = false;
 
         if needs_refresh {
-            tracing::info!("Refreshing log services for BMC");
+            tracing::info!(
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
+                "Refreshing log services for BMC"
+            );
+
             match self.discover_log_services().await {
                 Ok(services) => {
                     tracing::info!(
                         service_count = services.len(),
+                        rack_id = self.event_context.rack_id().map(tracing::field::display),
                         "Log service discovery complete"
                     );
 
@@ -242,7 +248,12 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                     refresh_triggered = true;
                 }
                 Err(e) => {
-                    tracing::error!(error=?e, "Failed to discover log services");
+                    tracing::error!(
+                        error = ?e,
+                        rack_id = self.event_context.rack_id().map(tracing::field::display),
+                        "Failed to discover log services"
+                    );
+
                     if self.state.is_none() {
                         return Err(e);
                     }
@@ -290,6 +301,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                             tracing::debug!(
                                 %service_id,
                                 ?error,
+                                rack_id = self.event_context.rack_id().map(tracing::field::display),
                                 "Failed to fetch filtered log entries, fetching all"
                             );
                             // Fallback - if filter is not supported properly
@@ -301,6 +313,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                                     tracing::warn!(
                                         %service_id,
                                         ?error,
+                                        rack_id = self.event_context.rack_id().map(tracing::field::display),
                                         "Failed to fetch log entries"
                                     );
                                     continue;
@@ -333,6 +346,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                             tracing::warn!(
                                 %service_id,
                                 ?error,
+                                rack_id = self.event_context.rack_id().map(tracing::field::display),
                                 "Failed to fetch log entries"
                             );
                             continue;
@@ -359,6 +373,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                         tracing::info!(
                             %service_id,
                             anchor_id,
+                            rack_id = self.event_context.rack_id().map(tracing::field::display),
                             "skip_initial_history: anchored at current log position, \
                              skipping historical entries"
                         );
@@ -368,6 +383,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                     tracing::info!(
                         %service_id,
                         endpoint=?self.endpoint.addr,
+                        rack_id = self.event_context.rack_id().map(tracing::field::display),
                         "Last seen id is empty, fetching all entries"
                     );
                     all_entries

--- a/crates/health/src/collectors/nvue/gnmi/client.rs
+++ b/crates/health/src/collectors/nvue/gnmi/client.rs
@@ -17,6 +17,7 @@
 
 use std::time::Duration;
 
+use carbide_uuid::rack::RackId;
 use tokio_stream::StreamExt;
 use tonic::metadata::MetadataMap;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
@@ -132,6 +133,7 @@ pub(super) fn nvue_subscribe_paths(paths_config: &NvueGnmiPaths) -> Vec<Path> {
 #[derive(Clone)]
 pub(super) struct GnmiClient {
     switch_id: String,
+    rack_id: Option<RackId>,
     host: String,
     port: u16,
     username: Option<String>,
@@ -145,6 +147,9 @@ pub(super) struct GnmiClient {
 pub(super) struct GnmiClientConfig {
     /// Switch identifier used in logs and error messages.
     pub switch_id: String,
+
+    /// Optional rack identifier added to endpoint-scoped logs.
+    pub rack_id: Option<RackId>,
 
     /// Switch host or IP address used for the gNMI channel.
     pub host: String,
@@ -204,6 +209,7 @@ impl GnmiClient {
     pub(super) fn new(config: GnmiClientConfig) -> Self {
         Self {
             switch_id: config.switch_id,
+            rack_id: config.rack_id,
             host: config.host,
             port: config.port,
             username: config.username,
@@ -250,12 +256,14 @@ impl GnmiClient {
             tracing::debug!(
                 switch_id = %self.switch_id,
                 target = %target,
+                rack_id = self.rack_id.as_ref().map(tracing::field::display),
                 "gNMI TLS channel established with certificate verification disabled"
             );
         } else {
             tracing::debug!(
                 switch_id = %self.switch_id,
                 target = %target,
+                rack_id = self.rack_id.as_ref().map(tracing::field::display),
                 "gNMI TLS channel established"
             );
         }
@@ -287,6 +295,7 @@ impl GnmiClient {
         tracing::debug!(
             switch_id = %self.switch_id,
             sample_interval_nanoseconds = sample_interval_nanos,
+            rack_id = self.rack_id.as_ref().map(tracing::field::display),
             "gNMI SAMPLE stream opened"
         );
 
@@ -316,6 +325,7 @@ impl GnmiClient {
 
         tracing::debug!(
             switch_id = %self.switch_id,
+            rack_id = self.rack_id.as_ref().map(tracing::field::display),
             "gNMI ON_CHANGE stream opened"
         );
 

--- a/crates/health/src/collectors/nvue/gnmi/on_change_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/on_change_processor.rs
@@ -122,6 +122,7 @@ impl GnmiOnChangeProcessor {
                     grpc_status_code = e.code,
                     error = %e.message,
                     stream = %self.collector_name,
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "nvue_gnmi ON_CHANGE: server error in stream"
                 );
                 return;
@@ -258,6 +259,7 @@ impl GnmiOnChangeProcessor {
             instance_id,
             severity,
             text,
+            rack_id = self.event_context.rack_id().map(tracing::field::display),
             "nvue_gnmi ON_CHANGE: row received"
         );
 

--- a/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use carbide_utils::none_if_empty::NoneIfEmpty;
+use carbide_uuid::rack::RackId;
 
 use super::client::{typed_value_to_f64, typed_value_to_string};
 use super::proto::{self, PathElem};
@@ -50,6 +51,7 @@ impl GnmiSampleProcessor {
                 tracing::warn!(
                     grpc_status_code = e.code,
                     error = %e.message,
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "nvue_gnmi SAMPLE: server error in stream"
                 );
                 return;
@@ -135,7 +137,9 @@ impl GnmiSampleProcessor {
         } else if let Some(metric_type) = numeric_interface_leaf(elems) {
             match typed_value_to_f64(val) {
                 Some(v) => self.emit_iface(metric_type.name, iface_name, v, metric_type.unit),
-                None => debug_unmapped_value(elems, val, metric_type.name),
+                None => {
+                    debug_unmapped_value(elems, val, metric_type.name, self.event_context.rack_id())
+                }
             }
         } else if leaf_matches(elems, &["infiniband", "state", "physical-port-state"]) {
             let current = physical_port_to_state(typed_value_to_string(val).as_deref());
@@ -158,17 +162,32 @@ impl GnmiSampleProcessor {
         } else if leaf_matches(elems, &["infiniband", "state", "speed"]) {
             match link_speed_to_gbps(typed_value_to_string(val).as_deref()) {
                 Some(v) => self.emit_iface("interface_link_speed_active", iface_name, v, "gbps"),
-                None => debug_unmapped_value(elems, val, "interface_link_speed_active"),
+                None => debug_unmapped_value(
+                    elems,
+                    val,
+                    "interface_link_speed_active",
+                    self.event_context.rack_id(),
+                ),
             }
         } else if leaf_matches(elems, &["infiniband", "state", "width"]) {
             match link_width_to_f64(typed_value_to_string(val).as_deref()) {
                 Some(v) => self.emit_iface("interface_link_width_active", iface_name, v, "lanes"),
-                None => debug_unmapped_value(elems, val, "interface_link_width_active"),
+                None => debug_unmapped_value(
+                    elems,
+                    val,
+                    "interface_link_width_active",
+                    self.event_context.rack_id(),
+                ),
             }
         } else if leaf_matches(elems, &["infiniband", "state", "supported-widths"]) {
             match link_width_to_f64(typed_value_to_string(val).as_deref()) {
                 Some(v) => self.emit_iface("interface_supported_width", iface_name, v, "lanes"),
-                None => debug_unmapped_value(elems, val, "interface_supported_width"),
+                None => debug_unmapped_value(
+                    elems,
+                    val,
+                    "interface_supported_width",
+                    self.event_context.rack_id(),
+                ),
             }
         } else if leaf_matches(elems, &["phy-diag", "state", "phy-manager-state"]) {
             let current = phy_manager_to_state(typed_value_to_string(val).as_deref());
@@ -390,7 +409,7 @@ impl GnmiSampleProcessor {
 
         match typed_value_to_f64(val) {
             Some(v) => self.emit_switch(metric_type, v, unit),
-            None => debug_unmapped_value(elems, val, metric_type),
+            None => debug_unmapped_value(elems, val, metric_type, self.event_context.rack_id()),
         }
     }
 
@@ -1011,11 +1030,17 @@ fn link_speed_to_gbps(speed: Option<&str>) -> Option<f64> {
 }
 
 /// Log when an interface leaf that matched a known mapping but value wasn't caught.
-fn debug_unmapped_value(elems: &[&PathElem], val: &proto::TypedValue, metric_type: &str) {
+fn debug_unmapped_value(
+    elems: &[&PathElem],
+    val: &proto::TypedValue,
+    metric_type: &str,
+    rack_id: Option<&RackId>,
+) {
     tracing::debug!(
         leaf = %leaf_path(elems),
         raw = ?typed_value_to_string(val),
         metric_type,
+        rack_id = rack_id.map(tracing::field::display),
         "nvue_gnmi SAMPLE: matched leaf but value coercion returned None; dropping"
     );
 }

--- a/crates/health/src/collectors/nvue/gnmi/subscriber.rs
+++ b/crates/health/src/collectors/nvue/gnmi/subscriber.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
+use carbide_uuid::rack::RackId;
 use prometheus::{Counter, Gauge, Histogram, HistogramOpts, IntGauge, Opts};
 use tokio::sync::OnceCell;
 use tokio_util::sync::CancellationToken;
@@ -36,7 +37,9 @@ use super::sample_processor::{GnmiSampleProcessor, NVUE_GNMI_SAMPLE_STREAM_ID, n
 use crate::HealthError;
 use crate::bmc::{CREDENTIAL_REFRESH_TIMEOUT, CredentialProvider};
 use crate::collectors::Collector;
-use crate::collectors::runtime::{BackoffConfig, ExponentialBackoff, StreamingConnectionGuard};
+use crate::collectors::runtime::{
+    BackoffConfig, ExponentialBackoff, StreamingConnectionGuard, collector_metric_labels,
+};
 use crate::config::{MtlsProfileConfig, NvueGnmiConfig};
 use crate::endpoint::{BmcAddr, BmcCredentials, BmcEndpoint};
 use crate::metrics::CollectorRegistry;
@@ -185,6 +188,7 @@ struct GnmiStreamConfig {
 #[derive(Clone)]
 struct GnmiClientProvider {
     switch_id: String,
+    rack_id: Option<RackId>,
     switch_connect_host: String,
     port: u16,
     request_timeout: Duration,
@@ -216,6 +220,7 @@ impl GnmiClientProvider {
         Ok((
             GnmiClient::new(GnmiClientConfig {
                 switch_id: self.switch_id.clone(),
+                rack_id: self.rack_id.clone(),
                 host: self.switch_connect_host.clone(),
                 port: self.port,
                 username: credentials.username,
@@ -236,6 +241,7 @@ impl GnmiClientProvider {
                 error = ?refresh_error,
                 original_error = ?error,
                 switch_id = %self.switch_id,
+                rack_id = self.rack_id.as_ref().map(tracing::field::display),
                 "Failed to refresh NVUE gNMI credentials after authentication error"
             );
         }
@@ -259,6 +265,7 @@ impl GnmiClientProvider {
                 error = ?refresh_error,
                 original_error = ?status,
                 switch_id = %self.switch_id,
+                rack_id = self.rack_id.as_ref().map(tracing::field::display),
                 "Failed to refresh NVUE gNMI credentials after authentication stream status"
             );
         }
@@ -467,6 +474,7 @@ pub(crate) fn spawn_gnmi_collector(
 
     let client_provider = GnmiClientProvider {
         switch_id: switch_id.clone(),
+        rack_id: endpoint.rack_id.clone(),
         switch_connect_host,
         port: gnmi_config.gnmi_port,
         request_timeout: gnmi_config.request_timeout,
@@ -483,13 +491,11 @@ pub(crate) fn spawn_gnmi_collector(
     let collector_removed_sample_context = sample_event_context.clone();
     let mut collector_removed_on_change_context = None;
 
-    let sample_const_labels = HashMap::from([
-        (
-            "collector_type".to_string(),
-            NVUE_GNMI_SAMPLE_STREAM_ID.to_string(),
-        ),
-        ("endpoint_key".to_string(), endpoint.hash_key().into_owned()),
-    ]);
+    let sample_const_labels = collector_metric_labels(
+        NVUE_GNMI_SAMPLE_STREAM_ID,
+        endpoint.hash_key().into_owned(),
+        endpoint,
+    );
 
     let sample_stream_metrics = GnmiStreamMetrics::new(registry, &prefix, "", sample_const_labels)?;
 
@@ -506,13 +512,11 @@ pub(crate) fn spawn_gnmi_collector(
     };
 
     let on_change_state = if gnmi_config.system_events_enabled {
-        let on_change_const_labels = HashMap::from([
-            (
-                "collector_type".to_string(),
-                ON_CHANGE_STREAM_ID_SYSTEM_EVENTS.to_string(),
-            ),
-            ("endpoint_key".to_string(), endpoint.hash_key().into_owned()),
-        ]);
+        let on_change_const_labels = collector_metric_labels(
+            ON_CHANGE_STREAM_ID_SYSTEM_EVENTS,
+            endpoint.hash_key().into_owned(),
+            endpoint,
+        );
 
         let on_change_stream_metrics =
             GnmiStreamMetrics::new(registry, &prefix, "_events", on_change_const_labels.clone())?;
@@ -544,6 +548,9 @@ pub(crate) fn spawn_gnmi_collector(
     let collector_removed_data_sink = data_sink;
 
     Ok(Collector::spawn_task(move |cancel_token| async move {
+        // Keep the subregistry registered until both gNMI stream tasks finish.
+        let _collector_registry = collector_registry;
+
         let sample_handle = tokio::spawn(gnmi_sample_task(
             cancel_token.clone(),
             sample_config,
@@ -618,6 +625,7 @@ async fn gnmi_sample_task(
                 tracing::warn!(
                     error = ?e.error,
                     switch_id = %sample_processor.switch_id,
+                    rack_id = config.client_provider.rack_id.as_ref().map(tracing::field::display),
                     "nvue_gnmi SAMPLE: connection failed, backing off"
                 );
             }
@@ -630,6 +638,7 @@ async fn gnmi_sample_task(
                 backoff.reset();
                 tracing::info!(
                     switch_id = %sample_processor.switch_id,
+                    rack_id = config.client_provider.rack_id.as_ref().map(tracing::field::display),
                     "nvue_gnmi SAMPLE: stream connected"
                 );
 
@@ -638,6 +647,7 @@ async fn gnmi_sample_task(
                         stream_metrics.connection_state.set(SHUTDOWN);
                         tracing::info!(
                             switch_id = %sample_processor.switch_id,
+                            rack_id = config.client_provider.rack_id.as_ref().map(tracing::field::display),
                             "nvue_gnmi SAMPLE: cancelled, shutting down"
                         );
                         return;
@@ -652,6 +662,7 @@ async fn gnmi_sample_task(
                             stream_metrics.server_initiated_closures_total.inc();
                             tracing::info!(
                                 switch_id = %sample_processor.switch_id,
+                                rack_id = config.client_provider.rack_id.as_ref().map(tracing::field::display),
                                 "nvue_gnmi SAMPLE: stream closed by server, reconnecting"
                             );
                             backoff.reset();
@@ -668,6 +679,7 @@ async fn gnmi_sample_task(
                             tracing::warn!(
                                 error = ?e,
                                 switch_id = %sample_processor.switch_id,
+                                rack_id = config.client_provider.rack_id.as_ref().map(tracing::field::display),
                                 "nvue_gnmi SAMPLE: stream error, reconnecting"
                             );
                             break;
@@ -729,6 +741,7 @@ async fn gnmi_on_change_task(
                     error = ?e.error,
                     switch_id = %on_change_processor.switch_id,
                     stream = %on_change_processor.collector_name,
+                    rack_id = client_provider.rack_id.as_ref().map(tracing::field::display),
                     "nvue_gnmi ON_CHANGE: connection failed, backing off"
                 );
             }
@@ -742,6 +755,7 @@ async fn gnmi_on_change_task(
                 tracing::info!(
                     switch_id = %on_change_processor.switch_id,
                     stream = %on_change_processor.collector_name,
+                    rack_id = client_provider.rack_id.as_ref().map(tracing::field::display),
                     "nvue_gnmi ON_CHANGE: stream connected"
                 );
 
@@ -751,6 +765,7 @@ async fn gnmi_on_change_task(
                         tracing::info!(
                             switch_id = %on_change_processor.switch_id,
                             stream = %on_change_processor.collector_name,
+                            rack_id = client_provider.rack_id.as_ref().map(tracing::field::display),
                             "nvue_gnmi ON_CHANGE: cancelled, shutting down"
                         );
                         return;
@@ -766,6 +781,7 @@ async fn gnmi_on_change_task(
                             tracing::info!(
                                 switch_id = %on_change_processor.switch_id,
                                 stream = %on_change_processor.collector_name,
+                                rack_id = client_provider.rack_id.as_ref().map(tracing::field::display),
                                 "nvue_gnmi ON_CHANGE: stream closed by server, reconnecting"
                             );
                             backoff.reset();
@@ -782,6 +798,7 @@ async fn gnmi_on_change_task(
                                 error = ?e,
                                 switch_id = %on_change_processor.switch_id,
                                 stream = %on_change_processor.collector_name,
+                                rack_id = client_provider.rack_id.as_ref().map(tracing::field::display),
                                 "nvue_gnmi ON_CHANGE: stream error, reconnecting"
                             );
                             break;
@@ -919,6 +936,7 @@ mod tests {
         let addr = test_addr();
         GnmiClientProvider {
             switch_id: "switch-1".to_string(),
+            rack_id: None,
             switch_connect_host: addr.ip.to_string(),
             port: 9339,
             request_timeout: Duration::from_secs(1),

--- a/crates/health/src/collectors/nvue/rest/collector.rs
+++ b/crates/health/src/collectors/nvue/rest/collector.rs
@@ -283,6 +283,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
             tracing::warn!(
                 ?error,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: skipping iteration — credential fetch failed"
             );
             return Ok(IterationResult {
@@ -310,6 +311,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect system health"
                 );
             }
@@ -328,6 +330,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect system reboot reason"
                 );
             }
@@ -354,6 +357,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect cluster apps"
                 );
             }
@@ -394,6 +398,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect SDN partitions"
                 );
             }
@@ -423,6 +428,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect link diagnostics"
                 );
             }
@@ -456,6 +462,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect platform environment fan"
                 );
             }
@@ -517,6 +524,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect platform environment temperature"
                 );
             }
@@ -536,6 +544,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect platform environment leakage"
                 );
             }
@@ -559,6 +568,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 tracing::warn!(
                 error = ?e,
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: failed to collect platform environment status"
                 );
             }
@@ -567,6 +577,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
         if saw_auth_failure {
             tracing::warn!(
                 switch_id = %self.switch_id,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "nvue_rest: auth failure observed, clearing cached credentials"
             );
             self.client.clear_credentials();
@@ -576,6 +587,7 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
 
         tracing::debug!(
             switch_id = %self.switch_id,
+            rack_id = self.event_context.rack_id().map(tracing::field::display),
             entity_count,
             "nvue_rest: collection iteration complete"
         );

--- a/crates/health/src/collectors/runtime.rs
+++ b/crates/health/src/collectors/runtime.rs
@@ -247,6 +247,24 @@ impl StreamMetrics {
     }
 }
 
+/// Builds collector metric labels and includes `rack_id` only when available.
+pub(crate) fn collector_metric_labels(
+    collector_type: &str,
+    endpoint_key: String,
+    endpoint: &BmcEndpoint,
+) -> HashMap<String, String> {
+    let mut labels = HashMap::from([
+        ("collector_type".to_string(), collector_type.to_string()),
+        ("endpoint_key".to_string(), endpoint_key),
+    ]);
+
+    if let Some(rack_id) = endpoint.rack_id.as_ref() {
+        labels.insert("rack_id".to_string(), rack_id.to_string());
+    }
+
+    labels
+}
+
 /// RAII guard: increments the passed IntGauge on construction, decrements on drop.
 /// Ensures every exit path from a connected stream (cancel, error, end, reconnect) dec's.
 pub(crate) struct StreamingConnectionGuard(IntGauge);
@@ -300,14 +318,8 @@ impl Collector {
 
         let mut runner = C::new_runner(bmc, endpoint.clone(), config)?;
 
-        let endpoint_key = endpoint.key();
-        let const_labels = HashMap::from([
-            (
-                "collector_type".to_string(),
-                runner.collector_type().to_string(),
-            ),
-            ("endpoint_key".to_string(), endpoint_key),
-        ]);
+        let const_labels =
+            collector_metric_labels(runner.collector_type(), endpoint.key(), &endpoint);
 
         let registry = collector_registry.registry();
 
@@ -362,7 +374,12 @@ impl Collector {
             loop {
                 tokio::select! {
                     _ = cancel_token_clone.cancelled() => {
-                        tracing::info!(endpoint = ?endpoint.addr, "collector cancelled");
+                        tracing::info!(
+                            endpoint = ?endpoint.addr,
+                            rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
+                            "collector cancelled"
+                        );
+
                         runner.stop().await;
                         break;
                     }
@@ -401,6 +418,7 @@ impl Collector {
                                     error = ?e,
                                     endpoint = ?endpoint.addr,
                                     collector_type = collector_type,
+                                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                                     "Error during collector iteration"
                                 );
                             }
@@ -442,14 +460,8 @@ impl Collector {
         let mut collector = S::new_runner(Arc::clone(&bmc), endpoint.clone(), config)?;
         let event_context = EventContext::from_endpoint(&endpoint, collector.collector_type());
 
-        let endpoint_key = endpoint.key();
-        let const_labels = HashMap::from([
-            (
-                "collector_type".to_string(),
-                collector.collector_type().to_string(),
-            ),
-            ("endpoint_key".to_string(), endpoint_key),
-        ]);
+        let const_labels =
+            collector_metric_labels(collector.collector_type(), endpoint.key(), &endpoint);
 
         let registry = collector_registry.registry();
         let metrics = StreamMetrics::new(registry, collector_registry.prefix(), const_labels)?;
@@ -463,6 +475,7 @@ impl Collector {
                 tracing::info!(
                     collector_type,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "streaming collector connecting"
                 );
 
@@ -479,6 +492,7 @@ impl Collector {
                             error = ?e,
                             collector_type,
                             endpoint = ?endpoint.addr,
+                            rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                             "streaming collector connection failed"
                         );
                         if !on_connect_result(Err(&e)) {
@@ -497,6 +511,7 @@ impl Collector {
                             error = ?error,
                             collector_type,
                             endpoint = ?endpoint.addr,
+                            rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                             "streaming collector connection failed"
                         );
 
@@ -513,6 +528,7 @@ impl Collector {
                         tracing::info!(
                             collector_type,
                             endpoint = ?endpoint.addr,
+                            rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                             "streaming collector connected"
                         );
 
@@ -522,6 +538,7 @@ impl Collector {
                                 tracing::info!(
                                     collector_type,
                                     endpoint = ?endpoint.addr,
+                                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                                     "streaming collector shutting down"
                                 );
                                 return;
@@ -539,6 +556,7 @@ impl Collector {
                                         error = ?e,
                                         collector_type,
                                         endpoint = ?endpoint.addr,
+                                        rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                                         "streaming collector stream error, reconnecting"
                                     );
                                     break;
@@ -547,6 +565,7 @@ impl Collector {
                                     tracing::info!(
                                         collector_type,
                                         endpoint = ?endpoint.addr,
+                                        rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                                         "streaming collector stream ended, reconnecting"
                                     );
                                     break;
@@ -605,6 +624,8 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    use carbide_uuid::rack::RackId;
+
     use super::*;
     use crate::endpoint::test_support::{mac, test_endpoint};
     use crate::metrics::MetricsManager;
@@ -633,6 +654,42 @@ mod tests {
                 self.0.fetch_add(1, Ordering::SeqCst);
             }
             Ok(())
+        }
+    }
+
+    #[test]
+    fn collector_metric_labels_include_only_available_rack_id() {
+        struct TestCase {
+            name: &'static str,
+            rack_id: Option<RackId>,
+            expected_rack_id: Option<&'static str>,
+        }
+
+        let cases = [
+            TestCase {
+                name: "rack identity is available",
+                rack_id: Some(RackId::new("RACK_1")),
+                expected_rack_id: Some("RACK_1"),
+            },
+            TestCase {
+                name: "rack identity is unavailable",
+                rack_id: None,
+                expected_rack_id: None,
+            },
+        ];
+
+        for case in cases {
+            let mut endpoint = test_endpoint(mac("00:11:22:33:44:55"));
+            endpoint.rack_id = case.rack_id;
+
+            let labels = collector_metric_labels("test_collector", endpoint.key(), &endpoint);
+
+            assert_eq!(
+                labels.get("rack_id").map(String::as_str),
+                case.expected_rack_id,
+                "{}",
+                case.name
+            );
         }
     }
 

--- a/crates/health/src/collectors/sensors.rs
+++ b/crates/health/src/collectors/sensors.rs
@@ -135,6 +135,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
         let Some(inventory) = self.shared.load_full() else {
             tracing::debug!(
                 bmc_address = ?self.endpoint.addr,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "No entity inventory available yet; skipping sensor iteration"
             );
             return Ok(IterationResult {
@@ -159,6 +160,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
         else {
             tracing::debug!(
                 bmc_address = ?self.endpoint.addr,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "BMC connection circuit is open; skipping sensor iteration"
             );
             return Ok(IterationResult {
@@ -171,6 +173,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
 
         tracing::debug!(
             bmc_address = ?self.endpoint.addr,
+            rack_id = self.event_context.rack_id().map(tracing::field::display),
             generation = inventory.generation,
             inventory_age_seconds = inventory.discovered_at.elapsed().as_secs(),
             entity_count = inventory.entities.len(),
@@ -274,6 +277,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
                     sensor_id = %sensor_link.odata_id(),
                     entity_type = entity.entity_type(),
                     error = ?e,
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "Failed to fetch sensor data"
                 );
                 return 0;
@@ -293,6 +297,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
                 tracing::debug!(
                     sensor_id = %sensor.base.id,
                     entity_type = entity.entity_type(),
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "Sensor does not have health status field, skipping"
                 );
                 return 0;
@@ -301,6 +306,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
                 tracing::warn!(
                     sensor_id = %sensor.base.id,
                     entity_type = entity.entity_type(),
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "Sensor missing required fields (reading, reading_type, or units)"
                 );
                 return 0;

--- a/crates/health/src/collectors/telemetry.rs
+++ b/crates/health/src/collectors/telemetry.rs
@@ -133,6 +133,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for TelemetryCollector<B> {
         let Some(telemetry_service) = service_root.telemetry_service().await? else {
             tracing::debug!(
                 bmc_address = ?self.endpoint.addr,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "BMC exposes no telemetry service; skipping iteration"
             );
             return Ok(IterationResult {
@@ -167,6 +168,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for TelemetryCollector<B> {
                         ?error,
                         report = %link.odata_id(),
                         bmc_address = ?self.endpoint.addr,
+                        rack_id = self.event_context.rack_id().map(tracing::field::display),
                         "Failed to fetch metric report"
                     );
                 }
@@ -216,6 +218,7 @@ impl<B: Bmc + 'static> TelemetryCollector<B> {
                 tracing::debug!(
                     ?error,
                     bmc_address = ?self.endpoint.addr,
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "Telemetry service published no metric definitions; \
                      readings will be recorded without units"
                 );
@@ -246,6 +249,7 @@ impl<B: Bmc + 'static> TelemetryCollector<B> {
             tracing::debug!(
                 report_id,
                 bmc_address = ?self.endpoint.addr,
+                rack_id = self.event_context.rack_id().map(tracing::field::display),
                 "Skipping metric report marked stale by the NVIDIA OEM extension"
             );
             return 0;
@@ -318,6 +322,7 @@ impl<B: Bmc + 'static> TelemetryCollector<B> {
                 tracing::debug!(
                     ?error,
                     bmc_address = ?self.endpoint.addr,
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
                     "Failed to read NVIDIA OEM extension on metric report"
                 );
                 false

--- a/crates/health/src/discovery/identity.rs
+++ b/crates/health/src/discovery/identity.rs
@@ -55,6 +55,7 @@ pub(super) async fn ensure_primary_system_uuid(endpoint: &BmcEndpoint) -> Result
             let Some(systems) = root.systems().await? else {
                 tracing::warn!(
                     bmc_address = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "BMC does not expose a ComputerSystem collection"
                 );
                 return Ok(None);
@@ -74,6 +75,7 @@ pub(super) async fn ensure_primary_system_uuid(endpoint: &BmcEndpoint) -> Result
             let Some(primary) = select_primary_system(&identities) else {
                 tracing::warn!(
                     bmc_address = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "BMC exposes an empty ComputerSystem collection"
                 );
                 return Ok(None);
@@ -82,6 +84,7 @@ pub(super) async fn ensure_primary_system_uuid(endpoint: &BmcEndpoint) -> Result
                 tracing::warn!(
                     bmc_address = ?endpoint.addr,
                     system_id = %primary.id,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Primary ComputerSystem does not expose a UUID"
                 );
             }

--- a/crates/health/src/discovery/iteration.rs
+++ b/crates/health/src/discovery/iteration.rs
@@ -100,6 +100,7 @@ pub async fn run_discovery_iteration(
                 tracing::warn!(
                     ?error,
                     bmc_address = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not resolve primary ComputerSystem UUID; continuing without it"
                 );
             }
@@ -141,6 +142,7 @@ pub async fn run_discovery_iteration(
             tracing::error!(
                 ?error,
                 %endpoint_key,
+                rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                 "Could not spawn collectors for endpoint"
             );
 

--- a/crates/health/src/discovery/reachability.rs
+++ b/crates/health/src/discovery/reachability.rs
@@ -163,12 +163,21 @@ pub(super) async fn reconcile_reachability_collectors(
                 ctx.collectors
                     .insert(CollectorKind::Reachability, key.clone(), collector);
 
-                tracing::info!(endpoint_key = %key, "Started TCP reachability collection");
+                tracing::info!(
+                    endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
+                    "Started TCP reachability collection"
+                );
             }
 
             Err(error) => {
                 // An absent entry is retried on the next discovery pass.
-                tracing::error!(?error, endpoint_key = %key, "Could not start TCP reachability collection");
+                tracing::error!(
+                    ?error,
+                    endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
+                    "Could not start TCP reachability collection"
+                );
             }
         }
     }

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -214,6 +214,7 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Discovery, key.clone().into(), monitor);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     discovery_collector_count = ctx.collectors.len(CollectorKind::Discovery),
                     "Started entity discovery for BMC endpoint"
                 );
@@ -222,6 +223,7 @@ fn spawn_generic_redfish_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start entity discovery collector"
                 );
             }
@@ -257,6 +259,7 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Sensor, key.clone().into(), monitor);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     sensor_collector_count = ctx.collectors.len(CollectorKind::Sensor),
                     "Started sensor collection for BMC endpoint"
                 );
@@ -265,6 +268,7 @@ fn spawn_generic_redfish_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start sensor collector"
                 );
             }
@@ -299,6 +303,7 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Metrics, key.clone().into(), monitor);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     entity_metrics_collector_count = ctx.collectors.len(CollectorKind::Metrics),
                     "Started entity metrics collection for BMC endpoint"
                 );
@@ -307,6 +312,7 @@ fn spawn_generic_redfish_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start entity metrics collector"
                 );
             }
@@ -338,6 +344,7 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Telemetry, key.clone().into(), monitor);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     telemetry_collector_count = ctx.collectors.len(CollectorKind::Telemetry),
                     "Started telemetry service collection for BMC endpoint"
                 );
@@ -346,6 +353,7 @@ fn spawn_generic_redfish_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start telemetry collector"
                 );
             }
@@ -411,7 +419,12 @@ fn spawn_generic_redfish_collectors(
                         |_| true,
                     ))
                 } else {
-                    tracing::warn!("SSE log collector requires a data sink, skipping");
+                    tracing::warn!(
+                        endpoint_key = %key,
+                        rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
+                        "SSE log collector requires a data sink, skipping"
+                    );
+
                     None
                 }
             }
@@ -431,6 +444,7 @@ fn spawn_generic_redfish_collectors(
                     let auto_cfg = logs_cfg.auto.clone().unwrap_or_default();
                     let registry = ctx.log_downgrade_registry.clone();
                     let endpoint_key: std::borrow::Cow<'static, str> = key.clone().into();
+                    let endpoint_rack_id = endpoint.rack_id.clone();
                     let mut budget = AutoFailureBudget::new(auto_cfg, Instant::now());
 
                     Some(Collector::start_streaming::<SseLogCollector<BmcClient>, _>(
@@ -454,7 +468,12 @@ fn spawn_generic_redfish_collectors(
                                 match budget.record(FailureKind::classify(e), Instant::now()) {
                                     BudgetDecision::Continue => true,
                                     BudgetDecision::Downgrade(reason) => {
-                                        registry.mark_downgraded(endpoint_key.clone(), reason);
+                                        registry.mark_downgraded(
+                                            endpoint_key.clone(),
+                                            endpoint_rack_id.as_ref(),
+                                            reason,
+                                        );
+
                                         false
                                     }
                                 }
@@ -462,7 +481,12 @@ fn spawn_generic_redfish_collectors(
                         },
                     ))
                 } else {
-                    tracing::warn!("auto-mode SSE log collector requires a data sink, skipping");
+                    tracing::warn!(
+                        endpoint_key = %key,
+                        rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
+                        "auto-mode SSE log collector requires a data sink, skipping"
+                    );
+
                     None
                 }
             }
@@ -474,6 +498,7 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Logs, key.clone().into(), collector);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     mode = ?logs_cfg.mode,
                     log_collector_count = ctx.collectors.len(CollectorKind::Logs),
                     "Started logs collection for BMC endpoint"
@@ -484,6 +509,7 @@ fn spawn_generic_redfish_collectors(
                     ?error,
                     mode = ?logs_cfg.mode,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start logs collector"
                 );
             }
@@ -516,6 +542,7 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Firmware, key.clone().into(), collector);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     firmware_collector_count = ctx.collectors.len(CollectorKind::Firmware),
                     "Started firmware collection for BMC endpoint"
                 );
@@ -524,6 +551,7 @@ fn spawn_generic_redfish_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start firmware collector"
                 )
             }
@@ -568,6 +596,7 @@ fn spawn_generic_redfish_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start GPU inventory collector"
                 );
             }
@@ -601,6 +630,7 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::LeakDetector, key.clone().into(), collector);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     leak_detector_collector_count =
                         ctx.collectors.len(CollectorKind::LeakDetector),
                     "Started leak detector collection for BMC endpoint"
@@ -610,6 +640,7 @@ fn spawn_generic_redfish_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start leak detector collector"
                 )
             }
@@ -702,6 +733,7 @@ fn spawn_switch_host_collectors(
                     .insert(CollectorKind::Nmxt, key.clone().into(), handle);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     nmxt_collector_count = ctx.collectors.len(CollectorKind::Nmxt),
                     "Started NMX-T collection for switch host endpoint"
                 );
@@ -710,6 +742,7 @@ fn spawn_switch_host_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start NMX-T collector for switch host"
                 )
             }
@@ -723,6 +756,7 @@ fn spawn_switch_host_collectors(
         if !ctx.log_event_sink_enabled {
             tracing::warn!(
                 endpoint_key = %key,
+                rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                 "NMX-C streaming collector requires an enabled tracing, log_file, or OTLP sink, skipping"
             );
         } else if let Some(data_sink) = data_sink.clone() {
@@ -745,6 +779,7 @@ fn spawn_switch_host_collectors(
 
                     tracing::info!(
                         endpoint_key = %key,
+                        rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                         nmxc_collector_count = ctx.collectors.len(CollectorKind::Nmxc),
                         "Started NMX-C streaming collection for switch endpoint"
                     );
@@ -754,6 +789,7 @@ fn spawn_switch_host_collectors(
                     tracing::error!(
                         ?error,
                         endpoint_key = %key,
+                        rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                         "Could not start NMX-C collector for switch"
                     );
                 }
@@ -761,6 +797,7 @@ fn spawn_switch_host_collectors(
         } else {
             tracing::warn!(
                 endpoint_key = %key,
+                rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                 "NMX-C streaming collector requires a data sink, skipping"
             );
         }
@@ -798,6 +835,7 @@ fn spawn_switch_host_collectors(
                     .insert(CollectorKind::NvueRest, key.clone().into(), handle);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     nvue_rest_collector_count = ctx.collectors.len(CollectorKind::NvueRest),
                     "Started NVUE REST collection for switch host endpoint"
                 );
@@ -806,6 +844,7 @@ fn spawn_switch_host_collectors(
                 tracing::error!(
                     ?error,
                     endpoint = ?endpoint.addr,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start NVUE REST collector for switch host"
                 )
             }
@@ -835,6 +874,7 @@ fn spawn_switch_host_collectors(
                     .insert(CollectorKind::NvueGnmi, key.clone().into(), handle);
                 tracing::info!(
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     nvue_gnmi_collector_count = ctx.collectors.len(CollectorKind::NvueGnmi),
                     "Started NVUE gNMI streaming collection for switch endpoint"
                 );
@@ -843,6 +883,7 @@ fn spawn_switch_host_collectors(
                 tracing::error!(
                     ?error,
                     endpoint_key = %key,
+                    rack_id = endpoint.rack_id.as_ref().map(tracing::field::display),
                     "Could not start NVUE gNMI collector for switch"
                 );
             }
@@ -1669,8 +1710,12 @@ mod tests {
                 .expect("context should initialize");
 
         let endpoint = test_endpoint(Ipv4Addr::new(10, 0, 0, 1), "aa:bb:cc:dd:ee:01", None);
-        ctx.log_downgrade_registry
-            .mark_downgraded(endpoint.key().into(), DowngradeReason::SseNotAvailable);
+
+        ctx.log_downgrade_registry.mark_downgraded(
+            endpoint.key().into(),
+            endpoint.rack_id.as_ref(),
+            DowngradeReason::SseNotAvailable,
+        );
 
         spawn_collectors_for_endpoint(&mut ctx, &endpoint, None, "test_auto_downgraded")
             .expect("spawn should succeed for downgraded auto endpoint");

--- a/crates/health/src/endpoint/cluster.rs
+++ b/crates/health/src/endpoint/cluster.rs
@@ -250,6 +250,7 @@ fn extract_manager_devices(
         let (Some(hostname), Some(bmc_ip_str)) = (hostname, bmc_ip_str) else {
             tracing::debug!(
                 item_keys = ?item.as_object().map(|o| o.keys().cloned().collect::<Vec<_>>()),
+                rack_id = rack.as_deref().map(tracing::field::display),
                 "Cluster manager device entry missing hostname or BMC IP; skipping. \
                  Update field paths in extract_manager_devices once head node is probed."
             );
@@ -262,6 +263,7 @@ fn extract_manager_devices(
                 tracing::warn!(
                     hostname,
                     bmc_ip_address = bmc_ip_str,
+                    rack_id = rack.as_deref().map(tracing::field::display),
                     error = %e,
                     "Invalid BMC IP; skipping"
                 );
@@ -427,11 +429,15 @@ fn build_endpoints(
     bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
 ) -> Vec<Arc<BmcEndpoint>> {
     let mut endpoints = Vec::with_capacity(nodes.len());
+
     for node in nodes {
+        let rack_id = node.rack.as_deref().map(RackId::new);
+
         let IpAddr::V4(v4) = node.bmc_ip else {
             tracing::warn!(
                 hostname = %node.hostname,
                 bmc_ip_address = %node.bmc_ip,
+                rack_id = rack_id.as_ref().map(tracing::field::display),
                 "cluster endpoint has non-IPv4 BMC address; skipping"
             );
             continue;
@@ -447,7 +453,7 @@ fn build_endpoints(
             port,
             mac,
         };
-        let rack_id = node.rack.as_deref().map(RackId::new);
+
         let bmc_latency_instrumentation = bmc_latency_metrics.clone().map(|metrics| {
             BmcLatencyInstrumentation::new(
                 metrics,
@@ -473,6 +479,7 @@ fn build_endpoints(
                 tracing::warn!(
                     error = ?e,
                     hostname = %node.hostname,
+                    rack_id = rack_id.as_ref().map(tracing::field::display),
                     "Failed to construct BmcClient for cluster endpoint; skipping"
                 );
                 continue;

--- a/crates/health/src/endpoint/sources.rs
+++ b/crates/health/src/endpoint/sources.rs
@@ -40,6 +40,7 @@ use crate::metrics::BmcLatencyMetrics;
 fn parse_static_nvlink_domain_uuid(
     value: Option<&str>,
     endpoint_kind: &str,
+    rack_id: Option<&str>,
 ) -> Option<NvLinkDomainId> {
     value.and_then(|value| match NvLinkDomainId::from_str(value) {
         Ok(domain_uuid) => Some(domain_uuid),
@@ -47,6 +48,7 @@ fn parse_static_nvlink_domain_uuid(
             tracing::warn!(
                 ?error,
                 nvlink_domain_uuid = ?value,
+                rack_id = rack_id.map(tracing::field::display),
                 "Invalid {endpoint_kind}.nvlink_domain_uuid in static endpoint config"
             );
 
@@ -100,6 +102,7 @@ impl StaticEndpointSource {
                     tracing::warn!(
                         ?error,
                         bmc_mac_address = ?cfg.mac,
+                        rack_id = cfg.rack_id.as_deref().map(tracing::field::display),
                         "Invalid MAC in static endpoint config"
                     );
                     continue;
@@ -113,6 +116,7 @@ impl StaticEndpointSource {
                         tracing::warn!(
                             ?error,
                             power_shelf_id = ?id,
+                            rack_id = cfg.rack_id.as_deref().map(tracing::field::display),
                             "Invalid power_shelf.id in static endpoint config"
                         );
                         None
@@ -132,6 +136,7 @@ impl StaticEndpointSource {
                         tracing::warn!(
                             ?error,
                             switch_id = ?id,
+                            rack_id = cfg.rack_id.as_deref().map(tracing::field::display),
                             "Invalid switch.id in static endpoint config"
                         );
                         None
@@ -143,9 +148,12 @@ impl StaticEndpointSource {
                     .or_else(|| switch.id.clone())
                     .unwrap_or_else(|| cfg.mac.clone());
 
-                let nvlink_domain_uuid =
-                    parse_static_nvlink_domain_uuid(switch.nvlink_domain_uuid.as_deref(), "switch")
-                        .filter(|domain_uuid| domain_uuid != &NvLinkDomainId::nil());
+                let nvlink_domain_uuid = parse_static_nvlink_domain_uuid(
+                    switch.nvlink_domain_uuid.as_deref(),
+                    "switch",
+                    cfg.rack_id.as_deref(),
+                )
+                .filter(|domain_uuid| domain_uuid != &NvLinkDomainId::nil());
 
                 let endpoint_role = match switch.endpoint_role {
                     StaticSwitchEndpointRole::Bmc => SwitchEndpointRole::Bmc,
@@ -170,7 +178,13 @@ impl StaticEndpointSource {
                 let machine_id = machine.id.as_deref().and_then(|id| match id.parse() {
                     Ok(machine_id) => Some(machine_id),
                     Err(error) => {
-                        tracing::warn!(?error, ?id, "Invalid machine.id in static endpoint config");
+                        tracing::warn!(
+                            ?error,
+                            ?id,
+                            rack_id = cfg.rack_id.as_deref().map(tracing::field::display),
+                            "Invalid machine.id in static endpoint config"
+                        );
+
                         None
                     }
                 });
@@ -178,6 +192,7 @@ impl StaticEndpointSource {
                 let nvlink_domain_uuid = parse_static_nvlink_domain_uuid(
                     machine.nvlink_domain_uuid.as_deref(),
                     "machine",
+                    cfg.rack_id.as_deref(),
                 );
 
                 let driver_version = machine
@@ -231,6 +246,7 @@ impl StaticEndpointSource {
                     tracing::warn!(
                         ?error,
                         bmc_address = ?addr,
+                        rack_id = rack_id.as_ref().map(tracing::field::display),
                         "Failed to construct BmcClient for static endpoint"
                     );
                     continue;

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -100,6 +100,8 @@ struct JsonLogRecord<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     machine_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    rack_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     system_uuid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     machine_serial: Option<&'a str>,
@@ -124,6 +126,7 @@ impl<'a> JsonLogRecord<'a> {
             endpoint: context.endpoint_key(),
             collector: context.collector_type,
             machine_id: context.machine_id().map(|id| id.to_string()),
+            rack_id: context.rack_id().map(|rack_id| rack_id.as_str()),
             system_uuid: context.system_uuid().map(|id| id.to_string()),
             machine_serial: context.machine_serial(),
             driver_version: context.driver_version(),
@@ -279,6 +282,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_uuid::nvlink::NvLinkDomainId;
+    use carbide_uuid::rack::RackId;
     use mac_address::MacAddress;
 
     use super::*;
@@ -304,6 +308,7 @@ mod tests {
     /// Builds a log context with representative machine metadata.
     fn machine_context() -> EventContext {
         EventContext {
+            rack_id: Some(RackId::new("RACK_1")),
             labels: std::collections::BTreeMap::from([(
                 "site".to_string(),
                 "rno-dev7".to_string(),
@@ -377,6 +382,7 @@ mod tests {
         assert_eq!(parsed["body"], "something happened");
         assert_eq!(parsed["severity"], "INFO");
         assert_eq!(parsed["endpoint"], "aa:bb:cc:dd:ee:ff");
+        assert!(parsed.get("rack_id").is_none());
     }
 
     #[test]
@@ -502,7 +508,7 @@ mod tests {
 
     /// Verifies that machine metadata is emitted as top-level JSONL fields.
     #[test]
-    fn test_writes_machine_metadata_as_jsonl_fields() {
+    fn test_writes_machine_and_rack_metadata_as_jsonl_fields() {
         let dir = tempfile::tempdir().expect("tempdir");
         let config = LogFileSinkConfig {
             include_diagnostics: false,
@@ -540,6 +546,7 @@ mod tests {
         assert_eq!(parsed["machine_serial"], "MN-001");
         assert_eq!(parsed["driver_version"], "570.82");
         assert_eq!(parsed["component_type"], "compute_node");
+        assert_eq!(parsed["rack_id"], "RACK_1");
         assert_eq!(parsed["labels"]["site"], "rno-dev7");
         assert_eq!(
             parsed["nvlink_domain_uuid"],

--- a/crates/health/src/sink/tracing.rs
+++ b/crates/health/src/sink/tracing.rs
@@ -56,6 +56,7 @@ impl DataSink for TracingSink {
                 tracing::info!(
                     endpoint = %context.endpoint_key(),
                     collector = %context.collector_type,
+                    rack_id = context.rack_id().map(tracing::field::display),
                     system_uuid = context.system_uuid().map(tracing::field::display),
                     labels = ?context.labels(),
                     "Metric collection start"
@@ -65,6 +66,7 @@ impl DataSink for TracingSink {
                 tracing::info!(
                     endpoint = %context.endpoint_key(),
                     collector = %context.collector_type,
+                    rack_id = context.rack_id().map(tracing::field::display),
                     system_uuid = context.system_uuid().map(tracing::field::display),
                     labels = ?context.labels(),
                     metric = %metric.name,
@@ -79,6 +81,7 @@ impl DataSink for TracingSink {
                 tracing::info!(
                     endpoint = %context.endpoint_key(),
                     collector = %context.collector_type,
+                    rack_id = context.rack_id().map(tracing::field::display),
                     system_uuid = context.system_uuid().map(tracing::field::display),
                     labels = ?context.labels(),
                     "Metric collection end"
@@ -88,6 +91,7 @@ impl DataSink for TracingSink {
                 tracing::info!(
                     endpoint = %context.endpoint_key(),
                     collector = %context.collector_type,
+                    rack_id = context.rack_id().map(tracing::field::display),
                     system_uuid = context.system_uuid().map(tracing::field::display),
                     labels = ?context.labels(),
                     "Collector removed"
@@ -101,6 +105,7 @@ impl DataSink for TracingSink {
                     endpoint = %context.endpoint_key(),
                     collector = %context.collector_type,
                     machine_id = context.machine_id().map(tracing::field::display),
+                    rack_id = context.rack_id().map(tracing::field::display),
                     system_uuid = context.system_uuid().map(tracing::field::display),
                     machine_serial = context.machine_serial(),
                     driver_version = context.driver_version(),
@@ -117,6 +122,7 @@ impl DataSink for TracingSink {
                 tracing::info!(
                     endpoint = %context.endpoint_key(),
                     collector = %context.collector_type,
+                    rack_id = context.rack_id().map(tracing::field::display),
                     system_uuid = context.system_uuid().map(tracing::field::display),
                     labels = ?context.labels(),
                     firmware_name = %info.component,
@@ -129,6 +135,7 @@ impl DataSink for TracingSink {
                     endpoint = %context.endpoint_key(),
                     collector = %context.collector_type,
                     machine_id = ?context.machine_id(),
+                    rack_id = context.rack_id().map(tracing::field::display),
                     system_uuid = context.system_uuid().map(tracing::field::display),
                     labels = ?context.labels(),
                     success_count = report.successes.len(),
@@ -150,6 +157,7 @@ mod tests {
     use std::borrow::Cow;
 
     use carbide_instrument::testing::capture_logs;
+    use carbide_uuid::rack::RackId;
 
     use super::*;
     use crate::endpoint::test_support::{mac, test_endpoint};
@@ -189,6 +197,28 @@ mod tests {
             log.field("attributes"),
             Some(r#"[("gentime", "2026-07-05 12:34:56"), ("user", "admin")]"#)
         );
+    }
+
+    #[test]
+    fn tracing_sink_includes_optional_rack_id() {
+        let sink = TracingSink::new(&TracingSinkConfig {
+            include_diagnostics: false,
+        });
+
+        for (rack_id, expected_rack_id) in
+            [(Some(RackId::new("RACK_1")), Some("RACK_1")), (None, None)]
+        {
+            let mut endpoint = test_endpoint(mac("00:11:22:33:44:55"));
+            endpoint.rack_id = rack_id;
+            let context = EventContext::from_endpoint(&endpoint, "test_collector");
+
+            let logs = capture_logs(|| {
+                sink.handle_event(&context, &CollectorEvent::MetricCollectionStart)
+            });
+
+            assert_eq!(logs.len(), 1);
+            assert_eq!(logs[0].field("rack_id"), expected_rack_id);
+        }
     }
 
     #[test]

--- a/docs/architecture/health_aggregation.md
+++ b/docs/architecture/health_aggregation.md
@@ -295,7 +295,7 @@ ranges or by interpreting the `health_ok` values provided by BMCs.
 
 Machine endpoints carry the inventory metadata needed to interpret hardware health in fleet context. This includes machine ID, primary Redfish system UUID, serial number, rack ID, rack placement, and NVLink domain UUID when present.
 
-Switch endpoints carry switch ID, serial number, rack placement, and NVLink domain UUID when present.
+Switch endpoints carry switch ID, serial number, rack ID, rack placement, and NVLink domain UUID when present. Power-shelf endpoints carry power-shelf ID, serial number, and rack ID when present.
 
 **For local and test deployments**, you can configure explicit machine, switch, or power-shelf identity with `[[endpoint_sources.static_bmc_endpoints]]`. Direct switch host endpoints can use `[[endpoint_sources.static_switch_host_endpoints]]` or `[[endpoint_sources.static_bmc_endpoints]]`. Note the following:
 
@@ -307,9 +307,13 @@ Switch endpoints carry switch ID, serial number, rack placement, and NVLink doma
 
 The publishing sinks expose that inventory context using the conventions of the target backend:
 
-- `[sinks.prometheus]` adds _machine_ metadata as metric labels named `machine_id`, `system_uuid`, `serial_number`, `rack_id`, `machine_slot_number`, `machine_tray_index`, and `nvlink_domain_uuid`. _Switch_ metadata labels are `switch_id`, `serial_number`, `rack_id`, `switch_slot_number`, `switch_tray_index`, and `nvlink_domain_uuid`. Static endpoint custom labels keep their configured names.
+- `[sinks.prometheus]` adds _machine_ metadata as metric labels named `machine_id`, `system_uuid`, `serial_number`, `rack_id`, `machine_slot_number`, `machine_tray_index`, and `nvlink_domain_uuid`. _Switch_ metadata labels are `switch_id`, `serial_number`, `rack_id`, `switch_slot_number`, `switch_tray_index`, and `nvlink_domain_uuid`. _Power-shelf_ metadata labels are `serial_number` and `rack_id`. Static endpoint custom labels keep their configured names.
+- `[sinks.tracing]` adds `rack_id` to every collector-event log when the endpoint supplies one. Endpoint-source, collector diagnostic, lifecycle, cancellation, and failure logs use the same optional field when they have endpoint context.
+- `[sinks.log_file]` adds `rack_id` as a top-level JSONL string field when the endpoint supplies one.
 - `[sinks.otlp]` adds the string resource attributes `collector.type` and either `bmc.endpoint` and `bmc.ip`, or `switch.endpoint` and `switch.ip` for host-side switch collection. Typed inventory adds the strings `component.type` and, when present, `rack.id`. _Machine_ metadata attributes are the strings `machine.id`, `system.uuid`, `machine.serial`, `driver.version`, and `nvlink.domain.uuid`, plus the integers `machine.slot_number` and `machine.tray_index`. _Switch_ metadata attributes are the strings `switch.id`, `switch.serial_number`, `switch.endpoint_role`, and `nvlink.domain.uuid`, the boolean `switch.is_primary`, and the integers `switch.slot_number` and `switch.tray_index`. Static endpoint custom labels are string resource attributes and keep their configured names.
 - `[sinks.health_report]`, `[sinks.rack_health_report]`, `[sinks.switch_health_report]`, and `[sinks.power_shelf_health_report]` use the same event context when submitting assessed health reports back to NICo API. The persisted `HealthReport` and `HealthProbeAlert` schemas remain the probe success/alert model described above.
+
+Collector runtime metrics and gNMI stream metrics include a `rack_id` label when the endpoint supplies one. The label is omitted when discovery does not supply a rack ID. Existing `collector_type` and `endpoint_key` label semantics remain unchanged.
 
 #### OTLP health-report log contract
 


### PR DESCRIPTION
Add optional rack ID context to health collector observability. Rack IDs from endpoint discovery are included in endpoint-scoped logs, tracing events, JSONL records, collector runtime metrics, and NVUE gNMI stream metrics. NICo API power-shelf endpoints now preserve their configured rack ID.

## Related issues

Resolves #5446

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)