### PR TITLE
fix(site-explorer): avoid batch health report update deadlock

### DIFF
--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -190,34 +190,41 @@ impl MachineValidationManager {
     /// Returns true if we stopped early due to a timeout.
     pub(crate) async fn run_single_iteration(&self) -> CarbideResult<()> {
         let mut metrics = MachineValidationMetrics::new();
-        // Completion events for the runs this iteration transitions, emitted
-        // only after the transaction commits: an iteration that fails and
-        // rolls back leaves the runs active, so an early emit would count
-        // them again when the next iteration re-flips the gate.
-        let mut completions: Vec<MachineValidationCompleted> = Vec::new();
-
-        let mut txn = db::Transaction::begin(&self.database_connection).await?;
         let now = chrono::Utc::now();
         let heartbeat_stale_timeout = heartbeat_stale_timeout(self.config.stale_run_timeout);
 
-        for validation in db::machine_validation::find_active(&mut txn).await? {
+        // Each reconciliation phase gets its own transaction. PostgreSQL
+        // keeps row locks until commit, so sharing a transaction would let a
+        // later phase restart from a lower MachineId while higher-ID locks
+        // from an earlier phase were still held, recreating SQLSTATE 40P01
+        // (`deadlock_detected`) with another ordered multi-machine writer.
+        let mut txn = db::Transaction::begin(&self.database_connection).await?;
+        let mut completions = Vec::new();
+        for validation in db::machine::MachineRowLockOrderIter::new(
+            db::machine_validation::find_active(&mut txn).await?,
+        ) {
             if let Some(completion) =
                 reconcile_terminal_run_items(txn.as_pgconn(), validation).await?
             {
                 completions.push(completion);
             }
         }
+        txn.commit().await?;
+        // Emit only after this phase is durable. Otherwise a rollback would
+        // leave the validation active and a later retry would count it again.
+        completions.into_iter().for_each(carbide_instrument::emit);
 
-        let stale_attempts = db::machine_validation_execution::find_stale_active_attempts(
-            &mut txn,
-            heartbeat_stale_timeout,
-            now,
+        let mut txn = db::Transaction::begin(&self.database_connection).await?;
+        let mut completions = Vec::new();
+        for stale_attempt in db::machine::MachineRowLockOrderIter::new(
+            db::machine_validation_execution::find_stale_active_attempts(
+                &mut txn,
+                heartbeat_stale_timeout,
+                now,
+            )
+            .await?,
         )
-        .await?;
-
-        for stale_attempt in stale_attempts
-            .into_iter()
-            .filter(|attempt| attempt.last_heartbeat_at.is_some())
+        .filter(|attempt| attempt.last_heartbeat_at.is_some())
         {
             if let Some(completion) =
                 reconcile_stale_attempt(txn.as_pgconn(), stale_attempt, now).await?
@@ -226,15 +233,17 @@ impl MachineValidationManager {
                 completions.push(completion);
             }
         }
+        txn.commit().await?;
+        completions.into_iter().for_each(carbide_instrument::emit);
 
-        let stale_validations = stale_validations(
+        let mut txn = db::Transaction::begin(&self.database_connection).await?;
+        let mut completions = Vec::new();
+        for validation in db::machine::MachineRowLockOrderIter::new(stale_validations(
             db::machine_validation::find_active(&mut txn).await?,
             self.config.stale_run_timeout,
             heartbeat_stale_timeout,
             now,
-        );
-
-        for validation in stale_validations {
+        )) {
             if let Some(completion) = reconcile_stale_validation(
                 txn.as_pgconn(),
                 validation,
@@ -290,12 +299,7 @@ impl MachineValidationManager {
         self.metric_holder.update_metrics(metrics);
 
         txn.commit().await?;
-
-        // The transitions are durable now, so count (and log) each completion
-        // exactly once.
-        for completion in completions {
-            carbide_instrument::emit(completion);
-        }
+        completions.into_iter().for_each(carbide_instrument::emit);
 
         Ok(())
     }

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -85,6 +85,64 @@ lazy_static! {
     );
 }
 
+/// An item associated with a row in `machines`.
+pub trait MachineRowLockItem {
+    /// Returns the ID used to order machine-row lock acquisition.
+    fn machine_id(&self) -> MachineId;
+}
+
+impl MachineRowLockItem for MachineId {
+    fn machine_id(&self) -> MachineId {
+        *self
+    }
+}
+
+impl<T> MachineRowLockItem for (MachineId, T) {
+    fn machine_id(&self) -> MachineId {
+        self.0
+    }
+}
+
+/// An owning iterator in canonical `machines` row-lock acquisition order.
+///
+/// PostgreSQL holds row locks acquired by `UPDATE` until the transaction ends.
+/// If two transactions update overlapping machine batches in different orders,
+/// each can hold a row needed by the other, and PostgreSQL aborts one with
+/// SQLSTATE 40P01 (`deadlock_detected`). A common order prevents that cycle.
+///
+/// Construct this before the batch's first machine-row write so concurrent
+/// transactions acquire row locks in the same order.
+pub struct MachineRowLockOrderIter<T>(std::vec::IntoIter<T>);
+
+impl<T: MachineRowLockItem> MachineRowLockOrderIter<T> {
+    /// Orders machine-scoped batch items by their machine IDs.
+    pub fn new(mut items: Vec<T>) -> Self {
+        items.sort_unstable_by_key(MachineRowLockItem::machine_id);
+        Self(items.into_iter())
+    }
+}
+
+impl<T> MachineRowLockOrderIter<T> {
+    /// Returns the remaining ordered items as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        self.0.as_slice()
+    }
+}
+
+impl<T> Iterator for MachineRowLockOrderIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<T> ExactSizeIterator for MachineRowLockOrderIter<T> {}
+
 /// Load a Machine object matching an interface, creating it if not already present.
 /// Returns a tuple of (Machine, bool did_we_just_create_it)
 ///

--- a/crates/api-db/src/machine_validation.rs
+++ b/crates/api-db/src/machine_validation.rs
@@ -26,7 +26,14 @@ use sqlx::PgConnection;
 
 use super::{ColumnInfo, FilterableQueryBuilder, ObjectColumnFilter};
 use crate::db_read::DbReader;
+use crate::machine::MachineRowLockItem;
 use crate::{DatabaseError, DatabaseResult};
+
+impl MachineRowLockItem for MachineValidation {
+    fn machine_id(&self) -> MachineId {
+        self.machine_id
+    }
+}
 
 #[derive(Copy, Clone)]
 pub struct IdColumn;

--- a/crates/api-db/src/machine_validation_execution.rs
+++ b/crates/api-db/src/machine_validation_execution.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use carbide_uuid::machine::MachineId;
 use carbide_uuid::machine_validation::{
     MachineValidationAttemptId, MachineValidationId, MachineValidationRunItemId,
 };
@@ -36,6 +37,7 @@ const SUMMARY_LIMIT: usize = 4096;
 
 #[derive(Clone, Debug, sqlx::FromRow)]
 pub struct StaleMachineValidationAttempt {
+    pub machine_id: MachineId,
     pub validation_id: MachineValidationId,
     pub run_item_id: MachineValidationRunItemId,
     pub attempt_id: MachineValidationAttemptId,
@@ -44,6 +46,12 @@ pub struct StaleMachineValidationAttempt {
     pub timeout_seconds: i64,
     pub started_at: Option<DateTime<Utc>>,
     pub last_heartbeat_at: Option<DateTime<Utc>>,
+}
+
+impl crate::machine::MachineRowLockItem for StaleMachineValidationAttempt {
+    fn machine_id(&self) -> MachineId {
+        self.machine_id
+    }
 }
 
 pub async fn materialize_run_plan(
@@ -264,6 +272,7 @@ pub async fn find_stale_active_attempts(
     const QUERY: &str = "
         WITH active_attempts AS (
             SELECT
+                validation.machine_id,
                 run_item.run_id AS validation_id,
                 run_item.id AS run_item_id,
                 attempt.id AS attempt_id,
@@ -288,6 +297,7 @@ pub async fn find_stale_active_attempts(
                 AND attempt.state='Running'
         )
         SELECT
+            machine_id,
             validation_id,
             run_item_id,
             attempt_id,

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -990,9 +990,14 @@ impl SiteExplorer {
         }
         metrics.record_phase_latency("audit_compute", audit_compute_start.elapsed());
 
+        // Match other multi-machine health-report writers' row-lock order to
+        // prevent PostgreSQL deadlocks when their batches overlap.
+        let pending_health_report_updates =
+            db::machine::MachineRowLockOrderIter::new(pending_health_report_updates);
         let audit_write_start = Instant::now();
-        for health_report_updates in
-            pending_health_report_updates.chunks(Self::SITE_EXPLORER_HEALTH_REPORT_WRITE_BATCH_SIZE)
+        for health_report_updates in pending_health_report_updates
+            .as_slice()
+            .chunks(Self::SITE_EXPLORER_HEALTH_REPORT_WRITE_BATCH_SIZE)
         {
             let mut txn = self.txn_begin().await?;
             for (id, health_report) in health_report_updates {


### PR DESCRIPTION
When batch updates of health reports were added, they introduced a possible deadlock when two transactions locked machine rows in opposite orders. This PR introduces a common iterator that defines a canonical order for all machine batch-processing transactions.

## Related issues

NvBug: 6606522
Introduced in #2550 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
