### PR TITLE
feat(helm-prereqs): provision RMS (rack-manager) via setup.sh phase 5c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ ssh-console/legacy/ssh-console
 dev/mac-local-dev/carbide-api-config-*.toml
 crates/dpf/doca-platform
 helm-prereqs/.dpf-src/
+helm-prereqs/.rms-src/
 helm-prereqs/values/nico-core.yaml.dpf.bak
 
 /helm/Chart.lock

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ ssh-console/legacy/ssh-console
 dev/mac-local-dev/carbide-api-config-*.toml
 crates/dpf/doca-platform
 helm-prereqs/.dpf-src/
-helm-prereqs/.rms-src/
 helm-prereqs/values/nico-core.yaml.dpf.bak
 
 /helm/Chart.lock

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = pxe/ipxe/upstream
 	url = https://github.com/ipxe/ipxe.git
 	ignore = dirty
+[submodule "helm-prereqs/nv-rms"]
+	path = helm-prereqs/nv-rms
+	url = https://github.com/dsx-ai-factory/nv-rms.git

--- a/helm-prereqs/.helmignore
+++ b/helm-prereqs/.helmignore
@@ -3,6 +3,8 @@
 # setup.sh --install-dpf caches at .dpf-src/ and whose large .git pack files
 # otherwise exceed helm's per-file size limit.
 .dpf-src/
+# Same for the nv-rms source clone cached by setup.sh --install-rms.
+.rms-src/
 .git/
 .gitignore
 *.bak

--- a/helm-prereqs/.helmignore
+++ b/helm-prereqs/.helmignore
@@ -5,6 +5,7 @@
 .dpf-src/
 # Same for the nv-rms source clone cached by setup.sh --install-rms.
 .rms-src/
+nv-rms/
 .git/
 .gitignore
 *.bak

--- a/helm-prereqs/clean.sh
+++ b/helm-prereqs/clean.sh
@@ -46,6 +46,12 @@ echo "=== [0/8] Uninstalling NICo REST stack ==="
 # from both nico-prereqs (DB creds, vault tokens) and the REST stack.
 helm uninstall flow                 -n flow                            2>/dev/null || true
 kubectl delete ns flow --wait=false --ignore-not-found                 2>/dev/null || true
+# --no-hooks: the rack-manager chart ships a pre-delete drop-database hook
+# (disabled in values/rms.yaml, but a hand-installed release may have it on)
+# that pulls postgres:15-alpine from Docker Hub — a mirror-only site would
+# hang here, and clean.sh drops the whole postgres namespace anyway.
+helm uninstall rack --no-hooks      -n rack-manager                    2>/dev/null || true
+kubectl delete ns rack-manager --wait=false --ignore-not-found         2>/dev/null || true
 helm uninstall nico-rest-site-agent -n nico-rest                       2>/dev/null || true
 helm uninstall nico-rest            -n nico-rest                       2>/dev/null || true
 helm uninstall temporal                -n temporal     2>/dev/null || true
@@ -287,7 +293,7 @@ kubectl delete clustersecretstore \
 # not strand their cluster-scoped resources.
 kubectl delete clusterexternalsecret \
     nico-roots-eso nico-db-eso \
-    flow-db-eso psm-db-eso nsm-db-eso \
+    flow-db-eso psm-db-eso nsm-db-eso rms-db-eso \
     --ignore-not-found 2>/dev/null || true
 kubectl delete clusterrole \
     vault-pki-config-reader eso-postgres-ns-role flow-vault-tokens-writer \

--- a/helm-prereqs/health-check.sh
+++ b/helm-prereqs/health-check.sh
@@ -402,6 +402,17 @@ else
   skip "flow namespace not present — flow disabled or not yet deployed"
 fi
 
+section "RMS (Rack Manager Service)"
+RMS_NS="${RMS_NS:-rack-manager}"
+if kc get ns "${RMS_NS}" &>/dev/null; then
+  _check_deployment "${RMS_NS}" rms-api-server
+  for _S in rms-api-server-certificate rms.nico.nico-pg-cluster.credentials; do
+    _check_secret_exists "${RMS_NS}" "${_S}"
+  done
+else
+  skip "rack-manager namespace not present — RMS not installed (opt-in via --install-rms)"
+fi
+
 section "NICo Jobs"
 _check_job_complete "${NICO_NS}" vault-pki-config
 # Migration job: find by label (name includes a random suffix)

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -469,12 +469,13 @@ if [[ -n "${KUBECONFIG:-}" && ! -f "${KUBECONFIG}" ]]; then
     ERRORS+=("KUBECONFIG='${KUBECONFIG}' does not exist — check the path to your cluster kubeconfig")
 fi
 
-# RMS requirements. RMS is opt-in (--install-rms / NICO_INSTALL_RMS=true).
-if [[ "${INSTALL_RMS:-false}" == "true" ]]; then
+# RMS requirements. RMS installs by default; these apply unless --skip-rms
+# (NICO_SKIP_RMS=true / NICO_INSTALL_RMS=false), which clears INSTALL_RMS.
+if [[ "${INSTALL_RMS:-true}" == "true" ]]; then
     command -v git &>/dev/null || \
         ERRORS+=("RMS requires 'git' to clone nv-rms — install it, or set NICO_RMS_CHART to a local chart path")
     [[ -z "${NICO_RMS_IMAGE_TAG:-}" ]] && \
-        ERRORS+=("NICO_RMS_IMAGE_TAG is not set    (RMS API server image tag; the rack-manager chart fails at render without one — required with --install-rms)")
+        ERRORS+=("NICO_RMS_IMAGE_TAG is not set    (RMS API server image tag; the rack-manager chart fails at render without one — required unless --skip-rms)")
     # The default rms-api image is entitlement-gated on NGC; without a key the
     # pod lands in ImagePullBackOff. A mirror override lifts the requirement.
     if [[ -z "${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}" && \

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -471,10 +471,15 @@ fi
 
 # RMS requirements. RMS is opt-in (--install-rms / NICO_INSTALL_RMS=true).
 if [[ "${INSTALL_RMS:-false}" == "true" ]]; then
+    command -v git &>/dev/null || \
+        ERRORS+=("RMS requires 'git' to clone nv-rms — install it, or set NICO_RMS_CHART to a local chart path")
     [[ -z "${NICO_RMS_IMAGE_TAG:-}" ]] && \
         ERRORS+=("NICO_RMS_IMAGE_TAG is not set    (RMS API server image tag; the rack-manager chart fails at render without one — required with --install-rms)")
-    if [[ -z "${NICO_RMS_CHART:-}" && -z "${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}" ]]; then
-        ERRORS+=("NICO_RMS_NGC_API_KEY / REGISTRY_PULL_SECRET not set and NICO_RMS_CHART not set — the rack-manager chart pull from NGC needs a key, or point NICO_RMS_CHART at a local chart")
+    # The default rms-api image is entitlement-gated on NGC; without a key the
+    # pod lands in ImagePullBackOff. A mirror override lifts the requirement.
+    if [[ -z "${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}" && \
+          -z "${NICO_RMS_IMAGE_REPO:-}" ]]; then
+        ERRORS+=("NICO_RMS_NGC_API_KEY / REGISTRY_PULL_SECRET not set — the default rms-api image is entitlement-gated on NGC; set a key, or point NICO_RMS_IMAGE_REPO at your own mirror")
     fi
 fi
 

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -478,7 +478,7 @@ fi
 if [[ "${INSTALL_RMS:-true}" == "true" ]]; then
     if [[ -z "${NICO_RMS_CHART:-}" ]]; then
         command -v git &>/dev/null || \
-            ERRORS+=("RMS requires 'git' to clone nv-rms — install it, or set NICO_RMS_CHART to a local chart path")
+            ERRORS+=("RMS requires 'git' to initialize the nv-rms submodule - install it, or set NICO_RMS_CHART to a local chart path")
     fi
     [[ -z "${NICO_RMS_IMAGE_TAG:-}" ]] && \
         ERRORS+=("NICO_RMS_IMAGE_TAG is not set    (RMS API server image tag; the rack-manager chart fails at render without one — required unless --skip-rms)")

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -486,7 +486,14 @@ if [[ "${INSTALL_RMS:-true}" == "true" ]]; then
     # pod lands in ImagePullBackOff. A mirror override lifts the requirement.
     if [[ -z "${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}" && \
           -z "${NICO_RMS_IMAGE_REPO:-}" ]]; then
-        ERRORS+=("NICO_RMS_NGC_API_KEY / REGISTRY_PULL_SECRET not set — the default rms-api image is entitlement-gated on NGC; set a key, or point NICO_RMS_IMAGE_REPO at your own mirror")
+        ERRORS+=("NICO_RMS_NGC_API_KEY / REGISTRY_PULL_SECRET not set - the default rms-api image is entitlement-gated on NGC; set a key, or point NICO_RMS_IMAGE_REPO at your own mirror")
+    fi
+    # Even with a key set: the default image path needs NGC rms-dev org
+    # entitlement, which standard site keys do not carry. Most sites should
+    # build or mirror the image into their own registry instead (README:
+    # "Building the RMS image") and set NICO_RMS_IMAGE_REPO.
+    if [[ -z "${NICO_RMS_IMAGE_REPO:-}" ]]; then
+        WARNINGS+=("NICO_RMS_IMAGE_REPO not set - the default rms-api image (nvcr.io/0837451325059433/rms-dev/rms-api) requires NGC rms-dev entitlement, which most site keys lack. If the pull lands in ImagePullBackOff, build/mirror the image into your registry (helm-prereqs/README.md: Building the RMS image)")
     fi
 fi
 

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -469,6 +469,15 @@ if [[ -n "${KUBECONFIG:-}" && ! -f "${KUBECONFIG}" ]]; then
     ERRORS+=("KUBECONFIG='${KUBECONFIG}' does not exist — check the path to your cluster kubeconfig")
 fi
 
+# RMS requirements. RMS is opt-in (--install-rms / NICO_INSTALL_RMS=true).
+if [[ "${INSTALL_RMS:-false}" == "true" ]]; then
+    [[ -z "${NICO_RMS_IMAGE_TAG:-}" ]] && \
+        ERRORS+=("NICO_RMS_IMAGE_TAG is not set    (RMS API server image tag; the rack-manager chart fails at render without one — required with --install-rms)")
+    if [[ -z "${NICO_RMS_CHART:-}" && -z "${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}" ]]; then
+        ERRORS+=("NICO_RMS_NGC_API_KEY / REGISTRY_PULL_SECRET not set and NICO_RMS_CHART not set — the rack-manager chart pull from NGC needs a key, or point NICO_RMS_CHART at a local chart")
+    fi
+fi
+
 # DPF requirements. DPF installs by default; these apply unless --skip-dpf
 # (NICO_SKIP_DPF=true / NICO_INSTALL_DPF=false), which clears INSTALL_DPF.
 if [[ "${INSTALL_DPF:-true}" == "true" ]]; then

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -86,6 +86,8 @@ if ! ${_SOURCED}; then
     # DPF is on by default; derive INSTALL_DPF from env, then let flags override.
     INSTALL_DPF="${INSTALL_DPF:-${NICO_INSTALL_DPF:-true}}"
     [[ "${NICO_SKIP_DPF:-false}" == "true" ]] && INSTALL_DPF=false
+    INSTALL_RMS="${INSTALL_RMS:-${NICO_INSTALL_RMS:-true}}"
+    [[ "${NICO_SKIP_RMS:-false}" == "true" ]] && INSTALL_RMS=false
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --skip-core)      SKIP_CORE=true ;;
@@ -93,6 +95,8 @@ if ! ${_SOURCED}; then
             --skip-flow)      SKIP_FLOW=true ;;
             --skip-dpf)       INSTALL_DPF=false ;;
             --install-dpf)    INSTALL_DPF=true ;;
