### PR TITLE
fix: select GB200 profiles from Site Explorer hardware

### DIFF
--- a/crates/api-core/src/handlers/client_resolution.rs
+++ b/crates/api-core/src/handlers/client_resolution.rs
@@ -25,10 +25,10 @@ use db::db_read::DbReader;
 use model::instance::config::tenant_config::HOSTNAME_RE;
 use model::instance::snapshot::InstanceSnapshot;
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{InstanceState, MachineInterfaceSnapshot, ManagedHostState};
+use model::machine::{InstanceState, Machine, MachineInterfaceSnapshot, ManagedHostState};
 use model::machine_interface::InterfaceType;
 use model::network_segment::NetworkSegmentType;
-use model::rack_type::select_dpu_nvconfig_profile;
+use model::rack_type::{RackProductFamily, select_dpu_nvconfig_profile};
 use sqlx::PgConnection;
 
 use crate::CarbideError;
@@ -236,9 +236,50 @@ pub(super) async fn resolve_machine_interface(
     }
 }
 
-/// Selects a DPU profile from the attached host's rack and the DPU's hardware
-/// identity. Missing relationships mean no platform profile applies; database
-/// failures still propagate to the caller.
+/// Returns the product family reported by Site Explorer, or falls back to the
+/// configured rack profile when that report does not name a known family.
+async fn resolve_host_product_family(
+    api: &Api,
+    conn: &mut PgConnection,
+    host: &Machine,
+) -> Result<Option<RackProductFamily>, CarbideError> {
+    if let Some(host_bmc_ip) = host.status.bmc_info.ip {
+        let endpoints = db::explored_endpoints::find_by_ips(&mut *conn, vec![host_bmc_ip]).await?;
+        if let Some(product_family) = endpoints
+            .first()
+            .and_then(|endpoint| endpoint.report.model())
+            .as_deref()
+            .and_then(RackProductFamily::from_hardware_model)
+        {
+            return Ok(Some(product_family));
+        }
+    }
+
+    let Some(rack_id) = host.rack_id.as_ref() else {
+        return Ok(None);
+    };
+    let Some(rack) = db::rack::find_by(
+        &mut *conn,
+        ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+    )
+    .await?
+    .pop() else {
+        return Ok(None);
+    };
+    let Some(rack_profile_id) = rack.rack_profile_id.as_ref() else {
+        return Ok(None);
+    };
+
+    Ok(api
+        .runtime_config
+        .rack_profiles
+        .get(rack_profile_id.as_str())
+        .and_then(|profile| profile.product_family.clone()))
+}
+
+/// Selects a DPU profile from the attached host's observed or configured
+/// product family and the DPU's hardware identity. Missing relationships mean
+/// no platform profile applies; database failures still propagate.
 async fn resolve_dpu_nvconfig_profile(
     api: &Api,
     conn: &mut PgConnection,
@@ -255,27 +296,7 @@ async fn resolve_dpu_nvconfig_profile(
     else {
         return Ok(None);
     };
-    let Some(rack_id) = host.rack_id.as_ref() else {
-        return Ok(None);
-    };
-    let Some(rack) = db::rack::find_by(
-        &mut *conn,
-        ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
-    )
-    .await?
-    .pop() else {
-        return Ok(None);
-    };
-    let Some(rack_profile_id) = rack.rack_profile_id.as_ref() else {
-        return Ok(None);
-    };
-    let Some(rack_profile) = api
-        .runtime_config
-        .rack_profiles
-        .get(rack_profile_id.as_str())
-    else {
-        return Ok(None);
-    };
+    let product_family = resolve_host_product_family(api, conn, &host).await?;
 
     let Some(dpu) =
         db::machine::find_one(&mut *conn, dpu_machine_id, MachineSearchConfig::default()).await?
@@ -283,11 +304,10 @@ async fn resolve_dpu_nvconfig_profile(
         return Ok(None);
     };
 
-    Ok(select_dpu_nvconfig_profile(
-        rack_profile.product_family.as_ref(),
-        dpu.status.hardware_info.as_ref(),
+    Ok(
+        select_dpu_nvconfig_profile(product_family.as_ref(), dpu.status.hardware_info.as_ref())
+            .map(rpc::DpuNvConfigProfile::from),
     )
-    .map(rpc::DpuNvConfigProfile::from))
 }
 
 /// Resolve a client IP to its `CloudInitInstructions` response. The

--- a/crates/api-core/src/tests/client_resolution.rs
+++ b/crates/api-core/src/tests/client_resolution.rs
@@ -80,6 +80,23 @@ async fn assert_client_resolution_fails_closed(
     }
 }
 
+/// Returns the NVConfig profile selected for a DPU cloud-init request.
+async fn resolved_dpu_nvconfig_profile(env: &TestEnv, dpu_ip: &str) -> i32 {
+    env.api
+        .get_cloud_init_instructions(
+            rpc::forge::CloudInitInstructionsRequest {
+                ip: dpu_ip.to_string(),
+            }
+            .into_request(),
+        )
+        .await
+        .expect("get_cloud_init_instructions returned an error")
+        .into_inner()
+        .discovery_instructions
+        .expect("DPU should receive discovery instructions")
+        .dpu_nvconfig_profile
+}
+
 // A client_ip that matches a row in machine_interface_addresses (the
 // common admin/host case) should resolve directly to that interface.
 #[crate::sqlx_test]
@@ -729,7 +746,7 @@ async fn test_cloud_init_local_hostname_omitted_when_instance_name_is_not_a_vali
 }
 
 #[crate::sqlx_test]
