### PR TITLE
fix: apply GB200 NVConfig during DPF provisioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,6 +1832,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "carbide-libmlx-model",
  "carbide-test-support",
  "carbide-utils",
  "carbide-uuid",
@@ -2489,6 +2490,7 @@ dependencies = [
  "carbide-health-report",
  "carbide-instrument",
  "carbide-ipmi",
+ "carbide-libmlx-model",
  "carbide-measured-boot",
  "carbide-proto-compiler",
  "carbide-redfish",

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -91,6 +91,14 @@ const RESERVED_DPF_DEPLOYMENT_NODE_LABELS: [(&str, &str); 2] = [
     ),
 ];
 
+const DPF_DEPLOYMENT_NAME_MAX_LENGTH: usize = 20;
+const DPF_FLAVOR_HASH_SUFFIX_LENGTH: usize = 17;
+const KUBERNETES_LABEL_NAME_MAX_LENGTH: usize = 63;
+const GB200_RESOURCE_SUFFIX: &str = "-gb200";
+// The DPUDeployment CRD allows only 20 characters. The default BF3 name already
+// uses 18, so `-g` is the longest suffix that preserves it without truncation.
+const GB200_DEPLOYMENT_SUFFIX: &str = "-g";
+
 /// Parses an optional duration ("30d", "12h", ...; absent = `None`) into
 /// `Option<chrono::Duration>`. Hand-rolled because `duration_str` deprecated
 /// its own Option variant -- we do NOT use the deprecated function.
@@ -1140,6 +1148,7 @@ impl CarbideConfig {
             firmware_global: self.firmware_global.clone(),
             machine_state_controller: self.machine_state_controller.clone(),
             host_health: self.host_health,
+            rack_profiles: self.rack_profiles.clone(),
 
             selected_profile: self.selected_profile,
             bios_profiles: self.bios_profiles.clone(),
@@ -1569,6 +1578,19 @@ fn is_valid_kubernetes_data_key(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
+fn is_valid_kubernetes_label_key(value: &str) -> bool {
+    let (prefix, name) = value
+        .split_once('/')
+        .map_or((None, value), |(prefix, name)| (Some(prefix), name));
+    let bytes = name.as_bytes();
+
+    prefix.is_none_or(is_valid_kubernetes_object_name)
+        && name.len() <= KUBERNETES_LABEL_NAME_MAX_LENGTH
+        && bytes.first().is_some_and(u8::is_ascii_alphanumeric)
+        && bytes.last().is_some_and(u8::is_ascii_alphanumeric)
+        && is_valid_kubernetes_data_key(name)
+}
+
 /// Kubernetes object kinds supported as DPF DPU-agent trust-anchor sources.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1866,7 +1888,7 @@ const BF4_ASTRA_EXTRA_SERVICES: &[DpfExtraService] = &[
 
 fn extra_service_types(deployment_type: DpuDeploymentType) -> &'static [DpfExtraService] {
     match deployment_type {
-        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => &[],
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf3Gb200 | DpuDeploymentType::Bf4Generic => &[],
         DpuDeploymentType::Bf4Astra => BF4_ASTRA_EXTRA_SERVICES,
     }
 }
@@ -2115,6 +2137,61 @@ impl Default for DpfDeploymentConfig {
     }
 }
 
+impl DpfDeploymentConfig {
+    /// Derives the GB200 BF3 deployment from the configured BF3 source and services.
+    pub(crate) fn bf3_gb200(&self) -> Self {
+        Self {
+            flavor_name: append_bounded_identifier_suffix(
+                &self.flavor_name,
+                GB200_RESOURCE_SUFFIX,
+                KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH - DPF_FLAVOR_HASH_SUFFIX_LENGTH,
+            ),
+            deployment_name: append_bounded_identifier_suffix(
+                &self.deployment_name,
+                GB200_DEPLOYMENT_SUFFIX,
+                DPF_DEPLOYMENT_NAME_MAX_LENGTH,
+            ),
+            node_label_key: append_gb200_label_suffix(&self.node_label_key),
+            ..self.clone()
+        }
+    }
+}
+
+/// Appends `suffix` while reserving its bytes inside `max_len`.
+///
+/// Kubernetes identifiers are ASCII. If truncation lands on a separator,
+/// remove it so the suffix still ends a valid segment. Startup validation
+/// checks both the configured and derived identifiers after this step.
+fn append_bounded_identifier_suffix(value: &str, suffix: &str, max_len: usize) -> String {
+    let max_prefix_len = max_len.saturating_sub(suffix.len());
+    let prefix = value
+        .char_indices()
+        .take_while(|(index, ch)| index + ch.len_utf8() <= max_prefix_len)
+        .map(|(_, ch)| ch)
+        .collect::<String>();
+    let prefix = prefix.trim_end_matches(['-', '.', '_']);
+
+    format!("{prefix}{suffix}")
+}
+
+/// Adds the GB200 suffix to the name segment of a Kubernetes label key.
+fn append_gb200_label_suffix(label_key: &str) -> String {
+    let Some((prefix, name)) = label_key.rsplit_once('/') else {
+        return append_bounded_identifier_suffix(
+            label_key,
+            GB200_RESOURCE_SUFFIX,
+            KUBERNETES_LABEL_NAME_MAX_LENGTH,
+        );
+    };
+    let name = append_bounded_identifier_suffix(
+        name,
+        GB200_RESOURCE_SUFFIX,
+        KUBERNETES_LABEL_NAME_MAX_LENGTH,
+    );
+
+    format!("{prefix}/{name}")
+}
+
 /// BlueFieldSoftware spec for BF4-class DPU provisioning. Mirrors the `spec` of
 /// the `provisioning.dpu.nvidia.com/v1alpha1` `BlueFieldSoftware` CR.
 ///
@@ -2167,10 +2244,12 @@ impl DpfDeploymentsConfig {
         v
     }
 
-    /// Validates that identifiers are unique and deployment label keys are not reserved.
-    /// Returns every conflict so the operator can fix them all in one pass.
+    /// Validates the final Kubernetes identifiers, their uniqueness, and reserved labels.
+    /// Returns every error so the operator can fix them all in one pass.
     pub fn validate_unique_identifiers(&self) -> eyre::Result<()> {
-        let deployments = self.all();
+        let bf3_gb200 = self.bf3.bf3_gb200();
+        let mut deployments = self.all();
+        deployments.push(("bf3_gb200", &bf3_gb200));
         let mut errors: Vec<String> = Vec::new();
 
         let name_vals: Vec<(&str, &str)> = deployments
@@ -2201,9 +2280,33 @@ impl DpfDeploymentsConfig {
             }
         }
 
