### PR TITLE
fix(bmc-explorer): pick the manager whose ManagerForServers links the explored system

### DIFF
--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -149,17 +149,31 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
     let other_system_with_bios = systems_iter.find(|system| system.raw().bios.is_some());
     let system = other_system_with_bios.unwrap_or(first_system);
 
-    let manager = root
+    let mut managers = root
         .managers()
         .await
         .map_err(Error::nv_redfish("managers"))?
         .ok_or_else(Error::bmc_not_provided("managers"))?
         .members()
         .await
-        .map_err(Error::nv_redfish("managers members"))?
-        .into_iter()
-        .next()
-        .ok_or_else(Error::bmc_not_provided("at least one manager"))?;
+        .map_err(Error::nv_redfish("managers members"))?;
+
+    // Prefer the manager that controls the chosen system —  Fall back to
+    // the first manager for BMCs.
+
+    let manager = match managers.iter().position(|m| {
+        m.raw()
+            .links
+            .as_ref()
+            .and_then(|l| l.manager_for_servers.as_ref())
+            .is_some_and(|servers| servers.iter().any(|s| s.id() == system.odata_id()))
+    }) {
+        Some(i) => managers.swap_remove(i),
+        None => managers
+            .into_iter()
+            .next()
+            .ok_or_else(Error::bmc_not_provided("at least one manager"))?,
+    };
 
     let is_bluefield_system = is_bluefield_system_id(system.id());
     let system_explore_config = computer_system::Config {


### PR DESCRIPTION
When exploring a BMC, `nv_generate_exploration_report` picks one ComputerSystem and one Manager, and the resulting `EndpointExplorationReport` pairs them as if they described the same machine. The system side is already careful: it skips
past the first member to prefer a system that actually exposes BIOS. The manager side was not — it unconditionally took `managers[0]`.

## Related issues
[Add support for Supermicro GB300 NVL](https://github.com/NVIDIA/infra-controller/issues/4096)
[ Add support for PowerEdge XE9780](https://github.com/NVIDIA/infra-controller/issues/3227)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


