### PR TITLE
feat(dpf): add initial support for deployment type migration

### DIFF
--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::model::{RpcInto, RpcTryFrom};
 use ::rpc::{common as rpc_common, forge as rpc};
-use carbide_dpf::dpu_cr_name;
+use carbide_dpf::{DpuDeploymentType, dpu_cr_name, dpu_node_cr_name};
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use carbide_utils::arch::CpuArchitecture;
@@ -49,6 +49,7 @@ use model::machine::{
 };
 use model::machine_update_module::HOST_UPDATE_HEALTH_PROBE_ID;
 use model::network_segment::NetworkSegmentSearchConfig;
+use model::rack_type::select_dpu_nvconfig_profile;
 use tonic::{Request, Response, Status};
 
 use crate::api::{Api, log_machine_id, log_request_data};
@@ -1337,6 +1338,137 @@ pub(crate) async fn dpu_agent_upgrade_policy_action(
     Ok(tonic::Response::new(response))
 }
 
+/// Returns whether adding a request for `machine_id` covers every attached DPU.
+fn reprovision_request_covers_all_attached_dpus(
+    snapshot: &ManagedHostStateSnapshot,
+    machine_id: &MachineId,
+) -> bool {
+    if machine_id.machine_type().is_dpu() {
+        snapshot
+            .dpu_snapshots
+            .iter()
+            .all(|dpu| dpu.id == *machine_id || dpu.reprovision_requested.is_some())
+    } else {
+        snapshot.has_managed_dpus()
+    }
+}
+
+/// Returns the DPUNode when this request may need the exact BF3 to GB200
+/// deployment migration.
+async fn dpf_deployment_migration_node(
+    api: &Api,
+    conn: &mut sqlx::PgConnection,
+    snapshot: &ManagedHostStateSnapshot,
+) -> Result<Option<String>, CarbideError> {
+    if !api.runtime_config.dpf.enabled
+        || !snapshot.host_snapshot.config.dpf.used_for_ingestion
+        || snapshot.dpu_snapshots.is_empty()
+    {
+        return Ok(None);
+    }
+
+    let Some(rack_id) = snapshot.host_snapshot.rack_id.as_ref() else {
+        return Ok(None);
+    };
+    let Some(rack) = db::rack::find_by(conn, ObjectColumnFilter::One(db::rack::IdColumn, rack_id))
+        .await?
+        .pop()
+    else {
+        return Ok(None);
+    };
+    let Some(rack_profile_id) = rack.rack_profile_id.as_ref() else {
+        return Ok(None);
+    };
+    let Some(rack_profile) = api
+        .runtime_config
+        .rack_profiles
+        .get(rack_profile_id.as_str())
+    else {
+        return Ok(None);
+    };
+    let every_dpu_uses_gb200_profile = snapshot.dpu_snapshots.iter().all(|dpu| {
+        select_dpu_nvconfig_profile(
+            rack_profile.product_family.as_ref(),
+            dpu.status.hardware_info.as_ref(),
+        )
+        .is_some()
+    });
+    if !every_dpu_uses_gb200_profile {
+        return Ok(None);
+    }
+
+    Ok(snapshot
+        .host_snapshot
+        .dpf_id()
+        .map(|dpf_id| dpu_node_cr_name(&dpf_id)))
+}
+
+/// Returns whether the live DPUNode still belongs to the generic BF3
+/// deployment and therefore needs a migration of the complete DPU set.
+async fn dpf_deployment_migration_source_is_active(
+    api: &Api,
+    node_name: &str,
+) -> Result<bool, CarbideError> {
+    let dpf_sdk = api.dpf_sdk.as_deref().ok_or_else(|| {
+        CarbideError::internal(
+            "DPF SDK is unavailable while checking a DPF deployment migration".to_string(),
+        )
+    })?;
+    if dpf_sdk
+        .verify_node_labels(node_name, DpuDeploymentType::Bf3Gb200)
+        .await
+        .map_err(CarbideError::DpfError)?
+    {
+        return Ok(false);
+    }
+
+    dpf_sdk
+        .verify_node_labels(node_name, DpuDeploymentType::Bf3)
+        .await
+        .map_err(CarbideError::DpfError)
+}
+
+/// Refuses a request change that would leave only part of the attached DPU set
+/// selected while the shared DPUNode still needs deployment migration.
+fn reject_partial_dpf_deployment_migration_request_set(
+    snapshot: &ManagedHostStateSnapshot,
+    machine_id: &MachineId,
+    mode: rpc::dpu_reprovisioning_request::Mode,
+    migration_source_is_active: bool,
+) -> Result<(), CarbideError> {
+    if !migration_source_is_active {
+        return Ok(());
+    }
+
+    let requested_count = snapshot
+        .dpu_snapshots
+        .iter()
+        .filter(|dpu| {
+            let request_targets_dpu = machine_id.machine_type().is_host() || dpu.id == *machine_id;
+            if request_targets_dpu {
+                mode == rpc::dpu_reprovisioning_request::Mode::Set
+            } else {
+                dpu.reprovision_requested.is_some()
+            }
+        })
+        .count();
+    if requested_count == 0 || requested_count == snapshot.dpu_snapshots.len() {
+        return Ok(());
+    }
+
+    let operation = match mode {
+        rpc::dpu_reprovisioning_request::Mode::Set => "Set",
+        rpc::dpu_reprovisioning_request::Mode::Clear => "Clear",
+        rpc::dpu_reprovisioning_request::Mode::Restart => "Restart",
+    };
+    Err(CarbideError::FailedPrecondition(format!(
+        "{operation} for DPU {machine_id} would leave only part of the attached DPU set selected \
+         while the shared DPUNode still needs the GB200 deployment; submit {operation} with host \
+         machine ID {} so every attached DPU changes together",
+        snapshot.host_snapshot.id,
+    )))
+}
+
 /// Refuses a reprovision request that would migrate a host to DPF while its
 /// instance still has extension services attached.
 ///
@@ -1361,16 +1493,7 @@ fn reject_dpf_migration_that_would_strand_extension_services(
         return Ok(());
     }
 
