### PR TITLE
patch(v2.1): correct provisioning deprecation warning

### DIFF
--- a/crates/admin-cli/src/managed_host/show/cmd.rs
+++ b/crates/admin-cli/src/managed_host/show/cmd.rs
@@ -209,7 +209,7 @@ fn convert_managed_hosts_to_nice_output(
     if is_dpf_not_used {
         warnings.push(
             "One or more DPUs are using a provisioning strategy (internal) which is \
-deprecated and will be removed in v2.1, see https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup for how to enable DPF management for DPUs"
+deprecated and will be removed in a future release, see https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup for how to enable DPF management for DPUs"
                 .to_string(),
         );
     }
@@ -396,7 +396,7 @@ fn show_managed_host_details_view(m: carbide_rpc_utils::ManagedHostOutput) -> Ca
     {
         dpf.push((
             "    WARN! One or more DPUs are using a provisioning strategy (internal) which is \
-deprecated and will be removed in v2.1, see https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup for how to enable DPF management for DPUs",
+deprecated and will be removed in a future release, see https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup for how to enable DPF management for DPUs",
             Some("".to_string()),
         ));
     }

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -556,7 +556,6 @@ async fn initialize_dpf_sdk(
 ) -> eyre::Result<Option<Arc<dyn DpfOperations>>> {
     if !carbide_config.dpf.enabled {
         tracing::warn!(
-            removed_in = "v2.1",
             docs = "https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup",
             "iPXE provisioning strategy (internally) is deprecated; enable DPF management for DPUs to migrate"
         );

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -3315,7 +3315,6 @@ pub fn dpf_based_dpu_provisioning_possible(
         );
         tracing::warn!(
             machine_id = %state.host_snapshot.id,
-            removed_in = "v2.1",
             docs = "https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup",
             "iPXE provisioning strategy (internally) is deprecated; enable DPF management for DPUs to migrate"
         );
@@ -3347,7 +3346,6 @@ pub fn dpf_based_dpu_provisioning_possible(
         );
         tracing::warn!(
             machine_id = %state.host_snapshot.id,
-            removed_in = "v2.1",
             docs = "https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup",
             "iPXE provisioning strategy (internally) is deprecated; enable DPF management for DPUs to migrate"
         );
@@ -3369,7 +3367,6 @@ pub fn dpf_based_dpu_provisioning_possible(
         );
         tracing::warn!(
             machine_id = %state.host_snapshot.id,
-            removed_in = "v2.1",
             docs = "https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup",
             "iPXE provisioning strategy (internally) is deprecated; enable DPF management for DPUs to migrate"
         );
@@ -3387,7 +3384,6 @@ pub fn dpf_based_dpu_provisioning_possible(
         );
         tracing::warn!(
             machine_id = %state.host_snapshot.id,
-            removed_in = "v2.1",
             docs = "https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup",
             "iPXE provisioning strategy (internally) is deprecated; enable DPF management for DPUs to migrate"
         );

--- a/crates/api-web/src/tests/managed_host.rs
+++ b/crates/api-web/src/tests/managed_host.rs
@@ -313,6 +313,8 @@ async fn test_managed_host_html_includes_health_alert_details(
             "IntrusionSensorTriggered [Target: HostBMC]: Physical Chassis Intrusion Alert"
         )
     );
+    assert!(body_str.contains("will be removed in a future release"));
+    assert!(!body_str.contains("v2.1"));
 
     Ok(())
 }

--- a/crates/api-web/templates/managed_host_show.html
+++ b/crates/api-web/templates/managed_host_show.html
@@ -155,7 +155,7 @@
 
 {% if has_dpf_warning %}
 <div class="bubble warning" style="margin-bottom: 1em;">
-	WARNING: One or more DPUs are using a provisioning strategy (internal) which is deprecated and will be removed in v2.1.
+	WARNING: One or more DPUs are using a provisioning strategy (internal) which is deprecated and will be removed in a future release.
 	See <a href="https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup">how to enable DPF management for DPUs</a>.
 </div>
 {% endif %}

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -2654,7 +2654,6 @@ impl StateHandler for MachineStateHandler {
         if !mh_snapshot.host_snapshot.config.dpf.used_for_ingestion {
             tracing::debug!(
                 machine_id = %host_machine_id,
-                removed_in = "v2.1",
                 docs = "https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup",
                 "iPXE provisioning strategy (internally) is deprecated; enable DPF management for DPUs to migrate"
             );


### PR DESCRIPTION
Warnings for the deprecated internal DPU provisioning strategy on `release/v2.1` specify a v2.1 removal deadline. That deadline is no longer accurate.

This backport:

- Replaces the fixed v2.1 deadline with “a future release” in the admin CLI and web UI.
- Removes the stale `removed_in = "v2.1"` fields from associated log events.
- Adds assertions covering the rendered web warning.

Existing provisioning behavior and iPXE-specific log messages remain unchanged.

## Related issues

- Backport of https://github.com/NVIDIA/infra-controller/pull/5076

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validation completed in the Linux build environment:

- Targeted `carbide-api-web` test — 1 passed, 0 failed.
- `cargo test --locked -p carbide-api-web --lib` — 54 passed, 0 failed.
- `cargo make --no-workspace clippy-flow` — passed.
- `cargo fmt --all -- --check` — passed.
- Repository-wide stale-warning scan — zero matches.

## Additional Notes

This is a warning and logging-metadata correction only. No provisioning logic or control-flow changes are included.
