### PR TITLE
Add file-backed UFM credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "spancounter",
  "sqlx",
  "sqlx-query-tracing",
+ "tempfile",
  "tokio",
  "tokio-util",
  "trace-propagation",

--- a/crates/admin-cli/src/credential/add_ufm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_ufm/cmd.rs
@@ -18,6 +18,7 @@
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::credential::common::map_ufm_credential_api_error;
 use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
@@ -25,6 +26,7 @@ pub(super) async fn add_ufm(data: Args, api_client: &ApiClient) -> CarbideCliRes
     api_client
         .0
         .create_credential(forgerpc::CredentialCreationRequest::try_from(data)?)
-        .await?;
+        .await
+        .map_err(map_ufm_credential_api_error)?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/common.rs
+++ b/crates/admin-cli/src/credential/common.rs
@@ -21,6 +21,16 @@ use crate::errors::CarbideCliError;
 
 pub(super) const DEFAULT_IB_FABRIC_NAME: &str = "default";
 
+/// Maps a failed-precondition response to the operator-facing UFM command
+/// error, while preserving the standard API error mapping for other statuses.
+pub(super) fn map_ufm_credential_api_error(status: tonic::Status) -> CarbideCliError {
+    if status.code() == tonic::Code::FailedPrecondition {
+        CarbideCliError::UfmCredentialCommandUnavailable(status.message().to_string())
+    } else {
+        status.into()
+    }
+}
+
 #[derive(ValueEnum, Parser, Debug, Clone)]
 pub(super) enum BmcCredentialType {
     // Site Wide BMC Root Account Credentials

--- a/crates/admin-cli/src/credential/delete_ufm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/cmd.rs
@@ -18,6 +18,7 @@
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::credential::common::map_ufm_credential_api_error;
 use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
@@ -25,6 +26,7 @@ pub(super) async fn delete_ufm(data: Args, api_client: &ApiClient) -> CarbideCli
     api_client
         .0
         .delete_credential(forgerpc::CredentialDeletionRequest::try_from(data)?)
-        .await?;
+        .await
+        .map_err(map_ufm_credential_api_error)?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/tests.rs
+++ b/crates/admin-cli/src/credential/tests.rs
@@ -32,8 +32,8 @@ use clap::{CommandFactory, Parser};
 use mac_address::MacAddress;
 
 use super::common::{
-    BmcCredentialType, RotationCredentialKind, UefiCredentialType, password_validator,
-    url_validator,
+    BmcCredentialType, RotationCredentialKind, UefiCredentialType, map_ufm_credential_api_error,
+    password_validator, url_validator,
 };
 use super::*;
 use crate::test_support::{parse_with_leaf_matches, raw_value};
@@ -46,6 +46,24 @@ use crate::test_support::{parse_with_leaf_matches, raw_value};
 #[test]
 fn verify_cmd_structure() {
     Cmd::command().debug_assert();
+}
+
+#[test]
+fn ufm_failed_precondition_has_operator_specific_error() {
+    let error = map_ufm_credential_api_error(tonic::Status::failed_precondition(
+        "UFM fabric \"default\" is supplied by a watched-file credential; update that file",
+    ));
+
+    assert_eq!(
+        error.to_string(),
+        "ufm credential command is unavailable: UFM fabric \"default\" is supplied by a \
+         watched-file credential; update that file"
+    );
+
+    assert!(matches!(
+        map_ufm_credential_api_error(tonic::Status::unavailable("server unavailable")),
+        crate::errors::CarbideCliError::ApiInvocationError(_)
+    ));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/crates/admin-cli/src/errors.rs
+++ b/crates/admin-cli/src/errors.rs
@@ -30,6 +30,9 @@ pub(crate) enum CarbideCliError {
     #[error("the API call to the forge API server returned {0}")]
     ApiInvocationError(#[from] tonic::Status),
 
+    #[error("ufm credential command is unavailable: {0}")]
+    UfmCredentialCommandUnavailable(String),
+
     #[error("error while writing into string: {0}")]
     StringWriteError(#[from] std::fmt::Error),
 

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -139,6 +139,7 @@ Use `site_explorer.dpu_policy` instead.
 | `log_history` | `LogHistoryConfig` | *(default)* | `integrations` | In-memory log history for the admin web live log viewer at `/admin/logs` (see [LogHistoryConfig](#loghistoryconfig)). |
 | `tracing` | `TracingConfig` | *(default)* | `integrations` | OTLP trace export settings (see [TracingConfig](#tracingconfig)). |
 | `secrets` | `Option<SecretsConfig>` | — | `security` | Secrets backend configuration. When present, the credential reader chain and write target are operator-configured (see [SecretsConfig](#secretsconfig)). |
+| `credentials` | `CredentialsConfig` | *(default)* | `security` | Operator-managed static credential sources and the UFM read/mutation policy (see [CredentialsConfig](#credentialsconfig)). The config stores source locations, not credential values. |
 | `dhcp_lease_expiry_handling` | `bool` | `false` | `networking` | Enables IP cleanup when a DHCP lease expires. |
 | `certificates` | `CertificatesConfig` | *(default)* | `security` | Certificate vending backend, selected independently of the credential store; the default shares the credential Vault (see [CertificatesConfig](#certificatesconfig)). |
 | `allow_insecure_discovery` | `bool` | `false` | `machines` | Allows machines to submit discovery without enforcing the request comes from the expected IP address. Needed for *Integration tests only*, should otherwise not be used. |
@@ -952,15 +953,78 @@ be propagated there by DPF.
 | `max_megabytes` | `usize` | `128` | Maximum amount of recent log history retained in memory, in MiB. Oldest lines are evicted once the budget is exceeded. |
 | `page_size` | `usize` | `500` | Number of lines sent in the initial view and in each scrollback page of the live log viewer. |
 
+### `CredentialsConfig`
+
+The optional `[credentials]` section configures non-secret locations from which
+NICo reads operator-managed credentials. Non-UFM credentials continue to read
+the local environment and file sources before the configured persistent
+backends. `ufm_source` controls the read precedence and mutation policy for UFM
+credentials.
+
+| Field | Type | Default | Description |
+| ------- | ------ | --------- | ------------- |
+| `ufm_source` | `UfmCredentialSource` | `local_first` | UFM credential policy. `local_first` reads environment/file entries before falling back to the persistent backend and writes to the backend. `backend` ignores local UFM entries. `local` makes environment/file entries authoritative and rejects persistent-backend UFM mutations. |
+| `file` | `Option<CredentialFileSourceConfig>` | — | Watched JSON or YAML static-credential file (see [CredentialFileSourceConfig](#credentialfilesourceconfig)). When present, it replaces the legacy file source selected by `CARBIDE_CREDENTIALS_FILE_*`; the environment source remains first when enabled. |
+
+When `ufm_source = "local"` and InfiniBand management is enabled, startup
+requires a local `ufm_auth_by_fabric` entry for every configured fabric. The
+mode is all-or-nothing: NICo does not fall back to Vault or Postgres for a
+missing fabric. When `ufm_source` is omitted, `local_first` preserves the
+pre-existing local-override behavior.
+
+#### Environment credential source
+
+The environment source is disabled by default. Set
+`CARBIDE_CREDENTIALS_ENV_ENABLED=true` on the `nico-api` process to enable it;
+the only accepted boolean values are `true` and `false`. The optional
+`CARBIDE_CREDENTIALS_ENV_PREFIX` overrides the default
+`CARBIDE_STATIC_CREDENTIAL_` prefix. Trailing underscores are removed from the
+configured prefix, then `__` separates each nested field.
+
+For example, these variables provide both fields required for the `default`
+UFM fabric using the default prefix:
+
+```bash
+export CARBIDE_CREDENTIALS_ENV_ENABLED=true
+export CARBIDE_STATIC_CREDENTIAL__UFM_AUTH_BY_FABRIC__DEFAULT__USERNAME=ignored-for-token-or-certificate-auth
+export CARBIDE_STATIC_CREDENTIAL__UFM_AUTH_BY_FABRIC__DEFAULT__PASSWORD=bearer-token-or-empty
+```
+
+Environment credentials are snapshotted at process startup. Changing them
+requires restarting `nico-api`; use the watched file source for runtime
+credential rotation. With `ufm_source = "local_first"`, an environment entry
+overrides the corresponding file and persistent-backend entries. With
+`ufm_source = "local"`, every configured fabric must be present in the enabled
+environment/file sources.
+
+### `CredentialFileSourceConfig`
+
+| Field | Type | Default | Description |
+| ------- | ------ | --------- | ------------- |
+| `path` | `PathBuf` | **required** | Absolute or working-directory-relative path to a JSON or YAML credential file. The file must exist and parse at startup. |
+| `poll_interval` | `Duration` | `60s` | Nonzero interval used in addition to filesystem events to detect projected-Secret replacements. Startup rejects zero. |
+
+The watcher keeps the last valid snapshot when a reload fails. A UFM-only YAML
+file has the following shape; both `username` and `password` are required. The
+password is the bearer token, while an empty password selects the default
+SPIFFE client certificate:
+
+```yaml
+ufm_auth_by_fabric:
+  default:
+    username: ignored-for-token-or-certificate-auth
+    password: bearer-token-or-empty
+```
+
 ### `SecretsConfig`
 
 | Field | Type | Default | Description |
 | ------- | ------ | --------- | ------------- |
 | `kms` | `KmsConfig` | **required** | KMS backend configuration (see [KmsConfig](#kmsconfig)). |
 | `routing` | `HashMap<String, String>` | **required** | Maps path prefixes to the `kek_id` that encrypts new writes under them, longest prefix winning. A `/` catch-all entry is required. Reads never consult routing — every stored row records the KEK that wrote it. |
-| `backends` | `Vec<CredentialBackend>` | `[vault]` | The credential backend read order, highest priority first (first match wins). The local-override readers (env, file) are always tried ahead of these when enabled. |
-| `writer` | `CredentialBackend` | `vault` | Where new credential writes go. Set to `postgres` to send new writes to the journal; independent of `backends`. |
-| `import_from` | `Option<ImportSource>` | — | A source backend to import secrets from at startup. Unset means a fresh site with nothing to import; unsupported values fail config parsing. |
+| `backends` | `Vec<CredentialBackend>` | `[vault]` | The persistent-backend read order, highest priority first (first match wins). Enabled local overrides are tried first for non-UFM credentials. UFM reads use these backends directly in `backend` mode and as fallback in `local_first` mode. |
+| `writer` | `CredentialBackend` | `vault` | Where new credential writes go. Set to `postgres` to send new writes to the journal; independent of `backends`. UFM mutations are rejected when `credentials.ufm_source = "local"`. |
+| `import_from` | `Option<ImportSource>` | — | A source backend to import secrets from at startup. Only `vault` is supported. When `credentials.ufm_source = "local"`, the import does not traverse or read `ufm/`; an import containing only excluded UFM entries still records completion. Unset means a fresh site with nothing to import. |
 | `import_approach` | `ImportApproach` | `missing_only` | How to treat secrets that already exist in Postgres during import. |
 
 ### `KmsConfig`

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -903,6 +903,15 @@ pub struct CarbideConfig {
     /// env -> file -> vault behavior as when it is absent); see `SecretsConfig`.
     pub secrets: Option<SecretsConfig>,
 
+    /// Operator-managed static credential sources. These settings contain
+    /// only source locations and reload policy; credential values stay in the
+    /// referenced file or process environment. When a file is configured, the
+    /// local environment/file chain is read first for non-UFM credentials.
+    /// `credentials.ufm_source` exclusively selects local or persistent
+    /// backend ownership for all UFM credentials.
+    #[serde(default)]
+    pub credentials: CredentialsConfig,
+
     /// IP cleanup on lease expiry
     #[serde(default)]
     pub dhcp_lease_expiry_handling: bool,
@@ -1045,6 +1054,75 @@ pub struct CertificatesConfig {
     /// `backend = "dedicated_vault"`, ignored otherwise.
     #[serde(default)]
     pub dedicated_vault: Option<DedicatedVaultSettings>,
+}
+
+/// Non-secret sources for operator-managed credentials.
+///
+/// The file source is optional. When present, it takes precedence over the
+/// legacy environment-selected file source and is read before credential
+/// backends such as Vault or Postgres. `ufm_source` controls whether UFM reads
+/// preserve that local-first order or use one authoritative source.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CredentialsConfig {
+    /// Selects the read precedence and mutation policy for UFM credentials.
+    /// Defaults to local-first reads with persistent-backend fallback.
+    #[serde(default)]
+    pub ufm_source: UfmCredentialSource,
+
+    /// A watched file containing static credentials. Its contents are never
+    /// embedded in `CarbideConfig`.
+    #[serde(default)]
+    pub file: Option<CredentialFileSourceConfig>,
+}
+
+/// Configuration for the watched static-credentials file.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CredentialFileSourceConfig {
+    /// Absolute or working-directory-relative path to the JSON or YAML file
+    /// containing static credentials.
+    pub path: PathBuf,
+
+    /// Nonzero interval used to detect projected-Secret replacements that do
+    /// not emit a filesystem watch event. Defaults to 60 seconds.
+    #[serde(
+        default = "CredentialFileSourceConfig::default_poll_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub poll_interval: std::time::Duration,
+}
+
+/// Read precedence and mutation policy for site UFM credentials.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UfmCredentialSource {
+    /// Preserve the existing local-first behavior: read environment/file UFM
+    /// entries before the persistent backend and mutate the backend.
+    #[default]
+    LocalFirst,
+    /// Read and mutate UFM credentials in the configured persistent backend.
+    /// Local environment/file UFM entries are ignored.
+    Backend,
+    /// Read UFM credentials only from the local environment/file sources.
+    /// Every configured fabric must be present when IB management starts, and
+    /// persistent backend mutation is disabled.
+    Local,
+}
+
+impl CredentialFileSourceConfig {
+    /// Returns the polling interval used when `poll_interval` is omitted.
+    pub const fn default_poll_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(60)
+    }
+}
+
+impl CredentialsConfig {
+    /// Returns whether local sources authoritatively own UFM credentials.
+    pub fn uses_authoritative_local_ufm_credentials(&self) -> bool {
+        self.ufm_source == UfmCredentialSource::Local
+    }
 }
 
 /// Tag selecting the certificate backend. The matching settings (if any) live
@@ -1386,11 +1464,12 @@ pub struct SecretsConfig {
     pub routing: std::collections::HashMap<String, String>,
 
     /// The credential *backend* read order, highest priority first (first match
-    /// wins). The local-override readers (env, file) are always tried ahead of
-    /// these, when their `[credentials.*]` section is enabled; this list only
-    /// orders the backends behind them. Order is the operator's choice -- list
-    /// the backends you want, in the priority you want. Defaults to `["vault"]`
-    /// -- with the local overrides, that is the env -> file -> vault chain.
+    /// wins). Enabled local-override readers (env, file) are normally tried
+    /// ahead of these; `credentials.ufm_source` can suppress local UFM entries
+    /// or make them authoritative. This list only orders the persistent
+    /// backends. Order is the operator's choice -- list the backends you want,
+    /// in the priority you want. Defaults to `["vault"]` -- with the local
+    /// overrides, that is the env -> file -> vault chain.
     ///
     /// For example, to roll Postgres in gradually, walk this list:
     ///
@@ -1415,7 +1494,8 @@ pub struct SecretsConfig {
     /// fresh site with nothing to import; unsupported values fail config
     /// parsing rather than silently skipping the import. Independent of
     /// `backends`/`writer` -- importing from vault is orthogonal to where
-    /// reads and writes flow.
+    /// reads and writes flow. When `credentials.ufm_source = "local"`, UFM
+    /// paths are excluded so the import preserves local ownership.
     pub import_from: Option<ImportSource>,
 
     /// How to treat secrets that already exist in Postgres during import.
@@ -4477,6 +4557,72 @@ mod tests {
         assert!(error.to_string().contains("unknown field `audience`"));
     }
 
+    #[test]
+    fn credentials_file_config_contract() {
+        scenarios!(
+            run = |config: &str| toml::from_str::<CredentialsConfig>(config).map_err(drop);
+            "optional source" {
+                "" => Yields(CredentialsConfig::default()),
+            }
+
+            "valid file source" {
+                r#"
+ufm_source = "local"
+
+[file]
+path = "/var/run/secrets/nico/ufm/credentials.yaml"
+poll_interval = "17s"
+"# => Yields(CredentialsConfig {
+                    ufm_source: UfmCredentialSource::Local,
+                    file: Some(CredentialFileSourceConfig {
+                        path: PathBuf::from("/var/run/secrets/nico/ufm/credentials.yaml"),
+                        poll_interval: std::time::Duration::from_secs(17),
+                    }),
+                }),
+            }
+
+            "file source default poll interval" {
+                r#"
+[file]
+path = "credentials.yaml"
+"# => Yields(CredentialsConfig {
+                    ufm_source: UfmCredentialSource::LocalFirst,
+                    file: Some(CredentialFileSourceConfig {
+                        path: PathBuf::from("credentials.yaml"),
+                        poll_interval: std::time::Duration::from_secs(60),
+                    }),
+                }),
+            }
+
+            "missing file path" {
+                "[file]\npoll_interval = \"17s\"" => Fails,
+            }
+
+            "unknown field" {
+                "[file]\npath = \"credentials.yaml\"\ntoken = \"not-a-secret-here\"" => Fails,
+            }
+
+            "unknown UFM source" {
+                "ufm_source = \"fallback\"" => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn ufm_source_contract() {
+        value_scenarios!(
+            run = |ufm_source| CredentialsConfig {
+                ufm_source,
+                file: None,
+            }.uses_authoritative_local_ufm_credentials();
+            "credential source modes" {
+                UfmCredentialSource::LocalFirst => false,
+                UfmCredentialSource::Backend => false,
+                UfmCredentialSource::Local => true,
+            }
+        );
+    }
+
     /// A cap below the clients' fixed 300 s lifetime is accepted-looking and
     /// fatal: every token the fleet mints exceeds it, so all of them are
     /// rejected. Startup has to refuse rather than let the fleet discover it.
@@ -5574,6 +5720,7 @@ mod tests {
         assert!(config.pools.is_none());
         assert!(config.ib_config.is_none());
         assert!(config.ib_fabrics.is_empty());
+        assert_eq!(config.credentials, CredentialsConfig::default());
         assert_eq!(
             config.bmc_session_lockout_threshold,
             default_bmc_session_lockout_threshold()
@@ -5680,6 +5827,18 @@ mod tests {
             (
                 r#"{{ .Values.auth.namespace | default (include "nico-api.namespace" .) }}"#,
                 "nico-system",
+            ),
+            (
+                r#"{{ printf "%s/credentials.yaml" (required "nico-api.credentials.file.mountPath is required when credentials.file.existingSecret.name is set" .Values.credentials.file.mountPath) | quote }}"#,
+                r#""/var/run/secrets/nico/ufm/credentials.yaml""#,
+            ),
+            (
+                r#"{{ required "nico-api.credentials.file.pollInterval is required when credentials.file.existingSecret.name is set" .Values.credentials.file.pollInterval | quote }}"#,
+                r#""60s""#,
+            ),
+            (
+                "{{ .Values.credentials.ufmSource | quote }}",
+                r#""local_first""#,
             ),
             (
                 "{{ range $i, $cn := .Values.auth.additionalIssuerCns }}{{ if $i }}, {{ end }}{{ $cn | quote }}{{ end }}",
@@ -5833,6 +5992,16 @@ mod tests {
             assert_eq!(config.metrics_endpoint, Some("[::]:1080".parse().unwrap()));
             assert_eq!(config.database_url, "postgres://othersql".to_string());
             assert_eq!(config.asn, 777);
+            assert_eq!(
+                config.credentials,
+                CredentialsConfig {
+                    ufm_source: UfmCredentialSource::Backend,
+                    file: Some(CredentialFileSourceConfig {
+                        path: PathBuf::from("/var/run/secrets/nico/ufm/credentials.yaml"),
+                        poll_interval: std::time::Duration::from_secs(17),
+                    }),
+                }
+            );
             assert_eq!(
                 config.dhcp_servers,
                 vec![Ipv4Addr::new(1, 2, 3, 4), Ipv4Addr::new(5, 6, 7, 8)]

--- a/crates/api-core/src/cfg/test_data/full_config.toml
+++ b/crates/api-core/src/cfg/test_data/full_config.toml
@@ -77,6 +77,13 @@ pkeys = [{ start = "1", end = "10" }]
 [ib_config]
 fabric_monitor_run_interval = "101s"
 
+[credentials]
+ufm_source = "backend"
+
+[credentials.file]
+path = "/var/run/secrets/nico/ufm/credentials.yaml"
+poll_interval = "17s"
+
 [site_explorer]
 enabled = true
 run_interval = "100s"

--- a/crates/api-core/src/errors.rs
+++ b/crates/api-core/src/errors.rs
@@ -388,6 +388,7 @@ impl From<IbError> for CarbideError {
             IbError::IBFabricError(msg) => Self::IBFabricError(msg),
             IbError::NotFoundError { kind, id } => Self::NotFoundError { kind, id },
             IbError::InvalidArgument(e) => Self::InvalidArgument(e),
+            IbError::CredentialConfigurationError(e) => Self::FailedPrecondition(e),
             IbError::NotImplemented => Self::NotImplemented,
             IbError::Internal { message } => Self::Internal { message },
         }

--- a/crates/api-core/src/handlers/credential.rs
+++ b/crates/api-core/src/handlers/credential.rs
@@ -22,6 +22,7 @@ use std::net::{IpAddr, SocketAddr};
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge::{self as rpc};
 use carbide_nvlink_manager::DEFAULT_NMX_M_NAME;
+use carbide_secrets::SecretsError;
 use carbide_secrets::credentials::{
     BgpCredentialType, BmcCredentialType, CredentialKey, CredentialReader, CredentialType,
     Credentials, NicLockdownIkm,
@@ -102,12 +103,11 @@ pub(crate) async fn create_credential(
                         },
                     )
                     .await
-                    .map_err(|e| {
-                        CarbideError::internal(format!(
-                            "error setting credential for ufm {}: {:?} ",
-                            username.clone(),
-                            e
-                        ))
+                    .map_err(|error| {
+                        map_ufm_credential_mutation_error(
+                            format!("error setting credential for ufm {username}"),
+                            error,
+                        )
                     })?;
             } else if req.username.is_none() && password.is_empty() && req.vendor.is_some() {
                 write_ufm_certs(api, req.vendor.unwrap_or_default()).await?;
@@ -348,12 +348,11 @@ pub(crate) async fn delete_credential(
                         },
                     )
                     .await
-                    .map_err(|e| {
-                        CarbideError::internal(format!(
-                            "error deleting credential for ufm {}: {:?} ",
-                            username.clone(),
-                            e
-                        ))
+                    .map_err(|error| {
+                        map_ufm_credential_mutation_error(
+                            format!("error deleting credential for ufm {username}"),
+                            error,
+                        )
                     })?;
             } else {
                 return Err(CarbideError::InvalidArgument("missing UFM url".to_string()).into());
@@ -404,6 +403,15 @@ pub(crate) async fn delete_credential(
     };
 
     Ok(Response::new(rpc::CredentialDeletionResult {}))
+}
+
+fn map_ufm_credential_mutation_error(context: String, error: SecretsError) -> CarbideError {
+    match error {
+        error @ SecretsError::UfmCredentialMutationBlocked { .. } => {
+            CarbideError::FailedPrecondition(error.to_string())
+        }
+        error => CarbideError::internal(format!("{context}: {error:?}")),
+    }
 }
 
 pub(crate) async fn update_machine_credentials(

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -366,6 +366,7 @@ pub fn get() -> CarbideConfig {
         tracing: TracingConfig::default(),
         ntp_servers: vec![],
         secrets: None,
+        credentials: Default::default(),
         dhcp_lease_expiry_handling: false,
         certificates: Default::default(),
     }

--- a/crates/api-core/tests/integration/credential_management.rs
+++ b/crates/api-core/tests/integration/credential_management.rs
@@ -18,10 +18,15 @@
 use std::sync::Arc;
 
 use carbide_api_core::AuthContext;
-use carbide_api_core::test_support::{MAX_BGP_PASSWORD_LENGTH, default_credential_key};
+use carbide_api_core::cfg::file::{CarbideConfig, UfmCredentialSource};
+use carbide_api_core::test_support::{
+    MAX_BGP_PASSWORD_LENGTH, default_config, default_credential_key,
+};
+use carbide_secrets::chained_reader::UFM_LOCAL_CREDENTIAL_REMEDIATION;
 use carbide_secrets::credentials::{
-    BgpCredentialType, BmcCredentialType, CredentialKey, CredentialReader, CredentialType,
-    CredentialWriter, Credentials,
+    BgpCredentialType, BmcCredentialType, CompositeCredentialManager, CredentialKey,
+    CredentialManager, CredentialReader, CredentialType, CredentialWriter, Credentials,
+    UfmCredentialMutationBlocker,
 };
 use carbide_secrets::test_support::credentials::TestCredentialManager;
 use carbide_test_harness::prelude::*;
@@ -33,13 +38,156 @@ use rpc::forge::{
 use tonic::Code;
 
 async fn init(pool: PgPool) -> (TestHarness, Arc<TestCredentialManager>) {
+    init_with_runtime_config(pool, default_config::get()).await
+}
+
+async fn init_with_runtime_config(
+    pool: PgPool,
+    runtime_config: CarbideConfig,
+) -> (TestHarness, Arc<TestCredentialManager>) {
     let credential_manager = Arc::new(TestCredentialManager::default());
-    let api_credential_manager = credential_manager.clone();
+    let writer: Arc<dyn CredentialWriter> = if runtime_config
+        .credentials
+        .uses_authoritative_local_ufm_credentials()
+    {
+        Arc::new(UfmCredentialMutationBlocker::new(
+            credential_manager.clone(),
+        ))
+    } else {
+        credential_manager.clone()
+    };
+    let api_credential_manager: Arc<dyn CredentialManager> = Arc::new(
+        CompositeCredentialManager::new(credential_manager.clone(), writer),
+    );
     let env = TestHarness::builder(pool)
-        .with_api_builder_fn(move |builder| builder.with_credential_manager(api_credential_manager))
+        .with_api_builder_fn(move |builder| {
+            builder
+                .with_credential_manager(api_credential_manager)
+                .with_runtime_config(Arc::new(runtime_config))
+        })
         .build()
         .await;
     (env, credential_manager)
+}
+
+fn config_with_ufm_source(ufm_source: UfmCredentialSource) -> CarbideConfig {
+    let mut config = default_config::get();
+    config.credentials.ufm_source = ufm_source;
+    config
+}
+
+fn ufm_create_request() -> CredentialCreationRequest {
+    CredentialCreationRequest {
+        credential_type: RpcCredentialType::Ufm.into(),
+        username: Some("https://ufm.example.com".to_string()),
+        password: "test-ufm-token".to_string(),
+        vendor: None,
+        mac_address: None,
+    }
+}
+
+fn ufm_delete_request() -> CredentialDeletionRequest {
+    CredentialDeletionRequest {
+        credential_type: RpcCredentialType::Ufm.into(),
+        username: Some("https://ufm.example.com".to_string()),
+        mac_address: None,
+    }
+}
+
+#[sqlx_test]
+async fn test_ufm_credential_mutations_reject_local_ownership(pool: PgPool) {
+    let (env, credential_manager) =
+        init_with_runtime_config(pool, config_with_ufm_source(UfmCredentialSource::Local)).await;
+    let key = CredentialKey::UfmAuth {
+        fabric: "default".to_string(),
+    };
+
+    let create_error = env
+        .api()
+        .create_credential(tonic::Request::new(ufm_create_request()))
+        .await
+        .expect_err("local UFM ownership must reject backend create");
+    assert_eq!(create_error.code(), Code::FailedPrecondition);
+    assert!(
+        create_error
+            .message()
+            .contains("local sources own all UFM credentials")
+    );
+    assert!(
+        create_error
+            .message()
+            .contains(UFM_LOCAL_CREDENTIAL_REMEDIATION)
+    );
+    assert_eq!(
+        credential_manager
+            .get_credentials_from_writer(&key)
+            .await
+            .expect("read backend after rejected create"),
+        None
+    );
+
+    let existing = Credentials::UsernamePassword {
+        username: "legacy-ufm".to_string(),
+        password: "existing-token".to_string(),
+    };
+    credential_manager
+        .set_credentials(&key, &existing)
+        .await
+        .expect("seed persistent UFM credential");
+
+    let delete_error = env
+        .api()
+        .delete_credential(tonic::Request::new(ufm_delete_request()))
+        .await
+        .expect_err("local UFM ownership must reject backend delete");
+    assert_eq!(delete_error.code(), Code::FailedPrecondition);
+    assert_eq!(delete_error.message(), create_error.message());
+    assert_eq!(
+        credential_manager
+            .get_credentials_from_writer(&key)
+            .await
+            .expect("read backend after rejected delete"),
+        Some(existing)
+    );
+}
+
+#[sqlx_test]
+async fn test_ufm_credential_mutations_allow_backend_ownership(pool: PgPool) {
+    let (env, credential_manager) =
+        init_with_runtime_config(pool, config_with_ufm_source(UfmCredentialSource::Backend)).await;
+    let key = CredentialKey::UfmAuth {
+        fabric: "default".to_string(),
+    };
+
+    env.api()
+        .create_credential(tonic::Request::new(ufm_create_request()))
+        .await
+        .expect("backend ownership must allow backend create");
+    assert_eq!(
+        credential_manager
+            .get_credentials_from_writer(&key)
+            .await
+            .expect("read backend after create"),
+        Some(Credentials::UsernamePassword {
+            username: "https://ufm.example.com".to_string(),
+            password: "test-ufm-token".to_string(),
+        })
+    );
+
+    env.api()
+        .delete_credential(tonic::Request::new(ufm_delete_request()))
+        .await
+        .expect("backend ownership must allow backend delete");
+    assert_eq!(
+        credential_manager
+            .get_credentials_from_writer(&key)
+            .await
+            .expect("read backend after delete"),
+        Some(Credentials::UsernamePassword {
+            username: "https://ufm.example.com".to_string(),
+            password: String::new(),
+        })
+    );
 }
 
 #[sqlx_test]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -104,6 +104,7 @@ trace-propagation = { path = "../trace-propagation" }
 
 # External dependencies. PLEASE KEEP ALPHABETIZED ORDER.
 http = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/api/src/resources.rs
+++ b/crates/api/src/resources.rs
@@ -21,16 +21,21 @@ use std::sync::Arc;
 use carbide_api_core::bootstrap::acquire_vault_import_work_lock;
 use carbide_api_core::cfg::file::{
     CarbideConfig, CredentialBackend, ImportSource, ProviderConfig, SecretsConfig,
+    UfmCredentialSource,
 };
 use carbide_api_core::secrets::{PostgresCredentialManager, SecretRouting, SecretsContext};
 use carbide_kms_provider::{
     DEFAULT_TRANSIT_MOUNT, IntegratedKmsProvider, KmsBackend, MultiKmsProvider, TransitKmsProvider,
 };
 use carbide_secrets::certificates::CertificateProvider;
-use carbide_secrets::credentials::{CredentialManager, CredentialReader, CredentialWriter};
+use carbide_secrets::chained_reader::{NonUfmCredentialReader, UfmBackendCredentialBlocker};
+use carbide_secrets::credentials::{
+    CredentialManager, CredentialPrefix, CredentialReader, CredentialWriter,
+    UfmCredentialMutationBlocker,
+};
 use carbide_secrets::{
-    CredentialConfig, ForgeVaultClient, MemoryCredentialStore, SpiffeIdentity, VaultConfig,
-    create_certificate_provider, create_credential_manager_from, create_vault_client,
+    CredentialConfig, ForgeVaultClient, MemoryCredentialStore, SecretsError, SpiffeIdentity,
+    VaultConfig, create_certificate_provider, create_credential_manager_from, create_vault_client,
 };
 use db::work_lock_manager::{self, WorkLockManagerHandle};
 use eyre::WrapErr;
@@ -52,6 +57,12 @@ pub(crate) struct RuntimeResources {
     pub work_lock_manager_handle: WorkLockManagerHandle,
     pub secrets_context: Option<SecretsContext>,
 }
+
+type CredentialRuntimeParts = (
+    Arc<dyn CredentialWriter>,
+    Vec<Box<dyn CredentialReader>>,
+    Option<SecretsContext>,
+);
 
 pub(crate) async fn setup_resources(
     carbide_config: &CarbideConfig,
@@ -88,18 +99,20 @@ pub(crate) async fn setup_resources(
     )
     .await?;
 
-    // Build the local-override readers (env, file); each is consulted only when
-    // its [credentials.*] section is enabled. The backends (postgres,
-    // vault) and the writer are chosen below.
-    let local_overrides = local_credential_readers(credential_config).await?;
+    // Build the local-override readers. The config-file credential source, if
+    // set, overrides the legacy environment-selected file source; env remains
+    // opt-in through its legacy environment configuration. The backends
+    // (postgres, vault) and the writer are chosen below.
+    let local_overrides = local_credential_readers(carbide_config, credential_config).await?;
 
     // With a [secrets] section, the credential chain and write target come from
-    // `backends`/`writer` -- defaulting to env -> file -> vault writing to vault,
-    // so the section alone changes nothing. The one-time vault import is
+    // `backends`/`writer` -- generally defaulting to env -> file -> vault
+    // writing to vault. `credentials.ufm_source` can retain that read order or
+    // select one authoritative UFM source. The one-time vault import is
     // independent: it runs iff `import_from` is set. Without the section, the
     // store comes from CARBIDE_CREDENTIAL_STORE: vault (the default), or an
     // in-memory store for development and testing.
-    let (credential_manager, secrets_context) = if let Some(secrets_config) =
+    let (writer, chain, secrets_context): CredentialRuntimeParts = if let Some(secrets_config) =
         &carbide_config.secrets
     {
         // Reject a nonsensical backends list before anything with side effects
@@ -156,7 +169,12 @@ pub(crate) async fn setup_resources(
             import_vault_secrets_once(
                 &db_pool,
                 &work_lock_manager_handle,
-                secrets_config,
+                VaultImportOptions {
+                    secrets: secrets_config,
+                    exclude_ufm: carbide_config
+                        .credentials
+                        .uses_authoritative_local_ufm_credentials(),
+                },
                 &routing,
                 kms.as_ref(),
                 &vault_client,
@@ -184,10 +202,7 @@ pub(crate) async fn setup_resources(
             CredentialBackend::Vault => vault_client.clone(),
             CredentialBackend::Postgres => pg_manager,
         };
-        (
-            create_credential_manager_from(writer, chain),
-            Some(SecretsContext { routing, kms }),
-        )
+        (writer, chain, Some(SecretsContext { routing, kms }))
     } else {
         let store: Arc<dyn CredentialManager> = match std::env::var("CARBIDE_CREDENTIAL_STORE")
             .as_deref()
@@ -202,14 +217,19 @@ pub(crate) async fn setup_resources(
             }
         };
         // env -> file -> the configured store; nothing from [secrets] applies.
+        // The local UFM blocker, when configured, stops before the store.
         let chain = local_overrides
             .into_iter()
             .chain(std::iter::once(
                 Box::new(store.clone()) as Box<dyn CredentialReader>
             ))
             .collect();
-        (create_credential_manager_from(store, chain), None)
+        (store, chain, None)
     };
+    // Apply the UFM mutation policy once, after selecting either persistent
+    // writer path, so the two setup branches cannot drift apart.
+    let writer = credential_writer_with_ufm_policy(carbide_config, writer);
+    let credential_manager = create_credential_manager_from(writer, chain);
 
     Ok(RuntimeResources {
         credential_manager,
@@ -304,26 +324,104 @@ fn validate_database_pool_durations(
 }
 
 async fn local_credential_readers(
-    config: &CredentialConfig,
+    carbide_config: &CarbideConfig,
+    credential_config: &CredentialConfig,
 ) -> eyre::Result<Vec<Box<dyn CredentialReader>>> {
-    let env_reader: Option<Box<dyn CredentialReader>> = if config.env.enabled() {
+    let env_reader: Option<Box<dyn CredentialReader>> = if credential_config.env.enabled() {
         Some(Box::new(
-            carbide_secrets::local_credentials::EnvCredentials::new(config.env.clone())?,
+            carbide_secrets::local_credentials::EnvCredentials::new(credential_config.env.clone())?,
         ))
     } else {
         None
     };
-    let file_reader: Option<Box<dyn CredentialReader>> = if config.file.enabled() {
+    let file_config = file_credentials_config(carbide_config, credential_config);
+    let file_reader: Option<Box<dyn CredentialReader>> = if file_config.enabled() {
         Some(Box::new(
-            carbide_secrets::local_credentials::FileCredentialsWatcher::new(config.file.clone())
-                .await?,
+            carbide_secrets::local_credentials::FileCredentialsWatcher::new(file_config).await?,
         ))
     } else {
         None
     };
-    // The local overrides that ended up enabled, in order -- always tried
-    // ahead of the backends.
-    Ok([env_reader, file_reader].into_iter().flatten().collect())
+    let mut local_readers: Vec<Box<dyn CredentialReader>> =
+        [env_reader, file_reader].into_iter().flatten().collect();
+    match carbide_config.credentials.ufm_source {
+        UfmCredentialSource::LocalFirst => Ok(local_readers),
+        UfmCredentialSource::Backend => {
+            let local_chain = carbide_secrets::ChainedCredentialReader::from(local_readers);
+            Ok(vec![Box::new(NonUfmCredentialReader::new(local_chain))])
+        }
+        UfmCredentialSource::Local => {
+            validate_local_ufm_credentials(carbide_config, &local_readers).await?;
+            tracing::info!(
+                "local environment/file sources own UFM credentials; persistent backend access is \
+                 disabled"
+            );
+            local_readers.push(Box::new(UfmBackendCredentialBlocker));
+            Ok(local_readers)
+        }
+    }
+}
+
+async fn validate_local_ufm_credentials(
+    carbide_config: &CarbideConfig,
+    local_readers: &[Box<dyn CredentialReader>],
+) -> eyre::Result<()> {
+    if !carbide_config
+        .ib_config
+        .as_ref()
+        .is_some_and(|config| config.enabled)
+    {
+        return Ok(());
+    }
+    for fabric in carbide_config.ib_fabrics.keys() {
+        let key = carbide_secrets::credentials::CredentialKey::UfmAuth {
+            fabric: fabric.clone(),
+        };
+        let mut found = false;
+        for reader in local_readers {
+            if reader.get_credentials(&key).await?.is_some() {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return Err(SecretsError::UfmCredentialReadBlocked {
+                fabric: fabric.clone(),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn file_credentials_config(
+    carbide_config: &CarbideConfig,
+    credential_config: &CredentialConfig,
+) -> carbide_secrets::FileCredentialsConfig {
+    carbide_config
+        .credentials
+        .file
+        .as_ref()
+        .map(|file| carbide_secrets::FileCredentialsConfig {
+            enabled: Some(true),
+            path: Some(file.path.clone()),
+            poll_interval: Some(file.poll_interval),
+        })
+        .unwrap_or_else(|| credential_config.file.clone())
+}
+
+fn credential_writer_with_ufm_policy(
+    carbide_config: &CarbideConfig,
+    writer: Arc<dyn CredentialWriter>,
+) -> Arc<dyn CredentialWriter> {
+    if carbide_config
+        .credentials
+        .uses_authoritative_local_ufm_credentials()
+    {
+        Arc::new(UfmCredentialMutationBlocker::new(writer))
+    } else {
+        writer
+    }
 }
 
 /// Build the KMS stack from the `[secrets.kms]` config: construct every
@@ -452,8 +550,10 @@ fn build_kms_backend(
 /// all-or-nothing bulk copy with no half-imported state to reason about.
 ///
 /// This is orthogonal to the reader chain and writer: an import seeds
-/// Postgres with vault's secrets, but the read order and write target stay
-/// exactly as `backends` / `writer` set them -- importing changes neither.
+/// Postgres with eligible Vault secrets, but the read order and write target
+/// stay exactly as `backends` / `writer` set them -- importing changes neither.
+/// UFM paths are ineligible while local sources own UFM credentials so the
+/// import cannot bypass that site-wide ownership boundary.
 ///
 /// Rolling upgrades still need care once writes move to Postgres: a replica
 /// running an older config can write rotated credentials to its own writer,
@@ -472,10 +572,15 @@ fn build_kms_backend(
 /// hard crash falls back to its lease expiry. Vault and KMS work is prepared
 /// before the transaction atomically commits every secret plus the marker, so
 /// an expired owner cannot write after a replacement takes over.
+struct VaultImportOptions<'a> {
+    secrets: &'a SecretsConfig,
+    exclude_ufm: bool,
+}
+
 async fn import_vault_secrets_once(
     db_pool: &PgPool,
     work_lock_manager: &WorkLockManagerHandle,
-    config: &SecretsConfig,
+    options: VaultImportOptions<'_>,
     routing: &SecretRouting,
     kms: &dyn KmsBackend,
     vault_client: &ForgeVaultClient,
@@ -501,20 +606,22 @@ async fn import_vault_secrets_once(
         // Strict enumeration: any list or read failure aborts the boot rather
         // than importing a subset and recording it as complete. The marker is
         // permanent, so a partial import here would be silent credential loss.
-        let secrets = vault_client
-            .get_secrets_strict()
+        let excluded_prefixes = if options.exclude_ufm {
+            &[CredentialPrefix::UfmAuth][..]
+        } else {
+            &[]
+        };
+        let (secrets, excluded_ufm_prefix_found) = vault_client
+            .get_secrets_strict_excluding_prefixes(excluded_prefixes)
             .await
             .map_err(eyre::Report::from)
             .wrap_err("enumerate vault secrets for import")?;
-        if secrets.is_empty() {
-            return Err(eyre::eyre!(
-                "vault enumeration returned no secrets; refusing to record an import from an empty vault. if this site really has no vault secrets, remove import_from from the [secrets] config; otherwise fix vault and restart"
-            ));
-        }
+        validate_vault_import_selection(secrets.len(), excluded_ufm_prefix_found)?;
 
         tracing::info!(
-            vault_secret_count = secrets.len(),
-            approach = ?config.import_approach,
+            import_secret_count = secrets.len(),
+            excluded_ufm_prefix_found,
+            approach = ?options.secrets.import_approach,
             "Importing secrets from vault"
         );
         let stats = carbide_api_core::secrets::import_vault_secrets(
@@ -523,7 +630,7 @@ async fn import_vault_secrets_once(
             routing,
             kms,
             &secrets,
-            config.import_approach,
+            options.secrets.import_approach,
         )
         .await
         .map_err(eyre::Report::new)
@@ -565,6 +672,19 @@ async fn import_vault_secrets_once(
     }
 }
 
+fn validate_vault_import_selection(
+    eligible_secret_count: usize,
+    excluded_prefix_found: bool,
+) -> eyre::Result<()> {
+    if eligible_secret_count == 0 && !excluded_prefix_found {
+        return Err(eyre::eyre!(
+            "vault enumeration returned no secrets; refusing to record an import from an empty vault. if this site really has no vault secrets, remove import_from from the [secrets] config; otherwise fix vault and restart"
+        ));
+    }
+
+    Ok(())
+}
+
 async fn is_import_complete(db_pool: &PgPool) -> eyre::Result<bool> {
     carbide_api_core::secrets::is_vault_import_complete(db_pool)
         .await
@@ -574,7 +694,295 @@ async fn is_import_complete(db_pool: &PgPool) -> eyre::Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    use carbide_secrets::credentials::{CredentialKey, Credentials};
+
     use super::*;
+
+    #[test]
+    fn vault_import_allows_an_excluded_only_source() {
+        for (name, eligible_secret_count, excluded_prefix_found, expected_ok) in [
+            ("empty vault", 0, false, false),
+            ("only excluded UFM credentials", 0, true, true),
+            ("eligible credentials", 1, false, true),
+        ] {
+            assert_eq!(
+                validate_vault_import_selection(eligible_secret_count, excluded_prefix_found)
+                    .is_ok(),
+                expected_ok,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn config_credentials_file_overrides_environment_selected_file_source() {
+        let mut carbide_config = carbide_api_core::test_support::default_config::get();
+        carbide_config.credentials.ufm_source = UfmCredentialSource::Local;
+        carbide_config.credentials.file =
+            Some(carbide_api_core::cfg::file::CredentialFileSourceConfig {
+                path: "/var/run/secrets/nico/ufm/credentials.yaml".into(),
+                poll_interval: std::time::Duration::from_secs(17),
+            });
+        let credential_config = CredentialConfig {
+            file: carbide_secrets::FileCredentialsConfig {
+                enabled: Some(true),
+                path: Some("legacy-credentials.yaml".into()),
+                poll_interval: Some(std::time::Duration::from_secs(23)),
+            },
+            ..Default::default()
+        };
+
+        let file_config = file_credentials_config(&carbide_config, &credential_config);
+
+        assert!(file_config.enabled());
+        assert_eq!(
+            file_config.path(),
+            std::path::PathBuf::from("/var/run/secrets/nico/ufm/credentials.yaml")
+        );
+        assert_eq!(
+            file_config.poll_interval(),
+            std::time::Duration::from_secs(17)
+        );
+    }
+
+    #[tokio::test]
+    async fn ufm_source_controls_legacy_file_read_precedence() {
+        let dir = tempfile::tempdir().expect("create credential directory");
+        let path = dir.path().join("credentials.json");
+        let key = CredentialKey::UfmAuth {
+            fabric: "default".to_string(),
+        };
+        let local_credentials = Credentials::UsernamePassword {
+            username: "local-user".to_string(),
+            password: "local-token".to_string(),
+        };
+        let backend_credentials = Credentials::UsernamePassword {
+            username: "legacy-user".to_string(),
+            password: "legacy-token".to_string(),
+        };
+
+        enum Expected {
+            Local,
+            Backend,
+            Blocked,
+        }
+        let default_ufm_source =
+            carbide_api_core::cfg::file::CredentialsConfig::default().ufm_source;
+        let cases = [
+            (
+                "default preserves a legacy file override",
+                r#"{
+  "ufm_auth_by_fabric": {
+    "default": {
+      "username": "local-user",
+      "password": "local-token"
+    }
+  }
+}"#,
+                default_ufm_source,
+                Expected::Local,
+            ),
+            (
+                "default falls back when the legacy file has no entry",
+                "{}",
+                default_ufm_source,
+                Expected::Backend,
+            ),
+            (
+                "authoritative file entry",
+                r#"{
+  "ufm_auth_by_fabric": {
+    "default": {
+      "username": "local-user",
+      "password": "local-token"
+    }
+  }
+}"#,
+                UfmCredentialSource::Local,
+                Expected::Local,
+            ),
+            (
+                "authoritative local source miss",
+                "{}",
+                UfmCredentialSource::Local,
+                Expected::Blocked,
+            ),
+            (
+                "backend mode ignores local entry",
+                r#"{
+  "ufm_auth_by_fabric": {
+    "default": {
+      "username": "local-user",
+      "password": "local-token"
+    }
+  }
+}"#,
+                UfmCredentialSource::Backend,
+                Expected::Backend,
+            ),
+        ];
+
+        for (name, file_contents, ufm_source, expected) in cases {
+            tokio::fs::write(&path, file_contents)
+                .await
+                .unwrap_or_else(|error| panic!("{name}: write local credential snapshot: {error}"));
+            let mut carbide_config = carbide_api_core::test_support::default_config::get();
+            let ib_config = carbide_config.ib_config.get_or_insert_default();
+            ib_config.enabled = true;
+            carbide_config.credentials.ufm_source = ufm_source;
+            let credential_config = CredentialConfig {
+                env: carbide_secrets::EnvCredentialsConfig {
+                    enabled: Some(false),
+                    ..Default::default()
+                },
+                file: carbide_secrets::FileCredentialsConfig {
+                    enabled: Some(true),
+                    path: Some(path.clone()),
+                    poll_interval: Some(std::time::Duration::from_secs(60)),
+                },
+                ..Default::default()
+            };
+            let mut readers =
+                match local_credential_readers(&carbide_config, &credential_config).await {
+                    Ok(readers) => {
+                        assert!(
+                            !matches!(expected, Expected::Blocked),
+                            "{name}: local-source startup unexpectedly succeeded"
+                        );
+                        readers
+                    }
+                    Err(error) => {
+                        assert!(
+                            matches!(expected, Expected::Blocked),
+                            "{name}: build local readers: {error}"
+                        );
+                        assert!(
+                            error.to_string().contains("default")
+                                && error.to_string().contains("credentials.ufm_source"),
+                            "{name}: {error}"
+                        );
+                        continue;
+                    }
+                };
+            let backend = MemoryCredentialStore::default();
+            backend
+                .set_credentials(&key, &backend_credentials)
+                .await
+                .expect("seed persistent backend");
+            readers.push(Box::new(backend));
+            let chain = carbide_secrets::ChainedCredentialReader::from(readers);
+
+            let result = chain.get_credentials(&key).await;
+
+            match expected {
+                Expected::Local => assert_eq!(
+                    result.unwrap_or_else(|error| panic!("{name}: file lookup failed: {error}")),
+                    Some(local_credentials.clone()),
+                    "{name}"
+                ),
+                Expected::Backend => assert_eq!(
+                    result.unwrap_or_else(|error| panic!("{name}: backend lookup failed: {error}")),
+                    Some(backend_credentials.clone()),
+                    "{name}"
+                ),
+                Expected::Blocked => unreachable!("handled during startup validation"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn local_ufm_validation_skips_disabled_ib_management() {
+        let dir = tempfile::tempdir().expect("create credential directory");
+        let path = dir.path().join("credentials.json");
+        tokio::fs::write(&path, "{}")
+            .await
+            .expect("write empty credential snapshot");
+        let mut carbide_config = carbide_api_core::test_support::default_config::get();
+        carbide_config.ib_config = None;
+        carbide_config.credentials.ufm_source = UfmCredentialSource::Local;
+        carbide_config.credentials.file =
+            Some(carbide_api_core::cfg::file::CredentialFileSourceConfig {
+                path,
+                poll_interval: std::time::Duration::from_secs(60),
+            });
+        let credential_config = CredentialConfig {
+            env: carbide_secrets::EnvCredentialsConfig {
+                enabled: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        local_credential_readers(&carbide_config, &credential_config)
+            .await
+            .expect("disabled IB management must not require dormant UFM credentials");
+    }
+
+    #[tokio::test]
+    async fn configured_ufm_source_controls_backend_mutations() {
+        let key = CredentialKey::UfmAuth {
+            fabric: "fabric-a".to_string(),
+        };
+        let credentials = Credentials::UsernamePassword {
+            username: "ufm-user".to_string(),
+            password: "ufm-token".to_string(),
+        };
+        let cases = [
+            (
+                "local ownership",
+                UfmCredentialSource::Local,
+                Some("local sources own all UFM credentials"),
+            ),
+            (
+                "local-first compatibility ownership",
+                UfmCredentialSource::LocalFirst,
+                None,
+            ),
+            ("backend ownership", UfmCredentialSource::Backend, None),
+        ];
+
+        for (name, ufm_source, blocked_message) in cases {
+            let mut carbide_config = carbide_api_core::test_support::default_config::get();
+            carbide_config.credentials.ufm_source = ufm_source;
+            let backend = Arc::new(MemoryCredentialStore::default());
+            let writer = credential_writer_with_ufm_policy(&carbide_config, backend.clone());
+
+            let result = writer.set_credentials(&key, &credentials).await;
+
+            if let Some(blocked_message) = blocked_message {
+                let error = result.expect_err("UFM backend mutation must be blocked");
+                assert!(
+                    matches!(
+                        &error,
+                        carbide_secrets::SecretsError::UfmCredentialMutationBlocked { .. }
+                    ),
+                    "{name}: {error}"
+                );
+                assert!(
+                    error.to_string().contains(blocked_message),
+                    "{name}: {error}"
+                );
+                assert_eq!(
+                    backend
+                        .get_credentials_from_writer(&key)
+                        .await
+                        .unwrap_or_else(|error| panic!("{name}: read backend: {error}")),
+                    None,
+                    "{name}"
+                );
+            } else {
+                result.unwrap_or_else(|error| panic!("{name}: write backend: {error}"));
+                assert_eq!(
+                    backend
+                        .get_credentials_from_writer(&key)
+                        .await
+                        .unwrap_or_else(|error| panic!("{name}: read backend: {error}")),
+                    Some(credentials.clone()),
+                    "{name}"
+                );
+            }
+        }
+    }
 
     /// The pool builder rejects zero-valued lifecycle settings before it
     /// touches the database, naming the offending field.

--- a/crates/ib-fabric/src/errors.rs
+++ b/crates/ib-fabric/src/errors.rs
@@ -35,6 +35,9 @@ pub enum IbError {
     },
     #[error("argument is invalid: {0}")]
     InvalidArgument(String),
+    /// An authoritative local UFM credential source is missing or invalid.
+    #[error("credential configuration error: {0}")]
+    CredentialConfigurationError(String),
     #[error("the function is not implemented")]
     NotImplemented,
     #[error("internal error: {message}")]
@@ -61,6 +64,7 @@ mod tests {
         Fabric,
         NotFound,
         InvalidArgument,
+        CredentialConfiguration,
         NotImplemented,
         Internal,
     }
@@ -73,6 +77,9 @@ mod tests {
                 id: "machine-1".to_string(),
             },
             ErrorCase::InvalidArgument => IbError::InvalidArgument("bad pkey".to_string()),
+            ErrorCase::CredentialConfiguration => {
+                IbError::CredentialConfigurationError("missing UFM token".to_string())
+            }
             ErrorCase::NotImplemented => IbError::NotImplemented,
             ErrorCase::Internal => IbError::internal("unexpected state".to_string()),
         }
@@ -86,6 +93,8 @@ mod tests {
                 ErrorCase::Fabric => "failed to call IBFabricManager: ufm failed".to_string(),
                 ErrorCase::NotFound => "Machine not found: machine-1".to_string(),
                 ErrorCase::InvalidArgument => "argument is invalid: bad pkey".to_string(),
+                ErrorCase::CredentialConfiguration =>
+                    "credential configuration error: missing UFM token".to_string(),
                 ErrorCase::NotImplemented => "the function is not implemented".to_string(),
                 ErrorCase::Internal => "internal error: unexpected state".to_string(),
             }

--- a/crates/ib-fabric/src/ib/mod.rs
+++ b/crates/ib-fabric/src/ib/mod.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use carbide_secrets::SecretsError;
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 pub use iface::{
     Filter, GetPartitionOptions, IBFabric, IBFabricConfig, IBFabricManager, IBFabricRawResponse,
@@ -254,10 +255,13 @@ impl IBFabricManager for IBFabricManagerImpl {
                     .credential_reader
                     .get_credentials(key)
                     .await
-                    .map_err(|err| {
-                        IbError::internal(format!(
-                            "Cannot create UFM client: secret manager error: {err}"
-                        ))
+                    .map_err(|error| match error {
+                        error @ SecretsError::UfmCredentialReadBlocked { .. } => {
+                            IbError::CredentialConfigurationError(error.to_string())
+                        }
+                        error => IbError::internal(format!(
+                            "Cannot create UFM client: secret manager error: {error}"
+                        )),
                     })?
                     .ok_or_else(|| {
                         IbError::internal(format!(
@@ -515,6 +519,37 @@ mod tests {
             ..Default::default()
         };
         create_ib_fabric_manager(reader, config).unwrap()
+    }
+
+    struct BlockedUfmCredentialReader;
+
+    #[async_trait]
+    impl CredentialReader for BlockedUfmCredentialReader {
+        async fn get_credentials(
+            &self,
+            key: &CredentialKey,
+        ) -> Result<Option<Credentials>, SecretsError> {
+            let CredentialKey::UfmAuth { fabric } = key else {
+                return Ok(None);
+            };
+            Err(SecretsError::UfmCredentialReadBlocked {
+                fabric: fabric.clone(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn blocked_ufm_credential_is_a_configuration_error() {
+        let manager = rest_manager(Arc::new(BlockedUfmCredentialReader));
+
+        let error = manager
+            .new_client("f1")
+            .await
+            .err()
+            .expect("authoritative local credential miss must fail client creation");
+
+        assert!(matches!(error, IbError::CredentialConfigurationError(_)));
+        assert!(error.to_string().contains("credentials.ufm_source"));
     }
 
     #[tokio::test]

--- a/crates/secrets/src/chained_reader.rs
+++ b/crates/secrets/src/chained_reader.rs
@@ -21,6 +21,65 @@ use crate::credentials::{CredentialKey, CredentialReader, Credentials};
 
 pub struct ChainedCredentialReader(Vec<Box<dyn CredentialReader>>);
 
+/// Operator action when a local UFM credential is active or required.
+pub const UFM_LOCAL_CREDENTIAL_REMEDIATION: &str =
+    // xtask:allow-error-case: UFM and NICo are product names
+    "when environment credentials supply the UFM fabric, update them and restart NICo; otherwise \
+     update the watched credential file (environment credentials take precedence over the file)";
+
+/// Operator action for switching the entire site back to backend-managed UFM
+/// credentials.
+pub const UFM_BACKEND_SOURCE_REMEDIATION: &str = "to restore persistent backend ownership for all UFM fabrics, set \
+     credentials.ufm_source = \"backend\" and restart NICo";
+
+/// Stops UFM credential lookup before the persistent backend portion of a
+/// reader chain when local sources own UFM credentials. Place this after local
+/// environment and file readers.
+#[derive(Debug)]
+pub struct UfmBackendCredentialBlocker;
+
+/// Delegates every non-UFM lookup while making local UFM entries invisible.
+/// Place this around the environment/file chain when the persistent backend
+/// owns UFM credentials.
+pub struct NonUfmCredentialReader<R>(R);
+
+impl<R> NonUfmCredentialReader<R> {
+    /// Wraps a reader and suppresses its `CredentialKey::UfmAuth` lookups.
+    pub fn new(reader: R) -> Self {
+        Self(reader)
+    }
+}
+
+#[async_trait]
+impl<R: CredentialReader> CredentialReader for NonUfmCredentialReader<R> {
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        if matches!(key, CredentialKey::UfmAuth { .. }) {
+            return Ok(None);
+        }
+        self.0.get_credentials(key).await
+    }
+}
+
+#[async_trait]
+impl CredentialReader for UfmBackendCredentialBlocker {
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        let CredentialKey::UfmAuth { fabric } = key else {
+            return Ok(None);
+        };
+
+        tracing::error!(%fabric, "local UFM credential is missing");
+        Err(SecretsError::UfmCredentialReadBlocked {
+            fabric: fabric.clone(),
+        })
+    }
+}
+
 impl From<Vec<Box<dyn CredentialReader>>> for ChainedCredentialReader {
     fn from(providers: Vec<Box<dyn CredentialReader>>) -> Self {
         Self(providers)
@@ -97,6 +156,84 @@ mod tests {
                 password: "vault-pass".to_string(),
             })
         );
+    }
+
+    #[tokio::test]
+    async fn ufm_backend_blocker_stops_lookup_before_backend() {
+        let backend = Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
+            username: "vault-user".to_string(),
+            password: "vault-pass".to_string(),
+        }));
+        let chain: ChainedCredentialReader = vec![
+            Box::new(UfmBackendCredentialBlocker) as Box<dyn CredentialReader>,
+            Box::new(backend),
+        ]
+        .into();
+        let key = CredentialKey::UfmAuth {
+            fabric: "fabric-a".to_string(),
+        };
+
+        let error = chain
+            .get_credentials(&key)
+            .await
+            .expect_err("UFM lookup must stop before the persistent backend");
+
+        let message = error.to_string();
+        assert!(matches!(
+            error,
+            SecretsError::UfmCredentialReadBlocked { ref fabric } if fabric == "fabric-a"
+        ));
+        assert!(message.contains("fabric-a"));
+        assert!(message.contains(UFM_LOCAL_CREDENTIAL_REMEDIATION));
+    }
+
+    #[tokio::test]
+    async fn ufm_backend_blocker_allows_other_credentials_to_continue() {
+        let expected = Credentials::UsernamePassword {
+            username: "vault-user".to_string(),
+            password: "vault-pass".to_string(),
+        };
+        let backend = Arc::new(TestCredentialManager::new(expected.clone()));
+        let chain: ChainedCredentialReader = vec![
+            Box::new(UfmBackendCredentialBlocker) as Box<dyn CredentialReader>,
+            Box::new(backend),
+        ]
+        .into();
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+
+        let value = chain
+            .get_credentials(&key)
+            .await
+            .expect("non-UFM lookup must continue to the backend");
+
+        assert_eq!(value, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn non_ufm_reader_hides_only_ufm_credentials() {
+        let expected = Credentials::UsernamePassword {
+            username: "local-user".to_string(),
+            password: "local-password".to_string(),
+        };
+        let reader = NonUfmCredentialReader::new(TestCredentialManager::new(expected.clone()));
+
+        let ufm_value = reader
+            .get_credentials(&CredentialKey::UfmAuth {
+                fabric: "fabric-a".to_string(),
+            })
+            .await
+            .expect("ignore local UFM credential");
+        let non_ufm_value = reader
+            .get_credentials(&CredentialKey::DpuUefi {
+                credential_type: CredentialType::SiteDefault,
+            })
+            .await
+            .expect("read local non-UFM credential");
+
+        assert_eq!(ufm_value, None);
+        assert_eq!(non_ufm_value, Some(expected));
     }
 
     #[tokio::test]

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -237,6 +237,62 @@ impl<T: CredentialWriter + ?Sized> CredentialWriter for Arc<T> {
     }
 }
 
+/// Blocks persistent UFM credential mutations while local sources own all UFM
+/// credentials, and delegates every other writer operation.
+pub struct UfmCredentialMutationBlocker {
+    writer: Arc<dyn CredentialWriter>,
+}
+
+impl UfmCredentialMutationBlocker {
+    /// Wraps a writer with the policy that rejects UFM mutations and delegates
+    /// every other credential operation.
+    pub fn new(writer: Arc<dyn CredentialWriter>) -> Self {
+        Self { writer }
+    }
+
+    fn ensure_mutation_allowed(key: &CredentialKey) -> Result<(), SecretsError> {
+        let CredentialKey::UfmAuth { fabric } = key else {
+            return Ok(());
+        };
+        Err(SecretsError::UfmCredentialMutationBlocked {
+            fabric: fabric.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl CredentialWriter for UfmCredentialMutationBlocker {
+    async fn get_credentials_from_writer(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        self.writer.get_credentials_from_writer(key).await
+    }
+
+    async fn set_credentials(
+        &self,
+        key: &CredentialKey,
+        credentials: &Credentials,
+    ) -> Result<(), SecretsError> {
+        Self::ensure_mutation_allowed(key)?;
+        self.writer.set_credentials(key, credentials).await
+    }
+
+    async fn create_credentials(
+        &self,
+        key: &CredentialKey,
+        credentials: &Credentials,
+    ) -> Result<(), SecretsError> {
+        Self::ensure_mutation_allowed(key)?;
+        self.writer.create_credentials(key, credentials).await
+    }
+
+    async fn delete_credentials(&self, key: &CredentialKey) -> Result<(), SecretsError> {
+        Self::ensure_mutation_allowed(key)?;
+        self.writer.delete_credentials(key).await
+    }
+}
+
 pub trait CredentialManager: CredentialReader + CredentialWriter {}
 
 pub struct CompositeCredentialManager<R, W> {
@@ -1004,6 +1060,65 @@ mod tests {
             .expect("writer readback");
 
         assert_eq!(writer_readback, Some(write_cred));
+    }
+
+    #[tokio::test]
+    async fn ufm_mutation_blocker_rejects_every_writer_mutation() {
+        let backend: Arc<dyn CredentialWriter> = Arc::new(TestCredentialManager::default());
+        let key = CredentialKey::UfmAuth {
+            fabric: "test-fabric".to_string(),
+        };
+        let credentials = Credentials::UsernamePassword {
+            username: "ufm-user".to_string(),
+            password: "ufm-password".to_string(),
+        };
+        let blocker = UfmCredentialMutationBlocker::new(backend);
+
+        let results = [
+            blocker.set_credentials(&key, &credentials).await,
+            blocker.create_credentials(&key, &credentials).await,
+            blocker.delete_credentials(&key).await,
+        ];
+
+        for result in results {
+            assert!(matches!(
+                result,
+                Err(SecretsError::UfmCredentialMutationBlocked { .. })
+            ));
+        }
+        assert_eq!(
+            blocker
+                .get_credentials_from_writer(&key)
+                .await
+                .expect("read writer after blocked mutations"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn ufm_mutation_blocker_delegates_non_ufm_mutations() {
+        let backend = Arc::new(TestCredentialManager::default());
+        let blocker = UfmCredentialMutationBlocker::new(backend.clone());
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+        let credentials = Credentials::UsernamePassword {
+            username: "dpu-user".to_string(),
+            password: "dpu-password".to_string(),
+        };
+
+        blocker
+            .set_credentials(&key, &credentials)
+            .await
+            .expect("write non-UFM credential");
+
+        assert_eq!(
+            backend
+                .get_credentials_from_writer(&key)
+                .await
+                .expect("read delegated credential"),
+            Some(credentials)
+        );
     }
 
     #[tokio::test]

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -41,7 +41,8 @@ use vaultrs::{kv2, pki};
 use crate::SecretsError;
 use crate::certificates::{Certificate, CertificateProvider};
 use crate::credentials::{
-    CredentialKey, CredentialManager, CredentialReader, CredentialWriter, Credentials,
+    CredentialKey, CredentialManager, CredentialPrefix, CredentialReader, CredentialWriter,
+    Credentials,
 };
 
 const DEFAULT_VAULT_CA_PATH: &str = "/var/run/secrets/forge-roots/ca.crt";
@@ -1144,6 +1145,12 @@ enum EnumerationMode {
     Strict,
 }
 
+fn vault_path_is_excluded(path: &str, excluded_prefixes: &[CredentialPrefix]) -> bool {
+    excluded_prefixes
+        .iter()
+        .any(|prefix| path.starts_with(prefix.as_str()))
+}
+
 async fn list_vault_path(
     vault_client: &VaultClient,
     mount: &str,
@@ -1258,11 +1265,24 @@ impl ForgeVaultClient {
         path_prefix: &str,
         mode: EnumerationMode,
     ) -> Result<Vec<String>, SecretsError> {
+        let (paths, _) = self
+            .list_secrets_for_path_excluding(path_prefix, mode, &[])
+            .await?;
+        Ok(paths)
+    }
+
+    async fn list_secrets_for_path_excluding(
+        &self,
+        path_prefix: &str,
+        mode: EnumerationMode,
+        excluded_prefixes: &[CredentialPrefix],
+    ) -> Result<(Vec<String>, bool), SecretsError> {
         let vault_client = self.vault_client().await?;
         let mount = &self.vault_client_config.kv_mount_location;
 
         let mut paths = Vec::new();
         let mut stack = vec![path_prefix.to_string()];
+        let mut excluded_prefix_found = false;
 
         while let Some(dir) = stack.pop() {
             let Some(entries) = list_vault_path(vault_client.deref(), mount, &dir, mode).await?
@@ -1271,25 +1291,26 @@ impl ForgeVaultClient {
             };
 
             for entry in entries {
-                if entry.ends_with('/') {
-                    let subdir = if dir.is_empty() {
-                        entry
-                    } else {
-                        format!("{dir}{entry}")
-                    };
-                    stack.push(subdir);
+                let is_directory = entry.ends_with('/');
+                let full = if dir.is_empty() {
+                    entry
                 } else {
-                    let full = if dir.is_empty() {
-                        entry
-                    } else {
-                        format!("{dir}{entry}")
-                    };
+                    format!("{dir}{entry}")
+                };
+                if vault_path_is_excluded(&full, excluded_prefixes) {
+                    excluded_prefix_found = true;
+                    continue;
+                }
+
+                if is_directory {
+                    stack.push(full);
+                } else {
                     paths.push(full);
                 }
             }
         }
 
-        Ok(paths)
+        Ok((paths, excluded_prefix_found))
     }
 
     /// get_secrets returns all secrets in the KV mount (paths plus
@@ -1307,10 +1328,23 @@ impl ForgeVaultClient {
     /// and leaves the completion marker unwritten -- rather than quietly
     /// importing a subset.
     pub async fn get_secrets_strict(&self) -> Result<Vec<(String, Credentials)>, SecretsError> {
-        let paths = self
-            .list_secrets_for_path("", EnumerationMode::Strict)
+        let (secrets, _) = self.get_secrets_strict_excluding_prefixes(&[]).await?;
+        Ok(secrets)
+    }
+
+    /// Returns all secrets outside `excluded_prefixes`, failing on the first
+    /// list or read error. Excluded directories are not traversed and excluded
+    /// credentials are not read. The boolean reports whether an excluded
+    /// prefix was found during enumeration.
+    pub async fn get_secrets_strict_excluding_prefixes(
+        &self,
+        excluded_prefixes: &[CredentialPrefix],
+    ) -> Result<(Vec<(String, Credentials)>, bool), SecretsError> {
+        let (paths, excluded_prefix_found) = self
+            .list_secrets_for_path_excluding("", EnumerationMode::Strict, excluded_prefixes)
             .await?;
-        self.read_secrets(&paths, EnumerationMode::Strict).await
+        let secrets = self.read_secrets(&paths, EnumerationMode::Strict).await?;
+        Ok((secrets, excluded_prefix_found))
     }
 
     /// get_secrets_for_prefix returns all secrets
@@ -1665,7 +1699,24 @@ mod tests {
         DedicatedVaultConfig, ForgeVaultAuthenticationType, ForgeVaultClientConfig, SpiffeIdentity,
         VaultConfig, VaultTokenRefreshWindowObserved, create_dedicated_vault_client,
         create_vault_client_settings, machine_spiffe_uri, service_account_role_name_from_jwt,
+        vault_path_is_excluded,
     };
+    use crate::credentials::CredentialPrefix;
+
+    #[test]
+    fn excluded_vault_prefix_covers_the_directory_and_its_credentials() {
+        for (path, expected) in [
+            ("ufm/", true),
+            ("ufm/default/auth", true),
+            ("machines/bmc/site/root", false),
+        ] {
+            assert_eq!(
+                vault_path_is_excluded(path, &[CredentialPrefix::UfmAuth]),
+                expected,
+                "{path}"
+            );
+        }
+    }
 
     /// Restores a process environment variable when a test finishes or panics.
     struct EnvironmentVariableGuard {

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -155,6 +155,17 @@ pub fn create_credential_manager_from(
 #[derive(Debug)]
 pub enum SecretsError {
     GenericError(eyre::Report),
+    /// A local UFM source owns credentials but has no entry for the requested
+    /// fabric; callers should surface the configuration remediation.
+    UfmCredentialReadBlocked {
+        fabric: String,
+    },
+    /// A caller attempted to mutate a persistent UFM credential while local
+    /// sources own UFM credentials; callers should direct the operator to the
+    /// configured local source.
+    UfmCredentialMutationBlocked {
+        fabric: String,
+    },
 }
 
 impl Display for SecretsError {
@@ -163,6 +174,20 @@ impl Display for SecretsError {
             SecretsError::GenericError(report) => {
                 write!(f, "Secrets operation failed: {}", report)
             }
+            SecretsError::UfmCredentialReadBlocked { fabric } => write!(
+                f,
+                "secrets operation failed: credential for UFM fabric {fabric:?} is absent from \
+                 the configured local sources; {}; {}",
+                crate::chained_reader::UFM_LOCAL_CREDENTIAL_REMEDIATION,
+                crate::chained_reader::UFM_BACKEND_SOURCE_REMEDIATION
+            ),
+            SecretsError::UfmCredentialMutationBlocked { fabric } => write!(
+                f,
+                "persistent backend credential mutation is disabled for UFM fabric {fabric:?} \
+                 because local sources own all UFM credentials; {}; {}",
+                crate::chained_reader::UFM_LOCAL_CREDENTIAL_REMEDIATION,
+                crate::chained_reader::UFM_BACKEND_SOURCE_REMEDIATION
+            ),
         }
     }
 }
@@ -177,6 +202,8 @@ impl From<SecretsError> for eyre::Report {
     fn from(value: SecretsError) -> Self {
         match value {
             SecretsError::GenericError(report) => report,
+            value @ SecretsError::UfmCredentialReadBlocked { .. } => eyre::eyre!("{value}"),
+            value @ SecretsError::UfmCredentialMutationBlocked { .. } => eyre::eyre!("{value}"),
         }
     }
 }

--- a/crates/secrets/src/local_credentials/env.rs
+++ b/crates/secrets/src/local_credentials/env.rs
@@ -142,6 +142,46 @@ mod tests {
     #[tokio::test]
     // Mutates process environment variables. Keep serialized to avoid cross-test interference.
     #[serial]
+    async fn parses_ufm_credentials_from_documented_environment_names() {
+        let key = CredentialKey::UfmAuth {
+            fabric: "default".to_string(),
+        };
+        let user_env = env_name(&["UFM_AUTH_BY_FABRIC", "DEFAULT", "USERNAME"]);
+        let pass_env = env_name(&["UFM_AUTH_BY_FABRIC", "DEFAULT", "PASSWORD"]);
+
+        // SAFETY: Initial lint enablement: `#[serial]` serializes participating tests,
+        // but it cannot prove Unix process-wide exclusion from unmarked environment
+        // readers. This needs owner review.
+        unsafe {
+            std::env::set_var(&user_env, "operator");
+            std::env::set_var(&pass_env, "token");
+        }
+        let provider =
+            EnvCredentials::new(EnvCredentialsConfig::default()).expect("create env provider");
+        let credentials = provider
+            .get_credentials(&key)
+            .await
+            .expect("parse UFM env credentials");
+        // SAFETY: Initial lint enablement: `#[serial]` serializes participating tests,
+        // but it cannot prove Unix process-wide exclusion from unmarked environment
+        // readers. This needs owner review.
+        unsafe {
+            std::env::remove_var(&user_env);
+            std::env::remove_var(&pass_env);
+        }
+
+        assert_eq!(
+            credentials,
+            Some(Credentials::UsernamePassword {
+                username: "operator".to_string(),
+                password: "token".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    // Mutates process environment variables. Keep serialized to avoid cross-test interference.
+    #[serial]
     async fn snapshots_env_at_startup() {
         let key = CredentialKey::DpuUefi {
             credential_type: CredentialType::SiteDefault,

--- a/crates/secrets/src/local_credentials/file.rs
+++ b/crates/secrets/src/local_credentials/file.rs
@@ -157,7 +157,11 @@ impl FileCredentialsWatcher {
     pub async fn new(config: FileCredentialsConfig) -> Result<Self, SecretsError> {
         let path = config.path();
         let poll_interval = config.poll_interval();
-        let credentials = Arc::new(ArcSwap::from_pointee(Self::load_file(&path).await?));
+        if poll_interval.is_zero() {
+            return Err(SecretsError::GenericError(eyre::eyre!(
+                "credentials.file.poll_interval must be greater than zero"
+            )));
+        }
         let (tx, mut rx) = mpsc::channel(4);
 
         let tx_clone = tx.clone();
@@ -195,6 +199,20 @@ impl FileCredentialsWatcher {
             .watch(&path, RecursiveMode::NonRecursive)
             .map_err(|err| SecretsError::GenericError(err.into()))?;
 
+        // Arm both watchers before reading the initial snapshot. Otherwise a
+        // replacement between the read and watcher registration could remain
+        // invisible until the file changes again. Events received while this
+        // read is in flight remain queued for the reload task below.
+        let initial = match Self::load_file(&path).await {
+            Ok(initial) => initial,
+            Err(error) => {
+                // Close the receiver before dropping the watchers so callbacks
+                // blocked on a full channel can exit during watcher teardown.
+                drop(rx);
+                return Err(error);
+            }
+        };
+        let credentials = Arc::new(ArcSwap::from_pointee(initial));
         let watched_path = path.clone();
         let credentials_clone = credentials.clone();
         tokio::spawn(async move {
@@ -246,9 +264,16 @@ impl FileCredentialsWatcher {
         }
 
         let parsed = serde_yaml::from_slice::<CredentialSnapshot>(&content).map_err(|err| {
-            SecretsError::GenericError(eyre::eyre!(
-                "failed to parse static credential file as JSON or YAML: {err}"
-            ))
+            let message = match err.location() {
+                Some(location) => format!(
+                    "failed to parse static credential file as JSON or YAML at line {}, column {}; parse details redacted",
+                    location.line(),
+                    location.column()
+                ),
+                None => "failed to parse static credential file as JSON or YAML; parse details redacted"
+                    .to_string(),
+            };
+            SecretsError::GenericError(eyre::eyre!(message))
         })?;
         Ok(parsed)
     }
@@ -340,6 +365,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reloads_ufm_credentials_after_atomic_file_replacement() {
+        let dir = tempdir().expect("create temp dir");
+        let file_path = dir.path().join("credentials.yaml");
+        tokio::fs::write(
+            &file_path,
+            r#"ufm_auth_by_fabric:
+  default:
+    username: ignored-by-ufm
+    password: token-before-rotation
+"#,
+        )
+        .await
+        .expect("write initial credentials file");
+
+        let provider = FileCredentialsWatcher::new(FileCredentialsConfig {
+            path: Some(file_path.clone()),
+            poll_interval: Some(Duration::from_millis(50)),
+            ..Default::default()
+        })
+        .await
+        .expect("create file provider");
+        let key = CredentialKey::UfmAuth {
+            fabric: "default".to_string(),
+        };
+
+        let replacement_path = dir.path().join("credentials.next.yaml");
+        tokio::fs::write(
+            &replacement_path,
+            r#"ufm_auth_by_fabric:
+  default:
+    username: ignored-by-ufm
+    password: token-after-rotation
+"#,
+        )
+        .await
+        .expect("write replacement credentials file");
+        tokio::fs::rename(&replacement_path, &file_path)
+            .await
+            .expect("atomically replace credentials file");
+
+        let expected = Some(Credentials::UsernamePassword {
+            username: "ignored-by-ufm".to_string(),
+            password: "token-after-rotation".to_string(),
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if provider
+                    .get_credentials(&key)
+                    .await
+                    .expect("read reloaded UFM credentials")
+                    == expected
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("watcher must reload atomically replaced UFM credentials");
+    }
+
+    #[tokio::test]
     async fn missing_file_returns_error() {
         let dir = tempdir().expect("create temp dir");
         let file_path = dir.path().join("does-not-exist.yaml");
@@ -349,6 +436,54 @@ mod tests {
         })
         .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn invalid_initial_file_error_redacts_scalar_values() {
+        let dir = tempdir().expect("create temp dir");
+        let file_path = dir.path().join("credentials.yaml");
+        let credential_fragment = "credential-fragment-987654321";
+        tokio::fs::write(
+            &file_path,
+            format!(
+                "mqtt_auth_by_credential_type:\n  {credential_fragment}:\n    username: mqtt-user\n    password: mqtt-password\n"
+            ),
+        )
+        .await
+        .expect("write invalid credentials file");
+
+        let error = FileCredentialsWatcher::new(FileCredentialsConfig {
+            path: Some(file_path),
+            ..Default::default()
+        })
+        .await
+        .err()
+        .expect("invalid initial file must fail");
+
+        let message = error.to_string();
+        assert!(message.contains("failed to parse"));
+        assert!(message.contains("parse details redacted"));
+        assert!(!message.contains(credential_fragment));
+    }
+
+    #[tokio::test]
+    async fn zero_poll_interval_returns_error() {
+        let dir = tempdir().expect("create temp dir");
+        let file_path = dir.path().join("credentials.yaml");
+        tokio::fs::write(&file_path, "{}")
+            .await
+            .expect("write credentials file");
+
+        let error = FileCredentialsWatcher::new(FileCredentialsConfig {
+            path: Some(file_path),
+            poll_interval: Some(Duration::ZERO),
+            ..Default::default()
+        })
+        .await
+        .err()
+        .expect("zero poll interval must fail");
+
+        assert!(error.to_string().contains("greater than zero"));
     }
 
     #[tokio::test]

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -91,6 +91,18 @@ spiffe_service_base_paths = [
 spiffe_machine_base_path = "/{{ .Values.auth.namespace | default (include "nico-api.namespace" .) }}/machine/"
 additional_issuer_cns = [{{ range $i, $cn := .Values.auth.additionalIssuerCns }}{{ if $i }}, {{ end }}{{ $cn | quote }}{{ end }}]
 
+{{- if not (has .Values.credentials.ufmSource (list "local_first" "backend" "local")) }}
+{{- fail "nico-api.credentials.ufmSource must be one of local_first, backend, or local" }}
+{{- end }}
+[credentials]
+ufm_source = {{ .Values.credentials.ufmSource | quote }}
+
+{{- if .Values.credentials.file.existingSecret.name }}
+[credentials.file]
+path = {{ printf "%s/credentials.yaml" (required "nico-api.credentials.file.mountPath is required when credentials.file.existingSecret.name is set" .Values.credentials.file.mountPath) | quote }}
+poll_interval = {{ required "nico-api.credentials.file.pollInterval is required when credentials.file.existingSecret.name is set" .Values.credentials.file.pollInterval | quote }}
+{{- end }}
+
 [machine_state_controller]
 failure_retry_time = "90m"
 

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -238,6 +238,11 @@ spec:
               mountPath: /etc/forge/carbide-api/site
             - name: {{ include "nico-api.name" . }}-site-config-files
               mountPath: /etc/nico/nico-api/site
+            {{- if .Values.credentials.file.existingSecret.name }}
+            - name: credentials-file
+              mountPath: {{ required "nico-api.credentials.file.mountPath is required when credentials.file.existingSecret.name is set" .Values.credentials.file.mountPath | quote }}
+              readOnly: true
+            {{- end }}
             - name: persistence
               mountPath: /mnt/persistence
             - name: spiffe
@@ -273,6 +278,14 @@ spec:
         - name: {{ include "nico-api.name" . }}-site-config-files
           configMap:
             name: {{ include "nico-api.name" . }}-site-config-files
+        {{- if .Values.credentials.file.existingSecret.name }}
+        - name: credentials-file
+          secret:
+            secretName: {{ .Values.credentials.file.existingSecret.name | quote }}
+            items:
+              - key: {{ required "nico-api.credentials.file.existingSecret.key is required when credentials.file.existingSecret.name is set" .Values.credentials.file.existingSecret.key | quote }}
+                path: credentials.yaml
+        {{- end }}
         - name: persistence
           emptyDir: {}
         - name: spiffe

--- a/helm/charts/nico-api/tests/credentials_file_config_test.yaml
+++ b/helm/charts/nico-api/tests/credentials_file_config_test.yaml
@@ -1,0 +1,62 @@
+suite: Static credential file configuration
+templates:
+  - configmap.yaml
+tests:
+  - it: omits credential-file settings by default
+    documentIndex: 0
+    asserts:
+      - notMatchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '\[credentials\.file\]'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^ufm_source = "local_first"$'
+
+  - it: configures a mounted Secret file without rendering its contents
+    documentIndex: 0
+    set:
+      credentials.file.existingSecret.name: ufm-credentials
+      credentials.file.existingSecret.key: static-credentials.yaml
+      credentials.file.mountPath: /var/run/secrets/nico/ufm
+      credentials.file.pollInterval: 15s
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^\[credentials\.file\]$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^path = "/var/run/secrets/nico/ufm/credentials\.yaml"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^poll_interval = "15s"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^ufm_source = "local_first"$'
+      - notMatchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'ufm_auth_by_fabric|token-after-rotation'
+
+  - it: selects local UFM credential ownership
+    documentIndex: 0
+    set:
+      credentials.ufmSource: local
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^ufm_source = "local"$'
+
+  - it: selects persistent-backend-only UFM credential ownership
+    documentIndex: 0
+    set:
+      credentials.ufmSource: backend
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^ufm_source = "backend"$'
+
+  - it: rejects an invalid UFM credential source
+    set:
+      credentials.ufmSource: fallback
+    asserts:
+      - failedTemplate:
+          errorMessage: "nico-api.credentials.ufmSource must be one of local_first, backend, or local"

--- a/helm/charts/nico-api/tests/credentials_file_deployment_test.yaml
+++ b/helm/charts/nico-api/tests/credentials_file_deployment_test.yaml
@@ -1,0 +1,60 @@
+suite: Static credential file mount
+templates:
+  - deployment.yaml
+tests:
+  - it: does not mount a credential file by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: credentials-file
+            mountPath: /var/run/secrets/nico/credentials
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: credentials-file
+
+  - it: mounts only the configured key from the existing Secret
+    set:
+      credentials.file.existingSecret.name: ufm-credentials
+      credentials.file.existingSecret.key: static-credentials.yaml
+      credentials.file.mountPath: /var/run/secrets/nico/ufm
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: credentials-file
+            mountPath: /var/run/secrets/nico/ufm
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: credentials-file
+            secret:
+              secretName: ufm-credentials
+              items:
+                - key: static-credentials.yaml
+                  path: credentials.yaml
+
+  - it: quotes YAML-sensitive credential values
+    set:
+      credentials.file.existingSecret.name: true
+      credentials.file.existingSecret.key: 123
+      credentials.file.mountPath: "#comment"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: credentials-file
+            mountPath: "#comment"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: credentials-file
+            secret:
+              secretName: "true"
+              items:
+                - key: "123"
+                  path: credentials.yaml

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -266,6 +266,33 @@ env:
   RUST_BACKTRACE: "full"
   RUST_LIB_BACKTRACE: "0"
 
+## Optional operator-managed static credential file. The chart mounts one key
+## from an existing Secret and configures nico-api to watch it; no credential
+## content is rendered into this chart's ConfigMaps or values. The selected key
+## must contain JSON or YAML. UFM entries have this shape (both fields are
+## required; an empty password selects the default SPIFFE client certificate):
+##
+## ufm_auth_by_fabric:
+##   default:
+##     username: ignored-for-token-or-certificate-auth
+##     password: bearer-token-or-empty
+##
+## In the default local_first mode, these entries override matching persistent
+## backend credentials. Set ufmSource to local to require local entries for
+## every configured fabric and disable persistent-backend UFM access.
+credentials:
+  # local_first preserves environment/file overrides with persistent-backend
+  # fallback. backend ignores local UFM entries. local requires every configured
+  # fabric in the environment/file sources and rejects backend mutations.
+  ufmSource: local_first
+  file:
+    existingSecret:
+      name: ""
+      key: credentials.yaml
+    mountPath: /var/run/secrets/nico/credentials
+    # Must be greater than zero.
+    pollInterval: "60s"
+
 ## Optional Figment dictionary for CARBIDE_API_DSX_EXCHANGE_EVENT_BUS.
 dsxExchangeEventBusConfig: ""
 


### PR DESCRIPTION
NICo currently retrieves UFM credentials from its persistent credential backend, leaving a Vault dependency that operators cannot replace with their normal secret-injection workflow. This change lets operators provide UFM credentials through environment variables or a watched file, including a Kubernetes Secret projection, and rotate file-backed credentials without restarting NICo.

Local sources can be made authoritative after a staged migration. In that mode, missing UFM credentials do not fall through to Vault or Postgres, and the credential CLI returns a clear precondition error instead of mutating a backend that is no longer authoritative.

## Related issues

Closes #1837

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The Helm chart mounts an operator-managed existing Secret and does not render credential contents into chart values or ConfigMaps. Legacy UFM fallback defaults to enabled for staged migration; operators can disable it once every configured fabric exists in the local source.

The local manual environment had no reachable UFM, so it exercised client invocation and the expected connection failure but not successful UFM authentication.