### PR TITLE
fix: pull in additional PNs to GB200xBF3 mlxconfig profile

### DIFF
--- a/crates/libmlx-model/src/nvconfig.rs
+++ b/crates/libmlx-model/src/nvconfig.rs
@@ -43,10 +43,12 @@ const GB200_B3240_V1_PARAMETERS: [&str; 18] = [
     "PCI_SWITCH0_UPSTREAM_PORT_PEX=0",
 ];
 
-const GB200_B3240_PART_NUMBERS: [&str; 3] = [
+const GB200_B3240_PART_NUMBERS: [&str; 5] = [
     "900-9D3B6-00CN-AB0",
     "900-9D3B6-00CN-PA0",
     "900-9D3B6-00SN-AB0",
+    "900-9D3B6-00CN-PN0",
+    "900-9D3B6-00CN-P_Ax",
 ];
 
 /// `DpuNvConfigProfile` identifies a fixed version of platform mlxconfig values.
@@ -59,9 +61,10 @@ pub enum DpuNvConfigProfile {
 impl DpuNvConfigProfile {
     /// Returns the GB200 profile for an exact supported B3240 part number.
     ///
-    /// Accepted part numbers are `900-9D3B6-00CN-AB0`, `900-9D3B6-00SN-AB0`,
-    /// and `900-9D3B6-00CN-PA0`. Surrounding whitespace and ASCII letter case
-    /// are ignored. The caller must separately verify that the DPU belongs to a
+    /// Accepted identities are `900-9D3B6-00CN-AB0`, `900-9D3B6-00SN-AB0`,
+    /// `900-9D3B6-00CN-PA0`, `900-9D3B6-00CN-PN0`, and
+    /// `900-9D3B6-00CN-P_Ax`. Surrounding whitespace and ASCII letter case are
+    /// ignored. The caller must separately verify that the DPU belongs to a
     /// GB200 rack. Broader B3240 product prefixes are not accepted.
     pub fn for_gb200_b3240_part_number(part_number: &str) -> Option<Self> {
         let part_number = part_number.trim();
@@ -90,10 +93,12 @@ mod tests {
     fn gb200_b3240_profile_requires_an_exact_supported_part_number() {
         value_scenarios!(
             run = DpuNvConfigProfile::for_gb200_b3240_part_number;
-            "supported part numbers" {
+            "supported identities" {
                 "900-9D3B6-00CN-AB0" => Some(DpuNvConfigProfile::Gb200B3240V1),
                 "900-9D3B6-00SN-AB0" => Some(DpuNvConfigProfile::Gb200B3240V1),
                 "900-9D3B6-00CN-PA0" => Some(DpuNvConfigProfile::Gb200B3240V1),
+                "900-9D3B6-00CN-PN0" => Some(DpuNvConfigProfile::Gb200B3240V1),
+                "900-9D3B6-00CN-P_Ax" => Some(DpuNvConfigProfile::Gb200B3240V1),
                 " 900-9d3b6-00cn-pa0\n" => Some(DpuNvConfigProfile::Gb200B3240V1),
             }
 


### PR DESCRIPTION
GB200 B3240 DPUs can report `900-9D3B6-00CN-PN0` in bootstrap Redfish data and `900-9D3B6-00CN-P_Ax` after Scout records the device identity. The shared selector did not accept either value, so DPF and Non-DPF provisioning selected the generic BF3 profile for those devices even when the rack was identified as GB200.

This adds both exact identities to the shared GB200 B3240 selector. The separate GB200 rack check remains required, and other B3240 prefixes remain rejected.

## Related issues

- Closes https://github.com/NVIDIA/infra-controller/issues/5541
- Follows https://github.com/NVIDIA/infra-controller/pull/5444 and https://github.com/NVIDIA/infra-controller/pull/5468
- Part of https://github.com/NVIDIA/infra-controller/issues/5029

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-libmlx-model`
- `cargo make clippy`
- `cargo make format-nightly`
- `git diff --check`

## Additional Notes

The existing DPF and Non-DPF integrations already consume this shared selector, so this PR does not change their NVConfig assignments.

The expanded local Carbide lints run (`--all-targets --all-features`) reaches existing `txn_held_across_await` failures in unchanged `crates/api-core/tests/integration/dns_resolution.rs`; that file is identical to `origin/main`. The hosted lint task does not compile that integration target.


Closes #5541
