### PR TITLE
feat(build): use mold linker on arm64 Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,9 +37,9 @@ rustflags = [
 #[target.x86_64-unknown-linux-gnu]
 #rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
 
-# mold is significantly faster and more memory-efficient than ld on aarch64
+# mold is significantly faster and more memory-efficient than ld on aarch64.
+# The build environment selects a native or cross compiler driver.
 [target.aarch64-unknown-linux-gnu]
-linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 [env]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,6 +37,11 @@ rustflags = [
 #[target.x86_64-unknown-linux-gnu]
 #rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
 
+# mold is significantly faster and more memory-efficient than ld on aarch64
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
 [env]
 RUST_TEST_THREADS = "40"
 

--- a/.envrc
+++ b/.envrc
@@ -4,6 +4,14 @@ export TESTDB_HOST=localhost
 
 export RUSTC_WRAPPER=sccache
 
+# Native ARM64 builds use Clang. Cross-build environments provide their own
+# target-aware compiler driver through the same Cargo environment variable.
+case "$(uname -s):$(uname -m)" in
+    Linux:aarch64|Linux:arm64)
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=clang
+        ;;
+esac
+
 # required for sqlx::test harnesses.
 export DATABASE_URL=postgresql://${TESTDB_USER}:${TESTDB_PASSWORD}@${TESTDB_HOST}
 export REPO_ROOT=$(git rev-parse --show-toplevel)

--- a/dev/docker/Dockerfile.build-artifacts-container-aarch64
+++ b/dev/docker/Dockerfile.build-artifacts-container-aarch64
@@ -16,6 +16,11 @@
 #
 FROM arm64v8/rust:1.97.1-slim-bullseye
 
+# Bullseye does not package mold. Keep this image on Bullseye for artifact
+# compatibility and install the pinned upstream ARM64 binary instead.
+ARG MOLD_VERSION=2.30.0
+ARG MOLD_SHA256=258aaf2b7808ea22fca625480efdf7a13830e9ee311716db0ba9c62af1770c07
+
 # Set in gitlab-templates/scripts/build-push-container-image.sh
 ARG CI_COMMIT_SHORT_SHA
 ENV CI_COMMIT_SHORT_SHA $CI_COMMIT_SHORT_SHA
@@ -59,6 +64,17 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update && \
 		wget \
 		git \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL --retry 5 \
+		-o /tmp/mold.tar.gz \
+		"https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-aarch64-linux.tar.gz" && \
+	echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum --check - && \
+	tar -C /usr/local --strip-components=1 -xzf /tmp/mold.tar.gz && \
+	rm /tmp/mold.tar.gz && \
+	mold --version
+
+# Use mold for builds that do not load the repository's Cargo configuration.
+RUN update-alternatives --install /usr/bin/ld ld /usr/local/bin/ld.mold 60
 
 RUN rustup component add rustfmt
 RUN cargo install cargo-cache cargo-make sccache && \

--- a/dev/docker/Dockerfile.build-artifacts-container-aarch64
+++ b/dev/docker/Dockerfile.build-artifacts-container-aarch64
@@ -73,8 +73,12 @@ RUN curl -fsSL --retry 5 \
 	rm /tmp/mold.tar.gz && \
 	mold --version
 
-# Use mold for builds that do not load the repository's Cargo configuration.
-RUN update-alternatives --install /usr/bin/ld ld /usr/local/bin/ld.mold 60
+# Keep the system linker for non-Rust builds such as iPXE, whose linker script
+# is not accepted by mold. Cargo uses this wrapper even outside the repository.
+RUN printf '#!/bin/sh\nexec clang -fuse-ld=mold "$@"\n' \
+		>/usr/local/bin/clang-mold && \
+	chmod 0755 /usr/local/bin/clang-mold
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/local/bin/clang-mold
 
 RUN rustup component add rustfmt
 RUN cargo install cargo-cache cargo-make sccache && \

--- a/dev/docker/Dockerfile.build-artifacts-container-cross-aarch64
+++ b/dev/docker/Dockerfile.build-artifacts-container-cross-aarch64
@@ -21,7 +21,7 @@ FROM rust:1.97.1-bookworm
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get -o Dpkg::Options::="--force-overwrite" install --assume-yes unzip libudev-dev:arm64 libssl-dev:arm64 libtss2-dev:arm64 g++-aarch64-linux-gnu libc6-dev-arm64-cross libclang-dev cmake
+    apt-get -o Dpkg::Options::="--force-overwrite" install --assume-yes unzip libudev-dev:arm64 libssl-dev:arm64 libtss2-dev:arm64 g++-aarch64-linux-gnu libc6-dev-arm64-cross libclang-dev cmake mold
 
 # protoc must match the image userspace (FROM rust:… resolves to host arch by default),
 # not the Rust target (aarch64); see prost-build protoc invocation.
@@ -40,5 +40,16 @@ ENV PATH="/protobuf/bin:${PATH}"
 
 RUN rustup target add aarch64-unknown-linux-gnu
 
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ PKG_CONFIG_PATH=/lib/aarch64-linux-gnu/pkgconfig PKG_CONFIG_SYSROOT_DIR=/lib/aarch64-linux-gnu
+# Keep the cross-GCC driver so it supplies the ARM64 sysroot, but make mold an
+# invariant of that driver rather than relying on a mounted checkout's Cargo
+# configuration.
+RUN printf '#!/bin/sh\nexec aarch64-linux-gnu-gcc -fuse-ld=mold "$@"\n' \
+      >/usr/local/bin/aarch64-linux-gnu-gcc-mold && \
+    chmod 0755 /usr/local/bin/aarch64-linux-gnu-gcc-mold && \
+    printf 'int main(void) { return 0; }\n' | \
+      aarch64-linux-gnu-gcc-mold -x c - -o /tmp/mold-smoke && \
+    readelf -p .comment /tmp/mold-smoke | grep -q mold && \
+    rm /tmp/mold-smoke
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc-mold CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ PKG_CONFIG_PATH=/lib/aarch64-linux-gnu/pkgconfig PKG_CONFIG_SYSROOT_DIR=/lib/aarch64-linux-gnu
 WORKDIR ./carbide

--- a/dev/docker/Dockerfile.build-container-aarch64
+++ b/dev/docker/Dockerfile.build-container-aarch64
@@ -54,6 +54,7 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update &&  \
 		libssl-dev \
 		libtss2-dev \
 		libudev-dev \
+		mold \
 		pandoc \
 		pkg-config \
 		tpm2-tools \
@@ -66,8 +67,8 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update &&  \
 		git \
 	&& rm -rf /var/lib/apt/lists/*
 
-# make LLVM's linker lld the default, because ld crashes using too much memory
-RUN update-alternatives --install /usr/bin/ld ld /usr/bin/lld 50
+# Use mold for builds that do not load the repository's Cargo configuration.
+RUN update-alternatives --install /usr/bin/ld ld /usr/bin/ld.mold 60
 
 RUN rustup component add rustfmt
 RUN cargo install cargo-cache cargo-make sccache --locked && \

--- a/dev/docker/Dockerfile.build-container-aarch64
+++ b/dev/docker/Dockerfile.build-container-aarch64
@@ -67,8 +67,12 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update &&  \
 		git \
 	&& rm -rf /var/lib/apt/lists/*
 
-# Use mold for builds that do not load the repository's Cargo configuration.
-RUN update-alternatives --install /usr/bin/ld ld /usr/bin/ld.mold 60
+# Keep the system linker for non-Rust builds such as iPXE, whose linker script
+# is not accepted by mold. Cargo uses this wrapper even outside the repository.
+RUN printf '#!/bin/sh\nexec clang -fuse-ld=mold "$@"\n' \
+		>/usr/local/bin/clang-mold && \
+	chmod 0755 /usr/local/bin/clang-mold
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/local/bin/clang-mold
 
 RUN rustup component add rustfmt
 RUN cargo install cargo-cache cargo-make sccache --locked && \

--- a/dev/docker/Dockerfile.cargo-docker-minimal
+++ b/dev/docker/Dockerfile.cargo-docker-minimal
@@ -17,14 +17,24 @@ RUN apt-get update && \
 	protobuf-compiler \
 	libpq-dev \
 	libssl-dev \
+	clang \
 	pkg-config \
 	lld \
+	mold \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN printf '#!/bin/sh\nexec clang -fuse-ld=lld "$@"\n' \
+		>/usr/local/bin/clang-lld && \
+	printf '#!/bin/sh\nexec clang -fuse-ld=mold "$@"\n' \
+		>/usr/local/bin/clang-mold && \
+	chmod 0755 /usr/local/bin/clang-lld /usr/local/bin/clang-mold
 
 # sccache: reuse compiled artifacts across runs (mount SCCACHE_DIR from host in run)
 RUN cargo install sccache --locked && rm -rf /usr/local/cargo/registry/src
 ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_DIR=/sccache
-# Use lld for linking (uses less RAM than default ld; avoids OOM when linking carbide-api tests).
+# Use lld on x86_64 and mold on aarch64 to avoid memory-heavy GNU ld links.
 # Enable tokio_unstable so tokio::task::Builder is available (used by api-db, api, etc.).
-ENV RUSTFLAGS="-C link-arg=-fuse-ld=lld --cfg tokio_unstable"
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/local/bin/clang-lld
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/local/bin/clang-mold
+ENV RUSTFLAGS="--cfg tokio_unstable"

--- a/docs/development/build-guide.md
+++ b/docs/development/build-guide.md
@@ -2,18 +2,30 @@
 
 ## Native Linux ARM64 Builds
 
-The repository's [Cargo configuration](../../.cargo/config.toml) selects Clang
-with mold when building the `aarch64-unknown-linux-gnu` target. Before running
-Cargo directly on a Linux ARM64 host, ensure that the `clang` and `mold`
-executables are on `PATH`. On Debian or Ubuntu, install both packages with:
+The repository's [Cargo configuration](../../.cargo/config.toml) requests mold
+when building the `aarch64-unknown-linux-gnu` target. On native Linux ARM64
+hosts, [`.envrc`](../../.envrc) selects Clang as the compiler driver. Before
+running Cargo directly, ensure that the `clang` and `mold` executables are on
+`PATH`. On Ubuntu 24.04 or Debian 12 (Bookworm) and newer, install both packages
+with:
 
 ```bash
 sudo apt-get install -y clang mold
 ```
 
-Without either executable, Cargo fails during linking. Containerized ARM64
-builds install both tools in their build images and do not require them on the
-host.
+Without either executable, Cargo fails during linking. If you do not use
+`direnv`, select Clang in the shell that runs Cargo:
+
+```bash
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=clang
+```
+
+Debian 11 (Bullseye) does not package mold. Use the containerized ARM64 build
+path for Bullseye-compatible artifacts; its
+[build image](../../dev/docker/Dockerfile.build-artifacts-container-aarch64)
+installs a checksum-verified upstream ARM64 release. Other containerized ARM64
+build paths also install both tools in their build images and do not require
+them on the host.
 
 ## Updating Pinned Dependencies
 

--- a/docs/development/build-guide.md
+++ b/docs/development/build-guide.md
@@ -1,5 +1,20 @@
 # Build Guide
 
+## Native Linux ARM64 Builds
+
+The repository's [Cargo configuration](../../.cargo/config.toml) selects Clang
+with mold when building the `aarch64-unknown-linux-gnu` target. Before running
+Cargo directly on a Linux ARM64 host, ensure that the `clang` and `mold`
+executables are on `PATH`. On Debian or Ubuntu, install both packages with:
+
+```bash
+sudo apt-get install -y clang mold
+```
+
+Without either executable, Cargo fails during linking. Containerized ARM64
+builds install both tools in their build images and do not require them on the
+host.
+
 ## Updating Pinned Dependencies
 
 ### Git submodules


### PR DESCRIPTION
## Summary

- use clang with mold for the aarch64 Linux Cargo target
- install and enforce mold in every ARM64 Cargo builder path: native Bookworm, native Bullseye artifacts, cross-compilation, and the minimal macOS Docker builder
- preserve GNU ld for non-Rust builds such as iPXE and retain lld for non-ARM64 builds in the multi-architecture minimal builder

## Motivation

GNU ld exhausted a 16 GiB ARM64 development VM while linking the ci-tests profile. Concurrent linker processes reached approximately 3.6 GiB and 4.1 GiB RSS before the kernel OOM killer terminated them. Mold is substantially more memory-efficient for these large test binaries.

The linker must also be present and selected inside containerized builds. In particular, the cross-compilation image previously overrode the repository Cargo linker with the ARM64 GCC driver, while the native artifact images did not provide mold. Linker selection remains scoped to Cargo because iPXE requires GNU ld for its EFI linker script.

## Testing

- cargo metadata --no-deps --format-version 1
- git diff --check
- completed full ARM64 image builds for all four changed builder Dockerfiles
- verified Cargo-built ARM64 ELF files identify mold in the native Bookworm, native Bullseye, cross, and minimal builders
- verified the native Bookworm and Bullseye images retain GNU ld.bfd as the system linker
- built the exact CI target bin-arm64-efi/snponly.efi at pinned iPXE revision bbd7821bd42da5456ee068a471ef73d525ea26a1 using the corrected Bullseye artifact image

## Note
mold and llm seem to provide similar gain in memory usage but mold provides the fastest execution time.
Ideally we should be using mold for dev+CI/CD and llm for production.