+        for (deployment, name) in &name_vals {
+            if name.len() > DPF_DEPLOYMENT_NAME_MAX_LENGTH || !is_valid_kubernetes_object_name(name)
+            {
+                errors.push(format!(
+                    "deployment_name {name:?} for deployment {deployment:?} is not a valid DPUDeployment name"
+                ));
+            }
+        }
+
+        for (deployment, name) in &flavor_vals {
+            if name.len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH > KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
+                || !is_valid_kubernetes_object_name(name)
+            {
+                errors.push(format!(
+                    "flavor_name {name:?} for deployment {deployment:?} cannot form a valid hash-suffixed DPUFlavor name"
+                ));
+            }
+        }
+
         // This is intentionally a local configuration check. Querying current DPUNode labels
         // cannot establish safety: these keys have fixed NICo semantics before any node exists.
         for (deployment, label_key) in &label_vals {
+            if !is_valid_kubernetes_label_key(label_key) {
+                errors.push(format!(
+                    "node_label_key {label_key:?} for deployment {deployment:?} is not a valid Kubernetes label key"
+                ));
+            }
             if let Some((_, purpose)) = RESERVED_DPF_DEPLOYMENT_NODE_LABELS
                 .iter()
                 .find(|(reserved, _)| label_key == reserved)
@@ -6664,7 +6767,11 @@ helm_repo_url = "oci://registry.example.test/doca"
         .unwrap();
 
         let deployment = DpfDeploymentConfig::default();
-        for deployment_type in [DpuDeploymentType::Bf3, DpuDeploymentType::Bf4Generic] {
+        for deployment_type in [
+            DpuDeploymentType::Bf3,
+            DpuDeploymentType::Bf3Gb200,
+            DpuDeploymentType::Bf4Generic,
+        ] {
             assert!(
                 config
                     .resolved_services_for(&deployment, deployment_type)
@@ -7252,6 +7359,55 @@ helm_repo_url = "oci://registry.example.test/doca"
                 ) => false,
             }
         );
+    }
+
+    #[test]
+    fn gb200_bf3_deployment_derives_distinct_identifiers_and_reuses_bf3_inputs() {
+        let bf3 = DpfDeploymentConfig {
+            bfb_url: Some("https://example.com/custom.bfb".to_string()),
+            flavor_name: "site-bf3-flavor".to_string(),
+            deployment_name: "site-bf3-deploy".to_string(),
+            node_label_key: "carbide.nvidia.com/site-bf3".to_string(),
+            ..Default::default()
+        };
+
+        let gb200 = bf3.bf3_gb200();
+        assert_eq!(gb200.bfb_url, bf3.bfb_url);
+        assert_eq!(gb200.flavor_name, "site-bf3-flavor-gb200");
+        assert_eq!(gb200.deployment_name, "site-bf3-deploy-g");
+        assert_eq!(gb200.node_label_key, "carbide.nvidia.com/site-bf3-gb200");
+    }
+
+    #[test]
+    fn gb200_bf3_derived_identifiers_stay_within_kubernetes_limits() {
+        let bf3 = DpfDeploymentConfig {
+            flavor_name: "f"
+                .repeat(KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH - DPF_FLAVOR_HASH_SUFFIX_LENGTH),
+            deployment_name: "d".repeat(DPF_DEPLOYMENT_NAME_MAX_LENGTH),
+            node_label_key: format!(
+                "carbide.nvidia.com/{}",
+                "n".repeat(KUBERNETES_LABEL_NAME_MAX_LENGTH)
+            ),
+            ..Default::default()
+        };
+
+        let gb200 = bf3.bf3_gb200();
+        let label_name = gb200.node_label_key.rsplit_once('/').unwrap().1;
+
+        assert_eq!(gb200.deployment_name.len(), DPF_DEPLOYMENT_NAME_MAX_LENGTH);
+        assert_eq!(
+            gb200.flavor_name.len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH,
+            KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
+        );
+        assert_eq!(label_name.len(), KUBERNETES_LABEL_NAME_MAX_LENGTH);
+        assert!(is_valid_kubernetes_label_key(&gb200.node_label_key));
+
+        let deployments = DpfDeploymentsConfig {
+            bf3,
+            bf4_generic: None,
+            bf4_astra: None,
+        };
+        assert!(deployments.validate_unique_identifiers().is_ok());
     }
 
     #[test]

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -649,7 +649,7 @@ async fn initialize_dpf_sdk(
         return Ok(None);
     }
 
-    let mut deployments = vec!["bf3"];
+    let mut deployments = vec!["bf3", "bf3_gb200"];
     if carbide_config.dpf.deployments.bf4_generic.is_some() {
         deployments.push("bf4_generic");
     }