+            --skip-rms)       INSTALL_RMS=false ;;
+            --install-rms)    INSTALL_RMS=true ;;
             -y|--yes)         AUTO_YES=true ;;
             --core-values)    CORE_VALUES="$2"; shift ;;
             --metallb-config) METALLB_CONFIG="$2"; shift ;;
@@ -472,8 +476,10 @@ fi
 # RMS requirements. RMS installs by default; these apply unless --skip-rms
 # (NICO_SKIP_RMS=true / NICO_INSTALL_RMS=false), which clears INSTALL_RMS.
 if [[ "${INSTALL_RMS:-true}" == "true" ]]; then
-    command -v git &>/dev/null || \
-        ERRORS+=("RMS requires 'git' to clone nv-rms — install it, or set NICO_RMS_CHART to a local chart path")
+    if [[ -z "${NICO_RMS_CHART:-}" ]]; then
+        command -v git &>/dev/null || \
+            ERRORS+=("RMS requires 'git' to clone nv-rms — install it, or set NICO_RMS_CHART to a local chart path")
+    fi
     [[ -z "${NICO_RMS_IMAGE_TAG:-}" ]] && \
         ERRORS+=("NICO_RMS_IMAGE_TAG is not set    (RMS API server image tag; the rack-manager chart fails at render without one — required unless --skip-rms)")
     # The default rms-api image is entitlement-gated on NGC; without a key the

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -99,10 +99,9 @@
 #                          Same override for the nico-dhcp-server chart.
 #   NICO_DPF_OTEL_CHART_VERSION
 #                          Same override for the nico-otelcol chart.
-#   NICO_INSTALL_RMS       Install the NVIDIA Rack Manager Service (rack-manager
-#                          chart, phase 5c). Default: false — opt in with
-#                          --install-rms once the site has NGC access to the
-#                          rms-dev org. Same as --install-rms.
+#   NICO_SKIP_RMS          Skip the NVIDIA Rack Manager Service (rack-manager
+#                          chart, phase 5c), which installs by DEFAULT.
+#                          Same as --skip-rms. (NICO_INSTALL_RMS=false honored too.)
 #   NICO_RMS_VERSION       nv-rms git ref (tag, branch, or full commit SHA) to
 #                          clone the rack-manager chart from — same model as
 #                          NICO_DPF_VERSION. Default: a pinned main commit;
@@ -139,7 +138,7 @@
 #   ./setup.sh --skip-flow              # skip Phase 7h NICo Flow (REST still installs)
 #                                       #   pair with helm-prereqs/values.yaml::flow.enabled=false
 #                                       #   to skip Flow prerequisites (database / ESO) too
-#   ./setup.sh --install-rms            # also install the Rack Manager Service (phase 5c)
+#   ./setup.sh --skip-rms               # skip the Rack Manager Service (installed by default otherwise)
 #   ./setup.sh --skip-core --skip-rest  # fully non-interactive infra-only run
 #   ./setup.sh --core-values /path/to/values.yaml      # use site-specific values for Phase 6
 #   ./setup.sh --metallb-config /path/to/metallb.yaml  # use site-specific MetalLB config (file or kustomize dir)
@@ -171,11 +170,11 @@ SKIP_FLOW=false
 # use the deprecated iPXE DPU path). NICO_INSTALL_DPF=false is honored too.
 INSTALL_DPF="${NICO_INSTALL_DPF:-true}"
 [[ "${NICO_SKIP_DPF:-false}" == "true" ]] && INSTALL_DPF=false
-# RMS (Rack Manager Service) is OPT-IN for now: the rack-manager chart and
-# rms-api image live in the NGC rms-dev org, which most sites cannot pull from
-# yet, and the image tag has no safe default. Flip the default once the chart
-# is public.
-INSTALL_RMS="${NICO_INSTALL_RMS:-false}"
+# RMS (Rack Manager Service) installs by DEFAULT, mirroring DPF. Opt out with
+# --skip-rms or NICO_SKIP_RMS=true (e.g. sites without rack management, or an
+# externally managed RMS). NICO_INSTALL_RMS=false is honored too.
+INSTALL_RMS="${NICO_INSTALL_RMS:-true}"
+[[ "${NICO_SKIP_RMS:-false}" == "true" ]] && INSTALL_RMS=false
 WITH_OBSERVABILITY="${WITH_OBSERVABILITY:-false}"
 CORE_VALUES=""
 METALLB_CONFIG=""
@@ -188,8 +187,8 @@ while [[ $# -gt 0 ]]; do
         --skip-flow)    SKIP_FLOW=true ;;
         --install-dpf)  INSTALL_DPF=true ;;   # explicit; DPF is the default
         --skip-dpf)     INSTALL_DPF=false ;;
-        --install-rms)  INSTALL_RMS=true ;;
-        --skip-rms)     INSTALL_RMS=false ;;  # explicit; RMS is opt-in for now
+        --install-rms)  INSTALL_RMS=true ;;   # explicit; RMS is the default
+        --skip-rms)     INSTALL_RMS=false ;;
         --with-observability) WITH_OBSERVABILITY=true ;;
         --debug)        set -x         ;;
         --core-values)
@@ -207,7 +206,7 @@ while [[ $# -gt 0 ]]; do
             SITE_OVERLAY="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
             [[ ! -d "${SITE_OVERLAY}" ]] && { echo "Error: --site-overlay directory not found: $2"; exit 1; }
             shift ;;
-        *) echo "Usage: $0 [-y] [--skip-core] [--skip-rest] [--skip-flow] [--skip-dpf] [--install-rms] [--with-observability] [--core-values <file>] [--metallb-config <file-or-dir>] [--site-overlay <dir>] [--debug]"; exit 1 ;;
+        *) echo "Usage: $0 [-y] [--skip-core] [--skip-rest] [--skip-flow] [--skip-dpf] [--skip-rms] [--with-observability] [--core-values <file>] [--metallb-config <file-or-dir>] [--site-overlay <dir>] [--debug]"; exit 1 ;;
     esac
     shift
 done
@@ -1383,7 +1382,7 @@ if "${INSTALL_RMS}"; then
 else
     echo ""
     echo "=== [5c] RMS (Rack Manager Service) ==="
-    echo "Skipped (opt in with --install-rms once the site has NGC rms-dev access)."
+    echo "Skipped (--skip-rms flag set)."
 fi
 
 # ---------------------------------------------------------------------------

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -103,17 +103,24 @@
 #                          chart, phase 5c). Default: false — opt in with
 #                          --install-rms once the site has NGC access to the
 #                          rms-dev org. Same as --install-rms.
+#   NICO_RMS_VERSION       nv-rms git ref (tag, branch, or full commit SHA) to
+#                          clone the rack-manager chart from — same model as
+#                          NICO_DPF_VERSION. Default: a pinned main commit;
+#                          switch to release tags once upstream cuts them.
+#   NICO_RMS_SRC_DIR       Where the nv-rms clone is cached.
+#                          Default: helm-prereqs/.rms-src
 #   NICO_RMS_CHART         Local rack-manager chart path (directory or .tgz),
 #                          e.g. an nv-rms checkout's helm/ dir. When set, no
-#                          NGC chart pull happens. Default: unset (pull from NGC).
-#   NICO_RMS_CHART_VERSION rack-manager chart version to pull from NGC. NGC
-#                          publishes with an -OSS suffix. Default: 1.0.1-OSS
-#   NICO_RMS_IMAGE_REPO    RMS API server image repository.
-#                          Default: nvcr.io/0837451325059433/rms-dev/rms-api
+#                          clone happens. Default: unset (clone NICO_RMS_VERSION).
+#   NICO_RMS_IMAGE_REPO    RMS API server image repository. Default: the NGC
+#                          rms-dev image, nvcr.io/0837451325059433/rms-dev/rms-api
+#                          (still entitlement-gated; point at your mirror
+#                          otherwise).
 #   NICO_RMS_IMAGE_TAG     RMS API server image tag (git-describe style, e.g.
 #                          v0.8.0). REQUIRED when RMS install is enabled — the
 #                          chart hard-fails at render without a tag.
