### PR TITLE
Add one-box Linux AMD64 and ARM64 development setup support

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -214,7 +214,7 @@ echo "Image carbide-build-minimal built. Run: cargo make cargo-docker-minimal --
 
 [tasks.build-pxe-build-container]
 category = "Build"
-description = "Build the PXE artifact build container image (Ubuntu 24.04 + Rust 1.97 + mkosi deps). Required once before pxe-docker-x86."
+description = "Build the native-architecture PXE builder that produces x86_64 Scout artifacts. Required once before pxe-docker-x86."
 workspace = false
 script = '''
 set -e
@@ -224,10 +224,15 @@ echo "Image carbide-pxe-builder built. Run: cargo make pxe-docker-x86"
 
 [tasks.pxe-docker-x86]
 category = "Build"
-description = "Build x86_64 PXE boot artifacts inside a privileged container. Requires build-pxe-build-container first. Artifacts land in pxe/static/blobs/internal/x86_64/ via the repo mount."
+description = "Build x86_64 PXE boot artifacts in a native AMD64 or ARM64 privileged container. Requires build-pxe-build-container first. Artifacts land in pxe/static/blobs/internal/x86_64/ via the repo mount."
 workspace = false
 script = '''
 set -e
+if [ "$(uname -m)" != "x86_64" ]; then
+  BINFMT_IMAGE="tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0"
+  docker run --privileged --rm "${BINFMT_IMAGE}" --uninstall qemu-x86_64
+  docker run --privileged --rm "${BINFMT_IMAGE}" --install amd64
+fi
 if [ -z "$CARGO_HOME" ]; then CARGO_HOME="$HOME/.cargo"; fi
 SCCACHE_HOST="${SCCACHE_DIR:-$HOME/.sccache}"
 mkdir -p "$SCCACHE_HOST"

--- a/crates/machine-a-tron/Dockerfile
+++ b/crates/machine-a-tron/Dockerfile
@@ -17,15 +17,14 @@
 
 # Build from the repo root:
 #
-#   docker buildx build --platform linux/amd64 \
+#   docker buildx build --platform linux/amd64,linux/arm64 \
 #     -f crates/machine-a-tron/Dockerfile \
 #     --build-arg VERSION=0.1.0 -t machine-a-tron:latest .
 #
 # NOTE: Cross-compilation architecture
-# The BUILDER stage always runs NATIVE on the build host ($BUILDPLATFORM) and
-# cross-compiles to x86_64-unknown-linux-gnu. This avoids QEMU emulation when
-# building on Apple Silicon hosts, which would otherwise SEGFAULT while
-# assembling aws-lc-sys's hand-written x86-64 assembly code.
+# The builder always runs natively on $BUILDPLATFORM and compiles for
+# $TARGETARCH. This avoids QEMU during compilation while allowing the same
+# Dockerfile to publish linux/amd64 and linux/arm64 images.
 #
 ARG RUST_VERSION=1.97.1
 
@@ -33,6 +32,7 @@ FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-slim-bookworm AS builder
 
 ARG VERSION
 ARG CI_COMMIT_SHORT_SHA
+ARG TARGETARCH
 ENV VERSION=${VERSION}
 ENV CI_COMMIT_SHORT_SHA=${CI_COMMIT_SHORT_SHA}
 
@@ -41,15 +41,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     protobuf-compiler \
     libprotobuf-dev \
-    && if [ "$(uname -m)" != "x86_64" ]; then \
-         apt-get install -y --no-install-recommends \
-           gcc-x86-64-linux-gnu libc6-dev-amd64-cross; \
-       else \
-         apt-get install -y --no-install-recommends gcc libc6-dev; \
-       fi \
+    && case "${TARGETARCH}:$(uname -m)" in \
+         amd64:x86_64|arm64:aarch64) \
+           apt-get install -y --no-install-recommends gcc libc6-dev ;; \
+         amd64:*) \
+           apt-get install -y --no-install-recommends gcc-x86-64-linux-gnu libc6-dev-amd64-cross ;; \
+         arm64:*) \
+           apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;; \
+         *) \
+           echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup target add x86_64-unknown-linux-gnu
+RUN case "${TARGETARCH}" in \
+      amd64) rustup target add x86_64-unknown-linux-gnu ;; \
+      arm64) rustup target add aarch64-unknown-linux-gnu ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac
 
 ENV CARGO_HOME=/cargo-home
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
@@ -59,20 +67,31 @@ ENV RUST_BACKTRACE=1
 WORKDIR /workspace
 COPY . .
 
-# Build release binary with cross-compilation
+# Build the release binary natively or with cross-compilation as needed.
 RUN --mount=type=cache,id=nico-mat-cross-cargo-home,target=/cargo-home,sharing=locked \
     --mount=type=cache,id=nico-mat-cross-cargo-target,target=/cargo-target,sharing=locked \
-    if [ "$(uname -m)" != "x86_64" ]; then \
-      export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
-             CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc; \
-    fi && \
+    case "${TARGETARCH}" in \
+      amd64) \
+        rust_target=x86_64-unknown-linux-gnu; \
+        if [ "$(uname -m)" != "x86_64" ]; then \
+          export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
+                 CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc; \
+        fi ;; \
+      arm64) \
+        rust_target=aarch64-unknown-linux-gnu; \
+        if [ "$(uname -m)" != "aarch64" ]; then \
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+                 CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc; \
+        fi ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
     cargo build -p carbide-machine-a-tron --bin machine-a-tron --locked --release \
-      --target x86_64-unknown-linux-gnu && \
+      --target "${rust_target}" && \
     mkdir -p /artifacts && \
-    cp /cargo-target/x86_64-unknown-linux-gnu/release/machine-a-tron /artifacts/machine-a-tron
+    cp "/cargo-target/${rust_target}/release/machine-a-tron" /artifacts/machine-a-tron
 
 # Runtime image
-FROM --platform=linux/amd64 debian:bookworm-slim
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim
 
 ARG VERSION
 ARG CI_COMMIT_SHORT_SHA

--- a/deploy/nico-system/kustomization.yaml
+++ b/deploy/nico-system/kustomization.yaml
@@ -44,7 +44,7 @@ configMapGenerator:
       - SECRET_REF=nico-system.nico.nico-pg-cluster.credentials.postgresql.acid.zalan.do
   - name: vault-cluster-info
     literals:
-      - VAULT_SERVICE=https://vault.vault.svc.cluster.local:8200
+      - VAULT_SERVICE=https://vault.vault:8200
       - NICO_VAULT_MOUNT=secrets
       - NICO_VAULT_PKI_MOUNT=nicoca
 

--- a/dev/docker/Dockerfile.pxe-build-container
+++ b/dev/docker/Dockerfile.pxe-build-container
@@ -18,37 +18,57 @@
 # Must be run with --privileged so mkosi can use Linux user namespaces.
 #
 # Ubuntu 24.04 matches the mkosi ToolsTreeRelease=noble used by the PXE profiles.
+# The container runs on the build host architecture and always produces x86_64
+# artifacts. This avoids running Rust under QEMU when building on ARM64 hosts.
 #
 # Build: cargo make build-pxe-build-container
 # Use:   cargo make pxe-docker-x86
 #
-FROM ubuntu:24.04
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM ubuntu:24.04
 
 ARG RUST_VERSION=1.97.1
+ARG BUILDARCH
 
-RUN apt-get update && \
+RUN set -eux; \
+	case "${BUILDARCH}" in \
+		amd64) \
+			target_packages='kea-dev kea-dhcp4-server kea-dhcp6-server libboost-dev libgrpc-dev libgrpc++-dev libprotobuf-dev libssl-dev libtss2-dev libudev-dev liblzma-dev' \
+			;; \
+		arm64) \
+			dpkg --add-architecture amd64; \
+			rm -f /etc/apt/sources.list.d/ubuntu.sources; \
+			printf '%s\n' \
+				'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main restricted universe multiverse' \
+				'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main restricted universe multiverse' \
+				'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main restricted universe multiverse' \
+				'deb [arch=amd64] http://archive.ubuntu.com/ubuntu noble main restricted universe multiverse' \
+				'deb [arch=amd64] http://archive.ubuntu.com/ubuntu noble-updates main restricted universe multiverse' \
+				'deb [arch=amd64] http://security.ubuntu.com/ubuntu noble-security main restricted universe multiverse' \
+				> /etc/apt/sources.list; \
+			target_packages='kea-dev:amd64 libboost-dev:amd64 libgrpc-dev:amd64 libgrpc++-dev:amd64 libprotobuf-dev:amd64 libssl-dev:amd64 libtss2-dev:amd64 libudev-dev:amd64 liblzma-dev:amd64' \
+			;; \
+		*) \
+			echo "unsupported build architecture: ${BUILDARCH}" >&2; \
+			exit 1 \
+			;; \
+	esac; \
+	apt-get update; \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	# Rust install
 	curl \
 	ca-certificates \
 	# For carbide-scout (Rust binary deps)
 	binutils-aarch64-linux-gnu \
+	binutils-x86-64-linux-gnu \
 	build-essential \
-	kea-dev \
-	kea-dhcp4-server \
-	kea-dhcp6-server \
-	libboost-dev \
-	libgrpc-dev \
-	libgrpc++-dev \
-	libprotobuf-dev \
+	g++-x86-64-linux-gnu \
+	gcc-x86-64-linux-gnu \
+	libc6-dev-amd64-cross \
 	libssl-dev \
-	libtss2-dev \
-	libudev-dev \
 	lld \
 	pkg-config \
 	protobuf-compiler \
-	# For iPXE build
-	liblzma-dev \
 	# For mkosi (OS image builder) — the binary comes from the pxe/mkosi submodule;
 	# these are the host-side deps mkosi needs for image construction
 	apt-utils \
@@ -78,11 +98,15 @@ RUN apt-get update && \
 	git \
 	jq \
 	zip \
