### PR TITLE
feat(rest-api): Recovery of missing VPC Peerings from Site inventory

### DIFF
--- a/rest-api/db/pkg/db/model/vpcpeering.go
+++ b/rest-api/db/pkg/db/model/vpcpeering.go
@@ -156,13 +156,22 @@ func (vp *VpcPeering) ToDeletionRequestProto() *corev1.VpcPeeringDeletionRequest
 }
 
 type VpcPeeringCreateInput struct {
+	VpcPeeringID             *uuid.UUID
 	Vpc1ID                   uuid.UUID
 	Vpc2ID                   uuid.UUID
 	SiteID                   uuid.UUID
 	IsMultiTenant            bool
 	InfrastructureProviderID *uuid.UUID
 	TenantID                 *uuid.UUID
+	Status                   string
 	CreatedByID              uuid.UUID
+}
+
+// VpcPeeringClearInput input parameters for Clear method
+type VpcPeeringClearInput struct {
+	VpcPeeringID uuid.UUID
+	// Deleted clears the soft-delete timestamp (undelete).
+	Deleted bool
 }
 
 type VpcPeeringFilterInput struct {
@@ -177,6 +186,8 @@ type VpcPeeringFilterInput struct {
 	// scopes results to the caller's authorization context.
 	PeerTenantIDs []uuid.UUID
 	Statuses      []string
+	// IncludeDeleted returns soft-deleted rows in addition to active ones.
+	IncludeDeleted bool
 }
 
 func (vp *VpcPeering) BeforeCreateTable(ctx context.Context, query *bun.CreateTableQuery) error {
@@ -200,6 +211,8 @@ type VpcPeeringDAO interface {
 	GetByID(ctx context.Context, tx *db.Tx, id uuid.UUID, includeRelations []string) (*VpcPeering, error)
 	//
 	UpdateStatusByID(ctx context.Context, tx *db.Tx, id uuid.UUID, newStatus string) error
+	//
+	Clear(ctx context.Context, tx *db.Tx, input VpcPeeringClearInput) (*VpcPeering, error)
 	//
 	Delete(ctx context.Context, tx *db.Tx, id uuid.UUID) error
 	//
@@ -231,15 +244,25 @@ func (vpsd VpcPeeringSQLDAO) Create(
 		return nil, errors.New("cannot peer a VPC with itself")
 	}
 
+	vpcPeeringID := uuid.New()
+	if input.VpcPeeringID != nil {
+		vpcPeeringID = *input.VpcPeeringID
+	}
+
+	status := input.Status
+	if status == "" {
+		status = VpcPeeringStatusPending
+	}
+
 	vp := &VpcPeering{
-		ID:                       uuid.New(),
+		ID:                       vpcPeeringID,
 		Vpc1ID:                   vpc1ID,
 		Vpc2ID:                   vpc2ID,
 		SiteID:                   input.SiteID,
 		IsMultiTenant:            input.IsMultiTenant,
 		InfrastructureProviderID: input.InfrastructureProviderID,
 		TenantID:                 input.TenantID,
-		Status:                   VpcPeeringStatusPending,
+		Status:                   status,
 		Created:                  db.GetCurTime(),
 		Updated:                  db.GetCurTime(),
 		CreatedBy:                input.CreatedByID,
@@ -267,6 +290,9 @@ func (vpsd VpcPeeringSQLDAO) GetAll(
 
 	vps := []VpcPeering{}
 	query := db.GetIDB(tx, vpsd.dbSession).NewSelect().Model(&vps)
+	if filter.IncludeDeleted {
+		query = query.WhereAllWithDeleted()
+	}
 	query, err := vpsd.setQueryWithFilter(filter, query, vpDAOSpan)
 	if err != nil {
 		return vps, 0, err
@@ -425,6 +451,36 @@ func (vpsd VpcPeeringSQLDAO) UpdateStatusByID(
 		Exec(ctx)
 
 	return err
+}
+
+// Clear clears VpcPeering attributes based on provided arguments
+func (vpsd VpcPeeringSQLDAO) Clear(ctx context.Context, tx *db.Tx, input VpcPeeringClearInput) (*VpcPeering, error) {
+	ctx, vpDAOSpan := vpsd.tracerSpan.CreateChildInCurrentContext(ctx, "VpcPeeringDAO.Clear")
+	if vpDAOSpan != nil {
+		defer vpDAOSpan.End()
+
+		vpsd.tracerSpan.SetAttribute(vpDAOSpan, "id", input.VpcPeeringID)
+	}
+
+	if input.Deleted {
+		_, err := db.GetIDB(tx, vpsd.dbSession).
+			NewUpdate().
+			Model((*VpcPeering)(nil)).
+			Set("deleted = NULL").
+			Set("updated = ?", db.GetCurTime()).
+			Where("id = ?", input.VpcPeeringID).
+			WhereAllWithDeleted().
+			Exec(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	vpcPeering, err := vpsd.GetByID(ctx, tx, input.VpcPeeringID, nil)
+	if err != nil {
+		return nil, err
+	}
+	return vpcPeering, nil
 }
 
 func (vpsd VpcPeeringSQLDAO) Delete(

--- a/rest-api/db/pkg/db/model/vpcpeering_test.go
+++ b/rest-api/db/pkg/db/model/vpcpeering_test.go
@@ -129,6 +129,7 @@ func TestVpcPeeringSQLDAO_Create(t *testing.T) {
 	vpsd := NewVpcPeeringDAO(dbSession)
 
 	_, _, ctx = testCommonTraceProviderSetup(t, ctx)
+	explicitVpcPeeringID := uuid.New()
 
 	tests := []struct {
 		desc               string
@@ -167,6 +168,16 @@ func TestVpcPeeringSQLDAO_Create(t *testing.T) {
 			vps: []VpcPeering{
 				{
 					Vpc1ID: vpc1.ID, Vpc2ID: vpc2.ID, SiteID: site.ID, IsMultiTenant: false, TenantID: &tenant1.ID, CreatedBy: user.ID,
+				},
+			},
+			expectError:        false,
+			verifyChildSpanner: true,
+		},
+		{
+			desc: "Create succeeds with supplied ID and status",
+			vps: []VpcPeering{
+				{
+					ID: explicitVpcPeeringID, Vpc1ID: vpc2.ID, Vpc2ID: vpc4.ID, SiteID: site.ID, IsMultiTenant: true, InfrastructureProviderID: &ip.ID, Status: VpcPeeringStatusReady, CreatedBy: user.ID,
 				},
 			},
 			expectError:        false,
@@ -225,23 +236,36 @@ func TestVpcPeeringSQLDAO_Create(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 
 			for _, i := range tc.vps {
+				var vpcPeeringID *uuid.UUID
+				if i.ID != uuid.Nil {
+					vpcPeeringID = &i.ID
+				}
+
 				got, err := vpsd.Create(ctx, nil, VpcPeeringCreateInput{
+					VpcPeeringID:             vpcPeeringID,
 					Vpc1ID:                   i.Vpc1ID,
 					Vpc2ID:                   i.Vpc2ID,
 					SiteID:                   i.SiteID,
 					IsMultiTenant:            i.IsMultiTenant,
 					InfrastructureProviderID: i.InfrastructureProviderID,
 					TenantID:                 i.TenantID,
+					Status:                   i.Status,
 					CreatedByID:              i.CreatedBy,
 				})
 				assert.Equal(t, tc.expectError, err != nil)
 				if !tc.expectError {
 					assert.NotNil(t, got)
+					if i.ID != uuid.Nil {
+						assert.Equal(t, i.ID, got.ID)
+					}
 					assert.Equal(t, i.SiteID, got.SiteID)
 					assert.Equal(t, i.IsMultiTenant, got.IsMultiTenant)
 					assert.Equal(t, i.InfrastructureProviderID, got.InfrastructureProviderID)
 					assert.Equal(t, i.TenantID, got.TenantID)
 					assert.Equal(t, i.CreatedBy, got.CreatedBy)
+					if i.Status != "" {
+						assert.Equal(t, i.Status, got.Status)
+					}
 				}
 				if tc.verifyChildSpanner {
 					span := otrace.SpanFromContext(ctx)
@@ -608,6 +632,65 @@ func TestVpcPeeringSQLDAO_UpdateStatusByID(t *testing.T) {
 	// Test updating status to invalid status string
 	err = vpsd.UpdateStatusByID(ctx, nil, vp.ID, "invalid_status")
 	assert.Error(t, err)
+}
+
+func TestVpcPeeringSQLDAO_ClearDeleted(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testInstanceInitDB(t)
+	defer dbSession.Close()
+	testVpcPeeringSetupSchema(t, dbSession)
+
+	ip := testInstanceBuildInfrastructureProvider(t, dbSession, "testIP")
+	site := testInstanceBuildSite(t, dbSession, ip, "testSite")
+	tenant := testInstanceBuildTenant(t, dbSession, "testTenant")
+	user := testInstanceBuildUser(t, dbSession, "testUser")
+	vpc1 := testInstanceBuildVpc(t, dbSession, ip, site, tenant, "testVpc1")
+	vpc2 := testInstanceBuildVpc(t, dbSession, ip, site, tenant, "testVpc2")
+	vpcPeeringDAO := NewVpcPeeringDAO(dbSession)
+
+	vpcPeering, err := vpcPeeringDAO.Create(ctx, nil, VpcPeeringCreateInput{
+		Vpc1ID:      vpc1.ID,
+		Vpc2ID:      vpc2.ID,
+		SiteID:      site.ID,
+		TenantID:    &tenant.ID,
+		Status:      VpcPeeringStatusDeleting,
+		CreatedByID: user.ID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, vpcPeeringDAO.Delete(ctx, nil, vpcPeering.ID))
+
+	deleted, _, err := vpcPeeringDAO.GetAll(
+		ctx,
+		nil,
+		VpcPeeringFilterInput{
+			IDs:            []uuid.UUID{vpcPeering.ID},
+			IncludeDeleted: true,
+		},
+		paginator.PageInput{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, deleted, 1)
+	require.NotNil(t, deleted[0].Deleted)
+
+	t.Run("clears soft-delete marker", func(t *testing.T) {
+		cleared, clearErr := vpcPeeringDAO.Clear(ctx, nil, VpcPeeringClearInput{
+			VpcPeeringID: vpcPeering.ID,
+			Deleted:      true,
+		})
+		require.NoError(t, clearErr)
+		require.NotNil(t, cleared)
+		assert.Nil(t, cleared.Deleted)
+		assert.Equal(t, VpcPeeringStatusDeleting, cleared.Status)
+	})
+
+	t.Run("returns not found for unknown VPC Peering", func(t *testing.T) {
+		_, clearErr := vpcPeeringDAO.Clear(ctx, nil, VpcPeeringClearInput{
+			VpcPeeringID: uuid.New(),
+			Deleted:      true,
+		})
+		assert.ErrorIs(t, clearErr, db.ErrDoesNotExist)
+	})
 }
 
 func TestVpcPeeringSQLDAO_Delete(t *testing.T) {

--- a/rest-api/db/pkg/db/model/vpcpeering_test.go
+++ b/rest-api/db/pkg/db/model/vpcpeering_test.go
@@ -263,9 +263,12 @@ func TestVpcPeeringSQLDAO_Create(t *testing.T) {
 					assert.Equal(t, i.InfrastructureProviderID, got.InfrastructureProviderID)
 					assert.Equal(t, i.TenantID, got.TenantID)
 					assert.Equal(t, i.CreatedBy, got.CreatedBy)
-					if i.Status != "" {
-						assert.Equal(t, i.Status, got.Status)
+
+					expectedStatus := i.Status
+					if expectedStatus == "" {
+						expectedStatus = VpcPeeringStatusPending
 					}
+					assert.Equal(t, expectedStatus, got.Status)
 				}
 				if tc.verifyChildSpanner {
 					span := otrace.SpanFromContext(ctx)
@@ -634,7 +637,7 @@ func TestVpcPeeringSQLDAO_UpdateStatusByID(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestVpcPeeringSQLDAO_ClearDeleted(t *testing.T) {
+func TestVpcPeeringSQLDAO_Clear(t *testing.T) {
 	ctx := context.Background()
 	dbSession := testInstanceInitDB(t)
 	defer dbSession.Close()
@@ -673,24 +676,40 @@ func TestVpcPeeringSQLDAO_ClearDeleted(t *testing.T) {
 	require.Len(t, deleted, 1)
 	require.NotNil(t, deleted[0].Deleted)
 
-	t.Run("clears soft-delete marker", func(t *testing.T) {
-		cleared, clearErr := vpcPeeringDAO.Clear(ctx, nil, VpcPeeringClearInput{
-			VpcPeeringID: vpcPeering.ID,
-			Deleted:      true,
-		})
-		require.NoError(t, clearErr)
-		require.NotNil(t, cleared)
-		assert.Nil(t, cleared.Deleted)
-		assert.Equal(t, VpcPeeringStatusDeleting, cleared.Status)
-	})
+	tests := []struct {
+		name          string
+		vpcPeeringID  uuid.UUID
+		expectedError error
+	}{
+		{
+			name:         "clears soft-delete marker",
+			vpcPeeringID: vpcPeering.ID,
+		},
+		{
+			name:          "returns not found for unknown VPC Peering",
+			vpcPeeringID:  uuid.New(),
+			expectedError: db.ErrDoesNotExist,
+		},
+	}
 
-	t.Run("returns not found for unknown VPC Peering", func(t *testing.T) {
-		_, clearErr := vpcPeeringDAO.Clear(ctx, nil, VpcPeeringClearInput{
-			VpcPeeringID: uuid.New(),
-			Deleted:      true,
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cleared, clearErr := vpcPeeringDAO.Clear(ctx, nil, VpcPeeringClearInput{
+				VpcPeeringID: test.vpcPeeringID,
+				Deleted:      true,
+			})
+			if test.expectedError != nil {
+				require.ErrorIs(t, clearErr, test.expectedError)
+				assert.Nil(t, cleared)
+				return
+			}
+
+			require.NoError(t, clearErr)
+			require.NotNil(t, cleared)
+			assert.Nil(t, cleared.Deleted)
+			assert.Equal(t, VpcPeeringStatusDeleting, cleared.Status)
 		})
-		assert.ErrorIs(t, clearErr, db.ErrDoesNotExist)
-	})
+	}
 }
 
 func TestVpcPeeringSQLDAO_Delete(t *testing.T) {

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -505,6 +505,14 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 				logger.Warn().Msg(fmt.Sprintf("unable to create VPC found on Site: tenant organization differs in REST cache and Site record %s", reportedVpc.Org))
 				return nil, nil
 			}
+			// Deleted records when the delete happened, so a delete newer than the interval can
+			// postdate this inventory. Undeleting then would revive a VPC the snapshot never saw
+			// removed. A later inventory undeletes it if the Site still reports it.
+			if site.IsTimeWithinStaleInventoryThreshold(*existingVpc.Deleted) {
+				logger.Info().Msgf("not undeleting VPC %s yet because it was deleted more recently than the inventory interval", vpcID)
+				return nil, nil
+			}
+
 			// Undelete only; UpdateVpcsInDB applies Site-reported field updates.
 			restored, clearErr := vpcDAO.Clear(ctx, tx, cdbm.VpcClearInput{VpcID: existingVpc.ID, Deleted: true})
 			if clearErr != nil {

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -1007,6 +1007,9 @@ func TestManageVpc_UpdateVpcsInDB_AutoCreatesAndRestores(t *testing.T) {
 		require.Len(t, deletedVpcs, 1)
 		require.NotNil(t, deletedVpcs[0].Deleted)
 
+		// The undelete is deferred while the delete is newer than the staleness threshold, so
+		// backdate it past that.
+		cwu.TestInventoryAgeDeletedTimestamp(ctx, t, dbSession, (*cdbm.Vpc)(nil), controllerVpcID)
 		cwu.TestInventoryAgeUpdatedTimestamp(ctx, t, dbSession, (*cdbm.Vpc)(nil))
 		_, err = manager.UpdateVpcsInDB(ctx, site.ID, inventory)
 		require.NoError(t, err)

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering.go
@@ -195,7 +195,7 @@ func (mvp ManageVpcPeering) createOrUpdateVpcPeeringFromSite(
 		return nil
 	}
 	if reportedVpcPeering.Vpc1ID == reportedVpcPeering.Vpc2ID {
-		logger.Warn().Msg("unable to create VPC Peering found on Site: VPC Peering cannot connect a VPC to itself")
+		logger.Warn().Msg("unable to create VPC Peering found on Site: vpcId and peerVpcId have the same value")
 		return nil
 	}
 
@@ -261,6 +261,14 @@ func (mvp ManageVpcPeering) createOrUpdateVpcPeeringFromSite(
 				(existingVpcPeering.Vpc1ID == vpc2.ID && existingVpcPeering.Vpc2ID == vpc1.ID)
 			if !sameVpcPair || existingVpcPeering.IsMultiTenant != isMultiTenant {
 				logger.Warn().Msgf("unable to create VPC Peering found on Site: VPC pair differs in REST cache and Site record for VPC Peering %s", controllerVpcPeeringID)
+				return nil, nil
+			}
+
+			// Deleted records when the delete happened, so a delete newer than the interval can
+			// postdate this inventory. Undeleting then would revive a VPC Peering the snapshot
+			// never saw removed. A later inventory undeletes it if the Site still reports it.
+			if site.IsTimeWithinStaleInventoryThreshold(*existingVpcPeering.Deleted) {
+				logger.Info().Msgf("not undeleting VPC Peering %s yet because it was deleted more recently than the inventory interval", controllerVpcPeeringID)
 				return nil, nil
 			}
 

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering.go
@@ -6,6 +6,7 @@ package vpcpeering
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -99,15 +100,24 @@ func (mvp ManageVpcPeering) UpdateVpcPeeringsInDB(
 
 	// Iterate through VpcPeering Inventory and update DB
 	for _, controllerVpcPeering := range vpcPeeringInventory.VpcPeerings {
-		slogger := logger.With().Str("controller VpcPeering ID", controllerVpcPeering.Id.Value).Logger()
-
-		vpcPeering, found := existingVpcPeeringIDMap[controllerVpcPeering.Id.Value]
-		if !found {
-			slogger.Warn().Msg("VpcPeering does not have a record in DB, possibly created directly on Site. Creating in cloud DB.")
-
-			// TODO: Create a new VPC Peering record in DB
-
+		if controllerVpcPeering == nil || controllerVpcPeering.GetId().GetValue() == "" {
+			logger.Error().Msg("received VPC Peering inventory entry with missing controller ID, skipping")
 			continue
+		}
+
+		controllerVpcPeeringID := controllerVpcPeering.GetId().GetValue()
+		slogger := logger.With().Str("VPC Peering Controller ID", controllerVpcPeeringID).Logger()
+		vpcPeering := existingVpcPeeringIDMap[controllerVpcPeeringID]
+
+		if vpcPeering == nil {
+
+			vpcPeering = mvp.createOrUpdateVpcPeeringFromSite(ctx, site, controllerVpcPeering)
+			if vpcPeering == nil {
+				continue
+			}
+
+			existingVpcPeeringIDMap[vpcPeering.ID.String()] = vpcPeering
+			logger.Info().Str("VPC Peering ID", vpcPeering.ID.String()).Msg("created or undeleted VPC Peering from Site inventory")
 		}
 
 		// In the case inventory paging is not enabled, we build reportedVpcPeeringIdMap here.
@@ -153,6 +163,160 @@ func (mvp ManageVpcPeering) UpdateVpcPeeringsInDB(
 	}
 
 	return nil
+}
+
+// createOrUpdateVpcPeeringFromSite creates a REST VPC Peering from Site inventory,
+// or undeletes a matching soft-deleted row. Returns nil when skipped or on failure.
+func (mvp ManageVpcPeering) createOrUpdateVpcPeeringFromSite(
+	ctx context.Context,
+	site *cdbm.Site,
+	controllerVpcPeering *corev1.VpcPeering,
+) *cdbm.VpcPeering {
+	logger := log.With().
+		Str("Activity", "UpdateVpcPeeringsInDB").
+		Str("Site ID", site.ID.String()).
+		Str("VPC Peering Controller ID", controllerVpcPeering.GetId().GetValue()).
+		Logger()
+
+	controllerVpcPeeringID, err := uuid.Parse(controllerVpcPeering.GetId().GetValue())
+	if err != nil {
+		logger.Warn().Msgf("unable to create VPC Peering found on Site: failed to parse VPC Peering Controller ID, not a valid UUID %s", controllerVpcPeering.GetId().GetValue())
+		return nil
+	}
+
+	reportedVpcPeering := new(cdbm.VpcPeering)
+	reportedVpcPeering.FromProto(controllerVpcPeering)
+	if reportedVpcPeering.Vpc1ID == uuid.Nil {
+		logger.Warn().Msg("unable to create VPC Peering found on Site: VPC Peering on Site is reporting empty VPC ID")
+		return nil
+	}
+	if reportedVpcPeering.Vpc2ID == uuid.Nil {
+		logger.Warn().Msg("unable to create VPC Peering found on Site: VPC Peering on Site is reporting empty peer VPC ID")
+		return nil
+	}
+	if reportedVpcPeering.Vpc1ID == reportedVpcPeering.Vpc2ID {
+		logger.Warn().Msg("unable to create VPC Peering found on Site: VPC Peering cannot connect a VPC to itself")
+		return nil
+	}
+
+	vpcPeering, err := cdb.WithTxResult(ctx, mvp.dbSession, func(tx *cdb.Tx) (*cdbm.VpcPeering, error) {
+		vpcDAO := cdbm.NewVpcDAO(mvp.dbSession)
+		vpcPeeringDAO := cdbm.NewVpcPeeringDAO(mvp.dbSession)
+		statusDetailDAO := cdbm.NewStatusDetailDAO(mvp.dbSession)
+
+		vpcs, _, vpcErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
+			VpcIDs:  []uuid.UUID{reportedVpcPeering.Vpc1ID, reportedVpcPeering.Vpc2ID},
+			SiteIDs: []uuid.UUID{site.ID},
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if vpcErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Peering found on Site: failed to retrieve VPCs by ID, DB error: %w", vpcErr)
+		}
+
+		vpcByID := make(map[uuid.UUID]*cdbm.Vpc, len(vpcs))
+		for i := range vpcs {
+			vpcByID[vpcs[i].ID] = &vpcs[i]
+		}
+		vpc1 := vpcByID[reportedVpcPeering.Vpc1ID]
+		if vpc1 == nil {
+			logger.Warn().Msgf("unable to create VPC Peering found on Site: no VPC was found for ID: %s", reportedVpcPeering.Vpc1ID)
+			return nil, nil
+		}
+		vpc2 := vpcByID[reportedVpcPeering.Vpc2ID]
+		if vpc2 == nil {
+			logger.Warn().Msgf("unable to create VPC Peering found on Site: no peer VPC was found for ID: %s", reportedVpcPeering.Vpc2ID)
+			return nil, nil
+		}
+
+		isMultiTenant := vpc1.TenantID != vpc2.TenantID
+		var infrastructureProviderID *uuid.UUID
+		var tenantID *uuid.UUID
+		if isMultiTenant {
+			infrastructureProviderID = cwutil.GetPtr(site.InfrastructureProviderID)
+		} else {
+			tenantID = cwutil.GetPtr(vpc1.TenantID)
+		}
+
+		matches, _, reloadErr := vpcPeeringDAO.GetAll(ctx, tx, cdbm.VpcPeeringFilterInput{
+			IDs:            []uuid.UUID{controllerVpcPeeringID},
+			IncludeDeleted: true,
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if reloadErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Peering found on Site: failed to retrieve VPC Peering by controller ID, DB error: %w", reloadErr)
+		}
+
+		var existingVpcPeering *cdbm.VpcPeering
+		if len(matches) > 0 {
+			existingVpcPeering = &matches[0]
+		}
+		if existingVpcPeering != nil {
+			if existingVpcPeering.SiteID != site.ID {
+				logger.Warn().Msgf("unable to create VPC Peering found on Site: VPC Peering ID already exists under a different Site for VPC Peering %s", controllerVpcPeeringID)
+				return nil, nil
+			}
+			if existingVpcPeering.Deleted == nil {
+				return existingVpcPeering, nil
+			}
+
+			sameVpcPair := (existingVpcPeering.Vpc1ID == vpc1.ID && existingVpcPeering.Vpc2ID == vpc2.ID) ||
+				(existingVpcPeering.Vpc1ID == vpc2.ID && existingVpcPeering.Vpc2ID == vpc1.ID)
+			if !sameVpcPair || existingVpcPeering.IsMultiTenant != isMultiTenant {
+				logger.Warn().Msgf("unable to create VPC Peering found on Site: VPC pair differs in REST cache and Site record for VPC Peering %s", controllerVpcPeeringID)
+				return nil, nil
+			}
+
+			restored, clearErr := vpcPeeringDAO.Clear(ctx, tx, cdbm.VpcPeeringClearInput{
+				VpcPeeringID: existingVpcPeering.ID,
+				Deleted:      true,
+			})
+			if clearErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Peering found on Site: failed to clear soft-delete timestamp for VPC Peering, DB error: %w", clearErr)
+			}
+
+			status := cdbm.VpcPeeringStatusReady
+			statusMessage := "VPC Peering has been re-detected on Site"
+			statusErr := mvp.updateVpcPeeringStatusInDB(ctx, tx, restored.ID, &status, &statusMessage)
+			if statusErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Peering found on Site: failed to update VPC Peering status after undelete, DB error: %w", statusErr)
+			}
+
+			restored, reloadErr = vpcPeeringDAO.GetByID(ctx, tx, restored.ID, nil)
+			if reloadErr != nil {
+				return nil, fmt.Errorf("unable to create VPC Peering found on Site: failed to retrieve VPC Peering after undelete, DB error: %w", reloadErr)
+			}
+			return restored, nil
+		}
+
+		readyMessage := "VPC Peering was found on Site, Ready for use"
+		created, createErr := vpcPeeringDAO.Create(ctx, tx, cdbm.VpcPeeringCreateInput{
+			VpcPeeringID:             &controllerVpcPeeringID,
+			Vpc1ID:                   vpc1.ID,
+			Vpc2ID:                   vpc2.ID,
+			SiteID:                   site.ID,
+			IsMultiTenant:            isMultiTenant,
+			InfrastructureProviderID: infrastructureProviderID,
+			TenantID:                 tenantID,
+			Status:                   cdbm.VpcPeeringStatusReady,
+			CreatedByID:              site.CreatedBy,
+		})
+		if createErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Peering found on Site: failed to create VPC Peering, DB error: %w", createErr)
+		}
+
+		_, statusErr := statusDetailDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
+			EntityID: created.ID.String(),
+			Status:   cdbm.VpcPeeringStatusReady,
+			Message:  &readyMessage,
+		})
+		if statusErr != nil {
+			return nil, fmt.Errorf("unable to create VPC Peering found on Site: failed to create Status Detail, DB error: %w", statusErr)
+		}
+		return created, nil
+	})
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to recover VPC Peering from Site inventory")
+		return nil
+	}
+	return vpcPeering
 }
 
 // updateVpcPeeringStatusInDB is helper function to write VpcPeering updates to DB

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering.go
@@ -110,7 +110,6 @@ func (mvp ManageVpcPeering) UpdateVpcPeeringsInDB(
 		vpcPeering := existingVpcPeeringIDMap[controllerVpcPeeringID]
 
 		if vpcPeering == nil {
-
 			vpcPeering = mvp.createOrUpdateVpcPeeringFromSite(ctx, site, controllerVpcPeering)
 			if vpcPeering == nil {
 				continue
@@ -199,11 +198,28 @@ func (mvp ManageVpcPeering) createOrUpdateVpcPeeringFromSite(
 		return nil
 	}
 
-	vpcPeering, err := cdb.WithTxResult(ctx, mvp.dbSession, func(tx *cdb.Tx) (*cdbm.VpcPeering, error) {
-		vpcDAO := cdbm.NewVpcDAO(mvp.dbSession)
-		vpcPeeringDAO := cdbm.NewVpcPeeringDAO(mvp.dbSession)
-		statusDetailDAO := cdbm.NewStatusDetailDAO(mvp.dbSession)
+	vpcDAO := cdbm.NewVpcDAO(mvp.dbSession)
+	vpcPeeringDAO := cdbm.NewVpcPeeringDAO(mvp.dbSession)
+	statusDetailDAO := cdbm.NewStatusDetailDAO(mvp.dbSession)
 
+	// Check for duplicate VPC Peering
+	peerings, _, err := vpcPeeringDAO.GetAll(ctx, nil, cdbm.VpcPeeringFilterInput{
+		VpcIDs: []uuid.UUID{reportedVpcPeering.Vpc1ID},
+	}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to get VPC Peerings for VPC from DB")
+		return nil
+	}
+
+	for _, peering := range peerings {
+		// The filter matches either end, so one side is already vpc1 and only the other needs checking
+		if peering.Vpc1ID == reportedVpcPeering.Vpc2ID || peering.Vpc2ID == reportedVpcPeering.Vpc2ID {
+			logger.Warn().Msgf("unable to create VPC Peering found on Site: an existing VPC Peering already connects the VPCs of VPC Peering: %s", controllerVpcPeeringID)
+			return nil
+		}
+	}
+
+	vpcPeering, err := cdb.WithTxResult(ctx, mvp.dbSession, func(tx *cdb.Tx) (*cdbm.VpcPeering, error) {
 		vpcs, _, vpcErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
 			VpcIDs:  []uuid.UUID{reportedVpcPeering.Vpc1ID, reportedVpcPeering.Vpc2ID},
 			SiteIDs: []uuid.UUID{site.ID},

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
@@ -505,66 +505,126 @@ func TestManageVpcPeering_UpdateVpcPeeringsInDB(t *testing.T) {
 }
 
 func TestManageVpcPeering_CreateOrUpdateVpcPeeringFromSite(t *testing.T) {
-	ctx := context.Background()
-	dbSession := testVpcPeeringInitDB(t)
-	defer dbSession.Close()
-	testVpcPeeringSetupSchema(t, dbSession)
-
-	org := "test-recovery-org"
-	user := testVpcPeeringBuildUser(t, dbSession, uuid.NewString(), org, []string{"FORGE_PROVIDER_ADMIN"})
-	infrastructureProvider := testVpcPeeringSiteBuildInfrastructureProvider(t, dbSession, "test-provider", org, user)
-	site := testVpcPeeringBuildSite(t, dbSession, infrastructureProvider, "test-site", user)
-	tenant := testVpcPeeringBuildTenant(t, dbSession, "test-tenant", org, user)
-	vpc1 := testVpcPeeringBuildVPC(t, dbSession, "vpc-1", infrastructureProvider, tenant, site, nil, nil, nil, user, cdbm.VpcStatusReady)
-	vpc2 := testVpcPeeringBuildVPC(t, dbSession, "vpc-2", infrastructureProvider, tenant, site, nil, nil, nil, user, cdbm.VpcStatusReady)
-
-	vpcPeeringID := uuid.New()
-	controllerVpcPeering := &corev1.VpcPeering{
-		Id:        &corev1.VpcPeeringId{Value: vpcPeeringID.String()},
-		VpcId:     &corev1.VpcId{Value: vpc1.ID.String()},
-		PeerVpcId: &corev1.VpcId{Value: vpc2.ID.String()},
+	type fixture struct {
+		ctx                  context.Context
+		dbSession            *cdb.Session
+		site                 *cdbm.Site
+		tenant               *cdbm.Tenant
+		vpc1                 *cdbm.Vpc
+		vpc2                 *cdbm.Vpc
+		vpcPeeringID         uuid.UUID
+		controllerVpcPeering *corev1.VpcPeering
+		manager              ManageVpcPeering
 	}
-	manager := NewManageVpcPeering(dbSession, nil)
-	vpcPeeringDAO := cdbm.NewVpcPeeringDAO(dbSession)
 
-	t.Run("skips VPC Peering with missing VPC", func(t *testing.T) {
-		recovered := manager.createOrUpdateVpcPeeringFromSite(ctx, site, &corev1.VpcPeering{
-			Id:        &corev1.VpcPeeringId{Value: uuid.NewString()},
-			VpcId:     &corev1.VpcId{Value: uuid.NewString()},
-			PeerVpcId: &corev1.VpcId{Value: vpc2.ID.String()},
+	newFixture := func(t *testing.T) *fixture {
+		t.Helper()
+
+		ctx := context.Background()
+		dbSession := testVpcPeeringInitDB(t)
+		t.Cleanup(dbSession.Close)
+		testVpcPeeringSetupSchema(t, dbSession)
+
+		org := "test-recovery-org"
+		user := testVpcPeeringBuildUser(t, dbSession, uuid.NewString(), org, []string{"FORGE_PROVIDER_ADMIN"})
+		infrastructureProvider := testVpcPeeringSiteBuildInfrastructureProvider(t, dbSession, "test-provider", org, user)
+		site := testVpcPeeringBuildSite(t, dbSession, infrastructureProvider, "test-site", user)
+		tenant := testVpcPeeringBuildTenant(t, dbSession, "test-tenant", org, user)
+		vpc1 := testVpcPeeringBuildVPC(t, dbSession, "vpc-1", infrastructureProvider, tenant, site, nil, nil, nil, user, cdbm.VpcStatusReady)
+		vpc2 := testVpcPeeringBuildVPC(t, dbSession, "vpc-2", infrastructureProvider, tenant, site, nil, nil, nil, user, cdbm.VpcStatusReady)
+		vpcPeeringID := uuid.New()
+
+		return &fixture{
+			ctx:          ctx,
+			dbSession:    dbSession,
+			site:         site,
+			tenant:       tenant,
+			vpc1:         vpc1,
+			vpc2:         vpc2,
+			vpcPeeringID: vpcPeeringID,
+			controllerVpcPeering: &corev1.VpcPeering{
+				Id:        &corev1.VpcPeeringId{Value: vpcPeeringID.String()},
+				VpcId:     &corev1.VpcId{Value: vpc1.ID.String()},
+				PeerVpcId: &corev1.VpcId{Value: vpc2.ID.String()},
+			},
+			manager: NewManageVpcPeering(dbSession, nil),
+		}
+	}
+
+	tests := []struct {
+		name              string
+		prepare           func(*testing.T, *fixture)
+		request           func(*fixture) *corev1.VpcPeering
+		expectedRecovered bool
+	}{
+		{
+			name: "skips VPC Peering with missing VPC",
+			request: func(f *fixture) *corev1.VpcPeering {
+				return &corev1.VpcPeering{
+					Id:        &corev1.VpcPeeringId{Value: uuid.NewString()},
+					VpcId:     &corev1.VpcId{Value: uuid.NewString()},
+					PeerVpcId: &corev1.VpcId{Value: f.vpc2.ID.String()},
+				}
+			},
+		},
+		{
+			name:              "creates VPC Peering from Site inventory",
+			expectedRecovered: true,
+		},
+		{
+			name: "undeletes VPC Peering from Site inventory",
+			prepare: func(t *testing.T, f *fixture) {
+				t.Helper()
+
+				vpcPeeringDAO := cdbm.NewVpcPeeringDAO(f.dbSession)
+				_, err := vpcPeeringDAO.Create(f.ctx, nil, cdbm.VpcPeeringCreateInput{
+					VpcPeeringID: &f.vpcPeeringID,
+					Vpc1ID:       f.vpc1.ID,
+					Vpc2ID:       f.vpc2.ID,
+					SiteID:       f.site.ID,
+					TenantID:     &f.tenant.ID,
+					Status:       cdbm.VpcPeeringStatusDeleting,
+					CreatedByID:  f.site.CreatedBy,
+				})
+				require.NoError(t, err)
+				require.NoError(t, vpcPeeringDAO.Delete(f.ctx, nil, f.vpcPeeringID))
+			},
+			expectedRecovered: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := newFixture(t)
+			if test.prepare != nil {
+				test.prepare(t, f)
+			}
+
+			request := f.controllerVpcPeering
+			if test.request != nil {
+				request = test.request(f)
+			}
+
+			recovered := f.manager.createOrUpdateVpcPeeringFromSite(f.ctx, f.site, request)
+			if !test.expectedRecovered {
+				assert.Nil(t, recovered)
+				return
+			}
+
+			require.NotNil(t, recovered)
+			assert.Equal(t, f.vpcPeeringID, recovered.ID)
+			assert.Equal(t, f.vpc1.ID, recovered.Vpc1ID)
+			assert.Equal(t, f.vpc2.ID, recovered.Vpc2ID)
+			assert.Equal(t, f.site.ID, recovered.SiteID)
+			assert.False(t, recovered.IsMultiTenant)
+			assert.Nil(t, recovered.InfrastructureProviderID)
+			require.NotNil(t, recovered.TenantID)
+			assert.Equal(t, f.tenant.ID, *recovered.TenantID)
+			assert.Equal(t, cdbm.VpcPeeringStatusReady, recovered.Status)
+			assert.Equal(t, f.site.CreatedBy, recovered.CreatedBy)
+			assert.Nil(t, recovered.Deleted)
 		})
-		assert.Nil(t, recovered)
-	})
-
-	createSucceeded := t.Run("creates VPC Peering from Site inventory", func(t *testing.T) {
-		recovered := manager.createOrUpdateVpcPeeringFromSite(ctx, site, controllerVpcPeering)
-		require.NotNil(t, recovered)
-		assert.Equal(t, vpcPeeringID, recovered.ID)
-		assert.Equal(t, vpc1.ID, recovered.Vpc1ID)
-		assert.Equal(t, vpc2.ID, recovered.Vpc2ID)
-		assert.Equal(t, site.ID, recovered.SiteID)
-		assert.False(t, recovered.IsMultiTenant)
-		assert.Nil(t, recovered.InfrastructureProviderID)
-		require.NotNil(t, recovered.TenantID)
-		assert.Equal(t, tenant.ID, *recovered.TenantID)
-		assert.Equal(t, cdbm.VpcPeeringStatusReady, recovered.Status)
-		assert.Equal(t, site.CreatedBy, recovered.CreatedBy)
-	})
-	if !createSucceeded {
-		t.FailNow()
 	}
-
-	t.Run("undeletes VPC Peering from Site inventory", func(t *testing.T) {
-		err := vpcPeeringDAO.UpdateStatusByID(ctx, nil, vpcPeeringID, cdbm.VpcPeeringStatusDeleting)
-		require.NoError(t, err)
-		require.NoError(t, vpcPeeringDAO.Delete(ctx, nil, vpcPeeringID))
-
-		recovered := manager.createOrUpdateVpcPeeringFromSite(ctx, site, controllerVpcPeering)
-		require.NotNil(t, recovered)
-		assert.Equal(t, vpcPeeringID, recovered.ID)
-		assert.Equal(t, cdbm.VpcPeeringStatusReady, recovered.Status)
-		assert.Nil(t, recovered.Deleted)
-	})
 }
 
 func TestNewManageVpcPeering(t *testing.T) {

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
@@ -618,6 +618,27 @@ func TestManageVpcPeering_CreateOrUpdateVpcPeeringFromSite(t *testing.T) {
 			},
 			expectedRecovered: false,
 		},
+		{
+			// The REST create path answers a duplicate pair with 409, so recovery must not add a
+			// second peering for the same VPCs under a different ID.
+			name: "skips VPC Peering when another already connects the same VPCs",
+			prepare: func(t *testing.T, f *fixture) {
+				t.Helper()
+
+				existingID := uuid.New()
+				_, err := cdbm.NewVpcPeeringDAO(f.dbSession).Create(f.ctx, nil, cdbm.VpcPeeringCreateInput{
+					VpcPeeringID: &existingID,
+					Vpc1ID:       f.vpc1.ID,
+					Vpc2ID:       f.vpc2.ID,
+					SiteID:       f.site.ID,
+					TenantID:     &f.tenant.ID,
+					Status:       cdbm.VpcPeeringStatusReady,
+					CreatedByID:  f.site.CreatedBy,
+				})
+				require.NoError(t, err)
+			},
+			expectedRecovered: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
@@ -16,6 +16,7 @@ import (
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun/extra/bundebug"
 	"go.temporal.io/sdk/testsuite"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -226,6 +227,7 @@ func TestManageVpcPeering_UpdateVpcPeeringsInDB(t *testing.T) {
 	site := testVpcPeeringBuildSite(t, dbSession, ip, "test-site", user)
 	site2 := testVpcPeeringBuildSite(t, dbSession, ip, "test-site-2", user)
 	site3 := testVpcPeeringBuildSite(t, dbSession, ip, "test-site-3", user)
+	site4 := testVpcPeeringBuildSite(t, dbSession, ip, "test-site-4", user)
 	tenant := testVpcPeeringBuildTenant(t, dbSession, "test-tenant", org, user)
 
 	// Build VPCs
@@ -235,6 +237,9 @@ func TestManageVpcPeering_UpdateVpcPeeringsInDB(t *testing.T) {
 	assert.NotNil(t, vpc2)
 	vpc3 := testVpcPeeringBuildVPC(t, dbSession, "vpc-3", ip, tenant, site, nil, nil, nil, user, "READY")
 	assert.NotNil(t, vpc3)
+	recoveredVpc1 := testVpcPeeringBuildVPC(t, dbSession, "recovered-vpc-1", ip, tenant, site4, nil, nil, nil, user, cdbm.VpcStatusReady)
+	recoveredVpc2 := testVpcPeeringBuildVPC(t, dbSession, "recovered-vpc-2", ip, tenant, site4, nil, nil, nil, user, cdbm.VpcStatusReady)
+	recoveredVpcPeeringID := uuid.New()
 
 	// Create VPC Peerings in DB
 	vp1 := testVpcPeeringBuildVpcPeering(t, dbSession, vpc1.ID, vpc2.ID, site.ID, false, user.ID)
@@ -445,6 +450,28 @@ func TestManageVpcPeering_UpdateVpcPeeringsInDB(t *testing.T) {
 			readyVpcPeerings:   pagedVpcPeerings[0:34],
 			deletedVpcPeerings: pagedVpcPeerings[34:38],
 		},
+		{
+			name: "test Vpc Peering inventory auto creates missing object",
+			fields: fields{
+				dbSession:      dbSession,
+				siteClientPool: tSiteClientPool,
+				env:            env,
+			},
+			args: args{
+				ctx:    ctx,
+				siteID: site4.ID,
+				vpcPeeringInventory: &corev1.VPCPeeringInventory{
+					VpcPeerings: []*corev1.VpcPeering{
+						{
+							Id:        &corev1.VpcPeeringId{Value: recoveredVpcPeeringID.String()},
+							VpcId:     &corev1.VpcId{Value: recoveredVpc1.ID.String()},
+							PeerVpcId: &corev1.VpcId{Value: recoveredVpc2.ID.String()},
+						},
+					},
+				},
+			},
+			readyVpcPeerings: []*cdbm.VpcPeering{{ID: recoveredVpcPeeringID}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -475,6 +502,69 @@ func TestManageVpcPeering_UpdateVpcPeeringsInDB(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManageVpcPeering_CreateOrUpdateVpcPeeringFromSite(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testVpcPeeringInitDB(t)
+	defer dbSession.Close()
+	testVpcPeeringSetupSchema(t, dbSession)
+
+	org := "test-recovery-org"
+	user := testVpcPeeringBuildUser(t, dbSession, uuid.NewString(), org, []string{"FORGE_PROVIDER_ADMIN"})
+	infrastructureProvider := testVpcPeeringSiteBuildInfrastructureProvider(t, dbSession, "test-provider", org, user)
+	site := testVpcPeeringBuildSite(t, dbSession, infrastructureProvider, "test-site", user)
+	tenant := testVpcPeeringBuildTenant(t, dbSession, "test-tenant", org, user)
+	vpc1 := testVpcPeeringBuildVPC(t, dbSession, "vpc-1", infrastructureProvider, tenant, site, nil, nil, nil, user, cdbm.VpcStatusReady)
+	vpc2 := testVpcPeeringBuildVPC(t, dbSession, "vpc-2", infrastructureProvider, tenant, site, nil, nil, nil, user, cdbm.VpcStatusReady)
+
+	vpcPeeringID := uuid.New()
+	controllerVpcPeering := &corev1.VpcPeering{
+		Id:        &corev1.VpcPeeringId{Value: vpcPeeringID.String()},
+		VpcId:     &corev1.VpcId{Value: vpc1.ID.String()},
+		PeerVpcId: &corev1.VpcId{Value: vpc2.ID.String()},
+	}
+	manager := NewManageVpcPeering(dbSession, nil)
+	vpcPeeringDAO := cdbm.NewVpcPeeringDAO(dbSession)
+
+	t.Run("skips VPC Peering with missing VPC", func(t *testing.T) {
+		recovered := manager.createOrUpdateVpcPeeringFromSite(ctx, site, &corev1.VpcPeering{
+			Id:        &corev1.VpcPeeringId{Value: uuid.NewString()},
+			VpcId:     &corev1.VpcId{Value: uuid.NewString()},
+			PeerVpcId: &corev1.VpcId{Value: vpc2.ID.String()},
+		})
+		assert.Nil(t, recovered)
+	})
+
+	createSucceeded := t.Run("creates VPC Peering from Site inventory", func(t *testing.T) {
+		recovered := manager.createOrUpdateVpcPeeringFromSite(ctx, site, controllerVpcPeering)
+		require.NotNil(t, recovered)
+		assert.Equal(t, vpcPeeringID, recovered.ID)
+		assert.Equal(t, vpc1.ID, recovered.Vpc1ID)
+		assert.Equal(t, vpc2.ID, recovered.Vpc2ID)
+		assert.Equal(t, site.ID, recovered.SiteID)
+		assert.False(t, recovered.IsMultiTenant)
+		assert.Nil(t, recovered.InfrastructureProviderID)
+		require.NotNil(t, recovered.TenantID)
+		assert.Equal(t, tenant.ID, *recovered.TenantID)
+		assert.Equal(t, cdbm.VpcPeeringStatusReady, recovered.Status)
+		assert.Equal(t, site.CreatedBy, recovered.CreatedBy)
+	})
+	if !createSucceeded {
+		t.FailNow()
+	}
+
+	t.Run("undeletes VPC Peering from Site inventory", func(t *testing.T) {
+		err := vpcPeeringDAO.UpdateStatusByID(ctx, nil, vpcPeeringID, cdbm.VpcPeeringStatusDeleting)
+		require.NoError(t, err)
+		require.NoError(t, vpcPeeringDAO.Delete(ctx, nil, vpcPeeringID))
+
+		recovered := manager.createOrUpdateVpcPeeringFromSite(ctx, site, controllerVpcPeering)
+		require.NotNil(t, recovered)
+		assert.Equal(t, vpcPeeringID, recovered.ID)
+		assert.Equal(t, cdbm.VpcPeeringStatusReady, recovered.Status)
+		assert.Nil(t, recovered.Deleted)
+	})
 }
 
 func TestNewManageVpcPeering(t *testing.T) {

--- a/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
+++ b/rest-api/workflow/pkg/activity/vpcpeering/vpcpeering_test.go
@@ -14,6 +14,7 @@ import (
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cdbu "github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
+	cwu "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -588,8 +589,34 @@ func TestManageVpcPeering_CreateOrUpdateVpcPeeringFromSite(t *testing.T) {
 				})
 				require.NoError(t, err)
 				require.NoError(t, vpcPeeringDAO.Delete(f.ctx, nil, f.vpcPeeringID))
+
+				// The undelete is deferred while the delete is newer than the staleness
+				// threshold, so backdate it past that.
+				cwu.TestInventoryAgeDeletedTimestamp(f.ctx, t, f.dbSession, (*cdbm.VpcPeering)(nil), f.vpcPeeringID)
 			},
 			expectedRecovered: true,
+		},
+		{
+			// The delete is newer than the interval, so this inventory may predate it and
+			// undeleting would revive a VPC Peering the snapshot never saw removed.
+			name: "does not undelete a VPC Peering deleted within the inventory interval",
+			prepare: func(t *testing.T, f *fixture) {
+				t.Helper()
+
+				vpcPeeringDAO := cdbm.NewVpcPeeringDAO(f.dbSession)
+				_, err := vpcPeeringDAO.Create(f.ctx, nil, cdbm.VpcPeeringCreateInput{
+					VpcPeeringID: &f.vpcPeeringID,
+					Vpc1ID:       f.vpc1.ID,
+					Vpc2ID:       f.vpc2.ID,
+					SiteID:       f.site.ID,
+					TenantID:     &f.tenant.ID,
+					Status:       cdbm.VpcPeeringStatusDeleting,
+					CreatedByID:  f.site.CreatedBy,
+				})
+				require.NoError(t, err)
+				require.NoError(t, vpcPeeringDAO.Delete(f.ctx, nil, f.vpcPeeringID))
+			},
+			expectedRecovered: false,
 		},
 	}
 

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -106,7 +106,7 @@ func (mvp ManageVpcPrefix) UpdateVpcPrefixesInDB(ctx context.Context, siteID uui
 		if vpcPrefix == nil {
 			// Inventory pushes are unordered Temporal workflows. A stale snapshot can still list a
 			// just-deleted prefix as TERMINATING/TERMINATED (or even READY). Never create/undelete
-			// from a terminal Site status — that re-claims IPAM and resurrects a user delete.
+			// from a terminal Site status, since that re-claims IPAM and resurrects a user delete.
 			reportedStatus, _ := getControllerVpcPrefixStatus(controllerVpcPrefix.GetStatus())
 			if reportedStatus == cdbm.VpcPrefixStatusDeleting || reportedStatus == cdbm.VpcPrefixStatusDeleted {
 				slogger.Info().Msgf("skipping create or undelete of VPC Prefix from Site inventory: Site reports status %s", reportedStatus)
@@ -301,7 +301,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 		}
 		if len(vpcMatches) == 0 {
 			// Even if this happens, the VPC will be created based on the createOrUpdateVpcFromSite function in the vpc activity
-			// hence we are just returning nil and next inventory iteration VPC will be created in the vpc activity
+			// so we are just returning nil and next inventory iteration VPC will be created in the vpc activity
 			logger.Warn().Msgf("unable to create VPC Prefix found on Site: no VPC was found for ID: %s", parentVpcID)
 			return nil, nil
 		}
@@ -346,6 +346,14 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			existingPrefix, parseErr := netip.ParsePrefix(existingVpcPrefix.Prefix)
 			if parseErr != nil || existingPrefix.Masked().String() != reportedVpcPrefix.Prefix {
 				logger.Warn().Msgf("unable to create VPC Prefix found on Site: prefix differs in REST cache and Site record for VPC Prefix %s", controllerVpcPrefixID)
+				return nil, nil
+			}
+			// Deleted records when the delete happened, so a delete newer than the interval can
+			// postdate this inventory. Undeleting then would revive a VPC Prefix the snapshot
+			// never saw removed. Skip before the IPAM work below rather than after, so there is
+			// no allocation to unwind. A later inventory undeletes it if the Site still reports it.
+			if site.IsTimeWithinStaleInventoryThreshold(*existingVpcPrefix.Deleted) {
+				logger.Info().Msgf("not undeleting VPC Prefix %s yet because it was deleted more recently than the inventory interval", controllerVpcPrefixID)
 				return nil, nil
 			}
 		}

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
@@ -21,6 +21,7 @@ import (
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
+	cwu "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -855,6 +856,9 @@ func testManageVpcPrefixUpdateVpcPrefixesInDBAutoCreatesAndRestores(t *testing.T
 			ctx, nil, dbSession, ipamStorage, ipBlock, controllerVpcPrefix.Config.Prefix,
 		))
 		require.NoError(t, vpcPrefixDAO.Delete(ctx, nil, controllerVpcPrefixID))
+		// The undelete is deferred while the delete is newer than the staleness threshold, so
+		// backdate it past that.
+		cwu.TestInventoryAgeDeletedTimestamp(ctx, t, dbSession, (*cdbm.VpcPrefix)(nil), controllerVpcPrefixID)
 
 		deleted, _, err := vpcPrefixDAO.GetAll(
 			ctx,
@@ -921,7 +925,7 @@ func testManageVpcPrefixUpdateVpcPrefixesInDBAutoCreatesAndRestores(t *testing.T
 		}()
 
 		// Depends on the preceding TERMINATING subtest leaving the row soft-deleted with
-		// Status=Deleting. Do not soft-delete here — that would hide failures in the prior case.
+		// Status=Deleting. Do not soft-delete here, that would hide failures in the prior case.
 		existing, _, err := vpcPrefixDAO.GetAll(
 			ctx,
 			nil,
@@ -1272,6 +1276,9 @@ func TestManageVpcPrefix_CreateOrUpdateVpcPrefixFromSite(t *testing.T) {
 			require.NoError(t, err)
 			err = testVpcPrefixDAO.Delete(testCtx, nil, controllerVpcPrefixID)
 			require.NoError(t, err)
+			// The undelete is deferred while the delete is newer than the staleness threshold,
+			// so backdate it past that.
+			cwu.TestInventoryAgeDeletedTimestamp(testCtx, t, testDBSession, (*cdbm.VpcPrefix)(nil), controllerVpcPrefixID)
 
 			if test.storedIPBlockStatus != cdbm.IPBlockStatusReady {
 				_, err = cdbm.NewIPBlockDAO(testDBSession).Update(testCtx, nil, cdbm.IPBlockUpdateInput{
@@ -1686,7 +1693,7 @@ func TestManageVpcPrefix_DeleteVpcPrefixFromDB(t *testing.T) {
 }
 
 func testCreateOrUpdateVpcPrefixSkipsIDOwnedByDifferentSite(t *testing.T) {
-	// Same controller UUID under another site must skip cleanly — not unique-constraint-fail every cycle.
+	// Same controller UUID under another site must skip cleanly, not unique-constraint-fail every cycle.
 	ctx := context.Background()
 	dbSession := testVpcPrefixInitDB(t)
 	defer dbSession.Close()

--- a/rest-api/workflow/pkg/util/testing.go
+++ b/rest-api/workflow/pkg/util/testing.go
@@ -313,6 +313,22 @@ func TestInventoryAgeUpdatedTimestamp(ctx context.Context, t *testing.T, dbSessi
 	}
 }
 
+// TestInventoryAgeDeletedTimestamp backdates a soft-deleted row's delete time past the inventory
+// staleness threshold. The inventory activities refuse to undelete a row deleted more recently
+// than that, so a fixture that soft-deletes a row and then feeds an inventory still reporting it
+// has to age the delete first. Pass a typed nil model, for example (*cdbm.Vpc)(nil).
+func TestInventoryAgeDeletedTimestamp(ctx context.Context, t *testing.T, dbSession *cdb.Session, model any, id any) {
+	t.Helper()
+
+	_, err := dbSession.DB.NewUpdate().
+		Model(model).
+		Set("deleted = ?", time.Now().Add(-2*cutil.DefaultInventoryReceiptInterval)).
+		Where("id = ?", id).
+		WhereAllWithDeleted().
+		Exec(ctx)
+	assert.NoError(t, err)
+}
+
 // TestBuildInfiniBandPartition builds and returns an InfiniBandPartition
 func TestBuildInfiniBandPartition(t *testing.T, dbSession *cdb.Session, name string, site *cdbm.Site, tenant *cdbm.Tenant, controllerIBPartitionID *uuid.UUID, status cdbm.InfiniBandPartitionStatus, isMissingOnSite bool) *cdbm.InfiniBandPartition {
 	ibp := &cdbm.InfiniBandPartition{


### PR DESCRIPTION
## Description
Site inventory previously skipped VPC Peerings that existed on Site but
had no active REST database record, leaving Site and REST state
inconsistent. This PR reconciles those VPC Peerings using their
controller ID.

Soft-deleted VPC Peerings are restored, while true orphans are
auto-created after resolving both parent VPCs and deriving the peering
ownership. Recovery writes are transactional and idempotent.

Key behaviors:
- Resolve both VPCs reported by Site inventory.
- Derive single-tenant or multi-tenant ownership from the parent VPCs.
- Preserve the Site-reported VPC Peering controller ID.
- Create recovered VPC Peerings in `Ready` status with a Status Detail.
- On undelete, validate the Site and VPC pair, clear the soft-delete
  marker, and refresh the status to `Ready`.
- Continue using the existing inventory status and deletion logic.

## Related issues
This PR is part of the issue (https://github.com/NVIDIA/infra-controller/issues/3436)

## Type of Change
- [x] **Add** - New feature or capability

## Testing
- [x] Unit tests added/updated

Tests executed:
```bash
go test ./db/pkg/db/model -run '^TestVpcPeering' -count=1
go test ./workflow/pkg/activity/vpcpeering -count=1
go vet ./db/pkg/db/model ./workflow/pkg/activity/vpcpeering
go tool golangci-lint run --new-from-rev=HEAD ./db/pkg/db/model ./workflow/pkg/activity/vpcpeering
```

## Additional Notes
- VPC Peering identity matching uses controller IDs.
- Adds `VpcPeeringDAO.Clear`, `IncludeDeleted`, and support for explicit
  IDs and statuses during creation.
- No database schema migration is required.
- No REST API or OpenAPI contract changes are required.