-async fn dpu_nvconfig_profile_resolution_follows_host_rack_and_dpu_identity(pool: sqlx::PgPool) {
+async fn dpu_nvconfig_profile_resolution_uses_report_or_rack_and_dpu_identity(pool: sqlx::PgPool) {
     let env = create_test_env_with_overrides(
         pool,
         TestEnvOverrides::with_config(get_config_with_rack_profiles()),
@@ -790,21 +807,55 @@ async fn dpu_nvconfig_profile_resolution_follows_host_rack_and_dpu_identity(pool
         .to_string();
     txn.rollback().await.unwrap();
 
-    let cloud_init = env
-        .api
-        .get_cloud_init_instructions(
-            rpc::forge::CloudInitInstructionsRequest {
-                ip: dpu_interface_ip,
-            }
-            .into_request(),
-        )
-        .await
-        .expect("get_cloud_init_instructions returned an error")
-        .into_inner();
-    let profile = cloud_init
-        .discovery_instructions
-        .expect("DPU should receive discovery instructions")
-        .dpu_nvconfig_profile;
+    assert_eq!(
+        resolved_dpu_nvconfig_profile(&env, &dpu_interface_ip).await,
+        rpc::forge::DpuNvConfigProfile::Gb200B3240V1 as i32,
+    );
 
-    assert_eq!(profile, rpc::forge::DpuNvConfigProfile::Gb200B3240V1 as i32,);
+    // Non-DPF provisioning sees the same early ingestion window as DPF: the
+    // Redfish report is present, but the host does not have a rack yet.
+    let mut txn = env.pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = NULL WHERE id = $1")
+        .bind(managed_host.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    managed_host
+        .host()
+        .set_exploration_model(&mut txn, "DGX GB200 Compute Tray")
+        .await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .rack_id
+            .is_none()
+    );
+    txn.commit().await.unwrap();
+
+    assert_eq!(
+        resolved_dpu_nvconfig_profile(&env, &dpu_interface_ip).await,
+        rpc::forge::DpuNvConfigProfile::Gb200B3240V1 as i32,
+    );
+
+    // A recognized report is more specific than the rack fallback. A GB300
+    // report must not inherit the GB200 profile from stale rack metadata.
+    let mut txn = env.pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(managed_host.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    managed_host
+        .host()
+        .set_exploration_model(&mut txn, "DGX GB300 Compute Tray")
+        .await;
+    txn.commit().await.unwrap();
+
+    assert_eq!(
+        resolved_dpu_nvconfig_profile(&env, &dpu_interface_ip).await,
+        rpc::forge::DpuNvConfigProfile::Unspecified as i32,
+    );
 }

--- a/crates/api-core/src/tests/common/api_fixtures/test_machine/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/test_machine/mod.rs
@@ -157,6 +157,39 @@ impl TestMachine {
         machine.bmc_addr().map(|addr| addr.ip())
     }
 
+    /// Replaces the model in this machine's persisted Site Explorer report.
+    pub(in crate::tests) async fn set_exploration_model(&self, txn: &mut Txn<'_>, model: &str) {
+        let bmc_ip = self
+            .bmc_ip(txn)
+            .await
+            .expect("fixture machine should have a BMC IP");
+        let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+            .await
+            .unwrap()
+            .pop()
+            .expect("fixture machine should have a Site Explorer report");
+        let old_version = endpoint.report_version;
+        let waiting_for_explorer_refresh = endpoint.waiting_for_explorer_refresh;
+        let mut report = endpoint.report;
+        report
+            .systems
+            .first_mut()
+            .expect("fixture report should contain a Redfish system")
+            .model = Some(model.to_string());
+        report.model = report.model();
+
+        let updated = db::explored_endpoints::try_update(
+            bmc_ip,
+            old_version,
+            &report,
+            waiting_for_explorer_refresh,
+            txn.as_mut(),
+        )
+        .await
+        .unwrap();
+        assert!(updated, "fixture Site Explorer report should be updated");
+    }
+
     pub(in crate::tests) async fn json_history(
         &self,
         limit: Option<usize>,

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -453,9 +453,9 @@ async fn test_multi_dpu_provisioning_registers_all_devices(pool: sqlx::PgPool) {
     );
 }
 
-/// GB200 rack identity and every attached B3240 DPU must select one shared deployment.
+/// GB200 host identity and every attached B3240 DPU must select one shared deployment.
 #[crate::sqlx_test]
-async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
+async fn test_gb200_b3240_pair_uses_specialized_deployment_from_report_or_rack(pool: sqlx::PgPool) {
     let classified_dpus = Arc::new(Mutex::new(Vec::new()));
     let verified_deployments = Arc::new(Mutex::new(Vec::new()));
     let registered_deployments = Arc::new(Mutex::new(Vec::new()));
@@ -566,6 +566,66 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
     assert_eq!(
         *registered_deployments.lock().unwrap(),
         vec![DpuDeploymentType::Bf3Gb200]
+    );
+
+    // Site Explorer can identify a GB200 before discovery assigns its rack.
+    // Repeat the same selection with only the persisted Redfish model present.
+    let mut txn = pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = NULL WHERE id = $1")
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    mh.host().set_exploration_model(&mut txn, "GB200 NVL").await;
+    assert!(mh.host().db_machine(&mut txn).await.rack_id.is_none());
+    txn.commit().await.unwrap();
+
+    verified_deployments.lock().unwrap().clear();
+    registered_deployments.lock().unwrap().clear();
+    set_reprovision_dpf_state(&pool, &mh.id, &mh.dpu_ids, DpfState::Provisioning).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during state controller iteration");
+
+    assert_eq!(
+        *verified_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3Gb200]
+    );
+    assert_eq!(
+        *registered_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3Gb200]
+    );
+
+    // A recognized report takes precedence over the rack fallback. Restore
+    // the GB200 rack and report GB300 so this pass selects generic BF3.
+    let mut txn = pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    mh.host()
+        .set_exploration_model(&mut txn, "DGX GB300 Compute Tray")
+        .await;
+    txn.commit().await.unwrap();
+
+    verified_deployments.lock().unwrap().clear();
+    registered_deployments.lock().unwrap().clear();
+    set_reprovision_dpf_state(&pool, &mh.id, &mh.dpu_ids, DpfState::Provisioning).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during state controller iteration");
+
+    assert_eq!(
+        *verified_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3]
+    );
+    assert_eq!(
+        *registered_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3]
     );
 }
 

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -93,10 +93,11 @@ pub enum RackProductFamily {
     Other(String),
 }
 
