### PR TITLE
feat(flow): add event-rule leakage detection

### DIFF
--- a/rest-api/flow/internal/eventrule/action.go
+++ b/rest-api/flow/internal/eventrule/action.go
@@ -142,7 +142,7 @@ func (a Action) Clone() Action {
 
 // Validate checks the action name, condition, and typed specification.
 func (a Action) Validate() error {
-	if err := validateIdentifier("action name", a.Name); err != nil {
+	if err := ValidateIdentifier("action name", a.Name); err != nil {
 		return err
 	}
 

--- a/rest-api/flow/internal/eventrule/errors.go
+++ b/rest-api/flow/internal/eventrule/errors.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package eventrule
+
+import "errors"
+
+// ErrTerminalProcessing identifies an event-processing failure that cannot
+// succeed by delivering the same envelope again.
+var ErrTerminalProcessing = errors.New("terminal event processing error")

--- a/rest-api/flow/internal/eventrule/event.go
+++ b/rest-api/flow/internal/eventrule/event.go
@@ -23,7 +23,7 @@ type EventKey struct {
 
 // Validate checks the canonical event identity.
 func (k EventKey) Validate() error {
-	if err := validateIdentifier("event source name", k.SourceName); err != nil {
+	if err := ValidateIdentifier("event source name", k.SourceName); err != nil {
 		return err
 	}
 

--- a/rest-api/flow/internal/eventrule/execution.go
+++ b/rest-api/flow/internal/eventrule/execution.go
@@ -22,7 +22,7 @@ func (k ExecutionKey) Validate() error {
 		return fmt.Errorf("execution event id is required")
 	}
 
-	return validateIdentifier("event rule action name", k.ActionName)
+	return ValidateIdentifier("event rule action name", k.ActionName)
 }
 
 // Execution records one immutable action plan and its mutable processing

--- a/rest-api/flow/internal/eventrule/execution_plan.go
+++ b/rest-api/flow/internal/eventrule/execution_plan.go
@@ -33,7 +33,7 @@ type PlannedExecution struct {
 
 // Validate checks the action identity and its corresponding execution plan.
 func (p PlannedExecution) Validate() error {
-	if err := validateIdentifier("event rule action name", p.ActionName); err != nil {
+	if err := ValidateIdentifier("event rule action name", p.ActionName); err != nil {
 		return err
 	}
 

--- a/rest-api/flow/internal/eventrule/ingestion/pipeline.go
+++ b/rest-api/flow/internal/eventrule/ingestion/pipeline.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ingestion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+)
+
+const defaultMaxDeliveryAttempts = 3
+
+// Config controls event delivery retries.
+type Config struct {
+	// RetryDelay is the pause between nonterminal delivery attempts.
+	RetryDelay time.Duration
+	// MaxAttempts includes the initial delivery and bounds how long a scheduled
+	// collection job can retain its worker during a persistent sink failure.
+	MaxAttempts int
+}
+
+// DefaultConfig returns the default event delivery behavior.
+func DefaultConfig() Config {
+	return Config{
+		RetryDelay:  time.Second,
+		MaxAttempts: defaultMaxDeliveryAttempts,
+	}
+}
+
+// Validate checks the ingestion configuration.
+func (c Config) Validate() error {
+	if c.RetryDelay <= 0 {
+		return fmt.Errorf("event delivery retry delay must be positive")
+	}
+	if c.MaxAttempts <= 0 {
+		return fmt.Errorf("event delivery max attempts must be positive")
+	}
+
+	return nil
+}
+
+// Pipeline registers event sources and delivers their normalized events.
+type Pipeline struct {
+	registry *registry
+	sink     Sink
+	config   Config
+}
+
+// Source delivers events under one registered source name.
+type Source struct {
+	name     string
+	pipeline *Pipeline
+}
+
+// New constructs an event ingestion pipeline.
+func New(sink Sink, config Config) (*Pipeline, error) {
+	if sink == nil {
+		return nil, fmt.Errorf("event sink is required")
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &Pipeline{
+		registry: newRegistry(),
+		sink:     sink,
+		config:   config,
+	}, nil
+}
+
+// RegisterSource returns an ingestion entry point bound to one stable source
+// name.
+func (p *Pipeline) RegisterSource(sourceName string) (*Source, error) {
+	if p == nil {
+		return nil, fmt.Errorf("event ingestion pipeline is nil")
+	}
+
+	if err := p.registry.register(sourceName); err != nil {
+		return nil, err
+	}
+
+	return &Source{
+		name:     sourceName,
+		pipeline: p,
+	}, nil
+}
+
+// Ingest applies the registered source name and delivers one event. A
+// nonterminal sink failure is retried with the same EventKey up to the
+// configured attempt limit. Terminal processing failures are not retried.
+func (s *Source) Ingest(ctx context.Context, envelope eventrule.Envelope) error {
+	if s == nil {
+		return fmt.Errorf("event source is nil")
+	}
+
+	envelope.Key.SourceName = s.name
+	if err := envelope.Validate(); err != nil {
+		return fmt.Errorf("event source %q: %w", s.name, err)
+	}
+
+	return s.pipeline.deliver(ctx, envelope)
+}
+
+func (p *Pipeline) deliver(ctx context.Context, envelope eventrule.Envelope) error {
+	for attempt := 1; ; attempt++ {
+		err := p.sink.Process(ctx, envelope.Clone())
+		if err == nil {
+			return nil
+		}
+
+		// A dependency may return its own operational error after cancellation.
+		// Prefer the context error so the scheduler recognizes a canceled job.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+
+		if errors.Is(err, eventrule.ErrTerminalProcessing) {
+			return fmt.Errorf("deliver event %q: %w", envelope.Key.SourceKey, err)
+		}
+
+		if attempt == p.config.MaxAttempts {
+			// Return control to the scheduled job. Its next run can redeliver the
+			// same stable event key after the dependency recovers.
+			return fmt.Errorf(
+				"deliver event %q after %d attempts: %w",
+				envelope.Key.SourceKey,
+				attempt,
+				err,
+			)
+		}
+
+		timer := time.NewTimer(p.config.RetryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/rest-api/flow/internal/eventrule/ingestion/pipeline_test.go
+++ b/rest-api/flow/internal/eventrule/ingestion/pipeline_test.go
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ingestion
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	require.Equal(t, time.Second, config.RetryDelay)
+	require.Equal(t, defaultMaxDeliveryAttempts, config.MaxAttempts)
+	require.NoError(t, config.Validate())
+}
+
+func TestNew(t *testing.T) {
+	tests := map[string]struct {
+		sink    Sink
+		config  Config
+		wantErr string
+	}{
+		"valid": {
+			sink:   &recordingSink{},
+			config: DefaultConfig(),
+		},
+		"missing sink": {
+			config:  DefaultConfig(),
+			wantErr: "event sink is required",
+		},
+		"invalid retry delay": {
+			sink:    &recordingSink{},
+			config:  Config{},
+			wantErr: "event delivery retry delay must be positive",
+		},
+		"invalid max attempts": {
+			sink: &recordingSink{},
+			config: Config{
+				RetryDelay: time.Second,
+			},
+			wantErr: "event delivery max attempts must be positive",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pipeline, err := New(test.sink, test.config)
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+				require.Nil(t, pipeline)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, pipeline)
+		})
+	}
+}
+
+func TestPipeline_RegisterSource(t *testing.T) {
+	tests := map[string]struct {
+		name        string
+		twice       bool
+		nilPipeline bool
+		wantErr     string
+	}{
+		"valid": {
+			name: "leakage",
+		},
+		"invalid name": {
+			name:    "Leakage",
+			wantErr: "event source name",
+		},
+		"duplicate": {
+			name:    "leakage",
+			twice:   true,
+			wantErr: "already registered",
+		},
+		"nil pipeline": {
+			name:        "leakage",
+			nilPipeline: true,
+			wantErr:     "event ingestion pipeline is nil",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pipeline := newTestPipeline(t, &recordingSink{})
+			if test.nilPipeline {
+				pipeline = nil
+			}
+
+			source, err := pipeline.RegisterSource(test.name)
+			if err == nil && test.twice {
+				source, err = pipeline.RegisterSource(test.name)
+			}
+
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				require.Nil(t, source)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, source)
+		})
+	}
+}
+
+func TestSource_Ingest(t *testing.T) {
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	envelope := eventrule.Envelope{
+		Key: eventrule.EventKey{
+			SourceName: "collector_supplied_name",
+			SourceKey:  "occurrence-1",
+		},
+		Type:       "test.event",
+		Resource:   eventrule.Resource{Kind: eventrule.ResourceKindRack, ID: uuid.New()},
+		ObservedAt: now,
+	}
+	storeErr := errors.New("store unavailable")
+	terminalErr := errors.Join(eventrule.ErrTerminalProcessing, errors.New("invalid event"))
+
+	tests := map[string]struct {
+		sourceName      string
+		sinkErrors      []error
+		envelope        eventrule.Envelope
+		nilSource       bool
+		cancelCtx       bool
+		wantErrIs       error
+		wantErrContains string
+		wantDelivered   int
+		wantKeys        []eventrule.EventKey
+	}{
+		"applies registered source name": {
+			sourceName:    "registered_source",
+			envelope:      envelope,
+			wantDelivered: 1,
+			wantKeys: []eventrule.EventKey{{
+				SourceName: "registered_source",
+				SourceKey:  "occurrence-1",
+			}},
+		},
+		"retries transient failure with the same key": {
+			sinkErrors:    []error{storeErr},
+			envelope:      envelope,
+			wantDelivered: 2,
+			wantKeys: []eventrule.EventKey{
+				{SourceName: "leakage", SourceKey: "occurrence-1"},
+				{SourceName: "leakage", SourceKey: "occurrence-1"},
+			},
+		},
+		"bounds persistent nonterminal failures": {
+			sinkErrors:      []error{storeErr, storeErr, storeErr},
+			envelope:        envelope,
+			wantErrIs:       storeErr,
+			wantErrContains: "after 3 attempts",
+			wantDelivered:   3,
+		},
+		"does not retry terminal failure": {
+			sinkErrors:    []error{terminalErr},
+			envelope:      envelope,
+			wantErrIs:     eventrule.ErrTerminalProcessing,
+			wantDelivered: 1,
+		},
+		"rejects invalid envelope": {
+			wantErrContains: `event source "leakage"`,
+		},
+		"rejects nil source": {
+			envelope:        envelope,
+			nilSource:       true,
+			wantErrContains: "event source is nil",
+		},
+		"does not deliver after cancellation": {
+			envelope:  envelope,
+			cancelCtx: true,
+			wantErrIs: context.Canceled,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sink := &recordingSink{errors: test.sinkErrors}
+
+			var source *Source
+			if !test.nilSource {
+				pipeline := newTestPipeline(t, sink)
+				sourceName := test.sourceName
+				if sourceName == "" {
+					sourceName = "leakage"
+				}
+
+				var err error
+				source, err = pipeline.RegisterSource(sourceName)
+				require.NoError(t, err)
+			}
+
+			ctx := context.Background()
+			if test.cancelCtx {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			err := source.Ingest(ctx, test.envelope)
+
+			if test.wantErrIs != nil {
+				require.ErrorIs(t, err, test.wantErrIs)
+			} else if test.wantErrContains == "" {
+				require.NoError(t, err)
+			}
+
+			if test.wantErrContains != "" {
+				require.ErrorContains(t, err, test.wantErrContains)
+			}
+
+			delivered := sink.delivered()
+			require.Len(t, delivered, test.wantDelivered)
+			for i, wantKey := range test.wantKeys {
+				require.Equal(t, wantKey, delivered[i].Key)
+			}
+		})
+	}
+}
+
+func newTestPipeline(t *testing.T, sink Sink) *Pipeline {
+	t.Helper()
+
+	config := DefaultConfig()
+	config.RetryDelay = time.Millisecond
+	pipeline, err := New(sink, config)
+	require.NoError(t, err)
+
+	return pipeline
+}
+
+type recordingSink struct {
+	mu        sync.Mutex
+	envelopes []eventrule.Envelope
+	errors    []error
+}
+
+func (s *recordingSink) Process(ctx context.Context, envelope eventrule.Envelope) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.envelopes = append(s.envelopes, envelope.Clone())
+
+	if len(s.errors) == 0 {
+		return nil
+	}
+
+	err := s.errors[0]
+	s.errors = s.errors[1:]
+
+	return err
+}
+
+func (s *recordingSink) delivered() []eventrule.Envelope {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cloned := make([]eventrule.Envelope, len(s.envelopes))
+	for i := range s.envelopes {
+		cloned[i] = s.envelopes[i].Clone()
+	}
+
+	return cloned
+}

--- a/rest-api/flow/internal/eventrule/ingestion/registry.go
+++ b/rest-api/flow/internal/eventrule/ingestion/registry.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ingestion registers event sources and delivers their normalized
+// envelopes through the event-rule sink.
+package ingestion
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+)
+
+// registry owns unique event source names.
+type registry struct {
+	mu      sync.Mutex
+	sources map[string]struct{}
+}
+
+func newRegistry() *registry {
+	return &registry{sources: make(map[string]struct{})}
+}
+
+func (r *registry) register(sourceName string) error {
+	if r == nil {
+		return fmt.Errorf("event source registry is nil")
+	}
+
+	if err := eventrule.ValidateIdentifier("event source name", sourceName); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.sources[sourceName]; exists {
+		return fmt.Errorf("event source %q is already registered", sourceName)
+	}
+
+	r.sources[sourceName] = struct{}{}
+
+	return nil
+}

--- a/rest-api/flow/internal/eventrule/ingestion/sink.go
+++ b/rest-api/flow/internal/eventrule/ingestion/sink.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ingestion
+
+import (
+	"context"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+)
+
+// Sink accepts normalized events. A nil error means the event was accepted as
+// a no-op, duplicate, or complete persisted execution plan.
+type Sink interface {
+	Process(context.Context, eventrule.Envelope) error
+}

--- a/rest-api/flow/internal/eventrule/leakage/detector/detector.go
+++ b/rest-api/flow/internal/eventrule/leakage/detector/detector.go
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package detector translates NICo leakage polling results into event-rule
+// envelopes.
+package detector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/leakage"
+	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
+	"github.com/google/uuid"
+)
+
+// SourceName is the stable logical identity shared by every instance of the
+// NICo leakage detector.
+const SourceName = "nico_core_leakage"
+
+// Reader exposes the NICo leakage queries used by Detector.
+type Reader interface {
+	GetLeakingMachineIds(context.Context) ([]string, error)
+	GetLeakingSwitchIds(context.Context) ([]string, error)
+}
+
+// IngestFunc synchronously accepts one constructed leakage event.
+type IngestFunc func(context.Context, eventrule.Envelope) error
+
+func newOccurrenceKey(
+	componentType flowtypes.ComponentType,
+	externalID string,
+	suffix string,
+) string {
+	return fmt.Sprintf(
+		"%s/%s/%s",
+		strings.ToLower(string(componentType)),
+		url.PathEscape(externalID),
+		suffix,
+	)
+}
+
+type occurrence struct {
+	externalID string
+	sourceKey  string
+}
+
+func (o occurrence) envelope(
+	componentType flowtypes.ComponentType,
+	observedAt time.Time,
+) eventrule.Envelope {
+	return eventrule.Envelope{
+		Key:      eventrule.EventKey{SourceKey: o.sourceKey},
+		Type:     leakage.TypeHardwareLeakDetected,
+		Severity: eventrule.SeverityCritical,
+		Resource: eventrule.Resource{
+			Kind:              eventrule.ResourceKindComponent,
+			ExternalID:        o.externalID,
+			ComponentTypeHint: componentType,
+		},
+		ObservedAt: observedAt,
+	}
+}
+
+// Detector polls NICo and retains one source key while a component remains in
+// the leaking result set. If a component clears and later leaks again, it gets
+// a new occurrence key. NICo currently exposes component identities but no
+// upstream leak-occurrence identity, so the detector generates and retains the
+// occurrence suffix locally.
+type Detector struct {
+	reader        Reader
+	mu            sync.Mutex
+	active        map[flowtypes.ComponentType]map[string]string
+	now           func() time.Time
+	newOccurrence func() string
+}
+
+// New constructs a NICo leakage detector.
+func New(reader Reader) (*Detector, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("leakage reader is required")
+	}
+
+	return &Detector{
+		reader:        reader,
+		active:        make(map[flowtypes.ComponentType]map[string]string),
+		now:           time.Now,
+		newOccurrence: uuid.NewString,
+	}, nil
+}
+
+// Collect reads every currently leaking machine and switch and ingests their
+// events one at a time. Terminal per-event failures are accumulated while
+// collection continues. Successful source queries update occurrence state
+// independently, so an outage in one query does not clear or suppress results
+// from the other.
+func (d *Detector) Collect(ctx context.Context, ingest IngestFunc) error {
+	if d == nil || d.reader == nil {
+		return fmt.Errorf("leakage detector is not configured")
+	}
+
+	if ingest == nil {
+		return fmt.Errorf("event ingestor is required")
+	}
+
+	var collectErr error
+
+	sources := []struct {
+		componentType flowtypes.ComponentType
+		load          func(context.Context) ([]string, error)
+	}{
+		{componentType: flowtypes.ComponentTypeCompute, load: d.reader.GetLeakingMachineIds},
+		{componentType: flowtypes.ComponentTypeNVSwitch, load: d.reader.GetLeakingSwitchIds},
+	}
+
+	for _, source := range sources {
+		ids, err := source.load(ctx)
+		if err != nil {
+			collectErr = errors.Join(
+				collectErr,
+				fmt.Errorf("collect leaking %s components: %w", source.componentType, err),
+			)
+			continue
+		}
+
+		ids = normalizeExternalIDs(ids)
+
+		err = d.ingestEvents(
+			ctx,
+			source.componentType,
+			ids,
+			ingest,
+		)
+		if err != nil {
+			if errors.Is(err, eventrule.ErrTerminalProcessing) {
+				collectErr = errors.Join(collectErr, err)
+
+				continue
+			}
+
+			return errors.Join(collectErr, err)
+		}
+	}
+
+	return collectErr
+}
+
+func (d *Detector) ingestEvents(
+	ctx context.Context,
+	componentType flowtypes.ComponentType,
+	externalIDs []string,
+	ingest IngestFunc,
+) error {
+	var terminalErr error
+
+	occurrences := d.buildOccurrences(componentType, externalIDs)
+	observedAt := d.now()
+
+	for _, occurrence := range occurrences {
+		envelope := occurrence.envelope(componentType, observedAt)
+		err := ingest(ctx, envelope)
+		if err != nil {
+			// A dependency may return its own error after cancellation. Preserve the
+			// context error so the scheduled job is recognized as canceled.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+
+			if !errors.Is(err, eventrule.ErrTerminalProcessing) {
+				return err
+			}
+
+			err = fmt.Errorf(
+				"ingest leaking %s component %q: %w",
+				componentType,
+				occurrence.externalID,
+				err,
+			)
+			terminalErr = errors.Join(terminalErr, err)
+		}
+	}
+
+	return terminalErr
+}
+
+func normalizeExternalIDs(externalIDs []string) []string {
+	uniqueIDs := make(map[string]struct{}, len(externalIDs))
+	for _, externalID := range externalIDs {
+		externalID = strings.TrimSpace(externalID)
+		if externalID == "" {
+			continue
+		}
+
+		uniqueIDs[externalID] = struct{}{}
+	}
+
+	ids := make([]string, 0, len(uniqueIDs))
+	for externalID := range uniqueIDs {
+		ids = append(ids, externalID)
+	}
+
+	slices.Sort(ids)
+
+	return ids
+}
+
+// buildOccurrences returns a stable source key for each component throughout
+// one continuous leakage occurrence. An identity remains active while it is
+// present in successive successful polls, so repeated events can be
+// deduplicated. A successful poll that omits the identity ends the occurrence;
+// if it appears again later, it receives a new source key. Load failures do not
+// call this method and therefore do not end active occurrences.
+func (d *Detector) buildOccurrences(
+	componentType flowtypes.ComponentType,
+	externalIDs []string,
+) []occurrence {
+	current := make(map[string]string, len(externalIDs))
+	occurrences := make([]occurrence, 0, len(externalIDs))
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	previous := d.active[componentType]
+
+	for _, externalID := range externalIDs {
+		key, exists := previous[externalID]
+		if !exists {
+			key = newOccurrenceKey(componentType, externalID, d.newOccurrence())
+		}
+
+		current[externalID] = key
+		occurrences = append(occurrences, occurrence{
+			externalID: externalID,
+			sourceKey:  key,
+		})
+	}
+
+	d.active[componentType] = current
+
+	return occurrences
+}

--- a/rest-api/flow/internal/eventrule/leakage/detector/detector_test.go
+++ b/rest-api/flow/internal/eventrule/leakage/detector/detector_test.go
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/leakage"
+	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetector_Collect(t *testing.T) {
+	t.Run("ingests one event per leaking component", func(t *testing.T) {
+		computeObservedAt := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+		switchObservedAt := computeObservedAt.Add(time.Second)
+		reader := &leakReader{
+			machines: []string{
+				"",
+				"machine-2",
+				"machine-1",
+				" machine-1",
+				"machine-2 ",
+				"\t",
+			},
+			switches: []string{"switch-1"},
+		}
+		detector := newTestDetector(t, reader, computeObservedAt)
+
+		observedAts := []time.Time{computeObservedAt, switchObservedAt}
+		nextObservedAt := 0
+		detector.now = func() time.Time {
+			observedAt := observedAts[nextObservedAt]
+			nextObservedAt++
+
+			return observedAt
+		}
+
+		envelopes, err := collectEnvelopes(context.Background(), detector)
+
+		require.NoError(t, err)
+		require.Len(t, envelopes, 3)
+		require.Equal(t, []string{"machine-1", "machine-2", "switch-1"}, []string{
+			envelopes[0].Resource.ExternalID,
+			envelopes[1].Resource.ExternalID,
+			envelopes[2].Resource.ExternalID,
+		})
+		require.Equal(t, []flowtypes.ComponentType{
+			flowtypes.ComponentTypeCompute,
+			flowtypes.ComponentTypeCompute,
+			flowtypes.ComponentTypeNVSwitch,
+		}, []flowtypes.ComponentType{
+			envelopes[0].Resource.ComponentTypeHint,
+			envelopes[1].Resource.ComponentTypeHint,
+			envelopes[2].Resource.ComponentTypeHint,
+		})
+		for _, envelope := range envelopes {
+			require.Empty(t, envelope.Key.SourceName)
+			require.NotEmpty(t, envelope.Key.SourceKey)
+			require.Equal(t, leakage.TypeHardwareLeakDetected, envelope.Type)
+			require.Equal(t, eventrule.SeverityCritical, envelope.Severity)
+			require.Equal(t, eventrule.ResourceKindComponent, envelope.Resource.Kind)
+		}
+		require.Equal(t, []time.Time{
+			computeObservedAt,
+			computeObservedAt,
+			switchObservedAt,
+		}, []time.Time{
+			envelopes[0].ObservedAt,
+			envelopes[1].ObservedAt,
+			envelopes[2].ObservedAt,
+		})
+	})
+
+	t.Run("retains source key for one occurrence", func(t *testing.T) {
+		now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+		reader := &leakReader{machines: []string{"machine/1"}}
+		detector := newTestDetector(t, reader, now)
+
+		first, err := collectEnvelopes(context.Background(), detector)
+		require.NoError(t, err)
+
+		second, err := collectEnvelopes(context.Background(), detector)
+		require.NoError(t, err)
+		require.Equal(t, first[0].Key.SourceKey, second[0].Key.SourceKey)
+		require.Equal(t, "compute/machine%2F1/occurrence-1", first[0].Key.SourceKey)
+
+		reader.machines = nil
+		_, err = collectEnvelopes(context.Background(), detector)
+		require.NoError(t, err)
+
+		reader.machines = []string{"machine/1"}
+
+		reappeared, err := collectEnvelopes(context.Background(), detector)
+		require.NoError(t, err)
+		require.Equal(t, "compute/machine%2F1/occurrence-2", reappeared[0].Key.SourceKey)
+	})
+
+	t.Run("ingests successful source after another source fails", func(t *testing.T) {
+		reader := &leakReader{
+			machineErr: errors.New("machine query unavailable"),
+			switches:   []string{"switch-1"},
+		}
+		detector := newTestDetector(t, reader, time.Now())
+
+		envelopes, err := collectEnvelopes(context.Background(), detector)
+
+		require.ErrorContains(t, err, "machine query unavailable")
+		require.Len(t, envelopes, 1)
+		require.Equal(t, "switch-1", envelopes[0].Resource.ExternalID)
+	})
+
+	t.Run("continues after terminal per-event failures", func(t *testing.T) {
+		terminalErr := errors.Join(
+			eventrule.ErrTerminalProcessing,
+			errors.New("component not found"),
+		)
+		detector := newTestDetector(t, &leakReader{
+			machines: []string{"machine-1", "machine-2"},
+			switches: []string{"switch-1"},
+		}, time.Now())
+
+		var ingested []string
+		err := detector.Collect(
+			context.Background(),
+			func(_ context.Context, envelope eventrule.Envelope) error {
+				externalID := envelope.Resource.ExternalID
+				ingested = append(ingested, externalID)
+				if externalID == "machine-1" || externalID == "switch-1" {
+					return terminalErr
+				}
+
+				return nil
+			},
+		)
+
+		require.ErrorIs(t, err, eventrule.ErrTerminalProcessing)
+		require.ErrorContains(t, err, `component "machine-1"`)
+		require.ErrorContains(t, err, `component "switch-1"`)
+		require.Equal(t, []string{"machine-1", "machine-2", "switch-1"}, ingested)
+	})
+
+	t.Run("stops on nonterminal ingestion failure", func(t *testing.T) {
+		terminalErr := errors.Join(
+			eventrule.ErrTerminalProcessing,
+			errors.New("component not found"),
+		)
+		ingestErr := errors.New("sink unavailable")
+		detector := newTestDetector(t, &leakReader{
+			machines: []string{"machine-1", "machine-2"},
+			switches: []string{"switch-1"},
+		}, time.Now())
+
+		ingested := 0
+		err := detector.Collect(
+			context.Background(),
+			func(context.Context, eventrule.Envelope) error {
+				ingested++
+				if ingested == 1 {
+					return terminalErr
+				}
+
+				return ingestErr
+			},
+		)
+
+		require.ErrorIs(t, err, ingestErr)
+		require.NotErrorIs(t, err, eventrule.ErrTerminalProcessing)
+		require.Equal(t, 2, ingested)
+	})
+
+	t.Run("stops when ingestion cancels the context", func(t *testing.T) {
+		detector := newTestDetector(t, &leakReader{
+			machines: []string{"machine-1", "machine-2"},
+			switches: []string{"switch-1"},
+		}, time.Now())
+		ctx, cancel := context.WithCancel(context.Background())
+
+		ingested := 0
+		err := detector.Collect(
+			ctx,
+			func(context.Context, eventrule.Envelope) error {
+				ingested++
+				cancel()
+
+				return errors.New("inventory unavailable")
+			},
+		)
+
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, ingested)
+	})
+
+	t.Run("rejects missing ingestor", func(t *testing.T) {
+		detector := newTestDetector(t, &leakReader{}, time.Now())
+
+		require.EqualError(
+			t,
+			detector.Collect(context.Background(), nil),
+			"event ingestor is required",
+		)
+	})
+}
+
+func collectEnvelopes(
+	ctx context.Context,
+	detector *Detector,
+) ([]eventrule.Envelope, error) {
+	var envelopes []eventrule.Envelope
+
+	err := detector.Collect(ctx, func(_ context.Context, envelope eventrule.Envelope) error {
+		envelopes = append(envelopes, envelope.Clone())
+
+		return nil
+	})
+
+	return envelopes, err
+}
+
+func newTestDetector(t *testing.T, reader Reader, now time.Time) *Detector {
+	t.Helper()
+
+	detector, err := New(reader)
+	require.NoError(t, err)
+
+	detector.now = func() time.Time { return now }
+
+	next := 0
+	detector.newOccurrence = func() string {
+		next++
+		return fmt.Sprintf("occurrence-%d", next)
+	}
+
+	return detector
+}
+
+type leakReader struct {
+	machines   []string
+	switches   []string
+	machineErr error
+	switchErr  error
+}
+
+func (r *leakReader) GetLeakingMachineIds(context.Context) ([]string, error) {
+	return r.machines, r.machineErr
+}
+
+func (r *leakReader) GetLeakingSwitchIds(context.Context) ([]string, error) {
+	return r.switches, r.switchErr
+}

--- a/rest-api/flow/internal/eventrule/leakage/detector/integration_test.go
+++ b/rest-api/flow/internal/eventrule/leakage/detector/integration_test.go
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package detector_test
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/ingestion"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/leakage"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/leakage/detector"
+	eventrulemanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/manager"
+	eventrulescheduler "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/scheduler"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
+	identifier "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/Identifier"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/deviceinfo"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/component"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetector_EventRuleIntegration(t *testing.T) {
+	tests := map[string]struct {
+		strategy eventrule.TargetStrategy
+		scope    eventrule.Scope
+		wantIDs  func(sourceID, belowID, aboveID uuid.UUID) []uuid.UUID
+	}{
+		"immutable affected-components default": {
+			strategy: eventrule.TargetStrategyAffectedComponents,
+			wantIDs: func(sourceID, belowID, _ uuid.UUID) []uuid.UUID {
+				return []uuid.UUID{sourceID, belowID}
+			},
+		},
+		"site component override": {
+			strategy: eventrule.TargetStrategyComponent,
+			scope:    eventrule.Scope{Type: eventrule.ScopeTypeSite},
+			wantIDs: func(sourceID, _, _ uuid.UUID) []uuid.UUID {
+				return []uuid.UUID{sourceID}
+			},
+		},
+		"rack override": {
+			strategy: eventrule.TargetStrategyRack,
+			scope:    eventrule.Scope{Type: eventrule.ScopeTypeRack},
+			wantIDs: func(sourceID, belowID, aboveID uuid.UUID) []uuid.UUID {
+				return []uuid.UUID{sourceID, belowID, aboveID}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			rackID := uuid.New()
+			sourceID := uuid.New()
+			belowID := uuid.New()
+			aboveID := uuid.New()
+
+			inventory := newLeakageInventory(rackID, []component.Component{
+				leakageComponent(sourceID, rackID, "machine-1", 10),
+				leakageComponent(belowID, rackID, "machine-below", 1),
+				leakageComponent(aboveID, rackID, "machine-above", 20),
+			})
+
+			tasks := &recordingTaskManager{}
+
+			ruleManager, err := eventrulemanager.New(eventrulemanager.Config{
+				Store: eventrulemanager.StoreConfig{
+					Backend: eventrulemanager.StoreBackendMemory,
+				},
+				Scheduler: eventrulemanager.SchedulerConfig{
+					InstanceID: "leakage-detector-integration",
+					Runtime:    eventrulescheduler.DefaultRuntimeConfig(),
+					Policy:     eventrulescheduler.DefaultPolicyConfig(),
+				},
+				Inventory:   inventory,
+				TaskManager: tasks,
+			})
+			require.NoError(t, err)
+
+			if test.scope.Type != "" {
+				rule, err := ruleManager.Create(ctx, leakageRule(test.strategy))
+				require.NoError(t, err)
+
+				scope := test.scope
+				if scope.Type == eventrule.ScopeTypeRack {
+					scope.ID = rackID
+				}
+
+				_, err = ruleManager.Bind(ctx, rule.ID, scope)
+				require.NoError(t, err)
+
+				require.NoError(t, ruleManager.SetEnabled(ctx, rule.ID, true))
+			}
+
+			require.NoError(t, ruleManager.Start(ctx))
+			defer func() { require.NoError(t, ruleManager.Stop()) }()
+
+			leakDetector, err := detector.New(staticLeakReader{machines: []string{"machine-1"}})
+			require.NoError(t, err)
+
+			ingestionConfig := ingestion.DefaultConfig()
+			ingestionConfig.RetryDelay = time.Millisecond
+			pipeline, err := ingestion.New(ruleManager, ingestionConfig)
+			require.NoError(t, err)
+
+			source, err := pipeline.RegisterSource(detector.SourceName)
+			require.NoError(t, err)
+
+			require.NoError(t, leakDetector.Collect(ctx, source.Ingest))
+
+			require.Eventually(t, func() bool {
+				return tasks.count() == 1
+			}, time.Second, time.Millisecond)
+
+			wantIDs := test.wantIDs(sourceID, belowID, aboveID)
+			slices.SortFunc(wantIDs, compareUUID)
+			require.Equal(t, wantIDs, tasks.componentIDs())
+
+			// The detector retains the occurrence key while the source stays active,
+			// so repeated polling observes the event without creating another
+			// execution or task.
+			require.NoError(t, leakDetector.Collect(ctx, source.Ingest))
+			require.Never(t, func() bool {
+				return tasks.count() > 1
+			}, 100*time.Millisecond, time.Millisecond)
+		})
+	}
+}
+
+func leakageRule(strategy eventrule.TargetStrategy) eventrule.RuleCreate {
+	return eventrule.RuleCreate{
+		Metadata:  eventrule.RuleMetadata{Name: "Leakage integration override"},
+		EventType: leakage.TypeHardwareLeakDetected,
+		Policy: eventrule.Policy{Actions: []eventrule.Action{{
+			Name: "power_off",
+			Spec: &eventrule.SubmitTask{
+				Operation: &operations.PowerControlTaskInfo{
+					Operation: operations.PowerOperationForcePowerOff,
+				},
+				TargetStrategy:   strategy,
+				ConflictStrategy: eventrule.ConflictStrategyQueue,
+			},
+		}}},
+	}
+}
+
+type staticLeakReader struct {
+	machines []string
+}
+
+func (r staticLeakReader) GetLeakingMachineIds(context.Context) ([]string, error) {
+	return slices.Clone(r.machines), nil
+}
+
+func (staticLeakReader) GetLeakingSwitchIds(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+type leakageInventory struct {
+	rack       *rack.Rack
+	components map[uuid.UUID]*component.Component
+}
+
+func newLeakageInventory(rackID uuid.UUID, components []component.Component) *leakageInventory {
+	resolvedRack := &rack.Rack{
+		Info:       deviceinfo.DeviceInfo{ID: rackID},
+		Components: slices.Clone(components),
+	}
+
+	byID := make(map[uuid.UUID]*component.Component, len(components))
+	for i := range components {
+		cloned := components[i]
+		byID[cloned.Info.ID] = &cloned
+	}
+
+	return &leakageInventory{rack: resolvedRack, components: byID}
+}
+
+func (i *leakageInventory) GetComponentByID(
+	_ context.Context,
+	id uuid.UUID,
+) (*component.Component, error) {
+	stored, ok := i.components[id]
+	if !ok {
+		return nil, fmt.Errorf("component %q not found", id)
+	}
+
+	resolved := *stored
+
+	return &resolved, nil
+}
+
+func (i *leakageInventory) GetComponentsByExternalIDs(
+	_ context.Context,
+	externalIDs []string,
+) ([]*component.Component, error) {
+	requested := make(map[string]struct{}, len(externalIDs))
+	for _, externalID := range externalIDs {
+		requested[externalID] = struct{}{}
+	}
+
+	var resolved []*component.Component
+	for _, stored := range i.components {
+		if _, ok := requested[stored.ComponentID]; !ok {
+			continue
+		}
+
+		cloned := *stored
+		resolved = append(resolved, &cloned)
+	}
+
+	return resolved, nil
+}
+
+func (i *leakageInventory) GetRackByIdentifier(
+	_ context.Context,
+	_ identifier.Identifier,
+	_ bool,
+) (*rack.Rack, error) {
+	cloned := *i.rack
+	cloned.Components = slices.Clone(i.rack.Components)
+
+	return &cloned, nil
+}
+
+func leakageComponent(
+	id uuid.UUID,
+	rackID uuid.UUID,
+	externalID string,
+	slot int,
+) component.Component {
+	return component.Component{
+		Type:        devicetypes.ComponentTypeCompute,
+		Info:        deviceinfo.DeviceInfo{ID: id},
+		Position:    component.InRackPosition{SlotID: slot},
+		ComponentID: externalID,
+		RackID:      rackID,
+	}
+}
+
+type recordingTaskManager struct {
+	mu       sync.Mutex
+	requests []*operation.Request
+}
+
+func (m *recordingTaskManager) SubmitTask(
+	_ context.Context,
+	request *operation.Request,
+) ([]uuid.UUID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.requests = append(m.requests, request)
+
+	return []uuid.UUID{uuid.New()}, nil
+}
+
+func (m *recordingTaskManager) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.requests)
+}
+
+func (m *recordingTaskManager) componentIDs() []uuid.UUID {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ids := make([]uuid.UUID, 0, len(m.requests[0].TargetSpec.Components))
+	for _, target := range m.requests[0].TargetSpec.Components {
+		ids = append(ids, target.UUID)
+	}
+
+	slices.SortFunc(ids, compareUUID)
+
+	return ids
+}
+
+func compareUUID(a, b uuid.UUID) int {
+	return slices.Compare(a[:], b[:])
+}

