### PR TITLE
Expose weave socket path to dpu agent container

### DIFF
--- a/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
@@ -218,6 +218,8 @@ spec:
             - name: hw-cache
               mountPath: /data
               readOnly: true
+            - name: host-grpc-socket-dir
+              mountPath: /var/run/dpf/weave/grpc
         - name: nico-lldp-sidecar
           securityContext:
             privileged: false
@@ -309,6 +311,10 @@ spec:
           hostPath:
             path: /etc/resolv.conf
             type: File
+        - name: host-grpc-socket-dir
+          hostPath:
+            path: /var/run/dpf/weave/grpc
+            type: DirectoryOrCreate
         {{- if eq $bootstrapCaSource "mounted" }}
         - name: bootstrap-ca-source
           {{- if eq $bootstrapCaObjectKind "Secret" }}

--- a/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
@@ -220,6 +220,7 @@ spec:
               readOnly: true
             - name: host-grpc-socket-dir
               mountPath: /var/run/dpf/weave/grpc
+              readOnly: true
         - name: nico-lldp-sidecar
           securityContext:
             privileged: false


### PR DESCRIPTION
Expose weave socket path to dpu agent container

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3205

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Closes https://github.com/NVIDIA/infra-controller/issues/5592

