### PR TITLE
feat(rest-api): Recovery of missing Subnets from Site inventory

### DIFF
--- a/rest-api/db/pkg/db/model/subnet.go
+++ b/rest-api/db/pkg/db/model/subnet.go
@@ -16,6 +16,7 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/google/uuid"
 
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
@@ -321,6 +322,7 @@ func splitNetworkPrefix(s string) (string, int, bool) {
 
 // SubnetCreateInput parameters for Create method
 type SubnetCreateInput struct {
+	SubnetID                   *uuid.UUID
 	Name                       string
 	Description                *string
 	Org                        string
@@ -378,6 +380,8 @@ type SubnetClearInput struct {
 	IPv6Gateway                bool
 	IPv6BlockID                bool
 	Mtu                        bool
+	// Deleted clears the soft-delete timestamp (undelete).
+	Deleted bool
 }
 
 // SubnetFilterInput input parameters for GetAll method
@@ -392,6 +396,8 @@ type SubnetFilterInput struct {
 	IPv6BlockIDs []uuid.UUID
 	Statuses     []string
 	SearchQuery  *string
+	// IncludeDeleted returns soft-deleted rows in addition to active ones.
+	IncludeDeleted bool
 }
 
 var _ bun.BeforeAppendModelHook = (*Subnet)(nil)
@@ -462,8 +468,13 @@ func (ssd SubnetSQLDAO) Create(ctx context.Context, tx *db.Tx, input SubnetCreat
 		ssd.tracerSpan.SetAttribute(sbDAOSpan, "name", input.Name)
 	}
 
+	id := input.SubnetID
+	if id == nil {
+		id = cutil.GetPtr(uuid.New())
+	}
+
 	s := &Subnet{
-		ID:                         uuid.New(),
+		ID:                         *id,
 		Name:                       input.Name,
 		Description:                input.Description,
 		Org:                        input.Org,
@@ -591,6 +602,10 @@ func (ssd SubnetSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter SubnetFilt
 	ss := []Subnet{}
 
 	query := db.GetIDB(tx, ssd.dbSession).NewSelect().Model(&ss)
+	// Soft-deleted rows are excluded by default.
+	if filter.IncludeDeleted {
+		query = query.WhereAllWithDeleted()
+	}
 	if filter.SubnetIDs != nil {
 		query = query.Where("su.id IN (?)", bun.In(filter.SubnetIDs))
 		ssd.tracerSpan.SetAttribute(sbDAOSpan, "subnet_ids", filter.SubnetIDs)
@@ -848,11 +863,20 @@ func (ssd SubnetSQLDAO) Clear(ctx context.Context, tx *db.Tx, input SubnetClearI
 		s.MTU = nil
 		updatedFields = append(updatedFields, "mtu")
 	}
+	if input.Deleted {
+		s.Deleted = nil
+		updatedFields = append(updatedFields, "deleted")
+	}
 
 	if len(updatedFields) > 0 {
 		updatedFields = append(updatedFields, "updated")
 
-		_, err := db.GetIDB(tx, ssd.dbSession).NewUpdate().Model(s).Column(updatedFields...).Where("id = ?", input.SubnetId).Exec(ctx)
+		query := db.GetIDB(tx, ssd.dbSession).NewUpdate().Model(s).Column(updatedFields...).Where("id = ?", input.SubnetId)
+		// Soft-deleted rows are excluded by default; include them when undeleting.
+		if input.Deleted {
+			query = query.WhereAllWithDeleted()
+		}
+		_, err := query.Exec(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/rest-api/db/pkg/db/model/subnet_test.go
+++ b/rest-api/db/pkg/db/model/subnet_test.go
@@ -1830,6 +1830,68 @@ func TestSubnetSQLDAO_Clear(t *testing.T) {
 	}
 }
 
+func TestSubnetSQLDAO_ClearDeleted(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testSubnetInitDB(t)
+	defer dbSession.Close()
+	testSubnetSetupSchema(t, dbSession)
+
+	ip := testSubnetBuildInfrastructureProvider(t, dbSession, "testIP")
+	site := testSubnetBuildSite(t, dbSession, ip, "testSite")
+	tenant := testSubnetBuildTenant(t, dbSession, "testTenant")
+	vpc := testSubnetBuildVpc(t, dbSession, ip, site, tenant, "testVpc")
+	user := testSubnetBuildUser(t, dbSession, "testUser")
+	ipBlock := testSubnetBuildIPBlock(t, dbSession, &site.ID, &ip.ID, "ipBlock", &user.ID)
+	subnetDAO := NewSubnetDAO(dbSession)
+	controllerSegmentID := uuid.New()
+
+	subnet, err := subnetDAO.Create(ctx, nil, SubnetCreateInput{
+		SubnetID:                   &controllerSegmentID,
+		Name:                       "test-clear-deleted",
+		Org:                        "test",
+		SiteID:                     site.ID,
+		VpcID:                      vpc.ID,
+		TenantID:                   tenant.ID,
+		ControllerNetworkSegmentID: &controllerSegmentID,
+		RoutingType:                &ipBlock.RoutingType,
+		IPv4Prefix:                 cutil.GetPtr("192.0.2.0"),
+		IPv4Gateway:                cutil.GetPtr("192.0.2.1"),
+		IPv4BlockID:                &ipBlock.ID,
+		PrefixLength:               24,
+		Status:                     SubnetStatusError,
+		CreatedBy:                  user.ID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, subnetDAO.Delete(ctx, nil, subnet.ID))
+
+	t.Run("clears soft-delete marker", func(t *testing.T) {
+		cleared, clearErr := subnetDAO.Clear(ctx, nil, SubnetClearInput{
+			SubnetId: subnet.ID,
+			Deleted:  true,
+		})
+		require.NoError(t, clearErr)
+		require.NotNil(t, cleared)
+		assert.Nil(t, cleared.Deleted)
+
+		updated, updateErr := subnetDAO.Update(ctx, nil, SubnetUpdateInput{
+			SubnetId:        subnet.ID,
+			Status:          cutil.GetPtr(SubnetStatusReady),
+			IsMissingOnSite: cutil.GetPtr(false),
+		})
+		require.NoError(t, updateErr)
+		assert.Equal(t, SubnetStatusReady, updated.Status)
+		assert.False(t, updated.IsMissingOnSite)
+	})
+
+	t.Run("returns not found for unknown Subnet", func(t *testing.T) {
+		_, clearErr := subnetDAO.Clear(ctx, nil, SubnetClearInput{
+			SubnetId: uuid.New(),
+			Deleted:  true,
+		})
+		assert.ErrorIs(t, clearErr, db.ErrDoesNotExist)
+	})
+}
+
 func TestSubnetSQLDAO_Delete(t *testing.T) {
 	ctx := context.Background()
 	dbSession := testSubnetInitDB(t)

--- a/rest-api/workflow/pkg/activity/subnet/subnet.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet.go
@@ -6,6 +6,9 @@ package subnet
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
+	"net/netip"
 	"slices"
 	"time"
 
@@ -82,7 +85,6 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 
 	if total == 0 {
 		logger.Info().Msg("No Subnets found for Site")
-		return nil, nil
 	}
 
 	// Construct a map of Controller Segment ID to Subnet
@@ -116,22 +118,45 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 
 	// Iterate through Subnet Inventory and update DB
 	for _, controllerSegment := range subnetInventory.Segments {
-		slogger := logger.With().Str("Controller Segment ID", controllerSegment.Id.Value).Logger()
+		if controllerSegment == nil || controllerSegment.GetId().GetValue() == "" {
+			logger.Error().Msg("received Subnet inventory entry with missing controller ID, skipping")
+			continue
+		}
 
-		subnet, ok := existingSubnetCtrlIDMap[controllerSegment.Id.Value]
+		controllerSegmentIDStr := controllerSegment.GetId().GetValue()
+		slogger := logger.With().Str("Controller Segment ID", controllerSegmentIDStr).Logger()
+
+		subnet, ok := existingSubnetCtrlIDMap[controllerSegmentIDStr]
 		if !ok {
 			// Check if the Subnet is found by ID (segment name == cloudSubnet.ID)
 			subnet, ok = existingSubnetIDMap[controllerSegment.GetMetadata().GetName()]
 			if ok {
-				existingSubnetCtrlIDMap[controllerSegment.Id.Value] = subnet
+				existingSubnetCtrlIDMap[controllerSegmentIDStr] = subnet
 			}
 		}
 
 		if subnet == nil {
-			if controllerSegment.GetConfig().GetSegmentType() == corev1.NetworkSegmentType_TENANT {
-				logger.Error().Str("Controller Segment ID", controllerSegment.Id.Value).Msg("Network Segment does not have a Subnet record in DB, possibly created directly on Site")
+			if controllerSegment.GetConfig().GetSegmentType() != corev1.NetworkSegmentType_TENANT {
+				continue
 			}
-			continue
+
+			reportedStatus, _ := getControllerSubnetStatus(controllerSegment.GetStatus())
+			if reportedStatus == cdbm.SubnetStatusDeleting || reportedStatus == cdbm.SubnetStatusDeleted {
+				slogger.Info().Msgf("skipping create or undelete of Subnet from Site inventory: Site reports status %s", reportedStatus)
+				continue
+			}
+
+			subnet = ms.createOrUpdateSubnetFromSite(ctx, site, controllerSegment)
+			if subnet == nil {
+				continue
+			}
+
+			// Keep in-memory maps in sync so later inventory entries and missing-on-Site detection see this Subnet.
+			existingSubnetIDMap[subnet.ID.String()] = subnet
+			if subnet.ControllerNetworkSegmentID != nil {
+				existingSubnetCtrlIDMap[subnet.ControllerNetworkSegmentID.String()] = subnet
+			}
+			slogger.Info().Str("Subnet ID", subnet.ID.String()).Msg("created or undeleted Subnet from Site inventory")
 		}
 
 		reportedSubnetIDMap[subnet.ID] = true
@@ -169,10 +194,9 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 		}
 
 		// Update Subnet in DB
-		status, statusMessage := getNICoSubnetStatus(controllerSegment.GetStatus().GetTenantState())
+		status, statusMessage := getControllerSubnetStatus(controllerSegment.GetStatus())
 
-		// If Subnet is already in Deleting state then no need to update status
-		if subnet.Status == cdbm.SubnetStatusDeleting {
+		if subnet.Status == cdbm.SubnetStatusDeleting && status != cdbm.SubnetStatusDeleting && status != cdbm.SubnetStatusDeleted {
 			continue
 		}
 
@@ -187,7 +211,7 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 			latestsd, _, serr := sdDAO.GetAll(ctx, nil, cdbm.StatusDetailFilterInput{EntityIDs: []string{subnet.ID.String()}}, cdbp.PageInput{Limit: cwutil.GetPtr(1)})
 			if serr != nil {
 				slogger.Error().Err(serr).Msg("failed to retrieve latest Status Detail for Subnet")
-			} else if len(latestsd) == 0 || (latestsd[0].Message != nil && *latestsd[0].Message != statusMessage) {
+			} else if len(latestsd) == 0 || latestsd[0].Message == nil || *latestsd[0].Message != statusMessage {
 				updateStatusInDB = true
 			}
 		}
@@ -304,6 +328,298 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 	return subnetLifecycleEvents, nil
 }
 
+// createOrUpdateSubnetFromSite creates a REST Subnet from Site inventory, or undeletes
+// a matching soft-deleted row (and resets Status from Site inventory on undelete).
+// Returns nil when skipped or on failure.
+func (ms ManageSubnet) createOrUpdateSubnetFromSite(
+	ctx context.Context,
+	site *cdbm.Site,
+	controllerSegment *corev1.NetworkSegment,
+) *cdbm.Subnet {
+	logger := log.With().
+		Str("Activity", "UpdateSubnetsInDB").
+		Str("Site ID", site.ID.String()).
+		Str("Controller Segment ID", controllerSegment.GetId().GetValue()).
+		Logger()
+
+	// Get the Controller Segment ID from the Site inventory
+	controllerSegmentID, err := uuid.Parse(controllerSegment.GetId().GetValue())
+	if err != nil {
+		logger.Warn().Msgf("unable to create Subnet found on Site: failed to parse Controller Segment ID, not a valid UUID %s", controllerSegment.GetId().GetValue())
+		return nil
+	}
+
+	// Get the reported Subnet from the Site inventory
+	reportedSubnet := new(cdbm.Subnet)
+	reportedSubnet.FromProto(controllerSegment)
+	if reportedSubnet.Name == "" {
+		reportedSubnet.Name = fmt.Sprintf("recovered-%s", controllerSegmentID.String()[:8])
+	}
+	if reportedSubnet.IPv4Prefix == nil {
+		logger.Warn().Msg("unable to create Subnet found on Site: Subnet on Site is reporting empty IPv4 Prefix")
+		return nil
+	}
+	reportedPrefixCIDR := ipam.GetCidrForIPBlock(ctx, *reportedSubnet.IPv4Prefix, reportedSubnet.PrefixLength)
+	reportedPrefix, err := netip.ParsePrefix(reportedPrefixCIDR)
+	if err != nil {
+		logger.Warn().Msgf("unable to create Subnet found on Site: failed to parse Prefix CIDR %s", reportedPrefixCIDR)
+		return nil
+	}
+	// netip.ParsePrefix accepts host bits (e.g. 10.20.0.1/16). Reject those before any
+	// IPAM mutation; otherwise the equal-length full-grant path can persist FullGrant
+	// with no Subnet when a later soft-skip commits the transaction.
+	maskedPrefixCIDR := reportedPrefix.Masked().String()
+	if reportedPrefix.String() != maskedPrefixCIDR {
+		logger.Warn().Msgf("unable to create Subnet found on Site: Prefix CIDR %s is not in canonical masked form %s", reportedPrefixCIDR, maskedPrefixCIDR)
+		return nil
+	}
+	reportedPrefixAddress := reportedPrefix.Masked().Addr().String()
+	reportedSubnet.IPv4Prefix = &reportedPrefixAddress
+	reportedSubnet.PrefixLength = reportedPrefix.Bits()
+	if reportedSubnet.VpcID == uuid.Nil {
+		logger.Warn().Msg("unable to create Subnet found on Site: Subnet on Site is reporting empty VPC ID")
+		return nil
+	}
+	parentVpcID := reportedSubnet.VpcID
+
+	subnet, err := cdb.WithTxResult(ctx, ms.dbSession, func(tx *cdb.Tx) (*cdbm.Subnet, error) {
+		subnetDAO := cdbm.NewSubnetDAO(ms.dbSession)
+		vpcDAO := cdbm.NewVpcDAO(ms.dbSession)
+		sdDAO := cdbm.NewStatusDetailDAO(ms.dbSession)
+
+		// Parent VPC must already exist in REST; inventory VpcId is the Site-facing VPC ID.
+		vpcMatches, _, vpcErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
+			VpcIDs: []uuid.UUID{parentVpcID}, SiteIDs: []uuid.UUID{site.ID},
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if vpcErr != nil {
+			return nil, fmt.Errorf("unable to create Subnet found on Site: failed to retrieve parent VPC by ID, DB error: %w", vpcErr)
+		}
+		if len(vpcMatches) == 0 {
+			// The VPC inventory activity will create a missing parent VPC, so retry this
+			// Subnet on the next inventory iteration.
+			logger.Warn().Msgf("unable to create Subnet found on Site: no VPC was found for ID: %s", parentVpcID)
+			return nil, nil
+		}
+		vpc := &vpcMatches[0]
+
+		// Lookup by primary key globally (not scoped to site.ID). A same-UUID row under
+		// another Site would otherwise be invisible here and Create would unique-constraint
+		// fail every inventory cycle.
+		matches, _, reloadErr := subnetDAO.GetAll(ctx, tx, cdbm.SubnetFilterInput{
+			SubnetIDs:      []uuid.UUID{reportedSubnet.ID},
+			IncludeDeleted: true,
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if reloadErr != nil {
+			return nil, fmt.Errorf("unable to create Subnet found on Site: failed to retrieve Subnet by Controller Segment ID, DB error: %w", reloadErr)
+		}
+
+		// Non-nil from here on means this inventory entry is an undelete, not a create.
+		var existingSubnet *cdbm.Subnet
+		if len(matches) > 0 {
+			existingSubnet = &matches[0]
+		}
+
+		// If the Subnet was found in the DB, check that it is valid before restoring it.
+		if existingSubnet != nil {
+			if existingSubnet.SiteID != site.ID {
+				logger.Warn().Msgf("unable to create Subnet found on Site: Subnet ID already exists under a different Site for Subnet %s", controllerSegmentID)
+				return nil, nil
+			}
+			if existingSubnet.Deleted == nil {
+				return existingSubnet, nil
+			}
+			if existingSubnet.VpcID != vpc.ID {
+				logger.Warn().Msgf("unable to create Subnet found on Site: VPC differs in REST cache and Site record for Subnet %s", controllerSegmentID)
+				return nil, nil
+			}
+			if existingSubnet.Org != vpc.Org {
+				logger.Warn().Msgf("unable to create Subnet found on Site: tenant organization differs in REST cache and Site record %s", vpc.Org)
+				return nil, nil
+			}
+			// Clear restores the row as stored; do not acquire a Site CIDR that disagrees with
+			// the cached Prefix/VpcID or DB and IPAM will permanently diverge.
+			if existingSubnet.IPv4Prefix == nil {
+				logger.Warn().Msgf("unable to create Subnet found on Site: stored IPv4 Prefix is missing for Subnet %s", controllerSegmentID)
+				return nil, nil
+			}
+			existingPrefixCIDR := ipam.GetCidrForIPBlock(ctx, *existingSubnet.IPv4Prefix, existingSubnet.PrefixLength)
+			existingPrefix, parseErr := netip.ParsePrefix(existingPrefixCIDR)
+			if parseErr != nil || existingPrefix.Masked().String() != maskedPrefixCIDR {
+				logger.Warn().Msgf("unable to create Subnet found on Site: Prefix differs in REST cache and Site record for Subnet %s", controllerSegmentID)
+				return nil, nil
+			}
+		}
+
+		// If the Subnet is being undeleted, use its stored IPv4 Block. Otherwise
+		// find the most specific Ready tenant IPv4 Block that contains its Prefix.
+		ipBlockDAO := cdbm.NewIPBlockDAO(ms.dbSession)
+		var ipBlock *cdbm.IPBlock
+		if existingSubnet != nil {
+			if existingSubnet.IPv4BlockID == nil {
+				logger.Warn().Msgf("unable to create Subnet found on Site: stored IPv4 Block ID is missing for Subnet %s", existingSubnet.ID)
+				return nil, nil
+			}
+
+			ipBlock, reloadErr = ipBlockDAO.GetByID(ctx, tx, *existingSubnet.IPv4BlockID, nil)
+			if reloadErr != nil {
+				if errors.Is(reloadErr, cdb.ErrDoesNotExist) {
+					logger.Warn().Msgf("unable to create Subnet found on Site: stored IPv4 Block %s was not found for Subnet %s", existingSubnet.IPv4BlockID, existingSubnet.ID)
+					return nil, nil
+				}
+				return nil, fmt.Errorf("unable to create Subnet found on Site: failed to retrieve stored IPv4 Block, DB error: %w", reloadErr)
+			}
+			if ipBlock.SiteID != site.ID {
+				logger.Warn().Msgf("unable to create Subnet found on Site: stored IPv4 Block belongs to a different Site for Subnet %s", existingSubnet.ID)
+				return nil, nil
+			}
+			if ipBlock.TenantID == nil || *ipBlock.TenantID != vpc.TenantID {
+				logger.Warn().Msgf("unable to create Subnet found on Site: stored IPv4 Block belongs to a different Tenant for Subnet %s", existingSubnet.ID)
+				return nil, nil
+			}
+			if !ipBlock.ContainsPrefix(reportedPrefix) {
+				logger.Warn().Msgf("unable to create Subnet found on Site: stored IPv4 Block does not contain Prefix %s for Subnet %s", reportedPrefix, existingSubnet.ID)
+				return nil, nil
+			}
+		} else {
+			ipBlocks, _, ipBlockErr := ipBlockDAO.GetAll(ctx, tx, cdbm.IPBlockFilterInput{
+				SiteIDs:   []uuid.UUID{site.ID},
+				TenantIDs: []uuid.UUID{vpc.TenantID},
+				Statuses:  []string{cdbm.IPBlockStatusReady},
+			}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+			if ipBlockErr != nil {
+				return nil, fmt.Errorf("unable to create Subnet found on Site: failed to retrieve IPv4 Blocks, DB error: %w", ipBlockErr)
+			}
+
+			for i := range ipBlocks {
+				candidateIPBlock := &ipBlocks[i]
+				if candidateIPBlock.FullGrant || !candidateIPBlock.ContainsPrefix(reportedPrefix) {
+					continue
+				}
+				if ipBlock == nil || candidateIPBlock.PrefixLength > ipBlock.PrefixLength {
+					ipBlock = candidateIPBlock
+				}
+			}
+			if ipBlock == nil {
+				logger.Warn().Msgf("unable to create Subnet found on Site: no containing IPv4 Block was found for Prefix: %s", reportedPrefix)
+				return nil, nil
+			}
+		}
+
+		// Claim the exact Site-reported CIDR in REST IPAM while holding the same
+		// tenant/IPBlock lock used by the normal REST create path.
+		lockErr := tx.AcquireAdvisoryLock(ctx, cdb.GetAdvisoryLockIDFromString(fmt.Sprintf("%s-%s", vpc.TenantID.String(), ipBlock.ID.String())), false)
+		if lockErr != nil {
+			return nil, fmt.Errorf("unable to create Subnet found on Site: failed to acquire advisory lock on IPv4 Block, DB error: %w", lockErr)
+		}
+
+		// Refresh FullGrant under the lock because the candidate scan read it before
+		// the lock and a concurrent create may have changed it.
+		freshIPBlock, reloadIPBlockErr := cdbm.NewIPBlockDAO(ms.dbSession).GetByID(ctx, tx, ipBlock.ID, nil)
+		if reloadIPBlockErr != nil {
+			return nil, fmt.Errorf("unable to create Subnet found on Site: failed to reload IPv4 Block under advisory lock, DB error: %w", reloadIPBlockErr)
+		}
+		ipBlock = freshIPBlock
+		if ipBlock.Status != cdbm.IPBlockStatusReady {
+			logger.Warn().Msgf("unable to create Subnet found on Site: IPv4 Block %s is no longer Ready", ipBlock.ID)
+			return nil, nil
+		}
+		if ipBlock.FullGrant {
+			logger.Warn().Msgf("unable to create Subnet found on Site: IPv4 Block %s was fully granted concurrently", ipBlock.ID)
+			return nil, nil
+		}
+
+		ipamStorage := ipam.NewIpamStorage(ms.dbSession.DB, tx.GetBunTx())
+		reportedPrefixLength := reportedPrefix.Bits()
+
+		var allocateErr error
+		if ipBlock.PrefixLength == reportedPrefixLength {
+			_, allocateErr = ipam.CreateChildIpamEntryForIPBlock(
+				ctx, tx, ms.dbSession, ipamStorage, ipBlock, reportedPrefixLength,
+			)
+		} else {
+			_, allocateErr = ipam.AcquireSpecificChildIpamEntryForIPBlock(
+				ctx, tx, ms.dbSession, ipamStorage, ipBlock, maskedPrefixCIDR,
+			)
+		}
+		if allocateErr != nil {
+			return nil, fmt.Errorf(
+				"unable to create Subnet found on Site: failed to create IPAM entry for Subnet: %w",
+				allocateErr,
+			)
+		}
+
+		// If the Subnet was soft-deleted, undelete it and reset Status from Site inventory.
+		if existingSubnet != nil {
+			restored, clearErr := subnetDAO.Clear(ctx, tx, cdbm.SubnetClearInput{SubnetId: existingSubnet.ID, Deleted: true})
+			if clearErr != nil {
+				return nil, fmt.Errorf("unable to create Subnet found on Site: failed to clear soft-delete timestamp for Subnet, DB error: %w", clearErr)
+			}
+			status, statusMessage := getControllerSubnetStatus(controllerSegment.GetStatus())
+			updated, updateErr := subnetDAO.Update(ctx, tx, cdbm.SubnetUpdateInput{
+				SubnetId: restored.ID,
+				Status:   &status,
+			})
+			if updateErr != nil {
+				return nil, fmt.Errorf("unable to create Subnet found on Site: failed to update Subnet status after undelete, DB error: %w", updateErr)
+			}
+			_, statusErr := sdDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
+				EntityID: updated.ID.String(), Status: status, Message: &statusMessage,
+			})
+			if statusErr != nil {
+				return nil, fmt.Errorf("unable to create Subnet found on Site: failed to create Status Detail after undelete, DB error: %w", statusErr)
+			}
+			return updated, nil
+		}
+
+		// If an active Subnet already uses this name for the Tenant/Site, append a recovered suffix.
+		nameConflictSubnets, _, nameErr := subnetDAO.GetAll(ctx, tx, cdbm.SubnetFilterInput{
+			Names: []string{reportedSubnet.Name}, TenantIDs: []uuid.UUID{vpc.TenantID}, SiteIDs: []uuid.UUID{site.ID},
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+		if nameErr != nil {
+			return nil, fmt.Errorf("unable to create Subnet found on Site: failed to retrieve Subnet by name, DB error: %w", nameErr)
+		}
+		if len(nameConflictSubnets) > 0 {
+			reportedSubnet.Name = fmt.Sprintf("%s-recovered-%s", reportedSubnet.Name, reportedSubnet.ID.String()[:8])
+		}
+
+		readyMsg := "Subnet was found on Site, Ready for use"
+		created, createErr := subnetDAO.Create(ctx, tx, cdbm.SubnetCreateInput{
+			SubnetID:                   &controllerSegmentID,
+			Name:                       reportedSubnet.Name,
+			Description:                reportedSubnet.Description,
+			Org:                        vpc.Org,
+			SiteID:                     site.ID,
+			VpcID:                      vpc.ID,
+			DomainID:                   reportedSubnet.DomainID,
+			TenantID:                   vpc.TenantID,
+			ControllerNetworkSegmentID: &controllerSegmentID,
+			RoutingType:                &ipBlock.RoutingType,
+			IPv4Prefix:                 reportedSubnet.IPv4Prefix,
+			IPv4Gateway:                reportedSubnet.IPv4Gateway,
+			IPv4BlockID:                &ipBlock.ID,
+			PrefixLength:               reportedPrefixLength,
+			Mtu:                        reportedSubnet.MTU,
+			Status:                     cdbm.SubnetStatusReady,
+			CreatedBy:                  site.CreatedBy,
+		})
+		if createErr != nil {
+			return nil, fmt.Errorf("unable to create Subnet found on Site: failed to create Subnet, DB error: %w", createErr)
+		}
+		_, statusErr := sdDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
+			EntityID: created.ID.String(), Status: cdbm.SubnetStatusReady, Message: &readyMsg,
+		})
+		if statusErr != nil {
+			return nil, fmt.Errorf("unable to create Subnet found on Site: failed to create Status Detail, DB error: %w", statusErr)
+		}
+		return created, nil
+	})
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to recover Subnet from Site inventory")
+		return nil
+	}
+	return subnet
+}
+
 // updateSubnetStatusInDB is helper function to write Subnet status updates to DB
 func (ms ManageSubnet) updateSubnetStatusInDB(ctx context.Context, tx *cdb.Tx, subnetID uuid.UUID, status *string, statusMessage *string) error {
 	if status != nil {
@@ -368,9 +684,14 @@ func (ms ManageSubnet) deleteSubnetFromDB(ctx context.Context, tx *cdb.Tx, subne
 	return nil
 }
 
-// Utility function to get NICo Subent status from Controller Segment state
-func getNICoSubnetStatus(controllerNetworkSegmentTenantState corev1.TenantState) (string, string) {
-	switch controllerNetworkSegmentTenantState {
+// getControllerSubnetStatus maps Controller Network Segment tenant state into REST status and status-detail text.
+func getControllerSubnetStatus(status *corev1.NetworkSegmentStatus) (string, string) {
+	// Older Controller builds did not report status; inventory presence meant ready.
+	if status == nil {
+		return cdbm.SubnetStatusReady, "Subnet is ready for use"
+	}
+
+	switch status.GetTenantState() {
 	case corev1.TenantState_PROVISIONING:
 		return cdbm.SubnetStatusProvisioning, "Subnet is being provisioned on Site"
 	case corev1.TenantState_READY:

--- a/rest-api/workflow/pkg/activity/subnet/subnet.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet.go
@@ -196,7 +196,9 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 		// Update Subnet in DB
 		status, statusMessage := getControllerSubnetStatus(controllerSegment.GetStatus())
 
-		if subnet.Status == cdbm.SubnetStatusDeleting && status != cdbm.SubnetStatusDeleting && status != cdbm.SubnetStatusDeleted {
+		// Preserve Deleting until the Subnet disappears from inventory and the
+		// cleanup path releases IPAM and soft-deletes the DB row.
+		if subnet.Status == cdbm.SubnetStatusDeleting {
 			continue
 		}
 
@@ -446,6 +448,14 @@ func (ms ManageSubnet) createOrUpdateSubnetFromSite(
 			existingPrefix, parseErr := netip.ParsePrefix(existingPrefixCIDR)
 			if parseErr != nil || existingPrefix.Masked().String() != maskedPrefixCIDR {
 				logger.Warn().Msgf("unable to create Subnet found on Site: Prefix differs in REST cache and Site record for Subnet %s", controllerSegmentID)
+				return nil, nil
+			}
+			// Deleted records when the delete happened, so a delete newer than the interval can
+			// postdate this inventory. Undeleting then would revive a Subnet the snapshot
+			// never saw removed. Skip before the IPAM work below rather than after, so there is
+			// no allocation to unwind. A later inventory undeletes it if the Site still reports it.
+			if site.IsTimeWithinStaleInventoryThreshold(*existingSubnet.Deleted) {
+				logger.Info().Msgf("not undeleting Subnet %s yet because it was deleted more recently than the inventory interval", controllerSegmentID)
 				return nil, nil
 			}
 		}

--- a/rest-api/workflow/pkg/activity/subnet/subnet.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet.go
@@ -610,7 +610,7 @@ func (ms ManageSubnet) createOrUpdateSubnetFromSite(
 			PrefixLength:               reportedPrefixLength,
 			Mtu:                        reportedSubnet.MTU,
 			Status:                     cdbm.SubnetStatusReady,
-			CreatedBy:                  site.CreatedBy,
+			CreatedBy:                  vpc.CreatedBy,
 		})
 		if createErr != nil {
 			return nil, fmt.Errorf("unable to create Subnet found on Site: failed to create Subnet, DB error: %w", createErr)

--- a/rest-api/workflow/pkg/activity/subnet/subnet_test.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet_test.go
@@ -4,19 +4,24 @@
 package subnet
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/ipam"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
+	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	cdbu "github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun/extra/bundebug"
@@ -208,7 +213,7 @@ func testSubnetBuildVPC(t *testing.T, dbSession *cdb.Session, name string, ip *c
 	input := cdbm.VpcCreateInput{
 		Name:                      name,
 		Description:               cutil.GetPtr("Test VPC"),
-		Org:                       st.Org,
+		Org:                       tn.Org,
 		InfrastructureProviderID:  ip.ID,
 		TenantID:                  tn.ID,
 		SiteID:                    st.ID,
@@ -662,6 +667,347 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 			}
 		})
 	}
+
+	regressionTests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{
+			name: "auto creates, replays, and restores Subnets",
+			run:  testManageSubnetUpdateSubnetsInDBAutoCreatesAndRestores,
+		},
+	}
+	for _, test := range regressionTests {
+		t.Run(test.name, test.run)
+	}
+}
+
+func testManageSubnetUpdateSubnetsInDBAutoCreatesAndRestores(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testSubnetInitDB(t)
+	defer dbSession.Close()
+	testSubnetSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testSubnetSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testSubnetBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testSubnetBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testSubnetBuildVPC(t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser)
+	controllerVpcID := parentVpc.ID
+	ipBlock := testSubnetBuildIPBlock(
+		t, dbSession, "test-subnet-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	manager := ManageSubnet{dbSession: dbSession}
+	subnetDAO := cdbm.NewSubnetDAO(dbSession)
+	statusDetailDAO := cdbm.NewStatusDetailDAO(dbSession)
+
+	controllerSegmentID := uuid.MustParse("abcdef01-2345-4678-9abc-def012345678")
+	gateway := "10.20.30.1"
+	controllerSegment := &corev1.NetworkSegment{
+		Id: &corev1.NetworkSegmentId{Value: controllerSegmentID.String()},
+		Config: &corev1.NetworkSegmentConfig{
+			VpcId:       &corev1.VpcId{Value: controllerVpcID.String()},
+			SegmentType: corev1.NetworkSegmentType_TENANT,
+			Prefixes: []*corev1.NetworkPrefix{
+				{Prefix: "10.20.30.0/24", Gateway: &gateway},
+			},
+		},
+		Metadata: &corev1.Metadata{
+			Name: "site-created-subnet",
+		},
+		Status: &corev1.NetworkSegmentStatus{
+			TenantState: corev1.TenantState_READY,
+		},
+	}
+	inventory := &corev1.SubnetInventory{
+		Segments: []*corev1.NetworkSegment{controllerSegment},
+	}
+
+	if !t.Run("auto creates Subnet from inventory", func(t *testing.T) {
+		var logOutput bytes.Buffer
+		originalLogger := log.Logger
+		log.Logger = zerolog.New(&logOutput)
+		defer func() {
+			log.Logger = originalLogger
+		}()
+
+		_, err := manager.UpdateSubnetsInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+		assert.Contains(t, logOutput.String(), "created or undeleted Subnet from Site inventory")
+
+		created, err := subnetDAO.GetByID(ctx, nil, controllerSegmentID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, controllerSegmentID, created.ID)
+		assert.Equal(t, parentVpc.ID, created.VpcID)
+		assert.Equal(t, tenant.ID, created.TenantID)
+		assert.Equal(t, tenantOrg, created.Org)
+		assert.Equal(t, site.ID, created.SiteID)
+		assert.Equal(t, site.CreatedBy, created.CreatedBy)
+		assert.Equal(t, cdbm.SubnetStatusReady, created.Status)
+		assert.Equal(t, "site-created-subnet", created.Name)
+		require.NotNil(t, created.IPv4Prefix)
+		assert.Equal(t, "10.20.30.0", *created.IPv4Prefix)
+		require.NotNil(t, created.IPv4Gateway)
+		assert.Equal(t, gateway, *created.IPv4Gateway)
+		assert.Equal(t, 24, created.PrefixLength)
+		require.NotNil(t, created.IPv4BlockID)
+		assert.Equal(t, ipBlock.ID, *created.IPv4BlockID)
+		require.NotNil(t, created.ControllerNetworkSegmentID)
+		assert.Equal(t, controllerSegmentID, *created.ControllerNetworkSegmentID)
+
+		ipamer := cipam.NewWithStorage(ipamStorage)
+		ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+			ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+		))
+		assert.NotNil(t, ipamer.PrefixFrom(ctx, controllerSegment.Config.Prefixes[0].Prefix))
+
+		statusDetails, _, statusErr := statusDetailDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{created.ID.String()}},
+			cdbp.PageInput{},
+		)
+		require.NoError(t, statusErr)
+		require.NotEmpty(t, statusDetails)
+		foundCreateMessage := false
+		for i := range statusDetails {
+			if statusDetails[i].Message != nil &&
+				*statusDetails[i].Message == "Subnet was found on Site, Ready for use" {
+				foundCreateMessage = true
+				break
+			}
+		}
+		assert.True(t, foundCreateMessage)
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("inventory replay is idempotent", func(t *testing.T) {
+		_, err := manager.UpdateSubnetsInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+		subnets, count, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{controllerSegmentID}},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, subnets, 1)
+		assert.Equal(t, 1, count)
+	}) {
+		t.FailNow()
+	}
+
+	t.Run("uppercase inventory ID follows the recovery path", func(t *testing.T) {
+		canonicalID := controllerSegment.Id.Value
+		controllerSegment.Id.Value = strings.ToUpper(canonicalID)
+		require.NotEqual(t, canonicalID, controllerSegment.Id.Value)
+		defer func() {
+			controllerSegment.Id.Value = canonicalID
+		}()
+
+		var logOutput bytes.Buffer
+		originalLogger := log.Logger
+		log.Logger = zerolog.New(&logOutput)
+		defer func() {
+			log.Logger = originalLogger
+		}()
+
+		_, err := manager.UpdateSubnetsInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+
+		subnets, count, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{controllerSegmentID}},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, subnets, 1)
+		assert.Equal(t, 1, count)
+		assert.Contains(t, logOutput.String(), "created or undeleted Subnet from Site inventory")
+	})
+
+	t.Run("inventory skips restore when Site reports TERMINATING", func(t *testing.T) {
+		_, err := subnetDAO.Update(ctx, nil, cdbm.SubnetUpdateInput{
+			SubnetId:        controllerSegmentID,
+			Status:          cutil.GetPtr(cdbm.SubnetStatusDeleting),
+			IsMissingOnSite: cutil.GetPtr(true),
+		})
+		require.NoError(t, err)
+		require.NoError(t, ipam.DeleteChildIpamEntryFromCidr(
+			ctx, nil, dbSession, ipamStorage, ipBlock, controllerSegment.Config.Prefixes[0].Prefix,
+		))
+		require.NoError(t, subnetDAO.Delete(ctx, nil, controllerSegmentID))
+
+		deleted, _, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{controllerSegmentID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deleted, 1)
+		require.NotNil(t, deleted[0].Deleted)
+		assert.Equal(t, cdbm.SubnetStatusDeleting, deleted[0].Status)
+		deletedAt := *deleted[0].Deleted
+
+		terminatingInventory := &corev1.SubnetInventory{
+			Segments: []*corev1.NetworkSegment{
+				{
+					Id: &corev1.NetworkSegmentId{Value: controllerSegmentID.String()},
+					Config: &corev1.NetworkSegmentConfig{
+						VpcId:       &corev1.VpcId{Value: controllerVpcID.String()},
+						SegmentType: corev1.NetworkSegmentType_TENANT,
+						Prefixes: []*corev1.NetworkPrefix{
+							{Prefix: controllerSegment.Config.Prefixes[0].Prefix, Gateway: &gateway},
+						},
+					},
+					Metadata: &corev1.Metadata{Name: "site-created-subnet"},
+					Status: &corev1.NetworkSegmentStatus{
+						TenantState: corev1.TenantState_TERMINATING,
+					},
+				},
+			},
+		}
+		_, err = manager.UpdateSubnetsInDB(ctx, site.ID, terminatingInventory)
+		require.NoError(t, err)
+
+		stillDeleted, _, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{controllerSegmentID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, stillDeleted, 1)
+		require.NotNil(t, stillDeleted[0].Deleted)
+		assert.Equal(t, deletedAt, *stillDeleted[0].Deleted)
+		assert.Equal(t, cdbm.SubnetStatusDeleting, stillDeleted[0].Status)
+
+		_, err = subnetDAO.GetByID(ctx, nil, controllerSegmentID, nil)
+		assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+		ipamer := cipam.NewWithStorage(ipamStorage)
+		ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+			ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+		))
+		assert.Nil(t, ipamer.PrefixFrom(ctx, controllerSegment.Config.Prefixes[0].Prefix))
+	})
+
+	t.Run("inventory restores soft-deleted Subnet", func(t *testing.T) {
+		var logOutput bytes.Buffer
+		originalLogger := log.Logger
+		log.Logger = zerolog.New(&logOutput)
+		defer func() {
+			log.Logger = originalLogger
+		}()
+
+		existing, _, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{controllerSegmentID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, existing, 1)
+		require.NotNil(t, existing[0].Deleted, "expected the Subnet to be soft-deleted by the preceding subtest")
+		require.Equal(t, cdbm.SubnetStatusDeleting, existing[0].Status)
+
+		_, err = manager.UpdateSubnetsInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+		assert.Contains(t, logOutput.String(), "created or undeleted Subnet from Site inventory")
+
+		restored, err := subnetDAO.GetByID(ctx, nil, controllerSegmentID, nil)
+		require.NoError(t, err)
+		assert.Nil(t, restored.Deleted)
+		assert.False(t, restored.IsMissingOnSite)
+		assert.Equal(t, cdbm.SubnetStatusReady, restored.Status)
+		ipamer := cipam.NewWithStorage(ipamStorage)
+		ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+			ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+		))
+		assert.NotNil(t, ipamer.PrefixFrom(ctx, controllerSegment.Config.Prefixes[0].Prefix))
+
+		statusDetails, _, statusErr := statusDetailDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{restored.ID.String()}},
+			cdbp.PageInput{},
+		)
+		require.NoError(t, statusErr)
+		foundReadyMessage := false
+		for i := range statusDetails {
+			if statusDetails[i].Message != nil &&
+				*statusDetails[i].Message == "Subnet is ready for use" {
+				foundReadyMessage = true
+				break
+			}
+		}
+		assert.True(t, foundReadyMessage)
+	})
+
+	t.Run("inventory skips restore when tenant organization differs", func(t *testing.T) {
+		require.NoError(t, ipam.DeleteChildIpamEntryFromCidr(
+			ctx, nil, dbSession, ipamStorage, ipBlock, controllerSegment.Config.Prefixes[0].Prefix,
+		))
+		require.NoError(t, subnetDAO.Delete(ctx, nil, controllerSegmentID))
+		deleted, _, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{controllerSegmentID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deleted, 1)
+		require.NotNil(t, deleted[0].Deleted)
+		deletedAt := *deleted[0].Deleted
+
+		_, err = dbSession.DB.NewUpdate().
+			Model((*cdbm.Subnet)(nil)).
+			Set("org = ?", "other-tenant-org").
+			Where("id = ?", controllerSegmentID).
+			WhereAllWithDeleted().
+			Exec(ctx)
+		require.NoError(t, err)
+
+		_, err = manager.UpdateSubnetsInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+
+		stillDeleted, _, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{controllerSegmentID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, stillDeleted, 1)
+		require.NotNil(t, stillDeleted[0].Deleted)
+		assert.Equal(t, deletedAt, *stillDeleted[0].Deleted)
+
+		_, err = subnetDAO.GetByID(ctx, nil, controllerSegmentID, nil)
+		assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+	})
 }
 
 func TestNewManageSubnet(t *testing.T) {
@@ -715,6 +1061,690 @@ func TestNewManageSubnet(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManageSubnet_CreateOrUpdateSubnetFromSite(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testSubnetInitDB(t)
+	defer dbSession.Close()
+	testSubnetSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testSubnetSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	site := testSubnetBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	authorizedTenantOrg := "test-authorized-tenant"
+	authorizedTenantUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), authorizedTenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	authorizedTenant := testSubnetBuildTenant(t, dbSession, "test-authorized-tenant", authorizedTenantOrg, authorizedTenantUser)
+
+	parentVpc := testSubnetBuildVPC(t, dbSession, "parent-vpc", provider, authorizedTenant, site, nil, nil, authorizedTenantUser)
+	controllerVpcID := parentVpc.ID
+	ipBlock := testSubnetBuildIPBlock(
+		t, dbSession, "test-subnet-ip-block", site, provider, &authorizedTenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.0.0.0", 8,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, authorizedTenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+	ipamer := cipam.NewWithStorage(ipamStorage)
+	ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+		ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	))
+	_, err = ipamer.AcquireSpecificChildPrefix(ctx, "10.0.0.0/8", "10.5.0.0/24")
+	require.NoError(t, err)
+	existingSubnet := testSubnetBuildSubnet(
+		t, dbSession, "existing-name", authorizedTenant, parentVpc, nil, nil,
+		&ipBlock.RoutingType, cutil.GetPtr("10.0.0.0"), cutil.GetPtr("10.0.0.1"),
+		&ipBlock.ID, 24, cdbm.SubnetStatusReady, authorizedTenantUser,
+	)
+
+	manager := ManageSubnet{dbSession: dbSession}
+
+	tests := []struct {
+		name              string
+		controllerSegment *corev1.NetworkSegment
+		wantSubnet        bool
+		wantName          string
+		wantNamePref      string
+	}{
+		{
+			name: "unknown parent VPC is rejected",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: uuid.NewString()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "10.1.0.0/24", Gateway: cutil.GetPtr("10.1.0.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "unknown-vpc-subnet"},
+			},
+		},
+		{
+			name: "invalid Controller Segment ID",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: "not-a-uuid"},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "10.1.0.0/24", Gateway: cutil.GetPtr("10.1.0.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "invalid-id-subnet"},
+			},
+		},
+		{
+			name: "empty Prefix is rejected",
+			controllerSegment: &corev1.NetworkSegment{
+				Id:       &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config:   &corev1.NetworkSegmentConfig{VpcId: &corev1.VpcId{Value: controllerVpcID.String()}},
+				Metadata: &corev1.Metadata{Name: "missing-prefix"},
+			},
+		},
+		{
+			name: "invalid Prefix CIDR is rejected",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "not-an-ip/24", Gateway: cutil.GetPtr("10.1.0.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "bad-cidr-subnet"},
+			},
+		},
+		{
+			name: "empty VPC ID is rejected",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config: &corev1.NetworkSegmentConfig{
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "10.1.0.0/24", Gateway: cutil.GetPtr("10.1.0.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "missing-vpc-id"},
+			},
+		},
+		{
+			name: "no containing IP Block is rejected",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "192.168.1.0/24", Gateway: cutil.GetPtr("192.168.1.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "no-ip-block-subnet"},
+			},
+		},
+		{
+			name: "already allocated Site CIDR is rejected",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "10.5.0.0/24", Gateway: cutil.GetPtr("10.5.0.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "allocated-subnet"},
+			},
+		},
+		{
+			name: "renames Subnet when active name already exists",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "10.2.0.0/24", Gateway: cutil.GetPtr("10.2.0.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: existingSubnet.Name},
+			},
+			wantSubnet:   true,
+			wantNamePref: existingSubnet.Name + "-recovered-",
+		},
+		{
+			name: "assigns recovered name when metadata name is empty",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: controllerVpcID.String()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "10.3.0.0/24", Gateway: cutil.GetPtr("10.3.0.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: ""},
+			},
+			wantSubnet:   true,
+			wantNamePref: "recovered-",
+		},
+		{
+			name: "creates Subnet using parent VPC REST ID as Site VPC ID",
+			controllerSegment: &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: uuid.NewString()},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: parentVpc.ID.String()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "10.4.0.0/24", Gateway: cutil.GetPtr("10.4.0.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "rest-id-parent-vpc-subnet"},
+			},
+			wantSubnet: true,
+			wantName:   "rest-id-parent-vpc-subnet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnet := manager.createOrUpdateSubnetFromSite(ctx, site, tt.controllerSegment)
+			if tt.wantSubnet {
+				require.NotNil(t, subnet)
+				assert.Equal(t, cdbm.SubnetStatusReady, subnet.Status)
+				assert.Equal(t, authorizedTenant.ID, subnet.TenantID)
+				assert.Equal(t, parentVpc.ID, subnet.VpcID)
+				require.NotNil(t, subnet.IPv4BlockID)
+				assert.Equal(t, ipBlock.ID, *subnet.IPv4BlockID)
+				assert.NotNil(t, ipamer.PrefixFrom(ctx, tt.controllerSegment.Config.Prefixes[0].Prefix))
+				if tt.wantName != "" {
+					assert.Equal(t, tt.wantName, subnet.Name)
+				}
+				if tt.wantNamePref != "" {
+					assert.True(t, len(subnet.Name) > len(tt.wantNamePref))
+					assert.Equal(t, tt.wantNamePref, subnet.Name[:len(tt.wantNamePref)])
+				}
+			} else {
+				assert.Nil(t, subnet)
+			}
+		})
+	}
+
+	storedIPBlockTests := []struct {
+		name                    string
+		storedIPBlockStatus     string
+		createMoreSpecificBlock bool
+		expectedRestore         bool
+	}{
+		{
+			name:                    "undelete ignores a newer more-specific IP Block",
+			storedIPBlockStatus:     cdbm.IPBlockStatusReady,
+			createMoreSpecificBlock: true,
+			expectedRestore:         true,
+		},
+		{
+			name:                "undelete skips a stored IP Block that is not Ready",
+			storedIPBlockStatus: cdbm.IPBlockStatusError,
+		},
+	}
+
+	for _, test := range storedIPBlockTests {
+		t.Run(test.name, func(t *testing.T) {
+			testCtx := context.Background()
+			testDBSession := testSubnetInitDB(t)
+			defer testDBSession.Close()
+			testSubnetSetupSchema(t, testDBSession)
+
+			testProviderOrg := "test-provider-org"
+			testProviderUser := testSubnetBuildUser(t, testDBSession, uuid.NewString(), testProviderOrg, []string{"FORGE_PROVIDER_ADMIN"})
+			testProvider := testSubnetSiteBuildInfrastructureProvider(t, testDBSession, "test-provider", testProviderOrg, testProviderUser)
+			testTenantOrg := "test-tenant-org"
+			testTenantUser := testSubnetBuildUser(t, testDBSession, uuid.NewString(), testTenantOrg, []string{"FORGE_TENANT_ADMIN"})
+			testTenant := testSubnetBuildTenant(t, testDBSession, "test-tenant", testTenantOrg, testTenantUser)
+			testSite := testSubnetBuildSite(t, testDBSession, testProvider, "test-site", testProviderUser)
+			testParentVpc := testSubnetBuildVPC(t, testDBSession, "parent-vpc", testProvider, testTenant, testSite, nil, nil, testTenantUser)
+			storedIPBlock := testSubnetBuildIPBlock(
+				t, testDBSession, "stored-ip-block", testSite, testProvider, &testTenant.ID,
+				cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+				cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, testTenantUser,
+			)
+
+			testIPAMStorage := ipam.NewIpamStorage(testDBSession.DB, nil)
+			_, err := ipam.CreateIpamEntryForIPBlock(
+				testCtx, testIPAMStorage, storedIPBlock.Prefix, storedIPBlock.PrefixLength,
+				storedIPBlock.RoutingType, storedIPBlock.InfrastructureProviderID.String(),
+				storedIPBlock.SiteID.String(),
+			)
+			require.NoError(t, err)
+
+			controllerSegmentID := uuid.New()
+			testSubnetDAO := cdbm.NewSubnetDAO(testDBSession)
+			_, err = testSubnetDAO.Create(testCtx, nil, cdbm.SubnetCreateInput{
+				SubnetID:                   &controllerSegmentID,
+				Name:                       "stored-ip-block-subnet",
+				Org:                        testTenant.Org,
+				SiteID:                     testSite.ID,
+				VpcID:                      testParentVpc.ID,
+				TenantID:                   testTenant.ID,
+				ControllerNetworkSegmentID: &controllerSegmentID,
+				RoutingType:                &storedIPBlock.RoutingType,
+				IPv4Prefix:                 cutil.GetPtr("10.20.30.0"),
+				IPv4Gateway:                cutil.GetPtr("10.20.30.1"),
+				IPv4BlockID:                &storedIPBlock.ID,
+				PrefixLength:               24,
+				Status:                     cdbm.SubnetStatusDeleting,
+				CreatedBy:                  testTenantUser.ID,
+			})
+			require.NoError(t, err)
+			err = testSubnetDAO.Delete(testCtx, nil, controllerSegmentID)
+			require.NoError(t, err)
+
+			if test.storedIPBlockStatus != cdbm.IPBlockStatusReady {
+				_, err = cdbm.NewIPBlockDAO(testDBSession).Update(testCtx, nil, cdbm.IPBlockUpdateInput{
+					IPBlockID: storedIPBlock.ID,
+					Status:    &test.storedIPBlockStatus,
+				})
+				require.NoError(t, err)
+			}
+			if test.createMoreSpecificBlock {
+				testSubnetBuildIPBlock(
+					t, testDBSession, "more-specific-ip-block", testSite, testProvider, &testTenant.ID,
+					cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.16.0", 20,
+					cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, testTenantUser,
+				)
+			}
+
+			controllerSegment := &corev1.NetworkSegment{
+				Id: &corev1.NetworkSegmentId{Value: controllerSegmentID.String()},
+				Config: &corev1.NetworkSegmentConfig{
+					VpcId: &corev1.VpcId{Value: testParentVpc.ID.String()},
+					Prefixes: []*corev1.NetworkPrefix{
+						{Prefix: "10.20.30.0/24", Gateway: cutil.GetPtr("10.20.30.1")},
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "stored-ip-block-subnet"},
+				Status: &corev1.NetworkSegmentStatus{
+					TenantState: corev1.TenantState_READY,
+				},
+			}
+
+			testManager := ManageSubnet{dbSession: testDBSession}
+			restored := testManager.createOrUpdateSubnetFromSite(testCtx, testSite, controllerSegment)
+			if !test.expectedRestore {
+				assert.Nil(t, restored)
+				deleted, _, getErr := testSubnetDAO.GetAll(
+					testCtx,
+					nil,
+					cdbm.SubnetFilterInput{
+						SubnetIDs:      []uuid.UUID{controllerSegmentID},
+						IncludeDeleted: true,
+					},
+					cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+					nil,
+				)
+				require.NoError(t, getErr)
+				require.Len(t, deleted, 1)
+				assert.NotNil(t, deleted[0].Deleted)
+				return
+			}
+			require.NotNil(t, restored)
+			require.NotNil(t, restored.IPv4BlockID)
+			assert.Equal(t, storedIPBlock.ID, *restored.IPv4BlockID)
+
+			testIPAMer := cipam.NewWithStorage(testIPAMStorage)
+			testIPAMer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+				testCtx, storedIPBlock.RoutingType, storedIPBlock.InfrastructureProviderID.String(),
+				storedIPBlock.SiteID.String(),
+			))
+			assert.NotNil(t, testIPAMer.PrefixFrom(testCtx, controllerSegment.Config.Prefixes[0].Prefix))
+		})
+	}
+
+	regressionTests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{
+			name: "rejects host bits in an equal-length CIDR",
+			run:  testCreateOrUpdateSubnetRejectsHostBitsEqualLengthCIDR,
+		},
+		{
+			name: "skips a fully granted IP Block",
+			run:  testCreateOrUpdateSubnetSkipsFullGrantIPBlock,
+		},
+		{
+			name: "skips undelete when the stored Prefix differs",
+			run:  testCreateOrUpdateSubnetSkipsRestoreWhenPrefixDiffers,
+		},
+		{
+			name: "skips a Controller Segment ID owned by another Site",
+			run:  testCreateOrUpdateSubnetSkipsIDOwnedByDifferentSite,
+		},
+	}
+
+	for _, test := range regressionTests {
+		t.Run(test.name, test.run)
+	}
+}
+
+func testCreateOrUpdateSubnetRejectsHostBitsEqualLengthCIDR(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testSubnetInitDB(t)
+	defer dbSession.Close()
+	testSubnetSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testSubnetSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testSubnetBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testSubnetBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testSubnetBuildVPC(t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser)
+	ipBlock := testSubnetBuildIPBlock(
+		t, dbSession, "test-full-grant-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	hostBitsSubnetID := uuid.New()
+	manager := ManageSubnet{dbSession: dbSession}
+	created := manager.createOrUpdateSubnetFromSite(ctx, site, &corev1.NetworkSegment{
+		Id: &corev1.NetworkSegmentId{Value: hostBitsSubnetID.String()},
+		Config: &corev1.NetworkSegmentConfig{
+			VpcId: &corev1.VpcId{Value: parentVpc.ID.String()},
+			Prefixes: []*corev1.NetworkPrefix{
+				{Prefix: "10.20.0.1/16", Gateway: cutil.GetPtr("10.20.0.2")},
+			},
+		},
+		Metadata: &corev1.Metadata{Name: "host-bits-subnet"},
+		Status:   &corev1.NetworkSegmentStatus{TenantState: corev1.TenantState_READY},
+	})
+	assert.Nil(t, created)
+
+	subnetDAO := cdbm.NewSubnetDAO(dbSession)
+	_, err = subnetDAO.GetByID(ctx, nil, hostBitsSubnetID, nil)
+	assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+	ipBlockDAO := cdbm.NewIPBlockDAO(dbSession)
+	reloadedIPBlock, err := ipBlockDAO.GetByID(ctx, nil, ipBlock.ID, nil)
+	require.NoError(t, err)
+	assert.False(t, reloadedIPBlock.FullGrant)
+
+	childPrefix, err := ipam.CreateChildIpamEntryForIPBlock(
+		ctx, nil, dbSession, ipamStorage, reloadedIPBlock, reloadedIPBlock.PrefixLength,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "10.20.0.0/16", childPrefix.Cidr)
+	reloadedIPBlock, err = ipBlockDAO.GetByID(ctx, nil, ipBlock.ID, nil)
+	require.NoError(t, err)
+	assert.True(t, reloadedIPBlock.FullGrant)
+}
+
+func testCreateOrUpdateSubnetSkipsFullGrantIPBlock(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testSubnetInitDB(t)
+	defer dbSession.Close()
+	testSubnetSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testSubnetSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testSubnetBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testSubnetBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testSubnetBuildVPC(t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser)
+	ipBlock := testSubnetBuildIPBlock(
+		t, dbSession, "test-full-grant-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	_, err = ipam.CreateChildIpamEntryForIPBlock(
+		ctx, nil, dbSession, ipamStorage, ipBlock, ipBlock.PrefixLength,
+	)
+	require.NoError(t, err)
+	ipBlockDAO := cdbm.NewIPBlockDAO(dbSession)
+	fullGrantedIPBlock, err := ipBlockDAO.GetByID(ctx, nil, ipBlock.ID, nil)
+	require.NoError(t, err)
+	require.True(t, fullGrantedIPBlock.FullGrant)
+
+	childSubnetID := uuid.New()
+	manager := ManageSubnet{dbSession: dbSession}
+	created := manager.createOrUpdateSubnetFromSite(ctx, site, &corev1.NetworkSegment{
+		Id: &corev1.NetworkSegmentId{Value: childSubnetID.String()},
+		Config: &corev1.NetworkSegmentConfig{
+			VpcId: &corev1.VpcId{Value: parentVpc.ID.String()},
+			Prefixes: []*corev1.NetworkPrefix{
+				{Prefix: "10.20.30.0/24", Gateway: cutil.GetPtr("10.20.30.1")},
+			},
+		},
+		Metadata: &corev1.Metadata{Name: "full-grant-child-subnet"},
+		Status:   &corev1.NetworkSegmentStatus{TenantState: corev1.TenantState_READY},
+	})
+	assert.Nil(t, created)
+
+	subnetDAO := cdbm.NewSubnetDAO(dbSession)
+	_, err = subnetDAO.GetByID(ctx, nil, childSubnetID, nil)
+	assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+	ipamer := cipam.NewWithStorage(ipamStorage)
+	ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+		ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	))
+	assert.Nil(t, ipamer.PrefixFrom(ctx, "10.20.30.0/24"))
+
+	reloadedIPBlock, err := ipBlockDAO.GetByID(ctx, nil, ipBlock.ID, nil)
+	require.NoError(t, err)
+	assert.True(t, reloadedIPBlock.FullGrant)
+}
+
+func testCreateOrUpdateSubnetSkipsRestoreWhenPrefixDiffers(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testSubnetInitDB(t)
+	defer dbSession.Close()
+	testSubnetSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testSubnetSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testSubnetBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testSubnetBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	parentVpc := testSubnetBuildVPC(t, dbSession, "parent-vpc", provider, tenant, site, nil, nil, tenantUser)
+	ipBlock := testSubnetBuildIPBlock(
+		t, dbSession, "test-prefix-mismatch-ip-block", site, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlock.Prefix, ipBlock.PrefixLength, ipBlock.RoutingType,
+		ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	storedCIDR := "10.20.30.0/24"
+	reportedCIDR := "10.20.31.0/24"
+	subnetID := uuid.New()
+	subnetDAO := cdbm.NewSubnetDAO(dbSession)
+	_, err = subnetDAO.Create(ctx, nil, cdbm.SubnetCreateInput{
+		SubnetID:                   &subnetID,
+		Name:                       "stored-subnet",
+		Org:                        tenant.Org,
+		SiteID:                     site.ID,
+		VpcID:                      parentVpc.ID,
+		TenantID:                   tenant.ID,
+		ControllerNetworkSegmentID: &subnetID,
+		RoutingType:                &ipBlock.RoutingType,
+		IPv4Prefix:                 cutil.GetPtr("10.20.30.0"),
+		IPv4Gateway:                cutil.GetPtr("10.20.30.1"),
+		IPv4BlockID:                &ipBlock.ID,
+		PrefixLength:               24,
+		Status:                     cdbm.SubnetStatusDeleting,
+		CreatedBy:                  tenantUser.ID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, subnetDAO.Delete(ctx, nil, subnetID))
+
+	deleted, _, err := subnetDAO.GetAll(
+		ctx,
+		nil,
+		cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{subnetID}, IncludeDeleted: true},
+		cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, deleted, 1)
+	require.NotNil(t, deleted[0].Deleted)
+	deletedAt := *deleted[0].Deleted
+
+	manager := ManageSubnet{dbSession: dbSession}
+	created := manager.createOrUpdateSubnetFromSite(ctx, site, &corev1.NetworkSegment{
+		Id: &corev1.NetworkSegmentId{Value: subnetID.String()},
+		Config: &corev1.NetworkSegmentConfig{
+			VpcId: &corev1.VpcId{Value: parentVpc.ID.String()},
+			Prefixes: []*corev1.NetworkPrefix{
+				{Prefix: reportedCIDR, Gateway: cutil.GetPtr("10.20.31.1")},
+			},
+		},
+		Metadata: &corev1.Metadata{Name: "drifted-subnet"},
+		Status:   &corev1.NetworkSegmentStatus{TenantState: corev1.TenantState_READY},
+	})
+	assert.Nil(t, created)
+
+	stillDeleted, _, err := subnetDAO.GetAll(
+		ctx,
+		nil,
+		cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{subnetID}, IncludeDeleted: true},
+		cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, stillDeleted, 1)
+	require.NotNil(t, stillDeleted[0].Deleted)
+	assert.Equal(t, deletedAt, *stillDeleted[0].Deleted)
+	require.NotNil(t, stillDeleted[0].IPv4Prefix)
+	assert.Equal(t, "10.20.30.0", *stillDeleted[0].IPv4Prefix)
+
+	_, err = subnetDAO.GetByID(ctx, nil, subnetID, nil)
+	assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+	ipamer := cipam.NewWithStorage(ipamStorage)
+	ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+		ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+	))
+	assert.Nil(t, ipamer.PrefixFrom(ctx, reportedCIDR))
+	assert.Nil(t, ipamer.PrefixFrom(ctx, storedCIDR))
+}
+
+func testCreateOrUpdateSubnetSkipsIDOwnedByDifferentSite(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testSubnetInitDB(t)
+	defer dbSession.Close()
+	testSubnetSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testSubnetSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testSubnetBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testSubnetBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	siteA := testSubnetBuildSite(t, dbSession, provider, "test-site-a", providerUser)
+	siteB := testSubnetBuildSite(t, dbSession, provider, "test-site-b", providerUser)
+
+	vpcA := testSubnetBuildVPC(t, dbSession, "vpc-a", provider, tenant, siteA, nil, nil, tenantUser)
+	vpcB := testSubnetBuildVPC(t, dbSession, "vpc-b", provider, tenant, siteB, nil, nil, tenantUser)
+
+	ipBlockA := testSubnetBuildIPBlock(
+		t, dbSession, "ip-block-a", siteA, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.10.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipBlockB := testSubnetBuildIPBlock(
+		t, dbSession, "ip-block-b", siteB, provider, &tenant.ID,
+		cdbm.IPBlockRoutingTypeDatacenterOnly, "10.20.0.0", 16,
+		cdbm.IPBlockProtocolVersionV4, false, cdbm.IPBlockStatusReady, tenantUser,
+	)
+	ipamStorage := ipam.NewIpamStorage(dbSession.DB, nil)
+	_, err := ipam.CreateIpamEntryForIPBlock(
+		ctx, ipamStorage, ipBlockB.Prefix, ipBlockB.PrefixLength, ipBlockB.RoutingType,
+		ipBlockB.InfrastructureProviderID.String(), ipBlockB.SiteID.String(),
+	)
+	require.NoError(t, err)
+
+	sharedSubnetID := uuid.New()
+	prefixA := "10.10.1.0"
+	prefixLengthA := 24
+	existing, err := cdbm.NewSubnetDAO(dbSession).Create(ctx, nil, cdbm.SubnetCreateInput{
+		SubnetID:                   &sharedSubnetID,
+		Name:                       "site-a-subnet",
+		Org:                        tenant.Org,
+		SiteID:                     siteA.ID,
+		VpcID:                      vpcA.ID,
+		TenantID:                   tenant.ID,
+		ControllerNetworkSegmentID: &sharedSubnetID,
+		RoutingType:                &ipBlockA.RoutingType,
+		IPv4Prefix:                 &prefixA,
+		IPv4Gateway:                cutil.GetPtr("10.10.1.1"),
+		IPv4BlockID:                &ipBlockA.ID,
+		PrefixLength:               prefixLengthA,
+		Status:                     cdbm.SubnetStatusReady,
+		CreatedBy:                  tenantUser.ID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, sharedSubnetID, existing.ID)
+	require.Equal(t, siteA.ID, existing.SiteID)
+
+	manager := ManageSubnet{dbSession: dbSession}
+	created := manager.createOrUpdateSubnetFromSite(ctx, siteB, &corev1.NetworkSegment{
+		Id: &corev1.NetworkSegmentId{Value: sharedSubnetID.String()},
+		Config: &corev1.NetworkSegmentConfig{
+			VpcId: &corev1.VpcId{Value: vpcB.ID.String()},
+			Prefixes: []*corev1.NetworkPrefix{
+				{Prefix: "10.20.1.0/24", Gateway: cutil.GetPtr("10.20.1.1")},
+			},
+		},
+		Metadata: &corev1.Metadata{Name: "site-b-collision-subnet"},
+		Status:   &corev1.NetworkSegmentStatus{TenantState: corev1.TenantState_READY},
+	})
+	assert.Nil(t, created)
+
+	subnetDAO := cdbm.NewSubnetDAO(dbSession)
+	stillOriginal, err := subnetDAO.GetByID(ctx, nil, sharedSubnetID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, siteA.ID, stillOriginal.SiteID)
+	require.NotNil(t, stillOriginal.IPv4Prefix)
+	assert.Equal(t, prefixA, *stillOriginal.IPv4Prefix)
+	assert.Equal(t, "site-a-subnet", stillOriginal.Name)
+	assert.Nil(t, stillOriginal.Deleted)
+
+	siteBSubnets, _, err := subnetDAO.GetAll(ctx, nil, cdbm.SubnetFilterInput{
+		SiteIDs: []uuid.UUID{siteB.ID},
+	}, cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, siteBSubnets)
+
+	ipamer := cipam.NewWithStorage(ipamStorage)
+	ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+		ctx, ipBlockB.RoutingType, ipBlockB.InfrastructureProviderID.String(), ipBlockB.SiteID.String(),
+	))
+	assert.Nil(t, ipamer.PrefixFrom(ctx, "10.20.1.0/24"))
 }
 
 // Test Subnet Metrics - CREATE operations

