### PR TITLE
patch(v2.1): Reconnect to external FMDS on every main-loop iteration

### DIFF
--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -361,6 +361,15 @@ pub struct RunOptions {
     pub fmds_grpc_server: Option<String>,
     #[clap(
         long,
+        default_value = "3",
+        value_parser = clap::value_parser!(u64).range(1..),
+        help = "Seconds to wait for one connection attempt to --fmds-grpc-server. The agent \
+                reconnects on every main-loop iteration, so this bounds how long an unreachable \
+                FMDS can hold the loop up. Ignored without --fmds-grpc-server."
+    )]
+    pub fmds_connect_timeout_secs: u64,
+    #[clap(
+        long,
         default_value = "container-exec",
         help = "Set the configuration mode for HBN. Specify \"container-exec\" or \"nvue-rest\".",
         env = "HBN_CONFIG_MODE"

--- a/crates/agent/src/fmds_client.rs
+++ b/crates/agent/src/fmds_client.rs
@@ -16,16 +16,17 @@
  */
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use carbide_host_support::agent_config::MachineIdentityConfig;
-use eyre::eyre;
+use eyre::{WrapErr, eyre};
 use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
 use rpc::fmds::fmds_config_service_client::FmdsConfigServiceClient;
 use rpc::fmds::{
     FmdsConfigUpdate, FmdsMachineIdentityConfig, IbDevice, IbInstance, UpdateConfigRequest,
 };
 use rpc::forge::ManagedHostNetworkConfigResponse;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, Endpoint};
 
 use crate::instance_metadata_endpoint::InstanceMetadataRouterStateImpl;
 use crate::instrumentation::FmdsPush;
