### PR TITLE
fix(api): refuse manual attestation triggers when SPDM is disabled

### DIFF
--- a/crates/api-core/src/handlers/attestation.rs
+++ b/crates/api-core/src/handlers/attestation.rs
@@ -32,6 +32,19 @@ pub(crate) async fn trigger_machine_attestation(
 ) -> Result<Response<rpc::SpdmMachineAttestationTriggerResponse>, Status> {
     log_request_data(&request);
 
+    // `spdm.enabled` decides whether the SPDM state controller is spawned at
+    // all, so with it off there is nothing to process the rows this would
+    // insert. Scheduling anyway strands the machine as permanently
+    // "under attestation".
+    if !api.runtime_config.spdm.enabled {
+        return Err(CarbideError::UnavailableError(
+            "SPDM attestation is disabled for this site, so no attestation \
+             controller is running to carry the request out"
+                .to_string(),
+        )
+        .into());
+    }
+
     let request_payload = request.get_ref();
     let machine_id = request_payload
         .machine_id

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -57,7 +57,7 @@ use carbide_rack_controller::context::RackStateHandlerServices;
 use carbide_rack_controller::firmware_object::FirmwareObjectFetcher;
 use carbide_rack_controller::handler::RackStateHandler;
 use carbide_rack_controller::io::RackStateControllerIO;
-use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimTestOverrides};
+use carbide_redfish::libredfish::test_support::RedfishSim;
 use carbide_secrets::credentials::{
     CompositeCredentialManager, CredentialKey, CredentialManager, CredentialReader, CredentialType,
     Credentials,
@@ -186,7 +186,6 @@ pub(in crate::tests) struct TestEnvOverrides {
     pub(in crate::tests) nmxc_fail_after_n_creates: Option<usize>,
     pub(in crate::tests) compute_allocation_enforcement: Option<ComputeAllocationEnforcement>,
     pub(in crate::tests) nmxc_simulator: Option<bool>,
-    pub(in crate::tests) redfish_overrides: Option<RedfishOverrides>,
 
     /// Optional compute-tray backend injected into the component manager.
     pub(in crate::tests) compute_tray_manager:
@@ -198,13 +197,6 @@ pub(in crate::tests) struct TestEnvOverrides {
     pub(in crate::tests) nras_should_fail_parsing: Option<Arc<AtomicBool>>,
     pub(in crate::tests) vpc_prefixes_drain_period: Option<chrono::Duration>,
     pub(in crate::tests) dhcp_lease_expiry_handling: Option<bool>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub(in crate::tests) struct RedfishOverrides {
-    pub(in crate::tests) no_component_integrities: bool,
-    pub(in crate::tests) firmware_for_component_error: bool,
-    pub(in crate::tests) get_task_trigger_evidence_returns_interrupted: bool,
 }
 
 impl TestEnvOverrides {
@@ -1258,16 +1250,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
         credential_manager.clone(),
     ));
 
-    let redfish_sim = if let Some(redfish_overrides) = overrides.redfish_overrides {
-        Arc::new(RedfishSim::with_test_overrides(RedfishSimTestOverrides {
-            no_component_integrities: redfish_overrides.no_component_integrities,
-            firmware_for_component_error: redfish_overrides.firmware_for_component_error,
-            get_task_trigger_evidence_returns_interrupted: redfish_overrides
-                .get_task_trigger_evidence_returns_interrupted,
-        }))
-    } else {
-        Arc::new(RedfishSim::default())
-    };
+    let redfish_sim = Arc::new(RedfishSim::default());
 
     // Seed the site-wide host and DPU UEFI site-default credentials (version 0).
     // These are written during site setup in production; tests don't run that.

--- a/crates/api-core/src/tests/spdm.rs
+++ b/crates/api-core/src/tests/spdm.rs
@@ -28,26 +28,77 @@ pub(in crate::tests) mod tests {
     //use sqlx::PgConnection;
     use tonic::Request;
 
+    use crate::cfg::file::CarbideConfig;
     use crate::tests::common::api_fixtures::{
-        RedfishOverrides, TestEnv, TestEnvOverrides, create_managed_host, create_test_env,
-        create_test_env_with_overrides,
+        TestEnv, TestEnvOverrides, create_managed_host, create_test_env,
+        create_test_env_with_overrides, get_config,
     };
+
+    /// The default test config leaves SPDM disabled, matching a fresh
+    /// deployment. `trigger_machine_attestation` refuses to schedule at a site
+    /// with it switched off, so every test that drives a trigger turns it on.
+    ///
+    /// Enabling it also makes `create_managed_host` attest the machine during
+    /// host init. Tests that model a misbehaving BMC therefore inject the fault
+    /// after setup, so it applies to the trigger under test rather than to that
+    /// unrelated attestation.
+    fn spdm_enabled_config() -> CarbideConfig {
+        let mut config = get_config();
+        config.spdm.enabled = true;
+        config
+    }
+
+    /// With SPDM off no state controller is spawned, so anything this scheduled
+    /// would sit unprocessed forever. The "enabled" half of the contract is
+    /// covered by every other test in this module, which all schedule
+    /// successfully with SPDM on.
+    #[crate::sqlx_test]
+    async fn trigger_is_refused_when_spdm_is_disabled_for_the_site(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        let env = create_test_env(pool).await;
+        assert!(
+            !env.config.spdm.enabled,
+            "this test relies on the default config leaving SPDM disabled"
+        );
+
+        let (machine_id, _dpu_id) = create_managed_host(&env).await.into();
+        let status = env
+            .api
+            .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
+                machine_id: Some(machine_id),
+                redfish_timeout_secs: u32::MAX,
+            }))
+            .await
+            .expect_err("a site with SPDM disabled must not start attestation");
+
+        assert_eq!(tonic::Code::Unavailable, status.code());
+
+        // Refusing has to leave no work behind: a caller that retries after
+        // enabling SPDM should start from nothing.
+        assert_eq!(0, list_machines_under_attestation(&env).await?.len());
+
+        Ok(())
+    }
 
     #[crate::sqlx_test]
     async fn test_component_integrity_fails_no_attestation_started(
         pool: sqlx::PgPool,
     ) -> Result<(), eyre::Error> {
-        // set up redfish to return no component integrities
-        let overrides = TestEnvOverrides {
-            redfish_overrides: Some(RedfishOverrides {
-                no_component_integrities: true,
+        let env = create_test_env_with_overrides(
+            pool,
+            TestEnvOverrides {
+                config: Some(spdm_enabled_config()),
                 ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let env = create_test_env_with_overrides(pool, overrides).await;
+            },
+        )
+        .await;
 
         let (machine_id, _dpu_id) = create_managed_host(&env).await.into();
+
+        // set up redfish to return no component integrities
+        env.redfish_sim.set_no_component_integrities(true);
+
         let response = env
             .api
             .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
@@ -70,17 +121,20 @@ pub(in crate::tests) mod tests {
     async fn test_fetch_metadata_fails_state_does_not_change(
         pool: sqlx::PgPool,
     ) -> Result<(), eyre::Error> {
-        // set up redfish to return an error in FetchMetadata state
-        let overrides = TestEnvOverrides {
-            redfish_overrides: Some(RedfishOverrides {
-                firmware_for_component_error: true,
+        let env = create_test_env_with_overrides(
+            pool,
+            TestEnvOverrides {
+                config: Some(spdm_enabled_config()),
                 ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let env = create_test_env_with_overrides(pool, overrides).await;
+            },
+        )
+        .await;
 
         let (machine_id, _dpu_id) = create_managed_host(&env).await.into();
+
+        // set up redfish to return an error in FetchMetadata state
+        env.redfish_sim.set_firmware_for_component_error(true);
+
         let response = env
             .api
             .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
@@ -127,17 +181,21 @@ pub(in crate::tests) mod tests {
     async fn test_poll_evidence_fails_controller_retries_then_fails(
         pool: sqlx::PgPool,
     ) -> Result<(), eyre::Error> {
-        // set up redfish to return an error in FetchMetadata state
-        let overrides = TestEnvOverrides {
-            redfish_overrides: Some(RedfishOverrides {
-                get_task_trigger_evidence_returns_interrupted: true,
+        let env = create_test_env_with_overrides(
+            pool,
+            TestEnvOverrides {
+                config: Some(spdm_enabled_config()),
                 ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let env = create_test_env_with_overrides(pool, overrides).await;
+            },
+        )
+        .await;
 
         let (machine_id, _dpu_id) = create_managed_host(&env).await.into();
+
+        // set up redfish to interrupt evidence collection
+        env.redfish_sim
+            .set_get_task_trigger_evidence_returns_interrupted(true);
+
         let response = env
             .api
             .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
@@ -214,7 +272,14 @@ pub(in crate::tests) mod tests {
         // -  cancel the whole thing - make sure it goes into cancelled state
         // verify the state in each iteration using direct db lookups
 
-        let env = create_test_env(pool).await;
+        let env = create_test_env_with_overrides(
+            pool,
+            TestEnvOverrides {
+                config: Some(spdm_enabled_config()),
+                ..Default::default()
+            },
+        )
+        .await;
         let (machine_id, _dpu_id) = create_managed_host(&env).await.into();
         let _ = env
             .api

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -283,18 +283,25 @@ impl RedfishSim {
             .unwrap_or_default()
     }
 
-    /// Build a simulator with optional SPDM / firmware-integration test flags.
-    pub fn with_test_overrides(overrides: RedfishSimTestOverrides) -> Self {
-        Self {
-            state: Arc::new(Mutex::new(RedfishSimState {
-                no_component_integrities: overrides.no_component_integrities,
-                firmware_for_component_error: overrides.firmware_for_component_error,
-                get_task_trigger_evidence_returns_interrupted: overrides
-                    .get_task_trigger_evidence_returns_interrupted,
-                ..Default::default()
-            })),
-            credential_manager: TestCredentialManager::default(),
-        }
+    /// Model a BMC that exposes no `ComponentIntegrity` collection, so nothing
+    /// is eligible for SPDM attestation.
+    pub fn set_no_component_integrities(&self, no_component_integrities: bool) {
+        self.state.lock().unwrap().no_component_integrities = no_component_integrities;
+    }
+
+    /// Fail the firmware-inventory lookup an attestation makes while fetching
+    /// component metadata.
+    pub fn set_firmware_for_component_error(&self, error: bool) {
+        self.state.lock().unwrap().firmware_for_component_error = error;
+    }
+
+    /// Return the evidence-collection task as `Interrupted`, modelling a BMC
+    /// that keeps failing to produce evidence.
+    pub fn set_get_task_trigger_evidence_returns_interrupted(&self, interrupted: bool) {
+        self.state
+            .lock()
+            .unwrap()
+            .get_task_trigger_evidence_returns_interrupted = interrupted;
     }
 
     pub fn set_machine_setup_bios_job_id(&self, job_id: Option<String>) {
@@ -501,14 +508,6 @@ impl RedfishSim {
             .await
             .expect("seed redfish-sim credential");
     }
-}
-
-/// Optional simulation flags used by API integration tests.
-#[derive(Clone, Default)]
-pub struct RedfishSimTestOverrides {
-    pub no_component_integrities: bool,
-    pub firmware_for_component_error: bool,
-    pub get_task_trigger_evidence_returns_interrupted: bool,
 }
 
 pub struct RedfishSimTimepoint {


### PR DESCRIPTION
The `SpdmMachineAttestationTrigger` API used to accept requests even at sites where SPDM attestation is turned off.

The problem is that the `spdm.enabled` setting decides whether the SPDM controller is started at all (see `crates/api-core/src/setup.rs`). If it is off, no controller is running, so nothing can do the attestation work. The API still wrote the request to the database and reported success. The machine was then marked "under attestation" forever, the caller never saw an error, and the only way out was to turn SPDM on and restart the API.

Now with this fix, the API checks the setting first and rejects the request with `UNAVAILABLE` and a message that says why. An operator gets a clear error instead of a stuck machine. Nothing is written to the database, so if they turn SPDM on and try again, they start clean.

This change also resulted in a test cleanup. Tests use SPDM disabled by default, so the existing SPDM tests had to switch it on.  `RedfishSim` now has three setter methods (`set_no_component_integrities`, `set_firmware_for_component_error`, and `set_get_task_trigger_evidence_returns_interrupted`) so a test can turn a fault on after setup finishes. The old `RedfishSimTestOverrides` struct and the `redfish_overrides` field on `TestEnvOverrides` are no longer needed and were removed.

## Related issues

## Type of Change

- [x] **Fix** - Bug fixes

https://github.com/NVIDIA/infra-controller/issues/5624

## Breaking Changes

- [x ] **This PR contains breaking changes**

At a site with SPDM off, this call used to return success and now returns `UNAVAILABLE`. The old success was not real, because the attestation never ran. Sites with SPDM on are not affected.

## Testing

- [x] Unit tests added/updated
