### PR TITLE
fix(helm): clamp the file-descriptor soft limit to the runtime hard limit

### DIFF
--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -34,7 +34,17 @@ spec:
             - /bin/sh
             - -c
             - |
-              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
+              {{- $fdLimit := .Values.fileDescriptorLimit | default 65536 | int }}
+              {{- if le $fdLimit 0 }}
+              {{- fail "fileDescriptorLimit must be a positive integer" }}
+              {{- end }}
+              FD_LIMIT={{ $fdLimit }}
+              FD_HARD="$(ulimit -Hn)"
+              if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
+                echo "fileDescriptorLimit ${FD_LIMIT} exceeds the hard limit ${FD_HARD}; clamping" >&2
+                FD_LIMIT="$FD_HARD"
+              fi
+              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
               if [ -x /opt/nico/nico-hw-health ]; then
                 exec /opt/nico/nico-hw-health
               else

--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -34,17 +34,21 @@ spec:
             - /bin/sh
             - -c
             - |
-              {{- $fdLimit := .Values.fileDescriptorLimit | default 65536 | int }}
+              {{- $fdLimit := 65536 }}
+              {{- if not (kindIs "invalid" .Values.fileDescriptorLimit) }}
+              {{- $fdLimit = .Values.fileDescriptorLimit | int }}
+              {{- end }}
               {{- if le $fdLimit 0 }}
               {{- fail "fileDescriptorLimit must be a positive integer" }}
               {{- end }}
               FD_LIMIT={{ $fdLimit }}
+              FD_REQUESTED="$FD_LIMIT"
               FD_HARD="$(ulimit -Hn)"
               if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
                 echo "fileDescriptorLimit ${FD_LIMIT} exceeds the hard limit ${FD_HARD}; clamping" >&2
                 FD_LIMIT="$FD_HARD"
               fi
-              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
+              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (requested ${FD_REQUESTED}, hard limit ${FD_HARD})" >&2; exit 1; }
               if [ -x /opt/nico/nico-hw-health ]; then
                 exec /opt/nico/nico-hw-health
               else

--- a/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
@@ -39,3 +39,9 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects zero at render time instead of falling back to the default
+    set:
+      fileDescriptorLimit: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'

--- a/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/file_descriptor_limit_test.yaml
@@ -2,15 +2,40 @@ suite: hardware-health file descriptor limit
 templates:
   - templates/deployment.yaml
 tests:
-  - it: uses the default soft limit
+  - it: uses the default soft limit with a hard-limit clamp
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 65536 \|\| exit 1'
+          pattern: 'FD_LIMIT=65536'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_HARD="\$\(ulimit -Hn\)"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn "\$FD_LIMIT"'
   - it: allows an override
     set:
       fileDescriptorLimit: 32768
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 32768 \|\| exit 1'
+          pattern: 'FD_LIMIT=32768'
+  - it: falls back to the default when the value is nulled out
+    set:
+      fileDescriptorLimit: null
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT=65536'
+  - it: rejects a non-numeric value at render time
+    set:
+      fileDescriptorLimit: unlimited
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects a negative value at render time
+    set:
+      fileDescriptorLimit: -1
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -31,7 +31,8 @@ replicas: 1
 resources: {}
 
 ## Soft open-file limit applied before startup. Clamped to the runtime hard
-## limit when it exceeds it; must be a positive integer (validated at render).
+## limit when it exceeds it. null falls back to 65536; non-null values must be
+## a positive integer (validated at render).
 fileDescriptorLimit: 65536
 
 service:

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -30,7 +30,8 @@ replicas: 1
 ## Container resource requests and limits. Empty by default.
 resources: {}
 
-## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
+## Soft open-file limit applied before startup. Clamped to the runtime hard
+## limit when it exceeds it; must be a positive integer (validated at render).
 fileDescriptorLimit: 65536
 
 service:

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -69,17 +69,21 @@ spec:
             - /bin/sh
             - -c
             - |
-              {{- $fdLimit := .Values.fileDescriptorLimit | default 65536 | int }}
+              {{- $fdLimit := 65536 }}
+              {{- if not (kindIs "invalid" .Values.fileDescriptorLimit) }}
+              {{- $fdLimit = .Values.fileDescriptorLimit | int }}
+              {{- end }}
               {{- if le $fdLimit 0 }}
               {{- fail "fileDescriptorLimit must be a positive integer" }}
               {{- end }}
               FD_LIMIT={{ $fdLimit }}
