### PR TITLE
fix: apply the complete GB200 B3240 NVConfig recipe

### DIFF
--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -778,6 +778,7 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment_from_report_or_rack(p
     // Site Explorer can identify a GB200 before discovery assigns its rack.
     // Repeat the same selection with only the persisted Redfish model present.
     let mut txn = pool.begin().await.unwrap();
+    let rack_id = mh.host().db_machine(&mut txn).await.rack_id.unwrap();
     sqlx::query("UPDATE machines SET rack_id = NULL WHERE id = $1")
         .bind(mh.id)
         .execute(txn.as_mut())

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -20,7 +20,7 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
-use carbide_libmlx_model::nvconfig::DpuNvConfigProfile;
+use carbide_libmlx_model::nvconfig::{DpuNvConfigProfile, GB200_B3240_V1_PF_TOTAL_SF};
 use kube::core::ObjectMeta;
 use sha2::{Digest, Sha256};
 
@@ -1490,6 +1490,11 @@ fn get_nvconfig(
     pf_total_sf: u32,
     deployment_type: DpuDeploymentType,
 ) -> DpuFlavorNvconfig {
+    let pf_total_sf = if deployment_type == DpuDeploymentType::Bf3Gb200 {
+        GB200_B3240_V1_PF_TOTAL_SF
+    } else {
+        pf_total_sf
+    };
     let mut parameters = vec![
         "PF_BAR2_ENABLE=0".to_string(),
         "PER_PF_NUM_SF=1".to_string(),
@@ -1510,9 +1515,15 @@ fn get_nvconfig(
     ];
 
     if deployment_type == DpuDeploymentType::Bf3Gb200 {
+        let configured_parameter_names = parameters
+            .iter()
+            .map(|parameter| nvconfig_parameter_name(parameter).to_string())
+            .collect::<BTreeSet<_>>();
+
         // DPF v26.4 accepts at most 32 parameters. These two assignments set
         // values that DPF already restores to their firmware default of 0, so
-        // omitting them preserves the required platform state.
+        // omitting them preserves the required platform state. Values already
+        // present in the BF3 base stay in their native DPF representation.
         // TODO(chet): Add PCI_SWITCH0_UPSTREAM_PORT_BUS=0 and
         // PCI_SWITCH0_UPSTREAM_PORT_PEX=0 after DPF accepts more than 32
         // NVConfig parameters.
@@ -1521,10 +1532,11 @@ fn get_nvconfig(
                 .parameters()
                 .iter()
                 .filter(|parameter| {
-                    !matches!(
-                        **parameter,
-                        "PCI_SWITCH0_UPSTREAM_PORT_BUS=0" | "PCI_SWITCH0_UPSTREAM_PORT_PEX=0"
-                    )
+                    !configured_parameter_names.contains(nvconfig_parameter_name(parameter))
+                        && !matches!(
+                            **parameter,
+                            "PCI_SWITCH0_UPSTREAM_PORT_BUS=0" | "PCI_SWITCH0_UPSTREAM_PORT_PEX=0"
+                        )
                 })
                 .map(|parameter| (*parameter).to_string()),
         );
@@ -1535,6 +1547,12 @@ fn get_nvconfig(
         device: Some(DpuFlavorNvconfigDevice::KopiumVariant0), //"*"
         parameters: Some(parameters),
     }
+}
+
+fn nvconfig_parameter_name(parameter: &str) -> &str {
+    parameter
+        .split_once('=')
+        .map_or(parameter, |(name, _)| name)
 }
 
 fn get_bf4_astra_nvconfig(pf_total_sf: u32) -> DpuFlavorNvconfig {
@@ -1895,10 +1913,17 @@ mod tests {
         };
         let bf3 = parameters(DpuDeploymentType::Bf3);
         let gb200 = parameters(DpuDeploymentType::Bf3Gb200);
+        let expected_gb200_base = bf3
+            .iter()
+            .map(|parameter| match parameter.as_str() {
+                "PF_TOTAL_SF=30" => "PF_TOTAL_SF=128".to_string(),
+                _ => parameter.clone(),
+            })
+            .collect::<Vec<_>>();
 
         assert_eq!(bf3.len(), 16);
         assert_eq!(gb200.len(), 32);
-        assert_eq!(&gb200[..bf3.len()], bf3.as_slice());
+        assert_eq!(&gb200[..bf3.len()], expected_gb200_base.as_slice());
         assert_eq!(
             &gb200[bf3.len()..],
             [

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -1001,10 +1001,15 @@ async fn scoped_bf3_gb200_bf4_and_astra_initialization_coexists() {
             .parameters
             .as_ref()
             .unwrap();
+        let expected_pf_total_sf = match deployment_type {
+            DpuDeploymentType::Bf3Gb200 => "PF_TOTAL_SF=128",
+            DpuDeploymentType::Bf3 | DpuDeploymentType::Bf4Generic => "PF_TOTAL_SF=37",
+            DpuDeploymentType::Bf4Astra => unreachable!("Astra is checked separately"),
+        };
         assert!(
             nvconfig
                 .iter()
-                .any(|parameter| parameter == "PF_TOTAL_SF=37")
+                .any(|parameter| parameter == expected_pf_total_sf)
         );
         assert_eq!(
             nvconfig

--- a/crates/libmlx-model/src/nvconfig.rs
+++ b/crates/libmlx-model/src/nvconfig.rs
@@ -22,7 +22,16 @@
 // <https://docs.nvidia.com/networking/display/mftv4341lts/mlxconfig-%E2%80%93-changing-device-configuration-tool>
 // The generic recipe uses PCI_BUS00_SPEED=4, while the validated GB200/B3240
 // platform uses 5. Applying this profile requires a cold host power cycle.
-const GB200_B3240_V1_PARAMETERS: [&str; 18] = [
+/// Number of PF scalable functions required by the GB200 B3240 V1 profile.
+pub const GB200_B3240_V1_PF_TOTAL_SF: u32 = 128;
+
+const GB200_B3240_V1_PARAMETERS: [&str; 28] = [
+    "PF_NUM_PF_MSIX_VALID=1",
+    "PER_PF_NUM_SF=1",
+    "NUM_PF_MSIX_VALID=0",
+    "PF_BAR2_ENABLE=0",
+    "LINK_TYPE_P1=2",
+    "LINK_TYPE_P2=2",
     "OFF_BOARD_SERIALIZER=1",
     "PCI_BUS00_HIERARCHY_TYPE=1",
     "PCI_BUS00_SPEED=5",
@@ -39,6 +48,10 @@ const GB200_B3240_V1_PARAMETERS: [&str; 18] = [
     "PCI_BUS16_HIERARCHY_TYPE=1",
     "PCI_BUS16_SPEED=4",
     "PCI_BUS16_WIDTH=3",
+    "PF_TOTAL_SF=128",
+    "PF_SF_BAR_SIZE=10",
+    "PF_NUM_PF_MSIX=228",
+    "LAG_RESOURCE_ALLOCATION=1",
     "PCI_SWITCH0_UPSTREAM_PORT_BUS=0",
     "PCI_SWITCH0_UPSTREAM_PORT_PEX=0",
 ];
@@ -120,6 +133,12 @@ mod tests {
         assert_eq!(
             parameters,
             &[
+                "PF_NUM_PF_MSIX_VALID=1",
+                "PER_PF_NUM_SF=1",
+                "NUM_PF_MSIX_VALID=0",
+                "PF_BAR2_ENABLE=0",
+                "LINK_TYPE_P1=2",
+                "LINK_TYPE_P2=2",
                 "OFF_BOARD_SERIALIZER=1",
                 "PCI_BUS00_HIERARCHY_TYPE=1",
                 "PCI_BUS00_SPEED=5",
@@ -136,6 +155,10 @@ mod tests {
                 "PCI_BUS16_HIERARCHY_TYPE=1",
                 "PCI_BUS16_SPEED=4",
                 "PCI_BUS16_WIDTH=3",
+                "PF_TOTAL_SF=128",
+                "PF_SF_BAR_SIZE=10",
+                "PF_NUM_PF_MSIX=228",
+                "LAG_RESOURCE_ALLOCATION=1",
                 "PCI_SWITCH0_UPSTREAM_PORT_BUS=0",
                 "PCI_SWITCH0_UPSTREAM_PORT_PEX=0",
             ],


### PR DESCRIPTION
> [!NOTE]
> This PR contains:
>
> - +38/-7 lines of production code.
> - +25/-2 lines of tests and test support.
> - No generated code.

The versioned GB200 B3240 profile currently contains the PCIe topology values and switch defaults, but Non-DPF provisioning still depends on opaque BFB defaults for the remaining validated settings. DPF supplies those settings through its generic BF3 base, but uses a calculated `PF_TOTAL_SF` value instead of the required `128`.

This expands `Gb200B3240V1` to the complete validated recipe plus the two existing PCI switch defaults. Non-DPF provisioning therefore applies all 28 assignments explicitly after `bfcfg`. DPF uses `PF_TOTAL_SF=128`, retains native representations already present in its BF3 base, skips duplicate keys from the shared profile, and remains at its limit of 32 parameters while continuing to omit the two switch defaults.

Generic BF3, BF4, and Astra configuration remains unchanged.

## Related issues

Fixes #5602

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified the exact shared profile, the rendered Non-DPF user data, the bounded DPF profile, and DPF initialization across multiple deployments. Rustfmt, workspace Clippy, diff checks, and targeted Carbide lints for both changed production crates passed.

## Additional Notes

The full Carbide lint traversal also encountered two existing `txn_held_across_await` findings in unchanged `crates/api-core/tests/integration/dns_resolution.rs`; neither is in this PR's changed path.


Closes #5602