-    // Requesting the host reprovisions every DPU. Requesting a single DPU only
-    // completes the set if every other DPU is already requested.
-    let migrates_host_to_dpf = if machine_id.machine_type().is_dpu() {
-        snapshot
-            .dpu_snapshots
-            .iter()
-            .all(|dpu| dpu.id == *machine_id || dpu.reprovision_requested.is_some())
-    } else {
-        snapshot.has_managed_dpus()
-    };
+    let migrates_host_to_dpf = reprovision_request_covers_all_attached_dpus(snapshot, machine_id);
 
     let has_attached_extension_services = snapshot.instance.as_ref().is_some_and(|instance| {
         !instance
@@ -1390,6 +1513,104 @@ fn reject_dpf_migration_that_would_strand_extension_services(
     Ok(())
 }
 
+/// Validates request conditions that do not require a Kubernetes read.
+fn validate_dpu_reprovisioning_request(
+    api: &Api,
+    snapshot: &ManagedHostStateSnapshot,
+    machine_id: &MachineId,
+    mode: rpc::dpu_reprovisioning_request::Mode,
+) -> Result<(), CarbideError> {
+    let update_alert = snapshot
+        .aggregate_health
+        .alerts
+        .iter()
+        .find(|alert| alert.id == *HOST_UPDATE_HEALTH_PROBE_ID);
+    if !update_alert.is_some_and(|alert| {
+        alert
+            .classifications
+            .contains(&health_report::HealthAlertClassification::prevent_allocations())
+    }) {
+        return Err(CarbideError::InvalidArgument(format!(
+            "machine {machine_id} must have a 'HostUpdateInProgress' health alert with the \
+             'PreventAllocations' classification before reprovisioning. set this precondition \
+             with: `machine health-override add --template host-update <id>`",
+        )));
+    }
+
+    let reprovisioning_started = snapshot.dpu_snapshots.iter().any(|dpu| {
+        dpu.reprovision_requested
+            .as_ref()
+            .is_some_and(|request| request.started_at.is_some())
+    });
+    if reprovisioning_started && mode != rpc::dpu_reprovisioning_request::Mode::Restart {
+        return Err(CarbideError::internal(
+            "reprovisioning is already started".to_string(),
+        ));
+    }
+
+    if mode == rpc::dpu_reprovisioning_request::Mode::Set {
+        reject_dpf_migration_that_would_strand_extension_services(api, snapshot, machine_id)?;
+    }
+
+    Ok(())
+}
+
+/// Locks every attached DPU row in stable order before validating a migration
+/// request set and updating any member of it.
+async fn lock_attached_dpus(
+    conn: &mut sqlx::PgConnection,
+    snapshot: &ManagedHostStateSnapshot,
+) -> Result<(), CarbideError> {
+    let dpu_ids = snapshot
+        .dpu_snapshots
+        .iter()
+        .map(|dpu| dpu.id)
+        .collect::<Vec<_>>();
+    let locked_dpus = db::machine::find(
+        conn,
+        db::ObjectFilter::List(&dpu_ids),
+        MachineSearchConfig {
+            for_update: true,
+            ..MachineSearchConfig::default()
+        },
+    )
+    .await?;
+    if locked_dpus.len() != dpu_ids.len() {
+        return Err(CarbideError::internal(format!(
+            "expected to lock {} attached DPUs but found {}",
+            dpu_ids.len(),
+            locked_dpus.len(),
+        )));
+    }
+
+    Ok(())
+}
+
+/// Loads the host snapshot used to validate and update DPU reprovisioning
+/// requests.
+async fn load_dpu_reprovisioning_snapshot(
+    api: &Api,
+    conn: &mut sqlx::PgConnection,
+    machine_id: &MachineId,
+) -> Result<ManagedHostStateSnapshot, CarbideError> {
+    db::managed_host::load_snapshot(
+        conn,
+        machine_id,
+        LoadSnapshotOptions {
+            include_history: false,
+            // The attached extension services checked by validation live on
+            // the instance.
+            include_instance_data: true,
+            host_health_config: api.runtime_config.host_health,
+        },
+    )
+    .await?
+    .ok_or(CarbideError::NotFoundError {
+        kind: "machine",
+        id: machine_id.to_string(),
+    })
+}
+
 /// Trigger DPU reprovisioning
 /// In case user passes a DPU ID, trigger_dpu_reprovisioning only for that particular DPU.
 /// In case user passes a host id, trigger_dpu_reprovisioning
@@ -1406,57 +1627,62 @@ pub(crate) async fn trigger_dpu_reprovisioning(
 
     let mut txn = api.txn_begin().await?;
 
-    let snapshot = db::managed_host::load_snapshot(
-        &mut txn,
-        &machine_id,
-        LoadSnapshotOptions {
-            include_history: false,
-            // The attached extension services checked below live on the instance.
-            include_instance_data: true,
-            host_health_config: api.runtime_config.host_health,
-        },
-    )
-    .await?
-    .ok_or(CarbideError::NotFoundError {
-        kind: "machine",
-        id: machine_id.to_string(),
-    })?;
+    let mut snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
+    let mode = req.mode();
+    validate_dpu_reprovisioning_request(api, &snapshot, &machine_id, mode)?;
 
-    // Start reprovisioning only if the host has an HostUpdateInProgress health alert
-    let update_alert = snapshot
-        .aggregate_health
-        .alerts
-        .iter()
-        .find(|a| a.id == *HOST_UPDATE_HEALTH_PROBE_ID);
-    if !update_alert.is_some_and(|alert| {
-        alert
-            .classifications
-            .contains(&health_report::HealthAlertClassification::prevent_allocations())
-    }) {
-        return Err(CarbideError::InvalidArgument(format!(
-            "machine {machine_id} must have a 'HostUpdateInProgress' health alert with the 'PreventAllocations' classification before reprovisioning. set this precondition with: `machine health-override add --template host-update <id>`",
-        )).into());
-    }
+    // The migration check reads Kubernetes, so release the database transaction
+    // before that external call. Set and Clear both change the request set and
+    // must preserve its empty or complete cardinality while the source selector
+    // remains active.
+    let migration_node = if matches!(mode, Mode::Set | Mode::Clear) {
+        dpf_deployment_migration_node(api, txn.as_mut(), &snapshot).await?
+    } else {
+        None
+    };
+    let (migration_source_is_active, admin_lock_admission) = if let Some(node_name) = migration_node
+    {
+        txn.rollback().await?;
+        let source_is_active = dpf_deployment_migration_source_is_active(api, &node_name).await?;
 
-    if snapshot.dpu_snapshots.iter().any(|ms| {
-        ms.reprovision_requested
-            .as_ref()
-            .is_some_and(|x| x.started_at.is_some())
-    }) {
-        match req.mode() {
-            Mode::Restart => {}
-            _ => {
-                return Err(CarbideError::internal(
-                    "reprovisioning is already started".to_string(),
-                )
-                .into());
-            }
+        // Site Explorer takes these same locks before it changes DPU
+        // attachments. Hold them through the request writes so the snapshots
+        // and DPU row locks below describe one complete DPU set.
+        let admin_lock_admission = if source_is_active {
+            Some(db::machine_interface::admin_lock_admission().await)
+        } else {
+            None
+        };
+        txn = api.txn_begin().await?;
+
+        if source_is_active {
+            db::machine_interface::lock_all_admin_segments(txn.as_mut()).await?;
         }
-    }
 
-    match req.mode() {
+        snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
+
+        if source_is_active {
+            lock_attached_dpus(txn.as_mut(), &snapshot).await?;
+            snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
+        }
+
+        // Recheck all database conditions after the Kubernetes call and after
+        // waiting for the row locks. Only this snapshot can authorize the
+        // writes below.
+        validate_dpu_reprovisioning_request(api, &snapshot, &machine_id, mode)?;
+        (source_is_active, admin_lock_admission)
+    } else {
+        (false, None)
+    };
+
+    match mode {
         Mode::Set => {
-            reject_dpf_migration_that_would_strand_extension_services(api, &snapshot, &machine_id)?;
+            reject_partial_dpf_deployment_migration_request_set(
+                &snapshot,
+                &machine_id,
+                mode,
+                migration_source_is_active,
+            )?;
 
             let initiator = req.initiator().as_str_name();
             if machine_id.machine_type().is_dpu() {
@@ -1480,6 +1706,12 @@ pub(crate) async fn trigger_dpu_reprovisioning(
             }
         }
         Mode::Clear => {
+            reject_partial_dpf_deployment_migration_request_set(
+                &snapshot,
+                &machine_id,
+                mode,
+                migration_source_is_active,
+            )?;
             if machine_id.machine_type().is_dpu() {
                 db::machine::clear_dpu_reprovisioning_request(&mut txn, &machine_id, true).await?;
             } else {
@@ -1527,6 +1759,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
     }
 
     txn.commit().await?;
+    drop(admin_lock_admission);
 
     Ok(Response::new(()))
 }

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -20,21 +20,25 @@
 //! Verifies that DPF states (`Reprovisioning` -> `Provisioning` -> `WaitingForReady`)
 //! transition correctly when the outer state is `DPUReprovision`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use carbide_dpf::types::{DpuDeviceSummary, DpuNodeSummary, HostDpfSnapshot};
-use carbide_dpf::{DpuDeploymentType, DpuPhase};
+use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
 use model::machine::{
     DpfState, DpuReprovisionStates, FailureCause, InstanceState, ManagedHostState, ReprovisionState,
 };
+use rpc::forge::dpu_reprovisioning_request::Mode;
+use rpc::forge::forge_server::Forge;
+use tokio::sync::Notify;
 use tokio::time::timeout;
 
 use super::{dpf_config, get_host_state};
+use crate::test_support::builder::TestApiBuilder;
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
     TEST_RMS_RACK_PROFILE_ID, TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
@@ -94,6 +98,120 @@ fn provisioning_mock_with_dpu_count(
         }
     });
     mock
+}
+
+/// Builds a DPF mock whose existing DPUNode still belongs to the generic BF3
+/// deployment while inventory now selects the GB200 deployment.
+fn source_deployment_mock(dpu_count: usize) -> MockDpfOperations {
+    source_deployment_mock_with_verification_observer(dpu_count, |_| {})
+}
+
+/// Builds a source deployment mock that reports each DPUNode label check to
+/// `observer`.
+fn source_deployment_mock_with_verification_observer(
+    dpu_count: usize,
+    observer: impl Fn(DpuDeploymentType) + Send + Sync + 'static,
+) -> MockDpfOperations {
+    let mut mock = MockDpfOperations::new();
+    mock.expect_register_dpu_device().returning(|_, _| Ok(()));
+    mock.expect_register_dpu_node().returning(|_| Ok(()));
+    mock.expect_release_maintenance_hold().returning(|_| Ok(()));
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_, _| Ok(DpuDeploymentType::Bf3));
+    mock.expect_verify_node_labels()
+        .returning(move |_, deployment| {
+            observer(deployment);
+            Ok(deployment == DpuDeploymentType::Bf3)
+        });
+    mock.expect_snapshot_host()
+        .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+    mock
+}
+
+/// A GB200 deployment migration waits for Site Explorer attachment writes
+/// before it snapshots and updates the complete DPU set.
+#[crate::sqlx_test]
+async fn test_gb200_deployment_migration_waits_for_attachment_updates(pool: sqlx::PgPool) {
+    let observe_migration_check = Arc::new(AtomicBool::new(false));
+    let source_deployment_checked = Arc::new(Notify::new());
+    let observe_migration_check_for_mock = observe_migration_check.clone();
+    let source_deployment_checked_for_mock = source_deployment_checked.clone();
+    let mock = source_deployment_mock_with_verification_observer(2, move |deployment| {
+        if observe_migration_check_for_mock.load(Ordering::SeqCst)
+            && deployment == DpuDeploymentType::Bf3
+        {
+            source_deployment_checked_for_mock.notify_one();
+        }
+    });
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    mh.mark_machine_for_updates().await;
+
+    // Stand in for Site Explorer while it changes DPU attachments. The API
+    // must wait for this transaction before it chooses the request set.
+    let admin_lock_admission = db::machine_interface::admin_lock_admission().await;
+    let mut attachment_txn = pool.begin().await.unwrap();
+    db::machine_interface::lock_all_admin_segments(attachment_txn.as_mut())
+        .await
+        .unwrap();
+
+    observe_migration_check.store(true, Ordering::SeqCst);
+    let api = env.api.clone();
+    let host_id = mh.id;
+    let mut request_task = tokio::spawn(async move {
+        api.trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: None,
+                machine_id: host_id.into(),
+                mode: Mode::Set as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await
+    });
+
+    timeout(TEST_TIMEOUT, source_deployment_checked.notified())
+        .await
+        .expect("timed out waiting for the deployment check");
+    assert!(
+        timeout(Duration::from_millis(250), &mut request_task)
+            .await
+            .is_err(),
+        "the migration request must wait for attachment updates"
+    );
+
+    attachment_txn.commit().await.unwrap();
+    drop(admin_lock_admission);
+    timeout(TEST_TIMEOUT, request_task)
+        .await
+        .expect("timed out after releasing the attachment locks")
+        .expect("the migration request task panicked")
+        .expect("the migration request failed");
+
+    let mut txn = pool.begin().await.unwrap();
+    let dpu_machines = mh.dpu_db_machines(&mut txn).await;
+    assert_eq!(dpu_machines.len(), mh.dpu_ids.len());
+    assert!(
+        dpu_machines
+            .iter()
+            .all(|dpu| dpu.reprovision_requested.is_some()),
+        "the host request must update every attached DPU"
+    );
+    txn.commit().await.unwrap();
 }
 
 /// Build the DPU reprovision states map for the given DPF sub-state.
@@ -175,6 +293,131 @@ async fn dpu_device_names(pool: &sqlx::PgPool, mh: &TestManagedHost) -> HashSet<
         names.insert(dpu.dpf_id().unwrap());
     }
     names
+}
+
+/// Gives a DPF test host the rack and DPU inventory that select the GB200
+/// deployment.
+async fn configure_gb200_b3240_host(pool: &sqlx::PgPool, mh: &TestManagedHost) {
+    let mut txn = pool.begin().await.unwrap();
+    let rack_id = TestRackDbBuilder::new()
+        .with_rack_profile_id(TEST_RMS_RACK_PROFILE_ID)
+        .persist(txn.as_mut())
+        .await
+        .unwrap();
+    let rack_assignment = sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    assert_eq!(
+        rack_assignment.rows_affected(),
+        1,
+        "the test host must be attached to the GB200 rack profile"
+    );
+    for dpu_id in &mh.dpu_ids {
+        let dpu = db::machine::find_one(txn.as_mut(), dpu_id, Default::default())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut hardware_info = dpu
+            .status
+            .hardware_info
+            .expect("fixture DPU should have hardware information");
+        hardware_info
+            .dpu_info
+            .as_mut()
+            .expect("fixture DPU should have DPU information")
+            .part_number = "900-9D3B6-00CN-PA0".to_string();
+        db::machine_topology::set_topology_update_needed(txn.as_mut(), dpu_id, true)
+            .await
+            .unwrap();
+        db::machine_topology::create_or_update(txn.as_mut(), dpu_id, &hardware_info)
+            .await
+            .unwrap();
+    }
+    txn.commit().await.unwrap();
+}
+
+/// Recreates the partial DPF reprovision state that a controller without
+/// deployment migration admission could persist during a rolling update.
+async fn set_started_partial_dpf_reprovision(
+    pool: &sqlx::PgPool,
+    mh: &TestManagedHost,
+    requested_dpu_index: usize,
+) {
+    let requested_dpu_id = mh.dpu_ids[requested_dpu_index];
+    let mut txn = pool.begin().await.unwrap();
+    db::machine::trigger_dpu_reprovisioning_request(&requested_dpu_id, txn.as_mut(), "test", true)
+        .await
+        .unwrap();
+    db::machine::update_dpu_reprovision_start_time(&requested_dpu_id, txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let states = mh
+        .dpu_ids
+        .iter()
+        .map(|dpu_id| {
+            let state = if *dpu_id == requested_dpu_id {
+                ReprovisionState::DpfStates {
+                    substate: DpfState::Reprovisioning,
+                }
+            } else {
+                ReprovisionState::NotUnderReprovision
+            };
+            (*dpu_id, state)
+        })
+        .collect();
+    write_host_state(
+        pool,
+        &mh.id,
+        &ManagedHostState::DPUReprovision {
+            dpu_states: DpuReprovisionStates { states },
+        },
+    )
+    .await;
+}
+
+/// Recreates a complete request set that an older controller has already
+/// advanced unevenly during a rolling update.
+async fn set_started_complete_dpf_reprovision_with_progress(
+    pool: &sqlx::PgPool,
+    mh: &TestManagedHost,
+) {
+    let mut txn = pool.begin().await.unwrap();
+    for dpu_id in &mh.dpu_ids {
+        db::machine::trigger_dpu_reprovisioning_request(dpu_id, txn.as_mut(), "test", true)
+            .await
+            .unwrap();
+        db::machine::update_dpu_reprovision_start_time(dpu_id, txn.as_mut())
+            .await
+            .unwrap();
+    }
+    txn.commit().await.unwrap();
+
+    let states = mh
+        .dpu_ids
+        .iter()
+        .enumerate()
+        .map(|(index, dpu_id)| {
+            let substate = if index == 0 {
+                DpfState::WaitingForReady { phase_detail: None }
+            } else {
+                DpfState::Reprovisioning
+            };
+            (*dpu_id, ReprovisionState::DpfStates { substate })
+        })
+        .collect();
+    write_host_state(
+        pool,
+        &mh.id,
+        &ManagedHostState::DPUReprovision {
+            dpu_states: DpuReprovisionStates { states },
+        },
+    )
+    .await;
 }
 
 /// Reprovisioning handler: `DpfState::Reprovisioning` transitions the DPU
@@ -500,48 +743,12 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
     )
     .await;
 
-    let mut txn = pool.begin().await.unwrap();
-    let rack_id = TestRackDbBuilder::new()
-        .with_rack_profile_id(TEST_RMS_RACK_PROFILE_ID)
-        .persist(txn.as_mut())
-        .await
-        .unwrap();
-    txn.commit().await.unwrap();
-
     let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
         .await
         .expect("timed out during initial provisioning");
 
     // Give the host a GB200 rack and both DPUs the supported B3240 identity.
-    let mut txn = pool.begin().await.unwrap();
-    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
-        .bind(rack_id.as_str())
-        .bind(mh.id)
-        .execute(txn.as_mut())
-        .await
-        .unwrap();
-    for dpu_id in &mh.dpu_ids {
-        let dpu = db::machine::find_one(txn.as_mut(), dpu_id, Default::default())
-            .await
-            .unwrap()
-            .unwrap();
-        let mut hardware_info = dpu
-            .status
-            .hardware_info
-            .expect("fixture DPU should have hardware information");
-        hardware_info
-            .dpu_info
-            .as_mut()
-            .expect("fixture DPU should have DPU information")
-            .part_number = "900-9D3B6-00CN-PA0".to_string();
-        db::machine_topology::set_topology_update_needed(txn.as_mut(), dpu_id, true)
-            .await
-            .unwrap();
-        db::machine_topology::create_or_update(txn.as_mut(), dpu_id, &hardware_info)
-            .await
-            .unwrap();
-    }
-    txn.commit().await.unwrap();
+    configure_gb200_b3240_host(&pool, &mh).await;
 
     // Ignore initial ingestion and observe one complete host deployment selection pass.
     classified_dpus.lock().unwrap().clear();
@@ -566,6 +773,556 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
     assert_eq!(
         *registered_deployments.lock().unwrap(),
         vec![DpuDeploymentType::Bf3Gb200]
+    );
+}
+
+/// A DPF-ingested GB200 host remains reprovisionable when runtime DPF support
+/// is disabled and no SDK is installed.
+#[crate::sqlx_test]
+async fn test_runtime_dpf_disable_skips_deployment_migration_probe(pool: sqlx::PgPool) {
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(source_deployment_mock(1))),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    mh.mark_machine_for_updates().await;
+
+    let mut disabled_config = get_config_with_rack_profiles();
+    disabled_config.dpf.enabled = false;
+    let disabled_api = TestApiBuilder::new(
+        env.pool.clone(),
+        env.api.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+    )
+    .with_runtime_config(Arc::new(disabled_config))
+    .build();
+    assert!(disabled_api.dpf_sdk.is_none());
+
+    disabled_api
+        .trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: None,
+                machine_id: mh.id.into(),
+                mode: Mode::Set as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await
+        .expect("runtime DPF disable must skip the deployment migration probe");
+
+    let mut txn = pool.begin().await.unwrap();
+    assert!(
+        mh.dpu_n(0)
+            .db_machine(&mut txn)
+            .await
+            .reprovision_requested
+            .is_some(),
+        "the request must persist without a DPF SDK"
+    );
+    txn.commit().await.unwrap();
+}
+
+/// A GB200 deployment migration rejects a request for one DPU, then proceeds
+/// when a host request includes every attached DPU.
+#[crate::sqlx_test]
+async fn test_gb200_deployment_migration_requires_every_dpu(pool: sqlx::PgPool) {
+    let node_uses_target_labels = Arc::new(AtomicBool::new(false));
+    let target_dpu_phase = Arc::new(AtomicUsize::new(0));
+    let released_holds = Arc::new(AtomicUsize::new(0));
+    let transferred_deployments = Arc::new(Mutex::new(Vec::new()));
+    let deleted_source_devices = Arc::new(Mutex::new(Vec::new()));
+
+    let mut mock = MockDpfOperations::new();
+    mock.expect_register_dpu_device().returning(|_, _| Ok(()));
+    mock.expect_register_dpu_node().returning(|_| Ok(()));
+    let released_holds_for_mock = released_holds.clone();
+    mock.expect_release_maintenance_hold().returning(move |_| {
+        released_holds_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_, _| Ok(DpuDeploymentType::Bf3));
+    let node_uses_target_labels_for_verify = node_uses_target_labels.clone();
+    mock.expect_verify_node_labels()
+        .returning(move |_, deployment| {
+            let expected = if node_uses_target_labels_for_verify.load(Ordering::SeqCst) {
+                DpuDeploymentType::Bf3Gb200
+            } else {
+                DpuDeploymentType::Bf3
+            };
+            Ok(deployment == expected)
+        });
+    mock.expect_snapshot_host()
+        .returning(|_| Ok(snapshot_with_crs_present(2)));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+    let target_dpu_phase_for_mock = target_dpu_phase.clone();
+    mock.expect_get_dpu_phases_for_deployment_type().returning(
+        move |device_names, _, deployment_type| {
+            assert_eq!(deployment_type, DpuDeploymentType::Bf3Gb200);
+            match target_dpu_phase_for_mock.load(Ordering::SeqCst) {
+                0 => Ok(None),
+                1 => Ok(Some(
+                    device_names
+                        .iter()
+                        .map(|name| {
+                            (
+                                name.clone(),
+                                DpuPhase::Provisioning("OsInstalling".to_string()),
+                            )
+                        })
+                        .collect::<BTreeMap<_, _>>(),
+                )),
+                2 => Ok(Some(
+                    device_names
+                        .iter()
+                        .map(|name| (name.clone(), DpuPhase::Ready))
+                        .collect::<BTreeMap<_, _>>(),
+                )),
+                _ => Err(DpfError::InvalidState(
+                    "target DPU has the wrong flavor".to_string(),
+                )),
+            }
+        },
+    );
+    let transferred_deployments_for_mock = transferred_deployments.clone();
+    mock.expect_transfer_dpu_node_deployment_labels()
+        .returning(move |_, source, target| {
+            let mut transfers = transferred_deployments_for_mock.lock().unwrap();
+            transfers.push((source, target));
+            node_uses_target_labels.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+    let deleted_source_devices_for_mock = deleted_source_devices.clone();
+    mock.expect_delete_source_dpus_for_deployment_migration()
+        .returning(move |device_names, _, source, target| {
+            assert_eq!(source, DpuDeploymentType::Bf3);
+            assert_eq!(target, DpuDeploymentType::Bf3Gb200);
+            *deleted_source_devices_for_mock.lock().unwrap() = device_names.to_vec();
+            Ok(())
+        });
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    let released_holds_before_migration = released_holds.load(Ordering::SeqCst);
+
+    mh.mark_machine_for_updates().await;
+    let partial_request_error = env
+        .api
+        .trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: None,
+                machine_id: mh.dpu_ids[0].into(),
+                mode: Mode::Set as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await;
+    let partial_request_error =
+        partial_request_error.expect_err("a request for one DPU must be rejected");
+    assert_eq!(
+        partial_request_error.code(),
+        tonic::Code::FailedPrecondition
+    );
+    assert!(
+        partial_request_error.message().contains(&mh.id.to_string()),
+        "the rejection must identify the request using the host ID that can migrate the full DPU set"
+    );
+
+    assert!(
+        matches!(get_host_state(&env, &mh).await, ManagedHostState::Ready),
+        "a rejected partial request must not change the host state"
+    );
+    assert!(transferred_deployments.lock().unwrap().is_empty());
+    assert!(deleted_source_devices.lock().unwrap().is_empty());
+
+    let mut txn = pool.begin().await.unwrap();
+    let first_request = mh.dpu_n(0).db_machine(&mut txn).await.reprovision_requested;
+    assert!(first_request.is_none());
+    assert!(
+        mh.dpu_n(1)
+            .db_machine(&mut txn)
+            .await
+            .reprovision_requested
+            .is_none()
+    );
+    txn.commit().await.unwrap();
+
+    mh.host().trigger_dpu_reprovisioning(Mode::Set, true).await;
+
+    let partial_clear_error = env
+        .api
+        .trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: None,
+                machine_id: mh.dpu_ids[0].into(),
+                mode: Mode::Clear as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await
+        .expect_err("clearing one DPU from a complete migration request must be rejected");
+    assert_eq!(partial_clear_error.code(), tonic::Code::FailedPrecondition);
+
+    let mut txn = pool.begin().await.unwrap();
+    for dpu_index in 0..mh.dpu_ids.len() {
+        assert!(
+            mh.dpu_n(dpu_index)
+                .db_machine(&mut txn)
+                .await
+                .reprovision_requested
+                .is_some(),
+            "a rejected partial clear must preserve every migration request"
+        );
+    }
+    txn.commit().await.unwrap();
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while starting the complete DPU set");
+
+    let started_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            started_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(
+                        state,
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::Reprovisioning
+                        }
+                    )
+                })
+        ),
+        "the host request must start every DPU in the source deployment: {started_state:?}"
+    );
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while parking deployment migration");
+
+    let parked_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            &parked_state,
+            ManagedHostState::DPUReprovision { dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(state, ReprovisionState::NotUnderReprovision)
+                })
+        ),
+        "the complete DPU set must be parked before changing selectors: {parked_state:?}"
+    );
+    assert!(transferred_deployments.lock().unwrap().is_empty());
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during deployment migration");
+
+    let migrated_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            migrated_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(state, ReprovisionState::NotUnderReprovision)
+                })
+        ),
+        "the migration must remain parked until every target DPU is observed: {migrated_state:?}"
+    );
+    assert_eq!(
+        *transferred_deployments.lock().unwrap(),
+        vec![(DpuDeploymentType::Bf3, DpuDeploymentType::Bf3Gb200)]
+    );
+    let expected_devices = dpu_device_names(&pool, &mh).await;
+    assert_eq!(
+        deleted_source_devices
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>(),
+        expected_devices
+    );
+
+    // A source DPU can briefly retain the deterministic name after the
+    // selector changes. Keep the complete set parked until target ownership
+    // is observed for every DPU in one snapshot.
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while checking a stale source DPU");
+
+    let stale_source_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            stale_source_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(state, ReprovisionState::NotUnderReprovision)
+                })
+        ),
+        "source ownership must keep every DPU parked: {stale_source_state:?}"
+    );
+    assert_eq!(
+        released_holds.load(Ordering::SeqCst),
+        released_holds_before_migration,
+        "a DPU owned by the source must not release the target deployment's hold"
+    );
+
+    target_dpu_phase.store(3, Ordering::SeqCst);
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while checking target deployment configuration drift");
+
+    let mismatched_target_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            &mismatched_target_state,
+            ManagedHostState::Failed { details, .. }
+                if matches!(
+                    &details.cause,
+                    FailureCause::DpfProvisioning { err }
+                        if err.contains("target DPU has the wrong flavor")
+                )
+        ),
+        "a Ready target DPU with configuration drift must fail visibly: {mismatched_target_state:?}"
+    );
+    assert_eq!(
+        released_holds.load(Ordering::SeqCst),
+        released_holds_before_migration,
+        "a mismatched target DPU must not release the maintenance hold"
+    );
+
+    // Restore the parked checkpoint to continue exercising the successful path.
+    write_host_state(&pool, &mh.id, &parked_state).await;
+
+    target_dpu_phase.store(1, Ordering::SeqCst);
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while checking target deployment provisioning");
+
+    let target_provisioning_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            target_provisioning_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(
+                        state,
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::WaitingForReady { .. }
+                        }
+                    )
+                })
+        ),
+        "observing the complete target set must move every DPU to WaitingForReady: {target_provisioning_state:?}"
+    );
+    assert_eq!(
+        released_holds.load(Ordering::SeqCst),
+        released_holds_before_migration,
+        "changing the durable migration marker must not release the maintenance hold"
+    );
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while processing target deployment provisioning");
+
+    let target_provisioning_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            target_provisioning_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(
+                        state,
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::WaitingForReady { .. }
+                        }
+                    )
+                })
+        ),
+        "target provisioning must remain in WaitingForReady: {target_provisioning_state:?}"
+    );
+    assert_eq!(
+        released_holds.load(Ordering::SeqCst),
+        released_holds_before_migration + 1,
+        "a target DPU may release the shared maintenance hold while provisioning"
+    );
+
+    target_dpu_phase.store(2, Ordering::SeqCst);
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while checking the target deployment");
+
+    let progressing_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            progressing_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().any(|state| {
+                    matches!(
+                        state,
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::DeviceReady
+                        }
+                    )
+                })
+        ),
+        "the target deployment labels must let reprovisioning continue: {progressing_state:?}"
+    );
+}
+
+/// A partial request started before the migration gate was rolled
+/// out continues under its current deployment instead of entering a terminal
+/// migration failure.
+#[crate::sqlx_test]
+async fn test_started_partial_migration_continues_under_source_deployment(pool: sqlx::PgPool) {
+    let reprovisioned_devices = Arc::new(Mutex::new(Vec::new()));
+    let mut mock = source_deployment_mock(2);
+    let reprovisioned_devices_for_mock = reprovisioned_devices.clone();
+    mock.expect_reprovision_dpu()
+        .times(1)
+        .returning(move |device_name, _| {
+            reprovisioned_devices_for_mock
+                .lock()
+                .unwrap()
+                .push(device_name.to_string());
+            Ok(())
+        });
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    set_started_partial_dpf_reprovision(&pool, &mh, 0).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while continuing the source deployment");
+
+    let waiting_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            waiting_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if matches!(
+                    dpu_states.states.get(&mh.dpu_ids[0]),
+                    Some(ReprovisionState::DpfStates {
+                        substate: DpfState::WaitingForReady { .. }
+                    })
+                ) && matches!(
+                    dpu_states.states.get(&mh.dpu_ids[1]),
+                    Some(ReprovisionState::NotUnderReprovision)
+                )
+        ),
+        "the DPU already being reprovisioned must continue without moving the shared selector: {waiting_state:?}"
+    );
+    assert_eq!(reprovisioned_devices.lock().unwrap().len(), 1);
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while accepting source deployment readiness");
+
+    let ready_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            ready_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if matches!(
+                    dpu_states.states.get(&mh.dpu_ids[0]),
+                    Some(ReprovisionState::DpfStates {
+                        substate: DpfState::DeviceReady
+                    })
+                ) && matches!(
+                    dpu_states.states.get(&mh.dpu_ids[1]),
+                    Some(ReprovisionState::NotUnderReprovision)
+                )
+        ),
+        "source labels must remain valid until the existing request finishes: {ready_state:?}"
+    );
+}
+
+/// A complete request already advanced by an older controller finishes under
+/// BF3 instead of failing when its DPU states are no longer synchronized at the
+/// migration handoff.
+#[crate::sqlx_test]
+async fn test_started_complete_migration_with_progress_continues_under_source_deployment(
+    pool: sqlx::PgPool,
+) {
+    let mut mock = source_deployment_mock(2);
+    mock.expect_reprovision_dpu().returning(|_, _| Ok(()));
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    set_started_complete_dpf_reprovision_with_progress(&pool, &mh).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while continuing the progressed request under BF3");
+
+    let state = get_host_state(&env, &mh).await;
+    let ManagedHostState::DPUReprovision { ref dpu_states } = state else {
+        panic!("an existing request must remain in DPUReprovision under BF3: {state:?}");
+    };
+    let stayed_in_dpf = dpu_states
+        .states
+        .values()
+        .all(|dpu_state| matches!(dpu_state, ReprovisionState::DpfStates { .. }));
+    let reached_device_ready = dpu_states.states.values().any(|dpu_state| {
+        matches!(
+            dpu_state,
+            ReprovisionState::DpfStates {
+                substate: DpfState::DeviceReady
+            }
+        )
+    });
+    let still_reprovisioning = dpu_states.states.values().any(|dpu_state| {
+        matches!(
+            dpu_state,
+            ReprovisionState::DpfStates {
+                substate: DpfState::Reprovisioning
+            }
+        )
+    });
+
+    assert!(
+        stayed_in_dpf && (reached_device_ready || !still_reprovisioning),
+        "an existing request must make progress under BF3 without entering the migration handoff: {state:?}"
     );
 }
 

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1645,14 +1645,19 @@ impl ManagedHostState {
         Self::Maintenance { operation }
     }
 