@@ -730,7 +730,9 @@ async fn initialize_dpf_sdk(
                 .resolved_services_for(deployment, deployment_type);
             let interfaces = match deployment_type {
                 DpuDeploymentType::Bf4Astra => &astra_interfaces,
-                DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => &effective_interfaces,
+                DpuDeploymentType::Bf3
+                | DpuDeploymentType::Bf3Gb200
+                | DpuDeploymentType::Bf4Generic => &effective_interfaces,
             };
             carbide_dpf::InitDpfResourcesConfig {
                 bfb_url: deployment.bfb_url.clone().unwrap_or_default(),
@@ -750,9 +752,9 @@ async fn initialize_dpf_sdk(
                 pf_total_sf_reserved: carbide_config.dpf.pf_total_sf_reserved,
                 intercept_bridging: match deployment_type {
                     DpuDeploymentType::Bf4Astra => None,
-                    DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => {
-                        intercept_bridging.clone()
-                    }
+                    DpuDeploymentType::Bf3
+                    | DpuDeploymentType::Bf3Gb200
+                    | DpuDeploymentType::Bf4Generic => intercept_bridging.clone(),
                 },
                 interfaces: interfaces.clone(),
                 proxy: carbide_config.dpf.proxy.clone(),
@@ -764,6 +766,15 @@ async fn initialize_dpf_sdk(
     sdk.create_initialization_objects(&make_init_config(bf3, DpuDeploymentType::Bf3, None))
         .await
         .map_err(|err| eyre::eyre!("failed to initialize bf3 DPF deployment: {err}"))?;
+
+    let bf3_gb200 = bf3.bf3_gb200();
+    sdk.create_initialization_objects(&make_init_config(
+        &bf3_gb200,
+        DpuDeploymentType::Bf3Gb200,
+        None,
+    ))
+    .await
+    .map_err(|err| eyre::eyre!("failed to initialize bf3 GB200 DPF deployment: {err}"))?;
 
     if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
         // Validation guarantees `bluefield_software` is set with exactly one PSID
@@ -820,8 +831,8 @@ async fn initialize_dpf_sdk(
 /// Build per-deployment-type node selector labels for the DPF labeler registry.
 ///
 /// Each deployment gets two labels: the shared `dpu-enabled` marker and its
-/// own deployment-specific key. BF3 is always included;
-/// BF4Generic is added when configured.
+/// own deployment-specific key. Both BF3 variants are always included;
+/// configured BF4 variants are added.
 fn build_deployment_type_labels(
     carbide_config: &CarbideConfig,
 ) -> std::collections::BTreeMap<DpuDeploymentType, std::collections::BTreeMap<String, String>> {
@@ -839,6 +850,11 @@ fn build_deployment_type_labels(
         DpuDeploymentType::Bf3,
         make_labels(&carbide_config.dpf.deployments.bf3.node_label_key),
     )]);
+    let bf3_gb200 = carbide_config.dpf.deployments.bf3.bf3_gb200();
+    map.insert(
+        DpuDeploymentType::Bf3Gb200,
+        make_labels(&bf3_gb200.node_label_key),
+    );
 
     if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
         map.insert(
@@ -2192,6 +2208,24 @@ mod tests {
             ))
             .extract()
             .expect("minimal CarbideConfig parses")
+    }
+
+    #[test]
+    fn dpf_labels_include_the_derived_gb200_deployment() {
+        let config = minimal_carbide_config();
+        let labels = build_deployment_type_labels(&config);
+        let gb200_label = format!("{}-gb200", config.dpf.deployments.bf3.node_label_key);
+
+        assert_eq!(
+            labels.get(&DpuDeploymentType::Bf3Gb200),
+            Some(&BTreeMap::from([
+                (
+                    carbide_dpf::DPU_ENABLED_NODE_LABEL.to_string(),
+                    "true".to_string()
+                ),
+                (gb200_label, "true".to_string()),
+            ]))
+        );
     }
 
     fn network_definition(mtu: i32) -> NetworkDefinition {

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -21,7 +21,7 @@
 //! transition correctly when the outer state is `DPUReprovision`.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -30,14 +30,16 @@ use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
 use model::machine::{
-    DpfState, DpuReprovisionStates, InstanceState, ManagedHostState, ReprovisionState,
+    DpfState, DpuReprovisionStates, FailureCause, InstanceState, ManagedHostState, ReprovisionState,
 };
 use tokio::time::timeout;
 
 use super::{dpf_config, get_host_state};
+use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
+    TEST_RMS_RACK_PROFILE_ID, TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
     create_managed_host_with_dpf_multi, create_test_env_with_overrides, get_config,
+    get_config_with_rack_profiles,
 };
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -449,6 +451,212 @@ async fn test_multi_dpu_provisioning_registers_all_devices(pool: sqlx::PgPool) {
          Registered: {registered:?}\n\
          Expected:   {expected:?}"
     );
+}
+
+/// GB200 rack identity and every attached B3240 DPU must select one shared deployment.
+#[crate::sqlx_test]
+async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
+    let classified_dpus = Arc::new(Mutex::new(Vec::new()));
+    let verified_deployments = Arc::new(Mutex::new(Vec::new()));
+    let registered_deployments = Arc::new(Mutex::new(Vec::new()));
+
+    let mut mock = MockDpfOperations::new();
+    mock.expect_register_dpu_device().returning(|_| Ok(()));
+    let registered_deployments_for_mock = registered_deployments.clone();
+    mock.expect_register_dpu_node().returning(move |info| {
+        registered_deployments_for_mock
+            .lock()
+            .unwrap()
+            .push(info.deployment_type);
+        Ok(())
+    });
+    mock.expect_release_maintenance_hold().returning(|_| Ok(()));
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    let classified_dpus_for_mock = classified_dpus.clone();
+    mock.expect_deployment_type_for_dpu()
+        .returning(move |dpu, _| {
+            classified_dpus_for_mock.lock().unwrap().push(dpu.id);
+            Ok(DpuDeploymentType::Bf3)
+        });
+    let verified_deployments_for_mock = verified_deployments.clone();
+    mock.expect_verify_node_labels()
+        .returning(move |_, deployment_type| {
+            verified_deployments_for_mock
+                .lock()
+                .unwrap()
+                .push(deployment_type);
+            Ok(true)
+        });
+    mock.expect_snapshot_host()
+        .returning(|_| Ok(snapshot_with_crs_present(2)));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+
+    let mut txn = pool.begin().await.unwrap();
+    let rack_id = TestRackDbBuilder::new()
+        .with_rack_profile_id(TEST_RMS_RACK_PROFILE_ID)
+        .persist(txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+
+    // Give the host a GB200 rack and both DPUs the supported B3240 identity.
+    let mut txn = pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    for dpu_id in &mh.dpu_ids {
+        let dpu = db::machine::find_one(txn.as_mut(), dpu_id, Default::default())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut hardware_info = dpu
+            .status
+            .hardware_info
+            .expect("fixture DPU should have hardware information");
+        hardware_info
+            .dpu_info
+            .as_mut()
+            .expect("fixture DPU should have DPU information")
+            .part_number = "900-9D3B6-00CN-PA0".to_string();
+        db::machine_topology::set_topology_update_needed(txn.as_mut(), dpu_id, true)
+            .await
+            .unwrap();
+        db::machine_topology::create_or_update(txn.as_mut(), dpu_id, &hardware_info)
+            .await
+            .unwrap();
+    }
+    txn.commit().await.unwrap();
+
+    // Ignore initial ingestion and observe one complete host deployment selection pass.
+    classified_dpus.lock().unwrap().clear();
+    verified_deployments.lock().unwrap().clear();
+    registered_deployments.lock().unwrap().clear();
+    set_reprovision_dpf_state(&pool, &mh.id, &mh.dpu_ids, DpfState::Provisioning).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during state controller iteration");
+
+    let classified = classified_dpus.lock().unwrap().clone();
+    assert_eq!(classified.len(), mh.dpu_ids.len());
+    assert_eq!(
+        classified.into_iter().collect::<HashSet<_>>(),
+        mh.dpu_ids.iter().copied().collect()
+    );
+    assert_eq!(
+        *verified_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3Gb200]
+    );
+    assert_eq!(
+        *registered_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3Gb200]
+    );
+}
+
+/// A mixed DPU pair must enter a terminal failure without starting a DPF registration attempt.
+#[crate::sqlx_test]
+async fn test_mixed_dpu_deployment_types_fail_without_registration(pool: sqlx::PgPool) {
+    let mixed_pair = Arc::new(AtomicBool::new(false));
+    let deployment_type_calls = Arc::new(AtomicUsize::new(0));
+    let registered_devices = Arc::new(AtomicUsize::new(0));
+    let registered_nodes = Arc::new(AtomicUsize::new(0));
+
+    let mut mock = MockDpfOperations::new();
+    let registered_devices_for_mock = registered_devices.clone();
+    mock.expect_register_dpu_device().returning(move |_| {
+        registered_devices_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+    let registered_nodes_for_mock = registered_nodes.clone();
+    mock.expect_register_dpu_node().returning(move |_| {
+        registered_nodes_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+    mock.expect_release_maintenance_hold().returning(|_| Ok(()));
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    let mixed_pair_for_mock = mixed_pair.clone();
+    let deployment_type_calls_for_mock = deployment_type_calls.clone();
+    mock.expect_deployment_type_for_dpu()
+        .returning(move |_, _| {
+            if !mixed_pair_for_mock.load(Ordering::SeqCst) {
+                return Ok(DpuDeploymentType::Bf3);
+            }
+            let index = deployment_type_calls_for_mock.fetch_add(1, Ordering::SeqCst);
+            Ok(if index.is_multiple_of(2) {
+                DpuDeploymentType::Bf3
+            } else {
+                DpuDeploymentType::Bf4Generic
+            })
+        });
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
+    mock.expect_snapshot_host()
+        .returning(|_| Ok(snapshot_with_crs_present(2)));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+
+    let mut config = get_config();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+
+    mixed_pair.store(true, Ordering::SeqCst);
+
+    // A mixed selection must become a visible terminal failure both before and after DPF resource
+    // registration. In either phase, it must not make a partial registration attempt.
+    for (scenario, dpf_state) in [
+        ("during provisioning", DpfState::Provisioning),
+        (
+            "while waiting for DPF",
+            DpfState::WaitingForReady { phase_detail: None },
+        ),
+    ] {
+        registered_devices.store(0, Ordering::SeqCst);
+        registered_nodes.store(0, Ordering::SeqCst);
+        deployment_type_calls.store(0, Ordering::SeqCst);
+        set_reprovision_dpf_state(&pool, &mh.id, &mh.dpu_ids, dpf_state).await;
+
+        timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+            .await
+            .expect("timed out during mixed-pair state controller iteration");
+
+        assert_eq!(registered_devices.load(Ordering::SeqCst), 0, "{scenario}");
+        assert_eq!(registered_nodes.load(Ordering::SeqCst), 0, "{scenario}");
+        assert!(
+            matches!(
+                get_host_state(&env, &mh).await,
+                ManagedHostState::Failed { details, .. }
+                    if matches!(
+                        &details.cause,
+                        FailureCause::DpfProvisioning { err }
+                            if err.starts_with("DPF deployment selection failed:")
+                                && err.contains("mixed DPF deployment types")
+                    )
+            ),
+            "{scenario}"
+        );
+    }
 }
 
 /// Reprovisioning with multiple DPUs: each DPU in Reprovisioning is

--- a/crates/dpf/Cargo.toml
+++ b/crates/dpf/Cargo.toml
@@ -46,8 +46,9 @@ tokio-stream = { workspace = true }
 rand = { workspace = true }
 sha2 = { workspace = true }
 
-carbide-uuid = { path = "../uuid", features = ["sqlx"] }
+carbide-libmlx-model = { path = "../libmlx-model" }
 carbide-utils = { path = "../utils" }
+carbide-uuid = { path = "../uuid", features = ["sqlx"] }
 
 # Optional dependencies for carbide-dpf-api-harness binary
 clap = { workspace = true, features = ["derive"], optional = true }

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -20,6 +20,7 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
+use carbide_libmlx_model::nvconfig::DpuNvConfigProfile;
 use kube::core::ObjectMeta;
 use sha2::{Digest, Sha256};
 
@@ -398,7 +399,9 @@ pub fn default_flavor_for(
     }
 
     let pf_total_sf = match deployment_type {
-        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => DEFAULT_PF_TOTAL_SF_RESERVED,
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf3Gb200 | DpuDeploymentType::Bf4Generic => {
+            DEFAULT_PF_TOTAL_SF_RESERVED
+        }
         DpuDeploymentType::Bf4Astra => unreachable!("handled above"),
     };
 
@@ -435,9 +438,10 @@ pub(crate) fn default_flavor_for_with_topology(
         DpuDeploymentType::Bf4Astra => Err(crate::error::DpfError::ConfigError(
             "BF4 Astra uses DPUFlavorTemplate; call flavor_bf4_astra() instead".to_string(),
         )),
-        DpuDeploymentType::Bf3 => default_flavor_with_topology(
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf3Gb200 => default_flavor_with_topology(
             namespace,
             proxy,
+            deployment_type,
             num_of_vfs,
             pf_total_sf,
             intercept_bridging,
@@ -723,6 +727,7 @@ pub fn default_flavor(
     default_flavor_with_topology(
         namespace,
         proxy,
+        DpuDeploymentType::Bf3,
         DEFAULT_DPU_NUM_OF_VFS,
         DEFAULT_PF_TOTAL_SF_RESERVED,
         None,
@@ -734,6 +739,7 @@ pub fn default_flavor(
 fn default_flavor_with_topology(
     namespace: &str,
     proxy: &Option<DpfProxyDetails>,
+    deployment_type: DpuDeploymentType,
     num_of_vfs: u32,
     pf_total_sf: u32,
     intercept_bridging: Option<&DpfInterceptBridging>,
@@ -756,13 +762,13 @@ fn default_flavor_with_topology(
             bfcfg_parameters: Some(bfcfg_parameters),
             config_files: Some(get_config_files(
                 proxy,
-                DpuDeploymentType::Bf3,
+                deployment_type,
                 dhcp_acl_interfaces,
             )?),
             containerd_config: None,
             grub: Some(get_default_grub()),
             host_network_interface_configs: None,
-            nvconfig: Some(vec![get_nvconfig(num_of_vfs, pf_total_sf)]),
+            nvconfig: Some(vec![get_nvconfig(num_of_vfs, pf_total_sf, deployment_type)]),
             ovs: Some(crate::crds::dpuflavors_generated::DpuFlavorOvs {
                 raw_config_script: Some(get_default_ovs_defaults_with_topology(intercept_bridging)),
             }),
@@ -804,7 +810,8 @@ fn get_default_grub() -> DpuFlavorGrub {
 /// Returns the base set of config files, plus an optional containerd proxy drop-in if `proxy` is set.
 ///
 /// `deployment_type` selects the few settings that differ between the deployments sharing this
-/// base set (BF3 and BF4 generic); [`get_bf4_astra_config_files`] builds the BF4 Astra set.
+/// base set (both BF3 variants and BF4 generic); [`get_bf4_astra_config_files`] builds the BF4
+/// Astra set.
 fn get_config_files(
     proxy: &Option<DpfProxyDetails>,
     deployment_type: DpuDeploymentType,
@@ -1406,9 +1413,13 @@ fn get_bf4_astra_config_files(
     Ok(config_files)
 }
 
-/// Builds BF3 nvconfig with the validated site VF population.
-fn get_nvconfig(num_of_vfs: u32, pf_total_sf: u32) -> DpuFlavorNvconfig {
-    let parameters = vec![
+/// Builds BF3 NVConfig with the validated site VF population and platform profile.
+fn get_nvconfig(
+    num_of_vfs: u32,
+    pf_total_sf: u32,
+    deployment_type: DpuDeploymentType,
+) -> DpuFlavorNvconfig {
+    let mut parameters = vec![
         "PF_BAR2_ENABLE=0".to_string(),
         "PER_PF_NUM_SF=1".to_string(),
         format!("PF_TOTAL_SF={pf_total_sf}"),
@@ -1426,6 +1437,27 @@ fn get_nvconfig(num_of_vfs: u32, pf_total_sf: u32) -> DpuFlavorNvconfig {
         "LINK_TYPE_P1=ETH".to_string(),
         "LINK_TYPE_P2=ETH".to_string(),
     ];
+
+    if deployment_type == DpuDeploymentType::Bf3Gb200 {
+        // DPF v26.4 accepts at most 32 parameters. These two assignments set
+        // values that DPF already restores to their firmware default of 0, so
+        // omitting them preserves the required platform state.
+        // TODO(chet): Add PCI_SWITCH0_UPSTREAM_PORT_BUS=0 and
+        // PCI_SWITCH0_UPSTREAM_PORT_PEX=0 after DPF accepts more than 32
+        // NVConfig parameters.
+        parameters.extend(
+            DpuNvConfigProfile::Gb200B3240V1
+                .parameters()
+                .iter()
+                .filter(|parameter| {
+                    !matches!(
+                        **parameter,
+                        "PCI_SWITCH0_UPSTREAM_PORT_BUS=0" | "PCI_SWITCH0_UPSTREAM_PORT_PEX=0"
+                    )
+                })
+                .map(|parameter| (*parameter).to_string()),
+        );
+    }
 
     DpuFlavorNvconfig {
         // DPF does not allow anyother wild card. It takes only '*'
@@ -1757,7 +1789,10 @@ mod tests {
             |flavor: DPUFlavor| flavor.spec.nvconfig.unwrap()[0].parameters.clone().unwrap();
 
         // BF3 and generic BF4 consume the validated site value.
-        let bf3 = parameters(default_flavor_with_topology("ns", &None, 3, 61, None, None).unwrap());
+        let bf3 = parameters(
+            default_flavor_with_topology("ns", &None, DpuDeploymentType::Bf3, 3, 61, None, None)
+                .unwrap(),
+        );
         assert!(bf3.contains(&"NUM_OF_VFS=3".to_string()));
         assert!(bf3.contains(&"PF_TOTAL_SF=61".to_string()));
         let generic_bf4 =
@@ -1775,6 +1810,44 @@ mod tests {
         assert!(astra.contains(&expected_astra_pf_total_sf_parameter()));
     }
 
+    #[test]
+    fn gb200_bf3_nvconfig_appends_the_bounded_profile_in_order() {
+        let parameters = |deployment_type| {
+            get_nvconfig(16, DEFAULT_PF_TOTAL_SF_RESERVED, deployment_type)
+                .parameters
+                .unwrap()
+        };
+        let bf3 = parameters(DpuDeploymentType::Bf3);
+        let gb200 = parameters(DpuDeploymentType::Bf3Gb200);
+
+        assert_eq!(bf3.len(), 16);
+        assert_eq!(gb200.len(), 32);
+        assert_eq!(&gb200[..bf3.len()], bf3.as_slice());
+        assert_eq!(
+            &gb200[bf3.len()..],
+            [
+                "OFF_BOARD_SERIALIZER=1",
+                "PCI_BUS00_HIERARCHY_TYPE=1",
+                "PCI_BUS00_SPEED=5",
+                "PCI_BUS00_WIDTH=5",
+                "PCI_BUS10_HIERARCHY_TYPE=1",
+                "PCI_BUS10_SPEED=4",
+                "PCI_BUS10_WIDTH=3",
+                "PCI_BUS12_HIERARCHY_TYPE=1",
+                "PCI_BUS12_SPEED=4",
+                "PCI_BUS12_WIDTH=3",
+                "PCI_BUS14_HIERARCHY_TYPE=1",
+                "PCI_BUS14_SPEED=4",
+                "PCI_BUS14_WIDTH=3",
+                "PCI_BUS16_HIERARCHY_TYPE=1",
+                "PCI_BUS16_SPEED=4",
+                "PCI_BUS16_WIDTH=3",
+            ]
+        );
+        assert!(!gb200.contains(&"PCI_SWITCH0_UPSTREAM_PORT_BUS=0".to_string()));
+        assert!(!gb200.contains(&"PCI_SWITCH0_UPSTREAM_PORT_PEX=0".to_string()));
+    }
+
     /// Verifies normalized input order cannot change rendered flavor identity.
     #[test]
     fn intercept_bridging_input_order_does_not_change_flavor_hash() {
@@ -1790,6 +1863,7 @@ mod tests {
             default_flavor_with_topology(
                 "ns",
                 &None,
+                DpuDeploymentType::Bf3,
                 16,
                 DEFAULT_PF_TOTAL_SF_RESERVED + 7,
                 Some(topology),
@@ -2825,7 +2899,7 @@ mod tests {
 
     #[test]
     fn default_nvconfig_shape() {
-        let nv = get_nvconfig(16, DEFAULT_PF_TOTAL_SF_RESERVED);
+        let nv = get_nvconfig(16, DEFAULT_PF_TOTAL_SF_RESERVED, DpuDeploymentType::Bf3);
         value_scenarios!(
             run = |v| v;
             "device is the only allowed wildcard variant" {

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -511,7 +511,7 @@ const BF4_ASTRA_RA2_2_RUNTIME_CONFIGMAP_KEY: &str = "RA2.2-runtime.yaml";
 /// which inlines its scripts instead of using `contentFrom`.
 fn extra_script_configmap_names(deployment_type: DpuDeploymentType) -> &'static [&'static str] {
     match deployment_type {
-        DpuDeploymentType::Bf3 => &[],
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf3Gb200 => &[],
         DpuDeploymentType::Bf4Generic => &[
             "extra-script-pre-ovs-bf4-generic",
             "extra-script-post-ovs-bf4-generic",
@@ -791,10 +791,11 @@ async fn create_dpu_flavor_template<R: DpuFlavorTemplateRepository>(
 ///
 /// BF3 intentionally uses an empty suffix so its CR names are unchanged — this
 /// keeps existing BF3 clusters untouched (no CR rename / orphaning on upgrade).
-/// Only additional deployments (BF4) are suffixed to avoid colliding with BF3.
+/// Additional deployment classes are suffixed to avoid colliding with BF3.
 pub fn deployment_cr_suffix(deployment_type: DpuDeploymentType) -> &'static str {
     match deployment_type {
         DpuDeploymentType::Bf3 => "",
+        DpuDeploymentType::Bf3Gb200 => "bf3gb200",
         DpuDeploymentType::Bf4Generic => "bf4generic",
         DpuDeploymentType::Bf4Astra => "bf4astra",
     }
@@ -808,6 +809,7 @@ pub fn deployment_cr_suffix(deployment_type: DpuDeploymentType) -> &'static str 
 fn service_interface_cr_suffix(deployment_type: DpuDeploymentType) -> &'static str {
     match deployment_type {
         DpuDeploymentType::Bf3 => "bf3",
+        DpuDeploymentType::Bf3Gb200 => "bf3gb200",
         DpuDeploymentType::Bf4Generic => "bf4",
         DpuDeploymentType::Bf4Astra => "astra",
     }
@@ -1672,7 +1674,9 @@ fn resolve_initialization_inventory<'a>(
         // Astra retains its established static inventory and ignores site topology policy.
         Cow::Owned(match config.deployment_type {
             DpuDeploymentType::Bf4Astra => build_astra_dpu_interfaces_vec(),
-            DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => {
+            DpuDeploymentType::Bf3
+            | DpuDeploymentType::Bf3Gb200
+            | DpuDeploymentType::Bf4Generic => {
                 build_effective_dpu_interfaces(config.num_of_vfs, None)
             }
         })
@@ -1684,11 +1688,13 @@ fn resolve_initialization_inventory<'a>(
 
     let pf_total_sf = match config.deployment_type {
         DpuDeploymentType::Bf4Astra => calculate_astra_pf_total_sf(interfaces.as_ref())?,
-        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => calculate_pf_total_sf(
-            interfaces.as_ref(),
-            config.intercept_bridging.as_ref(),
-            config.pf_total_sf_reserved,
-        )?,
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf3Gb200 | DpuDeploymentType::Bf4Generic => {
+            calculate_pf_total_sf(
+                interfaces.as_ref(),
+                config.intercept_bridging.as_ref(),
+                config.pf_total_sf_reserved,
+            )?
+        }
     };
 
     Ok(ResolvedInitialization {
@@ -1886,7 +1892,7 @@ async fn create_flavor_services_and_deployment<
         DpuDeploymentType::Bf4Astra => {
             create_dpu_flavor_template(repo, namespace, config, resolved).await?
         }
-        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => {
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf3Gb200 | DpuDeploymentType::Bf4Generic => {
             create_dpu_flavor(repo, namespace, config, resolved).await?
         }
     };
@@ -1904,7 +1910,7 @@ async fn create_flavor_services_and_deployment<
     //
     // The disabled path must retain the legacy resource names and empty selectors so installing a
     // new NICo release does not trigger a scoping migration for existing BF3/BF4 interfaces. The
-    // enabled path intentionally creates `-bf3`, `-bf4`, and `-astra` resources.
+    // enabled path intentionally creates `-bf3`, `-bf3gb200`, `-bf4`, and `-astra` resources.
     //
     // LABEL-PLANE SAFETY: A DPUServiceInterface node selector is evaluated against Nodes in the
     // remote DPU cluster, not management-cluster DPUNode CRs. DPF propagates its canonical
@@ -3279,6 +3285,11 @@ mod tests {
                 DpuDeploymentType::Bf3 => "bf3",
             }
 
+            "GB200 BF3" {
+                // The specialized flavor needs its own selector and interface resources.
+                DpuDeploymentType::Bf3Gb200 => "bf3gb200",
+            }
+
             "generic BF4" {
                 // Generic BF4 must not share interface resources with BF3 or Astra.
                 DpuDeploymentType::Bf4Generic => "bf4",
@@ -3882,12 +3893,24 @@ mod tests {
         let svc = ServiceDefinition::new(DOCA_HBN_SERVICE_NAME, "repo", "chart", "1.0.5");
 
         let bf3_suffix = deployment_cr_suffix(DpuDeploymentType::Bf3);
+        let bf3_gb200_suffix = deployment_cr_suffix(DpuDeploymentType::Bf3Gb200);
         let bf4_suffix = deployment_cr_suffix(DpuDeploymentType::Bf4Generic);
 
         // BF3: CR name unchanged.
         let bf3 = build_service_template(&svc, TEST_NAMESPACE, bf3_suffix);
         assert_eq!(bf3.metadata.name.as_deref(), Some(DOCA_HBN_SERVICE_NAME));
         assert_eq!(bf3.spec.deployment_service_name, DOCA_HBN_SERVICE_NAME);
+
+        // GB200 BF3: separate CR name while retaining the same logical service name.
+        let bf3_gb200 = build_service_template(&svc, TEST_NAMESPACE, bf3_gb200_suffix);
+        assert_eq!(
+            bf3_gb200.metadata.name.as_deref(),
+            Some("doca-hbn-bf3gb200")
+        );
+        assert_eq!(
+            bf3_gb200.spec.deployment_service_name,
+            DOCA_HBN_SERVICE_NAME
+        );
 
         // BF4: CR name suffixed, logical name unchanged.
         let bf4 = build_service_template(&svc, TEST_NAMESPACE, bf4_suffix);
@@ -3947,6 +3970,10 @@ mod tests {
             };
             "BF3 preserves unsuffixed resource names" {
                 DpuDeploymentType::Bf3 => ("", None),
+            }
+
+            "GB200 BF3 uses its deployment suffix" {
+                DpuDeploymentType::Bf3Gb200 => ("bf3gb200", None),
             }
 
             "generic BF4 uses its deployment suffix" {

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -90,6 +90,7 @@ impl ResourceLabeler for InitializationLabeler {
         // on a particular production deployment-label spelling.
         let deployment_label = match deployment_type {
             DpuDeploymentType::Bf3 => "test.nvidia.com/bf3",
+            DpuDeploymentType::Bf3Gb200 => "test.nvidia.com/bf3gb200",
             DpuDeploymentType::Bf4Generic => "test.nvidia.com/bf4",
             DpuDeploymentType::Bf4Astra => "test.nvidia.com/astra",
         };
@@ -663,11 +664,11 @@ async fn test_create_initialization_objects_bluefield_software() {
     drop(sdk);
 }
 
-/// Verifies configured BF3 and generic BF4 coexist with scoped Astra while flavors, Patch
-/// interfaces, service chains, and selectors retain one deployment-specific inventory view.
+/// Verifies ordinary and GB200 BF3, generic BF4, and Astra coexist while each
+/// deployment retains its own flavor, interfaces, service chains, and selectors.
 #[tokio::test]
-async fn scoped_bf3_bf4_and_astra_initialization_coexists() {
-    // Build one SDK so all three deployment classes share the production namespace.
+async fn scoped_bf3_gb200_bf4_and_astra_initialization_coexists() {
+    // Build one SDK so all four deployment classes share the production namespace.
     let mock = InitializationMock::default();
     let sdk = crate::sdk::DpfSdkBuilder::new(mock.clone(), TEST_NS, "test-password".to_string())
         .with_labeler(InitializationLabeler)
@@ -698,6 +699,17 @@ async fn scoped_bf3_bf4_and_astra_initialization_coexists() {
             deployment_scoped_service_interfaces: true,
             intercept_bridging: Some(topology.clone()),
             deployment_type: DpuDeploymentType::Bf3,
+            ..Default::default()
+        },
+        // GB200 BF3 reuses the BF3 source and services but owns a distinct flavor and selector.
+        InitDpfResourcesConfig {
+            bfb_url: "http://example.com/bf3.bfb".to_string(),
+            deployment_name: "bf3-gb200-deployment".to_string(),
+            flavor_name: "bf3-gb200-flavor".to_string(),
+            services: services.clone(),
+            deployment_scoped_service_interfaces: true,
+            intercept_bridging: Some(topology.clone()),
+            deployment_type: DpuDeploymentType::Bf3Gb200,
             ..Default::default()
         },
         // Generic BF4 proves the same topology through its BlueFieldSoftware path.
@@ -748,9 +760,9 @@ async fn scoped_bf3_bf4_and_astra_initialization_coexists() {
             .await
             .unwrap()
             .len(),
-        3
+        4
     );
-    assert_eq!(mock.flavors.len(), 2);
+    assert_eq!(mock.flavors.len(), 3);
     assert_eq!(mock.flavor_templates.len(), 1);
 
     // The effective inventories must produce exact, non-overlapping scoped resource names.
@@ -762,7 +774,7 @@ async fn scoped_bf3_bf4_and_astra_initialization_coexists() {
         .map(|interface| interface.metadata.name.clone().unwrap())
         .collect::<BTreeSet<_>>();
     let mut expected_interface_names = BTreeSet::new();
-    for suffix in ["bf3", "bf4"] {
+    for suffix in ["bf3", "bf3gb200", "bf4"] {
         for logical_name in ["p0", "p1", "c2pf3", "c2pf3vf4"] {
             expected_interface_names.insert(format!("{logical_name}-{suffix}"));
         }
@@ -795,6 +807,7 @@ async fn scoped_bf3_bf4_and_astra_initialization_coexists() {
     // management-plane class labels used by DPUNode selectors do not exist in the DPU cluster.
     for (suffix, deployment_name) in [
         ("bf3", "bf3-deployment"),
+        ("bf3gb200", "bf3-gb200-deployment"),
         ("bf4", "bf4-deployment"),
         ("astra", "astra-deployment"),
     ] {
@@ -824,8 +837,8 @@ async fn scoped_bf3_bf4_and_astra_initialization_coexists() {
         }
     }
 
-    // Both configured classes must serialize the same exact DPF-owned Patch pairs.
-    for suffix in ["bf3", "bf4"] {
+    // All three configured classes must serialize the same exact DPF-owned Patch pairs.
+    for suffix in ["bf3", "bf3gb200", "bf4"] {
         for (logical_name, peer_bridge, peer_patch_name) in [
             ("c2pf3", "br-pf3", "p-pf3"),
             ("c2pf3vf4", "br-vf4", "p-vf4"),
@@ -908,17 +921,28 @@ async fn scoped_bf3_bf4_and_astra_initialization_coexists() {
             "bf3-deployment",
             DpuDeploymentType::Bf3,
             "host_representor='pf3hpf'",
+            false,
+        ),
+        // GB200 BF3 shares BF3 networking while carrying the specialized NVConfig profile.
+        (
+            "bf3-gb200-deployment",
+            DpuDeploymentType::Bf3Gb200,
+            "host_representor='pf3hpf'",
+            true,
         ),
         // Generic BF4 must resolve the selected PF by its exact semantic identity.
         (
             "bf4-deployment",
             DpuDeploymentType::Bf4Generic,
             "resolve_dpf_pf 'c2pf3'",
+            false,
         ),
     ];
     // Each tuple identifies the deployment to inspect, the class-label source, and one
     // platform-specific OVS fragment proving that deployment received the correct flavor.
-    for (deployment_name, deployment_type, expected_ovs_marker) in configured_deployments {
+    for (deployment_name, deployment_type, expected_ovs_marker, expects_gb200_profile) in
+        configured_deployments
+    {
         // The deployment-referenced flavor must contain the configured topology and SF total.
         let deployment = DpuDeploymentRepository::get(&mock, deployment_name, TEST_NS)
             .await
@@ -937,6 +961,12 @@ async fn scoped_bf3_bf4_and_astra_initialization_coexists() {
             nvconfig
                 .iter()
                 .any(|parameter| parameter == "PF_TOTAL_SF=37")
+        );
+        assert_eq!(
+            nvconfig
+                .iter()
+                .any(|parameter| parameter == "OFF_BOARD_SERIALIZER=1"),
+            expects_gb200_profile
         );
         let ovs_script = flavor
             .spec

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -684,6 +684,8 @@ pub struct DpuServiceHelmChartObservation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DpuDeploymentType {
     Bf3,
+    /// BF3 B3240 on a GB200 platform using CPU as Root Complex mode.
+    Bf3Gb200,
     Bf4Generic,
     Bf4Astra,
 }

--- a/crates/machine-controller/Cargo.toml
+++ b/crates/machine-controller/Cargo.toml
@@ -42,6 +42,7 @@ carbide-utils = { path = "../utils", default-features = false }
 carbide-firmware = { path = "../firmware", default-features = false }
 carbide-instrument = { path = "../instrument" }
 carbide-ipmi = { path = "../ipmi", default-features = false }
+carbide-libmlx-model = { path = "../libmlx-model" }
 carbide-measured-boot = { path = "../measured-boot", default-features = false }
 carbide-redfish = { path = "../redfish", default-features = false }
 carbide-secrets = { path = "../secrets" }
@@ -78,7 +79,9 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 version-compare = { workspace = true }
 
 [dev-dependencies]
-carbide-api-model = { path = "../api-model", default-features = false, features = ["test-support"] }
+carbide-api-model = { path = "../api-model", default-features = false, features = [
+  "test-support",
+] }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-secrets = { path = "../secrets", features = ["test-support"] }

--- a/crates/machine-controller/src/config/mod.rs
+++ b/crates/machine-controller/src/config/mod.rs
@@ -38,6 +38,8 @@ pub struct MachineStateHandlerSiteConfig {
     pub firmware_global: FirmwareGlobal,
     pub machine_state_controller: MachineStateControllerConfig,
     pub host_health: HostHealthConfig,
+    /// Rack profiles used to refine DPF deployment selection from the host's rack identity.
+    pub rack_profiles: model::rack_type::RackProfileConfig,
 
     pub selected_profile: libredfish::BiosProfileType,
     pub bios_profiles: libredfish::BiosProfileVendor,
@@ -80,6 +82,7 @@ impl MachineStateHandlerSiteConfig {
             firmware_global: FirmwareGlobal::test_default(),
             machine_state_controller: MachineStateControllerConfig::test_default(),
             host_health: HostHealthConfig::default(),
+            rack_profiles: model::rack_type::RackProfileConfig::default(),
             selected_profile: libredfish::BiosProfileType::Performance,
             bios_profiles: HashMap::new(),
             oem_manager_profiles: HashMap::new(),

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -94,10 +94,10 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// Mark DPU node as rebooted (clear the external reboot required annotation).
     async fn reboot_complete(&self, node_name: &str) -> Result<(), DpfError>;
 
-    /// Resolve the deployment type of a DPU based on its hardware (BF3 vs BF4).
-    /// Returns `Err` when the part number is absent or does not match any known
-    /// generation, so unrecognized hardware never silently routes to a wrong
-    /// deployment.
+    /// Resolve a DPU's base hardware deployment class (BF3 or BF4).
+    ///
+    /// The state handler separately refines BF3 from the host rack and DPU
+    /// profile. This returns `Err` when the DMI product name is absent.
     fn deployment_type_for_dpu(
         &self,
         dpu: &Machine,
@@ -677,8 +677,11 @@ impl DpfOperations for DpfSdkOps {
         };
 
         tracing::info!(
-            "selected deployment type {deployment_type:?} for {product_name}, machine_id: {}, astra_nics: {astra_nics}",
-            dpu.id
+            machine_id = %dpu.id,
+            product_name,
+            astra_nics,
+            ?deployment_type,
+            "selected base DPF deployment type for DPU"
         );
 
         Ok(deployment_type)

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -22,14 +22,17 @@
 
 use std::net::IpAddr;
 
-use carbide_dpf::{DpfError, DpuPhase, dpu_node_cr_name};
+use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase, dpu_node_cr_name};
+use carbide_libmlx_model::nvconfig::DpuNvConfigProfile;
 use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
+use model::hardware_info::HardwareInfo;
 use model::machine::{
     DpfState, DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, Machine,
     ManagedHostState, ManagedHostStateSnapshot, PerformPowerOperation, ReprovisionState,
     StateMachineArea,
 };
+use model::rack_type::{RackProductFamily, select_dpu_nvconfig_profile};
 use state_controller::state_handler::{
     ExternalServiceError, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -54,6 +57,88 @@ fn dpf_id(machine: &Machine) -> Result<String, StateHandlerError> {
     machine.dpf_id().ok_or_else(|| {
         StateHandlerError::InvalidState(format!("BMC MAC is not set for machine {}", machine.id))
     })
+}
+
+async fn host_rack_product_family(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<Option<RackProductFamily>, StateHandlerError> {
+    let Some(rack_id) = state.host_snapshot.rack_id.as_ref() else {
+        return Ok(None);
+    };
+    let mut conn = ctx.services.db_pool.acquire().await?;
+    let Some(rack) = db::rack::find_by(
+        conn.as_mut(),
+        db::ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+    )
+    .await?
+    .pop() else {
+        return Ok(None);
+    };
+    let Some(profile_id) = rack.rack_profile_id.as_ref() else {
+        return Ok(None);
+    };
+    let Some(profile) = ctx
+        .services
+        .site_config
+        .rack_profiles
+        .get(profile_id.as_str())
+    else {
+        return Ok(None);
+    };
+
+    Ok(profile.product_family.clone())
+}
+
+async fn deployment_types_for_host(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    dpf_sdk: &dyn DpfOperations,
+    astra_nics: bool,
+) -> Result<Vec<DpuDeploymentType>, StateHandlerError> {
+    let product_family = host_rack_product_family(state, ctx).await?;
+    state
+        .dpu_snapshots
+        .iter()
+        .map(|dpu| {
+            let base = dpf_sdk
+                .deployment_type_for_dpu(dpu, astra_nics)
+                .map_err(dpf_error)?;
+            Ok::<_, StateHandlerError>(deployment_type_for_dpu_profile(
+                base,
+                product_family.as_ref(),
+                dpu.status.hardware_info.as_ref(),
+            ))
+        })
+        .collect()
+}
+
+fn deployment_type_for_dpu_profile(
+    base: DpuDeploymentType,
+    product_family: Option<&RackProductFamily>,
+    hardware_info: Option<&HardwareInfo>,
+) -> DpuDeploymentType {
+    match select_dpu_nvconfig_profile(product_family, hardware_info) {
+        Some(DpuNvConfigProfile::Gb200B3240V1) if base == DpuDeploymentType::Bf3 => {
+            DpuDeploymentType::Bf3Gb200
+        }
+        Some(DpuNvConfigProfile::Gb200B3240V1) | None => base,
+    }
+}
+
+fn consistent_deployment_type(
+    deployment_types: &[DpuDeploymentType],
+) -> Result<DpuDeploymentType, String> {
+    let Some(first) = deployment_types.first().copied() else {
+        return Err(
+            "cannot determine DPF deployment type for a host without attached DPUs".to_string(),
+        );
+    };
+    if deployment_types.iter().all(|candidate| *candidate == first) {
+        Ok(first)
+    } else {
+        Err("host has mixed DPF deployment types across attached DPUs".to_string())
+    }
 }
 
 /// Transition all DPU sub-states to the given DPF state, preserving the
@@ -176,8 +261,8 @@ fn waiting_for_ready_exit_state(
 
 async fn create_and_register_dpudevices_and_dpunode(
     state: &ManagedHostStateSnapshot,
-    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    deployment_type: DpuDeploymentType,
 ) -> Result<(), StateHandlerError> {
     let primary_dpu_id = state
         .host_snapshot
@@ -190,8 +275,16 @@ async fn create_and_register_dpudevices_and_dpunode(
             object_id: state.host_snapshot.id.to_string(),
             missing: "primary_dpu",
         })?;
-
-    let astra_nics = machine_has_astra_nics(state, ctx).await?;
+    if !state
+        .dpu_snapshots
+        .iter()
+        .any(|dpu| dpu.id == primary_dpu_id)
+    {
+        return Err(StateHandlerError::MissingData {
+            object_id: state.host_snapshot.id.to_string(),
+            missing: "primary_dpu_snapshot",
+        });
+    }
 
     for dpu in &state.dpu_snapshots {
         let serial_number = dpu
@@ -221,19 +314,6 @@ async fn create_and_register_dpudevices_and_dpunode(
             .await
             .map_err(dpf_error)?;
     }
-
-    let primary_dpu = state
-        .dpu_snapshots
-        .iter()
-        .find(|dpu| dpu.id == primary_dpu_id)
-        .ok_or_else(|| StateHandlerError::MissingData {
-            object_id: state.host_snapshot.id.to_string(),
-            missing: "primary_dpu_snapshot",
-        })?;
-
-    let deployment_type = dpf_sdk
-        .deployment_type_for_dpu(primary_dpu, astra_nics)
-        .map_err(dpf_error)?;
 
     let device_ids: Vec<String> = state
         .dpu_snapshots
@@ -295,14 +375,30 @@ fn dpf_cr_creation_failed(
     StateHandlerOutcome::transition(make_failure_state(state, details, state.host_snapshot.id))
 }
 
+fn dpf_deployment_selection_failed(
+    state: &ManagedHostStateSnapshot,
+    error: &str,
+) -> StateHandlerOutcome<ManagedHostState> {
+    let details = FailureDetails {
+        cause: FailureCause::DpfProvisioning {
+            err: format!("DPF deployment selection failed: {error}"),
+        },
+        failed_at: chrono::Utc::now(),
+        source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+    };
+    StateHandlerOutcome::transition(make_failure_state(state, details, state.host_snapshot.id))
+}
+
 /// Handle DpfState::Provisioning: register all DPU devices and the node, then
 /// transition all DPUs to WaitingForReady.
 async fn handle_dpf_provisioning(
     state: &ManagedHostStateSnapshot,
-    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    deployment_type: DpuDeploymentType,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    if let Err(err) = create_and_register_dpudevices_and_dpunode(state, ctx, dpf_sdk).await {
+    if let Err(err) =
+        create_and_register_dpudevices_and_dpunode(state, dpf_sdk, deployment_type).await
+    {
         return Ok(dpf_cr_creation_failed(state, &err));
     }
 
@@ -567,6 +663,7 @@ async fn handle_dpf_reprovisioning(
     dpu_snapshot: &Machine,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    deployment_type: DpuDeploymentType,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     let dpf_dpudevices_and_dpunode_crs_noexist =
@@ -578,7 +675,9 @@ async fn handle_dpf_reprovisioning(
             machine_id = %state.host_snapshot.id,
             "DPUDevice/DPUNode CRs do not exist, creating them before reprovisioning"
         );
-        if let Err(err) = create_and_register_dpudevices_and_dpunode(state, ctx, dpf_sdk).await {
+        if let Err(err) =
+            create_and_register_dpudevices_and_dpunode(state, dpf_sdk, deployment_type).await
+        {
             return Ok(dpf_cr_creation_failed(state, &err));
         }
         let next = transition_all_dpus_to_dpf_state(
@@ -691,9 +790,29 @@ pub(super) async fn handle_dpf_state(
 
     let astra_nics = machine_has_astra_nics(state, ctx).await?;
 
-    let deployment_type = dpf_sdk
-        .deployment_type_for_dpu(dpu_snapshot, astra_nics)
-        .map_err(dpf_error)?;
+    let deployment_types = deployment_types_for_host(state, ctx, dpf_sdk, astra_nics).await?;
+    let deployment_type = match consistent_deployment_type(&deployment_types) {
+        Ok(deployment_type) => deployment_type,
+        Err(error) => {
+            let selections = state
+                .dpu_snapshots
+                .iter()
+                .zip(&deployment_types)
+                .map(|(dpu, deployment_type)| format!("{}={deployment_type:?}", dpu.id))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let error = format!("{error}: {selections}");
+
+            return Ok(dpf_deployment_selection_failed(state, error.as_str()));
+        }
+    };
+    if matches!(dpf_state, DpfState::Provisioning) {
+        tracing::info!(
+            machine_id = %state.host_snapshot.id,
+            ?deployment_type,
+            "selected DPF deployment type for host"
+        );
+    }
     if !dpf_sdk
         .verify_node_labels(&node_name, deployment_type)
         .await
@@ -722,7 +841,7 @@ pub(super) async fn handle_dpf_state(
     }
 
     match dpf_state {
-        DpfState::Provisioning => handle_dpf_provisioning(state, ctx, dpf_sdk).await,
+        DpfState::Provisioning => handle_dpf_provisioning(state, dpf_sdk, deployment_type).await,
         DpfState::WaitingForReady { phase_detail } => {
             handle_dpf_waiting_for_ready(state, dpu_snapshot, phase_detail, ctx, dpf_sdk).await
         }
@@ -740,12 +859,135 @@ pub(super) async fn handle_dpf_state(
         }
         DpfState::DeviceReady => handle_dpf_device_ready(state),
         DpfState::Reprovisioning => {
-            handle_dpf_reprovisioning(state, dpu_snapshot, ctx, dpf_sdk).await
+            handle_dpf_reprovisioning(state, dpu_snapshot, ctx, dpf_sdk, deployment_type).await
         }
         DpfState::Unknown => {
             tracing::warn!(dpu_machine_id = %dpu_snapshot.id, "unknown DPF state in DB, transitioning to provisioning");
             let next = set_one_dpu_dpf_state(state, &dpu_snapshot.id, DpfState::Provisioning)?;
             Ok(StateHandlerOutcome::transition(next))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+    use model::hardware_info::DpuData;
+
+    use super::*;
+
+    fn hardware_info(part_number: &str) -> HardwareInfo {
+        HardwareInfo {
+            dpu_info: Some(DpuData {
+                part_number: part_number.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn gb200_b3240_profile_selects_only_the_specialized_bf3_deployment() {
+        /// Hardware and rack inputs used to refine one base DPF deployment class.
+        struct ProfileInput {
+            base: DpuDeploymentType,
+            product_family: Option<RackProductFamily>,
+            hardware_info: Option<HardwareInfo>,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "GB200 B3240 BF3",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf3,
+                        product_family: Some(RackProductFamily::Gb200),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CN-AB0")),
+                    },
+                    expect: DpuDeploymentType::Bf3Gb200,
+                },
+                Check {
+                    scenario: "non-GB200 B3240 BF3",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf3,
+                        product_family: Some(RackProductFamily::Other("other".to_string())),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CN-AB0")),
+                    },
+                    expect: DpuDeploymentType::Bf3,
+                },
+                Check {
+                    scenario: "GB200 other BF3",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf3,
+                        product_family: Some(RackProductFamily::Gb200),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CV-AA0")),
+                    },
+                    expect: DpuDeploymentType::Bf3,
+                },
+                Check {
+                    scenario: "BF3 without rack profile or hardware information",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf3,
+                        product_family: None,
+                        hardware_info: None,
+                    },
+                    expect: DpuDeploymentType::Bf3,
+                },
+                Check {
+                    scenario: "GB200 BF4 remains BF4",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf4Generic,
+                        product_family: Some(RackProductFamily::Gb200),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CN-AB0")),
+                    },
+                    expect: DpuDeploymentType::Bf4Generic,
+                },
+                Check {
+                    scenario: "Astra remains Astra",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf4Astra,
+                        product_family: Some(RackProductFamily::Gb200),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CN-AB0")),
+                    },
+                    expect: DpuDeploymentType::Bf4Astra,
+                },
+            ],
+            |input| {
+                deployment_type_for_dpu_profile(
+                    input.base,
+                    input.product_family.as_ref(),
+                    input.hardware_info.as_ref(),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn attached_dpus_require_one_consistent_deployment_type() {
+        check_values(
+            [
+                Check {
+                    scenario: "ordinary BF3 pair",
+                    input: vec![DpuDeploymentType::Bf3, DpuDeploymentType::Bf3],
+                    expect: Some(DpuDeploymentType::Bf3),
+                },
+                Check {
+                    scenario: "GB200 BF3 pair",
+                    input: vec![DpuDeploymentType::Bf3Gb200, DpuDeploymentType::Bf3Gb200],
+                    expect: Some(DpuDeploymentType::Bf3Gb200),
+                },
+                Check {
+                    scenario: "mixed GB200 eligibility",
+                    input: vec![DpuDeploymentType::Bf3Gb200, DpuDeploymentType::Bf3],
+                    expect: None,
+                },
+                Check {
+                    scenario: "host without attached DPUs",
+                    input: vec![],
+                    expect: None,
+                },
+            ],
+            |deployment_types| consistent_deployment_type(&deployment_types).ok(),
+        );
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR contains:
> - 345 lines of production code
> - 510 lines of tests
> - 8 lines of Cargo metadata
> - No generated code.

DPF provisioning currently reapplies the generic BF3 NVConfig with 16 values after firmware resets. GB200 systems with supported B3240 DPUs also need the CPU as Root Complex profile, so applying the generic flavor leaves their PCIe topology and uplink mapping incorrect.

This change adds a derived `Bf3Gb200` deployment that reuses the configured BF3 source and services with separate DPF resources and selectors. The derived names fit DPF's 20-character deployment limit and the Kubernetes limits after the flavor hash and label suffix are added. The machine controller selects it only when the rack profile identifies a GB200 system and every attached DPU has a supported B3240 part number. Mixed selections fail before resource registration instead of applying the profile to only part of the host.

DPF v26.4 permits 32 NVConfig values. The GB200 flavor keeps the existing 16 BF3 values and adds the 16 nondefault profile values. It leaves out the two explicit zero values that DPF already restores to their firmware defaults. Existing GB200 DPU nodes keep their ordinary BF3 labels until they are deleted and reprovisioned; that reprovision selects the new deployment and applies the profile. Ordinary BF3, BF4, and Astra selections are unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5439

Part of https://github.com/NVIDIA/infra-controller/issues/5029

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Details

- Targeted DPF and machine controller tests cover the flavor with 32 values, four deployment classes, exact profile selection, mixed DPU rejection, identifier length limits, and both registration paths.
- Database tests exercise the rack and DPU inventory lookup through the controller. `cargo make clippy`, focused custom lints, license, dependency ban, and workspace dependency checks passed.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable tree. Codex then reviewed the final diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 1 | 0 |
| CodeRabbit CLI | 1 | 1 | 0 |
| Claude CLI | 22 | 13 | 9 |
| common-nits-reviewer | 2 | 2 | 0 |
| **Total** | **26** | **17** | **9** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted (post-fix closure)** -- Failure text incorrectly claimed no DPF resources had ever been registered. **Resolution:** It now refers to the current registration attempt.

### CodeRabbit CLI

1. **Adopted** -- The public `rack_profiles` field lacked Rustdoc. **Resolution:** Documented its key and use.

### Claude CLI

1. **Adopted** -- Reprovisioning retried mixed selections indefinitely. **Resolution:** Both provisioning paths now enter `Failed` before registration.
2. **Adopted** -- Selection errors omitted DPU IDs. **Resolution:** Each ID is paired with its selected class.
3. **Declined** -- Fall back to BF3 after an exact GB200/B3240 allowlist miss. **Reason:** Failure is safer than applying incorrect NVConfig.
4. **Adopted** -- Classifier docs described a final result. **Resolution:** They now define the base BF3/BF4 class and DMI product name behavior.
5. **Adopted** -- The omitted zero values lacked a safety explanation. **Resolution:** The comment records the DPF limit and restored firmware defaults.
6. **Declined** -- Filter omitted values by key. **Reason:** Literal matching and the exact count test expose an unexpected value change.
7. **Adopted** -- `get_nvconfig` documented only BF3. **Resolution:** Its Rustdoc now covers the NVConfig list for each deployment.
8. **Adopted** -- SDK comments described three deployment classes. **Resolution:** Updated them for all four.
9. **Adopted** -- The SDK test did not prove the profile reached the flavor. **Resolution:** It verifies `OFF_BOARD_SERIALIZER=1` appears only in the GB200 flavor.
10. **Adopted** -- Handler tests used positional tuples. **Resolution:** They now use named inputs with `check_values`.
11. **Adopted** -- Test configuration used an inconsistent default expression. **Resolution:** It now uses the explicit type default.
12. **Adopted** -- The rack profile field lacked Rustdoc. **Resolution:** Added its contract; this overlaps the other reviewers.
13. **Adopted** -- A hardware type was fully qualified inline. **Resolution:** Imported and used it directly.
14. **Adopted** -- A test covered an unreachable empty DPU set. **Resolution:** Removed the row.
15. **Declined** -- Create the GB200 deployment conditionally. **Reason:** That adds policy and configuration behavior outside this fix.
16. **Declined** -- Add rollout documentation here. **Reason:** Documentation remains separate scope; the opening states the required reprovision.
17. **Declined** -- Apply all 18 profile values. **Reason:** DPF v26.4 permits 32 total values; the omitted zeros already match the firmware defaults.
18. **Adopted** -- A future profile could select a flavor fixed to V1. **Resolution:** The exhaustive `Gb200B3240V1` match requires a compile-time update.
19. **Declined** -- Extract a shared rack profile lookup. **Reason:** The copies use different crates and configuration sources; this is unrelated refactoring.
20. **Declined** -- Expand the DPF manual and Helm examples. **Reason:** Repository convention keeps documentation in a separate PR.
21. **Declined** -- Demote the base class log for each DPU. **Reason:** It records every input to the required consistency check.
22. **Declined** -- Add partial Kubernetes label length parsing. **Reason:** It misses the hash suffix, while the API validates the complete identifier.

### common-nits-reviewer

1. **Adopted** -- The public `rack_profiles` field lacked Rustdoc. **Resolution:** Added its contract; this overlaps CodeRabbit and Claude.
2. **Adopted** -- Selection accepted every future profile variant. **Resolution:** It now matches `Gb200B3240V1` exactly.

</details>

Closes #5439
