### PR TITLE
docs: announce repository move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NVIDIA Infra Controller
 
-> **Repository move notice:** On September 4, 2026, the NICo repository will move from the NVIDIA GitHub organization to `dsx-ai-factory`. Existing repository URLs and standard Git operations are expected to continue working through GitHub redirects. No action is needed for most users. If you maintain automation or integrations that reference `NVIDIA/infra-controller`—such as GitHub Actions, webhooks, or pinned repository URLs—please update them to `dsx-ai-factory/infra-controller` after the move.
+> **Repository move notice:** On September 4, 2026, the NICo repository will move from the NVIDIA GitHub organization to `dsx-ai-factory`. Existing repository URLs and standard Git operations are expected to continue working through GitHub redirects. No action is needed for most users. If you maintain automation or integrations that reference `NVIDIA/infra-controller`, such as GitHub Actions, webhooks, or pinned repository URLs, please update them to `dsx-ai-factory/infra-controller` after the move.
 
 NVIDIA Infra Controller (NICo) delivers zero-touch lifecycle automation for
 bare-metal systems that secures datacenter infrastructure at its foundation.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NVIDIA Infra Controller
 
+> **Repository move notice:** On September 4, 2026, the NICo repository will move from the NVIDIA GitHub organization to `dsx-ai-factory`. Existing repository URLs and standard Git operations are expected to continue working through GitHub redirects. No action is needed for most users. If you maintain automation or integrations that reference `NVIDIA/infra-controller`—such as GitHub Actions, webhooks, or pinned repository URLs—please update them to `dsx-ai-factory/infra-controller` after the move.
+
 NVIDIA Infra Controller (NICo) delivers zero-touch lifecycle automation for
 bare-metal systems that secures datacenter infrastructure at its foundation.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 # NICo — NVIDIA Infra Controller Documentation
 
+<Tip title="Repository move notice">
+On September 4, 2026, the NICo repository will move from the NVIDIA GitHub organization to `dsx-ai-factory`. Existing repository URLs and standard Git operations are expected to continue working through GitHub redirects. No action is needed for most users. If you maintain automation or integrations that reference `NVIDIA/infra-controller`, such as GitHub Actions, webhooks, or pinned repository URLs, please update them to `dsx-ai-factory/infra-controller` after the move.
+</Tip>
+
 NICo is an open source suite of microservices for site-local, zero-trust bare-metal lifecycle management. It automates hardware discovery, firmware validation, DPU provisioning, network isolation, and tenant sanitization — enabling NVIDIA Cloud Partners (NCPs) and infrastructure operators to stand up and operate AI factory-scale infrastructure.
 
 NICo is open source under the Apache 2.0 license.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # NICo — NVIDIA Infra Controller Documentation
 
-<Tip title="Repository move notice">
+<Note title="Repository move notice">
 On September 4, 2026, the NICo repository will move from the NVIDIA GitHub organization to `dsx-ai-factory`. Existing repository URLs and standard Git operations are expected to continue working through GitHub redirects. No action is needed for most users. If you maintain automation or integrations that reference `NVIDIA/infra-controller`, such as GitHub Actions, webhooks, or pinned repository URLs, please update them to `dsx-ai-factory/infra-controller` after the move.
-</Tip>
+</Note>
 
 NICo is an open source suite of microservices for site-local, zero-trust bare-metal lifecycle management. It automates hardware discovery, firmware validation, DPU provisioning, network isolation, and tenant sanitization — enabling NVIDIA Cloud Partners (NCPs) and infrastructure operators to stand up and operate AI factory-scale infrastructure.
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -21,7 +21,7 @@ check:
 
 navbar-links:
   - type: github
-    value: https://github.com/NVIDIA/infra-controller
+    value: https://github.com/dsx-ai-factory/infra-controller
 
 products:
   - display-name: NVIDIA Infra Controller

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -21,7 +21,7 @@ check:
 
 navbar-links:
   - type: github
-    value: https://github.com/dsx-ai-factory/infra-controller
+    value: https://github.com/nvidia/infra-controller
 
 products:
   - display-name: NVIDIA Infra Controller

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -12,6 +12,9 @@ instances:
 
 title: NVIDIA Infra Controller
 
+announcement:
+  message: "🔔 Infra Controller's GitHub repository is moving on September 4, 2026. Refer to the [front page](https://docs.nvidia.com/infra-controller) for more information."
+
 # metadata:
 #   canonical-host: "docs.nvidia.com/infra-controller"
 

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
-  "organization": "nvidia",
+  "organization": "dsx-ai-factory",
   "version": "5.94.0"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
-  "organization": "dsx-ai-factory",
-  "version": "5.94.0"
+  "organization": "nvidia",
+  "version": "5.108.0"
 }


### PR DESCRIPTION
## Related issues

None.

## Type of Change

- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Adds pre-move notices to the README and documentation landing page for the September 4, 2026 transfer of NICo from `NVIDIA/infra-controller` to `dsx-ai-factory/infra-controller`. The documentation notice uses the Fern `Tip` component. Infrastructure and canonical-link updates are intentionally deferred to cutover day.