### PR TITLE
chore: Changing tracing level of a message flooding the logs in get_a…

### DIFF
--- a/crates/api-core/src/handlers/astra.rs
+++ b/crates/api-core/src/handlers/astra.rs
@@ -72,7 +72,7 @@ pub(super) async fn get_astra_config(
     txn.commit().await?;
 
     if dpa_interfaces.is_empty() {
-        tracing::info!(
+        tracing::debug!(
             machine_id = %snapshot.host_snapshot.id,
             "No Astra NICs found; skipping Astra config retrieval",
         );


### PR DESCRIPTION
…stra_config

Change message log level to tracing so that it doesn't flood the logs

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Testing in VR minipod

Closes https://github.com/NVIDIA/infra-controller/issues/5673

