### PR TITLE
tests(core): move level_filter to integration suite

### DIFF
--- a/crates/api-core/src/test_support/mod.rs
+++ b/crates/api-core/src/test_support/mod.rs
@@ -25,14 +25,18 @@ pub mod network;
 pub mod network_segment;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use carbide_secrets::credentials::CredentialManager;
 use db::work_lock_manager::WorkLockManagerHandle;
 use model::resource_pool::common::CommonPools;
 pub use rpc;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 
 pub use crate::api::Api;
 pub use crate::api::metrics::ApiMetricsEmitter;
+pub use crate::logging::setup::dep_log_filter;
 
 pub const MAX_BGP_PASSWORD_LENGTH: usize = crate::handlers::credential::MAX_BGP_PASSWORD_LENGTH;
 
@@ -51,6 +55,16 @@ impl Api {
 
     pub fn credential_manager(&self) -> &Arc<dyn CredentialManager> {
         &self.credential_manager
+    }
+
+    pub fn start_dynamic_settings_reset_task(
+        &self,
+        join_set: &mut JoinSet<()>,
+        period: Duration,
+        cancel_token: CancellationToken,
+    ) {
+        self.dynamic_settings
+            .start_reset_task(join_set, period, cancel_token);
     }
 }
 

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -48,7 +48,6 @@ mod instance_ipxe_behaviors;
 mod instance_os;
 mod instance_type;
 mod ipxe;
-mod level_filter;
 mod lldp;
 mod machine_admin_force_delete;
 mod machine_boot_override;

--- a/crates/api-core/tests/integration/level_filter.rs
+++ b/crates/api-core/tests/integration/level_filter.rs
@@ -17,22 +17,19 @@
 
 use std::time::Duration;
 
-use common::api_fixtures::create_test_env;
-use rpc::forge::forge_server::Forge;
+use carbide_api_core::test_support::dep_log_filter;
+use carbide_test_harness::prelude::*;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::filter::EnvFilter;
 
-use crate::logging::setup::dep_log_filter;
-use crate::tests::common;
-
-#[crate::sqlx_test]
-async fn test_dynamic_log_filter(db_pool: sqlx::PgPool) -> eyre::Result<()> {
-    let env = create_test_env(db_pool.clone()).await;
+#[sqlx_test]
+async fn test_dynamic_log_filter(db_pool: PgPool) -> eyre::Result<()> {
+    let env = TestHarness::builder(db_pool).build().await;
     let mut join_set = JoinSet::new();
     let cancel_token = CancellationToken::new();
     // Real env does this in api/lib.rs::run
-    env.api.dynamic_settings.start_reset_task(
+    env.api().start_dynamic_settings_reset_task(
         &mut join_set,
         Duration::from_millis(300),
         cancel_token.clone(),
@@ -44,7 +41,7 @@ async fn test_dynamic_log_filter(db_pool: sqlx::PgPool) -> eyre::Result<()> {
         .parse(std::env::var("RUST_LOG").unwrap_or("trace".to_string()))
         .unwrap()
         .to_string();
-    let base = env.api.log_filter_string();
+    let base = env.api().log_filter_string();
     assert_eq!(local, base, "Startup log filter does not match RUST_LOG");
 
     // 2. Apply default dep log levels (as in fn setup_logging(...))
@@ -56,8 +53,10 @@ async fn test_dynamic_log_filter(db_pool: sqlx::PgPool) -> eyre::Result<()> {
         value: "debug".to_string(),
         expiry: Some("500ms".to_string()),
     };
-    env.api.set_dynamic_config(tonic::Request::new(req)).await?;
-    let current = env.api.log_filter_string();
+    env.api()
+        .set_dynamic_config(tonic::Request::new(req))
+        .await?;
+    let current = env.api().log_filter_string();
     // it should be something like: "...,debug until 2024-03-27 18:20:33.723829221 UTC"
     assert!(
         current.contains("debug until "),
@@ -66,7 +65,7 @@ async fn test_dynamic_log_filter(db_pool: sqlx::PgPool) -> eyre::Result<()> {
 
     // 4. After 'expiry' it automatically reverts
     tokio::time::sleep(Duration::from_secs(1)).await;
-    let base = env.api.log_filter_string();
+    let base = env.api().log_filter_string();
     assert_eq!(
         local.to_string(),
         base,

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -32,6 +32,7 @@ mod explored_mlx_devices;
 mod find_by_ids_guards;
 mod forge_agent_control;
 mod ib_fabric_find;
+mod level_filter;
 mod machine_bmc_metadata;
 mod machine_boot_interfaces;
 mod nvlink_domain_health;


### PR DESCRIPTION
Straight forward move of level filter tests to integration suite

## Related issues

#2001 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
