### PR TITLE
refactor(rack): submit NVOS image updates through component manager

### DIFF
--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -29,6 +29,7 @@ use carbide_dpf::types::{DpuDeviceSummary, DpuNodeSummary, HostDpfSnapshot};
 use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
+use carbide_uuid::rack::RackId;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     DpfState, DpuReprovisionStates, FailureCause, InstanceState, ManagedHostState, ReprovisionState,
@@ -418,16 +419,21 @@ async fn dpu_device_names(pool: &sqlx::PgPool, mh: &TestManagedHost) -> HashSet<
 }
 
 /// Gives a DPF test host the rack and DPU inventory that select the GB200
-/// deployment.
-async fn configure_gb200_b3240_host(pool: &sqlx::PgPool, mh: &TestManagedHost) {
+/// deployment and returns the created rack ID.
+async fn configure_gb200_b3240_host(pool: &sqlx::PgPool, mh: &TestManagedHost) -> RackId {
     let mut txn = pool.begin().await.unwrap();
-    configure_gb200_b3240_host_in_txn(txn.as_mut(), mh).await;
+    let rack_id = configure_gb200_b3240_host_in_txn(txn.as_mut(), mh).await;
     txn.commit().await.unwrap();
+
+    rack_id
 }
 
 /// Gives a DPF test host the GB200 rack and DPU inventory in an existing
-/// transaction.
-async fn configure_gb200_b3240_host_in_txn(conn: &mut sqlx::PgConnection, mh: &TestManagedHost) {
+/// transaction and returns the created rack ID.
+async fn configure_gb200_b3240_host_in_txn(
+    conn: &mut sqlx::PgConnection,
+    mh: &TestManagedHost,
+) -> RackId {
     let rack_id = TestRackDbBuilder::new()
         .with_rack_profile_id(TEST_RMS_RACK_PROFILE_ID)
         .persist(&mut *conn)
@@ -465,6 +471,8 @@ async fn configure_gb200_b3240_host_in_txn(conn: &mut sqlx::PgConnection, mh: &T
             .await
             .unwrap();
     }
+
+    rack_id
 }
 
 /// Recreates the partial DPF reprovision state that a controller without
@@ -876,7 +884,7 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment_from_report_or_rack(p
         .expect("timed out during initial provisioning");
 
     // Give the host a GB200 rack and both DPUs the supported B3240 identity.
-    configure_gb200_b3240_host(&pool, &mh).await;
+    let rack_id = configure_gb200_b3240_host(&pool, &mh).await;
 
     // Ignore initial ingestion and observe one complete host deployment selection pass.
     classified_dpus.lock().unwrap().clear();
@@ -906,7 +914,6 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment_from_report_or_rack(p
     // Site Explorer can identify a GB200 before discovery assigns its rack.
     // Repeat the same selection with only the persisted Redfish model present.
     let mut txn = pool.begin().await.unwrap();
-    let rack_id = mh.host().db_machine(&mut txn).await.rack_id.unwrap();
     sqlx::query("UPDATE machines SET rack_id = NULL WHERE id = $1")
         .bind(mh.id)
         .execute(txn.as_mut())

--- a/crates/component-manager/src/lib.rs
+++ b/crates/component-manager/src/lib.rs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod nvos_update_manager;
+#[cfg(test)]
+mod test_support;
+
 pub mod component_common;
 pub mod component_manager;
 pub mod compute_tray_manager;
@@ -13,10 +17,10 @@ pub mod nv_switch_manager;
 pub mod power_shelf_manager;
 pub mod psm;
 pub mod rms;
-#[cfg(test)]
-mod test_support;
 pub mod tls;
 pub mod types;
+
+pub use nvos_update_manager::{NvosUpdateManager, NvosUpdateRequest};
 
 pub mod proto {
     #[allow(clippy::enum_variant_names)]

--- a/crates/component-manager/src/nvos_update_manager.rs
+++ b/crates/component-manager/src/nvos_update_manager.rs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backend-neutral contracts for durable rack-level NVOS update submission.
+
+use carbide_uuid::rack::RackId;
+use model::rack::{FirmwareUpgradeDeviceInfo, NvosUpdateJob};
+use model::rack_type::RackProfile;
+
+use crate::error::ComponentManagerError;
+
+pub(crate) mod sealed {
+    pub trait Sealed {}
+}
+
+/// Input for one rack-level NVOS system-image update.
+pub struct NvosUpdateRequest<'a> {
+    /// Rack that owns every target switch.
+    pub rack_id: &'a RackId,
+
+    /// Rack profile used by the backend to identify target hardware.
+    pub profile: &'a RackProfile,
+
+    /// Source-of-truth NVOS firmware-object JSON.
+    pub config_json: &'a str,
+
+    /// Authorization token supplied with the maintenance request.
+    pub access_token: &'a str,
+
+    /// NV-Switch targets and their credentials.
+    pub switches: Vec<FirmwareUpgradeDeviceInfo>,
+}
+
+/// Backend contract for submitting rack-level NVOS updates.
+///
+/// Implementations return every parent or per-switch job handle needed to
+/// resume polling after a process restart.
+#[async_trait::async_trait]
+pub trait NvosUpdateManager: sealed::Sealed + Send + Sync {
+    /// Submits an NVOS system-image update and returns the initial status and
+    /// durable job handles for every requested switch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ComponentManagerError::InvalidArgument`] when the request cannot
+    /// be translated for the backend. An explicit backend rejection without a
+    /// durable job handle returns [`ComponentManagerError::RejectedBeforeDispatch`].
+    /// The current RMS backend reports RPC invocation failures as
+    /// [`ComponentManagerError::Internal`].
+    async fn start_nvos_update(
+        &self,
+        request: NvosUpdateRequest<'_>,
+    ) -> Result<NvosUpdateJob, ComponentManagerError>;
+}

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -20,7 +20,10 @@ use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
 use carbide_instrument::{Event, emit, red};
-use carbide_rack::firmware_object::rms_access_token_or_noauth;
+use carbide_rack::firmware_object::{
+    ANY_RACK_HARDWARE_TYPE, profile_hardware_type_wire_value, rms_access_token_or_noauth,
+};
+use carbide_rack::firmware_update::{build_new_node_info, firmware_type_for_profile};
 use carbide_rack::rms_node_type::{
     RmsNodeIdentity, compute_node_identity_for_profile,
     firmware_object_component_filters_for_node_identities, power_shelf_node_identity_for_profile,
@@ -35,6 +38,7 @@ use model::component_manager::{
     ComputeTrayComponent, ConfigureSwitchCertificateState, FirmwareState, NvSwitchComponent,
     PowerAction, PowerShelfComponent,
 };
+use model::rack::{NvosUpdateJob, NvosUpdateSwitchStatus};
 use model::rack_type::{RackHardwareTopology, RackProfile, RackProfileConfig};
 use model::switch::{FabricManagerState, FabricManagerStatus};
 use serde::Deserialize;
@@ -60,6 +64,7 @@ use crate::power_shelf_manager::{
     PowerShelfPowerStateResult,
 };
 use crate::types::FirmwareUpdateOptions;
+use crate::{NvosUpdateManager, NvosUpdateRequest};
 
 /// Common RMS identity needed to address a device in RMS.
 #[derive(Clone)]
@@ -181,6 +186,163 @@ impl RmsSwitchSystemImageStatusApi for librms::RackManagerApi {
     ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
         Ok(self.client.get_switch_system_image_job_status(cmd).await?)
     }
+}
+
+/// RMS implementation of durable rack-level NVOS operations.
+struct RmsNvosUpdateManager {
+    client: Arc<dyn RmsApi>,
+}
+
+impl crate::nvos_update_manager::sealed::Sealed for RmsNvosUpdateManager {}
+
+#[async_trait::async_trait]
+impl NvosUpdateManager for RmsNvosUpdateManager {
+    async fn start_nvos_update(
+        &self,
+        request: NvosUpdateRequest<'_>,
+    ) -> Result<NvosUpdateJob, ComponentManagerError> {
+        let started_at = chrono::Utc::now();
+
+        let switch_identity = switch_node_identity_for_profile(request.profile)
+            .map_err(|error| ComponentManagerError::InvalidArgument(error.to_string()))?;
+
+        let nodes = request
+            .switches
+            .iter()
+            .map(|switch| build_new_node_info(request.rack_id, switch, &switch_identity))
+            .collect();
+
+        let hardware_type = profile_hardware_type_wire_value(request.profile);
+
+        let hardware_type = if hardware_type.trim().is_empty() {
+            ANY_RACK_HARDWARE_TYPE.to_string()
+        } else {
+            hardware_type
+        };
+
+        let response = self
+            .client
+            .apply_switch_system_image(rms::ApplySwitchSystemImageRequest {
+                rack_id: request.rack_id.to_string(),
+                config_json: request.config_json.to_string(),
+                access_token: Some(rms_access_token_or_noauth(Some(request.access_token))),
+                software_type: firmware_type_for_profile(request.profile).to_string(),
+                hardware_type,
+                nodes: Some(rms::NodeSet { nodes }),
+            })
+            .await
+            .map_err(|error| {
+                let cause = match error {
+                    RackManagerError::ApiInvocationError(status) => status.to_string(),
+                    error => error.to_string(),
+                };
+
+                ComponentManagerError::Internal(format!(
+                    "failed to submit NVOS update to RMS: {cause}"
+                ))
+            })?;
+
+        let batch_response = response.response.as_ref();
+
+        let batch_status = batch_response
+            .map(|batch_response| batch_response.status)
+            .unwrap_or(rms::ReturnCode::Failure as i32);
+
+        let batch_job_id = batch_response
+            .map(|batch_response| batch_response.job_id.as_str())
+            .unwrap_or_default();
+
+        // A failed batch can still contain accepted jobs. Reject only responses
+        // without a durable handle so accepted work remains pollable.
+        if batch_status != rms::ReturnCode::Success as i32
+            && batch_job_id.is_empty()
+            && response.jobs.is_empty()
+        {
+            let message = batch_response
+                .map(|batch_response| batch_response.message.as_str())
+                .unwrap_or_default();
+
+            let message = if message.is_empty() {
+                "RMS returned failure for ApplySwitchSystemImage".to_string()
+            } else {
+                message.to_string()
+            };
+
+            return Err(ComponentManagerError::RejectedBeforeDispatch(message));
+        }
+
+        // RMS may return child handles, a parent handle, or both. Use the parent
+        // when a switch has no child handle so every accepted job can be polled.
+        let parent_job_id = (!batch_job_id.is_empty()).then(|| batch_job_id.to_string());
+
+        let child_jobs = response
+            .jobs
+            .iter()
+            .map(|child| (child.node_id.clone(), child.job_id.clone()))
+            .collect::<HashMap<_, _>>();
+
+        let switches: Vec<_> = request
+            .switches
+            .into_iter()
+            .map(|switch| {
+                let mut status = NvosUpdateSwitchStatus {
+                    node_id: switch.node_id.clone(),
+                    mac: switch.mac,
+                    bmc_ip: switch.bmc_ip,
+                    nvos_ip: switch.os_ip.unwrap_or_default(),
+                    status: "pending".into(),
+                    job_id: child_jobs
+                        .get(&switch.node_id)
+                        .cloned()
+                        .or_else(|| parent_job_id.clone()),
+                    error_message: None,
+                };
+
+                if status.job_id.is_none() {
+                    status.status = "failed".into();
+                    status.error_message =
+                        Some("RMS did not return a switch system image job for this switch".into());
+                }
+
+                status
+            })
+            .collect();
+
+        let total = switches.len();
+
+        let failed = switches
+            .iter()
+            .filter(|switch| switch.status == "failed")
+            .count();
+
+        let all_failed = total > 0 && failed == total;
+
+        Ok(NvosUpdateJob {
+            job_id: parent_job_id,
+            firmware_id: response.object_id,
+            image_filename: response.image_filename,
+            local_file_path: String::new(),
+            version: None,
+            status: Some(
+                if total > failed {
+                    "in_progress"
+                } else if all_failed {
+                    "failed"
+                } else {
+                    "completed"
+                }
+                .into(),
+            ),
+            started_at: Some(started_at),
+            completed_at: all_failed.then(chrono::Utc::now),
+            switches,
+        })
+    }
+}
+
+/// Creates the RMS implementation of durable rack-level NVOS update submission.
+pub fn rms_nvos_update_manager(client: Arc<dyn RmsApi>) -> impl NvosUpdateManager {
+    RmsNvosUpdateManager { client }
 }
 
 impl std::fmt::Debug for RmsBackend {
@@ -3232,6 +3394,7 @@ mod tests {
     use carbide_uuid::power_shelf::PowerShelfId;
     use carbide_uuid::rack::RackId;
     use carbide_uuid::switch::SwitchId;
+    use model::rack::FirmwareUpgradeDeviceInfo;
     use model::rack_type::{
         RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
         RackHardwareTopology, RackProductFamily, RackProfile, RackProfileConfig,
@@ -3302,6 +3465,123 @@ mod tests {
                 9999 => FirmwareState::Unknown,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn rack_nvos_submission_builds_request_and_preserves_job_handles() {
+        let mock = Arc::new(MockRmsApi::new());
+        let rack_id = RackId::new("rack-1");
+        let child_node_id = "switch-1";
+        let parent_node_id = "switch-2";
+
+        let child_switch = FirmwareUpgradeDeviceInfo {
+            node_id: child_node_id.to_string(),
+            mac: SW_MAC_1.to_string(),
+            bmc_ip: "192.0.2.10".to_string(),
+            bmc_username: "admin".to_string(),
+            bmc_password: "password".to_string(),
+            os_mac: Some("11:22:33:44:55:66".to_string()),
+            os_ip: Some("192.0.2.20".to_string()),
+            os_username: Some("nvos-admin".to_string()),
+            os_password: Some("nvos-password".to_string()),
+            os_hostname: None,
+        };
+
+        let parent_switch = FirmwareUpgradeDeviceInfo {
+            node_id: parent_node_id.to_string(),
+            mac: SW_MAC_2.to_string(),
+            bmc_ip: "192.0.2.11".to_string(),
+            os_mac: Some("22:33:44:55:66:77".to_string()),
+            os_ip: Some("192.0.2.21".to_string()),
+            ..child_switch.clone()
+        };
+
+        mock.enqueue_apply_switch_system_image(Ok(rms::ApplySwitchSystemImageResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                job_id: "nvos-parent-job".to_string(),
+                ..Default::default()
+            }),
+            jobs: vec![rms::SwitchSystemImageUpdateJobInfo {
+                node_id: child_node_id.to_string(),
+                job_id: "nvos-child-job".to_string(),
+            }],
+            object_id: "fw-json".to_string(),
+            image_filename: "nvos.img".to_string(),
+        }))
+        .await;
+
+        let manager = RmsNvosUpdateManager {
+            client: mock.clone(),
+        };
+
+        let job = manager
+            .start_nvos_update(NvosUpdateRequest {
+                rack_id: &rack_id,
+                profile: &test_rms_profile(),
+                config_json: r#"{"Id":"fw-nvos-default"}"#,
+                access_token: "token",
+                switches: vec![child_switch, parent_switch],
+            })
+            .await
+            .expect("NVOS submission should succeed");
+
+        assert_eq!(job.job_id.as_deref(), Some("nvos-parent-job"));
+        assert_eq!(job.switches[0].job_id.as_deref(), Some("nvos-child-job"));
+        assert_eq!(job.switches[1].job_id.as_deref(), Some("nvos-parent-job"));
+        assert_eq!(job.status.as_deref(), Some("in_progress"));
+
+        let calls = mock.apply_switch_system_image_calls().await;
+
+        let [call] = calls.as_slice() else {
+            panic!("expected one ApplySwitchSystemImage request");
+        };
+
+        assert_eq!(call.rack_id, rack_id.to_string());
+        assert_eq!(call.config_json, r#"{"Id":"fw-nvos-default"}"#);
+        assert_eq!(call.access_token.as_deref(), Some("token"));
+        assert_eq!(call.software_type, "prod");
+        assert_eq!(call.hardware_type, ANY_RACK_HARDWARE_TYPE);
+
+        let nodes = call.nodes.as_ref().expect("request nodes");
+
+        let [child_node, parent_node] = nodes.nodes.as_slice() else {
+            panic!("expected two switch nodes");
+        };
+
+        assert_eq!(child_node.node_id, child_node_id);
+        assert_eq!(parent_node.node_id, parent_node_id);
+
+        let bmc_endpoint = child_node.bmc_endpoint.as_ref().expect("BMC endpoint");
+        let bmc_interface = bmc_endpoint.interface.as_ref().expect("BMC interface");
+
+        assert_eq!(bmc_interface.ip_address, "192.0.2.10");
+        assert_eq!(bmc_interface.mac_address, SW_MAC_1);
+
+        assert!(matches!(
+            bmc_endpoint
+                .credentials
+                .as_ref()
+                .and_then(|credentials| credentials.auth.as_ref()),
+            Some(rms::credentials::Auth::UserPass(credentials))
+                if credentials.username == "admin" && credentials.password == "password"
+        ));
+
+        let host_endpoint = child_node.host_endpoint.as_ref().expect("NVOS endpoint");
+        let host_interface = host_endpoint.interface.as_ref().expect("NVOS interface");
+
+        assert_eq!(host_interface.ip_address, "192.0.2.20");
+        assert_eq!(host_interface.mac_address, "11:22:33:44:55:66");
+
+        assert!(matches!(
+            host_endpoint
+                .credentials
+                .as_ref()
+                .and_then(|credentials| credentials.auth.as_ref()),
+            Some(rms::credentials::Auth::UserPass(credentials))
+                if credentials.username == "nvos-admin"
+                    && credentials.password == "nvos-password"
+        ));
     }
 
     #[test]

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -29,8 +29,8 @@ use carbide_rack::firmware_update::{
 use carbide_rack::rack_manager_error;
 use carbide_rack::rms_client::SwitchSystemImageRmsClient;
 use carbide_rack::rms_node_type::{
-    RmsNodeIdentity, compute_node_identity_for_profile,
-    firmware_object_component_filters_for_node_identities, switch_node_identity_for_profile,
+    compute_node_identity_for_profile, firmware_object_component_filters_for_node_identities,
+    switch_node_identity_for_profile,
 };
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_rack_controller::fabric_manager::{
@@ -43,6 +43,8 @@ use carbide_uuid::rack::{RackId, RackProfileId};
 use component_manager::component_manager::ComponentManager;
 use component_manager::error::ComponentManagerError;
 use component_manager::nv_switch_manager::ScaleUpFabricManagerJobStatus;
+use component_manager::rms::rms_nvos_update_manager;
+use component_manager::{NvosUpdateManager, NvosUpdateRequest};
 use db::{
     host_machine_update as db_host_machine_update, machine as db_machine,
     machine_topology as db_machine_topology, power_options as db_power_options,
@@ -1467,138 +1469,6 @@ async fn rms_get_firmware_upgrade_status(
     Ok(updated)
 }
 
-struct NvosUpdateSource<'a> {
-    config_json: &'a str,
-    access_token: &'a str,
-}
-
-async fn rms_start_nvos_update(
-    rms_client: &dyn SwitchSystemImageRmsClient,
-    rack_id: &RackId,
-    source: NvosUpdateSource<'_>,
-    software_type: &str,
-    hardware_type: &str,
-    switch_node_identity: &RmsNodeIdentity,
-    switches: Vec<FirmwareUpgradeDeviceInfo>,
-) -> Result<NvosUpdateJob, StateHandlerError> {
-    let started_at = chrono::Utc::now();
-    let nodes: Vec<_> = switches
-        .iter()
-        .map(|switch| build_new_node_info(rack_id, switch, switch_node_identity))
-        .collect();
-    let nodes = Some(rms::NodeSet { nodes });
-    let NvosUpdateSource {
-        config_json,
-        access_token,
-    } = source;
-    let response = rms_client
-        .apply_switch_system_image(rms::ApplySwitchSystemImageRequest {
-            rack_id: rack_id.to_string(),
-            config_json: config_json.to_string(),
-            access_token: Some(rms_access_token_or_noauth(Some(access_token))),
-            software_type: software_type.to_string(),
-            hardware_type: hardware_type.to_string(),
-            nodes,
-        })
-        .await
-        .map_err(|error| {
-            StateHandlerError::GenericError(eyre::eyre!(
-                "failed to submit NVOS update to RMS: {}",
-                error
-            ))
-        })?;
-
-    let batch_response = response.response.as_ref();
-    let batch_status = batch_response
-        .map(|batch_response| batch_response.status)
-        .unwrap_or(rms::ReturnCode::Failure as i32);
-    let batch_job_id = batch_response
-        .map(|batch_response| batch_response.job_id.as_str())
-        .unwrap_or_default();
-    if batch_status != rms::ReturnCode::Success as i32
-        && batch_job_id.is_empty()
-        && response.jobs.is_empty()
-    {
-        let message = batch_response
-            .map(|batch_response| batch_response.message.as_str())
-            .unwrap_or_default();
-        let message = if message.is_empty() {
-            "RMS returned failure for ApplySwitchSystemImage".to_string()
-        } else {
-            message.to_string()
-        };
-        return Err(StateHandlerError::GenericError(eyre::eyre!(message)));
-    }
-
-    let parent_job_id = (!batch_job_id.is_empty()).then(|| batch_job_id.to_string());
-    let child_jobs = response
-        .jobs
-        .iter()
-        .map(|child| (child.node_id.clone(), child.job_id.clone()))
-        .collect::<std::collections::HashMap<_, _>>();
-    let switches: Vec<_> = switches
-        .into_iter()
-        .map(|switch| {
-            let mut status = NvosUpdateSwitchStatus {
-                node_id: switch.node_id.clone(),
-                mac: switch.mac,
-                bmc_ip: switch.bmc_ip,
-                nvos_ip: switch.os_ip.unwrap_or_default(),
-                status: "pending".into(),
-                job_id: child_jobs
-                    .get(&switch.node_id)
-                    .cloned()
-                    .or_else(|| parent_job_id.clone()),
-                error_message: None,
-            };
-
-            if status.job_id.is_none() {
-                status.status = "failed".into();
-                status.error_message =
-                    Some("RMS did not return a switch system image job for this switch".into());
-            }
-
-            status
-        })
-        .collect();
-
-    let failed = switches
-        .iter()
-        .filter(|switch| switch.status == "failed")
-        .count();
-    let completed = switches
-        .iter()
-        .filter(|switch| switch.status == "completed")
-        .count();
-    let total = switches.len();
-    let terminal = completed + failed;
-
-    Ok(NvosUpdateJob {
-        job_id: parent_job_id,
-        firmware_id: response.object_id,
-        image_filename: response.image_filename,
-        local_file_path: String::new(),
-        version: None,
-        status: Some(
-            if total > 0 && terminal < total {
-                "in_progress"
-            } else if failed > 0 {
-                "failed"
-            } else {
-                "completed"
-            }
-            .into(),
-        ),
-        started_at: Some(started_at),
-        completed_at: if total > 0 && terminal == total {
-            Some(chrono::Utc::now())
-        } else {
-            None
-        },
-        switches,
-    })
-}
-
 async fn rms_get_nvos_update_status(
     rms_client: &dyn SwitchSystemImageRmsClient,
     job: &NvosUpdateJob,
@@ -2759,16 +2629,20 @@ pub async fn handle_maintenance(
                     )
                     .await;
                 };
-                let Some(rms_client) = ctx.services.switch_system_image_rms_client.as_deref()
-                else {
+
+                let Some(rms_client) = ctx.services.rms_client.clone() else {
                     delete_rack_maintenance_access_token(
                         ctx.services.credential_manager.as_ref(),
                         id,
                     )
                     .await;
+
                     return transition_to_rack_error(id, state, "RMS client not configured", ctx)
                         .await;
                 };
+
+                let nvos_update_manager = rms_nvos_update_manager(rms_client);
+
                 let access_token = match load_rack_maintenance_access_token(
                     ctx.services.credential_manager.as_ref(),
                     id,
@@ -2781,9 +2655,8 @@ pub async fn handle_maintenance(
                         return transition_to_rack_error(id, state, &message, ctx).await;
                     }
                 };
+
                 let profile = super::resolve_profile(id, rack_profile_id, ctx);
-                let rack_hardware_type = profile_hardware_type_or_any(profile);
-                let software_type = profile.map(firmware_type_for_profile).unwrap_or("prod");
 
                 let switch_inventory = load_rack_switch_firmware_inventory(
                     &ctx.services.db_pool,
@@ -2830,17 +2703,20 @@ pub async fn handle_maintenance(
                     .await;
                 };
 
-                let switch_node_identity = match switch_node_identity_for_profile(profile) {
-                    Ok(identity) => identity,
-                    Err(error) => {
-                        delete_rack_maintenance_access_token(
-                            ctx.services.credential_manager.as_ref(),
-                            id,
-                        )
-                        .await;
-                        return transition_to_rack_error(id, state, error.to_string(), ctx).await;
-                    }
-                };
+                // Profile errors are terminal for this maintenance request and
+                // take precedence over retryable switch credential errors.
+                if let Err(error) = switch_node_identity_for_profile(profile) {
+                    delete_rack_maintenance_access_token(
+                        ctx.services.credential_manager.as_ref(),
+                        id,
+                    )
+                    .await;
+
+                    return transition_to_rack_error(id, state, error.to_string(), ctx).await;
+                }
+
+                let rack_hardware_type = profile_hardware_type_or_any(Some(profile));
+                let software_type = firmware_type_for_profile(profile);
 
                 tracing::info!(
                     rack_id = %id,
@@ -2871,26 +2747,31 @@ pub async fn handle_maintenance(
                     })?;
                 }
 
-                let source = NvosUpdateSource {
-                    config_json: &config_json,
-                    access_token: &access_token,
-                };
-                let submit_result = rms_start_nvos_update(
-                    rms_client,
-                    id,
-                    source,
-                    software_type,
-                    &rack_hardware_type,
-                    &switch_node_identity,
-                    switch_inventory.switches,
-                )
-                .await;
+                let submit_result = nvos_update_manager
+                    .start_nvos_update(NvosUpdateRequest {
+                        rack_id: id,
+                        profile,
+                        config_json: &config_json,
+                        access_token: &access_token,
+                        switches: switch_inventory.switches,
+                    })
+                    .await;
+
                 delete_rack_maintenance_access_token(ctx.services.credential_manager.as_ref(), id)
                     .await;
 
+                // Invalid requests cannot succeed on retry. Backend submission
+                // failures remain handler errors so the Start state is retried.
                 let job = match submit_result {
                     Ok(job) => job,
-                    Err(error) => return Err(error),
+                    Err(ComponentManagerError::InvalidArgument(cause)) => {
+                        return transition_to_rack_error(id, state, &cause, ctx).await;
+                    }
+                    Err(ComponentManagerError::Internal(cause))
+                    | Err(ComponentManagerError::RejectedBeforeDispatch(cause)) => {
+                        return Err(StateHandlerError::GenericError(eyre::eyre!(cause)));
+                    }
+                    Err(error) => return Err(StateHandlerError::GenericError(eyre::eyre!(error))),
                 };
 
                 let mut txn = ctx.services.db_pool.begin().await?;


### PR DESCRIPTION
Route NVOS update through component-manager to make this function backend agnostic. This is part of the cleanup tracked in #4240 (work spans across multiple PRs).

## Related issues

Supports #4240

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

### Simulation Testing

Method:

- Built a NICo image and deployed it to a cluster for simulation integration tests.
- Started a one-switch NVOS update with `nico-admin-cli` and observed NICo state history, RMS jobs, artifact transfer, installation, and final state.

Coverage:

- Successful update with an NVOS image.
- Undersized-image failure propagation.

Steps:

1. The failure path propagated the RMS error, and the simulated rack returned to `Ready`.
2. Submitted a valid image. RMS finished the image update, and observed the new version after switch reboot.
3. Confirmed NICo transitioned through `NVOSUpdate(Start)`, `NVOSUpdate(WaitForComplete)`, `Completed`, `Validating(Pending)`, and `Ready`.

Results:

- Successful submission, persistence, polling, installation, and completion.
- Failure propagation and recovery completed as expected.