### PR TITLE
patch(v2.1): pull in additional PNs to GB200xBF3 mlxconfig profile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -430,13 +430,22 @@ jobs:
           MAJOR_MINOR=$(echo "${VERSION}" | cut -d. -f1,2)
           echo "major_minor_version=${MAJOR_MINOR}" >> "$GITHUB_OUTPUT"
 
+          # `release/v2.1` integration tests still invoke `grpcurl`, which
+          # `main`'s build containers no longer include. Keep canonical v2.1
+          # checks on `v2.1-latest`; mirrors continue using the `latest` tag from
+          # their configured source registry.
+          build_container_fallback_version=latest
+          if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" && "${MAJOR_MINOR}" == "v2.1" ]]; then
+            build_container_fallback_version="${MAJOR_MINOR}-latest"
+          fi
+
           if [[ "$build_container_x86_64_run" == "true" ]]; then
             echo "build_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_container_x86_64_ref=${TARGET_REGISTRY}/build-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_container_x86_64_version_latest=${TARGET_REGISTRY}/build-container-x86_64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
           else
-            echo "build_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
-            echo "build_container_x86_64_ref=${SOURCE_REGISTRY}/build-container-x86_64:latest" >> "$GITHUB_OUTPUT"
+            echo "build_container_x86_64_version=${build_container_fallback_version}" >> "$GITHUB_OUTPUT"
+            echo "build_container_x86_64_ref=${SOURCE_REGISTRY}/build-container-x86_64:${build_container_fallback_version}" >> "$GITHUB_OUTPUT"
             echo "build_container_x86_64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 
@@ -455,8 +464,8 @@ jobs:
             echo "build_container_aarch64_ref=${TARGET_REGISTRY}/build-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_container_aarch64_version_latest=${TARGET_REGISTRY}/build-container-aarch64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
           else
-            echo "build_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
-            echo "build_container_aarch64_ref=${SOURCE_REGISTRY}/build-container-aarch64:latest" >> "$GITHUB_OUTPUT"
+            echo "build_container_aarch64_version=${build_container_fallback_version}" >> "$GITHUB_OUTPUT"
+            echo "build_container_aarch64_ref=${SOURCE_REGISTRY}/build-container-aarch64:${build_container_fallback_version}" >> "$GITHUB_OUTPUT"
             echo "build_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 

--- a/crates/libmlx-model/src/nvconfig.rs
+++ b/crates/libmlx-model/src/nvconfig.rs
@@ -43,10 +43,12 @@ const GB200_B3240_V1_PARAMETERS: [&str; 18] = [
     "PCI_SWITCH0_UPSTREAM_PORT_PEX=0",
 ];
 
-const GB200_B3240_PART_NUMBERS: [&str; 3] = [
+const GB200_B3240_PART_NUMBERS: [&str; 5] = [
     "900-9D3B6-00CN-AB0",
     "900-9D3B6-00CN-PA0",
     "900-9D3B6-00SN-AB0",
+    "900-9D3B6-00CN-PN0",
+    "900-9D3B6-00CN-P_Ax",
 ];
 
 /// `DpuNvConfigProfile` identifies a fixed version of platform mlxconfig values.
@@ -59,9 +61,10 @@ pub enum DpuNvConfigProfile {
 impl DpuNvConfigProfile {
     /// Returns the GB200 profile for an exact supported B3240 part number.
     ///
-    /// Accepted part numbers are `900-9D3B6-00CN-AB0`, `900-9D3B6-00SN-AB0`,
-    /// and `900-9D3B6-00CN-PA0`. Surrounding whitespace and ASCII letter case
-    /// are ignored. The caller must separately verify that the DPU belongs to a
+    /// Accepted identities are `900-9D3B6-00CN-AB0`, `900-9D3B6-00SN-AB0`,
+    /// `900-9D3B6-00CN-PA0`, `900-9D3B6-00CN-PN0`, and
+    /// `900-9D3B6-00CN-P_Ax`. Surrounding whitespace and ASCII letter case are
+    /// ignored. The caller must separately verify that the DPU belongs to a
     /// GB200 rack. Broader B3240 product prefixes are not accepted.
     pub fn for_gb200_b3240_part_number(part_number: &str) -> Option<Self> {
         let part_number = part_number.trim();
@@ -90,10 +93,12 @@ mod tests {
     fn gb200_b3240_profile_requires_an_exact_supported_part_number() {
         value_scenarios!(
             run = DpuNvConfigProfile::for_gb200_b3240_part_number;
-            "supported part numbers" {
+            "supported identities" {
                 "900-9D3B6-00CN-AB0" => Some(DpuNvConfigProfile::Gb200B3240V1),
                 "900-9D3B6-00SN-AB0" => Some(DpuNvConfigProfile::Gb200B3240V1),
                 "900-9D3B6-00CN-PA0" => Some(DpuNvConfigProfile::Gb200B3240V1),
+                "900-9D3B6-00CN-PN0" => Some(DpuNvConfigProfile::Gb200B3240V1),
+                "900-9D3B6-00CN-P_Ax" => Some(DpuNvConfigProfile::Gb200B3240V1),
                 " 900-9d3b6-00cn-pa0\n" => Some(DpuNvConfigProfile::Gb200B3240V1),
             }
 


### PR DESCRIPTION
This backports #5544 to v2.1. GB200 B3240 DPUs can report `900-9D3B6-00CN-PN0` in bootstrap Redfish data and `900-9D3B6-00CN-P_Ax` after Scout records the device identity. The v2.1 selector does not accept either value, so DPF and Non-DPF provisioning can select the generic BF3 profile for those devices even when the rack is identified as GB200.

This adds both exact identities to the shared GB200 B3240 selector. The separate GB200 rack check remains required, and other B3240 prefixes remain rejected.

The v2.1 integration tests still invoke `grpcurl`. #5386 removed it from `main`'s build containers, so release checks that do not rebuild a base container pull `latest` and fail before the integration tests start. This also makes the v2.1 workflow use its existing `v2.1-latest` x86_64 and aarch64 build container tags when those containers are not rebuilt.

## Related issues

- Closes https://github.com/NVIDIA/infra-controller/issues/5545
- Backports https://github.com/NVIDIA/infra-controller/pull/5544
- Builds on https://github.com/NVIDIA/infra-controller/pull/5482 and https://github.com/NVIDIA/infra-controller/pull/5506
- Accounts for https://github.com/NVIDIA/infra-controller/pull/5386
- Part of https://github.com/NVIDIA/infra-controller/issues/5029

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-libmlx-model`
- `cargo make clippy`
- `cargo make format-nightly`
- `cargo carbide-lints --all-targets --all-features`
- `git diff --check`

## Additional Notes

The existing v2.1 DPF and Non-DPF integrations already consume this shared selector, so this PR does not change their NVConfig assignments.

The `v2.1-latest` build container tags were published from the v2.1 Dockerfiles, which still install `grpcurl`. A Dockerfile change still selects the versioned container produced by that CI run. Mirrors continue using the `latest` tag from their configured source registry.


Closes #5545