+              FD_REQUESTED="$FD_LIMIT"
               FD_HARD="$(ulimit -Hn)"
               if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
                 echo "fileDescriptorLimit ${FD_LIMIT} exceeds the hard limit ${FD_HARD}; clamping" >&2
                 FD_LIMIT="$FD_HARD"
               fi
-              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
+              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (requested ${FD_REQUESTED}, hard limit ${FD_HARD})" >&2; exit 1; }
               if [ -x /opt/nico/nico ]; then BIN=/opt/nico/nico; else BIN=/opt/carbide/carbide; fi
               exec "$BIN" -s {{ .Values.bootArtifacts.servePath }}
           env:

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -69,7 +69,17 @@ spec:
             - /bin/sh
             - -c
             - |
-              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
+              {{- $fdLimit := .Values.fileDescriptorLimit | default 65536 | int }}
+              {{- if le $fdLimit 0 }}
+              {{- fail "fileDescriptorLimit must be a positive integer" }}
+              {{- end }}
+              FD_LIMIT={{ $fdLimit }}
+              FD_HARD="$(ulimit -Hn)"
+              if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
+                echo "fileDescriptorLimit ${FD_LIMIT} exceeds the hard limit ${FD_HARD}; clamping" >&2
+                FD_LIMIT="$FD_HARD"
+              fi
+              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
               if [ -x /opt/nico/nico ]; then BIN=/opt/nico/nico; else BIN=/opt/carbide/carbide; fi
               exec "$BIN" -s {{ .Values.bootArtifacts.servePath }}
           env:

--- a/helm/charts/nico-pxe/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-pxe/tests/file_descriptor_limit_test.yaml
@@ -39,3 +39,9 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects zero at render time instead of falling back to the default
+    set:
+      fileDescriptorLimit: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'

--- a/helm/charts/nico-pxe/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-pxe/tests/file_descriptor_limit_test.yaml
@@ -2,15 +2,40 @@ suite: pxe file descriptor limit
 templates:
   - templates/deployment.yaml
 tests:
-  - it: uses the default soft limit
+  - it: uses the default soft limit with a hard-limit clamp
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 65536 \|\| exit 1'
+          pattern: 'FD_LIMIT=65536'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_HARD="\$\(ulimit -Hn\)"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn "\$FD_LIMIT"'
   - it: allows an override
     set:
       fileDescriptorLimit: 32768
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 32768 \|\| exit 1'
+          pattern: 'FD_LIMIT=32768'
+  - it: falls back to the default when the value is nulled out
+    set:
+      fileDescriptorLimit: null
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT=65536'
+  - it: rejects a non-numeric value at render time
+    set:
+      fileDescriptorLimit: unlimited
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects a negative value at render time
+    set:
+      fileDescriptorLimit: -1
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -45,7 +45,8 @@ legacyAlias:
 
 replicas: 1
 
-## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
+## Soft open-file limit applied before startup. Clamped to the runtime hard
+## limit when it exceeds it; must be a positive integer (validated at render).
 fileDescriptorLimit: 65536
 
 ## Optional init containers (general-purpose pass-through)

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -46,7 +46,8 @@ legacyAlias:
 replicas: 1
 
 ## Soft open-file limit applied before startup. Clamped to the runtime hard
-## limit when it exceeds it; must be a positive integer (validated at render).
+## limit when it exceeds it. null falls back to 65536; non-null values must be
+## a positive integer (validated at render).
 fileDescriptorLimit: 65536
 
 ## Optional init containers (general-purpose pass-through)

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -35,7 +35,17 @@ spec:
             - /bin/sh
             - -c
             - |
