### PR TITLE
install grpcurl in release containers

### DIFF
--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -29,6 +29,11 @@ ENV CONTAINER_REPO_ROOT=/carbide
 
 RUN USER=root cargo new --bin carbide
 WORKDIR ./carbide
+
+# v0.10 integration tests invoke grpcurl. Install it here instead of relying on
+# the selected build container to provide this test prerequisite.
+RUN cd /tmp && curl -Lo ./grpcurl.tar.gz https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_arm64.tar.gz && tar xzf grpcurl.tar.gz && chmod +x ./grpcurl && mv grpcurl /usr/local/bin/ && rm LICENSE && rm grpcurl.tar.gz
+
 COPY . ./
 
 # --mount=type=cache persists the sccache directory across docker build invocations.

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -29,6 +29,11 @@ ENV CONTAINER_REPO_ROOT=/carbide
 
 RUN USER=root cargo new --bin carbide
 WORKDIR ./carbide
+
+# v0.10 integration tests invoke grpcurl. Install it here instead of relying on
+# the selected build container to provide this test prerequisite.
+RUN cd /tmp && curl -Lo ./grpcurl.tar.gz https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz && tar xzf grpcurl.tar.gz && chmod +x ./grpcurl && mv grpcurl /usr/local/bin/ && rm LICENSE && rm grpcurl.tar.gz
+
 COPY . ./
 
 # --mount=type=cache persists the sccache directory across docker build invocations.


### PR DESCRIPTION
Installing `grpcurl` in release containers to fix the following errors in the CI:

```
#16 1845.8 failures:
#16 1845.8 
#16 1845.8 ---- test_metrics_integration stdout ----
#16 1845.8 Error: Missing prerequisite binary: grpcurl
#16 1845.8 
#16 1845.8 Location:
#16 1845.8     crates/api-test-helper/src/utils.rs:345:17
#16 1845.8 
#16 1845.8 ---- test_integration stdout ----
#16 1845.8 Error: Missing prerequisite binary: grpcurl
```

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