--- a/rest-api/flow/internal/eventrule/manager/manager.go
+++ b/rest-api/flow/internal/eventrule/manager/manager.go
@@ -32,8 +32,6 @@ type Manager struct {
 }
 
 // New constructs a fully assembled event-rule manager.
-// TODO(flow-service-integration): Connect the manager to the Flow service root
-// after the durable event-rule store is implemented.
 func New(config Config) (*Manager, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err

--- a/rest-api/flow/internal/eventrule/processor/errors.go
+++ b/rest-api/flow/internal/eventrule/processor/errors.go
@@ -14,7 +14,7 @@ import (
 
 // ErrTerminal identifies event-processing failures that cannot succeed on
 // retry without changing the input or persisted state.
-var ErrTerminal = errors.New("terminal event processing error")
+var ErrTerminal = eventrule.ErrTerminalProcessing
 
 func classifyInventoryError(err error) error {
 	if errors.Is(err, inventoryresolver.ErrUnresolvable) {

--- a/rest-api/flow/internal/eventrule/validation.go
+++ b/rest-api/flow/internal/eventrule/validation.go
@@ -11,7 +11,9 @@ import (
 
 var identifierSegmentRE = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
-func validateIdentifier(name string, value string) error {
+// ValidateIdentifier checks that value is a non-empty lower-snake-case
+// identifier and uses name to identify the value in validation errors.
+func ValidateIdentifier(name string, value string) error {
 	if err := validateRequiredString(name, value); err != nil {
 		return err
 	}

--- a/rest-api/flow/internal/scheduler/jobs/leakdetection/job.go
+++ b/rest-api/flow/internal/scheduler/jobs/leakdetection/job.go
@@ -11,18 +11,55 @@ import (
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/config"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	eventingestion "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/ingestion"
+	leakagedetector "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/leakage/detector"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/scheduler/types"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/providerapi"
 	nicoprovider "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/componentmanager/providers/nico" //nolint
 	taskmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/manager"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 )
+
+type detectorRunner interface {
+	Run(context.Context) error
+}
+
+type detectorRunnerFunc func(context.Context) error
+
+func (f detectorRunnerFunc) Run(ctx context.Context) error { return f(ctx) }
+
+type reconcileFunc func(context.Context, devicetypes.ComponentType, []string)
+
+type reconcilingReader struct {
+	reader    leakagedetector.Reader
+	reconcile reconcileFunc
+}
+
+func (r reconcilingReader) GetLeakingMachineIds(ctx context.Context) ([]string, error) {
+	ids, err := r.reader.GetLeakingMachineIds(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	r.reconcile(ctx, devicetypes.ComponentTypeCompute, ids)
+
+	return ids, nil
+}
+
+func (r reconcilingReader) GetLeakingSwitchIds(ctx context.Context) ([]string, error) {
+	ids, err := r.reader.GetLeakingSwitchIds(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	r.reconcile(ctx, devicetypes.ComponentTypeNVSwitch, ids)
+
+	return ids, nil
+}
 
 // Job implements scheduler.Job for the leak detection task.
 type Job struct {
-	nicoClient nicoapi.Client
-	taskMgr    taskmanager.Manager
-	pool       *cdb.Session
+	detector detectorRunner
 }
 
 // New constructs a leak detection Job using the NICo provider from the
@@ -33,15 +70,12 @@ func New(
 	dbConf *cdb.Config,
 	taskMgr taskmanager.Manager,
 	providers *providerapi.ProviderRegistry,
+	pipeline *eventingestion.Pipeline,
 	cfg config.Config,
 ) (*Job, error) {
 	if cfg.DisableLeakDetection {
 		log.Info().Msg("Leak detection disabled by configuration")
 		return nil, nil
-	}
-
-	if dbConf == nil {
-		return nil, fmt.Errorf("database configuration is nil")
 	}
 
 	nicoProvider, err := providerapi.GetTyped[*nicoprovider.Provider](
@@ -53,16 +87,50 @@ func New(
 		return nil, nil
 	}
 
+	if dbConf == nil {
+		return nil, fmt.Errorf("database configuration is nil")
+	}
+
 	pool, err := cdb.NewSessionFromConfig(ctx, *dbConf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database pool: %w", err)
 	}
 
-	return &Job{
-		nicoClient: nicoProvider.Client(),
-		taskMgr:    taskMgr,
-		pool:       pool,
-	}, nil
+	// A nil pipeline selects the legacy detector during the migration to
+	// event-rule ingestion. The selected implementation is fixed for the
+	// lifetime of the Job.
+	if pipeline == nil {
+		return newJob(detectorRunnerFunc(func(ctx context.Context) error {
+			runLeakDetectionOne(ctx, nicoProvider.Client(), taskMgr, pool)
+
+			return nil
+		}))
+	}
+
+	reader := reconcilingReader{
+		reader: nicoProvider.Client(),
+		reconcile: func(
+			ctx context.Context,
+			componentType devicetypes.ComponentType,
+			ids []string,
+		) {
+			reconcileLeakStatus(ctx, pool, componentType, ids)
+		},
+	}
+
+	eventRuleDetector, err := leakagedetector.New(reader)
+	if err != nil {
+		return nil, fmt.Errorf("create event-rule leakage detector: %w", err)
+	}
+
+	eventRuleSource, err := pipeline.RegisterSource(leakagedetector.SourceName)
+	if err != nil {
+		return nil, fmt.Errorf("register event-rule leakage source: %w", err)
+	}
+
+	return newJob(detectorRunnerFunc(func(ctx context.Context) error {
+		return eventRuleDetector.Collect(ctx, eventRuleSource.Ingest)
+	}))
 }
 
 // Name returns the job name.
@@ -70,6 +138,13 @@ func (j *Job) Name() string { return "leak-detection" }
 
 // Run executes one iteration of leak detection.
 func (j *Job) Run(ctx context.Context, _ types.Event) error {
-	runLeakDetectionOne(ctx, j.nicoClient, j.taskMgr, j.pool)
-	return nil
+	return j.detector.Run(ctx)
+}
+
+func newJob(detector detectorRunner) (*Job, error) {
+	if detector == nil {
+		return nil, fmt.Errorf("leakage detector is required")
+	}
+
+	return &Job{detector: detector}, nil
 }

--- a/rest-api/flow/internal/scheduler/jobs/leakdetection/job_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/leakdetection/job_test.go
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package leakdetection
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	schedtypes "github.com/NVIDIA/infra-controller/rest-api/flow/internal/scheduler/types"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJob_Run(t *testing.T) {
+	runErr := errors.New("detector failed")
+
+	tests := map[string]struct {
+		runner  *countingRunner
+		wantErr error
+	}{
+		"runs detector": {
+			runner: &countingRunner{},
+		},
+		"returns detector error": {
+			runner:  &countingRunner{err: runErr},
+			wantErr: runErr,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			job, err := newJob(test.runner)
+			require.NoError(t, err)
+
+			err = job.Run(context.Background(), schedtypes.Event{})
+
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, int32(1), test.runner.runs.Load())
+		})
+	}
+}
+
+func TestNewJob(t *testing.T) {
+	tests := map[string]struct {
+		detector detectorRunner
+		wantErr  string
+	}{
+		"constructs job": {
+			detector: &countingRunner{},
+		},
+		"rejects nil detector": {
+			wantErr: "leakage detector is required",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			job, err := newJob(test.detector)
+
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+				require.Nil(t, job)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, job)
+			require.Equal(t, test.detector, job.detector)
+		})
+	}
+}
+
+func TestReconcilingReader_GetLeakingMachineIds(t *testing.T) {
+	loadErr := errors.New("machine load failed")
+
+	tests := map[string]struct {
+		ids            []string
+		loadErr        error
+		wantReconciled bool
+	}{
+		"reconciles successful load": {
+			ids:            []string{"machine-1", "machine-2"},
+			wantReconciled: true,
+		},
+		"does not reconcile failed load": {
+			loadErr: loadErr,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var reconciled bool
+			var reconciledType devicetypes.ComponentType
+			var reconciledIDs []string
+
+			reader := reconcilingReader{
+				reader: &stubLeakReader{
+					machineIDs: test.ids,
+					machineErr: test.loadErr,
+				},
+				reconcile: func(
+					_ context.Context,
+					componentType devicetypes.ComponentType,
+					ids []string,
+				) {
+					reconciled = true
+					reconciledType = componentType
+					reconciledIDs = ids
+				},
+			}
+
+			ids, err := reader.GetLeakingMachineIds(context.Background())
+
+			if test.loadErr != nil {
+				require.ErrorIs(t, err, test.loadErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.ids, ids)
+			}
+
+			require.Equal(t, test.wantReconciled, reconciled)
+			if test.wantReconciled {
+				require.Equal(t, devicetypes.ComponentTypeCompute, reconciledType)
+				require.Equal(t, test.ids, reconciledIDs)
+			}
+		})
+	}
+}
+
+func TestReconcilingReader_GetLeakingSwitchIds(t *testing.T) {
+	loadErr := errors.New("switch load failed")
+
+	tests := map[string]struct {
+		ids            []string
+		loadErr        error
+		wantReconciled bool
+	}{
+		"reconciles successful load": {
+			ids:            []string{"switch-1", "switch-2"},
+			wantReconciled: true,
+		},
+		"does not reconcile failed load": {
+			loadErr: loadErr,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var reconciled bool
+			var reconciledType devicetypes.ComponentType
+			var reconciledIDs []string
+
+			reader := reconcilingReader{
+				reader: &stubLeakReader{
+					switchIDs: test.ids,
+					switchErr: test.loadErr,
+				},
+				reconcile: func(
+					_ context.Context,
+					componentType devicetypes.ComponentType,
+					ids []string,
+				) {
+					reconciled = true
+					reconciledType = componentType
+					reconciledIDs = ids
+				},
+			}
+
+			ids, err := reader.GetLeakingSwitchIds(context.Background())
+
+			if test.loadErr != nil {
+				require.ErrorIs(t, err, test.loadErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.ids, ids)
+			}
+
+			require.Equal(t, test.wantReconciled, reconciled)
+			if test.wantReconciled {
+				require.Equal(t, devicetypes.ComponentTypeNVSwitch, reconciledType)
+				require.Equal(t, test.ids, reconciledIDs)
+			}
+		})
+	}
+}
+
+type countingRunner struct {
+	runs atomic.Int32
+	err  error
+}
+
+func (r *countingRunner) Run(context.Context) error {
+	r.runs.Add(1)
+
+	return r.err
+}
+
+type stubLeakReader struct {
+	machineIDs []string
+	switchIDs  []string
+	machineErr error
+	switchErr  error
+}
+
+func (r *stubLeakReader) GetLeakingMachineIds(context.Context) ([]string, error) {
+	return r.machineIDs, r.machineErr
+}
+
+func (r *stubLeakReader) GetLeakingSwitchIds(context.Context) ([]string, error) {
+	return r.switchIDs, r.switchErr
+}

--- a/rest-api/flow/internal/service/service.go
+++ b/rest-api/flow/internal/service/service.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
@@ -21,6 +22,9 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/grpclog"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/grpcrecovery"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/migrations"
+	eventingestion "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/ingestion"
+	eventrulemanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/manager"
+	eventrulescheduler "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/scheduler"
 	inventorymanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/manager"
 	inventorystore "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/store"
 	operationrunmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/operationrun/manager"
@@ -35,12 +39,20 @@ import (
 	taskmanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/manager"
 	taskstore "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/store"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
+	"github.com/google/uuid"
 )
 
-// ignoreMigrationSignatureChangesEnvVar enables the temporary migration
-// recovery workaround during service startup. When set to "true", changed
-// signatures are stored without re-running installed migration SQL.
-const ignoreMigrationSignatureChangesEnvVar = "FLOW_DB_MIGRATION_IGNORE_SIGNATURE_CHANGES"
+const (
+	// ignoreMigrationSignatureChangesEnvVar enables the temporary migration
+	// recovery workaround during service startup. When set to "true", changed
+	// signatures are stored without re-running installed migration SQL.
+	ignoreMigrationSignatureChangesEnvVar = "FLOW_DB_MIGRATION_IGNORE_SIGNATURE_CHANGES"
+
+	// eventRuleLeakDetectionEnabledEnvVar selects event-rule leakage detection
+	// at scheduler startup. It defaults to disabled, accepts the boolean values
+	// supported by strconv.ParseBool, and requires a restart to change paths.
+	eventRuleLeakDetectionEnabledEnvVar = "FLOW_EVENT_RULE_LEAK_DETECTION_ENABLED"
+)
 
 func migrationOptionsFromEnv() migrations.MigrateOptions {
 	return migrations.MigrateOptions{
@@ -48,8 +60,37 @@ func migrationOptionsFromEnv() migrations.MigrateOptions {
 	}
 }
 
+func leakDetectionPipelineFromEnv(
+	pipeline *eventingestion.Pipeline,
+) (*eventingestion.Pipeline, error) {
+	raw := os.Getenv(eventRuleLeakDetectionEnabledEnvVar)
+	if raw == "" {
+		return nil, nil
+	}
+
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%s must be a boolean: %w",
+			eventRuleLeakDetectionEnabledEnvVar,
+			err,
+		)
+	}
+
+	if !enabled {
+		return nil, nil
+	}
+
+	if pipeline == nil {
+		return nil, fmt.Errorf("event ingestion pipeline is not initialized")
+	}
+
+	return pipeline, nil
+}
+
 // Service is the top-level Flow service. It owns the gRPC server, database
-// session, inventory manager, and task manager and coordinates their lifecycles.
+// session, managers, and event collection runtime and coordinates their
+// lifecycles.
 type Service struct {
 	conf                   Config
 	grpcServer             *grpc.Server
@@ -60,7 +101,10 @@ type Service struct {
 	taskManager            taskmanager.Manager
 	operationRunManager    operationrunmanager.Manager
 	operationRunDispatcher *operationrundispatcher.Dispatcher
+	eventRuleManager       *eventrulemanager.Manager
+	eventIngestionPipeline *eventingestion.Pipeline
 	sched                  *scheduler.Scheduler
+	leakDetectionJob       *leakdetection.Job
 	taskScheduleStore      taskschedule.Store
 	taskScheduleDispatcher *taskschedule.Dispatcher
 }
@@ -115,7 +159,37 @@ func New(ctx context.Context, c Config) (*Service, error) {
 		return nil, fmt.Errorf("failed to create task manager: %w", err)
 	}
 
-	// 5. Create OperationRunManager (Business Logic Layer)
+	// 5. Create EventRuleManager (Business Logic Layer)
+	eventRuleManager, err := eventrulemanager.New(eventrulemanager.Config{
+		Store: eventrulemanager.StoreConfig{
+			Backend: eventrulemanager.StoreBackendMemory,
+		},
+		Scheduler: eventrulemanager.SchedulerConfig{
+			InstanceID: "flow-" + uuid.NewString(),
+			Runtime:    eventrulescheduler.DefaultRuntimeConfig(),
+			Policy:     eventrulescheduler.DefaultPolicyConfig(),
+		},
+		Inventory:   invManager,
+		TaskManager: taskManager,
+	})
+	if err != nil {
+		session.Close()
+
+		return nil, fmt.Errorf("failed to create event-rule manager: %w", err)
+	}
+
+	// 6. Create the event collection runtime used by scheduled collection jobs.
+	eventIngestionPipeline, err := eventingestion.New(
+		eventRuleManager,
+		eventingestion.DefaultConfig(),
+	)
+	if err != nil {
+		session.Close()
+
+		return nil, fmt.Errorf("failed to create event ingestion pipeline: %w", err)
+	}
+
+	// 7. Create OperationRunManager (Business Logic Layer)
 	operationRunLookup := operationrunplanner.NewInventoryTargetLookup(
 		invManager,
 		operationRunStore,
@@ -135,19 +209,21 @@ func New(ctx context.Context, c Config) (*Service, error) {
 	}
 
 	return &Service{
-		conf:                c,
-		session:             session,
-		inventoryManager:    invManager,
-		taskStore:           tskStore,
-		operationRunStore:   operationRunStore,
-		taskManager:         taskManager,
-		operationRunManager: operationRunManager,
-		taskScheduleStore:   schedStore,
+		conf:                   c,
+		session:                session,
+		inventoryManager:       invManager,
+		taskStore:              tskStore,
+		operationRunStore:      operationRunStore,
+		taskManager:            taskManager,
+		operationRunManager:    operationRunManager,
+		eventRuleManager:       eventRuleManager,
+		eventIngestionPipeline: eventIngestionPipeline,
+		taskScheduleStore:      schedStore,
 	}, nil
 }
 
-// Start starts the inventory manager, task manager, and inventory sync
-// goroutine, then begins serving gRPC requests on the configured port.
+// Start starts the inventory, task, and event-rule managers and the system
+// scheduler, then begins serving gRPC requests on the configured port.
 // It blocks until the gRPC server stops.
 func (s *Service) Start(ctx context.Context) (retErr error) {
 	log.Logger = log.With().Caller().Logger()
@@ -157,9 +233,10 @@ func (s *Service) Start(ctx context.Context) (retErr error) {
 	// because inventoryManager and taskManager are always non-nil (set in New)
 	// so a nil check cannot distinguish "created" from "started".
 	var (
-		invStarted  bool
-		taskStarted bool
-		lis         net.Listener
+		invStarted       bool
+		taskStarted      bool
+		eventRuleStarted bool
+		lis              net.Listener
 	)
 
 	defer func() {
@@ -176,6 +253,11 @@ func (s *Service) Start(ctx context.Context) (retErr error) {
 		}
 		if s.sched != nil {
 			s.sched.Stop(false) //nolint
+		}
+		if eventRuleStarted {
+			if err := s.eventRuleManager.Stop(); err != nil {
+				log.Error().Err(err).Msg("Failed to stop event-rule manager")
+			}
 		}
 		if lis != nil {
 			lis.Close()
@@ -211,6 +293,12 @@ func (s *Service) Start(ctx context.Context) (retErr error) {
 		taskStarted = true
 		log.Info().Msg("Task manager started")
 	}
+
+	if err := s.eventRuleManager.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start event-rule manager: %w", err)
+	}
+	eventRuleStarted = true
+	log.Info().Msg("Event-rule manager started")
 
 	// Pre-create the dispatcher without starting it. The listener and server
 	// implementation are constructed next so that a failure there does not
@@ -321,9 +409,9 @@ func streamServerInterceptors(authorizer *authz.Authorizer) []grpc.StreamServerI
 }
 
 // Stop gracefully shuts down the service in dependency order:
-//  1. Background producers (dispatcher, system scheduler) — stop submitting new work.
-//  2. gRPC server — drain in-flight RPCs; no new requests accepted after this.
-//  3. Task and inventory managers — safe to stop once no new submissions can arrive.
+//  1. Background producers (dispatchers and system scheduler).
+//  2. Event-rule scheduler after its leakage-event producer has stopped.
+//  3. gRPC server, task manager, and inventory manager.
 //  4. Database session.
 func (s *Service) Stop(ctx context.Context) {
 	log.Info().Msg("Starting graceful shutdown now...")
@@ -343,6 +431,14 @@ func (s *Service) Stop(ctx context.Context) {
 	if s.sched != nil {
 		s.sched.Stop(false) //nolint
 		log.Info().Msg("System job scheduler stopped")
+	}
+
+	if s.eventRuleManager != nil {
+		if err := s.eventRuleManager.Stop(); err != nil {
+			log.Error().Err(err).Msg("Failed to stop event-rule manager")
+		} else {
+			log.Info().Msg("Event-rule manager stopped")
+		}
 	}
 
 	if s.grpcServer != nil {
@@ -435,11 +531,20 @@ func (s *Service) startScheduler(ctx context.Context) error {
 	}
 
 	// Create and register the leak detection job
+	var leakDetectionPipeline *eventingestion.Pipeline
+	if !s.conf.FlowConfig.DisableLeakDetection {
+		leakDetectionPipeline, err = leakDetectionPipelineFromEnv(s.eventIngestionPipeline)
+		if err != nil {
+			return fmt.Errorf("configure leak detection implementation: %w", err)
+		}
+	}
+
 	leakJob, err := leakdetection.New(
 		ctx,
 		&s.conf.DBConf,
 		s.taskManager,
 		s.conf.ProviderRegistry,
+		leakDetectionPipeline,
 		s.conf.FlowConfig,
 	)
 	if err != nil {
@@ -447,6 +552,7 @@ func (s *Service) startScheduler(ctx context.Context) error {
 	}
 
 	if leakJob != nil {
+		s.leakDetectionJob = leakJob
 		leakTrigger, err := schedtypes.NewIntervalTrigger(s.conf.FlowConfig.LeakDetectionInterval)
 		if err != nil {
 			return fmt.Errorf("invalid leak detection interval: %w", err)

--- a/rest-api/flow/internal/service/service_test.go
+++ b/rest-api/flow/internal/service/service_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	eventingestion "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/ingestion"
+)
+
+func TestLeakDetectionPipelineFromEnv(t *testing.T) {
+	pipeline := &eventingestion.Pipeline{}
+
+	tests := map[string]struct {
+		raw         string
+		pipeline    *eventingestion.Pipeline
+		wantEnabled bool
+		wantErr     string
+	}{
+		"unset defaults to legacy": {
+			pipeline: pipeline,
+		},
+		"false selects legacy": {
+			raw:      "false",
+			pipeline: pipeline,
+		},
+		"true selects event rule": {
+			raw:         "true",
+			pipeline:    pipeline,
+			wantEnabled: true,
+		},
+		"accepted boolean selects event rule": {
+			raw:         "1",
+			pipeline:    pipeline,
+			wantEnabled: true,
+		},
+		"invalid value is rejected": {
+			raw:      "enabled",
+			pipeline: pipeline,
+			wantErr:  "must be a boolean",
+		},
+		"enabled requires initialized pipeline": {
+			raw:     "true",
+			wantErr: "event ingestion pipeline is not initialized",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(eventRuleLeakDetectionEnabledEnvVar, test.raw)
+
+			actual, err := leakDetectionPipelineFromEnv(test.pipeline)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				require.Nil(t, actual)
+
+				return
+			}
+
+			require.NoError(t, err)
+			if test.wantEnabled {
+				require.Same(t, test.pipeline, actual)
+
+				return
+			}
+
+			require.Nil(t, actual)
+		})
+	}
+}


### PR DESCRIPTION
Add source-bound event ingestion with stable source naming, envelope
validation, terminal error classification, and retry delivery.

Implement the NICo leakage detector as a streaming event producer,
wire the event-rule manager into the Flow service lifecycle, and gate
leakage cutover with FLOW_EVENT_RULE_LEAK_DETECTION_ENABLED
while retaining the legacy nil-pipeline path.

Add unit and integration coverage for ingestion, detector occurrence
identity and rule targeting, job delegation, and environment selection.

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