-              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
+              {{- $fdLimit := .Values.fileDescriptorLimit | default 65536 | int }}
+              {{- if le $fdLimit 0 }}
+              {{- fail "fileDescriptorLimit must be a positive integer" }}
+              {{- end }}
+              FD_LIMIT={{ $fdLimit }}
+              FD_HARD="$(ulimit -Hn)"
+              if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
+                echo "fileDescriptorLimit ${FD_LIMIT} exceeds the hard limit ${FD_HARD}; clamping" >&2
+                FD_LIMIT="$FD_HARD"
+              fi
+              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
               if [ -x /opt/nico/ssh-console ]; then
                 exec /opt/nico/ssh-console run -c /etc/nico/ssh-console/config.toml
               else

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -35,17 +35,21 @@ spec:
             - /bin/sh
             - -c
             - |
-              {{- $fdLimit := .Values.fileDescriptorLimit | default 65536 | int }}
+              {{- $fdLimit := 65536 }}
+              {{- if not (kindIs "invalid" .Values.fileDescriptorLimit) }}
+              {{- $fdLimit = .Values.fileDescriptorLimit | int }}
+              {{- end }}
               {{- if le $fdLimit 0 }}
               {{- fail "fileDescriptorLimit must be a positive integer" }}
               {{- end }}
               FD_LIMIT={{ $fdLimit }}
+              FD_REQUESTED="$FD_LIMIT"
               FD_HARD="$(ulimit -Hn)"
               if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
                 echo "fileDescriptorLimit ${FD_LIMIT} exceeds the hard limit ${FD_HARD}; clamping" >&2
                 FD_LIMIT="$FD_HARD"
               fi
-              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
+              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (requested ${FD_REQUESTED}, hard limit ${FD_HARD})" >&2; exit 1; }
               if [ -x /opt/nico/ssh-console ]; then
                 exec /opt/nico/ssh-console run -c /etc/nico/ssh-console/config.toml
               else

--- a/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
@@ -39,3 +39,9 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects zero at render time instead of falling back to the default
+    set:
+      fileDescriptorLimit: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'

--- a/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/file_descriptor_limit_test.yaml
@@ -2,15 +2,40 @@ suite: ssh-console file descriptor limit
 templates:
   - templates/deployment.yaml
 tests:
-  - it: uses the default soft limit
+  - it: uses the default soft limit with a hard-limit clamp
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 65536 \|\| exit 1'
+          pattern: 'FD_LIMIT=65536'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_HARD="\$\(ulimit -Hn\)"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn "\$FD_LIMIT"'
   - it: allows an override
     set:
       fileDescriptorLimit: 32768
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 32768 \|\| exit 1'
+          pattern: 'FD_LIMIT=32768'
+  - it: falls back to the default when the value is nulled out
+    set:
+      fileDescriptorLimit: null
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT=65536'
+  - it: rejects a non-numeric value at render time
+    set:
+      fileDescriptorLimit: unlimited
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects a negative value at render time
+    set:
+      fileDescriptorLimit: -1
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -33,7 +33,8 @@ resources: {}
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-ssh-console-rs.name" . }}-config-files'
 
-## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
+## Soft open-file limit applied before startup. Clamped to the runtime hard
+## limit when it exceeds it; must be a positive integer (validated at render).
 fileDescriptorLimit: 65536
 
 imagePullSecrets: []

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -34,7 +34,8 @@ annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-ssh-console-rs.name" . }}-config-files'
 
 ## Soft open-file limit applied before startup. Clamped to the runtime hard
-## limit when it exceeds it; must be a positive integer (validated at render).
+## limit when it exceeds it. null falls back to 65536; non-null values must be
+## a positive integer (validated at render).
 fileDescriptorLimit: 65536
 
 imagePullSecrets: []


### PR DESCRIPTION
Fixes #5535.

The ulimit fail-fast entrypoints crashloop on runtimes whose container hard nofile limit is below 65536 (reproduced on dev6: hard limit 65535 → all three deployments CrashLoopBackOff). The entrypoints now clamp to `$(ulimit -Hn)` with a logged notice, and print both limits before exiting on failure. Render-time validation replaces the silent-zero mode: null falls back to the 65536 default, non-numeric/non-positive values fail the render (previously rendered `ulimit -Sn 0`, which dash accepts).

## Testing
- [x] helm unittest: 5 cases per chart (default+clamp shape, override, null fallback, non-numeric and negative render failures) — 15/15 pass
- [ ] dev6 verification with the site FD-limit workarounds removed (in progress; results to follow as a comment)