### PR TITLE
feat(machine-validation): PR1 - add safe OCI plugin runner foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,6 +2524,7 @@ dependencies = [
  "carbide-uuid",
  "chrono",
  "futures-util",
+ "libc",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -2531,6 +2532,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/api-core/src/handlers/machine_scout.rs
+++ b/crates/api-core/src/handlers/machine_scout.rs
@@ -23,7 +23,6 @@ use model::machine::{
     FailureCause, FailureDetails, FailureSource, HostReprovisionState, InstanceState, MachineState,
     MachineValidatingState, ManagedHostState, MeasuringState, StateMachineArea, ValidationState,
 };
-use model::machine_validation::{MachineValidationState, MachineValidationStatus};
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
@@ -216,26 +215,25 @@ pub(crate) async fn forge_agent_control(
                     "Machine validation progress reported by scout",
                 );
                 if *is_enabled {
-                    db::machine_validation::update_status(
-                        &mut txn,
-                        id,
-                        MachineValidationStatus {
-                            state: MachineValidationState::InProgress,
-                            ..MachineValidationStatus::default()
-                        },
-                    )
-                    .await?;
-                    let machine_validation =
-                        db::machine_validation::find_by_id(&mut txn, id).await?;
-                    (
-                        Action::MachineValidation(fac::MachineValidation {
-                            is_enabled: true,
-                            context: context.clone(),
-                            validation_id: Some(*id),
-                            filter: Some(machine_validation.filter.unwrap_or_default().into()),
-                        }),
-                        Some(txn),
-                    )
+                    if let Some(machine_validation) =
+                        db::machine_validation::mark_in_progress_if_active(&mut txn, id).await?
+                    {
+                        (
+                            Action::MachineValidation(fac::MachineValidation {
+                                is_enabled: true,
+                                context: context.clone(),
+                                validation_id: Some(*id),
+                                filter: Some(machine_validation.filter.unwrap_or_default().into()),
+                            }),
+                            Some(txn),
+                        )
+                    } else {
+                        tracing::info!(
+                            machine_validation_id = %id,
+                            "Skipping machine validation dispatch because the run is no longer active"
+                        );
+                        (Action::noop(), Some(txn))
+                    }
                 } else {
                     // This avoids sending Machine validation command scout
                     tracing::info!("Skipped machine validation");

--- a/crates/api-core/src/tests/machine_validation.rs
+++ b/crates/api-core/src/tests/machine_validation.rs
@@ -187,7 +187,35 @@ async fn test_machine_validation_with_error(
         },
     )
     .await;
-    mh.machine_validation_completed().await;
+    let response = mh.host().forge_agent_control().await;
+    let Some(rpc::forge_agent_control_response::Action::MachineValidation(machine_validation)) =
+        response.action
+    else {
+        panic!("expected machine validation action");
+    };
+    let validation_id = machine_validation
+        .validation_id
+        .expect("machine validation action missing validation_id");
+
+    env.api
+        .machine_validation_completed(tonic::Request::new(
+            rpc::forge::MachineValidationCompletedRequest {
+                machine_id: Some(mh.host().id),
+                machine_validation_error: None,
+                validation_id: Some(validation_id),
+            },
+        ))
+        .await?;
+
+    // Regression for #4876: the host state has not advanced yet, so this
+    // reproduces a Scout poll after the run was completed. It must not
+    // re-dispatch the terminal run.
+    let response = mh.host().forge_agent_control().await;
+    assert!(matches!(
+        response.action,
+        Some(rpc::forge_agent_control_response::Action::Noop(_))
+    ));
+
     env.run_machine_state_controller_iteration_until_state_matches(
         &mh.host().id,
         1,

--- a/crates/api-db/src/machine_validation.rs
+++ b/crates/api-db/src/machine_validation.rs
@@ -77,19 +77,28 @@ pub async fn find_by<'a, C: ColumnInfo<'a, TableType = MachineValidation>>(
     Ok(custom_results)
 }
 
-pub async fn update_status(
+/// Mark a run in progress only while it is still active.
+///
+/// Scout can poll after another request has completed the run. Keeping the
+/// active predicate in this update makes that race harmless: a terminal run
+/// remains terminal and is not dispatched again.
+pub async fn mark_in_progress_if_active(
     txn: &mut PgConnection,
     id: &MachineValidationId,
-    status: MachineValidationStatus,
-) -> DatabaseResult<()> {
-    let query = "UPDATE machine_validation SET state=$2 WHERE id=$1 RETURNING *";
-    let _id = sqlx::query_as::<_, MachineValidation>(query)
+) -> DatabaseResult<Option<MachineValidation>> {
+    let query = "
+        UPDATE machine_validation
+        SET state=$2
+        WHERE id=$1
+        AND end_time IS NULL
+        AND state IN ('Started', 'InProgress')
+        RETURNING *";
+    sqlx::query_as::<_, MachineValidation>(query)
         .bind(id)
-        .bind(status.state.to_string())
-        .fetch_one(txn)
+        .bind(MachineValidationState::InProgress.to_string())
+        .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-    Ok(())
+        .map_err(|e| DatabaseError::query(query, e))
 }
 pub async fn update_end_time(
     txn: &mut PgConnection,

--- a/crates/machine-validation/Cargo.toml
+++ b/crates/machine-validation/Cargo.toml
@@ -47,6 +47,8 @@ reqwest = { default-features = false, features = [
   "stream",
 ], workspace = true }
 futures-util = { workspace = true }
+libc = { workspace = true }
+uuid = { features = ["v4"], workspace = true }
 
 [dev-dependencies]
 carbide-instrument = { path = "../instrument", features = ["test-support"] }

--- a/crates/machine-validation/src/lib.rs
+++ b/crates/machine-validation/src/lib.rs
@@ -27,6 +27,14 @@ use serde::{Deserialize, Serialize};
 
 mod errors;
 mod machine_validation;
+mod plugin_contract;
+// This foundation is intentionally dormant until the control-plane wiring is
+// introduced in the next PR.
+#[expect(
+    dead_code,
+    reason = "plugin runner is introduced before its opt-in wiring"
+)]
+mod plugin_runner;
 
 pub const MACHINE_VALIDATION_SERVER: &str = "carbide-pxe.forge";
 pub const SCHME: &str = "http";

--- a/crates/machine-validation/src/plugin_contract.rs
+++ b/crates/machine-validation/src/plugin_contract.rs
@@ -1,0 +1,171 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Machine Validation plugin result contract and safe result-file handling.
+
+use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+use serde::Deserialize;
+
+const MAX_RESULT_SIZE: u64 = 64 * 1024;
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PluginResult {
+    #[serde(rename = "contractVersion")]
+    pub(crate) contract_version: String,
+    pub(crate) kind: String,
+    pub(crate) outcome: String,
+    pub(crate) summary: String,
+    #[serde(default)]
+    pub(crate) severity: Option<String>,
+    #[serde(default)]
+    pub(crate) findings: Vec<PluginFinding>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PluginFinding {
+    pub(crate) name: String,
+    pub(crate) message: String,
+}
+
+pub(crate) fn read_plugin_result(path: &Path) -> Result<PluginResult, String> {
+    #[cfg(unix)]
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|error| format!("plugin did not write result.json: {error}"))?;
+    #[cfg(not(unix))]
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .open(path)
+        .map_err(|error| format!("plugin did not write result.json: {error}"))?;
+
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect plugin result: {error}"))?;
+    if !metadata.is_file() {
+        return Err("plugin result must be a regular file".to_owned());
+    }
+
+    let mut contents = Vec::with_capacity(MAX_RESULT_SIZE as usize);
+    file.take(MAX_RESULT_SIZE + 1)
+        .read_to_end(&mut contents)
+        .map_err(|error| format!("failed to read plugin result: {error}"))?;
+    if contents.len() > MAX_RESULT_SIZE as usize {
+        return Err("plugin result exceeds the 64 KiB limit".to_owned());
+    }
+    parse_plugin_result(&contents)
+}
+
+fn parse_plugin_result(contents: &[u8]) -> Result<PluginResult, String> {
+    let result: PluginResult = serde_json::from_slice(contents)
+        .map_err(|error| format!("invalid plugin result: {error}"))?;
+    if result.contract_version != "v1" {
+        return Err("plugin result has an unsupported contractVersion".to_owned());
+    }
+    if result.kind != "MachineValidationPluginResult" {
+        return Err("plugin result has an unsupported kind".to_owned());
+    }
+    if !matches!(result.outcome.as_str(), "pass" | "fail" | "error") {
+        return Err("plugin result has an unsupported outcome".to_owned());
+    }
+    if result.summary.len() > 4096 {
+        return Err("plugin result summary exceeds the 4 KiB limit".to_owned());
+    }
+    if result
+        .severity
+        .as_deref()
+        .is_some_and(|severity| !matches!(severity, "info" | "warning" | "critical" | "unknown"))
+    {
+        return Err("plugin result has an unsupported severity".to_owned());
+    }
+    if result.findings.len() > 100 {
+        return Err("plugin result has more than 100 findings".to_owned());
+    }
+    if result
+        .findings
+        .iter()
+        .any(|finding| finding.name.is_empty() || finding.message.len() > 4096)
+    {
+        return Err("plugin result contains an invalid finding".to_owned());
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[test]
+    fn plugin_result_contract_validation() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid result",
+                    input: r#"{"contractVersion":"v1","kind":"MachineValidationPluginResult","outcome":"pass","summary":"check completed","severity":"info","findings":[{"name":"gpu","message":"available"}]}"#,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "unknown outcome",
+                    input: r#"{"contractVersion":"v1","kind":"MachineValidationPluginResult","outcome":"skipped","summary":"check completed"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown field",
+                    input: r#"{"contractVersion":"v1","kind":"MachineValidationPluginResult","outcome":"pass","summary":"check completed","extra":"not allowed"}"#,
+                    expect: Fails,
+                },
+            ],
+            |contents| {
+                parse_plugin_result(contents.as_bytes())
+                    .map(|_| ())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn plugin_result_file_must_be_regular_and_bounded() {
+        let directory =
+            std::env::temp_dir().join(format!("plugin-contract-test-{}", Uuid::new_v4()));
+        std::fs::create_dir(&directory).expect("create test directory");
+        let result_path = directory.join("result.json");
+
+        std::fs::write(&result_path, vec![b'x'; MAX_RESULT_SIZE as usize + 1])
+            .expect("write oversized result");
+        assert!(read_plugin_result(&result_path).is_err());
+
+        #[cfg(unix)]
+        {
+            std::fs::remove_file(&result_path).expect("remove oversized result");
+            std::os::unix::fs::symlink("/etc/passwd", &result_path).expect("create result symlink");
+            assert!(read_plugin_result(&result_path).is_err());
+        }
+
+        std::fs::remove_dir_all(directory).expect("remove test directory");
+    }
+}

--- a/crates/machine-validation/src/plugin_runner.rs
+++ b/crates/machine-validation/src/plugin_runner.rs
@@ -1,0 +1,688 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Private OCI runtime building blocks for Machine Validation plugins.
+//!
+//! This module deliberately has no control-plane integration. Existing Machine
+//! Validation tests do not construct or call this runner. A later change will
+//! supply approved plugin definitions and opt into this execution path.
+
+#[cfg(unix)]
+use std::ffi::CString;
+use std::path::Path;
+use std::process::Stdio;
+#[cfg(unix)]
+use std::{os::unix::ffi::OsStrExt, os::unix::fs::MetadataExt, os::unix::fs::PermissionsExt};
+
+use carbide_utils::cmd::TokioCmd;
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::plugin_contract::{PluginResult, read_plugin_result};
+
+const MAX_OUTPUT_SIZE: usize = 1024 * 1024;
+const MAX_INPUT_SIZE: usize = 64 * 1024;
+const PLUGIN_UID: u32 = 65532;
+const PLUGIN_GID: u32 = 65532;
+const CONTAINER_CLEANUP_TIMEOUT_SECONDS: u64 = 30;
+const CONTAINER_REMOVE_ATTEMPTS: u8 = 3;
+
+const INPUT_PATH: &str = "/opt/nico/mv/input";
+const OUTPUT_PATH: &str = "/opt/nico/mv/output";
+const ATTEMPT_BASE_DIR: &str = "/run/nico/machine-validation";
+
+/// The runtime access granted to an approved plugin revision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PluginPrivilege {
+    /// A non-root container with no network and no additional capabilities.
+    Isolated,
+    /// A privileged container, without a host-root bind mount.
+    Privileged,
+    /// A privileged container with a writable host-root bind mount at `/host`.
+    FullHost,
+}
+
+/// Immutable execution settings supplied by a later control-plane integration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginRuntimeSpec {
+    pub(crate) image: String,
+    pub(crate) entrypoint: Vec<String>,
+    pub(crate) privilege: PluginPrivilege,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PluginExecution {
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) result: PluginResult,
+}
+
+struct CapturedOutput {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+/// Ensures a cancelled execution still removes its named container.
+///
+/// `nerdctl` can create a container before its client process exits. The
+/// caller's future may be cancelled during Scout shutdown, so relying only on
+/// `kill_on_drop` would leave that container running.
+struct ContainerCleanupGuard<F>
+where
+    F: FnOnce(String),
+{
+    container_name: Option<String>,
+    schedule_cleanup: Option<F>,
+}
+
+impl<F> ContainerCleanupGuard<F>
+where
+    F: FnOnce(String),
+{
+    fn new(container_name: String, schedule_cleanup: F) -> Self {
+        Self {
+            container_name: Some(container_name),
+            schedule_cleanup: Some(schedule_cleanup),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.container_name = None;
+    }
+}
+
+impl<F> Drop for ContainerCleanupGuard<F>
+where
+    F: FnOnce(String),
+{
+    fn drop(&mut self) {
+        let Some(container_name) = self.container_name.take() else {
+            return;
+        };
+        if let Some(schedule_cleanup) = self.schedule_cleanup.take() {
+            schedule_cleanup(container_name);
+        } else {
+            warn!("Could not schedule cleanup for cancelled machine validation plugin container");
+        }
+    }
+}
+
+fn schedule_container_cleanup(container_name: String) {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            std::mem::drop(handle.spawn(async move {
+                    if let Err(error) = force_remove_plugin_container(&container_name).await {
+                        warn!(%container_name, %error, "Failed to remove cancelled machine validation plugin container");
+                    }
+                }));
+        }
+        Err(error) => {
+            warn!(%container_name, %error, "Could not schedule cleanup for cancelled machine validation plugin container");
+        }
+    }
+}
+
+/// Runs an image that is already available to nerdctl.
+///
+/// The caller supplies the versioned plugin input document. On timeout, the
+/// named container is removed before its bind-mounted attempt directory is
+/// deleted. That matters especially for a FullHost plugin.
+pub(crate) async fn execute_plugin(
+    spec: &PluginRuntimeSpec,
+    input: &Value,
+    timeout: std::time::Duration,
+) -> Result<PluginExecution, String> {
+    validate_runtime_spec(spec)?;
+    let input = serialize_plugin_input(input)?;
+    let attempt_dir = plugin_attempt_directory()?;
+    let input_dir = attempt_dir.join("input");
+    let output_dir = attempt_dir.join("output");
+    if let Err(error) = prepare_plugin_directories(&attempt_dir, &input_dir, &output_dir) {
+        return match remove_attempt_directory(&attempt_dir) {
+            Ok(()) => Err(error),
+            Err(cleanup_error) => Err(format!("{error}; {cleanup_error}")),
+        };
+    }
+
+    let (execution, remove_attempt_dir) = async {
+        if let Err(error) = std::fs::write(input_dir.join("input.json"), input) {
+            return (Err(format!("failed to write plugin input: {error}")), true);
+        }
+
+        let container_name = format!("mv-plugin-{}", Uuid::new_v4());
+        let mut command = tokio::process::Command::new("nerdctl");
+        command
+            .args(plugin_runtime_args(
+                &input_dir,
+                &output_dir,
+                &container_name,
+                spec,
+            ))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => return (Err(format!("failed to execute plugin: {error}")), true),
+        };
+        let mut cleanup_guard =
+            ContainerCleanupGuard::new(container_name.clone(), schedule_container_cleanup);
+        match tokio::time::timeout(timeout, collect_plugin_output(child)).await {
+            Ok(Ok((status, stdout, stderr))) if status.success() => {
+                cleanup_guard.disarm();
+                (
+                    read_plugin_result(&output_dir.join("result.json")).map(|result| {
+                        PluginExecution {
+                            stdout: output_to_string(stdout),
+                            stderr: output_to_string(stderr),
+                            result,
+                        }
+                    }),
+                    true,
+                )
+            }
+            Ok(Ok((status, _, _))) => {
+                cleanup_guard.disarm();
+                (
+                    Err(format!(
+                        "plugin exited unsuccessfully with status {:?}; ignoring result.json",
+                        status.code()
+                    )),
+                    true,
+                )
+            }
+            Ok(Err(error)) => match force_remove_plugin_container(&container_name).await {
+                Ok(()) => {
+                    cleanup_guard.disarm();
+                    (Err(error), true)
+                }
+                Err(cleanup_error) => (
+                    Err(format!(
+                        "{error}; preserving attempt directory because {cleanup_error}"
+                    )),
+                    false,
+                ),
+            },
+            Err(_) => {
+                let timeout_error = format!("plugin timed out after {} seconds", timeout.as_secs());
+                match force_remove_plugin_container(&container_name).await {
+                    Ok(()) => {
+                        cleanup_guard.disarm();
+                        (Err(timeout_error), true)
+                    }
+                    Err(error) => (
+                        Err(format!(
+                            "{timeout_error}; preserving attempt directory because {error}"
+                        )),
+                        false,
+                    ),
+                }
+            }
+        }
+    }
+    .await;
+
+    if remove_attempt_dir {
+        remove_attempt_directory(&attempt_dir)?;
+    }
+    execution
+}
+
+fn validate_runtime_spec(spec: &PluginRuntimeSpec) -> Result<(), String> {
+    let Some((image_name, digest)) = spec.image.split_once('@') else {
+        return Err("plugin image must include a SHA-256 digest".to_owned());
+    };
+    if image_name.is_empty() || image_name.contains(char::is_whitespace) || digest.contains('@') {
+        return Err("plugin image must contain one image name and digest".to_owned());
+    }
+    let Some(digest_hex) = digest.strip_prefix("sha256:") else {
+        return Err("plugin image digest must use the sha256 algorithm".to_owned());
+    };
+    if digest_hex.len() != 64
+        || !digest_hex
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        return Err("plugin image digest must be a 64-character SHA-256 hex value".to_owned());
+    }
+    if spec.entrypoint.is_empty()
+        || spec
+            .entrypoint
+            .iter()
+            .any(|argument| argument.is_empty() || argument.contains('\0'))
+    {
+        return Err("plugin entrypoint must contain non-empty arguments".to_owned());
+    }
+    Ok(())
+}
+
+fn serialize_plugin_input(input: &Value) -> Result<Vec<u8>, String> {
+    let input = serde_json::to_vec(input)
+        .map_err(|error| format!("failed to serialize plugin input: {error}"))?;
+    if input.len() > MAX_INPUT_SIZE {
+        return Err("plugin input exceeds the 64 KiB limit".to_owned());
+    }
+    Ok(input)
+}
+
+async fn collect_plugin_output(
+    mut child: tokio::process::Child,
+) -> Result<(std::process::ExitStatus, CapturedOutput, CapturedOutput), String> {
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "plugin stdout was not captured".to_owned())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "plugin stderr was not captured".to_owned())?;
+    let (status, stdout, stderr) =
+        tokio::try_join!(child.wait(), read_limited(stdout), read_limited(stderr))
+            .map_err(|error| format!("failed to collect plugin output: {error}"))?;
+    Ok((status, stdout, stderr))
+}
+
+async fn read_limited<R>(mut reader: R) -> Result<CapturedOutput, std::io::Error>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut bytes = Vec::with_capacity(MAX_OUTPUT_SIZE);
+    let mut buffer = [0; 8192];
+    let mut truncated = false;
+    loop {
+        let bytes_read = reader.read(&mut buffer).await?;
+        if bytes_read == 0 {
+            break;
+        }
+        let remaining = MAX_OUTPUT_SIZE.saturating_sub(bytes.len());
+        let copied = bytes_read.min(remaining);
+        bytes.extend_from_slice(&buffer[..copied]);
+        truncated |= copied < bytes_read;
+    }
+    Ok(CapturedOutput { bytes, truncated })
+}
+
+fn output_to_string(output: CapturedOutput) -> String {
+    let mut contents = String::from_utf8_lossy(&output.bytes).into_owned();
+    if output.truncated {
+        contents.push_str("\n[plugin output truncated at 1 MiB]");
+    }
+    contents
+}
+
+fn plugin_runtime_args(
+    input_dir: &Path,
+    output_dir: &Path,
+    container_name: &str,
+    spec: &PluginRuntimeSpec,
+) -> Vec<String> {
+    let mut args = vec![
+        "-n".to_owned(),
+        "default".to_owned(),
+        "run".to_owned(),
+        "--rm".to_owned(),
+        "--network".to_owned(),
+        "none".to_owned(),
+        "--mount".to_owned(),
+        format!(
+            "type=bind,src={},dst={INPUT_PATH},options=rbind:ro",
+            input_dir.display()
+        ),
+        "--mount".to_owned(),
+        format!(
+            "type=bind,src={},dst={OUTPUT_PATH},options=rbind:rw",
+            output_dir.display()
+        ),
+    ];
+
+    match spec.privilege {
+        PluginPrivilege::Isolated => args.extend([
+            "--user".to_owned(),
+            format!("{PLUGIN_UID}:{PLUGIN_GID}"),
+            "--cap-drop".to_owned(),
+            "ALL".to_owned(),
+            "--security-opt".to_owned(),
+            "no-new-privileges".to_owned(),
+        ]),
+        PluginPrivilege::Privileged => args.push("--privileged".to_owned()),
+        PluginPrivilege::FullHost => args.extend([
+            "--privileged".to_owned(),
+            "--mount".to_owned(),
+            "type=bind,src=/,dst=/host,options=rbind:rw".to_owned(),
+        ]),
+    }
+
+    args.extend([
+        "--name".to_owned(),
+        container_name.to_owned(),
+        spec.image.clone(),
+    ]);
+    args.extend(spec.entrypoint.iter().cloned());
+    args
+}
+
+fn plugin_container_remove_args(container_name: &str) -> [&str; 5] {
+    ["-n", "default", "rm", "--force", container_name]
+}
+
+async fn force_remove_plugin_container(container_name: &str) -> Result<(), String> {
+    // Dropping the `nerdctl run` client does not stop a container that
+    // containerd already created. Remove it before cleaning up its mounts.
+    let mut last_error = None;
+    let mut only_not_found_errors = true;
+    for attempt in 1..=CONTAINER_REMOVE_ATTEMPTS {
+        match TokioCmd::new("nerdctl")
+            .args(plugin_container_remove_args(container_name))
+            .timeout(CONTAINER_CLEANUP_TIMEOUT_SECONDS)
+            .output_with_timeout()
+            .await
+        {
+            Ok(result) if result.exit_code == 0 => {
+                info!(%container_name, attempt, "Removed timed out machine validation plugin container");
+                return Ok(());
+            }
+            Ok(result) => {
+                only_not_found_errors &= container_not_found(&result.stderr);
+                last_error = Some(format!(
+                    "nerdctl returned {}: {}",
+                    result.exit_code, result.stderr
+                ));
+            }
+            Err(error) => {
+                only_not_found_errors = false;
+                last_error = Some(error.to_string());
+            }
+        }
+        warn!(%container_name, attempt, error = ?last_error, "Failed to remove timed out machine validation plugin container");
+        if attempt < CONTAINER_REMOVE_ATTEMPTS {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
+    if only_not_found_errors {
+        // A timeout can occur before `nerdctl` has created the container, or
+        // after `--rm` has removed it. Retrying first avoids accepting that
+        // response while the killed client is still starting the container.
+        info!(%container_name, "Timed out plugin container was already absent");
+        return Ok(());
+    }
+    Err(format!(
+        "could not remove timed out plugin container {container_name} after {CONTAINER_REMOVE_ATTEMPTS} attempts: {}",
+        last_error.unwrap_or_else(|| "unknown error".to_owned())
+    ))
+}
+
+fn container_not_found(stderr: &str) -> bool {
+    stderr.to_ascii_lowercase().contains("no such container")
+}
+
+fn plugin_attempt_directory() -> Result<std::path::PathBuf, String> {
+    let base_dir = Path::new(ATTEMPT_BASE_DIR);
+    if let Some(parent) = base_dir.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            format!("failed to create plugin runtime parent directory: {error}")
+        })?;
+        validate_root_owned_directory(parent, "plugin runtime parent directory")?;
+    }
+    std::fs::create_dir_all(base_dir)
+        .map_err(|error| format!("failed to create plugin runtime directory: {error}"))?;
+    validate_root_owned_directory(base_dir, "plugin runtime directory")?;
+
+    #[cfg(unix)]
+    {
+        std::fs::set_permissions(base_dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("failed to restrict plugin runtime directory: {error}"))?;
+    }
+
+    Ok(base_dir.join(Uuid::new_v4().to_string()))
+}
+
+#[cfg(unix)]
+fn validate_root_owned_directory(directory: &Path, name: &str) -> Result<(), String> {
+    let metadata = std::fs::symlink_metadata(directory)
+        .map_err(|error| format!("failed to inspect {name}: {error}"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() || metadata.uid() != 0 {
+        return Err(format!("{name} must be a root-owned directory"));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn validate_root_owned_directory(_directory: &Path, _name: &str) -> Result<(), String> {
+    Ok(())
+}
+
+fn remove_attempt_directory(attempt_dir: &Path) -> Result<(), String> {
+    std::fs::remove_dir_all(attempt_dir)
+        .map_err(|error| format!("failed to remove plugin attempt directory: {error}"))
+}
+
+#[cfg(unix)]
+fn prepare_plugin_directories(
+    attempt_dir: &Path,
+    input_dir: &Path,
+    output_dir: &Path,
+) -> Result<(), String> {
+    std::fs::create_dir_all(attempt_dir)
+        .map_err(|error| format!("failed to create plugin attempt directory: {error}"))?;
+    std::fs::set_permissions(attempt_dir, std::fs::Permissions::from_mode(0o711))
+        .map_err(|error| format!("failed to restrict plugin attempt directory: {error}"))?;
+
+    for directory in [input_dir, output_dir] {
+        std::fs::create_dir(directory)
+            .map_err(|error| format!("failed to create plugin directory: {error}"))?;
+        let path = CString::new(directory.as_os_str().as_bytes())
+            .map_err(|_| "plugin directory path contains a null byte".to_owned())?;
+        // Scout creates these directories for the fixed non-root container
+        // identity. The restrictive mode prevents another host user from
+        // pre-seeding or replacing the plugin's result.
+        // SAFETY: `path` is NUL-terminated and remains valid for this call.
+        if unsafe { libc::chown(path.as_ptr(), PLUGIN_UID, PLUGIN_GID) } != 0 {
+            return Err(format!(
+                "failed to grant plugin directory access: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("failed to restrict plugin directory: {error}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn prepare_plugin_directories(
+    _attempt_dir: &Path,
+    _input_dir: &Path,
+    _output_dir: &Path,
+) -> Result<(), String> {
+    Err("machine validation plugin execution requires a Unix host".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+
+    fn spec(privilege: PluginPrivilege) -> PluginRuntimeSpec {
+        PluginRuntimeSpec {
+            image: "registry.example/plugin@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_owned(),
+            entrypoint: vec!["/plugin/check".to_owned(), "--verify".to_owned()],
+            privilege,
+        }
+    }
+
+    #[test]
+    fn isolated_plugin_is_non_root_and_network_isolated() {
+        let args = plugin_runtime_args(
+            Path::new("/tmp/input"),
+            Path::new("/tmp/output"),
+            "plugin-test",
+            &spec(PluginPrivilege::Isolated),
+        );
+
+        assert!(args.windows(2).any(|pair| pair == ["--network", "none"]));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--user", "65532:65532"])
+        );
+        assert!(args.windows(2).any(|pair| pair == ["--cap-drop", "ALL"]));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--security-opt", "no-new-privileges"])
+        );
+        assert!(args.iter().any(|arg| arg.contains(INPUT_PATH)));
+        assert!(args.iter().any(|arg| arg.contains(OUTPUT_PATH)));
+        assert!(!args.iter().any(|arg| arg == "--privileged"));
+        assert!(!args.iter().any(|arg| arg.contains("dst=/host")));
+    }
+
+    #[test]
+    fn privileged_plugin_has_no_host_root_mount() {
+        let args = plugin_runtime_args(
+            Path::new("/tmp/input"),
+            Path::new("/tmp/output"),
+            "plugin-test",
+            &spec(PluginPrivilege::Privileged),
+        );
+
+        assert!(args.iter().any(|arg| arg == "--privileged"));
+        assert!(!args.iter().any(|arg| arg.contains("dst=/host")));
+    }
+
+    #[test]
+    fn full_host_plugin_has_privileged_runtime_and_host_root_mount() {
+        let args = plugin_runtime_args(
+            Path::new("/tmp/input"),
+            Path::new("/tmp/output"),
+            "plugin-test",
+            &spec(PluginPrivilege::FullHost),
+        );
+
+        assert!(args.iter().any(|arg| arg == "--privileged"));
+        assert!(
+            args.iter()
+                .any(|arg| arg.contains("dst=/host,options=rbind:rw"))
+        );
+    }
+
+    #[test]
+    fn runtime_spec_requires_a_sha256_image_digest_and_entrypoint() {
+        let mut runtime_spec = spec(PluginPrivilege::Isolated);
+        assert!(validate_runtime_spec(&runtime_spec).is_ok());
+
+        runtime_spec.image = "registry.example/plugin:latest".to_owned();
+        assert!(validate_runtime_spec(&runtime_spec).is_err());
+
+        runtime_spec.image = "registry.example/plugin@sha256:not-a-digest".to_owned();
+        assert!(validate_runtime_spec(&runtime_spec).is_err());
+
+        runtime_spec = spec(PluginPrivilege::Isolated);
+        runtime_spec.entrypoint = vec![];
+        assert!(validate_runtime_spec(&runtime_spec).is_err());
+    }
+
+    #[test]
+    fn plugin_input_is_bounded() {
+        assert!(serialize_plugin_input(&serde_json::json!({ "input": "ok" })).is_ok());
+        assert!(
+            serialize_plugin_input(&serde_json::json!({
+                "input": "x".repeat(MAX_INPUT_SIZE),
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn timed_out_plugin_removal_targets_the_named_container() {
+        assert_eq!(
+            plugin_container_remove_args("mv-plugin-example"),
+            ["-n", "default", "rm", "--force", "mv-plugin-example"]
+        );
+    }
+
+    #[test]
+    fn container_not_found_is_idempotent_cleanup() {
+        assert!(container_not_found(
+            "FATA[0000] no such container: mv-plugin-example"
+        ));
+        assert!(!container_not_found("permission denied"));
+    }
+
+    #[test]
+    fn cancelled_execution_schedules_container_cleanup() {
+        let removed_containers = Arc::new(Mutex::new(Vec::new()));
+        let scheduler_containers = Arc::clone(&removed_containers);
+        {
+            let _cleanup_guard =
+                ContainerCleanupGuard::new("mv-plugin-example".to_owned(), move |container_name| {
+                    scheduler_containers
+                        .lock()
+                        .expect("lock scheduled cleanup")
+                        .push(container_name);
+                });
+        }
+
+        assert_eq!(
+            *removed_containers.lock().expect("lock scheduled cleanup"),
+            ["mv-plugin-example"]
+        );
+    }
+
+    #[test]
+    fn completed_execution_does_not_schedule_container_cleanup() {
+        let removed_containers = Arc::new(Mutex::new(Vec::new()));
+        let scheduler_containers = Arc::clone(&removed_containers);
+        let mut cleanup_guard =
+            ContainerCleanupGuard::new("mv-plugin-example".to_owned(), move |container_name| {
+                scheduler_containers
+                    .lock()
+                    .expect("lock scheduled cleanup")
+                    .push(container_name);
+            });
+
+        cleanup_guard.disarm();
+        drop(cleanup_guard);
+        assert!(
+            removed_containers
+                .lock()
+                .expect("lock scheduled cleanup")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn plugin_output_is_bounded_while_the_stream_is_drained() {
+        let (mut writer, reader) = tokio::io::duplex(8192);
+        let payload = vec![b'x'; MAX_OUTPUT_SIZE + 1];
+        let writer = tokio::spawn(async move { writer.write_all(&payload).await });
+
+        let output = read_limited(reader).await.expect("read plugin output");
+        writer
+            .await
+            .expect("join writer")
+            .expect("write plugin output");
+
+        assert_eq!(output.bytes.len(), MAX_OUTPUT_SIZE);
+        assert!(output.truncated);
+        assert!(output_to_string(output).ends_with("[plugin output truncated at 1 MiB]"));
+    }
+}


### PR DESCRIPTION
## Summary

*NOTE*: This PR implements some of the Milestones defined in the Design Doc: https://github.com/NVIDIA/infra-controller/pull/5092

 This is PR1 of the pluggable Machine Validation framework https://github.com/NVIDIA/infra-controller/pull/5092.

  It adds the safe, internal OCI container-runner foundation needed for future Machine Validation plugins. The runner is not connected to the existing execution flow yet, so existing validation tests continue to run as they do today.

  This PR also fixes #4876: completed Machine Validation runs are no longer sent back to Scout repeatedly.

  ## What is included

  - A versioned plugin result contract using `contractVersion: "v1"`.
  - Safe OCI runner building blocks for:
    - isolated containers
    - privileged containers
    - privileged containers with writable `/host` access
  - Digest-pinned SHA-256 image validation.
  - Bounded plugin input, output, and result-file sizes.
  - Network isolation for isolated plugins.
  - Safe result-file handling and timeout/cancellation cleanup.
  - Regression coverage for terminal Machine Validation runs.

  ## Compatibility

  This PR does not change existing Machine Validation test definitions, catalog behavior, or Scout execution behavior.

  The new OCI runner is intentionally internal and dormant until later PRs add plugin configuration and execution wiring.

  ## Bigger picture

  The pluggable Machine Validation work is being introduced in small, compatible steps:

  1. **PR1 — this PR:** Safe runner and plugin-contract foundation.
  2. **Next:** Plugin definitions, site policy, verification/enablement, credentials, and full-host approval.
  3. **Then:** Select approved plugins during Machine Validation, execute them through Scout, record results, and stream execution logs.


## Related issues
https://github.com/NVIDIA/infra-controller/pull/5092
https://github.com/NVIDIA/infra-controller/issues/3655
https://github.com/NVIDIA/infra-controller/issues/2962
#4876

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
none
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Design Document: https://github.com/NVIDIA/infra-controller/pull/5092
