### PR TITLE
docs: announce repository move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NVIDIA Infra Controller
 
+> **Repository move notice:** On September 4, 2026, the NICo repository will move from the NVIDIA GitHub organization to `dsx-ai-factory`. Existing repository URLs and standard Git operations are expected to continue working through GitHub redirects. No action is needed for most users. If you maintain automation or integrations that reference `NVIDIA/infra-controller`, such as GitHub Actions, webhooks, or pinned repository URLs, please update them to `dsx-ai-factory/infra-controller` after the move.
+
 NVIDIA Infra Controller (NICo) delivers zero-touch lifecycle automation for
 bare-metal systems that secures datacenter infrastructure at its foundation.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 # NICo — NVIDIA Infra Controller Documentation
 
+<Note title="Repository move notice">
+On September 4, 2026, the NICo repository will move from the NVIDIA GitHub organization to `dsx-ai-factory`. Existing repository URLs and standard Git operations are expected to continue working through GitHub redirects. No action is needed for most users. If you maintain automation or integrations that reference `NVIDIA/infra-controller`, such as GitHub Actions, webhooks, or pinned repository URLs, please update them to `dsx-ai-factory/infra-controller` after the move.
+</Note>
+
 NICo is an open source suite of microservices for site-local, zero-trust bare-metal lifecycle management. It automates hardware discovery, firmware validation, DPU provisioning, network isolation, and tenant sanitization — enabling NVIDIA Cloud Partners (NCPs) and infrastructure operators to stand up and operate AI factory-scale infrastructure.
 
 NICo is open source under the Apache 2.0 license.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -12,8 +12,11 @@ instances:
 
 title: NVIDIA Infra Controller
 
-# metadata:
-#   canonical-host: "docs.nvidia.com/infra-controller"
+announcement:
+  message: "🔔 Infra Controller's GitHub repository is moving on September 4, 2026. Refer to the [front page](https://docs.nvidia.com/infra-controller) for more information."
+
+metadata:
+  canonical-host: "docs.nvidia.com/infra-controller"
 
 check:
   rules:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.94.0"
+  "version": "5.108.0"
 }


### PR DESCRIPTION
Adds pre-move notices to the README and documentation landing page for the September 4, 2026 transfer of NICo from NVIDIA/infra-controller to dsx-ai-factory/infra-controller. Infrastructure and canonical-link updates are intentionally deferred to cutover day.

(This is a redo of @deepak-poornachandra's #5466 that had some commit signing issues.)

## Related Issues

N/A

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

N/A