-	&& rm -rf /var/lib/apt/lists/*
+	${target_packages}; \
+	# Cross GCC searches its target binutils directory for the selected linker.
+	ln -sf /usr/bin/ld.lld /usr/x86_64-linux-gnu/bin/ld.lld; \
+	rm -rf /var/lib/apt/lists/*
 
 # Install Rust via rustup, pinned to match rust-toolchain.toml
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 	sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal && \
+	/root/.cargo/bin/rustup target add x86_64-unknown-linux-gnu && \
 	rm -rf /root/.cargo/registry
 
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -91,6 +115,12 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # tokio_unstable enables tokio::task::Builder used by several crates.
 # Note: iPXE uses its own Makefile with gcc/ld directly; RUSTFLAGS does not affect it.
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=lld --cfg tokio_unstable"
+ENV AR_x86_64_unknown_linux_gnu=x86_64-linux-gnu-ar
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+ENV CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc
+ENV CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV PKG_CONFIG_PATH_x86_64_unknown_linux_gnu=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
 
 RUN cargo install cargo-make sccache --locked && \
 	rm -rf /root/.cargo/registry

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -130,6 +130,7 @@ To tune PostgreSQL resources for your node capacity (the defaults are conservati
 ```yaml
 postgresql:
   instances: 3
+  synchronousMode: null  # automatic: false for one instance, true for multiple instances
   volumeSize: "10Gi"
   resources:
     limits:

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -184,8 +184,16 @@ docker build --file dev/docker/Dockerfile.runtime-container-x86_64 -t nico-runti
 
 ### Building the boot artifact containers
 
+Build the PXE builder container and run the x86_64 artifact workflow inside
+it. The builder runs natively on either an AMD64 or ARM64 build host. On ARM64,
+Rust, C/C++, and iPXE are cross-compiled for x86_64 instead of running an
+x86_64 compiler through QEMU user-mode emulation. The workflow also installs a
+pinned amd64 binfmt handler on ARM64 hosts for the x86_64 package scripts that
+mkosi must execute while assembling the Scout images.
+
 ```sh
-cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-x86-host-sa
+cargo make build-pxe-build-container
+cargo make pxe-docker-x86
 docker build --build-arg "CONTAINER_RUNTIME_X86_64=alpine:latest" -t boot-artifacts-x86_64 -f dev/docker/Dockerfile.release-artifacts-x86_64 .
 ```
 

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -321,7 +321,7 @@ the overwrite path.
 ```text
 local-path-provisioner     (raw manifest - StorageClasses for Vault + PostgreSQL PVCs)
 metallb                    (metallb/metallb 0.14.5 - LoadBalancer IPs via BGP or L2)
-postgres-operator          (zalando/postgres-operator 1.10.1 - manages nico-pg-cluster)
+postgres-operator          (zalando/postgres-operator 1.15.1 - manages nico-pg-cluster)
 cert-manager               (jetstack/cert-manager v1.17.1)
 vault                      (hashicorp/vault 0.25.0, 3-node HA Raft, TLS)
 external-secrets           (external-secrets/external-secrets 0.14.3)

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -144,6 +144,7 @@ The tables below summarize the keys that must be set per site.
 | `NICO_DPF_IMAGE_TAG` | No | DPF operator image tag. Defaults to `NICO_DPF_VERSION`. Set separately when your self-built image uses a different tag than the chart version. |
 | `NICO_DPF_IMAGE_PULL_SECRET` | No | Pull secret for the DPF operator/DOCA images. Unset by default — the GA `nvidia/doca` images are public and pull anonymously. Set only for a private DPF/DOCA registry or mirror. |
 | `NICO_DPF_HELM_REPO_OCI` / `_HTTPS` / `_CARBIDE` | No | Argo CD helm repository URLs DPF pulls operand/service charts from. `_OCI`/`_HTTPS` default to the public `nvidia/doca` repos; `_CARBIDE` defaults to the **private** `0837451325059433/carbide-dev` (the NICo DPUService charts). Must match the `[dpf.services.*].helm_repo_url` carbide-api requests — override in lockstep when mirroring. |
+| `HELMFILE_INSTALL_DIR` | No | Directory used when `setup.sh` installs Helmfile automatically. Defaults to `$HOME/.local/bin`, avoiding a root-owned system path. |
 
 ### `values.yaml`
 

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -157,6 +157,7 @@ The tables below summarize the keys that must be set per site.
 | `vault.nicoCliClientRole.ou` | `""` | No | Certificate `SubjectOU` stamped on issued CLI client certs; empty means use `name`. nico-api maps the OU to the ExternalUser group, but admin-CLI authorization is gated by the issuer CN (`auth.additionalIssuerCns`), not the OU value. Do not set `"Invalid"`. |
 | `vault.nicoCliClientRole.organization` | `""` | No | Optional certificate `SubjectO` value for deployments that want an additional identity marker. |
 | `postgresql.instances` | `3` | No | Number of PostgreSQL replicas |
+| `postgresql.synchronousMode` | `null` (automatic) | No | Patroni synchronous replication mode. Automatic mode disables it for one instance and enables it when more than one instance is configured; set `true` or `false` to override. |
 | `postgresql.volumeSize` | `"10Gi"` | No | PVC size per PostgreSQL replica |
 | `postgresql.storageClass` | `"local-path-persistent"` | No | StorageClass for the nico-prereqs PostgreSQL PVCs. Override through Helm values when using a non-local StorageClass. |
 | `temporal.useHaPostgres` | `false` | No | Move Temporal's default/visibility stores onto `nico-pg-cluster` instead of `postgres.postgres`. Named `useHaPostgres`, not `enabled`, because it only moves the database — it doesn't gate whether Temporal is deployed. See [Consolidating Temporal/Keycloak onto nico-pg-cluster](#consolidating-temporalkeycloak-onto-nico-pg-cluster). |

--- a/helm-prereqs/health-check.sh
+++ b/helm-prereqs/health-check.sh
@@ -73,7 +73,7 @@ if [[ -z "${NICO_NS:-}" ]]; then
 fi
 
 # vault namespace: parse from VAULT_SERVICE in vault-cluster-info
-# e.g. https://vault.vault.svc.cluster.local:8200 → vault
+# e.g. https://vault.vault:8200 → vault
 if [[ -z "${VAULT_NS:-}" ]]; then
   _VAULT_SVC=$(kc get configmap -n "${NICO_NS}" vault-cluster-info \
     -o jsonpath='{.data.VAULT_SERVICE}' || true)

--- a/helm-prereqs/helmfile.yaml
+++ b/helm-prereqs/helmfile.yaml
@@ -69,10 +69,9 @@ releases:
     namespace: postgres
     createNamespace: true
     chart: postgres-operator/postgres-operator
-    # NOTE: chart versions below 1.11.0 are no longer published in Zalando's chart
-    # repository. The CRD API (acid.zalan.do/v1) is unchanged across this bump, and
-    # nico-pg-cluster pins postgresql.version explicitly, so the database is unaffected.
-    version: "1.11.0"
+    # v1.15.1 publishes a multi-architecture operator image. Older releases such
+    # as v1.11.0 resolve to an amd64-only image and cannot run on arm64 clusters.
+    version: "1.15.1"
     wait: true
     timeout: 600
     values:

--- a/helm-prereqs/helmfile.yaml
+++ b/helm-prereqs/helmfile.yaml
@@ -29,8 +29,6 @@ repositories:
     url: https://charts.jetstack.io
   - name: hashicorp
     url: https://helm.releases.hashicorp.com
-  - name: external-secrets
-    url: https://charts.external-secrets.io
   - name: postgres-operator
     url: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
   - name: metallb
@@ -113,7 +111,7 @@ releases:
   - name: external-secrets
     namespace: external-secrets
     createNamespace: true
-    chart: external-secrets/external-secrets
+    chart: oci://ghcr.io/external-secrets/charts/external-secrets
     version: "0.14.3"
     wait: true
     timeout: 600

--- a/helm-prereqs/helmfile.yaml
+++ b/helm-prereqs/helmfile.yaml
@@ -69,10 +69,7 @@ releases:
     namespace: postgres
     createNamespace: true
     chart: postgres-operator/postgres-operator
-    # NOTE: chart versions below 1.11.0 are no longer published in Zalando's chart
-    # repository. The CRD API (acid.zalan.do/v1) is unchanged across this bump, and
-    # nico-pg-cluster pins postgresql.version explicitly, so the database is unaffected.
-    version: "1.11.0"
+    version: "1.15.1"
     wait: true
     timeout: 600
     values:

--- a/helm-prereqs/helmfile.yaml
+++ b/helm-prereqs/helmfile.yaml
@@ -25,6 +25,16 @@
 # =============================================================================
 
 repositories:
+  - name: jetstack
+    url: https://charts.jetstack.io
+  - name: hashicorp
+    url: https://helm.releases.hashicorp.com
+  - name: external-secrets
+    url: https://charts.external-secrets.io
+  - name: postgres-operator
+    url: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
+  - name: metallb
+    url: https://metallb.github.io/metallb
   - name: argo
     url: https://argoproj.github.io/argo-helm
   - name: nfd
@@ -42,7 +52,7 @@ releases:
   - name: metallb
     namespace: metallb-system
     createNamespace: true
-    chart: https://github.com/metallb/metallb/releases/download/metallb-chart-0.14.5/metallb-0.14.5.tgz
+    chart: metallb/metallb
     version: "0.14.5"
     wait: true
     timeout: 600
@@ -58,8 +68,11 @@ releases:
   - name: postgres-operator
     namespace: postgres
     createNamespace: true
-    chart: https://opensource.zalando.com/postgres-operator/charts/postgres-operator/postgres-operator-1.15.1.tgz
-    version: "1.15.1"
+    chart: postgres-operator/postgres-operator
+    # NOTE: chart versions below 1.11.0 are no longer published in Zalando's chart
+    # repository. The CRD API (acid.zalan.do/v1) is unchanged across this bump, and
+    # nico-pg-cluster pins postgresql.version explicitly, so the database is unaffected.
+    version: "1.11.0"
     wait: true
     timeout: 600
     values:
@@ -73,7 +86,7 @@ releases:
   - name: cert-manager
     namespace: cert-manager
     createNamespace: true
-    chart: oci://quay.io/jetstack/charts/cert-manager
+    chart: jetstack/cert-manager
     version: "v1.17.1"
     wait: true
     timeout: 600
@@ -89,7 +102,7 @@ releases:
   - name: vault
     namespace: vault
     createNamespace: true
-    chart: https://helm.releases.hashicorp.com/vault-0.25.0.tgz
+    chart: hashicorp/vault
     version: "0.25.0"
     wait: true
     timeout: 600
@@ -103,7 +116,7 @@ releases:
   - name: external-secrets
     namespace: external-secrets
     createNamespace: true
-    chart: oci://ghcr.io/external-secrets/charts/external-secrets
+    chart: external-secrets/external-secrets
     version: "0.14.3"
     wait: true
     timeout: 600

--- a/helm-prereqs/helmfile.yaml
+++ b/helm-prereqs/helmfile.yaml
@@ -25,14 +25,6 @@
 # =============================================================================
 
 repositories:
-  - name: jetstack
-    url: https://charts.jetstack.io
-  - name: hashicorp
-    url: https://helm.releases.hashicorp.com
-  - name: postgres-operator
-    url: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
-  - name: metallb
-    url: https://metallb.github.io/metallb
   - name: argo
     url: https://argoproj.github.io/argo-helm
   - name: nfd
@@ -50,7 +42,7 @@ releases:
   - name: metallb
     namespace: metallb-system
     createNamespace: true
-    chart: metallb/metallb
+    chart: https://github.com/metallb/metallb/releases/download/metallb-chart-0.14.5/metallb-0.14.5.tgz
     version: "0.14.5"
     wait: true
     timeout: 600
@@ -66,7 +58,7 @@ releases:
   - name: postgres-operator
     namespace: postgres
     createNamespace: true
-    chart: postgres-operator/postgres-operator
+    chart: https://opensource.zalando.com/postgres-operator/charts/postgres-operator/postgres-operator-1.15.1.tgz
     version: "1.15.1"
     wait: true
     timeout: 600
@@ -81,7 +73,7 @@ releases:
   - name: cert-manager
     namespace: cert-manager
     createNamespace: true
-    chart: jetstack/cert-manager
+    chart: oci://quay.io/jetstack/charts/cert-manager
     version: "v1.17.1"
     wait: true
     timeout: 600
@@ -97,7 +89,7 @@ releases:
   - name: vault
     namespace: vault
     createNamespace: true
-    chart: hashicorp/vault
+    chart: https://helm.releases.hashicorp.com/vault-0.25.0.tgz
     version: "0.25.0"
     wait: true
     timeout: 600

--- a/helm-prereqs/operators/values/postgres-operator.yaml
+++ b/helm-prereqs/operators/values/postgres-operator.yaml
@@ -1,4 +1,4 @@
-## Zalando postgres-operator (see helmfile.yaml for the version pin)
+## Zalando postgres-operator 1.15.1
 ## Reference: nico-external/manifests/nico-pg-operator-app/values.yaml
 
 configTarget: ConfigMap

--- a/helm-prereqs/operators/values/postgres-operator.yaml
+++ b/helm-prereqs/operators/values/postgres-operator.yaml
@@ -1,4 +1,4 @@
-## Zalando postgres-operator 1.15.1
+## Zalando postgres-operator (see helmfile.yaml for the version pin)
 ## Reference: nico-external/manifests/nico-pg-operator-app/values.yaml
 
 configTarget: ConfigMap

--- a/helm-prereqs/operators/values/vault.yaml
+++ b/helm-prereqs/operators/values/vault.yaml
@@ -33,7 +33,7 @@ server:
   ## -------------------------------------------------------------------------
   readinessProbe:
     enabled: true
-    path: "/v1/sys/health?standbyok=true"
+    path: "/v1/sys/health?standbyok=true&uninitcode=204"
   livenessProbe:
     enabled: true
     path: "/v1/sys/health?sealedcode=204&uninitcode=204&standbyok=true"

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -687,7 +687,7 @@ fi
 # MetalLB: a pool declared with no CIDR/range entries
 if [[ -f "${_METALLB_CFG}" && ! -d "${_METALLB_CFG}" ]]; then
     if _strip_comments "${_METALLB_CFG}" | grep -qE '^kind:[[:space:]]*IPAddressPool' && \
-       ! _strip_comments "${_METALLB_CFG}" | grep -qE '^[[:space:]]*-[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'; then
+       ! _strip_comments "${_METALLB_CFG}" | grep -qE '^[[:space:]]*-[[:space:]]*"?[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'; then
         ERRORS+=("${_METALLB_CFG_LABEL}: IPAddressPool has no addresses — add your VIP CIDR(s)/range(s)")
     fi
 fi

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -622,7 +622,20 @@ _existing_postgres_instances="$(kubectl get postgresql nico-pg-cluster -n postgr
     -o jsonpath='{.spec.numberOfInstances}' 2>/dev/null || true)"
 _existing_synchronous_mode="$(kubectl get postgresql nico-pg-cluster -n postgres \
     -o jsonpath='{.spec.patroni.synchronous_mode}' 2>/dev/null || true)"
-if [[ "${_existing_postgres_instances}" == "1" && "${_existing_synchronous_mode}" == "true" ]]; then
+_existing_sync_waiters=0
+if [[ "${_existing_postgres_instances}" == "1" ]]; then
+    _existing_postgres_primary="$(kubectl get pods -n postgres \
+        -l application=spilo,cluster-name=nico-pg-cluster,spilo-role=master \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [[ -n "${_existing_postgres_primary}" ]]; then
+        _existing_sync_waiters="$(kubectl exec -n postgres -c postgres "${_existing_postgres_primary}" -- \
+            su postgres -c "psql -X -d postgres -tAc \"SELECT count(*) FROM pg_stat_activity WHERE wait_event = 'SyncRep'\"" \
+            2>/dev/null | tr -d '[:space:]' || true)"
+        _existing_sync_waiters="${_existing_sync_waiters:-0}"
+    fi
+fi
+if [[ "${_existing_postgres_instances}" == "1" && \
+      ( "${_existing_synchronous_mode}" == "true" || "${_existing_sync_waiters}" != "0" ) ]]; then
     echo "Recovering existing single-instance PostgreSQL cluster from synchronous replication"
     kubectl patch postgresql nico-pg-cluster -n postgres --type=merge \
         -p '{"spec":{"patroni":{"synchronous_mode":false,"synchronous_mode_strict":false}}}'

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -922,14 +922,14 @@ while IFS='=' read -r _db_name _db_owner; do
 done < <(kubectl get postgresql nico-pg-cluster -n postgres \
     -o go-template='{{range $database, $owner := .spec.databases}}{{$database}}={{$owner}}{{"\n"}}{{end}}')
 
-# Install pg_trgm on nico_rest (needed by the nico-rest-db GIN index migration).
+# Install PostgreSQL extensions on nico_rest (needed by REST DB migrations).
 # Zalando's preparedDatabases conflicts with the databases section, so we install
 # the extension directly after the cluster is ready. Idempotent: IF NOT EXISTS.
 # Wait up to 120s for the Zalando operator to create the nico_rest database.
 if "${SKIP_REST}"; then
-    echo "pg_trgm skipped (--skip-rest flag set)"
+    echo "PostgreSQL REST extensions skipped (--skip-rest flag set)"
 else
-    _pg_trgm_installed=false
+    _rest_extensions_installed=false
     for _pg_i in $(seq 1 24); do
         _PG_PRIMARY="$(kubectl get pods -n postgres -l application=spilo \
             -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.spilo-role}{"\n"}{end}' \
@@ -940,19 +940,20 @@ else
             continue
         fi
         if kubectl exec -n postgres "${_PG_PRIMARY}" -- \
-            su postgres -c "psql -d nico_rest -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'" \
+            su postgres -c "psql -d nico_rest -v ON_ERROR_STOP=1 \
+                -c 'CREATE EXTENSION IF NOT EXISTS btree_gin;' \
+                -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'" \
             2>/dev/null; then
-            echo "pg_trgm ready"
-            _pg_trgm_installed=true
+            echo "PostgreSQL REST extensions ready"
+            _rest_extensions_installed=true
             break
         fi
-        echo "  pg_trgm: nico_rest not yet created by operator (${_pg_i}/24) — retrying in 5s..."
+        echo "  PostgreSQL REST extensions: nico_rest not yet available (${_pg_i}/24) — retrying in 5s..."
         sleep 5
     done
-    if [[ "${_pg_trgm_installed}" == "false" ]]; then
-        echo "  pg_trgm: nico_rest unavailable after 120s."
-        echo "    → If rest.enabled=false in nico-prereqs, the nico_rest database is not created — this is expected."
-        echo "    → If rest.enabled=true, the nico-rest-db migration will fail on the GIN index step."
+    if [[ "${_rest_extensions_installed}" == "false" ]]; then
+        echo "ERROR: failed to install PostgreSQL extensions in nico_rest after 120s" >&2
+        exit 1
     fi
 fi
 

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -473,7 +473,7 @@ fi
 
 # Recover only interrupted Helm transactions owned by this installer. A normal
 # deployed release is left untouched. This makes setup rerunnable after its SSH
-# client or local DANTE process is interrupted during a Helm upgrade.
+# client or local automation process is interrupted during a Helm upgrade.
 recover_pending_helm_release() {
     local release_name="$1"
     local release_namespace="$2"

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -613,12 +613,24 @@ echo "=== [1c] MetalLB ==="
 #   3. On sync failure, attempt CRD restoration before returning the error.
 #   4. Wait for CRDs to reach Established=True before applying site objects.
 #
-# Single source of truth for the chart version is the metallb release in
-# helmfile.yaml — read it from there so this bootstrap and the helm release
-# cannot drift when the version is bumped.
-METALLB_CHART_VERSION="$(awk '/chart: metallb\/metallb/{found=1} found && /^[[:space:]]*version:/{gsub(/"/,"",$2); print $2; exit}' helmfile.yaml)"
-if [[ -z "${METALLB_CHART_VERSION}" ]]; then
-    echo "ERROR: could not read the metallb chart version from helmfile.yaml" >&2
+# Single source of truth for the chart source and version is the metallb
+# release in helmfile.yaml. Read both from that release block so HTTP, OCI,
+# repository-qualified, and local chart coordinates all work consistently.
+METALLB_CHART="$(awk '
+    /^  - name:[[:space:]]*metallb[[:space:]]*$/ { release=1; next }
+    release && /^  - name:/ { exit }
+    release && /^    chart:/ {
+        sub(/^[^:]*:[[:space:]]*/, "")
+        gsub(/^"|"$/, "")
+        print
+        exit
+    }' helmfile.yaml)"
+METALLB_CHART_VERSION="$(awk '
+    /^  - name:[[:space:]]*metallb[[:space:]]*$/ { release=1; next }
+    release && /^  - name:/ { exit }
+    release && /^    version:/ { gsub(/"/, "", $2); print $2; exit }' helmfile.yaml)"
+if [[ -z "${METALLB_CHART}" || -z "${METALLB_CHART_VERSION}" ]]; then
+    echo "ERROR: could not read the metallb chart source and version from helmfile.yaml" >&2
     exit 1
 fi
 
@@ -629,7 +641,7 @@ fi
 # stderr is left attached so a repo/render failure says what actually broke
 # instead of surfacing as a confusing kubectl parse error downstream.
 _apply_metallb_crds() {
-    helm template metallb metallb/metallb --version "${METALLB_CHART_VERSION}" -n metallb-system --include-crds \
+    helm template metallb "${METALLB_CHART}" --version "${METALLB_CHART_VERSION}" -n metallb-system --include-crds \
         | awk '
             /^---[[:space:]]*$/ { if (doc ~ /kind: CustomResourceDefinition/) printf "%s---\n", doc; doc = ""; next }
             { doc = doc $0 "\n" }

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -618,6 +618,17 @@ fi
 # ---------------------------------------------------------------------------
 _SETUP_PHASE="[1b] postgres-operator"
 echo "=== [1b] postgres-operator ==="
+_existing_postgres_instances="$(kubectl get postgresql nico-pg-cluster -n postgres \
+    -o jsonpath='{.spec.numberOfInstances}' 2>/dev/null || true)"
+_existing_synchronous_mode="$(kubectl get postgresql nico-pg-cluster -n postgres \
+    -o jsonpath='{.spec.patroni.synchronous_mode}' 2>/dev/null || true)"
+if [[ "${_existing_postgres_instances}" == "1" && "${_existing_synchronous_mode}" == "true" ]]; then
+    echo "Recovering existing single-instance PostgreSQL cluster from synchronous replication"
+    kubectl patch postgresql nico-pg-cluster -n postgres --type=merge \
+        -p '{"spec":{"patroni":{"synchronous_mode":false,"synchronous_mode_strict":false}}}'
+    kubectl rollout restart deployment/postgres-operator -n postgres
+    kubectl rollout status deployment/postgres-operator -n postgres --timeout=120s
+fi
 recover_pending_helm_release postgres-operator postgres
 helmfile sync -l name=postgres-operator
 

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -809,7 +809,7 @@ helm template nico-prereqs . \
     --set imagePullSecrets.ngcNicoPull="${REGISTRY_PULL_SECRET:-}" \
     --show-only templates/site-root-certificate.yaml \
     --show-only templates/vault-tls-certs.yaml \
-    | kubectl apply --server-side --field-manager=helm -f -
+    | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
 
 kubectl wait --for=condition=Ready certificate/site-root \
     -n "${CERT_MANAGER_NS}" --timeout=120s

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -639,6 +639,13 @@ if [[ "${_existing_postgres_instances}" == "1" && \
     echo "Recovering existing single-instance PostgreSQL cluster from synchronous replication"
     kubectl patch postgresql nico-pg-cluster -n postgres --type=merge \
         -p '{"spec":{"patroni":{"synchronous_mode":false,"synchronous_mode_strict":false}}}'
+    if [[ -n "${_existing_postgres_primary:-}" && "${_existing_sync_waiters}" != "0" ]]; then
+        echo "Terminating ${_existing_sync_waiters} stale SyncRep backend(s)"
+        kubectl exec -n postgres -c postgres "${_existing_postgres_primary}" -- \
+            su postgres -c "psql -X -d postgres -v ON_ERROR_STOP=1 -c \
+                \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE pid <> pg_backend_pid() AND wait_event = 'SyncRep';\""
+    fi
     kubectl rollout restart deployment/postgres-operator -n postgres
     kubectl rollout status deployment/postgres-operator -n postgres --timeout=120s
 fi

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -801,6 +801,41 @@ if [[ "${_pg_cluster_ready}" != "true" ]]; then
 fi
 echo "nico-pg-cluster is Running"
 
+# Reconcile the databases declared on the Zalando PostgreSQL resource before
+# any NICo migration jobs run. The operator creates these asynchronously and a
+# cluster can report Running before every database has been created. This is
+# also needed when an existing PostgreSQL data volume is reused with an updated
+# database list.
+_PG_PRIMARY="$(kubectl get pods -n postgres -l application=spilo \
+    -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.spilo-role}{"\n"}{end}' \
+    2>/dev/null | awk '$2=="master"{print $1}' | head -1)"
+if [[ -z "${_PG_PRIMARY}" ]]; then
+    echo "ERROR: nico-pg-cluster has no Patroni primary pod" >&2
+    exit 1
+fi
+
+echo "Reconciling declared PostgreSQL databases..."
+while IFS='=' read -r _db_name _db_owner; do
+    [[ -n "${_db_name}" && -n "${_db_owner}" ]] || continue
+    if [[ ! "${_db_name}" =~ ^[A-Za-z0-9_.-]+$ || ! "${_db_owner}" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+        echo "ERROR: invalid PostgreSQL database or owner in nico-pg-cluster: ${_db_name}=${_db_owner}" >&2
+        exit 1
+    fi
+    if kubectl exec -n postgres "${_PG_PRIMARY}" -- \
+        su postgres -c "psql -d postgres -tAc \"SELECT 1 FROM pg_database WHERE datname = '${_db_name}'\"" \
+        2>/dev/null | grep -qx '1'; then
+        echo "  database ${_db_name} already exists"
+        continue
+    fi
+    if ! kubectl exec -n postgres "${_PG_PRIMARY}" -- \
+        su postgres -c "createdb --owner='${_db_owner}' '${_db_name}'"; then
+        echo "ERROR: failed to create PostgreSQL database ${_db_name} owned by ${_db_owner}" >&2
+        exit 1
+    fi
+    echo "  database ${_db_name} created"
+done < <(kubectl get postgresql nico-pg-cluster -n postgres \
+    -o go-template='{{range $database, $owner := .spec.databases}}{{$database}}={{$owner}}{{"\n"}}{{end}}')
+
 # Install pg_trgm on nico_rest (needed by the nico-rest-db GIN index migration).
 # Zalando's preparedDatabases conflicts with the databases section, so we install
 # the extension directly after the cluster is ready. Idempotent: IF NOT EXISTS.

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -471,6 +471,45 @@ if ! command -v helmfile &>/dev/null; then
     echo "helmfile $(helmfile --version) installed"
 fi
 
+# Recover only interrupted Helm transactions owned by this installer. A normal
+# deployed release is left untouched. This makes setup rerunnable after its SSH
+# client or local DANTE process is interrupted during a Helm upgrade.
+recover_pending_helm_release() {
+    local release_name="$1"
+    local release_namespace="$2"
+    local release_status
+    local deployed_revision
+
+    release_status="$(helm status "${release_name}" --namespace "${release_namespace}" \
+        --output json 2>/dev/null | jq -r '.info.status // empty' || true)"
+    case "${release_status}" in
+        pending-upgrade|pending-rollback)
+            deployed_revision="$(helm history "${release_name}" --namespace "${release_namespace}" \
+                --output json 2>/dev/null \
+                | jq -r '[.[] | select(.status == "deployed")][-1].revision // empty' || true)"
+            if [[ -z "${deployed_revision}" ]]; then
+                echo "ERROR: ${release_namespace}/${release_name} is ${release_status} with no deployed revision to restore" >&2
+                exit 1
+            fi
+            echo "Recovering ${release_namespace}/${release_name} from ${release_status} to deployed revision ${deployed_revision}"
+            helm rollback "${release_name}" "${deployed_revision}" \
+                --namespace "${release_namespace}" --wait --timeout 600s
+            ;;
+        pending-install)
+            deployed_revision="$(helm history "${release_name}" --namespace "${release_namespace}" \
+                --output json 2>/dev/null \
+                | jq -r '[.[] | select(.status == "deployed")][-1].revision // empty' || true)"
+            if [[ -n "${deployed_revision}" ]]; then
+                echo "ERROR: ${release_namespace}/${release_name} is pending-install but has deployed revision ${deployed_revision}" >&2
+                exit 1
+            fi
+            echo "Removing interrupted first install ${release_namespace}/${release_name}"
+            helm uninstall "${release_name}" --namespace "${release_namespace}" \
+                --wait --timeout 600s
+            ;;
+    esac
+}
+
 # ---------------------------------------------------------------------------
 # DNS check — verify cluster DNS is working before proceeding.
 #
@@ -579,6 +618,7 @@ fi
 # ---------------------------------------------------------------------------
 _SETUP_PHASE="[1b] postgres-operator"
 echo "=== [1b] postgres-operator ==="
+recover_pending_helm_release postgres-operator postgres
 helmfile sync -l name=postgres-operator
 
 # ---------------------------------------------------------------------------
@@ -675,6 +715,7 @@ _apply_metallb_crds
 
 # Capture helmfile sync exit code so CRDs can be restored even on failure.
 # With set -e active, the || construct is required to prevent immediate exit.
+recover_pending_helm_release metallb metallb-system
 _metallb_sync_rc=0
 helmfile sync -l name=metallb || _metallb_sync_rc=$?
 
@@ -725,6 +766,7 @@ echo "MetalLB ready"
 # ---------------------------------------------------------------------------
 _SETUP_PHASE="[2/6] cert-manager + Vault TLS bootstrap"
 echo "=== [2/6] cert-manager + Vault TLS bootstrap ==="
+recover_pending_helm_release cert-manager cert-manager
 helmfile sync -l name=cert-manager
 
 kubectl apply --server-side -f operators/crds/ \
@@ -751,6 +793,7 @@ echo "Vault TLS bootstrap complete"
 # ---------------------------------------------------------------------------
 _SETUP_PHASE="[3/6] vault install"
 echo "=== [3/6] vault ==="
+recover_pending_helm_release vault vault
 helmfile sync -l name=vault \
     --set server.dataStorage.storageClass="${NICO_STORAGE_CLASS}" \
     --set server.auditStorage.storageClass="${NICO_STORAGE_CLASS}"
@@ -770,7 +813,9 @@ echo "=== [4/6] unseal vault ==="
 # ---------------------------------------------------------------------------
 _SETUP_PHASE="[5/6] external-secrets + NICo prereqs"
 echo "=== [5/6] external-secrets + NICo prereqs ==="
+recover_pending_helm_release external-secrets external-secrets
 helmfile sync -l name=external-secrets
+recover_pending_helm_release nico-prereqs nico-system
 helmfile sync -l name=nico-prereqs
 
 # ---------------------------------------------------------------------------

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -866,18 +866,28 @@ while IFS='=' read -r _db_name _db_owner; do
         echo "ERROR: invalid PostgreSQL database or owner in nico-pg-cluster: ${_db_name}=${_db_owner}" >&2
         exit 1
     fi
-    if kubectl exec -n postgres "${_PG_PRIMARY}" -- \
-        su postgres -c "psql -d postgres -tAc \"SELECT 1 FROM pg_database WHERE datname = '${_db_name}'\"" \
-        2>/dev/null | grep -qx '1'; then
-        echo "  database ${_db_name} already exists"
-        continue
-    fi
-    if ! kubectl exec -n postgres "${_PG_PRIMARY}" -- \
-        su postgres -c "psql -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE \"${_db_name}\" OWNER \"${_db_owner}\"'"; then
+    _db_ready=false
+    for _db_attempt in $(seq 1 12); do
+        if kubectl exec -n postgres "${_PG_PRIMARY}" -- \
+            su postgres -c "psql -d postgres -tAc \"SELECT 1 FROM pg_database WHERE datname = '${_db_name}'\"" \
+            2>/dev/null | grep -qx '1'; then
+            echo "  database ${_db_name} already exists"
+            _db_ready=true
+            break
+        fi
+        if kubectl exec -n postgres "${_PG_PRIMARY}" -- \
+            su postgres -c "PGOPTIONS='-c lock_timeout=5s' psql -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE \"${_db_name}\" OWNER \"${_db_owner}\"'"; then
+            echo "  database ${_db_name} created"
+            _db_ready=true
+            break
+        fi
+        echo "  database ${_db_name} is still being reconciled (${_db_attempt}/12) — retrying in 5s..."
+        sleep 5
+    done
+    if [[ "${_db_ready}" != "true" ]]; then
         echo "ERROR: failed to create PostgreSQL database ${_db_name} owned by ${_db_owner}" >&2
         exit 1
     fi
-    echo "  database ${_db_name} created"
 done < <(kubectl get postgresql nico-pg-cluster -n postgres \
     -o go-template='{{range $database, $owner := .spec.databases}}{{$database}}={{$owner}}{{"\n"}}{{end}}')
 

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -873,7 +873,7 @@ while IFS='=' read -r _db_name _db_owner; do
         continue
     fi
     if ! kubectl exec -n postgres "${_PG_PRIMARY}" -- \
-        su postgres -c "createdb --owner='${_db_owner}' '${_db_name}'"; then
+        su postgres -c "psql -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE \"${_db_name}\" OWNER \"${_db_owner}\"'"; then
         echo "ERROR: failed to create PostgreSQL database ${_db_name} owned by ${_db_owner}" >&2
         exit 1
     fi

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -455,6 +455,8 @@ if ! command -v helmfile &>/dev/null; then
     if command -v brew &>/dev/null; then
         brew install helmfile
     else
+        HELMFILE_INSTALL_DIR="${HELMFILE_INSTALL_DIR:-${HOME}/.local/bin}"
+        mkdir -p "${HELMFILE_INSTALL_DIR}"
         # Download the latest release binary for Linux
         HELMFILE_VERSION="$(curl -fsSL https://api.github.com/repos/helmfile/helmfile/releases/latest \
             | grep '"tag_name"' | sed 's/.*"tag_name": *"v\([^"]*\)".*/\1/')"
@@ -462,8 +464,9 @@ if ! command -v helmfile &>/dev/null; then
         [[ "${ARCH}" == "x86_64" ]] && ARCH="amd64"
         [[ "${ARCH}" == "aarch64" ]] && ARCH="arm64"
         curl -fsSL "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_${ARCH}.tar.gz" \
-            | tar -xz -C /usr/local/bin helmfile
-        chmod +x /usr/local/bin/helmfile
+            | tar -xz -C "${HELMFILE_INSTALL_DIR}" helmfile
+        chmod +x "${HELMFILE_INSTALL_DIR}/helmfile"
+        export PATH="${HELMFILE_INSTALL_DIR}:${PATH}"
     fi
     echo "helmfile $(helmfile --version) installed"
 fi

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -805,30 +805,34 @@ echo "nico-pg-cluster is Running"
 # Zalando's preparedDatabases conflicts with the databases section, so we install
 # the extension directly after the cluster is ready. Idempotent: IF NOT EXISTS.
 # Wait up to 120s for the Zalando operator to create the nico_rest database.
-_pg_trgm_installed=false
-for _pg_i in $(seq 1 24); do
-    _PG_PRIMARY="$(kubectl get pods -n postgres -l application=spilo \
-        -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.spilo-role}{"\n"}{end}' \
-        2>/dev/null | awk '$2=="master"{print $1}' | head -1)"
-    if [[ -z "${_PG_PRIMARY}" ]]; then
-        echo "  pg_trgm: no Patroni primary yet (${_pg_i}/24) — retrying in 5s..."
+if "${SKIP_REST}"; then
+    echo "pg_trgm skipped (--skip-rest flag set)"
+else
+    _pg_trgm_installed=false
+    for _pg_i in $(seq 1 24); do
+        _PG_PRIMARY="$(kubectl get pods -n postgres -l application=spilo \
+            -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.spilo-role}{"\n"}{end}' \
+            2>/dev/null | awk '$2=="master"{print $1}' | head -1)"
+        if [[ -z "${_PG_PRIMARY}" ]]; then
+            echo "  pg_trgm: no Patroni primary yet (${_pg_i}/24) — retrying in 5s..."
+            sleep 5
+            continue
+        fi
+        if kubectl exec -n postgres "${_PG_PRIMARY}" -- \
+            su postgres -c "psql -d nico_rest -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'" \
+            2>/dev/null; then
+            echo "pg_trgm ready"
+            _pg_trgm_installed=true
+            break
+        fi
+        echo "  pg_trgm: nico_rest not yet created by operator (${_pg_i}/24) — retrying in 5s..."
         sleep 5
-        continue
+    done
+    if [[ "${_pg_trgm_installed}" == "false" ]]; then
+        echo "  pg_trgm: nico_rest unavailable after 120s."
+        echo "    → If rest.enabled=false in nico-prereqs, the nico_rest database is not created — this is expected."
+        echo "    → If rest.enabled=true, the nico-rest-db migration will fail on the GIN index step."
     fi
-    if kubectl exec -n postgres "${_PG_PRIMARY}" -- \
-        su postgres -c "psql -d nico_rest -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'" \
-        2>/dev/null; then
-        echo "pg_trgm ready"
-        _pg_trgm_installed=true
-        break
-    fi
-    echo "  pg_trgm: nico_rest not yet created by operator (${_pg_i}/24) — retrying in 5s..."
-    sleep 5
-done
-if [[ "${_pg_trgm_installed}" == "false" ]]; then
-    echo "  pg_trgm: nico_rest unavailable after 120s."
-    echo "    → If rest.enabled=false in nico-prereqs, the nico_rest database is not created — this is expected."
-    echo "    → If rest.enabled=true, the nico-rest-db migration will fail on the GIN index step."
 fi
 
 echo "Waiting for DB credentials to be synced by ESO..."

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -778,13 +778,27 @@ helmfile sync -l name=nico-prereqs
 # before NICo Core starts (the NICo Core API needs the DB credentials Secret).
 # ---------------------------------------------------------------------------
 echo "Waiting for nico-pg-cluster to reach Running state..."
-until kubectl get postgresql nico-pg-cluster -n postgres \
-    -o jsonpath='{.status.PostgresClusterStatus}' 2>/dev/null | grep -q "Running"; do
+_pg_cluster_ready=false
+for _pg_wait_i in $(seq 1 60); do
     STATUS="$(kubectl get postgresql nico-pg-cluster -n postgres \
-        -o jsonpath='{.status.PostgresClusterStatus}' 2>/dev/null || echo 'unknown')"
-    echo "  nico-pg-cluster status: ${STATUS} — retrying in 10s..."
+        -o jsonpath='{.status.PostgresClusterStatus}{.status.status}' 2>/dev/null || true)"
+    _PG_PRIMARY_READY="$(kubectl get pods -n postgres \
+        -l application=spilo,cluster-name=nico-pg-cluster,spilo-role=master \
+        -o jsonpath='{range .items[*]}{.status.containerStatuses[?(@.name=="postgres")].ready}{"\n"}{end}' \
+        2>/dev/null || true)"
+    if [[ "${STATUS}" == *"Running"* ]] || grep -qx "true" <<<"${_PG_PRIMARY_READY}"; then
+        _pg_cluster_ready=true
+        break
+    fi
+    echo "  nico-pg-cluster status: ${STATUS:-unknown}; primary ready: ${_PG_PRIMARY_READY:-false} (${_pg_wait_i}/60) — retrying in 10s..."
     sleep 10
 done
+if [[ "${_pg_cluster_ready}" != "true" ]]; then
+    echo "ERROR: nico-pg-cluster did not become ready within 600s" >&2
+    kubectl get postgresql nico-pg-cluster -n postgres -o yaml >&2 || true
+    kubectl get pods -n postgres -l application=spilo,cluster-name=nico-pg-cluster -o wide >&2 || true
+    exit 1
+fi
 echo "nico-pg-cluster is Running"
 
 # Install pg_trgm on nico_rest (needed by the nico-rest-db GIN index migration).

--- a/helm-prereqs/templates/postgresql.yaml
+++ b/helm-prereqs/templates/postgresql.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.postgresql.enabled }}
+{{- $configuredSynchronousMode := .Values.postgresql.synchronousMode }}
+{{- if not (or (kindIs "invalid" $configuredSynchronousMode) (kindIs "bool" $configuredSynchronousMode)) }}
+{{- fail "postgresql.synchronousMode must be true, false, or null (automatic)" }}
+{{- end }}
+{{- $synchronousMode := gt (int .Values.postgresql.instances) 1 }}
+{{- if kindIs "bool" $configuredSynchronousMode }}
+{{- $synchronousMode = $configuredSynchronousMode }}
+{{- end }}
 ## =============================================================================
 ## nico-pg-cluster-env — injected into every postgres pod as env vars.
 ## Created here (nico-prereqs chart) so Values.siteName flows in at install.
@@ -91,12 +99,10 @@ spec:
     keycloak: keycloak.nico
     {{- end }}
   patroni:
-    # Templated (no `| default`): Go templates treat an explicit `false` as empty,
-    # so a default here would silently re-enable sync mode. Default lives in values.yaml.
-    # Single-instance clusters must set synchronousMode=false or Patroni strict sync
-    # blocks all writes (including the operator's own CREATE DATABASE).
-    synchronous_mode: {{ .Values.postgresql.synchronousMode }}
-    synchronous_mode_strict: {{ .Values.postgresql.synchronousMode }}
+    # Automatic mode enables synchronous replication only when a standby exists.
+    # An explicit boolean value overrides the topology-derived behavior.
+    synchronous_mode: {{ $synchronousMode }}
+    synchronous_mode_strict: {{ $synchronousMode }}
     synchronous_node_count: 1
   postgresql:
     version: "15"

--- a/helm-prereqs/templates/vault-tls-certs.yaml
+++ b/helm-prereqs/templates/vault-tls-certs.yaml
@@ -62,6 +62,9 @@ spec:
     - vault-0.vault-internal
     - vault-1.vault-internal
     - vault-2.vault-internal
+    - vault-0.vault-internal.{{ .Values.vaultNamespace }}.svc.cluster.local
+    - vault-1.vault-internal.{{ .Values.vaultNamespace }}.svc.cluster.local
+    - vault-2.vault-internal.{{ .Values.vaultNamespace }}.svc.cluster.local
   {{- if .Values.vaultServiceIP }}
   ipAddresses:
     - {{ .Values.vaultServiceIP }}
@@ -94,6 +97,9 @@ spec:
     - vault-0.vault-internal
     - vault-1.vault-internal
     - vault-2.vault-internal
+    - vault-0.vault-internal.{{ .Values.vaultNamespace }}.svc.cluster.local
+    - vault-1.vault-internal.{{ .Values.vaultNamespace }}.svc.cluster.local
+    - vault-2.vault-internal.{{ .Values.vaultNamespace }}.svc.cluster.local
   issuerRef:
     name: site-issuer
     kind: ClusterIssuer

--- a/helm-prereqs/unseal_vault.sh
+++ b/helm-prereqs/unseal_vault.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # =============================================================================
-# unseal_vault.sh — initialize and unseal a 3-pod HashiCorp Vault HA cluster
+# unseal_vault.sh — initialize and unseal a HashiCorp Vault Raft cluster
 #
 # Run AFTER `helmfile sync -l name=vault` and BEFORE `helm install nico-prereqs`.
 #
@@ -45,6 +45,12 @@ VAULT_UNSEAL_ROUNDS="${VAULT_UNSEAL_ROUNDS:-3}"
 if ! [[ "${VAULT_STATUS_RETRIES}" =~ ^[1-9][0-9]*$ ]] ||
    ! [[ "${VAULT_UNSEAL_ROUNDS}" =~ ^[1-9][0-9]*$ ]]; then
     echo "ERROR: VAULT_STATUS_RETRIES and VAULT_UNSEAL_ROUNDS must be positive integers." >&2
+    exit 1
+fi
+
+VAULT_REPLICAS="$(kubectl get statefulset vault -n "${NAMESPACE}" -o jsonpath='{.spec.replicas}')"
+if ! [[ "${VAULT_REPLICAS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: Vault StatefulSet has an invalid replica count: ${VAULT_REPLICAS:-unset}" >&2
     exit 1
 fi
 
@@ -88,10 +94,11 @@ _vault_status_json() {
     return 1
 }
 
-echo "Waiting for all 3 Vault pods to be initialized..."
-# StatefulSets create pods sequentially — vault-1/vault-2 may not exist yet.
-# Poll until each pod exists, then wait for Initialized.
-for POD in vault-0 vault-1 vault-2; do
+echo "Waiting for all ${VAULT_REPLICAS} Vault pods to be initialized..."
+# StatefulSets create pods sequentially. Poll until each configured ordinal
+# exists, then wait for Initialized.
+for ORDINAL in $(seq 0 "$((VAULT_REPLICAS - 1))"); do
+    POD="vault-${ORDINAL}"
     until kubectl get pod "${POD}" -n "${NAMESPACE}" &>/dev/null; do
         echo "  ${POD} not yet created, retrying in 5s..."
         sleep 5
@@ -101,7 +108,7 @@ for POD in vault-0 vault-1 vault-2; do
         --for=condition=Initialized \
         --timeout=300s
 done
-echo "All Vault pods are initialized"
+echo "All ${VAULT_REPLICAS} Vault pods are initialized"
 
 echo "Checking Vault status on vault-0..."
 VAULT_STATUS_JSON="$(_vault_status_json vault-0)"
@@ -182,10 +189,13 @@ unseal_pod() {
 }
 
 unseal_pod vault-0
-# Wait for vault-0 (leader) to be elected before unsealing followers
-sleep 10
-unseal_pod vault-1
-unseal_pod vault-2
+if (( VAULT_REPLICAS > 1 )); then
+    # Wait for vault-0 (leader) to be elected before unsealing followers.
+    sleep 10
+    for ORDINAL in $(seq 1 "$((VAULT_REPLICAS - 1))"); do
+        unseal_pod "vault-${ORDINAL}"
+    done
+fi
 
 # Store individual unseal keys and root token as K8s secrets
 CLUSTER_JSON="$(kubectl -n "${NAMESPACE}" get secret vault-cluster-keys -o json \

--- a/helm-prereqs/unseal_vault.sh
+++ b/helm-prereqs/unseal_vault.sh
@@ -34,6 +34,8 @@
 #   VAULT_STATUS_SLEEP_SECONDS — delay between status attempts (default: 5)
 #   VAULT_UNSEAL_ROUNDS        — full key-sequence retries per pod before
 #                                giving up (default: 3)
+#   VAULT_INIT_STABILIZE_SECONDS — delay before first-time initialization so
+#                                  certificate reload hooks can settle (default: 15)
 # =============================================================================
 set -euo pipefail
 
@@ -41,10 +43,12 @@ NAMESPACE="vault"
 VAULT_STATUS_RETRIES="${VAULT_STATUS_RETRIES:-36}"
 VAULT_STATUS_SLEEP_SECONDS="${VAULT_STATUS_SLEEP_SECONDS:-5}"
 VAULT_UNSEAL_ROUNDS="${VAULT_UNSEAL_ROUNDS:-3}"
+VAULT_INIT_STABILIZE_SECONDS="${VAULT_INIT_STABILIZE_SECONDS:-15}"
 
 if ! [[ "${VAULT_STATUS_RETRIES}" =~ ^[1-9][0-9]*$ ]] ||
-   ! [[ "${VAULT_UNSEAL_ROUNDS}" =~ ^[1-9][0-9]*$ ]]; then
-    echo "ERROR: VAULT_STATUS_RETRIES and VAULT_UNSEAL_ROUNDS must be positive integers." >&2
+   ! [[ "${VAULT_UNSEAL_ROUNDS}" =~ ^[1-9][0-9]*$ ]] ||
+   ! [[ "${VAULT_INIT_STABILIZE_SECONDS}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: Vault retry values must be positive integers and VAULT_INIT_STABILIZE_SECONDS must be a non-negative integer." >&2
     exit 1
 fi
 
@@ -120,6 +124,22 @@ echo "Vault initialized: ${INITIALIZED}"
 echo "Vault sealed:      ${SEALED}"
 
 if [[ "${INITIALIZED}" == "false" ]]; then
+    # vault-cert-reload can send SIGHUP shortly after the pod starts. If that
+    # races with `vault operator init`, Vault may persist its barrier keys but
+    # terminate the client before it returns the only copy of those keys.
+    # Wait for startup certificate reloads to settle, then check again before
+    # issuing the irreversible initialization request.
+    if (( VAULT_INIT_STABILIZE_SECONDS > 0 )); then
+        echo "Waiting ${VAULT_INIT_STABILIZE_SECONDS}s for Vault certificate reload hooks to settle..."
+        sleep "${VAULT_INIT_STABILIZE_SECONDS}"
+        VAULT_STATUS_JSON="$(_vault_status_json vault-0)"
+        INITIALIZED="$(echo "${VAULT_STATUS_JSON}" | jq -r '.initialized')"
+        if [[ "${INITIALIZED}" != "false" ]]; then
+            echo "ERROR: Vault became initialized during the stabilization wait; refusing to initialize without confirmed key capture." >&2
+            exit 1
+        fi
+    fi
+
     echo "Vault is not initialized. Initializing via vault-0..."
     kubectl exec -n "${NAMESPACE}" vault-0 -c vault -- \
         vault operator init -tls-skip-verify -key-shares=5 -key-threshold=3 -format=json \

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -225,10 +225,10 @@ keycloak:
 postgresql:
   enabled: true
   instances: 3
-  ## Patroni synchronous replication. Set false for single-instance clusters
-  ## (for development or simulation) — strict sync mode with no replicas
-  ## blocks all writes.
-  synchronousMode: true
+  ## Patroni synchronous replication. null selects automatically from instances:
+  ## disabled for one instance and enabled when a standby exists. Set an explicit
+  ## boolean only when the deployment needs to override that topology-derived mode.
+  synchronousMode: null
   volumeSize: "10Gi"
   storageClass: "local-path-persistent"
   ## DB_HOST in nico-system-nico-database-config ConfigMap.

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -28,10 +28,10 @@ clusterApiServer: ""
 
 ## ---------------------------------------------------------------------------
 ## Vault connection (used by vault-pki-config Job and vault-nico-issuer)
-## Vault address uses vaultNamespace above: vault.<vaultNamespace>.svc.cluster.local
+## Vault address uses the namespace-qualified service name.
 ## ---------------------------------------------------------------------------
 vault:
-  address: "https://vault.vault.svc.cluster.local:8200"
+  address: "https://vault.vault:8200"
   ## Optional Vault Enterprise/HCP Vault Dedicated namespace. This is not a Kubernetes namespace.
   namespace: ""
   ## setup.sh/helmfile supplies this dynamically from vaultroottoken.

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -51,6 +51,16 @@ global:
 nico-api:
   hostname: ""   # REQUIRED: external nico-api hostname (e.g. api-<site>.<domain>)
 
+  # The lab installs NICo into nico-system while retaining compatibility
+  # aliases in forge-system. Own the legacy namespace in the Core release so
+  # the alias Services can be created on a fresh cluster.
+  legacyAlias:
+    enabled: true
+    aliases:
+      - name: carbide-api
+        namespace: forge-system
+        createNamespace: true
+
   ## Trust admin-CLI client certs minted from the site CA (CN=site-root) so admin-cli works
   ## with NO manual ConfigMap edit. Pair with helm-prereqs vault.nicoCliClientRole.
   ## "site-root" is the CN of the cert-manager site root created by nico-prereqs — generic, keep as-is.

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -51,7 +51,7 @@ global:
 nico-api:
   hostname: ""   # REQUIRED: external nico-api hostname (e.g. api-<site>.<domain>)
 
-  # The lab installs NICo into nico-system while retaining compatibility
+  # The one-box setup installs NICo into nico-system while retaining compatibility
   # aliases in forge-system. Own the legacy namespace in the Core release so
   # the alias Services can be created on a fresh cluster.
   legacyAlias:
@@ -414,7 +414,7 @@ nico-dhcp:
   # apiServiceName: carbide-api
   config:
     kea:
-      # Debian multiarch path; DANTE rewrites this for ARM64 Spark labs.
+      # Debian AMD64 multiarch path; override this for an ARM64 one-box setup.
       hookLibraryPath: "/usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so"
       hookParameters:
         # DPUs need a resolver that serves the .forge zone (carbide-api.forge etc.).

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -414,6 +414,8 @@ nico-dhcp:
   # apiServiceName: carbide-api
   config:
     kea:
+      # Debian multiarch path; DANTE rewrites this for ARM64 Spark labs.
+      hookLibraryPath: "/usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so"
       hookParameters:
         # DPUs need a resolver that serves the .forge zone (carbide-api.forge etc.).
         # nico-dns is authoritative-only and does NOT serve .forge, so hand DPUs

--- a/helm-prereqs/values/nico-prereqs-dynamic.yaml.gotmpl
+++ b/helm-prereqs/values/nico-prereqs-dynamic.yaml.gotmpl
@@ -6,7 +6,7 @@
 # DNS is working on this cluster — vault addressed by DNS name.
 # =============================================================================
 vault:
-  address: "https://vault.vault.svc.cluster.local:8200"
+  address: "https://vault.vault:8200"
   token: "{{ exec "sh" (list "-c" "kubectl get secret vaultroottoken -n vault -o jsonpath={.data.token} | base64 -d") }}"
 imagePullSecrets:
   ngcNicoPull: "{{ env "REGISTRY_PULL_SECRET" }}"

--- a/helm-prereqs/values/nico-site-agent.yaml
+++ b/helm-prereqs/values/nico-site-agent.yaml
@@ -57,9 +57,12 @@ envConfig:
   # DeadlineExceeded on the initial Version health-check RPC and leaves the
   # NicoClient nil, causing all inventory activity panics.
   # Site-agent reads CORE_GRPC_* first, then CARBIDE_* legacy fallbacks.
-  CORE_GRPC_ADDRESS: "nico-api.nico-system.svc.cluster.local:1079"
+  # The trailing dot makes this an absolute DNS name. Without it, resolver
+  # search domains can consume the gRPC connection deadline before CoreDNS
+  # receives the valid cluster-local query.
+  CORE_GRPC_ADDRESS: "nico-api.nico-system.svc.cluster.local.:1079"
   CORE_GRPC_SEC_OPT: "2"
-  CARBIDE_ADDRESS: "nico-api.nico-system.svc.cluster.local:1079"
+  CARBIDE_ADDRESS: "nico-api.nico-system.svc.cluster.local.:1079"
   CARBIDE_SEC_OPT: "2"
 
   # DB connection — nico-pg-cluster (Zalando-managed, shared with nico-rest-api).

--- a/helm-prereqs/values/nico-site-agent.yaml
+++ b/helm-prereqs/values/nico-site-agent.yaml
@@ -64,6 +64,7 @@ envConfig:
   CORE_GRPC_SEC_OPT: "2"
   CARBIDE_ADDRESS: "nico-api.nico-system.svc.cluster.local.:1079"
   CARBIDE_SEC_OPT: "2"
+  FLOW_GRPC_ADDRESS: "flow.flow.svc.cluster.local.:50051"
 
   # DB connection — nico-pg-cluster (Zalando-managed, shared with nico-rest-api).
   # DB_USER and DB_PASSWORD are injected from the db-creds Secret (secrets.dbCreds).
@@ -71,7 +72,7 @@ envConfig:
   DB_DATABASE: "nico_rest"
   DB_PORT: "5432"
 
-  TEMPORAL_HOST: "temporal-frontend.temporal"
+  TEMPORAL_HOST: "temporal-frontend-headless.temporal.svc.cluster.local."
   TEMPORAL_PORT: "7233"
   TEMPORAL_SERVER: "interservice.server.temporal.local"
   TEMPORAL_PUBLISH_NAMESPACE: "site"

--- a/helm/charts/nico-api/templates/_helpers.tpl
+++ b/helm/charts/nico-api/templates/_helpers.tpl
@@ -174,7 +174,9 @@ dnsNames:
   - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
-  - {{ . }}
+{{- if . }}
+  - {{ . | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if .cert.ipAddresses }}

--- a/helm/rest/nico-rest-site-agent/templates/statefulset.yaml
+++ b/helm/rest/nico-rest-site-agent/templates/statefulset.yaml
@@ -15,6 +15,8 @@ spec:
       {{- include "nico-rest-site-agent.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "nico-rest-site-agent.selectorLabels" . | nindent 8 }}
     spec:

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -168,7 +168,6 @@ dependencies = [
   "mkdir-static",
   "cleanup-pxe-submodule",
   { name = "package-scout-x86_64-release-local", path = "${REPO_ROOT}" },
-  "build",
   "create-ephemeral-image-x86-host",
   "ipxe-x86_64",
   "setup-apt-repo-amd64",
@@ -178,7 +177,6 @@ dependencies = [
 dependencies = [
   "mkdir-static",
   { name = "package-scout-x86_64-release-local", path = "${REPO_ROOT}" },
-  "build",
   "create-ephemeral-image-x86-host",
   "ipxe-x86_64",
   "setup-apt-repo-amd64",
@@ -739,16 +737,24 @@ dependencies = ["ipxe-build-efi-aarch64-ci"]
 category = "iPXE Kernel"
 description = "Build the x86_64 EFI iPXE kernel"
 script = '''
+  CROSS_ARG=""
   LD_ARG=""
-  if [ -n "${SA_ENABLEMENT}" ]; then
-    LD_ARG="LD=/usr/bin/ld.bfd"
+  if [ "$(uname -m)" != "x86_64" ]; then
+    CROSS_ARG="CROSS_COMPILE=x86_64-linux-gnu-"
   fi
-  make -j ${LD_ARG} \
+  if [ -n "${SA_ENABLEMENT}" ]; then
+    if [ -n "${CROSS_ARG}" ]; then
+      LD_ARG="LD=/usr/bin/x86_64-linux-gnu-ld.bfd"
+    else
+      LD_ARG="LD=/usr/bin/ld.bfd"
+    fi
+  fi
+  make -j ${CROSS_ARG} ${LD_ARG} \
     bin-x86_64-efi/snponly.efi \
     VERSION=${IPXE_BANNER_VERSION} \
     EMBED=${REPO_ROOT}/pxe/ipxe/local/embed.ipxe \
     DEBUG=tls
-  make -j ${LD_ARG} \
+  make -j ${CROSS_ARG} ${LD_ARG} \
     bin-x86_64-efi/golan.efi \
     VERSION=${IPXE_BANNER_VERSION} \
     EMBED=${REPO_ROOT}/pxe/ipxe/local/embed.ipxe \

--- a/pxe/mkosi.profiles/qcow-imager/mkosi.conf
+++ b/pxe/mkosi.profiles/qcow-imager/mkosi.conf
@@ -4,11 +4,14 @@ CompressOutput=zstd
 CompressLevel=19
 
 [Distribution]
+Architecture=x86-64
 Distribution=ubuntu
 Release=noble
 Repositories=main,restricted,universe,multiverse
 
 [Build]
+ToolsTreeDistribution=ubuntu
+ToolsTreeRelease=noble
 ToolsTree=default
 Environment=MKOSI_CHROOT_SUPPRESS_CHOWN=1
 

--- a/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.conf
@@ -4,6 +4,7 @@ CompressOutput=zstd
 CompressLevel=19
 
 [Distribution]
+Architecture=x86-64
 Distribution=ubuntu
 Release=noble
 Repositories=main,restricted,universe,multiverse

--- a/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.conf
@@ -5,6 +5,7 @@ CompressLevel=6
 Format=cpio
 
 [Distribution]
+Architecture=x86-64
 Distribution=ubuntu
 Release=noble
 Repositories=main,restricted,universe,multiverse

--- a/rest-api/scripts/setup-local.sh
+++ b/rest-api/scripts/setup-local.sh
@@ -227,7 +227,7 @@ create_site() {
 
 ensure_temporal_namespace() {
     local temporal_namespace=$1
-    local temporal_address="temporal-frontend.temporal.svc.cluster.local.:7233"
+    local temporal_address="temporal-frontend-headless.temporal.svc.cluster.local.:7233"
     local describe_error=""
     local create_error=""
 

--- a/rest-api/scripts/setup-local.sh
+++ b/rest-api/scripts/setup-local.sh
@@ -227,7 +227,15 @@ create_site() {
 
 ensure_temporal_namespace() {
     local temporal_namespace=$1
-    local temporal_address="temporal-frontend-headless.temporal.svc.cluster.local.:7233"
+    local temporal_frontend_ip
+    temporal_frontend_ip=$(kubectl -n temporal get pods \
+        -l app.kubernetes.io/component=frontend \
+        -o jsonpath='{.items[0].status.podIP}')
+    if [ -z "$temporal_frontend_ip" ]; then
+        echo "ERROR: Temporal frontend pod IP is unavailable" >&2
+        return 1
+    fi
+    local temporal_address="${temporal_frontend_ip}:7233"
     local describe_error=""
     local create_error=""
 

--- a/rest-api/scripts/setup-local.sh
+++ b/rest-api/scripts/setup-local.sh
@@ -227,15 +227,7 @@ create_site() {
 
 ensure_temporal_namespace() {
     local temporal_namespace=$1
-    local temporal_frontend_ip
-    temporal_frontend_ip=$(kubectl -n temporal get pods \
-        -l app.kubernetes.io/component=frontend \
-        -o jsonpath='{.items[0].status.podIP}')
-    if [ -z "$temporal_frontend_ip" ]; then
-        echo "ERROR: Temporal frontend pod IP is unavailable" >&2
-        return 1
-    fi
-    local temporal_address="${temporal_frontend_ip}:7233"
+    local temporal_address="temporal-frontend-headless.temporal.svc.cluster.local.:7233"
     local describe_error=""
     local create_error=""
 

--- a/rest-api/scripts/setup-local.sh
+++ b/rest-api/scripts/setup-local.sh
@@ -238,7 +238,7 @@ ensure_temporal_namespace() {
 
     echo "Registering Temporal namespace: $temporal_namespace"
     for attempt in {1..30}; do
-        if describe_error=$("${temporal_command[@]}" describe --namespace "$temporal_namespace" \
+        if describe_error=$("${temporal_command[@]}" describe -n "$temporal_namespace" \
             --address "$temporal_address" \
             --tls-cert-path /var/secrets/temporal/certs/server-interservice/tls.crt \
             --tls-key-path /var/secrets/temporal/certs/server-interservice/tls.key \
@@ -248,7 +248,8 @@ ensure_temporal_namespace() {
             return
         fi
 
-        create_error=$("${temporal_command[@]}" create --namespace "$temporal_namespace" \
+        create_error=$("${temporal_command[@]}" create -n "$temporal_namespace" \
+            --retention 72h \
             --address "$temporal_address" \
             --tls-cert-path /var/secrets/temporal/certs/server-interservice/tls.crt \
             --tls-key-path /var/secrets/temporal/certs/server-interservice/tls.key \
@@ -258,7 +259,7 @@ ensure_temporal_namespace() {
         sleep 5
     done
 
-    if describe_error=$("${temporal_command[@]}" describe --namespace "$temporal_namespace" \
+    if describe_error=$("${temporal_command[@]}" describe -n "$temporal_namespace" \
         --address "$temporal_address" \
         --tls-cert-path /var/secrets/temporal/certs/server-interservice/tls.crt \
         --tls-key-path /var/secrets/temporal/certs/server-interservice/tls.key \

--- a/rest-api/temporal-helm/temporal/templates/server-configmap.yaml
+++ b/rest-api/temporal-helm/temporal/templates/server-configmap.yaml
@@ -197,8 +197,15 @@ data:
 
     {{- end }}
 
+    {{- if $.Values.server.config.publicClient }}
+    publicClient:
+    {{- with $.Values.server.config.publicClient }}
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- else }}
     publicClient:
       hostPort: "{{ include "temporal.componentname" (list $ "frontend") }}.{{ $.Release.Namespace }}.svc.cluster.local.:{{ $.Values.server.frontend.service.port }}"
+    {{- end }}
 
     dynamicConfigClient:
       filepath: "/etc/temporal/dynamic_config/dynamic_config.yaml"

--- a/rest-api/temporal-helm/temporal/values.yaml
+++ b/rest-api/temporal-helm/temporal/values.yaml
@@ -281,6 +281,9 @@ server:
 
   worker:
     # replicaCount: 1
+    additionalEnv:
+      - name: TEMPORAL_ADDRESS
+        value: temporal-frontend-headless.temporal.svc.cluster.local:7233
     service:
       # type: ClusterIP
       port: 7239

--- a/rest-api/temporal-helm/temporal/values.yaml
+++ b/rest-api/temporal-helm/temporal/values.yaml
@@ -139,7 +139,7 @@ server:
   config:
     logLevel: "debug,info"
     publicClient:
-      hostPort: temporal-frontend-headless.temporal.svc.cluster.local:7233
+      hostPort: temporal-frontend-headless.temporal.svc.cluster.local.:7233
 
     # IMPORTANT: This value cannot be changed, once it's set.
     numHistoryShards: 512

--- a/rest-api/temporal-helm/temporal/values.yaml
+++ b/rest-api/temporal-helm/temporal/values.yaml
@@ -138,6 +138,8 @@ server:
 
   config:
     logLevel: "debug,info"
+    publicClient:
+      hostPort: temporal-frontend-headless.temporal.svc.cluster.local:7233
 
     # IMPORTANT: This value cannot be changed, once it's set.
     numHistoryShards: 512
@@ -281,9 +283,6 @@ server:
 
   worker:
     # replicaCount: 1
-    additionalEnv:
-      - name: TEMPORAL_ADDRESS
-        value: temporal-frontend-headless.temporal.svc.cluster.local:7233
     service:
       # type: ClusterIP
       port: 7239


### PR DESCRIPTION
This PR adds a one-box development setup path for NICo on Linux hosts running
either AMD64 or ARM64. The goal is to let a developer build the required
artifacts and bring up the local NICo stack on a single machine without assuming
an x86-only build host or a multi-node production topology.

The branch combines architecture-aware container and PXE builds with the
single-node deployment fixes needed to make the prerequisite, database, Vault,
Temporal, Core, and site-agent setup repeatable on a development box.

## Related issues

None linked.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Change breakdown

### Multi-architecture build support

- Makes the Machine-a-Tron Dockerfile target-aware so its native builder can
  compile and publish both `linux/amd64` and `linux/arm64` runtime images.
- Selects the Rust target, cross-linker, compiler, development libraries, and
  runtime platform from BuildKit's build and target architecture values.
- Makes the PXE builder run natively on either AMD64 or ARM64 while continuing
  to produce the x86_64 Scout, qcow, and iPXE artifacts required by the local
  managed-host workflow.
- Adds the AMD64 multiarch packages and Rust/C/C++ cross-toolchain needed to
  build x86_64 artifacts on an ARM64 host without running the compiler under
  QEMU.
- Installs a pinned AMD64 binfmt handler on non-x86 hosts for package scripts
  that mkosi must execute while assembling x86_64 images.
- Marks the affected mkosi profiles explicitly as x86-64 and configures a
  matching Ubuntu Noble tools tree.
- Updates the cargo-make entry points and build documentation for the same
  AMD64/ARM64 workflow.

### One-box prerequisite installation

- Installs `helmfile` under the user's local bin directory instead of requiring
  root access to `/usr/local/bin`.
- Uses named Helm repositories with explicit version pins for cert-manager,
  Vault, External Secrets, PostgreSQL, and MetalLB prerequisites.
- Pins the Zalando Postgres Operator chart at v1.15.1 to keep one-box setup
  portable across Linux AMD64 and ARM64 hosts. The previous v1.11.0 chart
  resolved to registry.opensource.zalan.do/acid/postgres-operator:v1.11.0,
  whose published manifest is AMD64-only. On DGX Spark ARM64 this caused the
  operator container to fail immediately with exec format error; Helm then
  surfaced the secondary context deadline exceeded error after waiting for the
  deployment on each retry. Chart v1.15.1 resolves to the GHCR operator image
  whose OCI index publishes both linux/amd64 and linux/arm64 manifests.
- Extends MetalLB chart parsing so direct HTTP, OCI, repository-qualified, and
  local chart coordinates work consistently.
- Recovers interrupted Helm installs, upgrades, and rollbacks before retrying
  the prerequisite workflow.
- Keeps the setup phases rerunnable after an interrupted SSH or local automation
  session.

### Single-node PostgreSQL reliability

- Derives synchronous replication from the configured replica count: disabled
  for a one-instance development database and enabled when a standby exists.
- Detects and repairs stale single-node synchronous-replication state and
  terminates stranded `SyncRep` sessions before reconciliation.
- Discovers the current PostgreSQL primary rather than relying on a fixed pod
  name.
- Creates and reconciles the NICo databases and required REST extensions
  through `psql`, with bounded retries and advisory locking for concurrent
  setup attempts.
- Makes prerequisite-mode REST setup skip waits that belong to the later
  application deployment phase.

### Vault bootstrap and certificate reconciliation

- Discovers the configured Vault replica count during initialization and
  unseal rather than assuming a fixed three-pod topology.
- Adds the service DNS names required for one-box TLS bootstrap and reconciles
  managed Vault certificates before initialization.
- Stabilizes first-time Vault startup, initialization, unseal rounds, and
  readiness checks so a single-node deployment can converge reliably.
- Ignores empty optional certificate DNS names instead of rendering invalid
  entries.

### Temporal, Core, and site-agent connectivity

- Uses Temporal's stable headless frontend service for local namespace setup
  and the site-agent runtime.
- Corrects Temporal namespace CLI arguments, configures retention, and exposes
  an explicit public client endpoint.
- Uses absolute cluster-local DNS names for Core, Flow, and Temporal to avoid
  resolver search-path delays on a one-box cluster.
- Adds a config checksum to roll the site-agent when its generated connection
  settings change.
- Creates the legacy Core namespace alias needed by fresh one-box setups and
  exposes the configurable Kea DHCP hook-library path used by architecture-
  specific one-box configuration.

### Documentation

- Documents topology-derived PostgreSQL synchronous mode in the quick start.
- Documents the native AMD64/ARM64 PXE builder and x86_64 cross-build flow.
- Updates prerequisite notes for the user-local Helmfile installation path.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Passed while preparing this draft:

- `git diff --check origin/main...dgx-spark-arm64`
- `bash -n` for `helm-prereqs/setup.sh`, `health-check.sh`, `preflight.sh`,
  `unseal_vault.sh`, and `rest-api/scripts/setup-local.sh`
- `helm lint helm/charts/nico-api`
- `helm lint helm/rest/nico-rest-site-agent`
- `helm lint rest-api/temporal-helm/temporal`
- Buildx Dockerfile checks for `linux/amd64,linux/arm64` on
  `crates/machine-a-tron/Dockerfile`
- Buildx Dockerfile checks for `linux/amd64,linux/arm64` on
  `dev/docker/Dockerfile.pxe-build-container`

Not run during this draft-preparation pass:

- Full `cargo make pre-commit-verify-workspace`
- Complete AMD64 and ARM64 image builds
- A fresh end-to-end one-box deployment and teardown on both architectures
- Fern and `rumdl` documentation validation

## Additional Notes

- This is intentionally a draft. Upstream `main` advanced by one commit after
  this branch's last rebase, so the branch must be refreshed before it is marked
  ready for review.
- All 37 branch commits contain a DCO `Signed-off-by` trailer. Local Git reports
  that they are not cryptographically signed; the repository's commit-signature
  requirement must be resolved before merge readiness.
- The one-box settings are development defaults and recovery behavior. They do
  not remove support for multi-replica prerequisite deployments.