--- a/rest-api/workflow/pkg/activity/subnet/subnet_test.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet_test.go
@@ -392,6 +392,9 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 	// Subnet 5 is reported as Ready in Controller inventory but is being deleted, so does not get updated
 	subnet5 := testSubnetBuildSubnet(t, dbSession, "test-subnet-5", tn, vpc, nil, cutil.GetPtr(uuid.New()), &ipb.RoutingType, &ipv4Prefix, &ipv4Gateway, &ipb.ID, 26, cdbm.SubnetStatusDeleting, tnu)
 
+	// Subnet 10 is reported as Terminated in Controller inventory but remains Deleting until it disappears from inventory
+	subnet10 := testSubnetBuildSubnet(t, dbSession, "test-subnet-10", tn, vpc, nil, cutil.GetPtr(uuid.New()), &ipb.RoutingType, &ipv4Prefix, &ipv4Gateway, &ipb.ID, 26, cdbm.SubnetStatusDeleting, tnu)
+
 	// Subnet 6 was previously missing but is reported as Ready in Controller inventory
 	subnet6 := testSubnetBuildSubnet(t, dbSession, "test-subnet-6", tn, vpc, nil, cutil.GetPtr(uuid.New()), &ipb.RoutingType, &ipv4Prefix, &ipv4Gateway, &ipb.ID, 26, cdbm.SubnetStatusError, tnu)
 
