### PR TITLE
fix(machine-controller): power hosts on after decommissioning cycle

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1418,6 +1418,8 @@ pub enum DecommissioningState {
     SuppressingOobDhcp,
     /// Power-cycles the host to force OOB rediscovery against the pre-cycle suppression.
     PowerCyclingHost,
+    /// Powers the host back on after the cycle so OOB rediscovery can proceed.
+    PoweringOnHost,
     /// Waiting for the pre-cycle OOB DHCP suppression to be acknowledged.
     WaitingForOobDhcpAcknowledgement,
     /// BMC DHCP is suppressed before the BMC factory reset.
@@ -2742,6 +2744,7 @@ impl Display for DecommissioningState {
             DecommissioningState::DeconfiguringDpus { .. } => write!(f, "DeconfiguringDpus"),
             DecommissioningState::SuppressingOobDhcp => write!(f, "SuppressingOobDhcp"),
             DecommissioningState::PowerCyclingHost => write!(f, "PowerCyclingHost"),
+            DecommissioningState::PoweringOnHost => write!(f, "PoweringOnHost"),
             DecommissioningState::WaitingForOobDhcpAcknowledgement => {
                 write!(f, "WaitingForOobDhcpAcknowledgement")
             }
@@ -3138,6 +3141,9 @@ pub fn state_sla(
             }
             DecommissioningState::PowerCyclingHost => {
                 StateSla::with_sla(slas::DECOMMISSIONING_POWER_CYCLING_HOST, time_in_state)
+            }
+            DecommissioningState::PoweringOnHost => {
+                StateSla::with_sla(slas::DECOMMISSIONING_POWERING_ON_HOST, time_in_state)
             }
             DecommissioningState::WaitingForOobDhcpAcknowledgement => StateSla::with_sla(
                 slas::DECOMMISSIONING_WAITING_FOR_OOB_DHCP_ACKNOWLEDGEMENT,

--- a/crates/api-model/src/machine/slas.rs
+++ b/crates/api-model/src/machine/slas.rs
@@ -104,6 +104,9 @@ pub const DECOMMISSIONING_SUPPRESSING_OOB_DHCP: Duration = Duration::from_secs(5
 /// SLA for the host power cycle that forces OOB rediscovery during decommissioning.
 pub const DECOMMISSIONING_POWER_CYCLING_HOST: Duration = Duration::from_secs(5 * 60);
 
+/// SLA for powering the host back on after the decommissioning power cycle.
+pub const DECOMMISSIONING_POWERING_ON_HOST: Duration = Duration::from_secs(5 * 60);
+
 /// SLA for waiting for OOB DHCP suppression acknowledgement after the host power
 /// cycle.
 pub const DECOMMISSIONING_WAITING_FOR_OOB_DHCP_ACKNOWLEDGEMENT: Duration =

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1315,6 +1315,14 @@ impl MachineStateHandler {
                 DecommissioningState::PowerCyclingHost => {
                     decommissioning::handle_power_cycling_host(mh_snapshot, ctx).await
                 }
+                DecommissioningState::PoweringOnHost => {
+                    decommissioning::handle_powering_on_host(
+                        mh_snapshot,
+                        ctx,
+                        self.reachability_params.power_down_wait,
+                    )
+                    .await
+                }
                 DecommissioningState::WaitingForOobDhcpAcknowledgement => {
                     decommissioning::handle_waiting_for_oob_dhcp_acknowledgement(mh_snapshot, ctx)
                         .await

--- a/crates/machine-controller/src/handler/decommissioning.rs
+++ b/crates/machine-controller/src/handler/decommissioning.rs
@@ -750,19 +750,28 @@ pub(super) async fn handle_powering_on_host(
         .create_redfish_client_from_machine(host)
         .await?;
     let power_state = super::host_power_state(redfish_client.as_ref()).await?;
-    if power_state != PowerState::On && power_state != PowerState::PoweringOn {
-        tracing::info!(
-            machine_id = %host.id,
-            %power_state,
-            "Host not On after decommissioning power cycle; powering on"
-        );
-        host_power_control(redfish_client.as_ref(), host, SystemPowerControl::On, ctx)
-            .await
-            .map_err(|error| {
-                StateHandlerError::GenericError(eyre::eyre!(
-                    "failed to power on host after decommissioning power cycle: {error}"
-                ))
-            })?;
+    match power_state {
+        PowerState::On | PowerState::PoweringOn => {}
+        PowerState::PoweringOff => {
+            return Ok(StateHandlerOutcome::wait(format!(
+                "waiting for {host_id} to finish powering off before powering on; current power state: {power_state}",
+                host_id = host.id,
+            )));
+        }
+        _ => {
+            tracing::info!(
+                machine_id = %host.id,
+                %power_state,
+                "Host not On after decommissioning power cycle; powering on"
+            );
+            host_power_control(redfish_client.as_ref(), host, SystemPowerControl::On, ctx)
+                .await
+                .map_err(|error| {
+                    StateHandlerError::GenericError(eyre::eyre!(
+                        "failed to power on host after decommissioning power cycle: {error}"
+                    ))
+                })?;
+        }
     }
 
     Ok(StateHandlerOutcome::transition(

--- a/crates/machine-controller/src/handler/decommissioning.rs
+++ b/crates/machine-controller/src/handler/decommissioning.rs
@@ -21,7 +21,7 @@ use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialW
 use carbide_uuid::machine::MachineId;
 use libredfish::model::task::TaskState;
 use libredfish::model::update_service::TransferProtocolType;
-use libredfish::{EnabledDisabled, JobState, RedfishError, SystemPowerControl};
+use libredfish::{EnabledDisabled, JobState, PowerState, RedfishError, SystemPowerControl};
 use model::bmc_suppression::{BmcSuppressionSubsystem, NewBmcSuppression};
 use model::dpa_interface::{DpaInterfaceControllerState, DpaInterfaceType, DpaLockMode};
 use model::machine::{
@@ -718,6 +718,53 @@ pub(super) async fn handle_power_cycling_host(
             "failed to power cycle host after suppressing OOB DHCP: {error}"
         ))
     })?;
+    Ok(StateHandlerOutcome::transition(
+        ManagedHostState::Decommissioning {
+            decommissioning_state: DecommissioningState::PoweringOnHost,
+        },
+    ))
+}
+
+pub(super) async fn handle_powering_on_host(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    power_down_wait: chrono::Duration,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let host = &state.host_snapshot;
+    let basetime = host
+        .status
+        .last_reboot_requested
+        .as_ref()
+        .map(|reboot| reboot.time)
+        .unwrap_or(host.state.version.timestamp());
+
+    if super::wait(&basetime, power_down_wait) {
+        return Ok(StateHandlerOutcome::wait(format!(
+            "waiting for power-down grace period before powering on {host_id}; power_down_wait: {power_down_wait}",
+            host_id = host.id,
+        )));
+    }
+
+    let redfish_client = ctx
+        .services
+        .create_redfish_client_from_machine(host)
+        .await?;
+    let power_state = super::host_power_state(redfish_client.as_ref()).await?;
+    if power_state != PowerState::On && power_state != PowerState::PoweringOn {
+        tracing::info!(
+            machine_id = %host.id,
+            %power_state,
+            "Host not On after decommissioning power cycle; powering on"
+        );
+        host_power_control(redfish_client.as_ref(), host, SystemPowerControl::On, ctx)
+            .await
+            .map_err(|error| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "failed to power on host after decommissioning power cycle: {error}"
+                ))
+            })?;
+    }
+
     Ok(StateHandlerOutcome::transition(
         ManagedHostState::Decommissioning {
             decommissioning_state: DecommissioningState::WaitingForOobDhcpAcknowledgement,

--- a/crates/machine-controller/src/handler/decommissioning.rs
+++ b/crates/machine-controller/src/handler/decommissioning.rs
@@ -751,13 +751,15 @@ pub(super) async fn handle_powering_on_host(
         .await?;
     let power_state = super::host_power_state(redfish_client.as_ref()).await?;
     match power_state {
-        PowerState::On | PowerState::PoweringOn => {}
-        PowerState::PoweringOff => {
-            return Ok(StateHandlerOutcome::wait(format!(
-                "waiting for {host_id} to finish powering off before powering on; current power state: {power_state}",
-                host_id = host.id,
-            )));
-        }
+        PowerState::On | PowerState::PoweringOn => Ok(StateHandlerOutcome::transition(
+            ManagedHostState::Decommissioning {
+                decommissioning_state: DecommissioningState::WaitingForOobDhcpAcknowledgement,
+            },
+        )),
+        PowerState::PoweringOff => Ok(StateHandlerOutcome::wait(format!(
+            "waiting for {host_id} to finish powering off before powering on; current power state: {power_state}",
+            host_id = host.id,
+        ))),
         _ => {
             tracing::info!(
                 machine_id = %host.id,
@@ -771,14 +773,12 @@ pub(super) async fn handle_powering_on_host(
                         "failed to power on host after decommissioning power cycle: {error}"
                     ))
                 })?;
+            Ok(StateHandlerOutcome::wait(format!(
+                "waiting for {host_id} to power on after decommissioning power cycle; current power state: {power_state}",
+                host_id = host.id,
+            )))
         }
     }
-
-    Ok(StateHandlerOutcome::transition(
-        ManagedHostState::Decommissioning {
-            decommissioning_state: DecommissioningState::WaitingForOobDhcpAcknowledgement,
-        },
-    ))
 }
 
 pub(super) async fn handle_waiting_for_oob_dhcp_acknowledgement(

--- a/crates/machine-controller/src/handler/decommissioning.rs
+++ b/crates/machine-controller/src/handler/decommissioning.rs
@@ -751,13 +751,17 @@ pub(super) async fn handle_powering_on_host(
         .await?;
     let power_state = super::host_power_state(redfish_client.as_ref()).await?;
     match power_state {
-        PowerState::On | PowerState::PoweringOn => Ok(StateHandlerOutcome::transition(
+        PowerState::On => Ok(StateHandlerOutcome::transition(
             ManagedHostState::Decommissioning {
                 decommissioning_state: DecommissioningState::WaitingForOobDhcpAcknowledgement,
             },
         )),
         PowerState::PoweringOff => Ok(StateHandlerOutcome::wait(format!(
             "waiting for {host_id} to finish powering off before powering on; current power state: {power_state}",
+            host_id = host.id,
+        ))),
+        PowerState::PoweringOn => Ok(StateHandlerOutcome::wait(format!(
+            "waiting for {host_id} to finish powering on; current power state: {power_state}",
             host_id = host.id,
         ))),
         _ => {

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -343,6 +343,7 @@ impl StateControllerIO for MachineStateControllerIO {
                     ("decommissioning", "suppressingoobdhcp")
                 }
                 DecommissioningState::PowerCyclingHost => ("decommissioning", "powercyclinghost"),
+                DecommissioningState::PoweringOnHost => ("decommissioning", "poweringonhost"),
                 DecommissioningState::WaitingForOobDhcpAcknowledgement => {
                     ("decommissioning", "waitingforoobdhcpacknowledgement")
                 }


### PR DESCRIPTION
While testing decommissioning on a GB200 managed host, I noticed it remained off after it went through the `PowerCyclingHost` state so it got stuck in the state machine until I manually powered it back on. Looks like `AcPowercycle` maps to `ForceOff` if the BMC doesn't support power cycle. 

In this PR I add a new state to power on the machine if it remains off for a certain amount of time.

## Related issues
#1969

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