-#   NICO_RMS_NGC_API_KEY   NGC API key for the chart pull and the rms-pull-secret.
+#   NICO_RMS_NGC_API_KEY   NGC API key for the rms-pull-secret. Required with
+#                          the default (entitlement-gated) image repo.
 #                          Default: $REGISTRY_PULL_SECRET
 #   NICO_RMS_NAMESPACE     Namespace for the rack-manager release. Must match
 #                          helm-prereqs/values.yaml::rms.namespace (the ESO
@@ -341,12 +348,14 @@ NICO_DPF_NICO_NGC_API_KEY="${NICO_DPF_NICO_NGC_API_KEY:-${NICO_DPF_NGC_API_KEY}}
 # to the chart version (NICO_DPF_VERSION) but can differ for a self-built image.
 NICO_DPF_IMAGE_REPO="${NICO_DPF_IMAGE_REPO:-nvcr.io/nvidia/doca/dpf-system}"
 NICO_DPF_IMAGE_TAG="${NICO_DPF_IMAGE_TAG:-${NICO_DPF_VERSION}}"
-# RMS (rack-manager chart, phase 5c). Chart versions on NGC carry an -OSS
-# suffix and image tags are git-describe style, decoupled from the chart
-# version — NICO_RMS_IMAGE_TAG has no default and preflight requires it when
-# RMS install is enabled.
+# RMS (rack-manager chart, phase 5c). The chart is cloned from the open-source
+# nv-rms repo at a pinned ref, mirroring the DPF doca-platform clone. Upstream
+# has no release tags yet, so the default pin is a main commit SHA; image tags
+# are git-describe style and decoupled from the chart — NICO_RMS_IMAGE_TAG has
+# no default and preflight requires it when RMS install is enabled.
 NICO_RMS_CHART="${NICO_RMS_CHART:-}"
-NICO_RMS_CHART_VERSION="${NICO_RMS_CHART_VERSION:-1.0.1-OSS}"
+NICO_RMS_VERSION="${NICO_RMS_VERSION:-5db9c6b3c3805a8549920111c097358d67b4c2c4}"
+NICO_RMS_SRC_DIR="${NICO_RMS_SRC_DIR:-${SCRIPT_DIR}/.rms-src}"
 NICO_RMS_IMAGE_REPO="${NICO_RMS_IMAGE_REPO:-nvcr.io/0837451325059433/rms-dev/rms-api}"
 NICO_RMS_IMAGE_TAG="${NICO_RMS_IMAGE_TAG:-}"
 NICO_RMS_NGC_API_KEY="${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}"
@@ -1279,28 +1288,30 @@ if "${INSTALL_RMS}"; then
         echo "NICO_RMS_NGC_API_KEY not set — skipping rms-pull-secret (mirror or pre-loaded registry)."
     fi
 
-    # 5c.3 Resolve the chart: local checkout/tarball via NICO_RMS_CHART, or
-    #      pull the pinned version from NGC into a cache dir. The pull is
-    #      skipped when the exact tarball is already cached.
+    # 5c.3 Resolve the chart: local checkout/tarball via NICO_RMS_CHART, or a
+    #      cached shallow clone of the open-source nv-rms repo at the pinned
+    #      ref — the same model as the doca-platform clone in 5b. `git fetch
+    #      <ref>` + FETCH_HEAD handles tags, branches, and full commit SHAs
+    #      uniformly (upstream has no release tags yet, so the default pin is
+    #      a commit).
     if [[ -n "${NICO_RMS_CHART}" ]]; then
         _RMS_CHART="${NICO_RMS_CHART}"
         echo "Using local rack-manager chart: ${_RMS_CHART}"
     else
-        _RMS_CHART_CACHE="${SCRIPT_DIR}/.rms-chart"
-        _RMS_CHART="${_RMS_CHART_CACHE}/rack-manager-${NICO_RMS_CHART_VERSION}.tgz"
-        if [[ ! -f "${_RMS_CHART}" ]]; then
-            [[ -z "${NICO_RMS_NGC_API_KEY}" ]] && {
-                echo "Error: pulling the rack-manager chart from NGC needs NICO_RMS_NGC_API_KEY"
-                echo "       (or set NICO_RMS_CHART to a local chart path)."
-                exit 1
-            }
-            echo "Pulling rack-manager ${NICO_RMS_CHART_VERSION} from NGC..."
-            mkdir -p "${_RMS_CHART_CACHE}"
-            helm pull \
-                "https://helm.ngc.nvidia.com/0837451325059433/rms-dev/charts/rack-manager-${NICO_RMS_CHART_VERSION}.tgz" \
-                --username='$oauthtoken' --password "${NICO_RMS_NGC_API_KEY}" \
-                --destination "${_RMS_CHART_CACHE}"
+        if [[ -d "${NICO_RMS_SRC_DIR}/.git" ]]; then
+            echo "Reusing nv-rms clone at ${NICO_RMS_SRC_DIR} (ref ${NICO_RMS_VERSION})..."
+        else
+            # Wipe any half-created dir (aborted mid-run, disk-full) so
+            # `git init` starts clean rather than inheriting stale state.
+            rm -rf "${NICO_RMS_SRC_DIR}"
+            echo "Cloning nv-rms ${NICO_RMS_VERSION}..."
+            git init -q "${NICO_RMS_SRC_DIR}"
+            git -C "${NICO_RMS_SRC_DIR}" remote add origin \
+                https://github.com/dsx-ai-factory/nv-rms.git
         fi
+        git -C "${NICO_RMS_SRC_DIR}" fetch --depth 1 origin "${NICO_RMS_VERSION}"
+        git -C "${NICO_RMS_SRC_DIR}" checkout -q -f FETCH_HEAD
+        _RMS_CHART="${NICO_RMS_SRC_DIR}/helm"
         echo "rack-manager chart: ${_RMS_CHART}"
     fi
 

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -121,9 +121,6 @@
 #   NICO_RMS_NGC_API_KEY   NGC API key for the rms-pull-secret. Required with
 #                          the default (entitlement-gated) image repo.
 #                          Default: $REGISTRY_PULL_SECRET
-#   NICO_RMS_NAMESPACE     Namespace for the rack-manager release. Must match
-#                          helm-prereqs/values.yaml::rms.namespace (the ESO
-#                          credential sync targets it). Default: rack-manager
 #
 # Usage:
 #   export KUBECONFIG=/path/to/kubeconfig
@@ -228,9 +225,6 @@ case "${INSTALL_RMS}" in
     true|false) ;;
     *) echo "Error: NICO_INSTALL_RMS must be true or false (got '${INSTALL_RMS}')"; exit 1 ;;
 esac
-# Re-exported under the NICO_ name for values/nico-prereqs-dynamic.yaml.gotmpl,
-# which gates the rms database / user / ESO sync on it at helmfile sync time.
-export NICO_INSTALL_RMS="${INSTALL_RMS}"
 
 # The predecessor Flow chart bundled PSM and NSM in the Flow Deployment. This
 # release does not provide an automatic migration for those workloads. Stop
@@ -358,7 +352,10 @@ NICO_RMS_SRC_DIR="${NICO_RMS_SRC_DIR:-${SCRIPT_DIR}/.rms-src}"
 NICO_RMS_IMAGE_REPO="${NICO_RMS_IMAGE_REPO:-nvcr.io/0837451325059433/rms-dev/rms-api}"
 NICO_RMS_IMAGE_TAG="${NICO_RMS_IMAGE_TAG:-}"
 NICO_RMS_NGC_API_KEY="${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}"
-NICO_RMS_NAMESPACE="${NICO_RMS_NAMESPACE:-rack-manager}"
+# The namespace is fixed: NICo Core's chart defaults dial
+# rms-api-server.rack-manager.svc.cluster.local, and the ESO sync,
+# health-check, and clean.sh all assume it. Not overridable by design.
+_RMS_NS="rack-manager"
 # Site-wide BMC root password. Optional: when provided, setup.sh calls
 # nico-admin-cli (phase 6b) to store the credential via the API so DPU
 # provisioning starts immediately. When omitted, carbide-api starts cleanly
@@ -1267,16 +1264,16 @@ if "${INSTALL_RMS}"; then
     # 5c.1 Namespace. Created here (not by the chart) so the pull secret and
     #      the ESO credential sync have somewhere to land before helm runs.
     #      The rms-db-eso ClusterExternalSecret selects it by metadata.name.
-    kubectl create namespace "${NICO_RMS_NAMESPACE}" --dry-run=client -o yaml \
+    kubectl create namespace "${_RMS_NS}" --dry-run=client -o yaml \
         | kubectl apply -f -
 
     # 5c.2 Image pull secret. Same off-argv construction as the DPF secrets:
     #      the NGC key must never appear in an exec argument.
     if [[ -n "${NICO_RMS_NGC_API_KEY}" ]]; then
-        echo "Creating rms-pull-secret in ${NICO_RMS_NAMESPACE}..."
+        echo "Creating rms-pull-secret in ${_RMS_NS}..."
         _rms_auth="$(printf '%s' "\$oauthtoken:${NICO_RMS_NGC_API_KEY}" | base64 | tr -d '\n')"
         kubectl create secret generic rms-pull-secret \