-    pub fn as_reprovision_state(&self, dpu_id: &MachineId) -> Option<&ReprovisionState> {
+    /// Returns the DPU reprovision states embedded in either host allocation mode.
+    pub fn dpu_reprovision_states(&self) -> Option<&DpuReprovisionStates> {
         match self {
-            ManagedHostState::DPUReprovision { dpu_states } => dpu_states.states.get(dpu_id),
-            ManagedHostState::Assigned {
+            ManagedHostState::DPUReprovision { dpu_states }
+            | ManagedHostState::Assigned {
                 instance_state: InstanceState::DPUReprovision { dpu_states },
-            } => dpu_states.states.get(dpu_id),
+            } => Some(dpu_states),
             _ => None,
         }
+    }
+
+    pub fn as_reprovision_state(&self, dpu_id: &MachineId) -> Option<&ReprovisionState> {
+        self.dpu_reprovision_states()?.states.get(dpu_id)
     }
 
     pub fn suppress_dpu_alerts(&self) -> bool {

--- a/crates/dpf/src/repository/kube.rs
+++ b/crates/dpf/src/repository/kube.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::StreamExt;
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
-use kube::api::{ListParams, Patch, PatchParams, PostParams};
+use kube::api::{DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions};
 use kube::runtime::controller::Action;
 use kube::runtime::{Controller, watcher};
 use kube::{Api, Client, Resource};
@@ -183,6 +183,19 @@ impl DpuRepository for KubeRepository {
     async fn delete(&self, name: &str, namespace: &str) -> Result<(), DpfError> {
         let api: Api<DPU> = self.api(namespace);
         api.delete(name, &Default::default()).await?;
+        Ok(())
+    }
+
+    async fn delete_if_uid(&self, name: &str, namespace: &str, uid: &str) -> Result<(), DpfError> {
+        let api: Api<DPU> = self.api(namespace);
+        let params = DeleteParams {
+            preconditions: Some(Preconditions {
+                uid: Some(uid.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        api.delete(name, &params).await?;
         Ok(())
     }
 

--- a/crates/dpf/src/repository/traits.rs
+++ b/crates/dpf/src/repository/traits.rs
@@ -83,6 +83,12 @@ pub trait DpuRepository: Send + Sync {
     ) -> Result<(), DpfError>;
     async fn delete(&self, name: &str, namespace: &str) -> Result<(), DpfError>;
 
+    /// Delete a DPU only when its Kubernetes UID matches `uid`.
+    ///
+    /// The UID check must be part of the delete operation so a DPU recreated
+    /// under the same name cannot be deleted using an earlier observation.
+    async fn delete_if_uid(&self, name: &str, namespace: &str, uid: &str) -> Result<(), DpfError>;
+
     /// Watch for DPU changes and invoke the handler for each object.
     ///
     /// The returned future runs until the watch is cancelled. The handler's

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -2563,6 +2563,90 @@ impl<R: DpuNodeRepository, L: ResourceLabeler> DpfSdk<R, L> {
         }))
     }
 
+    /// Moves one DPUNode from its source DPUDeployment selector to its target
+    /// selector.
+    ///
+    /// Labels shared by both deployments and labels outside either selector
+    /// are preserved. The transfer uses the DPUNode's `resourceVersion`, so a
+    /// concurrent update returns a Kubernetes conflict instead of being
+    /// overwritten. Repeating a completed transfer does nothing. A DPUNode that
+    /// matches neither selector is rejected rather than assigned to the target
+    /// deployment.
+    pub async fn transfer_dpu_node_deployment_labels(
+        &self,
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError> {
+        let node = DpuNodeRepository::get(&*self.repo, node_name, &self.namespace)
+            .await?
+            .ok_or_else(|| DpfError::not_found("DPUNode", node_name))?;
+        let source_labels = self
+            .labeler
+            .node_labels_for_deployment_type(source_deployment_type)?;
+        let target_labels = self
+            .labeler
+            .node_labels_for_deployment_type(target_deployment_type)?;
+        if source_labels.is_empty() || target_labels.is_empty() || source_labels == target_labels {
+            return Err(DpfError::ConfigError(format!(
+                "deployment label transfer requires distinct, nonempty selectors for \
+                 {source_deployment_type:?} and {target_deployment_type:?}"
+            )));
+        }
+        let current_labels = node.metadata.labels.unwrap_or_default();
+        let matches_selector = |selector: &BTreeMap<String, String>| {
+            selector
+                .iter()
+                .all(|(key, value)| current_labels.get(key) == Some(value))
+        };
+        let matches_source = matches_selector(&source_labels);
+        let matches_target = matches_selector(&target_labels);
+        if !matches_source && !matches_target {
+            return Err(DpfError::InvalidState(format!(
+                "DPUNode {node_name} labels match neither the {source_deployment_type:?} nor the \
+                 {target_deployment_type:?} deployment selector"
+            )));
+        }
+
+        let has_source_only_label = source_labels
+            .keys()
+            .any(|key| !target_labels.contains_key(key) && current_labels.contains_key(key));
+        let target_selector_differs = target_labels
+            .iter()
+            .any(|(key, value)| current_labels.get(key) != Some(value));
+        if !has_source_only_label && !target_selector_differs {
+            return Ok(());
+        }
+
+        let resource_version = node.metadata.resource_version.ok_or_else(|| {
+            DpfError::InvalidState(format!(
+                "DPUNode {node_name} has no resourceVersion for deployment label transfer"
+            ))
+        })?;
+        let mut label_changes: serde_json::Map<String, serde_json::Value> = source_labels
+            .keys()
+            .filter(|key| !target_labels.contains_key(*key))
+            .map(|key| (key.clone(), serde_json::Value::Null))
+            .collect();
+        label_changes.extend(
+            target_labels
+                .into_iter()
+                .map(|(key, value)| (key, serde_json::Value::String(value))),
+        );
+
+        // The transfer must not leave the DPUNode matching both deployment
+        // selectors. One merge patch makes the removal and addition atomic,
+        // while `resourceVersion` prevents this read from overwriting a
+        // concurrent DPUNode update.
+        let patch = json!({
+            "metadata": {
+                "resourceVersion": resource_version,
+                "labels": label_changes,
+            }
+        });
+        DpuNodeRepository::patch(&*self.repo, node_name, &self.namespace, patch).await
+    }
+
     /// Check if reboot is required for a DPU node.
     pub async fn is_reboot_required(&self, node_name: &str) -> Result<bool, DpfError> {
         let node = DpuNodeRepository::get(&*self.repo, node_name, &self.namespace).await?;
@@ -2638,7 +2722,9 @@ impl<R: DpuRepository, L> DpfSdk<R, L> {
     ///
     /// In the DPUDeployment (M4) model the operator creates DPU from DPUDevice; deleting the DPU
     /// CR causes the operator to remove it and create a new DPU (same name) that waits on node
-    /// effect. The DPUDevice CR is left in place.
+    /// effect. The DPUDevice CR is left in place. A missing DPU CR means deletion is already
+    /// complete. Treating that as success keeps retries safe when an earlier attempt deleted the
+    /// DPU but did not persist its next state, and when a DPUSet deletes it during label transfer.
     pub async fn reprovision_dpu(
         &self,
         dpu_device_name: &str,
@@ -2646,7 +2732,187 @@ impl<R: DpuRepository, L> DpfSdk<R, L> {
     ) -> Result<(), DpfError> {
         let dpf_id = node_id_from_dpu_node_cr_name(node_name);
         let cr_name = dpu_cr_name(dpu_device_name, dpf_id);
-        DpuRepository::delete(&*self.repo, &cr_name, &self.namespace).await
+        match DpuRepository::delete(&*self.repo, &cr_name, &self.namespace).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.is_not_found() => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+impl<R: DpuRepository + DpuDeploymentRepository, L: ResourceLabeler> DpfSdk<R, L> {
+    /// Read every requested DPU phase only when one deployment owns the full set.
+    ///
+    /// A DPU that is not Ready may not report its installed BFB yet, so ownership
+    /// is sufficient until that phase. A Ready DPU must also match the flavor and
+    /// provisioning source declared by the deployment. `None` means at least one
+    /// requested DPU is missing, is being deleted, belongs to another deployment,
+    /// has no status yet, or does not match the Ready configuration.
+    pub async fn get_dpu_phases_for_deployment_type(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<Option<BTreeMap<String, DpuPhase>>, DpfError> {
+        let (deployment_name, deployment) = self.deployment_for_type(deployment_type).await?;
+        if !dpu_deployment_is_ready(&deployment) {
+            return Ok(None);
+        }
+        if deployment.spec.dpus.flavor.is_none() {
+            return Err(DpfError::InvalidState(format!(
+                "DPUDeployment {deployment_name} uses a DPUFlavorTemplate, which cannot be \
+                 compared with DPU.spec.dpuFlavor"
+            )));
+        }
+
+        let expected_owner = dpu_deployment_owner_label_value(&self.namespace, &deployment_name);
+        let owner_selector = format!("{DPU_OWNED_BY_DEPLOYMENT_LABEL}={expected_owner}");
+        let dpf_id = node_id_from_dpu_node_cr_name(node_name);
+        let mut dpus_by_name =
+            DpuRepository::list(&*self.repo, &self.namespace, Some(&owner_selector))
+                .await?
+                .into_iter()
+                .filter_map(|dpu| Some((dpu.metadata.name.clone()?, dpu)))
+                .collect::<HashMap<_, _>>();
+        let mut phases = BTreeMap::new();
+
+        for dpu_device_name in dpu_device_names {
+            let cr_name = dpu_cr_name(dpu_device_name, dpf_id);
+            let Some(dpu) = dpus_by_name.remove(&cr_name) else {
+                return Ok(None);
+            };
+            let has_expected_owner = dpu
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(DPU_OWNED_BY_DEPLOYMENT_LABEL))
+                == Some(&expected_owner);
+            if !has_expected_owner || dpu.metadata.deletion_timestamp.is_some() {
+                return Ok(None);
+            }
+
+            let Some(status) = dpu.status.as_ref() else {
+                return Ok(None);
+            };
+            let phase = DpuPhase::from(status.phase.clone());
+            if phase == DpuPhase::Ready {
+                match dpu_comparison(&self.namespace, &dpu, &deployment) {
+                    DpuComparison::Match => {}
+                    DpuComparison::Mismatch(mismatch) => {
+                        return Err(DpfError::InvalidState(format!(
+                            "Ready DPU {} does not match DPUDeployment {deployment_name}; expected provisioning source {}",
+                            mismatch.dpu_cr_name, mismatch.target_source,
+                        )));
+                    }
+                    DpuComparison::Inconclusive => {
+                        return Err(DpfError::InvalidState(format!(
+                            "DPU {cr_name} cannot be compared with DPUDeployment {deployment_name}"
+                        )));
+                    }
+                }
+            }
+            phases.insert(dpu_device_name.clone(), phase);
+        }
+
+        Ok(Some(phases))
+    }
+
+    /// Delete source deployment DPU CRs without deleting target replacements.
+    ///
+    /// Each delete carries the observed DPU UID as a Kubernetes precondition.
+    /// If a source DPU disappears and a target DPU reuses its deterministic name,
+    /// a retry preserves the replacement. A DPU owned by any deployment other
+    /// than the declared source or target is rejected.
+    pub async fn delete_source_dpus_for_deployment_migration(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError> {
+        let (source_deployment_name, _) = self.deployment_for_type(source_deployment_type).await?;
+        let (target_deployment_name, _) = self.deployment_for_type(target_deployment_type).await?;
+        let source_owner =
+            dpu_deployment_owner_label_value(&self.namespace, &source_deployment_name);
+        let target_owner =
+            dpu_deployment_owner_label_value(&self.namespace, &target_deployment_name);
+        let dpf_id = node_id_from_dpu_node_cr_name(node_name);
+        let mut dpus_by_name = DpuRepository::list(&*self.repo, &self.namespace, None)
+            .await?
+            .into_iter()
+            .filter_map(|dpu| Some((dpu.metadata.name.clone()?, dpu)))
+            .collect::<HashMap<_, _>>();
+
+        for dpu_device_name in dpu_device_names {
+            let cr_name = dpu_cr_name(dpu_device_name, dpf_id);
+            let Some(dpu) = dpus_by_name.remove(&cr_name) else {
+                continue;
+            };
+            let owner = dpu
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(DPU_OWNED_BY_DEPLOYMENT_LABEL));
+            if owner == Some(&target_owner) {
+                continue;
+            }
+            if owner != Some(&source_owner) {
+                return Err(DpfError::InvalidState(format!(
+                    "DPU {cr_name} is owned by neither DPUDeployment \
+                     {source_deployment_name} nor {target_deployment_name}"
+                )));
+            }
+            let uid = dpu.metadata.uid.as_deref().ok_or_else(|| {
+                DpfError::InvalidState(format!(
+                    "DPU {cr_name} has no UID for deployment migration deletion"
+                ))
+            })?;
+            match DpuRepository::delete_if_uid(&*self.repo, &cr_name, &self.namespace, uid).await {
+                Ok(()) => {}
+                Err(error) if error.is_not_found() => {}
+                Err(error) => return Err(error),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Find the one live DPUDeployment whose DPUSet selects a deployment type.
+    async fn deployment_for_type(
+        &self,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<(String, DPUDeployment), DpfError> {
+        let required_labels = self
+            .labeler
+            .node_labels_for_deployment_type(deployment_type)?;
+        if required_labels.is_empty() {
+            return Err(DpfError::ConfigError(format!(
+                "DPUDeployment selector for {deployment_type:?} is empty"
+            )));
+        }
+
+        let deployments = DpuDeploymentRepository::list(&*self.repo, &self.namespace).await?;
+        let mut matching_deployments = deployments.into_iter().filter(|deployment| {
+            deployment.metadata.deletion_timestamp.is_none()
+                && dpu_deployment_selects_labels(deployment, &required_labels)
+        });
+        let deployment = matching_deployments.next().ok_or_else(|| {
+            DpfError::InvalidState(format!(
+                "no DPUDeployment selects {deployment_type:?} DPU nodes"
+            ))
+        })?;
+        if matching_deployments.next().is_some() {
+            return Err(DpfError::InvalidState(format!(
+                "multiple DPUDeployments select {deployment_type:?} DPU nodes"
+            )));
+        }
+        let deployment_name = deployment.metadata.name.clone().ok_or_else(|| {
+            DpfError::InvalidState(format!(
+                "DPUDeployment selecting {deployment_type:?} DPU nodes has no name"
+            ))
+        })?;
+
+        Ok((deployment_name, deployment))
     }
 }
 
@@ -2914,6 +3180,32 @@ fn dpu_deployment_is_ready(d: &DPUDeployment) -> bool {
         return false;
     };
     cond.status == "True" && cond.observed_generation == Some(generation)
+}
+
+/// Returns true when one DPUSet in a deployment contains every required
+/// DPUNode selector label.
+fn dpu_deployment_selects_labels(
+    deployment: &DPUDeployment,
+    required_labels: &BTreeMap<String, String>,
+) -> bool {
+    deployment
+        .spec
+        .dpus
+        .dpu_sets
+        .as_ref()
+        .is_some_and(|dpu_sets| {
+            dpu_sets.iter().any(|dpu_set| {
+                dpu_set
+                    .dpu_node_selector
+                    .as_ref()
+                    .and_then(|selector| selector.match_labels.as_ref())
+                    .is_some_and(|labels| {
+                        required_labels
+                            .iter()
+                            .all(|(key, value)| labels.get(key) == Some(value))
+                    })
+            })
+        })
 }
 
 /// True when a condition's `observedGeneration` matches the object's. Either
@@ -3981,6 +4273,14 @@ mod tests {
         )))
     }
 
+    /// Builds the Kubernetes response returned for an already absent resource.
+    fn not_found_error(name: &str) -> DpfError {
+        DpfError::KubeError(kube::Error::Api(Box::new(
+            kube::core::Status::failure(&format!("{name} was not found"), "NotFound")
+                .with_code(404),
+        )))
+    }
+
     const TEST_NAMESPACE: &str = "test-namespace";
 
     #[test]
@@ -4142,6 +4442,8 @@ mod tests {
         flavor_templates: Arc<RwLock<BTreeMap<String, DPUFlavorTemplate>>>,
         services: Arc<RwLock<BTreeMap<String, DPUService>>>,
         service_patch: Arc<RwLock<Option<(String, String, serde_json::Value)>>>,
+        node_patches: Arc<RwLock<Vec<serde_json::Value>>>,
+        dpu_delete_error: Arc<RwLock<Option<DpfError>>>,
     }
 
     impl SdkMock {
@@ -4333,6 +4635,8 @@ mod tests {
             ns: &str,
             patch: serde_json::Value,
         ) -> Result<(), DpfError> {
+            self.node_patches.write().unwrap().push(patch.clone());
+
             if let Some(node) = self.nodes.write().unwrap().get_mut(&Self::ns_key(ns, name)) {
                 if let Some(annos) = patch
                     .pointer("/metadata/annotations")
@@ -4402,8 +4706,26 @@ mod tests {
             Ok(())
         }
         async fn delete(&self, name: &str, ns: &str) -> Result<(), DpfError> {
+            if let Some(error) = self.dpu_delete_error.write().unwrap().take() {
+                return Err(error);
+            }
             self.dpus.write().unwrap().remove(&Self::ns_key(ns, name));
             Ok(())
+        }
+        async fn delete_if_uid(&self, name: &str, ns: &str, uid: &str) -> Result<(), DpfError> {
+            let current_uid = self
+                .dpus
+                .read()
+                .unwrap()
+                .get(&Self::ns_key(ns, name))
+                .map(|dpu| dpu.metadata.uid.clone())
+                .ok_or_else(|| not_found_error(name))?;
+            if current_uid.as_deref() != Some(uid) {
+                return Err(DpfError::InvalidState(format!(
+                    "DPU {name} UID changed before deletion"
+                )));
+            }
+            DpuRepository::delete(self, name, ns).await
         }
         fn watch<F, Fut>(
             &self,
@@ -4789,6 +5111,209 @@ mod tests {
         }
     }
 
+    /// Supplies selectors with one shared label and one label unique to each
+    /// deployment so transfer tests can distinguish both responsibilities.
+    struct DeploymentTransferLabeler;
+
+    impl ResourceLabeler for DeploymentTransferLabeler {
+        fn node_labels_for_deployment_type(
+            &self,
+            deployment_type: DpuDeploymentType,
+        ) -> Result<BTreeMap<String, String>, crate::DpfError> {
+            let deployment_label = match deployment_type {
+                DpuDeploymentType::Bf3 => "test/deployment-bf3",
+                DpuDeploymentType::Bf3Gb200 => "test/deployment-bf3gb200",
+                DpuDeploymentType::Bf4Generic => "test/deployment-bf4",
+                DpuDeploymentType::Bf4Astra => "test/deployment-astra",
+            };
+            Ok(BTreeMap::from([
+                ("test/shared".to_string(), "true".to_string()),
+                (deployment_label.to_string(), "true".to_string()),
+            ]))
+        }
+    }
+
+    /// Builds the existing DPUNode used to exercise a deployment label
+    /// transfer without involving registration behavior.
+    fn dpu_node_for_deployment_transfer() -> DPUNode {
+        DPUNode {
+            metadata: ObjectMeta {
+                name: Some("node-host-001".to_string()),
+                namespace: Some(TEST_NAMESPACE.to_string()),
+                resource_version: Some("7".to_string()),
+                labels: Some(BTreeMap::from([
+                    ("test/shared".to_string(), "true".to_string()),
+                    ("test/deployment-bf3".to_string(), "true".to_string()),
+                    ("test/host".to_string(), "host-001".to_string()),
+                    ("external/label".to_string(), "preserved".to_string()),
+                ])),
+                ..Default::default()
+            },
+            spec: DpuNodeSpec {
+                dpus: Some(vec![]),
+                node_dms_address: None,
+                node_reboot_method: None,
+            },
+            status: None,
+        }
+    }
+
+    /// A deployment transfer removes only the source selector, adds the target
+    /// selector, and leaves shared, contextual, and outside labels untouched.
+    #[tokio::test]
+    async fn deployment_label_transfer_is_idempotent_and_preserves_other_labels() {
+        let mock = SdkMock::new();
+        let node = dpu_node_for_deployment_transfer();
+        mock.nodes
+            .write()
+            .unwrap()
+            .insert(SdkMock::key(&node), node);
+        let sdk = DpfSdkBuilder::new(mock.clone(), TEST_NAMESPACE, String::new())
+            .with_labeler(DeploymentTransferLabeler)
+            .build_without_resources()
+            .await
+            .unwrap();
+
+        sdk.transfer_dpu_node_deployment_labels(
+            "node-host-001",
+            DpuDeploymentType::Bf3,
+            DpuDeploymentType::Bf3Gb200,
+        )
+        .await
+        .unwrap();
+
+        let node = mock
+            .nodes
+            .read()
+            .unwrap()
+            .get(&SdkMock::ns_key(TEST_NAMESPACE, "node-host-001"))
+            .cloned()
+            .unwrap();
+        assert_eq!(
+            node.metadata.labels,
+            Some(BTreeMap::from([
+                ("test/shared".to_string(), "true".to_string()),
+                ("test/deployment-bf3gb200".to_string(), "true".to_string()),
+                ("test/host".to_string(), "host-001".to_string()),
+                ("external/label".to_string(), "preserved".to_string()),
+            ]))
+        );
+        assert_eq!(
+            mock.node_patches.read().unwrap()[0]
+                .pointer("/metadata/resourceVersion")
+                .and_then(serde_json::Value::as_str),
+            Some("7")
+        );
+
+        sdk.transfer_dpu_node_deployment_labels(
+            "node-host-001",
+            DpuDeploymentType::Bf3,
+            DpuDeploymentType::Bf3Gb200,
+        )
+        .await
+        .unwrap();
+        assert_eq!(mock.node_patches.read().unwrap().len(), 1);
+
+        // Repair a node that was left matching both deployments by removing
+        // the source-only selector even though the target already matches.
+        mock.nodes
+            .write()
+            .unwrap()
+            .get_mut(&SdkMock::ns_key(TEST_NAMESPACE, "node-host-001"))
+            .unwrap()
+            .metadata
+            .labels
+            .as_mut()
+            .unwrap()
+            .insert("test/deployment-bf3".to_string(), "true".to_string());
+        sdk.transfer_dpu_node_deployment_labels(
+            "node-host-001",
+            DpuDeploymentType::Bf3,
+            DpuDeploymentType::Bf3Gb200,
+        )
+        .await
+        .unwrap();
+
+        let node = mock
+            .nodes
+            .read()
+            .unwrap()
+            .get(&SdkMock::ns_key(TEST_NAMESPACE, "node-host-001"))
+            .cloned()
+            .unwrap();
+        assert_eq!(
+            node.metadata.labels,
+            Some(BTreeMap::from([
+                ("test/shared".to_string(), "true".to_string()),
+                ("test/deployment-bf3gb200".to_string(), "true".to_string()),
+                ("test/host".to_string(), "host-001".to_string()),
+                ("external/label".to_string(), "preserved".to_string()),
+            ]))
+        );
+        assert_eq!(mock.node_patches.read().unwrap().len(), 2);
+    }
+
+    /// A DPUNode outside both selectors cannot be claimed by the target
+    /// deployment through the transfer operation.
+    #[tokio::test]
+    async fn deployment_label_transfer_rejects_unrelated_node() {
+        let mock = SdkMock::new();
+        let mut node = dpu_node_for_deployment_transfer();
+        node.metadata.labels = Some(BTreeMap::from([
+            ("test/shared".to_string(), "true".to_string()),
+            ("external/label".to_string(), "preserved".to_string()),
+        ]));
+        mock.nodes
+            .write()
+            .unwrap()
+            .insert(SdkMock::key(&node), node);
+        let sdk = DpfSdkBuilder::new(mock.clone(), TEST_NAMESPACE, String::new())
+            .with_labeler(DeploymentTransferLabeler)
+            .build_without_resources()
+            .await
+            .unwrap();
+
+        let error = sdk
+            .transfer_dpu_node_deployment_labels(
+                "node-host-001",
+                DpuDeploymentType::Bf3,
+                DpuDeploymentType::Bf3Gb200,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, DpfError::InvalidState(_)));
+        assert!(mock.node_patches.read().unwrap().is_empty());
+    }
+
+    /// Empty selectors cannot authorize a deployment transfer, even though an
+    /// empty map would otherwise match every DPUNode.
+    #[tokio::test]
+    async fn deployment_label_transfer_rejects_empty_selectors() {
+        let mock = SdkMock::new();
+        let node = dpu_node_for_deployment_transfer();
+        mock.nodes
+            .write()
+            .unwrap()
+            .insert(SdkMock::key(&node), node);
+        let sdk = DpfSdkBuilder::new(mock.clone(), TEST_NAMESPACE, String::new())
+            .build_without_resources()
+            .await
+            .unwrap();
+
+        let error = sdk
+            .transfer_dpu_node_deployment_labels(
+                "node-host-001",
+                DpuDeploymentType::Bf3,
+                DpuDeploymentType::Bf3Gb200,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, DpfError::ConfigError(_)));
+        assert!(mock.node_patches.read().unwrap().is_empty());
+    }
+
     #[tokio::test]
     async fn test_dpu_device_info_labels() {
         let mock = SdkMock::new();
@@ -5041,6 +5566,54 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(devices.len(), 1, "DPUDevice should remain");
+    }
+
+    /// Reprovision suppresses only the error for a missing DPU so retries are
+    /// safe after the deterministic DPU CR has already been deleted.
+    #[tokio::test]
+    async fn reprovision_dpu_suppresses_only_not_found() {
+        use carbide_test_support::Outcome::{Fails, Yields};
+        use carbide_test_support::{Case, check_cases_async};
+
+        /// Input for checking which DPU deletion errors reprovision suppresses.
+        struct ReprovisionDpuInput {
+            /// Error returned by the mock DPU repository.
+            delete_error: DpfError,
+        }
+
+        let run = |input: ReprovisionDpuInput| async move {
+            let mock = SdkMock::new();
+            *mock.dpu_delete_error.write().unwrap() = Some(input.delete_error);
+            let sdk = DpfSdkBuilder::new(mock, TEST_NAMESPACE, String::new())
+                .build_without_resources()
+                .await
+                .unwrap();
+
+            sdk.reprovision_dpu("dpu-001", "node-host-001")
+                .await
+                .map_err(|error| error.to_string())
+        };
+
+        check_cases_async(
+            [
+                Case {
+                    scenario: "DPU was already deleted",
+                    input: ReprovisionDpuInput {
+                        delete_error: not_found_error("node-host-001-device-dpu-001"),
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "DPU deletion failed",
+                    input: ReprovisionDpuInput {
+                        delete_error: DpfError::InvalidState("delete failed".to_string()),
+                    },
+                    expect: Fails,
+                },
+            ],
+            run,
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/dpf/src/test/helpers.rs
+++ b/crates/dpf/src/test/helpers.rs
@@ -160,6 +160,9 @@ impl DpuRepository for WatcherMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/dpf/src/test/maintenance_flow.rs
+++ b/crates/dpf/src/test/maintenance_flow.rs
@@ -121,6 +121,9 @@ impl DpuRepository for MaintenanceFlowMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -157,6 +157,9 @@ impl DpuRepository for DeviceRegistrationMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_host_snapshot.rs
+++ b/crates/dpf/src/test/sdk_host_snapshot.rs
@@ -124,6 +124,20 @@ impl DpuRepository for SnapshotMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, uid: &str) -> Result<(), DpfError> {
+        let current_uid = self
+            .dpus
+            .get(name)
+            .map(|dpu| dpu.metadata.uid.clone())
+            .ok_or_else(|| DpfError::not_found("DPU", name))?;
+        if current_uid.as_deref() != Some(uid) {
+            return Err(DpfError::InvalidState(format!(
+                "DPU {name} no longer has UID {uid}"
+            )));
+        }
+        self.dpus.remove(name);
+        Ok(())
+    }
     fn watch<F, Fut>(
         &self,
         _namespace: &str,

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -276,6 +276,20 @@ impl DpuRepository for InitializationMock {
         Ok(())
     }
 
+    async fn delete_if_uid(&self, name: &str, ns: &str, uid: &str) -> Result<(), DpfError> {
+        let current_uid = self
+            .dpus
+            .get(&ns_key(ns, name))
+            .map(|dpu| dpu.metadata.uid.clone())
+            .ok_or_else(|| DpfError::not_found("DPU", name))?;
+        if current_uid.as_deref() != Some(uid) {
+            return Err(DpfError::InvalidState(format!(
+                "DPU {name} no longer has UID {uid}"
+            )));
+        }
+        DpuRepository::delete(self, name, ns).await
+    }
+
     fn watch<F, Fut>(
         &self,
         _ns: &str,
@@ -482,6 +496,36 @@ impl DpfOperatorConfigRepository for InitializationMock {
     async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
         Ok(())
     }
+}
+
+/// A conditional delete must preserve a replacement DPU whose UID differs
+/// from the stale object observed by the migration reconciler.
+#[tokio::test]
+async fn conditional_dpu_delete_rejects_uid_mismatch() {
+    let mock = InitializationMock::default();
+    let dpu_name = "node-host-device-dpu";
+    let mut replacement = super::helpers::make_dpu(
+        TEST_NS,
+        dpu_name,
+        "device-dpu",
+        "node-host",
+        DpuStatusPhase::Ready,
+    );
+    replacement.metadata.uid = Some("replacement-uid".to_string());
+    mock.dpus.insert(resource_key(&replacement), replacement);
+
+    let error = DpuRepository::delete_if_uid(&mock, dpu_name, TEST_NS, "stale-uid")
+        .await
+        .expect_err("a stale UID must not delete the replacement DPU");
+
+    assert!(matches!(error, DpfError::InvalidState(_)));
+    assert!(
+        DpuRepository::get(&mock, dpu_name, TEST_NS)
+            .await
+            .unwrap()
+            .is_some(),
+        "the replacement DPU must remain after the rejected delete"
+    );
 }
 
 #[tokio::test]

--- a/crates/dpf/src/test/sdk_outdated_dpu.rs
+++ b/crates/dpf/src/test/sdk_outdated_dpu.rs
@@ -23,34 +23,40 @@
 
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
 use kube::core::ObjectMeta;
 
 use crate::crds::dpfoperatorconfigs_generated::DPFOperatorConfig;
-use crate::crds::dpudeployments_generated::DPUDeployment;
-use crate::crds::dpus_generated::DPU;
+use crate::crds::dpudeployments_generated::{
+    DPUDeployment, DpuDeploymentDpusDpuSets, DpuDeploymentDpusDpuSetsDpuNodeSelector,
+};
+use crate::crds::dpus_generated::{DPU, DpuStatusPhase};
 use crate::crds::dpuservicetemplates_generated::DPUServiceTemplate;
 use crate::error::DpfError;
 use crate::repository::{
     DpfOperatorConfigRepository, DpuDeploymentRepository, DpuRepository,
     DpuServiceTemplateRepository, K8sConfigRepository,
 };
-use crate::sdk::DpfSdkBuilder;
+use crate::sdk::{DpfSdkBuilder, ResourceLabeler};
+use crate::types::{DPU_ENABLED_NODE_LABEL, DpuDeploymentType, DpuPhase};
 
 const TEST_NS: &str = "test-namespace";
 const DEPLOYMENT: &str = "test-deployment";
 const FLAVOR: &str = "test-flavor";
 const DPU_NAME: &str = "node-host-001-device-001";
 const OWNED_BY_LABEL: &str = "svc.dpu.nvidia.com/owned-by-dpudeployment";
+const BF3_LABEL: &str = "test.nvidia.com/bf3";
+const GB200_LABEL: &str = "test.nvidia.com/bf3gb200";
 
 #[derive(Default, Clone)]
 struct OutdatedDpuMock {
     dpus: Arc<DashMap<String, DPU>>,
     deployments: Arc<DashMap<String, DPUDeployment>>,
     operator_config: Arc<DashMap<String, DPFOperatorConfig>>,
+    dpu_list_selectors: Arc<Mutex<Vec<Option<String>>>>,
 }
 
 impl OutdatedDpuMock {
@@ -67,7 +73,11 @@ impl DpuRepository for OutdatedDpuMock {
     async fn get(&self, name: &str, _ns: &str) -> Result<Option<DPU>, DpfError> {
         Ok(self.dpus.get(name).map(|dpu| dpu.clone()))
     }
-    async fn list(&self, _ns: &str, _selector: Option<&str>) -> Result<Vec<DPU>, DpfError> {
+    async fn list(&self, _ns: &str, selector: Option<&str>) -> Result<Vec<DPU>, DpfError> {
+        self.dpu_list_selectors
+            .lock()
+            .unwrap()
+            .push(selector.map(str::to_string));
         Ok(self.dpus.iter().map(|e| e.value().clone()).collect())
     }
     async fn patch_status(
@@ -78,8 +88,22 @@ impl DpuRepository for OutdatedDpuMock {
     ) -> Result<(), DpfError> {
         Ok(())
     }
-    async fn delete(&self, _name: &str, _ns: &str) -> Result<(), DpfError> {
+    async fn delete(&self, name: &str, _ns: &str) -> Result<(), DpfError> {
+        self.dpus.remove(name);
         Ok(())
+    }
+    async fn delete_if_uid(&self, name: &str, ns: &str, uid: &str) -> Result<(), DpfError> {
+        let current_uid = self
+            .dpus
+            .get(name)
+            .map(|dpu| dpu.metadata.uid.clone())
+            .ok_or_else(|| DpfError::not_found("DPU", name))?;
+        if current_uid.as_deref() != Some(uid) {
+            return Err(DpfError::InvalidState(format!(
+                "DPU {name} no longer has UID {uid}"
+            )));
+        }
+        DpuRepository::delete(self, name, ns).await
     }
     fn watch<F, Fut>(
         &self,
@@ -273,6 +297,88 @@ fn template_deployment(
     deployment
 }
 
+/// Supplies the two BF3 deployment selectors used by the conformance test.
+struct DeploymentTypeLabeler;
+
+impl ResourceLabeler for DeploymentTypeLabeler {
+    fn node_labels_for_deployment_type(
+        &self,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<BTreeMap<String, String>, DpfError> {
+        let deployment_label = match deployment_type {
+            DpuDeploymentType::Bf3 => BF3_LABEL,
+            DpuDeploymentType::Bf3Gb200 => GB200_LABEL,
+            other => {
+                return Err(DpfError::ConfigError(format!(
+                    "no test deployment configured for {other:?}"
+                )));
+            }
+        };
+
+        Ok(BTreeMap::from([
+            (DPU_ENABLED_NODE_LABEL.to_string(), "true".to_string()),
+            (deployment_label.to_string(), "true".to_string()),
+        ]))
+    }
+}
+
+/// Add the DPUSet selector that identifies a deployment type.
+fn deployment_with_selector(
+    bfb: Option<&str>,
+    ready: bool,
+    deployment_type: DpuDeploymentType,
+) -> DPUDeployment {
+    deployment_with_selector_for_fixture(deployment(bfb, None, ready), deployment_type)
+}
+
+/// Adds the selector for a deployment type to an otherwise complete fixture.
+fn deployment_with_selector_for_fixture(
+    mut deployment: DPUDeployment,
+    deployment_type: DpuDeploymentType,
+) -> DPUDeployment {
+    let match_labels = DeploymentTypeLabeler
+        .node_labels_for_deployment_type(deployment_type)
+        .expect("test deployment selector");
+    deployment.spec.dpus.dpu_sets = Some(vec![DpuDeploymentDpusDpuSets {
+        dpu_annotations: None,
+        dpu_selector: None,
+        name_suffix: "default".to_string(),
+        dpu_node_selector: Some(DpuDeploymentDpusDpuSetsDpuNodeSelector {
+            match_expressions: None,
+            match_labels: Some(match_labels),
+        }),
+        dpu_cluster_selector: None,
+        dpu_device_selector: None,
+        node_selector: None,
+    }]);
+    deployment
+}
+
+/// Replace the owning deployment label on a DPU fixture.
+fn set_dpu_owner(mut dpu: DPU, deployment_name: &str) -> DPU {
+    dpu.metadata.labels = Some(BTreeMap::from([(
+        OWNED_BY_LABEL.to_string(),
+        format!("{TEST_NS}_{deployment_name}"),
+    )]));
+    dpu
+}
+
+async fn phase_for_deployment_type(mock: OutdatedDpuMock) -> Result<Option<DpuPhase>, DpfError> {
+    let phases = DpfSdkBuilder::new(mock, TEST_NS, String::new())
+        .with_labeler(DeploymentTypeLabeler)
+        .build_without_resources()
+        .await
+        .expect("sdk")
+        .get_dpu_phases_for_deployment_type(
+            &["001".to_string()],
+            "node-host-001",
+            DpuDeploymentType::Bf3Gb200,
+        )
+        .await?;
+
+    Ok(phases.and_then(|mut phases| phases.remove("001")))
+}
+
 async fn is_outdated(mock: OutdatedDpuMock) -> Result<bool, DpfError> {
     DpfSdkBuilder::new(mock, TEST_NS, String::new())
         .build_without_resources()
@@ -280,6 +386,250 @@ async fn is_outdated(mock: OutdatedDpuMock) -> Result<bool, DpfError> {
         .expect("sdk")
         .is_dpu_outdated(DPU_NAME)
         .await
+}
+
+/// A phase read scoped to one deployment accepts work still running on the target,
+/// while Ready also requires the target flavor and provisioning source.
+#[tokio::test]
+async fn a_dpu_phase_must_belong_to_the_requested_deployment_type() {
+    struct Case {
+        name: &'static str,
+        owner: &'static str,
+        flavor: &'static str,
+        phase: DpuStatusPhase,
+        installed_bfb_file: Option<&'static str>,
+        deployment_ready: bool,
+        expected: Option<DpuPhase>,
+    }
+
+    let cases = [
+        Case {
+            name: "source deployment still owns the DPU",
+            owner: "source-deployment",
+            flavor: FLAVOR,
+            phase: DpuStatusPhase::Ready,
+            installed_bfb_file: Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            deployment_ready: true,
+            expected: None,
+        },
+        Case {
+            name: "target deployment owns a DPU still installing",
+            owner: DEPLOYMENT,
+            flavor: FLAVOR,
+            phase: DpuStatusPhase::OsInstalling,
+            installed_bfb_file: None,
+            deployment_ready: true,
+            expected: Some(DpuPhase::Provisioning("OsInstalling".to_string())),
+        },
+        Case {
+            name: "target deployment has not reconciled its DPU sets",
+            owner: DEPLOYMENT,
+            flavor: FLAVOR,
+            phase: DpuStatusPhase::Ready,
+            installed_bfb_file: Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            deployment_ready: false,
+            expected: None,
+        },
+        Case {
+            name: "target deployment owns a matching DPU",
+            owner: DEPLOYMENT,
+            flavor: FLAVOR,
+            phase: DpuStatusPhase::Ready,
+            installed_bfb_file: Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            deployment_ready: true,
+            expected: Some(DpuPhase::Ready),
+        },
+    ];
+
+    for case in cases {
+        let mut dpu = set_dpu_owner(
+            dpu(
+                Some("bf-bundle-abc"),
+                None,
+                case.installed_bfb_file,
+                case.flavor,
+            ),
+            case.owner,
+        );
+        dpu.status.as_mut().expect("DPU status").phase = case.phase;
+        let deployment = deployment_with_selector(
+            Some("bf-bundle-abc"),
+            case.deployment_ready,
+            DpuDeploymentType::Bf3Gb200,
+        );
+
+        assert_eq!(
+            phase_for_deployment_type(OutdatedDpuMock::with(dpu, deployment))
+                .await
+                .unwrap_or_else(|error| panic!("{}: {error}", case.name)),
+            case.expected,
+            "{}",
+            case.name
+        );
+    }
+}
+
+/// A Ready DPU owned by the target cannot converge without another deletion,
+/// so configuration drift must be reported instead of treated as recreation.
+#[tokio::test]
+async fn a_ready_target_dpu_with_configuration_drift_is_an_error() {
+    let dpu = dpu(
+        Some("bf-bundle-abc"),
+        None,
+        Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+        "source-flavor",
+    );
+    let deployment =
+        deployment_with_selector(Some("bf-bundle-abc"), true, DpuDeploymentType::Bf3Gb200);
+
+    let error = phase_for_deployment_type(OutdatedDpuMock::with(dpu, deployment))
+        .await
+        .expect_err("Ready configuration drift must be visible");
+    assert!(matches!(error, DpfError::InvalidState(_)));
+}
+
+/// A rendered DPUFlavorTemplate cannot be compared with the flavor name on a
+/// DPU CR, so migration conformance reports a visible configuration error.
+#[tokio::test]
+async fn a_deployment_type_phase_rejects_a_flavor_template() {
+    let dpu = dpu(
+        Some("bf-bundle-abc"),
+        None,
+        Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+        FLAVOR,
+    );
+    let mut deployment = template_deployment(Some("bf-bundle-abc"), None, true);
+    deployment = deployment_with_selector_for_fixture(deployment, DpuDeploymentType::Bf3Gb200);
+
+    let error = phase_for_deployment_type(OutdatedDpuMock::with(dpu, deployment))
+        .await
+        .expect_err("DPUFlavorTemplate must not produce a confident phase");
+    assert!(matches!(error, DpfError::InvalidState(_)));
+}
+
+/// A deployment scoped phase read requires one unambiguous deployment owner.
+#[tokio::test]
+async fn a_deployment_type_phase_requires_exactly_one_deployment() {
+    for (name, deployment_count, expected_message) in [
+        ("no matching deployment", 0, "no DPUDeployment selects"),
+        (
+            "multiple matching deployments",
+            2,
+            "multiple DPUDeployments select",
+        ),
+    ] {
+        let mock = OutdatedDpuMock::default();
+        for index in 0..deployment_count {
+            let mut deployment =
+                deployment_with_selector(Some("bf-bundle-abc"), true, DpuDeploymentType::Bf3Gb200);
+            let deployment_name = format!("target-deployment-{index}");
+            deployment.metadata.name = Some(deployment_name.clone());
+            mock.deployments.insert(deployment_name, deployment);
+        }
+
+        let error = phase_for_deployment_type(mock).await.expect_err(name);
+        assert!(
+            matches!(&error, DpfError::InvalidState(message) if message.contains(expected_message)),
+            "{name}: {error}"
+        );
+    }
+}
+
+/// A deployment phase read asks Kubernetes only for DPUs owned by the target
+/// deployment while retaining the per-resource ownership check.
+#[tokio::test]
+async fn a_deployment_type_phase_scopes_the_dpu_list_to_its_owner() {
+    let dpu = set_dpu_owner(
+        dpu(
+            Some("bf-bundle-abc"),
+            None,
+            Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            FLAVOR,
+        ),
+        DEPLOYMENT,
+    );
+    let deployment =
+        deployment_with_selector(Some("bf-bundle-abc"), true, DpuDeploymentType::Bf3Gb200);
+    let mock = OutdatedDpuMock::with(dpu, deployment);
+
+    phase_for_deployment_type(mock.clone())
+        .await
+        .expect("deployment phase");
+
+    assert_eq!(
+        *mock.dpu_list_selectors.lock().unwrap(),
+        vec![Some(format!("{OWNED_BY_LABEL}={TEST_NS}_{DEPLOYMENT}"))]
+    );
+}
+
+/// Retrying a deployment migration removes a DPU owned by the source but
+/// preserves a replacement with the same name once the target owns it.
+#[tokio::test]
+async fn deployment_migration_deletion_preserves_target_replacements() {
+    let mock = OutdatedDpuMock::default();
+    let mut source_deployment =
+        deployment_with_selector(Some("bf-bundle-abc"), true, DpuDeploymentType::Bf3);
+    source_deployment.metadata.name = Some("source-deployment".to_string());
+    let target_deployment =
+        deployment_with_selector(Some("bf-bundle-abc"), true, DpuDeploymentType::Bf3Gb200);
+    mock.deployments
+        .insert("source-deployment".to_string(), source_deployment);
+    mock.deployments
+        .insert(DEPLOYMENT.to_string(), target_deployment);
+
+    let mut source_dpu = set_dpu_owner(
+        dpu(
+            Some("bf-bundle-abc"),
+            None,
+            Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            FLAVOR,
+        ),
+        "source-deployment",
+    );
+    source_dpu.metadata.uid = Some("source-uid".to_string());
+    mock.dpus.insert(DPU_NAME.to_string(), source_dpu);
+
+    let sdk = DpfSdkBuilder::new(mock.clone(), TEST_NS, String::new())
+        .with_labeler(DeploymentTypeLabeler)
+        .build_without_resources()
+        .await
+        .expect("sdk");
+    sdk.delete_source_dpus_for_deployment_migration(
+        &["001".to_string()],
+        "node-host-001",
+        DpuDeploymentType::Bf3,
+        DpuDeploymentType::Bf3Gb200,
+    )
+    .await
+    .expect("source DPU deletion");
+    assert!(mock.dpus.get(DPU_NAME).is_none());
+
+    let mut target_dpu = set_dpu_owner(
+        dpu(
+            Some("bf-bundle-abc"),
+            None,
+            Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+            FLAVOR,
+        ),
+        DEPLOYMENT,
+    );
+    target_dpu.metadata.uid = Some("target-uid".to_string());
+    mock.dpus.insert(DPU_NAME.to_string(), target_dpu);
+
+    sdk.delete_source_dpus_for_deployment_migration(
+        &["001".to_string()],
+        "node-host-001",
+        DpuDeploymentType::Bf3,
+        DpuDeploymentType::Bf3Gb200,
+    )
+    .await
+    .expect("migration retry");
+
+    let replacement = mock
+        .dpus
+        .get(DPU_NAME)
+        .expect("target replacement must be preserved");
+    assert_eq!(replacement.metadata.uid.as_deref(), Some("target-uid"));
 }
 
 /// Both provisioning sources, matching and drifted. A DPUDeployment declares

--- a/crates/dpf/src/test/sdk_provisioning_flow.rs
+++ b/crates/dpf/src/test/sdk_provisioning_flow.rs
@@ -105,6 +105,9 @@ impl DpuRepository for ProvisioningFlowMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/dpf/src/test/watcher_errors.rs
+++ b/crates/dpf/src/test/watcher_errors.rs
@@ -97,6 +97,9 @@ impl DpuRepository for ErrorCapturingMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -93,6 +93,24 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
         node_name: &str,
     ) -> Result<DpuPhase, DpfError>;
 
+    /// Read every requested DPU phase only when one deployment owns the full
+    /// set and each Ready DPU matches its flavor and provisioning source.
+    async fn get_dpu_phases_for_deployment_type(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<Option<BTreeMap<String, DpuPhase>>, DpfError>;
+
+    /// Delete source deployment DPU CRs while preserving target replacements.
+    async fn delete_source_dpus_for_deployment_migration(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError>;
+
     /// Check if a DPU node is waiting for external reboot.
     async fn is_reboot_required(&self, node_name: &str) -> Result<bool, DpfError>;
 
@@ -116,6 +134,17 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
         node_name: &str,
         deployment_type: DpuDeploymentType,
     ) -> Result<bool, DpfError>;
+
+    /// Atomically moves a DPUNode from one deployment selector to another.
+    ///
+    /// A completed transfer does nothing, while a node matching neither selector
+    /// is rejected.
+    async fn transfer_dpu_node_deployment_labels(
+        &self,
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError>;
 
     /// Curated snapshot of all DPF CRs related to one host (DPUNode +
     /// DPUDevices + DPUs). `node_name` is the full DPUNode CR name.
@@ -646,6 +675,34 @@ impl DpfOperations for DpfSdkOps {
         self.sdk.get_dpu_phase(dpu_device_name, node_name).await
     }
 
+    async fn get_dpu_phases_for_deployment_type(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<Option<BTreeMap<String, DpuPhase>>, DpfError> {
+        self.sdk
+            .get_dpu_phases_for_deployment_type(dpu_device_names, node_name, deployment_type)
+            .await
+    }
+
+    async fn delete_source_dpus_for_deployment_migration(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError> {
+        self.sdk
+            .delete_source_dpus_for_deployment_migration(
+                dpu_device_names,
+                node_name,
+                source_deployment_type,
+                target_deployment_type,
+            )
+            .await
+    }
+
     async fn is_reboot_required(&self, node_name: &str) -> Result<bool, DpfError> {
         self.sdk.is_reboot_required(node_name).await
     }
@@ -703,6 +760,21 @@ impl DpfOperations for DpfSdkOps {
     ) -> Result<bool, DpfError> {
         self.sdk
             .verify_node_labels(node_name, deployment_type)
+            .await
+    }
+
+    async fn transfer_dpu_node_deployment_labels(
+        &self,
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError> {
+        self.sdk
+            .transfer_dpu_node_deployment_labels(
+                node_name,
+                source_deployment_type,
+                target_deployment_type,
+            )
             .await
     }
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -4074,7 +4074,23 @@ async fn handle_dpu_reprovision(
                 .with_txn(txn),
             )
         }
-        ReprovisionState::NotUnderReprovision => Ok(StateHandlerOutcome::do_nothing()),
+        ReprovisionState::NotUnderReprovision => {
+            if !dpf::deployment_migration_is_parked(state) {
+                return Ok(StateHandlerOutcome::do_nothing());
+            }
+            // Deployment migration is host scoped, while this handler is
+            // called once per DPU. Run it only for the first snapshot so one
+            // controller iteration observes and changes the DPF graph once.
+            if state.dpu_snapshots.first().map(|dpu| &dpu.id) != Some(dpu_machine_id) {
+                return Ok(StateHandlerOutcome::do_nothing());
+            }
+            let dpf = dpf_sdk.ok_or_else(|| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "DPF deployment migration reached but DPF is not configured"
+                ))
+            })?;
+            dpf::handle_dpf_deployment_migration(state, ctx, dpf).await
+        }
     }
 }
 
@@ -8535,6 +8551,41 @@ impl StateHandler for InstanceStateHandler {
                         return Ok(StateHandlerOutcome::transition(next_state));
                     }
 
+                    let reprov_can_be_started =
+                        if dpu_reprovisioning_needed(&mh_snapshot.dpu_snapshots) {
+                            // Usually all DPUs are updated with user_approval_received field as true
+                            // if `invoke_instance_power` is called.
+                            // TODO: multidpu: Move this field to `instances` table and unset on
+                            // reprovision is completed.
+                            mh_snapshot
+                                .dpu_snapshots
+                                .iter()
+                                .filter(|x| x.reprovision_requested.is_some())
+                                .all(|x| {
+                                    x.reprovision_requested
+                                        .as_ref()
+                                        .map(|x| x.user_approval_received || is_auto_approved)
+                                        .unwrap_or_default()
+                                })
+                        } else {
+                            false
+                        };
+                    let host_firmware_requested = if let Some(request) =
+                        &mh_snapshot.host_snapshot.host_reprovision_requested
+                    {
+                        request.user_approval_received || is_auto_approved
+                    } else {
+                        false
+                    };
+
+                    // Check if the instance needs to PXE boot. The
+                    // custom_pxe_reboot_requested flag is set by the API when the tenant calls
+                    // InvokeInstancePower with boot_with_custom_ipxe=true.
+                    // This triggers the HostPlatformConfiguration flow to verify BIOS boot order
+                    // before rebooting. The WaitingForRebootToReady handler will clear this flag
+                    // and set use_custom_pxe_on_boot, which the iPXE handler uses to serve the
+                    // tenant's script.
+                    let boot_with_custom_ipxe = instance.custom_pxe_reboot_requested;
                     // Run cleanup here so fully terminated extension services are
                     // removed from persisted instance config.
                     let mut txn_opt = None;
@@ -8581,45 +8632,9 @@ impl StateHandler for InstanceStateHandler {
                         }
                     }
 
-                    let reprov_can_be_started =
-                        if dpu_reprovisioning_needed(&mh_snapshot.dpu_snapshots) {
-                            // Usually all DPUs are updated with user_approval_received field as true
-                            // if `invoke_instance_power` is called.
-                            // TODO: multidpu: Move this field to `instances` table and unset on
-                            // reprovision is completed.
-                            mh_snapshot
-                                .dpu_snapshots
-                                .iter()
-                                .filter(|x| x.reprovision_requested.is_some())
-                                .all(|x| {
-                                    x.reprovision_requested
-                                        .as_ref()
-                                        .map(|x| x.user_approval_received || is_auto_approved)
-                                        .unwrap_or_default()
-                                })
-                        } else {
-                            false
-                        };
-                    let host_firmware_requested = if let Some(request) =
-                        &mh_snapshot.host_snapshot.host_reprovision_requested
-                    {
-                        request.user_approval_received || is_auto_approved
-                    } else {
-                        false
-                    };
-
                     if is_auto_approved && (reprov_can_be_started || host_firmware_requested) {
                         tracing::info!(machine_id = %host_machine_id, "Auto rebooting host for reprovision/upgrade due to being in approved time period");
                     }
-
-                    // Check if the instance needs to PXE boot. The custom_pxe_reboot_requested flag
-                    // is set by the API when the tenant calls InvokeInstancePower with boot_with_custom_ipxe=true
-                    //
-                    // This triggers the HostPlatformConfiguration flow to verify BIOS boot order
-                    // before rebooting. The WaitingForRebootToReady handler will clear this flag
-                    // and set use_custom_pxe_on_boot, which the iPXE handler uses to serve the
-                    // tenant's script.
-                    let boot_with_custom_ipxe = instance.custom_pxe_reboot_requested;
 
                     if instance.deleted.is_some()
                         || reprov_can_be_started

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -20,6 +20,7 @@
 //! 2. Wait for watcher callbacks (DPU ready, reboot required)
 //! 3. Handle cleanup on error/reprovisioning
 
+use std::collections::HashSet;
 use std::net::IpAddr;
 
 use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase, dpu_node_cr_name};
@@ -28,9 +29,9 @@ use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
 use model::hardware_info::HardwareInfo;
 use model::machine::{
-    DpfState, DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, Machine,
-    ManagedHostState, ManagedHostStateSnapshot, PerformPowerOperation, ReprovisionState,
-    StateMachineArea,
+    DpfState, DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
+    InstanceState, Machine, ManagedHostState, ManagedHostStateSnapshot, PerformPowerOperation,
+    ReprovisionState, StateMachineArea,
 };
 use model::rack_type::{RackProductFamily, select_dpu_nvconfig_profile};
 use state_controller::state_handler::{
@@ -41,6 +42,11 @@ use super::helpers::{DpuInitStateHelper, ManagedHostStateHelper, ReprovisionStat
 use super::{handler_host_power_control, host_power_state};
 use crate::context::MachineStateHandlerContextObjects;
 use crate::dpf::DpfOperations;
+
+// `deployment_type_for_dpu_profile` currently refines exactly one deployment:
+// generic BF3 becomes GB200 BF3. Only that forward migration is supported.
+const DEPLOYMENT_MIGRATION_SOURCE: DpuDeploymentType = DpuDeploymentType::Bf3;
+const DEPLOYMENT_MIGRATION_TARGET: DpuDeploymentType = DpuDeploymentType::Bf3Gb200;
 
 fn dpf_error(error: DpfError) -> StateHandlerError {
     ExternalServiceError::with_source("dpf", "", error.to_string(), "dpf_error", error).into()
@@ -139,6 +145,105 @@ fn consistent_deployment_type(
     } else {
         Err("host has mixed DPF deployment types across attached DPUs".to_string())
     }
+}
+
+/// Returns whether any attached DPU reprovision request has started.
+fn any_dpu_reprovision_request_has_started(state: &ManagedHostStateSnapshot) -> bool {
+    state.dpu_snapshots.iter().any(|dpu| {
+        dpu.reprovision_requested
+            .as_ref()
+            .is_some_and(|request| request.started_at.is_some())
+    })
+}
+
+/// Returns whether every attached DPU has a started reprovision request.
+fn all_dpu_reprovision_requests_have_started(state: &ManagedHostStateSnapshot) -> bool {
+    state.dpu_snapshots.iter().all(|dpu| {
+        dpu.reprovision_requested
+            .as_ref()
+            .is_some_and(|request| request.started_at.is_some())
+    })
+}
+
+/// Returns whether inventory, snapshots, and reprovision state describe the
+/// same complete, nonempty set of attached DPUs.
+fn deployment_migration_has_complete_dpu_set(
+    state: &ManagedHostStateSnapshot,
+    dpu_states: &DpuReprovisionStates,
+) -> bool {
+    let expected_dpu_ids = state
+        .host_snapshot
+        .associated_dpu_machine_ids()
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let snapshot_dpu_ids = state
+        .dpu_snapshots
+        .iter()
+        .map(|dpu| dpu.id)
+        .collect::<HashSet<_>>();
+    let state_dpu_ids = dpu_states.states.keys().copied().collect::<HashSet<_>>();
+
+    !expected_dpu_ids.is_empty()
+        && expected_dpu_ids == snapshot_dpu_ids
+        && expected_dpu_ids == state_dpu_ids
+}
+
+/// Returns whether the stored reprovision state may be a parked migration.
+///
+/// The migration handler validates the full DPU set before changing external
+/// resources. Keeping this detector broad turns damaged parked state into a
+/// visible failure instead of leaving every DPU idle indefinitely.
+pub(super) fn deployment_migration_is_parked(state: &ManagedHostStateSnapshot) -> bool {
+    let Some(dpu_states) = state.managed_state.dpu_reprovision_states() else {
+        return false;
+    };
+    !dpu_states.states.is_empty()
+        && dpu_states
+            .states
+            .values()
+            .all(|dpu_state| matches!(dpu_state, ReprovisionState::NotUnderReprovision))
+        && any_dpu_reprovision_request_has_started(state)
+}
+
+/// Returns whether every attached DPU has reached the migration handoff point.
+fn deployment_migration_can_start(state: &ManagedHostStateSnapshot) -> bool {
+    let Some(dpu_states) = state.managed_state.dpu_reprovision_states() else {
+        return false;
+    };
+
+    deployment_migration_has_complete_dpu_set(state, dpu_states)
+        && all_dpu_reprovision_requests_have_started(state)
+        && dpu_states.states.values().all(|dpu_state| {
+            matches!(
+                dpu_state,
+                ReprovisionState::DpfStates {
+                    substate: DpfState::Reprovisioning
+                }
+            )
+        })
+}
+
+/// Parks every attached DPU before changing its shared DPUNode selector.
+fn park_for_deployment_migration(
+    state: &ManagedHostStateSnapshot,
+) -> Result<ManagedHostState, StateHandlerError> {
+    // Reuse `NotUnderReprovision` so controllers from the same rollout can
+    // deserialize the state and leave it alone. Persisting it before the
+    // selector change also keeps retries out of ordinary handling for one DPU.
+    ReprovisionState::NotUnderReprovision.next_state_with_all_dpus_updated(
+        &state.managed_state,
+        &state.dpu_snapshots,
+        Vec::new(),
+    )
+}
+
+/// Returns the deterministic DPU names for every attached DPU snapshot.
+fn dpu_device_names(state: &ManagedHostStateSnapshot) -> Result<Vec<String>, StateHandlerError> {
+    state
+        .dpu_snapshots
+        .iter()
+        .map(dpf_id)
+        .collect::<Result<Vec<_>, _>>()
 }
 
 /// Transition all DPU sub-states to the given DPF state, preserving the
@@ -404,6 +509,25 @@ fn dpf_deployment_selection_failed(
     StateHandlerOutcome::transition(make_failure_state(state, details, state.host_snapshot.id))
 }
 
+/// Builds the terminal failure used when a deployment was selected but the
+/// host does not meet a migration precondition.
+fn dpf_deployment_migration_failed(
+    state: &ManagedHostStateSnapshot,
+    error: &str,
+) -> StateHandlerOutcome<ManagedHostState> {
+    let details = FailureDetails {
+        cause: FailureCause::DpfProvisioning {
+            err: format!(
+                "DPF deployment migration failed: {error}. Resolve the reported precondition \
+                 before retrying DPU reprovisioning"
+            ),
+        },
+        failed_at: chrono::Utc::now(),
+        source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+    };
+    StateHandlerOutcome::transition(make_failure_state(state, details, state.host_snapshot.id))
+}
+
 /// Handle DpfState::Provisioning: register all DPU devices and the node, then
 /// transition all DPUs to WaitingForReady.
 async fn handle_dpf_provisioning(
@@ -549,17 +673,41 @@ async fn handle_dpf_waiting_for_ready(
     waiting_phase_detail: &Option<String>,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    deployment_type: DpuDeploymentType,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     let dpu_device_name = dpf_id(dpu_snapshot)?;
-    let current_phase = match dpf_sdk.get_dpu_phase(&dpu_device_name, &node_name).await {
-        Ok(phase) => phase,
+    // During a deployment migration the source and target DPUSet reuse the
+    // deterministic DPU name. Read ownership, phase, and Ready conformance from
+    // one observation scoped to the target so an old source DPU cannot release
+    // the hold, trigger a reboot, or satisfy target readiness.
+    let current_phase = match if deployment_type == DEPLOYMENT_MIGRATION_TARGET {
+        let dpu_device_names = dpu_device_names(state)?;
+        dpf_sdk
+            .get_dpu_phases_for_deployment_type(&dpu_device_names, &node_name, deployment_type)
+            .await
+            .map(|phases| phases.and_then(|phases| phases.get(&dpu_device_name).cloned()))
+    } else {
+        dpf_sdk
+            .get_dpu_phase(&dpu_device_name, &node_name)
+            .await
+            .map(Some)
+    } {
+        Ok(Some(phase)) => phase,
+        Ok(None) => {
+            return Ok(StateHandlerOutcome::wait(
+                "Waiting for DPF to recreate the DPU from the GB200 deployment".to_string(),
+            ));
+        }
         // The operator briefly removes the old DPU CR before recreating a fresh one
         // during reprovision; treat that window as "keep waiting" rather than erroring.
         Err(DpfError::NotFound { .. }) => {
             return Ok(StateHandlerOutcome::wait(
                 "DPU CR not yet recreated after reprovision".to_string(),
             ));
+        }
+        Err(DpfError::InvalidState(error)) if deployment_type == DEPLOYMENT_MIGRATION_TARGET => {
+            return Ok(dpf_deployment_migration_failed(state, &error));
         }
         Err(err) => return Err(dpf_error(err)),
     };
@@ -666,6 +814,96 @@ fn handle_dpf_device_ready(
     }
 
     let next = waiting_for_ready_exit_state(state)?;
+    Ok(StateHandlerOutcome::transition(next))
+}
+
+/// Moves one host's existing DPF resources from generic BF3 to the GB200
+/// deployment during an active DPU reprovision request.
+///
+/// The DPUNode and initialized DPUDevices stay in place. Parking every DPU in
+/// `NotUnderReprovision` makes the label transfer and DPU deletions retryable
+/// when the process restarts before or after the selector changes.
+pub(super) async fn handle_dpf_deployment_migration(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    dpf_sdk: &dyn DpfOperations,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let Some(dpu_states) = state.managed_state.dpu_reprovision_states() else {
+        return Ok(dpf_deployment_migration_failed(
+            state,
+            "parked state does not contain DPU reprovision state",
+        ));
+    };
+    if !deployment_migration_has_complete_dpu_set(state, dpu_states)
+        || !all_dpu_reprovision_requests_have_started(state)
+    {
+        return Ok(dpf_deployment_migration_failed(
+            state,
+            "parked state does not contain a started request for every attached DPU",
+        ));
+    }
+
+    let astra_nics = machine_has_astra_nics(state, ctx).await?;
+    let deployment_types = deployment_types_for_host(state, ctx, dpf_sdk, astra_nics).await?;
+    let desired_deployment = match consistent_deployment_type(&deployment_types) {
+        Ok(deployment_type) => deployment_type,
+        Err(error) => return Ok(dpf_deployment_selection_failed(state, error.as_str())),
+    };
+    if desired_deployment != DEPLOYMENT_MIGRATION_TARGET {
+        let error = format!(
+            "parked DPF deployment migration now selects {desired_deployment:?}, expected \
+             {DEPLOYMENT_MIGRATION_TARGET:?}"
+        );
+        return Ok(dpf_deployment_migration_failed(state, &error));
+    }
+
+    let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
+    let dpu_device_names = dpu_device_names(state)?;
+
+    dpf_sdk
+        .transfer_dpu_node_deployment_labels(
+            &node_name,
+            DEPLOYMENT_MIGRATION_SOURCE,
+            DEPLOYMENT_MIGRATION_TARGET,
+        )
+        .await
+        .map_err(dpf_error)?;
+
+    dpf_sdk
+        .delete_source_dpus_for_deployment_migration(
+            &dpu_device_names,
+            &node_name,
+            DEPLOYMENT_MIGRATION_SOURCE,
+            DEPLOYMENT_MIGRATION_TARGET,
+        )
+        .await
+        .map_err(dpf_error)?;
+
+    // Keep the durable parked state until one DPF observation contains every
+    // target DPU. Controllers from before migration support ignore this state,
+    // so they cannot accept a source DPU recreated during the selector handoff.
+    match dpf_sdk
+        .get_dpu_phases_for_deployment_type(
+            &dpu_device_names,
+            &node_name,
+            DEPLOYMENT_MIGRATION_TARGET,
+        )
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) | Err(DpfError::NotFound { .. }) => {
+            return Ok(StateHandlerOutcome::wait(
+                "Waiting for DPF to recreate every DPU from the GB200 deployment".to_string(),
+            ));
+        }
+        Err(DpfError::InvalidState(error)) => {
+            return Ok(dpf_deployment_migration_failed(state, &error));
+        }
+        Err(error) => return Err(dpf_error(error)),
+    }
+
+    let next =
+        transition_all_dpus_to_dpf_state(DpfState::WaitingForReady { phase_detail: None }, state)?;
     Ok(StateHandlerOutcome::transition(next))
 }
 
@@ -806,7 +1044,7 @@ pub(super) async fn handle_dpf_state(
     let astra_nics = machine_has_astra_nics(state, ctx).await?;
 
     let deployment_types = deployment_types_for_host(state, ctx, dpf_sdk, astra_nics).await?;
-    let deployment_type = match consistent_deployment_type(&deployment_types) {
+    let mut deployment_type = match consistent_deployment_type(&deployment_types) {
         Ok(deployment_type) => deployment_type,
         Err(error) => {
             let selections = state
@@ -828,37 +1066,83 @@ pub(super) async fn handle_dpf_state(
             "selected DPF deployment type for host"
         );
     }
-    if !dpf_sdk
+    let node_has_desired_labels = dpf_sdk
         .verify_node_labels(&node_name, deployment_type)
         .await
-        .map_err(dpf_error)?
-    {
-        tracing::error!(
-            machine_id = %state.host_snapshot.id,
-            node = %node_name,
-            "DPUNode has stale labels, failing for reprovisioning"
-        );
-        let details = FailureDetails {
-            cause: FailureCause::DpfProvisioning {
-                err: format!(
-                    "DPUNode {node_name} has stale labels; \
-                     must be deleted and reprovisioned"
-                ),
-            },
-            failed_at: chrono::Utc::now(),
-            source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+        .map_err(dpf_error)?;
+    if !node_has_desired_labels {
+        let node_has_migration_source_labels = if deployment_type == DEPLOYMENT_MIGRATION_TARGET {
+            dpf_sdk
+                .verify_node_labels(&node_name, DEPLOYMENT_MIGRATION_SOURCE)
+                .await
+                .map_err(dpf_error)?
+        } else {
+            false
         };
-        return Ok(StateHandlerOutcome::transition(make_failure_state(
-            state,
-            details,
-            state.host_snapshot.id,
-        )));
+
+        if node_has_migration_source_labels
+            && matches!(dpf_state, DpfState::Reprovisioning)
+            && deployment_migration_can_start(state)
+        {
+            tracing::info!(
+                machine_id = %state.host_snapshot.id,
+                node = %node_name,
+                from = ?DEPLOYMENT_MIGRATION_SOURCE,
+                to = ?deployment_type,
+                "parking DPF deployment selector migration"
+            );
+            let next = park_for_deployment_migration(state)?;
+            return Ok(StateHandlerOutcome::transition(next));
+        } else if node_has_migration_source_labels && any_dpu_reprovision_request_has_started(state)
+        {
+            // A controller from before deployment migration support may have
+            // started only part of the DPU set or advanced one DPU before the
+            // rollout completed. Finish that work under its current deployment;
+            // a later host request can migrate the complete DPU set.
+            tracing::warn!(
+                machine_id = %state.host_snapshot.id,
+                node = %node_name,
+                from = ?DEPLOYMENT_MIGRATION_SOURCE,
+                to = ?deployment_type,
+                "deferring DPF deployment migration for work already in progress"
+            );
+            deployment_type = DEPLOYMENT_MIGRATION_SOURCE;
+        } else {
+            tracing::error!(
+                machine_id = %state.host_snapshot.id,
+                node = %node_name,
+                "DPUNode has stale labels, failing for reprovisioning"
+            );
+            let details = FailureDetails {
+                cause: FailureCause::DpfProvisioning {
+                    err: format!(
+                        "DPUNode {node_name} has stale labels; \
+                         must be deleted and reprovisioned"
+                    ),
+                },
+                failed_at: chrono::Utc::now(),
+                source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+            };
+            return Ok(StateHandlerOutcome::transition(make_failure_state(
+                state,
+                details,
+                state.host_snapshot.id,
+            )));
+        }
     }
 
     match dpf_state {
         DpfState::Provisioning => handle_dpf_provisioning(state, dpf_sdk, deployment_type).await,
         DpfState::WaitingForReady { phase_detail } => {
-            handle_dpf_waiting_for_ready(state, dpu_snapshot, phase_detail, ctx, dpf_sdk).await
+            handle_dpf_waiting_for_ready(
+                state,
+                dpu_snapshot,
+                phase_detail,
+                ctx,
+                dpf_sdk,
+                deployment_type,
+            )
+            .await
         }
         DpfState::HandleReboot { op, retry_count } => {
             handle_dpf_handle_reboot(


### PR DESCRIPTION
> [!NOTE]
> This PR contains:
>
> - +1054/-134 lines of production code.
> - +1507/-46 lines of test and test support changes.
> - No generated code.

Existing GB200 B3240 hosts can retain the generic `Bf3` selector on their `DPUNode`. When corrected inventory selects `Bf3Gb200` during DPU reprovisioning, NICo currently rejects the expected selector difference instead of moving the existing DPF resources to the GB200 deployment.

This adds the exact forward migration from `Bf3` to `Bf3Gb200`. The API rejects a Set or Clear operation that would leave only part of an attached DPU set selected while the node still uses `Bf3`; a host operation continues to change the complete set together. Once every attached DPU is requested, the controller parks the complete set before changing any Kubernetes ownership.

The DPF SDK then transfers the DPUNode selector atomically with its observed `resourceVersion` and deletes only source owned DPU CRs with their observed Kubernetes UIDs. A missing source CR is already complete, a replacement owned by the target is preserved, and an unrelated owner is rejected. NICo keeps the complete set parked until one DPF observation contains every requested replacement under the `Bf3Gb200` deployment. A Ready replacement with the wrong flavor or provisioning source fails visibly instead of waiting indefinitely.

The DPUNode, DPUDevices, credentials, and Site Explorer state remain unchanged. No reverse or arbitrary deployment migration is added. During a rolling controller update, work already admitted by an older controller can finish under `Bf3`; a later complete host request performs the migration.

## Manual Verification

Ran this migration against my target QA6 host successfully, where:
- Host and both DPUs are `Ready`; all reprovision, host reprovision, and maintenance requests are cleared.
- Original `DPUNode` and both `DPUDevice` UIDs were preserved.
- The selector is target-only; both DPU CRs are Ready under the GB200 `DPUSet`/flavor.
- Fresh topology has exactly five NVMe devices.
- Each DPU has p0 at 03:00.0, p1 at 03:00.1, and no p2.
- Zero DPU alerts.

## Related issues

Supports #5570

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

The implementation was rewritten after design review so incomplete migration requests are rejected at the API boundary and Kubernetes deletion is guarded by the observed owner and UID. Focused reviews then checked transaction serialization, restart recovery, DPF replacement ownership, hold release, and integration with current `main`.

| Reviewer | Received | Adopted | Deferred |
| --- | ---: | ---: | ---: |
| API concurrency review | 0 | 0 | 0 |
| Lifecycle safety review | 1 | 1 | 0 |
| Rebase integration review | 2 | 2 | 0 |
| Compiler and Clippy pass | 2 | 2 | 0 |
| CodeRabbit full review | 10 | 10 | 0 |
| **Total** | **15** | **15** | **0** |

</details>

<details>
<summary>Model Findings Details</summary>

### API concurrency review

No findings. The review verified deterministic database validation before Kubernetes reads, stable row locking before request changes, and restart behavior that does not change request membership.

### Lifecycle safety review

1. **Adopted** -- A target owned DPU that became Ready with the wrong flavor or provisioning source could wait forever because it would not be recreated automatically. **Resolution:** Report the mismatch through the existing visible DPF failure path and retain the maintenance hold. Added SDK and controller regression coverage.

### Rebase integration review

1. **Adopted** -- An operator error string contained a stray patch marker. **Resolution:** Removed the marker and restored the intended message.
2. **Adopted** -- The replacement check read every DPU in the namespace. **Resolution:** Retained one consistent list observation while scoping it to the target deployment owner.

### Compiler and Clippy pass

1. **Adopted** -- A test mock added on `main` did not implement the new UID guarded deletion method. **Resolution:** Added the inert mock implementation.
2. **Adopted** -- Two request targeting branches returned the same result. **Resolution:** Combined their condition into one named predicate.

### CodeRabbit full review

1. **Adopted** -- Two test repositories modeled an already deleted DPU differently from Kubernetes. **Resolution:** Both now return a not found error for an absent resource and preserve the distinct UID mismatch failure.
2. **Adopted** -- The admission path repeated the same host snapshot load three times. **Resolution:** Moved the exact options and error mapping into one private helper without changing the transaction boundaries.
3. **Adopted** -- An older controller compatibility test asserted only the outer state. **Resolution:** It now proves the request makes progress in DPF without entering the migration handoff.
4. **Adopted** -- Label transfer did not cover a node that temporarily matched both deployments. **Resolution:** Added a repair case that removes the source selector and preserves the target and unrelated labels.
5. **Adopted** -- Ambiguous deployment tests did not distinguish zero matches from multiple matches. **Resolution:** Each row now verifies its specific error.
6. **Adopted** -- The host scoped migration handler could run once per DPU in one controller iteration. **Resolution:** Only the first DPU snapshot performs the complete set operation.
7. **Adopted** -- The target replacement list was not filtered at the Kubernetes API. **Resolution:** Added the exact target owner selector while retaining the per-resource ownership check.
8. **Adopted** -- Admission could probe the absent DPF SDK after runtime DPF support was disabled. **Resolution:** Skip deployment migration admission whenever runtime DPF support is disabled and cover the path with an API regression that has no SDK installed.
9. **Adopted** -- Test repositories could report a successful UID guarded delete without verifying the observed UID. **Resolution:** Every new test implementation now returns not found for an absent DPU or validates the current UID before deletion. Added a regression proving that a stale UID preserves a replacement DPU.
10. **Adopted** -- Migration admission could reload a newly attached DPU after the Kubernetes check without holding the attachment lock, allowing a partial request set. **Resolution:** Admission now takes the same admin locks as Site Explorer before reloading and updating the complete attached DPU set. Added a deterministic concurrent attachment regression.

</details>


Closes #5570
