### PR TITLE
feat(flow): recover expired event action executions

### DIFF
--- a/rest-api/flow/internal/converter/dao/event_action_execution.go
+++ b/rest-api/flow/internal/converter/dao/event_action_execution.go
@@ -26,20 +26,21 @@ func EventActionExecutionTo(
 	}
 
 	return &dbmodel.EventActionExecution{
-		ID:            execution.ID,
-		EventID:       execution.EventID,
-		ActionName:    execution.ActionName,
-		ActionType:    string(execution.Plan.Type()),
-		Plan:          plan,
-		Status:        string(execution.Status),
-		Reason:        cutil.GetPtrIfNotZero(string(execution.Reason)),
-		Attempts:      execution.Attempts,
-		ClaimToken:    cutil.GetPtrIfNotZero(execution.ClaimToken),
-		ClaimOwner:    cutil.GetPtrIfNotZero(execution.ClaimOwner),
-		StatusMessage: cutil.GetPtrIfNotZero(execution.StatusMessage),
-		CreatedAt:     execution.CreatedAt,
-		UpdatedAt:     execution.UpdatedAt,
-		NextAttemptAt: cutil.GetPtrIfNotZero(execution.NextAttemptAt),
+		ID:             execution.ID,
+		EventID:        execution.EventID,
+		ActionName:     execution.ActionName,
+		ActionType:     string(execution.Plan.Type()),
+		Plan:           plan,
+		Status:         string(execution.Status),
+		Reason:         cutil.GetPtrIfNotZero(string(execution.Reason)),
+		Attempts:       execution.Attempts,
+		ClaimToken:     cutil.GetPtrIfNotZero(execution.ClaimToken),
+		ClaimOwner:     cutil.GetPtrIfNotZero(execution.ClaimOwner),
+		ClaimExpiresAt: cutil.GetPtrIfNotZero(execution.ClaimExpiresAt),
+		StatusMessage:  cutil.GetPtrIfNotZero(execution.StatusMessage),
+		CreatedAt:      execution.CreatedAt,
+		UpdatedAt:      execution.UpdatedAt,
+		NextAttemptAt:  cutil.GetPtrIfNotZero(execution.NextAttemptAt),
 	}, nil
 }
 