-            --namespace "${NICO_RMS_NAMESPACE}" \
+            --namespace "${_RMS_NS}" \
             --type=kubernetes.io/dockerconfigjson \
             --from-file=.dockerconfigjson=<(printf \
                 '{"auths":{"%s":{"username":"$oauthtoken","password":"%s","auth":"%s"}}}' \
@@ -1300,9 +1297,18 @@ if "${INSTALL_RMS}"; then
         if [[ -d "${NICO_RMS_SRC_DIR}/.git" ]]; then
             echo "Reusing nv-rms clone at ${NICO_RMS_SRC_DIR} (ref ${NICO_RMS_VERSION})..."
         else
-            # Wipe any half-created dir (aborted mid-run, disk-full) so
-            # `git init` starts clean rather than inheriting stale state.
-            rm -rf "${NICO_RMS_SRC_DIR}"
+            # Mirror the DPF clone guard: never auto-delete a path that is
+            # not our own clone, and reject dangerous override values.
+            case "${NICO_RMS_SRC_DIR}" in
+                ""|"/"|"${HOME}"|"${HOME}/")
+                    echo "ERROR: refusing to use NICO_RMS_SRC_DIR='${NICO_RMS_SRC_DIR}' — set it to a dedicated clone dir."
+                    exit 1 ;;
+            esac
+            if [[ -e "${NICO_RMS_SRC_DIR}" ]]; then
+                echo "ERROR: '${NICO_RMS_SRC_DIR}' exists but is not an nv-rms Git clone."
+                echo "  Remove it explicitly and re-run (refusing to auto-delete a non-clone path)."
+                exit 1
+            fi
             echo "Cloning nv-rms ${NICO_RMS_VERSION}..."
             git init -q "${NICO_RMS_SRC_DIR}"
             git -C "${NICO_RMS_SRC_DIR}" remote add origin \
@@ -1321,7 +1327,7 @@ if "${INSTALL_RMS}"; then
     _rms_creds_ok=false
     for _rms_i in $(seq 1 36); do
         if kubectl get secret rms.nico.nico-pg-cluster.credentials \
-            -n "${NICO_RMS_NAMESPACE}" &>/dev/null; then
+            -n "${_RMS_NS}" &>/dev/null; then
             _rms_creds_ok=true
             break
         fi
@@ -1329,7 +1335,7 @@ if "${INSTALL_RMS}"; then
         sleep 5
     done
     if [[ "${_rms_creds_ok}" == "false" ]]; then
-        echo "Error: rms.nico.nico-pg-cluster.credentials never appeared in ${NICO_RMS_NAMESPACE}."
+        echo "Error: rms.nico.nico-pg-cluster.credentials never appeared in ${_RMS_NS}."
         echo "  → Check 'kubectl describe clusterexternalsecret rms-db-eso' and that the"
         echo "    Zalando operator created the rms user (kubectl get secret -n postgres | grep rms)."
         echo "  → Confirm nico-prereqs synced with NICO_INSTALL_RMS=true (phase 5 of this run)."
@@ -1342,10 +1348,10 @@ if "${INSTALL_RMS}"; then
     #      failure mode gets its own message instead of a generic helm timeout.
     NICO_RMS_CMD=(
         helm upgrade --install rack "${_RMS_CHART}"
-        --namespace "${NICO_RMS_NAMESPACE}"
+        --namespace "${_RMS_NS}"
         -f "${SCRIPT_DIR}/values/rms.yaml"
         # The chart renders into .Values.namespace, not the -n flag; set both.
-        --set "namespace=${NICO_RMS_NAMESPACE}"
+        --set "namespace=${_RMS_NS}"
         --set-string "apiServer.image.repository=${NICO_RMS_IMAGE_REPO}"
         --set-string "global.image.tag=${NICO_RMS_IMAGE_TAG}"
     )
@@ -1360,14 +1366,14 @@ if "${INSTALL_RMS}"; then
     #      ContainerCreating until the Secret exists.
     echo "Waiting for the RMS API server certificate..."
     kubectl wait --for=condition=Ready certificate/rms-api-server-certificate \
-        -n "${NICO_RMS_NAMESPACE}" --timeout=180s
+        -n "${_RMS_NS}" --timeout=180s
 
     # The RMS binary refuses to start unless ca.crt is present in the TLS
     # Secret (it is the client-CA for mTLS). cert-manager's Vault issuer does
     # not populate ca.crt under every role/chain configuration, so verify it
     # here with a targeted message rather than letting the pod crashloop.
     if [[ -z "$(kubectl get secret rms-api-server-certificate \
-            -n "${NICO_RMS_NAMESPACE}" -o jsonpath='{.data.ca\.crt}' 2>/dev/null)" ]]; then
+            -n "${_RMS_NS}" -o jsonpath='{.data.ca\.crt}' 2>/dev/null)" ]]; then
         echo "Error: the issued Secret rms-api-server-certificate has no ca.crt."
         echo "  → RMS requires ca.crt as the mTLS client CA and will not start without it."
         echo "  → Check the vault-nico-issuer CA chain configuration, or pre-create a"
@@ -1377,12 +1383,12 @@ if "${INSTALL_RMS}"; then
 
     echo "Waiting for rms-api-server rollout..."
     kubectl rollout status deployment/rms-api-server \
-        -n "${NICO_RMS_NAMESPACE}" --timeout=300s
-    echo "RMS ready: rms-api-server.${NICO_RMS_NAMESPACE}.svc.cluster.local:8801"
+        -n "${_RMS_NS}" --timeout=300s
+    echo "RMS ready: rms-api-server.${_RMS_NS}.svc.cluster.local:8801"
 else
     echo ""
     echo "=== [5c] RMS (Rack Manager Service) ==="
-    echo "Skipped (--skip-rms flag set)."
+    echo "Skipped (RMS disabled via --skip-rms / NICO_SKIP_RMS / NICO_INSTALL_RMS=false)."
 fi
 
 # ---------------------------------------------------------------------------

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -102,15 +102,13 @@
 #   NICO_SKIP_RMS          Skip the NVIDIA Rack Manager Service (rack-manager
 #                          chart, phase 5c), which installs by DEFAULT.
 #                          Same as --skip-rms. (NICO_INSTALL_RMS=false honored too.)
-#   NICO_RMS_VERSION       nv-rms git ref (tag, branch, or full commit SHA) to
-#                          clone the rack-manager chart from — same model as
-#                          NICO_DPF_VERSION. Default: a pinned main commit;
-#                          switch to release tags once upstream cuts them.
-#   NICO_RMS_SRC_DIR       Where the nv-rms clone is cached.
-#                          Default: helm-prereqs/.rms-src
 #   NICO_RMS_CHART         Local rack-manager chart path (directory or .tgz),
-#                          e.g. an nv-rms checkout's helm/ dir. When set, no
-#                          clone happens. Default: unset (clone NICO_RMS_VERSION).
+#                          e.g. your own nv-rms checkout's helm/ dir. Default:
+#                          unset - the chart comes from the helm-prereqs/nv-rms
+#                          git submodule, pinned by this repo (initialized
+#                          automatically when git and network are available;
+#                          on airgapped hosts, clone nv-rms yourself and set
+#                          this variable).
 #   NICO_RMS_IMAGE_REPO    RMS API server image repository. Default: the NGC
 #                          rms-dev image, nvcr.io/0837451325059433/rms-dev/rms-api
 #                          (still entitlement-gated; point at your mirror
@@ -341,14 +339,12 @@ NICO_DPF_NICO_NGC_API_KEY="${NICO_DPF_NICO_NGC_API_KEY:-${NICO_DPF_NGC_API_KEY}}
 # to the chart version (NICO_DPF_VERSION) but can differ for a self-built image.
 NICO_DPF_IMAGE_REPO="${NICO_DPF_IMAGE_REPO:-nvcr.io/nvidia/doca/dpf-system}"
 NICO_DPF_IMAGE_TAG="${NICO_DPF_IMAGE_TAG:-${NICO_DPF_VERSION}}"
-# RMS (rack-manager chart, phase 5c). The chart is cloned from the open-source
-# nv-rms repo at a pinned ref, mirroring the DPF doca-platform clone. Upstream
-# has no release tags yet, so the default pin is a main commit SHA; image tags
-# are git-describe style and decoupled from the chart — NICO_RMS_IMAGE_TAG has
-# no default and preflight requires it when RMS install is enabled.
+# RMS (rack-manager chart, phase 5c). The chart ships as the helm-prereqs/nv-rms
+# git submodule, pinned to a reviewed nv-rms commit (bump the pin to move
+# versions). Image tags are git-describe style and decoupled from the chart -
+# NICO_RMS_IMAGE_TAG has no default and preflight requires it when RMS install
+# is enabled.
 NICO_RMS_CHART="${NICO_RMS_CHART:-}"
-NICO_RMS_VERSION="${NICO_RMS_VERSION:-5db9c6b3c3805a8549920111c097358d67b4c2c4}"
-NICO_RMS_SRC_DIR="${NICO_RMS_SRC_DIR:-${SCRIPT_DIR}/.rms-src}"
 NICO_RMS_IMAGE_REPO="${NICO_RMS_IMAGE_REPO:-nvcr.io/0837451325059433/rms-dev/rms-api}"
 NICO_RMS_IMAGE_TAG="${NICO_RMS_IMAGE_TAG:-}"
 NICO_RMS_NGC_API_KEY="${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}"
@@ -1284,40 +1280,29 @@ if "${INSTALL_RMS}"; then
         echo "NICO_RMS_NGC_API_KEY not set — skipping rms-pull-secret (mirror or pre-loaded registry)."
     fi
 