@@ -42,7 +43,11 @@ pub enum FmdsUpdater {
     /// External will send FMDS updates to an FMDS server,
     /// which is colocated on the same DPU, possibly in its
     /// own container.
-    External(Box<FmdsGrpcClient>),
+    External {
+        address: String,
+        machine_identity: MachineIdentityConfig,
+        connect_timeout: Duration,
+    },
 }
 
 impl FmdsUpdater {
@@ -52,20 +57,36 @@ impl FmdsUpdater {
         network_config: Option<Arc<ManagedHostNetworkConfigResponse>>,
     ) {
         match self {
-            FmdsUpdater::Embedded(state) => {
-                state.update_instance_data(instance_data);
-                state.update_network_configuration(network_config);
-            }
-            FmdsUpdater::External(client) => {
-                let result = client.update_config(&instance_data, &network_config).await;
-                match &result {
+            FmdsUpdater::External {
+                address,
+                machine_identity,
+                connect_timeout,
+            } => {
+                let result = match FmdsGrpcClient::connect(
+                    address,
+                    machine_identity.clone(),
+                    *connect_timeout,
+                )
+                .await
+                {
+                    Ok(mut client) => client.update_config(&instance_data, &network_config).await,
+                    Err(err) => Err(err),
+                };
+
+                // A failed push is dropped: the next main-loop iteration
+                // reconnects and pushes again.
+                match result {
                     Ok(()) => FmdsPush::Succeeded.emit(),
                     Err(err) => FmdsPush::Failed {
                         error: format!("{err:#}"),
-                        fmds_address: client.address.clone(),
+                        fmds_address: address.clone(),
                     }
                     .emit(),
                 }
+            }
+            FmdsUpdater::Embedded(state) => {
+                state.update_instance_data(instance_data);
+                state.update_network_configuration(network_config);
             }
         }
     }
@@ -81,10 +102,17 @@ impl FmdsGrpcClient {
     pub async fn connect(
         address: &str,
         machine_identity: MachineIdentityConfig,
+        connect_timeout: Duration,
     ) -> eyre::Result<Self> {
-        let client = FmdsConfigServiceClient::connect(address.to_string()).await?;
+        let channel = Endpoint::from_shared(address.to_string())
+            .wrap_err_with(|| format!("invalid FMDS address {address}"))?
+            .connect_timeout(connect_timeout)
+            .connect()
+            .await
+            .wrap_err_with(|| format!("failed to connect to FMDS at {address}"))?;
+
         Ok(Self {
-            client,
+            client: FmdsConfigServiceClient::new(channel),
             address: address.to_string(),
             machine_identity,
         })
@@ -163,5 +191,159 @@ impl FmdsGrpcClient {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::{SocketAddr, TcpListener};
+
+    use config_version::ConfigVersion;
+    use rpc::fmds::UpdateConfigResponse;
+    use rpc::fmds::fmds_config_service_server::{FmdsConfigService, FmdsConfigServiceServer};
+    use tokio::sync::mpsc;
+    use tokio::task::JoinHandle;
+    use tonic::{Request, Response, Status};
+
+    use super::*;
+
+    /// Minimal FMDS server that records the updates it is sent.
+    struct RecordingFmdsServer {
+        updates: mpsc::UnboundedSender<FmdsConfigUpdate>,
+    }
+
+    #[tonic::async_trait]
+    impl FmdsConfigService for RecordingFmdsServer {
+        async fn update_config(
+            &self,
+            request: Request<UpdateConfigRequest>,
+        ) -> Result<Response<UpdateConfigResponse>, Status> {
+            let update = request
+                .into_inner()
+                .config_update
+                .ok_or_else(|| Status::invalid_argument("missing config_update"))?;
+            let _ = self.updates.send(update);
+            Ok(Response::new(UpdateConfigResponse {}))
+        }
+    }
+
+    /// Serves [`RecordingFmdsServer`] on `addr`. The caller owns the returned
+    /// handle and aborts it at the end of the test.
+    fn serve_fmds(addr: SocketAddr) -> (JoinHandle<()>, mpsc::UnboundedReceiver<FmdsConfigUpdate>) {
+        let (updates, received) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(FmdsConfigServiceServer::new(RecordingFmdsServer {
+                    updates,
+                }))
+                .serve(addr)
+                .await
+                .expect("FMDS test server");
+        });
+        (handle, received)
+    }
+
+    /// Picks a free port. The listener is dropped, so the port is unbound when
+    /// this returns and the caller can serve on it.
+    fn free_addr() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local_addr");
+        drop(listener);
+        addr
+    }
+
+    /// [`serve_fmds`] binds on a spawned task, so it is not necessarily
+    /// listening when it returns. Waits until it is.
+    async fn wait_until_listening(addr: SocketAddr) {
+        for _ in 0..100 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("FMDS test server never started listening on {addr}");
+    }
+
+    fn test_instance_metadata() -> InstanceMetadata {
+        InstanceMetadata {
+            address: "192.168.1.1".to_string(),
+            hostname: "test-host".to_string(),
+            sitename: Some("test-site".to_string()),
+            instance_id: None,
+            machine_id: None,
+            user_data: "test-user-data".to_string(),
+            ib_devices: None,
+            config_version: ConfigVersion::initial(),
+            network_config_version: ConfigVersion::initial(),
+            extension_service_version: ConfigVersion::initial(),
+        }
+    }
+
+    fn test_external_updater(address: String) -> FmdsUpdater {
+        FmdsUpdater::External {
+            address,
+            machine_identity: MachineIdentityConfig::default(),
+            connect_timeout: Duration::from_millis(500),
+        }
+    }
+
+    /// The happy path through [`FmdsUpdater::update`]: it dials the external
+    /// FMDS on every call and the update lands on the server.
+    #[tokio::test]
+    async fn external_updater_connects_and_pushes_every_update() {
+        let addr = free_addr();
+        let (server, mut received) = serve_fmds(addr);
+        wait_until_listening(addr).await;
+
+        let mut updater = test_external_updater(format!("http://{addr}"));
+
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+
+        let update = received.recv().await.expect("server received an update");
+        assert_eq!(update.hostname, "test-host");
+        assert_eq!(update.address, "192.168.1.1");
+        assert!(update.machine_identity.is_some());
+
+        // A second iteration reconnects and pushes again.
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+
+        let update = received
+            .recv()
+            .await
+            .expect("server received the second update");
+        assert_eq!(update.hostname, "test-host");
+
+        server.abort();
+    }
+
+    /// The recovery this change exists for: an FMDS that is down when the agent
+    /// starts is picked up by a later iteration, instead of the agent degrading
+    /// for its whole lifetime.
+    #[tokio::test]
+    async fn external_updater_recovers_once_fmds_comes_up() {
+        let addr = free_addr();
+        let mut updater = test_external_updater(format!("http://{addr}"));
+
+        // Nothing is listening yet. The push fails and is dropped, but the
+        // updater stays usable rather than latching onto a degraded mode.
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+
+        // FMDS shows up, and the next iteration reaches it.
+        let (server, mut received) = serve_fmds(addr);
+        wait_until_listening(addr).await;
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+
+        let update = received.recv().await.expect("server received an update");
+        assert_eq!(update.hostname, "test-host");
+
+        server.abort();
     }
 }

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -173,34 +173,11 @@ pub async fn setup_and_run(
             fmds_address = fmds_addr,
             "Using FmdsUpdater::External FMDS service"
         );
-        let updater = match crate::fmds_client::FmdsGrpcClient::connect(
-            fmds_addr,
-            agent_config.machine_identity.clone(),
-        )
-        .await
-        {
-            Ok(fmds_client) => FmdsUpdater::External(Box::new(fmds_client)),
-            Err(e) => {
-                tracing::warn!(
-                    error = format!("{e:#}"),
-                    "Failed to connect to external FMDS service, falling back to embedded"
-                );
-                FmdsUpdater::Embedded(instance_metadata_state.clone())
-            }
-        };
-        // External FMDS was configured: expose whether we reached it (1) or fell
-        // back to embedded (0). A gauge, not a counter -- the fallback is decided
-        // once at startup, so a single pre-scrape counter bump would be invisible
-        // to rate()/increase(); a gauge reports the state at every scrape.
-        let reached_external = matches!(updater, FmdsUpdater::External(_));
-        get_dpu_agent_meter()
-            .u64_observable_gauge("carbide_dpu_agent_fmds_external_connected")
-            .with_description(
-                "Whether the DPU agent reached its configured external FMDS (1) or fell back to embedded (0)",
-            )
-            .with_callback(move |observer| observer.observe(reached_external as u64, &[]))
-            .build();
-        updater
+        FmdsUpdater::External {
+            address: fmds_addr.clone(),
+            machine_identity: agent_config.machine_identity.clone(),
+            connect_timeout: Duration::from_secs(options.fmds_connect_timeout_secs),
+        }
     } else {
         if options.enable_metadata_service {
             crate::metadata_service::spawn_metadata_service(

--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -120,6 +120,7 @@ pub fn setup_agent_run_env(
             skip_upgrade_check: false,
             dhcp_grpc_server: None,
             fmds_grpc_server: None,
+            fmds_connect_timeout_secs: 3,
             hbn_config_mode: crate::command_line::HbnConfigMode::ContainerExec,
             agent_platform_type: crate::command_line::AgentPlatformType::DpuOs,
             dhcp_server_interface_prepend: None,


### PR DESCRIPTION
This backports #4989 to `release/v2.1`. When external FMDS is configured but unavailable at DPU agent startup, the release branch makes one connection attempt, falls back to an embedded updater with no listening metadata service, and never reconnects. This keeps the external connection parameters and attempts a bounded connection on every main-loop update, so FMDS receives current metadata after it becomes available without restarting the agent. It also removes the obsolete one-time connectivity gauge and adds focused success and recovery tests.

## Related issues

- Backports https://github.com/NVIDIA/infra-controller/pull/4989

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo +nightly-2026-06-16 fmt --all -- --check`
- `cargo test --locked -p carbide-agent fmds_client::test -- --nocapture`
- `cargo test --locked -p carbide-agent`
- `cargo clippy --locked -p carbide-agent --all-targets --all-features -- -D warnings`
- `cargo carbide-lints -p carbide-agent --all-targets --all-features`
- `cargo --quiet xtask lint-error-messages`
- `cargo --quiet xtask check-event-names`
- `cargo --quiet xtask check-metric-docs`
- `cargo --quiet xtask check-workspace-deps`

## Additional Notes

The source test fixture uses the newer dual-stack public-address fields and instance name that are not present on `release/v2.1`; this backport uses the release branch's existing single-address fixture. The reconnect behavior and assertions are unchanged, and no adjacent source commit or dependency is included.
