### PR TITLE
chore: bump libredfish to v0.47.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6729,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.47.1#6cff6843cd09dfee5b066ea6f16c2b9c69ca5953"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.47.2#bfb704b8d7f14484fcb9eb95721e22844a565d6d"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.47.1" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.47.2" }
 librms = { git = "https://github.com/dsx-ai-factory/nv-rms-client.git", tag = "v0.10.1" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
This PR bumps libredfish to `v0.47.2` which brings in the following changes:

- fix: skip AMI refinement for identified Viking systems by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/134

## Related issues
https://github.com/NVIDIA/infra-controller/issues/5418

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