-    # 5c.3 Resolve the chart: local checkout/tarball via NICO_RMS_CHART, or a
-    #      cached shallow clone of the open-source nv-rms repo at the pinned
-    #      ref — the same model as the doca-platform clone in 5b. `git fetch
-    #      <ref>` + FETCH_HEAD handles tags, branches, and full commit SHAs
-    #      uniformly (upstream has no release tags yet, so the default pin is
-    #      a commit).
+    # 5c.3 Resolve the chart: an explicit NICO_RMS_CHART override, or the
+    #      pinned helm-prereqs/nv-rms git submodule. The submodule is the
+    #      supply-chain boundary: the commit is pinned and reviewed in this
+    #      repo, and git verifies the hash on init - setup.sh never clones an
+    #      arbitrary ref. Airgapped hosts clone nv-rms out-of-band and point
+    #      NICO_RMS_CHART at it.
     if [[ -n "${NICO_RMS_CHART}" ]]; then
         _RMS_CHART="${NICO_RMS_CHART}"
         echo "Using local rack-manager chart: ${_RMS_CHART}"
     else
-        if [[ -d "${NICO_RMS_SRC_DIR}/.git" ]]; then
-            echo "Reusing nv-rms clone at ${NICO_RMS_SRC_DIR} (ref ${NICO_RMS_VERSION})..."
-        else
-            # Mirror the DPF clone guard: never auto-delete a path that is
-            # not our own clone, and reject dangerous override values.
-            case "${NICO_RMS_SRC_DIR}" in
-                ""|"/"|"${HOME}"|"${HOME}/")
-                    echo "ERROR: refusing to use NICO_RMS_SRC_DIR='${NICO_RMS_SRC_DIR}' — set it to a dedicated clone dir."
-                    exit 1 ;;
-            esac
-            if [[ -e "${NICO_RMS_SRC_DIR}" ]]; then
-                echo "ERROR: '${NICO_RMS_SRC_DIR}' exists but is not an nv-rms Git clone."
-                echo "  Remove it explicitly and re-run (refusing to auto-delete a non-clone path)."
+        _RMS_SUBMODULE="${SCRIPT_DIR}/nv-rms"
+        if [[ ! -f "${_RMS_SUBMODULE}/helm/Chart.yaml" ]]; then
+            echo "Initializing the nv-rms submodule (pinned by this repo)..."
+            if ! git -C "${SCRIPT_DIR}/.." submodule update --init -- helm-prereqs/nv-rms; then
+                echo "Error: could not initialize the nv-rms submodule."
+                echo "  → On an airgapped host, clone https://github.com/dsx-ai-factory/nv-rms"
+                echo "    at the pinned commit (git -C ${SCRIPT_DIR}/.. submodule status) and"
+                echo "    set NICO_RMS_CHART=<clone>/helm."
                 exit 1
             fi
-            echo "Cloning nv-rms ${NICO_RMS_VERSION}..."
-            git init -q "${NICO_RMS_SRC_DIR}"
-            git -C "${NICO_RMS_SRC_DIR}" remote add origin \
-                https://github.com/dsx-ai-factory/nv-rms.git
         fi
-        git -C "${NICO_RMS_SRC_DIR}" fetch --depth 1 origin "${NICO_RMS_VERSION}"
-        git -C "${NICO_RMS_SRC_DIR}" checkout -q -f FETCH_HEAD
-        _RMS_CHART="${NICO_RMS_SRC_DIR}/helm"
-        echo "rack-manager chart: ${_RMS_CHART}"
+        _RMS_CHART="${_RMS_SUBMODULE}/helm"
+        echo "rack-manager chart: ${_RMS_CHART} ($(git -C "${_RMS_SUBMODULE}" rev-parse --short HEAD 2>/dev/null || echo pinned))"
     fi
 
     # 5c.4 Wait for the ESO-synced DB credentials. The rms database/user are

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -99,6 +99,25 @@
 #                          Same override for the nico-dhcp-server chart.
 #   NICO_DPF_OTEL_CHART_VERSION
 #                          Same override for the nico-otelcol chart.
+#   NICO_INSTALL_RMS       Install the NVIDIA Rack Manager Service (rack-manager
+#                          chart, phase 5c). Default: false — opt in with
+#                          --install-rms once the site has NGC access to the
+#                          rms-dev org. Same as --install-rms.
+#   NICO_RMS_CHART         Local rack-manager chart path (directory or .tgz),
+#                          e.g. an nv-rms checkout's helm/ dir. When set, no
+#                          NGC chart pull happens. Default: unset (pull from NGC).
+#   NICO_RMS_CHART_VERSION rack-manager chart version to pull from NGC. NGC
+#                          publishes with an -OSS suffix. Default: 1.0.1-OSS
+#   NICO_RMS_IMAGE_REPO    RMS API server image repository.
+#                          Default: nvcr.io/0837451325059433/rms-dev/rms-api
+#   NICO_RMS_IMAGE_TAG     RMS API server image tag (git-describe style, e.g.
+#                          v0.8.0). REQUIRED when RMS install is enabled — the
+#                          chart hard-fails at render without a tag.
+#   NICO_RMS_NGC_API_KEY   NGC API key for the chart pull and the rms-pull-secret.
+#                          Default: $REGISTRY_PULL_SECRET
+#   NICO_RMS_NAMESPACE     Namespace for the rack-manager release. Must match
+#                          helm-prereqs/values.yaml::rms.namespace (the ESO
+#                          credential sync targets it). Default: rack-manager
 #
 # Usage:
 #   export KUBECONFIG=/path/to/kubeconfig
@@ -113,6 +132,7 @@
 #   ./setup.sh --skip-flow              # skip Phase 7h NICo Flow (REST still installs)
 #                                       #   pair with helm-prereqs/values.yaml::flow.enabled=false
 #                                       #   to skip Flow prerequisites (database / ESO) too
+#   ./setup.sh --install-rms            # also install the Rack Manager Service (phase 5c)
 #   ./setup.sh --skip-core --skip-rest  # fully non-interactive infra-only run
 #   ./setup.sh --core-values /path/to/values.yaml      # use site-specific values for Phase 6
 #   ./setup.sh --metallb-config /path/to/metallb.yaml  # use site-specific MetalLB config (file or kustomize dir)
@@ -144,6 +164,11 @@ SKIP_FLOW=false
 # use the deprecated iPXE DPU path). NICO_INSTALL_DPF=false is honored too.
 INSTALL_DPF="${NICO_INSTALL_DPF:-true}"
 [[ "${NICO_SKIP_DPF:-false}" == "true" ]] && INSTALL_DPF=false
+# RMS (Rack Manager Service) is OPT-IN for now: the rack-manager chart and
+# rms-api image live in the NGC rms-dev org, which most sites cannot pull from
+# yet, and the image tag has no safe default. Flip the default once the chart
+# is public.
+INSTALL_RMS="${NICO_INSTALL_RMS:-false}"
 WITH_OBSERVABILITY="${WITH_OBSERVABILITY:-false}"
 CORE_VALUES=""
 METALLB_CONFIG=""
@@ -156,6 +181,8 @@ while [[ $# -gt 0 ]]; do
         --skip-flow)    SKIP_FLOW=true ;;
         --install-dpf)  INSTALL_DPF=true ;;   # explicit; DPF is the default
         --skip-dpf)     INSTALL_DPF=false ;;
+        --install-rms)  INSTALL_RMS=true ;;
+        --skip-rms)     INSTALL_RMS=false ;;  # explicit; RMS is opt-in for now
         --with-observability) WITH_OBSERVABILITY=true ;;
         --debug)        set -x         ;;
         --core-values)
@@ -173,7 +200,7 @@ while [[ $# -gt 0 ]]; do
             SITE_OVERLAY="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
             [[ ! -d "${SITE_OVERLAY}" ]] && { echo "Error: --site-overlay directory not found: $2"; exit 1; }
             shift ;;
-        *) echo "Usage: $0 [-y] [--skip-core] [--skip-rest] [--skip-flow] [--skip-dpf] [--with-observability] [--core-values <file>] [--metallb-config <file-or-dir>] [--site-overlay <dir>] [--debug]"; exit 1 ;;
+        *) echo "Usage: $0 [-y] [--skip-core] [--skip-rest] [--skip-flow] [--skip-dpf] [--install-rms] [--with-observability] [--core-values <file>] [--metallb-config <file-or-dir>] [--site-overlay <dir>] [--debug]"; exit 1 ;;
     esac
     shift
 done
@@ -183,7 +210,7 @@ done
 # (in-tree rest-api/) and NICO_REST_HELM_DIR (in-tree helm/rest/). Exits 1 if
 # user declines to continue.
 # ---------------------------------------------------------------------------
-export AUTO_YES SKIP_CORE SKIP_REST SKIP_FLOW INSTALL_DPF
+export AUTO_YES SKIP_CORE SKIP_REST SKIP_FLOW INSTALL_DPF INSTALL_RMS
 # Validate INSTALL_DPF BEFORE sourcing preflight — preflight gates its DPF
 # checks on INSTALL_DPF==true, so a garbage NICO_INSTALL_DPF would otherwise
 # silently skip those checks before erroring here.
@@ -191,6 +218,13 @@ case "${INSTALL_DPF}" in
     true|false) ;;
     *) echo "Error: NICO_INSTALL_DPF must be true or false (got '${INSTALL_DPF}')"; exit 1 ;;
 esac
+case "${INSTALL_RMS}" in
+    true|false) ;;
+    *) echo "Error: NICO_INSTALL_RMS must be true or false (got '${INSTALL_RMS}')"; exit 1 ;;
+esac
+# Re-exported under the NICO_ name for values/nico-prereqs-dynamic.yaml.gotmpl,
+# which gates the rms database / user / ESO sync on it at helmfile sync time.
+export NICO_INSTALL_RMS="${INSTALL_RMS}"
 
 # The predecessor Flow chart bundled PSM and NSM in the Flow Deployment. This
 # release does not provide an automatic migration for those workloads. Stop
@@ -307,6 +341,16 @@ NICO_DPF_NICO_NGC_API_KEY="${NICO_DPF_NICO_NGC_API_KEY:-${NICO_DPF_NGC_API_KEY}}
 # to the chart version (NICO_DPF_VERSION) but can differ for a self-built image.
 NICO_DPF_IMAGE_REPO="${NICO_DPF_IMAGE_REPO:-nvcr.io/nvidia/doca/dpf-system}"
 NICO_DPF_IMAGE_TAG="${NICO_DPF_IMAGE_TAG:-${NICO_DPF_VERSION}}"
