### PR TITLE
fix(health): preserve distinct Redfish log occurrences

### DIFF
--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -284,7 +284,14 @@ fn record_to_log(
         .as_ref()
         .map(|log_entry_ref| log_entry_ref.odata_id().to_string());
 
-    let mut attributes = vec![(Cow::Borrowed("message_id"), record.message_id.clone())];
+    let mut attributes = vec![
+        (Cow::Borrowed("message_id"), record.message_id.clone()),
+        (
+            Cow::Borrowed("event_record_id"),
+            record.base.odata_id().to_string(),
+        ),
+    ];
+
     if let Some(event_type) = redfish_event_type_string(Some(&record.event_type)) {
         attributes.push((Cow::Borrowed("event_type"), event_type));
     }
@@ -536,7 +543,9 @@ mod tests {
             attribute(record, "redfish.event.severity"),
             Some("Critical")
         );
+
         assert_eq!(attribute(record, "event_type"), Some("Alert"));
+        assert_eq!(attribute(record, "event_record_id"), Some(path));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/health/src/sink/event_mapper.rs
+++ b/crates/health/src/sink/event_mapper.rs
@@ -23,11 +23,25 @@ use super::LogRecord;
 
 #[cfg(not(feature = "bench-hooks"))]
 pub(crate) trait RedfishEventMapper: Send + Sync {
+    /// Returns the latest-wins queue key for one log record.
+    ///
+    /// Decoded protobuf notifications use their payload hash. Redfish state
+    /// notifications share a resource key. Periodic entries use their service
+    /// and entry IDs. SSE records prefer the event ID, then the linked log
+    /// entry URI, then the event record URI. Other records use message or body
+    /// content as a fallback.
     fn queue_key(&self, bmc_id: &str, attributes: &[(Cow<'static, str>, String)]) -> String;
 }
 
 #[cfg(feature = "bench-hooks")]
 pub trait RedfishEventMapper: Send + Sync {
+    /// Returns the latest-wins queue key for one log record.
+    ///
+    /// Decoded protobuf notifications use their payload hash. Redfish state
+    /// notifications share a resource key. Periodic entries use their service
+    /// and entry IDs. SSE records prefer the event ID, then the linked log
+    /// entry URI, then the event record URI. Other records use message or body
+    /// content as a fallback.
     fn queue_key(&self, bmc_id: &str, attributes: &[(Cow<'static, str>, String)]) -> String;
 }
 
@@ -72,22 +86,56 @@ impl RedfishEventMapper for OpenBmcEventMapper {
 
         let message_id = Self::find_attr(attributes, "message_id").unwrap_or("");
 
+        // State notifications share a resource key so a later state replaces
+        // the queued state for that resource.
+        if message_id.contains("SensorThreshold") {
+            let resource = Self::first_message_arg(attributes);
+            return format!("{bmc_id}|SensorThreshold|{resource}");
+        }
+
+        if message_id.starts_with("ResourceEvent.") && message_id.contains("ResourceStatusChanged")
+        {
+            let resource = Self::first_message_arg(attributes);
+            return format!("{bmc_id}|ResourceStatusChanged|{resource}");
+        }
+
+        // A periodic LogEntry ID is unique within its LogService, so both
+        // fields identify one occurrence.
+        if let (Some(service_id), Some(entry_id)) = (
+            Self::find_attr(attributes, "service_id").filter(|value| !value.is_empty()),
+            Self::find_attr(attributes, "entry_id").filter(|value| !value.is_empty()),
+        ) {
+            return format!("{bmc_id}|redfish-entry|{service_id}|{entry_id}");
+        }
+
+        // An SSE EventId identifies the delivered event and takes precedence
+        // over an optional link to its LogEntry.
+        if let Some(event_id) =
+            Self::find_attr(attributes, "event_id").filter(|value| !value.is_empty())
+        {
+            return format!("{bmc_id}|redfish-event|{event_id}");
+        }
+
+        // SSE events without an EventId use the linked LogEntry URI.
+        if let Some(log_entry_id) =
+            Self::find_attr(attributes, "log_entry_id").filter(|value| !value.is_empty())
+        {
+            return format!("{bmc_id}|redfish-entry|{log_entry_id}");
+        }
+
+        // SSE events without either optional identifier use the EventRecord URI.
+        if let Some(event_record_id) =
+            Self::find_attr(attributes, "event_record_id").filter(|value| !value.is_empty())
+        {
+            return format!("{bmc_id}|redfish-event-record|{event_record_id}");
+        }
+
         if message_id.is_empty() {
             let body = Self::find_attr(attributes, "body").unwrap_or("");
             return format!("{bmc_id}|raw|{}", Self::hash_string(body));
         }
 
         let resource = Self::first_message_arg(attributes);
-
-        if message_id.contains("SensorThreshold") {
-            return format!("{bmc_id}|SensorThreshold|{resource}");
-        }
-
-        if message_id.starts_with("ResourceEvent.") && message_id.contains("ResourceStatusChanged")
-        {
-            return format!("{bmc_id}|ResourceStatusChanged|{resource}");
-        }
-
         format!("{bmc_id}|{message_id}|{resource}")
     }
 }
@@ -95,6 +143,10 @@ impl RedfishEventMapper for OpenBmcEventMapper {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    type Attrs = &'static [(&'static str, &'static str)];
+
+    use carbide_test_support::value_scenarios;
 
     fn attrs(pairs: &[(&str, &str)]) -> Vec<(Cow<'static, str>, String)> {
         pairs
@@ -114,6 +166,8 @@ mod tests {
                     "OpenBMC.0.1.SensorThresholdWarningLowGoingHigh",
                 ),
                 ("message_args", r#"["HGX_GPU_0_Temp_1","3.96","-0.05"]"#),
+                ("service_id", "/redfish/v1/Systems/1/LogServices/EventLog"),
+                ("entry_id", "41"),
             ]),
         );
         let key_low = mapper.queue_key(
@@ -124,8 +178,11 @@ mod tests {
                     "OpenBMC.0.1.SensorThresholdWarningHighGoingLow",
                 ),
                 ("message_args", r#"["HGX_GPU_0_Temp_1","3.96","-0.05"]"#),
+                ("service_id", "/redfish/v1/Systems/1/LogServices/EventLog"),
+                ("entry_id", "42"),
             ]),
         );
+
         assert_eq!(key_high, key_low);
         assert!(key_high.contains("SensorThreshold"));
         assert!(key_high.contains("HGX_GPU_0_Temp_1"));
@@ -142,6 +199,7 @@ mod tests {
                     "ResourceEvent.1.0.ResourceStatusChangedCritical",
                 ),
                 ("message_args", r#"["leakage1"]"#),
+                ("event_id", "event-41"),
             ]),
         );
         let key_ok = mapper.queue_key(
@@ -149,8 +207,10 @@ mod tests {
             &attrs(&[
                 ("message_id", "ResourceEvent.1.0.ResourceStatusChangedOK"),
                 ("message_args", r#"["leakage1"]"#),
+                ("event_id", "event-42"),
             ]),
         );
+
         assert_eq!(key_critical, key_ok);
         assert!(key_critical.contains("ResourceStatusChanged"));
         assert!(key_critical.contains("leakage1"));
@@ -180,6 +240,56 @@ mod tests {
             ]),
         );
         assert_ne!(key_gpu0, key_gpu1);
+    }
+
+    #[test]
+    fn ordinary_occurrences_use_stable_redfish_identifiers() {
+        value_scenarios!(run = |(left, right): (Attrs, Attrs)| {
+            let mapper = OpenBmcEventMapper;
+            let left = mapper.queue_key("10.85.14.144", &attrs(left));
+            let right = mapper.queue_key("10.85.14.144", &attrs(right));
+
+            left == right
+        };
+            "periodic entry IDs are scoped by log service" {
+                (&[("service_id", "EventLog"), ("entry_id", "41")][..],
+                 &[("service_id", "Journal"), ("entry_id", "41")][..]) => false,
+            }
+
+            "periodic entry identity takes precedence over its event ID" {
+                (&[("service_id", "EventLog"), ("entry_id", "41"), ("event_id", "event-1")][..],
+                 &[("service_id", "EventLog"), ("entry_id", "41"), ("event_id", "event-2")][..]) => true,
+            }
+
+            "SSE events use their event ID" {
+                (&[("event_id", "event-41")][..], &[("event_id", "event-42")][..]) => false,
+            }
+
+            "SSE event ID takes precedence over its log entry link" {
+                (&[("event_id", "event-41"), ("log_entry_id", "entry-1")][..],
+                 &[("event_id", "event-41"), ("log_entry_id", "entry-2")][..]) => true,
+            }
+
+            "SSE events fall back to their log entry link" {
+                (&[("log_entry_id", "entry-1")][..],
+                 &[("log_entry_id", "entry-2")][..]) => false,
+            }
+
+            "empty SSE event IDs use the log entry link" {
+                (&[("event_id", ""), ("log_entry_id", "entry-1")][..],
+                 &[("event_id", ""), ("log_entry_id", "entry-2")][..]) => false,
+            }
+
+            "SSE events fall back to their event record URI" {
+                (&[("event_record_id", "record-1")][..],
+                 &[("event_record_id", "record-2")][..]) => false,
+            }
+
+            "SSE log entry links take precedence over event record URIs" {
+                (&[("log_entry_id", "entry-1"), ("event_record_id", "record-1")][..],
+                 &[("log_entry_id", "entry-1"), ("event_record_id", "record-2")][..]) => true,
+            }
+        );
     }
 
     #[test]

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -619,6 +619,44 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_log_occurrences_queue_separately_and_replays_replace() {
+        let occurrence = |entry_id: &str| {
+            let CollectorEvent::Log(mut record) = log_event(
+                "ResourceEvent.1.0.ResourceErrorsDetected",
+                r#"["resource-1","detail"]"#,
+            ) else {
+                unreachable!("log_event always returns a log event");
+            };
+
+            record
+                .attributes
+                .push((Cow::Borrowed("service_id"), "EventLog".to_string()));
+
+            record
+                .attributes
+                .push((Cow::Borrowed("entry_id"), entry_id.to_string()));
+
+            CollectorEvent::Log(record)
+        };
+
+        let first = occurrence("41");
+        let second = occurrence("42");
+        let sink = test_sink();
+        let context = test_context();
+
+        sink.handle_event(&context, &first);
+        sink.handle_event(&context, &second);
+
+        assert_eq!(sink.queue.len(), 2);
+        assert_eq!(sink.replaced_total.get() as u64, 0);
+
+        sink.handle_event(&context, &second);
+
+        assert_eq!(sink.queue.len(), 2);
+        assert_eq!(sink.replaced_total.get() as u64, 1);
+    }
+
+    #[test]
     fn bounded_signal_queues_drop_oldest_and_report_depth() {
         let metrics = MetricsCapture::start();
         let sink = bounded_test_sink(1);


### PR DESCRIPTION
Use Redfish occurrence identifiers when deriving OTLP log queue keys. Periodic records use the `LogService` and `LogEntry` identity. SSE records use `EventId`, with the linked `LogEntry` URI as a fallback.

State notifications continue to share resource keys, while distinct log occurrences remain separate and exact replays replace their queued copy.

## Related issues

Fixes #5503

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

Existing configuration and APIs are unchanged.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)