### PR TITLE
patch(v2.1): apply GB200 NVConfig during DPF provisioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,6 +1824,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "carbide-libmlx-model",
  "carbide-test-support",
  "carbide-utils",
  "carbide-uuid",
@@ -2454,6 +2455,7 @@ dependencies = [
  "carbide-health-report",
  "carbide-instrument",
  "carbide-ipmi",
+ "carbide-libmlx-model",
  "carbide-measured-boot",
  "carbide-redfish",
  "carbide-secrets",

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -68,11 +68,22 @@ use model::vpc::VpcConfig;
 pub use model::vpc::{PrefixFilterPolicyEntry, RouteTargetConfig};
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::CarbideError;
 
 pub(crate) const DEFAULT_DPU_NUM_OF_VFS: u32 = 16;
 pub(crate) const MAX_DPU_NUM_OF_VFS: u32 = 126;
+
+const DPF_DEPLOYMENT_NAME_MAX_LENGTH: usize = 20;
+const DPF_DERIVED_NAME_HASH_BYTES: usize = 16;
+const DPF_FLAVOR_HASH_SUFFIX_LENGTH: usize = 17;
+const KUBERNETES_DNS_LABEL_MAX_LENGTH: usize = 63;
+const KUBERNETES_LABEL_NAME_MAX_LENGTH: usize = 63;
+const GB200_RESOURCE_SUFFIX: &str = "-gb200";
+// The DPUDeployment CRD allows only 20 characters. The default BF3 name already
+// uses 18, so `-g` is the longest suffix that preserves it without truncation.
+const GB200_DEPLOYMENT_SUFFIX: &str = "-g";
 
 /// Parses an optional duration ("30d", "12h", ...; absent = `None`) into
 /// `Option<chrono::Duration>`. Hand-rolled because `duration_str` deprecated
@@ -944,6 +955,7 @@ impl CarbideConfig {
             firmware_global: self.firmware_global.clone(),
             machine_state_controller: self.machine_state_controller.clone(),
             host_health: self.host_health,
+            rack_profiles: self.rack_profiles.clone(),
 
             selected_profile: self.selected_profile,
             bios_profiles: self.bios_profiles.clone(),
@@ -1341,9 +1353,10 @@ fn is_valid_kubernetes_object_name(value: &str) -> bool {
         && value.len() <= KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
         && value.split('.').all(|label| {
             let bytes = label.as_bytes();
-            bytes
-                .first()
-                .is_some_and(|byte| is_dns_1123_alphanumeric(*byte))
+            label.len() <= KUBERNETES_DNS_LABEL_MAX_LENGTH
+                && bytes
+                    .first()
+                    .is_some_and(|byte| is_dns_1123_alphanumeric(*byte))
                 && bytes
                     .last()
                     .is_some_and(|byte| is_dns_1123_alphanumeric(*byte))
@@ -1366,6 +1379,19 @@ fn is_valid_kubernetes_data_key(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+fn is_valid_kubernetes_label_key(value: &str) -> bool {
+    let (prefix, name) = value
+        .split_once('/')
+        .map_or((None, value), |(prefix, name)| (Some(prefix), name));
+    let bytes = name.as_bytes();
+
+    prefix.is_none_or(is_valid_kubernetes_object_name)
+        && name.len() <= KUBERNETES_LABEL_NAME_MAX_LENGTH
+        && bytes.first().is_some_and(u8::is_ascii_alphanumeric)
+        && bytes.last().is_some_and(u8::is_ascii_alphanumeric)
+        && is_valid_kubernetes_data_key(name)
 }
 
 /// Kubernetes object kinds supported as DPF DPU-agent trust-anchor sources.
@@ -1552,7 +1578,7 @@ const BF4_ASTRA_EXTRA_SERVICES: &[DpfExtraService] = &[
 
 fn extra_service_types(deployment_type: DpuDeploymentType) -> &'static [DpfExtraService] {
     match deployment_type {
-        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => &[],
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf3Gb200 | DpuDeploymentType::Bf4Generic => &[],
         DpuDeploymentType::Bf4Astra => BF4_ASTRA_EXTRA_SERVICES,
     }
 }
@@ -1664,6 +1690,117 @@ impl Default for DpfDeploymentConfig {
     }
 }
 
+impl DpfDeploymentConfig {
+    /// Derives the GB200 BF3 deployment from the configured BF3 source and services.
+    pub(crate) fn bf3_gb200(&self) -> Self {
+        Self {
+            flavor_name: append_bounded_dns_subdomain_suffix(
+                &self.flavor_name,
+                GB200_RESOURCE_SUFFIX,
+                KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH - DPF_FLAVOR_HASH_SUFFIX_LENGTH,
+                KUBERNETES_DNS_LABEL_MAX_LENGTH - DPF_FLAVOR_HASH_SUFFIX_LENGTH,
+            ),
+            deployment_name: append_bounded_identifier_suffix(
+                &self.deployment_name,
+                GB200_DEPLOYMENT_SUFFIX,
+                DPF_DEPLOYMENT_NAME_MAX_LENGTH,
+            ),
+            node_label_key: append_gb200_label_suffix(&self.node_label_key),
+            ..self.clone()
+        }
+    }
+}
+
+/// Appends `suffix` while reserving its bytes inside `max_len`.
+///
+/// Kubernetes identifiers are ASCII. If truncation lands on a separator,
+/// remove it so the suffix still ends a valid segment. Startup validation
+/// checks both the configured and derived identifiers after this step.
+fn append_bounded_identifier_suffix(value: &str, suffix: &str, max_len: usize) -> String {
+    let max_prefix_len = max_len.saturating_sub(suffix.len());
+    let prefix = value
+        .char_indices()
+        .take_while(|(index, ch)| index + ch.len_utf8() <= max_prefix_len)
+        .map(|(_, ch)| ch)
+        .collect::<String>();
+    let prefix = prefix.trim_end_matches(['-', '.', '_']);
+
+    format!("{prefix}{suffix}")
+}
+
+/// Appends `suffix` to the final DNS label while reserving room for both the
+/// complete subdomain and the final label's later hash suffix. If preserving
+/// the dotted prefix leaves too little room, a hash of the complete source name
+/// keeps the derived identifier bounded and distinct.
+fn append_bounded_dns_subdomain_suffix(
+    value: &str,
+    suffix: &str,
+    max_len: usize,
+    max_label_len: usize,
+) -> String {
+    let (prefix, final_label) = value
+        .rsplit_once('.')
+        .map_or((None, value), |(prefix, label)| (Some(prefix), label));
+    let prefix_len = prefix.map_or(0, |prefix| prefix.len() + 1);
+    let available_label_len = max_label_len.min(max_len.saturating_sub(prefix_len));
+    let final_label = append_bounded_identifier_suffix(final_label, suffix, available_label_len);
+    let candidate = match prefix {
+        Some(prefix) => format!("{prefix}.{final_label}"),
+        None => final_label,
+    };
+    if candidate.len() <= max_len
+        && candidate
+            .rsplit('.')
+            .next()
+            .is_some_and(|label| label.len() <= max_label_len)
+        && is_valid_kubernetes_object_name(&candidate)
+    {
+        return candidate;
+    }
+
+    let short_hash = hex::encode(&Sha256::digest(value.as_bytes())[..DPF_DERIVED_NAME_HASH_BYTES]);
+    let hash_and_suffix = format!("-{short_hash}{suffix}");
+    let readable_len = max_label_len.saturating_sub(hash_and_suffix.len());
+    let readable = value
+        .rsplit('.')
+        .next()
+        .unwrap_or(value)
+        .char_indices()
+        .take_while(|(index, ch)| index + ch.len_utf8() <= readable_len)
+        .map(|(_, ch)| ch)
+        .collect::<String>();
+    let readable = readable.trim_end_matches('-');
+    let readable = if is_valid_kubernetes_object_name(readable) {
+        readable
+    } else {
+        "f"
+    };
+    let fallback = format!("{readable}{hash_and_suffix}");
+
+    debug_assert!(fallback.len() <= max_len);
+    debug_assert!(fallback.len() <= max_label_len);
+    debug_assert!(is_valid_kubernetes_object_name(&fallback));
+    fallback
+}
+
+/// Adds the GB200 suffix to the name segment of a Kubernetes label key.
+fn append_gb200_label_suffix(label_key: &str) -> String {
+    let Some((prefix, name)) = label_key.rsplit_once('/') else {
+        return append_bounded_identifier_suffix(
+            label_key,
+            GB200_RESOURCE_SUFFIX,
+            KUBERNETES_LABEL_NAME_MAX_LENGTH,
+        );
+    };
+    let name = append_bounded_identifier_suffix(
+        name,
+        GB200_RESOURCE_SUFFIX,
+        KUBERNETES_LABEL_NAME_MAX_LENGTH,
+    );
+
+    format!("{prefix}/{name}")
+}
+
 /// BlueFieldSoftware spec for BF4-class DPU provisioning. Mirrors the `spec` of
 /// the `provisioning.dpu.nvidia.com/v1alpha1` `BlueFieldSoftware` CR.
 ///
@@ -1763,11 +1900,12 @@ impl DpfDeploymentsConfig {
         v
     }
 
-    /// Validates that no two active deployments share a `deployment_name`,
-    /// `flavor_name`, or `node_label_key`. Returns an error listing every
-    /// conflict so the operator can fix them all in one pass.
+    /// Validates the final Kubernetes identifiers and their uniqueness.
+    /// Returns every error so the operator can fix them all in one pass.
     pub fn validate_unique_identifiers(&self) -> eyre::Result<()> {
-        let deployments = self.all();
+        let bf3_gb200 = self.bf3.bf3_gb200();
+        let mut deployments = self.all();
+        deployments.push(("bf3_gb200", &bf3_gb200));
         let mut errors: Vec<String> = Vec::new();
 
         let name_vals: Vec<(&str, &str)> = deployments
@@ -1798,11 +1936,40 @@ impl DpfDeploymentsConfig {
             }
         }
 
+        for (deployment, name) in &name_vals {
+            if name.len() > DPF_DEPLOYMENT_NAME_MAX_LENGTH || !is_valid_kubernetes_object_name(name)
+            {
+                errors.push(format!(
+                    "deployment_name {name:?} for deployment {deployment:?} is not a valid DPUDeployment name"
+                ));
+            }
+        }
+
+        for (deployment, name) in &flavor_vals {
+            if name.len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH > KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
+                || name.rsplit('.').next().is_none_or(|label| {
+                    label.len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH > KUBERNETES_DNS_LABEL_MAX_LENGTH
+                })
+                || !is_valid_kubernetes_object_name(name)
+            {
+                errors.push(format!(
+                    "flavor_name {name:?} for deployment {deployment:?} cannot form a valid hash-suffixed DPUFlavor name"
+                ));
+            }
+        }
+
+        for (deployment, label_key) in &label_vals {
+            if !is_valid_kubernetes_label_key(label_key) {
+                errors.push(format!(
+                    "node_label_key {label_key:?} for deployment {deployment:?} is not a valid Kubernetes label key"
+                ));
+            }
+        }
         if errors.is_empty() {
             Ok(())
         } else {
             Err(eyre::eyre!(
-                "DPF deployment configuration has conflicting identifiers:\n  - {}",
+                "DPF deployment configuration has invalid identifiers:\n  - {}",
                 errors.join("\n  - ")
             ))
         }
@@ -6151,6 +6318,21 @@ node_label_key = "carbide.nvidia.com/astra"
                     expect: true,
                 },
                 Check {
+                    scenario: "object name with a DNS label longer than the Kubernetes limit",
+                    input: ValidationInput {
+                        policy: DpfDpuAgentBootstrapCa::Mounted {
+                            object_kind: DpfBootstrapCaObjectKind::ConfigMap,
+                            name: format!(
+                                "{}.valid",
+                                "a".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH + 1)
+                            ),
+                            key: "ca.crt".to_string(),
+                        },
+                        expected_error: "name must be a valid Kubernetes DNS subdomain",
+                    },
+                    expect: true,
+                },
+                Check {
                     scenario: "object name longer than the Kubernetes limit",
                     input: ValidationInput {
                         policy: DpfDpuAgentBootstrapCa::Mounted {
@@ -6234,7 +6416,13 @@ node_label_key = "carbide.nvidia.com/astra"
                 Check {
                     scenario: "maximum-length object name and key",
                     input: (
-                        "a".repeat(KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH),
+                        [
+                            "a".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+                            "b".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+                            "c".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+                            "d".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH - 2),
+                        ]
+                        .join("."),
                         "A".repeat(KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH),
                     ),
                     expect: Ok(()),
@@ -6591,6 +6779,130 @@ node_label_key = "carbide.nvidia.com/astra"
             services: None,
             extra_services: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn gb200_bf3_deployment_derives_distinct_identifiers_and_reuses_bf3_inputs() {
+        let bf3 = DpfDeploymentConfig {
+            bfb_url: Some("https://example.com/custom.bfb".to_string()),
+            flavor_name: "site-bf3-flavor".to_string(),
+            deployment_name: "site-bf3-deploy".to_string(),
+            node_label_key: "carbide.nvidia.com/site-bf3".to_string(),
+            ..Default::default()
+        };
+
+        let gb200 = bf3.bf3_gb200();
+        assert_eq!(gb200.bfb_url, bf3.bfb_url);
+        assert_eq!(gb200.flavor_name, "site-bf3-flavor-gb200");
+        assert_eq!(gb200.deployment_name, "site-bf3-deploy-g");
+        assert_eq!(gb200.node_label_key, "carbide.nvidia.com/site-bf3-gb200");
+    }
+
+    #[test]
+    fn gb200_bf3_derived_identifiers_stay_within_kubernetes_limits() {
+        let max_flavor_name = [
+            "a".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "b".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "c".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "f".repeat(44),
+        ]
+        .join(".");
+        assert_eq!(
+            max_flavor_name.len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH,
+            KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
+        );
+        let bf3 = DpfDeploymentConfig {
+            flavor_name: max_flavor_name,
+            deployment_name: "d".repeat(DPF_DEPLOYMENT_NAME_MAX_LENGTH),
+            node_label_key: format!(
+                "carbide.nvidia.com/{}",
+                "n".repeat(KUBERNETES_LABEL_NAME_MAX_LENGTH)
+            ),
+            ..Default::default()
+        };
+
+        let gb200 = bf3.bf3_gb200();
+        let label_name = gb200.node_label_key.rsplit_once('/').unwrap().1;
+
+        assert_eq!(gb200.deployment_name.len(), DPF_DEPLOYMENT_NAME_MAX_LENGTH);
+        assert_eq!(
+            gb200.flavor_name.len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH,
+            KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
+        );
+        assert!(
+            gb200.flavor_name.rsplit('.').next().unwrap().len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH
+                <= KUBERNETES_DNS_LABEL_MAX_LENGTH
+        );
+        assert!(is_valid_kubernetes_object_name(&gb200.flavor_name));
+        assert_eq!(label_name.len(), KUBERNETES_LABEL_NAME_MAX_LENGTH);
+        assert!(is_valid_kubernetes_label_key(&gb200.node_label_key));
+
+        let deployments = DpfDeploymentsConfig {
+            bf3,
+            bf4_generic: None,
+            bf4_astra: None,
+        };
+        assert!(deployments.validate_unique_identifiers().is_ok());
+    }
+
+    #[test]
+    fn gb200_bf3_flavor_derivation_handles_a_full_prefix_and_short_final_label() {
+        let flavor_name = [
+            "a".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "b".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "c".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "d".repeat(42),
+            "f".to_string(),
+        ]
+        .join(".");
+        assert_eq!(
+            flavor_name.len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH,
+            KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
+        );
+
+        let deployments = DpfDeploymentsConfig {
+            bf3: DpfDeploymentConfig {
+                flavor_name,
+                ..Default::default()
+            },
+            bf4_generic: None,
+            bf4_astra: None,
+        };
+        let gb200 = deployments.bf3.bf3_gb200();
+
+        assert!(is_valid_kubernetes_object_name(&gb200.flavor_name));
+        assert!(
+            gb200.flavor_name.len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH
+                <= KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
+        );
+        assert!(
+            gb200.flavor_name.rsplit('.').next().unwrap().len() + DPF_FLAVOR_HASH_SUFFIX_LENGTH
+                <= KUBERNETES_DNS_LABEL_MAX_LENGTH
+        );
+        assert!(deployments.validate_unique_identifiers().is_ok());
+    }
+
+    #[test]
+    fn dpf_flavor_name_validation_reserves_final_label_for_hash() {
+        let deployments = DpfDeploymentsConfig {
+            bf3: DpfDeploymentConfig {
+                flavor_name: "f"
+                    .repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH - DPF_FLAVOR_HASH_SUFFIX_LENGTH + 1),
+                ..Default::default()
+            },
+            bf4_generic: None,
+            bf4_astra: None,
+        };
+
+        assert!(
+            deployments
+                .validate_unique_identifiers()
+                .is_err_and(|error| {
+                    error
+                        .to_string()
+                        .contains("cannot form a valid hash-suffixed DPUFlavor name")
+                })
+        );
     }
 
     #[test]

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -563,7 +563,7 @@ async fn initialize_dpf_sdk(
         return Ok(None);
     }
 
-    let mut deployments = vec!["bf3"];
+    let mut deployments = vec!["bf3", "bf3_gb200"];
     if carbide_config.dpf.deployments.bf4_generic.is_some() {
         deployments.push("bf4_generic");
     }
@@ -634,9 +634,11 @@ async fn initialize_dpf_sdk(
         };
 
     let bf3 = &carbide_config.dpf.deployments.bf3;
-    sdk.create_initialization_objects(&make_init_config(bf3, DpuDeploymentType::Bf3, None))
-        .await
-        .map_err(|err| eyre::eyre!("failed to initialize bf3 DPF deployment: {err}"))?;
+    let bf3_gb200 = bf3.bf3_gb200();
+    let mut init_configs = vec![
+        make_init_config(bf3, DpuDeploymentType::Bf3, None),
+        make_init_config(&bf3_gb200, DpuDeploymentType::Bf3Gb200, None),
+    ];
 
     if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
         // Validation guarantees `bluefield_software` is set with exactly one PSID
@@ -652,13 +654,11 @@ async fn initialize_dpf_sdk(
             os_iso: bfs.os_iso.clone(),
             pldm_fw_bundle: Some(pldm_url.clone()),
         };
-        sdk.create_initialization_objects(&make_init_config(
+        init_configs.push(make_init_config(
             bf4,
             DpuDeploymentType::Bf4Generic,
             Some(params),
-        ))
-        .await
-        .map_err(|err| eyre::eyre!("failed to initialize bf4_generic DPF deployment: {err}"))?;
+        ));
     }
 
     if let Some(bf4_astra) = &carbide_config.dpf.deployments.bf4_astra {
@@ -674,14 +674,16 @@ async fn initialize_dpf_sdk(
             os_iso: bfs.os_iso.clone(),
             pldm_fw_bundle: Some(pldm_url.clone()),
         };
-        sdk.create_initialization_objects(&make_init_config(
+        init_configs.push(make_init_config(
             bf4_astra,
             DpuDeploymentType::Bf4Astra,
             Some(params),
-        ))
-        .await
-        .map_err(|err| eyre::eyre!("failed to initialize bf4_astra DPF deployment: {err}"))?;
+        ));
     }
+
+    sdk.create_initialization_objects_for_deployments(&init_configs)
+        .await
+        .map_err(|err| eyre::eyre!("failed to initialize DPF deployments: {err}"))?;
 
     Ok(Some(Arc::new(DpfSdkOps::new(
         Arc::new(sdk),
@@ -693,8 +695,8 @@ async fn initialize_dpf_sdk(
 /// Build per-deployment-type node selector labels for the DPF labeler registry.
 ///
 /// Each deployment gets two labels: the shared `dpu-enabled` marker and its
-/// own deployment-specific key. BF3 is always included;
-/// BF4Generic is added when configured.
+/// own deployment-specific key. Both BF3 variants are always included;
+/// configured BF4 variants are added.
 fn build_deployment_type_labels(
     carbide_config: &CarbideConfig,
 ) -> std::collections::BTreeMap<DpuDeploymentType, std::collections::BTreeMap<String, String>> {
@@ -712,6 +714,11 @@ fn build_deployment_type_labels(
         DpuDeploymentType::Bf3,
         make_labels(&carbide_config.dpf.deployments.bf3.node_label_key),
     )]);
+    let bf3_gb200 = carbide_config.dpf.deployments.bf3.bf3_gb200();
+    map.insert(
+        DpuDeploymentType::Bf3Gb200,
+        make_labels(&bf3_gb200.node_label_key),
+    );
 
     if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
         map.insert(
@@ -1914,6 +1921,24 @@ mod tests {
             ))
             .extract()
             .expect("minimal CarbideConfig parses")
+    }
+
+    #[test]
+    fn dpf_labels_include_the_derived_gb200_deployment() {
+        let config = minimal_carbide_config();
+        let labels = build_deployment_type_labels(&config);
+        let gb200_label = format!("{}-gb200", config.dpf.deployments.bf3.node_label_key);
+
+        assert_eq!(
+            labels.get(&DpuDeploymentType::Bf3Gb200),
+            Some(&BTreeMap::from([
+                (
+                    "feature.node.kubernetes.io/dpu-enabled".to_string(),
+                    "true".to_string()
+                ),
+                (gb200_label, "true".to_string()),
+            ]))
+        );
     }
 
     fn network_definition(mtu: i32) -> NetworkDefinition {

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -21,7 +21,7 @@
 //! transition correctly when the outer state is `DPUReprovision`.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -30,14 +30,16 @@ use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
 use model::machine::{
-    DpfState, DpuReprovisionStates, InstanceState, ManagedHostState, ReprovisionState,
+    DpfState, DpuReprovisionStates, FailureCause, InstanceState, ManagedHostState, ReprovisionState,
 };
 use tokio::time::timeout;
 
 use super::{dpf_config, get_host_state};
+use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
+    TEST_RMS_RACK_PROFILE_ID, TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
     create_managed_host_with_dpf_multi, create_test_env_with_overrides, get_config,
+    get_config_with_rack_profiles,
 };
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -449,6 +451,210 @@ async fn test_multi_dpu_provisioning_registers_all_devices(pool: sqlx::PgPool) {
          Registered: {registered:?}\n\
          Expected:   {expected:?}"
     );
+}
+
+/// GB200 rack identity and every attached B3240 DPU must select one shared deployment.
+#[crate::sqlx_test]
+async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
+    let classified_dpus = Arc::new(Mutex::new(Vec::new()));
+    let verified_deployments = Arc::new(Mutex::new(Vec::new()));
+    let registered_deployments = Arc::new(Mutex::new(Vec::new()));
+
+    let mut mock = MockDpfOperations::new();
+    mock.expect_register_dpu_device().returning(|_| Ok(()));
+    let registered_deployments_for_mock = registered_deployments.clone();
+    mock.expect_register_dpu_node().returning(move |info| {
+        registered_deployments_for_mock
+            .lock()
+            .unwrap()
+            .push(info.deployment_type);
+        Ok(())
+    });
+    mock.expect_release_maintenance_hold().returning(|_| Ok(()));
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    let classified_dpus_for_mock = classified_dpus.clone();
+    mock.expect_deployment_type_for_dpu().returning(move |dpu| {
+        classified_dpus_for_mock.lock().unwrap().push(dpu.id);
+        Ok(DpuDeploymentType::Bf3)
+    });
+    let verified_deployments_for_mock = verified_deployments.clone();
+    mock.expect_verify_node_labels()
+        .returning(move |_, deployment_type| {
+            verified_deployments_for_mock
+                .lock()
+                .unwrap()
+                .push(deployment_type);
+            Ok(true)
+        });
+    mock.expect_snapshot_host()
+        .returning(|_| Ok(snapshot_with_crs_present(2)));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+
+    let mut txn = pool.begin().await.unwrap();
+    let rack_id = TestRackDbBuilder::new()
+        .with_rack_profile_id(TEST_RMS_RACK_PROFILE_ID)
+        .persist(txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+
+    // Give the host a GB200 rack and both DPUs the supported B3240 identity.
+    let mut txn = pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    for dpu_id in &mh.dpu_ids {
+        let dpu = db::machine::find_one(txn.as_mut(), dpu_id, Default::default())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut hardware_info = dpu
+            .status
+            .hardware_info
+            .expect("fixture DPU should have hardware information");
+        hardware_info
+            .dpu_info
+            .as_mut()
+            .expect("fixture DPU should have DPU information")
+            .part_number = "900-9D3B6-00CN-PA0".to_string();
+        db::machine_topology::set_topology_update_needed(txn.as_mut(), dpu_id, true)
+            .await
+            .unwrap();
+        db::machine_topology::create_or_update(txn.as_mut(), dpu_id, &hardware_info)
+            .await
+            .unwrap();
+    }
+    txn.commit().await.unwrap();
+
+    // Ignore initial ingestion and observe one complete host deployment selection pass.
+    classified_dpus.lock().unwrap().clear();
+    verified_deployments.lock().unwrap().clear();
+    registered_deployments.lock().unwrap().clear();
+    set_reprovision_dpf_state(&pool, &mh.id, &mh.dpu_ids, DpfState::Provisioning).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during state controller iteration");
+
+    let classified = classified_dpus.lock().unwrap().clone();
+    assert_eq!(classified.len(), mh.dpu_ids.len());
+    assert_eq!(
+        classified.into_iter().collect::<HashSet<_>>(),
+        mh.dpu_ids.iter().copied().collect()
+    );
+    assert_eq!(
+        *verified_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3Gb200]
+    );
+    assert_eq!(
+        *registered_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3Gb200]
+    );
+}
+
+/// A mixed DPU pair must enter a terminal failure without starting a DPF registration attempt.
+#[crate::sqlx_test]
+async fn test_mixed_dpu_deployment_types_fail_without_registration(pool: sqlx::PgPool) {
+    let mixed_pair = Arc::new(AtomicBool::new(false));
+    let deployment_type_calls = Arc::new(AtomicUsize::new(0));
+    let registered_devices = Arc::new(AtomicUsize::new(0));
+    let registered_nodes = Arc::new(AtomicUsize::new(0));
+
+    let mut mock = MockDpfOperations::new();
+    let registered_devices_for_mock = registered_devices.clone();
+    mock.expect_register_dpu_device().returning(move |_| {
+        registered_devices_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+    let registered_nodes_for_mock = registered_nodes.clone();
+    mock.expect_register_dpu_node().returning(move |_| {
+        registered_nodes_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+    mock.expect_release_maintenance_hold().returning(|_| Ok(()));
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    let mixed_pair_for_mock = mixed_pair.clone();
+    let deployment_type_calls_for_mock = deployment_type_calls.clone();
+    mock.expect_deployment_type_for_dpu().returning(move |_| {
+        if !mixed_pair_for_mock.load(Ordering::SeqCst) {
+            return Ok(DpuDeploymentType::Bf3);
+        }
+        let index = deployment_type_calls_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(if index.is_multiple_of(2) {
+            DpuDeploymentType::Bf3
+        } else {
+            DpuDeploymentType::Bf4Generic
+        })
+    });
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
+    mock.expect_snapshot_host()
+        .returning(|_| Ok(snapshot_with_crs_present(2)));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+
+    let mut config = get_config();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+
+    mixed_pair.store(true, Ordering::SeqCst);
+
+    // A mixed selection must become a visible terminal failure both before and after DPF resource
+    // registration. In either phase, it must not make a partial registration attempt.
+    for (scenario, dpf_state) in [
+        ("during provisioning", DpfState::Provisioning),
+        (
+            "while waiting for DPF",
+            DpfState::WaitingForReady { phase_detail: None },
+        ),
+    ] {
+        registered_devices.store(0, Ordering::SeqCst);
+        registered_nodes.store(0, Ordering::SeqCst);
+        deployment_type_calls.store(0, Ordering::SeqCst);
+        set_reprovision_dpf_state(&pool, &mh.id, &mh.dpu_ids, dpf_state).await;
+
+        timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+            .await
+            .expect("timed out during mixed-pair state controller iteration");
+
+        assert_eq!(registered_devices.load(Ordering::SeqCst), 0, "{scenario}");
+        assert_eq!(registered_nodes.load(Ordering::SeqCst), 0, "{scenario}");
+        assert!(
+            matches!(
+                get_host_state(&env, &mh).await,
+                ManagedHostState::Failed { details, .. }
+                    if matches!(
+                        &details.cause,
+                        FailureCause::DpfProvisioning { err }
+                            if err.starts_with("DPF deployment selection failed:")
+                                && err.contains("mixed DPF deployment types")
+                    )
+            ),
+            "{scenario}"
+        );
+    }
 }
 
 /// Reprovisioning with multiple DPUs: each DPU in Reprovisioning is

--- a/crates/dpf/Cargo.toml
+++ b/crates/dpf/Cargo.toml
@@ -46,8 +46,9 @@ tokio-stream = { workspace = true }
 rand = { workspace = true }
 sha2 = { workspace = true }
 
-carbide-uuid = { path = "../uuid", features = ["sqlx"] }
+carbide-libmlx-model = { path = "../libmlx-model" }
 carbide-utils = { path = "../utils" }
+carbide-uuid = { path = "../uuid", features = ["sqlx"] }
 
 # Optional dependencies for carbide-dpf-api-harness binary
 clap = { workspace = true, features = ["derive"], optional = true }

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -17,6 +17,7 @@
 
 //! DPUFlavor configuration for HBN.
 
+use carbide_libmlx_model::nvconfig::DpuNvConfigProfile;
 use kube::core::ObjectMeta;
 use sha2::{Digest, Sha256};
 
@@ -181,7 +182,9 @@ pub fn default_flavor_for(
     match deployment_type {
         DpuDeploymentType::Bf4Generic => flavor_bf4(namespace, proxy),
         DpuDeploymentType::Bf4Astra => flavor_bf4_astra(namespace, proxy),
-        DpuDeploymentType::Bf3 => default_flavor(namespace, proxy),
+        DpuDeploymentType::Bf3 | DpuDeploymentType::Bf3Gb200 => {
+            default_flavor_with_deployment_type(namespace, proxy, deployment_type)
+        }
     }
 }
 
@@ -429,6 +432,14 @@ pub fn default_flavor(
     namespace: &str,
     proxy: &Option<DpfProxyDetails>,
 ) -> Result<DPUFlavor, crate::error::DpfError> {
+    default_flavor_with_deployment_type(namespace, proxy, DpuDeploymentType::Bf3)
+}
+
+fn default_flavor_with_deployment_type(
+    namespace: &str,
+    proxy: &Option<DpfProxyDetails>,
+    deployment_type: DpuDeploymentType,
+) -> Result<DPUFlavor, crate::error::DpfError> {
     let bfcfg_parameters = vec![
         "UPDATE_ATF_UEFI=yes".to_string(),
         "UPDATE_DPU_OS=yes".to_string(),
@@ -448,7 +459,7 @@ pub fn default_flavor(
             containerd_config: None,
             grub: Some(get_default_grub()),
             host_network_interface_configs: None,
-            nvconfig: Some(vec![get_default_nvconfig()]),
+            nvconfig: Some(vec![get_default_nvconfig(deployment_type)]),
             ovs: Some(crate::crds::dpuflavors_generated::DpuFlavorOvs {
                 raw_config_script: Some(get_default_ovs_defaults()),
             }),
@@ -1182,8 +1193,8 @@ fn get_bf4_astra_config_files(
     Ok(config_files)
 }
 
-fn get_default_nvconfig() -> DpuFlavorNvconfig {
-    let parameters = vec![
+fn get_default_nvconfig(deployment_type: DpuDeploymentType) -> DpuFlavorNvconfig {
+    let mut parameters = vec![
         "PF_BAR2_ENABLE=0".to_string(),
         "PER_PF_NUM_SF=1".to_string(),
         "PF_TOTAL_SF=30".to_string(),
@@ -1201,6 +1212,27 @@ fn get_default_nvconfig() -> DpuFlavorNvconfig {
         "LINK_TYPE_P1=ETH".to_string(),
         "LINK_TYPE_P2=ETH".to_string(),
     ];
+
+    if deployment_type == DpuDeploymentType::Bf3Gb200 {
+        // DPF v26.4 accepts at most 32 parameters. These two assignments set
+        // values that DPF already restores to their firmware default of 0, so
+        // omitting them preserves the required platform state.
+        // TODO(chet): Add PCI_SWITCH0_UPSTREAM_PORT_BUS=0 and
+        // PCI_SWITCH0_UPSTREAM_PORT_PEX=0 after DPF accepts more than 32
+        // NVConfig parameters.
+        parameters.extend(
+            DpuNvConfigProfile::Gb200B3240V1
+                .parameters()
+                .iter()
+                .filter(|parameter| {
+                    !matches!(
+                        **parameter,
+                        "PCI_SWITCH0_UPSTREAM_PORT_BUS=0" | "PCI_SWITCH0_UPSTREAM_PORT_PEX=0"
+                    )
+                })
+                .map(|parameter| (*parameter).to_string()),
+        );
+    }
 
     DpuFlavorNvconfig {
         // DPF does not allow anyother wild card. It takes only '*'
@@ -2080,8 +2112,43 @@ mod tests {
     // ── get_default_nvconfig (pure constructor) ────────────────────────────
 
     #[test]
+    fn gb200_bf3_nvconfig_appends_the_bounded_profile_in_order() {
+        let parameters =
+            |deployment_type| get_default_nvconfig(deployment_type).parameters.unwrap();
+        let bf3 = parameters(DpuDeploymentType::Bf3);
+        let gb200 = parameters(DpuDeploymentType::Bf3Gb200);
+
+        assert_eq!(bf3.len(), 16);
+        assert_eq!(gb200.len(), 32);
+        assert_eq!(&gb200[..bf3.len()], bf3.as_slice());
+        assert_eq!(
+            &gb200[bf3.len()..],
+            [
+                "OFF_BOARD_SERIALIZER=1",
+                "PCI_BUS00_HIERARCHY_TYPE=1",
+                "PCI_BUS00_SPEED=5",
+                "PCI_BUS00_WIDTH=5",
+                "PCI_BUS10_HIERARCHY_TYPE=1",
+                "PCI_BUS10_SPEED=4",
+                "PCI_BUS10_WIDTH=3",
+                "PCI_BUS12_HIERARCHY_TYPE=1",
+                "PCI_BUS12_SPEED=4",
+                "PCI_BUS12_WIDTH=3",
+                "PCI_BUS14_HIERARCHY_TYPE=1",
+                "PCI_BUS14_SPEED=4",
+                "PCI_BUS14_WIDTH=3",
+                "PCI_BUS16_HIERARCHY_TYPE=1",
+                "PCI_BUS16_SPEED=4",
+                "PCI_BUS16_WIDTH=3",
+            ]
+        );
+        assert!(!gb200.contains(&"PCI_SWITCH0_UPSTREAM_PORT_BUS=0".to_string()));
+        assert!(!gb200.contains(&"PCI_SWITCH0_UPSTREAM_PORT_PEX=0".to_string()));
+    }
+
+    #[test]
     fn default_nvconfig_shape() {
-        let nv = get_default_nvconfig();
+        let nv = get_default_nvconfig(DpuDeploymentType::Bf3);
         value_scenarios!(
             run = |v| v;
             "device is the only allowed wildcard variant" {

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -17,6 +17,7 @@
 
 //! DPF SDK - High-level interface for DPF operations.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
@@ -94,6 +95,9 @@ use crate::watcher::DpuWatcherBuilder;
 const SECRET_NAME: &str = "bmc-shared-password";
 const BFB_NAME_PREFIX: &str = "bf-bundle";
 const BLUEFIELD_SOFTWARE_NAME_PREFIX: &str = "bf-software";
+const KUBERNETES_DNS_LABEL_MAX_LENGTH: usize = 63;
+const KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH: usize = 253;
+const SERVICE_CR_NAME_HASH_BYTES: usize = 16;
 /// Label set by the DPF operator on each DPU CR pointing back to its owning
 /// DPUDeployment. Value format: `<namespace>_<deployment_name>`.
 const DPU_OWNED_BY_DEPLOYMENT_LABEL: &str = "svc.dpu.nvidia.com/owned-by-dpudeployment";
@@ -615,10 +619,11 @@ async fn create_dpu_flavor<R: DpuFlavorRepository>(
 ///
 /// BF3 intentionally uses an empty suffix so its CR names are unchanged — this
 /// keeps existing BF3 clusters untouched (no CR rename / orphaning on upgrade).
-/// Only additional deployments (BF4) are suffixed to avoid colliding with BF3.
+/// Additional deployment classes are suffixed to avoid colliding with BF3.
 pub fn deployment_cr_suffix(deployment_type: DpuDeploymentType) -> &'static str {
     match deployment_type {
         DpuDeploymentType::Bf3 => "",
+        DpuDeploymentType::Bf3Gb200 => "bf3gb200",
         DpuDeploymentType::Bf4Generic => "bf4generic",
         DpuDeploymentType::Bf4Astra => "bf4astra",
     }
@@ -626,16 +631,147 @@ pub fn deployment_cr_suffix(deployment_type: DpuDeploymentType) -> &'static str 
 
 /// Per-deployment CR name for a service or NAD: its logical name with the
 /// deployment suffix appended (or the logical name unchanged when the suffix is
-/// empty, as for BF3). The logical name (used as the DPUDeployment `services`
-/// map key, `deploymentServiceName`, `dependsOn`, and service-chain references)
-/// is left unchanged; only the CR `metadata.name` and the references pointing at
-/// it are suffixed.
+/// empty, as for BF3). Names that would cross Kubernetes' DNS-subdomain or
+/// DNS-label length limits use a readable prefix and a hash of the complete
+/// logical name before the deployment suffix. The hash keeps distinct long
+/// logical names from collapsing onto the same truncated CR name.
+///
+/// The logical name (used as the DPUDeployment `services` map key,
+/// `deploymentServiceName`, `dependsOn`, and service-chain references) is left
+/// unchanged; only the CR `metadata.name` and the references pointing at it are
+/// suffixed.
 fn service_cr_name(logical_name: &str, suffix: &str) -> String {
     if suffix.is_empty() {
-        logical_name.to_string()
-    } else {
-        format!("{logical_name}-{suffix}")
+        return logical_name.to_string();
     }
+
+    let suffixed = format!("{logical_name}-{suffix}");
+    if has_valid_kubernetes_dns_subdomain_lengths(&suffixed) {
+        return suffixed;
+    }
+
+    let short_hash =
+        hex::encode(&Sha256::digest(logical_name.as_bytes())[..SERVICE_CR_NAME_HASH_BYTES]);
+    let hash_and_suffix = format!("-{short_hash}-{suffix}");
+
+    // Deployment suffixes are fixed, short DNS-label components. Keep this
+    // fallback defensive for direct builder callers so an unexpectedly long
+    // suffix cannot make name generation panic or return an invalid name.
+    if hash_and_suffix.len() >= KUBERNETES_DNS_LABEL_MAX_LENGTH {
+        let mut hasher = Sha256::new();
+        hasher.update(logical_name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(suffix.as_bytes());
+        return format!("service-{}", hex::encode(&hasher.finalize()[..24]));
+    }
+
+    let readable_length = KUBERNETES_DNS_LABEL_MAX_LENGTH - hash_and_suffix.len();
+    let final_label = logical_name.rsplit('.').next().unwrap_or(logical_name);
+    let readable_prefix = final_label
+        .char_indices()
+        .take_while(|(index, ch)| index + ch.len_utf8() <= readable_length)
+        .map(|(_, ch)| ch)
+        .collect::<String>();
+    let readable_prefix = readable_prefix.trim_end_matches('-');
+    let bounded = format!("{readable_prefix}{hash_and_suffix}");
+    debug_assert!(has_valid_kubernetes_dns_subdomain_lengths(&bounded));
+    bounded
+}
+
+fn has_valid_kubernetes_dns_subdomain_lengths(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH
+        && value
+            .split('.')
+            .all(|label| !label.is_empty() && label.len() <= KUBERNETES_DNS_LABEL_MAX_LENGTH)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum InitializationServiceObjectKind {
+    Template,
+    Configuration,
+    Nad,
+}
+
+impl InitializationServiceObjectKind {
+    fn resource_name(self) -> &'static str {
+        match self {
+            Self::Template => "DPUServiceTemplate",
+            Self::Configuration => "DPUServiceConfiguration",
+            Self::Nad => "DPUServiceNAD",
+        }
+    }
+}
+
+fn initialization_services(config: &InitDpfResourcesConfig) -> Cow<'_, [ServiceDefinition]> {
+    if config.services.is_empty() {
+        Cow::Owned(crate::services::default_services(
+            &crate::services::ServiceRegistryConfig::default(),
+        ))
+    } else {
+        Cow::Borrowed(&config.services)
+    }
+}
+
+fn record_initialization_service_object_name(
+    names: &mut BTreeMap<(InitializationServiceObjectKind, String), String>,
+    kind: InitializationServiceObjectKind,
+    name: String,
+    owner: String,
+) -> Result<(), DpfError> {
+    let key = (kind, name.clone());
+    if let Some(existing_owner) = names.get(&key) {
+        return Err(DpfError::ConfigError(format!(
+            "{} metadata.name {name:?} collides between {existing_owner} and {owner}",
+            kind.resource_name(),
+        )));
+    }
+    names.insert(key, owner);
+    Ok(())
+}
+
+/// Reject duplicate service CR identities before any deployment in a batch is
+/// created. Kubernetes object names are unique within a kind and namespace, so
+/// templates/configurations and NADs are tracked independently by kind.
+fn validate_initialization_service_object_names(
+    configs: &[InitDpfResourcesConfig],
+) -> Result<(), DpfError> {
+    let mut names = BTreeMap::new();
+    for config in configs {
+        let suffix = deployment_cr_suffix(config.deployment_type);
+        for (service_index, service) in initialization_services(config).iter().enumerate() {
+            let cr_name = service_cr_name(&service.name, suffix);
+            let owner = format!(
+                "service {:?} at index {service_index} in {:?} deployment {:?}",
+                service.name, config.deployment_type, config.deployment_name,
+            );
+            record_initialization_service_object_name(
+                &mut names,
+                InitializationServiceObjectKind::Template,
+                cr_name.clone(),
+                owner.clone(),
+            )?;
+            record_initialization_service_object_name(
+                &mut names,
+                InitializationServiceObjectKind::Configuration,
+                cr_name,
+                owner,
+            )?;
+
+            if let Some(nad) = &service.service_nad {
+                record_initialization_service_object_name(
+                    &mut names,
+                    InitializationServiceObjectKind::Nad,
+                    service_cr_name(&nad.name, suffix),
+                    format!(
+                        "NAD {:?} for service {:?} at index {service_index} in {:?} deployment {:?}",
+                        nad.name, service.name, config.deployment_type, config.deployment_name,
+                    ),
+                )?;
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn build_service_template(
@@ -1323,6 +1459,33 @@ impl<
         &self,
         config: &InitDpfResourcesConfig,
     ) -> Result<(), DpfError> {
+        self.create_initialization_objects_for_deployments(std::slice::from_ref(config))
+            .await
+    }
+
+    /// Create initialization objects for every configured deployment as one
+    /// preflighted batch.
+    ///
+    /// All service template/configuration/NAD `metadata.name` values are
+    /// derived and checked for collisions before the first deployment creates
+    /// or applies a Kubernetes object. This prevents a later deployment from
+    /// silently overwriting an earlier deployment's service resources.
+    pub async fn create_initialization_objects_for_deployments(
+        &self,
+        configs: &[InitDpfResourcesConfig],
+    ) -> Result<(), DpfError> {
+        validate_initialization_service_object_names(configs)?;
+        for config in configs {
+            self.create_initialization_objects_after_preflight(config)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn create_initialization_objects_after_preflight(
+        &self,
+        config: &InitDpfResourcesConfig,
+    ) -> Result<(), DpfError> {
         let source = match &config.bluefield_software {
             Some(params) => DpuProvisioningSource::BlueFieldSoftware(
                 create_bluefield_software(&*self.repo, &self.namespace, params).await?,
@@ -1331,16 +1494,12 @@ impl<
                 create_bfb(&*self.repo, &self.namespace, &config.bfb_url).await?,
             ),
         };
-        let services = if config.services.is_empty() {
-            crate::services::default_services(&crate::services::ServiceRegistryConfig::default())
-        } else {
-            config.services.clone()
-        };
+        let services = initialization_services(config);
         create_flavor_services_and_deployment(
             &*self.repo,
             &self.namespace,
             &self.labeler,
-            &services,
+            services.as_ref(),
             &config.deployment_name,
             &source,
             &config.flavor_name,
@@ -2205,7 +2364,7 @@ mod tests {
     use crate::repository::{
         DpuDeviceRepository, DpuFlavorRepository, DpuNodeRepository, DpuRepository,
     };
-    use crate::types::{DpuDeviceInfo, DpuNodeInfo};
+    use crate::types::{DpuDeviceInfo, DpuNodeInfo, ServiceNAD};
 
     fn already_exists_error(name: &str) -> DpfError {
         DpfError::KubeError(kube::Error::Api(Box::new(
@@ -2215,6 +2374,66 @@ mod tests {
     }
 
     const TEST_NAMESPACE: &str = "test-namespace";
+
+    fn assert_valid_kubernetes_dns_subdomain(name: &str) {
+        assert!(!name.is_empty());
+        assert!(
+            name.len() <= KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH,
+            "DNS subdomain exceeds {KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH} bytes: {name}"
+        );
+        for label in name.split('.') {
+            assert!(
+                !label.is_empty(),
+                "DNS subdomain contains an empty label: {name}"
+            );
+            assert!(
+                label.len() <= KUBERNETES_DNS_LABEL_MAX_LENGTH,
+                "DNS label exceeds {KUBERNETES_DNS_LABEL_MAX_LENGTH} bytes: {label}"
+            );
+            assert!(
+                label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'),
+                "DNS label contains an invalid character: {label}"
+            );
+            assert!(
+                label
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                    && label
+                        .as_bytes()
+                        .last()
+                        .is_some_and(u8::is_ascii_alphanumeric),
+                "DNS label must begin and end with an alphanumeric character: {label}"
+            );
+        }
+    }
+
+    fn initialization_test_service(name: &str, nad_name: Option<&str>) -> ServiceDefinition {
+        let mut service = ServiceDefinition::new(name, "repo", "chart", "1.0.0");
+        service.service_nad = nad_name.map(|name| ServiceNAD {
+            name: name.to_string(),
+            bridge: None,
+            ipam: None,
+            resource_type: ServiceNADResourceType::Sf,
+            mtu: None,
+        });
+        service
+    }
+
+    fn initialization_test_config(
+        deployment_type: DpuDeploymentType,
+        deployment_name: &str,
+        services: Vec<ServiceDefinition>,
+    ) -> InitDpfResourcesConfig {
+        InitDpfResourcesConfig {
+            deployment_name: deployment_name.to_string(),
+            deployment_type,
+            services,
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn otelcol_depends_on_includes_dts() {
@@ -2273,12 +2492,24 @@ mod tests {
         let svc = ServiceDefinition::new(DOCA_HBN_SERVICE_NAME, "repo", "chart", "1.0.5");
 
         let bf3_suffix = deployment_cr_suffix(DpuDeploymentType::Bf3);
+        let bf3_gb200_suffix = deployment_cr_suffix(DpuDeploymentType::Bf3Gb200);
         let bf4_suffix = deployment_cr_suffix(DpuDeploymentType::Bf4Generic);
 
         // BF3: CR name unchanged.
         let bf3 = build_service_template(&svc, TEST_NAMESPACE, bf3_suffix);
         assert_eq!(bf3.metadata.name.as_deref(), Some(DOCA_HBN_SERVICE_NAME));
         assert_eq!(bf3.spec.deployment_service_name, DOCA_HBN_SERVICE_NAME);
+
+        // GB200 BF3 uses separate resources but keeps the same logical service name.
+        let bf3_gb200 = build_service_template(&svc, TEST_NAMESPACE, bf3_gb200_suffix);
+        assert_eq!(
+            bf3_gb200.metadata.name.as_deref(),
+            Some("doca-hbn-bf3gb200")
+        );
+        assert_eq!(
+            bf3_gb200.spec.deployment_service_name,
+            DOCA_HBN_SERVICE_NAME
+        );
 
         // BF4: CR name suffixed, logical name unchanged.
         let bf4 = build_service_template(&svc, TEST_NAMESPACE, bf4_suffix);
@@ -2318,6 +2549,152 @@ mod tests {
     }
 
     #[test]
+    fn service_cr_name_bounds_suffixed_dns_subdomains() {
+        let suffix = deployment_cr_suffix(DpuDeploymentType::Bf3Gb200);
+        let label_boundary = "a".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH);
+        let total_boundary = format!(
+            "{}.{}.{}.{}",
+            "a".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "b".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "c".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH),
+            "d".repeat(61),
+        );
+        assert_eq!(total_boundary.len(), KUBERNETES_DNS_SUBDOMAIN_MAX_LENGTH);
+
+        let cases = [
+            (
+                "ordinary name",
+                DOCA_HBN_SERVICE_NAME.to_string(),
+                Some("doca-hbn-bf3gb200"),
+            ),
+            ("63-byte final label", label_boundary.clone(), None),
+            ("253-byte multi-label name", total_boundary, None),
+        ];
+
+        for (description, logical_name, expected) in cases {
+            let actual = service_cr_name(&logical_name, suffix);
+            assert_valid_kubernetes_dns_subdomain(&actual);
+            if let Some(expected) = expected {
+                assert_eq!(actual, expected, "{description}");
+            } else {
+                assert_ne!(actual, format!("{logical_name}-{suffix}"), "{description}");
+            }
+        }
+
+        // The empty BF3 suffix remains a compatibility exception: even a name
+        // at the label boundary is returned byte-for-byte without hashing.
+        assert_eq!(service_cr_name(&label_boundary, ""), label_boundary);
+    }
+
+    #[test]
+    fn service_cr_name_hash_distinguishes_long_logical_names() {
+        let suffix = deployment_cr_suffix(DpuDeploymentType::Bf3Gb200);
+        let common_prefix = "a".repeat(KUBERNETES_DNS_LABEL_MAX_LENGTH - 1);
+        let first_logical_name = format!("{common_prefix}b");
+        let second_logical_name = format!("{common_prefix}c");
+
+        let first = service_cr_name(&first_logical_name, suffix);
+        let second = service_cr_name(&second_logical_name, suffix);
+
+        assert_eq!(first, service_cr_name(&first_logical_name, suffix));
+        assert_ne!(first, second);
+        assert_valid_kubernetes_dns_subdomain(&first);
+        assert_valid_kubernetes_dns_subdomain(&second);
+    }
+
+    #[test]
+    fn initialization_name_preflight_rejects_within_and_cross_deployment_collisions() {
+        let cases = vec![
+            (
+                "suffix-shaped service name across deployments",
+                vec![
+                    initialization_test_config(
+                        DpuDeploymentType::Bf3,
+                        "bf3-deployment",
+                        vec![initialization_test_service("foo-bf3gb200", None)],
+                    ),
+                    initialization_test_config(
+                        DpuDeploymentType::Bf3Gb200,
+                        "gb200-deployment",
+                        vec![initialization_test_service("foo", None)],
+                    ),
+                ],
+                "DPUServiceTemplate metadata.name \"foo-bf3gb200\"",
+            ),
+            (
+                "suffix-shaped NAD name across deployments",
+                vec![
+                    initialization_test_config(
+                        DpuDeploymentType::Bf3,
+                        "bf3-deployment",
+                        vec![initialization_test_service(
+                            "first-service",
+                            Some("service-net-bf3gb200"),
+                        )],
+                    ),
+                    initialization_test_config(
+                        DpuDeploymentType::Bf3Gb200,
+                        "gb200-deployment",
+                        vec![initialization_test_service(
+                            "second-service",
+                            Some("service-net"),
+                        )],
+                    ),
+                ],
+                "DPUServiceNAD metadata.name \"service-net-bf3gb200\"",
+            ),
+            (
+                "duplicate service name within one deployment",
+                vec![initialization_test_config(
+                    DpuDeploymentType::Bf3,
+                    "bf3-deployment",
+                    vec![
+                        initialization_test_service("duplicate", None),
+                        initialization_test_service("duplicate", None),
+                    ],
+                )],
+                "DPUServiceTemplate metadata.name \"duplicate\"",
+            ),
+        ];
+
+        for (description, configs, expected_error) in cases {
+            let error = validate_initialization_service_object_names(&configs)
+                .expect_err("colliding initialization object names must be rejected");
+            let DpfError::ConfigError(message) = error else {
+                panic!("{description}: expected configuration error, got {error}");
+            };
+            assert!(
+                message.contains(expected_error),
+                "{description}: unexpected error: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn initialization_name_preflight_accepts_distinct_derived_names() {
+        let configs = vec![
+            initialization_test_config(
+                DpuDeploymentType::Bf3,
+                "bf3-deployment",
+                vec![initialization_test_service("foo", Some("service-net"))],
+            ),
+            initialization_test_config(
+                DpuDeploymentType::Bf3Gb200,
+                "gb200-deployment",
+                vec![initialization_test_service("foo", Some("service-net"))],
+            ),
+            initialization_test_config(
+                DpuDeploymentType::Bf4Generic,
+                "bf4-deployment",
+                vec![initialization_test_service("foo", Some("service-net"))],
+            ),
+        ];
+
+        validate_initialization_service_object_names(&configs)
+            .expect("deployment suffixes should keep ordinary service resources distinct");
+    }
+
+    #[test]
     fn deployment_type_controls_cr_suffix_and_astra_enablement() {
         value_scenarios!(
             run = |deployment_type| {
@@ -2338,6 +2715,10 @@ mod tests {
             };
             "BF3 preserves unsuffixed resource names" {
                 DpuDeploymentType::Bf3 => ("", None),
+            }
+
+            "GB200 BF3 uses its deployment suffix" {
+                DpuDeploymentType::Bf3Gb200 => ("bf3gb200", None),
             }
 
             "generic BF4 uses its deployment suffix" {

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -41,6 +41,7 @@ use crate::repository::{
     DpuServiceInterfaceRepository, DpuServiceNADRepository, DpuServiceTemplateRepository,
     K8sConfigRepository,
 };
+use crate::sdk::ResourceLabeler;
 use crate::types::*;
 
 const TEST_NS: &str = "sdk-init-ns";
@@ -70,6 +71,27 @@ struct InitializationMock {
     service_interfaces: Arc<DashMap<String, DPUServiceInterface>>,
     configs: Arc<DashMap<String, BTreeMap<String, String>>>,
     secrets: Arc<DashMap<String, BTreeMap<String, Vec<u8>>>>,
+}
+
+#[derive(Clone, Copy)]
+struct InitializationLabeler;
+
+impl ResourceLabeler for InitializationLabeler {
+    fn node_labels_for_deployment_type(
+        &self,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<BTreeMap<String, String>, DpfError> {
+        let deployment_type = match deployment_type {
+            DpuDeploymentType::Bf3 => "bf3",
+            DpuDeploymentType::Bf3Gb200 => "bf3gb200",
+            DpuDeploymentType::Bf4Generic => "bf4generic",
+            DpuDeploymentType::Bf4Astra => "bf4astra",
+        };
+        Ok(BTreeMap::from([(
+            "test.nvidia.com/deployment-type".to_string(),
+            deployment_type.to_string(),
+        )]))
+    }
 }
 
 #[async_trait]
@@ -395,6 +417,139 @@ async fn test_create_initialization_objects() {
     assert!(secret.is_some());
 
     drop(sdk);
+}
+
+/// Verifies BF3 and GB200 initialization persist separate flavor, service,
+/// and selector wiring in a shared namespace.
+#[tokio::test]
+async fn bf3_and_gb200_initialization_persists_distinct_resources() {
+    let mock = InitializationMock::default();
+    let sdk = crate::sdk::DpfSdkBuilder::new(mock.clone(), TEST_NS, "test-password".to_string())
+        .with_labeler(InitializationLabeler)
+        .build_without_resources()
+        .await
+        .unwrap();
+
+    let service_name = "test-service";
+    let services = vec![ServiceDefinition::new(
+        service_name,
+        "repo",
+        "chart",
+        "1.0.0",
+    )];
+    for (deployment_name, deployment_type) in [
+        ("bf3-deployment", DpuDeploymentType::Bf3),
+        ("gb200-deployment", DpuDeploymentType::Bf3Gb200),
+    ] {
+        sdk.create_initialization_objects(&InitDpfResourcesConfig {
+            bfb_url: "http://example.com/bf3.bfb".to_string(),
+            deployment_name: deployment_name.to_string(),
+            flavor_name: "bf3-flavor".to_string(),
+            services: services.clone(),
+            deployment_type,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    }
+
+    let bf3_deployment = DpuDeploymentRepository::get(&mock, "bf3-deployment", TEST_NS)
+        .await
+        .unwrap()
+        .expect("BF3 deployment must be persisted");
+    let gb200_deployment = DpuDeploymentRepository::get(&mock, "gb200-deployment", TEST_NS)
+        .await
+        .unwrap()
+        .expect("GB200 deployment must be persisted");
+    assert_eq!(mock.deployments.len(), 2);
+
+    let bf3_flavor_name = bf3_deployment
+        .spec
+        .dpus
+        .flavor
+        .as_deref()
+        .expect("BF3 deployment must reference a flavor");
+    let gb200_flavor_name = gb200_deployment
+        .spec
+        .dpus
+        .flavor
+        .as_deref()
+        .expect("GB200 deployment must reference a flavor");
+    assert_ne!(bf3_flavor_name, gb200_flavor_name);
+    assert_eq!(mock.flavors.len(), 2);
+
+    let bf3_flavor = DpuFlavorRepository::get(&mock, bf3_flavor_name, TEST_NS)
+        .await
+        .unwrap()
+        .expect("BF3 deployment flavor must be persisted");
+    let gb200_flavor = DpuFlavorRepository::get(&mock, gb200_flavor_name, TEST_NS)
+        .await
+        .unwrap()
+        .expect("GB200 deployment flavor must be persisted");
+    let bf3_nvconfig = bf3_flavor.spec.nvconfig.as_ref().unwrap()[0]
+        .parameters
+        .as_ref()
+        .unwrap();
+    let gb200_nvconfig = gb200_flavor.spec.nvconfig.as_ref().unwrap()[0]
+        .parameters
+        .as_ref()
+        .unwrap();
+    assert!(
+        !bf3_nvconfig
+            .iter()
+            .any(|parameter| parameter == "OFF_BOARD_SERIALIZER=1")
+    );
+    assert!(
+        gb200_nvconfig
+            .iter()
+            .any(|parameter| parameter == "OFF_BOARD_SERIALIZER=1")
+    );
+
+    let bf3_service = bf3_deployment
+        .spec
+        .services
+        .get(service_name)
+        .expect("BF3 deployment must reference the test service");
+    assert_eq!(bf3_service.service_template.as_deref(), Some(service_name));
+    assert_eq!(
+        bf3_service.service_configuration.as_deref(),
+        Some(service_name)
+    );
+    let gb200_service = gb200_deployment
+        .spec
+        .services
+        .get(service_name)
+        .expect("GB200 deployment must reference the test service");
+    assert_eq!(
+        gb200_service.service_template.as_deref(),
+        Some("test-service-bf3gb200")
+    );
+    assert_eq!(
+        gb200_service.service_configuration.as_deref(),
+        Some("test-service-bf3gb200")
+    );
+
+    let selector_label = "test.nvidia.com/deployment-type";
+    let bf3_selector_labels = bf3_deployment.spec.dpus.dpu_sets.as_ref().unwrap()[0]
+        .dpu_node_selector
+        .as_ref()
+        .and_then(|selector| selector.match_labels.as_ref())
+        .expect("BF3 deployment must have DPUNode selector labels");
+    let gb200_selector_labels = gb200_deployment.spec.dpus.dpu_sets.as_ref().unwrap()[0]
+        .dpu_node_selector
+        .as_ref()
+        .and_then(|selector| selector.match_labels.as_ref())
+        .expect("GB200 deployment must have DPUNode selector labels");
+    assert_eq!(
+        bf3_selector_labels.get(selector_label).map(String::as_str),
+        Some("bf3")
+    );
+    assert_eq!(
+        gb200_selector_labels
+            .get(selector_label)
+            .map(String::as_str),
+        Some("bf3gb200")
+    );
 }
 
 #[tokio::test]

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -274,6 +274,8 @@ pub struct DpuFlavorBridgeDefinition {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DpuDeploymentType {
     Bf3,
+    /// BF3 B3240 on a GB200 platform using CPU as Root Complex mode.
+    Bf3Gb200,
     Bf4Generic,
     Bf4Astra,
 }

--- a/crates/machine-controller/Cargo.toml
+++ b/crates/machine-controller/Cargo.toml
@@ -42,6 +42,7 @@ carbide-utils = { path = "../utils", default-features = false }
 carbide-firmware = { path = "../firmware", default-features = false }
 carbide-instrument = { path = "../instrument" }
 carbide-ipmi = { path = "../ipmi", default-features = false }
+carbide-libmlx-model = { path = "../libmlx-model" }
 carbide-measured-boot = { path = "../measured-boot", default-features = false }
 carbide-redfish = { path = "../redfish", default-features = false }
 carbide-secrets = { path = "../secrets" }
@@ -78,7 +79,9 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 version-compare = { workspace = true }
 
 [dev-dependencies]
-carbide-api-model = { path = "../api-model", default-features = false, features = ["test-support"] }
+carbide-api-model = { path = "../api-model", default-features = false, features = [
+  "test-support",
+] }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-secrets = { path = "../secrets", features = ["test-support"] }

--- a/crates/machine-controller/src/config/mod.rs
+++ b/crates/machine-controller/src/config/mod.rs
@@ -38,6 +38,8 @@ pub struct MachineStateHandlerSiteConfig {
     pub firmware_global: FirmwareGlobal,
     pub machine_state_controller: MachineStateControllerConfig,
     pub host_health: HostHealthConfig,
+    /// Rack profiles used to refine DPF deployment selection from the host's rack identity.
+    pub rack_profiles: model::rack_type::RackProfileConfig,
 
     pub selected_profile: libredfish::BiosProfileType,
     pub bios_profiles: libredfish::BiosProfileVendor,
@@ -76,6 +78,7 @@ impl MachineStateHandlerSiteConfig {
             firmware_global: FirmwareGlobal::test_default(),
             machine_state_controller: MachineStateControllerConfig::test_default(),
             host_health: HostHealthConfig::default(),
+            rack_profiles: model::rack_type::RackProfileConfig::default(),
             selected_profile: libredfish::BiosProfileType::Performance,
             bios_profiles: HashMap::new(),
             oem_manager_profiles: HashMap::new(),

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -86,10 +86,10 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// Mark DPU node as rebooted (clear the external reboot required annotation).
     async fn reboot_complete(&self, node_name: &str) -> Result<(), DpfError>;
 
-    /// Resolve the deployment type of a DPU based on its hardware (BF3 vs BF4).
-    /// Returns `Err` when the part number is absent or does not match any known
-    /// generation, so unrecognized hardware never silently routes to a wrong
-    /// deployment.
+    /// Resolve a DPU's base hardware deployment class (BF3 or BF4).
+    ///
+    /// The state handler separately refines BF3 from the host rack and DPU
+    /// profile. This returns `Err` when the DMI product name is absent.
     fn deployment_type_for_dpu(&self, dpu: &Machine) -> Result<DpuDeploymentType, DpfError>;
 
     /// Check that a DPUNode's labels match the current expected labels.
@@ -569,8 +569,10 @@ impl DpfOperations for DpfSdkOps {
         };
 
         tracing::info!(
-            "selected deployment type {deployment_type:?} for {product_name}, machine_id: {}",
-            dpu.id
+            machine_id = %dpu.id,
+            product_name,
+            ?deployment_type,
+            "selected base DPF deployment type for DPU"
         );
 
         Ok(deployment_type)

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -22,14 +22,17 @@
 
 use std::net::IpAddr;
 
-use carbide_dpf::{DpfError, DpuPhase, dpu_node_cr_name};
+use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase, dpu_node_cr_name};
+use carbide_libmlx_model::nvconfig::DpuNvConfigProfile;
 use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
+use model::hardware_info::HardwareInfo;
 use model::machine::{
     DpfState, DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, Machine,
     ManagedHostState, ManagedHostStateSnapshot, PerformPowerOperation, ReprovisionState,
     StateMachineArea,
 };
+use model::rack_type::{RackProductFamily, select_dpu_nvconfig_profile};
 use state_controller::state_handler::{
     ExternalServiceError, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -54,6 +57,85 @@ fn dpf_id(machine: &Machine) -> Result<String, StateHandlerError> {
     machine.dpf_id().ok_or_else(|| {
         StateHandlerError::InvalidState(format!("BMC MAC is not set for machine {}", machine.id))
     })
+}
+
+async fn host_rack_product_family(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<Option<RackProductFamily>, StateHandlerError> {
+    let Some(rack_id) = state.host_snapshot.rack_id.as_ref() else {
+        return Ok(None);
+    };
+    let mut conn = ctx.services.db_pool.acquire().await?;
+    let Some(rack) = db::rack::find_by(
+        conn.as_mut(),
+        db::ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+    )
+    .await?
+    .pop() else {
+        return Ok(None);
+    };
+    let Some(profile_id) = rack.rack_profile_id.as_ref() else {
+        return Ok(None);
+    };
+    let Some(profile) = ctx
+        .services
+        .site_config
+        .rack_profiles
+        .get(profile_id.as_str())
+    else {
+        return Ok(None);
+    };
+
+    Ok(profile.product_family.clone())
+}
+
+async fn deployment_types_for_host(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    dpf_sdk: &dyn DpfOperations,
+) -> Result<Vec<DpuDeploymentType>, StateHandlerError> {
+    let product_family = host_rack_product_family(state, ctx).await?;
+    state
+        .dpu_snapshots
+        .iter()
+        .map(|dpu| {
+            let base = dpf_sdk.deployment_type_for_dpu(dpu).map_err(dpf_error)?;
+            Ok::<_, StateHandlerError>(deployment_type_for_dpu_profile(
+                base,
+                product_family.as_ref(),
+                dpu.status.hardware_info.as_ref(),
+            ))
+        })
+        .collect()
+}
+
+fn deployment_type_for_dpu_profile(
+    base: DpuDeploymentType,
+    product_family: Option<&RackProductFamily>,
+    hardware_info: Option<&HardwareInfo>,
+) -> DpuDeploymentType {
+    match select_dpu_nvconfig_profile(product_family, hardware_info) {
+        Some(DpuNvConfigProfile::Gb200B3240V1) if base == DpuDeploymentType::Bf3 => {
+            DpuDeploymentType::Bf3Gb200
+        }
+        Some(DpuNvConfigProfile::Gb200B3240V1) | None => base,
+    }
+}
+
+fn consistent_deployment_type(
+    deployment_types: &[DpuDeploymentType],
+) -> Result<DpuDeploymentType, String> {
+    let Some(first) = deployment_types.first().copied() else {
+        return Err(
+            "cannot determine DPF deployment type for a host without attached DPUs".to_string(),
+        );
+    };
+    if deployment_types.iter().all(|candidate| *candidate == first) {
+        Ok(first)
+    } else {
+        Err("host has mixed DPF deployment types across attached DPUs".to_string())
+    }
 }
 
 /// Transition all DPU sub-states to the given DPF state, preserving the
@@ -177,6 +259,7 @@ fn waiting_for_ready_exit_state(
 async fn create_and_register_dpudevices_and_dpunode(
     state: &ManagedHostStateSnapshot,
     dpf_sdk: &dyn DpfOperations,
+    deployment_type: DpuDeploymentType,
 ) -> Result<(), StateHandlerError> {
     let primary_dpu_id = state
         .host_snapshot
@@ -189,6 +272,16 @@ async fn create_and_register_dpudevices_and_dpunode(
             object_id: state.host_snapshot.id.to_string(),
             missing: "primary_dpu",
         })?;
+    if !state
+        .dpu_snapshots
+        .iter()
+        .any(|dpu| dpu.id == primary_dpu_id)
+    {
+        return Err(StateHandlerError::MissingData {
+            object_id: state.host_snapshot.id.to_string(),
+            missing: "primary_dpu_snapshot",
+        });
+    }
 
     for dpu in &state.dpu_snapshots {
         let serial_number = dpu
@@ -218,18 +311,6 @@ async fn create_and_register_dpudevices_and_dpunode(
             .await
             .map_err(dpf_error)?;
     }
-
-    let primary_dpu = state
-        .dpu_snapshots
-        .iter()
-        .find(|dpu| dpu.id == primary_dpu_id)
-        .ok_or_else(|| StateHandlerError::MissingData {
-            object_id: state.host_snapshot.id.to_string(),
-            missing: "primary_dpu_snapshot",
-        })?;
-    let deployment_type = dpf_sdk
-        .deployment_type_for_dpu(primary_dpu)
-        .map_err(dpf_error)?;
 
     let device_ids: Vec<String> = state
         .dpu_snapshots
@@ -291,13 +372,30 @@ fn dpf_cr_creation_failed(
     StateHandlerOutcome::transition(make_failure_state(state, details, state.host_snapshot.id))
 }
 
+fn dpf_deployment_selection_failed(
+    state: &ManagedHostStateSnapshot,
+    error: &str,
+) -> StateHandlerOutcome<ManagedHostState> {
+    let details = FailureDetails {
+        cause: FailureCause::DpfProvisioning {
+            err: format!("DPF deployment selection failed: {error}"),
+        },
+        failed_at: chrono::Utc::now(),
+        source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+    };
+    StateHandlerOutcome::transition(make_failure_state(state, details, state.host_snapshot.id))
+}
+
 /// Handle DpfState::Provisioning: register all DPU devices and the node, then
 /// transition all DPUs to WaitingForReady.
 async fn handle_dpf_provisioning(
     state: &ManagedHostStateSnapshot,
     dpf_sdk: &dyn DpfOperations,
+    deployment_type: DpuDeploymentType,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    if let Err(err) = create_and_register_dpudevices_and_dpunode(state, dpf_sdk).await {
+    if let Err(err) =
+        create_and_register_dpudevices_and_dpunode(state, dpf_sdk, deployment_type).await
+    {
         return Ok(dpf_cr_creation_failed(state, &err));
     }
 
@@ -542,6 +640,7 @@ async fn handle_dpf_reprovisioning(
     dpu_snapshot: &Machine,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    deployment_type: DpuDeploymentType,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     let dpf_dpudevices_and_dpunode_crs_noexist =
@@ -553,7 +652,9 @@ async fn handle_dpf_reprovisioning(
             machine_id = %state.host_snapshot.id,
             "DPUDevice/DPUNode CRs do not exist, creating them before reprovisioning"
         );
-        if let Err(err) = create_and_register_dpudevices_and_dpunode(state, dpf_sdk).await {
+        if let Err(err) =
+            create_and_register_dpudevices_and_dpunode(state, dpf_sdk, deployment_type).await
+        {
             return Ok(dpf_cr_creation_failed(state, &err));
         }
         let next = transition_all_dpus_to_dpf_state(
@@ -596,9 +697,29 @@ pub async fn handle_dpf_state(
     power_down_wait: chrono::Duration,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
-    let deployment_type = dpf_sdk
-        .deployment_type_for_dpu(dpu_snapshot)
-        .map_err(dpf_error)?;
+    let deployment_types = deployment_types_for_host(state, ctx, dpf_sdk).await?;
+    let deployment_type = match consistent_deployment_type(&deployment_types) {
+        Ok(deployment_type) => deployment_type,
+        Err(error) => {
+            let selections = state
+                .dpu_snapshots
+                .iter()
+                .zip(&deployment_types)
+                .map(|(dpu, deployment_type)| format!("{}={deployment_type:?}", dpu.id))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let error = format!("{error}: {selections}");
+
+            return Ok(dpf_deployment_selection_failed(state, error.as_str()));
+        }
+    };
+    if matches!(dpf_state, DpfState::Provisioning) {
+        tracing::info!(
+            machine_id = %state.host_snapshot.id,
+            ?deployment_type,
+            "selected DPF deployment type for host"
+        );
+    }
     if !dpf_sdk
         .verify_node_labels(&node_name, deployment_type)
         .await
@@ -627,7 +748,7 @@ pub async fn handle_dpf_state(
     }
 
     match dpf_state {
-        DpfState::Provisioning => handle_dpf_provisioning(state, dpf_sdk).await,
+        DpfState::Provisioning => handle_dpf_provisioning(state, dpf_sdk, deployment_type).await,
         DpfState::WaitingForReady { phase_detail } => {
             handle_dpf_waiting_for_ready(state, dpu_snapshot, phase_detail, ctx, dpf_sdk).await
         }
@@ -645,12 +766,135 @@ pub async fn handle_dpf_state(
         }
         DpfState::DeviceReady => handle_dpf_device_ready(state),
         DpfState::Reprovisioning => {
-            handle_dpf_reprovisioning(state, dpu_snapshot, ctx, dpf_sdk).await
+            handle_dpf_reprovisioning(state, dpu_snapshot, ctx, dpf_sdk, deployment_type).await
         }
         DpfState::Unknown => {
             tracing::warn!(dpu_machine_id = %dpu_snapshot.id, "unknown DPF state in DB, transitioning to provisioning");
             let next = set_one_dpu_dpf_state(state, &dpu_snapshot.id, DpfState::Provisioning)?;
             Ok(StateHandlerOutcome::transition(next))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+    use model::hardware_info::DpuData;
+
+    use super::*;
+
+    fn hardware_info(part_number: &str) -> HardwareInfo {
+        HardwareInfo {
+            dpu_info: Some(DpuData {
+                part_number: part_number.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn gb200_b3240_profile_selects_only_the_specialized_bf3_deployment() {
+        /// Hardware and rack inputs used to refine one base DPF deployment class.
+        struct ProfileInput {
+            base: DpuDeploymentType,
+            product_family: Option<RackProductFamily>,
+            hardware_info: Option<HardwareInfo>,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "GB200 B3240 BF3",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf3,
+                        product_family: Some(RackProductFamily::Gb200),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CN-AB0")),
+                    },
+                    expect: DpuDeploymentType::Bf3Gb200,
+                },
+                Check {
+                    scenario: "non-GB200 B3240 BF3",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf3,
+                        product_family: Some(RackProductFamily::Other("other".to_string())),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CN-AB0")),
+                    },
+                    expect: DpuDeploymentType::Bf3,
+                },
+                Check {
+                    scenario: "GB200 other BF3",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf3,
+                        product_family: Some(RackProductFamily::Gb200),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CV-AA0")),
+                    },
+                    expect: DpuDeploymentType::Bf3,
+                },
+                Check {
+                    scenario: "BF3 without rack profile or hardware information",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf3,
+                        product_family: None,
+                        hardware_info: None,
+                    },
+                    expect: DpuDeploymentType::Bf3,
+                },
+                Check {
+                    scenario: "GB200 BF4 remains BF4",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf4Generic,
+                        product_family: Some(RackProductFamily::Gb200),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CN-AB0")),
+                    },
+                    expect: DpuDeploymentType::Bf4Generic,
+                },
+                Check {
+                    scenario: "Astra remains Astra",
+                    input: ProfileInput {
+                        base: DpuDeploymentType::Bf4Astra,
+                        product_family: Some(RackProductFamily::Gb200),
+                        hardware_info: Some(hardware_info("900-9D3B6-00CN-AB0")),
+                    },
+                    expect: DpuDeploymentType::Bf4Astra,
+                },
+            ],
+            |input| {
+                deployment_type_for_dpu_profile(
+                    input.base,
+                    input.product_family.as_ref(),
+                    input.hardware_info.as_ref(),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn attached_dpus_require_one_consistent_deployment_type() {
+        check_values(
+            [
+                Check {
+                    scenario: "ordinary BF3 pair",
+                    input: vec![DpuDeploymentType::Bf3, DpuDeploymentType::Bf3],
+                    expect: Some(DpuDeploymentType::Bf3),
+                },
+                Check {
+                    scenario: "GB200 BF3 pair",
+                    input: vec![DpuDeploymentType::Bf3Gb200, DpuDeploymentType::Bf3Gb200],
+                    expect: Some(DpuDeploymentType::Bf3Gb200),
+                },
+                Check {
+                    scenario: "mixed GB200 eligibility",
+                    input: vec![DpuDeploymentType::Bf3Gb200, DpuDeploymentType::Bf3],
+                    expect: None,
+                },
+                Check {
+                    scenario: "host without attached DPUs",
+                    input: vec![],
+                    expect: None,
+                },
+            ],
+            |deployment_types| consistent_deployment_type(&deployment_types).ok(),
+        );
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This deliberately backports the DPF half of #5468 to `release/v2.1`, on top of the Non-DPF support merged through #5482. It does not modify #5482.

DPF provisioning reapplies the generic BF3 NVConfig after firmware resets. On GB200 systems with supported B3240 DPUs, that leaves the PCIe topology and uplink mapping incorrect because those systems also require NVIDIA's CPU as Root Complex profile.

Add a derived `Bf3Gb200` deployment that reuses the configured BF3 provisioning source and services while giving the GB200 variant distinct flavors, selectors, service resources, and deployment identity. The machine controller selects it only when the host is in a GB200 rack and every attached DPU resolves to the supported GB200/B3240 profile. Mixed selections fail before resource registration instead of applying the profile to only part of a host.

DPF v26.4 permits 32 NVConfig values. The GB200 flavor retains the existing 16 BF3 values and adds the 16 nondefault CPU-as-Root-Complex values; the two explicit zero values are omitted because DPF restores those firmware defaults and cannot carry 34 entries.

The release-specific adaptation keeps the v2.1 controller and service contracts. It also validates complete Kubernetes DNS-label/subdomain limits and preflights service template, configuration, and NAD names across every active deployment before applying the first deployment object.

## Related issues

Backports https://github.com/NVIDIA/infra-controller/pull/5468.

Builds on the Non-DPF backport in https://github.com/NVIDIA/infra-controller/pull/5482.

Supports https://github.com/NVIDIA/infra-controller/issues/5439.

Part of https://github.com/NVIDIA/infra-controller/issues/5029.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

- #5457 is not required for this backport; no Astra template changes from that PR are included.
- Existing GB200 DPU nodes keep their ordinary BF3 labels until they are deleted and reprovisioned. Reprovisioning selects the derived deployment and applies the new flavor.
- Two independent review findings were adopted: enforce per-label limits after the flavor hash, and reject cross-deployment service-resource name collisions before any deployment apply. Final re-review found no remaining material issues.
- Local external-CLI review was omitted because the execution environment blocked transmitting the staged diff to external review services; the restriction was not bypassed.