+# RMS (rack-manager chart, phase 5c). Chart versions on NGC carry an -OSS
+# suffix and image tags are git-describe style, decoupled from the chart
+# version — NICO_RMS_IMAGE_TAG has no default and preflight requires it when
+# RMS install is enabled.
+NICO_RMS_CHART="${NICO_RMS_CHART:-}"
+NICO_RMS_CHART_VERSION="${NICO_RMS_CHART_VERSION:-1.0.1-OSS}"
+NICO_RMS_IMAGE_REPO="${NICO_RMS_IMAGE_REPO:-nvcr.io/0837451325059433/rms-dev/rms-api}"
+NICO_RMS_IMAGE_TAG="${NICO_RMS_IMAGE_TAG:-}"
+NICO_RMS_NGC_API_KEY="${NICO_RMS_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}"
+NICO_RMS_NAMESPACE="${NICO_RMS_NAMESPACE:-rack-manager}"
 # Site-wide BMC root password. Optional: when provided, setup.sh calls
 # nico-admin-cli (phase 6b) to store the credential via the API so DPU
 # provisioning starts immediately. When omitted, carbide-api starts cleanly
@@ -1195,6 +1239,140 @@ if ! "${SKIP_CORE}"; then
     else
         echo "REGISTRY_PULL_SECRET not set — skipping imagepullsecret creation (air-gapped or pre-loaded registry)."
     fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5c. RMS (NVIDIA Rack Manager Service) — optional rack-management backend.
+#     nico-api's chart defaults already dial rms-api-server.rack-manager.svc
+#     :8801 with component-manager backends set to rms; this phase provides
+#     that server. Needs nico-pg-cluster + ESO (5: the rms database, user, and
+#     rms-db-eso sync are created by nico-prereqs when NICO_INSTALL_RMS=true)
+#     and the vault-nico-issuer ClusterIssuer (5) for the mTLS certificate.
+#     Runs before Core (6) only so rack operations work as soon as Core is up;
+#     Core's RMS client is lazy and tolerates RMS arriving later.
+# ---------------------------------------------------------------------------
+if "${INSTALL_RMS}"; then
+    _SETUP_PHASE="[5c] Rack Manager Service"
+    echo ""
+    echo "=== [5c] RMS (Rack Manager Service) ==="
+
+    # 5c.1 Namespace. Created here (not by the chart) so the pull secret and
+    #      the ESO credential sync have somewhere to land before helm runs.
+    #      The rms-db-eso ClusterExternalSecret selects it by metadata.name.
+    kubectl create namespace "${NICO_RMS_NAMESPACE}" --dry-run=client -o yaml \
+        | kubectl apply -f -
+
+    # 5c.2 Image pull secret. Same off-argv construction as the DPF secrets:
+    #      the NGC key must never appear in an exec argument.
+    if [[ -n "${NICO_RMS_NGC_API_KEY}" ]]; then
+        echo "Creating rms-pull-secret in ${NICO_RMS_NAMESPACE}..."
+        _rms_auth="$(printf '%s' "\$oauthtoken:${NICO_RMS_NGC_API_KEY}" | base64 | tr -d '\n')"
+        kubectl create secret generic rms-pull-secret \
+            --namespace "${NICO_RMS_NAMESPACE}" \
+            --type=kubernetes.io/dockerconfigjson \
+            --from-file=.dockerconfigjson=<(printf \
+                '{"auths":{"%s":{"username":"$oauthtoken","password":"%s","auth":"%s"}}}' \
+                "nvcr.io" "${NICO_RMS_NGC_API_KEY}" "${_rms_auth}") \
+            --dry-run=client -o yaml | kubectl apply -f -
+        unset _rms_auth
+    else
+        echo "NICO_RMS_NGC_API_KEY not set — skipping rms-pull-secret (mirror or pre-loaded registry)."
+    fi
+
+    # 5c.3 Resolve the chart: local checkout/tarball via NICO_RMS_CHART, or
+    #      pull the pinned version from NGC into a cache dir. The pull is
+    #      skipped when the exact tarball is already cached.
+    if [[ -n "${NICO_RMS_CHART}" ]]; then
+        _RMS_CHART="${NICO_RMS_CHART}"
+        echo "Using local rack-manager chart: ${_RMS_CHART}"
+    else
+        _RMS_CHART_CACHE="${SCRIPT_DIR}/.rms-chart"
+        _RMS_CHART="${_RMS_CHART_CACHE}/rack-manager-${NICO_RMS_CHART_VERSION}.tgz"
+        if [[ ! -f "${_RMS_CHART}" ]]; then
+            [[ -z "${NICO_RMS_NGC_API_KEY}" ]] && {
+                echo "Error: pulling the rack-manager chart from NGC needs NICO_RMS_NGC_API_KEY"
+                echo "       (or set NICO_RMS_CHART to a local chart path)."
+                exit 1
+            }
+            echo "Pulling rack-manager ${NICO_RMS_CHART_VERSION} from NGC..."
+            mkdir -p "${_RMS_CHART_CACHE}"
+            helm pull \
+                "https://helm.ngc.nvidia.com/0837451325059433/rms-dev/charts/rack-manager-${NICO_RMS_CHART_VERSION}.tgz" \
+                --username='$oauthtoken' --password "${NICO_RMS_NGC_API_KEY}" \
+                --destination "${_RMS_CHART_CACHE}"
+        fi
+        echo "rack-manager chart: ${_RMS_CHART}"
+    fi
+
+    # 5c.4 Wait for the ESO-synced DB credentials. The rms database/user are
+    #      declared on nico-pg-cluster by nico-prereqs (phase 5); the Zalando
+    #      operator mints the credentials Secret and rms-db-eso projects it here.
+    echo "Waiting for RMS DB credentials..."
+    _rms_creds_ok=false
+    for _rms_i in $(seq 1 36); do
+        if kubectl get secret rms.nico.nico-pg-cluster.credentials \
+            -n "${NICO_RMS_NAMESPACE}" &>/dev/null; then
+            _rms_creds_ok=true
+            break
+        fi
+        echo "  credentials not yet synced (${_rms_i}/36) — retrying in 5s..."
+        sleep 5
+    done
+    if [[ "${_rms_creds_ok}" == "false" ]]; then
+        echo "Error: rms.nico.nico-pg-cluster.credentials never appeared in ${NICO_RMS_NAMESPACE}."
+        echo "  → Check 'kubectl describe clusterexternalsecret rms-db-eso' and that the"
+        echo "    Zalando operator created the rms user (kubectl get secret -n postgres | grep rms)."
+        echo "  → Confirm nico-prereqs synced with NICO_INSTALL_RMS=true (phase 5 of this run)."
+        exit 1
+    fi
+    echo "RMS DB credentials ready"
+
+    # 5c.5 Install. No --wait: the pod cannot start until cert-manager writes
+    #      the TLS Secret, so waiting is done explicitly below where each
+    #      failure mode gets its own message instead of a generic helm timeout.
+    NICO_RMS_CMD=(
+        helm upgrade --install rack "${_RMS_CHART}"
+        --namespace "${NICO_RMS_NAMESPACE}"
+        -f "${SCRIPT_DIR}/values/rms.yaml"
+        # The chart renders into .Values.namespace, not the -n flag; set both.
+        --set "namespace=${NICO_RMS_NAMESPACE}"
+        --set-string "apiServer.image.repository=${NICO_RMS_IMAGE_REPO}"
+        --set-string "global.image.tag=${NICO_RMS_IMAGE_TAG}"
+    )
+    [[ -n "${NICO_RMS_NGC_API_KEY}" ]] && \
+        NICO_RMS_CMD+=(--set "global.imagePullSecrets[0].name=rms-pull-secret")
+    "${WITH_OBSERVABILITY}" && \
+        NICO_RMS_CMD+=(--set "apiServer.serviceMonitor.enabled=true")
+    echo "Installing rack-manager helm chart..."
+    "${NICO_RMS_CMD[@]}"
+
+    # 5c.6 Certificate first: issuance is async, and the deployment sits in
+    #      ContainerCreating until the Secret exists.
+    echo "Waiting for the RMS API server certificate..."
+    kubectl wait --for=condition=Ready certificate/rms-api-server-certificate \
+        -n "${NICO_RMS_NAMESPACE}" --timeout=180s
+
+    # The RMS binary refuses to start unless ca.crt is present in the TLS
+    # Secret (it is the client-CA for mTLS). cert-manager's Vault issuer does
+    # not populate ca.crt under every role/chain configuration, so verify it
+    # here with a targeted message rather than letting the pod crashloop.
+    if [[ -z "$(kubectl get secret rms-api-server-certificate \
+            -n "${NICO_RMS_NAMESPACE}" -o jsonpath='{.data.ca\.crt}' 2>/dev/null)" ]]; then
+        echo "Error: the issued Secret rms-api-server-certificate has no ca.crt."
+        echo "  → RMS requires ca.crt as the mTLS client CA and will not start without it."
+        echo "  → Check the vault-nico-issuer CA chain configuration, or pre-create a"
+        echo "    Secret with tls.crt/tls.key/ca.crt and set apiServer.tls.existingSecret."
+        exit 1
+    fi
+
+    echo "Waiting for rms-api-server rollout..."
+    kubectl rollout status deployment/rms-api-server \
+        -n "${NICO_RMS_NAMESPACE}" --timeout=300s
+    echo "RMS ready: rms-api-server.${NICO_RMS_NAMESPACE}.svc.cluster.local:8801"
+else
+    echo ""
+    echo "=== [5c] RMS (Rack Manager Service) ==="
+    echo "Skipped (opt in with --install-rms once the site has NGC rms-dev access)."
 fi
 
 # ---------------------------------------------------------------------------

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -1266,18 +1266,24 @@ if "${INSTALL_RMS}"; then
     # 5c.2 Image pull secret. Same off-argv construction as the DPF secrets:
     #      the NGC key must never appear in an exec argument.
     if [[ -n "${NICO_RMS_NGC_API_KEY}" ]]; then