-/// Selects the fixed DPU NVConfig profile supported by a rack and DPU identity.
+/// Selects the fixed DPU NVConfig profile supported by a product family and DPU
+/// identity.
 ///
-/// A profile is selected only for a GB200 rack and an exact supported DPU part
-/// number. Missing identity does not select a profile.
+/// A profile is selected only for the GB200 product family and an exact
+/// supported DPU part number. Missing identity does not select a profile.
 pub fn select_dpu_nvconfig_profile(
     product_family: Option<&RackProductFamily>,
     hardware_info: Option<&HardwareInfo>,
@@ -110,6 +111,28 @@ pub fn select_dpu_nvconfig_profile(
 }
 
 impl RackProductFamily {
+    /// Returns `GB200` or `GB300` when a hardware model reported by Redfish
+    /// contains exactly one of those product family tokens.
+    ///
+    /// Matching ignores ASCII case and requires whole tokens separated by ASCII
+    /// whitespace. Unknown models, concatenated names, and models naming both
+    /// families return `None`.
+    pub fn from_hardware_model(model: &str) -> Option<Self> {
+        let mut has_gb200 = false;
+        let mut has_gb300 = false;
+
+        for token in model.split_ascii_whitespace() {
+            has_gb200 |= token.eq_ignore_ascii_case("gb200");
+            has_gb300 |= token.eq_ignore_ascii_case("gb300");
+        }
+
+        match (has_gb200, has_gb300) {
+            (true, false) => Some(Self::Gb200),
+            (false, true) => Some(Self::Gb300),
+            (false, false) | (true, true) => None,
+        }
+    }
+
     /// Returns the product-family identifier sent to descriptor-based backends.
     ///
     /// Named variants use their canonical lowercase value. Values stored in
@@ -506,11 +529,65 @@ mod tests {
     }
 
     #[test]
-    fn dpu_nvconfig_profile_requires_matching_rack_and_dpu_identity() {
+    fn hardware_model_requires_one_known_product_family_token() {
         check_values(
             [
                 Check {
-                    scenario: "GB200 rack with supported B3240",
+                    scenario: "DGX GB200 compute tray",
+                    input: "DGX GB200 Compute Tray",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "GB200 board",
+                    input: "GB200 1CPU:2GPU Board PC",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "GB200 NVL",
+                    input: "GB200 NVL",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "lowercase GB200 token",
+                    input: "dgx gb200 compute tray",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "GB200 token separated by ASCII whitespace",
+                    input: "DGX\tGB200\nCompute Tray",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "GB300 compute tray",
+                    input: "DGX GB300 Compute Tray",
+                    expect: Some(RackProductFamily::Gb300),
+                },
+                Check {
+                    scenario: "concatenated GB200 name",
+                    input: "GB200Nvl Compute Tray",
+                    expect: None,
+                },
+                Check {
+                    scenario: "model names multiple product families",
+                    input: "GB200 GB300 Compute Tray",
+                    expect: None,
+                },
+                Check {
+                    scenario: "unknown model",
+                    input: "PowerEdge R750",
+                    expect: None,
+                },
+            ],
+            RackProductFamily::from_hardware_model,
+        );
+    }
+
+    #[test]
+    fn dpu_nvconfig_profile_requires_matching_product_family_and_dpu_identity() {
+        check_values(
+            [
+                Check {
+                    scenario: "GB200 family with supported B3240",
                     input: (
                         Some(RackProductFamily::Gb200),
                         Some(dpu_hardware_info("900-9D3B6-00CN-PA0")),
@@ -518,7 +595,7 @@ mod tests {
                     expect: Some(DpuNvConfigProfile::Gb200B3240V1),
                 },
                 Check {
-                    scenario: "other rack family with supported B3240",
+                    scenario: "other product family with supported B3240",
                     input: (
                         Some(RackProductFamily::Gb300),
                         Some(dpu_hardware_info("900-9D3B6-00CN-PA0")),
@@ -526,7 +603,7 @@ mod tests {
                     expect: None,
                 },
                 Check {
-                    scenario: "GB200 rack with another BlueField 3 product",
+                    scenario: "GB200 family with another BlueField 3 product",
                     input: (
                         Some(RackProductFamily::Gb200),
                         Some(dpu_hardware_info("900-9D3B6-00CV-AA0")),
@@ -534,12 +611,12 @@ mod tests {
                     expect: None,
                 },
                 Check {
-                    scenario: "GB200 rack without DPU hardware information",
+                    scenario: "GB200 family without DPU hardware information",
                     input: (Some(RackProductFamily::Gb200), None),
                     expect: None,
                 },
                 Check {
-                    scenario: "GB200 rack without DPU identity",
+                    scenario: "GB200 family without DPU identity",
                     input: (
                         Some(RackProductFamily::Gb200),
                         Some(HardwareInfo::default()),
@@ -547,7 +624,7 @@ mod tests {
                     expect: None,
                 },
                 Check {
-                    scenario: "missing rack family with supported B3240",
+                    scenario: "missing product family with supported B3240",
                     input: (None, Some(dpu_hardware_info("900-9D3B6-00CN-PA0"))),
                     expect: None,
                 },

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -59,14 +59,30 @@ fn dpf_id(machine: &Machine) -> Result<String, StateHandlerError> {
     })
 }
 
-async fn host_rack_product_family(
+/// Returns the product family reported by Site Explorer, or falls back to the
+/// configured rack profile when that report does not name a known family.
+async fn host_product_family(
     state: &ManagedHostStateSnapshot,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> Result<Option<RackProductFamily>, StateHandlerError> {
+    let mut conn = ctx.services.db_pool.acquire().await?;
+
+    if let Some(host_bmc_ip) = state.host_snapshot.status.bmc_info.ip {
+        let endpoints =
+            db::explored_endpoints::find_by_ips(conn.as_mut(), vec![host_bmc_ip]).await?;
+        if let Some(product_family) = endpoints
+            .first()
+            .and_then(|endpoint| endpoint.report.model())
+            .as_deref()
+            .and_then(RackProductFamily::from_hardware_model)
+        {
+            return Ok(Some(product_family));
+        }
+    }
+
     let Some(rack_id) = state.host_snapshot.rack_id.as_ref() else {
         return Ok(None);
     };
-    let mut conn = ctx.services.db_pool.acquire().await?;
     let Some(rack) = db::rack::find_by(
         conn.as_mut(),
         db::ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
@@ -96,7 +112,7 @@ async fn deployment_types_for_host(
     dpf_sdk: &dyn DpfOperations,
     astra_nics: bool,
 ) -> Result<Vec<DpuDeploymentType>, StateHandlerError> {
-    let product_family = host_rack_product_family(state, ctx).await?;
+    let product_family = host_product_family(state, ctx).await?;
     state
         .dpu_snapshots
         .iter()


### PR DESCRIPTION
> [!NOTE]
> This PR contains:
>
> - +87/-28 lines of production code.
> - +223/-25 lines of tests and test support.
> - No generated code.

Site Explorer can persist a host's Redfish report before it restores the structured rack association after machine deletion. DPF registration can run during that gap. Because both DPF and Non-DPF profile selection currently rely on the rack association, supported GB200 hardware can incorrectly receive the generic BF3 configuration.

This resolves the host product family from a recognized `GB200` or `GB300` token in the persisted Redfish model before consulting the rack profile. A recognized report takes precedence over stale rack metadata; an absent, unknown, concatenated, or ambiguous model preserves the existing rack fallback. The exact DPU part number gate remains unchanged.

Both DPF deployment selection and Non-DPF cloud-init use the same parser and precedence. Integration coverage proves rack fallback, report selection without a rack, and report precedence over conflicting rack metadata in both paths.

## Related issues

Fixes #5598

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified the parser against all observed GB200 model forms used by the affected hardware, plus GB300, ASCII case and whitespace variations, unknown values, concatenated names, and models naming both families. Focused tests for both selection paths, formatting, Clippy, and targeted custom lints passed.

## Additional Notes

The implementation intentionally leaves the two database and configuration adapters local to their owning crates. They share the pure model parser and the existing profile selector, while retaining their distinct runtime and site configuration owners.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

| Reviewer | Received | Adopted | Declined | Deferred |
| --- | ---: | ---: | ---: | ---: |
| Scope and subtraction review | 3 | 2 | 1 | 0 |
| CodeRabbit CLI | 1 | 1 | 0 | 0 |
| Claude CLI | 6 | 1 | 0 | 5 |
| common-nits-reviewer | 0 | 0 | 0 | 0 |
| Codex self-review | 1 | 1 | 0 | 0 |
| **Total** | **11** | **5** | **1** | **5** |

</details>

<details>
<summary>Model Findings Details</summary>

### Adopted

1. Added report and rack precedence cases to both DPF and Non-DPF suites.
2. Removed repeated DPF assertions that did not prove another behavior.
3. Documented the exact known token, ASCII case, and whitespace contract.
4. Replaced stale rack terminology with product family terminology.
5. Added a parser case with tab and newline separators.

### Declined

1. Reduce the three positive GB200 model cases to one. They are distinct model values observed on supported hardware and protect the evidence behind the parser.

### Deferred

1. Add debug logging when a report supplies the product family.
2. Share the two small database and configuration adapters across crates.
3. Change the controller adapter to use a separate database reader handle.
4. Add a narrow database projection for one value inside the Redfish report.
5. Reconcile this strict parser with the separate, broader MNNVL GPU name heuristic.

These are not correctness requirements for this focused registration fix.

</details>


Closes #5598
