### PR TITLE
tests(core): move remaning power shelf tests to integration suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,6 +2718,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "state-controller",
+ "tokio",
  "tokio-util",
  "tonic",
  "tracing",

--- a/crates/api-core/src/test_support/health.rs
+++ b/crates/api-core/src/test_support/health.rs
@@ -37,9 +37,11 @@ use tonic::Status;
 
 /// The health-override fields common to every entity's status, as read back from a
 /// `find` RPC: the merged health report and the per-source override origins.
-pub(in crate::tests) struct HealthStatusView {
-    pub(in crate::tests) health: Option<rpc::health::HealthReport>,
-    pub(in crate::tests) health_sources: Vec<HealthSourceOrigin>,
+pub struct HealthStatusView {
+    /// The merged health report returned for the entity.
+    pub health: Option<rpc::health::HealthReport>,
+    /// The external health sources applied to the entity.
+    pub health_sources: Vec<HealthSourceOrigin>,
 }
 
 /// One entity's health-override CRUD surface, expressed as closures over a single
@@ -47,23 +49,23 @@ pub(in crate::tests) struct HealthStatusView {
 ///
 /// `Id` is the entity ID type; closures take it by value so the same harness can be
 /// pointed at a real ID or a freshly-minted nonexistent one.
-pub(in crate::tests) struct HealthCrud<Id, Ins, Lst, Rem, Fnd> {
+pub struct HealthCrud<Id, Ins, Lst, Rem, Fnd> {
     /// A persisted entity's ID, used by the behaviors that operate on a live entity.
-    pub(in crate::tests) real_id: Id,
+    pub real_id: Id,
     /// An ID that was never persisted, used by the "missing entity" check.
-    pub(in crate::tests) nonexistent_id: Id,
+    pub nonexistent_id: Id,
     /// A representative report carrying one alert (entity-specific alert ID).
-    pub(in crate::tests) alert: HealthReport,
+    pub alert: HealthReport,
     /// A source identifier the alert report is filed under.
-    pub(in crate::tests) alert_source: &'static str,
+    pub alert_source: &'static str,
     /// An override RPC: file `report` under its source for `id`, in `mode`.
-    pub(in crate::tests) insert: Ins,
+    pub insert: Ins,
     /// A list RPC: the override entries currently held for `id`.
-    pub(in crate::tests) list: Lst,
+    pub list: Lst,
     /// A remove RPC: drop the override filed under `source` for `id`.
-    pub(in crate::tests) remove: Rem,
+    pub remove: Rem,
     /// A find RPC: read back `id`'s status health view.
-    pub(in crate::tests) find: Fnd,
+    pub find: Fnd,
 }
 
 impl<Id, Ins, Lst, Rem, Fnd> HealthCrud<Id, Ins, Lst, Rem, Fnd>
@@ -76,7 +78,7 @@ where
 {
     /// Insert an override, confirm exactly one entry lists with the expected source
     /// and one alert, remove it, and confirm the list is empty again.
-    pub(in crate::tests) async fn check_insert_list_remove(&self) {
+    pub async fn check_insert_list_remove(&self) {
         (self.insert)(
             self.real_id.clone(),
             self.alert.clone(),
@@ -109,7 +111,7 @@ where
     }
 
     /// Inserting the same override repeatedly is idempotent: still one entry.
-    pub(in crate::tests) async fn check_idempotent_insert(&self) {
+    pub async fn check_idempotent_insert(&self) {
         for _ in 0..3 {
             (self.insert)(
                 self.real_id.clone(),
@@ -129,7 +131,7 @@ where
     /// A continuously-firing alert keeps the `in_alert_since` of its first
     /// report, so operators can tell how long the condition has lasted. Without
     /// this, every re-report restamps the alert and it always looks brand new.
-    pub(in crate::tests) async fn check_retains_in_alert_since(&self) {
+    pub async fn check_retains_in_alert_since(&self) {
         let in_alert_since = async || {
             let entries = (self.list)(self.real_id.clone())
                 .await
@@ -174,7 +176,7 @@ where
     }
 
     /// Removing a source that was never filed is a `NotFound`.
-    pub(in crate::tests) async fn check_remove_nonexistent_source(&self) {
+    pub async fn check_remove_nonexistent_source(&self) {
         let status = (self.remove)(self.real_id.clone(), "nonexistent-source".to_string())
             .await
             .expect_err("removing an unknown source should error");
@@ -182,7 +184,7 @@ where
     }
 
     /// Inserting an override for an entity that does not exist is an error.
-    pub(in crate::tests) async fn check_missing_entity(&self) {
+    pub async fn check_missing_entity(&self) {
         let status = (self.insert)(
             self.nonexistent_id.clone(),
             self.alert.clone(),
@@ -194,11 +196,7 @@ where
     }
 
     /// A `Replace`-mode override lists with `Replace` mode and clears on remove.
-    pub(in crate::tests) async fn check_replace_mode(
-        &self,
-        replace_report: HealthReport,
-        replace_source: &str,
-    ) {
+    pub async fn check_replace_mode(&self, replace_report: HealthReport, replace_source: &str) {
         (self.insert)(
             self.real_id.clone(),
             replace_report,
@@ -225,7 +223,7 @@ where
 
     /// An inserted override is visible on the entity's status from a `find` RPC:
     /// the merged health carries alerts, and the override source is recorded.
-    pub(in crate::tests) async fn check_visible_in_find(&self) {
+    pub async fn check_visible_in_find(&self) {
         (self.insert)(
             self.real_id.clone(),
             self.alert.clone(),
@@ -261,7 +259,7 @@ where
 /// `metric_entity` is the entity token in the metric names (e.g. `power_shelves`),
 /// `run_iteration` advances that entity's controller, and `insert`/`alert`/`empty`
 /// supply the entity's override RPC and reports.
-pub(in crate::tests) async fn check_health_aggregation<Id, Ins, Iter>(
+pub async fn check_health_aggregation<Id, Ins, Iter>(
     metric_entity: &str,
     real_id: Id,
     alert: HealthReport,

--- a/crates/api-core/src/test_support/mod.rs
+++ b/crates/api-core/src/test_support/mod.rs
@@ -18,6 +18,7 @@
 pub mod builder;
 pub mod default_config;
 pub mod fixture_config;
+pub mod health;
 pub(crate) mod ib_fabric;
 pub(crate) mod ib_guid_pool;
 pub mod mac_address_pool;

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -48,9 +48,6 @@ use carbide_nvlink_manager::nvlink::test_support::NmxcSimClient;
 use carbide_nvlink_manager::{
     NvlPartitionMonitor, SwitchCertificateMonitor, SwitchCertificateMonitorIterationResult,
 };
-use carbide_power_shelf_controller::context::PowerShelfStateHandlerServices;
-use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
-use carbide_power_shelf_controller::io::PowerShelfStateControllerIO;
 use carbide_rack::rms_client::test_support::RmsSim;
 use carbide_rack_controller::config::RackConfig;
 use carbide_rack_controller::context::RackStateHandlerServices;
@@ -284,7 +281,6 @@ pub(crate) struct TestEnv {
     vpc_prefix_controller: Arc<Mutex<StateController<VpcPrefixStateControllerIO>>>,
     extension_service_controller: Arc<Mutex<StateController<ExtensionServiceStateControllerIO>>>,
     ib_partition_controller: Arc<Mutex<StateController<IBPartitionStateControllerIO>>>,
-    power_shelf_controller: Arc<Mutex<StateController<PowerShelfStateControllerIO>>>,
     rack_controller: Arc<Mutex<StateController<RackStateControllerIO>>>,
     switch_controller: Arc<Mutex<StateController<SwitchStateControllerIO>>>,
     pub(in crate::tests) reachability_params: ReachabilityParams,
@@ -658,17 +654,6 @@ impl TestEnv {
             .await
             .run_single_iteration()
             .boxed()
-            .await;
-    }
-
-    /// Runs one iteration of the power shelf state controller handler with the services
-    /// in this test environment
-    #[allow(clippy::await_holding_refcell_ref)]
-    pub(in crate::tests) async fn run_power_shelf_controller_iteration(&self) {
-        self.power_shelf_controller
-            .lock()
-            .await
-            .run_single_iteration()
             .await;
     }
 
@@ -1670,29 +1655,6 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
         .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build ExtensionServiceStateController");
 
-    let power_shelf_controller = StateController::builder()
-        .database(db_pool.clone(), api.work_lock_manager_handle.clone())
-        .meter("carbide_power_shelves", test_meter.meter())
-        .processor_id(state_controller_id.clone())
-        .services(
-            PowerShelfStateHandlerServices {
-                db_pool: db_pool.clone(),
-                component_manager: test_component_manager.clone(),
-                credential_manager: credential_manager.clone(),
-                per_object_metrics_registry: per_object_metrics_registry.clone(),
-                rack_firmware_reprovisioning_enabled: false,
-                redfish_client_pool: redfish_sim.clone(),
-                bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
-                    db::credential_rotation::CredentialRotationType::Bmc,
-                ),
-                bmc_rotation_enabled: false,
-            }
-            .into(),
-        )
-        .state_handler(Arc::new(PowerShelfStateHandler::default()))
-        .build_for_manual_iterations(cancel_token.clone())
-        .expect("Unable to build PowerShelfStateController");
-
     let switch_controller = StateController::builder()
         .database(db_pool.clone(), api.work_lock_manager_handle.clone())
         .meter("carbide_switches", test_meter.meter())
@@ -1868,7 +1830,6 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
         network_segment_controller: Arc::new(Mutex::new(network_controller)),
         vpc_prefix_controller: Arc::new(Mutex::new(vpc_prefix_controller)),
         extension_service_controller: Arc::new(Mutex::new(extension_service_controller)),
-        power_shelf_controller: Arc::new(Mutex::new(power_shelf_controller)),
         rack_controller: Arc::new(Mutex::new(rack_controller)),
         reachability_params,
         attestation_enabled,

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -22,13 +22,11 @@ use std::net::IpAddr;
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::machine_validation::MachineValidationId;
-use carbide_uuid::power_shelf::{PowerShelfId, PowerShelfIdSource, PowerShelfType};
 use carbide_uuid::rack::{RackId, RackProfileId};
 use carbide_uuid::switch::SwitchId;
 use db::machine_interface::find_by_mac_address;
 use db::{
-    DatabaseError, expected_machine as db_expected_machine, power_shelf as db_power_shelf,
-    rack as db_rack, switch as db_switch,
+    DatabaseError, expected_machine as db_expected_machine, rack as db_rack, switch as db_switch,
 };
 use futures_util::FutureExt;
 use health_report::HealthReport;
@@ -42,8 +40,6 @@ use model::machine::{
     MachineState, MachineValidatingState, ManagedHostState, ManagedHostStateSnapshot,
     MeasuringState, SpdmMeasuringState, ValidationState,
 };
-use model::power_shelf::power_shelf_id::from_hardware_info;
-use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
 use model::rack::RackConfig;
 use model::site_explorer::{Chassis, EndpointExplorationReport, EndpointType};
 use model::switch::{NewSwitch, SwitchConfig};
@@ -1817,63 +1813,6 @@ pub(in crate::tests) async fn new_dpu_in_network_install(
         dpu_ids: vec![dpu_machine_id],
         api: env.api.clone(),
     })
-}
-
-/// Creates a new power shelf for testing purposes
-pub(in crate::tests) async fn new_power_shelf(
-    env: &TestEnv,
-    name: Option<String>,
-    capacity: Option<u32>,
-    voltage: Option<u32>,
-    _location: Option<String>,
-) -> eyre::Result<PowerShelfId> {
-    let mut txn = env.pool.begin().await.unwrap();
-
-    // Generate a unique name if not provided
-    let power_shelf_name = name.unwrap_or_else(|| {
-        format!(
-            "Test Power Shelf {}",
-            &uuid::Uuid::new_v4().to_string()[..8]
-        )
-    });
-
-    // Generate power shelf ID using hardware info
-    let power_shelf_serial = &power_shelf_name;
-    let power_shelf_vendor = "NVIDIA";
-    let power_shelf_model = "PowerShelf";
-
-    let power_shelf_id = from_hardware_info(
-        power_shelf_serial,
-        power_shelf_vendor,
-        power_shelf_model,
-        PowerShelfIdSource::ProductBoardChassisSerial,
-        PowerShelfType::Rack,
-    )
-    .map_err(|e| eyre::eyre!("failed to create power shelf ID: {:?}", e))?;
-
-    // Create power shelf configuration
-    let config = PowerShelfConfig {
-        name: power_shelf_name,
-        capacity: capacity.or(Some(100)),
-        voltage: voltage.or(Some(240)),
-    };
-
-    // Create the power shelf
-    let new_power_shelf = NewPowerShelf {
-        id: power_shelf_id,
-        config,
-        bmc_mac_address: None,
-        metadata: None,
-        rack_id: None,
-    };
-
-    let _power_shelf = db_power_shelf::create(&mut txn, &new_power_shelf)
-        .await
-        .map_err(|e| eyre::eyre!("failed to create power shelf: {:?}", e))?;
-
-    txn.commit().await.unwrap();
-
-    Ok(power_shelf_id)
 }
 
 /*

--- a/crates/api-core/src/tests/common/mod.rs
+++ b/crates/api-core/src/tests/common/mod.rs
@@ -27,7 +27,6 @@ pub(in crate::tests) mod endpoint;
 // Only this crate's own `#[cfg(test)]` health-override tests drive these shared CRUD
 // helpers; gate them out of test-support-only builds to keep dead-code detection honest.
 #[cfg(test)]
-pub(in crate::tests) mod health_crud;
 pub(in crate::tests) mod metadata;
 pub(in crate::tests) mod network_segment;
 pub(in crate::tests) mod overlay_address;

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -69,7 +69,6 @@ mod network_segment_find;
 mod network_segment_lifecycle;
 mod nvl_instance;
 mod nvl_logical_partition;
-mod power_shelf_health;
 mod preingestion_dpu_nic_mode;
 mod primary_interface;
 mod rack_health;

--- a/crates/api-core/src/tests/rack_health.rs
+++ b/crates/api-core/src/tests/rack_health.rs
@@ -28,12 +28,12 @@ use rpc::forge::{self as rpc_forge};
 use tonic::Request;
 
 use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
+use crate::test_support::health::{HealthCrud, HealthStatusView, check_health_aggregation};
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
     TestEnv, TestEnvOverrides, create_managed_host, create_managed_host_with_config,
     create_test_env_with_overrides, get_config, send_health_report_entry,
 };
-use crate::tests::common::health_crud::{HealthCrud, HealthStatusView, check_health_aggregation};
 
 fn leak_alert_report(source: &str) -> HealthReport {
     HealthReport {
@@ -78,7 +78,7 @@ async fn new_rack(pool: &sqlx::PgPool) -> Result<RackId, Box<dyn std::error::Err
 }
 
 /// Builds the rack health-override CRUD surface over `env` for `id`. The shared
-/// checks in [`crate::tests::common::health_crud`] drive these closures.
+/// checks in [`crate::test_support::health`] drive these closures.
 // The four `impl AsyncFn` members are intentionally distinct unnameable closure
 // types; there is nothing to factor into a `type` alias.
 #[allow(clippy::type_complexity)]

--- a/crates/api-core/src/tests/switch_health.rs
+++ b/crates/api-core/src/tests/switch_health.rs
@@ -21,11 +21,11 @@ use rpc::forge::forge_server::Forge;
 use rpc::forge::{self as rpc_forge};
 use tonic::Request;
 
+use crate::test_support::health::{HealthCrud, HealthStatusView, check_health_aggregation};
 use crate::tests::common::api_fixtures::site_explorer::new_switch;
 use crate::tests::common::api_fixtures::{
     TestEnv, TestEnvOverrides, create_test_env_with_overrides, get_config,
 };
-use crate::tests::common::health_crud::{HealthCrud, HealthStatusView, check_health_aggregation};
 
 fn alert_report(source: &str) -> HealthReport {
     HealthReport {
@@ -62,7 +62,7 @@ async fn test_env(pool: sqlx::PgPool) -> TestEnv {
 }
 
 /// Builds the switch health-override CRUD surface over `env` for `id`. The shared
-/// checks in [`crate::tests::common::health_crud`] drive these closures.
+/// checks in [`crate::test_support::health`] drive these closures.
 // The four `impl AsyncFn` members are intentionally distinct unnameable closure
 // types; there is nothing to factor into a `type` alias.
 #[allow(clippy::type_complexity)]

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -46,6 +46,7 @@ mod power_shelf;
 mod power_shelf_decommission;
 mod power_shelf_delete;
 mod power_shelf_find;
+mod power_shelf_health;
 mod power_shelf_maintenance;
 mod rack_find;
 mod rack_profile;

--- a/crates/api-core/tests/integration/power_shelf_health.rs
+++ b/crates/api-core/tests/integration/power_shelf_health.rs
@@ -15,17 +15,13 @@
  * limitations under the License.
  */
 
+use carbide_test_harness::prelude::*;
+use carbide_test_harness::test_support::health::{HealthCrud, HealthStatusView};
 use carbide_uuid::power_shelf::PowerShelfId;
 use health_report::{HealthAlertClassification, HealthProbeAlert, HealthReport};
-use rpc::forge::forge_server::Forge;
+use model::test_support::power_shelf;
 use rpc::forge::{self as rpc_forge};
 use tonic::Request;
-
-use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
-use crate::tests::common::api_fixtures::{
-    TestEnv, TestEnvOverrides, create_test_env_with_overrides, get_config,
-};
-use crate::tests::common::health_crud::{HealthCrud, HealthStatusView, check_health_aggregation};
 
 fn alert_report(source: &str) -> HealthReport {
     HealthReport {
@@ -57,17 +53,13 @@ fn empty_healthy_report(source: &str) -> HealthReport {
     }
 }
 
-async fn test_env(pool: sqlx::PgPool) -> TestEnv {
-    create_test_env_with_overrides(pool, TestEnvOverrides::with_config(get_config())).await
-}
-
 /// Builds the power-shelf health-override CRUD surface over `env` for `id`. The
-/// shared checks in [`crate::tests::common::health_crud`] drive these closures.
+/// shared checks in [`carbide_test_harness::test_support::health`] drive these closures.
 // The four `impl AsyncFn` members are intentionally distinct unnameable closure
 // types; there is nothing to factor into a `type` alias.
 #[allow(clippy::type_complexity)]
 fn power_shelf_crud(
-    env: &TestEnv,
+    env: &TestHarness,
     id: PowerShelfId,
 ) -> HealthCrud<
     PowerShelfId,
@@ -87,7 +79,7 @@ fn power_shelf_crud(
         alert_source: "external-monitor",
         insert: async move |id, report: HealthReport, mode| {
             let report: rpc::health::HealthReport = report.into();
-            env.api
+            env.api()
                 .insert_power_shelf_health_report(Request::new(
                     rpc_forge::InsertPowerShelfHealthReportRequest {
                         power_shelf_id: Some(id),
@@ -102,7 +94,7 @@ fn power_shelf_crud(
         },
         list: async move |id| {
             Ok(env
-                .api
+                .api()
                 .list_power_shelf_health_reports(Request::new(
                     rpc_forge::ListPowerShelfHealthReportsRequest {
                         power_shelf_id: Some(id),
@@ -113,7 +105,7 @@ fn power_shelf_crud(
                 .health_report_entries)
         },
         remove: async move |id, source| {
-            env.api
+            env.api()
                 .remove_power_shelf_health_report(Request::new(
                     rpc_forge::RemovePowerShelfHealthReportRequest {
                         power_shelf_id: Some(id),
@@ -125,7 +117,7 @@ fn power_shelf_crud(
         },
         find: async move |id| {
             let resp = env
-                .api
+                .api()
                 .find_power_shelves(Request::new(rpc_forge::PowerShelfQuery {
                     power_shelf_id: Some(id),
                     name: None,
@@ -142,97 +134,100 @@ fn power_shelf_crud(
     }
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_insert_list_remove_power_shelf_health_report(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
+    let env = TestHarness::builder(pool).build().await;
+    let id = env
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
     power_shelf_crud(&env, id).check_insert_list_remove().await;
     Ok(())
 }
 
-#[crate::sqlx_test]
-async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
+#[sqlx_test]
+async fn test_idempotent_insert(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool).build().await;
+    let id = env
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
     power_shelf_crud(&env, id).check_idempotent_insert().await;
     Ok(())
 }
 
-#[crate::sqlx_test]
-async fn test_retains_in_alert_since(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
+#[sqlx_test]
+async fn test_retains_in_alert_since(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool).build().await;
+    let id = env
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
     power_shelf_crud(&env, id)
         .check_retains_in_alert_since()
         .await;
     Ok(())
 }
 
-#[crate::sqlx_test]
-async fn test_remove_nonexistent_source(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
+#[sqlx_test]
+async fn test_remove_nonexistent_source(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool).build().await;
+    let id = env
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
     power_shelf_crud(&env, id)
         .check_remove_nonexistent_source()
         .await;
     Ok(())
 }
 
-#[crate::sqlx_test]
-async fn test_missing_power_shelf_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
+#[sqlx_test]
+async fn test_missing_power_shelf_id(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool).build().await;
+    let id = env
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
     power_shelf_crud(&env, id).check_missing_entity().await;
     Ok(())
 }
 
-#[crate::sqlx_test]
-async fn test_replace_mode(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
+#[sqlx_test]
+async fn test_replace_mode(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool).build().await;
+    let id = env
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
     power_shelf_crud(&env, id)
         .check_replace_mode(empty_healthy_report("admin-override"), "admin-override")
         .await;
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_health_visible_in_find_power_shelves(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
+    let env = TestHarness::builder(pool).build().await;
+    let id = env
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
     power_shelf_crud(&env, id).check_visible_in_find().await;
     Ok(())
 }
 
-async fn insert_power_shelf_health(env: &TestEnv, id: PowerShelfId, report: HealthReport) {
-    let report: rpc::health::HealthReport = report.into();
-    env.api
-        .insert_power_shelf_health_report(Request::new(
-            rpc_forge::InsertPowerShelfHealthReportRequest {
-                power_shelf_id: Some(id),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(report),
-                    mode: rpc_forge::HealthReportApplyMode::Replace as i32,
-                }),
-            },
-        ))
-        .await
-        .unwrap();
-}
-
 async fn power_shelf_health_history(
-    env: &TestEnv,
+    env: &TestHarness,
     id: PowerShelfId,
     start_time: Option<chrono::DateTime<chrono::Utc>>,
     end_time: Option<chrono::DateTime<chrono::Utc>>,
 ) -> Vec<rpc_forge::HealthHistoryRecord> {
-    env.api
+    env.api()
         .find_power_shelf_health_histories(Request::new(
             rpc_forge::PowerShelfHealthHistoriesRequest {
                 power_shelf_ids: vec![id],
@@ -249,59 +244,31 @@ async fn power_shelf_health_history(
         .records
 }
 
-/// The power-shelf controller records a health-history snapshot each iteration;
-/// the DB layer deduplicates unchanged observations and only appends when the
-/// aggregate health content changes. This exercises that path end-to-end through
-/// the `FindPowerShelfHealthHistories` RPC.
-#[crate::sqlx_test]
-async fn test_power_shelf_health_history_records_and_deduplicates(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
-
-    insert_power_shelf_health(&env, id, alert_report("external-monitor")).await;
-    env.run_power_shelf_controller_iteration().await;
-    let after_first = power_shelf_health_history(&env, id, None, None).await.len();
-    assert!(
-        after_first >= 1,
-        "expected at least one health-history record after the first iteration"
-    );
-
-    env.run_power_shelf_controller_iteration().await;
-    let after_second = power_shelf_health_history(&env, id, None, None).await.len();
-    assert_eq!(
-        after_first, after_second,
-        "unchanged aggregate health must not add a new record"
-    );
-
-    insert_power_shelf_health(&env, id, empty_healthy_report("external-monitor")).await;
-    env.run_power_shelf_controller_iteration().await;
-    let after_change = power_shelf_health_history(&env, id, None, None).await.len();
-    assert_eq!(
-        after_change,
-        after_second + 1,
-        "changed aggregate health must append exactly one record"
-    );
-
-    Ok(())
-}
-
 /// The `FindPowerShelfHealthHistories` handler must forward both time bounds
 /// from the request into the shared query. This proves the power-shelf-specific
 /// wiring; the shared range-filtering query in `find_by_object_ids` is also
 /// exercised by the machine time-range test.
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_power_shelf_health_history_respects_time_range(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
+    let env = TestHarness::builder(pool).build().await;
+    let id = env
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
 
     let before = chrono::Utc::now();
     tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-    insert_power_shelf_health(&env, id, alert_report("external-monitor")).await;
-    env.run_power_shelf_controller_iteration().await;
+    let mut txn = env.db_txn().await;
+    db::health_history::persist(
+        txn.as_mut(),
+        db::health_history::HealthHistoryTableId::PowerShelf,
+        &id,
+        &alert_report("external-monitor"),
+    )
+    .await?;
+    txn.commit().await?;
 
     let in_range =
         power_shelf_health_history(&env, id, Some(before), Some(chrono::Utc::now())).await;
@@ -331,13 +298,13 @@ async fn test_power_shelf_health_history_respects_time_range(
     Ok(())
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_find_power_shelf_health_histories_rejects_empty_ids(
-    pool: sqlx::PgPool,
+    pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
+    let env = TestHarness::builder(pool).build().await;
     let status = env
-        .api
+        .api()
         .find_power_shelf_health_histories(Request::new(
             rpc_forge::PowerShelfHealthHistoriesRequest {
                 power_shelf_ids: vec![],
@@ -348,38 +315,5 @@ async fn test_find_power_shelf_health_histories_rejects_empty_ids(
         .await
         .expect_err("empty power_shelf_ids must be rejected");
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_power_shelf_health_aggregation(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = test_env(pool).await;
-    let id = new_power_shelf(&env, None, None, None, None).await?;
-    check_health_aggregation(
-        "power_shelves",
-        id,
-        alert_report("external-monitor"),
-        empty_healthy_report("admin-override"),
-        &env.test_meter,
-        async |id, report: HealthReport, mode| {
-            let report: rpc::health::HealthReport = report.into();
-            env.api
-                .insert_power_shelf_health_report(Request::new(
-                    rpc_forge::InsertPowerShelfHealthReportRequest {
-                        power_shelf_id: Some(id),
-                        health_report_entry: Some(rpc_forge::HealthReportEntry {
-                            report: Some(report),
-                            mode: mode as i32,
-                        }),
-                    },
-                ))
-                .await
-                .map(|_| ())
-        },
-        async || env.run_power_shelf_controller_iteration().await,
-    )
-    .await;
     Ok(())
 }

--- a/crates/api-model/src/test_support/power_shelf.rs
+++ b/crates/api-model/src/test_support/power_shelf.rs
@@ -19,6 +19,11 @@
 
 use crate::power_shelf::PowerShelfConfig;
 
+/// Returns a default power shelf config with a unique name.
+pub fn default_config() -> PowerShelfConfig {
+    power_shelf_config(&format!("Test Power Shelf {}", uuid::Uuid::new_v4()))
+}
+
 /// Returns a power shelf config with capacity 100 and voltage 240.
 pub fn power_shelf_config(name: &str) -> PowerShelfConfig {
     PowerShelfConfig {

--- a/crates/power-shelf-controller/Cargo.toml
+++ b/crates/power-shelf-controller/Cargo.toml
@@ -54,6 +54,7 @@ carbide-test-harness = { path = "../test-harness" }
 state-controller = { path = "../state-controller", features = ["test-support"] }
 chrono = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 uuid = { workspace = true }

--- a/crates/power-shelf-controller/tests/integration/common.rs
+++ b/crates/power-shelf-controller/tests/integration/common.rs
@@ -23,6 +23,7 @@ use carbide_power_shelf_controller::context::{
     PowerShelfStateHandlerContextObjects, PowerShelfStateHandlerServices,
 };
 use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
+use carbide_power_shelf_controller::io::PowerShelfStateControllerIO;
 use carbide_power_shelf_controller::metrics::PowerShelfMetrics;
 use carbide_rack::rms_client::test_support::RmsSim;
 use carbide_redfish::libredfish::test_support::RedfishSim;
@@ -38,8 +39,11 @@ use model::power_shelf::{PowerShelf, PowerShelfControllerState};
 use model::rack_type::RackProfileConfig;
 use model::test_support::rms_rack_profiles;
 use sqlx::{PgConnection, PgPool};
+use state_controller::controller::StateController;
 use state_controller::db_write_batch::DbWriteBatch;
 use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 pub(super) struct ControllerEnv {
     pub(super) harness: TestHarness,
@@ -49,6 +53,7 @@ pub(super) struct ControllerEnv {
     pub(super) rms_sim: Arc<RmsSim>,
     pub(super) rack_profiles: RackProfileConfig,
     pub(super) per_object_metrics_registry: Arc<PerObjectMetricsRegistry>,
+    controller: Mutex<StateController<PowerShelfStateControllerIO>>,
 }
 
 impl ControllerEnv {
@@ -66,7 +71,7 @@ impl ControllerEnv {
                 .clone(),
             Duration::from_secs(60),
         );
-        let api_component_manager = component_manager::component_manager::build_component_manager(
+        let component_manager = component_manager::component_manager::build_component_manager(
             &ComponentManagerConfig {
                 nv_switch_backend: NvSwitchBackend::Rms,
                 power_shelf_backend: PowerShelfBackend::Rms,
@@ -83,6 +88,8 @@ impl ControllerEnv {
         )
         .await
         .expect("test component manager should build");
+        let component_manager = Arc::new(component_manager);
+        let api_component_manager = component_manager.clone();
         let api_redfish_sim = redfish_sim.clone();
         let api_credential_manager = credential_manager.clone();
         let api_rms_client = rms_sim
@@ -96,10 +103,32 @@ impl ControllerEnv {
                     .with_credential_manager(api_credential_manager)
                     .with_redfish_pool(api_redfish_sim)
                     .with_rms_client(api_rms_client)
-                    .with_component_manager(Arc::new(api_component_manager))
+                    .with_component_manager(api_component_manager)
             })
             .build()
             .await;
+        let controller = StateController::builder()
+            .database(pool.clone(), harness.api().work_lock_manager_handle())
+            .meter("carbide_power_shelves", harness.test_meter.meter())
+            .processor_id(uuid::Uuid::new_v4().to_string())
+            .services(
+                PowerShelfStateHandlerServices {
+                    db_pool: pool.clone(),
+                    component_manager: Some(component_manager),
+                    credential_manager: Arc::new(TestCredentialManager::default()),
+                    per_object_metrics_registry: per_object_metrics_registry.clone(),
+                    rack_firmware_reprovisioning_enabled: false,
+                    redfish_client_pool: redfish_sim.clone(),
+                    bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
+                        db::credential_rotation::CredentialRotationType::Bmc,
+                    ),
+                    bmc_rotation_enabled: false,
+                }
+                .into(),
+            )
+            .state_handler(Arc::new(PowerShelfStateHandler::default()))
+            .build_for_manual_iterations(CancellationToken::new())
+            .expect("power shelf state controller should build");
 
         Self {
             harness,
@@ -109,7 +138,12 @@ impl ControllerEnv {
             rms_sim,
             rack_profiles,
             per_object_metrics_registry,
+            controller: Mutex::new(controller),
         }
+    }
+
+    pub(super) async fn run_controller_iteration(&self) {
+        self.controller.lock().await.run_single_iteration().await;
     }
 }
 

--- a/crates/power-shelf-controller/tests/integration/health.rs
+++ b/crates/power-shelf-controller/tests/integration/health.rs
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_test_harness::prelude::*;
+use carbide_test_harness::test_support::health::check_health_aggregation;
+use carbide_uuid::power_shelf::PowerShelfId;
+use health_report::{HealthAlertClassification, HealthProbeAlert, HealthReport};
+use model::test_support::power_shelf;
+use rpc::forge as rpc_forge;
+use tonic::Request;
+
+use crate::common::ControllerEnv;
+
+fn alert_report(source: &str) -> HealthReport {
+    HealthReport {
+        source: source.to_string(),
+        triggered_by: None,
+        observed_at: Some(chrono::Utc::now()),
+        successes: vec![],
+        alerts: vec![HealthProbeAlert {
+            id: "PowerShelfUnhealthy".parse().unwrap(),
+            target: None,
+            in_alert_since: Some(chrono::Utc::now()),
+            message: "Power shelf health issue detected".to_string(),
+            tenant_message: None,
+            classifications: vec![
+                HealthAlertClassification::prevent_allocations(),
+                HealthAlertClassification::hardware(),
+            ],
+        }],
+    }
+}
+
+fn empty_healthy_report(source: &str) -> HealthReport {
+    HealthReport {
+        source: source.to_string(),
+        triggered_by: None,
+        observed_at: Some(chrono::Utc::now()),
+        successes: vec![],
+        alerts: vec![],
+    }
+}
+
+async fn insert_power_shelf_health(env: &ControllerEnv, id: PowerShelfId, report: HealthReport) {
+    let report: rpc::health::HealthReport = report.into();
+    env.harness
+        .api()
+        .insert_power_shelf_health_report(Request::new(
+            rpc_forge::InsertPowerShelfHealthReportRequest {
+                power_shelf_id: Some(id),
+                health_report_entry: Some(rpc_forge::HealthReportEntry {
+                    report: Some(report),
+                    mode: rpc_forge::HealthReportApplyMode::Replace as i32,
+                }),
+            },
+        ))
+        .await
+        .unwrap();
+}
+
+async fn power_shelf_health_history(
+    env: &ControllerEnv,
+    id: PowerShelfId,
+) -> Vec<rpc_forge::HealthHistoryRecord> {
+    env.harness
+        .api()
+        .find_power_shelf_health_histories(Request::new(
+            rpc_forge::PowerShelfHealthHistoriesRequest {
+                power_shelf_ids: vec![id],
+                start_time: None,
+                end_time: None,
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .histories
+        .remove(&id.to_string())
+        .unwrap_or_default()
+        .records
+}
+
+/// The power-shelf controller records a health-history snapshot each iteration;
+/// the DB layer deduplicates unchanged observations and only appends when the
+/// aggregate health content changes. This exercises that path end-to-end through
+/// the `FindPowerShelfHealthHistories` RPC.
+#[sqlx_test]
+async fn test_power_shelf_health_history_records_and_deduplicates(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = ControllerEnv::new(pool).await;
+    let id = env
+        .harness
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
+
+    insert_power_shelf_health(&env, id, alert_report("external-monitor")).await;
+    env.run_controller_iteration().await;
+    let after_first = power_shelf_health_history(&env, id).await.len();
+    assert!(
+        after_first >= 1,
+        "expected at least one health-history record after the first iteration"
+    );
+
+    env.run_controller_iteration().await;
+    let after_second = power_shelf_health_history(&env, id).await.len();
+    assert_eq!(
+        after_first, after_second,
+        "unchanged aggregate health must not add a new record"
+    );
+
+    insert_power_shelf_health(&env, id, empty_healthy_report("external-monitor")).await;
+    env.run_controller_iteration().await;
+    let after_change = power_shelf_health_history(&env, id).await.len();
+    assert_eq!(
+        after_change,
+        after_second + 1,
+        "changed aggregate health must append exactly one record"
+    );
+
+    Ok(())
+}
+
+#[sqlx_test]
+async fn test_power_shelf_health_aggregation(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = ControllerEnv::new(pool).await;
+    let id = env
+        .harness
+        .create_power_shelf(power_shelf::default_config())
+        .await
+        .id;
+    check_health_aggregation(
+        "power_shelves",
+        id,
+        alert_report("external-monitor"),
+        empty_healthy_report("admin-override"),
+        &env.harness.test_meter,
+        async |id, report: HealthReport, mode| {
+            let report: rpc::health::HealthReport = report.into();
+            env.harness
+                .api()
+                .insert_power_shelf_health_report(Request::new(
+                    rpc_forge::InsertPowerShelfHealthReportRequest {
+                        power_shelf_id: Some(id),
+                        health_report_entry: Some(rpc_forge::HealthReportEntry {
+                            report: Some(report),
+                            mode: mode as i32,
+                        }),
+                    },
+                ))
+                .await
+                .map(|_| ())
+        },
+        async || env.run_controller_iteration().await,
+    )
+    .await;
+    Ok(())
+}

--- a/crates/power-shelf-controller/tests/integration/main.rs
+++ b/crates/power-shelf-controller/tests/integration/main.rs
@@ -18,6 +18,7 @@
 mod bmc_rotation;
 mod common;
 mod error_state;
+mod health;
 mod maintenance;
 mod power_shelf_deletion;
 mod reprovisioning;

--- a/crates/power-shelf-controller/tests/integration/power_shelf_deletion.rs
+++ b/crates/power-shelf-controller/tests/integration/power_shelf_deletion.rs
@@ -15,29 +15,22 @@
  * limitations under the License.
  */
 
-use std::sync::Arc;
-use std::time::Duration;
-
-use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
-use carbide_power_shelf_controller::io::PowerShelfStateControllerIO;
 use carbide_test_harness::prelude::*;
 use model::power_shelf::PowerShelfConfig;
 use model::test_support::power_shelf_config;
-use state_controller::config::IterationConfig;
-use state_controller::controller::StateController;
-use tokio_util::sync::CancellationToken;
 use tonic::Request;
 
-use crate::common::{mark_power_shelf_as_deleted, services_without_component_manager};
+use crate::common::{ControllerEnv, mark_power_shelf_as_deleted};
 
 #[sqlx_test]
 async fn test_power_shelf_deletion_with_state_controller(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = TestHarness::builder(pool.clone()).build().await;
+    let env = ControllerEnv::new(pool).await;
 
     // Create a power shelf
     let power_shelf_id = env
+        .harness
         .create_power_shelf(PowerShelfConfig {
             capacity: Some(5000),
             ..power_shelf_config("Deletion with State Controller Test Power Shelf")
@@ -45,30 +38,13 @@ async fn test_power_shelf_deletion_with_state_controller(
         .await
         .id;
 
-    // Start the state controller
-    let power_shelf_handler = Arc::new(PowerShelfStateHandler::default());
-    const ITERATION_TIME: Duration = Duration::from_millis(50);
-
-    let cancel_token = CancellationToken::new();
-    let mut controller = StateController::<PowerShelfStateControllerIO>::builder()
-        .iteration_config(IterationConfig {
-            iteration_time: ITERATION_TIME,
-            processor_dispatch_interval: Duration::from_millis(10),
-            ..Default::default()
-        })
-        .database(pool.clone(), env.api().work_lock_manager_handle())
-        .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(services_without_component_manager(&pool, false).into())
-        .state_handler(power_shelf_handler.clone())
-        .build_for_manual_iterations(cancel_token.clone())
-        .unwrap();
-
     // Walk through state machine
     for _ in 0..20 {
-        controller.run_single_iteration().await;
+        env.run_controller_iteration().await;
     }
 
     let power_shelf = env
+        .harness
         .api()
         .find_power_shelves_by_ids(Request::new(rpc::forge::PowerShelvesByIdsRequest {
             power_shelf_ids: vec![power_shelf_id],
@@ -83,17 +59,18 @@ async fn test_power_shelf_deletion_with_state_controller(
     );
 
     // Mark the power shelf as deleted
-    let mut txn = env.db_txn().await;
+    let mut txn = env.harness.db_txn().await;
     mark_power_shelf_as_deleted(txn.as_mut(), &power_shelf_id).await?;
     txn.commit().await?;
 
     // Walk through state machine
     for _ in 0..20 {
-        controller.run_single_iteration().await;
+        env.run_controller_iteration().await;
     }
 
     // Verify that the DB object is gone
     let power_shelves = env
+        .harness
         .api()
         .find_power_shelves_by_ids(Request::new(rpc::forge::PowerShelvesByIdsRequest {
             power_shelf_ids: vec![power_shelf_id],


### PR DESCRIPTION
Move out remaining power shelf tests to integration suites (api core & controller).

Cleanup fixtures of power shelf inside api-core unit tests. 

## Related issues

#2001

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