-        echo "Creating rms-pull-secret in ${_RMS_NS}..."
-        _rms_auth="$(printf '%s' "\$oauthtoken:${NICO_RMS_NGC_API_KEY}" | base64 | tr -d '\n')"
+        # Scope the credential to the registry the image actually pulls from
+        # (a mirror override included), and honor REGISTRY_PULL_USERNAME -
+        # kubelet matches pull secrets by registry host, so an nvcr.io-only
+        # entry is useless for a mirror.
+        _rms_registry="${NICO_RMS_IMAGE_REPO%%/*}"
+        _rms_pull_user="${REGISTRY_PULL_USERNAME:-\$oauthtoken}"
+        echo "Creating rms-pull-secret in ${_RMS_NS} (registry: ${_rms_registry})..."
+        _rms_auth="$(printf '%s' "${_rms_pull_user}:${NICO_RMS_NGC_API_KEY}" | base64 | tr -d '\n')"
         kubectl create secret generic rms-pull-secret \
             --namespace "${_RMS_NS}" \
             --type=kubernetes.io/dockerconfigjson \
             --from-file=.dockerconfigjson=<(printf \
-                '{"auths":{"%s":{"username":"$oauthtoken","password":"%s","auth":"%s"}}}' \
-                "nvcr.io" "${NICO_RMS_NGC_API_KEY}" "${_rms_auth}") \
+                '{"auths":{"%s":{"username":"%s","password":"%s","auth":"%s"}}}' \
+                "${_rms_registry}" "${_rms_pull_user}" "${NICO_RMS_NGC_API_KEY}" "${_rms_auth}") \
             --dry-run=client -o yaml | kubectl apply -f -
         unset _rms_auth
     else
-        echo "NICO_RMS_NGC_API_KEY not set — skipping rms-pull-secret (mirror or pre-loaded registry)."
+        echo "NICO_RMS_NGC_API_KEY not set - skipping rms-pull-secret (mirror or pre-loaded registry)."
     fi
 
     # 5c.3 Resolve the chart: an explicit NICO_RMS_CHART override, or the
@@ -1291,15 +1297,22 @@ if "${INSTALL_RMS}"; then
         echo "Using local rack-manager chart: ${_RMS_CHART}"
     else
         _RMS_SUBMODULE="${SCRIPT_DIR}/nv-rms"
-        if [[ ! -f "${_RMS_SUBMODULE}/helm/Chart.yaml" ]]; then
-            echo "Initializing the nv-rms submodule (pinned by this repo)..."
-            if ! git -C "${SCRIPT_DIR}/.." submodule update --init -- helm-prereqs/nv-rms; then
-                echo "Error: could not initialize the nv-rms submodule."
-                echo "  → On an airgapped host, clone https://github.com/dsx-ai-factory/nv-rms"
-                echo "    at the pinned commit (git -C ${SCRIPT_DIR}/.. submodule status) and"
-                echo "    set NICO_RMS_CHART=<clone>/helm."
-                exit 1
-            fi
+        # The pin is only a boundary if the working tree honors it: refuse a
+        # dirty submodule, then align HEAD to the gitlink this repo records.
+        if [[ -d "${_RMS_SUBMODULE}/.git" || -f "${_RMS_SUBMODULE}/.git" ]] && \
+           [[ -n "$(git -C "${_RMS_SUBMODULE}" status --porcelain 2>/dev/null)" ]]; then
+            echo "Error: helm-prereqs/nv-rms has local modifications."
+            echo "  → Commit/stash them upstream, restore the submodule, or point"
+            echo "    NICO_RMS_CHART at your modified chart explicitly."
+            exit 1
+        fi
+        echo "Syncing the nv-rms submodule to the pinned commit..."
+        if ! git -C "${SCRIPT_DIR}/.." submodule update --init --checkout -- helm-prereqs/nv-rms; then
+            echo "Error: could not sync the nv-rms submodule to the pinned commit."
+            echo "  → On an airgapped host, clone https://github.com/dsx-ai-factory/nv-rms"
+            echo "    at the pinned commit (git -C ${SCRIPT_DIR}/.. submodule status) and"
+            echo "    set NICO_RMS_CHART=<clone>/helm."
+            exit 1
         fi
         _RMS_CHART="${_RMS_SUBMODULE}/helm"
         echo "rack-manager chart: ${_RMS_CHART} ($(git -C "${_RMS_SUBMODULE}" rev-parse --short HEAD 2>/dev/null || echo pinned))"

--- a/helm-prereqs/templates/eso-external-secrets.yaml
+++ b/helm-prereqs/templates/eso-external-secrets.yaml
@@ -137,4 +137,36 @@ spec:
           key: flow.nico.nico-pg-cluster.credentials.postgresql.acid.zalan.do
           version: v1
 {{- end }}