@@ -85,8 +86,11 @@ func EventActionExecutionFrom(
 		Attempts:   persisted.Attempts,
 		ClaimToken: cutil.GetValueOrZero(persisted.ClaimToken),
 		ClaimOwner: cutil.GetValueOrZero(persisted.ClaimOwner),
-		CreatedAt:  timeFromPersistence(persisted.CreatedAt),
-		UpdatedAt:  timeFromPersistence(persisted.UpdatedAt),
+		ClaimExpiresAt: optionalTimeFromPersistence(
+			persisted.ClaimExpiresAt,
+		),
+		CreatedAt: timeFromPersistence(persisted.CreatedAt),
+		UpdatedAt: timeFromPersistence(persisted.UpdatedAt),
 	}
 
 	if err := execution.Validate(); err != nil {

--- a/rest-api/flow/internal/converter/dao/event_action_execution_test.go
+++ b/rest-api/flow/internal/converter/dao/event_action_execution_test.go
@@ -62,7 +62,15 @@ func TestEventActionExecutionRoundTrip(t *testing.T) {
 			token := uuid.New()
 
 			if test.claim {
-				require.NoError(t, execution.Claim("scheduler-1", token, now.Add(time.Second)))
+				disposition, err := execution.AcquireClaim(
+					"scheduler-1",
+					token,
+					now.Add(time.Second),
+					now.Add(time.Minute),
+					4,
+				)
+				require.NoError(t, err)
+				require.Equal(t, eventrule.ClaimAcquired, disposition)
 			}
 			if test.result != nil {
 				require.NoError(
@@ -75,6 +83,10 @@ func TestEventActionExecutionRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 			persisted.CreatedAt = persisted.CreatedAt.In(local)
 			persisted.UpdatedAt = persisted.UpdatedAt.In(local)
+			if persisted.ClaimExpiresAt != nil {
+				claimExpiresAt := persisted.ClaimExpiresAt.In(local)
+				persisted.ClaimExpiresAt = &claimExpiresAt
+			}
 			if persisted.NextAttemptAt != nil {
 				nextAttemptAt := persisted.NextAttemptAt.In(local)
 				persisted.NextAttemptAt = &nextAttemptAt

--- a/rest-api/flow/internal/db/migrations/20260829000000_add_event_action_execution_claim_expiration.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260829000000_add_event_action_execution_claim_expiration.down.sql
@@ -1,0 +1,10 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE event_action_executions
+    DROP CONSTRAINT event_action_executions_claim_expiration_check;
+
+DROP INDEX event_action_executions_expired_claim_idx;
+
+ALTER TABLE event_action_executions
+    DROP COLUMN claim_expires_at;

--- a/rest-api/flow/internal/db/migrations/20260829000000_add_event_action_execution_claim_expiration.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260829000000_add_event_action_execution_claim_expiration.up.sql
@@ -1,0 +1,24 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Persist the lease deadline used to reclaim abandoned action executions.
+ALTER TABLE event_action_executions
+    ADD COLUMN claim_expires_at timestamp with time zone;
+
+ALTER TABLE event_action_executions
+    ADD CONSTRAINT event_action_executions_claim_expiration_check
+        CHECK (
+            (
+                status = 'running'
+                AND claim_expires_at IS NOT NULL
+                AND claim_expires_at > updated_at
+            )
+            OR (
+                status <> 'running'
+                AND claim_expires_at IS NULL
+            )
+        ) NOT VALID;
+
+CREATE INDEX event_action_executions_expired_claim_idx
+    ON event_action_executions (claim_expires_at, id)
+    WHERE status = 'running';

--- a/rest-api/flow/internal/db/migrations/event_action_execution_claim_expiration_test.go
+++ b/rest-api/flow/internal/db/migrations/event_action_execution_claim_expiration_test.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations_test
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/store/storetest"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed 20260829000000_add_event_action_execution_claim_expiration.up.sql
+var addEventActionExecutionClaimExpirationUp string
+
+//go:embed 20260829000000_add_event_action_execution_claim_expiration.down.sql
+var addEventActionExecutionClaimExpirationDown string
+
+func TestEventActionExecutionClaimExpirationMigration(t *testing.T) {
+	ctx := context.Background()
+	session := storetest.NewPostgresTestSession(t)
+
+	_, err := session.DB.ExecContext(ctx, addEventActionExecutionClaimExpirationDown)
+	require.NoError(t, err)
+
+	eventID := uuid.New()
+	now := time.Date(2026, time.August, 29, 12, 0, 0, 0, time.UTC)
+	_, err = session.DB.ExecContext(
+		ctx,
+		`INSERT INTO events (
+			id,
+			source_name,
+			source_key,
+			event_type,
+			resource_id,
+			resource_kind,
+			applied_rule_id,
+			effective_policy,
+			summary,
+			observations,
+			created_at,
+			last_observed_at
+		) VALUES (?, 'test', ?, 'test.event', ?, 'rack', ?, '{}', 'test event', 1, ?, ?)`,
+		eventID,
+		uuid.NewString(),
+		uuid.New(),
+		uuid.New(),
+		now,
+		now,
+	)
+	require.NoError(t, err)
+
+	legacyExecutionID := uuid.New()
+	_, err = session.DB.ExecContext(
+		ctx,
+		`INSERT INTO event_action_executions (
+			id,
+			event_id,
+			action_name,
+			action_type,
+			plan,
+			status,
+			attempts,
+			claim_token,
+			claim_owner,
+			created_at,
+			updated_at
+		) VALUES (?, ?, 'legacy', 'noop', '{}', 'running', 1, ?, 'worker', ?, ?)`,
+		legacyExecutionID,
+		eventID,
+		uuid.New(),
+		now,
+		now,
+	)
+	require.NoError(t, err)
+
+	_, err = session.DB.ExecContext(ctx, addEventActionExecutionClaimExpirationUp)
+	require.NoError(t, err)
+
+	var validated bool
+	err = session.DB.NewSelect().
+		TableExpr("pg_constraint").
+		Column("convalidated").
+		Where("conname = ?", "event_action_executions_claim_expiration_check").
+		Where("conrelid = ?::regclass", "event_action_executions").
+		Scan(ctx, &validated)
+	require.NoError(t, err)
+	require.False(t, validated)
+
+	tests := []struct {
+		name           string
+		status         string
+		attempts       int
+		claimToken     any
+		claimOwner     any
+		claimExpiresAt any
+		wantValid      bool
+	}{
+		{
+			name:           "running with future expiration",
+			status:         "running",
+			attempts:       1,
+			claimToken:     uuid.New(),
+			claimOwner:     "worker",
+			claimExpiresAt: now.Add(time.Minute),
+			wantValid:      true,
+		},
+		{
+			name:       "running without expiration",
+			status:     "running",
+			attempts:   1,
+			claimToken: uuid.New(),
+			claimOwner: "worker",
+		},
+		{
+			name:           "running with expiration equal to update",
+			status:         "running",
+			attempts:       1,
+			claimToken:     uuid.New(),
+			claimOwner:     "worker",
+			claimExpiresAt: now,
+		},
+		{
+			name:           "pending with expiration",
+			status:         "pending",
+			claimExpiresAt: now.Add(time.Minute),
+		},
+		{
+			name:      "pending without expiration",
+			status:    "pending",
+			wantValid: true,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := session.DB.ExecContext(
+				ctx,
+				`INSERT INTO event_action_executions (
+					id,
+					event_id,
+					action_name,
+					action_type,
+					plan,
+					status,
+					attempts,
+					claim_token,
+					claim_owner,
+					claim_expires_at,
+					created_at,
+					updated_at
+				) VALUES (?, ?, ?, 'noop', '{}', ?, ?, ?, ?, ?, ?, ?)`,
+				uuid.New(),
+				eventID,
+				fmt.Sprintf("case_%d", i),
+				test.status,
+				test.attempts,
+				test.claimToken,
+				test.claimOwner,
+				test.claimExpiresAt,
+				now,
+				now,
+			)
+			if test.wantValid {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(
+				t,
+				err,
+				"event_action_executions_claim_expiration_check",
+			)
+		})
+	}
+
+	_, err = session.DB.ExecContext(
+		ctx,
+		"DELETE FROM event_action_executions WHERE id = ?",
+		legacyExecutionID,
+	)
+	require.NoError(t, err)
+	_, err = session.DB.ExecContext(
+		ctx,
+		`ALTER TABLE event_action_executions
+			VALIDATE CONSTRAINT event_action_executions_claim_expiration_check`,
+	)
+	require.NoError(t, err)
+}

--- a/rest-api/flow/internal/db/model/event_action_execution.go
+++ b/rest-api/flow/internal/db/model/event_action_execution.go
@@ -16,18 +16,19 @@ import (
 type EventActionExecution struct {
 	bun.BaseModel `bun:"table:event_action_executions,alias:eae"`
 
-	ID            uuid.UUID       `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	EventID       uuid.UUID       `bun:"event_id,type:uuid,notnull"`
-	ActionName    string          `bun:"action_name,notnull"`
-	ActionType    string          `bun:"action_type,notnull"`
-	Plan          json.RawMessage `bun:"plan,type:jsonb,notnull"`
-	Status        string          `bun:"status,notnull"`
-	Reason        *string         `bun:"reason"`
-	Attempts      int             `bun:"attempts,notnull"`
-	ClaimToken    *uuid.UUID      `bun:"claim_token,type:uuid"`
-	ClaimOwner    *string         `bun:"claim_owner"`
-	StatusMessage *string         `bun:"status_message"`
-	CreatedAt     time.Time       `bun:"created_at,notnull"`
-	UpdatedAt     time.Time       `bun:"updated_at,notnull"`
-	NextAttemptAt *time.Time      `bun:"next_attempt_at"`
+	ID             uuid.UUID       `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	EventID        uuid.UUID       `bun:"event_id,type:uuid,notnull"`
+	ActionName     string          `bun:"action_name,notnull"`
+	ActionType     string          `bun:"action_type,notnull"`
+	Plan           json.RawMessage `bun:"plan,type:jsonb,notnull"`
+	Status         string          `bun:"status,notnull"`
+	Reason         *string         `bun:"reason"`
+	Attempts       int             `bun:"attempts,notnull"`
+	ClaimToken     *uuid.UUID      `bun:"claim_token,type:uuid"`
+	ClaimOwner     *string         `bun:"claim_owner"`
+	ClaimExpiresAt *time.Time      `bun:"claim_expires_at"`
+	StatusMessage  *string         `bun:"status_message"`
+	CreatedAt      time.Time       `bun:"created_at,notnull"`
+	UpdatedAt      time.Time       `bun:"updated_at,notnull"`
+	NextAttemptAt  *time.Time      `bun:"next_attempt_at"`
 }

--- a/rest-api/flow/internal/eventrule/execution.go
+++ b/rest-api/flow/internal/eventrule/execution.go
@@ -39,8 +39,10 @@ type Execution struct {
 	Attempts   int
 	ClaimToken uuid.UUID
 	ClaimOwner string
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	// ClaimExpiresAt is the store-timed expiration of the active running claim.
+	ClaimExpiresAt time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // Clone returns an independent execution snapshot.
@@ -51,93 +53,228 @@ func (e Execution) Clone() Execution {
 	return cloned
 }
 
-// Claim allocates the next attempt and moves an eligible execution to running.
-func (e *Execution) Claim(owner string, token uuid.UUID, now time.Time) error {
-	if e == nil {
-		return fmt.Errorf("execution is nil")
-	}
-
-	if !e.Status.CanBeClaimed() {
-		return fmt.Errorf("execution %s cannot be claimed from %q", e.ID, e.Status)
-	}
-
-	if err := ValidateExecutionClaimOwner(owner); err != nil {
-		return err
-	}
-	if token == uuid.Nil {
-		return fmt.Errorf("execution claim token is required")
-	}
-
+func (e *Execution) validateNow(now time.Time) error {
 	if now.IsZero() {
-		return fmt.Errorf("execution claim time is required")
+		return fmt.Errorf("execution time is required")
 	}
 	if now.Before(e.CreatedAt) {
-		return fmt.Errorf("execution claim time cannot precede creation time")
+		return fmt.Errorf("execution time cannot precede creation time")
 	}
 	if now.Before(e.UpdatedAt) {
-		return fmt.Errorf("execution claim time cannot precede update time")
+		return fmt.Errorf("execution time cannot precede update time")
 	}
-
-	e.ExecutionState = ExecutionState{
-		ExecutionStatusDetails: ExecutionStatusDetails{Status: ExecutionStatusRunning},
-	}
-	e.Attempts++
-	e.ClaimToken = token
-	e.ClaimOwner = owner
-	e.UpdatedAt = now
 
 	return nil
 }
 
+func (e *Execution) claimExpiredAt(t time.Time) bool {
+	return !t.Before(e.ClaimExpiresAt)
+}
+
+func invalidExecutionInputErrorf(format string, args ...any) error {
+	return fmt.Errorf("%w: %w", ErrInvalidExecutionInput, fmt.Errorf(format, args...))
+}
+
+func executionNotClaimableErrorf(format string, args ...any) error {
+	return fmt.Errorf("%w: %w", ErrExecutionNotClaimable, fmt.Errorf(format, args...))
+}
+
+func executionClaimLostErrorf(format string, args ...any) error {
+	return fmt.Errorf("%w: %w", ErrExecutionClaimLost, fmt.Errorf(format, args...))
+}
+
+// ClaimDisposition describes the durable result of acquiring an execution
+// claim.
+type ClaimDisposition uint8
+
+const (
+	// ClaimUnspecified means claim acquisition did not produce a disposition.
+	ClaimUnspecified ClaimDisposition = iota
+	// ClaimAcquired means ownership was assigned and the execution is running.
+	ClaimAcquired
+	// ClaimExhausted means an expired running execution reached its attempt
+	// limit and was failed instead of assigning new ownership.
+	ClaimExhausted
+)
+
+// AcquireClaim assigns the next attempt to an eligible execution or fails an
+// expired running execution whose attempt limit is exhausted. Invalid
+// arguments return ErrInvalidExecutionInput; an ineligible state returns
+// ErrExecutionNotClaimable.
+func (e *Execution) AcquireClaim(
+	owner string,
+	token uuid.UUID,
+	now time.Time,
+	claimExpiresAt time.Time,
+	maxAttempts int,
+) (ClaimDisposition, error) {
+	if maxAttempts <= 0 {
+		return ClaimUnspecified, invalidExecutionInputErrorf(
+			"execution claim max attempts must be positive",
+		)
+	}
+	if err := ValidateExecutionClaimOwner(owner); err != nil {
+		return ClaimUnspecified, invalidExecutionInputErrorf("%w", err)
+	}
+	if token == uuid.Nil {
+		return ClaimUnspecified, invalidExecutionInputErrorf(
+			"execution claim token is required",
+		)
+	}
+	if err := e.validateNow(now); err != nil {
+		return ClaimUnspecified, invalidExecutionInputErrorf("%w", err)
+	}
+	if !claimExpiresAt.After(now) {
+		return ClaimUnspecified, invalidExecutionInputErrorf(
+			"execution claim expiration must follow claim time",
+		)
+	}
+
+	if !e.Status.CanBeClaimed() {
+		return ClaimUnspecified, executionNotClaimableErrorf(
+			"execution %s cannot acquire claim from %q",
+			e.ID,
+			e.Status,
+		)
+	}
+
+	if e.Status == ExecutionStatusRunning {
+		if !e.claimExpiredAt(now) {
+			return ClaimUnspecified, executionNotClaimableErrorf(
+				"execution %s does not have an expired claim",
+				e.ID,
+			)
+		}
+
+		if e.Attempts >= maxAttempts {
+			e.ExecutionState = FailedExecutionResult(
+				fmt.Sprintf("execution claim expired after %d attempts", e.Attempts),
+			).stateAt(now)
+			e.ClaimToken = uuid.Nil
+			e.ClaimOwner = ""
+			e.ClaimExpiresAt = time.Time{}
+			e.UpdatedAt = now
+
+			return ClaimExhausted, nil
+		}
+
+		// The original claim may have expired because the configured duration
+		// underestimated a valid execution rather than because its worker died.
+		// Give every replacement attempt twice the configured duration so it has
+		// another bounded opportunity to finish without allowing recovery windows
+		// to grow exponentially across repeated reclamations.
+		claimExpiresAt = claimExpiresAt.Add(claimExpiresAt.Sub(now))
+	}
+
+	e.ExecutionState = ExecutionState{
+		ExecutionStatusDetails: ExecutionStatusDetails{
+			Status: ExecutionStatusRunning,
+		},
+	}
+	e.Attempts++
+	e.ClaimToken = token
+	e.ClaimOwner = owner
+	e.ClaimExpiresAt = claimExpiresAt
+	e.UpdatedAt = now
+
+	return ClaimAcquired, nil
+}
+
 // TransitionClaimedTo validates and applies the active attempt's result when
-// token still owns the execution.
+// token still owns the execution, including after its fixed expiration when it
+// has not yet been reclaimed. Invalid arguments return ErrInvalidExecutionInput;
+// lost ownership returns ErrExecutionClaimLost.
 func (e *Execution) TransitionClaimedTo(
 	token uuid.UUID,
 	result ExecutionResult,
 	now time.Time,
 ) error {
-	if e == nil {
-		return fmt.Errorf("execution is nil")
-	}
-
 	if token == uuid.Nil {
-		return fmt.Errorf("execution claim token is required")
-	}
-	if e.ClaimToken != token {
-		return fmt.Errorf("%w: execution %s", ErrExecutionClaimLost, e.ID)
-	}
-
-	if err := result.Validate(); err != nil {
-		return err
-	}
-	if !e.Status.CanTransitionTo(result.Status) {
-		return fmt.Errorf(
-			"execution %s cannot transition from %q to %q",
-			e.ID,
-			e.Status,
-			result.Status,
+		return invalidExecutionInputErrorf(
+			"execution claim token is required",
 		)
 	}
-
-	if now.IsZero() {
-		return fmt.Errorf("execution transition time is required")
+	if err := result.Validate(); err != nil {
+		return invalidExecutionInputErrorf("%w", err)
 	}
-	if now.Before(e.CreatedAt) {
-		return fmt.Errorf("execution transition time cannot precede creation time")
-	}
-	if now.Before(e.UpdatedAt) {
-		return fmt.Errorf("execution transition time cannot precede update time")
+	if err := e.validateNow(now); err != nil {
+		return invalidExecutionInputErrorf("%w", err)
 	}
 
-	if result.Status == ExecutionStatusDeferred &&
-		result.Reason == ExecutionReasonAttemptInterrupted {
+	if e.Status != ExecutionStatusRunning || e.ClaimToken != token {
+		return executionClaimLostErrorf("execution %s", e.ID)
+	}
+
+	if result.Reason == ExecutionReasonAttemptInterrupted {
 		e.Attempts--
 	}
 
 	e.ExecutionState = result.stateAt(now)
 	e.ClaimToken = uuid.Nil
 	e.ClaimOwner = ""
+	e.ClaimExpiresAt = time.Time{}
 	e.UpdatedAt = now
+
+	return nil
+}
+
+func (e *Execution) validateTimestamps() error {
+	if e.CreatedAt.IsZero() {
+		return fmt.Errorf("execution creation time is required")
+	}
+	if e.UpdatedAt.IsZero() {
+		return fmt.Errorf("execution updated time is required")
+	}
+	if e.UpdatedAt.Before(e.CreatedAt) {
+		return fmt.Errorf("execution updated time cannot precede creation time")
+	}
+
+	return nil
+}
+
+func (e *Execution) validateAttempts() error {
+	if e.Attempts < 0 {
+		return fmt.Errorf("execution attempts cannot be negative")
+	}
+	if (e.Status == ExecutionStatusPending || e.Status == ExecutionStatusSkipped) &&
+		e.Attempts != 0 {
+		return fmt.Errorf("%s execution cannot have attempts", e.Status)
+	}
+	if e.Status != ExecutionStatusPending &&
+		e.Status != ExecutionStatusSkipped &&
+		e.Attempts == 0 &&
+		!(e.Status == ExecutionStatusDeferred &&
+			e.Reason == ExecutionReasonAttemptInterrupted) {
+		return fmt.Errorf("%s execution requires an attempt", e.Status)
+	}
+
+	return nil
+}
+
+func (e *Execution) validateClaim() error {
+	if e.Status == ExecutionStatusRunning {
+		if e.ClaimToken == uuid.Nil {
+			return fmt.Errorf("running execution requires claim token")
+		}
+		if err := ValidateExecutionClaimOwner(e.ClaimOwner); err != nil {
+			return err
+		}
+		if e.claimExpiredAt(e.UpdatedAt) {
+			return fmt.Errorf("running execution claim expiration must follow update time")
+		}
+
+		return nil
+	}
+
+	if e.ClaimToken != uuid.Nil {
+		return fmt.Errorf("%s execution cannot have claim token", e.Status)
+	}
+	if e.ClaimOwner != "" {
+		return fmt.Errorf("%s execution cannot have claim owner", e.Status)
+	}
+	if !e.ClaimExpiresAt.IsZero() {
+		return fmt.Errorf("%s execution cannot have claim expiration", e.Status)
+	}
 
 	return nil
 }
@@ -160,46 +297,14 @@ func (e *Execution) Validate() error {
 	if err := e.ExecutionState.Validate(); err != nil {
 		return err
 	}
-
-	if e.Attempts < 0 {
-		return fmt.Errorf("execution attempts cannot be negative")
+	if err := e.validateTimestamps(); err != nil {
+		return err
 	}
-	if (e.Status == ExecutionStatusPending || e.Status == ExecutionStatusSkipped) &&
-		e.Attempts != 0 {
-		return fmt.Errorf("%s execution cannot have attempts", e.Status)
+	if err := e.validateAttempts(); err != nil {
+		return err
 	}
-	if e.Status != ExecutionStatusPending &&
-		e.Status != ExecutionStatusSkipped &&
-		e.Attempts == 0 &&
-		!(e.Status == ExecutionStatusDeferred &&
-			e.Reason == ExecutionReasonAttemptInterrupted) {
-		return fmt.Errorf("%s execution requires an attempt", e.Status)
-	}
-
-	if e.Status == ExecutionStatusRunning {
-		if e.ClaimToken == uuid.Nil {
-			return fmt.Errorf("running execution requires claim token")
-		}
-		if err := ValidateExecutionClaimOwner(e.ClaimOwner); err != nil {
-			return err
-		}
-	} else {
-		if e.ClaimToken != uuid.Nil {
-			return fmt.Errorf("%s execution cannot have claim token", e.Status)
-		}
-		if e.ClaimOwner != "" {
-			return fmt.Errorf("%s execution cannot have claim owner", e.Status)
-		}
-	}
-
-	if e.CreatedAt.IsZero() {
-		return fmt.Errorf("execution creation time is required")
-	}
-	if e.UpdatedAt.IsZero() {
-		return fmt.Errorf("execution updated time is required")
-	}
-	if e.UpdatedAt.Before(e.CreatedAt) {
-		return fmt.Errorf("execution updated time cannot precede creation time")
+	if err := e.validateClaim(); err != nil {
+		return err
 	}
 
 	return nil

--- a/rest-api/flow/internal/eventrule/execution_state.go
+++ b/rest-api/flow/internal/eventrule/execution_state.go
@@ -21,22 +21,12 @@ const (
 	ExecutionStatusFailed    ExecutionStatus = "failed"
 )
 
-// CanTransitionTo reports whether a running execution may accept an attempt
-// result.
-func (s ExecutionStatus) CanTransitionTo(target ExecutionStatus) bool {
-	if s != ExecutionStatusRunning {
-		return false
-	}
-
-	return target == ExecutionStatusCompleted ||
-		target == ExecutionStatusDeferred ||
-		target == ExecutionStatusFailed
-}
-
 // CanBeClaimed reports whether the scheduler may allocate an attempt for the
 // execution after applying lane-specific eligibility checks.
 func (s ExecutionStatus) CanBeClaimed() bool {
-	return s == ExecutionStatusPending || s == ExecutionStatusDeferred
+	return s == ExecutionStatusPending ||
+		s == ExecutionStatusRunning ||
+		s == ExecutionStatusDeferred
 }
 
 // RequiresRetryScheduling reports whether the status requires the store to

--- a/rest-api/flow/internal/eventrule/execution_test.go
+++ b/rest-api/flow/internal/eventrule/execution_test.go
@@ -91,12 +91,32 @@ func TestNewExecutionSkipsEmptySubmitTaskPlan(t *testing.T) {
 	require.NoError(t, execution.Validate())
 }
 
-func TestExecution_Claim(t *testing.T) {
+func TestExecutionStatus_CanBeClaimed(t *testing.T) {
+	tests := map[string]struct {
+		status ExecutionStatus
+		want   bool
+	}{
+		"pending":   {status: ExecutionStatusPending, want: true},
+		"running":   {status: ExecutionStatusRunning, want: true},
+		"deferred":  {status: ExecutionStatusDeferred, want: true},
+		"completed": {status: ExecutionStatusCompleted},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, test.status.CanBeClaimed())
+		})
+	}
+}
+
+func TestExecution_AcquireClaim(t *testing.T) {
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
 	tests := map[string]struct {
 		updatedAt time.Time
 		claimAt   time.Time
+		expiresAt time.Time
 		wantErr   string
+		wantIs    error
 	}{
 		"claimed": {
 			claimAt: now.Add(time.Second),
@@ -104,7 +124,8 @@ func TestExecution_Claim(t *testing.T) {
 		"claim time before latest update": {
 			updatedAt: now.Add(2 * time.Second),
 			claimAt:   now.Add(time.Second),
-			wantErr:   "execution claim time cannot precede update time",
+			wantErr:   "execution time cannot precede update time",
+			wantIs:    ErrInvalidExecutionInput,
 		},
 	}
 
@@ -118,30 +139,185 @@ func TestExecution_Claim(t *testing.T) {
 
 			before := execution.Clone()
 			token := uuid.New()
-			err = execution.Claim("scheduler-1", token, test.claimAt)
+			expiresAt := test.expiresAt
+			if expiresAt.IsZero() {
+				expiresAt = test.claimAt.Add(time.Minute)
+			}
+			disposition, err := execution.AcquireClaim(
+				"scheduler-1",
+				token,
+				test.claimAt,
+				expiresAt,
+				4,
+			)
 			if test.wantErr != "" {
 				require.ErrorContains(t, err, test.wantErr)
+				require.ErrorIs(t, err, test.wantIs)
 				require.Equal(t, before, *execution)
 
 				return
 			}
 
 			require.NoError(t, err)
+			require.Equal(t, ClaimAcquired, disposition)
 			require.Equal(t, ExecutionStatusRunning, execution.Status)
 			require.Equal(t, 1, execution.Attempts)
 			require.Equal(t, token, execution.ClaimToken)
 			require.Equal(t, "scheduler-1", execution.ClaimOwner)
+			require.Equal(t, expiresAt, execution.ClaimExpiresAt)
 			require.True(t, execution.NextAttemptAt.IsZero())
 			require.Equal(t, test.claimAt, execution.UpdatedAt)
 			require.NoError(t, execution.Validate())
 
-			require.ErrorContains(
-				t,
-				execution.Claim("scheduler-1", uuid.New(), now.Add(2*time.Second)),
-				"cannot be claimed",
+			_, err = execution.AcquireClaim(
+				"scheduler-1",
+				uuid.New(),
+				now.Add(2*time.Second),
+				now.Add(time.Minute),
+				4,
 			)
+			require.ErrorContains(t, err, "does not have an expired claim")
+			require.ErrorIs(t, err, ErrExecutionNotClaimable)
 		})
 	}
+
+	t.Run("expired running execution", func(t *testing.T) {
+		testExecutionAcquireExpiredClaim(t, now)
+	})
+
+	t.Run("unclaimable status", func(t *testing.T) {
+		execution, err := NewExecution(uuid.New(), "notify", &NoopPlan{}, now)
+		require.NoError(t, err)
+		execution.ExecutionState = CompletedExecutionResult().stateAt(now)
+		execution.Attempts = 1
+		before := execution.Clone()
+
+		disposition, err := execution.AcquireClaim(
+			"scheduler-1",
+			uuid.New(),
+			now,
+			now.Add(time.Minute),
+			4,
+		)
+
+		require.ErrorIs(t, err, ErrExecutionNotClaimable)
+		require.Equal(t, ClaimUnspecified, disposition)
+		require.Equal(t, before, *execution)
+	})
+
+	t.Run("validates input before status", func(t *testing.T) {
+		execution, err := NewExecution(uuid.New(), "notify", &NoopPlan{}, now)
+		require.NoError(t, err)
+		execution.ExecutionState = CompletedExecutionResult().stateAt(now)
+		execution.Attempts = 1
+
+		_, err = execution.AcquireClaim(
+			"",
+			uuid.New(),
+			now,
+			now.Add(time.Minute),
+			4,
+		)
+
+		require.ErrorIs(t, err, ErrInvalidExecutionInput)
+		require.NotErrorIs(t, err, ErrExecutionNotClaimable)
+	})
+}
+
+func testExecutionAcquireExpiredClaim(t *testing.T, now time.Time) {
+	t.Helper()
+
+	execution, err := NewExecution(uuid.New(), "notify", &NoopPlan{}, now)
+	require.NoError(t, err)
+	oldToken := uuid.New()
+	requireExecutionClaimAcquired(t, execution, "scheduler-1", oldToken, now, now.Add(time.Minute), 2)
+
+	t.Run("rotates ownership", func(t *testing.T) {
+		candidate := execution.Clone()
+		newToken := uuid.New()
+		claimAt := now.Add(time.Minute)
+		disposition, err := candidate.AcquireClaim(
+			"scheduler-2",
+			newToken,
+			claimAt,
+			claimAt.Add(time.Minute),
+			2,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, ClaimAcquired, disposition)
+		require.Equal(t, 2, candidate.Attempts)
+		require.Equal(t, newToken, candidate.ClaimToken)
+		require.Equal(t, "scheduler-2", candidate.ClaimOwner)
+		require.Equal(t, claimAt.Add(2*time.Minute), candidate.ClaimExpiresAt)
+		require.NoError(t, candidate.Validate())
+	})
+
+	t.Run("repeated reclamation remains bounded", func(t *testing.T) {
+		candidate := execution.Clone()
+		secondClaimAt := now.Add(time.Minute)
+		disposition, err := candidate.AcquireClaim(
+			"scheduler-2",
+			uuid.New(),
+			secondClaimAt,
+			secondClaimAt.Add(time.Minute),
+			3,
+		)
+		require.NoError(t, err)
+		require.Equal(t, ClaimAcquired, disposition)
+		require.Equal(t, secondClaimAt.Add(2*time.Minute), candidate.ClaimExpiresAt)
+
+		thirdClaimAt := candidate.ClaimExpiresAt
+		disposition, err = candidate.AcquireClaim(
+			"scheduler-3",
+			uuid.New(),
+			thirdClaimAt,
+			thirdClaimAt.Add(time.Minute),
+			3,
+		)
+		require.NoError(t, err)
+		require.Equal(t, ClaimAcquired, disposition)
+		require.Equal(t, thirdClaimAt.Add(2*time.Minute), candidate.ClaimExpiresAt)
+		require.Equal(t, 3, candidate.Attempts)
+		require.NoError(t, candidate.Validate())
+	})
+
+	t.Run("fails exhausted execution", func(t *testing.T) {
+		candidate := execution.Clone()
+		disposition, err := candidate.AcquireClaim(
+			"scheduler-2",
+			uuid.New(),
+			now.Add(time.Minute),
+			now.Add(2*time.Minute),
+			1,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, ClaimExhausted, disposition)
+		require.Equal(t, ExecutionStatusFailed, candidate.Status)
+		require.Equal(t, 1, candidate.Attempts)
+		require.Equal(t, uuid.Nil, candidate.ClaimToken)
+		require.Empty(t, candidate.ClaimOwner)
+		require.True(t, candidate.ClaimExpiresAt.IsZero())
+		require.NoError(t, candidate.Validate())
+	})
+
+	t.Run("rejects active claim", func(t *testing.T) {
+		candidate := execution.Clone()
+		before := candidate.Clone()
+		disposition, err := candidate.AcquireClaim(
+			"scheduler-2",
+			uuid.New(),
+			now.Add(30*time.Second),
+			now.Add(2*time.Minute),
+			2,
+		)
+
+		require.ErrorContains(t, err, "does not have an expired claim")
+		require.ErrorIs(t, err, ErrExecutionNotClaimable)
+		require.Equal(t, ClaimUnspecified, disposition)
+		require.Equal(t, before, candidate)
+	})
 }
 
 func TestExecution_TransitionClaimedTo(t *testing.T) {
@@ -154,6 +330,7 @@ func TestExecution_TransitionClaimedTo(t *testing.T) {
 		want            ExecutionStatus
 		wantAttempts    int
 		wantErr         string
+		wantIs          error
 	}{
 		"completed": {
 			result:          CompletedExecutionResult(),
@@ -187,12 +364,20 @@ func TestExecution_TransitionClaimedTo(t *testing.T) {
 			token:           func(uuid.UUID) uuid.UUID { return uuid.New() },
 			transitionAfter: time.Second,
 			wantErr:         "execution claim lost",
+			wantIs:          ErrExecutionClaimLost,
 		},
 		"transition time before latest update": {
 			result:          CompletedExecutionResult(),
 			claimAfter:      2 * time.Second,
 			transitionAfter: time.Second,
-			wantErr:         "execution transition time cannot precede update time",
+			wantErr:         "execution time cannot precede update time",
+			wantIs:          ErrInvalidExecutionInput,
+		},
+		"expired claim with current token": {
+			result:          CompletedExecutionResult(),
+			transitionAfter: time.Minute,
+			want:            ExecutionStatusCompleted,
+			wantAttempts:    1,
 		},
 	}
 
@@ -202,7 +387,14 @@ func TestExecution_TransitionClaimedTo(t *testing.T) {
 			require.NoError(t, err)
 
 			claimToken := uuid.New()
-			require.NoError(t, execution.Claim("scheduler-1", claimToken, now.Add(test.claimAfter)))
+			claimAt := now.Add(test.claimAfter)
+			requireExecutionClaimAcquired(t, execution,
+				"scheduler-1",
+				claimToken,
+				claimAt,
+				claimAt.Add(time.Minute),
+				4,
+			)
 			before := execution.Clone()
 
 			transitionToken := claimToken
@@ -217,6 +409,7 @@ func TestExecution_TransitionClaimedTo(t *testing.T) {
 			)
 			if test.wantErr != "" {
 				require.ErrorContains(t, err, test.wantErr)
+				require.ErrorIs(t, err, test.wantIs)
 				require.Equal(t, before, *execution)
 
 				return
@@ -227,6 +420,7 @@ func TestExecution_TransitionClaimedTo(t *testing.T) {
 			require.Equal(t, test.wantAttempts, execution.Attempts)
 			require.Equal(t, uuid.Nil, execution.ClaimToken)
 			require.Empty(t, execution.ClaimOwner)
+			require.True(t, execution.ClaimExpiresAt.IsZero())
 			require.NoError(t, execution.Validate())
 		})
 	}
@@ -282,6 +476,17 @@ func TestExecutionValidate(t *testing.T) {
 			},
 			wantErr: "execution claim owner is empty",
 		},
+		"running without claim expiration": {
+			mutate: func(execution *Execution) {
+				execution.ExecutionState = ExecutionState{
+					ExecutionStatusDetails: ExecutionStatusDetails{Status: ExecutionStatusRunning},
+				}
+				execution.Attempts = 1
+				execution.ClaimToken = uuid.New()
+				execution.ClaimOwner = "scheduler-1"
+			},
+			wantErr: "running execution claim expiration must follow update time",
+		},
 		"non-running with claim token": {
 			mutate:  func(execution *Execution) { execution.ClaimToken = uuid.New() },
 			wantErr: "pending execution cannot have claim token",
@@ -289,6 +494,10 @@ func TestExecutionValidate(t *testing.T) {
 		"non-running with claim owner": {
 			mutate:  func(execution *Execution) { execution.ClaimOwner = "scheduler-1" },
 			wantErr: "pending execution cannot have claim owner",
+		},
+		"non-running with claim expiration": {
+			mutate:  func(execution *Execution) { execution.ClaimExpiresAt = now.Add(time.Minute) },
+			wantErr: "pending execution cannot have claim expiration",
 		},
 	}
 
@@ -354,4 +563,26 @@ func TestExecutionResultValidate(t *testing.T) {
 			require.ErrorContains(t, err, test.wantErr)
 		})
 	}
+}
+
+func requireExecutionClaimAcquired(
+	t *testing.T,
+	execution *Execution,
+	owner string,
+	token uuid.UUID,
+	claimAt time.Time,
+	expiresAt time.Time,
+	maxAttempts int,
+) {
+	t.Helper()
+
+	disposition, err := execution.AcquireClaim(
+		owner,
+		token,
+		claimAt,
+		expiresAt,
+		maxAttempts,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ClaimAcquired, disposition)
 }

--- a/rest-api/flow/internal/eventrule/manager/postgres_integration_test.go
+++ b/rest-api/flow/internal/eventrule/manager/postgres_integration_test.go
@@ -98,7 +98,7 @@ func TestManager_PostgresDurableRetryWithoutRedelivery(t *testing.T) {
 	session := storetest.NewPostgresTestSession(t)
 	rackID := uuid.New()
 	inventory := newPostgresIntegrationInventory(rackID)
-	tasks := &postgresRetryTaskManager{}
+	tasks := &postgresRetryTaskManager{failFirst: true}
 	config := testManagerConfig()
 	store := eventstore.New(session)
 	config.Store = store
@@ -168,6 +168,82 @@ func TestManager_PostgresDurableRetryWithoutRedelivery(t *testing.T) {
 
 }
 
+func TestManager_PostgresExpiredClaimRecovery(t *testing.T) {
+	ctx := context.Background()
+	session := storetest.NewPostgresTestSession(t)
+	rackID := uuid.New()
+	inventory := newPostgresIntegrationInventory(rackID)
+	tasks := &postgresRetryTaskManager{}
+	config := testManagerConfig()
+	store := eventstore.New(session)
+	config.Store = store
+	config.Inventory = inventory
+	config.TaskManager = tasks
+	config.Scheduler.Runtime.PollInterval = 5 * time.Millisecond
+	config.Scheduler.Runtime.ClaimDuration = 120 * time.Millisecond
+	config.Scheduler.Policy.MaxAttempts = 2
+
+	manager, err := New(config)
+	require.NoError(t, err)
+
+	envelope := eventrule.Envelope{
+		Key: eventrule.EventKey{
+			SourceName: "manager_postgres_test",
+			SourceKey:  "expired-claim-recovery",
+		},
+		Type: leakage.TypeHardwareLeakDetected,
+		Resource: eventrule.Resource{
+			Kind: eventrule.ResourceKindComponent,
+			ID:   inventory.component.Info.ID,
+		},
+	}
+	require.NoError(t, manager.Process(ctx, envelope))
+
+	batch, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
+		Owner:         "crashed-scheduler",
+		Limit:         1,
+		ClaimDuration: 50 * time.Millisecond,
+		MaxAttempts:   2,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch.Claims, 1)
+	claim := batch.Claims[0]
+
+	require.Eventually(t, func() bool {
+		var expired bool
+		err := session.DB.NewSelect().
+			TableExpr("event_action_executions").
+			ColumnExpr("claim_expires_at <= transaction_timestamp()").
+			Where("id = ?", claim.Execution.ID).
+			Scan(ctx, &expired)
+
+		return err == nil && expired
+	}, time.Second, 5*time.Millisecond)
+
+	require.NoError(t, manager.Start(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, manager.Stop())
+	})
+
+	require.Eventually(t, func() bool {
+		executions, err := store.Executions(ctx)
+
+		return err == nil &&
+			len(executions) == 1 &&
+			executions[0].Status == eventrule.ExecutionStatusCompleted &&
+			executions[0].Attempts == 2
+	}, time.Second, 5*time.Millisecond)
+	require.Equal(t, 1, tasks.callCount())
+
+	err = store.TransitionClaimedExecution(
+		ctx,
+		claim.Execution.ID,
+		claim.Token,
+		eventrule.CompletedExecutionResult(),
+	)
+	require.ErrorIs(t, err, eventrule.ErrExecutionClaimLost)
+}
+
 type postgresIntegrationInventory struct {
 	rack      *rack.Rack
 	component *component.Component
@@ -230,8 +306,9 @@ func (i *postgresIntegrationInventory) GetRackByIdentifier(
 }
 
 type postgresRetryTaskManager struct {
-	mu    sync.Mutex
-	calls int
+	mu        sync.Mutex
+	calls     int
+	failFirst bool
 }
 
 func (m *postgresRetryTaskManager) SubmitTask(
@@ -242,7 +319,7 @@ func (m *postgresRetryTaskManager) SubmitTask(
 	defer m.mu.Unlock()
 
 	m.calls++
-	if m.calls == 1 {
+	if m.failFirst && m.calls == 1 {
 		return nil, errors.New("temporary task service failure")
 	}
 

--- a/rest-api/flow/internal/eventrule/scheduler/config.go
+++ b/rest-api/flow/internal/eventrule/scheduler/config.go
@@ -58,6 +58,13 @@ func (c LaneConfig) validate(name string) error {
 type RuntimeConfig struct {
 	PollInterval   time.Duration
 	PersistTimeout time.Duration
+	// ClaimDuration is the fixed interval before an initial running execution
+	// becomes eligible for recovery. Reclaimed executions receive twice this
+	// interval as a bounded safeguard against an underestimated duration. Current
+	// actions do not renew claims. If a future action can legitimately run longer
+	// without increasing the acceptable recovery delay, add an explicit renewable
+	// mode for that action instead of renewing every claim.
+	ClaimDuration time.Duration
 	// Lanes overrides capacity by supported lane name. Omitted lanes use their
 	// defaults; lane priority remains defined by the scheduler.
 	Lanes map[string]LaneConfig
@@ -73,6 +80,7 @@ func DefaultRuntimeConfig() RuntimeConfig {
 	return RuntimeConfig{
 		PollInterval:   time.Minute,
 		PersistTimeout: time.Second,
+		ClaimDuration:  30 * time.Second,
 		Lanes:          lanes,
 	}
 }
@@ -93,6 +101,9 @@ func (c RuntimeConfig) Validate() error {
 
 	if c.PersistTimeout <= 0 {
 		return fmt.Errorf("execution persist timeout must be positive")
+	}
+	if c.ClaimDuration <= 0 {
+		return fmt.Errorf("execution claim duration must be positive")
 	}
 
 	supportedLanes := make(map[string]struct{}, len(laneDefinitions))
@@ -165,6 +176,7 @@ func (c Config) runtime() runtime {
 		policy:            c.Policy,
 		pollInterval:      c.Runtime.PollInterval,
 		persistTimeout:    c.Runtime.PersistTimeout,
+		claimDuration:     c.Runtime.ClaimDuration,
 		wakeCh:            make(chan struct{}, 1),
 		fatalWorkerErrors: make(chan error, workerCount),
 	}

--- a/rest-api/flow/internal/eventrule/scheduler/config_test.go
+++ b/rest-api/flow/internal/eventrule/scheduler/config_test.go
@@ -73,6 +73,10 @@ func TestConfigValidate(t *testing.T) {
 			mutate:  func(config *Config) { config.Runtime.PersistTimeout = 0 },
 			wantErr: "execution persist timeout must be positive",
 		},
+		"invalid claim duration": {
+			mutate:  func(config *Config) { config.Runtime.ClaimDuration = 0 },
+			wantErr: "execution claim duration must be positive",
+		},
 		"invalid max attempts": {
 			mutate:  func(config *Config) { config.Policy.MaxAttempts = 0 },
 			wantErr: "retry max attempts must be positive",
@@ -111,6 +115,7 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	expected := RuntimeConfig{
 		PollInterval:   time.Minute,
 		PersistTimeout: time.Second,
+		ClaimDuration:  30 * time.Second,
 		Lanes: map[string]LaneConfig{
 			"pending":  {Workers: 1, ScanLimit: 1},
 			"deferred": {Workers: 1, ScanLimit: 1},
@@ -173,6 +178,7 @@ func TestConfig_runtime(t *testing.T) {
 	require.Equal(t, config.Policy, actual.policy)
 	require.Equal(t, config.Runtime.PollInterval, actual.pollInterval)
 	require.Equal(t, config.Runtime.PersistTimeout, actual.persistTimeout)
+	require.Equal(t, config.Runtime.ClaimDuration, actual.claimDuration)
 	require.Equal(t, 1, cap(actual.wakeCh))
 	require.Equal(t, 3, cap(actual.fatalWorkerErrors))
 }

--- a/rest-api/flow/internal/eventrule/scheduler/lane.go
+++ b/rest-api/flow/internal/eventrule/scheduler/lane.go
@@ -8,17 +8,18 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
-	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/executor"
+	eventexecutor "github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/executor"
 )
 
 type claimExecutionsFunc func(
 	context.Context,
 	eventrule.ExecutionClaimRequest,
-) ([]eventrule.ClaimedExecution, error)
+) (eventrule.ExecutionClaimBatch, error)
 
 type laneDefinition struct {
 	name          string
@@ -118,36 +119,40 @@ func (l *lane) returnSlot() error {
 func (l *lane) claim(
 	ctx context.Context,
 	owner string,
-) ([]eventrule.ClaimedExecution, error) {
+	claimDuration time.Duration,
+	maxAttempts int,
+) (eventrule.ExecutionClaimBatch, error) {
 	reserved := l.reserveAvailableSlots()
 	if reserved == 0 {
-		return nil, nil
+		return eventrule.ExecutionClaimBatch{}, nil
 	}
 
-	claims, err := l.claimFunc(
+	batch, err := l.claimFunc(
 		ctx,
 		eventrule.ExecutionClaimRequest{
-			Owner: owner,
-			Limit: reserved,
+			Owner:         owner,
+			Limit:         reserved,
+			ClaimDuration: claimDuration,
+			MaxAttempts:   maxAttempts,
 		},
 	)
 	if err != nil {
 		slotErr := l.returnSlots(reserved)
 		if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
-			return nil, slotErr
+			return eventrule.ExecutionClaimBatch{}, slotErr
 		}
 
-		return nil, errors.Join(
+		return eventrule.ExecutionClaimBatch{}, errors.Join(
 			fmt.Errorf("claim %s executions: %w", l.name, err),
 			slotErr,
 		)
 	}
 
-	if err := l.returnSlots(reserved - len(claims)); err != nil {
-		return nil, err
+	if err := l.returnSlots(reserved - len(batch.Claims)); err != nil {
+		return eventrule.ExecutionClaimBatch{}, err
 	}
 
-	return claims, nil
+	return batch, nil
 }
 
 func (l *lane) startWorkers(
@@ -193,37 +198,24 @@ func (l *lane) dispatch(
 	runtime *runtime,
 ) error {
 	execution := claim.Execution
-	actionExecutor, err := runtime.executors.Executor(execution.Plan.Type())
-	if err != nil {
-		return l.persistResult(
-			ctx,
-			claim,
-			runtime.policy.resultForExecutionError(execution.Attempts, err),
-			runtime,
-		)
-	}
+	var result eventrule.ExecutionResult
 
-	if err := actionExecutor.Execute(
-		ctx,
-		executor.ExecutionRequest{
+	executor, err := runtime.executors.Executor(execution.Plan.Type())
+	if err != nil {
+		result = runtime.policy.resultForExecutionError(execution.Attempts, err)
+	} else {
+		req := eventexecutor.ExecutionRequest{
 			ExecutionID: execution.ID,
 			Plan:        execution.Plan,
-		},
-	); err != nil {
-		return l.persistResult(
-			ctx,
-			claim,
-			runtime.policy.resultForExecutionError(execution.Attempts, err),
-			runtime,
-		)
+		}
+		if err := executor.Execute(ctx, req); err != nil {
+			result = runtime.policy.resultForExecutionError(execution.Attempts, err)
+		} else {
+			result = eventrule.CompletedExecutionResult()
+		}
 	}
 
-	return l.persistResult(
-		ctx,
-		claim,
-		eventrule.CompletedExecutionResult(),
-		runtime,
-	)
+	return l.persistResult(ctx, claim, result, runtime)
 }
 
 func (l *lane) persistResult(

--- a/rest-api/flow/internal/eventrule/scheduler/lane_test.go
+++ b/rest-api/flow/internal/eventrule/scheduler/lane_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -22,7 +23,7 @@ func TestLane_claim(t *testing.T) {
 			store.ClaimPendingExecutions,
 		)
 
-		_, err := workLane.claim(context.Background(), testInstanceID)
+		_, err := workLane.claim(context.Background(), testInstanceID, time.Minute, 4)
 		require.NoError(t, err)
 		require.Len(t, store.requests, 1)
 		require.Equal(t, 2, store.requests[0].Limit)
@@ -30,7 +31,7 @@ func TestLane_claim(t *testing.T) {
 
 		<-workLane.slots
 
-		_, err = workLane.claim(context.Background(), testInstanceID)
+		_, err = workLane.claim(context.Background(), testInstanceID, time.Minute, 4)
 		require.NoError(t, err)
 		require.Len(t, store.requests, 2)
 		require.Equal(t, 1, store.requests[1].Limit)
@@ -46,7 +47,7 @@ func TestLane_claim(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		_, err := workLane.claim(ctx, testInstanceID)
+		_, err := workLane.claim(ctx, testInstanceID, time.Minute, 4)
 		require.NoError(t, err)
 		require.Len(t, workLane.slots, 1)
 	})
@@ -56,13 +57,16 @@ func TestLane_claim(t *testing.T) {
 		workLane := newLane(
 			"pending",
 			LaneConfig{Workers: 1, ScanLimit: 1},
-			func(context.Context, eventrule.ExecutionClaimRequest) ([]eventrule.ClaimedExecution, error) {
+			func(
+				context.Context,
+				eventrule.ExecutionClaimRequest,
+			) (eventrule.ExecutionClaimBatch, error) {
 				cancel()
 
-				return nil, errors.New("store unavailable")
+				return eventrule.ExecutionClaimBatch{}, errors.New("store unavailable")
 			},
 		)
-		_, err := workLane.claim(ctx, testInstanceID)
+		_, err := workLane.claim(ctx, testInstanceID, time.Minute, 4)
 
 		require.EqualError(t, err, "claim pending executions: store unavailable")
 		require.Len(t, workLane.slots, 1)

--- a/rest-api/flow/internal/eventrule/scheduler/scheduler.go
+++ b/rest-api/flow/internal/eventrule/scheduler/scheduler.go
@@ -25,11 +25,13 @@ type runtime struct {
 	policy            PolicyConfig
 	pollInterval      time.Duration
 	persistTimeout    time.Duration
+	claimDuration     time.Duration
 	wakeCh            chan struct{}
 	fatalWorkerErrors chan error
 }
 
-// Scheduler claims and dispatches pending and due deferred executions.
+// Scheduler claims and dispatches pending, due deferred, and expired running
+// executions.
 type Scheduler struct {
 	instanceID  string
 	runtime     runtime
@@ -185,7 +187,12 @@ func (s *Scheduler) refill(ctx context.Context) error {
 			return nil
 		}
 
-		claims, err := workLane.claim(ctx, s.instanceID)
+		batch, err := workLane.claim(
+			ctx,
+			s.instanceID,
+			s.runtime.claimDuration,
+			s.runtime.policy.MaxAttempts,
+		)
 		if err != nil {
 			if errors.Is(err, errLaneCapacityAccounting) {
 				return err
@@ -202,7 +209,7 @@ func (s *Scheduler) refill(ctx context.Context) error {
 		}
 
 		channelCapacityMismatch := false
-		for _, claim := range claims {
+		for _, claim := range batch.Claims {
 			select {
 			case workLane.jobs <- claim:
 			default:
@@ -224,9 +231,9 @@ func (s *Scheduler) refill(ctx context.Context) error {
 			)
 		}
 
-		// A full scan may have truncated additional eligible work, so schedule
-		// another pass. Partial and empty scans avoid a redundant store read.
-		if len(claims) == workLane.scanLimit {
+		// A full candidate scan may have left additional eligible work, even when
+		// exhausted retries reduced the number of claims it produced.
+		if batch.ScanLimitReached {
 			s.wake()
 		}
 	}

--- a/rest-api/flow/internal/eventrule/scheduler/scheduler_test.go
+++ b/rest-api/flow/internal/eventrule/scheduler/scheduler_test.go
@@ -299,6 +299,15 @@ func TestScheduler_refill(t *testing.T) {
 		require.Empty(t, pending.slots)
 		require.Empty(t, store.transitions)
 	})
+
+	t.Run("wakes after a full scan produces no claims", func(t *testing.T) {
+		store := newFakeStore()
+		store.scanLimitReached["deferred"] = true
+		configured := newTestScheduler(t, store, successfulExecutorRegistry())
+
+		require.NoError(t, configured.refill(context.Background()))
+		require.Len(t, configured.runtime.wakeCh, 1)
+	})
 }
 
 const testInstanceID = "scheduler-test"
@@ -312,22 +321,24 @@ type transitionRecord struct {
 }
 
 type fakeStore struct {
-	mu            sync.Mutex
-	claims        map[string][]eventrule.ClaimedExecution
-	claimErrors   map[string]error
-	requests      []eventrule.ExecutionClaimRequest
-	requestLanes  []string
-	actionNames   map[uuid.UUID]string
-	transitionErr error
-	transitions   chan transitionRecord
+	mu               sync.Mutex
+	claims           map[string][]eventrule.ClaimedExecution
+	scanLimitReached map[string]bool
+	claimErrors      map[string]error
+	requests         []eventrule.ExecutionClaimRequest
+	requestLanes     []string
+	actionNames      map[uuid.UUID]string
+	transitionErr    error
+	transitions      chan transitionRecord
 }
 
 func newFakeStore() *fakeStore {
 	return &fakeStore{
-		claims:      make(map[string][]eventrule.ClaimedExecution),
-		claimErrors: make(map[string]error),
-		actionNames: make(map[uuid.UUID]string),
-		transitions: make(chan transitionRecord, 10),
+		claims:           make(map[string][]eventrule.ClaimedExecution),
+		scanLimitReached: make(map[string]bool),
+		claimErrors:      make(map[string]error),
+		actionNames:      make(map[uuid.UUID]string),
+		transitions:      make(chan transitionRecord, 10),
 	}
 }
 
@@ -358,14 +369,14 @@ func (s *fakeStore) requestCount() int {
 func (s *fakeStore) ClaimPendingExecutions(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	return s.claim(ctx, request, "pending")
 }
 
 func (s *fakeStore) ClaimRetryExecutions(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	return s.claim(ctx, request, "deferred")
 }
 
@@ -373,19 +384,19 @@ func (s *fakeStore) claim(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
 	lane string,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return eventrule.ExecutionClaimBatch{}, err
 	}
 
 	s.requests = append(s.requests, request)
 	s.requestLanes = append(s.requestLanes, lane)
 
 	if err := s.claimErrors[lane]; err != nil {
-		return nil, err
+		return eventrule.ExecutionClaimBatch{}, err
 	}
 
 	available := s.claims[lane]
@@ -398,7 +409,10 @@ func (s *fakeStore) claim(
 
 	s.claims[lane] = available[count:]
 
-	return claimed, nil
+	return eventrule.ExecutionClaimBatch{
+		Claims:           claimed,
+		ScanLimitReached: s.scanLimitReached[lane] || len(available) >= request.Limit,
+	}, nil
 }
 
 func (s *fakeStore) TransitionClaimedExecution(
@@ -447,7 +461,16 @@ func newClaimedExecution(
 	require.NoError(t, err)
 
 	token := uuid.New()
-	require.NoError(t, execution.Claim(owner, token, createdAt.Add(time.Second)))
+	claimAt := createdAt.Add(time.Second)
+	disposition, err := execution.AcquireClaim(
+		owner,
+		token,
+		claimAt,
+		time.Now().Add(time.Minute),
+		4,
+	)
+	require.NoError(t, err)
+	require.Equal(t, eventrule.ClaimAcquired, disposition)
 
 	execution.Attempts = attempts
 	require.NoError(t, execution.Validate())

--- a/rest-api/flow/internal/eventrule/store.go
+++ b/rest-api/flow/internal/eventrule/store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 	"unicode/utf8"
 
 	"github.com/google/uuid"
@@ -42,6 +43,14 @@ var ErrExecutionAlreadyExists = errors.New("execution already exists")
 // longer owns the execution attempt.
 var ErrExecutionClaimLost = errors.New("execution claim lost")
 
+// ErrExecutionNotClaimable identifies an execution whose current state does
+// not permit acquiring a claim.
+var ErrExecutionNotClaimable = errors.New("execution is not claimable")
+
+// ErrInvalidExecutionInput identifies invalid arguments passed to an
+// execution operation.
+var ErrInvalidExecutionInput = errors.New("invalid execution input")
+
 const maxExecutionClaimOwnerRunes = 128
 
 // ValidateExecutionClaimOwner checks that a claim owner is a bounded, nonempty
@@ -62,17 +71,25 @@ func ValidateExecutionClaimOwner(owner string) error {
 
 // ExecutionClaimRequest bounds one atomic scheduler-store selection.
 type ExecutionClaimRequest struct {
-	Owner string
-	Limit int
+	Owner         string
+	Limit         int
+	ClaimDuration time.Duration
+	MaxAttempts   int
 }
 
-// Validate checks the owner and claim limit.
+// Validate checks the owner, batch limit, claim duration, and attempt bound.
 func (r ExecutionClaimRequest) Validate() error {
 	if err := ValidateExecutionClaimOwner(r.Owner); err != nil {
 		return err
 	}
 	if r.Limit <= 0 {
 		return fmt.Errorf("execution claim limit must be positive")
+	}
+	if r.ClaimDuration <= 0 {
+		return fmt.Errorf("execution claim duration must be positive")
+	}
+	if r.MaxAttempts <= 0 {
+		return fmt.Errorf("execution claim max attempts must be positive")
 	}
 
 	return nil
@@ -83,6 +100,14 @@ func (r ExecutionClaimRequest) Validate() error {
 type ClaimedExecution struct {
 	Execution Execution
 	Token     uuid.UUID
+}
+
+// ExecutionClaimBatch contains claims produced by one bounded candidate scan.
+// ScanLimitReached means the store inspected request.Limit eligible rows, so
+// additional work may remain even when exhausted rows reduced Claims.
+type ExecutionClaimBatch struct {
+	Claims           []ClaimedExecution
+	ScanLimitReached bool
 }
 
 // Validate checks the running execution and ownership fence.
@@ -201,20 +226,22 @@ type EventPlanStore interface {
 type ExecutionStore interface {
 	// ClaimPendingExecutions atomically selects at most request.Limit pending
 	// rows, moves them to running, allocates attempts, and assigns request.Owner
-	// and fencing tokens.
+	// with fencing tokens and store-timed expirations.
 	ClaimPendingExecutions(
 		ctx context.Context,
 		request ExecutionClaimRequest,
-	) ([]ClaimedExecution, error)
-	// ClaimRetryExecutions atomically selects at most request.Limit due retry
-	// rows, moves them to running, allocates attempts, and assigns request.Owner
-	// and fencing tokens.
+	) (ExecutionClaimBatch, error)
+	// ClaimRetryExecutions atomically scans at most request.Limit due deferred or
+	// expired running rows. Expired rows whose attempt budget is exhausted are
+	// failed and may reduce the returned claim count; ScanLimitReached tells the
+	// caller to schedule another bounded scan.
 	ClaimRetryExecutions(
 		ctx context.Context,
 		request ExecutionClaimRequest,
-	) ([]ClaimedExecution, error)
+	) (ExecutionClaimBatch, error)
 	// TransitionClaimedExecution persists an attempt outcome only while token
-	// owns the running execution.
+	// owns the running execution. Expiration permits reclamation but does not
+	// invalidate the token before a reclaimer replaces it.
 	TransitionClaimedExecution(
 		ctx context.Context,
 		executionID uuid.UUID,

--- a/rest-api/flow/internal/eventrule/store/memory/execution.go
+++ b/rest-api/flow/internal/eventrule/store/memory/execution.go
@@ -169,15 +169,15 @@ func validateEventPlan(
 func (s *Store) ClaimPendingExecutions(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	return s.claimExecutions(ctx, request, pendingExecutionClaim)
 }
 
-// ClaimRetryExecutions atomically allocates due deferred attempts.
+// ClaimRetryExecutions atomically allocates due deferred or expired attempts.
 func (s *Store) ClaimRetryExecutions(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	return s.claimExecutions(ctx, request, retryExecutionClaim)
 }
 
@@ -185,12 +185,12 @@ func (s *Store) claimExecutions(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
 	kind executionClaimKind,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return eventrule.ExecutionClaimBatch{}, err
 	}
 	if err := request.Validate(); err != nil {
-		return nil, err
+		return eventrule.ExecutionClaimBatch{}, err
 	}
 
 	s.mu.Lock()
@@ -201,7 +201,7 @@ func (s *Store) claimExecutions(
 	for id := range s.executions {
 		execution, err := s.execution(id)
 		if err != nil {
-			return nil, err
+			return eventrule.ExecutionClaimBatch{}, err
 		}
 
 		if executionEligible(*execution, kind, now) {
@@ -211,7 +211,7 @@ func (s *Store) claimExecutions(
 
 	slices.SortFunc(eligible, func(a, b eventrule.Execution) int {
 		if kind == retryExecutionClaim {
-			if order := a.NextAttemptAt.Compare(b.NextAttemptAt); order != 0 {
+			if order := executionEligibilityTime(a).Compare(executionEligibilityTime(b)); order != 0 {
 				return order
 			}
 		} else if order := a.CreatedAt.Compare(b.CreatedAt); order != 0 {
@@ -220,47 +220,64 @@ func (s *Store) claimExecutions(
 
 		return cmp.Compare(a.ID.String(), b.ID.String())
 	})
-
-	if len(eligible) > request.Limit {
+	batch := eventrule.ExecutionClaimBatch{
+		Claims:           make([]eventrule.ClaimedExecution, 0, request.Limit),
+		ScanLimitReached: len(eligible) >= request.Limit,
+	}
+	if batch.ScanLimitReached {
 		eligible = eligible[:request.Limit]
 	}
 
 	type update struct {
-		id        uuid.UUID
-		persisted dbmodel.EventActionExecution
-		claim     eventrule.ClaimedExecution
+		id          uuid.UUID
+		persisted   dbmodel.EventActionExecution
+		disposition eventrule.ClaimDisposition
+		claim       eventrule.ClaimedExecution
 	}
-	updates := make([]update, len(eligible))
+	updates := make([]update, 0, len(eligible))
 	for i := range eligible {
 		execution := eligible[i].Clone()
 		token := uuid.New()
+		claimExpiresAt := now.Add(request.ClaimDuration)
 
-		if err := execution.Claim(request.Owner, token, now); err != nil {
-			return nil, err
+		disposition, err := execution.AcquireClaim(
+			request.Owner,
+			token,
+			now,
+			claimExpiresAt,
+			request.MaxAttempts,
+		)
+		if err != nil {
+			return eventrule.ExecutionClaimBatch{}, err
 		}
 
 		persisted, err := converterdao.EventActionExecutionTo(&execution)
 		if err != nil {
-			return nil, err
+			return eventrule.ExecutionClaimBatch{}, err
 		}
 
-		updates[i] = update{
-			id:        execution.ID,
-			persisted: *persisted,
-			claim: eventrule.ClaimedExecution{
+		item := update{
+			id:          execution.ID,
+			persisted:   *persisted,
+			disposition: disposition,
+		}
+		if disposition == eventrule.ClaimAcquired {
+			item.claim = eventrule.ClaimedExecution{
 				Execution: execution,
 				Token:     token,
-			},
+			}
+		}
+		updates = append(updates, item)
+	}
+
+	for _, update := range updates {
+		s.executions[update.id].persisted = update.persisted
+		if update.disposition == eventrule.ClaimAcquired {
+			batch.Claims = append(batch.Claims, update.claim)
 		}
 	}
 
-	claims := make([]eventrule.ClaimedExecution, len(updates))
-	for i, update := range updates {
-		s.executions[update.id].persisted = update.persisted
-		claims[i] = update.claim
-	}
-
-	return claims, nil
+	return batch, nil
 }
 
 func executionEligible(
@@ -272,10 +289,21 @@ func executionEligible(
 	case pendingExecutionClaim:
 		return execution.Status == eventrule.ExecutionStatusPending
 	case retryExecutionClaim:
-		return execution.RetryDue(now)
+		return execution.RetryDue(now) ||
+			(execution.Status == eventrule.ExecutionStatusRunning &&
+				!execution.ClaimExpiresAt.IsZero() &&
+				!now.Before(execution.ClaimExpiresAt))
 	default:
 		return false
 	}
+}
+
+func executionEligibilityTime(execution eventrule.Execution) time.Time {
+	if execution.Status == eventrule.ExecutionStatusRunning {
+		return execution.ClaimExpiresAt
+	}
+
+	return execution.NextAttemptAt
 }
 
 // TransitionClaimedExecution atomically persists an owned attempt result.

--- a/rest-api/flow/internal/eventrule/store/postgres/execution.go
+++ b/rest-api/flow/internal/eventrule/store/postgres/execution.go
@@ -27,15 +27,15 @@ const (
 func (s *Store) ClaimPendingExecutions(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	return s.claimExecutions(ctx, request, pendingExecutionClaim)
 }
 
-// ClaimRetryExecutions atomically allocates due deferred attempts.
+// ClaimRetryExecutions atomically allocates due deferred or expired attempts.
 func (s *Store) ClaimRetryExecutions(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	return s.claimExecutions(ctx, request, retryExecutionClaim)
 }
 
@@ -43,12 +43,14 @@ func (s *Store) claimExecutions(
 	ctx context.Context,
 	request eventrule.ExecutionClaimRequest,
 	kind executionClaimKind,
-) ([]eventrule.ClaimedExecution, error) {
+) (eventrule.ExecutionClaimBatch, error) {
 	if err := request.Validate(); err != nil {
-		return nil, err
+		return eventrule.ExecutionClaimBatch{}, err
 	}
 
-	var claims []eventrule.ClaimedExecution
+	batch := eventrule.ExecutionClaimBatch{
+		Claims: make([]eventrule.ClaimedExecution, 0, request.Limit),
+	}
 	err := s.runInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		now, err := s.timestamp(ctx, tx)
 		if err != nil {
@@ -68,9 +70,19 @@ func (s *Store) claimExecutions(
 				OrderExpr("eae.created_at ASC, eae.id ASC")
 		case retryExecutionClaim:
 			query = query.
-				Where("eae.status = ?", string(eventrule.ExecutionStatusDeferred)).
-				Where("eae.next_attempt_at <= ?", now).
-				OrderExpr("eae.next_attempt_at ASC, eae.id ASC")
+				Where(
+					"(eae.status = ? AND eae.next_attempt_at <= ?) OR "+
+						"(eae.status = ? AND eae.claim_expires_at <= ?)",
+					string(eventrule.ExecutionStatusDeferred),
+					now,
+					string(eventrule.ExecutionStatusRunning),
+					now,
+				).
+				OrderExpr(
+					"CASE WHEN eae.status = ? THEN eae.next_attempt_at "+
+						"ELSE eae.claim_expires_at END ASC, eae.id ASC",
+					string(eventrule.ExecutionStatusDeferred),
+				)
 		default:
 			return fmt.Errorf("unknown execution claim kind %d", kind)
 		}
@@ -78,8 +90,8 @@ func (s *Store) claimExecutions(
 		if err := query.Scan(ctx); err != nil {
 			return err
 		}
+		batch.ScanLimitReached = len(records) == request.Limit
 
-		claims = make([]eventrule.ClaimedExecution, len(records))
 		for i := range records {
 			execution, err := converterdao.EventActionExecutionFrom(&records[i])
 			if err != nil {
@@ -87,7 +99,15 @@ func (s *Store) claimExecutions(
 			}
 
 			token := uuid.New()
-			if err := execution.Claim(request.Owner, token, now); err != nil {
+			claimExpiresAt := now.Add(request.ClaimDuration)
+			disposition, err := execution.AcquireClaim(
+				request.Owner,
+				token,
+				now,
+				claimExpiresAt,
+				request.MaxAttempts,
+			)
+			if err != nil {
 				return err
 			}
 
@@ -95,23 +115,29 @@ func (s *Store) claimExecutions(
 				return err
 			}
 
-			claims[i] = eventrule.ClaimedExecution{
-				Execution: execution.Clone(),
-				Token:     token,
+			switch disposition {
+			case eventrule.ClaimAcquired:
+				batch.Claims = append(batch.Claims, eventrule.ClaimedExecution{
+					Execution: execution.Clone(),
+					Token:     token,
+				})
+			case eventrule.ClaimExhausted:
+			default:
+				return fmt.Errorf("unknown claim disposition %d", disposition)
 			}
 		}
 
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return eventrule.ExecutionClaimBatch{}, err
 	}
 
-	return claims, nil
+	return batch, nil
 }
 
 // TransitionClaimedExecution persists an attempt result only while token owns
-// the locked running execution.
+// the locked running execution. Expiration alone does not invalidate the token.
 func (s *Store) TransitionClaimedExecution(
 	ctx context.Context,
 	id uuid.UUID,
@@ -129,20 +155,12 @@ func (s *Store) TransitionClaimedExecution(
 	}
 
 	return s.runInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
-		var record dbmodel.EventActionExecution
-		err := tx.NewSelect().
-			Model(&record).
-			Where("eae.id = ?", id).
-			For("UPDATE").
-			Scan(ctx)
-		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("%w: %s", eventrule.ErrExecutionNotFound, id)
-		}
+		record, err := lockExecution(ctx, tx, id)
 		if err != nil {
 			return err
 		}
 
-		execution, err := converterdao.EventActionExecutionFrom(&record)
+		execution, err := converterdao.EventActionExecutionFrom(record)
 		if err != nil {
 			return err
 		}
@@ -158,6 +176,27 @@ func (s *Store) TransitionClaimedExecution(
 
 		return updateExecution(ctx, tx, execution)
 	})
+}
+
+func lockExecution(
+	ctx context.Context,
+	tx bun.Tx,
+	id uuid.UUID,
+) (*dbmodel.EventActionExecution, error) {
+	var record dbmodel.EventActionExecution
+	err := tx.NewSelect().
+		Model(&record).
+		Where("eae.id = ?", id).
+		For("UPDATE").
+		Scan(ctx)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %s", eventrule.ErrExecutionNotFound, id)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &record, nil
 }
 
 func updateExecution(
@@ -178,6 +217,7 @@ func updateExecution(
 			"attempts",
 			"claim_token",
 			"claim_owner",
+			"claim_expires_at",
 			"status_message",
 			"updated_at",
 			"next_attempt_at",

--- a/rest-api/flow/internal/eventrule/store/postgres/store_test.go
+++ b/rest-api/flow/internal/eventrule/store/postgres/store_test.go
@@ -60,10 +60,7 @@ func TestStore_DuplicateDoesNotResumeExecution(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
-	claims, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: 1,
-	})
+	claims, err := testPendingClaims(ctx, store, testClaimRequest("scheduler-1"))
 	require.NoError(t, err)
 	require.Len(t, claims, 1)
 
@@ -71,10 +68,7 @@ func TestStore_DuplicateDoesNotResumeExecution(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, duplicate)
 
-	more, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-2",
-		Limit: 1,
-	})
+	more, err := testPendingClaims(ctx, store, testClaimRequest("scheduler-2"))
 	require.NoError(t, err)
 	require.Empty(t, more)
 
@@ -142,10 +136,7 @@ func TestStore_UsesDatabaseTimeForRetryEligibility(t *testing.T) {
 	_, err := store.CommitEventPlan(ctx, testEventDefinition(), testEventPlan())
 	require.NoError(t, err)
 
-	claims, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: 1,
-	})
+	claims, err := testPendingClaims(ctx, store, testClaimRequest("scheduler-1"))
 	require.NoError(t, err)
 	require.Len(t, claims, 1)
 
@@ -160,24 +151,47 @@ func TestStore_UsesDatabaseTimeForRetryEligibility(t *testing.T) {
 		),
 	))
 
-	notDue, err := store.ClaimRetryExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-2",
-		Limit: 1,
-	})
+	notDue, err := testRetryClaims(ctx, store, testClaimRequest("scheduler-2"))
 	require.NoError(t, err)
 	require.Empty(t, notDue)
 
 	var due []eventrule.ClaimedExecution
 	require.Eventually(t, func() bool {
-		due, err = store.ClaimRetryExecutions(ctx, eventrule.ExecutionClaimRequest{
-			Owner: "scheduler-2",
-			Limit: 1,
-		})
+		due, err = testRetryClaims(ctx, store, testClaimRequest("scheduler-2"))
 
 		return err == nil && len(due) == 1
 	}, time.Second, 20*time.Millisecond)
 	require.NoError(t, err)
 	require.Len(t, due, 1)
+}
+
+func testClaimRequest(owner string) eventrule.ExecutionClaimRequest {
+	return eventrule.ExecutionClaimRequest{
+		Owner:         owner,
+		Limit:         1,
+		ClaimDuration: time.Minute,
+		MaxAttempts:   4,
+	}
+}
+
+func testPendingClaims(
+	ctx context.Context,
+	store *Store,
+	request eventrule.ExecutionClaimRequest,
+) ([]eventrule.ClaimedExecution, error) {
+	batch, err := store.ClaimPendingExecutions(ctx, request)
+
+	return batch.Claims, err
+}
+
+func testRetryClaims(
+	ctx context.Context,
+	store *Store,
+	request eventrule.ExecutionClaimRequest,
+) ([]eventrule.ClaimedExecution, error) {
+	batch, err := store.ClaimRetryExecutions(ctx, request)
+
+	return batch.Claims, err
 }
 
 func newTestStore(t *testing.T) *Store {

--- a/rest-api/flow/internal/eventrule/store/storetest/execution_contract.go
+++ b/rest-api/flow/internal/eventrule/store/storetest/execution_contract.go
@@ -50,6 +50,226 @@ func RunExecutionContract(t *testing.T, factory ExecutionFactory) {
 	t.Run("concurrent claim fencing", func(t *testing.T) {
 		testConcurrentClaimFencing(t, factory)
 	})
+	t.Run("expired claim recovery", func(t *testing.T) {
+		testExpiredClaimRecovery(t, factory)
+	})
+	t.Run("exhausted retries report a full bounded scan", func(t *testing.T) {
+		testExhaustedRetriesReportFullScan(t, factory)
+	})
+	t.Run("late claim completion", func(t *testing.T) {
+		testLateClaimCompletion(t, factory)
+	})
+	t.Run("completion expiration race", func(t *testing.T) {
+		testCompletionExpirationRace(t, factory)
+	})
+}
+
+func testExhaustedRetriesReportFullScan(
+	t *testing.T,
+	factory ExecutionFactory,
+) {
+	t.Helper()
+
+	ctx := context.Background()
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	store := factory(&now)
+
+	_, err := store.CommitEventPlan(ctx, newEventDefinition(), newEventPlan())
+	require.NoError(t, err)
+
+	request := claimRequest("scheduler-1", 1)
+	request.MaxAttempts = 2
+	first, err := claimPendingExecutions(store, ctx, request)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	now = first[0].Execution.ClaimExpiresAt
+	request.Owner = "scheduler-2"
+	firstRetry, err := claimRetryExecutions(store, ctx, request)
+	require.NoError(t, err)
+	require.Len(t, firstRetry, 1)
+
+	_, err = store.CommitEventPlan(ctx, newEventDefinition(), newEventPlan())
+	require.NoError(t, err)
+	second, err := claimPendingExecutions(store, ctx, request)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+
+	require.NoError(t, store.TransitionClaimedExecution(
+		ctx,
+		second[0].Execution.ID,
+		second[0].Token,
+		eventrule.DeferredExecutionResult(
+			eventrule.ExecutionReasonAttemptFailed,
+			"temporarily unavailable",
+			3*time.Minute,
+		),
+	))
+
+	// The first execution expires before the second execution becomes due, so a
+	// limit-one retry scan encounters and terminalizes the exhausted row first.
+	now = now.Add(3 * time.Minute)
+	request.Owner = "scheduler-3"
+	batch, err := store.ClaimRetryExecutions(ctx, request)
+	require.NoError(t, err)
+	require.Empty(t, batch.Claims)
+	require.True(t, batch.ScanLimitReached)
+
+	batch, err = store.ClaimRetryExecutions(ctx, request)
+	require.NoError(t, err)
+	require.Len(t, batch.Claims, 1)
+	require.Equal(t, second[0].Execution.ID, batch.Claims[0].Execution.ID)
+}
+
+func testLateClaimCompletion(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+
+	ctx := context.Background()
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	store := factory(&now)
+	_, err := store.CommitEventPlan(ctx, newEventDefinition(), newEventPlan())
+	require.NoError(t, err)
+
+	claims, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-1", 1))
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+	now = claims[0].Execution.ClaimExpiresAt
+
+	require.NoError(t, store.TransitionClaimedExecution(
+		ctx,
+		claims[0].Execution.ID,
+		claims[0].Token,
+		eventrule.CompletedExecutionResult(),
+	))
+
+	recovered, err := claimRetryExecutions(store, ctx, claimRequest("scheduler-2", 1))
+	require.NoError(t, err)
+	require.Empty(t, recovered)
+}
+
+func testCompletionExpirationRace(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+
+	ctx := context.Background()
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	store := factory(&now)
+	_, err := store.CommitEventPlan(ctx, newEventDefinition(), newEventPlan())
+	require.NoError(t, err)
+
+	first, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-1", 1))
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	now = first[0].Execution.ClaimExpiresAt
+
+	start := make(chan struct{})
+	transitionErr := make(chan error, 1)
+	retryResult := make(chan []eventrule.ClaimedExecution, 1)
+	retryErr := make(chan error, 1)
+	go func() {
+		<-start
+		transitionErr <- store.TransitionClaimedExecution(
+			ctx,
+			first[0].Execution.ID,
+			first[0].Token,
+			eventrule.CompletedExecutionResult(),
+		)
+	}()
+	go func() {
+		<-start
+		claims, err := claimRetryExecutions(store, ctx, claimRequest("scheduler-2", 1))
+		retryResult <- claims
+		retryErr <- err
+	}()
+	close(start)
+
+	claims := <-retryResult
+	require.NoError(t, <-retryErr)
+	err = <-transitionErr
+	if err == nil {
+		require.Empty(t, claims, "completion won the row lock")
+		return
+	}
+
+	require.ErrorIs(t, err, eventrule.ErrExecutionClaimLost)
+	require.Len(t, claims, 1, "reclamation won the row lock")
+	require.NotEqual(t, first[0].Token, claims[0].Token)
+}
+
+func testExpiredClaimRecovery(t *testing.T, factory ExecutionFactory) {
+	t.Helper()
+
+	ctx := context.Background()
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	store := factory(&now)
+	_, err := store.CommitEventPlan(ctx, newEventDefinition(), newEventPlan())
+	require.NoError(t, err)
+
+	request := claimRequest("scheduler-1", 1)
+	request.MaxAttempts = 2
+	first, err := claimPendingExecutions(store, ctx, request)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Equal(t, now.Add(time.Minute), first[0].Execution.ClaimExpiresAt)
+
+	now = now.Add(time.Minute)
+	request.Owner = "scheduler-2"
+	const schedulers = 20
+	results := make(chan []eventrule.ClaimedExecution, schedulers)
+	errs := make(chan error, schedulers)
+	var wg sync.WaitGroup
+	for range schedulers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			owner := "recovery-" + uuid.NewString()
+			recoveryRequest := request
+			recoveryRequest.Owner = owner
+			claims, err := claimRetryExecutions(store, ctx, recoveryRequest)
+			results <- claims
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	var reclaimed eventrule.ClaimedExecution
+	claimCount := 0
+	for claims := range results {
+		claimCount += len(claims)
+		if len(claims) == 1 {
+			reclaimed = claims[0]
+		}
+	}
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, claimCount)
+	require.Equal(t, 2, reclaimed.Execution.Attempts)
+	require.NotEqual(t, first[0].Token, reclaimed.Token)
+	require.Equal(t, now.Add(2*time.Minute), reclaimed.Execution.ClaimExpiresAt)
+
+	err = store.TransitionClaimedExecution(
+		ctx,
+		first[0].Execution.ID,
+		first[0].Token,
+		eventrule.CompletedExecutionResult(),
+	)
+	require.ErrorIs(t, err, eventrule.ErrExecutionClaimLost)
+
+	now = reclaimed.Execution.ClaimExpiresAt
+	request.Owner = "scheduler-3"
+	claims, err := claimRetryExecutions(store, ctx, request)
+	require.NoError(t, err)
+	require.Empty(t, claims, "an exhausted execution becomes terminal")
+
+	err = store.TransitionClaimedExecution(
+		ctx,
+		reclaimed.Execution.ID,
+		reclaimed.Token,
+		eventrule.CompletedExecutionResult(),
+	)
+	require.ErrorIs(t, err, eventrule.ErrExecutionClaimLost)
 }
 
 func testInterruptedAttemptRefund(t *testing.T, factory ExecutionFactory) {
@@ -61,10 +281,7 @@ func testInterruptedAttemptRefund(t *testing.T, factory ExecutionFactory) {
 	_, err := store.CommitEventPlan(ctx, newEventDefinition(), newEventPlan())
 	require.NoError(t, err)
 
-	claims, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: 1,
-	})
+	claims, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-1", 1))
 	require.NoError(t, err)
 	require.Len(t, claims, 1)
 
@@ -83,10 +300,7 @@ func testInterruptedAttemptRefund(t *testing.T, factory ExecutionFactory) {
 	))
 
 	now = now.Add(time.Minute)
-	claims, err = store.ClaimRetryExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-2",
-		Limit: 1,
-	})
+	claims, err = claimRetryExecutions(store, ctx, claimRequest("scheduler-2", 1))
 	require.NoError(t, err)
 	require.Len(t, claims, 1)
 
@@ -119,18 +333,12 @@ func testExecutionClaimLimit(t *testing.T, factory ExecutionFactory) {
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
-	first, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: 1,
-	})
+	first, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-1", 1))
 	require.NoError(t, err)
 	require.Len(t, first, 1)
 	requireValidClaims(t, first, "scheduler-1")
 
-	second, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: 1,
-	})
+	second, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-1", 1))
 	require.NoError(t, err)
 	require.Len(t, second, 1)
 	requireValidClaims(t, second, "scheduler-1")
@@ -173,10 +381,7 @@ func testAtomicEventLifecycle(t *testing.T, factory ExecutionFactory) {
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
-	claims, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: 10,
-	})
+	claims, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-1", 10))
 	require.NoError(t, err)
 	require.Len(t, claims, 1, "only the first event has a dispatchable execution")
 	requireValidClaims(t, claims, "scheduler-1")
@@ -226,10 +431,11 @@ func testConcurrentEventDeduplication(t *testing.T, factory ExecutionFactory) {
 	require.NoError(t, err)
 	require.Equal(t, deliveries+1, stored.Observations)
 
-	claims, err := store.ClaimPendingExecutions(context.Background(), eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: deliveries,
-	})
+	claims, err := claimPendingExecutions(
+		store,
+		context.Background(),
+		claimRequest("scheduler-1", deliveries),
+	)
 	require.NoError(t, err)
 	require.Len(t, claims, 1)
 	requireValidClaims(t, claims, "scheduler-1")
@@ -244,10 +450,7 @@ func testExecutionClaimLifecycle(t *testing.T, factory ExecutionFactory) {
 	_, err := store.CommitEventPlan(ctx, newEventDefinition(), newEventPlan())
 	require.NoError(t, err)
 
-	pending, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: 1,
-	})
+	pending, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-1", 1))
 	require.NoError(t, err)
 	require.Len(t, pending, 1)
 	requireValidClaims(t, pending, "scheduler-1")
@@ -257,10 +460,7 @@ func testExecutionClaimLifecycle(t *testing.T, factory ExecutionFactory) {
 	require.Equal(t, 1, first.Execution.Attempts)
 	require.NoError(t, first.Validate())
 
-	none, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-2",
-		Limit: 1,
-	})
+	none, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-2", 1))
 	require.NoError(t, err)
 	require.Empty(t, none)
 	requireValidClaims(t, none, "scheduler-2")
@@ -277,19 +477,13 @@ func testExecutionClaimLifecycle(t *testing.T, factory ExecutionFactory) {
 	)
 	require.NoError(t, err)
 
-	none, err = store.ClaimRetryExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-2",
-		Limit: 1,
-	})
+	none, err = claimRetryExecutions(store, ctx, claimRequest("scheduler-2", 1))
 	require.NoError(t, err)
 	require.Empty(t, none)
 	requireValidClaims(t, none, "scheduler-2")
 
 	now = now.Add(time.Minute)
-	deferred, err := store.ClaimRetryExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-2",
-		Limit: 1,
-	})
+	deferred, err := claimRetryExecutions(store, ctx, claimRequest("scheduler-2", 1))
 	require.NoError(t, err)
 	require.Len(t, deferred, 1)
 	requireValidClaims(t, deferred, "scheduler-2")
@@ -346,10 +540,7 @@ func testOrderedAtomicPlanCommit(t *testing.T, factory ExecutionFactory) {
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
-	claims, err := store.ClaimPendingExecutions(ctx, eventrule.ExecutionClaimRequest{
-		Owner: "scheduler-1",
-		Limit: 2,
-	})
+	claims, err := claimPendingExecutions(store, ctx, claimRequest("scheduler-1", 2))
 	require.NoError(t, err)
 	require.Len(t, claims, 2)
 	requireValidClaims(t, claims, "scheduler-1")
@@ -382,12 +573,10 @@ func testConcurrentClaimFencing(t *testing.T, factory ExecutionFactory) {
 			defer wg.Done()
 
 			owner := "scheduler-" + uuid.NewString()
-			claims, err := store.ClaimPendingExecutions(
+			claims, err := claimPendingExecutions(
+				store,
 				context.Background(),
-				eventrule.ExecutionClaimRequest{
-					Owner: owner,
-					Limit: 1,
-				},
+				claimRequest(owner, 1),
 			)
 
 			results <- result{owner: owner, claims: claims}
@@ -408,6 +597,35 @@ func testConcurrentClaimFencing(t *testing.T, factory ExecutionFactory) {
 	}
 
 	require.Equal(t, 1, claimed)
+}
+
+func claimRequest(owner string, limit int) eventrule.ExecutionClaimRequest {
+	return eventrule.ExecutionClaimRequest{
+		Owner:         owner,
+		Limit:         limit,
+		ClaimDuration: time.Minute,
+		MaxAttempts:   4,
+	}
+}
+
+func claimPendingExecutions(
+	store EventExecutionStore,
+	ctx context.Context,
+	request eventrule.ExecutionClaimRequest,
+) ([]eventrule.ClaimedExecution, error) {
+	batch, err := store.ClaimPendingExecutions(ctx, request)
+
+	return batch.Claims, err
+}
+
+func claimRetryExecutions(
+	store EventExecutionStore,
+	ctx context.Context,
+	request eventrule.ExecutionClaimRequest,
+) ([]eventrule.ClaimedExecution, error) {
+	batch, err := store.ClaimRetryExecutions(ctx, request)
+
+	return batch.Claims, err
 }
 
 func requireValidClaims(

--- a/rest-api/flow/internal/eventrule/store_test.go
+++ b/rest-api/flow/internal/eventrule/store_test.go
@@ -19,22 +19,44 @@ func TestExecutionClaimRequest_Validate(t *testing.T) {
 		wantErr string
 	}{
 		"valid": {
-			request: ExecutionClaimRequest{Owner: "scheduler-1", Limit: 1},
+			request: validExecutionClaimRequest(),
 		},
 		"missing owner": {
-			request: ExecutionClaimRequest{Limit: 1},
+			request: func() ExecutionClaimRequest {
+				request := validExecutionClaimRequest()
+				request.Owner = ""
+				return request
+			}(),
 			wantErr: "execution claim owner is empty",
 		},
 		"owner too long": {
 			request: ExecutionClaimRequest{
-				Owner: strings.Repeat("x", maxExecutionClaimOwnerRunes+1),
-				Limit: 1,
+				Owner:         strings.Repeat("x", maxExecutionClaimOwnerRunes+1),
+				Limit:         1,
+				ClaimDuration: time.Minute,
+				MaxAttempts:   4,
 			},
 			wantErr: "execution claim owner exceeds 128 characters",
 		},
 		"invalid limit": {
 			request: ExecutionClaimRequest{Owner: "scheduler-1"},
 			wantErr: "execution claim limit must be positive",
+		},
+		"invalid claim duration": {
+			request: func() ExecutionClaimRequest {
+				request := validExecutionClaimRequest()
+				request.ClaimDuration = 0
+				return request
+			}(),
+			wantErr: "execution claim duration must be positive",
+		},
+		"invalid max attempts": {
+			request: func() ExecutionClaimRequest {
+				request := validExecutionClaimRequest()
+				request.MaxAttempts = 0
+				return request
+			}(),
+			wantErr: "execution claim max attempts must be positive",
 		},
 	}
 
@@ -57,7 +79,15 @@ func TestClaimedExecution_Validate(t *testing.T) {
 	require.NoError(t, err)
 
 	token := uuid.New()
-	require.NoError(t, execution.Claim("scheduler-1", token, createdAt))
+	disposition, err := execution.AcquireClaim(
+		"scheduler-1",
+		token,
+		createdAt,
+		createdAt.Add(time.Minute),
+		4,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ClaimAcquired, disposition)
 
 	valid := ClaimedExecution{Execution: *execution, Token: token}
 
@@ -97,6 +127,15 @@ func TestClaimedExecution_Validate(t *testing.T) {
 
 			require.ErrorContains(t, err, test.wantErr)
 		})
+	}
+}
+
+func validExecutionClaimRequest() ExecutionClaimRequest {
+	return ExecutionClaimRequest{
+		Owner:         "scheduler-1",
+		Limit:         1,
+		ClaimDuration: time.Minute,
+		MaxAttempts:   4,
 	}
 }
 


### PR DESCRIPTION
Persist fixed claim expiration for event action executions and enforce
running/non-running expiration invariants with a non-validating migration
and partial recovery index.

Reclaim expired running executions atomically in memory and PostgreSQL,
rotate fencing tokens, bound recovered attempts, and give reclaimed attempts
twice the configured claim duration to tolerate underestimated execution time
without creating unbounded recovery windows.

Allow late results while their original token remains current, relying on store
locking to resolve completion-versus-reclamation races. Add scheduler
configuration for fixed claim duration and document when a future action-specific
renewable mode would be appropriate.

Cover migration semantics, expiration conversion, claim exhaustion, concurrent
reclamation fencing, late completion, and end-to-end PostgreSQL crash recovery.

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

