### PR TITLE
Draft: test: expose reboot regressions

### DIFF
--- a/crates/api-core/src/tests/instance_ipxe_behaviors.rs
+++ b/crates/api-core/src/tests/instance_ipxe_behaviors.rs
@@ -109,6 +109,13 @@ async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
         )
     })
     .await;
+
+    // The reboot request has already selected the one-time custom iPXE boot,
+    // but the host has not yet reported that the restart completed. The PXE
+    // request made during that window must still receive the requested script.
+    let pxe = host_interface.get_pxe_instructions(host_arch).await;
+    assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
+
     env.run_machine_state_controller_iteration().await;
     mh.host().reboot_completed().await;
     env.run_machine_state_controller_iteration_until_state_condition(&mh.id, 5, |machine| {

--- a/rest-api/api/pkg/api/handler/instance_test.go
+++ b/rest-api/api/pkg/api/handler/instance_test.go
@@ -4341,6 +4341,11 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	inst10 := testInstanceBuildInstance(t, dbSession, "test-instance-10", tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cutil.GetPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
 	assert.NotNil(t, inst10)
 
+	// Used only to characterize REST reboot status reporting after a successful
+	// site workflow completion.
+	instRebootStatus := testInstanceBuildInstance(t, dbSession, "test-instance-reboot-status", tn1.ID, ip.ID, st1.ID, &ist1.ID, vpc1.ID, cutil.GetPtr(mc1.ID), &os2.ID, nil, cdbm.InstanceStatusReady)
+	assert.NotNil(t, instRebootStatus)
+
 	instsub1 := testInstanceBuildInstanceInterface(t, dbSession, inst1.ID, &subnet1.ID, nil, nil, cdbm.InterfaceStatusReady)
 	assert.NotNil(t, instsub1)
 
@@ -4884,8 +4889,9 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 		// When true with nvlinkInterfacesToDelete, still assert those rows are Deleting but skip Pending-row count/order checks.
 		nvLinkSkipPendingDBAssertions bool
 		// Optional hook after building the echo context and before Handle (e.g. adjust DB timestamps for time-sensitive branches).
-		beforeHandle           func(t *testing.T)
-		ethernetReconciliation *ethernetReconciliationExpectation
+		beforeHandle                         func(t *testing.T)
+		ethernetReconciliation               *ethernetReconciliationExpectation
+		assertRebootStatusRemainsNonTerminal bool
 	}
 
 	tests := []struct {
@@ -5743,6 +5749,30 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 				reqOrg:                tnOrg1,
 				reqUser:               tnu1,
 				respCode:              http.StatusOK,
+			},
+			wantErr: false,
+		},
+		{
+			// The mocked site workflow's Get call returns successfully. This
+			// characterizes the REST API reporting gap: its only resulting
+			// status is still Rebooting, with no terminal provider outcome.
+			name: "test Instance reboot remains non-terminal after successful site workflow",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				scp:       scp,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIInstanceUpdateRequest{
+					TriggerReboot: cutil.GetPtr(true),
+				},
+				reqInstance:                          instRebootStatus.ID.String(),
+				cleanInstanceToStatus:                instRebootStatus.Status,
+				reqOrg:                               tnOrg1,
+				reqUser:                              tnu1,
+				respCode:                             http.StatusOK,
+				assertRebootStatusRemainsNonTerminal: true,
 			},
 			wantErr: false,
 		},
@@ -7410,6 +7440,30 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 			}
 
 			reqIns, _ := insDAO.GetByID(ec.Request().Context(), nil, uuid.MustParse(tt.args.reqInstance), nil)
+			if tt.args.assertRebootStatusRemainsNonTerminal {
+				require.NotNil(t, reqIns.PowerStatus)
+				assert.Equal(t, cdbm.InstancePowerStatusRebooting, *reqIns.PowerStatus)
+
+				sdDAO := cdbm.NewStatusDetailDAO(tt.fields.dbSession)
+				statusDetails, _, statusDetailsErr := sdDAO.GetAll(
+					ec.Request().Context(),
+					nil,
+					cdbm.StatusDetailFilterInput{EntityIDs: []string{reqIns.ID.String()}},
+					cdbp.PageInput{},
+				)
+				require.NoError(t, statusDetailsErr)
+				require.NotEmpty(t, statusDetails)
+
+				foundRebootingDetail := false
+				for _, statusDetail := range statusDetails {
+					if statusDetail.Status == cdbm.InstancePowerStatusRebooting {
+						foundRebootingDetail = true
+						require.NotNil(t, statusDetail.Message)
+						assert.Equal(t, "received Instance reboot request, processing", *statusDetail.Message)
+					}
+				}
+				assert.True(t, foundRebootingDetail, "successful reboot workflow did not record a terminal status")
+			}
 
 			if len(tt.expectedControllerVpcIDs) > 0 && len(tt.args.reqData.Interfaces) > 0 {
 				require.Len(t, rst.Interfaces, len(tt.args.reqData.Interfaces))


### PR DESCRIPTION
## Summary

Custom iPXE reboot: a one-time custom-iPXE reboot can enter `WaitingForRebootToReady` before the host asks for PXE instructions. In that state, the renderer serves a generic invalid-state script rather than the requested custom script, making QCOW-based reprovisioning dependent on timing.

REST reboot status reporting: after the site reboot workflow completes successfully, the REST API response, persisted power status, and status detail remain `Rebooting`. Because no terminal provider result is recorded or returned, clients cannot distinguish a completed reboot from one that has stalled or failed.

This draft PR contains focused reproducers only; the custom-iPXE assertion is expected to fail until the state/renderer race is fixed.

## Validation

- `cargo fmt --all -- --check`
- `go test ./api/pkg/api/handler -run "^$" -count=1`
- Focused REST test requires the repository's Docker-managed PostgreSQL service; Docker is unavailable locally.
- Focused API-core test could not execute locally because the macOS ARM build of the API-core test graph fails in the unsupported `tss-esapi-sys` TPM binding before tests run. Linux CI should reach the regression assertion.