+
+{{/*
+  RMS DB credential sync.
+  Projects the Zalando-generated rms.nico credentials into the rack-manager
+  namespace under the name the rack-manager chart's database.credentialsSecret
+  points at. The namespace is created and labeled by setup.sh phase 5c.
+*/}}
+{{- if and .Values.postgresql.enabled .Values.rms.enabled }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterExternalSecret
+metadata:
+  name: rms-db-eso
+spec:
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values: ["{{ .Values.rms.namespace }}"]
+  refreshTime: 30s
+  externalSecretSpec:
+    secretStoreRef:
+      name: postgres-ns-secretstore
+      kind: ClusterSecretStore
+    target:
+      name: rms.nico.nico-pg-cluster.credentials
+      deletionPolicy: Retain
+    dataFrom:
+      - extract:
+          key: rms.nico.nico-pg-cluster.credentials.postgresql.acid.zalan.do
+          version: v1
+{{- end }}
 {{- end }}

--- a/helm-prereqs/templates/eso-external-secrets.yaml
+++ b/helm-prereqs/templates/eso-external-secrets.yaml
@@ -155,7 +155,9 @@ spec:
     matchExpressions:
       - key: kubernetes.io/metadata.name
         operator: In
-        values: ["{{ .Values.rms.namespace }}"]
+        # Fixed, not a value: NICo Core dials rms-api-server.rack-manager by
+        # name and setup.sh phase 5c installs there - one source of truth.
+        values: ["rack-manager"]
   refreshTime: 30s
   externalSecretSpec:
     secretStoreRef:

--- a/helm-prereqs/templates/postgresql.yaml
+++ b/helm-prereqs/templates/postgresql.yaml
@@ -55,6 +55,11 @@ spec:
       - superuser
       - createdb
     {{- end }}
+    {{- if .Values.rms.enabled }}
+    rms.nico:
+      - superuser
+      - createdb
+    {{- end }}
   databases:
     nico_system_nico: nico-system.nico
     {{- if .Values.rest.enabled }}
@@ -62,6 +67,9 @@ spec:
     {{- end }}
     {{- if .Values.flow.enabled }}
     flow: flow.nico
+    {{- end }}
+    {{- if .Values.rms.enabled }}
+    rms: rms.nico
     {{- end }}
   patroni:
     # Templated (no `| default`): Go templates treat an explicit `false` as empty,

--- a/helm-prereqs/templates/postgresql.yaml
+++ b/helm-prereqs/templates/postgresql.yaml
@@ -56,9 +56,9 @@ spec:
       - createdb
     {{- end }}
     {{- if .Values.rms.enabled }}
-    rms.nico:
-      - superuser
-      - createdb
+    # No role flags: rms.nico owns only the rms database (databases: below);
+    # the RMS migrations create tables/indexes there and need nothing wider.
+    rms.nico: []
     {{- end }}
   databases:
     nico_system_nico: nico-system.nico

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -174,6 +174,26 @@ rest:
 ## pass --skip-flow on the setup.sh command line, otherwise phase 7h will
 ## try to install a chart whose database credentials are missing and fail.
 ## ---------------------------------------------------------------------------
+## ---------------------------------------------------------------------------
+## rms — NVIDIA Rack Manager Service (rack-manager chart) prerequisites.
+##
+## This toggle controls only the helm-prereqs side of RMS:
+##   - the rms database and rms.nico user on nico-pg-cluster (postgresql.yaml)
+##   - the rms-db-eso ClusterExternalSecret that syncs the credentials into
+##     the rack-manager namespace (eso-external-secrets.yaml)
+##
+## The rack-manager chart itself is installed by setup.sh phase 5c, gated on
+## --install-rms / NICO_INSTALL_RMS=true. setup.sh exports that flag, and
+## values/nico-prereqs-dynamic.yaml.gotmpl overrides this value from it, so
+## the two stay in lockstep on script-driven installs. This static default
+## only matters for direct `helmfile sync` runs.
+## ---------------------------------------------------------------------------
+rms:
+  enabled: false
+  ## Namespace the rack-manager release runs in — must match setup.sh's
+  ## NICO_RMS_NAMESPACE. ESO projects the DB credentials into it.
+  namespace: rack-manager
+
 flow:
   enabled: true
   ## Namespace flow runs in — must match the helm install -n flag for the

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -191,9 +191,6 @@ rest:
 ## ---------------------------------------------------------------------------
 rms:
   enabled: true
-  ## Namespace the rack-manager release runs in — must match setup.sh's
-  ## NICO_RMS_NAMESPACE. ESO projects the DB credentials into it.
-  namespace: rack-manager
 
 flow:
   enabled: true

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -182,14 +182,14 @@ rest:
 ##   - the rms-db-eso ClusterExternalSecret that syncs the credentials into
 ##     the rack-manager namespace (eso-external-secrets.yaml)
 ##
-## The rack-manager chart itself is installed by setup.sh phase 5c, gated on
-## --install-rms / NICO_INSTALL_RMS=true. setup.sh exports that flag, and
+## The rack-manager chart itself is installed by setup.sh phase 5c, by
+## DEFAULT (opt out with --skip-rms). setup.sh exports the flag, and
 ## values/nico-prereqs-dynamic.yaml.gotmpl overrides this value from it, so
 ## the two stay in lockstep on script-driven installs. This static default
 ## only matters for direct `helmfile sync` runs.
 ## ---------------------------------------------------------------------------
 rms:
-  enabled: false
+  enabled: true
   ## Namespace the rack-manager release runs in — must match setup.sh's
   ## NICO_RMS_NAMESPACE. ESO projects the DB credentials into it.
   namespace: rack-manager

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -183,10 +183,11 @@ rest:
 ##     the rack-manager namespace (eso-external-secrets.yaml)
 ##
 ## The rack-manager chart itself is installed by setup.sh phase 5c, by
-## DEFAULT (opt out with --skip-rms). setup.sh exports the flag, and
-## values/nico-prereqs-dynamic.yaml.gotmpl overrides this value from it, so
-## the two stay in lockstep on script-driven installs. This static default
-## only matters for direct `helmfile sync` runs.
+## DEFAULT (opt out with --skip-rms). Deliberately NOT driven by that flag:
+## --skip-rms skips only the chart install and never deprovisions these
+## prerequisites — removing them would strand a running rack-manager release
+## (same contract as --skip-flow). To skip the prerequisites too, set
+## enabled: false here, paired with --skip-rms.
 ## ---------------------------------------------------------------------------
 rms:
   enabled: true

--- a/helm-prereqs/values/nico-prereqs-dynamic.yaml.gotmpl
+++ b/helm-prereqs/values/nico-prereqs-dynamic.yaml.gotmpl
@@ -11,7 +11,7 @@ vault:
 imagePullSecrets:
   ngcNicoPull: "{{ env "REGISTRY_PULL_SECRET" }}"
 rms:
-  # Follows setup.sh's --install-rms / NICO_INSTALL_RMS flag so the rms
+  # Follows setup.sh's --skip-rms / NICO_INSTALL_RMS flag so the rms
   # database, user, and ESO sync exist exactly when phase 5c will install
-  # the rack-manager chart.
-  enabled: {{ env "NICO_INSTALL_RMS" | default "false" }}
+  # the rack-manager chart (default on, like the phase itself).
+  enabled: {{ env "NICO_INSTALL_RMS" | default "true" }}

--- a/helm-prereqs/values/nico-prereqs-dynamic.yaml.gotmpl
+++ b/helm-prereqs/values/nico-prereqs-dynamic.yaml.gotmpl
@@ -10,3 +10,8 @@ vault:
   token: "{{ exec "sh" (list "-c" "kubectl get secret vaultroottoken -n vault -o jsonpath={.data.token} | base64 -d") }}"
 imagePullSecrets:
   ngcNicoPull: "{{ env "REGISTRY_PULL_SECRET" }}"
+rms:
+  # Follows setup.sh's --install-rms / NICO_INSTALL_RMS flag so the rms
+  # database, user, and ESO sync exist exactly when phase 5c will install
+  # the rack-manager chart.
+  enabled: {{ env "NICO_INSTALL_RMS" | default "false" }}

--- a/helm-prereqs/values/nico-prereqs-dynamic.yaml.gotmpl
+++ b/helm-prereqs/values/nico-prereqs-dynamic.yaml.gotmpl
@@ -10,8 +10,3 @@ vault:
   token: "{{ exec "sh" (list "-c" "kubectl get secret vaultroottoken -n vault -o jsonpath={.data.token} | base64 -d") }}"
 imagePullSecrets:
   ngcNicoPull: "{{ env "REGISTRY_PULL_SECRET" }}"
-rms:
-  # Follows setup.sh's --skip-rms / NICO_INSTALL_RMS flag so the rms
-  # database, user, and ESO sync exist exactly when phase 5c will install
-  # the rack-manager chart (default on, like the phase itself).
-  enabled: {{ env "NICO_INSTALL_RMS" | default "true" }}

--- a/helm-prereqs/values/rms.yaml
+++ b/helm-prereqs/values/rms.yaml
@@ -1,0 +1,57 @@
+# =============================================================================
+# NICo site values for the NVIDIA Rack Manager Service (rack-manager) chart.
+# Applied by setup.sh phase 5c on top of the chart defaults. Image repository,
+# tag, and pull secret are passed on the command line from NICO_RMS_* env vars.
+#
+# Upstream chart defaults that are wrong for a NICo site are overridden here:
+#   - ServiceMonitor and Grafana dashboard default ON upstream and fail the
+#     install without prometheus-operator CRDs / a Grafana sidecar. setup.sh
+#     re-enables the ServiceMonitor when --with-observability is set.
+#   - dropDatabaseOnUninstall defaults ON upstream: a pre-delete hook that
+#     drops the RMS database and pulls postgres:15-alpine from Docker Hub.
+#   - The chart's TLS material is read once at startup and never reloaded, so
+#     the certificate lifetime is raised from the upstream 30 days to 1 year.
+#     Renewal still requires a rollout restart of rms-api-server.
+# =============================================================================
+
+# Must match values.yaml::rms.namespace in helm-prereqs. The chart renders
+# into .Values.namespace (NOT the helm -n flag), so setup.sh sets both.
+namespace: rack-manager
+createNamespace: false   # setup.sh creates and labels it for the ESO sync
+
+# mTLS via cert-manager, issued from the same CA that signs nico-api's SPIFFE
+# cert. RMS validates client certificates against this Secret's ca.crt, which
+# is what admits nico-api with zero extra configuration.
+certificates:
+  enabled: true
+  issuerRef:
+    name: vault-nico-issuer
+    kind: ClusterIssuer
+  duration: 8760h0m0s     # 1 year — RMS does not reload TLS material on renewal
+  renewBefore: 720h0m0s   # 30 days: leaves a wide window to restart the pod
+
+apiServer:
+  tls:
+    enabled: true
+    caEnabled: true
+  serviceMonitor:
+    enabled: false   # requires prometheus-operator CRDs; setup.sh flips this on with --with-observability
+
+# The RMS database lives on the shared nico-pg-cluster; the rms database and
+# rms.nico user are created by nico-prereqs (postgresql.yaml, rms.enabled) and
+# the credentials Secret is projected into this namespace by rms-db-eso.
+databaseMode: external
+database:
+  host: nico-pg-cluster.postgres.svc.cluster.local
+  port: "5432"
+  name: rms
+  credentialsSecret: rms.nico.nico-pg-cluster.credentials
+
+# Never drop the RMS database on `helm uninstall`: the pre-delete hook would
+# destroy state on any release re-create, and its hardcoded postgres:15-alpine
+# image is unreachable from mirror-only sites.
+dropDatabaseOnUninstall: false
+
+grafana:
+  dashboard:
+    enabled: false

--- a/helm-prereqs/values/rms.yaml
+++ b/helm-prereqs/values/rms.yaml
@@ -14,8 +14,9 @@
 #     Renewal still requires a rollout restart of rms-api-server.
 # =============================================================================
 
-# Must match values.yaml::rms.namespace in helm-prereqs. The chart renders
-# into .Values.namespace (NOT the helm -n flag), so setup.sh sets both.
+# Fixed: NICo Core dials rms-api-server.rack-manager by name, and the
+# helm-prereqs ESO sync targets the same namespace. The chart renders into
+# .Values.namespace (NOT the helm -n flag), so setup.sh sets both.
 namespace: rack-manager
 createNamespace: false   # setup.sh creates and labels it for the ESO sync
 


### PR DESCRIPTION
Adds RMS (Rack Management Service) provisioning to setup.sh as phase 5c, installed by default like DPF and skippable with `--skip-rms` / `NICO_SKIP_RMS=true`.

- The rack-manager chart ships as the `helm-prereqs/nv-rms` git submodule, pinned to a reviewed commit (per review: no install-time clone of an external repo). `NICO_RMS_CHART` overrides it for airgapped or self-managed checkouts.
- nico-prereqs creates the `rms` database and user (no role flags - it owns only its database) and the `rms-db-eso` credential sync, gated on `values.yaml::rms.enabled` (static, so `--skip-rms` never deprovisions under a running release).
- mTLS is issued from `vault-nico-issuer`; the phase fails fast with a targeted message if the issued Secret lacks `ca.crt` (RMS refuses to start without a client CA).
- The namespace is fixed to `rack-manager` - NICo Core's chart defaults dial the service by that name.
- Preflight requires `NICO_RMS_IMAGE_TAG` plus a pull key (or a mirror image repo) exactly when the phase will run; standalone `preflight.sh` parses the RMS flags. health-check and clean.sh cover the new namespace.

Sites without rack management must pass `--skip-rms` - the same contract DPF set with its required env vars.

## Related issues

Part of #5376 (PR 1 of 2; docs are #5588).

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [x] **This PR contains breaking changes**

`setup.sh` runs on sites without rack management now fail preflight until they pass `--skip-rms` (or export `NICO_RMS_IMAGE_TAG`), mirroring DPF's default-on contract.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated end to end on dev6: fresh-cluster install on the default path (post-#5325 rebase), idempotent re-runs, consumption proven via `nico-admin-cli rms inventory` from the nico-api pod over mTLS (RMS logs `peer_identity=CN=nico-api...`, gRPC status 0), a `--skip-rms` run that left the release untouched (revision unchanged, `rms-db-eso` intact), and preflight under all four flag/env scenarios.
