### PR TITLE
fix(rest-api): Restore deleted Machines if they re-appear in inventory from Site

### DIFF
--- a/rest-api/db/pkg/db/model/machine.go
+++ b/rest-api/db/pkg/db/model/machine.go
@@ -270,6 +270,8 @@ type MachineClearInput struct {
 	NetworkHealthMessage  bool
 	DefaultMacAddress     bool
 	Hostname              bool
+	// Deleted clears the soft-delete timestamp (undelete).
+	Deleted bool
 }
 
 // MachineFilterInput filtering options for GetAll method
@@ -290,6 +292,8 @@ type MachineFilterInput struct {
 	Labels                    map[string]string
 	IsMissingOnSite           *bool
 	ExcludeMetadata           bool // When true, excludes the metadata JSONB column from SELECT to improve performance on bulk queries
+	// IncludeDeleted returns soft-deleted rows in addition to active ones.
+	IncludeDeleted bool
 }
 
 type MachineHealth struct {
@@ -741,6 +745,9 @@ func (msd MachineSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter MachineFi
 	}
 
 	query := db.GetIDB(tx, msd.dbSession).NewSelect().Model(&machines)
+	if filter.IncludeDeleted {
+		query = query.WhereAllWithDeleted()
+	}
 
 	query, err := msd.setQueryWithFilter(filter, query, machineDAOSpan)
 	if err != nil {
@@ -850,11 +857,20 @@ func (msd MachineSQLDAO) Clear(ctx context.Context, tx *db.Tx, input MachineClea
 		m.Hostname = nil
 		updatedFields = append(updatedFields, "hostname")
 	}
+	if input.Deleted {
+		m.Deleted = nil
+		updatedFields = append(updatedFields, "deleted")
+	}
 
 	if len(updatedFields) > 0 {
 		updatedFields = append(updatedFields, "updated")
 
-		_, err := db.GetIDB(tx, msd.dbSession).NewUpdate().Model(m).Column(updatedFields...).Where("id = ?", input.MachineID).Exec(ctx)
+		query := db.GetIDB(tx, msd.dbSession).NewUpdate().Model(m).Column(updatedFields...).Where("id = ?", input.MachineID)
+		// Soft-deleted rows are excluded by default; include them when undeleting.
+		if input.Deleted {
+			query = query.WhereAllWithDeleted()
+		}
+		_, err := query.Exec(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/rest-api/db/pkg/db/model/machine_test.go
+++ b/rest-api/db/pkg/db/model/machine_test.go
@@ -12,6 +12,7 @@ import (
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	otrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
@@ -1267,6 +1268,35 @@ func TestMachineSQLDAO_GetAll(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("includes soft-deleted Machines when requested", func(t *testing.T) {
+		machineID := ms1[0].ID
+		err := msd.Delete(ctx, nil, machineID, false)
+		require.NoError(t, err)
+
+		active, activeTotal, err := msd.GetAll(
+			ctx,
+			nil,
+			MachineFilterInput{MachineIDs: []string{machineID}},
+			paginator.PageInput{Limit: cutil.GetPtr(paginator.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, active)
+		assert.Zero(t, activeTotal)
+
+		withDeleted, totalWithDeleted, err := msd.GetAll(
+			ctx,
+			nil,
+			MachineFilterInput{MachineIDs: []string{machineID}, IncludeDeleted: true},
+			paginator.PageInput{Limit: cutil.GetPtr(paginator.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, withDeleted, 1)
+		assert.Equal(t, 1, totalWithDeleted)
+		assert.NotNil(t, withDeleted[0].Deleted)
+	})
 }
 
 func TestMachineSQLDAO_Update(t *testing.T) {
@@ -1633,6 +1663,33 @@ func TestMachineSQLDAO_Clear(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("can clear soft-delete timestamp", func(t *testing.T) {
+		machineID := mcsExp[3].ID
+		err := msd.Delete(ctx, nil, machineID, false)
+		require.NoError(t, err)
+
+		var deleted Machine
+		err = dbSession.DB.NewSelect().
+			Model(&deleted).
+			Where("m.id = ?", machineID).
+			WhereAllWithDeleted().
+			Scan(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, deleted.Deleted)
+
+		restored, err := msd.Clear(ctx, nil, MachineClearInput{
+			MachineID: machineID,
+			Deleted:   true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, restored)
+		assert.Nil(t, restored.Deleted)
+
+		active, err := msd.GetByID(ctx, nil, machineID, nil, false)
+		require.NoError(t, err)
+		assert.Equal(t, machineID, active.ID)
+	})
 }
 
 func TestMachineSQLDAO_Delete(t *testing.T) {

--- a/rest-api/workflow/pkg/activity/machine/machine.go
+++ b/rest-api/workflow/pkg/activity/machine/machine.go
@@ -450,6 +450,9 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 			}
 
 			if wasDeleted {
+				// Clear bumps Updated, so restored Machines bypass the staleness check below
+				// for this inventory. The update below refreshes the row and keeps Updated
+				// recent; a subsequent inventory within the threshold may be deferred.
 				existingCloudMachine, err = mDAO.Clear(ctx, txn, cdbm.MachineClearInput{
 					MachineID: existingCloudMachine.ID,
 					Deleted:   true,

--- a/rest-api/workflow/pkg/activity/machine/machine.go
+++ b/rest-api/workflow/pkg/activity/machine/machine.go
@@ -209,8 +209,8 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 		}
 	}
 
-	for i := range existingMachines {
-		existingCloudMachineIDMap[existingMachines[i].ID] = &existingMachines[i]
+	for _, machine := range existingMachines {
+		existingCloudMachineIDMap[machine.ID] = &machine
 	}
 
 	miDAO := cdbm.NewMachineInterfaceDAO(mm.dbSession)
@@ -439,7 +439,9 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 			if wasDeleted && site.IsTimeWithinStaleInventoryThreshold(*existingCloudMachine.Deleted) {
 				// A snapshot collected before the delete can arrive after it. Wait until the
 				// delete is older than the inventory staleness threshold before restoring.
-				slogger.Info().Msg("not undeleting Machine yet because it was deleted more recently than the inventory interval")
+				slogger.Info().
+					Str("Machine ID", existingCloudMachine.ID).
+					Msg("not undeleting Machine yet because it was deleted more recently than the inventory interval")
 				continue
 			}
 

--- a/rest-api/workflow/pkg/activity/machine/machine.go
+++ b/rest-api/workflow/pkg/activity/machine/machine.go
@@ -184,7 +184,10 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 	// Get all machines for Site to allow faster lookups
 	mDAO := cdbm.NewMachineDAO(mm.dbSession)
 
-	filterInput := cdbm.MachineFilterInput{SiteIDs: []uuid.UUID{site.ID}}
+	filterInput := cdbm.MachineFilterInput{
+		SiteIDs:        []uuid.UUID{site.ID},
+		IncludeDeleted: true,
+	}
 
 	existingMachines, _, err := mDAO.GetAll(ctx, nil, filterInput, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
@@ -206,8 +209,8 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 		}
 	}
 
-	for _, machine := range existingMachines {
-		existingCloudMachineIDMap[machine.ID] = &machine
+	for i := range existingMachines {
+		existingCloudMachineIDMap[existingMachines[i].ID] = &existingMachines[i]
 	}
 
 	miDAO := cdbm.NewMachineInterfaceDAO(mm.dbSession)
@@ -432,24 +435,50 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 			// There could be a race between inventory and human changes in nico-rest-api,
 			// so we need to grab a txn and also lock on the machine record.
 
+			wasDeleted := existingCloudMachine.Deleted != nil
+			if wasDeleted && site.IsTimeWithinStaleInventoryThreshold(*existingCloudMachine.Deleted) {
+				// A snapshot collected before the delete can arrive after it. Wait until the
+				// delete is older than the inventory staleness threshold before restoring.
+				slogger.Info().Msg("not undeleting Machine yet because it was deleted more recently than the inventory interval")
+				continue
+			}
+
 			txn, err := cdb.BeginTx(ctx, mm.dbSession, &sql.TxOptions{})
 			if err != nil {
 				slogger.Error().Err(err).Msg("failed to start transaction")
 				continue
 			}
 
-			// Grab a fresh copy of the machine details and a lock on the record during the SELECT.
-			existingCloudMachine, err = mDAO.GetByID(ctx, txn, existingCloudMachine.ID, nil, true)
-			if err != nil {
-				slogger.Error().Err(err).Msg("failed to start transaction")
-				txn.Rollback()
-				continue
+			if wasDeleted {
+				existingCloudMachine, err = mDAO.Clear(ctx, txn, cdbm.MachineClearInput{
+					MachineID: existingCloudMachine.ID,
+					Deleted:   true,
+				})
+				if err != nil {
+					slogger.Error().Err(err).Msg("failed to clear soft-delete timestamp for Machine")
+					terr := txn.Rollback()
+					if terr != nil {
+						slogger.Error().Err(terr).Msg("failed to rollback transaction")
+					}
+					continue
+				}
+			} else {
+				// Grab a fresh copy of the machine details and a lock on the record during the SELECT.
+				existingCloudMachine, err = mDAO.GetByID(ctx, txn, existingCloudMachine.ID, nil, true)
+				if err != nil {
+					slogger.Error().Err(err).Msg("failed to retrieve Machine in transaction")
+					terr := txn.Rollback()
+					if terr != nil {
+						slogger.Error().Err(terr).Msg("failed to rollback transaction")
+					}
+					continue
+				}
 			}
 
 			// If the machine was updated at all since this inventory was received, we
 			// should consider the inventory details stale for this machine.
 			// We'll add a 5 second buffer to account for a little clock skew/drift.
-			if site.IsTimeWithinStaleInventoryThreshold(existingCloudMachine.Updated) {
+			if !wasDeleted && site.IsTimeWithinStaleInventoryThreshold(existingCloudMachine.Updated) {
 				slogger.Warn().Msg("machine updated more recently than inventory received time, skipping processing")
 				txn.Rollback()
 				continue
@@ -702,6 +731,10 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 	// If inventory paging is enabled, we only need to do this once and we do it on the last page
 	if machineInventory.InventoryPage == nil || machineInventory.InventoryPage.TotalPages == 0 || (machineInventory.InventoryPage.CurrentPage == machineInventory.InventoryPage.TotalPages) {
 		for _, existingMachine := range existingMachines {
+			if existingMachine.Deleted != nil {
+				continue
+			}
+
 			_, found := reportedMachineIDMap[existingMachine.ID]
 			if found {
 				continue

--- a/rest-api/workflow/pkg/activity/machine/machine_test.go
+++ b/rest-api/workflow/pkg/activity/machine/machine_test.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1470,6 +1472,100 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 		assert.Equal(t, cdbm.MachineStatusReady, statusDetails[0].Status)
 		require.NotNil(t, statusDetails[0].Message)
 		assert.Equal(t, "Machine is ready for assignment", *statusDetails[0].Message)
+	})
+
+	t.Run("leaves an unreported soft-deleted Machine untouched", func(t *testing.T) {
+		ctx := context.Background()
+		tombstoneSite := testMachineBuildSite(t, dbSession, ip, "test-machine-tombstone-site", cdbm.SiteStatusRegistered)
+		tombstone := testMachineBuildMachine(
+			t,
+			dbSession,
+			ip.ID,
+			tombstoneSite.ID,
+			nil,
+			nil,
+			false,
+			nil,
+			false,
+			nil,
+			cutil.GetPtr(cdbm.MachineStatusReady),
+		)
+
+		machineDAO := cdbm.NewMachineDAO(dbSession)
+		_, err := machineDAO.Update(ctx, nil, cdbm.MachineUpdateInput{
+			MachineID:        tombstone.ID,
+			IsUsableByTenant: cutil.GetPtr(true),
+		})
+		require.NoError(t, err)
+		require.NoError(t, machineDAO.Delete(ctx, nil, tombstone.ID, false))
+
+		getTombstone := func() *cdbm.Machine {
+			t.Helper()
+			machines, total, getErr := machineDAO.GetAll(
+				ctx,
+				nil,
+				cdbm.MachineFilterInput{
+					MachineIDs:     []string{tombstone.ID},
+					IncludeDeleted: true,
+				},
+				cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+				nil,
+			)
+			require.NoError(t, getErr)
+			require.Equal(t, 1, total)
+			require.Len(t, machines, 1)
+			require.NotNil(t, machines[0].Deleted)
+			return &machines[0]
+		}
+
+		before := getTombstone()
+		statusDetailDAO := cdbm.NewStatusDetailDAO(dbSession)
+		_, statusDetailCountBefore, err := statusDetailDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{tombstone.ID}},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+		)
+		require.NoError(t, err)
+
+		var logOutput bytes.Buffer
+		originalLogger := log.Logger
+		log.Logger = zerolog.New(&logOutput)
+		defer func() {
+			log.Logger = originalLogger
+		}()
+
+		manager := ManageMachine{
+			dbSession:      dbSession,
+			siteClientPool: tSiteClientPool,
+		}
+		emptyInventory := &corev1.MachineInventory{
+			Machines:        []*corev1.MachineInfo{},
+			Timestamp:       timestamppb.Now(),
+			InventoryStatus: corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
+		}
+
+		for range 2 {
+			err = manager.UpdateMachinesInDB(ctx, tombstoneSite.ID.String(), emptyInventory)
+			require.NoError(t, err)
+		}
+
+		after := getTombstone()
+		assert.Equal(t, before.Deleted, after.Deleted)
+		assert.True(t, after.Updated.Equal(before.Updated))
+		assert.Equal(t, before.Status, after.Status)
+		assert.Equal(t, before.IsMissingOnSite, after.IsMissingOnSite)
+		assert.Equal(t, before.IsUsableByTenant, after.IsUsableByTenant)
+
+		_, statusDetailCountAfter, err := statusDetailDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{tombstone.ID}},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, statusDetailCountBefore, statusDetailCountAfter)
+		assert.NotContains(t, logOutput.String(), "failed to update missing on Site flag in DB")
 	})
 }
 

--- a/rest-api/workflow/pkg/activity/machine/machine_test.go
+++ b/rest-api/workflow/pkg/activity/machine/machine_test.go
@@ -1352,6 +1352,125 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 			assert.Greater(t, *updatedSite.InventoryReceived, refTime)
 		})
 	}
+
+	t.Run("defers stale inventory then restores a soft-deleted Machine", func(t *testing.T) {
+		ctx := context.Background()
+		recoverySite := testMachineBuildSite(t, dbSession, ip, "test-machine-recovery-site", cdbm.SiteStatusRegistered)
+		recoveryMachine := testMachineBuildMachine(
+			t,
+			dbSession,
+			ip.ID,
+			recoverySite.ID,
+			nil,
+			nil,
+			false,
+			nil,
+			false,
+			nil,
+			cutil.GetPtr(cdbm.MachineStatusError),
+		)
+
+		machineDAO := cdbm.NewMachineDAO(dbSession)
+		_, err := machineDAO.Update(ctx, nil, cdbm.MachineUpdateInput{
+			MachineID:        recoveryMachine.ID,
+			IsMissingOnSite:  cutil.GetPtr(true),
+			IsUsableByTenant: cutil.GetPtr(false),
+		})
+		require.NoError(t, err)
+		require.NoError(t, machineDAO.Delete(ctx, nil, recoveryMachine.ID, false))
+
+		getDeleted := func() *cdbm.Machine {
+			t.Helper()
+			machines, total, getErr := machineDAO.GetAll(
+				ctx,
+				nil,
+				cdbm.MachineFilterInput{
+					MachineIDs:     []string{recoveryMachine.ID},
+					IncludeDeleted: true,
+				},
+				cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+				nil,
+			)
+			require.NoError(t, getErr)
+			require.Equal(t, 1, total)
+			require.Len(t, machines, 1)
+			require.NotNil(t, machines[0].Deleted)
+			return &machines[0]
+		}
+
+		deleted := getDeleted()
+		deletedAt := *deleted.Deleted
+		inventory := &corev1.MachineInventory{
+			Machines: []*corev1.MachineInfo{{
+				Machine: &corev1.Machine{
+					Id:     &corev1.MachineId{Id: recoveryMachine.ID},
+					State:  controllerMachineStatePrefixReady,
+					Status: &corev1.MachineStatus{},
+				},
+			}},
+			Timestamp:       timestamppb.Now(),
+			InventoryStatus: corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
+		}
+		manager := ManageMachine{
+			dbSession:      dbSession,
+			siteClientPool: tSiteClientPool,
+		}
+
+		// The first inventory may have been collected before the delete, so it must not
+		// immediately reverse the user action.
+		err = manager.UpdateMachinesInDB(ctx, recoverySite.ID.String(), inventory)
+		require.NoError(t, err)
+		stillDeleted := getDeleted()
+		assert.Equal(t, deletedAt, *stillDeleted.Deleted)
+
+		// Once the delete is older than the inventory interval, another report proves that
+		// the Machine still exists on Site and should restore the retained row.
+		agedDelete := time.Now().Add(-2 * time.Duration(cutil.DefaultInventoryReceiptInterval))
+		_, err = dbSession.DB.NewUpdate().
+			Model((*cdbm.Machine)(nil)).
+			Set("deleted = ?", agedDelete).
+			Where("id = ?", recoveryMachine.ID).
+			WhereAllWithDeleted().
+			Exec(ctx)
+		require.NoError(t, err)
+
+		err = manager.UpdateMachinesInDB(ctx, recoverySite.ID.String(), inventory)
+		require.NoError(t, err)
+
+		restored, err := machineDAO.GetByID(ctx, nil, recoveryMachine.ID, nil, false)
+		require.NoError(t, err)
+		assert.Nil(t, restored.Deleted)
+		assert.False(t, restored.IsMissingOnSite)
+		assert.True(t, restored.IsUsableByTenant)
+		assert.Equal(t, cdbm.MachineStatusReady, restored.Status)
+		assert.True(t, restored.Created.Equal(recoveryMachine.Created))
+
+		allMatches, total, err := machineDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.MachineFilterInput{
+				MachineIDs:     []string{recoveryMachine.ID},
+				IncludeDeleted: true,
+			},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 1, total)
+		require.Len(t, allMatches, 1)
+
+		statusDetails, _, err := cdbm.NewStatusDetailDAO(dbSession).GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{recoveryMachine.ID}},
+			cdbp.PageInput{Limit: cutil.GetPtr(1)},
+		)
+		require.NoError(t, err)
+		require.Len(t, statusDetails, 1)
+		assert.Equal(t, cdbm.MachineStatusReady, statusDetails[0].Status)
+		require.NotNil(t, statusDetails[0].Message)
+		assert.Equal(t, "Machine is ready for assignment", *statusDetails[0].Message)
+	})
 }
 
 func TestManageMachine_UpdateMachinesInDB_AddresslessInterface(t *testing.T) {


### PR DESCRIPTION
## Description
Site inventory already auto-created Machines that had no REST database record. However, soft-deleted Machines were excluded from inventory lookup, causing reconciliation to attempt a duplicate insert using the retained Machine ID instead of recovering the existing row.
This PR restores soft-deleted Machines when they continue to be reported by a newer Site inventory snapshot. Existing orphan auto-creation remains unchanged.
Key behaviors:
- Include soft-deleted Machines during Site inventory reconciliation.
- Defer restoration while the deletion is newer than the inventory staleness threshold.
- Clear the soft-delete timestamp and refresh Machine state from Site inventory in the same transaction.
- Exclude still-deleted Machines from missing-on-Site processing.
- Preserve the existing Machine identity instead of creating a duplicate record.

## Related issues
This PR is part of [issue #3436](https://github.com/NVIDIA/infra-controller/issues/3436) and fixes the bug 

## Type of Change
- [x] **Fix** - Bug fixes

## Testing
- [x] Unit tests added/updated

Tests executed:
`make -C rest-api test-workflow`
`GOFLAGS="-run=^TestManageMachine_UpdateMachinesInDB$" make -C rest-api test-workflow`
`go -C rest-api tool golangci-lint run --new-from-rev=HEAD ./db/pkg/db/model ./workflow/pkg/activity/machine`
The Machine database model tests passed. The complete database target retains unrelated failures in existing IPAM tests.
## Additional Notes
- Machine recovery matches the Controller Machine ID, not mutable metadata.
- Adds `MachineDAO.Clear` undelete and `IncludeDeleted` query support.
- Existing Machine auto-creation behavior is unchanged.
- No database schema migration is required.