@@ -466,7 +469,7 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 		args            args
 		updatedSubnet   *cdbm.Subnet
 		deletedSubnets  []*cdbm.Subnet
-		deletingSubnet  *cdbm.Subnet
+		deletingSubnets []*cdbm.Subnet
 		missingSubnets  []*cdbm.Subnet
 		restoredSubnet  *cdbm.Subnet
 		unpairedSubnets []*cdbm.Subnet
@@ -506,6 +509,7 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 					Segments: []*corev1.NetworkSegment{
 						testBuildNetworkSegment(subnet1.ControllerNetworkSegmentID.String(), subnet1.Name, &mtu, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
 						testBuildNetworkSegment(subnet5.ControllerNetworkSegmentID.String(), subnet5.Name, nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						testBuildNetworkSegment(subnet10.ControllerNetworkSegmentID.String(), subnet10.Name, nil, corev1.TenantState_TERMINATED, corev1.NetworkSegmentType_TENANT),
 						testBuildNetworkSegment(subnet6.ControllerNetworkSegmentID.String(), subnet6.Name, nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
 						testBuildNetworkSegment(uuid.NewString(), subnet8.ID.String(), nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
 						testBuildNetworkSegment(uuid.NewString(), subnet9.ID.String(), nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
@@ -514,7 +518,7 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 			},
 			updatedSubnet:   subnet1,
 			deletedSubnets:  []*cdbm.Subnet{subnet2, subnetFG, subnet7},
-			deletingSubnet:  subnet5,
+			deletingSubnets: []*cdbm.Subnet{subnet5, subnet10},
 			missingSubnets:  []*cdbm.Subnet{subnet3, subnet4},
 			restoredSubnet:  subnet6,
 			unpairedSubnets: []*cdbm.Subnet{subnet8, subnet9},
@@ -652,9 +656,9 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 				assert.Equal(t, cdbm.SubnetStatusReady, us.Status)
 			}
 
-			// Check that Subnet 5, which was in Deleting state, did not get its state changed to Ready if Site inventory reports it as Ready
-			if tt.deletingSubnet != nil {
-				us, err := subnetDAO.GetByID(ctx, nil, tt.deletingSubnet.ID, nil)
+			// Check that Subnets in Deleting state remain Deleting while they are still present in Site inventory
+			for _, subnet := range tt.deletingSubnets {
+				us, err := subnetDAO.GetByID(ctx, nil, subnet.ID, nil)
 				assert.Nil(t, err)
 				assert.Equal(t, cdbm.SubnetStatusDeleting, us.Status)
 			}
@@ -912,6 +916,83 @@ func testManageSubnetUpdateSubnetsInDBAutoCreatesAndRestores(t *testing.T) {
 		assert.Nil(t, ipamer.PrefixFrom(ctx, controllerSegment.Config.Prefixes[0].Prefix))
 	})
 
+	t.Run("inventory defers restore when delete is newer than the inventory interval", func(t *testing.T) {
+		recentlyDeletedSubnetID := uuid.New()
+		recentlyDeletedPrefix := "10.20.31.0"
+		recentlyDeletedCIDR := "10.20.31.0/24"
+		recentlyDeletedGateway := "10.20.31.1"
+		_, err := subnetDAO.Create(ctx, nil, cdbm.SubnetCreateInput{
+			SubnetID:                   &recentlyDeletedSubnetID,
+			Name:                       "recently-deleted-subnet",
+			Org:                        tenant.Org,
+			SiteID:                     site.ID,
+			VpcID:                      parentVpc.ID,
+			TenantID:                   tenant.ID,
+			ControllerNetworkSegmentID: &recentlyDeletedSubnetID,
+			RoutingType:                &ipBlock.RoutingType,
+			IPv4Prefix:                 &recentlyDeletedPrefix,
+			IPv4Gateway:                &recentlyDeletedGateway,
+			IPv4BlockID:                &ipBlock.ID,
+			PrefixLength:               24,
+			Status:                     cdbm.SubnetStatusDeleting,
+			CreatedBy:                  tenantUser.ID,
+		})
+		require.NoError(t, err)
+		require.NoError(t, subnetDAO.Delete(ctx, nil, recentlyDeletedSubnetID))
+
+		deleted, _, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{recentlyDeletedSubnetID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deleted, 1)
+		require.NotNil(t, deleted[0].Deleted)
+		deletedAt := *deleted[0].Deleted
+
+		recentInventory := &corev1.SubnetInventory{
+			Segments: []*corev1.NetworkSegment{
+				{
+					Id: &corev1.NetworkSegmentId{Value: recentlyDeletedSubnetID.String()},
+					Config: &corev1.NetworkSegmentConfig{
+						VpcId:       &corev1.VpcId{Value: controllerVpcID.String()},
+						SegmentType: corev1.NetworkSegmentType_TENANT,
+						Prefixes: []*corev1.NetworkPrefix{
+							{Prefix: recentlyDeletedCIDR, Gateway: &recentlyDeletedGateway},
+						},
+					},
+					Metadata: &corev1.Metadata{Name: "recently-deleted-subnet"},
+					Status:   &corev1.NetworkSegmentStatus{TenantState: corev1.TenantState_READY},
+				},
+			},
+		}
+		_, err = manager.UpdateSubnetsInDB(ctx, site.ID, recentInventory)
+		require.NoError(t, err)
+
+		stillDeleted, _, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{recentlyDeletedSubnetID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, stillDeleted, 1)
+		require.NotNil(t, stillDeleted[0].Deleted)
+		assert.Equal(t, deletedAt, *stillDeleted[0].Deleted)
+
+		_, err = subnetDAO.GetByID(ctx, nil, recentlyDeletedSubnetID, nil)
+		assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+
+		ipamer := cipam.NewWithStorage(ipamStorage)
+		ipamer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+			ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+		))
+		assert.Nil(t, ipamer.PrefixFrom(ctx, recentlyDeletedCIDR))
+	})
+
 	t.Run("inventory restores soft-deleted Subnet", func(t *testing.T) {
 		var logOutput bytes.Buffer
 		originalLogger := log.Logger
@@ -920,6 +1001,8 @@ func testManageSubnetUpdateSubnetsInDBAutoCreatesAndRestores(t *testing.T) {
 			log.Logger = originalLogger
 		}()
 
+		// Establish the soft-delete precondition here so this subtest can be
+		// selected with -run without executing the preceding lifecycle subtests.
 		existing, _, err := subnetDAO.GetAll(
 			ctx,
 			nil,
@@ -981,6 +1064,9 @@ func testManageSubnetUpdateSubnetsInDBAutoCreatesAndRestores(t *testing.T) {
 		require.Len(t, deleted, 1)
 		require.NotNil(t, deleted[0].Deleted)
 		require.Equal(t, cdbm.SubnetStatusDeleting, deleted[0].Status)
+		// The undelete is deferred while the delete is newer than the staleness threshold, so
+		// backdate it past that.
+		util.TestInventoryAgeDeletedTimestamp(ctx, t, dbSession, (*cdbm.Subnet)(nil), controllerSegmentID)
 
 		_, err = manager.UpdateSubnetsInDB(ctx, site.ID, inventory)
 		require.NoError(t, err)
@@ -1386,6 +1472,9 @@ func TestManageSubnet_CreateOrUpdateSubnetFromSite(t *testing.T) {
 			require.NoError(t, err)
 			err = testSubnetDAO.Delete(testCtx, nil, controllerSegmentID)
 			require.NoError(t, err)
+			// The undelete is deferred while the delete is newer than the staleness threshold,
+			// so backdate it past that.
+			util.TestInventoryAgeDeletedTimestamp(testCtx, t, testDBSession, (*cdbm.Subnet)(nil), controllerSegmentID)
 
 			if test.storedIPBlockStatus != cdbm.IPBlockStatusReady {
 				_, err = cdbm.NewIPBlockDAO(testDBSession).Update(testCtx, nil, cdbm.IPBlockUpdateInput{

--- a/rest-api/workflow/pkg/activity/subnet/subnet_test.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet_test.go
@@ -928,9 +928,59 @@ func testManageSubnetUpdateSubnetsInDBAutoCreatesAndRestores(t *testing.T) {
 			nil,
 		)
 		require.NoError(t, err)
+		if len(existing) == 0 {
+			created, createErr := subnetDAO.Create(ctx, nil, cdbm.SubnetCreateInput{
+				SubnetID:                   &controllerSegmentID,
+				Name:                       controllerSegment.GetMetadata().GetName(),
+				Org:                        tenant.Org,
+				SiteID:                     site.ID,
+				VpcID:                      parentVpc.ID,
+				TenantID:                   tenant.ID,
+				ControllerNetworkSegmentID: &controllerSegmentID,
+				RoutingType:                &ipBlock.RoutingType,
+				IPv4Prefix:                 cutil.GetPtr("10.20.30.0"),
+				IPv4Gateway:                &gateway,
+				IPv4BlockID:                &ipBlock.ID,
+				PrefixLength:               24,
+				Status:                     cdbm.SubnetStatusDeleting,
+				CreatedBy:                  tenantUser.ID,
+			})
+			require.NoError(t, createErr)
+			existing = []cdbm.Subnet{*created}
+		}
 		require.Len(t, existing, 1)
-		require.NotNil(t, existing[0].Deleted, "expected the Subnet to be soft-deleted by the preceding subtest")
-		require.Equal(t, cdbm.SubnetStatusDeleting, existing[0].Status)
+
+		if existing[0].Deleted == nil {
+			_, err = subnetDAO.Update(ctx, nil, cdbm.SubnetUpdateInput{
+				SubnetId:        controllerSegmentID,
+				Status:          cutil.GetPtr(cdbm.SubnetStatusDeleting),
+				IsMissingOnSite: cutil.GetPtr(true),
+			})
+			require.NoError(t, err)
+
+			setupIPAMer := cipam.NewWithStorage(ipamStorage)
+			setupIPAMer.SetNamespace(ipam.GetIpamNamespaceForIPBlock(
+				ctx, ipBlock.RoutingType, ipBlock.InfrastructureProviderID.String(), ipBlock.SiteID.String(),
+			))
+			if setupIPAMer.PrefixFrom(ctx, controllerSegment.Config.Prefixes[0].Prefix) != nil {
+				require.NoError(t, ipam.DeleteChildIpamEntryFromCidr(
+					ctx, nil, dbSession, ipamStorage, ipBlock, controllerSegment.Config.Prefixes[0].Prefix,
+				))
+			}
+			require.NoError(t, subnetDAO.Delete(ctx, nil, controllerSegmentID))
+		}
+
+		deleted, _, err := subnetDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.SubnetFilterInput{SubnetIDs: []uuid.UUID{controllerSegmentID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deleted, 1)
+		require.NotNil(t, deleted[0].Deleted)
+		require.Equal(t, cdbm.SubnetStatusDeleting, deleted[0].Status)
 
 		_, err = manager.UpdateSubnetsInDB(ctx, site.ID, inventory)
 		require.NoError(t, err)

--- a/rest-api/workflow/pkg/activity/subnet/subnet_test.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet_test.go
@@ -759,7 +759,7 @@ func testManageSubnetUpdateSubnetsInDBAutoCreatesAndRestores(t *testing.T) {
 		assert.Equal(t, tenant.ID, created.TenantID)
 		assert.Equal(t, tenantOrg, created.Org)
 		assert.Equal(t, site.ID, created.SiteID)
-		assert.Equal(t, site.CreatedBy, created.CreatedBy)
+		assert.Equal(t, parentVpc.CreatedBy, created.CreatedBy)
 		assert.Equal(t, cdbm.SubnetStatusReady, created.Status)
 		assert.Equal(t, "site-created-subnet", created.Name)
 		require.NotNil(t, created.IPv4Prefix)

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix.go
@@ -520,7 +520,7 @@ func (mvp ManageVpcPrefix) createOrUpdateVpcPrefixFromSite(
 			Prefix:       reportedVpcPrefix.Prefix,
 			PrefixLength: reportedPrefixLength,
 			Status:       cdbm.VpcPrefixStatusReady,
-			CreatedBy:    site.CreatedBy,
+			CreatedBy:    vpc.CreatedBy,
 		})
 		if createErr != nil {
 			return nil, fmt.Errorf("unable to create VPC Prefix found on Site: failed to create VPC Prefix, DB error: %w", createErr)

--- a/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
+++ b/rest-api/workflow/pkg/activity/vpcprefix/vpcprefix_test.go
@@ -761,7 +761,7 @@ func testManageVpcPrefixUpdateVpcPrefixesInDBAutoCreatesAndRestores(t *testing.T
 		assert.Equal(t, tenant.ID, created.TenantID)
 		assert.Equal(t, tenantOrg, created.Org)
 		assert.Equal(t, site.ID, created.SiteID)
-		assert.Equal(t, site.CreatedBy, created.CreatedBy)
+		assert.Equal(t, parentVpc.CreatedBy, created.CreatedBy)
 		assert.Equal(t, cdbm.VpcPrefixStatusReady, created.Status)
 		assert.Equal(t, "site-created-vpc-prefix", created.Name)
 		assert.Equal(t, "10.20.30.0/24", created.Prefix)


### PR DESCRIPTION
## Description
Site inventory previously skipped Subnets that existed on Site but had no active REST database record, leaving Site and REST state inconsistent. This PR reconciles those Subnets using their Controller Segment ID.

Soft-deleted Subnets are restored when reported by a newer inventory snapshot, while true orphans are auto-created after validating parent VPC ownership, a containing Ready tenant IPBlock, IPAM claim of the Site-reported CIDR, and name conflicts. Recovery writes are transactional and retry-safe.

Key behaviors:
- Resolve the most specific Ready tenant IPBlock that contains the reported prefix, skipping FullGrant blocks.
- Claim the Site-reported CIDR via IPAM under the same tenant/IPBlock advisory lock as the REST create path.
- Skip create/undelete when Site reports TERMINATING/TERMINATED so stale inventory cannot resurrect a user delete.
- On undelete, clear soft-delete and refresh Status from Site inventory in the same transaction.
- Reject non-canonical CIDRs and Prefix/VpcID/IPBlock drift before mutating IPAM.

## Related issues
This PR is part of [issue #3436](https://github.com/NVIDIA/infra-controller/issues/3436).

## Type of Change
- [x] **Add** - New feature or capability

## Testing
- [x] Unit tests added/updated

Tests executed:
go test -p 1 ./workflow/pkg/activity/subnet -count=1
go test -p 1 ./db/pkg/db/model -count=1
go test -race -p 1 ./workflow/pkg/activity/subnet -count=1

## Additional Notes
- Subnet recovery identity matching uses Controller Segment IDs.
- Empty inventory names become recovered-<8hex>; name conflicts append -recovered-<8hex>.
- Adds SubnetDAO.Clear/IncludeDeleted support and explicit Subnet IDs for recovery.
- Reuses the existing IPAM and IPBlock recovery helpers without modification.
- No database schema migration is required.

