### PR TITLE
fix(api): support Scout firmware upgrades for assigned hosts

### DIFF
--- a/crates/api-core/src/handlers/host_reprovisioning.rs
+++ b/crates/api-core/src/handlers/host_reprovisioning.rs
@@ -18,7 +18,7 @@ use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineId;
 use itertools::Itertools;
 use model::machine::{
-    HostReprovisionState, LoadSnapshotOptions, ManagedHostState, ScoutUpgradeResult,
+    HostReprovisionState, InstanceState, LoadSnapshotOptions, ManagedHostState, ScoutUpgradeResult,
 };
 use tonic::{Request, Response, Status};
 
@@ -173,21 +173,40 @@ pub(crate) async fn report_scout_firmware_upgrade_status(
 
     let (machine, mut txn) = api.load_machine(&machine_id, Default::default()).await?;
 
-    // Verify machine is in WaitingForScoutUpgrade state
-    let ManagedHostState::HostReprovision {
-        reprovision_state:
-            HostReprovisionState::WaitingForScoutUpgrade {
-                upgrade_task_id,
-                firmware_type,
-                final_version,
-                power_drains_needed,
-                started_at,
-                deadline,
-                task_json,
-                ..
-            },
-        retry_count,
-    } = machine.current_state().clone()
+    enum HostReprovisionContext {
+        Ready { retry_count: u32 },
+        Assigned,
+    }
+
+    let (reprovision_state, context) = match machine.current_state().clone() {
+        ManagedHostState::HostReprovision {
+            reprovision_state,
+            retry_count,
+        } => (
+            reprovision_state,
+            HostReprovisionContext::Ready { retry_count },
+        ),
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::HostReprovision { reprovision_state },
+        } => (reprovision_state, HostReprovisionContext::Assigned),
+        _ => {
+            return Err(CarbideError::FailedPrecondition(format!(
+                "machine {machine_id} is not in WaitingForScoutUpgrade state"
+            ))
+            .into());
+        }
+    };
+
+    let HostReprovisionState::WaitingForScoutUpgrade {
+        upgrade_task_id,
+        firmware_type,
+        final_version,
+        power_drains_needed,
+        started_at,
+        deadline,
+        task_json,
+        ..
+    } = reprovision_state
     else {
         return Err(CarbideError::FailedPrecondition(format!(
             "machine {machine_id} is not in WaitingForScoutUpgrade state"
@@ -212,24 +231,30 @@ pub(crate) async fn report_scout_firmware_upgrade_status(
     // is available in the scout logs if an operator needs to dig deeper.
     const MAX_STORED_OUTPUT_SIZE: usize = 1500;
 
-    let new_state = ManagedHostState::HostReprovision {
-        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
-            upgrade_task_id,
-            firmware_type,
-            final_version,
-            power_drains_needed,
-            started_at,
-            deadline,
-            task_json,
-            result: Some(ScoutUpgradeResult {
-                success: req.success,
-                exit_code: req.exit_code,
-                stdout: truncate(req.stdout, MAX_STORED_OUTPUT_SIZE),
-                stderr: truncate(req.stderr, MAX_STORED_OUTPUT_SIZE),
-                error: truncate(req.error, MAX_STORED_OUTPUT_SIZE),
-            }),
+    let reprovision_state = HostReprovisionState::WaitingForScoutUpgrade {
+        upgrade_task_id,
+        firmware_type,
+        final_version,
+        power_drains_needed,
+        started_at,
+        deadline,
+        task_json,
+        result: Some(ScoutUpgradeResult {
+            success: req.success,
+            exit_code: req.exit_code,
+            stdout: truncate(req.stdout, MAX_STORED_OUTPUT_SIZE),
+            stderr: truncate(req.stderr, MAX_STORED_OUTPUT_SIZE),
+            error: truncate(req.error, MAX_STORED_OUTPUT_SIZE),
+        }),
+    };
+    let new_state = match context {
+        HostReprovisionContext::Ready { retry_count } => ManagedHostState::HostReprovision {
+            reprovision_state,
+            retry_count,
         },
-        retry_count,
+        HostReprovisionContext::Assigned => ManagedHostState::Assigned {
+            instance_state: InstanceState::HostReprovision { reprovision_state },
+        },
     };
 
     db::machine::advance(&machine, &mut txn, &new_state, None).await?;

--- a/crates/api-core/src/handlers/machine_scout.rs
+++ b/crates/api-core/src/handlers/machine_scout.rs
@@ -372,6 +372,17 @@ pub(crate) async fn forge_agent_control(
                         ..
                     },
                 ..
+            }
+            | ManagedHostState::Assigned {
+                instance_state:
+                    InstanceState::HostReprovision {
+                        reprovision_state:
+                            HostReprovisionState::WaitingForScoutUpgrade {
+                                task_json,
+                                result: None,
+                                ..
+                            },
+                    },
             } => {
                 tracing::info!(
                     machine_id = %machine.id,

--- a/crates/api-core/tests/integration/forge_agent_control.rs
+++ b/crates/api-core/tests/integration/forge_agent_control.rs
@@ -220,6 +220,54 @@ async fn waiting_for_scout_upgrade_returns_task_without_cleanup_timestamp(pool: 
 }
 
 #[sqlx_test]
+async fn assigned_waiting_for_scout_upgrade_returns_task(pool: PgPool) {
+    let TestContext { mh, .. } = init(pool).await;
+    let upgrade_task_id = uuid::Uuid::new_v4().to_string();
+    let task_json = serde_json::json!({
+        "upgrade_task_id": &upgrade_task_id,
+        "component_type": "cx7",
+        "target_version": "28.47.2682",
+        "script": {
+            "url": "http://pxe/scripts/cx7_upgrade.sh",
+            "sha256": "script-sha",
+        },
+        "execution_timeout_seconds": 7200,
+        "artifact_download_timeout_seconds": 600,
+        "file_artifacts": [{
+            "url": "http://pxe/cx7.bin",
+            "sha256": "firmware-sha",
+        }],
+    })
+    .to_string();
+    mh.advance_state(ManagedHostState::Assigned {
+        instance_state: InstanceState::HostReprovision {
+            reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+                upgrade_task_id: upgrade_task_id.clone(),
+                firmware_type: FirmwareComponentType::Cx7,
+                final_version: "28.47.2682".to_string(),
+                power_drains_needed: Some(1),
+                started_at: chrono::Utc::now(),
+                deadline: chrono::Utc::now() + chrono::TimeDelta::hours(3),
+                task_json,
+                result: None,
+            },
+        },
+    })
+    .await;
+
+    let response = mh.host.forge_agent_control().await;
+    let Some(Action::FirmwareUpgrade(firmware_upgrade)) = response.action else {
+        panic!("expected typed firmware upgrade action");
+    };
+    let task = firmware_upgrade.task.expect("typed task");
+
+    assert_eq!(response.legacy_action, LegacyAction::FirmwareUpgrade as i32);
+    assert_eq!(task.component_type, "cx7");
+    assert_eq!(task.target_version, "28.47.2682");
+    assert_eq!(task.upgrade_task_id, upgrade_task_id);
+}
+
+#[sqlx_test]
 async fn invalid_json_falls_back_to_noop(pool: PgPool) {
     let TestContext { env, mh, .. } = init(pool).await;
     let mut txn = env.db_txn().await;

--- a/crates/api-core/tests/integration/scout_firmware_upgrade_status.rs
+++ b/crates/api-core/tests/integration/scout_firmware_upgrade_status.rs
@@ -19,7 +19,7 @@ use carbide_instrument::testing::MetricsCapture;
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
 use model::firmware::FirmwareComponentType;
-use model::machine::{HostReprovisionState, ManagedHostState};
+use model::machine::{HostReprovisionState, InstanceState, ManagedHostState};
 use model::test_support::ManagedHostConfig;
 use tonic::Request;
 
@@ -44,19 +44,31 @@ async fn init(pool: PgPool) -> TestContext {
     TestContext { env, mh }
 }
 
+fn waiting_reprovision_state(upgrade_task_id: &str) -> HostReprovisionState {
+    HostReprovisionState::WaitingForScoutUpgrade {
+        upgrade_task_id: upgrade_task_id.to_string(),
+        firmware_type: FirmwareComponentType::Bmc,
+        final_version: "1.2.3".to_string(),
+        power_drains_needed: None,
+        started_at: chrono::Utc::now(),
+        deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        task_json: String::new(),
+        result: None,
+    }
+}
+
 fn waiting_state(upgrade_task_id: &str) -> ManagedHostState {
     ManagedHostState::HostReprovision {
-        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
-            upgrade_task_id: upgrade_task_id.to_string(),
-            firmware_type: FirmwareComponentType::Bmc,
-            final_version: "1.2.3".to_string(),
-            power_drains_needed: None,
-            started_at: chrono::Utc::now(),
-            deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
-            task_json: String::new(),
-            result: None,
-        },
+        reprovision_state: waiting_reprovision_state(upgrade_task_id),
         retry_count: 0,
+    }
+}
+
+fn assigned_waiting_state(upgrade_task_id: &str) -> ManagedHostState {
+    ManagedHostState::Assigned {
+        instance_state: InstanceState::HostReprovision {
+            reprovision_state: waiting_reprovision_state(upgrade_task_id),
+        },
     }
 }
 
@@ -106,6 +118,39 @@ async fn stores_successful_result(pool: PgPool) {
     assert!(result.success);
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout, "upgrade complete");
+}
+
+#[sqlx_test]
+async fn stores_successful_result_for_assigned_host(pool: PgPool) {
+    const UPGRADE_TASK_ID: &str = "assigned-scout-upgrade-task-id";
+
+    let TestContext { env, mh } = init(pool).await;
+    mh.advance_state(assigned_waiting_state(UPGRADE_TASK_ID))
+        .await;
+
+    env.api()
+        .report_scout_firmware_upgrade_status(Request::new(
+            rpc::forge::ScoutFirmwareUpgradeStatusRequest {
+                stdout: "assigned upgrade complete".to_string(),
+                ..status_request(&mh, UPGRADE_TASK_ID)
+            },
+        ))
+        .await
+        .unwrap();
+
+    let machine = mh.host.machine().await;
+    let ManagedHostState::Assigned {
+        instance_state: InstanceState::HostReprovision { reprovision_state },
+    } = machine.current_state()
+    else {
+        panic!("assigned host reprovision wrapper was not preserved");
+    };
+    let HostReprovisionState::WaitingForScoutUpgrade { result, .. } = reprovision_state else {
+        panic!("Not in WaitingForScoutUpgrade");
+    };
+    let result = result.as_ref().expect("result should be set");
+    assert!(result.success);
+    assert_eq!(result.stdout, "assigned upgrade complete");
 }
 
 #[sqlx_test]


### PR DESCRIPTION
Fix Scout firmware upgrades for machines in Assigned/HostReprovision/WaitingForScoutUpgrade. I missed the fact that `WaitingForScoutUpgrade` can be nested inside the `Assigned` state so scout won't know about this work currently. This PR fixes it.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
The API now:
- Dispatches firmware upgrade tasks for assigned hosts.
- Accepts Scout completion reports while preserving the Assigned state wrapper.
- Adds regression tests for both paths.

