### PR TITLE
feat(cli): Treat arrays of max length 1 as scalars, display deprecation

### DIFF
--- a/rest-api/cli/pkg/commands.go
+++ b/rest-api/cli/pkg/commands.go
@@ -71,9 +71,11 @@ func (operation resolvedOp) execute(client *Client, pathParams, queryParams map[
 
 // bodyField tracks a request body property for type-aware flag reading.
 type bodyField struct {
-	jsonName string
-	flagName string
-	schema   *Schema
+	jsonName   string
+	flagName   string
+	schema     *Schema
+	wrapInList bool
+	itemType   SchemaType
 }
 
 // GeneratedCommandFlag describes a flag accepted by an OpenAPI-generated
@@ -84,8 +86,8 @@ type GeneratedCommandFlag struct {
 	TakesValue bool
 }
 
-// GeneratedCommandBodyField describes a scalar request-body property exposed
-// as a generated CLI flag.
+// GeneratedCommandBodyField describes a request-body property exposed as a
+// generated CLI flag.
 type GeneratedCommandBodyField struct {
 	JSONName string
 	FlagName string
@@ -653,8 +655,20 @@ func buildActionCommandWithOptions(spec *Spec, ro resolvedOp, subResource string
 			}
 			for name, prop := range schema.Properties {
 				resolved := spec.ResolveSchema(prop)
-				if resolved == nil || resolved.Type == "object" || resolved.Type == "array" {
+				if resolved == nil || resolved.Type == "object" {
 					continue
+				}
+				wrapInList := false
+				var itemType SchemaType
+				if resolved.Type == "array" {
+					if resolved.MaxItems == nil || *resolved.MaxItems != 1 {
+						continue
+					}
+					itemType = generatedSchemaType(spec.ResolveSchema(resolved.Items))
+					if itemType == "" || itemType == "object" || itemType == "array" {
+						continue
+					}
+					wrapInList = true
 				}
 				flagName := toKebab(name)
 				// Prefix body properties whose kebab-cased name collides with
@@ -668,13 +682,18 @@ func buildActionCommandWithOptions(spec *Spec, ro resolvedOp, subResource string
 					flagName = "body-" + flagName
 				}
 				usage := name
+				if prop.Deprecated || resolved.Deprecated {
+					usage += " (deprecated)"
+				}
 				if reqSet[name] {
 					usage += " (required)"
 				}
 				bodyFields = append(bodyFields, bodyField{
-					jsonName: name,
-					flagName: flagName,
-					schema:   resolved,
+					jsonName:   name,
+					flagName:   flagName,
+					schema:     resolved,
+					wrapInList: wrapInList,
+					itemType:   itemType,
 				})
 				flags = append(flags, schemaToFlag(flagName, usage, resolved))
 			}
@@ -1046,9 +1065,17 @@ func buildRequestBody(c *cli.Context, bodyFields []bodyField) ([]byte, error) {
 		if v == "" {
 			continue
 		}
-		val, err := coerceValue(v, bf.schema.Type)
+		valueType := bf.schema.Type
+		if bf.wrapInList {
+			valueType = bf.itemType
+		}
+		val, err := coerceValue(v, valueType)
 		if err != nil {
 			return nil, fmt.Errorf("flag --%s: %w", bf.flagName, err)
+		}
+		if bf.wrapInList {
+			obj[bf.jsonName] = []interface{}{val}
+			continue
 		}
 		obj[bf.jsonName] = val
 	}
@@ -1264,6 +1291,13 @@ func clientFromContext(c *cli.Context) (*Client, error) {
 func paramToFlag(p Parameter) cli.Flag {
 	flagName := toKebab(p.Name)
 	usage := p.Description
+	if p.Deprecated {
+		deprecatedUsage := p.Name + " (deprecated)"
+		if usage != "" {
+			deprecatedUsage += ": " + usage
+		}
+		usage = deprecatedUsage
+	}
 	if p.Schema != nil && len(p.Schema.Enum) > 0 {
 		usage += " [" + strings.Join(p.Schema.Enum, ", ") + "]"
 	}

--- a/rest-api/cli/pkg/commands_test.go
+++ b/rest-api/cli/pkg/commands_test.go
@@ -445,18 +445,28 @@ func TestGeneratedCommandInfos_ContainsConciseAliases(t *testing.T) {
 	}
 }
 
-// TestBuildActionCommand_ReservedBodyPropertyPrefixed verifies that when a
-// request body schema has a property whose kebab-cased name collides with a
-// reserved CLI-wrapper flag (data, data-file, output, all), the generated
-// command registers the body property under a "body-" prefix instead of
-// creating a duplicate flag.
-func TestBuildActionCommand_ReservedBodyPropertyPrefixed(t *testing.T) {
+// TestBuildActionCommand_BodyPropertyFlags verifies body-property flag naming
+// for reserved names and scalar-compatible, single-item arrays.
+func TestBuildActionCommand_BodyPropertyFlags(t *testing.T) {
+	one := 1
+	two := 2
 	spec := &Spec{
 		Paths: map[string]PathItem{
 			"/v2/org/{org}/nico/widget": {
 				Post: &Operation{
 					OperationID: "create-widget",
 					Tags:        []string{"Widget"},
+					Parameters: []Parameter{
+						{
+							Name:        "legacyFilter",
+							In:          "query",
+							Deprecated:  true,
+							Description: "Legacy filter",
+							Schema: &Schema{
+								Type: "string",
+							},
+						},
+					},
 					RequestBody: &RequestBody{
 						Content: map[string]MediaType{
 							"application/json": {
@@ -468,6 +478,24 @@ func TestBuildActionCommand_ReservedBodyPropertyPrefixed(t *testing.T) {
 										"dataFile": {Type: "string"},
 										"output":   {Type: "string"},
 										"all":      {Type: "boolean"},
+										"legacyBodyParam": {
+											Type:       "boolean",
+											Deprecated: true,
+										},
+										"rackIds": {
+											Type: "array",
+											Items: &Schema{
+												Type: "string",
+											},
+											MaxItems: &one,
+										},
+										"tagIds": {
+											Type: "array",
+											Items: &Schema{
+												Type: "string",
+											},
+											MaxItems: &two,
+										},
 									},
 									Required: []string{"name"},
 								},
@@ -511,6 +539,88 @@ func TestBuildActionCommand_ReservedBodyPropertyPrefixed(t *testing.T) {
 
 	// Non-colliding body property stays unprefixed.
 	assert.Equal(t, 1, counts["name"], "--name (non-reserved body property)")
+
+	// A primitive array constrained to one item is presented as a scalar flag.
+	// Arrays that permit multiple items still require JSON input.
+	assert.Equal(t, 1, counts["rack-ids"], "--rack-ids (single-item array property)")
+	assert.Equal(t, 0, counts["tag-ids"], "multi-item arrays do not get scalar flags")
+
+	app := &cli.App{
+		Name: "nicocli",
+		Commands: []*cli.Command{
+			{
+				Name: "widget",
+				Subcommands: []*cli.Command{
+					cmd,
+				},
+			},
+		},
+	}
+	var output bytes.Buffer
+	app.Writer = &output
+	err := app.Run([]string{
+		"nicocli",
+		"widget",
+		"create",
+		"-h",
+	})
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"--legacy-body-param value legacyBodyParam (deprecated)",
+		normalizedOptionHelpLine(output.String(), "--legacy-body-param value"),
+	)
+	assert.Equal(
+		t,
+		"--legacy-filter value legacyFilter (deprecated): Legacy filter",
+		normalizedOptionHelpLine(output.String(), "--legacy-filter value"),
+	)
+	assert.Equal(
+		t,
+		"--rack-ids value rackIds",
+		normalizedOptionHelpLine(output.String(), "--rack-ids value"),
+	)
+	assert.NotContains(t, output.String(), "[ --rack-ids value ]")
+}
+
+func TestBuildRequestBody(t *testing.T) {
+	var body []byte
+	app := &cli.App{
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "data",
+			},
+			&cli.StringFlag{
+				Name: "data-file",
+			},
+			&cli.StringFlag{
+				Name: "resource-ids",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			var err error
+			body, err = buildRequestBody(c, []bodyField{
+				{
+					jsonName: "resourceIds",
+					flagName: "resource-ids",
+					schema: &Schema{
+						Type: "array",
+					},
+					wrapInList: true,
+					itemType:   "string",
+				},
+			})
+			return err
+		},
+	}
+
+	err := app.Run([]string{
+		"test",
+		"--resource-ids",
+		"resource-1",
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"resourceIds":["resource-1"]}`, string(body))
 }
 
 // TestNewApp_DpuExtensionServiceCreate_DoesNotPanic loads the real embedded
@@ -1102,6 +1212,16 @@ func TestNewApp_MachineValidationStartExecutesRESTRequest(t *testing.T) {
 	assert.Equal(t, "/v2/org/test-org/nico/machine/machine-1/validation/run", path)
 	assert.Equal(t, "Bearer test-token", authorization)
 	assert.JSONEq(t, `{"allowedTests":["gpu_bandwidth"],"runUnverifiedTests":true}`, body)
+}
+
+func normalizedOptionHelpLine(output, option string) string {
+	for _, line := range strings.Split(output, "\n") {
+		normalized := strings.Join(strings.Fields(line), " ")
+		if strings.HasPrefix(normalized, option) {
+			return normalized
+		}
+	}
+	return ""
 }
 
 func TestNewApp_MachineValidationReadCommandsExecuteRESTRequests(t *testing.T) {

--- a/rest-api/cli/pkg/spec.go
+++ b/rest-api/cli/pkg/spec.go
@@ -55,6 +55,7 @@ type Parameter struct {
 	Name        string  `yaml:"name"`
 	In          string  `yaml:"in"`
 	Required    bool    `yaml:"required"`
+	Deprecated  bool    `yaml:"deprecated"`
 	Description string  `yaml:"description"`
 	Schema      *Schema `yaml:"schema"`
 }
@@ -94,9 +95,11 @@ type Schema struct {
 	Type       SchemaType         `yaml:"type"`
 	Format     string             `yaml:"format"`
 	Enum       []string           `yaml:"enum"`
+	Deprecated bool               `yaml:"deprecated"`
 	Properties map[string]*Schema `yaml:"properties"`
 	Required   []string           `yaml:"required"`
 	Items      *Schema            `yaml:"items"`
+	MaxItems   *int               `yaml:"maxItems"`
 	MinLength  *int               `yaml:"minLength"`
 	MaxLength  *int               `yaml:"maxLength"`
 	Minimum    *int               `yaml:"minimum"`


### PR DESCRIPTION
Previously, the autogenerated nicocli didn't allow users to directly specify array parameter values found in the REST API -- those could only be handled as JSON. This PR adds the ability to specify those array parameters where each element is a primitive AND the max length is one, for example the `siteIds` parameter in operating system creation.

Additionally, deprecated parameters are now labeled is such in helptext.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/5451

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

